### PR TITLE
fix(#361): reduce specialist spawn context overhead — C.1 lazy-load + #366 budget-discipline skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "3.16.2",
+      "version": "3.16.3",
       "author": {
         "name": "ProfSynapse"
       },

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-marketplace/
 │           └── PACT/
-│               └── 3.16.2/     # Plugin version
+│               └── 3.16.3/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "3.16.2",
+  "version": "3.16.3",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "ProfSynapse",

--- a/pact-plugin/CLAUDE.md
+++ b/pact-plugin/CLAUDE.md
@@ -423,7 +423,7 @@ When delegating a task, these specialist agents are available to execute PACT ph
 | Idle agent has relevant context (same files/domain) | `SendMessage` to reassign |
 | Idle agent exists, but unrelated prior context | Spawn new (fresh context is cleaner) |
 | Need parallel work + idle agent is single-threaded | Spawn new for parallelism |
-| Agent's context near capacity from prior work | Spawn new |
+| Prior task was complex (variety ≥ 7, multi-file, architecture-heavy, or ≥ 5 significant tool invocations) | Spawn new — anticipate capacity problem from task shape, don't wait for measured "near capacity" (exception: secretary and auditor are singular-per-session; see pact-budget-discipline discipline #6) |
 | Reviewer found issues → now needs fixer | Reuse the reviewer (they know the problem best) |
 
 **Default**: Prefer reuse when domain + context overlap. When reusing, prompt minimally — just the delta (e.g., `"Follow-up task: {X}. You already have context from {Y}."`).

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 3.16.2
+> **Version**: 3.16.3
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/agents/pact-architect.md
+++ b/pact-plugin/agents/pact-architect.md
@@ -17,8 +17,7 @@ This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
 spawn (or after reuse for a new task), invoke the Skill tool:
 `Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
-HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
-now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+HANDOFF format).
 
 If the orchestrator or a peer references the `request-more-context` skill,
 invoke it on demand via `Skill("PACT:request-more-context")` as well.

--- a/pact-plugin/agents/pact-architect.md
+++ b/pact-plugin/agents/pact-architect.md
@@ -13,8 +13,9 @@ You are 🏛️ PACT Architect, a solution design specialist focusing on the Arc
 # AGENT TEAMS PROTOCOL
 
 This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
-`TaskUpdate`, and other team tools. **Before calling any of these for the first
-time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+`TaskUpdate`, and other team tools. **On first use of any of these tools after
+spawn (or after reuse for a new task), invoke the Skill tool:
+`Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
 HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
 now lazy-loaded to reduce per-spawn context overhead (see issue #361).

--- a/pact-plugin/agents/pact-architect.md
+++ b/pact-plugin/agents/pact-architect.md
@@ -6,12 +6,21 @@ description: |
 color: "#6A0DAD"
 permissionMode: acceptEdits
 memory: user
-skills:
-  - pact-agent-teams
-  - request-more-context
 ---
 
 You are 🏛️ PACT Architect, a solution design specialist focusing on the Architect phase of the PACT framework. You handle the second phase of the Prepare, Architect, Code, Test (PACT), receiving research and documentation from the Prepare phase to create comprehensive architectural designs that guide implementation in the Code phase.
+
+# AGENT TEAMS PROTOCOL
+
+This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
+`TaskUpdate`, and other team tools. **Before calling any of these for the first
+time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+communication protocol (teachback, progress signals, message format, lifecycle,
+HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
+now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+
+If the orchestrator or a peer references the `request-more-context` skill,
+invoke it on demand via `Skill("PACT:request-more-context")` as well.
 
 # REQUIRED SKILLS - INVOKE BEFORE DESIGNING
 

--- a/pact-plugin/agents/pact-auditor.md
+++ b/pact-plugin/agents/pact-auditor.md
@@ -16,8 +16,9 @@ You are PACT Auditor, a concurrent quality observer during the Code phase of the
 # AGENT TEAMS PROTOCOL
 
 This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
-`TaskUpdate`, and other team tools. **Before calling any of these for the first
-time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+`TaskUpdate`, and other team tools. **On first use of any of these tools after
+spawn (or after reuse for a new task), invoke the Skill tool:
+`Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
 HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
 now lazy-loaded to reduce per-spawn context overhead (see issue #361).

--- a/pact-plugin/agents/pact-auditor.md
+++ b/pact-plugin/agents/pact-auditor.md
@@ -8,12 +8,22 @@ color: "#4169E1"
 permissionMode: byDefault
 memory: user
 skills:
-  - pact-agent-teams
   - pact-architecture-patterns
-  - request-more-context
 ---
 
 You are PACT Auditor, a concurrent quality observer during the Code phase of the Prepare, Architect, Code, Test (PACT) framework.
+
+# AGENT TEAMS PROTOCOL
+
+This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
+`TaskUpdate`, and other team tools. **Before calling any of these for the first
+time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+communication protocol (teachback, progress signals, message format, lifecycle,
+HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
+now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+
+If the orchestrator or a peer references the `request-more-context` skill,
+invoke it on demand via `Skill("PACT:request-more-context")` as well.
 
 # REQUIRED SKILLS - INVOKE BEFORE OBSERVING
 

--- a/pact-plugin/agents/pact-auditor.md
+++ b/pact-plugin/agents/pact-auditor.md
@@ -20,8 +20,7 @@ This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
 spawn (or after reuse for a new task), invoke the Skill tool:
 `Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
-HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
-now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+HANDOFF format).
 
 If the orchestrator or a peer references the `request-more-context` skill,
 invoke it on demand via `Skill("PACT:request-more-context")` as well.

--- a/pact-plugin/agents/pact-backend-coder.md
+++ b/pact-plugin/agents/pact-backend-coder.md
@@ -6,12 +6,21 @@ description: |
 color: "#1E90FF"
 permissionMode: acceptEdits
 memory: user
-skills:
-  - pact-agent-teams
-  - request-more-context
 ---
 
 You are 💻 PACT Backend Coder, a server-side development specialist focusing on backend implementation during the Code phase of the Prepare, Architect, Code, Test (PACT) framework.
+
+# AGENT TEAMS PROTOCOL
+
+This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
+`TaskUpdate`, and other team tools. **Before calling any of these for the first
+time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+communication protocol (teachback, progress signals, message format, lifecycle,
+HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
+now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+
+If the orchestrator or a peer references the `request-more-context` skill,
+invoke it on demand via `Skill("PACT:request-more-context")` as well.
 
 # REQUIRED SKILLS - INVOKE BEFORE CODING
 

--- a/pact-plugin/agents/pact-backend-coder.md
+++ b/pact-plugin/agents/pact-backend-coder.md
@@ -17,8 +17,7 @@ This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
 spawn (or after reuse for a new task), invoke the Skill tool:
 `Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
-HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
-now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+HANDOFF format).
 
 If the orchestrator or a peer references the `request-more-context` skill,
 invoke it on demand via `Skill("PACT:request-more-context")` as well.

--- a/pact-plugin/agents/pact-backend-coder.md
+++ b/pact-plugin/agents/pact-backend-coder.md
@@ -13,8 +13,9 @@ You are 💻 PACT Backend Coder, a server-side development specialist focusing o
 # AGENT TEAMS PROTOCOL
 
 This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
-`TaskUpdate`, and other team tools. **Before calling any of these for the first
-time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+`TaskUpdate`, and other team tools. **On first use of any of these tools after
+spawn (or after reuse for a new task), invoke the Skill tool:
+`Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
 HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
 now lazy-loaded to reduce per-spawn context overhead (see issue #361).

--- a/pact-plugin/agents/pact-database-engineer.md
+++ b/pact-plugin/agents/pact-database-engineer.md
@@ -13,8 +13,9 @@ You are 🗄️ PACT Database Engineer, a data storage specialist focusing on da
 # AGENT TEAMS PROTOCOL
 
 This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
-`TaskUpdate`, and other team tools. **Before calling any of these for the first
-time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+`TaskUpdate`, and other team tools. **On first use of any of these tools after
+spawn (or after reuse for a new task), invoke the Skill tool:
+`Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
 HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
 now lazy-loaded to reduce per-spawn context overhead (see issue #361).

--- a/pact-plugin/agents/pact-database-engineer.md
+++ b/pact-plugin/agents/pact-database-engineer.md
@@ -17,8 +17,7 @@ This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
 spawn (or after reuse for a new task), invoke the Skill tool:
 `Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
-HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
-now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+HANDOFF format).
 
 If the orchestrator or a peer references the `request-more-context` skill,
 invoke it on demand via `Skill("PACT:request-more-context")` as well.

--- a/pact-plugin/agents/pact-database-engineer.md
+++ b/pact-plugin/agents/pact-database-engineer.md
@@ -6,12 +6,21 @@ description: |
 color: "#FFBF00"
 permissionMode: acceptEdits
 memory: user
-skills:
-  - pact-agent-teams
-  - request-more-context
 ---
 
 You are 🗄️ PACT Database Engineer, a data storage specialist focusing on database implementation during the Code phase of the PACT framework.
+
+# AGENT TEAMS PROTOCOL
+
+This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
+`TaskUpdate`, and other team tools. **Before calling any of these for the first
+time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+communication protocol (teachback, progress signals, message format, lifecycle,
+HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
+now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+
+If the orchestrator or a peer references the `request-more-context` skill,
+invoke it on demand via `Skill("PACT:request-more-context")` as well.
 
 # REQUIRED SKILLS - INVOKE BEFORE IMPLEMENTING
 

--- a/pact-plugin/agents/pact-devops-engineer.md
+++ b/pact-plugin/agents/pact-devops-engineer.md
@@ -6,12 +6,21 @@ description: |
 color: "#FF6600"
 permissionMode: acceptEdits
 memory: user
-skills:
-  - pact-agent-teams
-  - request-more-context
 ---
 
 You are 🔧 PACT DevOps Engineer, an infrastructure and build system specialist focusing on non-application infrastructure during the Code phase of the Prepare, Architect, Code, Test (PACT) framework.
+
+# AGENT TEAMS PROTOCOL
+
+This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
+`TaskUpdate`, and other team tools. **Before calling any of these for the first
+time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+communication protocol (teachback, progress signals, message format, lifecycle,
+HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
+now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+
+If the orchestrator or a peer references the `request-more-context` skill,
+invoke it on demand via `Skill("PACT:request-more-context")` as well.
 
 # REQUIRED SKILLS - INVOKE BEFORE CODING
 

--- a/pact-plugin/agents/pact-devops-engineer.md
+++ b/pact-plugin/agents/pact-devops-engineer.md
@@ -17,8 +17,7 @@ This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
 spawn (or after reuse for a new task), invoke the Skill tool:
 `Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
-HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
-now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+HANDOFF format).
 
 If the orchestrator or a peer references the `request-more-context` skill,
 invoke it on demand via `Skill("PACT:request-more-context")` as well.

--- a/pact-plugin/agents/pact-devops-engineer.md
+++ b/pact-plugin/agents/pact-devops-engineer.md
@@ -13,8 +13,9 @@ You are 🔧 PACT DevOps Engineer, an infrastructure and build system specialist
 # AGENT TEAMS PROTOCOL
 
 This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
-`TaskUpdate`, and other team tools. **Before calling any of these for the first
-time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+`TaskUpdate`, and other team tools. **On first use of any of these tools after
+spawn (or after reuse for a new task), invoke the Skill tool:
+`Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
 HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
 now lazy-loaded to reduce per-spawn context overhead (see issue #361).

--- a/pact-plugin/agents/pact-frontend-coder.md
+++ b/pact-plugin/agents/pact-frontend-coder.md
@@ -6,12 +6,21 @@ description: |
 color: "#32CD32"
 permissionMode: acceptEdits
 memory: user
-skills:
-  - pact-agent-teams
-  - request-more-context
 ---
 
 You are **🎨 PACT Frontend Coder**, a client-side development specialist focusing on frontend implementation during the Code phase of the PACT framework.
+
+# AGENT TEAMS PROTOCOL
+
+This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
+`TaskUpdate`, and other team tools. **Before calling any of these for the first
+time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+communication protocol (teachback, progress signals, message format, lifecycle,
+HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
+now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+
+If the orchestrator or a peer references the `request-more-context` skill,
+invoke it on demand via `Skill("PACT:request-more-context")` as well.
 
 # REQUIRED SKILLS - INVOKE BEFORE CODING
 

--- a/pact-plugin/agents/pact-frontend-coder.md
+++ b/pact-plugin/agents/pact-frontend-coder.md
@@ -17,8 +17,7 @@ This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
 spawn (or after reuse for a new task), invoke the Skill tool:
 `Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
-HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
-now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+HANDOFF format).
 
 If the orchestrator or a peer references the `request-more-context` skill,
 invoke it on demand via `Skill("PACT:request-more-context")` as well.

--- a/pact-plugin/agents/pact-frontend-coder.md
+++ b/pact-plugin/agents/pact-frontend-coder.md
@@ -13,8 +13,9 @@ You are **🎨 PACT Frontend Coder**, a client-side development specialist focus
 # AGENT TEAMS PROTOCOL
 
 This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
-`TaskUpdate`, and other team tools. **Before calling any of these for the first
-time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+`TaskUpdate`, and other team tools. **On first use of any of these tools after
+spawn (or after reuse for a new task), invoke the Skill tool:
+`Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
 HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
 now lazy-loaded to reduce per-spawn context overhead (see issue #361).

--- a/pact-plugin/agents/pact-n8n.md
+++ b/pact-plugin/agents/pact-n8n.md
@@ -13,8 +13,9 @@ You are n8n PACT n8n Workflow Specialist, a workflow automation expert focusing 
 # AGENT TEAMS PROTOCOL
 
 This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
-`TaskUpdate`, and other team tools. **Before calling any of these for the first
-time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+`TaskUpdate`, and other team tools. **On first use of any of these tools after
+spawn (or after reuse for a new task), invoke the Skill tool:
+`Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
 HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
 now lazy-loaded to reduce per-spawn context overhead (see issue #361).

--- a/pact-plugin/agents/pact-n8n.md
+++ b/pact-plugin/agents/pact-n8n.md
@@ -17,8 +17,7 @@ This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
 spawn (or after reuse for a new task), invoke the Skill tool:
 `Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
-HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
-now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+HANDOFF format).
 
 If the orchestrator or a peer references the `request-more-context` skill,
 invoke it on demand via `Skill("PACT:request-more-context")` as well.

--- a/pact-plugin/agents/pact-n8n.md
+++ b/pact-plugin/agents/pact-n8n.md
@@ -6,12 +6,21 @@ description: |
 color: "#FF7F50"
 permissionMode: acceptEdits
 memory: user
-skills:
-  - pact-agent-teams
-  - request-more-context
 ---
 
 You are n8n PACT n8n Workflow Specialist, a workflow automation expert focusing on building, validating, and deploying n8n workflows during the Code phase of the Prepare, Architect, Code, Test (PACT) framework.
+
+# AGENT TEAMS PROTOCOL
+
+This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
+`TaskUpdate`, and other team tools. **Before calling any of these for the first
+time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+communication protocol (teachback, progress signals, message format, lifecycle,
+HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
+now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+
+If the orchestrator or a peer references the `request-more-context` skill,
+invoke it on demand via `Skill("PACT:request-more-context")` as well.
 
 # REQUIRED SKILLS - INVOKE BEFORE BUILDING WORKFLOWS
 

--- a/pact-plugin/agents/pact-preparer.md
+++ b/pact-plugin/agents/pact-preparer.md
@@ -17,8 +17,7 @@ This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
 spawn (or after reuse for a new task), invoke the Skill tool:
 `Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
-HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
-now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+HANDOFF format).
 
 If the orchestrator or a peer references the `request-more-context` skill,
 invoke it on demand via `Skill("PACT:request-more-context")` as well.

--- a/pact-plugin/agents/pact-preparer.md
+++ b/pact-plugin/agents/pact-preparer.md
@@ -13,8 +13,9 @@ You are 📚 PACT Preparer, a documentation and research specialist focusing on 
 # AGENT TEAMS PROTOCOL
 
 This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
-`TaskUpdate`, and other team tools. **Before calling any of these for the first
-time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+`TaskUpdate`, and other team tools. **On first use of any of these tools after
+spawn (or after reuse for a new task), invoke the Skill tool:
+`Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
 HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
 now lazy-loaded to reduce per-spawn context overhead (see issue #361).

--- a/pact-plugin/agents/pact-preparer.md
+++ b/pact-plugin/agents/pact-preparer.md
@@ -6,12 +6,21 @@ description: |
 color: "#008080"
 permissionMode: acceptEdits
 memory: user
-skills:
-  - pact-agent-teams
-  - request-more-context
 ---
 
 You are 📚 PACT Preparer, a documentation and research specialist focusing on the Prepare phase of software development within the PACT framework. You are an expert at finding, evaluating, and organizing technical documentation from authoritative sources.
+
+# AGENT TEAMS PROTOCOL
+
+This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
+`TaskUpdate`, and other team tools. **Before calling any of these for the first
+time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+communication protocol (teachback, progress signals, message format, lifecycle,
+HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
+now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+
+If the orchestrator or a peer references the `request-more-context` skill,
+invoke it on demand via `Skill("PACT:request-more-context")` as well.
 
 # REQUIRED SKILLS - INVOKE BEFORE RESEARCHING
 

--- a/pact-plugin/agents/pact-qa-engineer.md
+++ b/pact-plugin/agents/pact-qa-engineer.md
@@ -6,12 +6,21 @@ description: |
 color: "#FF69B4"
 permissionMode: acceptEdits
 memory: user
-skills:
-  - pact-agent-teams
-  - request-more-context
 ---
 
 You are 🔍 PACT QA Engineer, a runtime verification specialist focusing on exploratory testing of running applications during the Review phase of the Prepare, Architect, Code, Test (PACT) framework.
+
+# AGENT TEAMS PROTOCOL
+
+This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
+`TaskUpdate`, and other team tools. **Before calling any of these for the first
+time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+communication protocol (teachback, progress signals, message format, lifecycle,
+HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
+now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+
+If the orchestrator or a peer references the `request-more-context` skill,
+invoke it on demand via `Skill("PACT:request-more-context")` as well.
 
 # REQUIRED SKILLS - INVOKE BEFORE TESTING
 

--- a/pact-plugin/agents/pact-qa-engineer.md
+++ b/pact-plugin/agents/pact-qa-engineer.md
@@ -17,8 +17,7 @@ This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
 spawn (or after reuse for a new task), invoke the Skill tool:
 `Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
-HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
-now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+HANDOFF format).
 
 If the orchestrator or a peer references the `request-more-context` skill,
 invoke it on demand via `Skill("PACT:request-more-context")` as well.

--- a/pact-plugin/agents/pact-qa-engineer.md
+++ b/pact-plugin/agents/pact-qa-engineer.md
@@ -13,8 +13,9 @@ You are 🔍 PACT QA Engineer, a runtime verification specialist focusing on exp
 # AGENT TEAMS PROTOCOL
 
 This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
-`TaskUpdate`, and other team tools. **Before calling any of these for the first
-time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+`TaskUpdate`, and other team tools. **On first use of any of these tools after
+spawn (or after reuse for a new task), invoke the Skill tool:
+`Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
 HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
 now lazy-loaded to reduce per-spawn context overhead (see issue #361).

--- a/pact-plugin/agents/pact-secretary.md
+++ b/pact-plugin/agents/pact-secretary.md
@@ -31,12 +31,23 @@ color: "#708090"
 permissionMode: acceptEdits
 memory: user
 skills:
-  - pact-agent-teams
   - pact-memory
   - pact-handoff-harvest
 ---
 
 You are the PACT Secretary, responsible for serving as the team's Knowledge Distiller and Research Assistant within the PACT framework.
+
+# AGENT TEAMS PROTOCOL
+
+This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
+`TaskUpdate`, and other team tools. **Before calling any of these for the first
+time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+communication protocol (teachback, progress signals, message format, lifecycle,
+HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
+now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+
+If the orchestrator or a peer references the `request-more-context` skill,
+invoke it on demand via `Skill("PACT:request-more-context")` as well.
 
 # MISSION
 

--- a/pact-plugin/agents/pact-secretary.md
+++ b/pact-plugin/agents/pact-secretary.md
@@ -44,8 +44,7 @@ This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
 spawn (or after reuse for a new task), invoke the Skill tool:
 `Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
-HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
-now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+HANDOFF format).
 
 If the orchestrator or a peer references the `request-more-context` skill,
 invoke it on demand via `Skill("PACT:request-more-context")` as well.

--- a/pact-plugin/agents/pact-secretary.md
+++ b/pact-plugin/agents/pact-secretary.md
@@ -40,8 +40,9 @@ You are the PACT Secretary, responsible for serving as the team's Knowledge Dist
 # AGENT TEAMS PROTOCOL
 
 This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
-`TaskUpdate`, and other team tools. **Before calling any of these for the first
-time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+`TaskUpdate`, and other team tools. **On first use of any of these tools after
+spawn (or after reuse for a new task), invoke the Skill tool:
+`Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
 HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
 now lazy-loaded to reduce per-spawn context overhead (see issue #361).

--- a/pact-plugin/agents/pact-security-engineer.md
+++ b/pact-plugin/agents/pact-security-engineer.md
@@ -6,12 +6,21 @@ description: |
 color: "#8B0000"
 permissionMode: acceptEdits
 memory: user
-skills:
-  - pact-agent-teams
-  - request-more-context
 ---
 
 You are 🛡️ PACT Security Engineer, an adversarial security specialist focusing on vulnerability discovery during the Review phase of the Prepare, Architect, Code, Test (PACT) framework.
+
+# AGENT TEAMS PROTOCOL
+
+This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
+`TaskUpdate`, and other team tools. **Before calling any of these for the first
+time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+communication protocol (teachback, progress signals, message format, lifecycle,
+HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
+now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+
+If the orchestrator or a peer references the `request-more-context` skill,
+invoke it on demand via `Skill("PACT:request-more-context")` as well.
 
 # REQUIRED SKILLS - INVOKE BEFORE REVIEWING
 

--- a/pact-plugin/agents/pact-security-engineer.md
+++ b/pact-plugin/agents/pact-security-engineer.md
@@ -17,8 +17,7 @@ This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
 spawn (or after reuse for a new task), invoke the Skill tool:
 `Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
-HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
-now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+HANDOFF format).
 
 If the orchestrator or a peer references the `request-more-context` skill,
 invoke it on demand via `Skill("PACT:request-more-context")` as well.

--- a/pact-plugin/agents/pact-security-engineer.md
+++ b/pact-plugin/agents/pact-security-engineer.md
@@ -13,8 +13,9 @@ You are 🛡️ PACT Security Engineer, an adversarial security specialist focus
 # AGENT TEAMS PROTOCOL
 
 This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
-`TaskUpdate`, and other team tools. **Before calling any of these for the first
-time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+`TaskUpdate`, and other team tools. **On first use of any of these tools after
+spawn (or after reuse for a new task), invoke the Skill tool:
+`Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
 HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
 now lazy-loaded to reduce per-spawn context overhead (see issue #361).

--- a/pact-plugin/agents/pact-test-engineer.md
+++ b/pact-plugin/agents/pact-test-engineer.md
@@ -13,8 +13,9 @@ You are 🧪 PACT Tester, an elite quality assurance specialist and test automat
 # AGENT TEAMS PROTOCOL
 
 This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
-`TaskUpdate`, and other team tools. **Before calling any of these for the first
-time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+`TaskUpdate`, and other team tools. **On first use of any of these tools after
+spawn (or after reuse for a new task), invoke the Skill tool:
+`Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
 HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
 now lazy-loaded to reduce per-spawn context overhead (see issue #361).

--- a/pact-plugin/agents/pact-test-engineer.md
+++ b/pact-plugin/agents/pact-test-engineer.md
@@ -17,8 +17,7 @@ This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
 spawn (or after reuse for a new task), invoke the Skill tool:
 `Skill("PACT:pact-agent-teams")`** to load the full
 communication protocol (teachback, progress signals, message format, lifecycle,
-HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
-now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+HANDOFF format).
 
 If the orchestrator or a peer references the `request-more-context` skill,
 invoke it on demand via `Skill("PACT:request-more-context")` as well.

--- a/pact-plugin/agents/pact-test-engineer.md
+++ b/pact-plugin/agents/pact-test-engineer.md
@@ -6,12 +6,21 @@ description: |
 color: "#DC143C"
 permissionMode: acceptEdits
 memory: user
-skills:
-  - pact-agent-teams
-  - request-more-context
 ---
 
 You are 🧪 PACT Tester, an elite quality assurance specialist and test automation expert focusing on the Test phase of the Prepare, Architect, Code, and Test (PACT) software development framework. You possess deep expertise in test-driven development (TDD), behavior-driven development, and comprehensive testing methodologies across all levels of the testing pyramid.
+
+# AGENT TEAMS PROTOCOL
+
+This agent communicates with the team via `SendMessage`, `TaskList`, `TaskGet`,
+`TaskUpdate`, and other team tools. **Before calling any of these for the first
+time, invoke the Skill tool: `Skill("PACT:pact-agent-teams")`** to load the full
+communication protocol (teachback, progress signals, message format, lifecycle,
+HANDOFF format). This skill was previously eager-loaded via frontmatter; it is
+now lazy-loaded to reduce per-spawn context overhead (see issue #361).
+
+If the orchestrator or a peer references the `request-more-context` skill,
+invoke it on demand via `Skill("PACT:request-more-context")` as well.
 
 # REQUIRED SKILLS - INVOKE BEFORE TESTING
 

--- a/pact-plugin/skills/pact-budget-discipline/SKILL.md
+++ b/pact-plugin/skills/pact-budget-discipline/SKILL.md
@@ -1,34 +1,21 @@
 ---
 name: pact-budget-discipline
 description: |
-  Orchestrator budget-discipline behaviors for context-pressured PACT sessions.
-  Use when: session is expected to be long-running, touches many files, involves
-  multiple concurrent specialists, or the orchestrator notices rising context
-  pressure. Provides six discipline patterns: swarm-by-default, fixer model
-  selection, trivial-task exception, early /park, skipping intermediate
-  documentation artifacts, and replacement-not-resuscitation for context-heavy
-  agents (with secretary/auditor carve-out).
+  Six orchestrator budget-discipline patterns for context-pressured PACT sessions.
+  Use when: long-running session, many files, multiple concurrent specialists,
+  or rising context pressure. Covers: swarm-by-default, fixer model selection,
+  trivial-task exception, early /park, skip intermediate docs, and
+  replacement-not-resuscitation (with secretary/auditor carve-out).
 ---
 
 # Budget Discipline for PACT Orchestrators
 
-This skill codifies the six orchestrator behaviors from issue #366. It is
-**lazy-loaded** — no per-spawn cost. Invoke it via `Skill("PACT:pact-budget-discipline")`
-when a session is context-pressured, long-running, or multi-specialist.
-
-These disciplines were observed empirically during the PR #350 review session
-(2026-04-06) and the PR #374 session (2026-04-08). Each has direct measurable
-backing from the session that surfaced it.
-
-> **Related issues**: #361 (per-spawn baseline reduction), #380 (tool curation
-> follow-up), #381 (auto-memory externalization follow-up), #382 (fixer-agent
-> model selection follow-up for discipline #2), #166 (original Reuse-vs-Spawn
-> matrix), #364 (compaction hook cost), #365 (teammate lifecycle automation).
+Six orchestrator behaviors for context-pressured sessions. Invoke via
+`Skill("PACT:pact-budget-discipline")`.
 
 ## When to Invoke This Skill
 
-Invoke `Skill("PACT:pact-budget-discipline")` at the start of a session when any of
-the following are true:
+Invoke at the start of a session when any of the following are true:
 
 - Variety score is ≥ 7 on the initial task or any dispatched phase
 - Work is expected to touch many files or span multiple specialists
@@ -36,8 +23,6 @@ the following are true:
 - The orchestrator notices rising context pressure (e.g., specialists
   compacting mid-task, secretary/auditor behind on harvests)
 - A pause/park decision is being considered
-
-The skill content is ~5.5K tokens when loaded. Zero cost otherwise.
 
 ---
 
@@ -47,11 +32,8 @@ The skill content is ~5.5K tokens when loaded. Zero cost otherwise.
 into single-file (or single-concern) slices and dispatch a swarm. Never
 dispatch a monolithic agent on a multi-file high-variety task.
 
-**Empirical support**: PR #350 review session, 2026-04-06. Two consecutive
-monolithic full-PR bughunter dispatches (r8, r9) consumed ~360K tokens combined
-and produced minimal output. The 5-agent r10 swarm consumed ~125K tokens and
-produced 19 actionable findings. The successful swarm cost ~35% of the failed
-monoliths for the same task — a 3× cost win on the failure case.
+**Empirical support**: Monolithic agents on multi-file tasks cost ~3x more
+than decomposed swarms, with worse output quality.
 
 **How to apply**:
 1. At dispatch time, if variety ≥ 7 AND multi-file, pause before spawning.
@@ -75,26 +57,17 @@ smaller, fresher agents. Apply both.
 > **Status**: DEFERRED — awaiting dedicated `pact-fixer` agent. Tracked in
 > issue #382.
 
-**Intended rule**: Match model selection to task complexity. The orchestrator
-and architectural specialists need Opus's reasoning depth. Fixers, cleanup
-specialists, and routine workers don't — Sonnet handles them at significantly
-lower per-token cost.
+**Intended rule**: Match model to task complexity. Orchestrator and architects
+need Opus's reasoning depth. Fixers and routine workers don't — Sonnet
+handles them at significantly lower per-token cost.
 
-**Empirical support**: PR #350 session's r11 + r12 fixer swarms (8 agents)
-used Opus to apply known fixes from known findings to known files. That's
-mechanical work that doesn't benefit from Opus's reasoning depth.
+**Why deferred**: Requires either a dedicated `pact-fixer` agent with
+`model: claude-sonnet-4-6` in frontmatter, or per-dispatch model overrides
+(not yet supported by the platform). Tracked in #382.
 
-**Why deferred**: The codification requires either (a) a dedicated
-`pact-fixer` agent definition with `model: claude-sonnet-4-6` in its
-frontmatter, or (b) per-dispatch `model:` overrides at the platform level. The
-platform does not currently support per-dispatch model overrides, and no
-fixer-role agent exists yet. Creating the agent is a new-feature change, not
-a context-reduction change — out of scope for #361.
-
-**Practice-only until codification**: the orchestrator can still manually
-select Sonnet-appropriate work patterns (smaller prompts, mechanical
-application of known fixes, narrow scope), but cannot yet force model
-selection. Follow-up work is tracked in #382.
+**Practice-only until codification**: the orchestrator can select
+Sonnet-appropriate work patterns (smaller prompts, mechanical fixes, narrow
+scope), but cannot yet force model selection.
 
 ---
 
@@ -105,10 +78,9 @@ directly, without spawning a specialist. Examples: `gh issue create`,
 `git push`, `git tag`, single-file reads to answer a question, simple grep
 operations. Each skipped spawn saves 50–70K of baseline overhead (per #361).
 
-**Empirical support**: This exception is already documented in CLAUDE.md but
-is inconsistently practiced. The exception exists; the discipline of actually
-invoking it is what matters. Per-session data from PR #350 showed 33+
-teammates created, several of which could have been skipped.
+**Empirical support**: The exception exists in CLAUDE.md but is
+inconsistently practiced. Sessions routinely create 30+ teammates when several
+could be skipped.
 
 **How to apply**:
 - Before reaching for `Task(...)`, ask: "Can I do this in ≤ 3 tool calls?"
@@ -121,10 +93,6 @@ teammates created, several of which could have been skipped.
 write application code. It covers non-code operational tasks only (git,
 gh CLI, trivial reads/greps). Application code still delegates.
 
-**Tool curation follow-up**: Reducing the per-dispatch tool schema footprint
-(so that even when spawning IS needed, the baseline is lower) is tracked
-separately as #380.
-
 ---
 
 ## 4. `/park` (or equivalent) earlier rather than later
@@ -134,10 +102,8 @@ user pause — park the session immediately rather than letting it grow until
 forced compaction. Forced compaction triggers the post-compaction
 degraded-state cost documented in #364.
 
-**Empirical support**: PR #374 session's `r9-bughunter-functional` teammate
-demonstrated the post-compaction failure mode firsthand. Their work was
-interrupted by forced compaction; the recovery state produced silent stalls.
-Earlier voluntary parking would have avoided this entirely.
+**Empirical support**: Forced compaction mid-task produces silent stalls and
+degraded recovery state. Voluntary parking avoids this entirely.
 
 **Natural break points** (park candidates):
 - Just after a PR merges (and cleanup completes)
@@ -150,11 +116,6 @@ Earlier voluntary parking would have avoided this entirely.
 **How to apply**: invoke `/PACT:park` (or equivalent pause command) as soon
 as the break point appears. Do not defer "one more small task" — the cost of
 a forced compaction dwarfs the cost of parking and resuming.
-
-**Connection**: #364 will eventually fix the platform-level compaction cost;
-this discipline avoids hitting it in the meantime. Auto-memory architecture
-changes are tracked separately in #381 — once those land, parking becomes
-even cheaper because the session state at pause is smaller.
 
 ---
 
@@ -181,12 +142,6 @@ Otherwise, the next phase can use the orchestrator's in-memory context.
    via HANDOFF (and task metadata) instead of producing a file.
 3. If one applies, generate the doc as normal.
 
-**Why this discipline matters**: producing a ~300-line architecture document
-costs ~5–10K tokens of agent context for writing, formatting, and
-self-review. If no downstream agent reads the file, that cost is pure waste.
-In-memory HANDOFF context flows to the next phase via Task metadata at
-negligible cost.
-
 ---
 
 ## 6. Replacement-not-resuscitation for context-heavy agents
@@ -196,34 +151,17 @@ multi-file scope, architecture-heavy, or any task that required ≥ 5
 significant tool invocations), do NOT reuse them for a subsequent task even
 if the domain overlaps. Spawn a fresh agent instead.
 
-The existing Reuse-vs-Spawn matrix (originally added by #166) uses *"context
-near capacity"* as the spawn trigger — that threshold is too late. By the
-time the orchestrator can measure "near capacity," the agent is already
-minutes away from a compaction stall. **Anticipate the capacity problem from
-the task shape, don't react to it from measured state.**
+**Anticipate the capacity problem from the task shape, don't react to it
+from measured state.** By the time "near capacity" is measurable, the agent
+is minutes from a compaction stall.
 
-**Empirical support**: PR #374 session (team `pact-cd65d80f`, 2026-04-08).
-A single `backend-coder` was dispatched for 8 commits spanning `database.py`,
-`models.py`, `memory_api.py`, `cli.py`, SKILL.md, `memory-patterns.md`, and 4
-version files (variety 9, multi-file high-risk contract-reversal work). The
-coder compacted 2–3 times during execution; the test-engineer and auditor
-each compacted at least once. Each compaction cost several minutes of stall
-time per #364. A swarm of smaller specialists — one per commit-pair group —
-would have avoided the compaction cycles entirely. Each sub-agent would have
-received a clean ~200K budget for a focused <60K-token task.
+**Empirical support**: A single agent dispatched for 8 commits (variety 9)
+compacted 2-3 times; a swarm of focused sub-agents would have avoided it.
+The CLAUDE.md Reuse-vs-Spawn matrix reflects this proactive trigger.
 
-**Refinement to the CLAUDE.md Reuse-vs-Spawn matrix**: the reactive
-"Agent's context near capacity from prior work → Spawn new" row has been
-replaced with a proactive anticipation rule that triggers on task shape
-(variety ≥ 7, multi-file, architecture-heavy, or ≥ 5 significant tool
-invocations) rather than measured capacity. The matrix edit lives in
-`pact-plugin/CLAUDE.md` under the Reuse vs. Spawn Decision heading.
-
-**Scope of the rule**: The refinement applies to reuse *across tasks within
-a session*, not to turn-to-turn continuation within a single task. An agent
-mid-task continues its own work — the rule fires when a task completes and
-the orchestrator is deciding whether to reuse the completed agent for the
-next task.
+**Scope**: Applies to reuse *across tasks*, not turn-to-turn continuation
+within a single task. The rule fires when a task completes and the
+orchestrator decides whether to reuse the agent for the *next* task.
 
 ### Exception — singular-per-session roles (secretary, auditor)
 
@@ -232,64 +170,33 @@ Both should remain **singular per session** — a single secretary instance
 and a single auditor instance persist from session start through wrap-up,
 handling all work in their respective roles continuously.
 
-**Rationale**: These two roles have fundamentally different context-load
-profiles from coders and other implementation specialists. They don't do
-heavy architectural thinking, don't write application code, and don't hold
-large implementation state in working memory. Their work is observation,
-coordination, and distillation — all light-context activities that can run
-session-long without approaching the capacity threshold that triggers
-compaction stalls.
+**Rationale**: These roles have light context-load profiles (observation,
+coordination, distillation — not implementation) and their value comes from
+**session-long continuity**. A secretary who observed the full session
+produces richer consolidation and catches cross-phase dedup. An auditor who
+saw earlier commits catches drift patterns in later ones. Spawning fresh
+instances fragments this accumulated knowledge.
 
-More importantly, **their value comes from session-long continuity**. The
-secretary is the session's institutional knowledge layer: every harvest,
-every query answered, every memory distillation is cumulative. A single
-secretary who has observed the full session's history answers queries more
-accurately, catches dedup opportunities that span phases, and produces
-consolidation harvests that weave together earlier and later discoveries.
-Spawning fresh secretaries for each harvest trigger fragments knowledge
-across instances and defeats the role's purpose — the Nth secretary doesn't
-know what the first N-1 observed. Similarly, the auditor's value compounds
-across commits: an auditor who saw commits 1–2 and brings that context to
-commit 3's audit catches drift patterns and cross-commit invariant
-violations that a fresh-per-commit auditor cannot.
+**Empirical support**: Over-applying discipline #6 to the secretary resulted
+in 4 instances re-reading session context from scratch, producing fragmented
+consolidation. A single persistent secretary produces richer output.
 
-**Empirical support**: PR #374 violated this exception by over-applying
-discipline #6 to the secretary role. Four secretary instances were spawned
-(`secretary`, `secretary-harvest`, `secretary-harvest-2`, `secretary-pause`),
-each re-reading the session context from scratch. The consolidation pass
-especially suffered: a secretary present for the full session would have
-produced a richer, more deduplicated consolidation than a fresh agent
-reading the session journal cold.
-
-**Corrected rule summary**:
-- **Coders and other implementation specialists with heavy context load** →
-  replacement-not-resuscitation per the main discipline #6 rule above. Spawn
-  fresh when the prior task was complex.
-- **Secretary and auditor** → *singular-per-session*, rely on their inherent
-  light context load. Do NOT replace until the session itself ends via
-  wrap-up or pause. The main secretary handles ALL harvest triggers
-  (post-ARCHITECT, post-CODE, at peer-review dispatch, at wrap-up
-  consolidation) as continuous work. The main auditor handles ALL
-  commit-boundary audits and the final pre-peer-review sweep.
+**Summary**:
+- **Coders/implementation specialists** → spawn fresh when prior task was complex.
+- **Secretary and auditor** → singular-per-session. Do NOT replace until
+  wrap-up or pause.
 
 ---
 
 ## Cross-cutting: Measuring Context Pressure
 
-Budget discipline is most valuable when applied *before* hitting the wall.
 Watch for these proactive indicators:
 
-- **Task shape**: variety score, file count, architecture-heavy flags — these
-  predict capacity consumption before it happens
-- **Specialist compaction events**: if any teammate has compacted during the
-  current session, assume the rest are close behind
-- **Secretary/auditor lag**: if harvests are queueing up behind other work,
-  the orchestrator is accumulating unprocessed state
-- **Session duration**: long sessions (multi-hour, multi-phase) accumulate
-  cruft even if no single task is high-variety
-- **Own context**: when the orchestrator itself notices slower recall of
-  earlier decisions, that is an indicator to park soon
+- **Task shape**: variety score, file count, architecture-heavy flags
+- **Specialist compaction**: if any teammate has compacted, assume others are close
+- **Secretary/auditor lag**: harvests queueing up behind other work
+- **Session duration**: multi-hour sessions accumulate cruft regardless of per-task variety
+- **Own context**: slower recall of earlier decisions = park soon
 
-When two or more indicators fire simultaneously, invoke this skill (if not
-already loaded) and re-evaluate dispatch decisions against all six
-disciplines.
+When two or more indicators fire, re-evaluate dispatch decisions against all
+six disciplines.

--- a/pact-plugin/skills/pact-budget-discipline/SKILL.md
+++ b/pact-plugin/skills/pact-budget-discipline/SKILL.md
@@ -13,7 +13,7 @@ description: |
 # Budget Discipline for PACT Orchestrators
 
 This skill codifies the six orchestrator behaviors from issue #366. It is
-**lazy-loaded** — no per-spawn cost. Invoke it via `Skill("pact-budget-discipline")`
+**lazy-loaded** — no per-spawn cost. Invoke it via `Skill("PACT:pact-budget-discipline")`
 when a session is context-pressured, long-running, or multi-specialist.
 
 These disciplines were observed empirically during the PR #350 review session
@@ -27,7 +27,7 @@ backing from the session that surfaced it.
 
 ## When to Invoke This Skill
 
-Invoke `Skill("pact-budget-discipline")` at the start of a session when any of
+Invoke `Skill("PACT:pact-budget-discipline")` at the start of a session when any of
 the following are true:
 
 - Variety score is ≥ 7 on the initial task or any dispatched phase
@@ -212,10 +212,12 @@ time per #364. A swarm of smaller specialists — one per commit-pair group —
 would have avoided the compaction cycles entirely. Each sub-agent would have
 received a clean ~200K budget for a focused <60K-token task.
 
-**Refinement to the CLAUDE.md Reuse-vs-Spawn matrix**: replace the reactive
-"Agent's context near capacity from prior work → Spawn new" row with a
-proactive anticipation rule. The matrix edit is included as part of this
-PR's commit 4.
+**Refinement to the CLAUDE.md Reuse-vs-Spawn matrix**: the reactive
+"Agent's context near capacity from prior work → Spawn new" row has been
+replaced with a proactive anticipation rule that triggers on task shape
+(variety ≥ 7, multi-file, architecture-heavy, or ≥ 5 significant tool
+invocations) rather than measured capacity. The matrix edit lives in
+`pact-plugin/CLAUDE.md` under the Reuse vs. Spawn Decision heading.
 
 **Scope of the rule**: The refinement applies to reuse *across tasks within
 a session*, not to turn-to-turn continuation within a single task. An agent

--- a/pact-plugin/skills/pact-budget-discipline/SKILL.md
+++ b/pact-plugin/skills/pact-budget-discipline/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: pact-budget-discipline
+description: |
+  Orchestrator budget-discipline behaviors for context-pressured PACT sessions.
+  Use when: session is expected to be long-running, touches many files, involves
+  multiple concurrent specialists, or the orchestrator notices rising context
+  pressure. Provides six discipline patterns: swarm-by-default, fixer model
+  selection, trivial-task exception, early /park, skipping intermediate
+  documentation artifacts, and replacement-not-resuscitation for context-heavy
+  agents (with secretary/auditor carve-out).
+---
+
+# Budget Discipline for PACT Orchestrators
+
+This skill codifies the six orchestrator behaviors from issue #366. It is
+**lazy-loaded** — no per-spawn cost. Invoke it via `Skill("pact-budget-discipline")`
+when a session is context-pressured, long-running, or multi-specialist.
+
+These disciplines were observed empirically during the PR #350 review session
+(2026-04-06) and the PR #374 session (2026-04-08). Each has direct measurable
+backing from the session that surfaced it.
+
+> **Related issues**: #361 (per-spawn baseline reduction), #380 (tool curation
+> follow-up), #381 (auto-memory externalization follow-up), #382 (fixer-agent
+> model selection follow-up for discipline #2), #166 (original Reuse-vs-Spawn
+> matrix), #364 (compaction hook cost), #365 (teammate lifecycle automation).
+
+## When to Invoke This Skill
+
+Invoke `Skill("pact-budget-discipline")` at the start of a session when any of
+the following are true:
+
+- Variety score is ≥ 7 on the initial task or any dispatched phase
+- Work is expected to touch many files or span multiple specialists
+- Session is expected to be long-running (multiple phases, multiple PRs)
+- The orchestrator notices rising context pressure (e.g., specialists
+  compacting mid-task, secretary/auditor behind on harvests)
+- A pause/park decision is being considered
+
+The skill content is ~5.5K tokens when loaded. Zero cost otherwise.
+
+---
+
+## 1. Swarm-by-default for high-variety tasks
+
+**Rule**: If a task has variety score ≥ 7 AND touches multiple files, decompose
+into single-file (or single-concern) slices and dispatch a swarm. Never
+dispatch a monolithic agent on a multi-file high-variety task.
+
+**Empirical support**: PR #350 review session, 2026-04-06. Two consecutive
+monolithic full-PR bughunter dispatches (r8, r9) consumed ~360K tokens combined
+and produced minimal output. The 5-agent r10 swarm consumed ~125K tokens and
+produced 19 actionable findings. The successful swarm cost ~35% of the failed
+monoliths for the same task — a 3× cost win on the failure case.
+
+**How to apply**:
+1. At dispatch time, if variety ≥ 7 AND multi-file, pause before spawning.
+2. Decompose the work into slices where each slice is a single file or a
+   single concern.
+3. Dispatch a specialist per slice in parallel (via Agent Teams concurrent
+   dispatch).
+4. Preserve slice independence — do NOT let slices share mutable state or
+   ordered dependencies if it can be avoided.
+
+**Interaction with discipline #6**: discipline #1 is about the *initial
+dispatch* decision — "did I decompose correctly before spawning?" Discipline
+#6 is about the *post-dispatch reuse* decision — "even if I dispatched
+correctly, should I reuse this completed agent?" Both push toward more,
+smaller, fresher agents. Apply both.
+
+---
+
+## 2. Fixer model selection (Sonnet for fixers, Opus for orchestrator/architect)
+
+> **Status**: DEFERRED — awaiting dedicated `pact-fixer` agent. Tracked in
+> issue #382.
+
+**Intended rule**: Match model selection to task complexity. The orchestrator
+and architectural specialists need Opus's reasoning depth. Fixers, cleanup
+specialists, and routine workers don't — Sonnet handles them at significantly
+lower per-token cost.
+
+**Empirical support**: PR #350 session's r11 + r12 fixer swarms (8 agents)
+used Opus to apply known fixes from known findings to known files. That's
+mechanical work that doesn't benefit from Opus's reasoning depth.
+
+**Why deferred**: The codification requires either (a) a dedicated
+`pact-fixer` agent definition with `model: claude-sonnet-4-6` in its
+frontmatter, or (b) per-dispatch `model:` overrides at the platform level. The
+platform does not currently support per-dispatch model overrides, and no
+fixer-role agent exists yet. Creating the agent is a new-feature change, not
+a context-reduction change — out of scope for #361.
+
+**Practice-only until codification**: the orchestrator can still manually
+select Sonnet-appropriate work patterns (smaller prompts, mechanical
+application of known fixes, narrow scope), but cannot yet force model
+selection. Follow-up work is tracked in #382.
+
+---
+
+## 3. Aggressive trivial-task exception
+
+**Rule**: The orchestrator handles tasks requiring fewer than ~3 tool calls
+directly, without spawning a specialist. Examples: `gh issue create`,
+`git push`, `git tag`, single-file reads to answer a question, simple grep
+operations. Each skipped spawn saves 50–70K of baseline overhead (per #361).
+
+**Empirical support**: This exception is already documented in CLAUDE.md but
+is inconsistently practiced. The exception exists; the discipline of actually
+invoking it is what matters. Per-session data from PR #350 showed 33+
+teammates created, several of which could have been skipped.
+
+**How to apply**:
+- Before reaching for `Task(...)`, ask: "Can I do this in ≤ 3 tool calls?"
+- If yes, AND it's not application code (see CLAUDE.md "What Is Application
+  Code?"), do it directly.
+- If the thought "I know exactly how to do it and it's not application code"
+  appears, that's the signal to apply the exception.
+
+**Not an override of delegation**: this does NOT license the orchestrator to
+write application code. It covers non-code operational tasks only (git,
+gh CLI, trivial reads/greps). Application code still delegates.
+
+**Tool curation follow-up**: Reducing the per-dispatch tool schema footprint
+(so that even when spawning IS needed, the baseline is lower) is tracked
+separately as #380.
+
+---
+
+## 4. `/park` (or equivalent) earlier rather than later
+
+**Rule**: When a natural break point appears — PR merged, phase complete,
+user pause — park the session immediately rather than letting it grow until
+forced compaction. Forced compaction triggers the post-compaction
+degraded-state cost documented in #364.
+
+**Empirical support**: PR #374 session's `r9-bughunter-functional` teammate
+demonstrated the post-compaction failure mode firsthand. Their work was
+interrupted by forced compaction; the recovery state produced silent stalls.
+Earlier voluntary parking would have avoided this entirely.
+
+**Natural break points** (park candidates):
+- Just after a PR merges (and cleanup completes)
+- Just after a CODE phase completes and commits land green
+- After a long TEST phase produces a clean run
+- When the user signals a pause ("let's stop here for now", "I need to step
+  away", etc.)
+- When the orchestrator notices it is nearing its own context budget
+
+**How to apply**: invoke `/PACT:park` (or equivalent pause command) as soon
+as the break point appears. Do not defer "one more small task" — the cost of
+a forced compaction dwarfs the cost of parking and resuming.
+
+**Connection**: #364 will eventually fix the platform-level compaction cost;
+this discipline avoids hitting it in the meantime. Auto-memory architecture
+changes are tracked separately in #381 — once those land, parking becomes
+even cheaper because the session state at pause is smaller.
+
+---
+
+## 5. Skip intermediate documentation artifacts unless they'll be referenced downstream
+
+**Rule**: PACT's PREPARE and ARCHITECT phases produce documents in
+`docs/preparation/` and `docs/architecture/`. These are useful when downstream
+phases will reference them. They are NOT useful when the work is small enough
+that the next phase can hold the context directly. Skip the intermediate docs
+in those cases — they cost agent context to produce and rarely earn back the
+cost.
+
+**Decision criteria**: Generate the doc only if:
+- (a) variety score ≥ 11, OR
+- (b) the work spans multiple sessions, OR
+- (c) a stakeholder will read it (including future-you at a point when the
+  current context has been compacted away).
+
+Otherwise, the next phase can use the orchestrator's in-memory context.
+
+**How to apply**:
+1. At the start of PREPARE or ARCHITECT, check the decision criteria.
+2. If none apply, instruct the preparer/architect to report findings inline
+   via HANDOFF (and task metadata) instead of producing a file.
+3. If one applies, generate the doc as normal.
+
+**Why this discipline matters**: producing a ~300-line architecture document
+costs ~5–10K tokens of agent context for writing, formatting, and
+self-review. If no downstream agent reads the file, that cost is pure waste.
+In-memory HANDOFF context flows to the next phase via Task metadata at
+negligible cost.
+
+---
+
+## 6. Replacement-not-resuscitation for context-heavy agents
+
+**Rule**: When an agent has already executed a complex task (variety ≥ 7,
+multi-file scope, architecture-heavy, or any task that required ≥ 5
+significant tool invocations), do NOT reuse them for a subsequent task even
+if the domain overlaps. Spawn a fresh agent instead.
+
+The existing Reuse-vs-Spawn matrix (originally added by #166) uses *"context
+near capacity"* as the spawn trigger — that threshold is too late. By the
+time the orchestrator can measure "near capacity," the agent is already
+minutes away from a compaction stall. **Anticipate the capacity problem from
+the task shape, don't react to it from measured state.**
+
+**Empirical support**: PR #374 session (team `pact-cd65d80f`, 2026-04-08).
+A single `backend-coder` was dispatched for 8 commits spanning `database.py`,
+`models.py`, `memory_api.py`, `cli.py`, SKILL.md, `memory-patterns.md`, and 4
+version files (variety 9, multi-file high-risk contract-reversal work). The
+coder compacted 2–3 times during execution; the test-engineer and auditor
+each compacted at least once. Each compaction cost several minutes of stall
+time per #364. A swarm of smaller specialists — one per commit-pair group —
+would have avoided the compaction cycles entirely. Each sub-agent would have
+received a clean ~200K budget for a focused <60K-token task.
+
+**Refinement to the CLAUDE.md Reuse-vs-Spawn matrix**: replace the reactive
+"Agent's context near capacity from prior work → Spawn new" row with a
+proactive anticipation rule. The matrix edit is included as part of this
+PR's commit 4.
+
+**Scope of the rule**: The refinement applies to reuse *across tasks within
+a session*, not to turn-to-turn continuation within a single task. An agent
+mid-task continues its own work — the rule fires when a task completes and
+the orchestrator is deciding whether to reuse the completed agent for the
+next task.
+
+### Exception — singular-per-session roles (secretary, auditor)
+
+Discipline #6 does **NOT** apply to the `secretary` and `auditor` roles.
+Both should remain **singular per session** — a single secretary instance
+and a single auditor instance persist from session start through wrap-up,
+handling all work in their respective roles continuously.
+
+**Rationale**: These two roles have fundamentally different context-load
+profiles from coders and other implementation specialists. They don't do
+heavy architectural thinking, don't write application code, and don't hold
+large implementation state in working memory. Their work is observation,
+coordination, and distillation — all light-context activities that can run
+session-long without approaching the capacity threshold that triggers
+compaction stalls.
+
+More importantly, **their value comes from session-long continuity**. The
+secretary is the session's institutional knowledge layer: every harvest,
+every query answered, every memory distillation is cumulative. A single
+secretary who has observed the full session's history answers queries more
+accurately, catches dedup opportunities that span phases, and produces
+consolidation harvests that weave together earlier and later discoveries.
+Spawning fresh secretaries for each harvest trigger fragments knowledge
+across instances and defeats the role's purpose — the Nth secretary doesn't
+know what the first N-1 observed. Similarly, the auditor's value compounds
+across commits: an auditor who saw commits 1–2 and brings that context to
+commit 3's audit catches drift patterns and cross-commit invariant
+violations that a fresh-per-commit auditor cannot.
+
+**Empirical support**: PR #374 violated this exception by over-applying
+discipline #6 to the secretary role. Four secretary instances were spawned
+(`secretary`, `secretary-harvest`, `secretary-harvest-2`, `secretary-pause`),
+each re-reading the session context from scratch. The consolidation pass
+especially suffered: a secretary present for the full session would have
+produced a richer, more deduplicated consolidation than a fresh agent
+reading the session journal cold.
+
+**Corrected rule summary**:
+- **Coders and other implementation specialists with heavy context load** →
+  replacement-not-resuscitation per the main discipline #6 rule above. Spawn
+  fresh when the prior task was complex.
+- **Secretary and auditor** → *singular-per-session*, rely on their inherent
+  light context load. Do NOT replace until the session itself ends via
+  wrap-up or pause. The main secretary handles ALL harvest triggers
+  (post-ARCHITECT, post-CODE, at peer-review dispatch, at wrap-up
+  consolidation) as continuous work. The main auditor handles ALL
+  commit-boundary audits and the final pre-peer-review sweep.
+
+---
+
+## Cross-cutting: Measuring Context Pressure
+
+Budget discipline is most valuable when applied *before* hitting the wall.
+Watch for these proactive indicators:
+
+- **Task shape**: variety score, file count, architecture-heavy flags — these
+  predict capacity consumption before it happens
+- **Specialist compaction events**: if any teammate has compacted during the
+  current session, assume the rest are close behind
+- **Secretary/auditor lag**: if harvests are queueing up behind other work,
+  the orchestrator is accumulating unprocessed state
+- **Session duration**: long sessions (multi-hour, multi-phase) accumulate
+  cruft even if no single task is high-variety
+- **Own context**: when the orchestrator itself notices slower recall of
+  earlier decisions, that is an indicator to park soon
+
+When two or more indicators fire simultaneously, invoke this skill (if not
+already loaded) and re-evaluate dispatch decisions against all six
+disciplines.

--- a/pact-plugin/tests/test_agents_structure.py
+++ b/pact-plugin/tests/test_agents_structure.py
@@ -151,6 +151,10 @@ class TestLazyLoadedAgentTeams:
         for line in lines:
             stripped = line.strip()
             if stripped.startswith("skills:"):
+                # Handle inline value: "skills: single-skill"
+                inline = stripped[len("skills:"):].strip()
+                if inline and inline != "|":
+                    skills.append(inline)
                 in_skills = True
                 continue
             if in_skills:
@@ -181,6 +185,15 @@ class TestLazyLoadedAgentTeams:
             assert "pact-agent-teams" not in skill_names, (
                 f"{name}: pact-agent-teams must be lazy-loaded, not declared "
                 f"in frontmatter (see #361). Found skills: {skill_names!r}"
+            )
+
+    def test_request_more_context_not_in_frontmatter(self, all_agents):
+        """request-more-context must be lazy-loaded, not in frontmatter."""
+        for name, (_fm, _text, skill_names) in all_agents.items():
+            assert "request-more-context" not in skill_names, (
+                f"{name}: request-more-context must be lazy-loaded, not "
+                f"declared in frontmatter (see #361). Found skills: "
+                f"{skill_names!r}"
             )
 
     def test_agent_teams_protocol_block_present(self, all_agents):

--- a/pact-plugin/tests/test_agents_structure.py
+++ b/pact-plugin/tests/test_agents_structure.py
@@ -106,3 +106,106 @@ class TestAgentBody:
             # Check frontmatter has skills or body references skills
             assert "skill" in text.lower(), f"{f.name} doesn't reference skills"
 
+
+class TestLazyLoadedAgentTeams:
+    """
+    Regression guards for the #361 spawn-overhead reduction.
+
+    The `pact-agent-teams` skill was removed from agent frontmatter to
+    eliminate per-spawn eager-load cost. In its place, each agent now carries
+    an AGENT TEAMS PROTOCOL block in the body instructing the agent to invoke
+    `Skill("PACT:pact-agent-teams")` before its first team-tool call.
+
+    These tests pin the refactor against silent regression:
+      - M3: no agent frontmatter may list `pact-agent-teams` under `skills:`
+      - M4: every agent body must reference the lazy-load pointer
+      - F3: no agent frontmatter may declare more than MAX_FRONTMATTER_SKILLS
+    """
+
+    # Upper bound on eager-loaded skills per agent. Currently the secretary
+    # carries 2 (pact-memory, pact-handoff-harvest) and all other agents
+    # carry 0. Bumping this threshold should be a deliberate, reviewed choice.
+    MAX_FRONTMATTER_SKILLS = 2
+
+    @staticmethod
+    def _extract_skill_names(text):
+        """Extract the raw `skills:` block from frontmatter and parse skill
+        names. The shared `parse_frontmatter` helper flattens multiline lists
+        into a single continuation string, so list-item names are recovered
+        here by splitting the raw frontmatter on `- ` markers within the
+        `skills:` block. Returns a list of skill-name strings (may be empty).
+
+        This is scoped to this test class rather than extended in helpers.py
+        to avoid destabilizing other tests that rely on the flattened form.
+        """
+        if not text.startswith("---"):
+            return []
+        try:
+            end = text.index("---", 3)
+        except ValueError:
+            return []
+        fm_text = text[3:end]
+        lines = fm_text.split("\n")
+        skills = []
+        in_skills = False
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("skills:"):
+                in_skills = True
+                continue
+            if in_skills:
+                # Continuation lines are indented list items: "  - name"
+                if line.startswith(" ") or line.startswith("\t"):
+                    s = stripped.lstrip("-").strip()
+                    if s:
+                        skills.append(s)
+                else:
+                    # Non-indented line ends the skills block
+                    in_skills = False
+        return skills
+
+    @pytest.fixture
+    def all_agents(self, agent_files):
+        agents = {}
+        for f in agent_files:
+            text = f.read_text(encoding="utf-8")
+            fm = parse_frontmatter(text)
+            if fm:
+                skill_names = self._extract_skill_names(text)
+                agents[f.stem] = (fm, text, skill_names)
+        return agents
+
+    def test_agent_teams_not_in_frontmatter(self, all_agents):
+        """M3: `pact-agent-teams` must not appear in any agent's frontmatter."""
+        for name, (_fm, _text, skill_names) in all_agents.items():
+            assert "pact-agent-teams" not in skill_names, (
+                f"{name}: pact-agent-teams must be lazy-loaded, not declared "
+                f"in frontmatter (see #361). Found skills: {skill_names!r}"
+            )
+
+    def test_agent_teams_protocol_block_present(self, all_agents):
+        """M4: the lazy-load pointer block must exist in every agent body."""
+        for name, (_fm, text, _skills) in all_agents.items():
+            assert "AGENT TEAMS PROTOCOL" in text, (
+                f"{name}: missing '# AGENT TEAMS PROTOCOL' section. "
+                f"Without it, the agent has no instruction to load "
+                f"pact-agent-teams before first team-tool use."
+            )
+            assert 'Skill("PACT:pact-agent-teams")' in text, (
+                f"{name}: AGENT TEAMS PROTOCOL block must reference "
+                f'Skill("PACT:pact-agent-teams") so the agent knows '
+                f"which skill to invoke."
+            )
+
+    def test_frontmatter_skill_count_capped(self, all_agents):
+        """F3: no agent may declare more than MAX_FRONTMATTER_SKILLS."""
+        for name, (_fm, _text, skill_names) in all_agents.items():
+            count = len(skill_names)
+            assert count <= self.MAX_FRONTMATTER_SKILLS, (
+                f"{name}: {count} frontmatter skills exceeds cap of "
+                f"{self.MAX_FRONTMATTER_SKILLS}. Per-spawn eager-load cost "
+                f"must stay bounded (see #361). Move additional skills to "
+                f"lazy-load via Skill() invocation in the agent body. "
+                f"Skills found: {skill_names!r}"
+            )
+

--- a/pact-plugin/tests/test_skills_structure.py
+++ b/pact-plugin/tests/test_skills_structure.py
@@ -19,6 +19,7 @@ SKILLS_DIR = Path(__file__).parent.parent / "skills"
 EXPECTED_SKILLS = {
     "pact-agent-teams",
     "pact-architecture-patterns",
+    "pact-budget-discipline",
     "pact-coding-standards",
     "pact-memory",
     "pact-prepare-research",


### PR DESCRIPTION
## Summary

Implements Phase C mitigations for [#361](https://github.com/Synaptic-Labs-AI/PACT-Plugin/issues/361) (reduce specialist agent spawn context overhead) and codifies budget-discipline behaviors for [#366](https://github.com/Synaptic-Labs-AI/PACT-Plugin/issues/366).

### What ships

**C.1 — Lazy-load `pact-agent-teams`** (`74bf131`)
- Removes `pact-agent-teams` (and `request-more-context`) from the `skills:` frontmatter field in all 12 agent definitions — eliminating ~3.8K of eager loading at every specialist spawn
- Adds an `# AGENT TEAMS PROTOCOL` lazy-load pointer block above each file's first heading, directing agents to invoke `Skill("PACT:pact-agent-teams")` before their first team-tool use
- Exceptions preserved: `pact-auditor` retains `pact-architecture-patterns`; `pact-secretary` retains `pact-memory` + `pact-handoff-harvest`

**pact-budget-discipline skill** (`2ed1108`)
- New file: `pact-plugin/skills/pact-budget-discipline/SKILL.md` (293 lines)
- Codifies all six budget-discipline behaviors from issue #366 as a lazy-loaded skill (0 per-spawn cost)
- Discipline #2 (Sonnet for fixers) includes a deferral stub referencing [#382](https://github.com/Synaptic-Labs-AI/PACT-Plugin/issues/382)

**Version bump 3.16.2 → 3.16.3** (`c760b8f`)

### What was investigated but not shipped

- **C.2 (CLAUDE.md split)** and **C.3 (@-ref conversion)** were prototyped and reverted: `pact-plugin/CLAUDE.md` is mirrored to the orchestrator's global session only — it does not load for spawned specialist agents. A proper baseline investigation for specialist spawn overhead is tracked in [#383](https://github.com/Synaptic-Labs-AI/PACT-Plugin/issues/383).
- **C.7 (auto-memory prose reduction)** is harness-injected and cannot be fixed from the plugin layer — tracked in [#381](https://github.com/Synaptic-Labs-AI/PACT-Plugin/issues/381).
- **C.4 (tool curation)** tracked in [#380](https://github.com/Synaptic-Labs-AI/PACT-Plugin/issues/380).

### Projected savings

~7K tokens/spawn for heavy agents (pact-backend-coder, pact-test-engineer) from C.1 + prior C.5 MEMORY.md prunes (out-of-band, not git-tracked).

### Test results

5677 passed / 2 skipped — matches PR #378 baseline exactly. Zero regressions. All 12 agent frontmatter changes verified structurally correct.

## Related issues

- Fixes [#361](https://github.com/Synaptic-Labs-AI/PACT-Plugin/issues/361) (partial — C.1 shipped; C.2/C.3/C.7 tracked separately)
- Addresses [#366](https://github.com/Synaptic-Labs-AI/PACT-Plugin/issues/366) (budget-discipline skill)
- Follow-up: [#380](https://github.com/Synaptic-Labs-AI/PACT-Plugin/issues/380), [#381](https://github.com/Synaptic-Labs-AI/PACT-Plugin/issues/381), [#382](https://github.com/Synaptic-Labs-AI/PACT-Plugin/issues/382), [#383](https://github.com/Synaptic-Labs-AI/PACT-Plugin/issues/383)