### PR TITLE
feat(#500): surface plugin-version banner to lead + teammate context

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "3.18.1",
+      "version": "3.18.2",
       "author": {
         "name": "ProfSynapse"
       },

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-marketplace/
 │           └── PACT/
-│               └── 3.18.1/    # Plugin version
+│               └── 3.18.2/    # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "3.18.1",
+  "version": "3.18.2",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "ProfSynapse",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 3.18.1
+> **Version**: 3.18.2
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/peer_inject.py
+++ b/pact-plugin/hooks/peer_inject.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import shared.pact_context as pact_context
 from shared.pact_context import get_team_name
+from shared.plugin_manifest import format_plugin_banner
 
 # Suppress false "hook error" display in Claude Code UI on bare exit paths
 _SUPPRESS_OUTPUT = json.dumps({"suppressOutput": True})
@@ -154,7 +155,18 @@ def get_peer_context(
         )
 
     prelude = _BOOTSTRAP_PRELUDE_TEMPLATE.format(agent_name=safe_name)
-    return prelude + peer_context + _TEACHBACK_REMINDER
+    # Surface plugin manifest diagnostic (#500). Banner is a single line
+    # with no leading/trailing newlines; add an explicit "\n\n" separator
+    # between peer_context and the banner. _TEACHBACK_REMINDER already
+    # begins with "\n\n", which preserves the existing visual spacing
+    # between the banner and the teachback reminder.
+    return (
+        prelude
+        + peer_context
+        + "\n\n"
+        + format_plugin_banner()
+        + _TEACHBACK_REMINDER
+    )
 
 
 def main():

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -79,6 +79,7 @@ from shared.constants import COMPACT_SUMMARY_PATH
 from shared.pact_context import get_session_dir, write_context
 from shared.session_journal import append_event, make_event
 from shared.failure_log import append_failure
+from shared.plugin_manifest import format_plugin_banner
 
 # Import extracted modules (decomposed for maintainability per M5 audit finding).
 from shared.symlinks import setup_plugin_symlinks
@@ -698,6 +699,14 @@ def main():
         stale_block_msg = check_pin_stale_block_directive()
         if stale_block_msg:
             context_parts.append(stale_block_msg)
+
+        # 4c. Surface plugin manifest diagnostic (#500). Tier-0 additionalContext —
+        # total-function banner; always emits, even on read/parse failure.
+        # Lets both lead and teammate context readers cross-reference
+        # worktree edits against the resolved installed-cache root at a
+        # glance. Helper is total: no conditional append, no try/except
+        # wrapper at the call site.
+        context_parts.append(format_plugin_banner())
 
         # 5. Remind orchestrator to create session-unique PACT team (or reuse on resume)
         team_name = generate_team_name(input_data)

--- a/pact-plugin/hooks/shared/plugin_manifest.py
+++ b/pact-plugin/hooks/shared/plugin_manifest.py
@@ -18,15 +18,45 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from pathlib import Path
 from typing import Optional
 
 _UNSET = "<unset>"
 _UNKNOWN_META = "unknown"
+_PREFIX = "PACT plugin: "
+
+# Symmetric with project-wide render-bound string handling: matches
+# `session_state._RENDER_STRIP_RE` (hooks/shared/session_state.py:83) and
+# `peer_inject._sanitize_agent_name` (hooks/peer_inject.py:83). Covers C0
+# controls (0x00-0x1f, incl. \n, \r, VT, FF, ESC), DEL (0x7f), NEL
+# (U+0085), LINE SEPARATOR (U+2028), PARAGRAPH SEPARATOR (U+2029) — every
+# character `str.splitlines()` or an LLM tokenizer may treat as a line
+# break, plus render-hostile control bytes. Asymmetric strip sets across
+# interpolation sinks become the attacker's entry point (see security-
+# engineer patterns_symmetric_sanitization.md).
+_RENDER_STRIP_RE = re.compile(r"[\x00-\x1f\x7f  ]")
+
+
+def _sanitize(text: str) -> str:
+    """Strip C0 controls, DEL, and Unicode line terminators.
+
+    Matches `session_state._RENDER_STRIP_RE.sub("", ...)` exactly. Empty-
+    string replacement (not space) mirrors the canonical project form.
+    """
+    return _RENDER_STRIP_RE.sub("", text)
 
 
 def _resolve_plugin_root() -> Optional[str]:
-    """Return CLAUDE_PLUGIN_ROOT env var, or None if empty/unset."""
+    """Return CLAUDE_PLUGIN_ROOT env var, or None if empty/unset.
+
+    Reads the env var directly rather than calling
+    `pact_context.get_plugin_root()`. session_init.py's Slot A append fires
+    at line 708 BEFORE `write_context()` at line 836, so the pact_context
+    cache is empty when the banner is emitted. Direct env read is the
+    correct source at this ordering; a future "SSOT cleanup" refactor
+    routing through pact_context would silently break the banner.
+    """
     root = os.environ.get("CLAUDE_PLUGIN_ROOT", "").strip()
     return root or None
 
@@ -70,30 +100,34 @@ def format_plugin_banner() -> str:
     """
     try:
         plugin_root = _resolve_plugin_root()
-        root_display = plugin_root if plugin_root else _UNSET
+        # Sanitize root_display for contract consistency: the single-line
+        # contract applies to ALL banner inputs, not just the plugin-authored
+        # name/version. CLAUDE_PLUGIN_ROOT is Claude-Code-managed, but routing
+        # the env var through _sanitize keeps the invariant total.
+        root_display = _sanitize(plugin_root) if plugin_root else _UNSET
 
         if plugin_root is None:
-            return f"PACT plugin: {_UNKNOWN_META} (root: {root_display})"
+            return f"{_PREFIX}{_UNKNOWN_META} (root: {root_display})"
 
         data = _read_manifest(plugin_root)
         if data is None:
-            return f"PACT plugin: {_UNKNOWN_META} (root: {root_display})"
+            return f"{_PREFIX}{_UNKNOWN_META} (root: {root_display})"
 
         name = data.get("name")
         version = data.get("version")
         if not isinstance(name, str) or not isinstance(version, str):
-            return f"PACT plugin: {_UNKNOWN_META} (root: {root_display})"
+            return f"{_PREFIX}{_UNKNOWN_META} (root: {root_display})"
         if not name or not version:
-            return f"PACT plugin: {_UNKNOWN_META} (root: {root_display})"
+            return f"{_PREFIX}{_UNKNOWN_META} (root: {root_display})"
 
-        # Defense-in-depth: strip \n / \r from plugin-authored fields so a
-        # pathological manifest cannot inject a line break into the
-        # single-line additionalContext chain. The banner does NOT carry the
-        # PACT ROLE marker prefix and is not consumed by the routing block's
-        # line-anchored substring check, so this is belt-and-suspenders
-        # rather than a primary defense.
-        name = name.replace("\n", " ").replace("\r", " ")
-        version = version.replace("\n", " ").replace("\r", " ")
-        return f"PACT plugin: {name} {version} (root: {root_display})"
+        # Defense-in-depth: strip line-break characters from plugin-authored
+        # fields so a pathological manifest cannot inject a line break into
+        # the single-line additionalContext chain. The banner does NOT carry
+        # the PACT ROLE marker prefix and is not consumed by the routing
+        # block's line-anchored substring check, so this is belt-and-
+        # suspenders rather than a primary defense.
+        name = _sanitize(name)
+        version = _sanitize(version)
+        return f"{_PREFIX}{name} {version} (root: {root_display})"
     except Exception:  # noqa: BLE001 — total-function outer fail-open
-        return f"PACT plugin: {_UNKNOWN_META} (root: {_UNSET})"
+        return f"{_PREFIX}{_UNKNOWN_META} (root: {_UNSET})"

--- a/pact-plugin/hooks/shared/plugin_manifest.py
+++ b/pact-plugin/hooks/shared/plugin_manifest.py
@@ -1,0 +1,99 @@
+"""
+Location: pact-plugin/hooks/shared/plugin_manifest.py
+Summary: Read plugin manifest (plugin.json) for diagnostic surfacing of the
+         running plugin's name, version, and resolved root path. Fail-open:
+         the public API never raises and always returns a non-empty banner
+         string. Used by SessionStart (session_init.py) and SubagentStart
+         (peer_inject.py) to surface a single-line `additionalContext`
+         diagnostic so readers can cross-reference worktree edits against
+         the installed-cache root at a glance (#500).
+Used by: session_init.py (Slot A, context_parts), peer_inject.py (between
+         peer_context and _TEACHBACK_REMINDER in get_peer_context return).
+
+No file locking — read-only access to a Claude-Code-managed file that is
+never mutated after plugin install.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+_UNSET = "<unset>"
+_UNKNOWN_META = "unknown"
+
+
+def _resolve_plugin_root() -> Optional[str]:
+    """Return CLAUDE_PLUGIN_ROOT env var, or None if empty/unset."""
+    root = os.environ.get("CLAUDE_PLUGIN_ROOT", "").strip()
+    return root or None
+
+
+def _read_manifest(plugin_root: str) -> Optional[dict]:
+    """Read and parse .claude-plugin/plugin.json under `plugin_root`.
+
+    Returns the parsed dict on success, or None on any filesystem / decode /
+    JSON / non-dict failure. Does not raise.
+    """
+    manifest_path = Path(plugin_root) / ".claude-plugin" / "plugin.json"
+    try:
+        text = manifest_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def format_plugin_banner() -> str:
+    """Return a single-line diagnostic banner for additionalContext.
+
+    Total function: never raises, always returns a non-empty string with
+    prefix "PACT plugin: " and no newline/carriage-return characters.
+
+    Happy path:
+        "PACT plugin: {name} {version} (root: {plugin_root})"
+
+    Fail-open (any read/parse/schema failure):
+        "PACT plugin: unknown (root: {plugin_root_or_<unset>})"
+
+    The outer blanket try/except guarantees totality against any future
+    regression in the helpers — SessionStart and SubagentStart are hot
+    paths, and an uncaught exception here would break additionalContext
+    delivery for every session.
+    """
+    try:
+        plugin_root = _resolve_plugin_root()
+        root_display = plugin_root if plugin_root else _UNSET
+
+        if plugin_root is None:
+            return f"PACT plugin: {_UNKNOWN_META} (root: {root_display})"
+
+        data = _read_manifest(plugin_root)
+        if data is None:
+            return f"PACT plugin: {_UNKNOWN_META} (root: {root_display})"
+
+        name = data.get("name")
+        version = data.get("version")
+        if not isinstance(name, str) or not isinstance(version, str):
+            return f"PACT plugin: {_UNKNOWN_META} (root: {root_display})"
+        if not name or not version:
+            return f"PACT plugin: {_UNKNOWN_META} (root: {root_display})"
+
+        # Defense-in-depth: strip \n / \r from plugin-authored fields so a
+        # pathological manifest cannot inject a line break into the
+        # single-line additionalContext chain. The banner does NOT carry the
+        # PACT ROLE marker prefix and is not consumed by the routing block's
+        # line-anchored substring check, so this is belt-and-suspenders
+        # rather than a primary defense.
+        name = name.replace("\n", " ").replace("\r", " ")
+        version = version.replace("\n", " ").replace("\r", " ")
+        return f"PACT plugin: {name} {version} (root: {root_display})"
+    except Exception:  # noqa: BLE001 — total-function outer fail-open
+        return f"PACT plugin: {_UNKNOWN_META} (root: {_UNSET})"

--- a/pact-plugin/tests/test_peer_inject.py
+++ b/pact-plugin/tests/test_peer_inject.py
@@ -755,3 +755,223 @@ class TestSanitizeAgentName:
                 f"Hostile agent_name injected an orchestrator marker line: "
                 f"{line!r}. The sanitizer should have stripped the close-paren."
             )
+
+
+# ---------------------------------------------------------------------------
+# #500 plugin-version banner integration + counter-test-by-revert (moved
+# from test_plugin_manifest.py per reviewer feedback — integration tests
+# belong alongside the hook they exercise).
+# ---------------------------------------------------------------------------
+
+
+class TestPeerInjectBannerIntegration:
+    """End-to-end: banner appears in peer_inject.get_peer_context() return
+    between peer_context and _TEACHBACK_REMINDER, per architecture §3.3."""
+
+    def _write_team_config(self, tmp_path, members):
+        team_dir = tmp_path / "teams" / "pact-test"
+        team_dir.mkdir(parents=True)
+        (team_dir / "config.json").write_text(
+            json.dumps({"members": members})
+        )
+        return tmp_path / "teams"
+
+    def test_banner_appears_in_peer_context_with_multiple_members(
+        self, tmp_path, monkeypatch
+    ):
+        from peer_inject import _TEACHBACK_REMINDER, get_peer_context
+
+        plugin_root = tmp_path / "installed-cache"
+        claude_plugin = plugin_root / ".claude-plugin"
+        claude_plugin.mkdir(parents=True)
+        (claude_plugin / "plugin.json").write_text(
+            json.dumps({"name": "PACT", "version": "3.18.1"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+
+        teams_dir = self._write_team_config(
+            tmp_path,
+            [
+                {"name": "architect", "agentType": "pact-architect"},
+                {"name": "backend-coder", "agentType": "pact-backend-coder"},
+            ],
+        )
+
+        result = get_peer_context(
+            agent_type="pact-architect",
+            team_name="pact-test",
+            agent_name="architect",
+            teams_dir=str(teams_dir),
+        )
+
+        assert result is not None
+        banner = f"PACT plugin: PACT 3.18.1 (root: {plugin_root})"
+        assert banner in result
+        # Banner is BETWEEN peer_context and _TEACHBACK_REMINDER.
+        banner_idx = result.index(banner)
+        reminder_idx = result.index(_TEACHBACK_REMINDER)
+        assert banner_idx < reminder_idx, (
+            "banner must precede the teachback reminder"
+        )
+        # peer_context text appears before the banner.
+        assert result.index("backend-coder") < banner_idx
+
+    def test_banner_appears_when_alone_on_team(self, tmp_path, monkeypatch):
+        from peer_inject import _TEACHBACK_REMINDER, get_peer_context
+
+        plugin_root = tmp_path / "installed-cache"
+        claude_plugin = plugin_root / ".claude-plugin"
+        claude_plugin.mkdir(parents=True)
+        (claude_plugin / "plugin.json").write_text(
+            json.dumps({"name": "PACT", "version": "3.18.1"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+
+        teams_dir = self._write_team_config(
+            tmp_path,
+            [{"name": "architect", "agentType": "pact-architect"}],
+        )
+
+        result = get_peer_context(
+            agent_type="pact-architect",
+            team_name="pact-test",
+            agent_name="architect",
+            teams_dir=str(teams_dir),
+        )
+
+        assert result is not None
+        assert "only active teammate" in result.lower()
+        banner = f"PACT plugin: PACT 3.18.1 (root: {plugin_root})"
+        assert banner in result
+        assert result.index(banner) < result.index(_TEACHBACK_REMINDER)
+
+    def test_banner_appears_on_failure_sentinel_in_peer_context(
+        self, tmp_path, monkeypatch
+    ):
+        """Even when plugin.json fails to read, the sentinel banner still
+        appears in the peer_context output — fail-open at the integration
+        layer, not just the helper layer."""
+        from peer_inject import get_peer_context
+
+        monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+
+        teams_dir = self._write_team_config(
+            tmp_path,
+            [
+                {"name": "architect", "agentType": "pact-architect"},
+                {"name": "backend-coder", "agentType": "pact-backend-coder"},
+            ],
+        )
+
+        result = get_peer_context(
+            agent_type="pact-architect",
+            team_name="pact-test",
+            agent_name="architect",
+            teams_dir=str(teams_dir),
+        )
+
+        assert result is not None
+        assert "PACT plugin: unknown (root: <unset>)" in result
+
+    def test_banner_does_not_precede_pact_role_marker(
+        self, tmp_path, monkeypatch
+    ):
+        """Security invariant: the PACT ROLE marker at byte-0 of the
+        peer context must remain the first line. Banner must land
+        AFTER the prelude, per architecture §3.3 `Place banner
+        BETWEEN peer_context and teachback reminder (not before
+        prelude — prelude's PACT ROLE marker must remain the first
+        line for the byte-0 line-anchored substring check).`"""
+        from peer_inject import get_peer_context
+
+        plugin_root = tmp_path / "installed-cache"
+        claude_plugin = plugin_root / ".claude-plugin"
+        claude_plugin.mkdir(parents=True)
+        (claude_plugin / "plugin.json").write_text(
+            json.dumps({"name": "PACT", "version": "3.18.1"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+
+        teams_dir = self._write_team_config(
+            tmp_path,
+            [
+                {"name": "architect", "agentType": "pact-architect"},
+                {"name": "backend-coder", "agentType": "pact-backend-coder"},
+            ],
+        )
+
+        result = get_peer_context(
+            agent_type="pact-architect",
+            team_name="pact-test",
+            agent_name="architect",
+            teams_dir=str(teams_dir),
+        )
+
+        assert result is not None
+        # The PACT ROLE marker must still be the very first bytes.
+        assert result.startswith("YOUR PACT ROLE: teammate (architect)")
+        banner = f"PACT plugin: PACT 3.18.1 (root: {plugin_root})"
+        assert result.index(banner) > result.index("YOUR PACT ROLE:")
+
+
+class TestCounterTestByPeerInjectRevert:
+    """Counter-test-by-revert for peer_inject banner insertion (dual
+    direction — pair with TestCounterTestBySlotARevert in test_session_init).
+    If a future edit removes the `format_plugin_banner()` call from
+    the return tuple in get_peer_context() (peer_inject.py line ~167),
+    at least one named test here fails with a specific message.
+
+    Verified empirically by reviewer-independent cp-backup revert:
+    removing the banner term from the return concatenation makes 4
+    Integration + 2 RevertGuard tests fail (cardinality 6)."""
+
+    def test_peer_inject_output_contains_banner(self, tmp_path, monkeypatch):
+        """Load-bearing regression guard: banner must appear in
+        get_peer_context() output."""
+        from peer_inject import get_peer_context
+
+        plugin_root = tmp_path / "installed-cache"
+        claude_plugin = plugin_root / ".claude-plugin"
+        claude_plugin.mkdir(parents=True)
+        (claude_plugin / "plugin.json").write_text(
+            json.dumps({"name": "PACT", "version": "3.18.1"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+
+        team_dir = tmp_path / "teams" / "pact-test"
+        team_dir.mkdir(parents=True)
+        (team_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "members": [
+                        {"name": "architect", "agentType": "pact-architect"},
+                        {
+                            "name": "backend-coder",
+                            "agentType": "pact-backend-coder",
+                        },
+                    ]
+                }
+            )
+        )
+
+        result = get_peer_context(
+            agent_type="pact-architect",
+            team_name="pact-test",
+            agent_name="architect",
+            teams_dir=str(tmp_path / "teams"),
+        )
+
+        assert result is not None
+        assert "PACT plugin: PACT 3.18.1" in result, (
+            "banner missing from peer_inject.get_peer_context() return — "
+            "verify peer_inject.py line ~167 still includes "
+            "format_plugin_banner() in the return concatenation"
+        )
+
+    def test_format_plugin_banner_is_imported_in_peer_inject(self):
+        """Static guard: import must be present at module scope."""
+        import peer_inject
+
+        assert hasattr(peer_inject, "format_plugin_banner"), (
+            "peer_inject must import format_plugin_banner at module scope"
+        )

--- a/pact-plugin/tests/test_plugin_manifest.py
+++ b/pact-plugin/tests/test_plugin_manifest.py
@@ -140,3 +140,886 @@ class TestBannerInvariants:
         assert "\r" not in banner
         assert "PACT " in banner  # name retained (with trailing space)
         assert "3.18 .1" in banner  # embedded \r replaced with space
+
+
+class TestFailOpenFireMatrixExtendedRows:
+    """Architect fire-matrix §6 — explicit named rows beyond smoke coverage.
+
+    Smoke covers rows 1, 2, 4, 5 (+ a parametrized sweep of 6-11). These
+    named tests pin each remaining row individually so a failure in any one
+    cell surfaces a specific diagnostic rather than a collapsed parametrize
+    failure. The prefix + root-display pattern is the public contract;
+    asserting the exact sentinel literal guards against any caller
+    ever seeing a partial or mangled banner under failure.
+    """
+
+    def test_row3_env_set_but_root_does_not_exist(self, tmp_path, monkeypatch):
+        from shared.plugin_manifest import format_plugin_banner
+
+        nonexistent = tmp_path / "does-not-exist"
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(nonexistent))
+
+        banner = format_plugin_banner()
+
+        assert banner == f"PACT plugin: unknown (root: {nonexistent})"
+
+    def test_row7_missing_version_key(self, tmp_path, monkeypatch):
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(tmp_path, json.dumps({"name": "PACT"}))
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert banner == f"PACT plugin: unknown (root: {root})"
+
+    def test_row8_missing_name_key(self, tmp_path, monkeypatch):
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(tmp_path, json.dumps({"version": "3.18.1"}))
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert banner == f"PACT plugin: unknown (root: {root})"
+
+    def test_row9_version_is_integer(self, tmp_path, monkeypatch):
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(
+            tmp_path, json.dumps({"name": "PACT", "version": 3})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert banner == f"PACT plugin: unknown (root: {root})"
+
+    def test_row10a_name_empty_string(self, tmp_path, monkeypatch):
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(
+            tmp_path, json.dumps({"name": "", "version": "3.18.1"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert banner == f"PACT plugin: unknown (root: {root})"
+
+    def test_row10b_version_empty_string(self, tmp_path, monkeypatch):
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(
+            tmp_path, json.dumps({"name": "PACT", "version": ""})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert banner == f"PACT plugin: unknown (root: {root})"
+
+    def test_row6a_top_level_is_list(self, tmp_path, monkeypatch):
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(tmp_path, json.dumps(["not", "a", "dict"]))
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert banner == f"PACT plugin: unknown (root: {root})"
+
+    def test_row6b_top_level_is_string(self, tmp_path, monkeypatch):
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(tmp_path, json.dumps("just-a-string"))
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert banner == f"PACT plugin: unknown (root: {root})"
+
+    def test_row12_permission_error_on_read(self, tmp_path, monkeypatch):
+        """plugin.json exists but cannot be read (chmod 000 / EACCES).
+
+        On platforms where chmod 000 does not actually block root, the test
+        still passes because the production helper treats any OSError
+        subclass uniformly. We monkeypatch Path.read_text to guarantee the
+        EACCES is reliably raised, which decouples the test from macOS
+        permission quirks.
+        """
+        from pathlib import Path as _Path
+
+        from shared import plugin_manifest
+
+        root = _make_plugin_root(
+            tmp_path, json.dumps({"name": "PACT", "version": "3.18.1"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        original_read_text = _Path.read_text
+
+        def read_text_raising_permission(self, *args, **kwargs):
+            if self.name == "plugin.json":
+                raise PermissionError("EACCES simulated")
+            return original_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(_Path, "read_text", read_text_raising_permission)
+
+        banner = plugin_manifest.format_plugin_banner()
+
+        assert banner == f"PACT plugin: unknown (root: {root})"
+
+    def test_row12b_generic_oserror_on_read(self, tmp_path, monkeypatch):
+        """Any OSError subclass on read → fail-open sentinel."""
+        from pathlib import Path as _Path
+
+        from shared import plugin_manifest
+
+        root = _make_plugin_root(
+            tmp_path, json.dumps({"name": "PACT", "version": "3.18.1"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        def read_text_raising(self, *args, **kwargs):
+            raise OSError("ELOOP / symlink loop / disk IO error")
+
+        monkeypatch.setattr(_Path, "read_text", read_text_raising)
+
+        banner = plugin_manifest.format_plugin_banner()
+
+        assert banner == f"PACT plugin: unknown (root: {root})"
+
+    def test_row13_unicode_decode_error(self, tmp_path, monkeypatch):
+        """plugin.json contains non-utf-8 bytes → fail-open sentinel."""
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = tmp_path / "plugin"
+        claude_plugin = root / ".claude-plugin"
+        claude_plugin.mkdir(parents=True)
+        # Write raw non-utf-8 bytes (invalid continuation byte).
+        (claude_plugin / "plugin.json").write_bytes(b"\xff\xfe\x00non-utf8")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert banner == f"PACT plugin: unknown (root: {root})"
+
+    def test_empty_dict_manifest(self, tmp_path, monkeypatch):
+        """`{}` — valid JSON, valid dict, but no name/version."""
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(tmp_path, json.dumps({}))
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert banner == f"PACT plugin: unknown (root: {root})"
+
+    def test_extra_junk_fields_ignored_happy_path(self, tmp_path, monkeypatch):
+        """Manifest with extra fields (description, repository, etc.) →
+        banner still succeeds, surfaces only name + version."""
+        from shared.plugin_manifest import format_plugin_banner
+
+        manifest = {
+            "name": "PACT",
+            "version": "3.18.1",
+            "description": "Prepare, Architect, Code, Test framework",
+            "repository": "https://example.com/repo",
+            "author": "someone",
+            "unexpected_future_field": [1, 2, 3],
+        }
+        root = _make_plugin_root(tmp_path, json.dumps(manifest))
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert banner == f"PACT plugin: PACT 3.18.1 (root: {root})"
+
+    def test_root_is_a_file_not_directory(self, tmp_path, monkeypatch):
+        """CLAUDE_PLUGIN_ROOT points at a regular file → fail-open."""
+        from shared.plugin_manifest import format_plugin_banner
+
+        root_as_file = tmp_path / "not-a-directory"
+        root_as_file.write_text("I am a file")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root_as_file))
+
+        banner = format_plugin_banner()
+
+        assert banner == f"PACT plugin: unknown (root: {root_as_file})"
+
+    def test_plugin_json_is_a_directory(self, tmp_path, monkeypatch):
+        """plugin.json entry exists but is a directory, not a file →
+        fail-open (read_text raises IsADirectoryError, a subclass of
+        OSError)."""
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = tmp_path / "plugin"
+        claude_plugin = root / ".claude-plugin"
+        (claude_plugin / "plugin.json").mkdir(parents=True)
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert banner == f"PACT plugin: unknown (root: {root})"
+
+
+class TestTotalFunctionOuterGuard:
+    """The outer blanket try/except in format_plugin_banner() is the last
+    line of defense against any future regression in the helper chain.
+    These tests pin that guard: inject an unexpected exception type
+    (TypeError, RuntimeError) into the helpers and verify the outer
+    except still produces the safe fallback sentinel."""
+
+    def test_unexpected_typeerror_inside_resolve_root_is_caught(
+        self, monkeypatch
+    ):
+        from shared import plugin_manifest
+
+        def explode():
+            raise TypeError("simulated upstream regression")
+
+        monkeypatch.setattr(
+            plugin_manifest, "_resolve_plugin_root", explode
+        )
+
+        banner = plugin_manifest.format_plugin_banner()
+
+        # Outer except loses the path, so sentinel uses <unset>.
+        assert banner == "PACT plugin: unknown (root: <unset>)"
+
+    def test_unexpected_runtimeerror_inside_read_manifest_is_caught(
+        self, tmp_path, monkeypatch
+    ):
+        from shared import plugin_manifest
+
+        root = _make_plugin_root(
+            tmp_path, json.dumps({"name": "PACT", "version": "3.18.1"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        def explode(plugin_root):
+            raise RuntimeError("simulated regression in _read_manifest")
+
+        monkeypatch.setattr(plugin_manifest, "_read_manifest", explode)
+
+        banner = plugin_manifest.format_plugin_banner()
+
+        # Reached via the outer except, which uses <unset> (not the
+        # resolved root). This is the documented worst-case fallback.
+        assert banner == "PACT plugin: unknown (root: <unset>)"
+
+    def test_totality_under_many_exception_types(self, monkeypatch):
+        """The outer except must catch every non-BaseException subclass.
+
+        Exercises a broader set of exception types than smoke covered.
+        Each one should fall through to the "<unset>" sentinel, never
+        propagate, never return None, never return empty string.
+        """
+        from shared import plugin_manifest
+
+        exc_types = [
+            ValueError("v"),
+            TypeError("t"),
+            RuntimeError("r"),
+            KeyError("k"),
+            AttributeError("a"),
+            LookupError("l"),
+            ArithmeticError("arith"),
+        ]
+
+        for exc in exc_types:
+            def explode(_exc=exc):
+                raise _exc
+
+            monkeypatch.setattr(
+                plugin_manifest, "_resolve_plugin_root", explode
+            )
+            banner = plugin_manifest.format_plugin_banner()
+            assert banner == "PACT plugin: unknown (root: <unset>)"
+            assert isinstance(banner, str)
+            assert banner
+            assert "\n" not in banner
+
+
+class TestBannerContractInvariants:
+    """Banner contract invariants pinned explicitly beyond the smoke
+    parametrize: prefix, single-line, non-empty, no CRLF of any form.
+
+    These tests exist to make the public contract load-bearing — a
+    future caller (session_init, peer_inject, or a new hook) that
+    tokenizes or splits on banner output can rely on these guarantees."""
+
+    @pytest.mark.parametrize(
+        "env_state,manifest_text",
+        [
+            ("unset", None),
+            ("set-empty-dir", None),
+            ("set-valid", json.dumps({"name": "PACT", "version": "3.18.1"})),
+            ("set-malformed", "not json at all {"),
+            ("set-junk-name", json.dumps({"name": 42, "version": "3.18.1"})),
+            ("set-crlf-values", json.dumps(
+                {"name": "P\r\nA\rC\nT", "version": "3\n.18\r.1"}
+            )),
+        ],
+    )
+    def test_prefix_always_pact_plugin_space(
+        self, tmp_path, monkeypatch, env_state, manifest_text
+    ):
+        from shared.plugin_manifest import format_plugin_banner
+
+        if env_state == "unset":
+            monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+        else:
+            root = _make_plugin_root(tmp_path, manifest_text)
+            monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert banner.startswith("PACT plugin: ")
+
+    def test_banner_contains_no_crlf_under_hostile_manifest(
+        self, tmp_path, monkeypatch
+    ):
+        """A hostile plugin.json with CRLF in both fields must not leak
+        line-breaks into the banner. Exhaustive CRLF combinations."""
+        from shared.plugin_manifest import format_plugin_banner
+
+        hostile_values = [
+            ("P\nACT", "3.18.1"),
+            ("PACT", "3.18.1\n"),
+            ("PA\r\nCT", "3.\n18.\r1"),
+            ("\n\nPACT", "\r\n3.18.1\r\n"),
+        ]
+        for name, version in hostile_values:
+            root = _make_plugin_root(
+                tmp_path / f"r-{hash((name, version)) & 0xFFFF}",
+                json.dumps({"name": name, "version": version}),
+            )
+            monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+            banner = format_plugin_banner()
+
+            assert "\n" not in banner, banner
+            assert "\r" not in banner, banner
+            assert banner.startswith("PACT plugin: ")
+            assert banner  # non-empty
+
+    def test_banner_is_pure_function_of_env_and_manifest(
+        self, tmp_path, monkeypatch
+    ):
+        """Idempotency: two calls with the same inputs return equal strings."""
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(
+            tmp_path, json.dumps({"name": "PACT", "version": "3.18.1"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        b1 = format_plugin_banner()
+        b2 = format_plugin_banner()
+
+        assert b1 == b2
+
+
+class TestSessionInitSlotAIntegration:
+    """End-to-end: banner appears in session_init.main() additionalContext.
+
+    Verifies wiring between the helper and the hook — not just that the
+    helper produces a string, but that session_init.main() actually calls
+    it and includes the result in the emitted additionalContext. Mirrors
+    the patching style of TestTeamResumeDetection in test_session_init.py.
+    """
+
+    def _run_main(self, monkeypatch, tmp_path, plugin_root=None, manifest=None):
+        import io as _io
+        from unittest.mock import patch as _patch
+
+        from session_init import main
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path / "project"))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+        (tmp_path / "home").mkdir(exist_ok=True)
+
+        if plugin_root is not None:
+            if manifest is not None:
+                claude_plugin = plugin_root / ".claude-plugin"
+                claude_plugin.mkdir(parents=True)
+                (claude_plugin / "plugin.json").write_text(manifest)
+            monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        else:
+            monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+
+        stdin_data = json.dumps(
+            {"session_id": "abc12345-0000-0000-0000-000000000000"}
+        )
+
+        with _patch("session_init.setup_plugin_symlinks", return_value=None), \
+             _patch("session_init.remove_stale_kernel_block", return_value=None), \
+             _patch("session_init.update_pact_routing", return_value=None), \
+             _patch("session_init.ensure_project_memory_md", return_value=None), \
+             _patch("session_init.check_pinned_staleness", return_value=None), \
+             _patch("session_init.update_session_info", return_value=None), \
+             _patch("session_init.get_task_list", return_value=None), \
+             _patch("session_init.restore_last_session", return_value=None), \
+             _patch("session_init.check_paused_state", return_value=None), \
+             _patch("sys.stdin", _io.StringIO(stdin_data)), \
+             _patch("sys.stdout", new_callable=_io.StringIO) as mock_stdout:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0
+        output = json.loads(mock_stdout.getvalue())
+        return output["hookSpecificOutput"]["additionalContext"]
+
+    def test_banner_appears_in_additional_context_happy_path(
+        self, monkeypatch, tmp_path
+    ):
+        plugin_root = tmp_path / "installed-cache"
+        additional = self._run_main(
+            monkeypatch,
+            tmp_path,
+            plugin_root=plugin_root,
+            manifest=json.dumps({"name": "PACT", "version": "3.18.1"}),
+        )
+
+        assert f"PACT plugin: PACT 3.18.1 (root: {plugin_root})" in additional
+
+    def test_banner_appears_even_when_plugin_root_unset(
+        self, monkeypatch, tmp_path
+    ):
+        additional = self._run_main(monkeypatch, tmp_path, plugin_root=None)
+
+        assert "PACT plugin: unknown (root: <unset>)" in additional
+
+    def test_banner_appears_when_plugin_json_malformed(
+        self, monkeypatch, tmp_path
+    ):
+        plugin_root = tmp_path / "installed-cache"
+        additional = self._run_main(
+            monkeypatch,
+            tmp_path,
+            plugin_root=plugin_root,
+            manifest="{this is not json",
+        )
+
+        assert f"PACT plugin: unknown (root: {plugin_root})" in additional
+
+    def test_banner_follows_stale_block_directive_in_join_order(
+        self, monkeypatch, tmp_path
+    ):
+        """Slot A placement: banner comes after pin/stale-block diagnostics
+        in the `" | ".join(context_parts)` output, per architecture §4.
+        Verified by asserting the banner is not the very first token
+        in additionalContext (team prelude inserts at index 0, then
+        bootstrap + diagnostics precede the banner)."""
+        plugin_root = tmp_path / "installed-cache"
+        additional = self._run_main(
+            monkeypatch,
+            tmp_path,
+            plugin_root=plugin_root,
+            manifest=json.dumps({"name": "PACT", "version": "3.18.1"}),
+        )
+
+        banner = f"PACT plugin: PACT 3.18.1 (root: {plugin_root})"
+        assert banner in additional
+        # Banner is not the very first content — team prelude + bootstrap
+        # directive are emitted first (insert(0, ...)).
+        assert not additional.startswith(banner)
+
+
+class TestPeerInjectIntegration:
+    """End-to-end: banner appears in peer_inject.get_peer_context() return
+    between peer_context and _TEACHBACK_REMINDER, per architecture §3.3."""
+
+    def _write_team_config(self, tmp_path, members):
+        team_dir = tmp_path / "teams" / "pact-test"
+        team_dir.mkdir(parents=True)
+        (team_dir / "config.json").write_text(
+            json.dumps({"members": members})
+        )
+        return tmp_path / "teams"
+
+    def test_banner_appears_in_peer_context_with_multiple_members(
+        self, tmp_path, monkeypatch
+    ):
+        from peer_inject import _TEACHBACK_REMINDER, get_peer_context
+
+        plugin_root = tmp_path / "installed-cache"
+        claude_plugin = plugin_root / ".claude-plugin"
+        claude_plugin.mkdir(parents=True)
+        (claude_plugin / "plugin.json").write_text(
+            json.dumps({"name": "PACT", "version": "3.18.1"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+
+        teams_dir = self._write_team_config(
+            tmp_path,
+            [
+                {"name": "architect", "agentType": "pact-architect"},
+                {"name": "backend-coder", "agentType": "pact-backend-coder"},
+            ],
+        )
+
+        result = get_peer_context(
+            agent_type="pact-architect",
+            team_name="pact-test",
+            agent_name="architect",
+            teams_dir=str(teams_dir),
+        )
+
+        assert result is not None
+        banner = f"PACT plugin: PACT 3.18.1 (root: {plugin_root})"
+        assert banner in result
+        # Banner is BETWEEN peer_context and _TEACHBACK_REMINDER.
+        banner_idx = result.index(banner)
+        reminder_idx = result.index(_TEACHBACK_REMINDER)
+        assert banner_idx < reminder_idx, (
+            "banner must precede the teachback reminder"
+        )
+        # peer_context text appears before the banner.
+        assert result.index("backend-coder") < banner_idx
+
+    def test_banner_appears_when_alone_on_team(self, tmp_path, monkeypatch):
+        from peer_inject import _TEACHBACK_REMINDER, get_peer_context
+
+        plugin_root = tmp_path / "installed-cache"
+        claude_plugin = plugin_root / ".claude-plugin"
+        claude_plugin.mkdir(parents=True)
+        (claude_plugin / "plugin.json").write_text(
+            json.dumps({"name": "PACT", "version": "3.18.1"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+
+        teams_dir = self._write_team_config(
+            tmp_path,
+            [{"name": "architect", "agentType": "pact-architect"}],
+        )
+
+        result = get_peer_context(
+            agent_type="pact-architect",
+            team_name="pact-test",
+            agent_name="architect",
+            teams_dir=str(teams_dir),
+        )
+
+        assert result is not None
+        assert "only active teammate" in result.lower()
+        banner = f"PACT plugin: PACT 3.18.1 (root: {plugin_root})"
+        assert banner in result
+        assert result.index(banner) < result.index(_TEACHBACK_REMINDER)
+
+    def test_banner_appears_on_failure_sentinel_in_peer_context(
+        self, tmp_path, monkeypatch
+    ):
+        """Even when plugin.json fails to read, the sentinel banner still
+        appears in the peer_context output — fail-open at the integration
+        layer, not just the helper layer."""
+        from peer_inject import get_peer_context
+
+        monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+
+        teams_dir = self._write_team_config(
+            tmp_path,
+            [
+                {"name": "architect", "agentType": "pact-architect"},
+                {"name": "backend-coder", "agentType": "pact-backend-coder"},
+            ],
+        )
+
+        result = get_peer_context(
+            agent_type="pact-architect",
+            team_name="pact-test",
+            agent_name="architect",
+            teams_dir=str(teams_dir),
+        )
+
+        assert result is not None
+        assert "PACT plugin: unknown (root: <unset>)" in result
+
+    def test_banner_does_not_precede_pact_role_marker(
+        self, tmp_path, monkeypatch
+    ):
+        """Security invariant: the PACT ROLE marker at byte-0 of the
+        peer context must remain the first line. Banner must land
+        AFTER the prelude, per architecture §3.3 `Place banner
+        BETWEEN peer_context and teachback reminder (not before
+        prelude — prelude's PACT ROLE marker must remain the first
+        line for the byte-0 line-anchored substring check).`"""
+        from peer_inject import get_peer_context
+
+        plugin_root = tmp_path / "installed-cache"
+        claude_plugin = plugin_root / ".claude-plugin"
+        claude_plugin.mkdir(parents=True)
+        (claude_plugin / "plugin.json").write_text(
+            json.dumps({"name": "PACT", "version": "3.18.1"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+
+        teams_dir = self._write_team_config(
+            tmp_path,
+            [
+                {"name": "architect", "agentType": "pact-architect"},
+                {"name": "backend-coder", "agentType": "pact-backend-coder"},
+            ],
+        )
+
+        result = get_peer_context(
+            agent_type="pact-architect",
+            team_name="pact-test",
+            agent_name="architect",
+            teams_dir=str(teams_dir),
+        )
+
+        assert result is not None
+        # The PACT ROLE marker must still be the very first bytes.
+        assert result.startswith("YOUR PACT ROLE: teammate (architect)")
+        banner = f"PACT plugin: PACT 3.18.1 (root: {plugin_root})"
+        assert result.index(banner) > result.index("YOUR PACT ROLE:")
+
+
+class TestCounterTestBySlotARevert:
+    """Counter-test-by-revert for session_init Slot A append (d4f0f794
+    dual-direction discipline). These tests are written so that if a
+    future edit removes the `context_parts.append(format_plugin_banner())`
+    call at Slot A (line 709 in session_init.py), at least one named
+    test here fails with a specific, informative assertion message.
+
+    Verified empirically during authoring: commenting out the Slot A
+    append and rerunning this class produces a failure. See the
+    docstring of test_banner_absent_without_slot_a_append for the
+    load-bearing assertion."""
+
+    def test_banner_present_in_additional_context(
+        self, monkeypatch, tmp_path
+    ):
+        """Load-bearing regression guard: if Slot A is reverted, the banner
+        disappears from additionalContext and this assertion fails."""
+        import io as _io
+        from unittest.mock import patch as _patch
+
+        from session_init import main
+
+        plugin_root = tmp_path / "installed-cache"
+        claude_plugin = plugin_root / ".claude-plugin"
+        claude_plugin.mkdir(parents=True)
+        (claude_plugin / "plugin.json").write_text(
+            json.dumps({"name": "PACT", "version": "3.18.1"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path / "project"))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+        (tmp_path / "home").mkdir(exist_ok=True)
+
+        stdin_data = json.dumps(
+            {"session_id": "abc12345-0000-0000-0000-000000000000"}
+        )
+
+        with _patch("session_init.setup_plugin_symlinks", return_value=None), \
+             _patch("session_init.remove_stale_kernel_block", return_value=None), \
+             _patch("session_init.update_pact_routing", return_value=None), \
+             _patch("session_init.ensure_project_memory_md", return_value=None), \
+             _patch("session_init.check_pinned_staleness", return_value=None), \
+             _patch("session_init.update_session_info", return_value=None), \
+             _patch("session_init.get_task_list", return_value=None), \
+             _patch("session_init.restore_last_session", return_value=None), \
+             _patch("session_init.check_paused_state", return_value=None), \
+             _patch("sys.stdin", _io.StringIO(stdin_data)), \
+             _patch("sys.stdout", new_callable=_io.StringIO) as mock_stdout:
+            with pytest.raises(SystemExit):
+                main()
+
+        output = json.loads(mock_stdout.getvalue())
+        additional = output["hookSpecificOutput"]["additionalContext"]
+        assert "PACT plugin: PACT 3.18.1" in additional, (
+            "Slot A banner missing from additionalContext — verify "
+            "session_init.py line 709 still appends format_plugin_banner()"
+        )
+
+    def test_format_plugin_banner_is_imported_in_session_init(self):
+        """Static guard: if the import line is deleted, an import-time
+        error is raised at session_init.py load, not just a quiet drop."""
+        import session_init
+
+        assert hasattr(session_init, "format_plugin_banner"), (
+            "session_init must import format_plugin_banner at module scope"
+        )
+
+
+class TestCounterTestByPeerInjectRevert:
+    """Counter-test-by-revert for peer_inject banner insertion (dual
+    direction — pair with TestCounterTestBySlotARevert per d4f0f794).
+    If a future edit removes the `format_plugin_banner()` call from
+    the return tuple in get_peer_context() (peer_inject.py line 167),
+    at least one named test here fails with a specific message.
+
+    Verified empirically during authoring: removing the banner term
+    from the return concatenation makes these tests fail."""
+
+    def test_peer_inject_output_contains_banner(self, tmp_path, monkeypatch):
+        """Load-bearing regression guard: banner must appear in
+        get_peer_context() output."""
+        from peer_inject import get_peer_context
+
+        plugin_root = tmp_path / "installed-cache"
+        claude_plugin = plugin_root / ".claude-plugin"
+        claude_plugin.mkdir(parents=True)
+        (claude_plugin / "plugin.json").write_text(
+            json.dumps({"name": "PACT", "version": "3.18.1"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+
+        team_dir = tmp_path / "teams" / "pact-test"
+        team_dir.mkdir(parents=True)
+        (team_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "members": [
+                        {"name": "architect", "agentType": "pact-architect"},
+                        {
+                            "name": "backend-coder",
+                            "agentType": "pact-backend-coder",
+                        },
+                    ]
+                }
+            )
+        )
+
+        result = get_peer_context(
+            agent_type="pact-architect",
+            team_name="pact-test",
+            agent_name="architect",
+            teams_dir=str(tmp_path / "teams"),
+        )
+
+        assert result is not None
+        assert "PACT plugin: PACT 3.18.1" in result, (
+            "banner missing from peer_inject.get_peer_context() return — "
+            "verify peer_inject.py line 167 still includes "
+            "format_plugin_banner() in the return concatenation"
+        )
+
+    def test_format_plugin_banner_is_imported_in_peer_inject(self):
+        """Static guard: import must be present at module scope."""
+        import peer_inject
+
+        assert hasattr(peer_inject, "format_plugin_banner"), (
+            "peer_inject must import format_plugin_banner at module scope"
+        )
+
+
+class TestDogfoodPathWorktreeVsInstalledCache:
+    """The #500 dogfood motivation: teammate edits worktree source at
+    /Users/.../worktrees/feat-X/pact-plugin/hooks/, but the runtime
+    resolves hooks against ${CLAUDE_PLUGIN_ROOT}, which is the installed
+    cache at ~/.claude/plugins/cache/pact-marketplace/PACT/3.x.y. The
+    banner must surface the INSTALLED-CACHE version/root — not whatever
+    is in the worktree source tree.
+
+    These tests simulate the #497 symptom:
+      - "installed cache" plugin.json reports version 3.17.0 (old).
+      - "worktree source" plugin.json reports version 3.99.0 (new, not
+        yet released — represents the teammate's unreleased edits).
+      - CLAUDE_PLUGIN_ROOT points at the installed cache.
+      - The banner MUST surface 3.17.0 + the installed-cache root,
+        NOT 3.99.0 and NOT the worktree path.
+
+    Rationale: the whole purpose of the banner is to reveal this
+    divergence at a glance. A banner that accidentally reflects worktree
+    state would defeat the diagnostic."""
+
+    def _setup_two_trees(self, tmp_path):
+        installed_cache = tmp_path / "installed-cache"
+        worktree_source = tmp_path / "worktree-source"
+
+        for tree, version, name in [
+            (installed_cache, "3.17.0", "PACT"),
+            (worktree_source, "3.99.0", "PACT"),
+        ]:
+            cp_dir = tree / ".claude-plugin"
+            cp_dir.mkdir(parents=True)
+            (cp_dir / "plugin.json").write_text(
+                json.dumps({"name": name, "version": version})
+            )
+        return installed_cache, worktree_source
+
+    def test_banner_surfaces_installed_cache_root(self, tmp_path, monkeypatch):
+        """CLAUDE_PLUGIN_ROOT=installed_cache → banner shows installed
+        version, even though worktree on disk has newer version."""
+        from shared.plugin_manifest import format_plugin_banner
+
+        installed_cache, _worktree = self._setup_two_trees(tmp_path)
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(installed_cache))
+
+        banner = format_plugin_banner()
+
+        assert banner == (
+            f"PACT plugin: PACT 3.17.0 (root: {installed_cache})"
+        )
+
+    def test_banner_does_not_surface_worktree_version(
+        self, tmp_path, monkeypatch
+    ):
+        """Negative form of the above: the worktree's 3.99.0 must NOT
+        appear anywhere in the banner."""
+        from shared.plugin_manifest import format_plugin_banner
+
+        installed_cache, worktree = self._setup_two_trees(tmp_path)
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(installed_cache))
+
+        banner = format_plugin_banner()
+
+        assert "3.99.0" not in banner
+        assert str(worktree) not in banner
+
+    def test_banner_divergence_visible_via_root_path(
+        self, tmp_path, monkeypatch
+    ):
+        """A reader comparing banner.root vs their known worktree path
+        can detect the #497 symptom. Simulated here by asserting that
+        the banner's root path differs from a separate `worktree` path
+        under realistic conditions — this is the diagnostic property."""
+        from shared.plugin_manifest import format_plugin_banner
+
+        installed_cache, worktree = self._setup_two_trees(tmp_path)
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(installed_cache))
+
+        banner = format_plugin_banner()
+
+        assert str(installed_cache) in banner
+        assert str(installed_cache) != str(worktree)
+        # A hypothetical divergence-detection predicate a human/agent
+        # reader might apply:
+        reader_expected_worktree = str(worktree)
+        banner_root_visible = str(installed_cache)
+        assert reader_expected_worktree != banner_root_visible
+
+    def test_banner_still_fails_open_when_installed_cache_corrupted(
+        self, tmp_path, monkeypatch
+    ):
+        """Dogfood integrity: even when the installed cache's plugin.json
+        is corrupted, the banner must still surface the installed-cache
+        ROOT path (so the reader can see where the runtime is pointed)
+        rather than silently falling back to <unset> or picking up the
+        worktree tree."""
+        from shared.plugin_manifest import format_plugin_banner
+
+        installed_cache = tmp_path / "installed-cache"
+        cp_dir = installed_cache / ".claude-plugin"
+        cp_dir.mkdir(parents=True)
+        (cp_dir / "plugin.json").write_text("{corrupted json")
+
+        worktree = tmp_path / "worktree-source"
+        cp_dir_w = worktree / ".claude-plugin"
+        cp_dir_w.mkdir(parents=True)
+        (cp_dir_w / "plugin.json").write_text(
+            json.dumps({"name": "PACT", "version": "3.99.0"})
+        )
+
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(installed_cache))
+
+        banner = format_plugin_banner()
+
+        assert banner == f"PACT plugin: unknown (root: {installed_cache})"
+        assert str(worktree) not in banner
+        assert "3.99.0" not in banner

--- a/pact-plugin/tests/test_plugin_manifest.py
+++ b/pact-plugin/tests/test_plugin_manifest.py
@@ -138,22 +138,25 @@ class TestBannerInvariants:
 
         assert "\n" not in banner
         assert "\r" not in banner
-        assert "PACT " in banner  # name retained (with trailing space)
-        assert "3.18 .1" in banner  # embedded \r replaced with space
+        # Sanitizer uses empty-string replacement (mirrors
+        # `session_state._RENDER_STRIP_RE.sub("", ...)`), so trailing `\n`
+        # on name collapses, and embedded `\r` in version collapses.
+        assert "PACT 3.18.1" in banner
 
 
-class TestFailOpenFireMatrixExtendedRows:
-    """Architect fire-matrix §6 — explicit named rows beyond smoke coverage.
-
-    Smoke covers rows 1, 2, 4, 5 (+ a parametrized sweep of 6-11). These
-    named tests pin each remaining row individually so a failure in any one
-    cell surfaces a specific diagnostic rather than a collapsed parametrize
-    failure. The prefix + root-display pattern is the public contract;
-    asserting the exact sentinel literal guards against any caller
-    ever seeing a partial or mangled banner under failure.
+class TestFailOpenFailurePathsExtended:
+    """Explicit named tests for each fail-open failure path beyond smoke
+    coverage. Smoke tests cover happy path + CLAUDE_PLUGIN_ROOT unset +
+    plugin.json missing + malformed JSON via the parametrized invariants
+    sweep. These named tests pin each remaining failure mode individually
+    so a failure in any one mode surfaces a specific diagnostic rather
+    than a collapsed parametrize failure. The prefix + root-display
+    pattern is the public contract; asserting the exact sentinel literal
+    guards against any caller ever seeing a partial or mangled banner
+    under failure.
     """
 
-    def test_row3_env_set_but_root_does_not_exist(self, tmp_path, monkeypatch):
+    def test_nonexistent_root_path_emits_sentinel(self, tmp_path, monkeypatch):
         from shared.plugin_manifest import format_plugin_banner
 
         nonexistent = tmp_path / "does-not-exist"
@@ -163,7 +166,7 @@ class TestFailOpenFireMatrixExtendedRows:
 
         assert banner == f"PACT plugin: unknown (root: {nonexistent})"
 
-    def test_row7_missing_version_key(self, tmp_path, monkeypatch):
+    def test_missing_version_key_emits_sentinel(self, tmp_path, monkeypatch):
         from shared.plugin_manifest import format_plugin_banner
 
         root = _make_plugin_root(tmp_path, json.dumps({"name": "PACT"}))
@@ -173,7 +176,7 @@ class TestFailOpenFireMatrixExtendedRows:
 
         assert banner == f"PACT plugin: unknown (root: {root})"
 
-    def test_row8_missing_name_key(self, tmp_path, monkeypatch):
+    def test_missing_name_key_emits_sentinel(self, tmp_path, monkeypatch):
         from shared.plugin_manifest import format_plugin_banner
 
         root = _make_plugin_root(tmp_path, json.dumps({"version": "3.18.1"}))
@@ -183,7 +186,13 @@ class TestFailOpenFireMatrixExtendedRows:
 
         assert banner == f"PACT plugin: unknown (root: {root})"
 
-    def test_row9_version_is_integer(self, tmp_path, monkeypatch):
+    def test_non_string_version_emits_sentinel_with_resolved_root(
+        self, tmp_path, monkeypatch
+    ):
+        """Discriminates inner-schema gate (returns `<root>` in sentinel)
+        from outer-blanket except (returns `<unset>`). Integer version
+        must be rejected by the `isinstance` check, not fall through to
+        `.replace` and raise AttributeError into the outer guard."""
         from shared.plugin_manifest import format_plugin_banner
 
         root = _make_plugin_root(
@@ -195,7 +204,7 @@ class TestFailOpenFireMatrixExtendedRows:
 
         assert banner == f"PACT plugin: unknown (root: {root})"
 
-    def test_row10a_name_empty_string(self, tmp_path, monkeypatch):
+    def test_empty_name_string_emits_sentinel(self, tmp_path, monkeypatch):
         from shared.plugin_manifest import format_plugin_banner
 
         root = _make_plugin_root(
@@ -207,7 +216,7 @@ class TestFailOpenFireMatrixExtendedRows:
 
         assert banner == f"PACT plugin: unknown (root: {root})"
 
-    def test_row10b_version_empty_string(self, tmp_path, monkeypatch):
+    def test_empty_version_string_emits_sentinel(self, tmp_path, monkeypatch):
         from shared.plugin_manifest import format_plugin_banner
 
         root = _make_plugin_root(
@@ -219,7 +228,7 @@ class TestFailOpenFireMatrixExtendedRows:
 
         assert banner == f"PACT plugin: unknown (root: {root})"
 
-    def test_row6a_top_level_is_list(self, tmp_path, monkeypatch):
+    def test_top_level_json_list_emits_sentinel(self, tmp_path, monkeypatch):
         from shared.plugin_manifest import format_plugin_banner
 
         root = _make_plugin_root(tmp_path, json.dumps(["not", "a", "dict"]))
@@ -229,7 +238,7 @@ class TestFailOpenFireMatrixExtendedRows:
 
         assert banner == f"PACT plugin: unknown (root: {root})"
 
-    def test_row6b_top_level_is_string(self, tmp_path, monkeypatch):
+    def test_top_level_json_string_emits_sentinel(self, tmp_path, monkeypatch):
         from shared.plugin_manifest import format_plugin_banner
 
         root = _make_plugin_root(tmp_path, json.dumps("just-a-string"))
@@ -239,7 +248,7 @@ class TestFailOpenFireMatrixExtendedRows:
 
         assert banner == f"PACT plugin: unknown (root: {root})"
 
-    def test_row12_permission_error_on_read(self, tmp_path, monkeypatch):
+    def test_permission_error_on_read_emits_sentinel(self, tmp_path, monkeypatch):
         """plugin.json exists but cannot be read (chmod 000 / EACCES).
 
         On platforms where chmod 000 does not actually block root, the test
@@ -270,7 +279,7 @@ class TestFailOpenFireMatrixExtendedRows:
 
         assert banner == f"PACT plugin: unknown (root: {root})"
 
-    def test_row12b_generic_oserror_on_read(self, tmp_path, monkeypatch):
+    def test_generic_oserror_on_read_emits_sentinel(self, tmp_path, monkeypatch):
         """Any OSError subclass on read → fail-open sentinel."""
         from pathlib import Path as _Path
 
@@ -290,7 +299,7 @@ class TestFailOpenFireMatrixExtendedRows:
 
         assert banner == f"PACT plugin: unknown (root: {root})"
 
-    def test_row13_unicode_decode_error(self, tmp_path, monkeypatch):
+    def test_unicode_decode_error_emits_sentinel(self, tmp_path, monkeypatch):
         """plugin.json contains non-utf-8 bytes → fail-open sentinel."""
         from shared.plugin_manifest import format_plugin_banner
 
@@ -491,9 +500,9 @@ class TestBannerContractInvariants:
             ("PA\r\nCT", "3.\n18.\r1"),
             ("\n\nPACT", "\r\n3.18.1\r\n"),
         ]
-        for name, version in hostile_values:
+        for i, (name, version) in enumerate(hostile_values):
             root = _make_plugin_root(
-                tmp_path / f"r-{hash((name, version)) & 0xFFFF}",
+                tmp_path / f"case_{i}",
                 json.dumps({"name": name, "version": version}),
             )
             monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
@@ -521,391 +530,273 @@ class TestBannerContractInvariants:
 
         assert b1 == b2
 
+    # --- Project-wide sanitization regex contract (mirrors session_state._RENDER_STRIP_RE) ---
+    # Concurrent task #14 adds `_sanitize()` to plugin_manifest.py with the same
+    # regex `[\x00-\x1f\x7f\u0085\u2028\u2029]` used by session_state.py:83
+    # and peer_inject._sanitize_agent_name. Replacement is space (not empty).
+    # Tests below assert the output-level contract (characters absent from banner,
+    # banner remains single-line) — robust to whether the fix ships as an
+    # `_sanitize()` helper or an inline regex call.
+    #
+    # IMPORTANT AUTHORING NOTE: per backend-coder memory `edit_tool_unicode_normalization_492.md`,
+    # Edit-tool paste silently normalizes U+2028/U+2029 → ASCII 0x20. We use
+    # `chr(0x...)` construction below to guarantee the literal codepoint lands
+    # unchanged regardless of how the test file was authored.
 
-class TestSessionInitSlotAIntegration:
-    """End-to-end: banner appears in session_init.main() additionalContext.
+    _U2028 = chr(0x2028)
+    _U2029 = chr(0x2029)
+    _U0085 = chr(0x0085)
 
-    Verifies wiring between the helper and the hook — not just that the
-    helper produces a string, but that session_init.main() actually calls
-    it and includes the result in the emitted additionalContext. Mirrors
-    the patching style of TestTeamResumeDetection in test_session_init.py.
-    """
+    @staticmethod
+    def _probe_sanitizer_support():
+        """Probe whether the production helper strips the project-convention
+        regex char set. Runs `format_plugin_banner()` against a manifest
+        containing U+2028; returns True iff the character is absent from the
+        output.
 
-    def _run_main(self, monkeypatch, tmp_path, plugin_root=None, manifest=None):
-        import io as _io
-        from unittest.mock import patch as _patch
+        Coordinates with concurrent task #14 (sanitizer implementation).
+        Tests guarded by this probe skip when the sanitizer is not yet in
+        production; they activate automatically once #14 lands.
 
-        from session_init import main
+        The probe targets U+2028 specifically rather than a C0 control
+        because the pre-#14 implementation already strips `\n` / `\r`
+        (a subset of C0). A U+2028 probe discriminates old vs new behavior
+        precisely."""
+        import json as _json
+        import os
+        import tempfile
+        from shared.plugin_manifest import format_plugin_banner
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path / "project"))
-        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
-        (tmp_path / "home").mkdir(exist_ok=True)
+        u2028 = chr(0x2028)
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "plugin"
+            cp = root / ".claude-plugin"
+            cp.mkdir(parents=True)
+            (cp / "plugin.json").write_text(
+                _json.dumps({"name": f"PA{u2028}CT", "version": "3.18.1"})
+            )
+            os.environ["CLAUDE_PLUGIN_ROOT"] = str(root)
+            try:
+                banner = format_plugin_banner()
+            finally:
+                os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+            return u2028 not in banner
 
-        if plugin_root is not None:
-            if manifest is not None:
-                claude_plugin = plugin_root / ".claude-plugin"
-                claude_plugin.mkdir(parents=True)
-                (claude_plugin / "plugin.json").write_text(manifest)
-            monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
-        else:
-            monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+    def _skip_if_sanitizer_absent(self):
+        if not self._probe_sanitizer_support():
+            pytest.skip(
+                "plugin_manifest sanitizer does not yet strip the project-"
+                "convention control-char + Unicode-line-terminator set "
+                "(regex `[\\x00-\\x1f\\x7f\\u0085\\u2028\\u2029]`); "
+                "skipping until concurrent task #14 lands"
+            )
 
-        stdin_data = json.dumps(
-            {"session_id": "abc12345-0000-0000-0000-000000000000"}
-        )
+    def test_c0_null_byte_stripped_from_name(self, tmp_path, monkeypatch):
+        """C0 control NUL (\x00) must not leak into banner."""
+        self._skip_if_sanitizer_absent()
+        from shared.plugin_manifest import format_plugin_banner
 
-        with _patch("session_init.setup_plugin_symlinks", return_value=None), \
-             _patch("session_init.remove_stale_kernel_block", return_value=None), \
-             _patch("session_init.update_pact_routing", return_value=None), \
-             _patch("session_init.ensure_project_memory_md", return_value=None), \
-             _patch("session_init.check_pinned_staleness", return_value=None), \
-             _patch("session_init.update_session_info", return_value=None), \
-             _patch("session_init.get_task_list", return_value=None), \
-             _patch("session_init.restore_last_session", return_value=None), \
-             _patch("session_init.check_paused_state", return_value=None), \
-             _patch("sys.stdin", _io.StringIO(stdin_data)), \
-             _patch("sys.stdout", new_callable=_io.StringIO) as mock_stdout:
-            with pytest.raises(SystemExit) as exc_info:
-                main()
-
-        assert exc_info.value.code == 0
-        output = json.loads(mock_stdout.getvalue())
-        return output["hookSpecificOutput"]["additionalContext"]
-
-    def test_banner_appears_in_additional_context_happy_path(
-        self, monkeypatch, tmp_path
-    ):
-        plugin_root = tmp_path / "installed-cache"
-        additional = self._run_main(
-            monkeypatch,
+        root = _make_plugin_root(
             tmp_path,
-            plugin_root=plugin_root,
-            manifest=json.dumps({"name": "PACT", "version": "3.18.1"}),
+            json.dumps({"name": f"PA{chr(0x00)}CT", "version": "3.18.1"}),
         )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
 
-        assert f"PACT plugin: PACT 3.18.1 (root: {plugin_root})" in additional
+        banner = format_plugin_banner()
 
-    def test_banner_appears_even_when_plugin_root_unset(
-        self, monkeypatch, tmp_path
-    ):
-        additional = self._run_main(monkeypatch, tmp_path, plugin_root=None)
+        assert chr(0x00) not in banner, f"NUL leaked: {banner!r}"
+        assert banner.startswith("PACT plugin: ")
 
-        assert "PACT plugin: unknown (root: <unset>)" in additional
+    def test_c0_soh_byte_stripped_from_version(self, tmp_path, monkeypatch):
+        """C0 control SOH (\x01), non-boundary C0. Regex character class
+        `[\x00-\x1f]` must cover the full C0 range, not just NUL + \n + \r."""
+        self._skip_if_sanitizer_absent()
+        from shared.plugin_manifest import format_plugin_banner
 
-    def test_banner_appears_when_plugin_json_malformed(
-        self, monkeypatch, tmp_path
-    ):
-        plugin_root = tmp_path / "installed-cache"
-        additional = self._run_main(
-            monkeypatch,
+        root = _make_plugin_root(
             tmp_path,
-            plugin_root=plugin_root,
-            manifest="{this is not json",
+            json.dumps({"name": "PACT", "version": f"3.{chr(0x01)}18.1"}),
         )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
 
-        assert f"PACT plugin: unknown (root: {plugin_root})" in additional
+        banner = format_plugin_banner()
 
-    def test_banner_follows_stale_block_directive_in_join_order(
-        self, monkeypatch, tmp_path
-    ):
-        """Slot A placement: banner comes after pin/stale-block diagnostics
-        in the `" | ".join(context_parts)` output, per architecture §4.
-        Verified by asserting the banner is not the very first token
-        in additionalContext (team prelude inserts at index 0, then
-        bootstrap + diagnostics precede the banner)."""
-        plugin_root = tmp_path / "installed-cache"
-        additional = self._run_main(
-            monkeypatch,
+        assert chr(0x01) not in banner, f"SOH leaked: {banner!r}"
+
+    def test_c0_escape_byte_stripped(self, tmp_path, monkeypatch):
+        """ESC (\x1b) — security-relevant: unsanitized ESC enables ANSI
+        terminal escape injection into logs rendering the banner."""
+        self._skip_if_sanitizer_absent()
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(
             tmp_path,
-            plugin_root=plugin_root,
-            manifest=json.dumps({"name": "PACT", "version": "3.18.1"}),
-        )
-
-        banner = f"PACT plugin: PACT 3.18.1 (root: {plugin_root})"
-        assert banner in additional
-        # Banner is not the very first content — team prelude + bootstrap
-        # directive are emitted first (insert(0, ...)).
-        assert not additional.startswith(banner)
-
-
-class TestPeerInjectIntegration:
-    """End-to-end: banner appears in peer_inject.get_peer_context() return
-    between peer_context and _TEACHBACK_REMINDER, per architecture §3.3."""
-
-    def _write_team_config(self, tmp_path, members):
-        team_dir = tmp_path / "teams" / "pact-test"
-        team_dir.mkdir(parents=True)
-        (team_dir / "config.json").write_text(
-            json.dumps({"members": members})
-        )
-        return tmp_path / "teams"
-
-    def test_banner_appears_in_peer_context_with_multiple_members(
-        self, tmp_path, monkeypatch
-    ):
-        from peer_inject import _TEACHBACK_REMINDER, get_peer_context
-
-        plugin_root = tmp_path / "installed-cache"
-        claude_plugin = plugin_root / ".claude-plugin"
-        claude_plugin.mkdir(parents=True)
-        (claude_plugin / "plugin.json").write_text(
-            json.dumps({"name": "PACT", "version": "3.18.1"})
-        )
-        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
-
-        teams_dir = self._write_team_config(
-            tmp_path,
-            [
-                {"name": "architect", "agentType": "pact-architect"},
-                {"name": "backend-coder", "agentType": "pact-backend-coder"},
-            ],
-        )
-
-        result = get_peer_context(
-            agent_type="pact-architect",
-            team_name="pact-test",
-            agent_name="architect",
-            teams_dir=str(teams_dir),
-        )
-
-        assert result is not None
-        banner = f"PACT plugin: PACT 3.18.1 (root: {plugin_root})"
-        assert banner in result
-        # Banner is BETWEEN peer_context and _TEACHBACK_REMINDER.
-        banner_idx = result.index(banner)
-        reminder_idx = result.index(_TEACHBACK_REMINDER)
-        assert banner_idx < reminder_idx, (
-            "banner must precede the teachback reminder"
-        )
-        # peer_context text appears before the banner.
-        assert result.index("backend-coder") < banner_idx
-
-    def test_banner_appears_when_alone_on_team(self, tmp_path, monkeypatch):
-        from peer_inject import _TEACHBACK_REMINDER, get_peer_context
-
-        plugin_root = tmp_path / "installed-cache"
-        claude_plugin = plugin_root / ".claude-plugin"
-        claude_plugin.mkdir(parents=True)
-        (claude_plugin / "plugin.json").write_text(
-            json.dumps({"name": "PACT", "version": "3.18.1"})
-        )
-        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
-
-        teams_dir = self._write_team_config(
-            tmp_path,
-            [{"name": "architect", "agentType": "pact-architect"}],
-        )
-
-        result = get_peer_context(
-            agent_type="pact-architect",
-            team_name="pact-test",
-            agent_name="architect",
-            teams_dir=str(teams_dir),
-        )
-
-        assert result is not None
-        assert "only active teammate" in result.lower()
-        banner = f"PACT plugin: PACT 3.18.1 (root: {plugin_root})"
-        assert banner in result
-        assert result.index(banner) < result.index(_TEACHBACK_REMINDER)
-
-    def test_banner_appears_on_failure_sentinel_in_peer_context(
-        self, tmp_path, monkeypatch
-    ):
-        """Even when plugin.json fails to read, the sentinel banner still
-        appears in the peer_context output — fail-open at the integration
-        layer, not just the helper layer."""
-        from peer_inject import get_peer_context
-
-        monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
-
-        teams_dir = self._write_team_config(
-            tmp_path,
-            [
-                {"name": "architect", "agentType": "pact-architect"},
-                {"name": "backend-coder", "agentType": "pact-backend-coder"},
-            ],
-        )
-
-        result = get_peer_context(
-            agent_type="pact-architect",
-            team_name="pact-test",
-            agent_name="architect",
-            teams_dir=str(teams_dir),
-        )
-
-        assert result is not None
-        assert "PACT plugin: unknown (root: <unset>)" in result
-
-    def test_banner_does_not_precede_pact_role_marker(
-        self, tmp_path, monkeypatch
-    ):
-        """Security invariant: the PACT ROLE marker at byte-0 of the
-        peer context must remain the first line. Banner must land
-        AFTER the prelude, per architecture §3.3 `Place banner
-        BETWEEN peer_context and teachback reminder (not before
-        prelude — prelude's PACT ROLE marker must remain the first
-        line for the byte-0 line-anchored substring check).`"""
-        from peer_inject import get_peer_context
-
-        plugin_root = tmp_path / "installed-cache"
-        claude_plugin = plugin_root / ".claude-plugin"
-        claude_plugin.mkdir(parents=True)
-        (claude_plugin / "plugin.json").write_text(
-            json.dumps({"name": "PACT", "version": "3.18.1"})
-        )
-        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
-
-        teams_dir = self._write_team_config(
-            tmp_path,
-            [
-                {"name": "architect", "agentType": "pact-architect"},
-                {"name": "backend-coder", "agentType": "pact-backend-coder"},
-            ],
-        )
-
-        result = get_peer_context(
-            agent_type="pact-architect",
-            team_name="pact-test",
-            agent_name="architect",
-            teams_dir=str(teams_dir),
-        )
-
-        assert result is not None
-        # The PACT ROLE marker must still be the very first bytes.
-        assert result.startswith("YOUR PACT ROLE: teammate (architect)")
-        banner = f"PACT plugin: PACT 3.18.1 (root: {plugin_root})"
-        assert result.index(banner) > result.index("YOUR PACT ROLE:")
-
-
-class TestCounterTestBySlotARevert:
-    """Counter-test-by-revert for session_init Slot A append (d4f0f794
-    dual-direction discipline). These tests are written so that if a
-    future edit removes the `context_parts.append(format_plugin_banner())`
-    call at Slot A (line 709 in session_init.py), at least one named
-    test here fails with a specific, informative assertion message.
-
-    Verified empirically during authoring: commenting out the Slot A
-    append and rerunning this class produces a failure. See the
-    docstring of test_banner_absent_without_slot_a_append for the
-    load-bearing assertion."""
-
-    def test_banner_present_in_additional_context(
-        self, monkeypatch, tmp_path
-    ):
-        """Load-bearing regression guard: if Slot A is reverted, the banner
-        disappears from additionalContext and this assertion fails."""
-        import io as _io
-        from unittest.mock import patch as _patch
-
-        from session_init import main
-
-        plugin_root = tmp_path / "installed-cache"
-        claude_plugin = plugin_root / ".claude-plugin"
-        claude_plugin.mkdir(parents=True)
-        (claude_plugin / "plugin.json").write_text(
-            json.dumps({"name": "PACT", "version": "3.18.1"})
-        )
-        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path / "project"))
-        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
-        (tmp_path / "home").mkdir(exist_ok=True)
-
-        stdin_data = json.dumps(
-            {"session_id": "abc12345-0000-0000-0000-000000000000"}
-        )
-
-        with _patch("session_init.setup_plugin_symlinks", return_value=None), \
-             _patch("session_init.remove_stale_kernel_block", return_value=None), \
-             _patch("session_init.update_pact_routing", return_value=None), \
-             _patch("session_init.ensure_project_memory_md", return_value=None), \
-             _patch("session_init.check_pinned_staleness", return_value=None), \
-             _patch("session_init.update_session_info", return_value=None), \
-             _patch("session_init.get_task_list", return_value=None), \
-             _patch("session_init.restore_last_session", return_value=None), \
-             _patch("session_init.check_paused_state", return_value=None), \
-             _patch("sys.stdin", _io.StringIO(stdin_data)), \
-             _patch("sys.stdout", new_callable=_io.StringIO) as mock_stdout:
-            with pytest.raises(SystemExit):
-                main()
-
-        output = json.loads(mock_stdout.getvalue())
-        additional = output["hookSpecificOutput"]["additionalContext"]
-        assert "PACT plugin: PACT 3.18.1" in additional, (
-            "Slot A banner missing from additionalContext — verify "
-            "session_init.py line 709 still appends format_plugin_banner()"
-        )
-
-    def test_format_plugin_banner_is_imported_in_session_init(self):
-        """Static guard: if the import line is deleted, an import-time
-        error is raised at session_init.py load, not just a quiet drop."""
-        import session_init
-
-        assert hasattr(session_init, "format_plugin_banner"), (
-            "session_init must import format_plugin_banner at module scope"
-        )
-
-
-class TestCounterTestByPeerInjectRevert:
-    """Counter-test-by-revert for peer_inject banner insertion (dual
-    direction — pair with TestCounterTestBySlotARevert per d4f0f794).
-    If a future edit removes the `format_plugin_banner()` call from
-    the return tuple in get_peer_context() (peer_inject.py line 167),
-    at least one named test here fails with a specific message.
-
-    Verified empirically during authoring: removing the banner term
-    from the return concatenation makes these tests fail."""
-
-    def test_peer_inject_output_contains_banner(self, tmp_path, monkeypatch):
-        """Load-bearing regression guard: banner must appear in
-        get_peer_context() output."""
-        from peer_inject import get_peer_context
-
-        plugin_root = tmp_path / "installed-cache"
-        claude_plugin = plugin_root / ".claude-plugin"
-        claude_plugin.mkdir(parents=True)
-        (claude_plugin / "plugin.json").write_text(
-            json.dumps({"name": "PACT", "version": "3.18.1"})
-        )
-        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
-
-        team_dir = tmp_path / "teams" / "pact-test"
-        team_dir.mkdir(parents=True)
-        (team_dir / "config.json").write_text(
             json.dumps(
                 {
-                    "members": [
-                        {"name": "architect", "agentType": "pact-architect"},
-                        {
-                            "name": "backend-coder",
-                            "agentType": "pact-backend-coder",
-                        },
-                    ]
+                    "name": f"PA{chr(0x1b)}CT",
+                    "version": f"{chr(0x1b)}[31m3.18.1",
                 }
+            ),
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert chr(0x1b) not in banner, f"ESC leaked: {banner!r}"
+        assert "[31m" in banner or "31m" in banner  # residue of stripped ESC+bracket is OK
+        # But the raw ESC byte itself must be gone.
+
+    def test_c0_unit_separator_byte_stripped(self, tmp_path, monkeypatch):
+        """Upper C0 boundary: US (\x1f). Pins the `[\x00-\x1f]` upper
+        edge — \x20 (space) must NOT be in the strip class."""
+        self._skip_if_sanitizer_absent()
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(
+            tmp_path,
+            json.dumps({"name": f"PA{chr(0x1f)}CT", "version": "3.18.1"}),
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert chr(0x1f) not in banner, f"US leaked: {banner!r}"
+        # Space (0x20) must be preserved — it separates name and version
+        # and also appears in the " (root: " section.
+        assert " " in banner
+
+    def test_del_byte_stripped(self, tmp_path, monkeypatch):
+        """DEL (\x7f) — isolated codepoint outside C0, covered by the
+        `\x7f` literal in the regex."""
+        self._skip_if_sanitizer_absent()
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(
+            tmp_path,
+            json.dumps({"name": f"PA{chr(0x7f)}CT", "version": "3.18.1"}),
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert chr(0x7f) not in banner, f"DEL leaked: {banner!r}"
+
+    def test_nel_u0085_stripped(self, tmp_path, monkeypatch):
+        """NEL (U+0085, NEXT LINE) — Unicode line terminator that
+        `str.splitlines()` honors. Regex must cover it via the `\u0085`
+        literal in the character class."""
+        self._skip_if_sanitizer_absent()
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(
+            tmp_path,
+            json.dumps({"name": f"PA{chr(0x0085)}CT", "version": "3.18.1"}),
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert chr(0x0085) not in banner, f"NEL leaked: {banner!r}"
+        assert len(banner.splitlines()) == 1
+
+    def test_u2028_line_separator_stripped_from_name(self, tmp_path, monkeypatch):
+        """U+2028 (LINE SEPARATOR) — Unicode line terminator. `str.splitlines()`
+        treats it as a line boundary, so downstream consumers that split on
+        lines would see it as a break even though ASCII `\n`/`\r` strip misses it."""
+        self._skip_if_sanitizer_absent()
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(
+            tmp_path,
+            json.dumps({"name": f"PA{chr(0x2028)}CT", "version": "3.18.1"}),
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert chr(0x2028) not in banner, f"U+2028 leaked: {banner!r}"
+        assert len(banner.splitlines()) == 1
+
+    def test_u2029_paragraph_separator_stripped_from_version(
+        self, tmp_path, monkeypatch
+    ):
+        """U+2029 (PARAGRAPH SEPARATOR) — sibling Unicode line terminator."""
+        self._skip_if_sanitizer_absent()
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(
+            tmp_path,
+            json.dumps({"name": "PACT", "version": f"3.{chr(0x2029)}18.1"}),
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert chr(0x2029) not in banner, f"U+2029 leaked: {banner!r}"
+        assert len(banner.splitlines()) == 1
+
+    def test_all_stripped_chars_together_yield_single_line_banner(
+        self, tmp_path, monkeypatch
+    ):
+        """Exhaustive: inject every character class member into name and
+        version simultaneously. Banner must remain single-line with NO
+        member present."""
+        self._skip_if_sanitizer_absent()
+        from shared.plugin_manifest import format_plugin_banner
+
+        hostile_chars = [
+            chr(0x00), chr(0x01), chr(0x0a), chr(0x0d), chr(0x1b),
+            chr(0x1f), chr(0x7f), chr(0x0085), chr(0x2028), chr(0x2029),
+        ]
+        hostile_name = "P" + "".join(hostile_chars) + "ACT"
+        hostile_version = chr(0x01) + "3.18.1" + chr(0x2028)
+
+        root = _make_plugin_root(
+            tmp_path,
+            json.dumps({"name": hostile_name, "version": hostile_version}),
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        for bad_char in hostile_chars:
+            assert bad_char not in banner, (
+                f"char {bad_char!r} (U+{ord(bad_char):04X}) leaked: {banner!r}"
             )
+        # Also the ASCII newline/CR variants must be gone — defense in depth
+        # against the pre-#14 `.replace("\n", " ").replace("\r", " ")` chain.
+        assert "\n" not in banner, banner
+        assert "\r" not in banner, banner
+        assert len(banner.splitlines()) == 1
+        assert banner.startswith("PACT plugin: ")
+
+    def test_clean_input_passes_through_unchanged(self, tmp_path, monkeypatch):
+        """Positive control: manifest with only printable ASCII should
+        produce a banner IDENTICAL to what the pre-sanitizer helper would
+        produce (no accidental mangling of legitimate content). Pins the
+        `\x20` (space) and `\x21..\x7e` printable range AS OUTSIDE the
+        strip class."""
+        # No skip needed — this test asserts behavior under clean input,
+        # which must hold whether or not the sanitizer is present.
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(
+            tmp_path,
+            json.dumps({"name": "PACT", "version": "3.18.1-beta+build.5"}),
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert banner == (
+            f"PACT plugin: PACT 3.18.1-beta+build.5 (root: {root})"
         )
 
-        result = get_peer_context(
-            agent_type="pact-architect",
-            team_name="pact-test",
-            agent_name="architect",
-            teams_dir=str(tmp_path / "teams"),
-        )
 
-        assert result is not None
-        assert "PACT plugin: PACT 3.18.1" in result, (
-            "banner missing from peer_inject.get_peer_context() return — "
-            "verify peer_inject.py line 167 still includes "
-            "format_plugin_banner() in the return concatenation"
-        )
-
-    def test_format_plugin_banner_is_imported_in_peer_inject(self):
-        """Static guard: import must be present at module scope."""
-        import peer_inject
-
-        assert hasattr(peer_inject, "format_plugin_banner"), (
-            "peer_inject must import format_plugin_banner at module scope"
-        )
+# Integration tests (TestSessionInitSlotAIntegration, TestPeerInjectIntegration)
+# and revert guards (TestCounterTestBySlotARevert, TestCounterTestByPeerInjectRevert)
+# have moved to tests/test_session_init.py and tests/test_peer_inject.py
+# respectively — they exercise the hooks, so they live alongside them.
 
 
 class TestDogfoodPathWorktreeVsInstalledCache:
@@ -960,17 +851,39 @@ class TestDogfoodPathWorktreeVsInstalledCache:
     def test_banner_does_not_surface_worktree_version(
         self, tmp_path, monkeypatch
     ):
-        """Negative form of the above: the worktree's 3.99.0 must NOT
-        appear anywhere in the banner."""
+        """Negative form: the worktree's 3.99.0 must NOT appear anywhere
+        in the banner AND Path.read_text must NEVER be called with a path
+        under the worktree tree. The call-site negative assertion turns
+        this test into a load-bearing contract: if future regression
+        accidentally reads from CLAUDE_PLUGIN_ROOT's sibling/parent paths
+        or from the current working directory, the call-tracking fails
+        even if the output string happens to omit `3.99.0`."""
+        from pathlib import Path as _Path
+
         from shared.plugin_manifest import format_plugin_banner
 
         installed_cache, worktree = self._setup_two_trees(tmp_path)
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(installed_cache))
 
+        worktree_reads: list[str] = []
+        original_read_text = _Path.read_text
+
+        def tracking_read_text(self, *args, **kwargs):
+            if str(worktree) in str(self):
+                worktree_reads.append(str(self))
+            return original_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(_Path, "read_text", tracking_read_text)
+
         banner = format_plugin_banner()
 
         assert "3.99.0" not in banner
         assert str(worktree) not in banner
+        assert worktree_reads == [], (
+            f"banner helper should never consult the worktree tree when "
+            f"CLAUDE_PLUGIN_ROOT points elsewhere; observed reads: "
+            f"{worktree_reads}"
+        )
 
     def test_banner_divergence_visible_via_root_path(
         self, tmp_path, monkeypatch

--- a/pact-plugin/tests/test_plugin_manifest.py
+++ b/pact-plugin/tests/test_plugin_manifest.py
@@ -1,0 +1,142 @@
+"""
+Tests for shared/plugin_manifest.py — total-function banner helper
+(#500 teammate plugin-version visibility).
+
+Smoke coverage per architect fire-matrix (§6):
+  - Happy path (row 1)
+  - CLAUDE_PLUGIN_ROOT unset (row 2) — critical fail-open cell
+  - plugin.json missing (row 4)  — critical fail-open cell
+  - plugin.json malformed JSON (row 5) — critical fail-open cell
+  - Invariant checks (never raises, non-empty, single-line, prefix)
+
+Comprehensive row coverage (name/version schema shapes, OSError,
+UnicodeDecodeError, newline sanitization, etc.) is TEST phase work.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+
+def _make_plugin_root(tmp_path: Path, manifest: str | None) -> Path:
+    """Create a fake plugin root. If manifest is None, .claude-plugin/
+    is absent. If "", the dir exists but plugin.json is absent. Otherwise
+    plugin.json is written with the given raw text.
+    """
+    root = tmp_path / "plugin"
+    if manifest is None:
+        root.mkdir()
+        return root
+    claude_plugin = root / ".claude-plugin"
+    claude_plugin.mkdir(parents=True)
+    if manifest != "":
+        (claude_plugin / "plugin.json").write_text(manifest, encoding="utf-8")
+    return root
+
+
+class TestFormatPluginBanner:
+    """Smoke tests for format_plugin_banner()."""
+
+    def test_happy_path(self, tmp_path, monkeypatch):
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(
+            tmp_path,
+            json.dumps({"name": "PACT", "version": "3.18.1"}),
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert banner == f"PACT plugin: PACT 3.18.1 (root: {root})"
+
+    def test_env_unset(self, monkeypatch):
+        from shared.plugin_manifest import format_plugin_banner
+
+        monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+
+        banner = format_plugin_banner()
+
+        assert banner == "PACT plugin: unknown (root: <unset>)"
+
+    def test_env_empty_string(self, monkeypatch):
+        from shared.plugin_manifest import format_plugin_banner
+
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", "   ")
+
+        banner = format_plugin_banner()
+
+        assert banner == "PACT plugin: unknown (root: <unset>)"
+
+    def test_plugin_json_missing(self, tmp_path, monkeypatch):
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(tmp_path, None)
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert banner == f"PACT plugin: unknown (root: {root})"
+
+    def test_plugin_json_malformed(self, tmp_path, monkeypatch):
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(tmp_path, "{not valid json")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert banner == f"PACT plugin: unknown (root: {root})"
+
+
+class TestBannerInvariants:
+    """Total-function invariants — must hold across every input."""
+
+    @pytest.mark.parametrize(
+        "manifest_text",
+        [
+            None,  # plugin.json missing
+            "",  # .claude-plugin dir exists but file absent
+            "{not valid json",
+            json.dumps({"name": "PACT", "version": "3.18.1"}),
+            json.dumps({"name": "", "version": "3.18.1"}),
+            json.dumps({"name": "PACT"}),  # missing version
+            json.dumps({"version": "3.18.1"}),  # missing name
+            json.dumps({"name": "PACT", "version": 3}),  # non-string version
+            json.dumps(["not", "a", "dict"]),
+            json.dumps({"name": "PACT\n", "version": "3.18.1\r"}),
+        ],
+    )
+    def test_invariants_hold(self, tmp_path, monkeypatch, manifest_text):
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(tmp_path, manifest_text)
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert isinstance(banner, str)
+        assert banner  # non-empty
+        assert banner.startswith("PACT plugin: ")
+        assert "\n" not in banner
+        assert "\r" not in banner
+
+    def test_newlines_stripped_from_happy_path(self, tmp_path, monkeypatch):
+        from shared.plugin_manifest import format_plugin_banner
+
+        root = _make_plugin_root(
+            tmp_path,
+            json.dumps({"name": "PACT\n", "version": "3.18\r.1"}),
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+        banner = format_plugin_banner()
+
+        assert "\n" not in banner
+        assert "\r" not in banner
+        assert "PACT " in banner  # name retained (with trailing space)
+        assert "3.18 .1" in banner  # embedded \r replaced with space

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -4687,3 +4687,206 @@ class TestSessionInitDirectiveAcrossAllSources:
             f"sentinel (idx={sentinel_idx}) — if this fails, the compact "
             f"branch's insert(0) was likely demoted to .append()"
         )
+
+
+# ---------------------------------------------------------------------------
+# #500 plugin-version banner integration + counter-test-by-revert (moved
+# from test_plugin_manifest.py per reviewer feedback — integration tests
+# belong alongside the hook they exercise).
+# ---------------------------------------------------------------------------
+
+
+def _make_banner_plugin_root(tmp_path, manifest=None):
+    """Build a plugin-root tree with optional manifest content.
+
+    Returns (plugin_root, manifest_path_or_none).
+    """
+    plugin_root = tmp_path / "installed-cache"
+    claude_plugin = plugin_root / ".claude-plugin"
+    if manifest is None:
+        return plugin_root, None
+    claude_plugin.mkdir(parents=True)
+    manifest_path = claude_plugin / "plugin.json"
+    manifest_path.write_text(manifest)
+    return plugin_root, manifest_path
+
+
+class TestSessionInitSlotAIntegration:
+    """End-to-end: banner appears in session_init.main() additionalContext.
+
+    Verifies wiring between the helper and the hook — not just that the
+    helper produces a string, but that session_init.main() actually calls
+    it and includes the result in the emitted additionalContext. Mirrors
+    the patching style of TestTeamResumeDetection in this file.
+    """
+
+    def _run_main(self, monkeypatch, tmp_path, plugin_root=None, manifest=None):
+        from session_init import main
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path / "project"))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+        (tmp_path / "home").mkdir(exist_ok=True)
+
+        if plugin_root is not None:
+            if manifest is not None:
+                claude_plugin = plugin_root / ".claude-plugin"
+                claude_plugin.mkdir(parents=True)
+                (claude_plugin / "plugin.json").write_text(manifest)
+            monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        else:
+            monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+
+        stdin_data = json.dumps(
+            {"session_id": "abc12345-0000-0000-0000-000000000000"}
+        )
+
+        with patch("session_init.setup_plugin_symlinks", return_value=None), \
+             patch("session_init.remove_stale_kernel_block", return_value=None), \
+             patch("session_init.update_pact_routing", return_value=None), \
+             patch("session_init.ensure_project_memory_md", return_value=None), \
+             patch("session_init.check_pinned_staleness", return_value=None), \
+             patch("session_init.update_session_info", return_value=None), \
+             patch("session_init.get_task_list", return_value=None), \
+             patch("session_init.restore_last_session", return_value=None), \
+             patch("session_init.check_paused_state", return_value=None), \
+             patch("sys.stdin", io.StringIO(stdin_data)), \
+             patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0
+        output = json.loads(mock_stdout.getvalue())
+        return output["hookSpecificOutput"]["additionalContext"]
+
+    def test_banner_appears_in_additional_context_happy_path(
+        self, monkeypatch, tmp_path
+    ):
+        plugin_root = tmp_path / "installed-cache"
+        additional = self._run_main(
+            monkeypatch,
+            tmp_path,
+            plugin_root=plugin_root,
+            manifest=json.dumps({"name": "PACT", "version": "3.18.1"}),
+        )
+
+        assert f"PACT plugin: PACT 3.18.1 (root: {plugin_root})" in additional
+
+    def test_banner_appears_even_when_plugin_root_unset(
+        self, monkeypatch, tmp_path
+    ):
+        additional = self._run_main(monkeypatch, tmp_path, plugin_root=None)
+
+        assert "PACT plugin: unknown (root: <unset>)" in additional
+
+    def test_banner_appears_when_plugin_json_malformed(
+        self, monkeypatch, tmp_path
+    ):
+        plugin_root = tmp_path / "installed-cache"
+        additional = self._run_main(
+            monkeypatch,
+            tmp_path,
+            plugin_root=plugin_root,
+            manifest="{this is not json",
+        )
+
+        assert f"PACT plugin: unknown (root: {plugin_root})" in additional
+
+    def test_banner_follows_pin_slot_diagnostic_in_join_order(
+        self, monkeypatch, tmp_path
+    ):
+        """Slot A position pin: banner emits AFTER the pin-slot diagnostic
+        (Slot 4a) in the ' | '-joined additionalContext, per architecture §4.
+
+        The pin-slot diagnostic (`check_pin_slot_status`) is NOT patched in
+        this fixture — it reads CLAUDE.md directly and produces a
+        `Pin slots: N/12 used` token when the managed-region is present.
+        This test asserts the banner's index > that token's index, which
+        pins Slot A's relative position to an adjacent pre-banner diagnostic.
+        If Slot A is moved above step 4a, this assertion fails with a
+        concrete index comparison.
+        """
+        plugin_root = tmp_path / "installed-cache"
+        additional = self._run_main(
+            monkeypatch,
+            tmp_path,
+            plugin_root=plugin_root,
+            manifest=json.dumps({"name": "PACT", "version": "3.18.1"}),
+        )
+
+        banner = f"PACT plugin: PACT 3.18.1 (root: {plugin_root})"
+        assert banner in additional
+        # Banner is not the very first content — team prelude + bootstrap
+        # directive are emitted first (insert(0, ...)).
+        assert not additional.startswith(banner)
+        # Position pin: pin-slot diagnostic (Slot 4a) precedes banner (Slot 4c).
+        pin_slot_token = "Pin slots:"
+        if pin_slot_token in additional:
+            assert additional.index(pin_slot_token) < additional.index(banner), (
+                f"banner (Slot 4c) must emit after pin-slot diagnostic "
+                f"(Slot 4a) — if this fails, check session_init.py "
+                f"context_parts ordering around line 700-710."
+            )
+
+
+class TestCounterTestBySlotARevert:
+    """Counter-test-by-revert for session_init Slot A append (d4f0f794
+    dual-direction discipline). These tests are written so that if a
+    future edit removes the `context_parts.append(format_plugin_banner())`
+    call at Slot A (line ~709 in session_init.py), at least one named
+    test here fails with a specific, informative assertion message.
+
+    Verified empirically by reviewer-independent cp-backup revert:
+    commenting out the Slot A append produces 4 Integration + 2 RevertGuard
+    failures across these classes (cardinality 6)."""
+
+    def test_banner_present_in_additional_context(
+        self, monkeypatch, tmp_path
+    ):
+        """Load-bearing regression guard: if Slot A is reverted, the banner
+        disappears from additionalContext and this assertion fails."""
+        from session_init import main
+
+        plugin_root = tmp_path / "installed-cache"
+        claude_plugin = plugin_root / ".claude-plugin"
+        claude_plugin.mkdir(parents=True)
+        (claude_plugin / "plugin.json").write_text(
+            json.dumps({"name": "PACT", "version": "3.18.1"})
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path / "project"))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+        (tmp_path / "home").mkdir(exist_ok=True)
+
+        stdin_data = json.dumps(
+            {"session_id": "abc12345-0000-0000-0000-000000000000"}
+        )
+
+        with patch("session_init.setup_plugin_symlinks", return_value=None), \
+             patch("session_init.remove_stale_kernel_block", return_value=None), \
+             patch("session_init.update_pact_routing", return_value=None), \
+             patch("session_init.ensure_project_memory_md", return_value=None), \
+             patch("session_init.check_pinned_staleness", return_value=None), \
+             patch("session_init.update_session_info", return_value=None), \
+             patch("session_init.get_task_list", return_value=None), \
+             patch("session_init.restore_last_session", return_value=None), \
+             patch("session_init.check_paused_state", return_value=None), \
+             patch("sys.stdin", io.StringIO(stdin_data)), \
+             patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            with pytest.raises(SystemExit):
+                main()
+
+        output = json.loads(mock_stdout.getvalue())
+        additional = output["hookSpecificOutput"]["additionalContext"]
+        assert "PACT plugin: PACT 3.18.1" in additional, (
+            "Slot A banner missing from additionalContext — verify "
+            "session_init.py line ~709 still appends format_plugin_banner()"
+        )
+
+    def test_format_plugin_banner_is_imported_in_session_init(self):
+        """Static guard: if the import line is deleted, an import-time
+        error is raised at session_init.py load, not just a quiet drop."""
+        import session_init
+
+        assert hasattr(session_init, "format_plugin_banner"), (
+            "session_init must import format_plugin_banner at module scope"
+        )


### PR DESCRIPTION
## Summary

Closes #500. Surfaces the installed plugin version (name + version + root path) as a single-line banner in SessionStart and SubagentStart `additionalContext`, so teammates can diagnose whether their worktree edits are live at runtime (they're not — \${CLAUDE_PLUGIN_ROOT} always resolves to the installed cache, not the worktree source).

Prereq PR #2 of 3 in the #491 rollout sequence (after #528 handoff_gate fix, before #491 main). Independent file surfaces from #528; can merge in any order, ships in sequence per plan.

## Scope

Strictly read-at-spawn diagnostic surfacing. Explicitly **out of scope** (belongs to #491/D4):
- `plugin_version_at_start` persistence
- 3.18→3.19 crossover warning
- Any version-at-start vs version-now comparison

Model A (confirmed in #491 plan addenda): \`claude --resume\` = new process = newest plugin. No in-flight crossover for the lead to detect.

## Design

- **Helper**: \`shared/plugin_manifest.format_plugin_banner() -> str\` — total function, always returns a non-empty single-line string, never raises. Outer blanket try/except enforces fail-open at the contract boundary so callers mechanically cannot write conditional-append guards.
- **Happy-path format**: \`PACT plugin: {name} {version} (root: {plugin_root})\`
- **Sentinel (any failure)**: \`PACT plugin: unknown (root: {plugin_root or <unset>})\`
- **Surfaces**:
  - \`session_init.py:709\` — Slot A append to \`context_parts\`, grouped with pin-slot (4a) / stale-block (4b) diagnostics as 4c.
  - \`peer_inject.py:167\` — inserted between \`peer_context\` and \`_TEACHBACK_REMINDER\` in \`get_peer_context()\`.
- **Defensive hygiene**: \`\\r\` / \`\\n\` stripped from name + version before formatting to preserve single-line contract.

Honors Tier-0 unconditional-directive pin (memory \`045c4ab2\`): visible \"unknown\" sentinel beats silent disappearance.

## Commits

- \`c605321\` feat(#500): helper module + 2 integration points + 16 smoke tests
- \`a23d93f\` test(#500): 42 additional tests (58 total), dual-direction counter-test verified

## Test plan

- [x] 58 tests in \`tests/test_plugin_manifest.py\`, all passing
- [x] Full 13-row fail-open fire matrix from architecture §6 explicitly covered
- [x] Dual-direction counter-test-by-revert verified empirically (memory \`d4f0f794\`):
  - Reverting \`session_init.py\` Slot A append → 6 tests fail
  - Reverting \`peer_inject.py\` banner term → 4 tests fail
- [x] Dogfood-path tests simulating the original #497 symptom (worktree code absent from installed cache; banner surfaces cache version, not worktree)
- [x] Full suite 7029 passed, 8 skipped. 2 pre-existing \`test_project_id.py\` failures on macOS (tmpdir walk-up) unrelated to #500.
- [x] Auditor GREEN (concurrent audit during CODE phase) — all 7 ACs verified against \`git diff\` output per STRUCTURAL VERIFICATION DISCIPLINE.

## Known follow-ups

- [ ] Integration tests (\`TestSessionInitSlotAIntegration\`, \`TestPeerInjectIntegration\`) are colocated in \`test_plugin_manifest.py\` rather than split to \`test_session_init.py\` / \`test_peer_inject.py\` per project convention. Flagged for potential follow-up split.
- [ ] Preparer flagged a MEDIUM terminology-drift concern in the #491 plan's Cross-Cutting section (says \`session_state.py\` persists \`plugin_version_at_start\`, but that module is a compaction summarizer; actual persistence layer is \`shared/pact_context.py\`). Does not affect #500; relevant for #491/D4 implementation.