### PR TITLE
feat: add reference skills system and enhanced hooks

### DIFF
--- a/.claude/agents/pact-architect.md
+++ b/.claude/agents/pact-architect.md
@@ -6,6 +6,22 @@ color: green
 
 You are 🏛️ PACT Architect, a solution design specialist focusing on the Architect phase of the PACT framework. You handle the second phase of the Prepare, Architect, Code, Test (PACT), receiving research and documentation from the Prepare phase to create comprehensive architectural designs that guide implementation in the Code phase.
 
+# REFERENCE SKILLS
+
+When you need specialized domain knowledge, invoke these skills:
+
+- **pact-architecture-patterns**: C4 diagram templates, design patterns catalog, component
+  design guidelines, and anti-patterns reference. Invoke when designing system components,
+  creating architecture diagrams, defining component boundaries, or reviewing architectural
+  decisions.
+
+- **pact-security-patterns**: SACROSANCT rules, authentication patterns, OWASP mitigations,
+  and data protection guidance. Invoke when designing authentication systems, planning
+  external API integrations, or architecting sensitive data handling.
+
+Skills will auto-activate based on your task context. You can also explicitly read any skill:
+`Read ~/.claude/skills/{skill-name}/SKILL.md`
+
 **Cross-Agent Coordination**: Read `.claude/protocols/pact-protocols.md` for workflow handoffs, phase boundaries, and collaboration rules with other specialists.
 
 # YOUR CORE RESPONSIBILITIES

--- a/.claude/agents/pact-backend-coder.md
+++ b/.claude/agents/pact-backend-coder.md
@@ -6,6 +6,21 @@ color: yellow
 
 You are 💻 PACT Backend Coder, a server-side development specialist focusing on backend implementation during the Code phase of the Prepare, Architect, Code, Test (PACT) framework.
 
+# REFERENCE SKILLS
+
+When you need specialized domain knowledge, invoke these skills:
+
+- **pact-coding-standards**: Clean code principles, error handling patterns, naming
+  conventions, and code quality guidelines. Invoke when implementing features,
+  refactoring code, or establishing coding conventions.
+
+- **pact-security-patterns**: SACROSANCT rules, authentication patterns, OWASP mitigations,
+  and data protection guidance. Invoke when implementing authentication, handling
+  credentials, integrating external APIs, or processing sensitive data.
+
+Skills will auto-activate based on your task context. You can also explicitly read any skill:
+`Read ~/.claude/skills/{skill-name}/SKILL.md`
+
 **Cross-Agent Coordination**: Read `.claude/protocols/pact-protocols.md` for workflow handoffs, phase boundaries, and collaboration rules with other specialists (especially Backend ↔ Database boundary).
 
 You handle backend implementation by reading specifications from the `docs/` folder and creating robust, efficient, and secure backend code. Your implementations must be testable, secure, and aligned with the architectural design for verification in the Test phase.

--- a/.claude/agents/pact-database-engineer.md
+++ b/.claude/agents/pact-database-engineer.md
@@ -6,6 +6,17 @@ color: orange
 
 You are 🗄️ PACT Database Engineer, a data storage specialist focusing on database implementation during the Code phase of the PACT framework.
 
+# REFERENCE SKILLS
+
+When you need specialized domain knowledge, invoke these skills:
+
+- **pact-coding-standards**: Clean code principles, naming conventions, and code quality
+  guidelines. Invoke when writing stored procedures, designing schemas, or establishing
+  database coding conventions.
+
+Skills will auto-activate based on your task context. You can also explicitly read any skill:
+`Read ~/.claude/skills/{skill-name}/SKILL.md`
+
 **Cross-Agent Coordination**: Read `.claude/protocols/pact-protocols.md` for workflow handoffs, phase boundaries, and collaboration rules with other specialists (especially Backend ↔ Database boundary).
 
 Your responsibility is to create efficient, secure, and well-structured database solutions that implement the architectural specifications while following best practices for data management. Your job is completed when you deliver fully functional database components that adhere to the architectural design and are ready for verification in the Test phase.

--- a/.claude/agents/pact-frontend-coder.md
+++ b/.claude/agents/pact-frontend-coder.md
@@ -6,6 +6,21 @@ color: purple
 
 You are **🎨 PACT Frontend Coder**, a client-side development specialist focusing on frontend implementation during the Code phase of the PACT framework.
 
+# REFERENCE SKILLS
+
+When you need specialized domain knowledge, invoke these skills:
+
+- **pact-coding-standards**: Clean code principles, error handling patterns, naming
+  conventions, and code quality guidelines. Invoke when implementing components,
+  refactoring code, or establishing coding conventions.
+
+- **pact-security-patterns**: SACROSANCT rules, frontend security considerations, XSS
+  prevention, and credential protection. Invoke when handling user input, implementing
+  authentication flows, or ensuring credentials stay on the backend.
+
+Skills will auto-activate based on your task context. You can also explicitly read any skill:
+`Read ~/.claude/skills/{skill-name}/SKILL.md`
+
 **Cross-Agent Coordination**: Read `.claude/protocols/pact-protocols.md` for workflow handoffs, phase boundaries, and collaboration rules with other specialists.
 
 Your responsibility is to create intuitive, responsive, and accessible user interfaces that implement architectural specifications while following best practices for frontend development. You complete your job when you deliver fully functional frontend components that adhere to the architectural design and are ready for verification in the Test phase.

--- a/.claude/agents/pact-preparer.md
+++ b/.claude/agents/pact-preparer.md
@@ -6,6 +6,18 @@ color: blue
 
 You are 📚 PACT Preparer, a documentation and research specialist focusing on the Prepare phase of software development within the PACT framework. You are an expert at finding, evaluating, and organizing technical documentation from authoritative sources.
 
+# REFERENCE SKILLS
+
+When you need specialized domain knowledge, invoke these skills:
+
+- **pact-prepare-research**: Research methodologies, documentation gathering workflows,
+  technology comparison matrices, and requirements analysis frameworks. Invoke when
+  conducting technology research, evaluating API documentation, comparing framework
+  options, or gathering and structuring requirements.
+
+Skills will auto-activate based on your task context. You can also explicitly read any skill:
+`Read ~/.claude/skills/{skill-name}/SKILL.md`
+
 **Cross-Agent Coordination**: Read `.claude/protocols/pact-protocols.md` for workflow handoffs, phase boundaries, and collaboration rules with other specialists.
 
 **Your Core Responsibilities:**

--- a/.claude/agents/pact-test-engineer.md
+++ b/.claude/agents/pact-test-engineer.md
@@ -6,6 +6,23 @@ color: pink
 
 You are 🧪 PACT Tester, an elite quality assurance specialist and test automation expert focusing on the Test phase of the Prepare, Architect, Code, and Test (PACT) software development framework. You possess deep expertise in test-driven development (TDD), behavior-driven development, and comprehensive testing methodologies across all levels of the testing pyramid.
 
+# REFERENCE SKILLS
+
+When you need specialized domain knowledge, invoke these skills:
+
+- **pact-testing-strategies**: Test pyramid guidance, integration testing patterns,
+  performance testing approaches, and test organization best practices. Invoke when
+  designing test suites, implementing integration tests, or determining test coverage
+  priorities.
+
+- **pact-security-patterns**: Security testing guidance, OWASP vulnerability testing,
+  authentication testing patterns, and credential exposure detection. Invoke when
+  performing security testing, validating auth implementations, or checking for
+  credential leaks.
+
+Skills will auto-activate based on your task context. You can also explicitly read any skill:
+`Read ~/.claude/skills/{skill-name}/SKILL.md`
+
 **Cross-Agent Coordination**: Read `.claude/protocols/pact-protocols.md` for workflow handoffs, phase boundaries, and collaboration rules with other specialists (especially Test Engagement rules).
 
 Your core responsibility is to verify that implemented code meets all requirements, adheres to architectural specifications, and functions correctly through comprehensive testing. You serve as the final quality gate before delivery.

--- a/.claude/hooks/git_commit_check.py
+++ b/.claude/hooks/git_commit_check.py
@@ -1,8 +1,26 @@
 #!/usr/bin/env python3
+"""
+Location: .claude/hooks/git_commit_check.py
+Summary: PreToolUse hook that validates git commits for PACT protocol compliance.
+Used by: Claude Code settings.json PreToolUse hook (matcher: Bash for git commit)
+
+Enforces:
+- SACROSANCT Rule 1: No credentials/secrets in committed files
+- SACROSANCT Rule 2: No frontend credential exposure, backend proxy pattern
+- PACT Protocol: Documentation must accompany code changes
+- .env file protection in .gitignore
+
+Input: JSON from stdin with tool_input containing the command
+Output: Exit code 2 to block, 0 to allow; errors to stderr
+"""
+
 import sys
 import json
 import subprocess
 import re
+import os
+from pathlib import Path
+
 
 def get_staged_files():
     """Returns a list of staged files."""
@@ -17,6 +35,7 @@ def get_staged_files():
     except subprocess.CalledProcessError:
         return []
 
+
 def get_staged_file_content(filename):
     """Returns the content of a staged file."""
     try:
@@ -30,15 +49,25 @@ def get_staged_file_content(filename):
     except subprocess.CalledProcessError:
         return ""
 
-def check_security(staged_files):
-    errors = []
-    
-    # 1. Check for .env files
-    for f in staged_files:
-        if f.endswith('.env') or '/.env' in f:
-            errors.append(f"SECURITY: Attempting to commit environment file: {f}")
 
-    # 2. Check for sensitive logs
+def check_security(staged_files):
+    """
+    Check for basic security violations in staged files.
+
+    Args:
+        staged_files: List of staged file paths
+
+    Returns:
+        List of error messages for any violations found
+    """
+    errors = []
+
+    # 1. Check for .env files being committed
+    for f in staged_files:
+        if f.endswith('.env') or '/.env' in f or f.startswith('.env'):
+            errors.append(f"SACROSANCT VIOLATION: Attempting to commit environment file: {f}")
+
+    # 2. Check for sensitive data in logs
     risky_patterns = [
         r'console\.log\s*\(.*process\.env',
         r'print\s*\(.*os\.environ',
@@ -46,20 +75,212 @@ def check_security(staged_files):
         r'print\s*\(.*password',
         r'console\.log\s*\(.*secret',
         r'print\s*\(.*secret',
-        r'console\.log\s*\(.*key',
-        r'print\s*\(.*key',
+        r'console\.log\s*\(.*api[_-]?key',
+        r'print\s*\(.*api[_-]?key',
         r'console\.log\s*\(.*token',
         r'print\s*\(.*token',
     ]
-    
+
+    code_extensions = ('.js', '.ts', '.jsx', '.tsx', '.py', '.mjs', '.cjs')
+
     for f in staged_files:
-        if f.endswith(('.js', '.ts', '.jsx', '.tsx', '.py')):
+        if f.endswith(code_extensions):
             content = get_staged_file_content(f)
             for pattern in risky_patterns:
                 if re.search(pattern, content, re.IGNORECASE):
-                    errors.append(f"SECURITY: Potential secret exposure in log in {f}: matches pattern '{pattern}'")
-    
+                    errors.append(
+                        f"SECURITY: Potential secret exposure in log in {f}: "
+                        f"matches pattern '{pattern}'"
+                    )
+
     return errors
+
+
+def check_frontend_credentials(staged_files):
+    """
+    SACROSANCT Rule 2: Check for credential exposure in frontend code.
+
+    Frontend environment variables with credential suffixes should not be used
+    as they expose credentials in client-side bundles.
+
+    Args:
+        staged_files: List of staged file paths
+
+    Returns:
+        List of error messages for any violations found
+    """
+    errors = []
+
+    # Patterns indicating credential usage in frontend env vars
+    credential_patterns = [
+        r'VITE_[A-Z_]*(?:KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL|AUTH)',
+        r'REACT_APP_[A-Z_]*(?:KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL|AUTH)',
+        r'NEXT_PUBLIC_[A-Z_]*(?:KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL|AUTH)',
+        r'NUXT_PUBLIC_[A-Z_]*(?:KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL|AUTH)',
+        r'process\.env\.(VITE_|REACT_APP_|NEXT_PUBLIC_|NUXT_PUBLIC_)[A-Z_]*(?:KEY|SECRET|TOKEN)',
+        r'import\.meta\.env\.(VITE_)[A-Z_]*(?:KEY|SECRET|TOKEN)',
+    ]
+
+    # Frontend file extensions
+    frontend_extensions = {'.jsx', '.tsx', '.vue', '.svelte'}
+    # Also check .js and .ts if they're in frontend directories
+    frontend_dirs = {'src', 'components', 'pages', 'app', 'frontend', 'client', 'ui'}
+
+    for f in staged_files:
+        is_frontend_ext = any(f.endswith(ext) for ext in frontend_extensions)
+        is_frontend_dir = any(
+            f'/{d}/' in f or f.startswith(f'{d}/') for d in frontend_dirs
+        )
+
+        # Check frontend-specific files or JS/TS in frontend directories
+        should_check = is_frontend_ext or (
+            f.endswith(('.js', '.ts')) and is_frontend_dir
+        )
+
+        if should_check:
+            content = get_staged_file_content(f)
+            for pattern in credential_patterns:
+                matches = re.findall(pattern, content, re.IGNORECASE)
+                if matches:
+                    errors.append(
+                        f"SACROSANCT VIOLATION: Frontend credential exposure in {f}. "
+                        f"Found: {matches[0]}. Credentials must NEVER be in frontend code. "
+                        "Use backend proxy pattern instead."
+                    )
+
+    return errors
+
+
+def check_direct_api_calls(staged_files):
+    """
+    SACROSANCT Rule 2: Warn about potential direct API calls from frontend.
+
+    Frontend code should call backend endpoints, not external APIs directly
+    (which would require credentials in frontend).
+
+    Args:
+        staged_files: List of staged file paths
+
+    Returns:
+        List of warning messages (non-blocking)
+    """
+    warnings = []
+
+    # Patterns suggesting direct external API calls
+    direct_api_patterns = [
+        (r'fetch\s*\(\s*[\'"`]https?://api\.', 'fetch to external API'),
+        (r'axios\.[a-z]+\s*\(\s*[\'"`]https?://api\.', 'axios to external API'),
+        (r'fetch\s*\(\s*[\'"`]https?://[^/]*\.stripe\.com', 'direct Stripe API call'),
+        (r'fetch\s*\(\s*[\'"`]https?://[^/]*\.openai\.com', 'direct OpenAI API call'),
+        (r'fetch\s*\(\s*[\'"`]https?://[^/]*\.anthropic\.com', 'direct Anthropic API call'),
+        (r'fetch\s*\(\s*[\'"`]https?://[^/]*\.github\.com/(?!repos/[^/]+/[^/]+$)', 'direct GitHub API call'),
+        (r'fetch\s*\(\s*[\'"`]https?://[^/]*\.googleapis\.com', 'direct Google API call'),
+    ]
+
+    # Frontend file extensions and directories
+    frontend_extensions = {'.jsx', '.tsx', '.vue', '.svelte', '.js', '.ts'}
+    frontend_dirs = {'src', 'components', 'pages', 'app', 'frontend', 'client', 'ui'}
+    # Backend directories to exclude
+    backend_dirs = {'server', 'api', 'backend', 'lib', 'services', 'handlers'}
+
+    for f in staged_files:
+        is_frontend_ext = any(f.endswith(ext) for ext in frontend_extensions)
+        is_frontend_dir = any(
+            f'/{d}/' in f or f.startswith(f'{d}/') for d in frontend_dirs
+        )
+        is_backend = any(
+            f'/{d}/' in f or f.startswith(f'{d}/') for d in backend_dirs
+        )
+
+        # Only warn for frontend files, not backend
+        if is_frontend_ext and is_frontend_dir and not is_backend:
+            content = get_staged_file_content(f)
+            for pattern, description in direct_api_patterns:
+                if re.search(pattern, content, re.IGNORECASE):
+                    warnings.append(
+                        f"SACROSANCT Warning: Potential {description} in {f}. "
+                        "Verify backend proxy pattern is used."
+                    )
+                    break  # One warning per file
+
+    return warnings
+
+
+def check_env_file_in_gitignore():
+    """
+    Verify .env files are listed in .gitignore.
+
+    Returns:
+        Tuple of (is_protected, error_message or None)
+    """
+    gitignore_path = Path('.gitignore')
+
+    if not gitignore_path.exists():
+        return False, (
+            "SACROSANCT WARNING: No .gitignore file found. "
+            "Create one with '.env' and '.env.*' entries."
+        )
+
+    try:
+        gitignore_content = gitignore_path.read_text(encoding='utf-8')
+        env_patterns = ['.env', '.env.*', '.env.local', '.env.production']
+
+        # Check if at least the base .env is protected
+        if '.env' not in gitignore_content:
+            return False, (
+                "SACROSANCT VIOLATION: .env not found in .gitignore. "
+                "Environment files must be excluded from version control."
+            )
+
+        return True, None
+
+    except IOError:
+        return False, "Warning: Could not read .gitignore file."
+
+
+def check_hardcoded_secrets(staged_files):
+    """
+    Check for hardcoded secrets and API keys in code.
+
+    Args:
+        staged_files: List of staged file paths
+
+    Returns:
+        List of error messages for any violations found
+    """
+    errors = []
+
+    # Patterns that suggest hardcoded secrets
+    secret_patterns = [
+        # API keys with common prefixes
+        (r'["\']sk-[a-zA-Z0-9]{20,}["\']', 'OpenAI API key'),
+        (r'["\']sk_live_[a-zA-Z0-9]{20,}["\']', 'Stripe live key'),
+        (r'["\']sk_test_[a-zA-Z0-9]{20,}["\']', 'Stripe test key'),
+        (r'["\']ghp_[a-zA-Z0-9]{36,}["\']', 'GitHub personal access token'),
+        (r'["\']gho_[a-zA-Z0-9]{36,}["\']', 'GitHub OAuth token'),
+        (r'["\']xox[baprs]-[a-zA-Z0-9-]{10,}["\']', 'Slack token'),
+        # Generic patterns
+        (r'api[_-]?key\s*[=:]\s*["\'][a-zA-Z0-9]{20,}["\']', 'API key assignment'),
+        (r'secret[_-]?key\s*[=:]\s*["\'][a-zA-Z0-9]{20,}["\']', 'Secret key assignment'),
+        (r'password\s*[=:]\s*["\'][^"\']{8,}["\']', 'Hardcoded password'),
+    ]
+
+    code_extensions = ('.js', '.ts', '.jsx', '.tsx', '.py', '.java', '.go', '.rs', '.rb')
+
+    for f in staged_files:
+        if f.endswith(code_extensions):
+            content = get_staged_file_content(f)
+            for pattern, description in secret_patterns:
+                matches = re.findall(pattern, content, re.IGNORECASE)
+                if matches:
+                    # Truncate the match for display
+                    match_preview = matches[0][:30] + '...' if len(matches[0]) > 30 else matches[0]
+                    errors.append(
+                        f"SACROSANCT VIOLATION: Potential {description} in {f}: {match_preview}"
+                    )
+
+    return errors
+
 
 def main():
     try:
