### PR TITLE
feat(policy): Add User Approval non-negotiable to prevent premature PR merges

### DIFF
--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -20,6 +20,7 @@ This section defines the non-negotiable boundaries within which all operations o
 | **Quality** | Merge known-broken code, skip tests | Verify tests pass before PR |
 | **Ethics** | Generate deceptive or harmful content | Maintain honesty and transparency |
 | **Delegation** | Write application code directly | Delegate to specialist agents |
+| **User Approval** | Merge or close PRs without explicit user authorization | Wait for user's decision |
 
 **If a non-negotiable would be violated**: Stop work and report to user. No operational pressure justifies crossing these boundaries.
 
@@ -30,6 +31,7 @@ This section defines the non-negotiable boundaries within which all operations o
 | Before CODE phase | Architecture aligns with project principles |
 | Before using Edit/Write | "Am I about to edit application code?" → Delegate if yes |
 | Before creating PR | Tests pass; system integrity maintained |
+| After PR review completes | Present findings to user; await their merge decision |
 | On specialist conflict | Project values guide resolution |
 | On repeated blockers | Escalate to user if viability threatened |
 

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -331,9 +331,10 @@ If a sub-task emerges that is too complex for a single specialist invocation:
 
 ## After All Phases Complete
 
-> **S5 Policy Checkpoint (Pre-Merge)**: Before creating PR, verify: "Do all tests pass? Is system integrity maintained? Have S5 non-negotiables been respected throughout?"
+> **S5 Policy Checkpoint (Pre-PR)**: Before creating PR, verify: "Do all tests pass? Is system integrity maintained? Have S5 non-negotiables been respected throughout?"
 
 1. **Update plan status** (if plan exists): IN_PROGRESS → IMPLEMENTED
 2. **Run `/PACT:peer-review`** to commit, create PR, and get multi-agent review
-3. **S4 Retrospective**: Briefly note—what worked well? What should we adapt for next time?
-4. **High-variety audit trail** (variety 10+ only): Delegate to `pact-memory-agent` to save key orchestration decisions, S3/S4 tensions resolved, and lessons learned. This preserves the audit trail that formal decision logs previously provided.
+3. **Present review summary and stop** — orchestrator never merges (S5 policy)
+4. **S4 Retrospective** (after user decides): Briefly note—what worked well? What should we adapt for next time?
+5. **High-variety audit trail** (variety 10+ only): Delegate to `pact-memory-agent` to save key orchestration decisions, S3/S4 tensions resolved, and lessons learned

--- a/pact-plugin/commands/peer-review.md
+++ b/pact-plugin/commands/peer-review.md
@@ -23,4 +23,7 @@ Select the domain coder based on PR focus:
 - Database changes → **pact-database-engineer** (Query efficiency, schema design, data integrity)
 - Multiple domains → Coder for domain with most significant changes, or all relevant domain coders if changes are equally significant
 
-**After all reviews complete**: Synthesize findings into a unified review summary with consolidated recommendations, noting areas of agreement and any conflicting opinions.
+**After all reviews complete**:
+1. Synthesize findings into a unified review summary with consolidated recommendations
+2. State merge readiness: "Ready to merge" or "Changes requested: [specifics]"
+3. Present to user and **stop** — merging requires explicit user authorization (S5 policy)

--- a/pact-plugin/protocols/pact-s5-policy.md
+++ b/pact-plugin/protocols/pact-s5-policy.md
@@ -12,6 +12,7 @@ These rules are **never** overridden by operational pressure:
 | **Quality** | No known-broken code merged; tests must pass | Maintains system integrity |
 | **Ethics** | No deceptive outputs; no harmful content | Aligns with responsible AI principles |
 | **Delegation** | Orchestrator never writes application code | Maintains role boundaries |
+| **User Approval** | Never merge PRs without explicit user authorization | User controls their codebase |
 
 **If a rule would be violated**: Stop work, report to user. These are not trade-offs—they are boundaries.
 
@@ -54,7 +55,8 @@ At defined points, verify alignment with project principles:
 |------------|------|----------|
 | **Pre-CODE** | Before CODE phase begins | "Does the architecture align with project principles?" |
 | **Pre-Edit** | Before using Edit/Write tools | "Is this application code? If yes, delegate." |
-| **Pre-Merge** | Before creating PR | "Does this maintain system integrity? Are tests passing?" |
+| **Pre-PR** | Before creating PR | "Does this maintain system integrity? Are tests passing?" |
+| **Post-Review** | After PR review completes | "Have I presented findings to user? Am I waiting for their merge decision?" |
 | **On Conflict** | When specialists disagree | "What do project values dictate?" |
 | **On Blocker** | When normal flow can't proceed | "Is this an operational issue (imPACT) or viability threat (escalate to user)?" |
 
@@ -66,6 +68,10 @@ The **user is ultimate S5**. When conflicts cannot be resolved at lower levels:
 - Unclear non-negotiable boundaries → Escalate to user
 
 The orchestrator has authority to make operational decisions within policy. It does not have authority to override policy.
+
+### Merge Authorization Boundary
+
+**Never merge or close PRs without explicit user approval.** Present review findings, state merge readiness, then stop and wait. "All reviewers approved" ≠ user authorized merge.
 
 ### S5 Decision Framing Protocol
 


### PR DESCRIPTION
## Summary

- Adds **User Approval** to S5 non-negotiables: orchestrator cannot merge/close PRs without explicit user authorization
- Adds **Post-Review** policy checkpoint for awaiting user's merge decision
- Adds **Merge Authorization Boundary** section to S5 policy protocol
- Updates peer-review and orchestrate commands with one-liner references to S5 policy

## Problem

In another project, the orchestrator prematurely merged a PR after `/PACT:peer-review` completed, interpreting "all reviewers approved" as authorization to merge.

## Solution

Establish merge authorization as an S5 policy boundary - the orchestrator can execute merges, but only after explicit user approval. Review approval ≠ merge authorization.

## Test plan

- [ ] Verify new non-negotiable appears in CLAUDE.md S5 Policy table
- [ ] Verify Post-Review checkpoint appears in Policy Checkpoints table
- [ ] Verify Merge Authorization Boundary section exists in pact-s5-policy.md
- [ ] Verify peer-review.md ends with "(S5 policy)" reference
- [ ] Verify orchestrate.md step 3 includes "(S5 policy)" reference