### PR TITLE
feat: add task-assignment signal to teachback protocol

### DIFF
--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -380,6 +380,12 @@ When an agent reports a blocker or algedonic signal via `SendMessage`:
 4. Present to user and await resolution
 5. On resolution: mark signal task `completed` (unblocks downstream)
 
+When a teammate sends a **teachback signal** (task with `metadata.type == "teachback_signal"`):
+1. The `task_assignment` event wakes you — process the corresponding `SendMessage` teachback from the teammate's inbox
+2. Mark the signal task `completed`: `TaskUpdate(signalTaskId, status="completed")`
+
+These are lightweight wake notifications, not work items — they don't need blocking or scope amplification.
+
 ### What Is "Application Code"?
 
 The delegation rule applies to **application code**. Here's what that means:

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -380,12 +380,6 @@ When an agent reports a blocker or algedonic signal via `SendMessage`:
 4. Present to user and await resolution
 5. On resolution: mark signal task `completed` (unblocks downstream)
 
-When a teammate sends a **teachback signal** (task with `metadata.type == "teachback_signal"`):
-1. The `task_assignment` event wakes you — process the corresponding `SendMessage` teachback from the teammate's inbox
-2. Mark the signal task `completed`: `TaskUpdate(signalTaskId, status="completed")`
-
-These are lightweight wake notifications, not work items — they don't need blocking or scope amplification.
-
 ### What Is "Application Code"?
 
 The delegation rule applies to **application code**. Here's what that means:

--- a/pact-plugin/protocols/pact-ct-teachback.md
+++ b/pact-plugin/protocols/pact-ct-teachback.md
@@ -31,8 +31,14 @@ When a downstream agent receives an upstream handoff (via `TaskGet`), their firs
 2. Agent reads upstream handoff via `TaskGet(#5)`
 3. Agent sends teachback to lead via `SendMessage`:
    "[{sender}→lead] Teachback: My understanding is... [key decisions restated]. Proceeding unless corrected."
+   a. Agent records teachback: `TaskUpdate(taskId, metadata={"teachback_sent": true})`
+   b. Agent creates signal task (supplementary, fail-open):
+      `signalTaskId = TaskCreate("Review teachback: {your-name} on #{taskId}", metadata={"type": "teachback_signal"})`
+      `TaskUpdate(signalTaskId, owner="lead")`
 4. Agent proceeds with work (non-blocking)
-5. If orchestrator spots misunderstanding, they must `SendMessage` to agent to correct it
+5. Orchestrator receives `task_assignment` event for the signal task → processes the `SendMessage` teachback
+   a. If misunderstanding spotted, orchestrator sends correction via `SendMessage`
+   b. Orchestrator marks signal task completed: `TaskUpdate(signalTaskId, status="completed")`
 ```
 
 #### Why Non-Blocking

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -21,6 +21,7 @@ You are a member of a PACT Agent Team. You have access to Task tools (`TaskGet`,
 4. **GATE — Send teachback**: Send a teachback to lead restating your understanding of the task. Nothing proceeds until this is sent. (See [Teachback](#teachback-conversation-verification) below)
    - **DO NOT** call `Edit`, `Write`, or `Bash` before sending your teachback
    - After sending, record it: `TaskUpdate(taskId, metadata={"teachback_sent": true})`
+   - Create a signal task to wake the lead: `TaskCreate("Review teachback: {your-name} on #{taskId}", metadata={"type": "teachback_signal"})` then `TaskUpdate(signalTaskId, owner="lead")` — this generates a `task_assignment` event that reliably notifies the idle lead
    - Non-blocking: proceed immediately after sending — do not wait for the lead's reply
 5. Begin work — check your agent memory (`~/.claude/agent-memory/<your-name>/`) for relevant patterns and knowledge as part of your working process
 
@@ -51,17 +52,29 @@ If `TaskGet` returns no metadata or the referenced task doesn't exist, proceed w
 
 > **ORDERING RULE**: Send your teachback via `SendMessage` BEFORE calling `Edit`, `Write`, or `Bash` for implementation work. Reading files to understand the task (via `Read`, `Glob`, `Grep`) is permitted before teachback. The prohibition is on *implementation actions*, not *understanding actions*.
 
-**Format**:
+**Format** (complete sequence):
 ```
