### PR TITLE
feat(#414): persist source field on session_start events (R2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "3.17.3",
+      "version": "3.17.4",
       "author": {
         "name": "ProfSynapse"
       },

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-marketplace/
 │           └── PACT/
-│               └── 3.17.3/     # Plugin version
+│               └── 3.17.4/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "3.17.3",
+  "version": "3.17.4",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "ProfSynapse",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 3.17.3
+> **Version**: 3.17.4
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -426,15 +426,10 @@ def main():
         # Default to "startup" if missing (backwards compat with older Claude Code).
         # Validate against the known set — an unrecognized source is surfaced
         # as "unknown" so it cannot inject arbitrary text into additionalContext.
-        # The isinstance(str) guard short-circuits the membership test for
-        # unhashable values (list, dict): without it, the `in` check on the
-        # _VALID_SOURCES set raises TypeError("unhashable type"), which would
-        # bubble out of the input-normalization step and bypass both the
-        # journal write at the bottom of the try and the source-conditioned
-        # branches that depend on it. With the guard, any non-string source
-        # cleanly clamps to "unknown" and the rest of main() runs to
-        # completion, persisting source="unknown" into the session_start
-        # event (#414 R2 fail-open contract).
+        # isinstance(str) guard short-circuits the `in _VALID_SOURCES` test for
+        # unhashable inputs (list, dict) that would otherwise raise TypeError,
+        # bubble to the outer safety-net, and skip the session_start journal
+        # write — breaking #414 R2's fail-open contract.
         _VALID_SOURCES = {"startup", "resume", "compact", "clear"}
         raw_source = input_data.get("source", "startup")
         source = (
@@ -674,11 +669,11 @@ def main():
                 print(f"session_init: could not write context file: {e}", file=sys.stderr)
 
             # Write session_start event to journal (after write_context so path is available).
-            # `source` is the already-normalized value from line 431 — one of
-            # {startup, resume, compact, clear, unknown}. Persisting it here
-            # gives downstream triage direct attribution for marker-wipe and
-            # other source-conditioned behavior, instead of forcing
-            # triangulation from timing clusters (#414 R2).
+            # `source` is the already-normalized value from the `_VALID_SOURCES`
+            # check above — one of {startup, resume, compact, clear, unknown}.
+            # Persisting it here gives downstream triage direct attribution for
+            # marker-wipe and other source-conditioned behavior, instead of
+            # forcing triangulation from timing clusters (#414 R2).
             append_event(
                 make_event(
                     "session_start",

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -426,9 +426,22 @@ def main():
         # Default to "startup" if missing (backwards compat with older Claude Code).
         # Validate against the known set — an unrecognized source is surfaced
         # as "unknown" so it cannot inject arbitrary text into additionalContext.
+        # The isinstance(str) guard short-circuits the membership test for
+        # unhashable values (list, dict): without it, the `in` check on the
+        # _VALID_SOURCES set raises TypeError("unhashable type"), which would
+        # bubble out of the input-normalization step and bypass both the
+        # journal write at the bottom of the try and the source-conditioned
+        # branches that depend on it. With the guard, any non-string source
+        # cleanly clamps to "unknown" and the rest of main() runs to
+        # completion, persisting source="unknown" into the session_start
+        # event (#414 R2 fail-open contract).
         _VALID_SOURCES = {"startup", "resume", "compact", "clear"}
         raw_source = input_data.get("source", "startup")
-        source = raw_source if raw_source in _VALID_SOURCES else "unknown"
+        source = (
+            raw_source
+            if isinstance(raw_source, str) and raw_source in _VALID_SOURCES
+            else "unknown"
+        )
         is_context_reset = source in ("compact", "clear")
         # Marker deletion uses a narrower guard: only user-initiated clear
         # triggers it. Compact is involuntary (auto-compaction under context
@@ -661,6 +674,11 @@ def main():
                 print(f"session_init: could not write context file: {e}", file=sys.stderr)
 
             # Write session_start event to journal (after write_context so path is available).
+            # `source` is the already-normalized value from line 431 — one of
+            # {startup, resume, compact, clear, unknown}. Persisting it here
+            # gives downstream triage direct attribution for marker-wipe and
+            # other source-conditioned behavior, instead of forcing
+            # triangulation from timing clusters (#414 R2).
             append_event(
                 make_event(
                     "session_start",
@@ -668,6 +686,7 @@ def main():
                     session_id=session_id,
                     project_dir=project_dir,
                     worktree="",  # Not yet created at this point
+                    source=source,
                 ),
             )
 

--- a/pact-plugin/hooks/shared/session_journal.py
+++ b/pact-plugin/hooks/shared/session_journal.py
@@ -147,6 +147,28 @@ _REQUIRED_FIELDS_BY_TYPE: dict[str, dict[str, type]] = {
 }
 
 
+# Per-type optional fields, with expected Python type. Fields listed here
+# are NOT required — an event missing them still passes validation — but
+# when they ARE present, the validator enforces type. This is the schema
+# contract counterpart to runtime clamps (e.g. the `source` isinstance
+# guard in session_init.py:425-444): if a future writer bypasses the
+# normalization path and emits the wrong type directly to `make_event`,
+# the event is rejected at validate time rather than landing on disk.
+# Same type-symmetry rules as _REQUIRED_FIELDS_BY_TYPE: `int` fields
+# reject `bool` because bool subclasses int.
+#
+# When adding a new optional field, add it here and add a matching
+# happy-path + wrong-type case to TestValidateOptionalFieldTypes in
+# test_session_journal.py.
+_OPTIONAL_FIELDS_BY_TYPE: dict[str, dict[str, type]] = {
+    # hooks/session_init.py writes session_start with an optional `source`
+    # drawn from stdin. The session_init normalization path clamps non-str
+    # inputs to "unknown" before the journal write; this schema contract
+    # catches any future writer that bypasses that path.
+    "session_start": {"source": str},
+}
+
+
 # --- Write API ---
 
 
@@ -206,6 +228,15 @@ def _validate_event_schema(event: dict[str, Any]) -> tuple[bool, str]:
       `make_event("…")` call site silently bypasses per-type checks. The
       TestValidateEventSchemaPerType suite catches that at test time.
 
+    Optional fields (for types in _OPTIONAL_FIELDS_BY_TYPE):
+    - Absent fields pass (the field is optional by definition).
+    - Present fields must match the declared type, applying the same
+      bool-in-int + empty-str rules as required fields. This is the
+      schema-level counterpart to runtime clamping paths such as the
+      `source` isinstance guard in session_init.py — a future writer
+      that bypasses the clamp and emits the wrong type directly to
+      `make_event` is rejected at validate time.
+
     This is the bulwark that prevents BugF1: a malformed `phase_transition`
     event (missing `phase` field, or `phase=""`, or `phase=42`) from any
     writer causes `append_event` or the CLI write path to return False
@@ -260,6 +291,35 @@ def _validate_event_schema(event: dict[str, Any]) -> tuple[bool, str]:
                 False,
                 f"field '{field}' for type '{event_type}' must be "
                 f"non-empty string",
+            )
+    # Per-type optional field checks. Absent fields pass (that's what
+    # "optional" means); present fields must match the declared type.
+    # Symmetric with required-field checks: rejects bool in int fields,
+    # rejects empty/whitespace-only str. Event types with no optional
+    # declarations (the common case) get a no-op empty dict from .get()
+    # and skip the loop entirely.
+    optional = _OPTIONAL_FIELDS_BY_TYPE.get(event_type, {})
+    for field, expected_type in optional.items():
+        if field not in event or event[field] is None:
+            continue  # Absent optional field — pass through.
+        value = event[field]
+        if expected_type is int and isinstance(value, bool):
+            return (
+                False,
+                f"optional field '{field}' for type '{event_type}' must "
+                f"be int, got bool",
+            )
+        if not isinstance(value, expected_type):
+            return (
+                False,
+                f"optional field '{field}' for type '{event_type}' must "
+                f"be {expected_type.__name__}, got {type(value).__name__}",
+            )
+        if expected_type is str and not value.strip():
+            return (
+                False,
+                f"optional field '{field}' for type '{event_type}' must "
+                f"be non-empty string",
             )
     return True, "ok"
 

--- a/pact-plugin/hooks/shared/session_journal.py
+++ b/pact-plugin/hooks/shared/session_journal.py
@@ -150,10 +150,10 @@ _REQUIRED_FIELDS_BY_TYPE: dict[str, dict[str, type]] = {
 # Per-type optional fields, with expected Python type. Fields listed here
 # are NOT required — an event missing them still passes validation — but
 # when they ARE present, the validator enforces type. This is the schema
-# contract counterpart to runtime clamps (e.g. the `source` isinstance
-# guard in session_init.py:425-444): if a future writer bypasses the
-# normalization path and emits the wrong type directly to `make_event`,
-# the event is rejected at validate time rather than landing on disk.
+# contract counterpart to runtime clamps (e.g. the `_VALID_SOURCES` clamp
+# in session_init.py): if a future writer bypasses the normalization
+# path and emits the wrong type directly to `make_event`, the event is
+# rejected at validate time rather than landing on disk.
 # Same type-symmetry rules as _REQUIRED_FIELDS_BY_TYPE: `int` fields
 # reject `bool` because bool subclasses int.
 #

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -1943,7 +1943,7 @@ Events are JSONL entries with common fields `v` (schema version), `type`, and `t
 
 | Type | Written By | Fields | Recovery Use |
 |------|-----------|--------|--------------|
-| `session_start` | session_init hook | `team`, `session_id`, `project_dir`, `worktree` | Session boundary marker |
+| `session_start` | session_init hook | `team`, `session_id`, `project_dir`, `worktree`, `source` | Session boundary marker; `source` ∈ {`startup`, `resume`, `compact`, `clear`, `unknown`} attributes the event to startup vs auto-compact vs `/clear` vs `/resume` for direct triage (no timing-cluster triangulation needed) |
 | `session_end` | session_end hook | `warning` (optional) | Detect incomplete shutdowns |
 | `session_paused` | pause command | `pr_number`, `branch`, `worktree_path`, `consolidation_completed`, `team_name` | Resume paused PR work |
 | `variety_assessed` | orchestrate command | `score`, `dimensions` | Restore variety context |

--- a/pact-plugin/protocols/pact-state-recovery.md
+++ b/pact-plugin/protocols/pact-state-recovery.md
@@ -28,7 +28,7 @@ Events are JSONL entries with common fields `v` (schema version), `type`, and `t
 
 | Type | Written By | Fields | Recovery Use |
 |------|-----------|--------|--------------|
-| `session_start` | session_init hook | `team`, `session_id`, `project_dir`, `worktree` | Session boundary marker |
+| `session_start` | session_init hook | `team`, `session_id`, `project_dir`, `worktree`, `source` | Session boundary marker; `source` ∈ {`startup`, `resume`, `compact`, `clear`, `unknown`} attributes the event to startup vs auto-compact vs `/clear` vs `/resume` for direct triage (no timing-cluster triangulation needed) |
 | `session_end` | session_end hook | `warning` (optional) | Detect incomplete shutdowns |
 | `session_paused` | pause command | `pr_number`, `branch`, `worktree_path`, `consolidation_completed`, `team_name` | Resume paused PR work |
 | `variety_assessed` | orchestrate command | `score`, `dimensions` | Restore variety context |

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -3523,6 +3523,24 @@ class TestSessionStartSourceField:
     matching the existing default at line 430).
     """
 
+    @pytest.fixture(autouse=True)
+    def _reset_pact_context_cache(self, monkeypatch):
+        """Reset `shared.pact_context` module state between tests in this
+        class. Mirrors the identically-named fixture on
+        `TestPluginRootEnvWiring` (see that class for the full rationale).
+
+        Why this class needs it: tests here exercise `main()` against the
+        same tmp_path-rooted Path.home() but patch `write_context`, so the
+        cache doesn't get populated from inside the test. That makes the
+        tests incidentally safe today — but a future refactor that stops
+        patching `write_context` (e.g. to exercise real context writes)
+        would inherit silent cache leakage from a prior test. Matching
+        the sibling class's pattern now hardens the class against that
+        regression."""
+        import shared.pact_context as pact_context
+        monkeypatch.setattr(pact_context, "_context_path", None)
+        monkeypatch.setattr(pact_context, "_cache", None)
+
     def _captured_session_start_event(self, mock_append):
         """Helper: pull the session_start dict out of an append_event mock."""
         starts = [
@@ -3584,19 +3602,33 @@ class TestSessionStartSourceField:
         )
         assert event.get("source") == source
 
+    @pytest.mark.parametrize(
+        "unknown_source",
+        [
+            "",                       # empty string — no whitespace, no characters
+            "   ",                    # whitespace-only — would pass a naive .strip()-based normalization
+            "STARTUP",                # case variant — catches accidental .lower() in the clamp path
+            "startup_but_extra",      # long/compound — catches accidental startswith/prefix match
+            "\u03a0\u039b\u0397\u03a1\u039f\u03a6\u039f\u03a1\u0399\u0391",
+            # Unicode (Greek "INFORMATION") — non-ASCII, valid str, must still clamp via set-membership miss
+        ],
+    )
     def test_unknown_source_clamps_to_unknown_in_event(
-        self, monkeypatch, tmp_path
+        self, monkeypatch, tmp_path, unknown_source
     ):
         """An unrecognized stdin source clamps to `"unknown"` in the
         event — symmetric with the input validation at line 431 that
         prevents arbitrary text from bleeding into source-conditioned
-        downstream logic."""
+        downstream logic. Parametrized over empty, whitespace,
+        case-variant, compound, and Unicode strings to catch
+        normalization regressions (e.g., an accidental `.lower()`
+        that would silently map `"STARTUP"` → `"startup"`)."""
         event = self._run_main_and_capture_event(
             monkeypatch,
             tmp_path,
             {
                 "session_id": "aabb1122-0000-0000-0000-000000000000",
-                "source": "garbage-not-a-real-source",
+                "source": unknown_source,
             },
         )
         assert event.get("source") == "unknown"
@@ -3616,30 +3648,33 @@ class TestSessionStartSourceField:
         )
         assert event.get("source") == "startup"
 
+    @pytest.mark.parametrize("bad_source", [42, [], {}, True, None])
     def test_non_string_source_clamps_to_unknown_in_event(
-        self, monkeypatch, tmp_path
+        self, monkeypatch, tmp_path, bad_source
     ):
         """Fail-open: a non-string `source` (int, list, dict, bool, None)
         from stdin MUST NOT block session start. It clamps to `"unknown"`
         because the membership test against `_VALID_SOURCES` cannot match
-        a non-string."""
-        # `None` is treated as missing-key by `dict.get(..., default)`
-        # only when the key itself is absent — an explicit `None` value
-        # bypasses the default and reaches the validator. Test it
-        # explicitly to lock that branch in.
-        for bad_source in (42, [], {}, True, None):
-            event = self._run_main_and_capture_event(
-                monkeypatch,
-                tmp_path,
-                {
-                    "session_id": "aabb1122-0000-0000-0000-000000000000",
-                    "source": bad_source,
-                },
-            )
-            assert event.get("source") == "unknown", (
-                f"non-string source {bad_source!r} should clamp to "
-                f"'unknown', got {event.get('source')!r}"
-            )
+        a non-string. Parametrized so each bad-value type is reported
+        independently — without parametrization, the first failure aborts
+        the remaining iterations and loses diagnostic power.
+
+        `None` is treated as missing-key by `dict.get(..., default)`
+        only when the key itself is absent — an explicit `None` value
+        bypasses the default and reaches the validator. This case locks
+        that branch in."""
+        event = self._run_main_and_capture_event(
+            monkeypatch,
+            tmp_path,
+            {
+                "session_id": "aabb1122-0000-0000-0000-000000000000",
+                "source": bad_source,
+            },
+        )
+        assert event.get("source") == "unknown", (
+            f"non-string source {bad_source!r} should clamp to "
+            f"'unknown', got {event.get('source')!r}"
+        )
 
     def test_event_preserves_all_existing_fields(
         self, monkeypatch, tmp_path

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -3500,3 +3500,170 @@ class TestBootstrapMarkerCleanup:
                 main()
 
         assert exc_info.value.code == 0
+
+
+# =============================================================================
+# Issue #414 R2: session_start event includes `source` field
+# =============================================================================
+
+
+class TestSessionStartSourceField:
+    """Issue #414 R2 — the `session_start` journal event written by
+    session_init.main() must include the normalized session source so
+    downstream triage can directly attribute the event to startup vs
+    auto-compact vs user `/clear` vs `/resume`, instead of triangulating
+    from timing clusters (which is how R1 was diagnosed — painfully).
+
+    The value persisted is the same `source` already computed at line 431
+    of session_init.py: any unrecognized stdin source clamps to `"unknown"`
+    so the journal field is bounded to {startup, resume, compact, clear,
+    unknown}. Fail-open is SACROSANCT — a missing or non-string source
+    must NEVER block session start; it lands in the journal as
+    `"unknown"` (or as `"startup"` when stdin omits the key entirely,
+    matching the existing default at line 430).
+    """
+
+    def _captured_session_start_event(self, mock_append):
+        """Helper: pull the session_start dict out of an append_event mock."""
+        starts = [
+            call.args[0]
+            for call in mock_append.call_args_list
+            if call.args and call.args[0].get("type") == "session_start"
+        ]
+        assert len(starts) == 1, (
+            f"Expected exactly one session_start event, got {len(starts)}: "
+            f"{starts!r}"
+        )
+        return starts[0]
+
+    def _run_main_and_capture_event(self, monkeypatch, tmp_path, stdin_payload):
+        """Helper: run session_init.main() with the given stdin payload and
+        return the dict that was passed to append_event for session_start."""
+        from session_init import main
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        stdin_data = json.dumps(stdin_payload)
+
+        with patch("session_init.setup_plugin_symlinks", return_value=None), \
+             patch("session_init.remove_stale_kernel_block", return_value=None), \
+             patch("session_init.update_pact_routing", return_value=None), \
+             patch("session_init.ensure_project_memory_md", return_value=None), \
+             patch("session_init.check_pinned_staleness", return_value=None), \
+             patch("session_init.update_session_info", return_value=None), \
+             patch("session_init.get_task_list", return_value=None), \
+             patch("session_init.restore_last_session", return_value=None), \
+             patch("session_init.check_paused_state", return_value=None), \
+             patch("session_init.write_context", return_value=None), \
+             patch("session_init.append_event") as mock_append, \
+             patch("sys.stdin", io.StringIO(stdin_data)), \
+             patch("sys.stdout", new_callable=io.StringIO):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        # Fail-open: session start must always succeed regardless of source.
+        assert exc_info.value.code == 0
+        return self._captured_session_start_event(mock_append)
+
+    @pytest.mark.parametrize(
+        "source", ["startup", "resume", "compact", "clear"]
+    )
+    def test_canonical_source_round_trips_into_event(
+        self, monkeypatch, tmp_path, source
+    ):
+        """All four canonical Claude-Code sources land in the event
+        verbatim — no remapping, no clamping."""
+        event = self._run_main_and_capture_event(
+            monkeypatch,
+            tmp_path,
+            {
+                "session_id": "aabb1122-0000-0000-0000-000000000000",
+                "source": source,
+            },
+        )
+        assert event.get("source") == source
+
+    def test_unknown_source_clamps_to_unknown_in_event(
+        self, monkeypatch, tmp_path
+    ):
+        """An unrecognized stdin source clamps to `"unknown"` in the
+        event — symmetric with the input validation at line 431 that
+        prevents arbitrary text from bleeding into source-conditioned
+        downstream logic."""
+        event = self._run_main_and_capture_event(
+            monkeypatch,
+            tmp_path,
+            {
+                "session_id": "aabb1122-0000-0000-0000-000000000000",
+                "source": "garbage-not-a-real-source",
+            },
+        )
+        assert event.get("source") == "unknown"
+
+    def test_missing_source_defaults_to_startup_in_event(
+        self, monkeypatch, tmp_path
+    ):
+        """When stdin omits `source` entirely, the existing default at
+        line 430 applies: source is `"startup"`. The event mirrors that
+        default rather than synthesizing `"unknown"` — preserving the
+        backwards-compat contract with older Claude Code releases that
+        never sent a source key."""
+        event = self._run_main_and_capture_event(
+            monkeypatch,
+            tmp_path,
+            {"session_id": "aabb1122-0000-0000-0000-000000000000"},
+        )
+        assert event.get("source") == "startup"
+
+    def test_non_string_source_clamps_to_unknown_in_event(
+        self, monkeypatch, tmp_path
+    ):
+        """Fail-open: a non-string `source` (int, list, dict, bool, None)
+        from stdin MUST NOT block session start. It clamps to `"unknown"`
+        because the membership test against `_VALID_SOURCES` cannot match
+        a non-string."""
+        # `None` is treated as missing-key by `dict.get(..., default)`
+        # only when the key itself is absent — an explicit `None` value
+        # bypasses the default and reaches the validator. Test it
+        # explicitly to lock that branch in.
+        for bad_source in (42, [], {}, True, None):
+            event = self._run_main_and_capture_event(
+                monkeypatch,
+                tmp_path,
+                {
+                    "session_id": "aabb1122-0000-0000-0000-000000000000",
+                    "source": bad_source,
+                },
+            )
+            assert event.get("source") == "unknown", (
+                f"non-string source {bad_source!r} should clamp to "
+                f"'unknown', got {event.get('source')!r}"
+            )
+
+    def test_event_preserves_all_existing_fields(
+        self, monkeypatch, tmp_path
+    ):
+        """Additive-only contract: adding `source` MUST NOT drop or
+        rename any of the pre-R2 session_start fields. This guards
+        against an accidental kwarg replacement during refactors."""
+        event = self._run_main_and_capture_event(
+            monkeypatch,
+            tmp_path,
+            {
+                "session_id": "aabb1122-0000-0000-0000-000000000000",
+                "source": "compact",
+            },
+        )
+        assert event.get("type") == "session_start"
+        assert event.get("session_id") == (
+            "aabb1122-0000-0000-0000-000000000000"
+        )
+        assert event.get("project_dir") == "/Users/mj/Sites/test-project"
+        assert event.get("team") == "pact-aabb1122"
+        # `worktree` is always written as "" at this point in the hook —
+        # the worktree is not yet created. The empty string is the
+        # documented placeholder, not a missing value.
+        assert event.get("worktree") == ""
+        # And the new field rides alongside.
+        assert event.get("source") == "compact"

--- a/pact-plugin/tests/test_session_journal.py
+++ b/pact-plugin/tests/test_session_journal.py
@@ -2301,6 +2301,7 @@ class TestSessionInitJournalWrite:
         events = read_events("session_start")
         assert len(events) >= 1
         assert events[0]["team"] == "pact-abc12345"
+        assert events[0].get("source") == "startup"
 
 
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_session_journal.py
+++ b/pact-plugin/tests/test_session_journal.py
@@ -2279,6 +2279,15 @@ class TestSessionInitJournalWrite:
         self, journal_home, monkeypatch, stdin_source, expected_on_disk
     ):
         """session_init.main() writes session_start event to journal."""
+        # NOTE: The class-level `mock_get_session_dir` autouse fixture at
+        # test_session_journal.py:188-197 patches `_get_session_dir()` on the
+        # session_journal module, so this test bypasses the real
+        # `pact_context`-backed session-dir derivation. What IS verified
+        # end-to-end: the source-normalization branches in
+        # session_init.main(), journal serialization to JSONL on disk, and
+        # read_events() round-trip — including the non-string isinstance
+        # guard via the (42, "unknown") case. What is NOT exercised:
+        # `pact_context.init()` path resolution.
         import io
 
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(journal_home / "project"))

--- a/pact-plugin/tests/test_session_journal.py
+++ b/pact-plugin/tests/test_session_journal.py
@@ -2264,7 +2264,20 @@ class TestHandoffGateJournalWrite:
 class TestSessionInitJournalWrite:
     """Tests that session_init.main() writes session_start event to journal."""
 
-    def test_writes_session_start_event(self, journal_home, monkeypatch):
+    @pytest.mark.parametrize(
+        "stdin_source, expected_on_disk",
+        [
+            ("startup", "startup"),
+            ("resume", "resume"),
+            ("compact", "compact"),
+            ("clear", "clear"),
+            ("unknown", "unknown"),
+            (42, "unknown"),
+        ],
+    )
+    def test_writes_session_start_event(
+        self, journal_home, monkeypatch, stdin_source, expected_on_disk
+    ):
         """session_init.main() writes session_start event to journal."""
         import io
 
@@ -2274,7 +2287,7 @@ class TestSessionInitJournalWrite:
 
         input_data = {
             "session_id": "abc12345-test",
-            "source": "startup",
+            "source": stdin_source,
         }
 
         with patch("sys.stdin", io.StringIO(json.dumps(input_data))), \
@@ -2301,7 +2314,7 @@ class TestSessionInitJournalWrite:
         events = read_events("session_start")
         assert len(events) >= 1
         assert events[0]["team"] == "pact-abc12345"
-        assert events[0].get("source") == "startup"
+        assert events[0].get("source") == expected_on_disk
 
 
 # ---------------------------------------------------------------------------
@@ -3325,3 +3338,231 @@ class TestValidateEventSchemaPerType:
             "non-empty string"
         ) in result.stderr
         assert not journal_file.exists() or journal_file.read_text() == ""
+
+
+# ---------------------------------------------------------------------------
+# Per-type optional-field validation (BR-M2)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateOptionalFieldTypes:
+    """Per-type optional-field schema validation tests for BR-M2.
+
+    The validator enforces type on optional fields declared in
+    _OPTIONAL_FIELDS_BY_TYPE. A field is optional iff absent is OK; when
+    present, it must match the declared Python type. This is the schema
+    contract counterpart to runtime clamps (e.g. the `source` isinstance
+    guard in session_init.py) — a future writer that bypasses the clamp
+    and emits the wrong type directly to `make_event` is rejected at
+    validate time instead of landing a bad type on disk.
+    """
+
+    def test_optional_fields_dict_shape(self):
+        """_OPTIONAL_FIELDS_BY_TYPE maps event_type → {field: type}.
+
+        Meta-test: validates the declaration shape so a malformed entry
+        fails here rather than surfacing as a cryptic TypeError inside
+        the validator.
+        """
+        from shared.session_journal import _OPTIONAL_FIELDS_BY_TYPE
+
+        assert isinstance(_OPTIONAL_FIELDS_BY_TYPE, dict)
+        for event_type, field_types in _OPTIONAL_FIELDS_BY_TYPE.items():
+            assert isinstance(event_type, str) and event_type.strip()
+            assert isinstance(field_types, dict)
+            for field, expected_type in field_types.items():
+                assert isinstance(field, str) and field.strip()
+                assert isinstance(expected_type, type)
+
+    def test_session_start_source_declared_optional(self):
+        """session_start has `source: str` in _OPTIONAL_FIELDS_BY_TYPE.
+
+        Pins the canonical case — the isinstance guard in session_init.py
+        clamps `source` at runtime; this schema entry pins the contract
+        at the journal boundary.
+        """
+        from shared.session_journal import _OPTIONAL_FIELDS_BY_TYPE
+
+        assert _OPTIONAL_FIELDS_BY_TYPE.get("session_start") == {"source": str}
+
+    def test_optional_field_correct_type_passes(self):
+        """Optional field with correct type passes validation."""
+        from shared.session_journal import _validate_event_schema, make_event
+
+        event = make_event(
+            "session_start",
+            session_id="s1",
+            project_dir="/tmp/p",
+            source="startup",
+        )
+        ok, reason = _validate_event_schema(event)
+        assert ok is True
+        assert reason == "ok"
+
+    def test_optional_field_absent_passes(self):
+        """Optional field missing entirely passes validation.
+
+        That's what "optional" means — absence is not a violation. All
+        existing session_init writers prior to R2 took this code path.
+        """
+        from shared.session_journal import _validate_event_schema, make_event
+
+        event = make_event("session_start", session_id="s1", project_dir="/tmp/p")
+        ok, reason = _validate_event_schema(event)
+        assert ok is True
+        assert reason == "ok"
+
+    def test_optional_field_none_passes(self):
+        """Optional field explicitly set to None passes validation.
+
+        Symmetric with the required-field check (`field not in event or
+        event[field] is None`): for optional fields, None is treated the
+        same as missing — both skip the type check.
+        """
+        from shared.session_journal import _validate_event_schema, make_event
+
+        event = make_event(
+            "session_start",
+            session_id="s1",
+            project_dir="/tmp/p",
+            source=None,
+        )
+        ok, reason = _validate_event_schema(event)
+        assert ok is True
+        assert reason == "ok"
+
+    @pytest.mark.parametrize(
+        "bad_value, got_name",
+        [
+            (42, "int"),
+            (3.14, "float"),
+            ([1, 2], "list"),
+            ({"k": "v"}, "dict"),
+            ((1, 2), "tuple"),
+            (b"bytes", "bytes"),
+        ],
+        ids=["int", "float", "list", "dict", "tuple", "bytes"],
+    )
+    def test_optional_field_wrong_type_rejected(self, bad_value, got_name):
+        """Optional field with wrong type fails validation with precise reason.
+
+        Reason-string format mirrors the required-field mismatch reason
+        but uses "optional field" prefix so CLI stderr diagnostics make
+        the source of the failure unambiguous. This pins the format so
+        operators get a sharp diagnostic instead of a generic 'invalid
+        event schema'.
+        """
+        from shared.session_journal import _validate_event_schema, make_event
+
+        event = make_event(
+            "session_start",
+            session_id="s1",
+            project_dir="/tmp/p",
+            source=bad_value,
+        )
+        ok, reason = _validate_event_schema(event)
+        assert ok is False, f"source={bad_value!r} should be rejected"
+        expected = (
+            f"optional field 'source' for type 'session_start' must "
+            f"be str, got {got_name}"
+        )
+        assert reason == expected, f"expected {expected!r}, got {reason!r}"
+
+    def test_optional_str_field_rejects_empty_and_whitespace(self):
+        """Optional str fields reject empty/whitespace-only values.
+
+        Symmetric with required-str semantics — a whitespace-only
+        `source` ("" or "   ") is indistinguishable from missing for
+        downstream consumers. The validator strips before checking.
+        """
+        from shared.session_journal import _validate_event_schema, make_event
+
+        for bad in ["", "   ", "\t", "\n", "   \t  "]:
+            event = make_event(
+                "session_start",
+                session_id="s1",
+                project_dir="/tmp/p",
+                source=bad,
+            )
+            ok, reason = _validate_event_schema(event)
+            assert ok is False, f"source={bad!r} should be rejected"
+            assert reason == (
+                "optional field 'source' for type 'session_start' must "
+                "be non-empty string"
+            )
+
+    def test_undeclared_event_type_with_optional_looking_field_passes(self):
+        """Event types with no optional declaration don't trip on arbitrary fields.
+
+        `phase_transition` is not in _OPTIONAL_FIELDS_BY_TYPE, so even a
+        same-named field with a wrong type on that event passes optional
+        validation. This guards against cross-contamination — optional
+        declarations are per-event-type, not global.
+        """
+        from shared.session_journal import _validate_event_schema, make_event
+
+        event = make_event(
+            "phase_transition",
+            phase="CODE",
+            status="started",
+            source=42,  # Would fail on session_start; passes on phase_transition.
+        )
+        ok, reason = _validate_event_schema(event)
+        assert ok is True
+        assert reason == "ok"
+
+    def test_unknown_event_type_passes_optional_check(self):
+        """Unknown event types bypass the optional-field loop.
+
+        Mirrors the required-field "unknown type is opt-in" behavior:
+        per-type checks are opt-in whitelists, so free-form "test" types
+        used in unit tests sail through regardless of payload shape.
+        """
+        from shared.session_journal import _validate_event_schema, make_event
+
+        event = make_event(
+            "some_unit_test_type_not_in_dict",
+            source=42,
+        )
+        ok, reason = _validate_event_schema(event)
+        assert ok is True
+        assert reason == "ok"
+
+    def test_append_event_rejects_wrong_typed_optional_field(self, journal_home):
+        """append_event returns False when optional field has wrong type.
+
+        End-to-end check: the write path (fail-open) rejects the event
+        without ever touching disk. A future session_init regression that
+        forgets the isinstance guard would produce a wrong-typed source;
+        this test is the schema-level bulwark against that reaching disk.
+        """
+        from shared.session_journal import append_event, make_event
+
+        bad_event = make_event(
+            "session_start",
+            session_id="s1",
+            project_dir="/tmp/p",
+            source=42,
+        )
+        assert append_event(bad_event) is False
+
+    def test_append_event_accepts_correct_optional_field(self, journal_home):
+        """append_event returns True for a well-formed session_start with source.
+
+        The positive end-to-end case — pins the happy path of the R2
+        contract so a regression in the validator (e.g. rejecting str
+        values accidentally) fails here instead of silently dropping
+        every session_start write.
+        """
+        from shared.session_journal import append_event, make_event, read_events
+
+        good_event = make_event(
+            "session_start",
+            session_id="s1",
+            project_dir="/tmp/p",
+            source="startup",
+        )
+        assert append_event(good_event) is True
+        events = read_events("session_start")
+        assert len(events) == 1
+        assert events[0].get("source") == "startup"


### PR DESCRIPTION
## Summary

Adds `source` (startup | resume | compact | clear | unknown) to
`session_start` journal events so auto-compact vs user-clear vs startup
is directly attributable from journal data — no timing-cluster
triangulation needed. Addresses R2 from #414.

Also includes a 1-line R1 hardening: an `isinstance(str)` guard
short-circuits the `_VALID_SOURCES` set membership test for unhashable
inputs (list, dict). Without it, such inputs raise `TypeError` on the
`in` check and bubble to the outer safety-net, skipping the journal
write entirely — which would break R2's fail-open contract. Latent
pre-existing bug in R1's input normalization; now load-bearing under R2.

## Changes

- `pact-plugin/hooks/session_init.py`: `isinstance` guard + `source`
  field on session_start event
- `pact-plugin/protocols/pact-state-recovery.md`: Journal Event Types
  table row for `session_start` lists the new field
- `pact-plugin/tests/test_session_init.py`: 8 new tests (parametrized
  canonical round-trip + unknown clamp + missing default + non-string
  clamp over 5 bad-value types + all-existing-fields preservation)

## Test plan

- [ ] `python3 -m pytest pact-plugin/tests/test_session_init.py -v` passes (all 159)
- [ ] Full plugin suite passes (6142/6142 at commit time; 2 pre-existing skips)
- [ ] No behavior change when `source` is one of the 4 canonical values
- [ ] Unhashable source (list, dict) cleanly clamps to `"unknown"` and journal write still occurs
- [ ] Missing source stdin field still defaults to `"startup"` (backwards compat)

Partial fix for #414 — R2 only. R1 shipped in #415; R3 (bootstrap.md skill-body truncation) still open.