### PR TITLE
fix: telegram reply hint + remove session-end spam

### DIFF
--- a/pact-plugin/hooks/hooks.json
+++ b/pact-plugin/hooks/hooks.json
@@ -102,10 +102,6 @@
           {
             "type": "command",
             "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/memory_prompt.py\""
-          },
-          {
-            "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/telegram/notify.py\""
           }
         ]
       }

--- a/pact-plugin/telegram/tools.py
+++ b/pact-plugin/telegram/tools.py
@@ -54,7 +54,7 @@ MAX_PENDING_REPLIES = 10
 STALE_FUTURE_BUFFER = 60
 
 # Reply hint appended to telegram_ask messages
-ASK_REPLY_HINT = "\n\n↩️ Reply to this message to respond"
+ASK_REPLY_HINT = "\n\n💬 Tap a button, or swipe-reply with text or a voice note"
 
 
 def _get_project_name() -> str:


### PR DESCRIPTION
## Summary
- Better reply hint: "Tap a button, or swipe-reply with text or a voice note"
- Remove Stop hook telegram notification (floods chat with useless "Session ended" messages)

## Test plan
- [x] 301/301 telegram tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)