+# Step 1: Send the teachback content
 SendMessage(type="message", recipient="lead",
   content="[{sender}→lead] Teachback:\n- Building: {what you understand you're building}\n- Key constraints: {constraints you're working within}\n- Interfaces: {interfaces you'll produce or consume}\n- Approach: {your intended approach, briefly}\nProceeding unless corrected.",
   summary="Teachback: {1-line summary}")
+
+# Step 2: Record teachback in your task metadata
+TaskUpdate(taskId, metadata={"teachback_sent": true})
+
+# Step 3: Create signal task to wake the lead (supplementary — fail-open)
+TaskCreate("Review teachback: {your-name} on #{taskId}",
+  metadata={"type": "teachback_signal"})
+TaskUpdate(signalTaskId, owner="lead")
 ```
+
+> **Why the signal task?** `SendMessage` to an idle lead has intermittent delivery latency. Task assignment generates a system-level `task_assignment` event that reaches the lead reliably and immediately. The signal task is supplementary — if it fails, the SendMessage teachback still works. The lead marks signal tasks completed after processing.
 
 **Rules**:
 - Send teachback as your **first message** after reading your task description (and any upstream handoffs)
 - Keep it concise: 3-6 bullet points
 - After sending, record it: `TaskUpdate(taskId, metadata={"teachback_sent": true})`
+- Create a signal task to wake the lead: `TaskCreate("Review teachback: {your-name} on #{taskId}", metadata={"type": "teachback_signal"})` then `TaskUpdate(signalTaskId, owner="lead")`. This is fail-open — if TaskCreate fails, proceed anyway.
 - If the lead sends a correction, adjust your approach as soon as you see it
 
 **When**: Always — every task dispatch. Only exception: consultant questions (peer asks you something).

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -21,7 +21,7 @@ You are a member of a PACT Agent Team. You have access to Task tools (`TaskGet`,
 4. **GATE — Send teachback**: Send a teachback to lead restating your understanding of the task. Nothing proceeds until this is sent. (See [Teachback](#teachback-conversation-verification) below)
    - **DO NOT** call `Edit`, `Write`, or `Bash` before sending your teachback
    - After sending, record it: `TaskUpdate(taskId, metadata={"teachback_sent": true})`
-   - Create a signal task to wake the lead: `TaskCreate("Review teachback: {your-name} on #{taskId}", metadata={"type": "teachback_signal"})` then `TaskUpdate(signalTaskId, owner="lead")` — this generates a `task_assignment` event that reliably notifies the idle lead
+   - Create a signal task to wake the lead (see [Teachback Rules](#teachback-conversation-verification) below for the full sequence)
    - Non-blocking: proceed immediately after sending — do not wait for the lead's reply
 5. Begin work — check your agent memory (`~/.claude/agent-memory/<your-name>/`) for relevant patterns and knowledge as part of your working process
 
@@ -63,18 +63,21 @@ SendMessage(type="message", recipient="lead",
 TaskUpdate(taskId, metadata={"teachback_sent": true})
 
 # Step 3: Create signal task to wake the lead (supplementary — fail-open)
-TaskCreate("Review teachback: {your-name} on #{taskId}",
+signalTaskId = TaskCreate("Review teachback: {your-name} on #{taskId}",
+  description="Signal task for teachback notification. Mark completed after processing.",
   metadata={"type": "teachback_signal"})
 TaskUpdate(signalTaskId, owner="lead")
 ```
 
