### PR TITLE
docs: trim CLAUDE.md + ontology refinements + cascade cleanup (6.71% reduction)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "3.16.0",
+      "version": "3.16.1",
       "author": {
         "name": "ProfSynapse"
       },

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-marketplace/
 │           └── PACT/
-│               └── 3.16.0/     # Plugin version
+│               └── 3.16.1/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "ProfSynapse",

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -420,12 +420,6 @@ When delegating a task, these specialist agents are available to execute PACT ph
 2. `TaskUpdate(taskId, owner="{name}")` — assign ownership
 3. `Task(name="{name}", team_name="{team_name}", subagent_type="pact-{type}", prompt="You are joining team {team_name}. Check `TaskList` for tasks assigned to you.")` — spawn the teammate
 
-**Why Agent Teams?**
-- Teammates self-manage task status (claim, progress, complete)
-- Communication via `SendMessage` (HANDOFFs, blockers, algedonic signals)
-- Completed-phase teammates remain as consultants for questions
-- Multiple specialists run concurrently within the same team
-
 #### Reuse vs. Spawn Decision
 
 | Situation | Action |

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -160,7 +160,7 @@ When a user requests work without specifying a workflow, invoke the appropriate 
 
 PACT uses three memory layers with distinct ownership:
 
-- **Auto-memory** (`MEMORY.md`, platform-managed) — you write directly via the base memory tool when you learn durable user, feedback, project, or reference facts. Only the first 200 lines / 25KB of `MEMORY.md` auto-load at session start; content past that is still readable on demand.
+- **Auto-memory** (`MEMORY.md`, auto-loaded each session) — write durable user, feedback, project, or reference facts directly to `MEMORY.md` and individual memory files via the `Write` tool. Only the first 200 lines / 25KB of `MEMORY.md` auto-load at session start; content past that is still readable on demand.
 - **pact-memory** (SQLite, secretary-managed) — query via `SendMessage` to the secretary; delegate saves via harvest triggers or ad-hoc save requests.
 - **Agent persistent memory** (per-specialist, self-managed) — not your concern; specialists manage their own accumulated domain expertise.
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -154,10 +154,12 @@ When a user requests work without specifying a workflow, invoke the appropriate 
 
 ### Memory Management
 
-Three independent decisions govern where memory goes:
+Whenever you have an insight worth remembering, save it as a memory.
 
-- **User/feedback/project/reference fact?** → Write to `MEMORY.md` and individual memory files directly via the `Write` tool. Only the first 200 lines / 25KB of `MEMORY.md` auto-load at session start; content past that is still readable on demand.
-- **Durable cross-session project knowledge** (architectural decisions, recurring patterns, calibration data)? → Delegate to the secretary — query via `SendMessage` for reads; delegate saves via harvest triggers or ad-hoc save requests.
+Ask these three questions to decide where to save the memory:
+
+- **Context you need loaded at every session start?** (user profile, feedback/corrections, project state, external references) → Save to auto-memory per the auto-memory protocol (documented in the `# auto memory` system prompt section loaded at session start). Only the first 200 lines / 25KB of `MEMORY.md` auto-load; content past that is still readable on demand.
+- **Queryable knowledge for on-demand retrieval by any agent?** (architectural decisions, recurring patterns, calibration data) → Delegate to the secretary — query via `SendMessage` for reads; delegate saves via harvest triggers or ad-hoc save requests.
 - **Agent-specific expertise?** → Skip — specialists manage their own accumulated domain knowledge.
 
 #### Querying the Secretary

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -167,7 +167,27 @@ When a user requests work without specifying a workflow, invoke the appropriate 
 
 ### Memory Management
 
-Delegate memory queries to the secretary (`secretary`) via `SendMessage` and HANDOFF review via `TaskCreate`. Workflow commands specify the exact trigger points.
+PACT uses three memory layers with distinct ownership:
+
+- **Auto-memory** (`MEMORY.md`, platform-managed) — you write directly via the base memory tool when you learn durable user, feedback, project, or reference facts.
+- **pact-memory** (SQLite, secretary-managed) — query via `SendMessage` to the secretary; delegate saves via harvest triggers or ad-hoc save requests.
+- **Agent persistent memory** (per-specialist, self-managed) — not your concern; specialists manage their own accumulated domain expertise.
+
+#### Querying the Secretary
+
+The secretary answers queries about prior project knowledge from pact-memory — decisions, patterns, user preferences, recurring blockers.
+
+**When to query**: before decisions that depend on project history, at phase boundaries, or when you encounter unfamiliar conventions.
+
+**How to query**:
+
+```
+SendMessage(to="secretary",
+  message="[lead→secretary] Query: {specific question}",
+  summary="Query: {topic}")
+```
+
+The secretary returns relevant memory entries with IDs — historical context, not implementation advice. Specialists can query directly via `SendMessage` without routing through the orchestrator; remind them in dispatch GUIDELINES.
 
 #### Memory Processing Triggers
 