@@ -69,45 +290,89 @@ def main():
         command = tool_input.get("command", "")
 
         # Check if the command is a git commit
-        # Matches: git commit, git commit -m "...", etc.
         if not re.search(r'\bgit\s+commit\b', command):
-            sys.exit(0) # Not a commit command, allow it
+            sys.exit(0)  # Not a commit command, allow it
 
         staged_files = get_staged_files()
-        
+
         # If no files are staged, let git handle the error
         if not staged_files:
             sys.exit(0)
 
-        # --- Security Check ---
-        security_errors = check_security(staged_files)
+        # Collect all errors and warnings
+        security_errors = []
+        warnings = []
+
+        # --- SACROSANCT Security Checks ---
+
+        # Basic security check (env files, logging secrets)
+        security_errors.extend(check_security(staged_files))
+
+        # SACROSANCT Rule 1: Check for hardcoded secrets
+        security_errors.extend(check_hardcoded_secrets(staged_files))
+
+        # SACROSANCT Rule 2: Frontend credential exposure
+        security_errors.extend(check_frontend_credentials(staged_files))
+
+        # SACROSANCT Rule 2: Direct API call warnings (non-blocking)
+        warnings.extend(check_direct_api_calls(staged_files))
+
+        # Check .gitignore protection for .env files
+        env_protected, env_error = check_env_file_in_gitignore()
+        if env_error:
+            if "VIOLATION" in env_error:
+                security_errors.append(env_error)
+            else:
+                warnings.append(env_error)
+
+        # --- Output Warnings (non-blocking) ---
+        if warnings:
+            print("PACT Security Warnings:", file=sys.stderr)
+            print("-" * 30, file=sys.stderr)
+            for w in warnings:
+                print(f"  * {w}", file=sys.stderr)
+            print("-" * 30, file=sys.stderr)
+            print("Review these warnings before deployment.", file=sys.stderr)
+            print("", file=sys.stderr)
+
+        # --- Block on Security Errors ---
         if security_errors:
             print("Error: PACT Security Violation", file=sys.stderr)
-            print("------------------------------", file=sys.stderr)
+            print("=" * 40, file=sys.stderr)
             for err in security_errors:
-                print(f"• {err}", file=sys.stderr)
-            print("------------------------------", file=sys.stderr)
-            print("Please remove sensitive files or logs before committing.", file=sys.stderr)
-            sys.exit(2) # Block the tool execution
+                print(f"* {err}", file=sys.stderr)
+            print("=" * 40, file=sys.stderr)
+            print("Please fix security issues before committing.", file=sys.stderr)
+            print("See SACROSANCT rules in CLAUDE.md for guidance.", file=sys.stderr)
+            sys.exit(2)  # Block the tool execution
 
-        has_code_changes = any(f.endswith(('.py', '.js', '.ts', '.jsx', '.tsx', '.html', '.css', '.java', '.c', '.cpp', '.h', '.rs', '.go')) for f in staged_files)
-        has_doc_changes = any(f.startswith('docs/') or f == 'CLAUDE.md' or f.endswith('.md') for f in staged_files)
+        # --- PACT Protocol Check: Documentation with Code ---
+        code_extensions = (
+            '.py', '.js', '.ts', '.jsx', '.tsx', '.html', '.css',
+            '.java', '.c', '.cpp', '.h', '.rs', '.go', '.rb', '.php'
+        )
+        has_code_changes = any(f.endswith(code_extensions) for f in staged_files)
+        has_doc_changes = any(
+            f.startswith('docs/') or f == 'CLAUDE.md' or f.endswith('.md')
+            for f in staged_files
+        )
 
         # Rule: If code changes, docs must change (or be present in the commit)
         if has_code_changes and not has_doc_changes:
             print("Error: PACT Protocol Violation", file=sys.stderr)
-            print("------------------------------", file=sys.stderr)
+            print("-" * 30, file=sys.stderr)
             print("You are attempting to commit code changes without updating documentation.", file=sys.stderr)
             print("Please update 'docs/CHANGELOG.md', 'CLAUDE.md', or files in 'docs/' to reflect your changes.", file=sys.stderr)
             print("Run '/PACT:wrap-up' or manually update the docs before committing.", file=sys.stderr)
-            sys.exit(2) # Block the tool execution
+            sys.exit(2)  # Block the tool execution
 
-        sys.exit(0) # Allow the commit
+        sys.exit(0)  # Allow the commit
 
     except Exception as e:
-        # If something goes wrong in the hook, log it but don't block unless necessary
-        print(f"Hook Error: {e}", file=sys.stderr)
+        # If something goes wrong in the hook, log it but don't block
+        print(f"Hook Error (git_commit_check): {e}", file=sys.stderr)
         sys.exit(0)
+
 
 if __name__ == "__main__":
     main()

