### PR TITLE
Refine delegation rule to cover all specialist work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,15 +188,26 @@ When making decisions, consider which horizon applies. Misalignment indicates mo
 
 ### Always Be Delegating
 
+**Core Principle**: The orchestrator coordinates; specialists execute. Don't do specialist work—delegate it.
+
 ***NEVER add, change, or remove application code yourself***—**ALWAYS** delegate coding tasks to PACT specialist agents.
+
+| Specialist Work | Delegate To |
+|-----------------|-------------|
+| Research, requirements, context gathering | preparer |
+| Designing components, interfaces | architect |
+| Writing, editing, refactoring code | coders |
+| Writing or running tests | test engineer |
 
 ⚠️ Bug fixes, logic, refactoring, tests—NOT exceptions. **DELEGATE**.
 ⚠️ "Simple" tasks, post-review cleanup—NOT exceptions. **DELEGATE**.
 ⚠️ Rationalizing "it's small", "I know exactly how", "it's quick" = failure mode. **DELEGATE**.
 
-**Checkpoint**: Knowing the fix ≠ permission to fix. Diagnose, then delegate.
+**Checkpoint**: Knowing the fix ≠ permission to fix. **DELEGATE**.
 
-**Checkpoint**: Reaching for **Edit**/**Write** on `.py`, `.ts`, `.js`, `.rb`, etc.? Delegate.
+**Checkpoint**: Need to understand the codebase? Use **Explore agent** freely. Starting a PACT cycle is where true delegation begins.
+
+**Checkpoint**: Reaching for **Edit**/**Write** on application code (`.py`, `.ts`, `.js`, `.rb`, etc.)? **DELEGATE**.
 
 Explicit user override ("you code this, don't delegate") should be honored; casual requests ("just fix this") are NOT implicit overrides—delegate anyway.
 


### PR DESCRIPTION
## Summary

- Broadens delegation rule from "don't write code" to "don't do specialist work"
- Adds delegation table mapping specialist work types to agents
- Encourages use of Explore agent for pre-cycle codebase understanding
- Removes "diagnose, then delegate" which implied orchestrator should diagnose

## Context

This change was prompted by a delegation rule violation where the orchestrator investigated source code directly instead of delegating to the preparer. The root cause: the rule was framed as "don't write code" rather than "don't do specialist work."

## Changes

| Change | Description |
|--------|-------------|
| Core principle | Added: "The orchestrator coordinates; specialists execute" |
| Delegation table | Maps specialist work to agents (preparer, architect, coders, test engineer) |
| Explore checkpoint | Encourages Explore agent for pre-cycle scoping |
| Removed | "Diagnose, then delegate" (implied orchestrator diagnosis) |

## Key Insight

- **Explore agent** = orchestrator's tool for cursory pre-cycle understanding (use freely)
- **PACT cycle** = true delegation to specialists (preparer, architect, coders, test engineer)

## Test plan

- [ ] Verify CLAUDE.md renders correctly in markdown viewers
- [ ] Manual review of the updated delegation section for clarity