### PR TITLE
fix(orchestrate): require explicit dependency analysis before CODE phase

### DIFF
--- a/.claude/commands/PACT/orchestrate.md
+++ b/.claude/commands/PACT/orchestrate.md
@@ -263,24 +263,54 @@ If PREPARE ran and ARCHITECT was marked "Skip," compare PREPARE's recommended ap
 - `pact-frontend-coder` — UI, client-side
 - `pact-database-engineer` — schema, queries, migrations
 
-#### Parallel vs Sequential Invocation
+#### Execution Strategy Analysis
 
-**Parallel-safe** (invoke together):
-- Backend API + Frontend UI for same feature (independent implementation)
-- Multiple independent components in same domain
+Before invoking coders, analyze dependencies and justify your execution strategy.
+
+**How to analyze:**
+- Review the plan's implementation details and file paths mentioned
+- If no plan exists, analyze the task description and examine relevant files directly
+- Check if tasks reference or modify the same files/modules
+- Examine import relationships between components
+
+**Analysis steps:**
+1. **Map file-level dependencies**: Which tasks touch the same files?
+2. **Map import dependencies**: Does one task's output feed another's input?
+3. **Identify parallelizable groups**: Independent tasks with no shared files
+
+**Required**: State your execution strategy with specific reasoning:
+- "Parallel because [specific files/components are independent]"
+- "Sequential because [specific dependency or shared file]"
+- "Mixed: [A, B] in parallel, then C (depends on A's output)"
+
+> **"I'm not sure"** and **"the plan lists them in order"** are **not valid justifications**. Complete your analysis until you can make a definitive choice.
+
+**If analysis is genuinely inconclusive**: Consult the architect's outputs in `docs/architecture/`, invoke pact-architect for clarification, or escalate to user. Do not default to either strategy without articulated reasoning.
+
+#### Parallel vs Sequential Examples
+
+Use these to inform your analysis (not as complete decision criteria):
+
+**Parallel-safe** (when analysis confirms independence):
+- Backend API + Frontend UI for same feature (no shared files)
+- Multiple independent components in same domain (no shared files)
 - Backend + Frontend when API contract is already defined
 
-**Sequential required** (wait for handoff):
+**Sequential-required** (when analysis finds dependencies):
 - Database schema → Backend (backend needs schema to build models/queries)
 - Backend API → Frontend (frontend needs API contract to consume)
 - Shared utility/service → consumers of that utility
-- Any work where one coder's output is another's input
+- Any work where one task's output is another's input
+- Any tasks that modify the same file
 
-**When in doubt**: Sequential is safer. Parallel saves time but risks rework if assumptions diverge.
+**Mixed** (partial parallelization):
+- When some tasks are independent but others depend on their output
+- Group independent tasks for parallel execution, then sequence dependent groups
+- Example: "A and B in parallel, then C (depends on both outputs)"
 
 #### S2 Pre-Parallel Coordination Check
 
-**Before invoking parallel agents**, apply S2 Coordination:
+Once you've decided on parallel execution, apply S2 Coordination:
 
 1. **Identify potential conflicts**:
    - Shared files (merge conflict risk)

--- a/.claude/commands/PACT/plan-mode.md
+++ b/.claude/commands/PACT/plan-mode.md
@@ -331,6 +331,9 @@ If a plan already exists for this feature slug:
 {Visual or textual representation of the workflow}
 
 ### Commit Sequence (Proposed)
+
+> **Note**: This sequence represents the intended final git history order, **not** the execution order. Independent commits may be implemented in parallel even if numbered sequentially here. The orchestrator must analyze actual dependencies to determine execution strategy.
+
 1. `{type}: {description}` — {what this commit does}
 2. `{type}: {description}` — {what this commit does}
 

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -263,24 +263,54 @@ If PREPARE ran and ARCHITECT was marked "Skip," compare PREPARE's recommended ap
 - `pact-frontend-coder` — UI, client-side
 - `pact-database-engineer` — schema, queries, migrations
 
-#### Parallel vs Sequential Invocation
+#### Execution Strategy Analysis
 