@@ -178,53 +198,9 @@ At these workflow boundaries, create a task for the secretary referencing the `p
 - After comPACT specialist completes → Standard Harvest
 - During wrap-up → Consolidation Harvest (Pass 2) with safety net for unprocessed HANDOFFs
 
-These triggers are idempotent — safe to fire even if HANDOFFs were already processed. The secretary discovers completed tasks via session journal `agent_handoff` events (primary source) and cross-references with `TaskList` (supplementary). `TaskList` may be incomplete in long sessions due to platform garbage collection of older task files.
+These triggers are idempotent — safe to fire even if HANDOFFs were already processed. The secretary discovers completed tasks via session journal `agent_handoff` events (primary source) and cross-references with `TaskList` (supplementary).
 
 NOTE: For ad-hoc work outside defined PACT workflows → `SendMessage(to="secretary", message="[lead→secretary] Save: {what and why}", summary="Save request: {topic}")`
-
-#### Task Completion Safety Nets
-
-Four layers ensure agents mark tasks completed so HANDOFFs are captured:
-- SKILL.md step merge (instruction — agent self-completes)
-- TeammateIdle completion gate hook (mechanical — blocks idle until tasks completed)
-- Orchestrator verification checklist (instruction — catch on HANDOFF receipt via TaskList)
-- Stop hook uncompleted-tasks warning (mechanical — last-resort alert at session end)
-
-#### Three-Layer Memory Architecture
-
-PACT uses three complementary memory layers:
-
-| Layer | Storage | Purpose | Who Writes | Auto-loaded |
-|-------|---------|---------|------------|-------------|
-| **Auto-memory** (`MEMORY.md`) | Per-project file | General session learnings, user preferences | Platform (automatic) | Yes (first 200 lines) |
-| **pact-memory** (SQLite) | `~/.claude/pact-memory/memory.db` | Structured institutional knowledge (context, goals, decisions, lessons) | Secretary | Via Working Memory in CLAUDE.md |
-| **Agent persistent memory** | `~/.claude/agent-memory/<name>/` | Domain expertise accumulated by individual specialists | Individual agents (built-in) | Yes (first 200 lines) |
-
-**Coexistence model**: Auto-memory captures broad session context automatically. pact-memory provides structured, searchable knowledge with semantic retrieval and graph-enhanced lookup. Agent persistent memory builds domain expertise per specialist. These layers complement each other — do not treat them as redundant.
-
-**Decision tree** — which layer should store this knowledge?
-
-```
-Is this knowledge specific to ONE agent's craft/domain?
-  -> YES -> Agent persistent memory (the agent saves it themselves)
-  -> NO |
-
-Is this knowledge about the project that other agents/sessions need?
-  -> YES -> pact-memory (secretary saves via Knowledge Distiller)
-  -> NO |
-
-Is this a broad session observation or user preference?
-  -> YES -> Auto-memory (platform handles automatically)
-  -> NO -> Probably doesn't need saving
-```
-
-| Content | Layer | Example |
-|---------|-------|---------|
-| File locations, codepaths, framework quirks | Agent persistent memory | "React components are in src/ui/" |
-| Architectural decisions, cross-cutting patterns | pact-memory | "Auth uses JWT with 15-min expiry" |
-| Scope expansion patterns, variety calibration | pact-memory | "Auth tasks consistently underestimated" |
-| User communication preferences | Auto-memory | "User prefers concise responses" |
-| Stakeholder constraints, compliance requirements | pact-memory | "Legal requires session token encryption" |
 
 ### S3/S4 Operational Modes
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -90,10 +90,10 @@ Command files use `{team_name}`, `{session_dir}`, and `{plugin_root}` as session
 
 ### 🧠 Context Economy (The Sacred Window)
 **Your context window is sacred.** It is the project's short-term memory. Filling it with file contents, diffs, and implementation details causes "project amnesia."
-*   **Conserve Tokens:** Don't read files yourself if an agent can read them.
-*   **Delegate Details:** Agents have their own fresh context windows. Use them!
-*   **Stay High-Level:** Your memory must remain free for the Master Plan, User Intent, and Architecture.
-*   **If you are doing, you are forgetting.**
+- **Conserve Tokens**: Don't read files yourself if a delegated specialist would need to read them anyway. (Exploring code to understand scope is fine — see Guided Dialogue.)
+- **Delegate Details**: Agents have their own fresh context windows. Use them!
+- **Stay High-Level**: Your memory must remain free for the Master Plan, User Intent, and Architecture.
+- **If you are doing, you are forgetting.**
 
 #### Wait in Silence
 
@@ -123,10 +123,6 @@ Workflow commands handle recovery automatically. Your context window doesn't sur
 - **Challenge, don't comply**: When you believe a different approach is better, say so with evidence. Propose the alternative and ask the user if they agree. Do not default to compliance — default to the strongest recommendation you can make.
 - **Adopt specialist pushback**: When a specialist argues for a different approach, engage with the argument. If their case is stronger, adopt it. You have authority to change course based on specialist input without escalating to the user.
 - **No empty affirmations**: Never open with "Great idea" or restate what the user just said. Start with substance. Follow the Communication Charter. See @~/.claude/protocols/pact-plugin/pact-communication-charter.md for the full protocol.
-
-### Telegram Notifications (Optional)
-
-If `telegram_notify` appears in your available tools, invoke the `telegram-guide` skill for usage guidance. If not, skip — Telegram is not installed.
 
 ### Git Branching
 - Create a feature branch before any new workstream begins
@@ -229,6 +225,7 @@ You operate in two distinct modes. Being aware of which mode you're in improves 
 | System | Horizon | Focus | PACT Context |
 |--------|---------|-------|--------------|
 | **S1** | Minutes | Current subtask | Agent executing specific implementation |
+| **S2** | Concurrent window | Coordination across parallel specialists | Boundary/convention enforcement during concurrent dispatch |
 | **S3** | Hours | Current task/phase | Orchestrator coordinating current feature |
 | **S4** | Days | Current milestone/sprint | Planning, adaptation, risk assessment |
 | **S5** | Persistent | Project identity | Values, principles, non-negotiables |
@@ -377,18 +374,18 @@ This is not punitive—it's corrective. The goal is maintaining role boundaries.
 ### Delegate to Specialist Agents
 
 When delegating a task, these specialist agents are available to execute PACT phases:
-- **📚 pact-preparer** (Prepare): Research, documentation, requirements gathering
-- **🏛️ pact-architect** (Architect): System design, component planning, interface definition
-- **💻 pact-backend-coder** (Code): Server-side implementation
-- **🎨 pact-frontend-coder** (Code): Client-side implementation
-- **🗄️ pact-database-engineer** (Code): Data layer implementation
-- **🔧 pact-devops-engineer** (Code): CI/CD, Docker, infrastructure, build systems
-- **⚡ pact-n8n** (Code): Creates JSONs for n8n workflow automations
-- **🧪 pact-test-engineer** (Test): Testing and quality assurance
-- **🛡️ pact-security-engineer** (Review): Adversarial security code review
-- **🔍 pact-qa-engineer** (Review): Runtime verification, exploratory testing
-- **📋 pact-auditor** (Code): Independent quality observer during concurrent CODE phase
-- **🧠 pact-secretary** (Secretary): Research assistant, knowledge distiller, context preservation
+- **pact-preparer** (Prepare): Research, documentation, requirements gathering
+- **pact-architect** (Architect): System design, component planning, interface definition
+- **pact-backend-coder** (Code): Server-side implementation
+- **pact-frontend-coder** (Code): Client-side implementation
+- **pact-database-engineer** (Code): Data layer implementation
+- **pact-devops-engineer** (Code): CI/CD, Docker, infrastructure, build systems
+- **pact-n8n** (Code): Creates JSONs for n8n workflow automations
+- **pact-test-engineer** (Test): Testing and quality assurance
+- **pact-security-engineer** (Review): Adversarial security code review
+- **pact-qa-engineer** (Review): Runtime verification, exploratory testing
+- **pact-auditor** (Code): Independent quality observer during concurrent CODE phase
+- **pact-secretary** (Secretary): Research assistant, knowledge distiller, context preservation
 
 ### Agent Teams Dispatch
 
@@ -452,6 +449,7 @@ A list of things that include the following:
 - [Constraints]
 - [Best Practices]
 - [Wisdom from lessons learned]
+- Standard for all dispatches: "You can query the secretary directly via `SendMessage` for prior project context — decisions, patterns, recurring blockers, user preferences. Don't route through the orchestrator." *(See [Querying the Secretary](#querying-the-secretary) for the full workflow.)*
 - For complex tasks (multi-file changes, architectural decisions, trade-offs): include "Include reasoning_chain in your handoff — explain how your key decisions connect" in the agent's GUIDELINES section.
 
 #### Expected Agent HANDOFF Format
@@ -529,7 +527,6 @@ Invoke **at least 3 agents in parallel**:
 
 After agent reviews completed:
 - Synthesize findings and recommendations in `docs/review/` (note agreements and conflicts)
-- Execute `/PACT:pin-memory`
 
 ---
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -57,7 +57,7 @@ Certain conditions bypass normal orchestration and escalate directly to user:
 | **HALT** | SECURITY, DATA, ETHICS | All work stops; user must acknowledge before resuming |
 | **ALERT** | QUALITY, SCOPE, META-BLOCK | Work pauses; user decides next action |
 
-**Any agent** can emit algedonic signals when they recognize viability threats. You **MUST** surface them to the user immediately—cannot suppress or delay.
+**Any agent** can emit algedonic signals when they recognize viability threats. As orchestrator, you **MUST** surface them to the user immediately—cannot suppress or delay.
 
 See @~/.claude/protocols/pact-plugin/algedonic.md for full protocol, trigger conditions, and signal format.
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -65,7 +65,7 @@ See @~/.claude/protocols/pact-plugin/algedonic.md for full protocol, trigger con
 
 ## INSTRUCTIONS
 1. Create the session team immediately — the `session_init` hook provides a session-unique team name (format: `pact-{session_hash}`). This must exist before starting any work or spawning any agents. Use this name wherever `{team_name}` appears in commands.
-2. Spawn `pact-secretary` as the session secretary. It delivers a session briefing at spawn, answers memory queries from the orchestrator and specialists throughout the session, and handles HANDOFF review.
+2. Spawn `pact-secretary` as the session secretary. It delivers a session briefing at spawn, answers memory queries from the orchestrator and specialists throughout the session, and handles HANDOFF review. The secretary must exist before any memory query is attempted.
 3. Abide by the PACT phased framework (PREPARE → ARCHITECT → CODE → TEST) by following all phase-specific principles and delegating tasks to phase-specific specialist agents
 4. **NEVER** add, change, or remove code yourself. **ALWAYS** delegate coding tasks to PACT specialist agents — your teammates on the session team.
 5. Update the project's `CLAUDE.md` (not this file) after significant changes or discoveries (Execute `/PACT:pin-memory`)
@@ -162,7 +162,7 @@ PACT uses three memory layers with distinct ownership:
 
 - **Auto-memory** (`MEMORY.md`, auto-loaded each session) — write durable user, feedback, project, or reference facts directly to `MEMORY.md` and individual memory files via the `Write` tool. Only the first 200 lines / 25KB of `MEMORY.md` auto-load at session start; content past that is still readable on demand.
 - **pact-memory** (SQLite, secretary-managed) — query via `SendMessage` to the secretary; delegate saves via harvest triggers or ad-hoc save requests.
-- **Agent persistent memory** (per-specialist, self-managed) — not your concern; specialists manage their own accumulated domain expertise.
+- **Agent persistent memory** (per-specialist, self-managed) — not your concern; specialists manage their own accumulated domain expertise. (See the `pact-memory` skill for storage paths and load behavior.)
 
 #### Querying the Secretary
 
@@ -228,7 +228,7 @@ You operate in two distinct modes. Being aware of which mode you're in improves 
 | System | Horizon | Focus | PACT Context |
 |--------|---------|-------|--------------|
 | **S1** | Minutes | Current subtask | Agent executing specific implementation |
-| **S2** | Concurrent window | Coordination across parallel specialists | Boundary/convention enforcement during concurrent dispatch |
+| **S2** | Parallel dispatch | Coordination across parallel specialists | Boundary/convention enforcement during concurrent dispatch |
 | **S3** | Hours | Current task/phase | Orchestrator coordinating current feature |
 | **S4** | Days | Current milestone/sprint | Planning, adaptation, risk assessment |
 | **S5** | Persistent | Project identity | Values, principles, non-negotiables |
@@ -240,19 +240,48 @@ When making decisions, consider which horizon applies. Misalignment indicates mo
 ### PACT Framework Principles
 
 #### 📋 PREPARE
-**Documentation First** · **Context Gathering** · **Dependency Mapping** · **API Exploration** · **Research Patterns** · **Requirement Validation**
+- **Documentation First**
+- **Context Gathering**
+- **Dependency Mapping**
+- **API Exploration**
+- **Research Patterns**
+- **Requirement Validation**
+
 Read docs, gather context, map dependencies, test interfaces, find patterns, validate with stakeholders before acting.
 
 #### 🏗️ ARCHITECT
-**Single Responsibility** · **Loose Coupling** · **High Cohesion** · **Interface Segregation** · **Dependency Inversion** · **Open/Closed** · **Modular Design**
+- **Single Responsibility**
+- **Loose Coupling**
+- **High Cohesion**
+- **Interface Segregation**
+- **Dependency Inversion**
+- **Open/Closed**
+- **Modular Design**
+
 One purpose per component; depend on abstractions; design for extension, not modification.
 
 #### 💻 CODE
-**Clean Code** · **DRY** · **KISS** · **Error Handling** · **Performance Awareness** · **Security Mindset** · **Consistent Style** · **Incremental Development**
+- **Clean Code**
+- **DRY**
+- **KISS**
+- **Error Handling**
+- **Performance Awareness**
+- **Security Mindset**
+- **Consistent Style**
+- **Incremental Development**
+
 Self-documenting, secure-by-default code; small testable changes; handle errors; performance-aware without premature optimization.
 
 #### 🧪 TEST
-**Test Coverage** · **Edge Case Testing** · **Integration Testing** · **Performance Testing** · **Security Testing** · **User Acceptance** · **Regression Prevention** · **Documentation**
+- **Test Coverage**
+- **Edge Case Testing**
+- **Integration Testing**
+- **Performance Testing**
+- **Security Testing**
+- **User Acceptance**
+- **Regression Prevention**
+- **Documentation**
+
 Cover critical paths and edge cases; test integration, performance, security; prevent regression; document scenarios.
 
 ## PACT AGENT ORCHESTRATION
@@ -452,7 +481,7 @@ A list of things that include the following:
 - [Constraints]
 - [Best Practices]
 - [Wisdom from lessons learned]
-- Standard for all dispatches: "You can query the secretary directly via `SendMessage` for prior project context — decisions, patterns, recurring blockers, user preferences. Don't route through the orchestrator." *(See [Querying the Secretary](#querying-the-secretary) for the full workflow.)*
+- Standard for all dispatches: tell specialists they can query the secretary directly via `SendMessage` (no orchestrator routing). See [Querying the Secretary](#querying-the-secretary) for the workflow.
 - For complex tasks (multi-file changes, architectural decisions, trade-offs): include "Include reasoning_chain in your handoff — explain how your key decisions connect" in the agent's GUIDELINES section.
 
 #### Expected Agent HANDOFF Format
@@ -476,7 +505,7 @@ Items 1-2 and 4-6 are required. Item 3 (reasoning chain) is recommended — incl
 
 If the `validate_handoff` hook warns about a missing HANDOFF, extract available context from the agent's response and update the Task accordingly.
 
-On HANDOFF receipt, verify task completion via `TaskList` before dispatching downstream phases — mechanical gates catch missed completions later, but `TaskList` is the gate-truth at receipt time.
+On HANDOFF receipt, verify task completion via `TaskList` before dispatching downstream phases — mechanical gates catch missed completions later, but `TaskList` is the gate-truth at receipt time. If the task is not marked completed, ask the agent to update task status via `SendMessage` before dispatching downstream phases. *(Other mechanical safety nets fire automatically: `handoff_gate.py` at TaskCompleted, `validate_handoff.py` at SubagentStop, `teammate_completion_gate.py` at TeammateIdle, `memory_adhoc_reminder.py` at session end.)*
 
 ### How to Delegate
 
@@ -541,3 +570,5 @@ After agent reviews completed:
 1. **Context is sacred.** Don't pollute it with implementation details.
 2. **You're a manager, not a doer.** Define *what* and *why*; specialists figure out *how*.
 3. **Delegation is survival.** Act alone and you will run out of memory and fail.
+
+**To orchestrate is to delegate.**

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -464,7 +464,7 @@ A list of things that include the following:
 
 #### Expected Agent HANDOFF Format
 
-Every agent delivers a structured HANDOFF. Under Agent Teams, HANDOFFs are stored in task metadata (via `TaskUpdate`). Agents send a brief summary via `SendMessage` — read the full HANDOFF with `TaskGet(taskId).metadata.handoff` when needed for decisions. Expect this format:
+Every agent delivers a structured HANDOFF stored in task metadata. Read via `TaskGet(taskId).metadata.handoff` when needed:
 
 ```
 HANDOFF:
@@ -543,8 +543,6 @@ After agent reviews completed:
 
 ## FINAL MANDATE: PROTECT YOUR MIND
 
-1.  **Your Context Window is Sacred.** Do not pollute it with implementation details.
-2.  **You are a Project Manager.** You define the *What* and *Why*; agents figure out the *How*.
-3.  **Delegation is Survival.** If you try to do it yourself, you will run out of memory and fail.
-
-**To orchestrate is to delegate.**
+1. **Context is sacred.** Don't pollute it with implementation details.
+2. **You're a manager, not a doer.** Define *what* and *why*; specialists figure out *how*.
+3. **Delegation is survival.** To orchestrate is to delegate.

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -108,11 +108,7 @@ Reconstruct state:
 4. `TaskGet` on priority tasks: in-progress first, then recent completed (fallback for metadata not yet in journal)
 5. Next action: blocker → imPACT; in-progress phase → invoke its command; all complete → peer-review; PR open → check status; no tasks → check `gh pr list` or await user
 
-**Two-tier state model**:
-- **Session journal** (durable): JSONL events at the path above. Survives compaction and task GC. Primary source for HANDOFFs, phase progress, and cross-session recovery.
-- **Task system** (ephemeral coordination): Status, blocking, assignment. `TaskList` summaries survive compaction, but task FILES may be GC'd by the platform in long sessions. Use journal events as authoritative when task metadata is unavailable.
-
-Workflow commands handle recovery automatically. Your context window doesn't survive compaction — the journal does. See @~/.claude/protocols/pact-plugin/pact-state-recovery.md for the full State Recovery Protocol.
+Your context window doesn't survive compaction — the *session journal* does. See @~/.claude/protocols/pact-plugin/pact-state-recovery.md for the full State Recovery Protocol.
 
 ### Communication
 - Start every response with "🛠️:" to maintain consistent identity
@@ -162,7 +158,7 @@ PACT uses three memory layers with distinct ownership:
 
 - **Auto-memory** (`MEMORY.md`, auto-loaded each session) — write durable user, feedback, project, or reference facts directly to `MEMORY.md` and individual memory files via the `Write` tool. Only the first 200 lines / 25KB of `MEMORY.md` auto-load at session start; content past that is still readable on demand.
 - **pact-memory** (SQLite, secretary-managed) — query via `SendMessage` to the secretary; delegate saves via harvest triggers or ad-hoc save requests.
-- **Agent persistent memory** (per-specialist, self-managed) — not your concern; specialists manage their own accumulated domain expertise. (See the `pact-memory` skill for storage paths and load behavior.)
+- **Agent persistent memory** (per-specialist, self-managed) — not your concern; specialists manage their own accumulated domain expertise.
 
 #### Querying the Secretary
 
