### PR TITLE
fix(#414): stop bootstrap marker wipe on auto-compact

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "3.17.2",
+      "version": "3.17.3",
       "author": {
         "name": "ProfSynapse"
       },

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-marketplace/
 │           └── PACT/
-│               └── 3.17.2/     # Plugin version
+│               └── 3.17.3/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "3.17.2",
+  "version": "3.17.3",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "ProfSynapse",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 3.17.2
+> **Version**: 3.17.3
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -430,6 +430,12 @@ def main():
         raw_source = input_data.get("source", "startup")
         source = raw_source if raw_source in _VALID_SOURCES else "unknown"
         is_context_reset = source in ("compact", "clear")
+        # Marker deletion uses a narrower guard: only user-initiated clear
+        # triggers it. Compact is involuntary (auto-compaction under context
+        # pressure) and the orchestrator is still mid-work — wiping the marker
+        # on compact re-engages the bootstrap gate mid-task, blocking
+        # Edit/Write/Agent when the orchestrator needs them most (#414).
+        is_marker_reset = source == "clear"
 
         # Clean up stale compact-summary from previous sessions.
         # Only "compact" source needs it (just written by postcompact_verify).
@@ -439,18 +445,13 @@ def main():
             except OSError:
                 pass  # Fail-open: don't block session init for cleanup
 
-        # Clear bootstrap-complete marker on context reset (#401).
-        # Re-engages the bootstrap gate hooks (Layers 2 & 3) so the
-        # orchestrator must re-invoke Skill("PACT:bootstrap") after
-        # compaction or context clear. The narrow gate allowlist ensures
-        # exploration tools (Read, Glob, Grep) remain available for state
-        # recovery during the rebootstrap window.
+        # Clear bootstrap-complete marker on user-initiated clear only (#414).
         #
         # Cannot use get_session_dir() here because the context module
         # hasn't been initialized yet (write_context() runs at step 5a
         # below). Uses build_session_path() directly — it has its own
         # path traversal guard (Path.parents containment check).
-        if is_context_reset:
+        if is_marker_reset:
             try:
                 reset_session_id = input_data.get("session_id", "")
                 if reset_session_id and project_dir:

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -3354,16 +3354,17 @@ class TestMainExceptionSafetyNet:
 
 
 # ---------------------------------------------------------------------------
-# #401 — bootstrap-complete marker cleanup on compact/clear
+# #414 — bootstrap-complete marker cleanup on clear only (compact excluded)
 # ---------------------------------------------------------------------------
 
 
 class TestBootstrapMarkerCleanup:
-    """Tests for bootstrap-complete marker deletion on compact/clear sources.
+    """Tests for bootstrap-complete marker deletion on clear source only.
 
-    session_init.main() must delete the bootstrap-complete marker when
-    source is "compact" or "clear" to re-engage the bootstrap gate hooks
-    after context is reset. The marker is at:
+    session_init.main() must delete the bootstrap-complete marker only when
+    source is "clear" (user-initiated reset). Compact is excluded because
+    auto-compaction is involuntary and the orchestrator is still mid-work
+    (#414). The marker is at:
     ~/.claude/pact-sessions/{slug}/{session_id}/bootstrap-complete
     """
 
@@ -3412,11 +3413,11 @@ class TestBootstrapMarkerCleanup:
         assert exc_info.value.code == 0
         return marker.exists()
 
-    def test_compact_deletes_marker(self, monkeypatch, tmp_path):
-        """compact source must delete bootstrap-complete marker."""
+    def test_compact_preserves_marker(self, monkeypatch, tmp_path):
+        """compact source must NOT delete bootstrap-complete marker (#414)."""
         still_exists = self._run_main_with_marker(monkeypatch, tmp_path, "compact")
-        assert not still_exists, (
-            "bootstrap-complete marker should be deleted for source='compact'"
+        assert still_exists, (
+            "bootstrap-complete marker should be preserved for source='compact' (#414)"
         )
 
     def test_clear_deletes_marker(self, monkeypatch, tmp_path):
@@ -3426,16 +3427,16 @@ class TestBootstrapMarkerCleanup:
             "bootstrap-complete marker should be deleted for source='clear'"
         )
 
-    @pytest.mark.parametrize("source", ["startup", "resume"])
+    @pytest.mark.parametrize("source", ["startup", "resume", "compact"])
     def test_non_reset_sources_preserve_marker(self, monkeypatch, tmp_path, source):
-        """startup and resume should NOT delete the marker."""
+        """startup, resume, and compact should NOT delete the marker (#414)."""
         still_exists = self._run_main_with_marker(monkeypatch, tmp_path, source)
         assert still_exists, (
             f"bootstrap-complete marker should be preserved for source='{source}'"
         )
 
     def test_missing_marker_is_noop(self, monkeypatch, tmp_path):
-        """compact with no marker should not raise (unlink(missing_ok=True))."""
+        """clear with no marker should not raise (unlink(missing_ok=True))."""
         from session_init import main
 
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
@@ -3450,7 +3451,7 @@ class TestBootstrapMarkerCleanup:
 
         stdin_data = json.dumps({
             "session_id": session_id,
-            "source": "compact",
+            "source": "clear",
         })
 
         with patch("session_init.COMPACT_SUMMARY_PATH", tmp_path / "no-such-file"), \
@@ -3480,7 +3481,7 @@ class TestBootstrapMarkerCleanup:
 
         stdin_data = json.dumps({
             "session_id": "",
-            "source": "compact",
+            "source": "clear",
         })
 
         with patch("session_init.COMPACT_SUMMARY_PATH", tmp_path / "no-such-file"), \


### PR DESCRIPTION
## Summary

- Auto-compaction fires `SessionStart(source="compact")` involuntarily under context pressure. `session_init.py` was treating compact identically to `clear` for marker deletion, re-engaging the bootstrap gate mid-task and blocking `Edit/Write/Agent` calls.
- Introduces `is_marker_reset` (only `source == "clear"`) as a narrower guard for marker deletion, separate from `is_context_reset` (both compact + clear) which still controls symlink-skip and additional-directories-skip behavior.
- 151/151 tests pass. The marker cleanup test class is updated to reflect the new behavior.

Closes the R1 (marker wipe) symptom of #414. R2 (observability) and R3 (skill truncation restructure) remain open for a follow-up PR.

## Test plan

- [x] `TestBootstrapMarkerCleanup::test_compact_preserves_marker` — compact source no longer deletes marker
- [x] `TestBootstrapMarkerCleanup::test_clear_deletes_marker` — clear source still deletes marker (unchanged)
- [x] `TestBootstrapMarkerCleanup::test_non_reset_sources_preserve_marker[compact]` — compact now in the "preserve" parametrize set
- [x] `TestSourceAwareness::test_compact_skips_symlinks` — compact still skips symlinks (is_context_reset unchanged)
- [x] Full suite: 151/151 pass
- [x] Manual verification: applied fix to installed plugin, confirmed Edit/Write/Agent unblocked after auto-compact in a live session with 6 compaction events over 43 minutes