### PR TITLE
Add post-PREPARE re-assessment checkpoint for ARCHITECT phase

### DIFF
--- a/.claude/commands/PACT/orchestrate.md
+++ b/.claude/commands/PACT/orchestrate.md
@@ -137,9 +137,23 @@ Each specialist should end with a structured handoff (2-4 sentences):
 
 ---
 
+### Post-PREPARE Re-assessment
+
+If PREPARE ran and ARCHITECT was marked "Skip," compare PREPARE's recommended approach to the skip rationale:
+
+- **Approach matches rationale** → Skip holds
+- **Novel approach** (new components, interfaces, expanded scope) → Override, run ARCHITECT
+
+**Example**:
+> Skip rationale: "following established pattern in `src/utils/`"
+> PREPARE recommends "add helper to existing utils" → Skip holds
+> PREPARE recommends "new ValidationService class" → Override, run ARCHITECT
+
+---
+
 ### Phase 2: ARCHITECT → `pact-architect`
 
-**Skip criteria met?** → Proceed to Phase 3.
+**Skip criteria met (after re-assessment)?** → Proceed to Phase 3.
 
 **Plan sections to pass** (if plan exists):
 - "Architecture Phase"


### PR DESCRIPTION
## Summary

- Adds a re-assessment checkpoint after PREPARE phase completes
- Orchestrator compares PREPARE's recommended approach to the original ARCHITECT skip rationale
- If PREPARE discovers a novel approach requiring architectural design, ARCHITECT phase runs instead of being skipped

## Problem

The `/PACT:orchestrate` workflow made phase skip/run decisions upfront during Context Assessment. If PREPARE discovered something that invalidated the initial ARCHITECT skip decision, there was no checkpoint to catch it.

## Solution

Added a concise Post-PREPARE Re-assessment section (~13 lines) between Phase 1 and Phase 2 with:
- Clear decision criteria (approach matches → skip holds; novel approach → override)
- Generic example showing both outcomes

Fixes #53

## Test plan

- [ ] Run `/PACT:orchestrate` on a task where PREPARE might discover novel approach
- [ ] Verify orchestrator states re-assessment before proceeding to Phase 2