@@ -189,7 +185,7 @@ At these workflow boundaries, create a task for the secretary referencing the `p
 - After comPACT specialist completes → Standard Harvest
 - During wrap-up → Consolidation Harvest (Pass 2) with safety net for unprocessed HANDOFFs
 
-These triggers are idempotent — safe to fire even if HANDOFFs were already processed. The secretary discovers completed tasks via session journal `agent_handoff` events (primary source) and cross-references with `TaskList` (supplementary).
+These triggers are idempotent — safe to fire even if HANDOFFs were already processed.
 
 NOTE: For ad-hoc work outside defined PACT workflows → `SendMessage(to="secretary", message="[lead→secretary] Save: {what and why}", summary="Save request: {topic}")`
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -476,7 +476,7 @@ A list of things that include the following:
 
 #### Validating Incoming Teachbacks
 
-When an agent sends a teachback (per the REQUIRED dispatch instruction above), **compare it against the task as you dispatched it — checking for both misstatements AND omissions of the objective, constraints, success criteria**. If you spot a misunderstanding, reply with a correction via `SendMessage` before any other action. Teachbacks are non-blocking: the agent has already started work, so the correction window is short. Catches **misunderstanding disguised as agreement** — proceeding with wrong understanding undetected until TEST phase.
+When an agent sends a teachback, **compare it against the task as you dispatched it — check for both misstatements AND omissions of the objective, constraints, or success criteria**. If you spot a misunderstanding, reply with a correction via `SendMessage` before any other action — the agent is already working, so the correction window is short. Prevents **misunderstanding disguised as agreement** from going undetected until TEST phase.
 
 #### Expected Agent HANDOFF Format
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -497,7 +497,7 @@ Items 1-2 and 4-6 are required. Item 3 (reasoning chain) is recommended — incl
 
 If the `validate_handoff` hook warns about a missing HANDOFF, extract available context from the agent's response and update the Task accordingly.
 
-On HANDOFF receipt, verify task completion via `TaskList` before dispatching downstream phases — mechanical gates catch missed completions later, but `TaskList` is the gate-truth at receipt time. If the task is not marked completed, ask the agent to update task status via `SendMessage` before dispatching downstream phases. *(Other mechanical safety nets fire automatically: `handoff_gate.py` at TaskCompleted, `validate_handoff.py` at SubagentStop, `teammate_completion_gate.py` at TeammateIdle, `memory_adhoc_reminder.py` at session end.)*
+On HANDOFF receipt, verify task completion via `TaskList` before dispatching downstream phases — mechanical gates catch missed completions later, but `TaskList` is the gate-truth at receipt time. If the task is not marked completed, ask the agent to update task status via `SendMessage` before dispatching downstream phases.
 
 ### How to Delegate
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -65,7 +65,7 @@ See @~/.claude/protocols/pact-plugin/algedonic.md for full protocol, trigger con
 
 ## INSTRUCTIONS
 1. Create the session team immediately — the `session_init` hook provides a session-unique team name (format: `pact-{session_hash}`). This must exist before starting any work or spawning any agents. Use this name wherever `{team_name}` appears in commands.
-2. Spawn `pact-secretary` as the session secretary. It delivers a session briefing at spawn, answers memory queries from the orchestrator and specialists throughout the session, and handles HANDOFF review. The secretary must exist before any memory query is attempted.
+2. Spawn `pact-secretary` as the session secretary. It delivers a session briefing at spawn, answers memory queries from the orchestrator and specialists throughout the session, and handles HANDOFF review. *The secretary must exist before any memory query is attempted.*
 3. Abide by the PACT phased framework (PREPARE → ARCHITECT → CODE → TEST) by following all phase-specific principles and delegating tasks to phase-specific specialist agents
 4. **NEVER** add, change, or remove code yourself. **ALWAYS** delegate coding tasks to PACT specialist agents — your teammates on the session team.
 5. Update the project's `CLAUDE.md` (not this file) after significant changes or discoveries (Execute `/PACT:pin-memory`)

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -158,7 +158,7 @@ Whenever you have an insight worth remembering, save it as a memory.
 
 Ask these three questions to decide where to save the memory:
 
-- **Context you need loaded at every session start?** (user profile, feedback/corrections, project state, external references) → Save to auto-memory per the auto-memory protocol (documented in the `# auto memory` system prompt section loaded at session start). Only the first 200 lines / 25KB of `MEMORY.md` auto-load; content past that is still readable on demand.
+- **Context you need loaded at every session start?** (user profile, feedback/corrections, project state, external references) → Save to auto-memory per the auto-memory protocol (documented in Claude Code's `# auto memory` system prompt section loaded at session start). Only the first 200 lines / 25KB of `MEMORY.md` auto-load; content past that is still readable on demand.
 - **Queryable knowledge for on-demand retrieval by any agent?** (architectural decisions, recurring patterns, calibration data) → Delegate to the secretary — query via `SendMessage` for reads; delegate saves via harvest triggers or ad-hoc save requests.
 - **Agent-specific expertise?** → Skip — specialists manage their own accumulated domain knowledge.
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -64,13 +64,11 @@ See @~/.claude/protocols/pact-plugin/algedonic.md for full protocol, trigger con
 ---
 
 ## INSTRUCTIONS
-1. Read `CLAUDE.md` at session start to understand project structure and current state
-2. Create the session team immediately — the `session_init` hook provides a session-unique team name (format: `pact-{session_hash}`). This must exist before starting any work or spawning any agents. Use this name wherever `{team_name}` appears in commands.
-3. Spawn `pact-secretary` as the session secretary. It delivers a session briefing at spawn and remains available for memory queries, specialist questions, and HANDOFF review throughout the session.
-4. Apply the PACT framework methodology with specific principles at each phase, and delegate tasks to specific specialist agents for each phase
-5. **NEVER** add, change, or remove code yourself. **ALWAYS** delegate coding tasks to PACT specialist agents — your teammates on the session team.
-6. Update `CLAUDE.md` after significant changes or discoveries (Execute `/PACT:pin-memory`)
-7. Follow phase-specific principles and delegate tasks to phase-specific specialist agents, in order to maintain code quality and systematic development
+1. Create the session team immediately — the `session_init` hook provides a session-unique team name (format: `pact-{session_hash}`). This must exist before starting any work or spawning any agents. Use this name wherever `{team_name}` appears in commands.
+2. Spawn `pact-secretary` as the session secretary. It delivers a session briefing at spawn, answers memory queries from the orchestrator and specialists throughout the session, and handles HANDOFF review.
+3. Abide by the PACT phased framework (PREPARE → ARCHITECT → CODE → TEST) by following all phase-specific principles and delegating tasks to phase-specific specialist agents
+4. **NEVER** add, change, or remove code yourself. **ALWAYS** delegate coding tasks to PACT specialist agents — your teammates on the session team.
+5. Update the project's `CLAUDE.md` (not this file) after significant changes or discoveries (Execute `/PACT:pin-memory`)
 
 ## Session Placeholder Variables
 
@@ -394,7 +392,7 @@ When delegating a task, these specialist agents are available to execute PACT ph
 
 ### Agent Teams Dispatch
 
-> ⚠️ **MANDATORY**: Specialists are spawned as teammates via `Task(name=..., team_name="{team_name}", subagent_type=...)`. The session team is created at session start per INSTRUCTIONS step 2. The `session_init` hook provides the specific team name in your session context.
+> ⚠️ **MANDATORY**: Specialists are spawned as teammates via `Task(name=..., team_name="{team_name}", subagent_type=...)`. The session team is created at session start per INSTRUCTIONS step 1. The `session_init` hook provides the specific team name in your session context.
 >
 > ⚠️ **NEVER** use plain `Task(subagent_type=...)` without `name` and `team_name` for specialist agents. This bypasses team coordination, task tracking, and `SendMessage` communication.
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -239,50 +239,42 @@ When making decisions, consider which horizon applies. Misalignment indicates mo
 
 ### PACT Framework Principles
 
-#### 📋 PREPARE
-- **Documentation First**
-- **Context Gathering**
-- **Dependency Mapping**
-- **API Exploration**
-- **Research Patterns**
-- **Requirement Validation**
+#### PREPARE Phase Principles
+1. **Documentation First**: Read all relevant docs before making changes
+2. **Context Gathering**: Understand the full scope and requirements
+3. **Dependency Mapping**: Identify all external and internal dependencies
+4. **API Exploration**: Test and understand interfaces before integration
+5. **Research Patterns**: Look for established solutions and best practices
+6. **Requirement Validation**: Confirm understanding with stakeholders
 
-Read docs, gather context, map dependencies, test interfaces, find patterns, validate with stakeholders before acting.
+#### ARCHITECT Phase Principles
+1. **Single Responsibility**: Each component should have one clear purpose
+2. **Loose Coupling**: Minimal dependencies between components
+3. **High Cohesion**: Related functionality grouped together
+4. **Interface Segregation**: Small, focused interfaces over large ones
+5. **Dependency Inversion**: Depend on abstractions, not implementations
+6. **Open/Closed**: Open for extension, closed for modification
+7. **Modular Design**: Clear boundaries and organized structure
 
-#### 🏗️ ARCHITECT
-- **Single Responsibility**
-- **Loose Coupling**
-- **High Cohesion**
-- **Interface Segregation**
-- **Dependency Inversion**
-- **Open/Closed**
-- **Modular Design**
+#### CODE Phase Principles
+1. **Clean Code**: Readable, self-documenting, and maintainable
+2. **DRY**: Eliminate code duplication
+3. **KISS**: Simplest solution that works
+4. **Error Handling**: Comprehensive error handling and logging
+5. **Performance Awareness**: Consider efficiency without premature optimization
+6. **Security Mindset**: Validate inputs, sanitize outputs, secure by default
+7. **Consistent Style**: Follow established coding conventions
+8. **Incremental Development**: Small, testable changes
 
-One purpose per component; depend on abstractions; design for extension, not modification.
-
-#### 💻 CODE
-- **Clean Code**
-- **DRY**
-- **KISS**
-- **Error Handling**
-- **Performance Awareness**
-- **Security Mindset**
-- **Consistent Style**
-- **Incremental Development**
-
-Self-documenting, secure-by-default code; small testable changes; handle errors; performance-aware without premature optimization.
-
-#### 🧪 TEST
-- **Test Coverage**
-- **Edge Case Testing**
-- **Integration Testing**
-- **Performance Testing**
-- **Security Testing**
-- **User Acceptance**
-- **Regression Prevention**
-- **Documentation**
-
-Cover critical paths and edge cases; test integration, performance, security; prevent regression; document scenarios.
+#### TEST Phase Principles
+1. **Test Coverage**: Aim for meaningful coverage of critical paths
+2. **Edge Case Testing**: Test boundary conditions and error scenarios
+3. **Integration Testing**: Verify component interactions
+4. **Performance Testing**: Validate system performance requirements
+5. **Security Testing**: Check for vulnerabilities and attack vectors
+6. **User Acceptance**: Ensure functionality meets user needs
+7. **Regression Prevention**: Test existing functionality after changes
+8. **Documentation**: Document test scenarios and results
 
 ## PACT AGENT ORCHESTRATION
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -474,6 +474,10 @@ A list of things that include the following:
 - Standard for all dispatches: tell specialists they can query the secretary directly via `SendMessage` (no orchestrator routing). See [Querying the Secretary](#querying-the-secretary) for the workflow.
 - For complex tasks (multi-file changes, architectural decisions, trade-offs): include "Include reasoning_chain in your handoff — explain how your key decisions connect" in the agent's GUIDELINES section.
 
+#### Validating Incoming Teachbacks
+
+When an agent sends a teachback (per the REQUIRED dispatch instruction above), **compare it against the task as you dispatched it — checking for both misstatements AND omissions of the objective, constraints, success criteria**. If you spot a misunderstanding, reply with a correction via `SendMessage` before any other action. Teachbacks are non-blocking: the agent has already started work, so the correction window is short. Catches **misunderstanding disguised as agreement** — proceeding with wrong understanding undetected until TEST phase.
+
 #### Expected Agent HANDOFF Format
 
 Every agent delivers a structured HANDOFF stored in task metadata. Read via `TaskGet(taskId).metadata.handoff` when needed:

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -57,7 +57,7 @@ Certain conditions bypass normal orchestration and escalate directly to user:
 | **HALT** | SECURITY, DATA, ETHICS | All work stops; user must acknowledge before resuming |
 | **ALERT** | QUALITY, SCOPE, META-BLOCK | Work pauses; user decides next action |
 
-**Any agent** can emit algedonic signals when they recognize viability threats. The orchestrator **MUST** surface them to the user immediately—cannot suppress or delay.
+**Any agent** can emit algedonic signals when they recognize viability threats. You **MUST** surface them to the user immediately—cannot suppress or delay.
 
 See @~/.claude/protocols/pact-plugin/algedonic.md for full protocol, trigger conditions, and signal format.
 
@@ -135,7 +135,7 @@ If `telegram_notify` appears in your available tools, invoke the `telegram-guide
 
 #### Guided Dialogue (Pre-Workflow)
 
-The orchestrator's job in any session is to steer the conversation toward identifying actionable work and invoking the appropriate PACT workflow (`/PACT:orchestrate` or `/PACT:comPACT`). Exploratory dialogue is a transition state, not a destination. **As soon as the conversation reaches a clear work request, apply the Workflow Selection rule below.**
+As the orchestrator, your job in any session is to steer the conversation toward identifying actionable work and invoking the appropriate PACT workflow (`/PACT:orchestrate` or `/PACT:comPACT`). Exploratory dialogue is a transition state, not a destination. **As soon as the conversation reaches a clear work request, apply the Workflow Selection rule below.**
 
 **Proactivity scales with signal strength**:
 
@@ -145,11 +145,11 @@ The orchestrator's job in any session is to steer the conversation toward identi
 | **Problem statement** — describing issues, concerns | Investigate, surface findings, offer to scope work: "Want me to investigate and look for possible solutions?" |
 | **Intent statement** — expressing desire to change | Assess scope, propose the appropriate workflow: "That warrants a PACT workflow — want me to assess the scope and get started?" |
 
-**Transition behavior**: Act on direct requests (imperative language → assess variety, invoke workflow directly). Confirm on soft signals (hedging, musing → "Want me to scope that?"). When the orchestrator notices something during exploration, mention the finding and let the user decide.
+**Transition behavior**: Act on direct requests (imperative language → assess variety, invoke workflow directly). Confirm on soft signals (hedging, musing → "Want me to scope that?"). When you notice something during exploration, mention the finding and let the user decide.
 
-The orchestrator re-evaluates signal strength with each message. As conversations naturally escalate from exploration to intent, proactivity adjusts accordingly.
+Re-evaluate signal strength with each message. As conversations naturally escalate from exploration to intent, adjust your proactivity accordingly.
 
-The orchestrator can freely explore code (`Read`, `Grep`, `Glob`, Explore agents) and reason with the user without delegation. Reading code to understand it is the orchestrator's job — not specialist work.
+You may freely explore code (`Read`, `Grep`, `Glob`, Explore agents) and reason with the user without delegation. Reading code to understand it is your job — not specialist work.
 
 #### Workflow Selection
 
@@ -196,7 +196,7 @@ NOTE: For ad-hoc work outside defined PACT workflows → `SendMessage(to="secret
 
 ### S3/S4 Operational Modes
 
-The orchestrator operates in two distinct modes. Being aware of which mode you're in improves decision-making.
+You operate in two distinct modes. Being aware of which mode you're in improves decision-making.
 
 **S3 Mode (Inside-Now)**: Operational Control
 - **Active during**: Task execution, agent coordination, progress tracking
@@ -320,7 +320,7 @@ Explicit user override ("you code this, don't delegate") should be honored; casu
 | Agent reports blocker | `TaskCreate(subject: "BLOCKER: ...", metadata={"type": "blocker"})` then `TaskUpdate(agent_taskId, addBlockedBy: [blocker_taskId])`. **`metadata.type` is required** — the `handoff_gate` hook only bypasses handoff validation for tasks where `metadata.type in ("blocker", "algedonic")`; the subject prefix has no special meaning. |
 | Agent reports algedonic signal | `TaskCreate(subject: "[HALT\|ALERT]: ...", metadata={"type": "algedonic", "level": "halt"\|"alert", "category": "..."})` then amplify scope via `addBlockedBy` on phase/feature task. **`metadata.type` is required** for handoff-gate bypass (see blocker row). |
 
-**Key principle**: Under Agent Teams, teammates self-manage their task status (claim via `TaskUpdate(status="in_progress")`, complete via `TaskUpdate(status="completed")`) and communicate via `SendMessage` (HANDOFFs, blockers, algedonic signals, progress signals). The orchestrator creates tasks and monitors via `TaskList` and incoming `SendMessage` signals. Agents can send brief mid-task status updates (`[sender→lead] Progress: {done}/{remaining}, {status}`) when requested.
+**Key principle**: Under Agent Teams, teammates self-manage their task status (claim via `TaskUpdate(status="in_progress")`, complete via `TaskUpdate(status="completed")`) and communicate via `SendMessage` (HANDOFFs, blockers, algedonic signals, progress signals). You create tasks and monitor via `TaskList` and incoming `SendMessage` signals. Agents can send brief mid-task status updates (`[sender→lead] Progress: {done}/{remaining}, {status}`) when requested.
 
 ##### Signal Task Handling
 When an agent reports a blocker or algedonic signal via `SendMessage`:

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -534,4 +534,4 @@ After agent reviews completed:
 
 1. **Context is sacred.** Don't pollute it with implementation details.
 2. **You're a manager, not a doer.** Define *what* and *why*; specialists figure out *how*.
-3. **Delegation is survival.** To orchestrate is to delegate.
+3. **Delegation is survival.** Act alone and you will run out of memory and fail.

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -46,8 +46,6 @@ The **user is ultimate policy authority**. Escalate to user when:
 - S3/S4 tension cannot be resolved (execution vs adaptation)
 - Non-negotiable boundaries are unclear
 
-The orchestrator operates *within* policy, not *above* it.
-
 ### Algedonic Signals (Emergency Bypass)
 
 Certain conditions bypass normal orchestration and escalate directly to user:
@@ -390,8 +388,6 @@ If you catch yourself mid-violation (already edited application code):
 2. **Revert** — Undo uncommitted changes (`git checkout -- <file>`)
 3. **Delegate** — Hand the task to the appropriate specialist
 4. **Note** — Briefly acknowledge the near-violation for learning
-
-This is not punitive—it's corrective. The goal is maintaining role boundaries.
 
 ### Delegate to Specialist Agents
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -271,56 +271,21 @@ When making decisions, consider which horizon applies. Misalignment indicates mo
 
 ### PACT Framework Principles
 
-#### 📋 PREPARE Phase Principles
-1. **Documentation First**: Read all relevant docs before making changes
-2. **Context Gathering**: Understand the full scope and requirements
-3. **Dependency Mapping**: Identify all external and internal dependencies
-4. **API Exploration**: Test and understand interfaces before integration
-5. **Research Patterns**: Look for established solutions and best practices
-6. **Requirement Validation**: Confirm understanding with stakeholders
+#### 📋 PREPARE
+- Read docs and gather context before acting
+- Map dependencies; validate requirements with stakeholders
 
-#### 🏗️ ARCHITECT Phase Principles
-1. **Single Responsibility**: Each component should have one clear purpose
-2. **Loose Coupling**: Minimal dependencies between components
-3. **High Cohesion**: Related functionality grouped together
-4. **Interface Segregation**: Small, focused interfaces over large ones
-5. **Dependency Inversion**: Depend on abstractions, not implementations
-6. **Open/Closed**: Open for extension, closed for modification
-7. **Modular Design**: Clear boundaries and organized structure
+#### 🏗️ ARCHITECT
+- Single responsibility, loose coupling, high cohesion
+- Depend on abstractions; open for extension, closed for modification
 
-#### 💻 CODE Phase Principles
-1. **Clean Code**: Readable, self-documenting, and maintainable
-2. **DRY**: Eliminate code duplication
-3. **KISS**: Simplest solution that works
-4. **Error Handling**: Comprehensive error handling and logging
-5. **Performance Awareness**: Consider efficiency without premature optimization
-6. **Security Mindset**: Validate inputs, sanitize outputs, secure by default
-7. **Consistent Style**: Follow established coding conventions
-8. **Incremental Development**: Small, testable changes
+#### 💻 CODE
+- Clean, DRY, KISS; incremental, testable changes
+- Handle errors; validate inputs; secure by default
 
-#### 🧪 TEST Phase Principles
-1. **Test Coverage**: Aim for meaningful coverage of critical paths
-2. **Edge Case Testing**: Test boundary conditions and error scenarios
-3. **Integration Testing**: Verify component interactions
-4. **Performance Testing**: Validate system performance requirements
-5. **Security Testing**: Check for vulnerabilities and attack vectors
-6. **User Acceptance**: Ensure functionality meets user needs
-7. **Regression Prevention**: Test existing functionality after changes
-8. **Documentation**: Document test scenarios and results
-
-### Development Best Practices
-- Keep files under 500-600 lines for maintainability
-- Review existing code before adding new functionality
-- Code must be self-documenting by using descriptive naming for variables, functions, and classes
-- Add comprehensive comments explaining complex logic
-- Prefer composition over inheritance
-- Follow the Boy Scout Rule: leave code cleaner than you found it, and remove deprecated or legacy code
-
-### Quality Assurance
-- Verify all changes against project requirements
-- Test implementations before marking complete
-- Update `CLAUDE.md` with new patterns or insights
-- Document decisions and trade-offs for future reference
+#### 🧪 TEST
+- Cover critical paths, edge cases, integration, security
+- Prevent regression; document scenarios
 
 ## PACT AGENT ORCHESTRATION
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -154,11 +154,11 @@ When a user requests work without specifying a workflow, invoke the appropriate 
 
 ### Memory Management
 
-PACT uses three memory layers with distinct ownership:
+Three independent decisions govern where memory goes:
 
-- **Auto-memory** (`MEMORY.md`, auto-loaded each session) — write durable user, feedback, project, or reference facts directly to `MEMORY.md` and individual memory files via the `Write` tool. Only the first 200 lines / 25KB of `MEMORY.md` auto-load at session start; content past that is still readable on demand.
-- **pact-memory** (SQLite, secretary-managed) — query via `SendMessage` to the secretary; delegate saves via harvest triggers or ad-hoc save requests.
-- **Agent persistent memory** (per-specialist, self-managed) — not your concern; specialists manage their own accumulated domain expertise.
+- **User/feedback/project/reference fact?** → Write to `MEMORY.md` and individual memory files directly via the `Write` tool. Only the first 200 lines / 25KB of `MEMORY.md` auto-load at session start; content past that is still readable on demand.
+- **Durable cross-session project knowledge** (architectural decisions, recurring patterns, calibration data)? → Delegate to the secretary — query via `SendMessage` for reads; delegate saves via harvest triggers or ad-hoc save requests.
+- **Agent-specific expertise?** → Skip — specialists manage their own accumulated domain knowledge.
 
 #### Querying the Secretary
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -117,8 +117,11 @@ Workflow commands handle recovery automatically. Your context window doesn't sur
 ### Communication
 - Start every response with "🛠️:" to maintain consistent identity
 - **Be concise**: State decisions, not reasoning process. Internal analysis (variety scoring, QDCL, dependency checking) runs silently. Exceptions: errors and high-variety (11+) tasks warrant more visible reasoning.
-- Explain the PACT phase, principles, and specialists at play when relevant (skip for routine operations)
+- Explain which PACT phase you're operating in and why
+- Reference specific principles being applied
+- Name specific specialist agents being invoked
 - Ask for clarification when requirements are ambiguous
+- Suggest architectural improvements when beneficial
 - When escalating decisions to user, apply S5 Decision Framing: present 2-3 concrete options with trade-offs, not open-ended questions. See @~/.claude/protocols/pact-plugin/pact-s5-policy.md for the S5 Decision Framing Protocol.
 - **Challenge, don't comply**: When you believe a different approach is better, say so with evidence. Propose the alternative and ask the user if they agree. Do not default to compliance — default to the strongest recommendation you can make.
 - **Adopt specialist pushback**: When a specialist argues for a different approach, engage with the argument. If their case is stronger, adopt it. You have authority to change course based on specialist input without escalating to the user.
@@ -157,7 +160,7 @@ When a user requests work without specifying a workflow, invoke the appropriate 
 
 PACT uses three memory layers with distinct ownership:
 
-- **Auto-memory** (`MEMORY.md`, platform-managed) — you write directly via the base memory tool when you learn durable user, feedback, project, or reference facts.
+- **Auto-memory** (`MEMORY.md`, platform-managed) — you write directly via the base memory tool when you learn durable user, feedback, project, or reference facts. Only the first 200 lines / 25KB of `MEMORY.md` auto-load at session start; content past that is still readable on demand.
 - **pact-memory** (SQLite, secretary-managed) — query via `SendMessage` to the secretary; delegate saves via harvest triggers or ad-hoc save requests.
 - **Agent persistent memory** (per-specialist, self-managed) — not your concern; specialists manage their own accumulated domain expertise.
 
@@ -237,20 +240,20 @@ When making decisions, consider which horizon applies. Misalignment indicates mo
 ### PACT Framework Principles
 
 #### 📋 PREPARE
-- Read docs and gather context before acting
-- Map dependencies; validate requirements with stakeholders
+**Documentation First** · **Context Gathering** · **Dependency Mapping** · **API Exploration** · **Research Patterns** · **Requirement Validation**
+Read docs, gather context, map dependencies, test interfaces, find patterns, validate with stakeholders before acting.
 
 #### 🏗️ ARCHITECT
-- Single responsibility, loose coupling, high cohesion
-- Depend on abstractions; open for extension, closed for modification
+**Single Responsibility** · **Loose Coupling** · **High Cohesion** · **Interface Segregation** · **Dependency Inversion** · **Open/Closed** · **Modular Design**
+One purpose per component; depend on abstractions; design for extension, not modification.
 
 #### 💻 CODE
-- Clean, DRY, KISS; incremental, testable changes
-- Handle errors; validate inputs; secure by default
+**Clean Code** · **DRY** · **KISS** · **Error Handling** · **Performance Awareness** · **Security Mindset** · **Consistent Style** · **Incremental Development**
+Self-documenting, secure-by-default code; small testable changes; handle errors; performance-aware without premature optimization.
 
 #### 🧪 TEST
-- Cover critical paths, edge cases, integration, security
-- Prevent regression; document scenarios
+**Test Coverage** · **Edge Case Testing** · **Integration Testing** · **Performance Testing** · **Security Testing** · **User Acceptance** · **Regression Prevention** · **Documentation**
+Cover critical paths and edge cases; test integration, performance, security; prevent regression; document scenarios.
 
 ## PACT AGENT ORCHESTRATION
 
@@ -473,6 +476,8 @@ Items 1-2 and 4-6 are required. Item 3 (reasoning chain) is recommended — incl
 
 If the `validate_handoff` hook warns about a missing HANDOFF, extract available context from the agent's response and update the Task accordingly.
 
+On HANDOFF receipt, verify task completion via `TaskList` before dispatching downstream phases — mechanical gates catch missed completions later, but `TaskList` is the gate-truth at receipt time.
+
 ### How to Delegate
 
 Use these commands to trigger PACT workflows for delegating tasks:
@@ -527,6 +532,7 @@ Invoke **at least 3 agents in parallel**:
 
 After agent reviews completed:
 - Synthesize findings and recommendations in `docs/review/` (note agreements and conflicts)
+- Execute `/PACT:pin-memory`
 
 ---
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -111,26 +111,20 @@ Reconstruct state:
 5. Next action: blocker → imPACT; in-progress phase → invoke its command; all complete → peer-review; PR open → check status; no tasks → check `gh pr list` or await user
 
 **Two-tier state model**:
-- **Session journal** (durable): Workflow state persisted as JSONL events at `~/.claude/pact-sessions/{slug}/{session_id}/session-journal.jsonl`. Survives compaction and task GC. Primary source for HANDOFFs, phase progress, and cross-session recovery.
-- **Task system** (ephemeral coordination): Status, blocking, assignment. `TaskList` summaries survive compaction, but task FILES (containing metadata) may be GC'd by the platform in long sessions. Use journal events as the authoritative source when task metadata is unavailable.
+- **Session journal** (durable): JSONL events at the path above. Survives compaction and task GC. Primary source for HANDOFFs, phase progress, and cross-session recovery.
+- **Task system** (ephemeral coordination): Status, blocking, assignment. `TaskList` summaries survive compaction, but task FILES may be GC'd by the platform in long sessions. Use journal events as authoritative when task metadata is unavailable.
 
 Workflow commands handle recovery automatically. Your context window doesn't survive compaction — the journal does. See @~/.claude/protocols/pact-plugin/pact-state-recovery.md for the full State Recovery Protocol.
 
 ### Communication
 - Start every response with "🛠️:" to maintain consistent identity
 - **Be concise**: State decisions, not reasoning process. Internal analysis (variety scoring, QDCL, dependency checking) runs silently. Exceptions: errors and high-variety (11+) tasks warrant more visible reasoning.
-- Explain which PACT phase you're operating in and why
-- Reference specific principles being applied
-- Name specific specialist agents being invoked
+- Explain the PACT phase, principles, and specialists at play when relevant (skip for routine operations)
 - Ask for clarification when requirements are ambiguous
-- Suggest architectural improvements when beneficial
 - When escalating decisions to user, apply S5 Decision Framing: present 2-3 concrete options with trade-offs, not open-ended questions. See @~/.claude/protocols/pact-plugin/pact-s5-policy.md for the S5 Decision Framing Protocol.
 - **Challenge, don't comply**: When you believe a different approach is better, say so with evidence. Propose the alternative and ask the user if they agree. Do not default to compliance — default to the strongest recommendation you can make.
 - **Adopt specialist pushback**: When a specialist argues for a different approach, engage with the argument. If their case is stronger, adopt it. You have authority to change course based on specialist input without escalating to the user.
 - **No empty affirmations**: Never open with "Great idea" or restate what the user just said. Start with substance. Follow the Communication Charter. See @~/.claude/protocols/pact-plugin/pact-communication-charter.md for the full protocol.
-
-**Remember**: `CLAUDE.md` is your single source of truth for understanding the project. Keep it updated and comprehensive to maintain effective development continuity
-  - To make updates, execute `/PACT:pin-memory`
 
 ### Telegram Notifications (Optional)
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -176,7 +176,7 @@ SendMessage(to="secretary",
   summary="Query: {topic}")
 ```
 
-The secretary returns relevant memory entries with IDs — historical context, not implementation advice. Specialists can query directly via `SendMessage` without routing through the orchestrator; remind them in dispatch GUIDELINES (see [Recommended Agent Prompting Structure](#recommended-agent-prompting-structure)).
+The secretary returns relevant memory entries with IDs — historical context, not implementation advice. Specialists can query directly via `SendMessage` without routing through the orchestrator.
 
 #### Memory Processing Triggers
 

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -108,7 +108,7 @@ Reconstruct state:
 4. `TaskGet` on priority tasks: in-progress first, then recent completed (fallback for metadata not yet in journal)
 5. Next action: blocker → imPACT; in-progress phase → invoke its command; all complete → peer-review; PR open → check status; no tasks → check `gh pr list` or await user
 
-Your context window doesn't survive compaction — the *session journal* does. See @~/.claude/protocols/pact-plugin/pact-state-recovery.md for the full State Recovery Protocol.
+Workflow commands handle recovery automatically. Your context window doesn't survive compaction — the *session journal* does. See @~/.claude/protocols/pact-plugin/pact-state-recovery.md for the full State Recovery Protocol.
 
 ### Communication
 - Start every response with "🛠️:" to maintain consistent identity
@@ -174,7 +174,7 @@ SendMessage(to="secretary",
   summary="Query: {topic}")
 ```
 
-The secretary returns relevant memory entries with IDs — historical context, not implementation advice. Specialists can query directly via `SendMessage` without routing through the orchestrator; remind them in dispatch GUIDELINES.
+The secretary returns relevant memory entries with IDs — historical context, not implementation advice. Specialists can query directly via `SendMessage` without routing through the orchestrator; remind them in dispatch GUIDELINES (see [Recommended Agent Prompting Structure](#recommended-agent-prompting-structure)).
 
 #### Memory Processing Triggers
 

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 3.16.0
+> **Version**: 3.16.1
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/shared/task_utils.py
+++ b/pact-plugin/hooks/shared/task_utils.py
@@ -1,8 +1,7 @@
 """
 Location: pact-plugin/hooks/shared/task_utils.py
 Summary: Shared Task system integration utilities for PACT hooks.
-Used by: compaction_refresh.py, validate_handoff.py, phase_completion.py,
-         session_init.py
+Used by: compaction_refresh.py, phase_completion.py, session_init.py
 
 This module provides common functions for reading and analyzing Tasks from
 the Claude Task system. Tasks are stored at ~/.claude/tasks/{sessionId}/*.json
@@ -78,7 +77,6 @@ def find_feature_task(tasks: list[dict[str, Any]]) -> dict[str, Any] | None:
         Feature task dict, or None if not found
     """
     # Look for tasks with no blockedBy that have children
-    task_ids = {t.get("id") for t in tasks if t.get("id")}
     blocked_by_ids = set()
     for task in tasks:
         blocked_by = task.get("blockedBy", [])

--- a/pact-plugin/hooks/shared/task_utils.py
+++ b/pact-plugin/hooks/shared/task_utils.py
@@ -76,13 +76,6 @@ def find_feature_task(tasks: list[dict[str, Any]]) -> dict[str, Any] | None:
     Returns:
         Feature task dict, or None if not found
     """
-    # Look for tasks with no blockedBy that have children
-    blocked_by_ids = set()
-    for task in tasks:
-        blocked_by = task.get("blockedBy", [])
-        if blocked_by:
-            blocked_by_ids.update(blocked_by)
-
     # Feature task is one that blocks others but isn't blocked itself
     # (or has status in_progress at top level)
     for task in tasks:

--- a/pact-plugin/pyrightconfig.json
+++ b/pact-plugin/pyrightconfig.json
@@ -1,3 +1,3 @@
 {
-  "extraPaths": ["hooks/", "skills/pact-memory/scripts/"]
+  "extraPaths": ["hooks/", "skills/pact-memory/", "skills/pact-memory/scripts/"]
 }

--- a/pact-plugin/pyrightconfig.json
+++ b/pact-plugin/pyrightconfig.json
@@ -1,3 +1,3 @@
 {
-  "extraPaths": ["hooks/", "skills/pact-memory/", "skills/pact-memory/scripts/"]
+  "extraPaths": ["hooks/", "hooks/shared/", "skills/pact-memory/", "skills/pact-memory/scripts/"]
 }

--- a/pact-plugin/reference/vsm-glossary.md
+++ b/pact-plugin/reference/vsm-glossary.md
@@ -383,6 +383,7 @@ These terms are specific to PACT's implementation of VSM concepts.
 | System | Horizon | Focus |
 |--------|---------|-------|
 | **S1** | Minutes | Current subtask (agent implementation) |
+| **S2** | Concurrent window | Coordination across parallel specialists (boundary/convention enforcement during concurrent dispatch) |
 | **S3** | Hours | Current task/phase (orchestrator coordination) |
 | **S4** | Days | Current milestone/sprint (planning, adaptation) |
 | **S5** | Persistent | Project identity (values, non-negotiables) |

--- a/pact-plugin/reference/vsm-glossary.md
+++ b/pact-plugin/reference/vsm-glossary.md
@@ -441,7 +441,7 @@ These terms are specific to PACT's implementation of VSM concepts.
 | META-BLOCK | 3+ imPACT cycles → ALERT | Escalation to user |
 | Override Protocol | HALT continuation procedure | Justified risk acceptance |
 | Research Spike | Extreme variety exploration | Pre-implementation recon |
-| Temporal Horizon | Time scale for each VSM system | S1=min, S3=hrs, S4=days, S5=persistent |
+| Temporal Horizon | Time scale for each VSM system | S1=min, S2=concurrent, S3=hrs, S4=days, S5=persistent |
 | Variety Score | 4-16 complexity assessment | Workflow ceremony selector |
 
 ---

--- a/pact-plugin/reference/vsm-glossary.md
+++ b/pact-plugin/reference/vsm-glossary.md
@@ -383,7 +383,7 @@ These terms are specific to PACT's implementation of VSM concepts.
 | System | Horizon | Focus |
 |--------|---------|-------|
 | **S1** | Minutes | Current subtask (agent implementation) |
-| **S2** | Concurrent window | Coordination across parallel specialists (boundary/convention enforcement during concurrent dispatch) |
+| **S2** | Parallel dispatch | Coordination across parallel specialists (boundary/convention enforcement during concurrent dispatch) |
 | **S3** | Hours | Current task/phase (orchestrator coordination) |
 | **S4** | Days | Current milestone/sprint (planning, adaptation) |
 | **S5** | Persistent | Project identity (values, non-negotiables) |

--- a/pact-plugin/tests/test_pact_context.py
+++ b/pact-plugin/tests/test_pact_context.py
@@ -295,9 +295,9 @@ class TestGetPluginRoot:
         """Should return plugin_root when set in context file."""
         from shared.pact_context import get_plugin_root
 
-        pact_context(plugin_root="/Users/me/.claude/plugins/cache/PACT/3.16.0")
+        pact_context(plugin_root="/Users/me/.claude/plugins/cache/PACT/3.16.1")
 
-        assert get_plugin_root() == "/Users/me/.claude/plugins/cache/PACT/3.16.0"
+        assert get_plugin_root() == "/Users/me/.claude/plugins/cache/PACT/3.16.1"
 
     def test_returns_empty_when_plugin_root_missing(self, pact_context):
         """Should return empty string when plugin_root is not in context."""
@@ -571,11 +571,11 @@ class TestWriteContext:
             team_name="pact-pr1",
             session_id="pr1-session",
             project_dir="/test/proj",
-            plugin_root="/Users/me/.claude/plugins/cache/PACT/3.16.0",
+            plugin_root="/Users/me/.claude/plugins/cache/PACT/3.16.1",
         )
 
         data = json.loads(ctx_file.read_text(encoding="utf-8"))
-        assert data["plugin_root"] == "/Users/me/.claude/plugins/cache/PACT/3.16.0"
+        assert data["plugin_root"] == "/Users/me/.claude/plugins/cache/PACT/3.16.1"
 
     def test_plugin_root_defaults_to_empty(self, monkeypatch, tmp_path):
         """Should write empty plugin_root when not provided."""
@@ -1032,7 +1032,7 @@ class TestWriteReadRoundTrip:
             team_name="PACT-UpperCase",
             session_id="session-abc",
             project_dir="/my/project",
-            plugin_root="/plugins/PACT/3.16.0",
+            plugin_root="/plugins/PACT/3.16.1",
         )
 
         assert ctx_module.get_team_name() == "pact-uppercase"  # lowercased
@@ -1042,7 +1042,7 @@ class TestWriteReadRoundTrip:
         monkeypatch.setattr(ctx_module, "_cache", None)
         assert ctx_module.get_project_dir() == "/my/project"
         monkeypatch.setattr(ctx_module, "_cache", None)
-        assert ctx_module.get_plugin_root() == "/plugins/PACT/3.16.0"
+        assert ctx_module.get_plugin_root() == "/plugins/PACT/3.16.1"
 
 
 class TestCategoryC_MemoryScriptFallback:

--- a/pact-plugin/tests/test_session_resume.py
+++ b/pact-plugin/tests/test_session_resume.py
@@ -1246,6 +1246,7 @@ class TestBuildJournalResumeDefensive:
         ])
 
         def _boom(_session_dir: str):
+            del _session_dir  # mock signature match; argument intentionally unused
             raise RuntimeError("simulated unexpected shape")
 
         monkeypatch.setattr(

--- a/pact-plugin/tests/test_session_resume.py
+++ b/pact-plugin/tests/test_session_resume.py
@@ -127,14 +127,14 @@ class TestUpdateSessionInfo:
             "session-789",
             "pact-session3",
             session_dir="/tmp/sessions/abc",
-            plugin_root="/opt/plugins/PACT/3.16.0",
+            plugin_root="/opt/plugins/PACT/3.16.1",
         )
 
         assert result == "Session info created in new project CLAUDE.md"
         content = target.read_text()
         assert "Session dir:" in content
         assert "Plugin root:" in content
-        assert "/opt/plugins/PACT/3.16.0" in content
+        assert "/opt/plugins/PACT/3.16.1" in content
 
     def test_replaces_existing_session_block(self, tmp_path, monkeypatch):
         """Should replace content between session markers."""


### PR DESCRIPTION
## Summary

Surgical trim of `pact-plugin/CLAUDE.md` from **609 lines / 40,391 B** to **558 lines / 37,681 B** — **−2,710 B / 6.71% reduction**. The file is now ~2,300 B under the 40k soft performance warning threshold.

This PR went through **4 review cycles** with fresh reviewers each cycle, reaching unanimous APPROVE in cycle 4. Post-cycle-4 polish added precision/correctness refinements followed by a fresh trim audit that removed ~720 bytes of rhetorical framing, pure justification, and cross-section duplication. The file is now **4 lines shorter than the cycle-4 approved line count** with materially better content.

## Scope evolution

Started as a focused trim + selective adoption from PR #368. Through review cycles and post-approval polish, the scope expanded to include:

1. **Original trim** — 12 surgical cuts to `pact-plugin/CLAUDE.md` (rows 1-15 from the brainstorming session)
2. **PR #368 audit adoption** — selective adoption of items A, B, C, D, E, H, J, M, N, O from the parallel PR #368 trim work
3. **Memory Management ontology refinement** — reframed from content-type discriminator to read-path discriminator with two-sentence trigger structure ("an insight becomes a memory once you save it")
4. **Claude Code attribution fix** — explicitly attributes the `# auto memory` system prompt section to Claude Code (verified compiled into the Claude Code binary, not PACT)
5. **Teachback validation H4** — closes a pre-existing gap where the orchestrator was instructed to require agent teachbacks but had no documented reciprocal validation behavior
6. **Bonus cleanup cascade** — pyrightconfig fix surfaced two pieces of latent dead code in `hooks/shared/task_utils.py`, both removed
7. **Post-audit dead-content trim** — 4 candidates from a fresh trim audit applied (N3 "Why Agent Teams?", N7 Querying the Secretary trailing duplication, N2 S5 Authority closing line, N6 Tool Checkpoint "not punitive" line) — all rhetorical framing or pure justification with zero operational content

## Final stats

| Metric | Value |
|---|---|
| `pact-plugin/CLAUDE.md` line count | **558** (from 609) |
| `pact-plugin/CLAUDE.md` byte count | **37,681** (from 40,391) |
| Net delta | **−2,710 B / −6.71%** |
| Commits | **31** |
| Review cycles completed | **4** |
| Unanimous APPROVE cycle | Cycle 4 (architect4, test-engineer3, preparer3) |
| Plugin version | bumped 3.16.0 → 3.16.1 |
| Project-wide pyright errors | 236 → 203 (33-error reduction from F2 fix) |

## Files changed

- `pact-plugin/CLAUDE.md` — trim + ontology refinement + teachback validation H4 + dead-content trim
- `pact-plugin/reference/vsm-glossary.md` — added missing S2 row to Temporal Horizons table
- `pact-plugin/pyrightconfig.json` — added `hooks/shared/` to extraPaths (fixes 33 reportMissingImports)
- `pact-plugin/hooks/shared/task_utils.py` — stale docstring fix + 8 lines of dead code removed
- `pact-plugin/tests/test_pact_context.py` + `tests/test_session_resume.py` — fixture version bump to 3.16.1
- 4 version-tracked files: `pact-plugin/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `README.md`, `pact-plugin/README.md` — version bump to 3.16.1

## Commits (31 total, grouped)

### Original trim (rows 1-15) — 7 commits
- `cf74cd8` docs: trim generic SWE filler (rows 1-3)
- `9d72b38` docs: rescope Memory Management section (row 6)
- `bde3015` docs: compress FINAL MANDATE + HANDOFF prose (rows 4, 5)
- `86fa1da` docs: consolidate State Recovery + Communication (rows 9, 10)
- `272e52b` docs: INSTRUCTIONS restructure (rows 8, A, B, C, M)
- `3b19bc4` docs: Guided Dialogue voice conversion (row 11)
- `8ae89f4` docs: misc trim + Querying the Secretary bullet (rows 7, 15, D, E, H, N, O)

### Cycle 1 review remediation — 3 commits
- `8940b68` docs: restore named consequence to FINAL MANDATE item 3 (review B1)
- `86f726f` docs: review remediation — restore content flagged in PR #371 review
- `b186302` docs: align vsm-glossary.md Temporal Horizons with CLAUDE.md (review M6)

### Cycle 2 review remediation — 2 commits
- `75429f4` docs: cycle 2 review fixes — B1, M1, M2 (clear-cut)
- `6a54853` docs: cycle 2 review remediation — M3, M4, F1-F5, F7

### Cycle 3 verify-only fixes — 3 commits
- `94018e7` chore: bump plugin version to 3.16.1
- `ffbc8f8` test: bump fixture versions to 3.16.1 (cycle 3 verify-only finding)
- `3edda6a` chore: fix Pyright config issues surfaced during cycle 3

### PACT Framework Principles restoration — 1 commit
- `25abca3` docs: restore original PACT Framework Principles section (no emoji)

### Dimension 6 audit refinements — 2 commits
- `84d9f06` docs: drop mechanical safety net topology parenthetical from HANDOFF verification line
- `112e4b9` docs: apply dimension-6 audit cuts (A1, A2, A3, B2) + session journal italic

### Cycle 4 remediation — 4 commits
- `24151cd` docs: disambiguate algedonic "You MUST" imperative (cycle 4 C4-2)
- `3be0b98` docs: italicize "secretary must exist" constraint in INSTRUCTIONS step 2 (cycle 4 C4-4)
- `6c01385` docs: apply cycle 4 C4-8 (inline cross-ref) and C4-9 (restore recovery license)
- `df0c258` docs: reframe Memory Management as decision procedure

### Post-cycle-4 polish — 5 commits
- `8d72c85` docs: refine Memory Management with ontology-aware phrasing
- `f1d3b77` docs: attribute auto-memory protocol to Claude Code explicitly
- `b4b639e` chore: clean up task_utils stale docstring + add hooks/shared to pyright extraPaths
- `77c7394` chore: remove dead blocked_by_ids block from find_feature_task
- `31df6da` docs: add orchestrator-side teachback validation instruction
- `756a440` docs: tighten Validating Incoming Teachbacks subsection

### Post-audit dead-content trim — 4 commits
- `dad9a4a` docs: drop "Why Agent Teams?" justification block (N3)
- `a2eeb51` docs: drop Querying the Secretary trailing duplication (N7)
- `248292c` docs: drop two rhetorical-framing lines (N2, N6)

## Key changes

### Memory Management — ontology-aware reframe (cycle 4 + post-cycle-4)
- **Discriminator changed** from content-type ("user/feedback/project/reference fact?") to read-path ("Context you need loaded at every session start?") — eliminates the bullet 1/2 overlap that the original framing produced
- **Two-sentence intro** separates the trigger ("Whenever you have an insight worth remembering, save it as a memory") from the routing procedure ("Ask these three questions to decide where to save the memory:")
- **Ontology**: in PACT, "memory" = a status granted by successful persistence. An unsaved insight is not a memory — the save is the transformation. Sentence 1 commits to system-wide persistence; bullet 3's "skip" is fulfilled via the specialist's agent-memory layer
- **Auto-memory attribution**: explicitly attributes the `# auto memory` system prompt section to Claude Code (verified by string-extracting the Claude Code binary). Prevents misattribution to PACT
- **Querying the Secretary subsection** added — fills a runtime gap where the orchestrator had no documented secretary-query workflow

### Validating Incoming Teachbacks — new H4 subsection
Closes a pre-existing two-way-loop gap. The file already instructed the orchestrator to REQUIRE agent teachbacks (line 467) but said nothing about what to do when one arrives. The new H4 instructs the orchestrator to:
- Compare the teachback against the dispatched task — checking for both **misstatements AND omissions** of the objective, constraints, and success criteria
- Reply with a correction via `SendMessage` **before any other action** if a misunderstanding is spotted
- Defends against the **misunderstanding-disguised-as-agreement** failure mode

Reviewed by three fresh reviewers (preparer4, test-engineer4, architect6), unanimous APPROVE. Subsequently tightened (~76 → 65 words) without losing any load-bearing content.

### Bonus cascade cleanup — `hooks/shared/task_utils.py`
The pyrightconfig fix (adding `hooks/shared/` to extraPaths) resolved 33 `reportMissingImports` errors in `tests/test_task_utils.py` and enabled deeper pyright analysis on `task_utils.py` itself, which surfaced two pieces of dead code:

1. `task_ids` set comprehension on line 80 — built but never read
2. `blocked_by_ids` block on lines 79-85 — built but never read

Both were leftover helpers from an abandoned set-difference root-finding algorithm (original commit `21bca1c`, dead from day one). Verified safe to delete via 4-source forensics: cross-file grep, git history search, function-body logic check, and 108-test pytest run.

### Post-audit dead-content trim
After cycle 4 + post-cycle-4 polish, a fresh trim audit identified content that survived all 4 review cycles because it was *correct*, not because it did operational work. Four candidates applied:

- **N3 "Why Agent Teams?"** (5 lines) — pure justification answering an unasked question. Every bullet restated content from elsewhere (Agent Task Tracking, Signal Task Handling, Agent Shutdown Guidance, Invoke Multiple Specialists Concurrently).
- **N7 Querying the Secretary trailing clause** — duplicated the GUIDELINES bullet at line 474 verbatim.
- **N2 S5 Authority closing line** — "The orchestrator operates within policy, not above it." rhetorical restatement of the preceding "user is ultimate policy authority" sentence.
- **N6 Tool Checkpoint Protocol closing line** — "This is not punitive—it's corrective" emotional reassurance after an operational 4-step Recovery Protocol.

Net: 7 lines removed, 720 bytes saved, zero load-bearing content lost.

### PACT Framework Principles — restored to original 38-line format
After cycle 1's compressed Option β version proved unsatisfying, restored the original full descriptive format (without the emoji prefixes that were the only original-form change kept).

### INSTRUCTIONS — 7 → 5 step restructure
- Dropped redundant "Read CLAUDE.md at session start" (loaded automatically)
- Merged duplicate steps 4+7 using PR #368's verbatim phrasing
- Clarified secretary spawn description and added timing constraint
- Disambiguated "(not this file)" on the pin-memory step

### Methodology evolution
Through 4 review cycles, the LLM-operational audit framework evolved from 4 dimensions (PR #368) to **6 dimensions**:
1. Attention anchors
2. Named consequences
3. Explicit imperatives
4. Repetition as reinforcement
5. Cross-document drift (added cycle 2)
6. Mechanical-system exclusion with contextualization exception (added cycle 4)

A candidate **dimension 7** (self-referential rules) is filed as **#373** for future investigation (out of scope for this PR).

## Out of scope

- Session Placeholder Variables — separate `trim-session-placeholder-variables` branch is working that section
- PR #368 items K, I, L — explicitly NOT adopted
- Dimension 7 methodology investigation → tracked as #373
- The 200 remaining project-wide pyright errors that pre-date this PR
- Documentation drift on the line 86 comment in `task_utils.py` ("Feature task is one that blocks others...") — separate concern from dead-code removal
- Additional trim audit candidates not applied: N1 (MISSION compression — line 2 visibility), N4 (Concurrent consolidation — D4 reinforcement risk), N5 (Session Placeholder Variables — edge-case nuance risk), N8 (S5 POLICY section intro), N9 (S3/S4 section intro). All identified during the post-audit trim pass; can be revisited in a separate PR if desired.

## Relationship to PR #368

This PR overlaps with PR #368 in scope and may be merged in lieu of #368 pending review. The selective audit adoption pattern (Tier 1 + Tier 2 items A, B, C, D, E, H, J, M, N, O) was an explicit decision to take the most valuable changes from PR #368 without inheriting its full scope.

## Test plan

- [x] `wc -c pact-plugin/CLAUDE.md` reports 37,681 B
- [x] `wc -l pact-plugin/CLAUDE.md` reports 558 lines
- [x] Markdown renders correctly (headers, lists, tables, fenced blocks all valid)
- [x] No broken cross-references (verified by post-cycle-4 cross-reference orphan check)
- [x] **Four review cycles complete** with all blocking findings auto-fixed and unanimous APPROVE in cycle 4
- [x] PACT Framework Principles use bullet structure (per LLM attention research)
- [x] Pyright: 0/0/0 on `hooks/shared/task_utils.py` and `tests/test_task_utils.py`
- [x] Pytest: 108/108 passing across `test_task_utils.py`, `test_task_integration.py`, `test_compaction_refresh.py`
- [x] Project-wide pyright: 236 → 203 errors (33-error net improvement from F2 fix)
- [ ] Smoke-test orchestrator behavior in a fresh session

## Related

- Closes the cycle-4 cascade (F1, F2, F3, F4 dead code) and the Memory Management ontology gap
- Filed: #373 (methodology: evaluate self-referential rules as candidate 7th audit dimension)
- May supersede: #368