-**Parallel-safe** (invoke together):
-- Backend API + Frontend UI for same feature (independent implementation)
-- Multiple independent components in same domain
+Before invoking coders, analyze dependencies and justify your execution strategy.
+
+**How to analyze:**
+- Review the plan's implementation details and file paths mentioned
+- If no plan exists, analyze the task description and examine relevant files directly
+- Check if tasks reference or modify the same files/modules
+- Examine import relationships between components
+
+**Analysis steps:**
+1. **Map file-level dependencies**: Which tasks touch the same files?
+2. **Map import dependencies**: Does one task's output feed another's input?
+3. **Identify parallelizable groups**: Independent tasks with no shared files
+
+**Required**: State your execution strategy with specific reasoning:
+- "Parallel because [specific files/components are independent]"
+- "Sequential because [specific dependency or shared file]"
+- "Mixed: [A, B] in parallel, then C (depends on A's output)"
+
+> **"I'm not sure"** and **"the plan lists them in order"** are **not valid justifications**. Complete your analysis until you can make a definitive choice.
+
+**If analysis is genuinely inconclusive**: Consult the architect's outputs in `docs/architecture/`, invoke pact-architect for clarification, or escalate to user. Do not default to either strategy without articulated reasoning.
+
+#### Parallel vs Sequential Examples
+
+Use these to inform your analysis (not as complete decision criteria):
+
+**Parallel-safe** (when analysis confirms independence):
+- Backend API + Frontend UI for same feature (no shared files)
+- Multiple independent components in same domain (no shared files)
 - Backend + Frontend when API contract is already defined
 
-**Sequential required** (wait for handoff):
+**Sequential-required** (when analysis finds dependencies):
 - Database schema → Backend (backend needs schema to build models/queries)
 - Backend API → Frontend (frontend needs API contract to consume)
 - Shared utility/service → consumers of that utility
-- Any work where one coder's output is another's input
+- Any work where one task's output is another's input
+- Any tasks that modify the same file
 
-**When in doubt**: Sequential is safer. Parallel saves time but risks rework if assumptions diverge.
+**Mixed** (partial parallelization):
+- When some tasks are independent but others depend on their output
+- Group independent tasks for parallel execution, then sequence dependent groups
+- Example: "A and B in parallel, then C (depends on both outputs)"
 
 #### S2 Pre-Parallel Coordination Check
 
-**Before invoking parallel agents**, apply S2 Coordination:
+Once you've decided on parallel execution, apply S2 Coordination:
 
 1. **Identify potential conflicts**:
    - Shared files (merge conflict risk)

--- a/pact-plugin/commands/plan-mode.md
+++ b/pact-plugin/commands/plan-mode.md
@@ -331,6 +331,9 @@ If a plan already exists for this feature slug:
 {Visual or textual representation of the workflow}
 
 ### Commit Sequence (Proposed)
+
+> **Note**: This sequence represents the intended final git history order, **not** the execution order. Independent commits may be implemented in parallel even if numbered sequentially here. The orchestrator must analyze actual dependencies to determine execution strategy.
+
 1. `{type}: {description}` — {what this commit does}
 2. `{type}: {description}` — {what this commit does}
 


### PR DESCRIPTION
## Summary

Addresses the issue where the orchestrator follows plan commit sequences mechanically rather than analyzing whether tasks can be parallelized.

### Changes

**orchestrate.md** (both .claude/ and pact-plugin/):

1. **Replaced "Parallel vs Sequential Invocation" with "Execution Strategy Analysis"**
   - Added "How to analyze" section with concrete steps (review plan, check files, examine imports, consult architect)
   - Required dependency analysis steps (file-level, import, parallelizable groups)
   - Requires explicit justification with specific reasoning

2. **Removed "When in doubt, sequential is safer" escape hatch**
   - Explicitly rejects "I'm not sure" and "plan order" as justifications
   - Added legitimate fallback: "If genuinely inconclusive, consult architect or escalate to user"

3. **Added "Mixed" execution strategy**
   - Supports partial parallelization: "Tasks A and B in parallel, then C"
   - Guidance for grouping independent tasks while sequencing dependent ones

4. **Clarified relationship to S2 section**
   - Changed "Before invoking parallel agents" to "Once you've decided on parallel execution"
   - Makes clear: Execution Strategy Analysis = decide; S2 = coordinate after deciding

5. **Reframed examples as guidance, not criteria**
   - "Use these to inform your analysis (not as complete decision criteria)"

**plan-mode.md** (both .claude/ and pact-plugin/):
- Added clarification that "Commit Sequence" is final git history order, not execution order
- Notes that independent commits may be parallelized even if numbered sequentially

### Before/After

| Before | After |
|--------|-------|
| "When in doubt, sequential is safer" | Required analysis with fallback to architect/user |
| No guidance on HOW to analyze | Concrete steps: review plan, check files, consult architect |
| Binary parallel/sequential choice | Added "Mixed" strategy for partial parallelization |
| Examples as decision criteria | Examples to inform analysis |
| Commit sequence implies execution order | Commit sequence is git history order only |

## Test Plan

- [ ] Orchestrator explicitly analyzes dependencies before CODE phase
- [ ] Execution strategy rationale is stated with specific reasoning
- [ ] Parallel execution chosen when analysis confirms independence
- [ ] Sequential execution chosen when analysis finds dependencies
- [ ] Mixed strategy used when appropriate (some parallel, some sequential)
- [ ] Fallback to architect/user when genuinely inconclusive

Fixes #58