-> **Why the signal task?** `SendMessage` to an idle lead has intermittent delivery latency. Task assignment generates a system-level `task_assignment` event that reaches the lead reliably and immediately. The signal task is supplementary — if it fails, the SendMessage teachback still works. The lead marks signal tasks completed after processing.
+> **Why the signal task?** `SendMessage` to an idle lead has intermittent delivery latency. Task assignment generates a system-level `task_assignment` event that reaches the lead reliably and immediately. The signal task is supplementary — if it fails, the SendMessage teachback still works.
+
+> **Lead-side processing**: When the lead receives a `task_assignment` notification for a task with `metadata.type == "teachback_signal"`, process the corresponding `SendMessage` teachback from the teammate's inbox, then mark the signal task completed: `TaskUpdate(signalTaskId, status="completed")`.
 
 **Rules**:
 - Send teachback as your **first message** after reading your task description (and any upstream handoffs)
 - Keep it concise: 3-6 bullet points
 - After sending, record it: `TaskUpdate(taskId, metadata={"teachback_sent": true})`
-- Create a signal task to wake the lead: `TaskCreate("Review teachback: {your-name} on #{taskId}", metadata={"type": "teachback_signal"})` then `TaskUpdate(signalTaskId, owner="lead")`. This is fail-open — if TaskCreate fails, proceed anyway.
+- Create a signal task to wake the lead: `signalTaskId = TaskCreate("Review teachback: {your-name} on #{taskId}", description="Signal task for teachback notification. Mark completed after processing.", metadata={"type": "teachback_signal"})` then `TaskUpdate(signalTaskId, owner="lead")`. This is fail-open — if TaskCreate fails, proceed anyway.
 - If the lead sends a correction, adjust your approach as soon as you see it
 
 **When**: Always — every task dispatch. Only exception: consultant questions (peer asks you something).

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -69,10 +69,6 @@ signalTaskId = TaskCreate("Review teachback: {your-name} on #{taskId}",
 TaskUpdate(signalTaskId, owner="lead")
 ```
 
-> **Why the signal task?** `SendMessage` to an idle lead has intermittent delivery latency. Task assignment generates a system-level `task_assignment` event that reaches the lead reliably and immediately. The signal task is supplementary — if it fails, the SendMessage teachback still works.
-
-> **Lead-side processing**: When the lead receives a `task_assignment` notification for a task with `metadata.type == "teachback_signal"`, process the corresponding `SendMessage` teachback from the teammate's inbox, then mark the signal task completed: `TaskUpdate(signalTaskId, status="completed")`.
-
 **Rules**:
 - Send teachback as your **first message** after reading your task description (and any upstream handoffs)
 - Keep it concise: 3-6 bullet points


### PR DESCRIPTION
## Summary

Closes #337

- Adds supplementary task-assignment notification when teammates send teachbacks
- After the existing SendMessage teachback, agents now create a signal task (`TaskCreate` + `TaskUpdate` with `owner="lead"`) that generates a reliable `task_assignment` event to wake the idle lead
- Signal tasks carry metadata `{"type": "teachback_signal"}` so the lead can distinguish them from real work
- Fail-open design: if the signal task fails, SendMessage teachback still works

## Changes

- `pact-plugin/skills/pact-agent-teams/SKILL.md` — 3 modification points:
  - On Start lifecycle step 4: added signal task sub-bullet
  - Teachback Format section: expanded to show complete 3-step sequence (SendMessage → record metadata → create signal task)
  - Teachback Rules section: added fail-open signal task rule

## Context

Issue #337 documents 5 experiments proving that `TaskCreate` + `TaskUpdate(owner=...)` is the only reliable cross-agent notification mechanism in Claude Code. Hook exit codes, stderr, and `additionalContext` are all dead ends. The task-assignment event is system-level and reaches the lead immediately.

## Test plan

- [ ] Verify SKILL.md markdown renders correctly
- [ ] Confirm teachback protocol instructions are clear and unambiguous
- [ ] Verify fail-open language is present (agent proceeds even if TaskCreate fails)
- [ ] Check that signal task metadata type is documented for lead-side filtering