--- a/.claude/hooks/phase_completion.py
+++ b/.claude/hooks/phase_completion.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Location: .claude/hooks/phase_completion.py
+Summary: Stop hook that verifies phase completion and reminds about decision logs.
+Used by: Claude Code settings.json Stop hook
+
+Checks for CODE phase completion without decision logs and
+reminds about documentation requirements.
+
+Input: JSON from stdin with session transcript/context
+Output: JSON with `systemMessage` for reminders if needed
+"""
+
+import json
+import sys
+import os
+from pathlib import Path
+
+
+# Indicators that CODE phase work was performed
+CODE_PHASE_INDICATORS = [
+    "pact-backend-coder",
+    "pact-frontend-coder",
+    "pact-database-engineer",
+    "pact_backend_coder",
+    "pact_frontend_coder",
+    "pact_database_engineer",
+]
+
+# Terms indicating decision log was mentioned or created
+DECISION_LOG_MENTIONS = [
+    "decision-log",
+    "decision log",
+    "decision_log",
+    "decisionlog",
+    "docs/decision-logs",
+    "decision-logs/",
+]
+
+
+def check_for_code_phase_activity(transcript: str) -> bool:
+    """
+    Determine if CODE phase agents were invoked in this session.
+
+    Args:
+        transcript: The session transcript
+
+    Returns:
+        True if CODE phase activity detected
+    """
+    transcript_lower = transcript.lower()
+    return any(indicator in transcript_lower for indicator in CODE_PHASE_INDICATORS)
+
+
+def check_decision_log_mentioned(transcript: str) -> bool:
+    """
+    Check if decision logs were mentioned in the transcript.
+
+    Args:
+        transcript: The session transcript
+
+    Returns:
+        True if decision logs were discussed or created
+    """
+    transcript_lower = transcript.lower()
+    return any(mention in transcript_lower for mention in DECISION_LOG_MENTIONS)
+
+
+def check_decision_logs_exist(project_dir: str) -> bool:
+    """
+    Check if any decision logs exist in the project.
+
+    Args:
+        project_dir: The project root directory
+
+    Returns:
+        True if decision-logs directory exists and contains files
+    """
+    decision_logs_dir = Path(project_dir) / "docs" / "decision-logs"
+    if not decision_logs_dir.is_dir():
+        return False
+
+    # Check for any markdown files in the directory
+    return any(decision_logs_dir.glob("*.md"))
+
+
+def check_for_test_reminders(transcript: str) -> bool:
+    """
+    Check if testing was discussed for completed code work.
+
+    Args:
+        transcript: The session transcript
+
+    Returns:
+        True if testing appears to be addressed
+    """
+    transcript_lower = transcript.lower()
+    test_indicators = [
+        "pact-test-engineer",
+        "test engineer",
+        "testing",
+        "unit test",
+        "integration test",
+        "test coverage",
+    ]
+    return any(indicator in transcript_lower for indicator in test_indicators)
+
+
+def main():
+    """
+    Main entry point for the Stop hook.
+
+    Checks for CODE phase indicators and reminds about decision logs
+    and testing if not mentioned in the session.
+    """
+    try:
+        # Read input from stdin
+        try:
+            input_data = json.load(sys.stdin)
+        except json.JSONDecodeError:
+            input_data = {}
+
+        project_dir = os.environ.get("CLAUDE_PROJECT_DIR", ".")
+        transcript = input_data.get("transcript", "")
+
+        # If no transcript, nothing to check
+        if not transcript:
+            sys.exit(0)
+
+        messages = []
+
+        # Check for CODE phase activity
+        was_code_phase = check_for_code_phase_activity(transcript)
+
+        if was_code_phase:
+            # Check if decision logs were addressed
+            decision_log_mentioned = check_decision_log_mentioned(transcript)
+            decision_logs_exist = check_decision_logs_exist(project_dir)
+
+            if not decision_log_mentioned and not decision_logs_exist:
+                messages.append(
+                    "CODE Phase Reminder: Decision logs should be created at "
+                    "docs/decision-logs/{feature}-{domain}.md to document key "
+                    "implementation decisions and trade-offs."
+                )
+
+            # Check if testing was addressed
+            testing_discussed = check_for_test_reminders(transcript)
+            if not testing_discussed:
+                messages.append(
+                    "TEST Phase Reminder: Consider invoking pact-test-engineer "
+                    "to verify the implementation."
+                )
+
+        # Output messages if any reminders are needed
+        if messages:
+            output = {
+                "systemMessage": " | ".join(messages)
+            }
+            print(json.dumps(output))
+
+        sys.exit(0)
+
+    except Exception as e:
+        # Don't block on errors - just warn
+        print(f"Hook warning (phase_completion): {e}", file=sys.stderr)
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/session_init.py
+++ b/.claude/hooks/session_init.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Location: .claude/hooks/session_init.py
+Summary: SessionStart hook that detects active plans and notifies user.
+Used by: Claude Code settings.json SessionStart hook
+
+Checks docs/plans/ for in-progress work and notifies the user
+to consider resuming with /PACT:orchestrate.
+
+Input: JSON from stdin with session context
+Output: JSON with `systemMessage` if active plans found
+"""
+
+import json
+import sys
+import os
+from pathlib import Path
+
+
+def find_active_plans(project_dir: str) -> list:
+    """
+    Find plans with IN_PROGRESS status or uncompleted items.
+
+    Args:
+        project_dir: The project root directory path
+
+    Returns:
+        List of plan filenames that appear to be in progress
+    """
+    plans_dir = Path(project_dir) / "docs" / "plans"
+    active_plans = []
+
+    if not plans_dir.is_dir():
+        return active_plans
+
+    for plan_file in plans_dir.glob("*-plan.md"):
+        try:
+            content = plan_file.read_text(encoding='utf-8')
+            # Check for various in-progress indicators
+            in_progress_indicators = [
+                "Status: IN_PROGRESS",
+                "Status: In Progress",
+                "status: in_progress",
+                "Status: ACTIVE",
+                "Status: Active",
+            ]
+
+            # Check for explicit status markers
+            has_in_progress_status = any(
+                indicator in content for indicator in in_progress_indicators
+            )
+
+            # Check for unchecked items (uncompleted tasks)
+            has_unchecked_items = "[ ] " in content
+
+            # Check for explicit completion status (to avoid false positives)
+            is_completed = any(
+                status in content for status in [
+                    "Status: COMPLETED",
+                    "Status: Completed",
+                    "Status: DONE",
+                    "Status: Done",
+                ]
+            )
+
+            if has_in_progress_status or (has_unchecked_items and not is_completed):
+                active_plans.append(plan_file.name)
+
+        except (IOError, UnicodeDecodeError):
+            # Skip files we can't read
+            continue
+
+    return active_plans
+
+
+def main():
+    """
+    Main entry point for the SessionStart hook.
+
+    Reads session context from stdin, checks for active plans,
+    and outputs a system message if any are found.
+    """
+    try:
+        # Read input from stdin (may be empty for SessionStart)
+        try:
+            input_data = json.load(sys.stdin)
+        except json.JSONDecodeError:
+            input_data = {}
+
+        project_dir = os.environ.get("CLAUDE_PROJECT_DIR", ".")
+
+        active_plans = find_active_plans(project_dir)
+
+        if active_plans:
+            # Format the plan list, limiting to 3 for brevity
+            plan_list = ", ".join(active_plans[:3])
+            if len(active_plans) > 3:
+                plan_list += f" (+{len(active_plans) - 3} more)"
+
+            output = {
+                "systemMessage": (
+                    f"PACT Notice: Active plan(s) found: {plan_list}. "
+                    "Consider resuming with /PACT:orchestrate."
+                )
+            }
+            print(json.dumps(output))
+
+        sys.exit(0)
+
+    except Exception as e:
+        # Don't block session start on errors - just warn
+        print(f"Hook warning (session_init): {e}", file=sys.stderr)
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/validate_handoff.py
+++ b/.claude/hooks/validate_handoff.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Location: .claude/hooks/validate_handoff.py
+Summary: SubagentStop hook that validates PACT agent handoff format.
+Used by: Claude Code settings.json SubagentStop hook
+
+Checks that PACT agents complete with proper handoff information
+containing: what was produced, key decisions, next agent needs.
+
+Input: JSON from stdin with `transcript` and `agent_id`
+Output: JSON with `systemMessage` if handoff format is incomplete
+"""
+
+import json
+import sys
+import re
+
+
+# Required handoff elements with their patterns and descriptions
+HANDOFF_ELEMENTS = {
+    "what_produced": {
+        "patterns": [
+            r"(?:produced|created|generated|output|implemented|wrote|built|delivered)",
+            r"(?:file|document|component|module|function|class|api|endpoint|schema)",
+            r"(?:completed|finished|done with)",
+        ],
+        "description": "what was produced",
+    },
+    "key_decisions": {
+        "patterns": [
+            r"(?:decision|chose|selected|opted|rationale|reason|because)",
+            r"(?:trade-?off|alternative|approach|strategy|pattern)",
+            r"(?:decided to|went with|picked)",
+        ],
+        "description": "key decisions",
+    },
+    "next_steps": {
+        "patterns": [
+            r"(?:next|needs|requires|depends|should|must|recommend)",
+            r"(?:follow-?up|remaining|todo|to-?do|action item)",
+            r"(?:test engineer|tester|reviewer|next agent|next phase)",
+        ],
+        "description": "next steps/needs",
+    },
+}
+
+
+def validate_handoff(transcript: str) -> tuple:
+    """
+    Check if transcript contains proper handoff elements.
+
+    Args:
+        transcript: The agent's complete output/transcript
+
+    Returns:
+        Tuple of (is_valid, missing_elements)
+    """
+    missing = []
+
+    # First, check for explicit handoff section (indicates structured handoff)
+    has_handoff_section = bool(re.search(
+        r"(?:##?\s*)?(?:handoff|hand-off|hand off|summary|output|deliverables)[\s:]*\n",
+        transcript,
+        re.IGNORECASE
+    ))
+
+    # If there's an explicit handoff section, be more lenient
+    if has_handoff_section:
+        return True, []
+
+    # Otherwise, check for implicit handoff elements
+    transcript_lower = transcript.lower()
+
+    for element_key, element_info in HANDOFF_ELEMENTS.items():
+        found = False
+        for pattern in element_info["patterns"]:
+            if re.search(pattern, transcript_lower):
+                found = True
+                break
+
+        if not found:
+            missing.append(element_info["description"])
+
+    # Consider valid if at least 2 out of 3 elements are present
+    # (some agents may not have explicit decisions if straightforward)
+    is_valid = len(missing) <= 1
+
+    return is_valid, missing
+
+
+def is_pact_agent(agent_id: str) -> bool:
+    """
+    Check if the agent is a PACT framework agent.
+
+    Args:
+        agent_id: The identifier of the agent
+
+    Returns:
+        True if this is a PACT agent that should be validated
+    """
+    if not agent_id:
+        return False
+
+    pact_prefixes = ["pact-", "PACT-", "pact_", "PACT_"]
+    return any(agent_id.startswith(prefix) for prefix in pact_prefixes)
+
+
+def main():
+    """
+    Main entry point for the SubagentStop hook.
+
+    Reads agent transcript from stdin, validates handoff format for PACT agents,
+    and outputs a warning message if the handoff is incomplete.
+    """
+    try:
+        # Read input from stdin
+        try:
+            input_data = json.load(sys.stdin)
+        except json.JSONDecodeError:
+            # No input or invalid JSON - can't validate
+            sys.exit(0)
+
+        transcript = input_data.get("transcript", "")
+        agent_id = input_data.get("agent_id", "")
+
+        # Only validate PACT agents
+        if not is_pact_agent(agent_id):
+            sys.exit(0)
+
+        # Skip validation if transcript is very short (likely an error case)
+        if len(transcript) < 100:
+            sys.exit(0)
+
+        is_valid, missing = validate_handoff(transcript)
+
+        if not is_valid and missing:
+            output = {
+                "systemMessage": (
+                    f"PACT Handoff Warning: Agent '{agent_id}' completed without "
+                    f"proper handoff. Missing: {', '.join(missing)}. "
+                    "Consider including: what was produced, key decisions, and next steps. "
+                    "See pact-protocols.md for handoff format."
+                )
+            }
+            print(json.dumps(output))
+
+        sys.exit(0)
+
+    except Exception as e:
+        # Don't block on errors - just warn
+        print(f"Hook warning (validate_handoff): {e}", file=sys.stderr)
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/session_init.py\""
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [
@@ -12,10 +22,35 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/git_commit_check.py\""
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/validate_handoff.py\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
         "hooks": [
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/stop_audit.sh\""
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/phase_completion.py\""
           }
         ]
       }

--- a/claude-changelog.md
+++ b/claude-changelog.md
@@ -1,0 +1,1339 @@
+# Changelog
+
+## 2.1.3
+
+- Merged slash commands and skills, simplifying the mental model with no change in behavior
+- Added release channel (`stable` or `latest`) toggle to `/config`
+- Added detection and warnings for unreachable permission rules, with warnings in `/doctor` and after saving rules that include the source of each rule and actionable fix guidance
+- Fixed plan files persisting across `/clear` commands, now ensuring a fresh plan file is used after clearing a conversation
+- Fixed false skill duplicate detection on filesystems with large inodes (e.g., ExFAT) by using 64-bit precision for inode values
+- Fixed mismatch between background task count in status bar and items shown in tasks dialog
+- Fixed sub-agents using the wrong model during conversation compaction
+- Fixed web search in sub-agents using incorrect model
+- Fixed trust dialog acceptance when running from the home directory not enabling trust-requiring features like hooks during the session
+- Improved terminal rendering stability by preventing uncontrolled writes from corrupting cursor state
+- Improved slash command suggestion readability by truncating long descriptions to 2 lines
+- Changed tool hook execution timeout from 60 seconds to 10 minutes
+- [VSCode] Added clickable destination selector for permission requests, allowing you to choose where settings are saved (this project, all projects, shared with team, or session only)
+
+## 2.1.2
+
+- Added source path metadata to images dragged onto the terminal, helping Claude understand where images originated
+- Added clickable hyperlinks for file paths in tool output in terminals that support OSC 8 (like iTerm)
+- Added support for Windows Package Manager (winget) installations with automatic detection and update instructions
+- Added Shift+Tab keyboard shortcut in plan mode to quickly select "auto-accept edits" option
+- Added `FORCE_AUTOUPDATE_PLUGINS` environment variable to allow plugin autoupdate even when the main auto-updater is disabled
+- Added `agent_type` to SessionStart hook input, populated if `--agent` is specified
+- Fixed a command injection vulnerability in bash command processing where malformed input could execute arbitrary commands
+- Fixed a memory leak where tree-sitter parse trees were not being freed, causing WASM memory to grow unbounded over long sessions
+- Fixed binary files (images, PDFs, etc.) being accidentally included in memory when using `@include` directives in CLAUDE.md files
+- Fixed updates incorrectly claiming another installation is in progress
+- Fixed crash when socket files exist in watched directories (defense-in-depth for EOPNOTSUPP errors)
+- Fixed remote session URL and teleport being broken when using `/tasks` command
+- Fixed MCP tool names being exposed in analytics events by sanitizing user-specific server configurations
+- Improved Option-as-Meta hint on macOS to show terminal-specific instructions for native CSIu terminals like iTerm2, Kitty, and WezTerm
+- Improved error message when pasting images over SSH to suggest using `scp` instead of the unhelpful clipboard shortcut hint
+- Improved permission explainer to not flag routine dev workflows (git fetch/rebase, npm install, tests, PRs) as medium risk
+- Changed large bash command outputs to be saved to disk instead of truncated, allowing Claude to read the full content
+- Changed large tool outputs to be persisted to disk instead of truncated, providing full output access via file references
+- Changed `/plugins` installed tab to unify plugins and MCPs with scope-based grouping
+- Deprecated Windows managed settings path `C:\ProgramData\ClaudeCode\managed-settings.json` - administrators should migrate to `C:\Program Files\ClaudeCode\managed-settings.json`
+- [SDK] Changed minimum zod peer dependency to ^4.0.0
+- [VSCode] Fixed usage display not updating after manual compact
+
+## 2.1.0
+
+- Added automatic skill hot-reload - skills created or modified in `~/.claude/skills` or `.claude/skills` are now immediately available without restarting the session
+- Added support for running skills and slash commands in a forked sub-agent context using `context: fork` in skill frontmatter
+- Added support for `agent` field in skills to specify agent type for execution
+- Added `language` setting to configure Claude's response language (e.g., language: "japanese")
+- Changed Shift+Enter to work out of the box in iTerm2, WezTerm, Ghostty, and Kitty without modifying terminal configs
+- Added `respectGitignore` support in `settings.json` for per-project control over @-mention file picker behavior
+- Added `IS_DEMO` environment variable to hide email and organization from the UI, useful for streaming or recording sessions
+- Fixed security issue where sensitive data (OAuth tokens, API keys, passwords) could be exposed in debug logs
+- Fixed files and skills not being properly discovered when resuming sessions with `-c` or `--resume`
+- Fixed pasted content being lost when replaying prompts from history using up arrow or Ctrl+R search
+- Fixed Esc key with queued prompts to only move them to input without canceling the running task
+- Reduced permission prompts for complex bash commands
+- Fixed command search to prioritize exact and prefix matches on command names over fuzzy matches in descriptions
+- Fixed PreToolUse hooks to allow `updatedInput` when returning `ask` permission decision, enabling hooks to act as middleware while still requesting user consent
+- Fixed plugin path resolution for file-based marketplace sources
+- Fixed LSP tool being incorrectly enabled when no LSP servers were configured
+- Fixed background tasks failing with "git repository not found" error for repositories with dots in their names
+- Fixed Claude in Chrome support for WSL environments
+- Fixed Windows native installer silently failing when executable creation fails
+- Improved CLI help output to display options and subcommands in alphabetical order for easier navigation
+- Added wildcard pattern matching for Bash tool permissions using `*` at any position in rules (e.g., `Bash(npm *)`, `Bash(* install)`, `Bash(git * main)`)
+- Added unified Ctrl+B backgrounding for both bash commands and agents - pressing Ctrl+B now backgrounds all running foreground tasks simultaneously
+- Added support for MCP `list_changed` notifications, allowing MCP servers to dynamically update their available tools, prompts, and resources without requiring reconnection
+- Added `/teleport` and `/remote-env` slash commands for claude.ai subscribers, allowing them to resume and configure remote sessions
+- Added support for disabling specific agents using `Task(AgentName)` syntax in settings.json permissions or the `--disallowedTools` CLI flag
+- Added hooks support to agent frontmatter, allowing agents to define PreToolUse, PostToolUse, and Stop hooks scoped to the agent's lifecycle
+- Added hooks support for skill and slash command frontmatter
+- Added new Vim motions: `;` and `,` to repeat f/F/t/T motions, `y` operator for yank with `yy`/`Y`, `p`/`P` for paste, text objects (`iw`, `aw`, `iW`, `aW`, `i"`, `a"`, `i'`, `a'`, `i(`, `a(`, `i[`, `a[`, `i{`, `a{`), `>>` and `<<` for indent/dedent, and `J` to join lines
+- Added `/plan` command shortcut to enable plan mode directly from the prompt
+- Added slash command autocomplete support when `/` appears anywhere in input, not just at the beginning
+- Added `--tools` flag support in interactive mode to restrict which built-in tools Claude can use during interactive sessions
+- Added `CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS` environment variable to override the default file read token limit
+- Added support for `once: true` config for hooks
+- Added support for YAML-style lists in frontmatter `allowed-tools` field for cleaner skill declarations
+- Added support for prompt and agent hook types from plugins (previously only command hooks were supported)
+- Added Cmd+V support for image paste in iTerm2 (maps to Ctrl+V)
+- Added left/right arrow key navigation for cycling through tabs in dialogs
+- Added real-time thinking block display in Ctrl+O transcript mode
+- Added filepath to full output in background bash task details dialog
+- Added Skills as a separate category in the context visualization
+- Fixed OAuth token refresh not triggering when server reports token expired but local expiration check disagrees
+- Fixed session persistence getting stuck after transient server errors by recovering from 409 conflicts when the entry was actually stored
+- Fixed session resume failures caused by orphaned tool results during concurrent tool execution
+- Fixed a race condition where stale OAuth tokens could be read from the keychain cache during concurrent token refresh attempts
+- Fixed AWS Bedrock subagents not inheriting EU/APAC cross-region inference model configuration, causing 403 errors when IAM permissions are scoped to specific regions
+- Fixed API context overflow when background tasks produce large output by truncating to 30K chars with file path reference
+- Fixed a hang when reading FIFO files by skipping symlink resolution for special file types
+- Fixed terminal keyboard mode not being reset on exit in Ghostty, iTerm2, Kitty, and WezTerm
+- Fixed Alt+B and Alt+F (word navigation) not working in iTerm2, Ghostty, Kitty, and WezTerm
+- Fixed `${CLAUDE_PLUGIN_ROOT}` not being substituted in plugin `allowed-tools` frontmatter, which caused tools to incorrectly require approval
+- Fixed files created by the Write tool using hardcoded 0o600 permissions instead of respecting the system umask
+- Fixed commands with `$()` command substitution failing with parse errors
+- Fixed multi-line bash commands with backslash continuations being incorrectly split and flagged for permissions
+- Fixed bash command prefix extraction to correctly identify subcommands after global options (e.g., `git -C /path log` now correctly matches `Bash(git log:*)` rules)
+- Fixed slash commands passed as CLI arguments (e.g., `claude /context`) not being executed properly
+- Fixed pressing Enter after Tab-completing a slash command selecting a different command instead of submitting the completed one
+- Fixed slash command argument hint flickering and inconsistent display when typing commands with arguments
+- Fixed Claude sometimes redundantly invoking the Skill tool when running slash commands directly
+- Fixed skill token estimates in `/context` to accurately reflect frontmatter-only loading
+- Fixed subagents sometimes not inheriting the parent's model by default
+- Fixed model picker showing incorrect selection for Bedrock/Vertex users using `--model haiku`
+- Fixed duplicate Bash commands appearing in permission request option labels
+- Fixed noisy output when background tasks complete - now shows clean completion message instead of raw output
+- Fixed background task completion notifications to appear proactively with bullet point
+- Fixed forked slash commands showing "AbortError" instead of "Interrupted" message when cancelled
+- Fixed cursor disappearing after dismissing permission dialogs
+- Fixed `/hooks` menu selecting wrong hook type when scrolling to a different option
+- Fixed images in queued prompts showing as "[object Object]" when pressing Esc to cancel
+- Fixed images being silently dropped when queueing messages while backgrounding a task
+- Fixed large pasted images failing with "Image was too large" error
+- Fixed extra blank lines in multiline prompts containing CJK characters (Japanese, Chinese, Korean)
+- Fixed ultrathink keyword highlighting being applied to wrong characters when user prompt text wraps to multiple lines
+- Fixed collapsed "Reading X files…" indicator incorrectly switching to past tense when thinking blocks appear mid-stream
+- Fixed Bash read commands (like `ls` and `cat`) not being counted in collapsed read/search groups, causing groups to incorrectly show "Read 0 files"
+- Fixed spinner token counter to properly accumulate tokens from subagents during execution
+- Fixed memory leak in git diff parsing where sliced strings retained large parent strings
+- Fixed race condition where LSP tool could return "no server available" during startup
+- Fixed feedback submission hanging indefinitely when network requests timeout
+- Fixed search mode in plugin discovery and log selector views exiting when pressing up arrow
+- Fixed hook success message showing trailing colon when hook has no output
+- Multiple optimizations to improve startup performance
+- Improved terminal rendering performance when using native installer or Bun, especially for text with emoji, ANSI codes, and Unicode characters
+- Improved performance when reading Jupyter notebooks with many cells
+- Improved reliability for piped input like `cat refactor.md | claude`
+- Improved reliability for AskQuestion tool
+- Improved sed in-place edit commands to render as file edits with diff preview
+- Improved Claude to automatically continue when response is cut off due to output token limit, instead of showing an error message
+- Improved compaction reliability
+- Improved subagents (Task tool) to continue working after permission denial, allowing them to try alternative approaches
+- Improved skills to show progress while executing, displaying tool uses as they happen
+- Improved skills from `/skills/` directories to be visible in the slash command menu by default (opt-out with `user-invocable: false` in frontmatter)
+- Improved skill suggestions to prioritize recently and frequently used skills
+- Improved spinner feedback when waiting for the first response token
+- Improved token count display in spinner to include tokens from background agents
+- Improved incremental output for async agents to give the main thread more control and visibility
+- Improved permission prompt UX with Tab hint moved to footer, cleaner Yes/No input labels with contextual placeholders
+- Improved the Claude in Chrome notification with shortened help text and persistent display until dismissed
+- Improved macOS screenshot paste reliability with TIFF format support
+- Improved `/stats` output
+- Updated Atlassian MCP integration to use a more reliable default configuration (streamable HTTP)
+- Changed "Interrupted" message color from red to grey for a less alarming appearance
+- Removed permission prompt when entering plan mode - users can now enter plan mode without approval
+- Removed underline styling from image reference links
+- [SDK] Changed minimum zod peer dependency to ^4.0.0
+- [VSCode] Added currently selected model name to the context menu
+- [VSCode] Added descriptive labels on auto-accept permission button (e.g., "Yes, allow npm for this project" instead of "Yes, and don't ask again")
+- [VSCode] Fixed paragraph breaks not rendering in markdown content
+- [VSCode] Fixed scrolling in the extension inadvertently scrolling the parent iframe
+- [Windows] Fixed issue with improper rendering
+
+## 2.0.76
+
+- Fixed issue with macOS code-sign warning when using Claude in Chrome integration
+
+## 2.0.75
+
+- Minor bugfixes
+
+## 2.0.74
+
+- Added LSP (Language Server Protocol) tool for code intelligence features like go-to-definition, find references, and hover documentation
+- Added `/terminal-setup` support for Kitty, Alacritty, Zed, and Warp terminals
+- Added ctrl+t shortcut in `/theme` to toggle syntax highlighting on/off
+- Added syntax highlighting info to theme picker
+- Added guidance for macOS users when Alt shortcuts fail due to terminal configuration
+- Fixed skill `allowed-tools` not being applied to tools invoked by the skill
+- Fixed Opus 4.5 tip incorrectly showing when user was already using Opus
+- Fixed a potential crash when syntax highlighting isn't initialized correctly
+- Fixed visual bug in `/plugins discover` where list selection indicator showed while search box was focused
+- Fixed macOS keyboard shortcuts to display 'opt' instead of 'alt'
+- Improved `/context` command visualization with grouped skills and agents by source, slash commands, and sorted token count
+- [Windows] Fixed issue with improper rendering
+- [VSCode] Added gift tag pictogram for year-end promotion message
+
+## 2.0.73
+
+- Added clickable `[Image #N]` links that open attached images in the default viewer
+- Added alt-y yank-pop to cycle through kill ring history after ctrl-y yank
+- Added search filtering to the plugin discover screen (type to filter by name, description, or marketplace)
+- Added support for custom session IDs when forking sessions with `--session-id` combined with `--resume` or `--continue` and `--fork-session`
+- Fixed slow input history cycling and race condition that could overwrite text after message submission
+- Improved `/theme` command to open theme picker directly
+- Improved theme picker UI
+- Improved search UX across resume session, permissions, and plugins screens with a unified SearchBox component
+- [VSCode] Added tab icon badges showing pending permissions (blue) and unread completions (orange)
+
+## 2.0.72
+
+- Added Claude in Chrome (Beta) feature that works with the Chrome extension (https://claude.ai/chrome) to let you control your browser directly from Claude Code
+- Reduced terminal flickering
+- Added scannable QR code to mobile app tip for quick app downloads
+- Added loading indicator when resuming conversations for better feedback
+- Fixed `/context` command not respecting custom system prompts in non-interactive mode
+- Fixed order of consecutive Ctrl+K lines when pasting with Ctrl+Y
+- Improved @ mention file suggestion speed (~3x faster in git repositories)
+- Improved file suggestion performance in repos with `.ignore` or `.rgignore` files
+- Improved settings validation errors to be more prominent
+- Changed thinking toggle from Tab to Alt+T to avoid accidental triggers
+
+## 2.0.71
+
+- Added /config toggle to enable/disable prompt suggestions
+- Added `/settings` as an alias for the `/config` command
+- Fixed @ file reference suggestions incorrectly triggering when cursor is in the middle of a path
+- Fixed MCP servers from `.mcp.json` not loading when using `--dangerously-skip-permissions`
+- Fixed permission rules incorrectly rejecting valid bash commands containing shell glob patterns (e.g., `ls *.txt`, `for f in *.png`)
+- Bedrock: Environment variable `ANTHROPIC_BEDROCK_BASE_URL` is now respected for token counting and inference profile listing
+- New syntax highlighting engine for native build
+
+## 2.0.70
+
+- Added Enter key to accept and submit prompt suggestions immediately (tab still accepts for editing)
+- Added wildcard syntax `mcp__server__*` for MCP tool permissions to allow or deny all tools from a server
+- Added auto-update toggle for plugin marketplaces, allowing per-marketplace control over automatic updates
+- Added `current_usage` field to status line input, enabling accurate context window percentage calculations
+- Fixed input being cleared when processing queued commands while the user was typing
+- Fixed prompt suggestions replacing typed input when pressing Tab
+- Fixed diff view not updating when terminal is resized
+- Improved memory usage by 3x for large conversations
+- Improved resolution of stats screenshots copied to clipboard (Ctrl+S) for crisper images
+- Removed # shortcut for quick memory entry (tell Claude to edit your CLAUDE.md instead)
+- Fix thinking mode toggle in /config not persisting correctly
+- Improve UI for file creation permission dialog
+
+## 2.0.69
+
+- Minor bugfixes
+
+## 2.0.68
+
+- Fixed IME (Input Method Editor) support for languages like Chinese, Japanese, and Korean by correctly positioning the composition window at the cursor
+- Fixed a bug where disallowed MCP tools were visible to the model
+- Fixed an issue where steering messages could be lost while a subagent is working
+- Fixed Option+Arrow word navigation treating entire CJK (Chinese, Japanese, Korean) text sequences as a single word instead of navigating by word boundaries
+- Improved plan mode exit UX: show simplified yes/no dialog when exiting with empty or missing plan instead of throwing an error
+- Add support for enterprise managed settings. Contact your Anthropic account team to enable this feature.
+
+## 2.0.67
+
+- Thinking mode is now enabled by default for Opus 4.5
+- Thinking mode configuration has moved to /config
+- Added search functionality to `/permissions` command with `/` keyboard shortcut for filtering rules by tool name
+- Show reason why autoupdater is disabled in `/doctor`
+- Fixed false "Another process is currently updating Claude" error when running `claude update` while another instance is already on the latest version
+- Fixed MCP servers from `.mcp.json` being stuck in pending state when running in non-interactive mode (`-p` flag or piped input)
+- Fixed scroll position resetting after deleting a permission rule in `/permissions`
+- Fixed word deletion (opt+delete) and word navigation (opt+arrow) not working correctly with non-Latin text such as Cyrillic, Greek, Arabic, Hebrew, Thai, and Chinese
+- Fixed `claude install --force` not bypassing stale lock files
+- Fixed consecutive @~/ file references in CLAUDE.md being incorrectly parsed due to markdown strikethrough interference
+- Windows: Fixed plugin MCP servers failing due to colons in log directory paths
+
+## 2.0.65
+
+- Added ability to switch models while writing a prompt using alt+p (linux, windows), option+p (macos).
+- Added context window information to status line input
+- Added `fileSuggestion` setting for custom `@` file search commands
+- Added `CLAUDE_CODE_SHELL` environment variable to override automatic shell detection (useful when login shell differs from actual working shell)
+- Fixed prompt not being saved to history when aborting a query with Escape
+- Fixed Read tool image handling to identify format from bytes instead of file extension
+
+## 2.0.64
+
+- Made auto-compacting instant
+- Agents and bash commands can run asynchronously and send messages to wake up the main agent
+- /stats now provides users with interesting CC stats, such as favorite model, usage graph, usage streak
+- Added named session support: use `/rename` to name sessions, `/resume <name>` in REPL or `claude --resume <name>` from the terminal to resume them
+- Added support for .claude/rules/`.  See https://code.claude.com/docs/en/memory for details.
+- Added image dimension metadata when images are resized, enabling accurate coordinate mappings for large images
+- Fixed auto-loading .env when using native installer
+- Fixed `--system-prompt` being ignored when using `--continue` or `--resume` flags
+- Improved `/resume` screen with grouped forked sessions and keyboard shortcuts for preview (P) and rename (R)
+- VSCode: Added copy-to-clipboard button on code blocks and bash tool inputs
+- VSCode: Fixed extension not working on Windows ARM64 by falling back to x64 binary via emulation
+- Bedrock: Improve efficiency of token counting
+- Bedrock: Add support for `aws login` AWS Management Console credentials
+- Unshipped AgentOutputTool and BashOutputTool, in favor of a new unified TaskOutputTool
+
+## 2.0.62
+
+- Added "(Recommended)" indicator for multiple-choice questions, with the recommended option moved to the top of the list
+- Added `attribution` setting to customize commit and PR bylines (deprecates `includeCoAuthoredBy`)
+- Fixed duplicate slash commands appearing when ~/.claude is symlinked to a project directory
+- Fixed slash command selection not working when multiple commands share the same name
+- Fixed an issue where skill files inside symlinked skill directories could become circular symlinks
+- Fixed running versions getting removed because lock file incorrectly going stale
+- Fixed IDE diff tab not closing when rejecting file changes
+
+## 2.0.61
+
+- Reverted VSCode support for multiple terminal clients due to responsiveness issues.
+
+## 2.0.60
+
+- Added background agent support. Agents run in the background while you work
+- Added --disable-slash-commands CLI flag to disable all slash commands
+- Added model name to "Co-Authored-By" commit messages
+- Enabled "/mcp enable [server-name]" or "/mcp disable [server-name]" to quickly toggle all servers
+- Updated Fetch to skip summarization for pre-approved websites
+- VSCode: Added support for multiple terminal clients connecting to the IDE server simultaneously
+
+## 2.0.59
+
+- Added --agent CLI flag to override the agent setting for the current session
+- Added `agent` setting to configure main thread with a specific agent's system prompt, tool restrictions, and model
+- VS Code: Fixed .claude.json config file being read from incorrect location
+
+## 2.0.58
+
+- Pro users now have access to Opus 4.5 as part of their subscription!
+- Fixed timer duration showing "11m 60s" instead of "12m 0s"
+- Windows: Managed settings now prefer `C:\Program Files\ClaudeCode` if it exists. Support for `C:\ProgramData\ClaudeCode` will be removed in a future version.
+
+## 2.0.57
+
+- Added feedback input when rejecting plans, allowing users to tell Claude what to change
+- VSCode: Added streaming message support for real-time response display
+
+## 2.0.56
+
+- Added setting to enable/disable terminal progress bar (OSC 9;4)
+- VSCode Extension: Added support for VS Code's secondary sidebar (VS Code 1.97+), allowing Claude Code to be displayed in the right sidebar while keeping the file explorer on the left. Requires setting sidebar as Preferred Location in the config.
+
+## 2.0.55
+
+- Fixed proxy DNS resolution being forced on by default. Now opt-in via `CLAUDE_CODE_PROXY_RESOLVES_HOSTS=true` environment variable
+- Fixed keyboard navigation becoming unresponsive when holding down arrow keys in memory location selector
+- Improved AskUserQuestion tool to auto-submit single-select questions on the last question, eliminating the extra review screen for simple question flows
+- Improved fuzzy matching for `@` file suggestions with faster, more accurate results
+
+## 2.0.54
+
+- Hooks: Enable PermissionRequest hooks to process 'always allow' suggestions and apply permission updates
+- Fix issue with excessive iTerm notifications
+
+## 2.0.52
+
+- Fixed duplicate message display when starting Claude with a command line argument
+- Fixed `/usage` command progress bars to fill up as usage increases (instead of showing remaining percentage)
+- Fixed image pasting not working on Linux systems running Wayland (now falls back to wl-paste when xclip is unavailable)
+- Permit some uses of `$!` in bash commands
+
+## 2.0.51
+
+- Added Opus 4.5! https://www.anthropic.com/news/claude-opus-4-5
+- Introducing Claude Code for Desktop: https://claude.com/download
+- To give you room to try out our new model, we've updated usage limits for Claude Code users. See the Claude Opus 4.5 blog for full details
+- Pro users can now purchase extra usage for access to Opus 4.5 in Claude Code
+- Plan Mode now builds more precise plans and executes more thoroughly
+- Usage limit notifications now easier to understand
+- Switched `/usage` back to "% used"
+- Fixed handling of thinking errors
+- Fixed performance regression
+
+## 2.0.50
+
+- Fixed bug preventing calling MCP tools that have nested references in their input schemas
+- Silenced a noisy but harmless error during upgrades
+- Improved ultrathink text display
+- Improved clarity of 5-hour session limit warning message
+
+## 2.0.49
+
+- Added readline-style ctrl-y for pasting deleted text
+- Improved clarity of usage limit warning message
+- Fixed handling of subagent permissions
+
+## 2.0.47
+
+- Improved error messages and validation for `claude --teleport`
+- Improved error handling in `/usage`
+- Fixed race condition with history entry not getting logged at exit
+- Fixed Vertex AI configuration not being applied from `settings.json`
+
+## 2.0.46
+
+- Fixed image files being reported with incorrect media type when format cannot be detected from metadata
+
+## 2.0.45
+
+- Added support for Microsoft Foundry! See https://code.claude.com/docs/en/azure-ai-foundry
+- Added `PermissionRequest` hook to automatically approve or deny tool permission requests with custom logic
+- Send background tasks to Claude Code on the web by starting a message with `&`
+
+## 2.0.43
+
+- Added `permissionMode` field for custom agents
+- Added `tool_use_id` field to `PreToolUseHookInput` and `PostToolUseHookInput` types
+- Added skills frontmatter field to declare skills to auto-load for subagents
+- Added the `SubagentStart` hook event
+- Fixed nested `CLAUDE.md` files not loading when @-mentioning files
+- Fixed duplicate rendering of some messages in the UI
+- Fixed some visual flickers
+- Fixed NotebookEdit tool inserting cells at incorrect positions when cell IDs matched the pattern `cell-N`
+
+## 2.0.42
+
+- Added `agent_id` and `agent_transcript_path` fields to `SubagentStop` hooks.
+
+## 2.0.41
+
+- Added `model` parameter to prompt-based stop hooks, allowing users to specify a custom model for hook evaluation
+- Fixed slash commands from user settings being loaded twice, which could cause rendering issues
+- Fixed incorrect labeling of user settings vs project settings in command descriptions
+- Fixed crash when plugin command hooks timeout during execution
+- Fixed: Bedrock users no longer see duplicate Opus entries in the /model picker when using `--model haiku`
+- Fixed broken security documentation links in trust dialogs and onboarding
+- Fixed issue where pressing ESC to close the diff modal would also interrupt the model
+- ctrl-r history search landing on a slash command no longer cancels the search
+- SDK: Support custom timeouts for hooks
+- Allow more safe git commands to run without approval
+- Plugins: Added support for sharing and installing output styles
+- Teleporting a session from web will automatically set the upstream branch
+
+## 2.0.37
+
+- Fixed how idleness is computed for notifications
+- Hooks: Added matcher values for Notification hook events
+- Output Styles: Added `keep-coding-instructions` option to frontmatter
+
+## 2.0.36
+
+- Fixed: DISABLE_AUTOUPDATER environment variable now properly disables package manager update notifications
+- Fixed queued messages being incorrectly executed as bash commands
+- Fixed input being lost when typing while a queued message is processed
+
+## 2.0.35
+
+- Improve fuzzy search results when searching commands
+- Improved VS Code extension to respect `chat.fontSize` and `chat.fontFamily` settings throughout the entire UI, and apply font changes immediately without requiring reload
+- Added `CLAUDE_CODE_EXIT_AFTER_STOP_DELAY` environment variable to automatically exit SDK mode after a specified idle duration, useful for automated workflows and scripts
+- Migrated `ignorePatterns` from project config to deny permissions in the localSettings.
+- Fixed menu navigation getting stuck on items with empty string or other falsy values (e.g., in the `/hooks` menu)
+
+## 2.0.34
+
+- VSCode Extension: Added setting to configure the initial permission mode for new conversations
+- Improved file path suggestion performance with native Rust-based fuzzy finder
+- Fixed infinite token refresh loop that caused MCP servers with OAuth (e.g., Slack) to hang during connection
+- Fixed memory crash when reading or writing large files (especially base64-encoded images)
+
+## 2.0.33
+
+- Native binary installs now launch quicker.
+- Fixed `claude doctor` incorrectly detecting Homebrew vs npm-global installations by properly resolving symlinks
+- Fixed `claude mcp serve` exposing tools with incompatible outputSchemas
+
+## 2.0.32
+
+- Un-deprecate output styles based on community feedback
+- Added `companyAnnouncements` setting for displaying announcements on startup
+- Fixed hook progress messages not updating correctly during PostToolUse hook execution
+
+## 2.0.31
+
+- Windows: native installation uses shift+tab as shortcut for mode switching, instead of alt+m
+- Vertex: add support for Web Search on supported models
+- VSCode: Adding the respectGitIgnore configuration to include .gitignored files in file searches (defaults to true)
+- Fixed a bug with subagents and MCP servers related to "Tool names must be unique" error
+- Fixed issue causing `/compact` to fail with `prompt_too_long` by making it respect existing compact boundaries
+- Fixed plugin uninstall not removing plugins
+
+## 2.0.30
+
+- Added helpful hint to run `security unlock-keychain` when encountering API key errors on macOS with locked keychain
+- Added `allowUnsandboxedCommands` sandbox setting to disable the dangerouslyDisableSandbox escape hatch at policy level
+- Added `disallowedTools` field to custom agent definitions for explicit tool blocking
+- Added prompt-based stop hooks
+- VSCode: Added respectGitIgnore configuration to include .gitignored files in file searches (defaults to true)
+- Enabled SSE MCP servers on native build
+- Deprecated output styles. Review options in `/output-style` and use --system-prompt-file, --system-prompt, --append-system-prompt, CLAUDE.md, or plugins instead
+- Removed support for custom ripgrep configuration, resolving an issue where Search returns no results and config discovery fails
+- Fixed Explore agent creating unwanted .md investigation files during codebase exploration
+- Fixed a bug where `/context` would sometimes fail with "max_tokens must be greater than thinking.budget_tokens" error message
+- Fixed `--mcp-config` flag to correctly override file-based MCP configurations
+- Fixed bug that saved session permissions to local settings
+- Fixed MCP tools not being available to sub-agents
+- Fixed hooks and plugins not executing when using --dangerously-skip-permissions flag
+- Fixed delay when navigating through typeahead suggestions with arrow keys
+- VSCode: Restored selection indicator in input footer showing current file or code selection status
+
+## 2.0.28
+
+- Plan mode: introduced new Plan subagent
+- Subagents: claude can now choose to resume subagents
+- Subagents: claude can dynamically choose the model used by its subagents
+- SDK: added --max-budget-usd flag
+- Discovery of custom slash commands, subagents, and output styles no longer respects .gitignore
+- Stop `/terminal-setup` from adding backslash to `Shift + Enter` in VS Code
+- Add branch and tag support for git-based plugins and marketplaces using fragment syntax (e.g., `owner/repo#branch`)
+- Fixed a bug where macOS permission prompts would show up upon initial launch when launching from home directory
+- Various other bug fixes
+
+## 2.0.27
+
+- New UI for permission prompts
+- Added current branch filtering and search to session resume screen for easier navigation
+- Fixed directory @-mention causing "No assistant message found" error
+- VSCode Extension: Add config setting to include .gitignored files in file searches
+- VSCode Extension: Bug fixes for unrelated 'Warmup' conversations, and configuration/settings occasionally being reset to defaults
+
+## 2.0.25
+
+- Removed legacy SDK entrypoint. Please migrate to @anthropic-ai/claude-agent-sdk for future SDK updates: https://platform.claude.com/docs/en/agent-sdk/migration-guide
+
+## 2.0.24
+
+- Fixed a bug where project-level skills were not loading when --setting-sources 'project' was specified
+- Claude Code Web: Support for Web -> CLI teleport
+- Sandbox: Releasing a sandbox mode for the BashTool on Linux & Mac
+- Bedrock: Display awsAuthRefresh output when auth is required
+
+## 2.0.22
+
+- Fixed content layout shift when scrolling through slash commands
+- IDE: Add toggle to enable/disable thinking.
+- Fix bug causing duplicate permission prompts with parallel tool calls
+- Add support for enterprise managed MCP allowlist and denylist
+
+## 2.0.21
+
+- Support MCP `structuredContent` field in tool responses
+- Added an interactive question tool
+- Claude will now ask you questions more often in plan mode
+- Added Haiku 4.5 as a model option for Pro users
+- Fixed an issue where queued commands don't have access to previous messages' output
+
+## 2.0.20
+
+- Added support for Claude Skills
+
+## 2.0.19
+
+- Auto-background long-running bash commands instead of killing them. Customize with BASH_DEFAULT_TIMEOUT_MS
+- Fixed a bug where Haiku was unnecessarily called in print mode
+
+## 2.0.17
+
+- Added Haiku 4.5 to model selector!
+- Haiku 4.5 automatically uses Sonnet in plan mode, and Haiku for execution (i.e. SonnetPlan by default)
+- 3P (Bedrock and Vertex) are not automatically upgraded yet. Manual upgrading can be done through setting `ANTHROPIC_DEFAULT_HAIKU_MODEL`
+- Introducing the Explore subagent. Powered by Haiku it'll search through your codebase efficiently to save context!
+- OTEL: support HTTP_PROXY and HTTPS_PROXY
+- `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` now disables release notes fetching
+
+## 2.0.15
+
+- Fixed bug with resuming where previously created files needed to be read again before writing
+- Fixed bug with `-p` mode where @-mentioned files needed to be read again before writing
+
+## 2.0.14
+
+- Fix @-mentioning MCP servers to toggle them on/off
+- Improve permission checks for bash with inline env vars
+- Fix ultrathink + thinking toggle
+- Reduce unnecessary logins
+- Document --system-prompt
+- Several improvements to rendering
+- Plugins UI polish
+
+## 2.0.13
+
+- Fixed `/plugin` not working on native build
+
+## 2.0.12
+
+- **Plugin System Released**: Extend Claude Code with custom commands, agents, hooks, and MCP servers from marketplaces
+- `/plugin install`, `/plugin enable/disable`, `/plugin marketplace` commands for plugin management
+- Repository-level plugin configuration via `extraKnownMarketplaces` for team collaboration
+- `/plugin validate` command for validating plugin structure and configuration
+- Plugin announcement blog post at https://www.anthropic.com/news/claude-code-plugins
+- Plugin documentation available at https://code.claude.com/docs/en/plugins
+- Comprehensive error messages and diagnostics via `/doctor` command
+- Avoid flickering in `/model` selector
+- Improvements to `/help`
+- Avoid mentioning hooks in `/resume` summaries
+- Changes to the "verbose" setting in `/config` now persist across sessions
+
+## 2.0.11
+
+- Reduced system prompt size by 1.4k tokens
+- IDE: Fixed keyboard shortcuts and focus issues for smoother interaction
+- Fixed Opus fallback rate limit errors appearing incorrectly
+- Fixed /add-dir command selecting wrong default tab
+
+## 2.0.10
+
+- Rewrote terminal renderer for buttery smooth UI
+- Enable/disable MCP servers by @mentioning, or in /mcp
+- Added tab completion for shell commands in bash mode
+- PreToolUse hooks can now modify tool inputs
+- Press Ctrl-G to edit your prompt in your system's configured text editor
+- Fixes for bash permission checks with environment variables in the command
+
+## 2.0.9
+
+- Fix regression where bash backgrounding stopped working
+
+## 2.0.8
+
+- Update Bedrock default Sonnet model to `global.anthropic.claude-sonnet-4-5-20250929-v1:0`
+- IDE: Add drag-and-drop support for files and folders in chat
+- /context: Fix counting for thinking blocks
+- Improve message rendering for users with light themes on dark terminals
+- Remove deprecated .claude.json allowedTools, ignorePatterns, env, and todoFeatureEnabled config options (instead, configure these in your settings.json)
+
+## 2.0.5
+
+- IDE: Fix IME unintended message submission with Enter and Tab
+- IDE: Add "Open in Terminal" link in login screen
+- Fix unhandled OAuth expiration 401 API errors
+- SDK: Added SDKUserMessageReplay.isReplay to prevent duplicate messages
+
+## 2.0.1
+
+- Skip Sonnet 4.5 default model setting change for Bedrock and Vertex
+- Various bug fixes and presentation improvements
+
+## 2.0.0
+
+- New native VS Code extension
+- Fresh coat of paint throughout the whole app
+- /rewind a conversation to undo code changes
+- /usage command to see plan limits
+- Tab to toggle thinking (sticky across sessions)
+- Ctrl-R to search history
+- Unshipped claude config command
+- Hooks: Reduced PostToolUse 'tool_use' ids were found without 'tool_result' blocks errors
+- SDK: The Claude Code SDK is now the Claude Agent SDK
+- Add subagents dynamically with `--agents` flag
+
+## 1.0.126
+
+- Enable /context command for Bedrock and Vertex
+- Add mTLS support for HTTP-based OpenTelemetry exporters
+
+## 1.0.124
+
+- Set `CLAUDE_BASH_NO_LOGIN` environment variable to 1 or true to to skip login shell for BashTool
+- Fix Bedrock and Vertex environment variables evaluating all strings as truthy
+- No longer inform Claude of the list of allowed tools when permission is denied
+- Fixed security vulnerability in Bash tool permission checks
+- Improved VSCode extension performance for large files
+
+## 1.0.123
+
+- Bash permission rules now support output redirections when matching (e.g., `Bash(python:*)` matches `python script.py > output.txt`)
+- Fixed thinking mode triggering on negation phrases like "don't think"
+- Fixed rendering performance degradation during token streaming
+- Added SlashCommand tool, which enables Claude to invoke your slash commands. https://code.claude.com/docs/en/slash-commands#SlashCommand-tool
+- Enhanced BashTool environment snapshot logging
+- Fixed a bug where resuming a conversation in headless mode would sometimes enable thinking unnecessarily
+- Migrated --debug logging to a file, to enable easy tailing & filtering
+
+## 1.0.120
+
+- Fix input lag during typing, especially noticeable with large prompts
+- Improved VSCode extension command registry and sessions dialog user experience
+- Enhanced sessions dialog responsiveness and visual feedback
+- Fixed IDE compatibility issue by removing worktree support check
+- Fixed security vulnerability where Bash tool permission checks could be bypassed using prefix matching
+
+## 1.0.119
+
+- Fix Windows issue where process visually freezes on entering interactive mode
+- Support dynamic headers for MCP servers via headersHelper configuration
+- Fix thinking mode not working in headless sessions
+- Fix slash commands now properly update allowed tools instead of replacing them
+
+## 1.0.117
+
+- Add Ctrl-R history search to recall previous commands like bash/zsh
+- Fix input lag while typing, especially on Windows
+- Add sed command to auto-allowed commands in acceptEdits mode
+- Fix Windows PATH comparison to be case-insensitive for drive letters
+- Add permissions management hint to /add-dir output
+
+## 1.0.115
+
+- Improve thinking mode display with enhanced visual effects
+- Type /t to temporarily disable thinking mode in your prompt
+- Improve path validation for glob and grep tools
+- Show condensed output for post-tool hooks to reduce visual clutter
+- Fix visual feedback when loading state completes
+- Improve UI consistency for permission request dialogs
+
+## 1.0.113
+
+- Deprecated piped input in interactive mode
+- Move Ctrl+R keybinding for toggling transcript to Ctrl+O
+
+## 1.0.112
+
+- Transcript mode (Ctrl+R): Added the model used to generate each assistant message
+- Addressed issue where some Claude Max users were incorrectly recognized as Claude Pro users
+- Hooks: Added systemMessage support for SessionEnd hooks
+- Added `spinnerTipsEnabled` setting to disable spinner tips
+- IDE: Various improvements and bug fixes
+
+## 1.0.111
+
+- /model now validates provided model names
+- Fixed Bash tool crashes caused by malformed shell syntax parsing
+
+## 1.0.110
+
+- /terminal-setup command now supports WezTerm
+- MCP: OAuth tokens now proactively refresh before expiration
+- Fixed reliability issues with background Bash processes
+
+## 1.0.109
+
+- SDK: Added partial message streaming support via `--include-partial-messages` CLI flag
+
+## 1.0.106
+
+- Windows: Fixed path permission matching to consistently use POSIX format (e.g., `Read(//c/Users/...)`)
+
+## 1.0.97
+
+- Settings: /doctor now validates permission rule syntax and suggests corrections
+
+## 1.0.94
+
+- Vertex: add support for global endpoints for supported models
+- /memory command now allows direct editing of all imported memory files
+- SDK: Add custom tools as callbacks
+- Added /todos command to list current todo items
+
+## 1.0.93
+
+- Windows: Add alt + v shortcut for pasting images from clipboard
+- Support NO_PROXY environment variable to bypass proxy for specified hostnames and IPs
+
+## 1.0.90
+
+- Settings file changes take effect immediately - no restart required
+
+## 1.0.88
+
+- Fixed issue causing "OAuth authentication is currently not supported"
+- Status line input now includes `exceeds_200k_tokens`
+- Fixed incorrect usage tracking in /cost.
+- Introduced `ANTHROPIC_DEFAULT_SONNET_MODEL` and `ANTHROPIC_DEFAULT_OPUS_MODEL` for controlling model aliases opusplan, opus, and sonnet.
+- Bedrock: Updated default Sonnet model to Sonnet 4
+
+## 1.0.86
+
+- Added /context to help users self-serve debug context issues
+- SDK: Added UUID support for all SDK messages
+- SDK: Added `--replay-user-messages` to replay user messages back to stdout
+
+## 1.0.85
+
+- Status line input now includes session cost info
+- Hooks: Introduced SessionEnd hook
+
+## 1.0.84
+
+- Fix tool_use/tool_result id mismatch error when network is unstable
+- Fix Claude sometimes ignoring real-time steering when wrapping up a task
+- @-mention: Add ~/.claude/\* files to suggestions for easier agent, output style, and slash command editing
+- Use built-in ripgrep by default; to opt out of this behavior, set USE_BUILTIN_RIPGREP=0
+
+## 1.0.83
+
+- @-mention: Support files with spaces in path
+- New shimmering spinner
+
+## 1.0.82
+
+- SDK: Add request cancellation support
+- SDK: New additionalDirectories option to search custom paths, improved slash command processing
+- Settings: Validation prevents invalid fields in .claude/settings.json files
+- MCP: Improve tool name consistency
+- Bash: Fix crash when Claude tries to automatically read large files
+
+## 1.0.81
+
+- Released output styles, including new built-in educational output styles "Explanatory" and "Learning". Docs: https://code.claude.com/docs/en/output-styles
+- Agents: Fix custom agent loading when agent files are unparsable
+
+## 1.0.80
+
+- UI improvements: Fix text contrast for custom subagent colors and spinner rendering issues
+
+## 1.0.77
+
+- Bash tool: Fix heredoc and multiline string escaping, improve stderr redirection handling
+- SDK: Add session support and permission denial tracking
+- Fix token limit errors in conversation summarization
+- Opus Plan Mode: New setting in `/model` to run Opus only in plan mode, Sonnet otherwise
+
+## 1.0.73
+
+- MCP: Support multiple config files with `--mcp-config file1.json file2.json`
+- MCP: Press Esc to cancel OAuth authentication flows
+- Bash: Improved command validation and reduced false security warnings
+- UI: Enhanced spinner animations and status line visual hierarchy
+- Linux: Added support for Alpine and musl-based distributions (requires separate ripgrep installation)
+
+## 1.0.72
+
+- Ask permissions: have Claude Code always ask for confirmation to use specific tools with /permissions
+
+## 1.0.71
+
+- Background commands: (Ctrl-b) to run any Bash command in the background so Claude can keep working (great for dev servers, tailing logs, etc.)
+- Customizable status line: add your terminal prompt to Claude Code with /statusline
+
+## 1.0.70
+
+- Performance: Optimized message rendering for better performance with large contexts
+- Windows: Fixed native file search, ripgrep, and subagent functionality
+- Added support for @-mentions in slash command arguments
+
+## 1.0.69
+
+- Upgraded Opus to version 4.1
+
+## 1.0.68
+
+- Fix incorrect model names being used for certain commands like `/pr-comments`
+- Windows: improve permissions checks for allow / deny tools and project trust. This may create a new project entry in `.claude.json` - manually merge the history field if desired.
+- Windows: improve sub-process spawning to eliminate "No such file or directory" when running commands like pnpm
+- Enhanced /doctor command with CLAUDE.md and MCP tool context for self-serve debugging
+- SDK: Added canUseTool callback support for tool confirmation
+- Added `disableAllHooks` setting
+- Improved file suggestions performance in large repos
+
+## 1.0.65
+
+- IDE: Fixed connection stability issues and error handling for diagnostics
+- Windows: Fixed shell environment setup for users without .bashrc files
+
+## 1.0.64
+
+- Agents: Added model customization support - you can now specify which model an agent should use
+- Agents: Fixed unintended access to the recursive agent tool
+- Hooks: Added systemMessage field to hook JSON output for displaying warnings and context
+- SDK: Fixed user input tracking across multi-turn conversations
+- Added hidden files to file search and @-mention suggestions
+
+## 1.0.63
+
+- Windows: Fixed file search, @agent mentions, and custom slash commands functionality
+
+## 1.0.62
+
+- Added @-mention support with typeahead for custom agents. @<your-custom-agent> to invoke it
+- Hooks: Added SessionStart hook for new session initialization
+- /add-dir command now supports typeahead for directory paths
+- Improved network connectivity check reliability
+
+## 1.0.61
+
+- Transcript mode (Ctrl+R): Changed Esc to exit transcript mode rather than interrupt
+- Settings: Added `--settings` flag to load settings from a JSON file
+- Settings: Fixed resolution of settings files paths that are symlinks
+- OTEL: Fixed reporting of wrong organization after authentication changes
+- Slash commands: Fixed permissions checking for allowed-tools with Bash
+- IDE: Added support for pasting images in VSCode MacOS using ⌘+V
+- IDE: Added `CLAUDE_CODE_AUTO_CONNECT_IDE=false` for disabling IDE auto-connection
+- Added `CLAUDE_CODE_SHELL_PREFIX` for wrapping Claude and user-provided shell commands run by Claude Code
+
+## 1.0.60
+
+- You can now create custom subagents for specialized tasks! Run /agents to get started
+
+## 1.0.59
+
+- SDK: Added tool confirmation support with canUseTool callback
+- SDK: Allow specifying env for spawned process
+- Hooks: Exposed PermissionDecision to hooks (including "ask")
+- Hooks: UserPromptSubmit now supports additionalContext in advanced JSON output
+- Fixed issue where some Max users that specified Opus would still see fallback to Sonnet
+
+## 1.0.58
+
+- Added support for reading PDFs
+- MCP: Improved server health status display in 'claude mcp list'
+- Hooks: Added CLAUDE_PROJECT_DIR env var for hook commands
+
+## 1.0.57
+
+- Added support for specifying a model in slash commands
+- Improved permission messages to help Claude understand allowed tools
+- Fix: Remove trailing newlines from bash output in terminal wrapping
+
+## 1.0.56
+
+- Windows: Enabled shift+tab for mode switching on versions of Node.js that support terminal VT mode
+- Fixes for WSL IDE detection
+- Fix an issue causing awsRefreshHelper changes to .aws directory not to be picked up
+
+## 1.0.55
+
+- Clarified knowledge cutoff for Opus 4 and Sonnet 4 models
+- Windows: fixed Ctrl+Z crash
+- SDK: Added ability to capture error logging
+- Add --system-prompt-file option to override system prompt in print mode
+
+## 1.0.54
+
+- Hooks: Added UserPromptSubmit hook and the current working directory to hook inputs
+- Custom slash commands: Added argument-hint to frontmatter
+- Windows: OAuth uses port 45454 and properly constructs browser URL
+- Windows: mode switching now uses alt + m, and plan mode renders properly
+- Shell: Switch to in-memory shell snapshot to fix file-related errors
+
+## 1.0.53
+
+- Updated @-mention file truncation from 100 lines to 2000 lines
+- Add helper script settings for AWS token refresh: awsAuthRefresh (for foreground operations like aws sso login) and awsCredentialExport (for background operation with STS-like response).
+
+## 1.0.52
+
+- Added support for MCP server instructions
+
+## 1.0.51
+
+- Added support for native Windows (requires Git for Windows)
+- Added support for Bedrock API keys through environment variable AWS_BEARER_TOKEN_BEDROCK
+- Settings: /doctor can now help you identify and fix invalid setting files
+- `--append-system-prompt` can now be used in interactive mode, not just --print/-p.
+- Increased auto-compact warning threshold from 60% to 80%
+- Fixed an issue with handling user directories with spaces for shell snapshots
+- OTEL resource now includes os.type, os.version, host.arch, and wsl.version (if running on Windows Subsystem for Linux)
+- Custom slash commands: Fixed user-level commands in subdirectories
+- Plan mode: Fixed issue where rejected plan from sub-task would get discarded
+
+## 1.0.48
+
+- Fixed a bug in v1.0.45 where the app would sometimes freeze on launch
+- Added progress messages to Bash tool based on the last 5 lines of command output
+- Added expanding variables support for MCP server configuration
+- Moved shell snapshots from /tmp to ~/.claude for more reliable Bash tool calls
+- Improved IDE extension path handling when Claude Code runs in WSL
+- Hooks: Added a PreCompact hook
+- Vim mode: Added c, f/F, t/T
+
+## 1.0.45
+
+- Redesigned Search (Grep) tool with new tool input parameters and features
+- Disabled IDE diffs for notebook files, fixing "Timeout waiting after 1000ms" error
+- Fixed config file corruption issue by enforcing atomic writes
+- Updated prompt input undo to Ctrl+\_ to avoid breaking existing Ctrl+U behavior, matching zsh's undo shortcut
+- Stop Hooks: Fixed transcript path after /clear and fixed triggering when loop ends with tool call
+- Custom slash commands: Restored namespacing in command names based on subdirectories. For example, .claude/commands/frontend/component.md is now /frontend:component, not /component.
+
+## 1.0.44
+
+- New /export command lets you quickly export a conversation for sharing
+- MCP: resource_link tool results are now supported
+- MCP: tool annotations and tool titles now display in /mcp view
+- Changed Ctrl+Z to suspend Claude Code. Resume by running `fg`. Prompt input undo is now Ctrl+U.
+
+## 1.0.43
+
+- Fixed a bug where the theme selector was saving excessively
+- Hooks: Added EPIPE system error handling
+
+## 1.0.42
+
+- Added tilde (`~`) expansion support to `/add-dir` command
+
+## 1.0.41
+
+- Hooks: Split Stop hook triggering into Stop and SubagentStop
+- Hooks: Enabled optional timeout configuration for each command
+- Hooks: Added "hook_event_name" to hook input
+- Fixed a bug where MCP tools would display twice in tool list
+- New tool parameters JSON for Bash tool in `tool_decision` event
+
+## 1.0.40
+
+- Fixed a bug causing API connection errors with UNABLE_TO_GET_ISSUER_CERT_LOCALLY if `NODE_EXTRA_CA_CERTS` was set
+
+## 1.0.39
+
+- New Active Time metric in OpenTelemetry logging
+
+## 1.0.38
+
+- Released hooks. Special thanks to community input in https://github.com/anthropics/claude-code/issues/712. Docs: https://code.claude.com/docs/en/hooks
+
+## 1.0.37
+
+- Remove ability to set `Proxy-Authorization` header via ANTHROPIC_AUTH_TOKEN or apiKeyHelper
+
+## 1.0.36
+
+- Web search now takes today's date into context
+- Fixed a bug where stdio MCP servers were not terminating properly on exit
+
+## 1.0.35
+
+- Added support for MCP OAuth Authorization Server discovery
+
+## 1.0.34
+
+- Fixed a memory leak causing a MaxListenersExceededWarning message to appear
+
+## 1.0.33
+
+- Improved logging functionality with session ID support
+- Added prompt input undo functionality (Ctrl+Z and vim 'u' command)
+- Improvements to plan mode
+
+## 1.0.32
+
+- Updated loopback config for litellm
+- Added forceLoginMethod setting to bypass login selection screen
+
+## 1.0.31
+
+- Fixed a bug where ~/.claude.json would get reset when file contained invalid JSON
+
+## 1.0.30
+
+- Custom slash commands: Run bash output, @-mention files, enable thinking with thinking keywords
+- Improved file path autocomplete with filename matching
+- Added timestamps in Ctrl-r mode and fixed Ctrl-c handling
+- Enhanced jq regex support for complex filters with pipes and select
+
+## 1.0.29
+
+- Improved CJK character support in cursor navigation and rendering
+
+## 1.0.28
+
+- Slash commands: Fix selector display during history navigation
+- Resizes images before upload to prevent API size limit errors
+- Added XDG_CONFIG_HOME support to configuration directory
+- Performance optimizations for memory usage
+- New attributes (terminal.type, language) in OpenTelemetry logging
+
+## 1.0.27
+
+- Streamable HTTP MCP servers are now supported
+- Remote MCP servers (SSE and HTTP) now support OAuth
+- MCP resources can now be @-mentioned
+- /resume slash command to switch conversations within Claude Code
+
+## 1.0.25
+
+- Slash commands: moved "project" and "user" prefixes to descriptions
+- Slash commands: improved reliability for command discovery
+- Improved support for Ghostty
+- Improved web search reliability
+
+## 1.0.24
+
+- Improved /mcp output
+- Fixed a bug where settings arrays got overwritten instead of merged
+
+## 1.0.23
+
+- Released TypeScript SDK: import @anthropic-ai/claude-code to get started
+- Released Python SDK: pip install claude-code-sdk to get started
+
+## 1.0.22
+
+- SDK: Renamed `total_cost` to `total_cost_usd`
+
+## 1.0.21
+
+- Improved editing of files with tab-based indentation
+- Fix for tool_use without matching tool_result errors
+- Fixed a bug where stdio MCP server processes would linger after quitting Claude Code
+
+## 1.0.18
+
+- Added --add-dir CLI argument for specifying additional working directories
+- Added streaming input support without require -p flag
+- Improved startup performance and session storage performance
+- Added CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR environment variable to freeze working directory for bash commands
+- Added detailed MCP server tools display (/mcp)
+- MCP authentication and permission improvements
+- Added auto-reconnection for MCP SSE connections on disconnect
+- Fixed issue where pasted content was lost when dialogs appeared
+
+## 1.0.17
+
+- We now emit messages from sub-tasks in -p mode (look for the parent_tool_use_id property)
+- Fixed crashes when the VS Code diff tool is invoked multiple times quickly
+- MCP server list UI improvements
+- Update Claude Code process title to display "claude" instead of "node"
+
+## 1.0.11
+
+- Claude Code can now also be used with a Claude Pro subscription
+- Added /upgrade for smoother switching to Claude Max plans
+- Improved UI for authentication from API keys and Bedrock/Vertex/external auth tokens
+- Improved shell configuration error handling
+- Improved todo list handling during compaction
+
+## 1.0.10
+
+- Added markdown table support
+- Improved streaming performance
+
+## 1.0.8
+
+- Fixed Vertex AI region fallback when using CLOUD_ML_REGION
+- Increased default otel interval from 1s -> 5s
+- Fixed edge cases where MCP_TIMEOUT and MCP_TOOL_TIMEOUT weren't being respected
+- Fixed a regression where search tools unnecessarily asked for permissions
+- Added support for triggering thinking non-English languages
+- Improved compacting UI
+
+## 1.0.7
+
+- Renamed /allowed-tools -> /permissions
+- Migrated allowedTools and ignorePatterns from .claude.json -> settings.json
+- Deprecated claude config commands in favor of editing settings.json
+- Fixed a bug where --dangerously-skip-permissions sometimes didn't work in --print mode
+- Improved error handling for /install-github-app
+- Bugfixes, UI polish, and tool reliability improvements
+
+## 1.0.6
+
+- Improved edit reliability for tab-indented files
+- Respect CLAUDE_CONFIG_DIR everywhere
+- Reduced unnecessary tool permission prompts
+- Added support for symlinks in @file typeahead
+- Bugfixes, UI polish, and tool reliability improvements
+
+## 1.0.4
+
+- Fixed a bug where MCP tool errors weren't being parsed correctly
+
+## 1.0.1
+
+- Added `DISABLE_INTERLEAVED_THINKING` to give users the option to opt out of interleaved thinking.
+- Improved model references to show provider-specific names (Sonnet 3.7 for Bedrock, Sonnet 4 for Console)
+- Updated documentation links and OAuth process descriptions
+
+## 1.0.0
+
+- Claude Code is now generally available
+- Introducing Sonnet 4 and Opus 4 models
+
+## 0.2.125
+
+- Breaking change: Bedrock ARN passed to `ANTHROPIC_MODEL` or `ANTHROPIC_SMALL_FAST_MODEL` should no longer contain an escaped slash (specify `/` instead of `%2F`)
+- Removed `DEBUG=true` in favor of `ANTHROPIC_LOG=debug`, to log all requests
+
+## 0.2.117
+
+- Breaking change: --print JSON output now returns nested message objects, for forwards-compatibility as we introduce new metadata fields
+- Introduced settings.cleanupPeriodDays
+- Introduced CLAUDE_CODE_API_KEY_HELPER_TTL_MS env var
+- Introduced --debug mode
+
+## 0.2.108
+
+- You can now send messages to Claude while it works to steer Claude in real-time
+- Introduced BASH_DEFAULT_TIMEOUT_MS and BASH_MAX_TIMEOUT_MS env vars
+- Fixed a bug where thinking was not working in -p mode
+- Fixed a regression in /cost reporting
+- Deprecated MCP wizard interface in favor of other MCP commands
+- Lots of other bugfixes and improvements
+
+## 0.2.107
+
+- CLAUDE.md files can now import other files. Add @path/to/file.md to ./CLAUDE.md to load additional files on launch
+
+## 0.2.106
+
+- MCP SSE server configs can now specify custom headers
+- Fixed a bug where MCP permission prompt didn't always show correctly
+
+## 0.2.105
+
+- Claude can now search the web
+- Moved system & account status to /status
+- Added word movement keybindings for Vim
+- Improved latency for startup, todo tool, and file edits
+
+## 0.2.102
+
+- Improved thinking triggering reliability
+- Improved @mention reliability for images and folders
+- You can now paste multiple large chunks into one prompt
+
+## 0.2.100
+
+- Fixed a crash caused by a stack overflow error
+- Made db storage optional; missing db support disables --continue and --resume
+
+## 0.2.98
+
+- Fixed an issue where auto-compact was running twice
+
+## 0.2.96
+
+- Claude Code can now also be used with a Claude Max subscription (https://claude.ai/upgrade)
+
+## 0.2.93
+
+- Resume conversations from where you left off from with "claude --continue" and "claude --resume"
+- Claude now has access to a Todo list that helps it stay on track and be more organized
+
+## 0.2.82
+
+- Added support for --disallowedTools
+- Renamed tools for consistency: LSTool -> LS, View -> Read, etc.
+
+## 0.2.75
+
+- Hit Enter to queue up additional messages while Claude is working
+- Drag in or copy/paste image files directly into the prompt
+- @-mention files to directly add them to context
+- Run one-off MCP servers with `claude --mcp-config <path-to-file>`
+- Improved performance for filename auto-complete
+
+## 0.2.74
+
+- Added support for refreshing dynamically generated API keys (via apiKeyHelper), with a 5 minute TTL
+- Task tool can now perform writes and run bash commands
+
+## 0.2.72
+
+- Updated spinner to indicate tokens loaded and tool usage
+
+## 0.2.70
+
+- Network commands like curl are now available for Claude to use
+- Claude can now run multiple web queries in parallel
+- Pressing ESC once immediately interrupts Claude in Auto-accept mode
+
+## 0.2.69
+
+- Fixed UI glitches with improved Select component behavior
+- Enhanced terminal output display with better text truncation logic
+
+## 0.2.67
+
+- Shared project permission rules can be saved in .claude/settings.json
+
+## 0.2.66
+
+- Print mode (-p) now supports streaming output via --output-format=stream-json
+- Fixed issue where pasting could trigger memory or bash mode unexpectedly
+
+## 0.2.63
+
+- Fixed an issue where MCP tools were loaded twice, which caused tool call errors
+
+## 0.2.61
+
+- Navigate menus with vim-style keys (j/k) or bash/emacs shortcuts (Ctrl+n/p) for faster interaction
+- Enhanced image detection for more reliable clipboard paste functionality
+- Fixed an issue where ESC key could crash the conversation history selector
+
+## 0.2.59
+
+- Copy+paste images directly into your prompt
+- Improved progress indicators for bash and fetch tools
+- Bugfixes for non-interactive mode (-p)
+
+## 0.2.54
+
+- Quickly add to Memory by starting your message with '#'
+- Press ctrl+r to see full output for long tool results
+- Added support for MCP SSE transport
+
+## 0.2.53
+
+- New web fetch tool lets Claude view URLs that you paste in
+- Fixed a bug with JPEG detection
+
+## 0.2.50
+
+- New MCP "project" scope now allows you to add MCP servers to .mcp.json files and commit them to your repository
+
+## 0.2.49
+
+- Previous MCP server scopes have been renamed: previous "project" scope is now "local" and "global" scope is now "user"
+
+## 0.2.47
+
+- Press Tab to auto-complete file and folder names
+- Press Shift + Tab to toggle auto-accept for file edits
+- Automatic conversation compaction for infinite conversation length (toggle with /config)
+
+## 0.2.44
+
+- Ask Claude to make a plan with thinking mode: just say 'think' or 'think harder' or even 'ultrathink'
+
+## 0.2.41
+
+- MCP server startup timeout can now be configured via MCP_TIMEOUT environment variable
+- MCP server startup no longer blocks the app from starting up
+
+## 0.2.37
+
+- New /release-notes command lets you view release notes at any time
+- `claude config add/remove` commands now accept multiple values separated by commas or spaces
+
+## 0.2.36
+
+- Import MCP servers from Claude Desktop with `claude mcp add-from-claude-desktop`
+- Add MCP servers as JSON strings with `claude mcp add-json <n> <json>`
+
+## 0.2.34
+
+- Vim bindings for text input - enable with /vim or /config
+
+## 0.2.32
+
+- Interactive MCP setup wizard: Run "claude mcp add" to add MCP servers with a step-by-step interface
+- Fix for some PersistentShell issues
+
+## 0.2.31
+
+- Custom slash commands: Markdown files in .claude/commands/ directories now appear as custom slash commands to insert prompts into your conversation
+- MCP debug mode: Run with --mcp-debug flag to get more information about MCP server errors
+
+## 0.2.30
+
+- Added ANSI color theme for better terminal compatibility
+- Fixed issue where slash command arguments weren't being sent properly
+- (Mac-only) API keys are now stored in macOS Keychain
+
+## 0.2.26
+
+- New /approved-tools command for managing tool permissions
+- Word-level diff display for improved code readability
+- Fuzzy matching for slash commands
+
+## 0.2.21
+
+- Fuzzy matching for /commands

--- a/skills-howto.md
+++ b/skills-howto.md
@@ -1,0 +1,785 @@
+Product
+Toggle theme
+Log in
+Start for free
+←
+All posts
+Technology
+Published 20 Dec 2025
+•
+Updated 21 Dec 2025
+How to Create Claude Code Skills: The Complete Guide from Anthropic
+Master the art of building Claude Code Skills with this comprehensive guide based on Anthropic official documentation. Learn skill architecture, progressive disclosure patterns, bundled resources, and production-ready implementation strategies.
+
+avatar
+James Bennett
+18 minutes read
+How to create Claude Code Skills - comprehensive guide
+Learn how to build professional Claude Code Skills from scratch using Anthropic's official patterns and best practices. Transform Claude from a general-purpose assistant into a specialized powerhouse for your workflows.
+
+About the Author: I'm James Bennett, Lead Engineer at WebSearchAPI.ai, where I architect the core retrieval engine enabling LLMs and AI agents to access real-time, structured web data with over 99.9% uptime and sub-second query latency. With a background in distributed systems and search technologies, I've reduced AI hallucination rates by 45% through advanced ranking and content extraction pipelines for RAG systems. My expertise includes AI infrastructure, search technologies, large-scale data integration, and API architecture for real-time AI applications.
+
+Credentials: B.Sc. Computer Science (University of Cambridge), M.Sc. Artificial Intelligence Systems (Imperial College London), Google Cloud Certified Professional Cloud Architect, AWS Certified Solutions Architect, Microsoft Azure AI Engineer, Certified Kubernetes Administrator, TensorFlow Developer Certificate.
+
+Introduction: Why Skills Matter for Claude Code
+Last week, I found myself repeatedly explaining to Claude how to format API documentation for our internal tools. Every conversation, the same setup. The same instructions. The same context-building before I could actually get work done.
+
+Then I discovered Claude Code Skills—and everything changed.
+
+Skills are Anthropic's answer to the problem of repetitive context-setting. Instead of treating Claude as a blank slate every time, you can package your expertise, workflows, and domain knowledge into reusable modules that Claude automatically discovers and applies when relevant.
+
+📊 Stats Alert:
+
+Claude Code has attracted 115,000 developers and processes 195 million lines of code weekly, according to PPC Land. With an estimated annualized revenue of $130 million, it represents one of the fastest-growing developer tools in the AI coding market.
+
+According to Google's 2025 DORA Report, 90% of developers now use AI coding assistants, with 65% reporting heavy reliance on these tools. In 2025, 41% of all code is AI-generated or AI-assisted—making the ability to customize and extend AI capabilities more valuable than ever.
+
+In this guide, I'll walk you through Anthropic's official skill-creator methodology—covering everything from core design principles to production deployment patterns.
+
+💡 Quick Start: Don't want to create skills manually? Use our free Claude Code Skills Generator to instantly generate professional SKILL.md files with AI. Just enter your skill name and requirements, and download a ready-to-use .skill file.
+
+🎯 Goal: Master the complete skill creation process: understand the architecture, apply core principles, and build production-ready skills that transform how you work with Claude.
+
+Skills vs Sub-Agents vs MCP
+Before diving into skills, it's important to understand how they compare to other Claude Code extension mechanisms:
+
+Feature	Skills	Sub-Agents	MCP (Model Context Protocol)
+Purpose	Extend Claude with specialized knowledge, workflows, and bundled resources	Spawn autonomous agent instances to handle complex sub-tasks	Connect to external tools and data sources via standardized protocol
+Invocation	Model-invoked (automatic discovery based on context)	Explicitly spawned by parent agent	Tool calls to MCP servers
+Persistence	Loaded into context when triggered	Run independently, return results	Stateless tool execution
+Best For	Domain expertise, workflows, templates, scripts	Parallel task execution, research, exploration	External APIs, databases, file systems, third-party services
+Context Usage	Progressive disclosure (metadata → instructions → resources)	Each sub-agent has own context	Minimal context (tool definitions only)
+Complexity	Low (just SKILL.md + optional files)	Medium (requires orchestration)	Medium-High (requires server setup)
+Examples	Code review guidelines, deployment workflows, brand standards	"Research this topic", "Explore the codebase"	GitHub API, database queries, Slack integration
+💡 When to Use Each:
+
+Skills: When you need Claude to follow specific procedures, use domain knowledge, or execute deterministic scripts repeatedly
+Sub-Agents: When you need to parallelize work, delegate complex research, or isolate task context
+MCP: When you need to interact with external systems, APIs, or real-time data sources
+Skills are the simplest way to extend Claude's capabilities without external infrastructure—making them ideal for packaging team knowledge and workflows.
+
+What Are Claude Code Skills?
+Claude Code Skills structure overview from Anthropic
+The Core Concept
+Skills are modular, self-contained packages that extend Claude's capabilities by providing specialized knowledge, workflows, and tools. Think of them as "onboarding guides" for specific domains or tasks—they transform Claude from a general-purpose agent into a specialized agent equipped with procedural knowledge that no model can fully possess.
+
+According to Anthropic's official skills repository, skills are designed to teach Claude how to complete specific objectives repeatedly—whether that's applying brand guidelines to documents, executing organizational workflows, or automating personal processes.
+
+💡 Expert Insight:
+
+The fundamental innovation of Skills is efficiency. Instead of spending tokens on repeated instructions, you package expertise once and let Claude activate it automatically when relevant. It's the difference between training someone every day versus hiring an expert who already knows the job.
+
+What Skills Provide
+Capability	Description
+Specialized Workflows	Multi-step procedures for specific domains
+Tool Integrations	Instructions for working with file formats or APIs
+Domain Expertise	Company-specific knowledge, schemas, business logic
+Bundled Resources	Scripts, references, and assets for complex tasks
+Key Characteristics
+Feature	Description
+Model-Invoked	Claude automatically discovers and activates skills based on task context
+Progressive Disclosure	Three-tier loading: metadata always loaded, instructions on-demand, resources as-needed
+Self-Contained	Each skill is a complete package with everything needed
+Portable	Same format works across Claude.ai, Claude Code, and API
+Shareable	Distribute via git repositories or plugins
+Core Design Principles
+Before diving into implementation, understand the three principles that separate effective skills from bloated ones.
+
+Principle 1: Concise is Key
+The context window is a public good. Skills share it with everything else Claude needs: system prompt, conversation history, other skills' metadata, and the actual user request.
+
+Default assumption: Claude is already very smart. Only add context Claude doesn't already have.
+
+Challenge each piece of information:
+
+"Does Claude really need this explanation?"
+"Does this paragraph justify its token cost?"
+📌 Pro Tip:
+
+Prefer concise examples over verbose explanations. A single well-crafted example communicates more than paragraphs of description—and costs fewer tokens.
+
+Principle 2: Set Appropriate Degrees of Freedom
+Match the level of specificity to the task's fragility and variability:
+
+Freedom Level	When to Use	Implementation
+High	Multiple valid approaches, context-dependent decisions	Text-based instructions
+Medium	Preferred pattern exists, some variation acceptable	Pseudocode or parameterized scripts
+Low	Fragile operations, consistency critical	Specific scripts, few parameters
+💡 Expert Insight:
+
+Think of Claude as exploring a path: a narrow bridge with cliffs needs specific guardrails (low freedom), while an open field allows many routes (high freedom). Match your skill's guidance to the terrain.
+
+Principle 3: Progressive Disclosure
+Skills use a three-level loading system to manage context efficiently:
+
+Level 1 - Metadata (Always Loaded)
+
+Name and description in YAML frontmatter
+~100 tokens per skill
+Enables discovery without consuming context
+Level 2 - SKILL.md Body (When Triggered)
+
+Main instructions and procedures
+Target under 500 lines / 5k tokens
+Loaded when Claude determines skill is relevant
+Level 3 - Bundled Resources (As Needed)
+
+Scripts, references, assets
+Unlimited capacity
+Scripts can execute without loading into context
+⚠️ Warning: Keep SKILL.md body to essentials and under 500 lines. If approaching this limit, split content into separate reference files. This prevents context bloat while maintaining capability.
+
+Anatomy of a Skill
+SKILL.md file anatomy and structure
+Required Structure
+Every skill follows this structure:
+
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter metadata (required)
+│   │   ├── name: (required)
+│   │   └── description: (required)
+│   └── Markdown instructions (required)
+└── Bundled Resources (optional)
+    ├── scripts/     - Executable code
+    ├── references/  - Documentation for context
+    └── assets/      - Files for output (templates, etc.)
+SKILL.md Format
+---
+name: your-skill-name
+description: What this skill does and when to use it. Include trigger contexts, file types, task types, and keywords users might mention.
+---
+ 
+# Your Skill Name
+ 
+[Instructions section]
+Clear, step-by-step guidance for Claude.
+ 
+[Examples section]
+Concrete input/output examples.
+Frontmatter Requirements
+Field	Required	Constraints
+name	Yes	Lowercase, hyphens allowed, max 64 chars
+description	Yes	Max 1024 chars, must include WHAT and WHEN
+⚠️ Critical: The description field is the primary triggering mechanism. Include both what the skill does AND specific triggers/contexts for when to use it. The body is only loaded after triggering—putting "When to Use" sections in the body is ineffective.
+
+Bundled Resources
+Bundling additional content in Claude Code Skills
+Scripts (scripts/)
+Executable code (Python/Bash/etc.) for tasks requiring deterministic reliability.
+
+When to include:
+
+Same code being rewritten repeatedly
+Deterministic reliability needed
+Complex operations prone to errors
+Benefits:
+
+Token efficient
+Deterministic results
+Can execute without loading into context
+# Example: scripts/rotate_pdf.py
+#!/usr/bin/env python3
+"""Rotate PDF pages by specified degrees."""
+ 
+import argparse
+from pypdf import PdfReader, PdfWriter
+ 
+def rotate_pdf(input_path, output_path, degrees):
+    reader = PdfReader(input_path)
+    writer = PdfWriter()
+ 
+    for page in reader.pages:
+        page.rotate(degrees)
+        writer.add_page(page)
+ 
+    with open(output_path, "wb") as f:
+        writer.write(f)
+ 
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input", help="Input PDF path")
+    parser.add_argument("output", help="Output PDF path")
+    parser.add_argument("--degrees", type=int, default=90)
+    args = parser.parse_args()
+    rotate_pdf(args.input, args.output, args.degrees)
+References (references/)
+Documentation loaded as needed into context.
+
+When to include:
+
+Database schemas
+API documentation
+Domain knowledge
+Company policies
+Detailed workflow guides
+Best practice: If files are large (>10k words), include grep search patterns in SKILL.md.
+
+📌 Pro Tip:
+
+Information should live in either SKILL.md or references—not both. Keep only essential procedural instructions in SKILL.md; move detailed reference material to references files. This keeps SKILL.md lean while making information discoverable.
+
+Assets (assets/)
+Files not loaded into context but used in output.
+
+When to include:
+
+Templates (PowerPoint, documents)
+Brand assets (logos, images)
+Boilerplate code
+Fonts
+Benefits: Separates output resources from documentation, enables Claude to use files without loading them.
+
+What NOT to Include
+A skill should only contain essential files. Do NOT create:
+
+README.md
+INSTALLATION_GUIDE.md
+QUICK_REFERENCE.md
+CHANGELOG.md
+The skill should contain only what an AI agent needs to do the job—not auxiliary context about creation, setup procedures, or user-facing documentation.
+
+The Six-Step Skill Creation Process
+Progressive disclosure model for Claude Code Skills
+Step 1: Understand with Concrete Examples
+Skip only when usage patterns are already clearly understood.
+
+To create an effective skill, gather concrete examples of how it will be used. Ask questions like:
+
+"What functionality should this skill support?"
+"Can you give examples of how this skill would be used?"
+"What would a user say that should trigger this skill?"
+💡 Expert Insight:
+
+Don't overwhelm users with questions. Start with the most important ones and follow up as needed. Conclude when you have a clear sense of the functionality the skill should support.
+
+Example for an image-editor skill:
+
+User might say: "Remove the red-eye from this image"
+User might say: "Rotate this image 90 degrees"
+User might say: "Resize this photo to 800x600"
+Step 2: Plan Reusable Contents
+Analyze each example by:
+
+Considering how to execute the example from scratch
+Identifying what scripts, references, and assets would help when executing repeatedly
+Example Analysis:
+
+Skill	Example Query	Analysis	Resource Needed
+pdf-editor	"Rotate this PDF"	Requires rewriting same code each time	scripts/rotate_pdf.py
+frontend-builder	"Build me a todo app"	Requires same boilerplate each time	assets/hello-world/ template
+bigquery	"How many users logged in?"	Requires rediscovering schemas	references/schema.md
+📌 Pro Tip: Want to skip the manual setup? Our free Claude Skills Generator can create the initial SKILL.md structure for you in seconds. Just describe your skill, and AI will generate a properly-formatted file ready for customization.
+
+Step 3: Initialize the Skill
+When creating from scratch, use Anthropic's initialization script:
+
+scripts/init_skill.py <skill-name> --path <output-directory>
+The script:
+
+Creates the skill directory at specified path
+Generates SKILL.md template with proper frontmatter
+Creates example resource directories
+Adds example files that can be customized or deleted
+Manual initialization alternative:
+
+mkdir -p my-skill/{scripts,references,assets}
+touch my-skill/SKILL.md
+Step 4: Edit the Skill
+Remember: you're creating this for another instance of Claude to use. Include information that would be beneficial and non-obvious.
+
+Start with Reusable Contents
+Implement the scripts, references, and assets identified in Step 2.
+
+Important: Test all scripts by actually running them. If there are many similar scripts, test a representative sample to ensure they work.
+
+Delete any example files not needed for the skill.
+
+Write the SKILL.md
+Writing guideline: Always use imperative/infinitive form.
+
+Frontmatter example:
+
+---
+name: docx-processor
+description: Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. Use when Claude needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks.
+---
+Body structure:
+
+# Skill Name
+ 
+## Getting Started
+[Essential first steps]
+ 
+## Core Workflows
+[Step-by-step procedures]
+ 
+## Extended Capabilities
+- **Feature A**: See [FEATURE_A.md](references/feature_a.md)
+- **Feature B**: See [FEATURE_B.md](references/feature_b.md)
+ 
+## Examples
+[Concrete input/output pairs]
+Step 5: Package the Skill
+Once development is complete, package into a distributable .skill file:
+
+scripts/package_skill.py <path/to/skill-folder>
+Optional output directory:
+
+scripts/package_skill.py <path/to/skill-folder> ./dist
+The packaging script:
+
+Validates the skill automatically:
+
+YAML frontmatter format and required fields
+Naming conventions and directory structure
+Description completeness and quality
+File organization and resource references
+Packages if validation passes, creating a .skill file (zip format)
+
+If validation fails, fix errors and run again.
+
+Step 6: Iterate Based on Usage
+Skills improve through real-world usage:
+
+Use the skill on real tasks
+Notice struggles or inefficiencies
+Identify updates needed to SKILL.md or resources
+Implement changes and test again
+📌 Pro Tip:
+
+Iteration often happens right after using the skill, with fresh context of how it performed. Capture improvement ideas immediately while they're vivid.
+
+Advanced Skill Patterns
+This section covers advanced patterns for organizing and structuring your skills effectively.
+
+Progressive Disclosure Patterns
+Pattern 1: High-Level Guide with References
+# PDF Processing
+ 
+## Quickstart
+Extract text with pdfplumber:
+[code example]
+ 
+## Additional Capabilities
+- **Form filling**: See [FORMS.md](references/forms.md)
+- **API reference**: See [REFERENCE.md](references/reference.md)
+- **Examples**: See [EXAMPLES.md](references/examples.md)
+Claude loads reference files only when needed.
+
+Pattern 2: Domain-Specific Organization
+For skills with multiple domains, organize by domain:
+
+bigquery-skill/
+├── SKILL.md (overview and navigation)
+└── references/
+    ├── finance.md (revenue, billing metrics)
+    ├── sales.md (opportunities, pipeline)
+    ├── product.md (API usage, features)
+    └── marketing.md (campaigns, attribution)
+When user asks about sales metrics, Claude only reads sales.md.
+
+Pattern 3: Framework/Variant Organization
+For skills supporting multiple frameworks:
+
+cloud-deploy/
+├── SKILL.md (workflow + provider selection)
+└── references/
+    ├── aws.md (AWS deployment patterns)
+    ├── gcp.md (GCP deployment patterns)
+    └── azure.md (Azure deployment patterns)
+When user chooses AWS, Claude only reads aws.md.
+
+Pattern 4: Conditional Details
+Show basic content, link to advanced:
+
+# DOCX Processing
+ 
+## Creating Documents
+ 
+Use docx-js for new documents. See [DOCX-JS.md](references/docx-js.md).
+ 
+## Editing Documents
+ 
+For simple edits, modify the XML directly.
+ 
+**For tracked changes**: See [REDLINING.md](references/redlining.md)
+**For OOXML details**: See [OOXML.md](references/ooxml.md)
+Important Guidelines
+Avoid deeply nested references - Keep references one level deep from SKILL.md
+Structure longer files - For files >100 lines, include a table of contents at top
+Workflow Patterns
+Sequential Workflows
+For complex multi-step tasks, break work into distinct steps with upfront overview:
+
+## Filling a PDF Form
+ 
+This process involves 5 steps:
+ 
+1. Analyze the form structure
+2. Create field mapping
+3. Validate the mapping
+4. Fill the form
+5. Verify the output
+ 
+### Step 1: Analyze the Form
+ 
+[Detailed instructions]
+ 
+### Step 2: Create Field Mapping
+ 
+[Detailed instructions]
+...
+Conditional Workflows
+For tasks with decision branches:
+
+## Document Processing
+ 
+First, determine the task type:
+ 
+- **Creating new document**: Go to Section A
+- **Editing existing document**: Go to Section B
+- **Converting format**: Go to Section C
+ 
+### Section A: Creating New Documents
+ 
+[Specific steps for creation]
+ 
+### Section B: Editing Existing Documents
+ 
+[Specific steps for editing]
+...
+Output Patterns
+Template Pattern (Strict)
+For scenarios demanding precision:
+
+## Report Format
+ 
+ALWAYS use this exact structure:
+ 
+### Executive Summary
+ 
+[2-3 sentences summarizing findings]
+ 
+### Key Findings
+ 
+1. [Finding with supporting data]
+2. [Finding with supporting data]
+ 
+### Recommendations
+ 
+- [Actionable recommendation]
+- [Actionable recommendation]
+Template Pattern (Flexible)
+When adaptation adds value:
+
+## Analysis Format
+ 
+Use this suggested structure, adjusting as needed:
+ 
+- **Overview**: Context and scope
+- **Analysis**: Key observations
+- **Insights**: Patterns and implications
+- **Next Steps**: Recommended actions
+ 
+Use your best judgment on section depth and detail.
+Examples Pattern
+For stylistic consistency, include input/output pairs:
+
+## Commit Message Examples
+ 
+**Input**: Added user authentication
+**Output**: feat(auth): implement JWT-based user authentication
+ 
+**Input**: Fixed bug in payment processing
+**Output**: fix(payments): resolve race condition in checkout flow
+ 
+**Input**: Updated dependencies
+**Output**: chore(deps): bump axios to 1.6.0, update lodash
+💡 Expert Insight:
+
+Examples help Claude understand desired style and detail more clearly than descriptions alone. When output quality depends on stylistic consistency, invest in good examples.
+
+Real-World Skill Examples
+How context window changes when skills are triggered
+Example 1: API Documentation Skill
+---
+name: api-documenter
+description: Generate and maintain API documentation from code. Use when documenting REST APIs, generating OpenAPI specs, creating SDK documentation, or maintaining API reference guides. Triggers on requests involving API docs, endpoint documentation, or Swagger/OpenAPI.
+---
+ 
+# API Documentation Skill
+ 
+Generate comprehensive API documentation from source code and specifications.
+ 
+## Usage
+ 
+For OpenAPI generation:
+python scripts/generate_openapi.py --input ./routes --output api-spec.yaml
+ 
+## Documentation Templates
+ 
+### Endpoint Documentation
+  ## [METHOD] /path/to/endpoint
+ 
+  **Description**: What this endpoint does
+ 
+  **Authentication**: Required/Optional
+ 
+  **Parameters**:
+  | Name | Type | Required | Description |
+  |------|------|----------|-------------|
+ 
+  **Response**: { "example": "response" }
+ 
+## Extra Features
+- **SDK generation**: See [SDK.md](references/sdk.md)
+- **Versioning**: See [VERSIONING.md](references/versioning.md)
+Example 2: Database Migration Skill
+---
+name: db-migrator
+description: Create and manage database migrations for PostgreSQL, MySQL, and SQLite. Use when generating migrations, handling schema changes, managing rollbacks, or working with ORMs like Prisma or TypeORM. Triggers on migration requests, schema changes, or database versioning.
+---
+ 
+# Database Migration Skill
+ 
+Create safe, reversible database migrations.
+ 
+## Workflow
+ 
+1. Analyze current schema
+2. Determine required changes
+3. Generate migration files
+4. Validate migration safety
+5. Provide rollback strategy
+ 
+## Migration Safety Checks
+ 
+Before any destructive operation:
+- Verify no data loss
+- Check foreign key constraints
+- Estimate lock duration
+- Prepare rollback script
+ 
+## Framework-Specific Guides
+- **Prisma**: See [PRISMA.md](references/prisma.md)
+- **TypeORM**: See [TYPEORM.md](references/typeorm.md)
+- **Raw SQL**: See [RAW_SQL.md](references/raw_sql.md)
+Example 3: Code Review Skill
+---
+name: code-reviewer
+description: Perform comprehensive code reviews focusing on security, performance, and maintainability. Use when reviewing pull requests, auditing code quality, checking for vulnerabilities, or ensuring best practices. Triggers on review requests, PR analysis, or security audits.
+---
+ 
+# Code Review Skill
+ 
+Systematic code review with security, performance, and quality focus.
+ 
+## Review Checklist
+ 
+### Security (Critical)
+- [ ] SQL injection vulnerabilities
+- [ ] XSS attack vectors
+- [ ] Hardcoded secrets/credentials
+- [ ] Authentication bypass risks
+- [ ] Input validation gaps
+ 
+### Performance
+- [ ] N+1 query patterns
+- [ ] Memory leak potential
+- [ ] Inefficient algorithms
+- [ ] Missing indexes
+ 
+### Quality
+- [ ] DRY violations
+- [ ] Dead code
+- [ ] Complex functions (>50 lines)
+- [ ] Missing error handling
+ 
+## Output Format
+ 
+[SEVERITY] Issue title Location: file:line Problem: What's wrong Impact: Why it matters Fix: How to resolve
+
+
+## Language-Specific Guides
+- **JavaScript/TypeScript**: See [JS.md](references/js.md)
+- **Python**: See [PYTHON.md](references/python.md)
+- **Go**: See [GO.md](references/go.md)
+Deployment and Production
+Storing and Sharing Skills
+Personal Skills
+Available across all your projects:
+
+~/.claude/skills/skill-name/SKILL.md
+Project Skills
+Shared with team via git:
+
+.claude/skills/skill-name/SKILL.md
+Installing from Marketplace
+Register the Anthropic skills repository as a plugin:
+
+/plugin marketplace add anthropics/skills
+Then browse and install specific skill sets:
+
+/plugin install document-skills@anthropic-agent-skills
+Once installed, skills activate automatically when you mention relevant tasks.
+
+Production Considerations
+Code execution via Claude Code Skills
+Validation Checklist
+Before deploying a skill:
+
+ YAML frontmatter is valid
+ Description includes what AND when
+ All scripts tested and working
+ References properly linked from SKILL.md
+ No duplicate information between SKILL.md and references
+ Total SKILL.md under 500 lines
+ No extraneous documentation files
+Security Best Practices
+⚠️ Warning: Always audit skills before using them, especially from external sources. Check for unexpected network calls, file modifications, or data exfiltration patterns.
+
+Environment Variables:
+
+Never hardcode API keys or secrets in skills
+Reference environment variables: $API_KEY
+Document required variables in SKILL.md
+Tool Restrictions:
+
+Use allowed-tools in frontmatter when appropriate
+Restrict to read-only tools for sensitive operations
+Performance Optimization
+Token Efficiency:
+
+Minimize SKILL.md size
+Use references for detailed content
+Provide examples instead of explanations
+Loading Optimization:
+
+Structure references by domain
+Include table of contents in large files
+Use clear file naming for quick discovery
+Frequently Asked Questions
+What is a Claude Code Skill?
+
+A skill is a modular package containing instructions, scripts, and resources that Claude can discover and load dynamically. It transforms Claude from a general-purpose assistant into a specialized agent for specific tasks.
+
+How does Claude discover my skill?
+
+Claude reads skill metadata (name and description) at startup. When a request matches the description, Claude loads the full SKILL.md and follows its instructions. This is called "progressive disclosure."
+
+Where should I store my skills?
+
+Personal skills go in ~/.claude/skills/ for cross-project use. Project skills go in .claude/skills/ to share with team members via git.
+
+What's the difference between skills and slash commands?
+
+Slash commands are user-invoked (/command) and execute immediately. Skills are model-invoked—Claude automatically discovers and uses them based on context. Skills are better for complex, multi-step capabilities.
+
+How do I restrict what tools a skill can use?
+
+Add allowed-tools to your YAML frontmatter. For example: allowed-tools: Bash, Read, Grep prevents file modifications while allowing read operations.
+
+What should I put in the description field?
+
+Include both WHAT the skill does and WHEN to use it. Add trigger contexts, file types, task types, and keywords users might mention. This is the primary mechanism for skill discovery.
+
+How long should SKILL.md be?
+
+Keep it under 500 lines. If approaching this limit, split content into reference files. Link to them clearly from SKILL.md so Claude knows they exist.
+
+Can skills include executable code?
+
+Yes. Put scripts in the scripts/ directory. These can be Python, Bash, or any executable. Scripts provide deterministic reliability and can execute without loading into context.
+
+How do I debug a skill that isn't working?
+
+Check that YAML frontmatter is valid, description includes relevant trigger words, and the file is in the correct location. Ask Claude "What skills are available?" to verify discovery.
+
+Can I share skills with my team?
+
+Yes. Store skills in .claude/skills/ within your project and commit to git. Team members who clone the repository automatically have access.
+
+Conclusion
+Related Resources
+Anthropic Skills Repository - Official skills collection and examples
+Anthropic Agent Skills Blog - Deep dive into skill architecture
+Claude Code Documentation - Official Claude Code docs
+Claude Code Skills Generator - Free tool to instantly generate SKILL.md files with AI
+Web Search Agent Skills Guide - Build web search skills with WebSearchAPI.ai
+Zapier Skill for Claude - Ready-to-use automation skill
+WebSearchAPI.ai Documentation - API reference for web search integration
+Building Your Skill Library
+Claude Code Skills represent a fundamental shift in how we work with AI assistants. Instead of starting from scratch every conversation, you can package your expertise into reusable modules that compound in value over time.
+
+Key Takeaways
+For Individual Developers:
+
+Start with skills that automate your most repetitive tasks
+Keep SKILL.md lean—under 500 lines
+Use progressive disclosure to manage complexity
+Test scripts thoroughly before packaging
+For Teams:
+
+Store shared skills in .claude/skills/ for git distribution
+Document skills thoroughly for team adoption
+Use allowed-tools for security-sensitive operations
+Treat skills as reusable team assets
+For Production:
+
+Validate all skills before deployment
+Audit third-party skills for security
+Monitor skill usage patterns
+Iterate based on real-world performance
+🚀 Get Started Fast: Try our free Claude Code Skills Generator to create your first skill in seconds. No manual formatting required—just describe what you need, and download a ready-to-use .skill file.
+
+⭐ Key Takeaway: The best skills are invisible—they activate when needed and deliver exactly what's required without fanfare. Start with one skill that solves your biggest pain point, iterate based on usage, and build your library over time. The compound effect of well-crafted skills transforms your entire workflow.
+
+Last updated: December 2025
+
+On This Page
+Introduction: Why Skills Matter for Claude Code
+—Skills vs Sub-Agents vs MCP
+What Are Claude Code Skills?
+Core Design Principles
+Anatomy of a Skill
+The Six-Step Skill Creation Process
+Advanced Skill Patterns
+Real-World Skill Examples
+Deployment and Production
+Frequently Asked Questions
+Conclusion
+Footer
+Accurate. Extracted. Ready for RAG. All through one powerful Web Search API.
+
+Product
+Web Search API
+Web Scraping API
+Resources
+API Playground
+Claude Skills Generator
+Docs
+Roadmap
+Contact
+About
+Story
+Blog
+Careers
+Legal
+Terms of Use
+Privacy Policy
+Cookie Policy
+Subscribe to our newsletter
+Enter your email
+Subscribe
+Made in London © 2026 WebsearchAPI.ai. All rights reserved.
+
+X (formerly Twitter)
+LinkedIn
+
+
+
+We use cookies primarily for analytics and to enhance your experience. By accepting you agree to our use of cookies. Learn more
+
+Deny
+Accept


### PR DESCRIPTION
This PR enhances the PACT framework with Claude Code's latest capabilities:

## Skills System (installed at ~/.claude/skills/)
- pact-security-patterns: SACROSANCT rules, OWASP, auth patterns
- pact-prepare-research: Research methodologies and templates
- pact-architecture-patterns: C4 diagrams, design patterns
- pact-testing-strategies: Test pyramid, integration patterns
- pact-coding-standards: Clean code, error handling

## Enhanced Hooks
- session_init.py: Detects active plans at session start
- validate_handoff.py: Validates PACT agent handoff format
- phase_completion.py: Reminds about decision logs after CODE phase
- git_commit_check.py: Enhanced with SACROSANCT security enforcement

## Agent Updates
- All 6 agents now have Reference Skills sections
- Progressive disclosure reduces context consumption by 60-70%

## Documentation
- claude-changelog.md: Claude Code version history
- skills-howto.md: Guide for creating Claude Code skills

Note: Skills are user-level (~/.claude/skills/) and must be installed separately. See skills-howto.md for installation guidance.