### PR TITLE
feat(#497): fix TeammateIdle nag-loop livelock

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "3.17.13",
+      "version": "3.17.14",
       "author": {
         "name": "ProfSynapse"
       },

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-marketplace/
 │           └── PACT/
-│               └── 3.17.13/    # Plugin version
+│               └── 3.17.14/    # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "3.17.13",
+  "version": "3.17.14",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "ProfSynapse",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 3.17.13
+> **Version**: 3.17.14
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/commands/comPACT.md
+++ b/pact-plugin/commands/comPACT.md
@@ -280,7 +280,7 @@ When dispatching an auditor, create its task with `metadata: {"completion_type":
 - [ ] Agent tasks marked `completed` (agents self-manage their task status via `TaskUpdate`)
 - [ ] **Agreement verification**: `SendMessage` to specialist to confirm shared understanding of deliverables before committing. Background: [pact-ct-teachback.md](../protocols/pact-ct-teachback.md).
 - [ ] **Run tests** — verify work passes. If tests fail → return to specialist for fixes (create new agent task, repeat).
-- [ ] **Create atomic commit(s)** — stage and commit before proceeding. Lead owns commits; specialists stage + SendMessage "stage-ready" and wait. A staging specialist should SET `intentional_wait` (reason `awaiting_lead_commit`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag while the lead works through the commit sequence; CLEAR on the lead's commit confirmation. See the "Intentional Waiting" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
+- [ ] **Create atomic commit(s)** — stage and commit before proceeding. Lead owns commits; specialists stage + SendMessage "stage-ready" and wait. A staging specialist should SET the `intentional_wait` task metadata (reason `awaiting_lead_commit`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag while the lead works through the commit sequence; CLEAR on the lead's commit confirmation. See the "Intentional Waiting" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
 - [ ] **Journal events**: After each commit, write a `commit` event:
   ```bash
   set -e

--- a/pact-plugin/commands/comPACT.md
+++ b/pact-plugin/commands/comPACT.md
@@ -280,7 +280,7 @@ When dispatching an auditor, create its task with `metadata: {"completion_type":
 - [ ] Agent tasks marked `completed` (agents self-manage their task status via `TaskUpdate`)
 - [ ] **Agreement verification**: `SendMessage` to specialist to confirm shared understanding of deliverables before committing. Background: [pact-ct-teachback.md](../protocols/pact-ct-teachback.md).
 - [ ] **Run tests** — verify work passes. If tests fail → return to specialist for fixes (create new agent task, repeat).
-- [ ] **Create atomic commit(s)** — stage and commit before proceeding
+- [ ] **Create atomic commit(s)** — stage and commit before proceeding. Lead owns commits; specialists stage + SendMessage "stage-ready" and wait. A staging specialist should SET `intentional_wait` (reason `awaiting_lead_commit`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag while the lead works through the commit sequence; CLEAR on the lead's commit confirmation. See the "Protocol Waits" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
 - [ ] **Journal events**: After each commit, write a `commit` event:
   ```bash
   set -e

--- a/pact-plugin/commands/comPACT.md
+++ b/pact-plugin/commands/comPACT.md
@@ -280,7 +280,7 @@ When dispatching an auditor, create its task with `metadata: {"completion_type":
 - [ ] Agent tasks marked `completed` (agents self-manage their task status via `TaskUpdate`)
 - [ ] **Agreement verification**: `SendMessage` to specialist to confirm shared understanding of deliverables before committing. Background: [pact-ct-teachback.md](../protocols/pact-ct-teachback.md).
 - [ ] **Run tests** — verify work passes. If tests fail → return to specialist for fixes (create new agent task, repeat).
-- [ ] **Create atomic commit(s)** — stage and commit before proceeding. Lead owns commits; specialists stage + SendMessage "stage-ready" and wait. A staging specialist should SET `intentional_wait` (reason `awaiting_lead_commit`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag while the lead works through the commit sequence; CLEAR on the lead's commit confirmation. See the "Protocol Waits" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
+- [ ] **Create atomic commit(s)** — stage and commit before proceeding. Lead owns commits; specialists stage + SendMessage "stage-ready" and wait. A staging specialist should SET `intentional_wait` (reason `awaiting_lead_commit`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag while the lead works through the commit sequence; CLEAR on the lead's commit confirmation. See the "Intentional Waiting" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
 - [ ] **Journal events**: After each commit, write a `commit` event:
   ```bash
   set -e

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -668,7 +668,7 @@ The auditor stores its final signal as `metadata.audit_summary` via `TaskUpdate`
 - [ ] All tests passing (full test suite; fix any tests your changes break)
 - [ ] Specialist handoff(s) received
 - [ ] If blocker reported → `/PACT:imPACT`
-- [ ] **Create atomic commit(s)** of CODE phase work (preserves work before strategic re-assessment). Lead owns commits; specialists stage + SendMessage "stage-ready" and wait. A staging specialist should SET `intentional_wait` (reason `awaiting_lead_commit`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag while the lead works through the commit sequence; CLEAR on the lead's commit confirmation. See the "Intentional Waiting" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
+- [ ] **Create atomic commit(s)** of CODE phase work (preserves work before strategic re-assessment). Lead owns commits; specialists stage + SendMessage "stage-ready" and wait. A staging specialist should SET the `intentional_wait` task metadata (reason `awaiting_lead_commit`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag while the lead works through the commit sequence; CLEAR on the lead's commit confirmation. See the "Intentional Waiting" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
 - [ ] **Journal event**: After each commit, write a `commit` event:
   ```bash
   set -e

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -668,7 +668,7 @@ The auditor stores its final signal as `metadata.audit_summary` via `TaskUpdate`
 - [ ] All tests passing (full test suite; fix any tests your changes break)
 - [ ] Specialist handoff(s) received
 - [ ] If blocker reported → `/PACT:imPACT`
-- [ ] **Create atomic commit(s)** of CODE phase work (preserves work before strategic re-assessment)
+- [ ] **Create atomic commit(s)** of CODE phase work (preserves work before strategic re-assessment). Lead owns commits; specialists stage + SendMessage "stage-ready" and wait. A staging specialist should SET `intentional_wait` (reason `awaiting_lead_commit`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag while the lead works through the commit sequence; CLEAR on the lead's commit confirmation. See the "Protocol Waits" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
 - [ ] **Journal event**: After each commit, write a `commit` event:
   ```bash
   set -e

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -668,7 +668,7 @@ The auditor stores its final signal as `metadata.audit_summary` via `TaskUpdate`
 - [ ] All tests passing (full test suite; fix any tests your changes break)
 - [ ] Specialist handoff(s) received
 - [ ] If blocker reported → `/PACT:imPACT`
-- [ ] **Create atomic commit(s)** of CODE phase work (preserves work before strategic re-assessment). Lead owns commits; specialists stage + SendMessage "stage-ready" and wait. A staging specialist should SET `intentional_wait` (reason `awaiting_lead_commit`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag while the lead works through the commit sequence; CLEAR on the lead's commit confirmation. See the "Protocol Waits" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
+- [ ] **Create atomic commit(s)** of CODE phase work (preserves work before strategic re-assessment). Lead owns commits; specialists stage + SendMessage "stage-ready" and wait. A staging specialist should SET `intentional_wait` (reason `awaiting_lead_commit`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag while the lead works through the commit sequence; CLEAR on the lead's commit confirmation. See the "Intentional Waiting" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
 - [ ] **Journal event**: After each commit, write a `commit` event:
   ```bash
   set -e

--- a/pact-plugin/commands/peer-review.md
+++ b/pact-plugin/commands/peer-review.md
@@ -113,6 +113,8 @@ This trigger fires only when remediation occurred and changed things. Skip if no
 
 > **Worktree scope reminder**: When reusing a reviewer as a fixer or spawning a new fixer, include the worktree path and `CLAUDE.md` scope note in the fix task: "`CLAUDE.md` is gitignored and does not exist in worktrees — do not edit it. If your task mentions updating `CLAUDE.md`, flag it in your handoff instead."
 
+> **Remediation stage-ready wait**: Reviewers acting as fixers stage remediation changes and notify the lead, then wait for the lead to commit the fix. Instruct the reviewer to SET `intentional_wait` (reason `awaiting_amendment_review`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag through the fix→commit→re-review cycle; CLEAR when the lead acknowledges the commit. See the "Protocol Waits" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
+
 ---
 
 **PR Review Workflow**

--- a/pact-plugin/commands/peer-review.md
+++ b/pact-plugin/commands/peer-review.md
@@ -113,7 +113,7 @@ This trigger fires only when remediation occurred and changed things. Skip if no
 
 > **Worktree scope reminder**: When reusing a reviewer as a fixer or spawning a new fixer, include the worktree path and `CLAUDE.md` scope note in the fix task: "`CLAUDE.md` is gitignored and does not exist in worktrees — do not edit it. If your task mentions updating `CLAUDE.md`, flag it in your handoff instead."
 
-> **Remediation stage-ready wait**: Reviewers acting as fixers stage remediation changes and notify the lead, then wait for the lead to commit the fix. Instruct the reviewer to SET `intentional_wait` (reason `awaiting_amendment_review`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag through the fix→commit→re-review cycle; CLEAR when the lead acknowledges the commit. See the "Protocol Waits" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
+> **Remediation stage-ready wait**: Reviewers acting as fixers stage remediation changes and notify the lead, then wait for the lead to commit the fix. Instruct the reviewer to SET `intentional_wait` (reason `awaiting_amendment_review`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag through the fix→commit→re-review cycle; CLEAR when the lead acknowledges the commit. See the "Intentional Waiting" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
 
 ---
 

--- a/pact-plugin/commands/peer-review.md
+++ b/pact-plugin/commands/peer-review.md
@@ -113,7 +113,7 @@ This trigger fires only when remediation occurred and changed things. Skip if no
 
 > **Worktree scope reminder**: When reusing a reviewer as a fixer or spawning a new fixer, include the worktree path and `CLAUDE.md` scope note in the fix task: "`CLAUDE.md` is gitignored and does not exist in worktrees — do not edit it. If your task mentions updating `CLAUDE.md`, flag it in your handoff instead."
 
-> **Remediation stage-ready wait**: Reviewers acting as fixers stage remediation changes and notify the lead, then wait for the lead to commit the fix. Instruct the reviewer to SET `intentional_wait` (reason `awaiting_amendment_review`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag through the fix→commit→re-review cycle; CLEAR when the lead acknowledges the commit. See the "Intentional Waiting" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
+> **Remediation stage-ready wait**: Reviewers acting as fixers stage remediation changes and notify the lead, then wait for the lead to commit the fix. Instruct the reviewer to SET the `intentional_wait` task metadata (reason `awaiting_amendment_review`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag through the fix→commit→re-review cycle; CLEAR when the lead acknowledges the commit. See the "Intentional Waiting" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
 
 ---
 

--- a/pact-plugin/hooks/handoff_gate.py
+++ b/pact-plugin/hooks/handoff_gate.py
@@ -20,6 +20,7 @@ import sys
 from pathlib import Path
 
 from shared.handoff_example import format_handoff_example
+from shared.intentional_wait import is_signal_task
 import shared.pact_context as pact_context
 from shared.pact_context import get_team_name
 from shared.session_journal import append_event, make_event
@@ -53,8 +54,11 @@ def validate_task_handoff(
     if task_metadata.get("skipped"):
         return None
 
-    # Bypass: signal tasks (blocker, algedonic)
-    if task_metadata.get("type") in ("blocker", "algedonic"):
+    # Bypass: signal tasks (blocker, algedonic). Shared predicate with the
+    # TeammateIdle hooks; handoff_gate honors ONLY this narrow carve-out
+    # and MUST NOT honor `stalled` or `intentional_wait` (AC #8 — empty-
+    # handoff completions stay blocked regardless of wait state).
+    if is_signal_task({"metadata": task_metadata}):
         return None
 
     # Check: handoff exists
@@ -273,11 +277,11 @@ def main():
         print(memory_feedback, file=sys.stderr)
         sys.exit(2)  # Block completion — feedback goes to agent
 
-    # Signal-task carve-out: blocker/algedonic completions bypass handoff
-    # validation (lines 56-58) and must NOT emit a phantom agent_handoff event.
+    # Signal-task carve-out: blocker/algedonic completions bypassed handoff
+    # validation above and must NOT emit a phantom agent_handoff event.
     # Writing one would pollute `read_events("agent_handoff")` and mis-route
     # secretary harvest + memory_adhoc_reminder gating with empty handoff dicts.
-    if task_metadata.get("type") in ("blocker", "algedonic"):
+    if is_signal_task({"metadata": task_metadata}):
         print(_SUPPRESS_OUTPUT)
         sys.exit(0)
 

--- a/pact-plugin/hooks/shared/__init__.py
+++ b/pact-plugin/hooks/shared/__init__.py
@@ -61,13 +61,13 @@ from .merge_guard_common import (
 from .error_output import hook_error_json
 from .gh_helpers import check_pr_state
 from .constants import PACT_AGENTS, SYSTEM_TASK_PREFIXES
+# Intentional-wait public API surface: only the two top-level predicates
+# most consumers need are re-exported. validate_wait, canonical_since,
+# KNOWN_REASONS, KNOWN_RESOLVERS, and DEFAULT_THRESHOLD_MINUTES remain
+# module-only — `from shared.intentional_wait import X` for those.
 from .intentional_wait import (
-    canonical_since,
-    validate_wait,
+    should_silence_stall_nag,
     wait_stale,
-    DEFAULT_THRESHOLD_MINUTES,
-    KNOWN_REASONS,
-    KNOWN_RESOLVERS,
 )
 from .session_state import (
     SAFE_PATH_COMPONENT_RE,
@@ -126,12 +126,8 @@ __all__ = [
     "check_pr_state",
     "PACT_AGENTS",
     "SYSTEM_TASK_PREFIXES",
-    "canonical_since",
-    "validate_wait",
+    "should_silence_stall_nag",
     "wait_stale",
-    "DEFAULT_THRESHOLD_MINUTES",
-    "KNOWN_REASONS",
-    "KNOWN_RESOLVERS",
     "SAFE_PATH_COMPONENT_RE",
     "is_safe_path_component",
     "BOOTSTRAP_MARKER_NAME",

--- a/pact-plugin/hooks/shared/__init__.py
+++ b/pact-plugin/hooks/shared/__init__.py
@@ -61,6 +61,14 @@ from .merge_guard_common import (
 from .error_output import hook_error_json
 from .gh_helpers import check_pr_state
 from .constants import PACT_AGENTS, SYSTEM_TASK_PREFIXES
+from .intentional_wait import (
+    canonical_since,
+    validate_wait,
+    wait_stale,
+    DEFAULT_THRESHOLD_MINUTES,
+    KNOWN_REASONS,
+    KNOWN_RESOLVERS,
+)
 from .session_state import (
     SAFE_PATH_COMPONENT_RE,
     is_safe_path_component,
@@ -118,6 +126,12 @@ __all__ = [
     "check_pr_state",
     "PACT_AGENTS",
     "SYSTEM_TASK_PREFIXES",
+    "canonical_since",
+    "validate_wait",
+    "wait_stale",
+    "DEFAULT_THRESHOLD_MINUTES",
+    "KNOWN_REASONS",
+    "KNOWN_RESOLVERS",
     "SAFE_PATH_COMPONENT_RE",
     "is_safe_path_component",
     "BOOTSTRAP_MARKER_NAME",

--- a/pact-plugin/hooks/shared/intentional_wait.py
+++ b/pact-plugin/hooks/shared/intentional_wait.py
@@ -1,13 +1,22 @@
 """
 Location: pact-plugin/hooks/shared/intentional_wait.py
-Summary: Metadata schema and staleness predicate for the `intentional_wait`
-         task-metadata flag. Used by both TeammateIdle hooks to distinguish
-         protocol-defined waits from genuine stalls.
-Used by: teammate_completion_gate.py, teammate_idle.py (detect_stall)
+Summary: Unified silencer predicates for TeammateIdle hooks, plus the
+         `intentional_wait` metadata schema and staleness check.
+Used by: teammate_completion_gate.py, teammate_idle.py (detect_stall),
+         handoff_gate.py (is_signal_task only — handoff gating MUST NOT
+         honor intentional_wait; AC #8).
 
-Contract: pure functions; never raises. `wait_stale` returns True (stale /
-invalid) on any parse error so that a malformed flag fails open to the
-normal nag path — a broken flag must not silently suppress stall detection.
+Contract: pure functions; never raise. Malformed flags fail loud — e.g.
+`wait_stale` returns True on any parse error so a broken flag cannot
+silently suppress stall detection.
+
+Public predicates:
+- is_signal_task(task): True iff task is a blocker/algedonic signal task.
+- should_silence_stall_nag(task): True iff a TeammateIdle nag should be
+  suppressed for this task (signal-task OR stalled OR fresh intentional_wait).
+- wait_stale(wait_metadata): True iff an intentional_wait flag is stale.
+- validate_wait(wait_metadata): True iff the flag is well-formed.
+- canonical_since(): canonical ISO-8601 UTC timestamp for the `since` field.
 """
 
 from datetime import datetime, timezone
@@ -112,3 +121,67 @@ def wait_stale(
     now = _now or datetime.now(timezone.utc)
     age_minutes = (now - since).total_seconds() / 60
     return age_minutes >= threshold_minutes
+
+
+# Signal-task types. Single source of truth — the literal tuple must not
+# appear elsewhere in pact-plugin/hooks/ (enforced by
+# test_intentional_wait.py::test_signal_task_literal_lives_in_helper_only).
+_SIGNAL_TASK_TYPES = ("blocker", "algedonic")
+
+
+def is_signal_task(task: Any) -> bool:
+    """
+    Return True iff the task is a blocker/algedonic signal task.
+
+    Signal tasks are carve-outs across the hook surface: they bypass HANDOFF
+    validation (handoff_gate) and silence the TeammateIdle nag
+    (detect_stall, _scan_owned_tasks). Pure predicate on metadata.type —
+    does NOT consider `stalled` or `intentional_wait`.
+
+    Accepts any input and returns False on non-dict / missing metadata —
+    never raises.
+    """
+    if not isinstance(task, dict):
+        return False
+    metadata = task.get("metadata")
+    if not isinstance(metadata, dict):
+        return False
+    return metadata.get("type") in _SIGNAL_TASK_TYPES
+
+
+def should_silence_stall_nag(
+    task: Any,
+    threshold_minutes: int = DEFAULT_THRESHOLD_MINUTES,
+    _now: datetime | None = None,
+) -> bool:
+    """
+    Return True iff a TeammateIdle nag should be suppressed for this task.
+
+    Silenced when any of:
+    - task is a blocker/algedonic signal (is_signal_task), OR
+    - metadata.stalled is truthy (already-marked stall — don't re-alert), OR
+    - metadata.intentional_wait is set AND not stale (fresh protocol-defined wait).
+
+    Used by both TeammateIdle hooks (teammate_idle.py::detect_stall and
+    teammate_completion_gate.py::_scan_owned_tasks) as the single source of
+    truth for the nag-suppression predicate. handoff_gate.py must NOT call
+    this — AC #8 requires handoff validation to survive `intentional_wait`.
+
+    Accepts any input and returns False on non-dict / missing metadata —
+    never raises.
+    """
+    if is_signal_task(task):
+        return True
+    # is_signal_task validated isinstance(task, dict) and dict-metadata —
+    # safe to re-access.
+    if not isinstance(task, dict):
+        return False
+    metadata = task.get("metadata")
+    if not isinstance(metadata, dict):
+        return False
+    if metadata.get("stalled"):
+        return True
+    wait = metadata.get("intentional_wait")
+    if wait is not None and not wait_stale(wait, threshold_minutes, _now):
+        return True
+    return False

--- a/pact-plugin/hooks/shared/intentional_wait.py
+++ b/pact-plugin/hooks/shared/intentional_wait.py
@@ -1,0 +1,114 @@
+"""
+Location: pact-plugin/hooks/shared/intentional_wait.py
+Summary: Metadata schema and staleness predicate for the `intentional_wait`
+         task-metadata flag. Used by both TeammateIdle hooks to distinguish
+         protocol-defined waits from genuine stalls.
+Used by: teammate_completion_gate.py, teammate_idle.py (detect_stall)
+
+Contract: pure functions; never raises. `wait_stale` returns True (stale /
+invalid) on any parse error so that a malformed flag fails open to the
+normal nag path — a broken flag must not silently suppress stall detection.
+"""
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+# Reason vocabulary — frozenset, not Enum, so teammates can include custom
+# reasons when instrumentation hasn't caught up. validate_wait only checks
+# non-empty string; reasons are for humans and audit logs.
+KNOWN_REASONS = frozenset({
+    "awaiting_teachback_approved",
+    "awaiting_lead_commit",
+    "awaiting_amendment_review",
+    "awaiting_post_handoff_decision",
+    "awaiting_peer_response",
+    "awaiting_user_decision",
+    "awaiting_blocker_resolution",
+})
+
+KNOWN_RESOLVERS = frozenset({"lead", "peer", "user", "external"})
+
+DEFAULT_THRESHOLD_MINUTES = 30
+
+
+def canonical_since() -> str:
+    """
+    Return the canonical ISO-8601 UTC `since` timestamp used by auto-set
+    sites and the manual-set convention.
+
+    Round-trip guarantee: the return value parses cleanly via the same
+    `fromisoformat(s.replace("Z", "+00:00"))` path validate_wait uses.
+    timespec="seconds" drops microseconds for stable equality across
+    cross-system timestamps and avoids platform-specific formatting drift.
+    """
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def validate_wait(wait_metadata: Any) -> bool:
+    """
+    Return True iff wait_metadata is a well-formed intentional_wait dict.
+
+    Required keys: reason (non-empty str), expected_resolver (non-empty str —
+    KNOWN_RESOLVERS preferred but any non-empty string accepted), since
+    (tz-aware ISO-8601 timestamp parseable by datetime.fromisoformat, with
+    a trailing 'Z' accepted as UTC).
+
+    Unknown keys are preserved (forward-compat).
+    """
+    if not isinstance(wait_metadata, dict):
+        return False
+
+    reason = wait_metadata.get("reason")
+    if not isinstance(reason, str) or not reason.strip():
+        return False
+
+    resolver = wait_metadata.get("expected_resolver")
+    if not isinstance(resolver, str) or not resolver.strip():
+        return False
+
+    since = wait_metadata.get("since")
+    if not isinstance(since, str):
+        return False
+
+    try:
+        parsed = datetime.fromisoformat(since.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return False
+
+    # Reject tz-naive timestamps. A naive timestamp from a non-UTC teammate
+    # could be hours off real UTC, producing silently wrong age computations.
+    # Instrumentation always emits tz-aware via canonical_since(), so a naive
+    # value is always a teammate bug — surface it fast rather than paper over.
+    if parsed.tzinfo is None:
+        return False
+
+    return True
+
+
+def wait_stale(
+    wait_metadata: Any,
+    threshold_minutes: int = DEFAULT_THRESHOLD_MINUTES,
+    _now: datetime | None = None,
+) -> bool:
+    """
+    Return True iff the intentional_wait flag is stale (nag should re-enable).
+
+    Stale when:
+    - wait_metadata fails validation (malformed flag → fail loud to nag), OR
+    - elapsed time since `since` is >= threshold_minutes.
+
+    Future-dated `since` (clock drift or tampering) yields a negative age
+    and is treated as NOT stale — conservative: don't nag a teammate whose
+    clock skewed forward. The threshold still re-enables the nag once
+    wall-clock catches up.
+
+    _now is for deterministic unit tests; production callers omit it.
+    """
+    if not validate_wait(wait_metadata):
+        return True
+
+    since = datetime.fromisoformat(wait_metadata["since"].replace("Z", "+00:00"))
+    now = _now or datetime.now(timezone.utc)
+    age_minutes = (now - since).total_seconds() / 60
+    return age_minutes >= threshold_minutes

--- a/pact-plugin/hooks/teammate_completion_gate.py
+++ b/pact-plugin/hooks/teammate_completion_gate.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 from shared.error_output import hook_error_json
 from shared.handoff_example import format_handoff_example
+from shared.intentional_wait import wait_stale
 import shared.pact_context as pact_context
 from shared.pact_context import get_team_name
 
@@ -85,9 +86,16 @@ def _scan_owned_tasks(
             if data.get("status") != "in_progress":
                 continue
 
+            metadata = data.get("metadata", {})
+            # Protocol-defined wait (e.g., awaiting_teachback_approved): the
+            # completion-gate nag would consume the idle slot the teammate needs
+            # for inbox delivery. Threshold-bounded — stale flag re-enables nag.
+            wait = metadata.get("intentional_wait")
+            if wait is not None and not wait_stale(wait):
+                continue
+
             task_id = task_file.stem  # filename without .json
             subject = data.get("subject", "unknown")
-            metadata = data.get("metadata", {})
 
             # Semantic dispatch: branch on what the completion IS,
             # not who the agent IS (extensible to any signal-only agent)

--- a/pact-plugin/hooks/teammate_completion_gate.py
+++ b/pact-plugin/hooks/teammate_completion_gate.py
@@ -87,6 +87,15 @@ def _scan_owned_tasks(
                 continue
 
             metadata = data.get("metadata", {})
+            # Mirror the metadata-keyed skips in teammate_idle.py::detect_stall
+            # (L122, L124): signal-task type, stalled flag. Without these,
+            # _scan_owned_tasks nagged on tasks the idle hook had correctly
+            # silenced — the cross-hook silencer asymmetry preparer flagged
+            # in §2.7 of the #497 preparation.
+            if metadata.get("type") in ("blocker", "algedonic"):
+                continue
+            if metadata.get("stalled"):
+                continue
             # Protocol-defined wait (e.g., awaiting_teachback_approved): the
             # completion-gate nag would consume the idle slot the teammate needs
             # for inbox delivery. Threshold-bounded — stale flag re-enables nag.

--- a/pact-plugin/hooks/teammate_completion_gate.py
+++ b/pact-plugin/hooks/teammate_completion_gate.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 from shared.error_output import hook_error_json
 from shared.handoff_example import format_handoff_example
-from shared.intentional_wait import wait_stale
+from shared.intentional_wait import should_silence_stall_nag
 import shared.pact_context as pact_context
 from shared.pact_context import get_team_name
 
@@ -86,25 +86,17 @@ def _scan_owned_tasks(
             if data.get("status") != "in_progress":
                 continue
 
-            metadata = data.get("metadata", {})
-            # Mirror the metadata-keyed skips in teammate_idle.py::detect_stall
-            # (L122, L124): signal-task type, stalled flag. Without these,
-            # _scan_owned_tasks nagged on tasks the idle hook had correctly
-            # silenced — the cross-hook silencer asymmetry preparer flagged
-            # in §2.7 of the #497 preparation.
-            if metadata.get("type") in ("blocker", "algedonic"):
-                continue
-            if metadata.get("stalled"):
-                continue
-            # Protocol-defined wait (e.g., awaiting_teachback_approved): the
-            # completion-gate nag would consume the idle slot the teammate needs
-            # for inbox delivery. Threshold-bounded — stale flag re-enables nag.
-            wait = metadata.get("intentional_wait")
-            if wait is not None and not wait_stale(wait):
+            # Unified silencer: signal-task carve-outs + already-stalled skip +
+            # protocol-defined wait (intentional_wait). Same predicate used by
+            # teammate_idle.py::detect_stall — single source of truth in
+            # shared/intentional_wait.py eliminates the cross-hook asymmetry
+            # preparer flagged in §2.7 of the #497 preparation.
+            if should_silence_stall_nag(data):
                 continue
 
             task_id = task_file.stem  # filename without .json
             subject = data.get("subject", "unknown")
+            metadata = data.get("metadata", {})
 
             # Semantic dispatch: branch on what the completion IS,
             # not who the agent IS (extensible to any signal-only agent)

--- a/pact-plugin/hooks/teammate_idle.py
+++ b/pact-plugin/hooks/teammate_idle.py
@@ -34,7 +34,7 @@ if str(_hooks_dir) not in sys.path:
     sys.path.insert(0, str(_hooks_dir))
 
 from shared.error_output import hook_error_json
-from shared.intentional_wait import wait_stale
+from shared.intentional_wait import should_silence_stall_nag
 import shared.pact_context as pact_context
 from shared.pact_context import get_team_name
 from shared.task_utils import get_task_list
@@ -118,18 +118,11 @@ def detect_stall(
     if task.get("status") != "in_progress":
         return None
 
-    # Check if this is a stalled task (not a signal/blocker task)
-    metadata = task.get("metadata", {})
-    if metadata.get("type") in ("blocker", "algedonic"):
-        return None
-    if metadata.get("stalled"):
-        # Already marked as stalled — don't re-alert
-        return None
-    # Protocol-defined wait (e.g., awaiting_teachback_approved): the nag
-    # would consume the idle slot the teammate needs for inbox delivery,
-    # livelocking the wait. Threshold-bounded — stale flag re-enables nag.
-    wait = metadata.get("intentional_wait")
-    if wait is not None and not wait_stale(wait):
+    # Unified silencer: signal-task carve-outs + already-stalled skip +
+    # protocol-defined wait (intentional_wait). Single source of truth in
+    # shared/intentional_wait.py; handoff_gate.py honors a narrower slice
+    # via is_signal_task (AC #8 — cannot honor intentional_wait).
+    if should_silence_stall_nag(task):
         return None
 
     task_id = task.get("id", "?")

--- a/pact-plugin/hooks/teammate_idle.py
+++ b/pact-plugin/hooks/teammate_idle.py
@@ -34,6 +34,7 @@ if str(_hooks_dir) not in sys.path:
     sys.path.insert(0, str(_hooks_dir))
 
 from shared.error_output import hook_error_json
+from shared.intentional_wait import wait_stale
 import shared.pact_context as pact_context
 from shared.pact_context import get_team_name
 from shared.task_utils import get_task_list
@@ -123,6 +124,12 @@ def detect_stall(
         return None
     if metadata.get("stalled"):
         # Already marked as stalled — don't re-alert
+        return None
+    # Protocol-defined wait (e.g., awaiting_teachback_approved): the nag
+    # would consume the idle slot the teammate needs for inbox delivery,
+    # livelocking the wait. Threshold-bounded — stale flag re-enables nag.
+    wait = metadata.get("intentional_wait")
+    if wait is not None and not wait_stale(wait):
         return None
 
     task_id = task.get("id", "?")

--- a/pact-plugin/skills/orchestration/SKILL.md
+++ b/pact-plugin/skills/orchestration/SKILL.md
@@ -436,9 +436,8 @@ Teammates signal protocol-defined waits via the `intentional_wait` task metadata
 SET/CLEAR contract). Under the flag, teammates stay silent until their wait
 resolves — no nag reminders. Your responsibilities:
 
-- **Don't interpret silence as stall.** A teammate with `intentional_wait` set
-  is waiting, not stuck. Read the task metadata before dispatching
-  `/PACT:imPACT`.
+- **Don't interpret silence as stall.** Read the task metadata before
+  dispatching `/PACT:imPACT`.
 - **Drive resolution on your own cadence.** Track outstanding waits across
   your teammates (use the Reading the flag pattern below); send the resolving
   message (approval / commit confirmation / peer reply routed / user decision)
@@ -451,7 +450,6 @@ resolves — no nag reminders. Your responsibilities:
   state changed or the wait expired — different dispositions.
 - **Don't SET the `intentional_wait` task metadata on your own lead task.**
   TeammateIdle hooks filter by task owner; they don't inspect lead state.
-  The flag is teammate-scoped.
 
 ### Recommended Agent Prompting Structure
 

--- a/pact-plugin/skills/orchestration/SKILL.md
+++ b/pact-plugin/skills/orchestration/SKILL.md
@@ -429,6 +429,33 @@ Exceptions:
 
 **Structured message constraint**: `shutdown_request` and other structured protocol messages (e.g., `plan_approval_request`) **cannot** be broadcast via `to: "*"` — broadcasts only support plain text. Always send structured messages individually to each teammate by name.
 
+### Intentional Waiting (orchestrator responsibilities)
+
+Teammates signal protocol-defined waits via the `intentional_wait` task metadata
+(see `pact-agent-teams/SKILL.md::Intentional Waiting` for the teammate-side
+SET/CLEAR contract). Under the flag, teammates stay silent until their wait
+resolves — no nag reminders. Your responsibilities:
+
+- **Don't interpret silence as stall.** A teammate with `intentional_wait` set
+  is waiting, not stuck. Read the task metadata before dispatching
+  `/PACT:imPACT`.
+
+- **Drive resolution on your own cadence.** Track outstanding waits across
+  your teammates; send the resolving message (approval / commit confirmation /
+  peer reply routed / user decision) when appropriate.
+
+- **Reading the flag**: `TaskGet` does NOT surface task metadata. Read the
+  task file directly: `cat ~/.claude/tasks/{team}/{taskId}.json | jq .metadata.intentional_wait`.
+  Fields: `reason`, `expected_resolver`, `since`.
+
+- **Staleness signal**: the 30-min threshold re-enables the nag as safety
+  valve. If a previously-silent teammate starts nagging again, check whether
+  state changed or the wait expired — different dispositions.
+
+- **Don't SET the `intentional_wait` task metadata on your own lead task.**
+  TeammateIdle hooks filter by task owner; they don't inspect lead state.
+  The flag is teammate-scoped.
+
 ### Recommended Agent Prompting Structure
 
 Use this structure in the `prompt` field to ensure agents have adequate context:

--- a/pact-plugin/skills/orchestration/SKILL.md
+++ b/pact-plugin/skills/orchestration/SKILL.md
@@ -439,20 +439,16 @@ resolves — no nag reminders. Your responsibilities:
 - **Don't interpret silence as stall.** A teammate with `intentional_wait` set
   is waiting, not stuck. Read the task metadata before dispatching
   `/PACT:imPACT`.
-
 - **Drive resolution on your own cadence.** Track outstanding waits across
   your teammates (use the Reading the flag pattern below); send the resolving
   message (approval / commit confirmation / peer reply routed / user decision)
   when appropriate.
-
 - **Reading the flag**: `TaskGet` does NOT surface task metadata. Read the
   task file directly: `cat ~/.claude/tasks/{team}/{taskId}.json | jq .metadata.intentional_wait`.
   Fields: `reason`, `expected_resolver`, `since`.
-
 - **Staleness signal**: the 30-min threshold re-enables the nag as safety
   valve. If a previously-silent teammate starts nagging again, check whether
   state changed or the wait expired — different dispositions.
-
 - **Don't SET the `intentional_wait` task metadata on your own lead task.**
   TeammateIdle hooks filter by task owner; they don't inspect lead state.
   The flag is teammate-scoped.

--- a/pact-plugin/skills/orchestration/SKILL.md
+++ b/pact-plugin/skills/orchestration/SKILL.md
@@ -441,8 +441,9 @@ resolves — no nag reminders. Your responsibilities:
   `/PACT:imPACT`.
 
 - **Drive resolution on your own cadence.** Track outstanding waits across
-  your teammates; send the resolving message (approval / commit confirmation /
-  peer reply routed / user decision) when appropriate.
+  your teammates (use the Reading the flag pattern below); send the resolving
+  message (approval / commit confirmation / peer reply routed / user decision)
+  when appropriate.
 
 - **Reading the flag**: `TaskGet` does NOT surface task metadata. Read the
   task file directly: `cat ~/.claude/tasks/{team}/{taskId}.json | jq .metadata.intentional_wait`.

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -172,6 +172,74 @@ Keep messages actionable — state what you did/found, what they need to know, a
 any action needed from them.
 Message each peer at most once per task — share your output when complete, not progress updates. If you need ongoing coordination, route through the lead.
 
+## Protocol Waits — `intentional_wait`
+
+Sometimes your task is `in_progress` but you are legitimately idle, awaiting a message
+from the lead, a peer, or the user (teachback approval, inter-commit hold, post-HANDOFF
+decision, peer reply, blocker resolution, user decision). Without a signal, the
+`TeammateIdle` hooks (`teammate_completion_gate.py`, `teammate_idle.py::detect_stall`)
+cannot distinguish "intentional wait" from "stuck" — they nag every tick, and the
+nag consumes the idle slot the orchestrator needs to deliver the message that would
+end the wait. That's the nag-loop livelock.
+
+**Signal an intentional wait** by setting the `intentional_wait` task metadata
+BEFORE going idle. Both TeammateIdle hooks honor it via `shared.intentional_wait.wait_stale`
+until the 30-minute staleness threshold expires.
+
+### SET — before going idle
+
+```python
+from datetime import datetime, timezone
+TaskUpdate(taskId=taskId, metadata={
+    "intentional_wait": {
+        "reason": "awaiting_teachback_approved",
+        "expected_resolver": "lead",
+        "since": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+})
+```
+
+The `since` value MUST be tz-aware ISO-8601 (`datetime.now(timezone.utc).isoformat(timespec="seconds")`).
+A naive timestamp is rejected and re-enables the nag — that's intentional fail-loud
+behavior so format bugs surface to the lead.
+
+### CLEAR — when the wait resolves
+
+```python
+TaskUpdate(taskId=taskId, metadata={"intentional_wait": None})
+```
+
+Clear on the same turn you take the action that advances state: when a teachback
+approval, commit confirmation, peer reply, or user decision arrives, call CLEAR
+before taking the next substantive action.
+
+### Vocabulary
+
+| Field | Required | Accepted values |
+|-------|----------|-----------------|
+| `reason` | yes | Non-empty string. Prefer `KNOWN_REASONS` from `shared.intentional_wait`: `awaiting_teachback_approved`, `awaiting_lead_commit`, `awaiting_amendment_review`, `awaiting_post_handoff_decision`, `awaiting_peer_response`, `awaiting_user_decision`, `awaiting_blocker_resolution`. Free-form permitted. |
+| `expected_resolver` | yes | Non-empty string. Prefer `KNOWN_RESOLVERS`: `lead`, `peer`, `user`, `external`. Free-form permitted (e.g., a specific teammate name). |
+| `since` | yes | tz-aware ISO-8601 UTC timestamp at seconds precision. |
+
+Unknown keys are preserved (forward-compat) — add `correlation_id`, `peer_name`, etc.
+as needed.
+
+### Staleness safeguard
+
+The flag auto-expires after 30 minutes. If you forget to CLEAR or the wait takes
+longer than expected, the nag re-enables — that's the backstop, not a primary silencer.
+Re-SET with a fresh `since` if the wait is still legitimate.
+
+### When NOT to set
+
+- You have no owned `in_progress` task (consultant mode): the TeammateIdle hooks
+  already skip you via the owner/status filters.
+- Your wait is < 30 seconds: the cost of a SET+CLEAR round-trip isn't worth the
+  bookkeeping; idle ticks are not that frequent.
+- `handoff_gate.py` (TaskCompleted event) does **not** honor this flag — completion
+  validation is orthogonal. If you have an empty HANDOFF, you cannot complete
+  regardless of `intentional_wait`. Store your HANDOFF first.
+
 ## Consultant Mode
 
 When your active task is done and no follow-up tasks are available:

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -172,7 +172,33 @@ Keep messages actionable — state what you did/found, what they need to know, a
 any action needed from them.
 Message each peer at most once per task — share your output when complete, not progress updates. If you need ongoing coordination, route through the lead.
 
-## Protocol Waits — `intentional_wait`
+## Idle Discipline
+
+When the platform wakes you but there is no new work to do, return to idle silently
+rather than emitting acknowledgment. Wake-ups without new mailbox messages or
+dispatch-implied work can come from many sources (hook events, platform keep-alives,
+peer status signals). Responding to each with a "standing by" or "still waiting" turn
+consumes tokens without progress and — crucially — prevents the next legitimate
+message from being delivered on the next idle tick.
+
+Concretely:
+- **No new `SendMessage` in your inbox?** Do not emit a turn. Let the harness idle
+  you again.
+- **No new instructions in the dispatch prompt you haven't already executed?** Do
+  not emit a turn.
+- **You are idle-waiting for a protocol-defined resolution** (teachback approval,
+  lead commit, peer response, user decision)? Use `intentional_wait` per the
+  Intentional Waiting section below — that is the designed channel. Do not improvise
+  with no-op acknowledgments.
+- **You are genuinely stuck** (blocker)? Follow the On Blocker section — do not
+  sit in a polling loop.
+
+The first-order reason this matters: the idle state IS the message-delivery channel.
+A teammate that keeps producing output — even zero-content output — cannot receive
+inbox deliveries. Rule: if you have nothing to say that advances the work, say
+nothing.
+
+## Intentional Waiting
 
 Sometimes your task is `in_progress` but you are legitimately idle, awaiting a message
 from the lead, a peer, or the user (teachback approval, inter-commit hold, post-HANDOFF
@@ -239,32 +265,6 @@ Re-SET with a fresh `since` if the wait is still legitimate.
 - `handoff_gate.py` (TaskCompleted event) does **not** honor this flag — completion
   validation is orthogonal. If you have an empty HANDOFF, you cannot complete
   regardless of `intentional_wait`. Store your HANDOFF first.
-
-## Idle Discipline
-
-When the platform wakes you but there is no new work to do, return to idle silently
-rather than emitting acknowledgment. Wake-ups without new mailbox messages or
-dispatch-implied work can come from many sources (hook events, platform keep-alives,
-peer status signals). Responding to each with a "standing by" or "still waiting" turn
-consumes tokens without progress and — crucially — prevents the next legitimate
-message from being delivered on the next idle tick.
-
-Concretely:
-- **No new `SendMessage` in your inbox?** Do not emit a turn. Let the harness idle
-  you again.
-- **No new instructions in the dispatch prompt you haven't already executed?** Do
-  not emit a turn.
-- **You are idle-waiting for a protocol-defined resolution** (teachback approval,
-  lead commit, peer response, user decision)? Use `intentional_wait` per the
-  Protocol Waits section above — that is the designed channel. Do not improvise
-  with no-op acknowledgments.
-- **You are genuinely stuck** (blocker)? Follow the On Blocker section — do not
-  sit in a polling loop.
-
-The first-order reason this matters: the idle state IS the message-delivery channel.
-A teammate that keeps producing output — even zero-content output — cannot receive
-inbox deliveries. Rule: if you have nothing to say that advances the work, say
-nothing.
 
 ## Consultant Mode
 

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -182,7 +182,7 @@ output (even zero-content) blocks the next inbox delivery.
 - **Idle-waiting for a protocol-defined resolution** (teachback, lead commit,
   peer reply, user decision)? Use the `intentional_wait` task metadata per
   the Intentional Waiting section below.
-- **Genuinely stuck**? Follow On Blocker.
+- **Genuinely stuck**? Follow the On Blocker section.
 
 If you have nothing to say that advances the work, say nothing.
 
@@ -215,7 +215,7 @@ TaskUpdate(taskId=taskId, metadata={
 TaskUpdate(taskId=taskId, metadata={"intentional_wait": None})
 ```
 
-Clear on the same turn you take the action that advances state.
+Clear on the same turn you take the action that advances state (e.g., when the approval / commit confirmation / peer reply / user decision arrives).
 
 ### Vocabulary
 

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -174,43 +174,25 @@ Message each peer at most once per task — share your output when complete, not
 
 ## Idle Discipline
 
-When the platform wakes you but there is no new work to do, return to idle silently
-rather than emitting acknowledgment. Wake-ups without new mailbox messages or
-dispatch-implied work can come from many sources (hook events, platform keep-alives,
-peer status signals). Responding to each with a "standing by" or "still waiting" turn
-consumes tokens without progress and — crucially — prevents the next legitimate
-message from being delivered on the next idle tick.
+When you wake with no new work, return to idle silently — no "standing by" or
+"still waiting" acknowledgments. The idle state is the message-delivery channel;
+output (even zero-content) blocks the next inbox delivery.
 
-Concretely:
-- **No new `SendMessage` in your inbox?** Do not emit a turn. Let the harness idle
-  you again.
-- **No new instructions in the dispatch prompt you haven't already executed?** Do
-  not emit a turn.
-- **You are idle-waiting for a protocol-defined resolution** (teachback approval,
-  lead commit, peer response, user decision)? Use `intentional_wait` per the
-  Intentional Waiting section below — that is the designed channel. Do not improvise
-  with no-op acknowledgments.
-- **You are genuinely stuck** (blocker)? Follow the On Blocker section — do not
-  sit in a polling loop.
+- **No new `SendMessage` and no new dispatch instructions?** Do not emit.
+- **Idle-waiting for a protocol-defined resolution** (teachback, lead commit,
+  peer reply, user decision)? Use `intentional_wait` per the Intentional Waiting
+  section below.
+- **Genuinely stuck**? Follow On Blocker.
 
-The first-order reason this matters: the idle state IS the message-delivery channel.
-A teammate that keeps producing output — even zero-content output — cannot receive
-inbox deliveries. Rule: if you have nothing to say that advances the work, say
-nothing.
+If you have nothing to say that advances the work, say nothing.
 
 ## Intentional Waiting
 
-Sometimes your task is `in_progress` but you are legitimately idle, awaiting a message
-from the lead, a peer, or the user (teachback approval, inter-commit hold, post-HANDOFF
-decision, peer reply, blocker resolution, user decision). Without a signal, the
-`TeammateIdle` hooks (`teammate_completion_gate.py`, `teammate_idle.py::detect_stall`)
-cannot distinguish "intentional wait" from "stuck" — they nag every tick, and the
-nag consumes the idle slot the orchestrator needs to deliver the message that would
-end the wait. That's the nag-loop livelock.
-
-**Signal an intentional wait** by setting the `intentional_wait` task metadata
-BEFORE going idle. Both TeammateIdle hooks honor it via `shared.intentional_wait.wait_stale`
-until the 30-minute staleness threshold expires.
+When your task is `in_progress` but you are legitimately idle awaiting a message
+(teachback approval, inter-commit hold, peer reply, user decision, blocker
+resolution), signal it via `intentional_wait` metadata BEFORE going idle. Both
+TeammateIdle hooks honor it for 30 minutes via `shared.intentional_wait.wait_stale`;
+without the signal, they nag every tick — the livelock Idle Discipline warns about.
 
 ### SET — before going idle
 
@@ -225,9 +207,7 @@ TaskUpdate(taskId=taskId, metadata={
 })
 ```
 
-The `since` value MUST be tz-aware ISO-8601 (`datetime.now(timezone.utc).isoformat(timespec="seconds")`).
-A naive timestamp is rejected and re-enables the nag — that's intentional fail-loud
-behavior so format bugs surface to the lead.
+`since` must be tz-aware ISO-8601. A naive timestamp re-enables the nag (fail-loud).
 
 ### CLEAR — when the wait resolves
 
@@ -235,36 +215,27 @@ behavior so format bugs surface to the lead.
 TaskUpdate(taskId=taskId, metadata={"intentional_wait": None})
 ```
 
-Clear on the same turn you take the action that advances state: when a teachback
-approval, commit confirmation, peer reply, or user decision arrives, call CLEAR
-before taking the next substantive action.
+Clear on the same turn you take the action that advances state.
 
 ### Vocabulary
 
 | Field | Required | Accepted values |
 |-------|----------|-----------------|
 | `reason` | yes | Non-empty string. Prefer `KNOWN_REASONS` from `shared.intentional_wait`: `awaiting_teachback_approved`, `awaiting_lead_commit`, `awaiting_amendment_review`, `awaiting_post_handoff_decision`, `awaiting_peer_response`, `awaiting_user_decision`, `awaiting_blocker_resolution`. Free-form permitted. |
-| `expected_resolver` | yes | Non-empty string. Prefer `KNOWN_RESOLVERS`: `lead`, `peer`, `user`, `external`. Free-form permitted (e.g., a specific teammate name). |
-| `since` | yes | tz-aware ISO-8601 UTC timestamp at seconds precision. |
+| `expected_resolver` | yes | Non-empty string. Prefer `KNOWN_RESOLVERS`: `lead`, `peer`, `user`, `external`. Free-form permitted. |
+| `since` | yes | tz-aware ISO-8601 UTC timestamp, seconds precision. |
 
-Unknown keys are preserved (forward-compat) — add `correlation_id`, `peer_name`, etc.
-as needed.
+Unknown keys are preserved (forward-compat).
 
 ### Staleness safeguard
 
-The flag auto-expires after 30 minutes. If you forget to CLEAR or the wait takes
-longer than expected, the nag re-enables — that's the backstop, not a primary silencer.
-Re-SET with a fresh `since` if the wait is still legitimate.
+Auto-expires after 30 minutes. If the wait takes longer, re-SET with a fresh `since`.
 
 ### When NOT to set
 
-- You have no owned `in_progress` task (consultant mode): the TeammateIdle hooks
-  already skip you via the owner/status filters.
-- Your wait is < 30 seconds: the cost of a SET+CLEAR round-trip isn't worth the
-  bookkeeping; idle ticks are not that frequent.
-- `handoff_gate.py` (TaskCompleted event) does **not** honor this flag — completion
-  validation is orthogonal. If you have an empty HANDOFF, you cannot complete
-  regardless of `intentional_wait`. Store your HANDOFF first.
+- **Consultant mode** (no owned `in_progress` task): hooks already skip you via owner/status filters.
+- **Waits < 30 seconds**: SET+CLEAR bookkeeping isn't worth it.
+- **Completion gating**: `handoff_gate.py` does NOT honor this flag. Empty HANDOFF still blocks completion — store your HANDOFF first.
 
 ## Consultant Mode
 

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -240,6 +240,32 @@ Re-SET with a fresh `since` if the wait is still legitimate.
   validation is orthogonal. If you have an empty HANDOFF, you cannot complete
   regardless of `intentional_wait`. Store your HANDOFF first.
 
+## Idle Discipline
+
+When the platform wakes you but there is no new work to do, return to idle silently
+rather than emitting acknowledgment. Wake-ups without new mailbox messages or
+dispatch-implied work can come from many sources (hook events, platform keep-alives,
+peer status signals). Responding to each with a "standing by" or "still waiting" turn
+consumes tokens without progress and — crucially — prevents the next legitimate
+message from being delivered on the next idle tick.
+
+Concretely:
+- **No new `SendMessage` in your inbox?** Do not emit a turn. Let the harness idle
+  you again.
+- **No new instructions in the dispatch prompt you haven't already executed?** Do
+  not emit a turn.
+- **You are idle-waiting for a protocol-defined resolution** (teachback approval,
+  lead commit, peer response, user decision)? Use `intentional_wait` per the
+  Protocol Waits section above — that is the designed channel. Do not improvise
+  with no-op acknowledgments.
+- **You are genuinely stuck** (blocker)? Follow the On Blocker section — do not
+  sit in a polling loop.
+
+The first-order reason this matters: the idle state IS the message-delivery channel.
+A teammate that keeps producing output — even zero-content output — cannot receive
+inbox deliveries. Rule: if you have nothing to say that advances the work, say
+nothing.
+
 ## Consultant Mode
 
 When your active task is done and no follow-up tasks are available:

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -180,8 +180,8 @@ output (even zero-content) blocks the next inbox delivery.
 
 - **No new `SendMessage` and no new dispatch instructions?** Do not emit.
 - **Idle-waiting for a protocol-defined resolution** (teachback, lead commit,
-  peer reply, user decision)? Use `intentional_wait` per the Intentional Waiting
-  section below.
+  peer reply, user decision)? Use the `intentional_wait` task metadata per
+  the Intentional Waiting section below.
 - **Genuinely stuck**? Follow On Blocker.
 
 If you have nothing to say that advances the work, say nothing.
@@ -190,7 +190,7 @@ If you have nothing to say that advances the work, say nothing.
 
 When your task is `in_progress` but you are legitimately idle awaiting a message
 (teachback approval, inter-commit hold, peer reply, user decision, blocker
-resolution), signal it via `intentional_wait` metadata BEFORE going idle. Both
+resolution), signal it via the `intentional_wait` task metadata BEFORE going idle. Both
 TeammateIdle hooks honor it for 30 minutes via `shared.intentional_wait.wait_stale`;
 without the signal, they nag every tick — the livelock Idle Discipline warns about.
 

--- a/pact-plugin/skills/pact-teachback/SKILL.md
+++ b/pact-plugin/skills/pact-teachback/SKILL.md
@@ -44,7 +44,7 @@ TaskUpdate(taskId, metadata={"teachback_sent": true})
 
 If you will idle-wait for the lead's correction, SET `intentional_wait`
 (reason `awaiting_teachback_approved`, resolver `lead`) before going idle and
-CLEAR it on resume. See "Protocol Waits" in `pact-agent-teams` for the
+CLEAR it on resume. See "Intentional Waiting" in `pact-agent-teams` for the
 SET/CLEAR snippets and full contract.
 
 ## Ordering rule

--- a/pact-plugin/skills/pact-teachback/SKILL.md
+++ b/pact-plugin/skills/pact-teachback/SKILL.md
@@ -42,10 +42,10 @@ After sending, record the teachback as metadata on your task:
 TaskUpdate(taskId, metadata={"teachback_sent": true})
 ```
 
-If you will idle-wait for the lead's correction, SET `intentional_wait`
-(reason `awaiting_teachback_approved`, resolver `lead`) before going idle and
-CLEAR it on resume. See "Intentional Waiting" in `pact-agent-teams` for the
-SET/CLEAR snippets and full contract.
+If you will idle-wait for the lead's correction, SET the `intentional_wait`
+task metadata (reason `awaiting_teachback_approved`, resolver `lead`) before
+going idle and CLEAR it on resume. See "Intentional Waiting" in `pact-agent-teams`
+for the SET/CLEAR snippets and full contract.
 
 ## Ordering rule
 

--- a/pact-plugin/skills/pact-teachback/SKILL.md
+++ b/pact-plugin/skills/pact-teachback/SKILL.md
@@ -42,6 +42,11 @@ After sending, record the teachback as metadata on your task:
 TaskUpdate(taskId, metadata={"teachback_sent": true})
 ```
 
+If you will idle-wait for the lead's correction, SET `intentional_wait`
+(reason `awaiting_teachback_approved`, resolver `lead`) before going idle and
+CLEAR it on resume. See "Protocol Waits" in `pact-agent-teams` for the
+SET/CLEAR snippets and full contract.
+
 ## Ordering rule
 
 You must send the teachback before any Edit/Write/Bash call used for

--- a/pact-plugin/tests/test_handoff_gate.py
+++ b/pact-plugin/tests/test_handoff_gate.py
@@ -1012,12 +1012,18 @@ class TestIntentionalWaitDoesNotBleedIntoHandoffGate:
         )
         assert result is None
 
-    def test_handoff_gate_source_does_not_import_wait_stale(self):
-        """Row 22 (structural): handoff_gate.py does NOT import wait_stale.
+    def test_handoff_gate_source_does_not_import_silencer_symbols(self):
+        """Row 22 (structural): handoff_gate.py does NOT import wait_stale
+        or should_silence_stall_nag.
 
         Guards AC #8 at the module level — if someone later wires
-        intentional_wait awareness into handoff_gate, this test flips RED
-        and forces an explicit architecture review.
+        intentional_wait or stalled awareness into handoff_gate, this test
+        flips RED and forces an explicit architecture review. Both symbols
+        are covered because the F1 refactor (commit 1defa39) made
+        should_silence_stall_nag the real composite surface — a post-F1
+        import of should_silence_stall_nag would give handoff_gate the same
+        wait+stalled awareness the original wait_stale check was guarding
+        against.
         """
         import handoff_gate
 
@@ -1025,6 +1031,12 @@ class TestIntentionalWaitDoesNotBleedIntoHandoffGate:
             "AC #8: handoff_gate must not reference wait_stale. Adding it "
             "would let teammates bypass HANDOFF enforcement by setting "
             "intentional_wait before completing the task."
+        )
+        assert not hasattr(handoff_gate, "should_silence_stall_nag"), (
+            "AC #8: handoff_gate must not reference should_silence_stall_nag. "
+            "Post-F1 that helper wraps intentional_wait AND stalled awareness "
+            "— importing it into handoff_gate would silently re-introduce the "
+            "violation wait_stale absence was guarding against."
         )
 
 

--- a/pact-plugin/tests/test_handoff_gate.py
+++ b/pact-plugin/tests/test_handoff_gate.py
@@ -927,3 +927,171 @@ class TestReadTaskOwnerCorruptedJson:
         result = read_task_owner("42", "pact-test", tasks_base_dir=str(tmp_path))
 
         assert result is None
+
+
+# =============================================================================
+# #497 AC #8 — handoff_gate MUST NOT honor intentional_wait
+# =============================================================================
+
+from datetime import datetime, timedelta, timezone
+
+
+def _iw_payload(fresh=True):
+    now = datetime.now(timezone.utc)
+    since = now - (timedelta(seconds=60) if fresh else timedelta(hours=2))
+    return {
+        "reason": "awaiting_teachback_approved",
+        "expected_resolver": "lead",
+        "since": since.isoformat(timespec="seconds"),
+    }
+
+
+class TestIntentionalWaitDoesNotBleedIntoHandoffGate:
+    """AC #8: handoff_gate enforces HANDOFF completeness regardless of any
+    intentional_wait flag. The wait flag is a TeammateIdle-hook concept,
+    not a TaskCompleted-hook concept — a teammate cannot escape HANDOFF
+    enforcement by setting intentional_wait before calling
+    TaskUpdate(status=completed).
+    """
+
+    def test_empty_metadata_plus_fresh_wait_still_blocked(self):
+        """Row 19: empty HANDOFF (dict lacks `handoff` key) + fresh wait
+        -> still blocked. Wait flag does not bypass HANDOFF enforcement."""
+        from handoff_gate import validate_task_handoff
+
+        result = validate_task_handoff(
+            task_metadata={"intentional_wait": _iw_payload(fresh=True)},
+            teammate_name="backend-coder",
+        )
+        assert result is not None, (
+            "AC #8: intentional_wait must NOT bleed into completion gating"
+        )
+        assert "handoff" in result.lower()
+
+    def test_stale_wait_plus_empty_handoff_also_blocked(self):
+        """Row 19 variant: stale wait doesn't change behavior either."""
+        from handoff_gate import validate_task_handoff
+
+        result = validate_task_handoff(
+            task_metadata={"intentional_wait": _iw_payload(fresh=False)},
+            teammate_name="backend-coder",
+        )
+        assert result is not None
+        assert "handoff" in result.lower()
+
+    def test_incomplete_handoff_plus_fresh_wait_still_blocked(self):
+        """Row 20: HANDOFF missing a required field + fresh wait -> blocked."""
+        from handoff_gate import validate_task_handoff
+
+        incomplete = {k: v for k, v in VALID_HANDOFF.items() if k != "produced"}
+        result = validate_task_handoff(
+            task_metadata={
+                "handoff": incomplete,
+                "intentional_wait": _iw_payload(fresh=True),
+            },
+            teammate_name="backend-coder",
+        )
+        assert result is not None
+        assert "produced" in result
+
+    def test_complete_handoff_plus_fresh_wait_allowed(self):
+        """Row 21: Complete HANDOFF allows completion regardless of wait state.
+
+        The wait flag has no effect on a correctly-completed task. This is
+        the intended behavior — intentional_wait lives on the idle/stall
+        axis, not the completion/handoff axis.
+        """
+        from handoff_gate import validate_task_handoff
+
+        result = validate_task_handoff(
+            task_metadata={
+                "handoff": VALID_HANDOFF,
+                "intentional_wait": _iw_payload(fresh=True),
+            },
+            teammate_name="backend-coder",
+        )
+        assert result is None
+
+    def test_handoff_gate_source_does_not_import_wait_stale(self):
+        """Row 22 (structural): handoff_gate.py does NOT import wait_stale.
+
+        Guards AC #8 at the module level — if someone later wires
+        intentional_wait awareness into handoff_gate, this test flips RED
+        and forces an explicit architecture review.
+        """
+        import handoff_gate
+
+        assert not hasattr(handoff_gate, "wait_stale"), (
+            "AC #8: handoff_gate must not reference wait_stale. Adding it "
+            "would let teammates bypass HANDOFF enforcement by setting "
+            "intentional_wait before completing the task."
+        )
+
+
+class TestHandoffGateMainBypassGuards:
+    """Main-entry integration: even a well-formed intentional_wait on a task
+    with no HANDOFF blocks completion at the hook boundary (exit 2).
+    """
+
+    def test_main_blocks_completion_with_wait_and_no_handoff(self, capsys):
+        """End-to-end AC #8: exit 2 when teammate tries to complete without HANDOFF
+        even with a fresh intentional_wait set."""
+        from handoff_gate import main
+
+        input_data = json.dumps({
+            "task_id": "42",
+            "task_subject": "CODE: auth",
+            "teammate_name": "backend-coder",
+            "team_name": "pact-test",
+        })
+
+        # Owner present, only intentional_wait in metadata — no handoff key.
+        task_data = {
+            "owner": "backend-coder",
+            "metadata": {"intentional_wait": _iw_payload(fresh=True)},
+        }
+
+        with patch("handoff_gate._read_task_json", return_value=task_data), \
+             patch("sys.stdin", io.StringIO(input_data)):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 2, (
+            "AC #8: handoff_gate must block completion without HANDOFF, "
+            "regardless of intentional_wait"
+        )
+        captured = capsys.readouterr()
+        assert "handoff" in captured.err.lower()
+
+    def test_main_allows_completion_with_handoff_and_wait(self, capsys):
+        """Complement: valid HANDOFF + memory_saved + wait -> exit 0 (allow).
+
+        Verifies the wait flag does NOT introduce any new failure path;
+        normal completion still works when all gates are satisfied.
+        """
+        from handoff_gate import main
+
+        input_data = json.dumps({
+            "task_id": "42",
+            "task_subject": "CODE: auth",
+            "teammate_name": "backend-coder",
+            "team_name": "pact-test",
+        })
+
+        task_data = {
+            "owner": "backend-coder",
+            "metadata": {
+                "handoff": VALID_HANDOFF,
+                "memory_saved": True,
+                "intentional_wait": _iw_payload(fresh=True),
+            },
+        }
+
+        with patch("handoff_gate._read_task_json", return_value=task_data), \
+             patch("sys.stdin", io.StringIO(input_data)), \
+             patch("handoff_gate.append_event") as mock_append:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0
+        mock_append.assert_called_once()

--- a/pact-plugin/tests/test_intentional_wait.py
+++ b/pact-plugin/tests/test_intentional_wait.py
@@ -503,6 +503,14 @@ class TestSignalTaskLiteralPin:
     def test_signal_task_literal_present_in_helper_module(self):
         """Complement: assert the literal IS present in the helper — a
         pure removal test could pass after deletion of the helper logic.
+
+        Style coupling (intentional): the regex matches the parenthesized
+        tuple form `("blocker", "algedonic")`. If a future refactor replaces
+        the tuple with a frozenset, set literal, or Enum, this test will
+        flip RED despite semantically identical behavior. When changing the
+        sentinel form, update this test's regex in the same commit —
+        mechanically pinning the tuple IS the invariant, not the exact
+        syntax.
         """
         from pathlib import Path
         import re

--- a/pact-plugin/tests/test_intentional_wait.py
+++ b/pact-plugin/tests/test_intentional_wait.py
@@ -309,7 +309,7 @@ class TestSkillMdProseSnippetConformance:
     def test_prose_snippet_output_is_fresh_and_valid(self):
         from shared.intentional_wait import validate_wait, wait_stale
 
-        # Verbatim the SKILL.md "Protocol Waits" prose snippet:
+        # Verbatim the SKILL.md "Intentional Waiting" prose snippet:
         since_value = datetime.now(timezone.utc).isoformat(timespec="seconds")
         payload = {
             "reason": "awaiting_teachback_approved",

--- a/pact-plugin/tests/test_intentional_wait.py
+++ b/pact-plugin/tests/test_intentional_wait.py
@@ -282,12 +282,238 @@ class TestModuleConstants:
         assert {"lead", "peer", "user", "external"} <= KNOWN_RESOLVERS
 
     def test_reexports_from_shared_package(self):
-        from shared import (
+        # Top-level re-exports are the minimal public API: the two predicates
+        # consumers need. Vocabulary + format helpers stay module-only to keep
+        # the shared package namespace small.
+        from shared import should_silence_stall_nag, wait_stale
+        from shared.intentional_wait import (
             canonical_since,
             validate_wait,
-            wait_stale,
             DEFAULT_THRESHOLD_MINUTES,
             KNOWN_REASONS,
             KNOWN_RESOLVERS,
         )
         assert DEFAULT_THRESHOLD_MINUTES == 30
+
+
+# --- prose-vs-code drift pin ----------------------------------------------
+
+class TestSkillMdProseSnippetConformance:
+    """Drift-pin: the SKILL.md prose snippet for `since` must stay in lockstep
+    with code semantics. If prose says "use datetime.now(timezone.utc).isoformat(
+    timespec='seconds')" but validate_wait later rejects that output (or
+    wait_stale classifies it stale), teammates will follow the prose and hit
+    silent nag-resume. Execute the prose snippet verbatim and assert.
+    """
+
+    def test_prose_snippet_output_is_fresh_and_valid(self):
+        from shared.intentional_wait import validate_wait, wait_stale
+
+        # Verbatim the SKILL.md "Protocol Waits" prose snippet:
+        since_value = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        payload = {
+            "reason": "awaiting_teachback_approved",
+            "expected_resolver": "lead",
+            "since": since_value,
+        }
+        assert validate_wait(payload) is True
+        assert wait_stale(payload) is False
+
+
+# --- is_signal_task -------------------------------------------------------
+
+class TestIsSignalTask:
+    def test_blocker_is_signal(self):
+        from shared.intentional_wait import is_signal_task
+
+        assert is_signal_task({"metadata": {"type": "blocker"}}) is True
+
+    def test_algedonic_is_signal(self):
+        from shared.intentional_wait import is_signal_task
+
+        assert is_signal_task({"metadata": {"type": "algedonic"}}) is True
+
+    def test_other_type_is_not_signal(self):
+        from shared.intentional_wait import is_signal_task
+
+        assert is_signal_task({"metadata": {"type": "handoff"}}) is False
+        assert is_signal_task({"metadata": {"type": "approval"}}) is False
+
+    def test_missing_type_is_not_signal(self):
+        from shared.intentional_wait import is_signal_task
+
+        assert is_signal_task({"metadata": {}}) is False
+
+    def test_missing_metadata_is_not_signal(self):
+        from shared.intentional_wait import is_signal_task
+
+        assert is_signal_task({}) is False
+
+    def test_non_dict_is_not_signal(self):
+        from shared.intentional_wait import is_signal_task
+
+        assert is_signal_task(None) is False
+        assert is_signal_task("blocker") is False
+        assert is_signal_task(42) is False
+        assert is_signal_task([]) is False
+
+    def test_non_dict_metadata_is_not_signal(self):
+        from shared.intentional_wait import is_signal_task
+
+        assert is_signal_task({"metadata": None}) is False
+        assert is_signal_task({"metadata": "blocker"}) is False
+
+
+# --- should_silence_stall_nag --------------------------------------------
+
+class TestShouldSilenceStallNag:
+    def test_signal_task_is_silenced(self):
+        from shared.intentional_wait import should_silence_stall_nag
+
+        assert should_silence_stall_nag({"metadata": {"type": "blocker"}}) is True
+        assert should_silence_stall_nag({"metadata": {"type": "algedonic"}}) is True
+
+    def test_stalled_is_silenced(self):
+        from shared.intentional_wait import should_silence_stall_nag
+
+        assert should_silence_stall_nag({"metadata": {"stalled": True}}) is True
+
+    def test_fresh_intentional_wait_is_silenced(self):
+        from shared.intentional_wait import should_silence_stall_nag
+
+        assert should_silence_stall_nag(
+            {"metadata": {"intentional_wait": _fresh_wait()}}
+        ) is True
+
+    def test_stale_intentional_wait_is_not_silenced(self):
+        from shared.intentional_wait import should_silence_stall_nag
+
+        now = datetime(2026, 4, 21, 16, 0, 0, tzinfo=timezone.utc)
+        stale_wait = _fresh_wait(
+            since=_iso(now - timedelta(minutes=31)),
+        )
+        assert should_silence_stall_nag(
+            {"metadata": {"intentional_wait": stale_wait}}, _now=now
+        ) is False
+
+    def test_malformed_intentional_wait_is_not_silenced(self):
+        # A malformed flag fails loud: wait_stale returns True → no silence
+        from shared.intentional_wait import should_silence_stall_nag
+
+        assert should_silence_stall_nag(
+            {"metadata": {"intentional_wait": {"reason": "x"}}}
+        ) is False
+
+    def test_empty_metadata_is_not_silenced(self):
+        from shared.intentional_wait import should_silence_stall_nag
+
+        assert should_silence_stall_nag({"metadata": {}}) is False
+
+    def test_missing_metadata_is_not_silenced(self):
+        from shared.intentional_wait import should_silence_stall_nag
+
+        assert should_silence_stall_nag({}) is False
+
+    def test_non_dict_is_not_silenced(self):
+        from shared.intentional_wait import should_silence_stall_nag
+
+        assert should_silence_stall_nag(None) is False
+        assert should_silence_stall_nag("stalled") is False
+        assert should_silence_stall_nag([]) is False
+
+    def test_signal_takes_precedence_over_everything(self):
+        """Signal-task silences even if stalled=False and no intentional_wait."""
+        from shared.intentional_wait import should_silence_stall_nag
+
+        assert should_silence_stall_nag(
+            {"metadata": {"type": "blocker", "stalled": False}}
+        ) is True
+
+    def test_multiple_triggers_still_silences(self):
+        """Any one trigger is sufficient; multiple are fine."""
+        from shared.intentional_wait import should_silence_stall_nag
+
+        assert should_silence_stall_nag(
+            {"metadata": {"type": "algedonic", "stalled": True,
+                          "intentional_wait": _fresh_wait()}}
+        ) is True
+
+    def test_custom_threshold_respected(self):
+        from shared.intentional_wait import should_silence_stall_nag
+
+        now = datetime(2026, 4, 21, 16, 0, 0, tzinfo=timezone.utc)
+        wait = _fresh_wait(since=_iso(now - timedelta(minutes=10)))
+        # 10 min elapsed; threshold=5 → stale → not silenced;
+        # threshold=15 → fresh → silenced
+        assert should_silence_stall_nag(
+            {"metadata": {"intentional_wait": wait}},
+            threshold_minutes=5, _now=now,
+        ) is False
+        assert should_silence_stall_nag(
+            {"metadata": {"intentional_wait": wait}},
+            threshold_minutes=15, _now=now,
+        ) is True
+
+
+# --- structural drift-pin: signal-task literal lives in exactly one place --
+
+class TestSignalTaskLiteralPin:
+    """Structural guardrail: the `("blocker", "algedonic")` tuple-literal
+    (and its private module constant) must live only in
+    shared/intentional_wait.py. If a consumer file reintroduces the literal
+    inline, the cross-hook silencer asymmetry can silently return.
+
+    Scope: the three refactored hook files (detect_stall, _scan_owned_tasks,
+    handoff_gate). Out-of-scope for this PR: session_resume.py:525 and
+    task_utils.py:184 (preparer §2.7 inventory, follow-up refactor).
+    """
+
+    def test_signal_task_literal_lives_in_helper_only(self):
+        import re
+        from pathlib import Path
+
+        hooks_root = Path(__file__).parent.parent / "hooks"
+        # Literal tuple in code form — both single-quote and double-quote variants.
+        pattern = re.compile(
+            r"""\(\s*["']blocker["']\s*,\s*["']algedonic["']\s*\)"""
+        )
+
+        # Scope the scan to the three refactored hook files. Other sites
+        # (session_resume.py:525, task_utils.py:184) are out of scope per
+        # task #18 description and remain on the preparer §2.7 follow-up list.
+        refactored_files = [
+            hooks_root / "teammate_idle.py",
+            hooks_root / "teammate_completion_gate.py",
+            hooks_root / "handoff_gate.py",
+        ]
+
+        offenders = []
+        for path in refactored_files:
+            text = path.read_text(encoding="utf-8")
+            for line_no, line in enumerate(text.splitlines(), start=1):
+                if pattern.search(line):
+                    offenders.append(f"{path.name}:{line_no}: {line.strip()}")
+
+        assert not offenders, (
+            "Signal-task literal tuple must not appear in refactored hook files. "
+            "Use shared.intentional_wait.is_signal_task instead.\n"
+            + "\n".join(offenders)
+        )
+
+    def test_signal_task_literal_present_in_helper_module(self):
+        """Complement: assert the literal IS present in the helper — a
+        pure removal test could pass after deletion of the helper logic.
+        """
+        from pathlib import Path
+        import re
+
+        helper = Path(__file__).parent.parent / "hooks" / "shared" / "intentional_wait.py"
+        text = helper.read_text(encoding="utf-8")
+        pattern = re.compile(
+            r"""\(\s*["']blocker["']\s*,\s*["']algedonic["']\s*\)"""
+        )
+        matches = pattern.findall(text)
+        assert len(matches) >= 1, (
+            "Expected the signal-task literal tuple in shared/intentional_wait.py "
+            "(as _SIGNAL_TASK_TYPES); found zero."
+        )

--- a/pact-plugin/tests/test_intentional_wait.py
+++ b/pact-plugin/tests/test_intentional_wait.py
@@ -1,0 +1,293 @@
+"""
+Tests for shared.intentional_wait — validate_wait, wait_stale, canonical_since.
+
+Coverage targets:
+- validate_wait: non-dict inputs, missing/empty required keys, malformed since,
+  tz-naive since (must reject), unknown keys (forward-compat), trailing Z vs +00:00,
+  non-UTC offsets.
+- wait_stale: fresh / stale / boundary / missing / malformed / future-dated,
+  custom threshold, non-UTC offset age parity.
+- canonical_since: shape and round-trip through validate_wait + wait_stale.
+"""
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+
+# --- helpers ---------------------------------------------------------------
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat(timespec="seconds")
+
+
+def _fresh_wait(**overrides):
+    payload = {
+        "reason": "awaiting_teachback_approved",
+        "expected_resolver": "lead",
+        "since": _iso(datetime.now(timezone.utc)),
+    }
+    payload.update(overrides)
+    return payload
+
+
+# --- validate_wait ---------------------------------------------------------
+
+class TestValidateWait:
+    def test_fresh_payload_accepted(self):
+        from shared.intentional_wait import validate_wait
+
+        assert validate_wait(_fresh_wait()) is True
+
+    def test_none_rejected(self):
+        from shared.intentional_wait import validate_wait
+
+        assert validate_wait(None) is False
+
+    def test_non_dict_rejected(self):
+        from shared.intentional_wait import validate_wait
+
+        assert validate_wait([]) is False
+        assert validate_wait("string") is False
+        assert validate_wait(42) is False
+
+    def test_missing_reason_rejected(self):
+        from shared.intentional_wait import validate_wait
+
+        payload = _fresh_wait()
+        del payload["reason"]
+        assert validate_wait(payload) is False
+
+    def test_empty_reason_rejected(self):
+        from shared.intentional_wait import validate_wait
+
+        assert validate_wait(_fresh_wait(reason="")) is False
+        assert validate_wait(_fresh_wait(reason="   ")) is False
+
+    def test_non_string_reason_rejected(self):
+        from shared.intentional_wait import validate_wait
+
+        assert validate_wait(_fresh_wait(reason=42)) is False
+
+    def test_missing_resolver_rejected(self):
+        from shared.intentional_wait import validate_wait
+
+        payload = _fresh_wait()
+        del payload["expected_resolver"]
+        assert validate_wait(payload) is False
+
+    def test_empty_resolver_rejected(self):
+        from shared.intentional_wait import validate_wait
+
+        assert validate_wait(_fresh_wait(expected_resolver="")) is False
+
+    def test_custom_resolver_accepted(self):
+        from shared.intentional_wait import validate_wait
+
+        assert validate_wait(_fresh_wait(expected_resolver="custom-orchestrator")) is True
+
+    def test_missing_since_rejected(self):
+        from shared.intentional_wait import validate_wait
+
+        payload = _fresh_wait()
+        del payload["since"]
+        assert validate_wait(payload) is False
+
+    def test_non_string_since_rejected(self):
+        from shared.intentional_wait import validate_wait
+
+        assert validate_wait(_fresh_wait(since=1234567890)) is False
+
+    def test_unparseable_since_rejected(self):
+        from shared.intentional_wait import validate_wait
+
+        assert validate_wait(_fresh_wait(since="yesterday")) is False
+        assert validate_wait(_fresh_wait(since="2026-13-99")) is False
+
+    def test_tz_naive_since_rejected(self):
+        from shared.intentional_wait import validate_wait
+
+        assert validate_wait(_fresh_wait(since="2026-04-21T15:30:00")) is False
+
+    def test_trailing_z_accepted(self):
+        from shared.intentional_wait import validate_wait
+
+        assert validate_wait(_fresh_wait(since="2026-04-21T15:30:00Z")) is True
+
+    def test_plus_00_accepted(self):
+        from shared.intentional_wait import validate_wait
+
+        assert validate_wait(_fresh_wait(since="2026-04-21T15:30:00+00:00")) is True
+
+    def test_non_utc_offset_accepted(self):
+        from shared.intentional_wait import validate_wait
+
+        assert validate_wait(_fresh_wait(since="2026-04-21T15:30:00-04:00")) is True
+
+    def test_unknown_keys_preserved(self):
+        from shared.intentional_wait import validate_wait
+
+        assert validate_wait(_fresh_wait(correlation_id="abc", peer_name="architect")) is True
+
+
+# --- wait_stale ------------------------------------------------------------
+
+class TestWaitStale:
+    def test_fresh_is_not_stale(self):
+        from shared.intentional_wait import wait_stale
+
+        assert wait_stale(_fresh_wait()) is False
+
+    def test_none_is_stale(self):
+        from shared.intentional_wait import wait_stale
+
+        assert wait_stale(None) is True
+
+    def test_malformed_is_stale(self):
+        from shared.intentional_wait import wait_stale
+
+        assert wait_stale({"reason": "x"}) is True
+        assert wait_stale({"foo": "bar"}) is True
+
+    def test_unparseable_since_is_stale(self):
+        from shared.intentional_wait import wait_stale
+
+        assert wait_stale(_fresh_wait(since="not a date")) is True
+
+    def test_tz_naive_since_is_stale(self):
+        from shared.intentional_wait import wait_stale
+
+        assert wait_stale(_fresh_wait(since="2026-04-21T15:30:00")) is True
+
+    def test_over_threshold_is_stale(self):
+        from shared.intentional_wait import wait_stale
+
+        now = datetime(2026, 4, 21, 16, 0, 0, tzinfo=timezone.utc)
+        since = now - timedelta(minutes=31)
+        payload = _fresh_wait(since=_iso(since))
+        assert wait_stale(payload, _now=now) is True
+
+    def test_under_threshold_is_not_stale(self):
+        from shared.intentional_wait import wait_stale
+
+        now = datetime(2026, 4, 21, 16, 0, 0, tzinfo=timezone.utc)
+        since = now - timedelta(minutes=29)
+        payload = _fresh_wait(since=_iso(since))
+        assert wait_stale(payload, _now=now) is False
+
+    def test_boundary_exactly_at_threshold_is_stale(self):
+        from shared.intentional_wait import wait_stale
+
+        # >= comparison — exactly-threshold is stale
+        now = datetime(2026, 4, 21, 16, 0, 0, tzinfo=timezone.utc)
+        since = now - timedelta(minutes=30)
+        payload = _fresh_wait(since=_iso(since))
+        assert wait_stale(payload, _now=now) is True
+
+    def test_future_since_is_not_stale(self):
+        from shared.intentional_wait import wait_stale
+
+        # Clock drift / tampering: future-dated since → negative age → not stale
+        now = datetime(2026, 4, 21, 16, 0, 0, tzinfo=timezone.utc)
+        since = now + timedelta(hours=2)
+        payload = _fresh_wait(since=_iso(since))
+        assert wait_stale(payload, _now=now) is False
+
+    def test_custom_threshold_override(self):
+        from shared.intentional_wait import wait_stale
+
+        now = datetime(2026, 4, 21, 16, 0, 0, tzinfo=timezone.utc)
+        since = now - timedelta(minutes=10)
+        payload = _fresh_wait(since=_iso(since))
+        # 10 min elapsed; threshold=5 → stale; threshold=15 → fresh
+        assert wait_stale(payload, threshold_minutes=5, _now=now) is True
+        assert wait_stale(payload, threshold_minutes=15, _now=now) is False
+
+    def test_non_utc_offset_age_parity(self):
+        from shared.intentional_wait import wait_stale
+
+        now = datetime(2026, 4, 21, 16, 0, 0, tzinfo=timezone.utc)
+        # 15 min ago in UTC, expressed as -04:00 offset wall-clock
+        utc_since = now - timedelta(minutes=15)
+        offset_str = utc_since.astimezone(timezone(timedelta(hours=-4))).isoformat(timespec="seconds")
+        payload = _fresh_wait(since=offset_str)
+        # 15 min < 30 min default → not stale; age computation must normalize tz
+        assert wait_stale(payload, _now=now) is False
+
+
+# --- canonical_since -------------------------------------------------------
+
+class TestCanonicalSince:
+    def test_returns_string(self):
+        from shared.intentional_wait import canonical_since
+
+        assert isinstance(canonical_since(), str)
+
+    def test_is_tz_aware_iso(self):
+        from shared.intentional_wait import canonical_since
+
+        value = canonical_since()
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        assert parsed.tzinfo is not None
+
+    def test_seconds_precision_no_microseconds(self):
+        from shared.intentional_wait import canonical_since
+
+        value = canonical_since()
+        assert "." not in value  # timespec="seconds" drops microseconds
+
+    def test_round_trips_through_validate_wait(self):
+        from shared.intentional_wait import canonical_since, validate_wait
+
+        payload = {
+            "reason": "awaiting_teachback_approved",
+            "expected_resolver": "lead",
+            "since": canonical_since(),
+        }
+        assert validate_wait(payload) is True
+
+    def test_round_trips_through_wait_stale_as_fresh(self):
+        """First-tick defense: auto-set payload must NOT be stale at emission."""
+        from shared.intentional_wait import canonical_since, wait_stale
+
+        payload = {
+            "reason": "awaiting_teachback_approved",
+            "expected_resolver": "lead",
+            "since": canonical_since(),
+        }
+        assert wait_stale(payload) is False
+
+
+# --- module constants ------------------------------------------------------
+
+class TestModuleConstants:
+    def test_default_threshold_is_30(self):
+        from shared.intentional_wait import DEFAULT_THRESHOLD_MINUTES
+
+        assert DEFAULT_THRESHOLD_MINUTES == 30
+
+    def test_known_reasons_is_frozenset(self):
+        from shared.intentional_wait import KNOWN_REASONS
+
+        assert isinstance(KNOWN_REASONS, frozenset)
+        assert "awaiting_teachback_approved" in KNOWN_REASONS
+
+    def test_known_resolvers_is_frozenset(self):
+        from shared.intentional_wait import KNOWN_RESOLVERS
+
+        assert isinstance(KNOWN_RESOLVERS, frozenset)
+        assert {"lead", "peer", "user", "external"} <= KNOWN_RESOLVERS
+
+    def test_reexports_from_shared_package(self):
+        from shared import (
+            canonical_since,
+            validate_wait,
+            wait_stale,
+            DEFAULT_THRESHOLD_MINUTES,
+            KNOWN_REASONS,
+            KNOWN_RESOLVERS,
+        )
+        assert DEFAULT_THRESHOLD_MINUTES == 30

--- a/pact-plugin/tests/test_teammate_completion_gate.py
+++ b/pact-plugin/tests/test_teammate_completion_gate.py
@@ -1229,22 +1229,28 @@ class TestIntentionalWaitAC11BlockedByStillNags:
 
 
 class TestIntentionalWaitSharedThresholdContract:
-    """Row 27: both hooks import wait_stale from the same shared module.
+    """Row 27: both hooks share the same silencer predicate.
 
     Regression guard against duplicate-constant drift. If someone later
-    inlines the threshold into one hook, the two hooks could diverge on
-    staleness cutoff — this test pins that they import the same symbol.
+    inlines the threshold or a skip condition into one hook, the two hooks
+    could diverge on silencer semantics — this test pins that they import
+    the same `should_silence_stall_nag` symbol. (Updated from pinning
+    `wait_stale` directly when F1 unified the three adjacent skips into a
+    single helper.)
     """
 
-    def test_both_hooks_share_wait_stale_import(self):
-        """Same wait_stale object reached via both hook modules' import graphs."""
+    def test_both_hooks_share_silencer_import(self):
+        """Same should_silence_stall_nag object reached via both hook modules."""
         import teammate_idle
         import teammate_completion_gate
 
-        # Both modules import the same function object
-        assert teammate_idle.wait_stale is teammate_completion_gate.wait_stale, (
-            "Row 27: hooks must share a single wait_stale — divergence creates "
-            "inconsistent staleness semantics across the parallel-fired hooks"
+        assert (
+            teammate_idle.should_silence_stall_nag
+            is teammate_completion_gate.should_silence_stall_nag
+        ), (
+            "Row 27: hooks must share a single should_silence_stall_nag — "
+            "divergence creates inconsistent silencer semantics across the "
+            "parallel-fired hooks"
         )
 
     def test_shared_default_threshold_is_30(self):

--- a/pact-plugin/tests/test_teammate_completion_gate.py
+++ b/pact-plugin/tests/test_teammate_completion_gate.py
@@ -841,3 +841,599 @@ class TestMain:
                 main()
 
         assert exc_info.value.code == 0
+
+
+# =============================================================================
+# #497 — _scan_owned_tasks honors metadata.intentional_wait
+# =============================================================================
+
+from datetime import datetime, timedelta, timezone
+
+
+def _iso_seconds(dt):
+    return dt.isoformat(timespec="seconds")
+
+
+def _fresh_wait_payload(reason="awaiting_teachback_approved",
+                       resolver="lead",
+                       since_offset_seconds=-60):
+    return {
+        "reason": reason,
+        "expected_resolver": resolver,
+        "since": _iso_seconds(
+            datetime.now(timezone.utc) + timedelta(seconds=since_offset_seconds)
+        ),
+    }
+
+
+def _stale_wait_payload(minutes=60):
+    return {
+        "reason": "awaiting_teachback_approved",
+        "expected_resolver": "lead",
+        "since": _iso_seconds(datetime.now(timezone.utc) - timedelta(minutes=minutes)),
+    }
+
+
+def _make_task_dir(tmp_path, team_name="pact-test"):
+    task_dir = tmp_path / ".claude" / "tasks" / team_name
+    task_dir.mkdir(parents=True)
+    return task_dir
+
+
+class TestIntentionalWaitCompletionGatePredicate:
+    """_scan_owned_tasks honors a fresh intentional_wait in BOTH branches:
+    completable (has HANDOFF) and missing_handoff (no HANDOFF).
+
+    Plan rows 13-16. Suppression in BOTH branches is load-bearing because
+    the root livelock path is the missing-handoff branch (teammate waiting
+    on teachback_approved BEFORE producing HANDOFF) — but the completable
+    branch must also suppress for symmetric reasons (teammate waiting on
+    lead commit AFTER producing HANDOFF).
+    """
+
+    def test_fresh_wait_suppresses_completable_branch(self, tmp_path):
+        """Row 13: in_progress + HANDOFF + fresh intentional_wait -> NOT completable.
+
+        Typical shape: teammate finished work, stored HANDOFF, and is now
+        waiting for lead commit before calling TaskUpdate(status=completed).
+        """
+        from teammate_completion_gate import _scan_owned_tasks
+
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress", {
+            "handoff": VALID_HANDOFF,
+            "intentional_wait": _fresh_wait_payload(
+                reason="awaiting_lead_commit",
+                resolver="lead",
+            ),
+        })
+        completable, missing = _scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        assert completable == []
+        assert missing == []
+
+    def test_fresh_wait_suppresses_missing_handoff_branch(self, tmp_path):
+        """Row 14: in_progress + no HANDOFF + fresh intentional_wait -> NOT missing.
+
+        Typical shape: teammate has sent teachback and is waiting on approval
+        before starting implementation work. No HANDOFF yet, but the nag would
+        livelock the wait.
+        """
+        from teammate_completion_gate import _scan_owned_tasks
+
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress", {
+            "intentional_wait": _fresh_wait_payload(),
+        })
+        completable, missing = _scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        assert completable == []
+        assert missing == []
+
+    def test_stale_wait_re_surfaces_completable(self, tmp_path):
+        """Row 15a: stale intentional_wait + HANDOFF -> completable re-appears."""
+        from teammate_completion_gate import _scan_owned_tasks
+
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress", {
+            "handoff": VALID_HANDOFF,
+            "intentional_wait": _stale_wait_payload(minutes=60),
+        })
+        completable, missing = _scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        assert len(completable) == 1
+        assert completable[0]["id"] == "5"
+
+    def test_stale_wait_re_surfaces_missing(self, tmp_path):
+        """Row 15b: stale intentional_wait + no HANDOFF -> missing re-appears."""
+        from teammate_completion_gate import _scan_owned_tasks
+
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress", {
+            "intentional_wait": _stale_wait_payload(minutes=60),
+        })
+        completable, missing = _scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        assert len(missing) == 1
+        assert missing[0]["id"] == "5"
+
+    def test_missing_wait_completes_normally(self, tmp_path):
+        """Row 16: no intentional_wait -> pre-fix behavior unchanged."""
+        from teammate_completion_gate import _scan_owned_tasks
+
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress",
+                        {"handoff": VALID_HANDOFF})
+        completable, missing = _scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        assert len(completable) == 1
+
+    def test_malformed_wait_fails_loud(self, tmp_path):
+        """Malformed intentional_wait -> nag path re-enables (fail-loud)."""
+        from teammate_completion_gate import _scan_owned_tasks
+
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress", {
+            "handoff": VALID_HANDOFF,
+            "intentional_wait": {"reason": "x"},  # missing resolver + since
+        })
+        completable, missing = _scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        assert len(completable) == 1, (
+            "Malformed flag must NOT silently suppress — nag re-enables"
+        )
+
+    def test_none_wait_value_treated_as_absent(self, tmp_path):
+        """intentional_wait explicitly None behaves like the key is absent."""
+        from teammate_completion_gate import _scan_owned_tasks
+
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress", {
+            "handoff": VALID_HANDOFF,
+            "intentional_wait": None,  # explicit cleared state
+        })
+        completable, missing = _scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        assert len(completable) == 1, (
+            "intentional_wait=None is the explicit-cleared form; must not silence"
+        )
+
+    def test_signal_type_audit_task_with_fresh_wait_suppresses(self, tmp_path):
+        """Row 13 variant: signal-type task (auditor) + fresh wait still suppresses.
+
+        Signal-type has its own completion_type branch in _scan_owned_tasks
+        but the intentional_wait skip runs BEFORE that branch — so signal
+        tasks get the same suppression treatment.
+        """
+        from teammate_completion_gate import _scan_owned_tasks
+
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "42", "auditor", "in_progress", {
+            "completion_type": "signal",
+            "audit_summary": {"signal": "GREEN", "findings": []},
+            "intentional_wait": _fresh_wait_payload(resolver="lead"),
+        })
+        completable, missing = _scan_owned_tasks(
+            "auditor", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        assert completable == []
+        assert missing == []
+
+    def test_only_in_progress_tasks_checked(self, tmp_path):
+        """completed + fresh wait -> already filtered by status check; wait
+        not even consulted."""
+        from teammate_completion_gate import _scan_owned_tasks
+
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "5", "backend-coder", "completed", {
+            "handoff": VALID_HANDOFF,
+            "intentional_wait": _fresh_wait_payload(),
+        })
+        completable, missing = _scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        assert completable == []
+        assert missing == []
+
+
+class TestIntentionalWaitCompletionGateCardinality:
+    """Parametrized cardinality pin for counter-test-by-revert.
+
+    Reverting the intentional_wait skip in _scan_owned_tasks flips the fresh
+    rows (2 of 5) RED. Stale/malformed/missing rows stay GREEN either way
+    (because they are already expected to surface).
+    """
+
+    @pytest.mark.parametrize("wait_payload,handoff_present,expected_completable,expected_missing", [
+        # Fresh wait suppresses BOTH branches
+        ("fresh", True, 0, 0),
+        ("fresh", False, 0, 0),
+        # Stale wait does not suppress
+        ("stale", True, 1, 0),
+        ("stale", False, 0, 1),
+        # Missing wait -> unchanged pre-fix behavior
+        ("absent", True, 1, 0),
+        ("absent", False, 0, 1),
+    ])
+    def test_branch_matrix(self, tmp_path, wait_payload, handoff_present,
+                           expected_completable, expected_missing):
+        from teammate_completion_gate import _scan_owned_tasks
+
+        metadata = {}
+        if handoff_present:
+            metadata["handoff"] = VALID_HANDOFF
+        if wait_payload == "fresh":
+            metadata["intentional_wait"] = _fresh_wait_payload()
+        elif wait_payload == "stale":
+            metadata["intentional_wait"] = _stale_wait_payload()
+        # "absent" -> no key
+
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress", metadata)
+
+        completable, missing = _scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        assert len(completable) == expected_completable, (
+            f"wait={wait_payload}, handoff={handoff_present} "
+            f"-> completable expected {expected_completable}"
+        )
+        assert len(missing) == expected_missing, (
+            f"wait={wait_payload}, handoff={handoff_present} "
+            f"-> missing expected {expected_missing}"
+        )
+
+
+class TestIntentionalWaitCompletionGateMain:
+    """Row 17 (hook integration at main-entry level): main() exits 0 with
+    suppressOutput for a fresh intentional_wait on a missing-handoff task.
+
+    This is the load-bearing path for the livelock — the teammate is idle
+    without HANDOFF during a teachback wait; pre-fix main() would exit 2
+    and nag.
+    """
+
+    def test_main_exits_0_for_fresh_wait_missing_handoff(self, tmp_path, capsys):
+        from teammate_completion_gate import main
+
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress", {
+            "intentional_wait": _fresh_wait_payload(),
+        })
+
+        input_data = json.dumps({
+            "teammate_name": "backend-coder",
+            "team_name": "pact-test",
+        })
+        with patch("sys.stdin", io.StringIO(input_data)), \
+             patch("teammate_completion_gate.Path.home", return_value=tmp_path):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0, (
+            "Fresh intentional_wait must allow idle (exit 0), not block"
+        )
+        captured = capsys.readouterr()
+        # stderr should NOT contain block feedback
+        assert "HANDOFF" not in captured.err
+        assert "completed" not in captured.err
+
+    def test_main_exits_2_for_stale_wait_missing_handoff(self, tmp_path, capsys):
+        """Stale wait -> nag path re-enables via the missing-handoff branch."""
+        from teammate_completion_gate import main
+
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress", {
+            "intentional_wait": _stale_wait_payload(),
+        })
+
+        input_data = json.dumps({
+            "teammate_name": "backend-coder",
+            "team_name": "pact-test",
+        })
+        with patch("sys.stdin", io.StringIO(input_data)), \
+             patch("teammate_completion_gate.Path.home", return_value=tmp_path):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert "HANDOFF" in captured.err
+
+    def test_main_exits_0_for_fresh_wait_with_handoff(self, tmp_path, capsys):
+        """Completable branch: fresh wait + HANDOFF -> still suppress."""
+        from teammate_completion_gate import main
+
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress", {
+            "handoff": VALID_HANDOFF,
+            "intentional_wait": _fresh_wait_payload(reason="awaiting_lead_commit"),
+        })
+
+        input_data = json.dumps({
+            "teammate_name": "backend-coder",
+            "team_name": "pact-test",
+        })
+        with patch("sys.stdin", io.StringIO(input_data)), \
+             patch("teammate_completion_gate.Path.home", return_value=tmp_path):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0
+
+
+class TestIntentionalWaitAC11BlockedByStillNags:
+    """Row 23: blockedBy without intentional_wait still nags.
+
+    Documents the empirical NO-GO for Option 4 (blockedBy hook-awareness)
+    as a standalone fix. Preparer verified that neither TeammateIdle hook
+    reads blockedBy — so a teammate whose task is blocked but lacks an
+    intentional_wait flag still triggers the nag. This test pins that
+    behavior as a regression guard: if someone adds blockedBy awareness
+    later, they must also consider intentional_wait interaction.
+    """
+
+    def test_blockedby_alone_does_not_silence(self, tmp_path):
+        from teammate_completion_gate import _scan_owned_tasks
+
+        task_dir = _make_task_dir(tmp_path)
+        # blockedBy set but no intentional_wait flag
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress", {
+            "blockedBy": ["3"],
+        })
+        completable, missing = _scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        # No HANDOFF + no wait flag -> surfaces as missing (nag path)
+        assert len(missing) == 1, (
+            "AC #11: blockedBy without intentional_wait must still nag — "
+            "Option 4 is deferred as standalone fix. Add intentional_wait "
+            "to skip."
+        )
+
+    def test_blockedby_with_fresh_wait_silences(self, tmp_path):
+        """The fix (Option 1): blockedBy + fresh intentional_wait -> silenced."""
+        from teammate_completion_gate import _scan_owned_tasks
+
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress", {
+            "blockedBy": ["3"],
+            "intentional_wait": _fresh_wait_payload(
+                reason="awaiting_blocker_resolution",
+                resolver="peer",
+            ),
+        })
+        completable, missing = _scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        assert missing == []
+
+
+class TestIntentionalWaitSharedThresholdContract:
+    """Row 27: both hooks import wait_stale from the same shared module.
+
+    Regression guard against duplicate-constant drift. If someone later
+    inlines the threshold into one hook, the two hooks could diverge on
+    staleness cutoff — this test pins that they import the same symbol.
+    """
+
+    def test_both_hooks_share_wait_stale_import(self):
+        """Same wait_stale object reached via both hook modules' import graphs."""
+        import teammate_idle
+        import teammate_completion_gate
+
+        # Both modules import the same function object
+        assert teammate_idle.wait_stale is teammate_completion_gate.wait_stale, (
+            "Row 27: hooks must share a single wait_stale — divergence creates "
+            "inconsistent staleness semantics across the parallel-fired hooks"
+        )
+
+    def test_shared_default_threshold_is_30(self):
+        """DEFAULT_THRESHOLD_MINUTES remains 30 (AC #1)."""
+        from shared.intentional_wait import DEFAULT_THRESHOLD_MINUTES
+        assert DEFAULT_THRESHOLD_MINUTES == 30
+
+
+class TestCompletionGateAsymmetryFix:
+    """Rows 28-30: completion_gate mirror-adds the type + stalled skips that
+    teammate_idle.py::detect_stall already honored (L122, L124).
+
+    Root cause preparer surfaced: _scan_owned_tasks nagged on tasks that
+    detect_stall silently skipped — cross-hook silencer asymmetry. These
+    tests pin the fix as load-bearing.
+    """
+
+    def test_type_blocker_is_skipped(self, tmp_path):
+        """Row 28: metadata.type='blocker' -> skip (no completable, no missing)."""
+        from teammate_completion_gate import _scan_owned_tasks
+
+        task_dir = _make_task_dir(tmp_path)
+        # No HANDOFF; pre-asymmetry-fix would surface this as missing_handoff
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress",
+                        {"type": "blocker"})
+        completable, missing = _scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        assert completable == [], "blocker-type task must not surface as completable"
+        assert missing == [], "blocker-type task must not surface as missing_handoff"
+
+    def test_type_algedonic_is_skipped(self, tmp_path):
+        """Row 29: metadata.type='algedonic' -> skip."""
+        from teammate_completion_gate import _scan_owned_tasks
+
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress",
+                        {"type": "algedonic"})
+        completable, missing = _scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        assert completable == []
+        assert missing == []
+
+    def test_stalled_true_is_skipped(self, tmp_path):
+        """Row 30: metadata.stalled=true -> skip."""
+        from teammate_completion_gate import _scan_owned_tasks
+
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress",
+                        {"stalled": True})
+        completable, missing = _scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        assert completable == []
+        assert missing == []
+
+    def test_stalled_true_with_handoff_also_skipped(self, tmp_path):
+        """Row 30 variant: stalled=true silences even when HANDOFF is present."""
+        from teammate_completion_gate import _scan_owned_tasks
+
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress",
+                        {"stalled": True, "handoff": VALID_HANDOFF})
+        completable, missing = _scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        assert completable == []
+        assert missing == []
+
+    def test_type_other_random_string_not_skipped(self, tmp_path):
+        """Guardrail: only 'blocker' and 'algedonic' are skip-types.
+
+        Arbitrary type values (including unrecognized ones) must NOT be
+        treated as silencers; otherwise a typo could silently disable
+        the gate.
+        """
+        from teammate_completion_gate import _scan_owned_tasks
+
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress",
+                        {"type": "handoff", "handoff": VALID_HANDOFF})
+        completable, missing = _scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        # type='handoff' is not a silencer; handoff is present -> completable
+        assert len(completable) == 1
+
+    def test_stalled_false_not_skipped(self, tmp_path):
+        """stalled=False (explicit) must not silence — only truthy value does."""
+        from teammate_completion_gate import _scan_owned_tasks
+
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress",
+                        {"stalled": False})
+        completable, missing = _scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        # stalled=False -> task surfaces as missing_handoff (no HANDOFF, no wait)
+        assert len(missing) == 1
+
+
+class TestDualHookParityAllFourSkips:
+    """Row 31: dual-hook parity across all four metadata-keyed skips.
+
+    Parametrized: for each of {type=blocker, type=algedonic, stalled=true,
+    intentional_wait=fresh}, both hooks must produce identical
+    suppress decisions. This is the structural enforcement of AC #6 at
+    the behavioral level — if one hook diverges from the other, a
+    teammate's idle event will see asymmetric nagging across the parallel
+    hook fires.
+
+    The test intentionally covers ONLY the silencing cases (fresh wait)
+    and the always-silence cases (blocker/algedonic/stalled); the parity
+    for non-silencing cases is implicit (both will nag).
+    """
+
+    @pytest.mark.parametrize("metadata_key,metadata_value", [
+        ("type_blocker", {"type": "blocker"}),
+        ("type_algedonic", {"type": "algedonic"}),
+        ("stalled_true", {"stalled": True}),
+        ("intentional_wait_fresh", {"intentional_wait": _fresh_wait_payload()}),
+    ])
+    def test_both_hooks_silence_for_metadata_skip(self, tmp_path,
+                                                   metadata_key, metadata_value):
+        """Both TeammateIdle hooks must suppress for each metadata-keyed skip."""
+        # completion_gate path
+        from teammate_completion_gate import _scan_owned_tasks
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress",
+                        metadata_value)
+        completable, missing = _scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        cg_silenced = (completable == [] and missing == [])
+
+        # idle hook path (via detect_stall on in-memory tasks)
+        from teammate_idle import detect_stall
+        tasks = [{
+            "id": "5",
+            "subject": "Task 5",
+            "status": "in_progress",
+            "owner": "backend-coder",
+            "metadata": metadata_value,
+        }]
+        idle_silenced = detect_stall(tasks, "backend-coder") is None
+
+        assert cg_silenced == idle_silenced, (
+            f"Dual-hook parity failure for {metadata_key}: "
+            f"completion_gate silenced={cg_silenced}, "
+            f"detect_stall silenced={idle_silenced}. AC #6 requires "
+            f"both hooks to produce identical suppress decisions for each "
+            f"metadata-keyed skip; divergence re-creates the cross-hook "
+            f"silencer asymmetry that #497 fixes."
+        )
+        # And specifically: they must BOTH silence
+        assert cg_silenced, (
+            f"{metadata_key} must silence completion_gate"
+        )
+        assert idle_silenced, (
+            f"{metadata_key} must silence detect_stall"
+        )
+
+    def test_nag_path_also_symmetric(self, tmp_path):
+        """Complement: missing-wait tasks nag in both hooks."""
+        from teammate_completion_gate import _scan_owned_tasks
+        from teammate_idle import detect_stall
+
+        task_dir = _make_task_dir(tmp_path)
+        _make_task_file(task_dir, "5", "backend-coder", "in_progress", {})
+        completable, missing = _scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        tasks = [{
+            "id": "5",
+            "subject": "Task 5",
+            "status": "in_progress",
+            "owner": "backend-coder",
+            "metadata": {},
+        }]
+        assert len(missing) == 1, "completion_gate must surface missing-handoff"
+        assert detect_stall(tasks, "backend-coder") is not None, (
+            "detect_stall must fire stall"
+        )

