### PR TITLE
fix(#529): symmetrize pin_caps_gate Edit/Write smuggle detection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "3.18.0",
+      "version": "3.18.1",
       "author": {
         "name": "ProfSynapse"
       },

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-marketplace/
 │           └── PACT/
-│               └── 3.18.0/    # Plugin version
+│               └── 3.18.1/    # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "ProfSynapse",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 3.18.0
+> **Version**: 3.18.1
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/pin_caps_gate.py
+++ b/pact-plugin/hooks/pin_caps_gate.py
@@ -353,14 +353,12 @@ def _extract_new_body(
     mutated pin whose BODY contains a `### ` heading (smuggling an extra
     pin past the count cap on reload).
 
-    For Edit (`new_string` present): return `new_string`, the fragment
-    being INSERTED. `compute_deny_reason` scans it via parse_pins; any
-    `### ` inside denies with DENY_REASON_EMBEDDED_PIN.
-
-    For Write (full-file replacement, #492 F7 — security-engineer-1
-    MEDIUM): legitimate CLAUDE.md content contains pin headings by
-    construction, so scanning the whole payload would reject every
-    Write. The defense operates at the PARSED post_pins level instead:
+    Both Write (full-file replacement, #492 F7 — security-engineer-1
+    MEDIUM) and Edit (#529) use the SAME pre/post post_pins diff when
+    pre_pins and post_pins are both available. Legitimate CLAUDE.md
+    content contains pin headings by construction, so scanning the raw
+    payload (Write: full content; Edit: new_string) would reject every
+    legitimate add. The defense operates at the PARSED post_pins level:
 
     Synthesize a synthetic "### H" heading line for each post_pin that
     BOTH (1) is not present in pre_pins by heading AND (2) lacks a
@@ -380,12 +378,14 @@ def _extract_new_body(
     pin from a prior manual edit) are excluded via the heading-in-pre
     check — pre-malformed state never denies (F1 livelock precedent).
 
-    If pre_pins or post_pins is None (e.g., fallback path), return "" —
-    caller's semantic is unchanged.
+    Edit fallback: if pre_pins or post_pins is None (error path before
+    simulation succeeded), fall through to the naive `new_string`-as-body
+    check to preserve conservative deny behavior.
+
+    Write fallback: if pre_pins or post_pins is None on Write, return ""
+    — scanning full content with naive logic would reject every Write.
     """
-    if "content" in tool_input:
-        if pre_pins is None or post_pins is None:
-            return ""
+    if pre_pins is not None and post_pins is not None:
         pre_headings = {p.heading for p in pre_pins}
         # A smuggle signal: post pin whose heading is NEW AND carries no
         # date-comment marker. Surface it by synthesizing the heading line
@@ -400,6 +400,9 @@ def _extract_new_body(
             return ""
         # Join with newlines so parse_pins treats each as its own line.
         return "\n".join(f"{h}\nsmuggled body marker\n" for h in smuggle_headings)
+
+    if "content" in tool_input:
+        return ""
     new_string = tool_input.get("new_string", "")
     return new_string if isinstance(new_string, str) else ""
 

--- a/pact-plugin/hooks/pin_caps_gate.py
+++ b/pact-plugin/hooks/pin_caps_gate.py
@@ -291,9 +291,9 @@ def _check_tool_allowed(input_data: dict) -> Optional[str]:
         return None
 
     # Net-worse predicate over pre/post pins + embedded-pin check on body.
-    # For Write, pass pre/post_pins so _extract_new_body can derive the
-    # new-or-mutated-body concatenation (#492 F7). For Edit, pre/post
-    # are ignored; the Edit path uses new_string verbatim.
+    # _extract_new_body uses pre/post_pins (when available) to synthesize
+    # a smuggle-heading body identically for Write and Edit (#529); see
+    # its docstring for the fallback hierarchy.
     new_body = _extract_new_body(
         tool_input, pre_pins=pre_pins, post_pins=post_pins
     )
@@ -354,11 +354,12 @@ def _extract_new_body(
     pin past the count cap on reload).
 
     Both Write (full-file replacement, #492 F7 — security-engineer-1
-    MEDIUM) and Edit (#529) use the SAME pre/post post_pins diff when
-    pre_pins and post_pins are both available. Legitimate CLAUDE.md
-    content contains pin headings by construction, so scanning the raw
-    payload (Write: full content; Edit: new_string) would reject every
-    legitimate add. The defense operates at the PARSED post_pins level:
+    MEDIUM) and Edit (#529) use the SAME pre-vs-post heading diff on
+    parsed pins when pre_pins and post_pins are both available.
+    Legitimate CLAUDE.md content contains pin headings by construction,
+    so scanning the raw payload (Write: full content; Edit: new_string)
+    would reject every legitimate add. The defense operates at the
+    PARSED post_pins level:
 
     Synthesize a synthetic "### H" heading line for each post_pin that
     BOTH (1) is not present in pre_pins by heading AND (2) lacks a
@@ -378,12 +379,18 @@ def _extract_new_body(
     pin from a prior manual edit) are excluded via the heading-in-pre
     check — pre-malformed state never denies (F1 livelock precedent).
 
-    Edit fallback: if pre_pins or post_pins is None (error path before
-    simulation succeeded), fall through to the naive `new_string`-as-body
-    check to preserve conservative deny behavior.
-
-    Write fallback: if pre_pins or post_pins is None on Write, return ""
-    — scanning full content with naive logic would reject every Write.
+    Fallback contract — signature-level defense only. No production path
+    reaches the helper with `pre_pins=None` or `post_pins=None`: the sole
+    caller `_check_tool_allowed` computes both via `_parse_baseline` and
+    `apply_edit_and_parse`, each of which either returns a list or raises
+    an exception the caller catches with an early `return None` before
+    reaching this helper. The `Optional[list] = None` defaults exist so
+    a future direct test probe that omits pins gets a safe, deterministic
+    result rather than a TypeError:
+      - Edit fallback: fall through to naive `new_string`-as-body check
+        (pre-#529 conservative deny shape).
+      - Write fallback: return "" (scanning full content with naive logic
+        would reject every Write by construction).
     """
     if pre_pins is not None and post_pins is not None:
         pre_headings = {p.heading for p in pre_pins}

--- a/pact-plugin/tests/test_pin_caps_gate.py
+++ b/pact-plugin/tests/test_pin_caps_gate.py
@@ -305,13 +305,18 @@ class TestPinCapsGate_Smoke:
     def test_edit_legitimate_new_pin_with_date_comment_allows(
         self, caps_gate_env
     ):
-        """#529: an Edit that adds a legitimate new pin (date-comment marker
-        + `### Title` + body, no embedded `### ` inside the body) must be
-        ALLOWED. The Edit-path smuggle-detection must mirror the Write path
-        and distinguish legitimate date-marked adds from naked-heading
-        smuggles — pre-fix, the Edit branch of `_extract_new_body` returned
-        `new_string` verbatim, so compute_deny_reason's `parse_pins(new_body)`
-        check flagged the `### Title` and denied every new-pin Edit.
+        """Guards against #529 regression (PR #530): pre-fix the Edit path
+        fell through to naive `return new_string`, so every date-marked
+        new-pin Edit denied via `DENY_REASON_EMBEDDED_PIN`. Post-fix the
+        Edit path mirrors Write via the pre/post-pin diff: legitimate adds
+        (carrying a `<!-- pinned: YYYY-MM-DD -->` marker) ALLOW; naked
+        smuggles deny.
+
+        An Edit that adds a legitimate new pin (date-comment marker +
+        `### Title` + body, no embedded `### ` inside the body) must be
+        ALLOWED. The Edit-path smuggle-detection must mirror the Write
+        path and distinguish legitimate date-marked adds from naked-heading
+        smuggles.
 
         This is the documented `/PACT:pin-memory` Add flow: Read CLAUDE.md,
         insert `<!-- pinned: YYYY-MM-DD -->` + `### Entry Title` + body via

--- a/pact-plugin/tests/test_pin_caps_gate.py
+++ b/pact-plugin/tests/test_pin_caps_gate.py
@@ -302,6 +302,73 @@ class TestPinCapsGate_Smoke:
             })
         assert result is None
 
+    def test_edit_legitimate_new_pin_with_date_comment_allows(
+        self, caps_gate_env
+    ):
+        """#529: an Edit that adds a legitimate new pin (date-comment marker
+        + `### Title` + body, no embedded `### ` inside the body) must be
+        ALLOWED. The Edit-path smuggle-detection must mirror the Write path
+        and distinguish legitimate date-marked adds from naked-heading
+        smuggles — pre-fix, the Edit branch of `_extract_new_body` returned
+        `new_string` verbatim, so compute_deny_reason's `parse_pins(new_body)`
+        check flagged the `### Title` and denied every new-pin Edit.
+
+        This is the documented `/PACT:pin-memory` Add flow: Read CLAUDE.md,
+        insert `<!-- pinned: YYYY-MM-DD -->` + `### Entry Title` + body via
+        Edit, commit. Pre-fix this flow was structurally broken.
+        """
+        env = caps_gate_env(pin_count=3)  # baseline has 3 clean pins, well under 12
+        new_pin_block = (
+            "<!-- pinned: 2026-04-23 -->\n"
+            "### LegitimateNewPin\n"
+            "Legitimate body content.\n\n"
+        )
+        result = _call_gate({
+            "tool_name": "Edit",
+            "tool_input": {
+                "file_path": str(env["claude_md"]),
+                # old_string must exist in baseline — "## Working Memory\n"
+                # appears verbatim in make_claude_md_with_pins output.
+                "old_string": "## Working Memory\n",
+                "new_string": new_pin_block + "## Working Memory\n",
+                "replace_all": False,
+            },
+        })
+        assert result is None, (
+            f"#529 regressed: Edit adding a legitimate date-marked pin "
+            f"denied (expected allow). Got: {result!r}"
+        )
+
+    def test_edit_smuggled_pin_without_date_comment_denies(
+        self, caps_gate_env
+    ):
+        """#529 dual-direction counter: an Edit whose `new_string` inserts
+        a naked `### Title` heading WITHOUT a `<!-- pinned: -->` date-comment
+        marker must still DENY with DENY_REASON_EMBEDDED_PIN — the smuggle
+        signature the fix must preserve. Together with the legitimate-allow
+        test, this pins the Edit-path discriminator: date-comment presence
+        is the signal that separates legitimate adds from smuggles.
+        """
+        env = caps_gate_env(pin_count=3)
+        smuggled_block = (
+            "### SmuggledNoDateMarker\n"
+            "body without a preceding <!-- pinned: --> marker\n\n"
+        )
+        result = _call_gate({
+            "tool_name": "Edit",
+            "tool_input": {
+                "file_path": str(env["claude_md"]),
+                "old_string": "## Working Memory\n",
+                "new_string": smuggled_block + "## Working Memory\n",
+                "replace_all": False,
+            },
+        })
+        assert result is not None, (
+            "#529 dual-direction counter regressed: Edit with a naked "
+            "`### ` heading (no date-comment) allowed; smuggle-detection off."
+        )
+        assert "embedded pin structure" in result
+
 
 class TestPinCapsGate_FailOpen:
     """SACROSANCT: gate bugs never block (with Write-baseline exception)."""

--- a/pact-plugin/tests/test_pin_caps_gate_matrix.py
+++ b/pact-plugin/tests/test_pin_caps_gate_matrix.py
@@ -162,44 +162,38 @@ class TestPinCapsGate_Matrix_Edit:
         ],
     )
     def test_edit_count_axis(self, gate_env, pre_count, post_count, expected_allow):
