### PR TITLE
fix: include pact-sessions in additionalDirectories check

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "3.17.5",
+      "version": "3.17.6",
       "author": {
         "name": "ProfSynapse"
       },

--- a/README.md
+++ b/README.md
@@ -245,7 +245,8 @@ Add the following to your `settings.json` (global `~/.claude/settings.json` or p
   },
   "permissions": {
     "additionalDirectories": [
-      "~/.claude/teams"
+      "~/.claude/teams",
+      "~/.claude/pact-sessions"
     ],
     "allow": [
       "Write(~/.claude/agent-memory/**)",
@@ -265,7 +266,7 @@ Add the following to your `settings.json` (global `~/.claude/settings.json` or p
 }
 ```
 
-The `env` setting enables Agent Teams. The `permissions.additionalDirectories` entry allows agents to access team coordination files in `~/.claude/teams/` without permission prompts. The `permissions.allow` rules prevent recurring prompts for agent memory, session state, and Telegram config file operations.
+The `env` setting enables Agent Teams. The `permissions.additionalDirectories` entries allow agents to access team coordination files in `~/.claude/teams/` and session journals in `~/.claude/pact-sessions/` without permission prompts. The `permissions.allow` rules prevent recurring prompts for agent memory, session state, and Telegram config file operations.
 
 > **Note:** Bash allow rules are intentionally omitted — they are [fragile](https://docs.anthropic.com/en/docs/claude-code/settings#permission-settings) for commands with arguments. When agents run `mkdir` or `rm` in `~/.claude/` paths, select **"Yes, and always allow from this project"** to add the rule automatically.
 

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-marketplace/
 │           └── PACT/
-│               └── 3.17.5/     # Plugin version
+│               └── 3.17.6/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "3.17.5",
+  "version": "3.17.6",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "ProfSynapse",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 3.17.5
+> **Version**: 3.17.6
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -14,13 +14,14 @@ Turn a single Claude Code session into a managed team of specialist AI agents th
 cp ~/.claude/plugins/cache/pact-marketplace/PACT/*/CLAUDE.md ~/.claude/CLAUDE.md
 ```
 
-Then add `~/.claude/teams` to your `additionalDirectories` and PACT allow rules in `~/.claude/settings.json` to prevent permission prompts during agent operations:
+Then add `~/.claude/teams` and `~/.claude/pact-sessions` to your `additionalDirectories` and PACT allow rules in `~/.claude/settings.json` to prevent permission prompts during agent operations:
 
 ```json
 {
   "permissions": {
     "additionalDirectories": [
-      "~/.claude/teams"
+      "~/.claude/teams",
+      "~/.claude/pact-sessions"
     ],
     "allow": [
       "Write(~/.claude/agent-memory/**)",

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -485,12 +485,12 @@ def main():
             except OSError:
                 pass  # Fail-open: don't block session init for marker cleanup
 
-        # 0. Check if ~/.claude/teams is in additionalDirectories (one-time tip)
+        # 0. Check required PACT dirs are in additionalDirectories (one-time tip)
         # Only check on fresh startup — resumed/compacted sessions already had the check
         if not is_context_reset:
-            teams_tip = check_additional_directories()
-            if teams_tip:
-                system_messages.append(teams_tip)
+            dirs_tip = check_additional_directories()
+            if dirs_tip:
+                system_messages.append(dirs_tip)
 
         # 1. Set up plugin symlinks (enables @~/.claude/protocols/pact-plugin/ references)
         # Context resets (compact/clear): symlinks are already set up from original session

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -96,9 +96,11 @@ def check_pinned_staleness():
 
 def check_additional_directories() -> str | None:
     """
-    Check if ~/.claude/teams is in additionalDirectories in settings.json.
+    Check if required PACT directories are in additionalDirectories in settings.json.
 
-    Returns a tip message if the setting is missing, or None if already present.
+    Checks for both ~/.claude/teams and ~/.claude/pact-sessions.
+    Returns a tip message listing whichever directories are missing,
+    or None if all are already present.
     Fail-open: returns None on any error (file missing, malformed JSON, etc.).
     """
     try:
@@ -114,9 +116,8 @@ def check_additional_directories() -> str | None:
         if not isinstance(additional_dirs, list):
             return None  # Unexpected type — fail-open
 
-        # Normalize the target path for comparison
-        target = Path.home() / ".claude" / "teams"
-
+        # Resolve all configured paths for comparison
+        configured: set[Path] = set()
         for entry in additional_dirs:
             if not isinstance(entry, str):
                 continue
@@ -125,13 +126,28 @@ def check_additional_directories() -> str | None:
                 expanded = (Path.home() / entry[2:]).resolve()
             else:
                 expanded = Path(entry).resolve()
-            if expanded == target.resolve():
-                return None  # Already configured
+            configured.add(expanded)
 
+        # Check which required directories are missing
+        required = {
+            "~/.claude/teams": (Path.home() / ".claude" / "teams").resolve(),
+            "~/.claude/pact-sessions": (
+                Path.home() / ".claude" / "pact-sessions"
+            ).resolve(),
+        }
+        missing = [
+            tilde for tilde, resolved in required.items()
+            if resolved not in configured
+        ]
+
+        if not missing:
+            return None  # All required directories configured
+
+        dirs_list = ", ".join(f"`{d}`" for d in missing)
         return (
-            "PACT tip: Add `~/.claude/teams` to `additionalDirectories` in your "
-            "~/.claude/settings.json to avoid permission prompts for team file "
-            "operations."
+            f"PACT tip: Add {dirs_list} to `additionalDirectories` in your "
+            "~/.claude/settings.json to avoid permission prompts for team and "
+            "session file operations."
         )
     except Exception:
         return None  # Fail-open: never block session start

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -846,11 +846,12 @@ class TestCompactSummaryCleanup:
 
 
 class TestCheckAdditionalDirectories:
-    """Tests for check_additional_directories() — ~/.claude/teams tip.
+    """Tests for check_additional_directories() — multi-directory tip.
 
-    The function reads ~/.claude/settings.json and checks if ~/.claude/teams
-    (or its absolute equivalent) is listed in permissions.additionalDirectories.
-    Returns a tip message if missing, None if present. Fail-open on all errors.
+    The function reads ~/.claude/settings.json and checks if both ~/.claude/teams
+    and ~/.claude/pact-sessions (or their absolute equivalents) are listed in
+    permissions.additionalDirectories. Returns a tip message listing whichever
+    directories are missing, or None if all are present. Fail-open on all errors.
     """
 
     def _write_settings(self, tmp_path, settings_data):
@@ -861,22 +862,38 @@ class TestCheckAdditionalDirectories:
         settings_file.write_text(json.dumps(settings_data), encoding="utf-8")
         return settings_file
 
-    def test_returns_none_when_absolute_path_present(self, monkeypatch, tmp_path):
-        """Should return None when absolute path to teams dir is in additionalDirectories."""
+    def test_returns_none_when_both_dirs_present_absolute(self, monkeypatch, tmp_path):
+        """Should return None when absolute paths to both dirs are in additionalDirectories."""
         from session_init import check_additional_directories
 
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         teams_abs = str(tmp_path / ".claude" / "teams")
+        sessions_abs = str(tmp_path / ".claude" / "pact-sessions")
         self._write_settings(tmp_path, {
-            "permissions": {"additionalDirectories": [teams_abs]}
+            "permissions": {"additionalDirectories": [teams_abs, sessions_abs]}
         })
 
         result = check_additional_directories()
 
         assert result is None
 
-    def test_returns_none_when_tilde_path_present(self, monkeypatch, tmp_path):
-        """Should return None when ~/.claude/teams (tilde form) is in additionalDirectories."""
+    def test_returns_none_when_both_dirs_present_tilde(self, monkeypatch, tmp_path):
+        """Should return None when tilde-form paths to both dirs are in additionalDirectories."""
+        from session_init import check_additional_directories
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        self._write_settings(tmp_path, {
+            "permissions": {"additionalDirectories": [
+                "~/.claude/teams", "~/.claude/pact-sessions"
+            ]}
+        })
+
+        result = check_additional_directories()
+
+        assert result is None
+
+    def test_returns_tip_for_pact_sessions_when_only_teams_present(self, monkeypatch, tmp_path):
+        """Should return tip mentioning pact-sessions when only teams is configured."""
         from session_init import check_additional_directories
 
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
@@ -886,10 +903,27 @@ class TestCheckAdditionalDirectories:
 
         result = check_additional_directories()
 
-        assert result is None
+        assert result is not None
+        assert "~/.claude/pact-sessions" in result
+        assert "~/.claude/teams" not in result
 
-    def test_returns_tip_when_setting_missing(self, monkeypatch, tmp_path):
-        """Should return tip message when teams dir is not in additionalDirectories."""
+    def test_returns_tip_for_teams_when_only_pact_sessions_present(self, monkeypatch, tmp_path):
+        """Should return tip mentioning teams when only pact-sessions is configured."""
+        from session_init import check_additional_directories
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        self._write_settings(tmp_path, {
+            "permissions": {"additionalDirectories": ["~/.claude/pact-sessions"]}
+        })
+
+        result = check_additional_directories()
+
+        assert result is not None
+        assert "~/.claude/teams" in result
+        assert "~/.claude/pact-sessions" not in result
+
+    def test_returns_tip_for_both_when_neither_present(self, monkeypatch, tmp_path):
+        """Should return tip mentioning both dirs when neither is configured."""
         from session_init import check_additional_directories
 
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
@@ -902,9 +936,10 @@ class TestCheckAdditionalDirectories:
         assert result is not None
         assert "additionalDirectories" in result
         assert "~/.claude/teams" in result
+        assert "~/.claude/pact-sessions" in result
 
     def test_returns_tip_when_additional_directories_empty(self, monkeypatch, tmp_path):
-        """Should return tip when additionalDirectories is an empty list."""
+        """Should return tip mentioning both dirs when additionalDirectories is empty."""
         from session_init import check_additional_directories
 
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
@@ -916,6 +951,7 @@ class TestCheckAdditionalDirectories:
 
         assert result is not None
         assert "~/.claude/teams" in result
+        assert "~/.claude/pact-sessions" in result
 
     def test_returns_none_when_settings_file_missing(self, monkeypatch, tmp_path):
         """Should return None (fail-open) when settings.json does not exist."""
@@ -951,9 +987,10 @@ class TestCheckAdditionalDirectories:
         result = check_additional_directories()
 
         # permissions missing → .get("permissions", {}).get("additionalDirectories", [])
-        # returns [] → no matching entry → tip message returned
+        # returns [] → no matching entry → tip message with both dirs
         assert result is not None
         assert "~/.claude/teams" in result
+        assert "~/.claude/pact-sessions" in result
 
     def test_returns_none_when_additional_dirs_not_list(self, monkeypatch, tmp_path):
         """Should return None (fail-open) when additionalDirectories is not a list."""
@@ -982,18 +1019,21 @@ class TestCheckAdditionalDirectories:
         assert result is None
 
     def test_ignores_non_string_entries(self, monkeypatch, tmp_path):
-        """Should skip non-string entries in additionalDirectories without crashing."""
+        """Should skip non-string entries and still find valid paths."""
         from session_init import check_additional_directories
 
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         teams_abs = str(tmp_path / ".claude" / "teams")
+        sessions_abs = str(tmp_path / ".claude" / "pact-sessions")
         self._write_settings(tmp_path, {
-            "permissions": {"additionalDirectories": [42, None, teams_abs]}
+            "permissions": {"additionalDirectories": [
+                42, None, teams_abs, sessions_abs
+            ]}
         })
 
         result = check_additional_directories()
 
-        assert result is None  # Found the valid path after skipping non-strings
+        assert result is None  # Found both valid paths after skipping non-strings
 
 
 class TestCheckAdditionalDirectoriesMainIntegration:
@@ -1035,20 +1075,22 @@ class TestCheckAdditionalDirectoriesMainIntegration:
         system_msg = output.get("systemMessage", "")
         assert "additionalDirectories" in system_msg
         assert "~/.claude/teams" in system_msg
+        assert "~/.claude/pact-sessions" in system_msg
 
     def test_no_tip_when_setting_present(self, monkeypatch, tmp_path):
-        """No tip should appear when teams dir is already configured."""
+        """No tip should appear when both required dirs are configured."""
         from session_init import main
 
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
-        # Create settings.json WITH ~/.claude/teams in additionalDirectories
+        # Create settings.json WITH both dirs in additionalDirectories
         teams_abs = str(tmp_path / ".claude" / "teams")
+        sessions_abs = str(tmp_path / ".claude" / "pact-sessions")
         settings_dir = tmp_path / ".claude"
         settings_dir.mkdir(parents=True)
         (settings_dir / "settings.json").write_text(
-            json.dumps({"permissions": {"additionalDirectories": [teams_abs]}}),
+            json.dumps({"permissions": {"additionalDirectories": [teams_abs, sessions_abs]}}),
             encoding="utf-8",
         )
 

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -1035,6 +1035,39 @@ class TestCheckAdditionalDirectories:
 
         assert result is None  # Found both valid paths after skipping non-strings
 
+    def test_returns_none_when_mixed_tilde_and_absolute_forms(self, monkeypatch, tmp_path):
+        """Should return None when one dir uses tilde form and the other uses absolute form."""
+        from session_init import check_additional_directories
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        sessions_abs = str(tmp_path / ".claude" / "pact-sessions")
+        self._write_settings(tmp_path, {
+            "permissions": {"additionalDirectories": [
+                "~/.claude/teams", sessions_abs
+            ]}
+        })
+
+        result = check_additional_directories()
+
+        assert result is None
+
+    def test_tip_mentions_exactly_two_directories_when_none_configured(self, monkeypatch, tmp_path):
+        """Cardinality check: exactly 2 required directories should be checked."""
+        from session_init import check_additional_directories
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        self._write_settings(tmp_path, {
+            "permissions": {"additionalDirectories": []}
+        })
+
+        result = check_additional_directories()
+
+        assert result is not None
+        # Count occurrences of ~/.claude/ paths in the tip message
+        import re
+        dir_mentions = re.findall(r"`~/.claude/[^`]+`", result)
+        assert len(dir_mentions) == 2, f"Expected exactly 2 directory mentions, got {dir_mentions}"
+
 
 class TestCheckAdditionalDirectoriesMainIntegration:
     """Integration tests: check_additional_directories wiring in session_init.main()."""


### PR DESCRIPTION
## Summary
- Extend `check_additional_directories()` in `session_init.py` to verify both `~/.claude/teams` and `~/.claude/pact-sessions` are in `additionalDirectories`
- Return a consolidated tip listing whichever directories are missing (one or both)
- Update recommended settings in both `README.md` and `pact-plugin/README.md` to include `pact-sessions`

## Test plan
- [x] All 169 session_init tests pass
- [x] Combinatorial coverage: both present, only teams, only pact-sessions, neither
- [x] Edge cases preserved: non-list, non-string entries, missing permissions key