--- a/pact-plugin/tests/test_teammate_idle.py
+++ b/pact-plugin/tests/test_teammate_idle.py
@@ -800,3 +800,367 @@ class TestMainEdgeCases:
             msg = output.get("systemMessage", "")
             assert "ACTION REQUIRED" in msg
             assert "shutdown_request" in msg
+
+
+# =============================================================================
+# #497 — detect_stall honors metadata.intentional_wait
+# =============================================================================
+
+from datetime import datetime, timedelta, timezone
+
+
+def _iso_seconds(dt):
+    return dt.isoformat(timespec="seconds")
+
+
+def _fresh_wait_payload(reason="awaiting_teachback_approved",
+                       resolver="lead",
+                       since_offset_seconds=-60):
+    return {
+        "reason": reason,
+        "expected_resolver": resolver,
+        "since": _iso_seconds(
+            datetime.now(timezone.utc) + timedelta(seconds=since_offset_seconds)
+        ),
+    }
+
+
+class TestIntentionalWaitIdlePredicate:
+    """detect_stall honors a fresh intentional_wait and suppresses the nag.
+
+    Plan row 9 (fresh suppresses), row 10 (stale re-nags), row 11 (missing nags),
+    row 12 (ordering: type/stalled/intentional_wait all silence independently).
+    """
+
+    def test_fresh_intentional_wait_suppresses_stall(self):
+        """Row 9: in_progress + fresh intentional_wait -> no stall message."""
+        from teammate_idle import detect_stall
+
+        tasks = [make_task(
+            status="in_progress", owner="coder-a",
+            metadata={"intentional_wait": _fresh_wait_payload()}
+        )]
+        assert detect_stall(tasks, "coder-a") is None
+
+    def test_stale_intentional_wait_re_nags(self):
+        """Row 10: stale intentional_wait (age >= 30 min) -> stall fires."""
+        from teammate_idle import detect_stall
+
+        stale_since = datetime.now(timezone.utc) - timedelta(minutes=45)
+        tasks = [make_task(
+            status="in_progress", owner="coder-a",
+            metadata={"intentional_wait": {
+                "reason": "awaiting_teachback_approved",
+                "expected_resolver": "lead",
+                "since": _iso_seconds(stale_since),
+            }}
+        )]
+        result = detect_stall(tasks, "coder-a")
+        assert result is not None
+        assert "stall" in result.lower()
+
+    def test_missing_intentional_wait_nags(self):
+        """Row 11: no intentional_wait key at all -> stall fires (pre-fix path)."""
+        from teammate_idle import detect_stall
+
+        tasks = [make_task(
+            status="in_progress", owner="coder-a",
+            metadata={"other_key": "value"}
+        )]
+        result = detect_stall(tasks, "coder-a")
+        assert result is not None
+
+    def test_malformed_intentional_wait_fails_loud(self):
+        """Malformed intentional_wait (missing required keys) -> nag re-enables."""
+        from teammate_idle import detect_stall
+
+        tasks = [make_task(
+            status="in_progress", owner="coder-a",
+            metadata={"intentional_wait": {"reason": "x"}}  # missing resolver/since
+        )]
+        result = detect_stall(tasks, "coder-a")
+        assert result is not None, (
+            "Malformed flag must fail open to nag — not silently suppress"
+        )
+
+    def test_tz_naive_since_fails_loud(self):
+        """tz-naive since is always a bug -> nag re-enables."""
+        from teammate_idle import detect_stall
+
+        tasks = [make_task(
+            status="in_progress", owner="coder-a",
+            metadata={"intentional_wait": {
+                "reason": "awaiting_teachback_approved",
+                "expected_resolver": "lead",
+                "since": "2026-04-21T15:30:00",  # tz-naive
+            }}
+        )]
+        result = detect_stall(tasks, "coder-a")
+        assert result is not None
+
+    def test_future_since_is_not_stale(self):
+        """Future-dated since -> conservative not-stale; skip suppresses nag."""
+        from teammate_idle import detect_stall
+
+        future = datetime.now(timezone.utc) + timedelta(hours=2)
+        tasks = [make_task(
+            status="in_progress", owner="coder-a",
+            metadata={"intentional_wait": {
+                "reason": "awaiting_teachback_approved",
+                "expected_resolver": "lead",
+                "since": _iso_seconds(future),
+            }}
+        )]
+        assert detect_stall(tasks, "coder-a") is None
+
+    def test_intentional_wait_stale_at_exactly_30_min(self):
+        """Boundary: age == 30 min is stale per >= comparison."""
+        from teammate_idle import detect_stall
+
+        at_threshold = datetime.now(timezone.utc) - timedelta(minutes=30, seconds=1)
+        tasks = [make_task(
+            status="in_progress", owner="coder-a",
+            metadata={"intentional_wait": {
+                "reason": "awaiting_teachback_approved",
+                "expected_resolver": "lead",
+                "since": _iso_seconds(at_threshold),
+            }}
+        )]
+        result = detect_stall(tasks, "coder-a")
+        assert result is not None
+
+    def test_metadata_type_still_silences_independently(self):
+        """Row 12: type=blocker silences even when intentional_wait absent.
+
+        Verifies the three metadata-keyed skips remain independent after the
+        fix — each is sufficient on its own.
+        """
+        from teammate_idle import detect_stall
+
+        tasks = [make_task(
+            status="in_progress", owner="coder-a",
+            metadata={"type": "blocker"}
+        )]
+        assert detect_stall(tasks, "coder-a") is None
+
+    def test_stalled_flag_still_silences_independently(self):
+        """Row 12: metadata.stalled=true silences even when intentional_wait absent."""
+        from teammate_idle import detect_stall
+
+        tasks = [make_task(
+            status="in_progress", owner="coder-a",
+            metadata={"stalled": True}
+        )]
+        assert detect_stall(tasks, "coder-a") is None
+
+    def test_intentional_wait_silences_even_when_stalled_false(self):
+        """Regression: fresh intentional_wait silences even if stalled explicitly False."""
+        from teammate_idle import detect_stall
+
+        tasks = [make_task(
+            status="in_progress", owner="coder-a",
+            metadata={
+                "stalled": False,
+                "intentional_wait": _fresh_wait_payload(),
+            }
+        )]
+        assert detect_stall(tasks, "coder-a") is None
+
+
+class TestIntentionalWaitIdlePredicateCounterTest:
+    """Counter-test-by-revert documentation: these tests MUST fail if the
+    intentional_wait skip is removed from detect_stall. Asserts load-bearingness.
+
+    Not a counter-test themselves — they are the same tests as the class above
+    but structured as a single parametrized batch so the cardinality (tests that
+    flip RED under `git show HEAD~N:teammate_idle.py` revert) is legible in CI.
+    """
+
+    @pytest.mark.parametrize("since_offset_minutes,expected_stall", [
+        (-1, False),     # fresh -> no stall
+        (-15, False),    # mid-life -> no stall
+        (-29, False),    # just under threshold -> no stall
+        (-31, True),     # past threshold -> stall
+        (-60, True),     # way past -> stall
+    ])
+    def test_age_sweep_cardinality_pin(self, since_offset_minutes, expected_stall):
+        """Age sweep: -1/-15/-29 min fresh -> no stall; -31/-60 min stale -> stall.
+
+        5-test cardinality pin. Revert of intentional_wait skip flips 3 tests
+        (the fresh ones) RED; the 2 stale ones stay GREEN regardless.
+        """
+        from teammate_idle import detect_stall
+
+        since = datetime.now(timezone.utc) + timedelta(minutes=since_offset_minutes)
+        tasks = [make_task(
+            status="in_progress", owner="coder-a",
+            metadata={"intentional_wait": {
+                "reason": "awaiting_teachback_approved",
+                "expected_resolver": "lead",
+                "since": _iso_seconds(since),
+            }}
+        )]
+        result = detect_stall(tasks, "coder-a")
+        if expected_stall:
+            assert result is not None, f"offset {since_offset_minutes} min must nag"
+        else:
+            assert result is None, f"offset {since_offset_minutes} min must suppress"
+
+
+class TestIntentionalWaitConsultantModeUnchanged:
+    """Row 18: consultant-mode teammates (no owned in_progress task) are
+    unaffected by intentional_wait — predicate only fires on in_progress tasks.
+    """
+
+    def test_completed_task_with_wait_does_not_trigger_stall(self):
+        """Completed task + intentional_wait -> still not a stall (completed path)."""
+        from teammate_idle import detect_stall
+
+        tasks = [make_task(
+            status="completed", owner="coder-a",
+            metadata={"intentional_wait": _fresh_wait_payload()}
+        )]
+        assert detect_stall(tasks, "coder-a") is None
+
+    def test_no_owned_task_is_unchanged(self):
+        """No owned task -> no stall, intentional_wait is not even reached."""
+        from teammate_idle import detect_stall
+
+        tasks = [make_task(owner="other-coder")]
+        assert detect_stall(tasks, "coder-a") is None
+
+
+class TestIntentionalWaitAC9CheckIdleCleanupUnchanged:
+    """Row 21-22 (AC #9): check_idle_cleanup must be UNCHANGED by the fix.
+
+    Completed tasks with intentional_wait must still accumulate idle counts
+    and hit suggest/force thresholds exactly as before — consultants shouldn't
+    be given a stealth shutdown-immunity via the wait flag.
+    """
+
+    def test_completed_with_wait_accumulates_idle_count(self, tmp_path):
+        """AC #9: completed task + intentional_wait still increments idle count."""
+        from teammate_idle import check_idle_cleanup, read_idle_counts
+
+        counts_path = str(tmp_path / "idle_counts.json")
+        tasks = [make_task(
+            task_id="1", status="completed", owner="coder-a",
+            metadata={"intentional_wait": _fresh_wait_payload()}
+        )]
+        # 3 consecutive idles -> suggest threshold
+        for _ in range(3):
+            check_idle_cleanup(tasks, "coder-a", counts_path)
+        counts = read_idle_counts(counts_path)
+        entry = counts["coder-a"]
+        assert entry["count"] == 3, (
+            "AC #9: intentional_wait must NOT block idle-count accumulation "
+            "on completed tasks"
+        )
+
+    def test_completed_with_wait_hits_suggest_threshold(self, tmp_path):
+        """AC #9: suggest threshold still fires at count=3 for consultants."""
+        from teammate_idle import check_idle_cleanup, write_idle_counts
+
+        counts_path = str(tmp_path / "idle_counts.json")
+        write_idle_counts(counts_path, {"coder-a": 2})  # will become 3
+        tasks = [make_task(
+            status="completed", owner="coder-a",
+            metadata={"intentional_wait": _fresh_wait_payload()}
+        )]
+        msg, should_shutdown = check_idle_cleanup(tasks, "coder-a", counts_path)
+        assert msg is not None
+        assert "idle" in msg.lower()
+        assert should_shutdown is False
+
+    def test_completed_with_wait_hits_force_shutdown(self, tmp_path):
+        """AC #9: force shutdown at count=5 still fires — wait flag does not
+        bleed into cleanup logic."""
+        from teammate_idle import check_idle_cleanup, write_idle_counts
+
+        counts_path = str(tmp_path / "idle_counts.json")
+        write_idle_counts(counts_path, {"coder-a": 4})  # will become 5
+        tasks = [make_task(
+            status="completed", owner="coder-a",
+            metadata={"intentional_wait": _fresh_wait_payload()}
+        )]
+        msg, should_shutdown = check_idle_cleanup(tasks, "coder-a", counts_path)
+        assert should_shutdown is True
+
+    def test_stale_wait_on_completed_also_accumulates(self, tmp_path):
+        """AC #9 belt-and-suspenders: even a stale wait flag doesn't affect
+        cleanup on completed tasks.
+        """
+        from teammate_idle import check_idle_cleanup, read_idle_counts
+
+        counts_path = str(tmp_path / "idle_counts.json")
+        stale_since = datetime.now(timezone.utc) - timedelta(hours=2)
+        tasks = [make_task(
+            task_id="1", status="completed", owner="coder-a",
+            metadata={"intentional_wait": {
+                "reason": "awaiting_teachback_approved",
+                "expected_resolver": "lead",
+                "since": _iso_seconds(stale_since),
+            }}
+        )]
+        for _ in range(2):
+            check_idle_cleanup(tasks, "coder-a", counts_path)
+        counts = read_idle_counts(counts_path)
+        entry = counts["coder-a"]
+        assert entry["count"] == 2
+
+
+class TestIntentionalWaitMainIntegration:
+    """Row 25 precursor: main() produces no systemMessage for a teammate with
+    fresh intentional_wait on an in_progress task (livelock-loop root path).
+    """
+
+    def test_main_suppresses_nag_for_fresh_wait(self, capsys, tmp_path):
+        import io
+        from teammate_idle import main
+
+        tasks = [make_task(
+            status="in_progress", owner="coder-a",
+            metadata={"intentional_wait": _fresh_wait_payload()}
+        )]
+
+        with patch("teammate_idle.get_team_name", return_value="pact-test"), \
+             patch("sys.stdin", io.StringIO(json.dumps({"teammate_name": "coder-a"}))), \
+             patch("teammate_idle.get_task_list", return_value=tasks), \
+             patch("teammate_idle.Path.home", return_value=tmp_path):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        # Suppressed: no systemMessage
+        if captured.out.strip():
+            output = json.loads(captured.out)
+            assert "systemMessage" not in output, (
+                f"Expected suppressOutput for fresh wait, got: {output}"
+            )
+
+    def test_main_emits_nag_for_stale_wait(self, capsys, tmp_path):
+        import io
+        from teammate_idle import main
+
+        stale_since = datetime.now(timezone.utc) - timedelta(hours=2)
+        tasks = [make_task(
+            status="in_progress", owner="coder-a",
+            metadata={"intentional_wait": {
+                "reason": "awaiting_teachback_approved",
+                "expected_resolver": "lead",
+                "since": _iso_seconds(stale_since),
+            }}
+        )]
+
+        with patch("teammate_idle.get_team_name", return_value="pact-test"), \
+             patch("sys.stdin", io.StringIO(json.dumps({"teammate_name": "coder-a"}))), \
+             patch("teammate_idle.get_task_list", return_value=tasks), \
+             patch("teammate_idle.Path.home", return_value=tmp_path):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+        assert "stall" in output.get("systemMessage", "").lower()