-        """Count-axis Edit: replace the managed region wholesale.
+        """Count-axis Edit: count-DECREASE and count-UNCHANGED cases only.
 
-        Strategy: Edit the ENTIRE pre-CLAUDE.md content with a freshly
-        built new-CLAUDE.md via old_string=<whole-file>, new_string=<new-
-        whole-file>. The `new_string` DOES contain `### ` headings
-        (legitimate pins) but the embedded-pin check is computed against
-        `_extract_new_body` which for Edit returns `new_string` — so a
-        count test via Edit's full-file replacement trips embedded-pin
-        every time.
-
-        Real-world Edit usage for count changes is single-pin Edit: the
-        old_string is a 1-pin block, new_string removes/replaces that
-        block with a plain-text fragment. Simulate that instead: start
-        with N pins, replace the ENTIRE managed region via a Write-like
-        Edit (old=baseline, new=target) but route the count comparison
-        via Write tool semantics — the embedded-pin carve-out applies
-        to Write (content key) not to Edit (new_string key).
+        Post-#529 (PR #530), count-INCREASE via Edit IS allowed when the
+        new pin carries a `<!-- pinned: -->` date-comment marker — see
+        `TestPinCapsGate_Smoke::test_edit_legitimate_new_pin_with_date_comment_allows`
+        for the legitimate-add legitimate-allow path, and
+        `test_edit_embedded_pin_denies` (this file) for the smuggle-deny
+        counter. Count-increase coverage in this parametrized matrix is
+        intentionally scoped to DECREASE + UNCHANGED: fixture/payload
+        bookkeeping for date-marked increase-adds is heavier than the
+        incremental signal justifies, since the smoke file already pins
+        the legitimate-allow outcome.
 
         The honest test: use Edit to REMOVE `### PinN` headings entirely
         (no `### ` in new_string). Pre count 3 → remove 0 → post count
         3 (allow). Pre count 3 → remove a pin-comment → post 2 (allow).
