### PR TITLE
docs(commands): reinforce parallel-first defaults in orchestration

### DIFF
--- a/pact-plugin/commands/comPACT.md
+++ b/pact-plugin/commands/comPACT.md
@@ -1,10 +1,12 @@
 ---
-description: Delegate a focused task within a single domain (light ceremony)
+description: Delegate within a single domain—parallel agents for independent sub-tasks
 argument-hint: [backend|frontend|database|prepare|test|architect] <task>
 ---
 Delegate this focused task within a single PACT domain: $ARGUMENTS
 
 **Default: parallel for independent sub-tasks.** If the task contains multiple independent items (bugs, endpoints, components), invoke multiple specialists of the same type in parallel unless they share files.
+
+> ⚠️ **Single domain ≠ single agent.** "Backend domain" with 3 bugs = 3 backend-coders in parallel. The domain is singular; the agents are not.
 
 ---
 
@@ -91,29 +93,9 @@ Before invoking multiple specialists in parallel, perform this coordination chec
 
 **Create feature branch** if not already on one (recommended for behavior changes; optional for trivial).
 
-### Single Specialist (Default)
+### Parallel Specialist Agents (Default)
 
-**Invoke the specialist with**:
-```
-comPACT mode: Work directly from this task description.
-Check docs/plans/, docs/preparation/, docs/architecture/ briefly if they exist—reference relevant context.
-Do not create new documentation artifacts in docs/.
-Focus on the task at hand.
-Testing responsibilities:
-- New unit tests: Required for logic changes; optional for trivial changes (documentation, comments, config).
-- Existing tests: If your changes break existing tests, fix them.
-- Before handoff: Run the test suite and ensure all tests pass.
-
-> **Smoke vs comprehensive tests**: These are verification tests—enough to confirm your implementation works. Comprehensive coverage (edge cases, integration, E2E, adversarial) is TEST phase work handled by `pact-test-engineer`.
-
-If you hit a blocker, STOP and report it so the orchestrator can run /PACT:imPACT.
-
-Task: [user's task description]
-```
-
-### Parallel Specialists (Same-Domain)
-
-When invoking multiple specialists in parallel, add boundary context to each:
+When the task contains multiple independent items, invoke multiple specialists in parallel with boundary context:
 
 ```
 comPACT mode (parallel): You are one of [N] specialists working in parallel.
@@ -137,6 +119,32 @@ Task: [this agent's specific sub-task]
 ```
 
 **After all parallel agents complete**: Verify no conflicts occurred, run full test suite.
