### PR TITLE
fix(orchestrate): correct TEST phase skip criterion

### DIFF
--- a/.claude/commands/PACT/orchestrate.md
+++ b/.claude/commands/PACT/orchestrate.md
@@ -129,7 +129,7 @@ Before executing phases, assess which are needed based on existing context:
 | **PREPARE** | Requirements unclear, external APIs to research, dependencies unmapped | Approved plan exists with Preparation Phase section, OR requirements explicit in task, OR existing `docs/preparation/` covers scope |
 | **ARCHITECT** | New component or module, interface contracts undefined, architectural decisions required | Approved plan exists with Architecture Phase section, OR following established patterns, OR `docs/architecture/` covers design |
 | **CODE** | Always run | Never skip |
-| **TEST** | Integration/E2E tests needed, complex component interactions, security/performance verification | Trivial change (no new logic requiring tests), no integration boundaries crossed, isolated change with no meaningful test scenarios |
+| **TEST** | Integration/E2E tests needed, complex component interactions, security/performance verification | Trivial change (no new logic requiring tests) AND no integration boundaries crossed AND isolated change with no meaningful test scenarios |
 
 **Conflict resolution**: When both "Run if" and "Skip if" criteria apply, **run the phase** (safer default). Example: A plan exists but requirements have changed—run PREPARE to validate.
 

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -129,7 +129,7 @@ Before executing phases, assess which are needed based on existing context:
 | **PREPARE** | Requirements unclear, external APIs to research, dependencies unmapped | Approved plan exists with Preparation Phase section, OR requirements explicit in task, OR existing `docs/preparation/` covers scope |
 | **ARCHITECT** | New component or module, interface contracts undefined, architectural decisions required | Approved plan exists with Architecture Phase section, OR following established patterns, OR `docs/architecture/` covers design |
 | **CODE** | Always run | Never skip |
-| **TEST** | Integration/E2E tests needed, complex component interactions, security/performance verification | Trivial change (no new logic requiring tests), no integration boundaries crossed, isolated change with no meaningful test scenarios |
+| **TEST** | Integration/E2E tests needed, complex component interactions, security/performance verification | Trivial change (no new logic requiring tests) AND no integration boundaries crossed AND isolated change with no meaningful test scenarios |
 
 **Conflict resolution**: When both "Run if" and "Skip if" criteria apply, **run the phase** (safer default). Example: A plan exists but requirements have changed—run PREPARE to validate.
 


### PR DESCRIPTION
## Summary

Fixed multiple issues with TEST phase skip criterion and related documentation inconsistencies.

### Changes Made

1. **Skip criterion fix** - Removed incorrect "unit tests from coders sufficient" (coders only do smoke tests)
2. **Explicit AND** - Made logical AND explicit in skip criteria (consistent with OR in other phases)
3. **Duplicate file sync** - Applied all fixes to `pact-plugin/commands/orchestrate.md`
4. **Handoff example fix** - Changed "unit tests passing" → "smoke tests passing"
5. **Example consistency fix** - Made the skip example internally consistent

## Problem

The orchestrate.md skip criterion said:
> Skip if: "Unit tests from coders sufficient..."

But coder agents explicitly state:
> "No comprehensive unit tests—that's TEST phase work."

This caused the orchestrator to skip TEST phase thinking coders had written unit tests when they only performed smoke tests.

## Detailed Changes

### 1. Skip Criterion (line 132)

| Before | After |
|--------|-------|
| Unit tests from coders sufficient, no integration boundaries crossed, isolated change | Trivial change (no new logic requiring tests) **AND** no integration boundaries crossed **AND** isolated change with no meaningful test scenarios |

*Note: PREPARE/ARCHITECT use explicit "OR" (any condition allows skip). TEST now uses explicit "AND" (all conditions required to skip) - appropriately restrictive for the final quality gate.*

### 2. Example Text (line 148)

| Before | After |
|--------|-------|
| Running PREPARE (external API needs research)... Skipping TEST (isolated change, unit tests sufficient) | Skipping PREPARE (requirements explicit in task)... Skipping TEST (trivial change, no new logic to test) |

*The old example was internally inconsistent - if researching an external API, it's not a trivial change.*

### 3. Handoff Example (line 190)

| Before | After |
|--------|-------|
| ...unit tests passing... | ...smoke tests passing... |

## Files Changed

- `.claude/commands/PACT/orchestrate.md` - All fixes
- `pact-plugin/commands/orchestrate.md` - All fixes (kept in sync)

## Commits

1. `1ae6153` - Initial fix for skip criterion
2. `7cec090` - Sync pact-plugin copy + fix handoff example
3. `f10e0c8` - Make example internally consistent
4. `bf835ce` - Make AND explicit in skip criteria

## Test Plan

- [x] Verify no "unit tests from coders" references remain
- [x] Confirm both orchestrate.md files are identical
- [x] Skip criteria uses explicit logical operators (OR/AND)
- [ ] Verify orchestrator uses new skip criterion correctly
- [ ] Confirm TEST phase runs for substantive code changes

Fixes #62