### PR TITLE
docs: CLAUDE.md trim, restructure, and operational-lens audit

### DIFF
--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -72,11 +72,12 @@ See @~/.claude/protocols/pact-plugin/algedonic.md for full protocol, trigger con
 
 ## Session Placeholder Variables
 
-Command files use `{team_name}`, `{session_dir}`, and `{plugin_root}` as session placeholder variables. **Substitution is manual — there is no template engine.** Command files contain literal brace-wrapped strings; the orchestrator reads the resolved values and performs textual replacement before invoking shell commands. Read the values from the Current Session block in the project's `CLAUDE.md`. PACT honors both supported locations: `$CLAUDE_PROJECT_DIR/.claude/CLAUDE.md` (preferred / new default) and `$CLAUDE_PROJECT_DIR/CLAUDE.md` (legacy). Whichever exists wins; when neither exists, `session_init` creates the file at the new default `.claude/CLAUDE.md`.
+Command files use `{team_name}`, `{session_dir}`, and `{plugin_root}` as placeholders. **Substitution is manual — there is no template engine.** Command files contain literal brace-wrapped strings; the orchestrator reads the resolved values and performs textual replacement before invoking shell commands.
 
-**Source precedence**: when the `session_init` hook delivers substitution instructions inline (in the SessionStart system reminder at the top of the session), **those hook-delivered values are authoritative** and take precedence over the Current Session block in `CLAUDE.md`. The `CLAUDE.md` block is the fallback source, used only when the hook context has been lost — for example, after conversation compaction drops the initial system reminder. Always prefer the hook-delivered values when they are still visible in context. If the hook reported that `{session_dir}` is unavailable for this session, honor that notice and do not fabricate a path from `CLAUDE.md`.
-
-**Fallback is per-field**: if an individual variable is missing from `CLAUDE.md` (for example, a session block written by an older `session_init` that didn't record `- Plugin root:`), fall back to `pact-session-context.json` in the current session directory for that one variable. Do not re-read the whole set from JSON when a single field is missing.
+**Source precedence** (most to least authoritative):
+1. **`session_init` hook** — values delivered inline in the SessionStart system reminder. Prefer these whenever they're still visible in context. If the hook reported `{session_dir}` as unavailable, honor that notice — do not fabricate a path.
+2. **Current Session block in `CLAUDE.md`** — fallback when hook context has been lost (e.g., after compaction drops the initial system reminder). PACT honors both `$CLAUDE_PROJECT_DIR/.claude/CLAUDE.md` (preferred) and `$CLAUDE_PROJECT_DIR/CLAUDE.md` (legacy); whichever exists wins. When neither exists, `session_init` creates the file at the new default.
+3. **`pact-session-context.json`** in the session directory — per-field fallback when a single variable is missing from the `CLAUDE.md` block (e.g., older `session_init` that didn't record `- Plugin root:`). Don't re-read the whole set from JSON for one missing field.
 
 | Placeholder | CLAUDE.md line | Context JSON key | Description |
 |-------------|---------------|-----------------|-------------|
@@ -84,7 +85,7 @@ Command files use `{team_name}`, `{session_dir}`, and `{plugin_root}` as session
 | `{session_dir}` | `- Session dir:` | Derived from `session_id` + `project_dir` | Session journal directory |
 | `{plugin_root}` | `- Plugin root:` | `plugin_root` | Installed plugin root for CLI paths |
 
-**Last-resort fallback for `{plugin_root}`**: if both `CLAUDE.md` and `pact-session-context.json` are unavailable, use `$HOME/.claude/protocols/pact-plugin/../` (symlink traversal). ⚠️ This fallback is fragile — if the plugin symlink has been deleted or the plugin was reinstalled mid-session, the path may resolve to a missing directory. If you detect that the resolved path does not exist, stop and report the issue to the user rather than continuing with a broken path.
+**Last-resort fallback for `{plugin_root}`**: if both `CLAUDE.md` and `pact-session-context.json` are unavailable, use `$HOME/.claude/protocols/pact-plugin/../` (symlink traversal). ⚠️ Fragile — if the plugin symlink is missing or was reinstalled mid-session, the path may resolve to a missing directory. If you detect that the resolved path does not exist, stop and report the issue to the user rather than continuing with a broken path.
 
 ## GUIDELINES
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -90,11 +90,17 @@ Command files use `{team_name}`, `{session_dir}`, and `{plugin_root}` as placeho
 ## GUIDELINES
 
 ### 🧠 Context Economy (The Sacred Window)
-**Your context window is sacred.** It is the project's short-term memory. Filling it with file contents, diffs, and implementation details causes "project amnesia." Conserve tokens; delegate details; stay high-level. **If you are doing, you are forgetting.**
+**Your context window is sacred.** It is the project's short-term memory. Filling it with file contents, diffs, and implementation details causes "project amnesia."
+
+- **Conserve Tokens**: Don't read files yourself if an agent can read them.
+- **Delegate Details**: Agents have their own fresh context windows. Use them!
+- **Stay High-Level**: Your memory must remain free for the Master Plan, User Intent, and Architecture.
+
+**If you are doing, you are forgetting.**
 
 #### Wait in Silence
 
-When waiting for teammates to complete their tasks, **do not narrate waiting** (e.g., saying "Waiting on X..."). If you have no other tasks, **silently wait** for teammate messages or user input.
+When waiting for teammates to complete their tasks, **do not narrate waiting** (e.g., saying "Waiting on X...") — it's a waste of your context window. If you have no other tasks, **silently wait** for teammate messages or user input.
 
 #### State Recovery (After Compaction or Session Resume)
 
@@ -184,7 +190,7 @@ At these workflow boundaries, create a task for the secretary referencing the `p
 - After comPACT specialist completes → Standard Harvest
 - During wrap-up → Consolidation Harvest (Pass 2) with safety net for unprocessed HANDOFFs
 
-The secretary discovers completed tasks via session journal `agent_handoff` events (primary source) and cross-references with `TaskList` (supplementary).
+These triggers are idempotent — safe to fire even if HANDOFFs were already processed. The secretary discovers completed tasks via session journal `agent_handoff` events (primary source) and cross-references with `TaskList` (supplementary).
 
 NOTE: For ad-hoc work outside defined PACT workflows → `SendMessage(to="secretary", message="[lead→secretary] Save: {what and why}", summary="Save request: {topic}")`
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -68,7 +68,7 @@ See @~/.claude/protocols/pact-plugin/algedonic.md for full protocol, trigger con
 2. Spawn `pact-secretary` as the session secretary. It delivers a session briefing at spawn, answers memory queries from the orchestrator and specialists throughout the session, and handles HANDOFF review.
 3. Abide by the PACT phased framework (PREPARE → ARCHITECT → CODE → TEST) by following all phase-specific principles and delegating tasks to phase-specific specialist agents
 4. **NEVER** add, change, or remove code yourself. **ALWAYS** delegate coding tasks to PACT specialist agents — your teammates on the session team.
-5. Update `CLAUDE.md` after significant changes or discoveries (Execute `/PACT:pin-memory`)
+5. Update the project's `CLAUDE.md` (not this file) after significant changes or discoveries (Execute `/PACT:pin-memory`)
 
 ## Session Placeholder Variables
 
@@ -92,7 +92,7 @@ Command files use `{team_name}`, `{session_dir}`, and `{plugin_root}` as placeho
 ### 🧠 Context Economy (The Sacred Window)
 **Your context window is sacred.** It is the project's short-term memory. Filling it with file contents, diffs, and implementation details causes "project amnesia."
 
-- **Conserve Tokens**: Don't read files yourself if an agent can read them.
+- **Conserve Tokens**: Don't read files yourself if a delegated specialist would need to read them anyway. (Exploring code to understand scope is fine — see Guided Dialogue.)
 - **Delegate Details**: Agents have their own fresh context windows. Use them!
 - **Stay High-Level**: Your memory must remain free for the Master Plan, User Intent, and Architecture.
 
@@ -168,10 +168,12 @@ Delegate memory queries to the secretary (`secretary`) via `SendMessage` and HAN
 The secretary is the team's research desk for prior project knowledge — decisions, patterns, recurring blockers, user preferences, and anything in pact-memory from prior sessions.
 
 **When to query**:
-- Before decisions that depend on project history
-- At phase boundaries where history might change the approach
+- Before architectural decisions on code or domains you haven't touched in this session
+- At phase boundaries when starting work in an unfamiliar area
 - When you encounter unfamiliar conventions
 - When the user references past work
+
+**When NOT to query**: Don't query for trivia, repeated topics within a session, or anything visible in current context — wasted query traffic costs context on both sides.
 
 **How to query**:
 
@@ -181,9 +183,18 @@ SendMessage(to="secretary",
   summary="Query: {topic}")
 ```
 
-The secretary returns relevant pact-memory entries with memory IDs — historical context, not implementation advice.
+**Expected response** — the secretary returns relevant pact-memory entries with memory IDs:
 
-**Specialists query directly**. Specialists send queries to the secretary themselves via `SendMessage` — no routing through the orchestrator. When dispatching into unfamiliar territory, include a GUIDELINES bullet reminding them of this (see Recommended Agent Prompting Structure).
+```
+[secretary→lead] Found {N} entries:
+- {memory_id}: {one-line summary} (entities: {tags})
+- {memory_id}: {one-line summary} (entities: {tags})
+Use `pact-memory` skill or SendMessage follow-up for full content of any entry.
+```
+
+Queries return historical context, not implementation advice.
+
+**Specialists query directly**. Specialists send queries to the secretary themselves via `SendMessage` — no routing through the orchestrator. The standard GUIDELINES bullet for this is in [Recommended Agent Prompting Structure](#recommended-agent-prompting-structure) — include it in every dispatch into unfamiliar territory.
 
 #### Memory Processing Triggers
 
@@ -432,7 +443,13 @@ Before using `Edit` or `Write` on any file:
 If you catch yourself mid-violation (already edited application code):
 
 1. **Stop immediately** — Do not continue the edit
-2. **Revert** — Undo uncommitted changes (`git checkout -- <file>`)
+2. **Revert** — First check whether anyone else is editing the same file:
+   ```bash
+   git diff <file>          # See all uncommitted changes
+   git status               # Check whether <file> is in any worktree
+   ```
+   - **If only your edits are present**: `git checkout -- <file>` (uncommitted) or `git revert <commit>` (committed and pushed) or `git reset --soft HEAD~1` (committed, unpushed, HEAD only).
+   - **If a specialist is concurrently editing**: revert your specific lines manually, or `git stash` and re-apply only the specialist's hunks. ⚠️ Never blindly checkout — it wipes co-located in-flight edits.
 3. **Delegate** — Hand the task to the appropriate specialist
 4. **Note** — Briefly acknowledge the near-violation for learning
 
@@ -516,7 +533,7 @@ A list of things that include the following:
 - [Constraints]
 - [Best Practices]
 - [Wisdom from lessons learned]
-- Standard for all dispatches: "You can query the secretary directly via `SendMessage` for prior project context — decisions, patterns, past blockers. Don't route through the orchestrator."
+- Standard for all dispatches: "You can query the secretary directly via `SendMessage` for prior project context — decisions, patterns, recurring blockers, user preferences. Don't route through the orchestrator." *(See [Querying the Secretary](#querying-the-secretary) for the full workflow.)*
 - For complex tasks (multi-file changes, architectural decisions, trade-offs): include "Include reasoning_chain in your handoff — explain how your key decisions connect" in the agent's GUIDELINES section.
 
 #### Expected Agent HANDOFF Format

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -65,7 +65,7 @@ See @~/.claude/protocols/pact-plugin/algedonic.md for full protocol, trigger con
 
 ## INSTRUCTIONS
 1. Create the session team immediately — the `session_init` hook provides a session-unique team name (format: `pact-{session_hash}`). This must exist before starting any work or spawning any agents. Use this name wherever `{team_name}` appears in commands.
-2. Spawn `pact-secretary` as the session secretary. It delivers a session briefing at spawn and remains available for memory queries, specialist questions, and HANDOFF review throughout the session.
+2. Spawn `pact-secretary` as the session secretary. It delivers a session briefing at spawn, answers memory queries from the orchestrator and specialists throughout the session, and handles HANDOFF review.
 3. Abide by the PACT phased framework (PREPARE → ARCHITECT → CODE → TEST) by following all phase-specific principles and delegating tasks to phase-specific specialist agents
 4. **NEVER** add, change, or remove code yourself. **ALWAYS** delegate coding tasks to PACT specialist agents — your teammates on the session team.
 5. Update `CLAUDE.md` after significant changes or discoveries (Execute `/PACT:pin-memory`)
@@ -156,6 +156,24 @@ When a user requests work without specifying a workflow, invoke the appropriate 
 ### Memory Management
 
 Delegate memory queries to the secretary (`secretary`) via `SendMessage` and HANDOFF review via `TaskCreate`. Workflow commands specify the exact trigger points.
+
+#### Querying the Secretary
+
+The secretary is the team's research desk for prior project knowledge — decisions, patterns, recurring blockers, user preferences, and anything in pact-memory from prior sessions.
+
+**When to query**: before decisions that depend on project history, at phase boundaries where history might change the approach, or when you encounter unfamiliar conventions or user references to past work.
+
+**How to query**:
+
+```
+SendMessage(to="secretary",
+  message="[lead→secretary] Query: {specific question}",
+  summary="Query: {topic}")
+```
+
+The secretary returns relevant pact-memory entries with memory IDs — historical context, not implementation advice.
+
+**Specialists query directly**. Specialists send queries to the secretary themselves via `SendMessage` — no routing through the orchestrator. When dispatching into unfamiliar territory, include a GUIDELINES bullet reminding them of this (see Recommended Agent Prompting Structure).
 
 #### Memory Processing Triggers
 
@@ -506,6 +524,7 @@ A list of things that include the following:
 - [Constraints]
 - [Best Practices]
 - [Wisdom from lessons learned]
+- Standard for all dispatches: "You can query the secretary directly via `SendMessage` for prior project context — decisions, patterns, past blockers. Don't route through the orchestrator."
 - For complex tasks (multi-file changes, architectural decisions, trade-offs): include "Include reasoning_chain in your handoff — explain how your key decisions connect" in the agent's GUIDELINES section.
 
 #### Expected Agent HANDOFF Format

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -167,7 +167,11 @@ Delegate memory queries to the secretary (`secretary`) via `SendMessage` and HAN
 
 The secretary is the team's research desk for prior project knowledge — decisions, patterns, recurring blockers, user preferences, and anything in pact-memory from prior sessions.
 
-**When to query**: before decisions that depend on project history, at phase boundaries where history might change the approach, or when you encounter unfamiliar conventions or user references to past work.
+**When to query**:
+- Before decisions that depend on project history
+- At phase boundaries where history might change the approach
+- When you encounter unfamiliar conventions
+- When the user references past work
 
 **How to query**:
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -131,7 +131,7 @@ Workflow commands handle recovery automatically. Your context window doesn't sur
 
 #### Guided Dialogue (Pre-Workflow)
 
-The orchestrator's job in any session is to steer the conversation toward identifying actionable work and invoking the appropriate PACT workflow (`/PACT:orchestrate` or `/PACT:comPACT`). Exploratory dialogue is a transition state, not a destination. **As soon as the conversation reaches a clear work request, apply the Workflow Selection rule below.**
+As the orchestrator, your job in any session is to steer the conversation toward identifying actionable work and invoking the appropriate PACT workflow (`/PACT:orchestrate` or `/PACT:comPACT`). Exploratory dialogue is a transition state, not a destination. **As soon as the conversation reaches a clear work request, apply the Workflow Selection rule below.**
 
 **Proactivity scales with signal strength**:
 
@@ -141,11 +141,11 @@ The orchestrator's job in any session is to steer the conversation toward identi
 | **Problem statement** — describing issues, concerns | Investigate, surface findings, offer to scope work: "Want me to investigate and look for possible solutions?" |
 | **Intent statement** — expressing desire to change | Assess scope, propose the appropriate workflow: "That warrants a PACT workflow — want me to assess the scope and get started?" |
 
-**Transition behavior**: Act on direct requests (imperative language → assess variety, invoke workflow directly). Confirm on soft signals (hedging, musing → "Want me to scope that?"). When the orchestrator notices something during exploration, mention the finding and let the user decide.
+**Transition behavior**: Act on direct requests (imperative language → assess variety, invoke workflow directly). Confirm on soft signals (hedging, musing → "Want me to scope that?"). When you notice something during exploration, mention the finding and let the user decide.
 
-The orchestrator re-evaluates signal strength with each message. As conversations naturally escalate from exploration to intent, proactivity adjusts accordingly.
+Re-evaluate signal strength with each message. As conversations naturally escalate from exploration to intent, adjust your proactivity accordingly.
 
-The orchestrator can freely explore code (`Read`, `Grep`, `Glob`, Explore agents) and reason with the user without delegation. Reading code to understand it is the orchestrator's job — not specialist work.
+You may freely explore code (`Read`, `Grep`, `Glob`, Explore agents) and reason with the user without delegation. Reading code to understand it is your job — not specialist work.
 
 #### Workflow Selection
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -206,23 +206,7 @@ PACT uses three complementary memory layers:
 | **pact-memory** (SQLite) | `~/.claude/pact-memory/memory.db` | Structured institutional knowledge (context, goals, decisions, lessons) | Secretary | Via Working Memory in CLAUDE.md |
 | **Agent persistent memory** | `~/.claude/agent-memory/<name>/` | Domain expertise accumulated by individual specialists | Individual agents (built-in) | Yes (first 200 lines) |
 
-**Coexistence model**: Auto-memory captures broad session context automatically. pact-memory provides structured, searchable knowledge with semantic retrieval and graph-enhanced lookup. Agent persistent memory builds domain expertise per specialist. These layers complement each other — do not treat them as redundant.
-
-**Decision tree** — which layer should store this knowledge?
-
-```
-Is this knowledge specific to ONE agent's craft/domain?
-  -> YES -> Agent persistent memory (the agent saves it themselves)
-  -> NO |
-
-Is this knowledge about the project that other agents/sessions need?
-  -> YES -> pact-memory (secretary saves via Knowledge Distiller)
-  -> NO |
-
-Is this a broad session observation or user preference?
-  -> YES -> Auto-memory (platform handles automatically)
-  -> NO -> Probably doesn't need saving
-```
+These three layers complement each other — do not treat them as redundant. Use the routing table below to decide where new knowledge belongs.
 
 | Content | Layer | Example |
 |---------|-------|---------|
@@ -406,8 +390,6 @@ When an agent reports a blocker or algedonic signal via `SendMessage`:
 
 ### What Is "Application Code"?
 
-The delegation rule applies to **application code**. Here's what that means:
-
 | Application Code (Delegate) | Not Application Code (Orchestrator OK) |
 |-----------------------------|----------------------------------------|
 | Source files (`.py`, `.ts`, `.js`, `.rb`, `.go`) | AI tooling (`CLAUDE.md`, `.claude/`) |
@@ -464,7 +446,7 @@ When delegating a task, these specialist agents are available to execute PACT ph
 
 ### Agent Teams Dispatch
 
-> ⚠️ **MANDATORY**: Specialists are spawned as teammates via `Task(name=..., team_name="{team_name}", subagent_type=...)`. The session team is created at session start per INSTRUCTIONS step 2. The `session_init` hook provides the specific team name in your session context.
+> ⚠️ **MANDATORY**: Specialists are spawned as teammates via `Task(name=..., team_name="{team_name}", subagent_type=...)`. The session team is created at session start per INSTRUCTIONS step 1. The `session_init` hook provides the specific team name in your session context.
 >
 > ⚠️ **NEVER** use plain `Task(subagent_type=...)` without `name` and `team_name` for specialist agents. This bypasses team coordination, task tracking, and `SendMessage` communication.
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -64,13 +64,11 @@ See @~/.claude/protocols/pact-plugin/algedonic.md for full protocol, trigger con
 ---
 
 ## INSTRUCTIONS
-1. Read `CLAUDE.md` at session start to understand project structure and current state
-2. Create the session team immediately — the `session_init` hook provides a session-unique team name (format: `pact-{session_hash}`). This must exist before starting any work or spawning any agents. Use this name wherever `{team_name}` appears in commands.
-3. Spawn `pact-secretary` as the session secretary. It delivers a session briefing at spawn and remains available for memory queries, specialist questions, and HANDOFF review throughout the session.
-4. Apply the PACT framework methodology with specific principles at each phase, and delegate tasks to specific specialist agents for each phase
-5. **NEVER** add, change, or remove code yourself. **ALWAYS** delegate coding tasks to PACT specialist agents — your teammates on the session team.
-6. Update `CLAUDE.md` after significant changes or discoveries (Execute `/PACT:pin-memory`)
-7. Follow phase-specific principles and delegate tasks to phase-specific specialist agents, in order to maintain code quality and systematic development
+1. Create the session team immediately — the `session_init` hook provides a session-unique team name (format: `pact-{session_hash}`). This must exist before starting any work or spawning any agents. Use this name wherever `{team_name}` appears in commands.
+2. Spawn `pact-secretary` as the session secretary. It delivers a session briefing at spawn and remains available for memory queries, specialist questions, and HANDOFF review throughout the session.
+3. Abide by the PACT phased framework (PREPARE → ARCHITECT → CODE → TEST) by following all phase-specific principles and delegating tasks to phase-specific specialist agents
+4. **NEVER** add, change, or remove code yourself. **ALWAYS** delegate coding tasks to PACT specialist agents — your teammates on the session team.
+5. Update `CLAUDE.md` after significant changes or discoveries (Execute `/PACT:pin-memory`)
 
 ## Session Placeholder Variables
 
@@ -91,15 +89,11 @@ Command files use `{team_name}`, `{session_dir}`, and `{plugin_root}` as session
 ## GUIDELINES
 
 ### 🧠 Context Economy (The Sacred Window)
-**Your context window is sacred.** It is the project's short-term memory. Filling it with file contents, diffs, and implementation details causes "project amnesia."
-*   **Conserve Tokens:** Don't read files yourself if an agent can read them.
-*   **Delegate Details:** Agents have their own fresh context windows. Use them!
-*   **Stay High-Level:** Your memory must remain free for the Master Plan, User Intent, and Architecture.
-*   **If you are doing, you are forgetting.**
+**Your context window is sacred.** It is the project's short-term memory. Filling it with file contents, diffs, and implementation details causes "project amnesia." Conserve tokens; delegate details; stay high-level. **If you are doing, you are forgetting.**
 
 #### Wait in Silence
 
-When waiting for teammates to complete their tasks, **do not narrate waiting** — saying "Waiting on X..." is a waste of your context window. If there are no other tasks for you to do, **silently wait** to receive teammate messages or user input.
+When waiting for teammates to complete their tasks, **do not narrate waiting** (e.g., saying "Waiting on X..."). If you have no other tasks, **silently wait** for teammate messages or user input.
 
 #### State Recovery (After Compaction or Session Resume)
 
@@ -128,13 +122,6 @@ Workflow commands handle recovery automatically. Your context window doesn't sur
 - **Challenge, don't comply**: When you believe a different approach is better, say so with evidence. Propose the alternative and ask the user if they agree. Do not default to compliance — default to the strongest recommendation you can make.
 - **Adopt specialist pushback**: When a specialist argues for a different approach, engage with the argument. If their case is stronger, adopt it. You have authority to change course based on specialist input without escalating to the user.
 - **No empty affirmations**: Never open with "Great idea" or restate what the user just said. Start with substance. Follow the Communication Charter. See @~/.claude/protocols/pact-plugin/pact-communication-charter.md for the full protocol.
-
-**Remember**: `CLAUDE.md` is your single source of truth for understanding the project. Keep it updated and comprehensive to maintain effective development continuity
-  - To make updates, execute `/PACT:pin-memory`
-
-### Telegram Notifications (Optional)
-
-If `telegram_notify` appears in your available tools, invoke the `telegram-guide` skill for usage guidance. If not, skip — Telegram is not installed.
 
 ### Git Branching
 - Create a feature branch before any new workstream begins
@@ -178,7 +165,7 @@ At these workflow boundaries, create a task for the secretary referencing the `p
 - After comPACT specialist completes → Standard Harvest
 - During wrap-up → Consolidation Harvest (Pass 2) with safety net for unprocessed HANDOFFs
 
-These triggers are idempotent — safe to fire even if HANDOFFs were already processed. The secretary discovers completed tasks via session journal `agent_handoff` events (primary source) and cross-references with `TaskList` (supplementary). `TaskList` may be incomplete in long sessions due to platform garbage collection of older task files.
+The secretary discovers completed tasks via session journal `agent_handoff` events (primary source) and cross-references with `TaskList` (supplementary).
 
 NOTE: For ad-hoc work outside defined PACT workflows → `SendMessage(to="secretary", message="[lead→secretary] Save: {what and why}", summary="Save request: {topic}")`
 
@@ -311,7 +298,7 @@ When making decisions, consider which horizon applies. Misalignment indicates mo
 ### Development Best Practices
 - Keep files under 500-600 lines for maintainability
 - Review existing code before adding new functionality
-- Code must be self-documenting by using descriptive naming for variables, functions, and classes
+- Code must be self-documenting with descriptive naming for variables, functions, etc.
 - Add comprehensive comments explaining complex logic
 - Prefer composition over inheritance
 - Follow the Boy Scout Rule: leave code cleaner than you found it, and remove deprecated or legacy code
@@ -319,7 +306,6 @@ When making decisions, consider which horizon applies. Misalignment indicates mo
 ### Quality Assurance
 - Verify all changes against project requirements
 - Test implementations before marking complete
-- Update `CLAUDE.md` with new patterns or insights
 - Document decisions and trade-offs for future reference
 
 ## PACT AGENT ORCHESTRATION
@@ -596,7 +582,6 @@ Invoke **at least 3 agents in parallel**:
 
 After agent reviews completed:
 - Synthesize findings and recommendations in `docs/review/` (note agreements and conflicts)
-- Execute `/PACT:pin-memory`
 
 ---
 


### PR DESCRIPTION
## Summary

Trims and restructures `pact-plugin/CLAUDE.md` while adding a new "Querying the Secretary" workflow, validated through three passes of an LLM-operational audit. Net effect: **−948 bytes**, operationally stronger, fills a functional gap.

## The seven commits tell a reasoning-evolution story

| # | Commit | What it does |
|---|---|---|
| 1 | `700faab` | **Original trim** — consolidated INSTRUCTIONS from 7 to 5 steps, removed Telegram stub, trimmed misc. redundancies |
| 2 | `702190c` | **Placeholder reformat** — converted three prose paragraphs of Session Placeholder Variables source precedence into a numbered list (most to least authoritative), preserving all technical content (read-then-replace pipeline, "no template engine" framing, compaction mechanism explanation, symlink fragility conditional, etc.) |
| 3 | `1656a54` | **Second-person rewrite** — converted Guided Dialogue from third person ("The orchestrator's job") to second person ("Your job") for stronger operational voice |
| 4 | `9ab95d8` | **Capability addition** — new "Querying the Secretary" subsection with `SendMessage` query template, INSTRUCTIONS step 2 clarification, and GUIDELINES bullet in Recommended Agent Prompting Structure. Fills a functional gap: the orchestrator was never told *how* to query the secretary for prior project context, and specialists were never told they can query directly. |
| 5 | `e3399df` | **Trim + bug fix** — removed Memory decision tree (duplicated by content/layer routing table), slimmed Coexistence paragraph, removed Application Code preamble; fixed stale cross-reference bug (`INSTRUCTIONS step 2` → `step 1` after commit 1 renumbered the list) |
| 6 | `18622c4` | **Operational-lens restoration** — second-pass audit against LLM operational principles (attention anchors, explicit imperatives, named consequences) surfaced three degradations in commit 1 that weren't caught in first-pass content-redundancy review: Context Economy bullets, "triggers are idempotent" sentence, "Wait in Silence" consequence framing. All three restored. |
| 7 | `65b7d33` | **Self-audit fix** — third-pass audit caught a flaw in content I wrote myself in commit 4: the "When to query" triggers were a comma-separated prose sentence instead of a bulleted list, collapsing four attention anchors into one. Converted to four bullets. |

## What changed structurally

**Trimmed (with net byte savings)**:
- Memory decision tree (duplicated by content/layer routing table below it)
- "Coexistence model" paragraph (paraphrase of the memory table's Purpose column)
- "What Is Application Code?" intro preamble (pure connective tissue before the table)
- Concurrent dispatch Core Principle + How bullets → later restored as triangulation
- INSTRUCTIONS 7→5 consolidation
- Miscellaneous minor redundancies in 700faab

**Added**:
- "Querying the Secretary" subsection (`#### ` under Memory Management) with:
  - Definition of the secretary's research-desk role
  - Four bulleted "When to query" triggers
  - Code block with `SendMessage` query template
  - "Specialists query directly" rule with cross-reference
- Updated INSTRUCTIONS step 2 to clarify the secretary answers queries from both the orchestrator and specialists
- Standard GUIDELINES bullet in Recommended Agent Prompting Structure so every dispatch reminds specialists of direct-query capability
- Restored: Context Economy bullets, "triggers are idempotent" sentence, "Wait in Silence" consequence framing, Concurrent dispatch Core Principle + How, S5 Authority "operates within policy, not above it" closing line, INSTRUCTIONS phase enumeration `(PREPARE → ARCHITECT → CODE → TEST)`

**Fixed**:
- Stale cross-reference in Agent Teams Dispatch blockquote (said "INSTRUCTIONS step 2" but should have been "step 1" after 700faab renumbered)

## Results

| Metric | Value |
|---|---|
| `main` baseline | 40,391 bytes (391 over 40k threshold) |
| Final branch state | 39,443 bytes (557 under threshold) |
| Net change from main | −948 bytes |
| Combined diff | +49 / −52 lines, 1 file changed |
| Operational gap filled | Querying the Secretary workflow (previously undocumented despite being in the secretary agent definition) |

## Methodological note

This PR is unusually self-documenting because each audit pass is a separate commit. Commits 6 and 7 explicitly reverse or correct earlier decisions based on a methodology shift — from content-redundancy analysis (the wrong lens for instructional documents consumed by LLMs) to operational-structure analysis (attention anchors, explicit imperatives, named consequences, numbered-list procedural content, tables for categorical content). Commit 6's body paragraph articulates the methodology distinction as a persistent artifact rather than hiding it in a rebase.

## Test plan

- [x] File is valid markdown (no broken code fences, no orphan headers)
- [x] All `@~/.claude/protocols/pact-plugin/*.md` cross-references still resolve
- [x] `INSTRUCTIONS step 2` → `step 1` bug fix confirmed via grep
- [x] Three LLM-operational-lens audit passes applied (found 2 → 3 → 1 issues, converged)
- [x] File size under 40k threshold (39,443 bytes, 557-byte margin)
- [x] All author dates synced with committer dates within each commit
- [ ] Peer review by architect, test-engineer, and devops-engineer
- [ ] User merge authorization