### PR TITLE
docs: rebrand PACT from framework to orchestration harness

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "3.9.3",
+      "version": "3.9.4",
       "author": {
         "name": "ProfSynapse"
       },

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-marketplace/
 │           └── PACT/
-│               └── 3.9.3/      # Plugin version
+│               └── 3.9.4/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "3.9.3",
+  "version": "3.9.4",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "ProfSynapse",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 3.9.3
+> **Version**: 3.9.4
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 


### PR DESCRIPTION
## Summary

- Rewrite root `README.md` with marketing-first structure: benefit hook, problem/solution contrast, compressed quick start, examples before technical details, VSM jargon moved to "Under the Hood"
- Compress `pact-plugin/README.md` to 49 lines with links to root for details
- Update `plugin.json` and `marketplace.json` descriptions to "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents"
- Establish naming tiers: "PACT" (casual), "PACT Harness" (short), "PACT — Orchestration Harness for Claude Code" (full descriptor)

Closes #229

## Test plan
- [ ] Verify zero uses of "framework" describing PACT (one reference to VSM as "a cybernetics framework" is correct)
- [ ] Verify hook/value prop in first 3 lines of root README
- [ ] Verify GIF placeholder present
- [ ] Verify plugin README ≤60 lines
- [ ] Verify JSON descriptions updated in both files
- [ ] Verify all existing technical content preserved (reorganized, not deleted)
- [ ] Check markdown rendering on GitHub