### PR TITLE
fix(telegram): replace cwd with env.PYTHONPATH in .mcp.json

### DIFF
--- a/pact-plugin/.mcp.json
+++ b/pact-plugin/.mcp.json
@@ -2,6 +2,8 @@
   "pact-telegram": {
     "command": "python3",
     "args": ["-m", "telegram"],
-    "cwd": "${CLAUDE_PLUGIN_ROOT}"
+    "env": {
+      "PYTHONPATH": "${CLAUDE_PLUGIN_ROOT}"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Claude Code's plugin MCP config processor resolves `${CLAUDE_PLUGIN_ROOT}` in `command`, `args`, and `env` fields, but **not** in `cwd`
- This caused `python3 -m telegram` to fail with `"No module named telegram"` because the unresolved literal `${CLAUDE_PLUGIN_ROOT}` was passed as the working directory
- Fix: replace `"cwd": "${CLAUDE_PLUGIN_ROOT}"` with `"env": {"PYTHONPATH": "${CLAUDE_PLUGIN_ROOT}"}` so Python can locate the telegram module regardless of working directory

## Root Cause

In Claude Code's `gYY` function (plugin MCP config resolver), the `cwd` field is not passed through the `${CLAUDE_PLUGIN_ROOT}` substitution pipeline. Only `command`, `args`, and `env` values are resolved. This means any plugin using `"cwd": "${CLAUDE_PLUGIN_ROOT}"` will get the literal string as cwd, which fails.

## Test Plan

- [x] Verified `PYTHONPATH` approach works: `python3 -m telegram` finds the module correctly
- [x] Confirmed full MCP handshake succeeds (initialize → tools/list returns all 4 telegram tools)
- [x] Tested in fresh Claude Code session — `plugin:PACT:pact-telegram` shows as connected in `/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)