-        For the OVER-cap direction we must go via Write (full payload)
-        or use an Edit-time fragment that DOESN'T embed `### ` but still
-        mutates count, which is architecturally impossible via Edit for
-        a count INCREASE — you cannot add a pin without introducing
-        `### `. So count-INCREASE tests belong in the Write matrix.
+        For count-INCREASE coverage see the smoke file; for over-cap
+        count denies see the Write matrix.
 
         For Edit, we test count-DECREASE (allow paths) and count-UNCHANGED
         (irrelevant-fragment Edit).
         """
-        # Count-increase via Edit is architecturally impossible without
-        # the fragment containing `### ` → embedded-pin DENY. So we skip
-        # increase tests here and defer them to the Write matrix.
+        # Count-increase via Edit with a date-marker is a legitimate add
+        # (covered by TestPinCapsGate_Smoke); count-increase via Edit
+        # WITHOUT a date-marker is a smuggle and denies (covered by
+        # test_edit_embedded_pin_denies above). Skip increase cases in
+        # this parametrized matrix to keep the payload bookkeeping lean.
         if post_count > pre_count:
             pytest.skip(
-                "count-increase via Edit requires `### ` in new_string → "
-                "embedded-pin DENY path (tested separately); count matrix "
-                "belongs in the Write axis"
+                "count-increase Edit coverage: legitimate (date-marked) "
+                "allow case → TestPinCapsGate_Smoke; smuggle (no date "
+                "marker) deny case → test_edit_embedded_pin_denies"
             )
 
         env = gate_env(pin_count=pre_count)
@@ -285,16 +279,33 @@ class TestPinCapsGate_Matrix_Edit:
             assert "cap" in result.lower()
 
     def test_edit_embedded_pin_denies(self, gate_env):
-        """Edit new_string containing a `### ` heading → DENY embedded_pin."""
+        """Edit with a naked `### ` heading (no `<!-- pinned: -->` date-comment)
+        correctly DENIES via `DENY_REASON_EMBEDDED_PIN`. Post-#529 (PR #530)
+        the Edit path mirrors Write: legitimate date-marked adds allow
+        (covered in `TestPinCapsGate_Smoke::
+        test_edit_legitimate_new_pin_with_date_comment_allows`); smuggles
+        (heading without a preceding date-comment marker) still deny.
+
+        Prior to #530 this test used a legitimate-shaped date-marked payload
+        and asserted DENY — codifying the #529 asymmetric-path bug as
+        intended behavior. The payload has been reworked to a true smuggle
+        so the assertion reflects the actual contract: naked `### Title`
+        without a date-comment marker is the smuggle signature.
+        """
         env = gate_env(pin_count=3)
         result = _call_gate({
             "tool_name": "Edit",
             "tool_input": {
                 "file_path": str(env["claude_md"]),
-                "old_string": "Pin0",
+                # Prepend a naked `### ` heading (no `<!-- pinned: -->`
+                # marker) before the Pinned-Context section's terminator
+                # boundary — a real smuggle attempt that preserves existing
+                # pins but injects an undated heading.
+                "old_string": "## Working Memory\n",
                 "new_string": (
-                    "<!-- pinned: 2026-04-20 -->\n"
-                    "### Sneaky Embedded Pin\nbody-smuggled"
+                    "### SmuggledNoDateMarker\n"
+                    "body-smuggled\n\n"
+                    "## Working Memory\n"
                 ),
                 "replace_all": False,
             },


### PR DESCRIPTION
## Summary

- Unify `_extract_new_body` Edit + Write branches so both share the same smuggle discriminator (post_pin with new heading AND no `<!-- pinned: -->` date-comment).
- Add Edit-path legitimate-allow + smuggle-deny tests closing the asymmetric-path coverage gap that let #529 regress through PR #493.
- Counter-test-by-revert verified: legitimate-allow assertion fails with the exact #529 regression signature against the pre-fix hook.

Closes #529.

## Root cause

In PR #493 (4ac2ec9, plugin 3.18.0), `_extract_new_body` Write branch got sophisticated pre/post-pin-diff smuggle detection, but the Edit branch fell through to `return new_string`. `compute_deny_reason` then flagged every `### ` heading as an embedded-pin smuggle — breaking the documented `/PACT:pin-memory` Add flow.

## Fix shape

Restructure `_extract_new_body` so the pre/post-pin-diff is the PRIMARY path gated on `pre_pins is not None and post_pins is not None`, not on tool type. Fallbacks stay tool-specific:
- Write no-pins → `""` (naive scan would reject every Write per #492 F7).
- Edit no-pins → `new_string` (conservative pre-#493 behavior for the parse/simulate error path).

No caller changes — `_check_tool_allowed:297-299` already passes both pre_pins and post_pins.

## Test plan

- [x] 16/16 `tests/test_pin_caps_gate.py` pass (14 pre-existing + 2 new)
- [x] 259 broader pin_caps family tests pass (test_pin_caps_gate_matrix, test_pin_caps, test_check_pin_caps, test_pin_staleness_gate, test_pin_caps_integration)
- [x] Counter-test-by-revert: `test_edit_legitimate_new_pin_with_date_comment_allows` FAILS against HEAD with `DENY_REASON_EMBEDDED_PIN` (exact #529 signature); PASSES with fix
- [x] Manual smoke: legitimate Edit with date-comment → exit 0; smuggled Edit without date-comment → exit 2

## New tests

- `test_edit_legitimate_new_pin_with_date_comment_allows` — Edit adds `<!-- pinned: ... -->` + `### Title` + body; asserts allow. Load-bearing on the fix.
- `test_edit_smuggled_pin_without_date_comment_denies` — dual-direction counter; Edit with naked `### Title` heading denies with `embedded pin structure` signature. Safety-valve (passes pre- and post-fix) that pins the discriminator shape.

Together with existing Write-path coverage, forms explicit 2×2 {Write, Edit} × {legitimate, smuggle} matrix.