+
+### Single Specialist Agent (When Required)
+
+Use a single specialist agent only when:
+- Task is atomic (one bug, one endpoint, one component)
+- Sub-tasks modify the same files
+- Sub-tasks have dependencies on each other
+- Conventions haven't been established yet (run one first to set patterns)
+
+**Invoke the specialist with**:
+```
+comPACT mode: Work directly from this task description.
+Check docs/plans/, docs/preparation/, docs/architecture/ briefly if they exist—reference relevant context.
+Do not create new documentation artifacts in docs/.
+Focus on the task at hand.
+Testing responsibilities:
+- New unit tests: Required for logic changes; optional for trivial changes (documentation, comments, config).
+- Existing tests: If your changes break existing tests, fix them.
+- Before handoff: Run the test suite and ensure all tests pass.
+
+> **Smoke vs comprehensive tests**: These are verification tests—enough to confirm your implementation works. Comprehensive coverage (edge cases, integration, E2E, adversarial) is TEST phase work handled by `pact-test-engineer`.
+
+If you hit a blocker, STOP and report it so the orchestrator can run /PACT:imPACT.
+
+Task: [user's task description]
+```
 
 ---
 

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -66,6 +66,20 @@ Before running orchestration, assess task variety using the protocol in [pact-va
 
 ---
 
+## Execution Philosophy
+
+**Default: Parallel unless proven dependent.**
+
+This applies across ALL phases, not just CODE:
+- PREPARE with multiple research areas → parallel preparers
+- ARCHITECT with independent component designs → parallel architects
+- CODE with multiple domains or independent tasks → parallel coders
+- TEST with independent test suites → parallel test engineers
+
+Sequential execution is the exception requiring explicit justification. When assessing any phase, ask: "Can parts of this run in parallel?" The answer is usually yes.
+
+---
+
 1. **Create feature branch** if not already on one
 2. **Check for plan** in `docs/plans/` matching this task
 
@@ -101,15 +115,9 @@ Before executing phases, assess which are needed based on existing context:
 1. Which skip criterion was met
 2. The context source (plan path, doc path, or pattern name)
 
-Example:
+Example: "Skipping PREPARE (plan has Preparation section). Skipping ARCHITECT (following pattern in `src/utils/`). Running CODE and TEST."
 
-> "Approved plan found at `docs/plans/user-auth-jwt-plan.md`. Skipping PREPARE (plan has Preparation Phase section). Skipping ARCHITECT (plan has Architecture Phase section). Running CODE. Running TEST (plan specifies integration tests needed)."
-
-Or without a plan:
-
-> "No plan found. Skipping PREPARE (requirements explicit in task). Skipping ARCHITECT (following established pattern in `src/utils/`). Running CODE. Skipping TEST (trivial change, no new logic to test)."
-
-The user can override your assessment if they want more or less ceremony.
+The user can override your assessment.
 
 ---
 
@@ -128,8 +136,6 @@ When a phase is skipped but a coder encounters a decision that would have been h
 **Coder instruction when phases were skipped**:
 
 > "PREPARE and/or ARCHITECT were skipped based on existing context. Minor decisions (naming, local structure) are yours to make. For moderate decisions (interface shape, error patterns), decide and implement but flag the decision with your rationale in the handoff so it can be validated. Major decisions affecting other components are blockers—don't implement, escalate."
-
-This prevents excessive ping-pong for small decisions while catching real issues.
 
 ---
 
@@ -166,6 +172,8 @@ Each specialist should end with a structured handoff:
 - [ ] Specialist handoff received (see Handoff Format below)
 - [ ] If blocker reported → `/PACT:imPACT`
 - [ ] **S4 Checkpoint** (see [pact-s4-checkpoints.md](../protocols/pact-s4-checkpoints.md)): Environment stable? Model aligned? Plan viable?
+
+**Parallel within PREPARE**: If research spans multiple independent areas (e.g., "research auth options AND caching strategies"), invoke multiple preparers in parallel with clear scope boundaries.
 
 ---
 
@@ -204,6 +212,8 @@ If PREPARE ran and ARCHITECT was marked "Skip," compare PREPARE's recommended ap
 - [ ] If blocker reported → `/PACT:imPACT`
 - [ ] **S4 Checkpoint**: Environment stable? Model aligned? Plan viable?
 
+**Parallel within ARCHITECT**: If designing multiple independent components (e.g., "design user service AND notification service"), invoke multiple architects in parallel. Ensure interface contracts between components are defined as a coordination checkpoint.
+
 ---
 
 ### Phase 3: CODE → `pact-*-coder(s)`
@@ -229,9 +239,7 @@ If PREPARE ran and ARCHITECT was marked "Skip," compare PREPARE's recommended ap
 
 #### Parallel-First Philosophy
 
-**Default stance**: Parallel unless proven dependent.
-
-The orchestrator should **expect** to use parallel execution. Sequential is the exception requiring explicit justification. This philosophy reflects the reality that most CODE phase work involves independent domains (backend, frontend, database) or independent components within a domain.
+**Default stance**: Parallel unless proven dependent. Sequential requires explicit justification.
 
 **Required decision output** (no exceptions):
 - "**Parallel**: [groupings]" — the expected outcome
@@ -246,9 +254,7 @@ The orchestrator should **expect** to use parallel execution. Sequential is the 
 
 #### Execution Strategy Analysis
 
-Before invoking coders, complete the **Quick Dependency Checklist (QDCL)** to determine your execution strategy.
-
-> **REQUIRED**: You must complete the QDCL and emit the checklist output before invoking coders. This is not optional.
+**REQUIRED**: Complete the QDCL and emit the result before invoking coders.
 
 **Quick Dependency Checklist (QDCL)**:
 
@@ -326,6 +332,8 @@ If a sub-task emerges that is too complex for a single specialist invocation:
 - [ ] All tests passing
 - [ ] Specialist handoff received (see Handoff Format above)
 - [ ] If blocker reported → `/PACT:imPACT`
+
+**Parallel within TEST**: If test suites are independent (e.g., "unit tests AND E2E tests" or "API tests AND UI tests"), invoke multiple test engineers in parallel with clear suite boundaries.
 
 ---
 


### PR DESCRIPTION
## Summary
- Fixes issue where orchestrator interpreted "single domain" as "single agent" in comPACT
- Adds top-level Execution Philosophy section in orchestrate.md establishing parallel-first globally
- Reorders comPACT sections so parallel invocation is presented as the default

## Changes

### comPACT.md
- Updated description: "Delegate within a single domain—parallel agents for independent sub-tasks"
- Added callout: "⚠️ Single domain ≠ single agent"
- Reordered sections: Parallel Invocation (Default) now comes before Sequential Invocation (When Required)
- Renamed section headers to reinforce default vs exception framing

### orchestrate.md
- Added "Execution Philosophy" section before "Before Starting" establishing parallel-first across ALL phases
- Added parallel guidance to PREPARE phase
- Added parallel guidance to ARCHITECT phase

## Test plan
- [ ] Review that comPACT command description clearly signals parallelism
- [ ] Verify section ordering in comPACT makes parallel the visual default
- [ ] Confirm Execution Philosophy section is prominent in orchestrate.md
- [ ] Check that PREPARE and ARCHITECT phases now have explicit parallel guidance