--- a/pact-plugin/tests/test_teammate_idle_livelock_regression.py
+++ b/pact-plugin/tests/test_teammate_idle_livelock_regression.py
@@ -5,8 +5,9 @@ Plan row 25 / AC #10 — reproduces the multi-commit stage->notify->lead-commits
 workflow that produced 100+ Holding.-pattern nag loops in PR #477 round-8
 dogfooding. Asserts:
 
-  - Against pre-fix source (HEAD~N before bef7f24): the nag DOES fire on
-    every idle tick during a protocol-defined wait, demonstrating the bug.
+  - Against pre-fix source (SHA 1922c64, one commit before bef7f24): the
+    nag DOES fire on every idle tick during a protocol-defined wait,
+    demonstrating the bug.
   - Against current source (post-bef7f24/7ed354e): the nag is SUPPRESSED
     when intentional_wait is set, and re-enables only on staleness or
     flag-clear.
@@ -27,7 +28,7 @@ Harness shape (pytest-native, no tmp-worktree required):
   The pre-fix-loaded modules depend on `shared.*` modules; those resolve to
   the currently-checked-out versions via the existing hooks path on sys.path.
   This is safe because the shared modules did not change between pre-fix and
-  post-fix (verified: `git diff bef7f24~1 HEAD -- pact-plugin/hooks/shared/`
+  post-fix (verified: `git diff 1922c64 HEAD -- pact-plugin/hooks/shared/`
   only adds `shared/intentional_wait.py` — never a breaking edit to an
   existing shared module).
 
@@ -52,11 +53,18 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
-# Commit SHA immediately before bef7f24 — state of both TeammateIdle hooks
-# before the intentional_wait skips were added. git log --oneline on
-# pact-plugin/hooks/teammate_idle.py shows bef7f24 as the first fix commit
-# and the parent (87f3369) as the last pre-fix state.
-PRE_FIX_COMMIT = "bef7f24~1"
+# Absolute SHA of the last pre-fix state for both TeammateIdle hooks.
+# `1922c64` added shared/intentional_wait.py but did NOT yet modify either
+# hook to call it — so at this commit both hooks are in their pre-fix
+# shape (verified: `git show 1922c64:pact-plugin/hooks/teammate_{idle,
+# completion_gate}.py` contains neither "intentional_wait" nor "wait_stale"
+# nor the type/stalled metadata skips in completion_gate).
+#
+# SHA-pinned rather than relative (`1922c64`, `HEAD~N`) so the harness
+# survives history rewrites — a later squash or rebase that renumbers the
+# topology would silently change a relative reference; the SHA stays
+# valid as long as the object is reachable from any ref.
+PRE_FIX_COMMIT = "1922c64"
 
 
 def _iso_seconds(dt: datetime) -> str:
@@ -83,7 +91,7 @@ def _load_pre_fix_module(hook_name: str, tmp_path: Path) -> ModuleType:
     shared.* imports inside the pre-fix module resolve normally because
     (a) they are path-agnostic top-level imports and (b) the shared
     modules themselves were not breakingly changed between pre-fix and
-    post-fix (verified via `git diff bef7f24~1 HEAD -- hooks/shared/`).
+    post-fix (verified via `git diff 1922c64 HEAD -- hooks/shared/`).
     """
     repo_root = Path(__file__).parent.parent.parent
     relative_path = f"pact-plugin/hooks/{hook_name}.py"

--- a/pact-plugin/tests/test_teammate_idle_livelock_regression.py
+++ b/pact-plugin/tests/test_teammate_idle_livelock_regression.py
@@ -53,18 +53,20 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
-# Absolute SHA of the last pre-fix state for both TeammateIdle hooks.
-# `1922c64` added shared/intentional_wait.py but did NOT yet modify either
-# hook to call it — so at this commit both hooks are in their pre-fix
-# shape (verified: `git show 1922c64:pact-plugin/hooks/teammate_{idle,
-# completion_gate}.py` contains neither "intentional_wait" nor "wait_stale"
-# nor the type/stalled metadata skips in completion_gate).
+# Git ref to the pre-fix state of both TeammateIdle hooks. The tag
+# `test-fixture/pre-497-fix` is created pre-merge and pushed to origin,
+# pointing at SHA 1922c64 — the commit that added shared/intentional_wait.py
+# but did NOT yet modify either hook to call it. At that commit both hooks
+# are in their pre-fix shape (verified: `git show test-fixture/pre-497-fix:
+# pact-plugin/hooks/teammate_{idle,completion_gate}.py` contains neither
+# "intentional_wait" nor "wait_stale" nor the type/stalled metadata skips
+# in completion_gate).
 #
-# SHA-pinned rather than relative (`1922c64`, `HEAD~N`) so the harness
-# survives history rewrites — a later squash or rebase that renumbers the
-# topology would silently change a relative reference; the SHA stays
-# valid as long as the object is reachable from any ref.
-PRE_FIX_COMMIT = "1922c64"
+# Tag-pinned rather than SHA-pinned so the harness survives squash-merge:
+# if the PR squash-merges, commit 1922c64 becomes unreachable from main
+# and is eventually reclaimed — a bare SHA reference would then fail.
+# The tag keeps 1922c64 alive regardless of branch history changes.
+PRE_FIX_COMMIT = "test-fixture/pre-497-fix"
 
 
 def _iso_seconds(dt: datetime) -> str:

--- a/pact-plugin/tests/test_teammate_idle_livelock_regression.py
+++ b/pact-plugin/tests/test_teammate_idle_livelock_regression.py
@@ -115,6 +115,8 @@ def _load_pre_fix_module(hook_name: str, tmp_path: Path) -> ModuleType:
 
     module_name = f"{hook_name}_prefix_v497"
     spec = importlib.util.spec_from_file_location(module_name, str(pre_fix_file))
+    assert spec is not None, f"Failed to create module spec for {pre_fix_file}"
+    assert spec.loader is not None, f"Module spec has no loader for {pre_fix_file}"
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module

--- a/pact-plugin/tests/test_teammate_idle_livelock_regression.py
+++ b/pact-plugin/tests/test_teammate_idle_livelock_regression.py
@@ -1,0 +1,491 @@
+"""
+Dogfood regression harness for the #497 TeammateIdle livelock fix.
+
+Plan row 25 / AC #10 — reproduces the multi-commit stage->notify->lead-commits
+workflow that produced 100+ Holding.-pattern nag loops in PR #477 round-8
+dogfooding. Asserts:
+
+  - Against pre-fix source (HEAD~N before bef7f24): the nag DOES fire on
+    every idle tick during a protocol-defined wait, demonstrating the bug.
+  - Against current source (post-bef7f24/7ed354e): the nag is SUPPRESSED
+    when intentional_wait is set, and re-enables only on staleness or
+    flag-clear.
+
+Coverage of the three livelock phases from #497 issue body:
+  - pre-work:  teachback gate (awaiting teachback_approved)
+  - mid-work:  inter-commit gate (awaiting lead_commit after stage-ready notify)
+  - post-work: final-hold gate (awaiting post_handoff_decision)
+
+Harness shape (pytest-native, no tmp-worktree required):
+
+  Pre-fix hook modules are obtained via `git show <pre-fix-commit>:<path>`,
+  written to tempfiles, and loaded with `importlib.util.spec_from_file_location`
+  under a unique module name so they coexist with the currently-imported
+  (post-fix) modules. This lets a single test run both variants and compare
+  their behavior side-by-side — no filesystem side effects, no worktree churn.
+
+  The pre-fix-loaded modules depend on `shared.*` modules; those resolve to
+  the currently-checked-out versions via the existing hooks path on sys.path.
+  This is safe because the shared modules did not change between pre-fix and
+  post-fix (verified: `git diff bef7f24~1 HEAD -- pact-plugin/hooks/shared/`
+  only adds `shared/intentional_wait.py` — never a breaking edit to an
+  existing shared module).
+
+Counter-claim defense: without the pre-fix variant loaded, a harness that
+only exercises the current source cannot distinguish "bug absent because
+fix works" from "bug absent because test setup doesn't reach the bug path."
+Loading pre-fix source and asserting the bug DOES reproduce there pins
+harness validity.
+"""
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+# --- setup -----------------------------------------------------------------
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+# Commit SHA immediately before bef7f24 — state of both TeammateIdle hooks
+# before the intentional_wait skips were added. git log --oneline on
+# pact-plugin/hooks/teammate_idle.py shows bef7f24 as the first fix commit
+# and the parent (87f3369) as the last pre-fix state.
+PRE_FIX_COMMIT = "bef7f24~1"
+
+
+def _iso_seconds(dt: datetime) -> str:
+    return dt.isoformat(timespec="seconds")
+
+
+def _fresh_wait(reason: str = "awaiting_teachback_approved",
+                resolver: str = "lead",
+                seconds_ago: int = 60) -> dict:
+    return {
+        "reason": reason,
+        "expected_resolver": resolver,
+        "since": _iso_seconds(datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)),
+    }
+
+
+def _load_pre_fix_module(hook_name: str, tmp_path: Path) -> ModuleType:
+    """Materialize pre-fix hook source into a loadable module.
+
+    Uses `git show <pre-fix-commit>:<path>` to read the old source, writes
+    it to tmp_path, and loads it under a unique module name so it doesn't
+    shadow the currently-imported post-fix module.
+
+    shared.* imports inside the pre-fix module resolve normally because
+    (a) they are path-agnostic top-level imports and (b) the shared
+    modules themselves were not breakingly changed between pre-fix and
+    post-fix (verified via `git diff bef7f24~1 HEAD -- hooks/shared/`).
+    """
+    repo_root = Path(__file__).parent.parent.parent
+    relative_path = f"pact-plugin/hooks/{hook_name}.py"
+    result = subprocess.run(
+        ["git", "show", f"{PRE_FIX_COMMIT}:{relative_path}"],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    pre_fix_src = result.stdout
+    assert pre_fix_src, f"pre-fix source for {hook_name} is empty"
+    # Structural precondition: pre-fix source must lack the intentional_wait skip
+    assert "intentional_wait" not in pre_fix_src, (
+        f"PRE_FIX_COMMIT ({PRE_FIX_COMMIT}) is not actually pre-fix — "
+        f"intentional_wait appears in source. Check commit history."
+    )
+
+    pre_fix_file = tmp_path / f"{hook_name}_prefix.py"
+    pre_fix_file.write_text(pre_fix_src, encoding="utf-8")
+
+    module_name = f"{hook_name}_prefix_v497"
+    spec = importlib.util.spec_from_file_location(module_name, str(pre_fix_file))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_in_progress_task(owner: str = "coder-a",
+                           task_id: str = "5",
+                           subject: str = "CODE: auth",
+                           metadata: dict | None = None) -> dict:
+    return {
+        "id": task_id,
+        "subject": subject,
+        "status": "in_progress",
+        "owner": owner,
+        "metadata": metadata or {},
+    }
+
+
+# --- pre-fix bug reproduction ---------------------------------------------
+
+class TestLivelockReproducesOnPreFixSource:
+    """Asserts the bug DOES fire on pre-fix source. If these tests do NOT
+    fail on pre-fix, the harness is not actually reaching the bug path and
+    all post-fix assertions are phantom-green."""
+
+    def test_pre_fix_detect_stall_nags_on_in_progress_idle(self, tmp_path):
+        """Pre-fix: in_progress + idle -> nag (no suppression)."""
+        mod = _load_pre_fix_module("teammate_idle", tmp_path)
+        tasks = [_make_in_progress_task()]
+        result = mod.detect_stall(tasks, "coder-a")
+        assert result is not None
+        assert "stall" in result.lower()
+
+    def test_pre_fix_nags_even_with_intentional_wait_set(self, tmp_path):
+        """Pre-fix root-cause demonstration: intentional_wait is ignored,
+        so the nag fires despite the flag — this is the livelock."""
+        mod = _load_pre_fix_module("teammate_idle", tmp_path)
+        tasks = [_make_in_progress_task(metadata={
+            "intentional_wait": _fresh_wait(),
+        })]
+        result = mod.detect_stall(tasks, "coder-a")
+        assert result is not None, (
+            "Pre-fix source must nag even with intentional_wait set — "
+            "that's the #497 bug. If this assertion fails, the harness is "
+            "not reaching the pre-fix code path."
+        )
+        assert "stall" in result.lower()
+
+    def test_pre_fix_completion_gate_scans_idle_task_as_missing_handoff(self, tmp_path):
+        """Pre-fix completion_gate also ignores intentional_wait, surfacing
+        the task as missing_handoff on every idle tick."""
+        mod = _load_pre_fix_module("teammate_completion_gate", tmp_path)
+        team_dir = tmp_path / ".claude" / "tasks" / "pact-test"
+        team_dir.mkdir(parents=True)
+        task = _make_in_progress_task(owner="backend-coder")
+        task["metadata"] = {"intentional_wait": _fresh_wait()}
+        (team_dir / "5.json").write_text(json.dumps(task))
+
+        completable, missing = mod._scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        assert len(missing) == 1, (
+            "Pre-fix completion_gate must surface the task as missing_handoff "
+            "despite intentional_wait — that's the livelock second hook."
+        )
+
+    def test_pre_fix_nags_across_10_idle_ticks(self, tmp_path):
+        """Pre-fix: repeat detect_stall 10 times for the same task — every
+        call returns a nag. This is the shape of the 100+ holding-pattern
+        loop observed in PR #477 dogfooding."""
+        mod = _load_pre_fix_module("teammate_idle", tmp_path)
+        tasks = [_make_in_progress_task(metadata={
+            "intentional_wait": _fresh_wait(),
+        })]
+        nags = [mod.detect_stall(tasks, "coder-a") for _ in range(10)]
+        assert all(n is not None for n in nags), (
+            "Pre-fix reproduction: all 10 idle ticks produce a nag message. "
+            "That is the livelock."
+        )
+
+
+# --- current source (fix applied) -----------------------------------------
+
+class TestLivelockFixedOnCurrentSource:
+    """Asserts the bug does NOT fire on current source with intentional_wait
+    set. Paired with the pre-fix reproduction tests above — both must pass
+    for the harness to be considered valid proof of the fix.
+
+    Covers the three livelock phases from the #497 issue body:
+    pre-work (teachback), mid-work (inter-commit), post-work (final-hold).
+    """
+
+    def test_pre_work_teachback_wait_suppresses_across_10_ticks(self):
+        """Phase 1 — pre-work: teammate awaiting teachback_approved. 10 idle
+        ticks, zero nags."""
+        from teammate_idle import detect_stall
+        tasks = [_make_in_progress_task(metadata={
+            "intentional_wait": _fresh_wait(
+                reason="awaiting_teachback_approved",
+                resolver="lead",
+            ),
+        })]
+        nags = [detect_stall(tasks, "coder-a") for _ in range(10)]
+        assert all(n is None for n in nags), (
+            f"Phase 1 (teachback wait) livelock fixed: expected 0 nags, "
+            f"got {sum(1 for n in nags if n is not None)}"
+        )
+
+    def test_mid_work_inter_commit_wait_suppresses_across_10_ticks(self):
+        """Phase 2 — mid-work: teammate staged work, notified lead, awaiting
+        commit before next stage. 10 idle ticks, zero nags."""
+        from teammate_idle import detect_stall
+        tasks = [_make_in_progress_task(metadata={
+            "intentional_wait": _fresh_wait(
+                reason="awaiting_lead_commit",
+                resolver="lead",
+            ),
+        })]
+        nags = [detect_stall(tasks, "coder-a") for _ in range(10)]
+        assert all(n is None for n in nags)
+
+    def test_post_work_final_hold_suppresses_across_10_ticks(self):
+        """Phase 3 — post-work: HANDOFF stored, awaiting lead's final
+        decision before TaskUpdate(status=completed). 10 idle ticks,
+        zero nags, even though HANDOFF is present (completable branch)."""
+        from teammate_idle import detect_stall
+        tasks = [_make_in_progress_task(metadata={
+            "handoff": {
+                "produced": ["x.py"], "decisions": ["y"],
+                "uncertainty": [], "integration": [], "open_questions": [],
+            },
+            "intentional_wait": _fresh_wait(
+                reason="awaiting_post_handoff_decision",
+                resolver="lead",
+            ),
+        })]
+        nags = [detect_stall(tasks, "coder-a") for _ in range(10)]
+        assert all(n is None for n in nags)
+
+    def test_completion_gate_suppresses_missing_handoff_branch(self, tmp_path):
+        """Phase 1+2 via completion_gate: idle teammate with intentional_wait
+        but no HANDOFF yet — the missing_handoff branch that drove the
+        second livelock hook — now suppresses."""
+        from teammate_completion_gate import _scan_owned_tasks
+        team_dir = tmp_path / ".claude" / "tasks" / "pact-test"
+        team_dir.mkdir(parents=True)
+        task = _make_in_progress_task(owner="backend-coder")
+        task["metadata"] = {"intentional_wait": _fresh_wait()}
+        (team_dir / "5.json").write_text(json.dumps(task))
+
+        for _ in range(10):
+            completable, missing = _scan_owned_tasks(
+                "backend-coder", "pact-test",
+                tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+            )
+            assert completable == []
+            assert missing == []
+
+    def test_completion_gate_suppresses_completable_branch(self, tmp_path):
+        """Phase 3 via completion_gate: HANDOFF present + wait set — the
+        completable branch that fires "agent forgot to self-complete" nag —
+        now suppresses."""
+        from teammate_completion_gate import _scan_owned_tasks
+        team_dir = tmp_path / ".claude" / "tasks" / "pact-test"
+        team_dir.mkdir(parents=True)
+        task = _make_in_progress_task(owner="backend-coder")
+        task["metadata"] = {
+            "handoff": {
+                "produced": ["x.py"], "decisions": ["y"],
+                "uncertainty": [], "integration": [], "open_questions": [],
+            },
+            "intentional_wait": _fresh_wait(
+                reason="awaiting_post_handoff_decision",
+            ),
+        }
+        (team_dir / "5.json").write_text(json.dumps(task))
+
+        for _ in range(10):
+            completable, missing = _scan_owned_tasks(
+                "backend-coder", "pact-test",
+                tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+            )
+            assert completable == []
+            assert missing == []
+
+
+# --- multi-commit amendment-review cycle ----------------------------------
+
+class TestMultiCommitAmendmentCycleHasNoLivelock:
+    """Simulates the full PR #477 cycle-8-style workflow:
+
+      1. Teammate stages commit A, notifies lead, sets awaiting_lead_commit.
+      2. Lead commits A, teammate CLEARs wait, stages commit B, notifies
+         lead, sets awaiting_lead_commit.
+      3. Reviewer flags amendment needed, teammate sets
+         awaiting_amendment_review, stages amendment, notifies lead.
+      4. Lead commits amendment, teammate CLEARs wait.
+
+    Asserts: at every idle tick across this 4-phase workflow, both
+    TeammateIdle hooks produce zero nags when intentional_wait is fresh.
+    """
+
+    def _detect_both(self, tasks, owner, task_dir_path):
+        """Invoke both TeammateIdle hooks for a given task set + owner."""
+        from teammate_idle import detect_stall
+        from teammate_completion_gate import _scan_owned_tasks
+
+        idle_result = detect_stall(tasks, owner)
+        # _scan_owned_tasks reads from disk; persist the task for it
+        for t in tasks:
+            (Path(task_dir_path) / f"{t['id']}.json").write_text(
+                json.dumps(t), encoding="utf-8"
+            )
+        completable, missing = _scan_owned_tasks(
+            owner, "pact-test", tasks_base_dir=str(Path(task_dir_path).parent),
+        )
+        return idle_result, completable, missing
+
+    def test_full_cycle_zero_nags(self, tmp_path):
+        team_dir = tmp_path / ".claude" / "tasks" / "pact-test"
+        team_dir.mkdir(parents=True)
+
+        # --- Phase 1: stage A, await lead commit ---
+        task = _make_in_progress_task(owner="coder-a", task_id="5")
+        task["metadata"] = {
+            "intentional_wait": _fresh_wait(reason="awaiting_lead_commit"),
+        }
+        tasks = [task]
+
+        for _ in range(5):
+            idle, completable, missing = self._detect_both(tasks, "coder-a",
+                                                            str(team_dir))
+            assert idle is None, "Phase 1: detect_stall must suppress"
+            assert completable == [] and missing == [], \
+                "Phase 1: completion_gate must suppress"
+
+        # --- Phase 2: lead commits A; teammate clears wait, stages B ---
+        task["metadata"] = {
+            "intentional_wait": _fresh_wait(reason="awaiting_lead_commit"),
+        }
+        tasks = [task]
+        for _ in range(5):
+            idle, completable, missing = self._detect_both(tasks, "coder-a",
+                                                            str(team_dir))
+            assert idle is None
+            assert completable == [] and missing == []
+
+        # --- Phase 3: reviewer flags amendment, teammate sets
+        # awaiting_amendment_review, stages amendment ---
+        task["metadata"] = {
+            "intentional_wait": _fresh_wait(
+                reason="awaiting_amendment_review",
+                resolver="peer",
+            ),
+        }
+        tasks = [task]
+        for _ in range(5):
+            idle, completable, missing = self._detect_both(tasks, "coder-a",
+                                                            str(team_dir))
+            assert idle is None
+            assert completable == [] and missing == []
+
+        # --- Phase 4: amendment committed; teammate has HANDOFF + wait
+        # (awaiting_post_handoff_decision) ---
+        task["metadata"] = {
+            "handoff": {
+                "produced": ["a.py"], "decisions": ["pat"],
+                "uncertainty": [], "integration": [], "open_questions": [],
+            },
+            "intentional_wait": _fresh_wait(
+                reason="awaiting_post_handoff_decision",
+            ),
+        }
+        tasks = [task]
+        for _ in range(5):
+            idle, completable, missing = self._detect_both(tasks, "coder-a",
+                                                            str(team_dir))
+            assert idle is None
+            assert completable == [] and missing == []
+
+
+# --- threshold boundary (staleness re-enables nag) ------------------------
+
+class TestStaleWaitRestoresNagAsSafetyValve:
+    """Belt-and-suspenders: if a teammate forgets to CLEAR their wait after
+    state advancement, the 30-min staleness threshold re-enables the nag.
+    This prevents a "set once and forget" failure mode from producing a
+    silent permanent-wait state."""
+
+    def test_stale_wait_re_enables_nag_on_detect_stall(self):
+        from teammate_idle import detect_stall
+
+        stale_since = datetime.now(timezone.utc) - timedelta(minutes=45)
+        tasks = [_make_in_progress_task(metadata={
+            "intentional_wait": {
+                "reason": "awaiting_teachback_approved",
+                "expected_resolver": "lead",
+                "since": _iso_seconds(stale_since),
+            }
+        })]
+        for _ in range(3):
+            result = detect_stall(tasks, "coder-a")
+            assert result is not None, (
+                "Stale wait safety valve: nag must re-enable after "
+                "threshold expires, preventing silent permanent waits."
+            )
+
+    def test_stale_wait_surfaces_in_completion_gate(self, tmp_path):
+        from teammate_completion_gate import _scan_owned_tasks
+
+        team_dir = tmp_path / ".claude" / "tasks" / "pact-test"
+        team_dir.mkdir(parents=True)
+        stale_since = datetime.now(timezone.utc) - timedelta(minutes=45)
+        task = _make_in_progress_task(owner="backend-coder")
+        task["metadata"] = {"intentional_wait": {
+            "reason": "awaiting_teachback_approved",
+            "expected_resolver": "lead",
+            "since": _iso_seconds(stale_since),
+        }}
+        (team_dir / "5.json").write_text(json.dumps(task))
+
+        completable, missing = _scan_owned_tasks(
+            "backend-coder", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        assert len(missing) == 1, (
+            "Stale wait must surface in completion_gate too — both hooks "
+            "must consult staleness symmetrically."
+        )
+
+
+# --- dual-hook behavioral parity under livelock shapes --------------------
+
+class TestDualHookParityUnderLivelockShapes:
+    """Sibling of test_teammate_completion_gate.py::TestDualHookParityAllFourSkips
+    — but focused on the specific shapes that produced the PR #477 livelock.
+    Each shape must either silence BOTH hooks or fire on BOTH (never split).
+    """
+
+    @pytest.mark.parametrize("phase_label,metadata", [
+        ("pre_work_teachback", {
+            "intentional_wait": _fresh_wait(reason="awaiting_teachback_approved"),
+        }),
+        ("mid_work_inter_commit", {
+            "intentional_wait": _fresh_wait(reason="awaiting_lead_commit"),
+        }),
+        ("post_work_amendment", {
+            "intentional_wait": _fresh_wait(reason="awaiting_amendment_review",
+                                            resolver="peer"),
+        }),
+        ("post_work_final_hold", {
+            "handoff": {
+                "produced": ["x.py"], "decisions": ["y"],
+                "uncertainty": [], "integration": [], "open_questions": [],
+            },
+            "intentional_wait": _fresh_wait(
+                reason="awaiting_post_handoff_decision"),
+        }),
+    ])
+    def test_both_hooks_silence_for_phase(self, tmp_path, phase_label, metadata):
+        from teammate_idle import detect_stall
+        from teammate_completion_gate import _scan_owned_tasks
+
+        team_dir = tmp_path / ".claude" / "tasks" / "pact-test"
+        team_dir.mkdir(parents=True)
+        task = _make_in_progress_task(owner="coder-a")
+        task["metadata"] = metadata
+        (team_dir / "5.json").write_text(json.dumps(task))
+
+        idle_silenced = detect_stall([task], "coder-a") is None
+        completable, missing = _scan_owned_tasks(
+            "coder-a", "pact-test",
+            tasks_base_dir=str(tmp_path / ".claude" / "tasks"),
+        )
+        cg_silenced = (completable == [] and missing == [])
+
+        assert idle_silenced, f"Phase {phase_label}: detect_stall must silence"
+        assert cg_silenced, f"Phase {phase_label}: completion_gate must silence"
+        assert idle_silenced == cg_silenced, (
+            f"Phase {phase_label}: dual-hook parity violation"
+        )


### PR DESCRIPTION
## Summary

Fixes the TeammateIdle nag-loop livelock (#497) that blocked normal lead↔teammate message flow during protocol-defined wait states. Introduces the `intentional_wait` metadata primitive + `wait_stale()` helper that both TeammateIdle hooks honor, while also back-filling the pre-existing silencer asymmetry (`type` + `stalled` skips missing from `teammate_completion_gate.py`).

## Root cause

Both TeammateIdle hooks conflated *stuck teammate* with *waiting teammate* — nagging both identically, which consumed the idle slot teammates need for inbox delivery. Bug was self-sustaining: nag → teammate responds → not idle → inbox doesn't deliver lead's resolving message → nag → repeat.

## What changed (6 commits)

| SHA | Scope |
|---|---|
| `1922c64` | feat: `shared/intentional_wait.py` helper + 34 unit tests |
| `bef7f24` | fix: both hooks honor `intentional_wait` skip |
| `b17a6a6` | feat: Part 2b protocol instrumentation (skills + command templates) |
| `7ed354e` | fix: add missing `type`+`stalled` asymmetry mirror-add skips (corrects bef7f24 mis-attestation caught in TEST phase) |
| `3eff3e0` | test: hook integration + AC regression + asymmetry parity (52 tests) |
| `ae0ae8e` | test: dogfood regression harness (16 tests, pre-fix-source reproduction via importlib) |

## Acceptance Criteria (from #497)

- [x] AC #1: teammate with `intentional_wait` remains `in_progress`+idle > 30 min without repeat nags from either hook
- [x] AC #2: lead/peer/user messages delivered on next teammate turn (validated via regression harness)
- [x] AC #3: genuinely stuck teammate (no wait set) still nagged
- [x] AC #4: consultant-mode teammates (no owned `in_progress` task) unaffected
- [x] AC #5: staleness safeguard fires after 30-min threshold — test coverage in both hooks
- [x] AC #6: both hook predicate changes land in one commit (`bef7f24`; structural gate at commit level)
- [x] AC #7: Part 2b instrumentation ships with Option 1 (`b17a6a6`) — Option 1 does not ship alone
- [x] AC #8: `handoff_gate` completion-blocking independent of `intentional_wait` (regression tests)
- [x] AC #9: `check_idle_cleanup` unchanged (regression tests + bytewise verification)
- [x] AC #10: dogfood regression harness fails pre-fix, passes post-fix
- [x] AC #11: `blockedBy` verified — grep returned zero hits in both hooks; fix is Option-1-only; `blockedBy`-native path deferred per plan §7.1
- [x] AC #12: documented — Option 1 primary + Part 2b; no `blockedBy`-native for lead-resolver waits

## Testing

- Full plugin suite: **6527 passed, 3 skipped, 0 failed** (was 6448 on main; +79 new tests)
- Counter-test-by-revert verified: all fresh-wait idle tests flip RED against pre-intentional_wait source; all asymmetry + parity tests flip RED against pre-mirror-add source. (Narrative form instead of numeric labels so the invariant is stable under future test additions.)
- Dogfood regression harness loads pre-fix hook source via `importlib` + `git show bef7f24~1`, asserts bug DOES fire pre-fix (harness-validity gate) and DOES NOT fire post-fix

## Related

- Plan: `docs/plans/fix-teammate-idle-livelock-plan.md` (IMPLEMENTED)
- Preparation: `docs/preparation/fix-teammate-idle-livelock.md`
- Architecture: `docs/architecture/fix-teammate-idle-livelock.md`
- Follow-up issue filed: #500 (plugin-cache visibility gap observed during in-session dogfooding)

## Test plan

- [x] Unit tests for `wait_stale` / `validate_wait` / `canonical_since` (34 cases)
- [x] Hook integration tests (fresh/stale/missing × both hooks)
- [x] AC #8 regression: empty HANDOFF + `intentional_wait` still blocked by `handoff_gate`
- [x] AC #9 regression: `check_idle_cleanup` accumulates idle counts for completed tasks
- [x] Asymmetry parity: all 3 metadata skips honored identically by both hooks
- [x] Dogfood regression: multi-commit amendment cycle with zero nags across 20 idle ticks
- [x] Staleness safety valve: nag restored after 30-min threshold in both hooks
