### PR TITLE
fix(#438): default wrap-up end-session to natural cleanup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "3.17.8",
+      "version": "3.17.9",
       "author": {
         "name": "ProfSynapse"
       },

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-marketplace/
 │           └── PACT/
-│               └── 3.17.8/     # Plugin version
+│               └── 3.17.9/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "3.17.8",
+  "version": "3.17.9",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "ProfSynapse",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 3.17.8
+> **Version**: 3.17.9
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/commands/wrap-up.md
+++ b/pact-plugin/commands/wrap-up.md
@@ -18,7 +18,7 @@ TaskUpdate(taskId, owner="secretary")
 
 This is the deep-clean pass. Pass 1 (workflow-level HANDOFF review) is the primary mechanism; this consolidation is recommended — skip only for trivial sessions (single comPACT, no variety assessment performed).
 
-> **Why this runs first**: Memory consolidation reads task HANDOFFs via `TaskGet`. Task audit (step 3) may delete completed tasks. Running consolidation first ensures HANDOFF data is available.
+> **Why this runs first**: Memory consolidation reads task HANDOFFs via `TaskGet`. Task audit (step 7) may delete completed tasks. Running consolidation first ensures HANDOFF data is available.
 
 ## 2. Documentation Sync
 
@@ -107,5 +107,5 @@ Audit and optionally clean up Task state:
 Use `AskUserQuestion` with these exact options:
 - **"Yes, continue"** (description: "Keep team alive, ready for next task") → On selection: Report "Ready for next task."
 - **"Pause work for now"** (description: "Save session knowledge and pause — resume later") → On selection: invoke `/PACT:pause`
-- **"No, end session"** (description: "End session — platform reaps teammates, 30-day TTL handles team/task cleanup (recommended)") → On selection: Report "Session complete. Teammate processes will be terminated when this session ends. Team and task directories (`~/.claude/teams/`, `~/.claude/tasks/`) are reaped automatically after 30 days by TTL cleanup (PR #433)."
-- **"End session (graceful)"** (description: "Explicit shutdown + TeamDelete — for immediate zero-residue cleanup or pathological states") → On selection: Shut down remaining teammates — send `shutdown_request` individually to each active teammate **by name** (do NOT broadcast structured messages via `to: "*"` — broadcasts only support plain text). Wait for each response. Delete the team (`TeamDelete`). If `TeamDelete` fails because active members remain, report which teammates are still running and ask the user whether to force shutdown or leave them. Report "Session complete."
+- **"No, end session"** (description: "Natural cleanup — platform reaps processes, 30-day TTL cleans directories (recommended)") → On selection: Report "Session complete. Teammate processes will be terminated when this session ends. Team and task directories (`~/.claude/teams/`, `~/.claude/tasks/`) are reaped automatically after 30 days by TTL cleanup (PR #433)."
+- **"End session (graceful)"** (description: "Explicit shutdown + TeamDelete — for immediate cleanup or recovery from interrupted sessions") → On selection: Shut down remaining teammates — send `shutdown_request` individually to each active teammate **by name** (do NOT broadcast structured messages via `to: "*"` — broadcasts only support plain text). Wait for each response. Delete the team (`TeamDelete`). If `TeamDelete` fails because active members remain, report which teammates are still running and ask the user whether to force shutdown or leave them. Report "Session complete."

--- a/pact-plugin/commands/wrap-up.md
+++ b/pact-plugin/commands/wrap-up.md
@@ -52,12 +52,12 @@ entities: ["orchestration_calibration", "{domain}"]
 
 **Skip when**: Session was trivial (single comPACT, no variety assessment performed).
 
-## 5. Journal Drain-Before-Delete
+## 5. Journal Drain-Before-Close
 
-Before deleting the team (step 7), ensure all journal entries have been processed:
+Before ending the session (step 8), ensure all journal entries have been processed:
 
 1. Confirm the secretary has completed the consolidation harvest (step 1). The secretary should confirm via `SendMessage`: "All journal entries processed to pact-memory."
-2. **Only on confirmation**: Proceed to worktree cleanup and team deletion.
+2. **Only on confirmation**: Proceed to worktree cleanup and session decision.
 3. **If secretary cannot confirm**: Warn user — unprocessed journal entries will not be distilled to pact-memory. The journal itself is safe (stored in `~/.claude/pact-sessions/`, not the team directory).
 
 **Journal event**: Write a `session_end` event after confirmation:
@@ -68,7 +68,7 @@ python3 "{plugin_root}/hooks/shared/session_journal.py" write \
   --type session_end --session-dir '{session_dir}'
 ```
 
-**Recovery note**: The journal survives `TeamDelete` — it lives in `~/.claude/pact-sessions/{slug}/{session_id}/`, independent of the team directory. Old session directories are cleaned automatically after 30 days (with paused-session preservation). See [pact-state-recovery.md](../protocols/pact-state-recovery.md) for the full State Recovery Protocol.
+**Recovery note**: The journal lives in `~/.claude/pact-sessions/{slug}/{session_id}/`, independent of the team directory — it survives both natural TTL cleanup and explicit `TeamDelete`. Old session directories are cleaned automatically after 30 days (with paused-session preservation). See [pact-state-recovery.md](../protocols/pact-state-recovery.md) for the full State Recovery Protocol.
 
 ## 6. Worktree Cleanup
 
@@ -107,4 +107,5 @@ Audit and optionally clean up Task state:
 Use `AskUserQuestion` with these exact options:
 - **"Yes, continue"** (description: "Keep team alive, ready for next task") → On selection: Report "Ready for next task."
 - **"Pause work for now"** (description: "Save session knowledge and pause — resume later") → On selection: invoke `/PACT:pause`
-- **"No, end session"** (description: "Shut down teammates and close session") → On selection: Shut down remaining teammates — send `shutdown_request` individually to each active teammate **by name** (do NOT broadcast structured messages via `to: "*"` — broadcasts only support plain text). Wait for each response. Delete the team (`TeamDelete`). If `TeamDelete` fails because active members remain, report which teammates are still running and ask the user whether to force shutdown or leave them. Report "Session complete."
+- **"No, end session"** (description: "End session — platform reaps teammates, 30-day TTL handles team/task cleanup (recommended)") → On selection: Report "Session complete. Teammate processes will be terminated when this session ends. Team and task directories (`~/.claude/teams/`, `~/.claude/tasks/`) are reaped automatically after 30 days by TTL cleanup (PR #433)."
+- **"End session (graceful)"** (description: "Explicit shutdown + TeamDelete — for immediate zero-residue cleanup or pathological states") → On selection: Shut down remaining teammates — send `shutdown_request` individually to each active teammate **by name** (do NOT broadcast structured messages via `to: "*"` — broadcasts only support plain text). Wait for each response. Delete the team (`TeamDelete`). If `TeamDelete` fails because active members remain, report which teammates are still running and ask the user whether to force shutdown or leave them. Report "Session complete."

--- a/pact-plugin/tests/test_commands_structure.py
+++ b/pact-plugin/tests/test_commands_structure.py
@@ -95,14 +95,14 @@ class TestAskUserQuestionOptions:
     def peer_review_content(self):
         return (COMMANDS_DIR / "peer-review.md").read_text(encoding="utf-8")
 
-    # --- wrap-up.md Step 7 ---
+    # --- wrap-up.md Step 8 ---
 
-    def test_wrapup_has_three_options(self, wrapup_content):
-        """Step 7 session decision has 3 options."""
+    def test_wrapup_has_four_options(self, wrapup_content):
+        """Step 8 session decision has 4 options."""
         # Extract only from the Session Decision section (after "Session Decision")
         session_section = wrapup_content.split("Session Decision")[1]
         labels = _extract_option_labels(session_section)
-        assert len(labels) == 3, f"wrap-up.md session decision should have 3 options, found {len(labels)}: {labels}"
+        assert len(labels) == 4, f"wrap-up.md session decision should have 4 options, found {len(labels)}: {labels}"
 
     def test_wrapup_yes_continue_option(self, wrapup_content):
         assert '"Yes, continue"' in wrapup_content
@@ -112,6 +112,9 @@ class TestAskUserQuestionOptions:
 
     def test_wrapup_no_end_session_option(self, wrapup_content):
         assert '"No, end session"' in wrapup_content
+
+    def test_wrapup_graceful_end_session_option(self, wrapup_content):
+        assert '"End session (graceful)"' in wrapup_content
 
     def test_wrapup_pause_invokes_pause_command(self, wrapup_content):
         """Pause option should invoke /PACT:pause."""


### PR DESCRIPTION
## Summary

- Drop the explicit `shutdown_request` + `TeamDelete` ceremony from `/PACT:wrap-up` step 8 as the default end-session path
- PR #433's TTL reapers now auto-clean `~/.claude/teams/` and `~/.claude/tasks/` within 30 days, and the platform reaps teammate processes on session exit
- Preserve the ceremony as an opt-in 4th option ("End session (graceful)") for immediate zero-residue cleanup or pathological states
- Fix stale step 5 cross-reference and rename "Drain-Before-Delete" → "Drain-Before-Close"

## Test plan

- [x] Structural test updated: 3 → 4 AskUserQuestion options
- [x] New test added for graceful shutdown option
- [x] Full suite passes (6282 pass, 0 fail, 2 skip)

Closes #438