### PR TITLE
feat(#520): git-style prefix resolution for pact-memory get

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "3.19.0",
+      "version": "3.19.1",
       "author": {
         "name": "ProfSynapse"
       },

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-marketplace/
 │           └── PACT/
-│               └── 3.19.0/    # Plugin version
+│               └── 3.19.1/    # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "3.19.0",
+  "version": "3.19.1",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "ProfSynapse",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 3.19.0
+> **Version**: 3.19.1
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/skills/pact-memory/SKILL.md
+++ b/pact-plugin/skills/pact-memory/SKILL.md
@@ -60,8 +60,8 @@ python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" search "auth tokens" --current-file
 # List recent memories
 python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" list --limit 10
 
-# Get a specific memory by ID
-python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" get <memory_id>
+# Get a specific memory by full ID or unique prefix (>= 4 chars)
+python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" get <memory_id_or_prefix>
 
 # Update an existing memory (scalar fields replace; list fields merge additively)
 python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" update <memory_id> '{"goal": "Updated goal"}'
@@ -135,7 +135,7 @@ Each memory can contain:
 | `search <query> --current-file <path>` | Search with graph boosting | `[...]` (boosts file-related memories) |
 | `list` | List recent memories | `[{"id": "...", "context": "...", ...}, ...]` |
 | `list --limit N` | List with limit | `[...]` (default: 20) |
-| `get <id>` | Get memory by ID | `{"id": "...", "context": "...", ...}` |
+| `get <id\|prefix>` | Get memory by full ID or unique prefix (>= 4 chars). Ambiguous prefix returns `AMBIGUOUS_PREFIX` with `matches: [...]`; too-short returns `PREFIX_TOO_SHORT` | `{"id": "...", "context": "...", ...}` |
 | `update <id> <json>` | Update memory fields (list fields merge additively) | `{"memory_id": "<hex>"}` |
 | `update <id> --stdin` | Update from piped JSON | `{"memory_id": "<hex>"}` |
 | `update <id> <json> --replace` | Replace list fields wholesale instead of merging | `{"memory_id": "<hex>"}` |

--- a/pact-plugin/skills/pact-memory/SKILL.md
+++ b/pact-plugin/skills/pact-memory/SKILL.md
@@ -136,7 +136,7 @@ Each memory can contain:
 | `search <query> --current-file <path>` | Search with graph boosting | `[...]` (boosts file-related memories) |
 | `list` | List recent memories | `[{"id": "...", "context": "...", ...}, ...]` |
 | `list --limit N` | List with limit | `[...]` (default: 20) |
-| `get <id\|prefix>` | Get memory by full ID or unique prefix (>= 7 chars, case-insensitive). Ambiguous prefix returns `AMBIGUOUS_PREFIX` with `matches: [...]`, `truncated`, `total_matches`; too-short returns `PREFIX_TOO_SHORT` | `{"id": "...", "context": "...", ...}` |
+| `get <id\|prefix>` | Get memory by full ID or unique prefix (>= 7 chars, case-insensitive). Ambiguous prefix returns `AMBIGUOUS_PREFIX` with `matches: [...]`, `matches_capped`, `total_matches`; too-short returns `PREFIX_TOO_SHORT` | `{"id": "...", "context": "...", ...}` |
 | `update <id\|prefix> <json>` | Update memory fields (list fields merge additively). Same prefix-resolution rules as `get`; ambiguous prefix is refused | `{"memory_id": "<hex>"}` |
 | `update <id\|prefix> --stdin` | Update from piped JSON | `{"memory_id": "<hex>"}` |
 | `update <id\|prefix> <json> --replace` | Replace list fields wholesale instead of merging | `{"memory_id": "<hex>"}` |

--- a/pact-plugin/skills/pact-memory/SKILL.md
+++ b/pact-plugin/skills/pact-memory/SKILL.md
@@ -60,14 +60,15 @@ python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" search "auth tokens" --current-file
 # List recent memories
 python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" list --limit 10
 
-# Get a specific memory by full ID or unique prefix (>= 4 chars)
+# Get a specific memory by full ID or unique prefix (>= 7 chars, case-insensitive)
 python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" get <memory_id_or_prefix>
 
-# Update an existing memory (scalar fields replace; list fields merge additively)
-python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" update <memory_id> '{"goal": "Updated goal"}'
+# Update an existing memory by full ID or unique prefix (scalar fields replace;
+# list fields merge additively). Ambiguous prefix is refused.
+python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" update <memory_id_or_prefix> '{"goal": "Updated goal"}'
 
-# Delete a memory
-python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" delete <memory_id>
+# Delete a memory by full ID or unique prefix. Ambiguous prefix is refused.
+python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" delete <memory_id_or_prefix>
 
 # Check system status
 python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" status
@@ -135,11 +136,11 @@ Each memory can contain:
 | `search <query> --current-file <path>` | Search with graph boosting | `[...]` (boosts file-related memories) |
 | `list` | List recent memories | `[{"id": "...", "context": "...", ...}, ...]` |
 | `list --limit N` | List with limit | `[...]` (default: 20) |
-| `get <id\|prefix>` | Get memory by full ID or unique prefix (>= 4 chars). Ambiguous prefix returns `AMBIGUOUS_PREFIX` with `matches: [...]`; too-short returns `PREFIX_TOO_SHORT` | `{"id": "...", "context": "...", ...}` |
-| `update <id> <json>` | Update memory fields (list fields merge additively) | `{"memory_id": "<hex>"}` |
-| `update <id> --stdin` | Update from piped JSON | `{"memory_id": "<hex>"}` |
-| `update <id> <json> --replace` | Replace list fields wholesale instead of merging | `{"memory_id": "<hex>"}` |
-| `delete <id>` | Delete a memory | `{"deleted": true, "memory_id": "<hex>"}` |
+| `get <id\|prefix>` | Get memory by full ID or unique prefix (>= 7 chars, case-insensitive). Ambiguous prefix returns `AMBIGUOUS_PREFIX` with `matches: [...]`, `truncated`, `total_matches`; too-short returns `PREFIX_TOO_SHORT` | `{"id": "...", "context": "...", ...}` |
+| `update <id\|prefix> <json>` | Update memory fields (list fields merge additively). Same prefix-resolution rules as `get`; ambiguous prefix is refused | `{"memory_id": "<hex>"}` |
+| `update <id\|prefix> --stdin` | Update from piped JSON | `{"memory_id": "<hex>"}` |
+| `update <id\|prefix> <json> --replace` | Replace list fields wholesale instead of merging | `{"memory_id": "<hex>"}` |
+| `delete <id\|prefix>` | Delete a memory. Same prefix-resolution rules as `get`; ambiguous prefix is refused | `{"deleted": true, "memory_id": "<hex>"}` |
 | `status` | System status | `{"memory_count": N, "db_path": "...", ...}` |
 | `setup` | Initialize system | `{"status": "ready", "message": "..."}` |
 

--- a/pact-plugin/skills/pact-memory/scripts/cli.py
+++ b/pact-plugin/skills/pact-memory/scripts/cli.py
@@ -172,7 +172,7 @@ def cmd_get(args, db_path=None):
             str(exc),
             prefix=exc.prefix,
             matches=scrubbed_matches,
-            truncated=exc.truncated,
+            matches_capped=exc.matches_capped,
             total_matches=exc.total_matches,
         )
     if result is None:
@@ -242,7 +242,7 @@ def cmd_update(args, db_path=None):
             str(exc),
             prefix=exc.prefix,
             matches=scrubbed_matches,
-            truncated=exc.truncated,
+            matches_capped=exc.matches_capped,
             total_matches=exc.total_matches,
         )
     except ValueError as exc:
@@ -282,7 +282,7 @@ def cmd_delete(args, db_path=None):
             str(exc),
             prefix=exc.prefix,
             matches=scrubbed_matches,
-            truncated=exc.truncated,
+            matches_capped=exc.matches_capped,
             total_matches=exc.total_matches,
         )
     if resolved_id is None:
@@ -355,8 +355,9 @@ def build_parser():
             "Retrieve a memory by its full 32-char ID or a unique prefix of "
             "at least 7 characters. A unique prefix returns the matching "
             "memory; an ambiguous prefix returns an AMBIGUOUS_PREFIX error "
-            "with a capped list of matching IDs (truncated/total_matches "
-            "fields indicate when the cap was applied); a prefix shorter "
+            "with a capped list of matching IDs (matches_capped/"
+            "total_matches fields indicate when the cap was applied); "
+            "a prefix shorter "
             "than 7 characters returns a PREFIX_TOO_SHORT error; no match "
             "returns NOT_FOUND. Prefix is case-insensitive."
         ),

--- a/pact-plugin/skills/pact-memory/scripts/cli.py
+++ b/pact-plugin/skills/pact-memory/scripts/cli.py
@@ -18,9 +18,12 @@ Commands:
     save <json>          Save a memory object (or --stdin for piped input)
     search <query>       Semantic search across memories
     list [--limit N]     List recent memories (default: 20)
-    get <id|prefix>      Retrieve a memory by full ID or unique prefix (>= 4 chars)
-    update <id> <json>   Update an existing memory (or --stdin for piped input)
-    delete <id>          Delete a memory by ID
+    get <id|prefix>      Retrieve a memory by full ID or unique prefix (>= 7 chars)
+    update <id|prefix> <json>
+                         Update an existing memory by full ID or unique prefix
+                         (or --stdin for piped input). Ambiguous prefix is refused.
+    delete <id|prefix>   Delete a memory by full ID or unique prefix.
+                         Ambiguous prefix is refused.
     status               Show memory system status
     setup                Initialize/verify memory system
 """
@@ -143,9 +146,9 @@ def cmd_list(args, db_path=None):
 def cmd_get(args, db_path=None):
     """Handle the 'get' subcommand.
 
-    Accepts a full 32-char memory ID or a prefix of >= 4 chars. A unique
-    prefix returns the matching memory. An ambiguous prefix returns an
-    AMBIGUOUS_PREFIX error envelope with the full list of matching IDs.
+    Accepts a full 32-char memory ID or a unique prefix. Ambiguous prefix
+    surfaces as an AMBIGUOUS_PREFIX envelope including a capped match list,
+    truncation flag, and total match count.
     """
     memory = PACTMemory(db_path=db_path)
     try:
@@ -162,6 +165,8 @@ def cmd_get(args, db_path=None):
             str(exc),
             prefix=exc.prefix,
             matches=exc.matches,
+            truncated=exc.truncated,
+            total_matches=exc.total_matches,
         )
     if result is None:
         _error("NOT_FOUND", f"Memory '{args.memory_id}' not found")
@@ -190,7 +195,11 @@ def cmd_setup(args, db_path=None):
 
 
 def cmd_update(args, db_path=None):
-    """Handle the 'update' subcommand."""
+    """Handle the 'update' subcommand.
+
+    Accepts a full 32-char memory ID or a unique prefix. Ambiguous prefix
+    refuses the update and surfaces an AMBIGUOUS_PREFIX envelope.
+    """
     if args.stdin:
         raw = sys.stdin.read()
     elif args.json_data:
@@ -209,6 +218,19 @@ def cmd_update(args, db_path=None):
     memory = PACTMemory(db_path=db_path)
     try:
         success = memory.update(args.memory_id, updates, replace=args.replace)
+    except PrefixTooShortError as exc:
+        # Order: PrefixTooShortError IS a ValueError; catch it before the
+        # field-validation ValueError handler below.
+        _error("PREFIX_TOO_SHORT", str(exc), minimum=exc.minimum)
+    except AmbiguousPrefixError as exc:
+        _error(
+            "AMBIGUOUS_PREFIX",
+            str(exc),
+            prefix=exc.prefix,
+            matches=exc.matches,
+            truncated=exc.truncated,
+            total_matches=exc.total_matches,
+        )
     except ValueError as exc:
         _error(
             "ValueError",
@@ -223,9 +245,25 @@ def cmd_update(args, db_path=None):
 
 
 def cmd_delete(args, db_path=None):
-    """Handle the 'delete' subcommand."""
+    """Handle the 'delete' subcommand.
+
+    Accepts a full 32-char memory ID or a unique prefix. Ambiguous prefix
+    refuses the delete and surfaces an AMBIGUOUS_PREFIX envelope.
+    """
     memory = PACTMemory(db_path=db_path)
-    success = memory.delete(args.memory_id)
+    try:
+        success = memory.delete(args.memory_id)
+    except PrefixTooShortError as exc:
+        _error("PREFIX_TOO_SHORT", str(exc), minimum=exc.minimum)
+    except AmbiguousPrefixError as exc:
+        _error(
+            "AMBIGUOUS_PREFIX",
+            str(exc),
+            prefix=exc.prefix,
+            matches=exc.matches,
+            truncated=exc.truncated,
+            total_matches=exc.total_matches,
+        )
     if not success:
         _error("NOT_FOUND", f"Memory '{args.memory_id}' not found")
     _success({"deleted": True, "memory_id": args.memory_id})
@@ -291,20 +329,21 @@ def build_parser():
     # get
     get_parser = subparsers.add_parser(
         "get",
-        help="Get a memory by full ID or unique prefix (>= 4 chars)",
+        help="Get a memory by full ID or unique prefix (>= 7 chars)",
         description=(
             "Retrieve a memory by its full 32-char ID or a unique prefix of "
-            "at least 4 characters. A unique prefix returns the matching "
+            "at least 7 characters. A unique prefix returns the matching "
             "memory; an ambiguous prefix returns an AMBIGUOUS_PREFIX error "
-            "with the full list of matching IDs; a prefix shorter than 4 "
-            "characters returns a PREFIX_TOO_SHORT error; no match returns "
-            "NOT_FOUND."
+            "with a capped list of matching IDs (truncated/total_matches "
+            "fields indicate when the cap was applied); a prefix shorter "
+            "than 7 characters returns a PREFIX_TOO_SHORT error; no match "
+            "returns NOT_FOUND. Prefix is case-insensitive."
         ),
         parents=[parent],
     )
     get_parser.add_argument(
         "memory_id",
-        help="Full 32-char memory ID, or a unique prefix of >= 4 characters",
+        help="Full 32-char memory ID, or a unique prefix of >= 7 characters",
     )
 
     # status
@@ -319,9 +358,21 @@ def build_parser():
 
     # update
     update_parser = subparsers.add_parser(
-        "update", help="Update an existing memory", parents=[parent]
+        "update",
+        help="Update a memory by full ID or unique prefix (>= 7 chars)",
+        description=(
+            "Update an existing memory by its full 32-char ID or a unique "
+            "prefix of at least 7 characters. An ambiguous prefix is refused "
+            "(AMBIGUOUS_PREFIX error with a capped match list); a prefix "
+            "shorter than 7 characters returns PREFIX_TOO_SHORT; no match "
+            "returns NOT_FOUND. Prefix is case-insensitive."
+        ),
+        parents=[parent],
     )
-    update_parser.add_argument("memory_id", help="Memory ID to update")
+    update_parser.add_argument(
+        "memory_id",
+        help="Full 32-char memory ID, or a unique prefix of >= 7 characters",
+    )
     update_parser.add_argument("json_data", nargs="?", help="JSON with fields to update")
     update_parser.add_argument(
         "--stdin", action="store_true", help="Read JSON from stdin"
@@ -338,9 +389,21 @@ def build_parser():
 
     # delete
     delete_parser = subparsers.add_parser(
-        "delete", help="Delete a memory", parents=[parent]
+        "delete",
+        help="Delete a memory by full ID or unique prefix (>= 7 chars)",
+        description=(
+            "Delete a memory by its full 32-char ID or a unique prefix of "
+            "at least 7 characters. An ambiguous prefix is refused "
+            "(AMBIGUOUS_PREFIX error with a capped match list); a prefix "
+            "shorter than 7 characters returns PREFIX_TOO_SHORT; no match "
+            "returns NOT_FOUND. Prefix is case-insensitive."
+        ),
+        parents=[parent],
     )
-    delete_parser.add_argument("memory_id", help="Memory ID to delete")
+    delete_parser.add_argument(
+        "memory_id",
+        help="Full 32-char memory ID, or a unique prefix of >= 7 characters",
+    )
 
     return parser
 

--- a/pact-plugin/skills/pact-memory/scripts/cli.py
+++ b/pact-plugin/skills/pact-memory/scripts/cli.py
@@ -217,7 +217,7 @@ def cmd_update(args, db_path=None):
 
     memory = PACTMemory(db_path=db_path)
     try:
-        success = memory.update(args.memory_id, updates, replace=args.replace)
+        resolved_id = memory.update(args.memory_id, updates, replace=args.replace)
     except PrefixTooShortError as exc:
         # Order: PrefixTooShortError IS a ValueError; catch it before the
         # field-validation ValueError handler below.
@@ -239,9 +239,9 @@ def cmd_update(args, db_path=None):
             exit_code=2,
             allowed_fields=sorted(CALLER_FACING_UPDATE_FIELDS),
         )
-    if not success:
+    if resolved_id is None:
         _error("NOT_FOUND", f"Memory '{args.memory_id}' not found")
-    _success({"memory_id": args.memory_id})
+    _success({"memory_id": resolved_id})
 
 
 def cmd_delete(args, db_path=None):
@@ -252,7 +252,7 @@ def cmd_delete(args, db_path=None):
     """
     memory = PACTMemory(db_path=db_path)
     try:
-        success = memory.delete(args.memory_id)
+        resolved_id = memory.delete(args.memory_id)
     except PrefixTooShortError as exc:
         _error("PREFIX_TOO_SHORT", str(exc), minimum=exc.minimum)
     except AmbiguousPrefixError as exc:
@@ -264,9 +264,9 @@ def cmd_delete(args, db_path=None):
             truncated=exc.truncated,
             total_matches=exc.total_matches,
         )
-    if not success:
+    if resolved_id is None:
         _error("NOT_FOUND", f"Memory '{args.memory_id}' not found")
-    _success({"deleted": True, "memory_id": args.memory_id})
+    _success({"deleted": True, "memory_id": resolved_id})
 
 
 def _positive_int(value):

--- a/pact-plugin/skills/pact-memory/scripts/cli.py
+++ b/pact-plugin/skills/pact-memory/scripts/cli.py
@@ -18,7 +18,7 @@ Commands:
     save <json>          Save a memory object (or --stdin for piped input)
     search <query>       Semantic search across memories
     list [--limit N]     List recent memories (default: 20)
-    get <id>             Retrieve a specific memory by ID
+    get <id|prefix>      Retrieve a memory by full ID or unique prefix (>= 4 chars)
     update <id> <json>   Update an existing memory (or --stdin for piped input)
     delete <id>          Delete a memory by ID
     status               Show memory system status
@@ -41,6 +41,8 @@ if _SKILL_ROOT not in sys.path:
 from scripts.database import (
     CALLER_FACING_CREATE_FIELDS,
     CALLER_FACING_UPDATE_FIELDS,
+    AmbiguousPrefixError,
+    PrefixTooShortError,
 )
 from scripts.memory_api import PACTMemory
 from scripts.setup_memory import ensure_initialized, get_setup_status
@@ -139,9 +141,28 @@ def cmd_list(args, db_path=None):
 
 
 def cmd_get(args, db_path=None):
-    """Handle the 'get' subcommand."""
+    """Handle the 'get' subcommand.
+
+    Accepts a full 32-char memory ID or a prefix of >= 4 chars. A unique
+    prefix returns the matching memory. An ambiguous prefix returns an
+    AMBIGUOUS_PREFIX error envelope with the full list of matching IDs.
+    """
     memory = PACTMemory(db_path=db_path)
-    result = memory.get(args.memory_id)
+    try:
+        result = memory.get(args.memory_id)
+    except PrefixTooShortError as exc:
+        _error(
+            "PREFIX_TOO_SHORT",
+            str(exc),
+            minimum=exc.minimum,
+        )
+    except AmbiguousPrefixError as exc:
+        _error(
+            "AMBIGUOUS_PREFIX",
+            str(exc),
+            prefix=exc.prefix,
+            matches=exc.matches,
+        )
     if result is None:
         _error("NOT_FOUND", f"Memory '{args.memory_id}' not found")
     _success(result.to_dict())
@@ -269,9 +290,22 @@ def build_parser():
 
     # get
     get_parser = subparsers.add_parser(
-        "get", help="Get a memory by ID", parents=[parent]
+        "get",
+        help="Get a memory by full ID or unique prefix (>= 4 chars)",
+        description=(
+            "Retrieve a memory by its full 32-char ID or a unique prefix of "
+            "at least 4 characters. A unique prefix returns the matching "
+            "memory; an ambiguous prefix returns an AMBIGUOUS_PREFIX error "
+            "with the full list of matching IDs; a prefix shorter than 4 "
+            "characters returns a PREFIX_TOO_SHORT error; no match returns "
+            "NOT_FOUND."
+        ),
+        parents=[parent],
     )
-    get_parser.add_argument("memory_id", help="Memory ID to retrieve")
+    get_parser.add_argument(
+        "memory_id",
+        help="Full 32-char memory ID, or a unique prefix of >= 4 characters",
+    )
 
     # status
     subparsers.add_parser(

--- a/pact-plugin/skills/pact-memory/scripts/cli.py
+++ b/pact-plugin/skills/pact-memory/scripts/cli.py
@@ -160,11 +160,18 @@ def cmd_get(args, db_path=None):
             minimum=exc.minimum,
         )
     except AmbiguousPrefixError as exc:
+        # Scrub user HOME from each match's `context` snippet so a memory
+        # whose context recorded an absolute path doesn't leak it via the
+        # disambiguation envelope. Per-site scrub keeps the redaction
+        # obvious; do not centralize into `_error`.
+        scrubbed_matches = [
+            {**m, "context": _scrub(m["context"])} for m in exc.matches
+        ]
         _error(
             "AMBIGUOUS_PREFIX",
             str(exc),
             prefix=exc.prefix,
-            matches=exc.matches,
+            matches=scrubbed_matches,
             truncated=exc.truncated,
             total_matches=exc.total_matches,
         )
@@ -223,11 +230,18 @@ def cmd_update(args, db_path=None):
         # field-validation ValueError handler below.
         _error("PREFIX_TOO_SHORT", str(exc), minimum=exc.minimum)
     except AmbiguousPrefixError as exc:
+        # Scrub user HOME from each match's `context` snippet so a memory
+        # whose context recorded an absolute path doesn't leak it via the
+        # disambiguation envelope. Per-site scrub keeps the redaction
+        # obvious; do not centralize into `_error`.
+        scrubbed_matches = [
+            {**m, "context": _scrub(m["context"])} for m in exc.matches
+        ]
         _error(
             "AMBIGUOUS_PREFIX",
             str(exc),
             prefix=exc.prefix,
-            matches=exc.matches,
+            matches=scrubbed_matches,
             truncated=exc.truncated,
             total_matches=exc.total_matches,
         )
@@ -256,11 +270,18 @@ def cmd_delete(args, db_path=None):
     except PrefixTooShortError as exc:
         _error("PREFIX_TOO_SHORT", str(exc), minimum=exc.minimum)
     except AmbiguousPrefixError as exc:
+        # Scrub user HOME from each match's `context` snippet so a memory
+        # whose context recorded an absolute path doesn't leak it via the
+        # disambiguation envelope. Per-site scrub keeps the redaction
+        # obvious; do not centralize into `_error`.
+        scrubbed_matches = [
+            {**m, "context": _scrub(m["context"])} for m in exc.matches
+        ]
         _error(
             "AMBIGUOUS_PREFIX",
             str(exc),
             prefix=exc.prefix,
-            matches=exc.matches,
+            matches=scrubbed_matches,
             truncated=exc.truncated,
             total_matches=exc.total_matches,
         )

--- a/pact-plugin/skills/pact-memory/scripts/database.py
+++ b/pact-plugin/skills/pact-memory/scripts/database.py
@@ -38,6 +38,35 @@ from .config import DB_PATH, PACT_MEMORY_DIR
 # Configure logging
 logger = logging.getLogger(__name__)
 
+# Memory IDs are 32-char hex (secrets.token_hex(16) — see generate_id).
+# Prefix resolution accepts any input shorter than the full ID, but enforces
+# a minimum of 4 characters to keep ambiguity manageable on growing stores.
+MEMORY_ID_LENGTH = 32
+MIN_PREFIX_LENGTH = 4
+
+
+class PrefixTooShortError(ValueError):
+    """Raised when a memory-ID prefix is shorter than MIN_PREFIX_LENGTH."""
+
+    def __init__(self, prefix: str, minimum: int = MIN_PREFIX_LENGTH):
+        self.prefix = prefix
+        self.minimum = minimum
+        super().__init__(
+            f"Prefix '{prefix}' is too short — provide at least {minimum} characters."
+        )
+
+
+class AmbiguousPrefixError(LookupError):
+    """Raised when a memory-ID prefix matches multiple stored memories."""
+
+    def __init__(self, prefix: str, matches: List[Dict[str, Any]]):
+        self.prefix = prefix
+        # Each match is {"id": <full_id>, "context": <first 60 chars or "">}
+        self.matches = matches
+        super().__init__(
+            f"Prefix '{prefix}' is ambiguous — {len(matches)} memories match."
+        )
+
 
 def get_db_path() -> Path:
     """Get the database file path, creating parent directories if needed."""
@@ -821,16 +850,82 @@ def create_memory(
     return memory_id
 
 
+def resolve_memory_id_prefix(
+    conn: sqlite3.Connection,
+    prefix: str,
+    *,
+    descriptor_chars: int = 60,
+) -> Optional[str]:
+    """
+    Resolve a memory-ID prefix to a single full ID, git-style.
+
+    Args:
+        conn: Active database connection.
+        prefix: Memory-ID prefix (>= MIN_PREFIX_LENGTH chars; full IDs allowed).
+        descriptor_chars: Length of the context snippet attached to each match
+            on ambiguity (for terse disambiguation output).
+
+    Returns:
+        The full memory ID when the prefix uniquely matches one row, or None
+        when no row matches.
+
+    Raises:
+        PrefixTooShortError: prefix shorter than MIN_PREFIX_LENGTH.
+        AmbiguousPrefixError: prefix matches more than one row. The exception's
+            `matches` attribute is a list of {"id", "context"} dicts.
+    """
+    ensure_initialized(conn)
+
+    if len(prefix) < MIN_PREFIX_LENGTH:
+        raise PrefixTooShortError(prefix)
+
+    # Escape SQL LIKE wildcards in the prefix so a literal '%' or '_' from a
+    # malformed input never expands. Memory IDs are hex, so this is defensive
+    # — it costs nothing and removes a foot-gun for future non-hex IDs.
+    escaped = prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+    # LIMIT 2 short-circuits the common case (unique match): we only need to
+    # know whether more than one row matches before issuing a wider query.
+    cursor = conn.execute(
+        "SELECT id FROM memories WHERE id LIKE ? ESCAPE '\\' LIMIT 2",
+        (escaped + "%",),
+    )
+    rows = cursor.fetchall()
+
+    if not rows:
+        return None
+    if len(rows) == 1:
+        return rows[0]["id"]
+
+    # Ambiguous — fetch the full match list with a short context descriptor.
+    cursor = conn.execute(
+        "SELECT id, context FROM memories WHERE id LIKE ? ESCAPE '\\' ORDER BY id",
+        (escaped + "%",),
+    )
+    matches = [
+        {
+            "id": row["id"],
+            "context": (row["context"] or "")[:descriptor_chars],
+        }
+        for row in cursor.fetchall()
+    ]
+    raise AmbiguousPrefixError(prefix, matches)
+
+
 def get_memory(
     conn: sqlite3.Connection,
     memory_id: str
 ) -> Optional[Dict[str, Any]]:
     """
-    Retrieve a memory by ID.
+    Retrieve a memory by exact ID.
+
+    This is the exact-match storage primitive. Callers that want git-style
+    prefix resolution should compose with resolve_memory_id_prefix above
+    (see PACTMemory.get for the canonical pattern).
 
     Args:
         conn: Active database connection.
-        memory_id: The unique memory identifier.
+        memory_id: The unique memory identifier (full ID).
 
     Returns:
         Memory dictionary if found, None otherwise.

--- a/pact-plugin/skills/pact-memory/scripts/database.py
+++ b/pact-plugin/skills/pact-memory/scripts/database.py
@@ -47,6 +47,9 @@ MIN_PREFIX_LENGTH = 7
 
 # Cap for the disambiguation match list. Two queries fire only on the
 # ambiguous branch (rare); the unique-match common path is unaffected.
+# 50 is the human/agent disambiguation ceiling: with a >=7-char prefix
+# (16^7 ~= 268M keyspace), >50 collisions implies caller-malformed input,
+# at which point matches_capped/total_matches already signal truncation.
 AMBIGUOUS_MATCH_CAP = 50
 
 # Upper bound for prefix range scan: smallest ASCII char strictly greater
@@ -72,7 +75,7 @@ class AmbiguousPrefixError(LookupError):
 
     The `matches` attribute is a list of {"id", "context"} dicts capped at
     AMBIGUOUS_MATCH_CAP entries. `total_matches` is the true row count and
-    `truncated` is True when the cap was applied.
+    `matches_capped` is True when the cap was applied.
     """
 
     def __init__(
@@ -80,14 +83,14 @@ class AmbiguousPrefixError(LookupError):
         prefix: str,
         matches: List[Dict[str, Any]],
         *,
-        truncated: bool = False,
+        matches_capped: bool = False,
         total_matches: Optional[int] = None,
     ):
         self.prefix = prefix
         self.matches = matches
-        self.truncated = truncated
+        self.matches_capped = matches_capped
         self.total_matches = total_matches if total_matches is not None else len(matches)
-        suffix = f" (showing {len(matches)} of {self.total_matches})" if truncated else ""
+        suffix = f" (showing {len(matches)} of {self.total_matches})" if matches_capped else ""
         super().__init__(
             f"Prefix '{prefix}' is ambiguous — {self.total_matches} memories match.{suffix}"
         )
@@ -897,7 +900,8 @@ def resolve_memory_id_prefix(
             on ambiguity (for terse disambiguation output). Security-relevant
             knob if multi-tenant access is ever introduced — context may carry
             tenant data the disambiguation reader is not entitled to read; in
-            that case shorten or drop the snippet, or scope it by tenant.
+            that case shorten or drop the snippet, or scope it by tenant
+            (see issue #548).
 
     Returns:
         The full memory ID when the prefix uniquely matches one row, or None
@@ -907,8 +911,8 @@ def resolve_memory_id_prefix(
         PrefixTooShortError: prefix shorter than MIN_PREFIX_LENGTH.
         AmbiguousPrefixError: prefix matches more than one row. The exception
             carries `matches` (list capped at AMBIGUOUS_MATCH_CAP),
-            `truncated` (True if the cap was applied), and `total_matches`
-            (the true row count).
+            `matches_capped` (True if the cap was applied), and
+            `total_matches` (the true row count).
     """
     ensure_initialized(conn)
 
@@ -952,9 +956,10 @@ def resolve_memory_id_prefix(
         matches.append({
             "id": row["id"],
             "context": snippet,
-            # Per-match flag distinct from the list-level `truncated` on the
-            # exception: signals that THIS row's `context` was clipped to
-            # `descriptor_chars`, not that the match list itself was capped.
+            # Per-match flag distinct from the list-level `matches_capped`
+            # on the exception: signals that THIS row's `context` was
+            # clipped to `descriptor_chars`, not that the match list
+            # itself was capped.
             "context_truncated": len(full_context) > descriptor_chars,
         })
     count_row = conn.execute(
@@ -962,11 +967,11 @@ def resolve_memory_id_prefix(
         (lo, hi),
     ).fetchone()
     total_matches = count_row["n"]
-    truncated = total_matches > len(matches)
+    matches_capped = total_matches > len(matches)
     raise AmbiguousPrefixError(
         prefix,
         matches,
-        truncated=truncated,
+        matches_capped=matches_capped,
         total_matches=total_matches,
     )
 

--- a/pact-plugin/skills/pact-memory/scripts/database.py
+++ b/pact-plugin/skills/pact-memory/scripts/database.py
@@ -38,11 +38,16 @@ from .config import DB_PATH, PACT_MEMORY_DIR
 # Configure logging
 logger = logging.getLogger(__name__)
 
-# Memory IDs are 32-char hex (secrets.token_hex(16) — see generate_id).
+# Memory IDs are 32-char lowercase hex (secrets.token_hex(16) — see generate_id).
 # Prefix resolution accepts any input shorter than the full ID, but enforces
-# a minimum of 4 characters to keep ambiguity manageable on growing stores.
+# a minimum of 7 characters to match git's default core.abbrev and keep
+# false-ambiguity rare on stores of practical size.
 MEMORY_ID_LENGTH = 32
-MIN_PREFIX_LENGTH = 4
+MIN_PREFIX_LENGTH = 7
+
+# Cap for the disambiguation match list. Two queries fire only on the
+# ambiguous branch (rare); the unique-match common path is unaffected.
+AMBIGUOUS_MATCH_CAP = 50
 
 
 class PrefixTooShortError(ValueError):
@@ -57,14 +62,28 @@ class PrefixTooShortError(ValueError):
 
 
 class AmbiguousPrefixError(LookupError):
-    """Raised when a memory-ID prefix matches multiple stored memories."""
+    """Raised when a memory-ID prefix matches multiple stored memories.
 
-    def __init__(self, prefix: str, matches: List[Dict[str, Any]]):
+    The `matches` attribute is a list of {"id", "context"} dicts capped at
+    AMBIGUOUS_MATCH_CAP entries. `total_matches` is the true row count and
+    `truncated` is True when the cap was applied.
+    """
+
+    def __init__(
+        self,
+        prefix: str,
+        matches: List[Dict[str, Any]],
+        *,
+        truncated: bool = False,
+        total_matches: Optional[int] = None,
+    ):
         self.prefix = prefix
-        # Each match is {"id": <full_id>, "context": <first 60 chars or "">}
         self.matches = matches
+        self.truncated = truncated
+        self.total_matches = total_matches if total_matches is not None else len(matches)
+        suffix = f" (showing {len(matches)} of {self.total_matches})" if truncated else ""
         super().__init__(
-            f"Prefix '{prefix}' is ambiguous — {len(matches)} memories match."
+            f"Prefix '{prefix}' is ambiguous — {self.total_matches} memories match.{suffix}"
         )
 
 
@@ -859,11 +878,17 @@ def resolve_memory_id_prefix(
     """
     Resolve a memory-ID prefix to a single full ID, git-style.
 
+    The prefix is lowercased before lookup so `ABCD1234` and `abcd1234`
+    resolve identically. IDs are stored as lowercase hex.
+
     Args:
         conn: Active database connection.
         prefix: Memory-ID prefix (>= MIN_PREFIX_LENGTH chars; full IDs allowed).
         descriptor_chars: Length of the context snippet attached to each match
-            on ambiguity (for terse disambiguation output).
+            on ambiguity (for terse disambiguation output). Security-relevant
+            knob if multi-tenant access is ever introduced — context may carry
+            tenant data the disambiguation reader is not entitled to read; in
+            that case shorten or drop the snippet, or scope it by tenant.
 
     Returns:
         The full memory ID when the prefix uniquely matches one row, or None
@@ -871,17 +896,26 @@ def resolve_memory_id_prefix(
 
     Raises:
         PrefixTooShortError: prefix shorter than MIN_PREFIX_LENGTH.
-        AmbiguousPrefixError: prefix matches more than one row. The exception's
-            `matches` attribute is a list of {"id", "context"} dicts.
+        AmbiguousPrefixError: prefix matches more than one row. The exception
+            carries `matches` (list capped at AMBIGUOUS_MATCH_CAP),
+            `truncated` (True if the cap was applied), and `total_matches`
+            (the true row count).
     """
     ensure_initialized(conn)
 
     if len(prefix) < MIN_PREFIX_LENGTH:
         raise PrefixTooShortError(prefix)
 
-    # Escape SQL LIKE wildcards in the prefix so a literal '%' or '_' from a
-    # malformed input never expands. Memory IDs are hex, so this is defensive
-    # — it costs nothing and removes a foot-gun for future non-hex IDs.
+    # Trust boundary: `prefix` arrives untrusted from CLI argv. The escape
+    # below + parameter binding below are the only barriers between user
+    # input and a SQL LIKE clause. Do not bypass either.
+    # Case-fold to match the lowercase hex IDs produced by generate_id.
+    prefix = prefix.lower()
+
+    # SQL LIKE escape. Order is load-bearing: backslash MUST be doubled
+    # FIRST, because the subsequent `%` and `_` substitutions introduce new
+    # backslashes that must NOT themselves be re-escaped. The `ESCAPE '\\'`
+    # clause on the SELECT pairs with this.
     escaped = prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
     # LIMIT 2 short-circuits the common case (unique match): we only need to
@@ -897,19 +931,39 @@ def resolve_memory_id_prefix(
     if len(rows) == 1:
         return rows[0]["id"]
 
-    # Ambiguous — fetch the full match list with a short context descriptor.
+    # Ambiguous — fetch a capped match list with a short context descriptor
+    # plus a separate COUNT for the true total. Both queries fire only on
+    # this branch; the unique-match path above is single-query.
+    pattern = escaped + "%"
     cursor = conn.execute(
-        "SELECT id, context FROM memories WHERE id LIKE ? ESCAPE '\\' ORDER BY id",
-        (escaped + "%",),
+        "SELECT id, context FROM memories WHERE id LIKE ? ESCAPE '\\' "
+        "ORDER BY id LIMIT ?",
+        (pattern, AMBIGUOUS_MATCH_CAP),
     )
-    matches = [
-        {
+    matches = []
+    for row in cursor.fetchall():
+        full_context = row["context"] or ""
+        snippet = full_context[:descriptor_chars]
+        matches.append({
             "id": row["id"],
-            "context": (row["context"] or "")[:descriptor_chars],
-        }
-        for row in cursor.fetchall()
-    ]
-    raise AmbiguousPrefixError(prefix, matches)
+            "context": snippet,
+            # Per-match flag distinct from the list-level `truncated` on the
+            # exception: signals that THIS row's `context` was clipped to
+            # `descriptor_chars`, not that the match list itself was capped.
+            "context_truncated": len(full_context) > descriptor_chars,
+        })
+    count_row = conn.execute(
+        "SELECT COUNT(*) AS n FROM memories WHERE id LIKE ? ESCAPE '\\'",
+        (pattern,),
+    ).fetchone()
+    total_matches = count_row["n"]
+    truncated = total_matches > len(matches)
+    raise AmbiguousPrefixError(
+        prefix,
+        matches,
+        truncated=truncated,
+        total_matches=total_matches,
+    )
 
 
 def get_memory(

--- a/pact-plugin/skills/pact-memory/scripts/database.py
+++ b/pact-plugin/skills/pact-memory/scripts/database.py
@@ -49,6 +49,12 @@ MIN_PREFIX_LENGTH = 7
 # ambiguous branch (rare); the unique-match common path is unaffected.
 AMBIGUOUS_MATCH_CAP = 50
 
+# Upper bound for prefix range scan: smallest ASCII char strictly greater
+# than 'f' (max char of lowercase hex alphabet). If `generate_id` ever
+# broadens the alphabet beyond [0-9a-f], this constant must change AND
+# the alphabet-invariant test on generate_id will fail loudly.
+_PREFIX_UPPER_BOUND_CHAR = "g"
+
 
 class PrefixTooShortError(ValueError):
     """Raised when a memory-ID prefix is shorter than MIN_PREFIX_LENGTH."""
@@ -878,7 +884,10 @@ def resolve_memory_id_prefix(
     """
     Resolve a memory-ID prefix to a single full ID, git-style.
 
-    The prefix is lowercased before lookup so `ABCD1234` and `abcd1234`
+    Lookup uses a half-open range scan (`id >= prefix AND id < prefix + 'g'`)
+    against the BINARY-collated primary key, which lets SQLite walk the
+    index instead of full-scanning under a LIKE pattern. The prefix is
+    lowercased before bounds construction so `ABCD1234` and `abcd1234`
     resolve identically. IDs are stored as lowercase hex.
 
     Args:
@@ -906,23 +915,20 @@ def resolve_memory_id_prefix(
     if len(prefix) < MIN_PREFIX_LENGTH:
         raise PrefixTooShortError(prefix)
 
-    # Trust boundary: `prefix` arrives untrusted from CLI argv. The escape
-    # below + parameter binding below are the only barriers between user
-    # input and a SQL LIKE clause. Do not bypass either.
     # Case-fold to match the lowercase hex IDs produced by generate_id.
     prefix = prefix.lower()
 
-    # SQL LIKE escape. Order is load-bearing: backslash MUST be doubled
-    # FIRST, because the subsequent `%` and `_` substitutions introduce new
-    # backslashes that must NOT themselves be re-escaped. The `ESCAPE '\\'`
-    # clause on the SELECT pairs with this.
-    escaped = prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    # Half-open range bounds; see `_PREFIX_UPPER_BOUND_CHAR` for the
+    # alphabet-invariant. [lo, hi) covers exactly the rows whose ID begins
+    # with `prefix` under BINARY collation on the lowercase-hex PK.
+    lo = prefix
+    hi = prefix + _PREFIX_UPPER_BOUND_CHAR
 
     # LIMIT 2 short-circuits the common case (unique match): we only need to
     # know whether more than one row matches before issuing a wider query.
     cursor = conn.execute(
-        "SELECT id FROM memories WHERE id LIKE ? ESCAPE '\\' LIMIT 2",
-        (escaped + "%",),
+        "SELECT id FROM memories WHERE id >= ? AND id < ? LIMIT 2",
+        (lo, hi),
     )
     rows = cursor.fetchall()
 
@@ -934,11 +940,10 @@ def resolve_memory_id_prefix(
     # Ambiguous — fetch a capped match list with a short context descriptor
     # plus a separate COUNT for the true total. Both queries fire only on
     # this branch; the unique-match path above is single-query.
-    pattern = escaped + "%"
     cursor = conn.execute(
-        "SELECT id, context FROM memories WHERE id LIKE ? ESCAPE '\\' "
+        "SELECT id, context FROM memories WHERE id >= ? AND id < ? "
         "ORDER BY id LIMIT ?",
-        (pattern, AMBIGUOUS_MATCH_CAP),
+        (lo, hi, AMBIGUOUS_MATCH_CAP),
     )
     matches = []
     for row in cursor.fetchall():
@@ -953,8 +958,8 @@ def resolve_memory_id_prefix(
             "context_truncated": len(full_context) > descriptor_chars,
         })
     count_row = conn.execute(
-        "SELECT COUNT(*) AS n FROM memories WHERE id LIKE ? ESCAPE '\\'",
-        (pattern,),
+        "SELECT COUNT(*) AS n FROM memories WHERE id >= ? AND id < ?",
+        (lo, hi),
     ).fetchone()
     total_matches = count_row["n"]
     truncated = total_matches > len(matches)

--- a/pact-plugin/skills/pact-memory/scripts/database.py
+++ b/pact-plugin/skills/pact-memory/scripts/database.py
@@ -900,8 +900,7 @@ def resolve_memory_id_prefix(
             on ambiguity (for terse disambiguation output). Security-relevant
             knob if multi-tenant access is ever introduced — context may carry
             tenant data the disambiguation reader is not entitled to read; in
-            that case shorten or drop the snippet, or scope it by tenant
-            (see issue #548).
+            that case shorten or drop the snippet, or scope it by tenant.
 
     Returns:
         The full memory ID when the prefix uniquely matches one row, or None

--- a/pact-plugin/skills/pact-memory/scripts/memory_api.py
+++ b/pact-plugin/skills/pact-memory/scripts/memory_api.py
@@ -534,11 +534,14 @@ class PACTMemory:
         """
         Resolve a caller-supplied ID into a full 32-char memory ID.
 
-        Full-length input is returned unchanged (no DB query). Shorter
-        input is treated as a prefix and resolved via the storage-layer
-        resolver: a unique prefix returns the full ID; ambiguity raises
-        AmbiguousPrefixError; too-short raises PrefixTooShortError; no
-        match returns None.
+        Input is case-folded to lowercase before any branch, so an
+        uppercase or mixed-case full ID resolves identically to its
+        lowercase form (memory IDs are stored as lowercase hex).
+        Full-length input is then returned unchanged (no DB query).
+        Shorter input is treated as a prefix and resolved via the
+        storage-layer resolver: a unique prefix returns the full ID;
+        ambiguity raises AmbiguousPrefixError; too-short raises
+        PrefixTooShortError; no match returns None.
 
         Caller already owns an open `conn` (inside a `db_connection`
         context manager). This helper does not open or close connections.
@@ -546,14 +549,18 @@ class PACTMemory:
         Args:
             conn: Active database connection.
             memory_id: Full 32-char ID or a prefix >= MIN_PREFIX_LENGTH.
+                Case-insensitive: uppercase and mixed-case input is
+                normalized to lowercase before lookup.
 
         Returns:
-            The full memory ID, or None if the prefix matches no row.
+            The full memory ID (lowercase), or None if the prefix matches
+            no row.
 
         Raises:
             PrefixTooShortError: prefix shorter than MIN_PREFIX_LENGTH.
             AmbiguousPrefixError: prefix matches more than one memory.
         """
+        memory_id = memory_id.lower()
         if len(memory_id) >= MEMORY_ID_LENGTH:
             return memory_id
         return resolve_memory_id_prefix(conn, memory_id)

--- a/pact-plugin/skills/pact-memory/scripts/memory_api.py
+++ b/pact-plugin/skills/pact-memory/scripts/memory_api.py
@@ -528,17 +528,47 @@ class PACTMemory:
 
         return search_by_file(file_path, self._project_id, limit)
 
+    def _resolve_id_or_full(
+        self, conn, memory_id: str
+    ) -> Optional[str]:
+        """
+        Resolve a caller-supplied ID into a full 32-char memory ID.
+
+        Full-length input is returned unchanged (no DB query). Shorter
+        input is treated as a prefix and resolved via the storage-layer
+        resolver: a unique prefix returns the full ID; ambiguity raises
+        AmbiguousPrefixError; too-short raises PrefixTooShortError; no
+        match returns None.
+
+        Caller already owns an open `conn` (inside a `db_connection`
+        context manager). This helper does not open or close connections.
+
+        Args:
+            conn: Active database connection.
+            memory_id: Full 32-char ID or a prefix >= MIN_PREFIX_LENGTH.
+
+        Returns:
+            The full memory ID, or None if the prefix matches no row.
+
+        Raises:
+            PrefixTooShortError: prefix shorter than MIN_PREFIX_LENGTH.
+            AmbiguousPrefixError: prefix matches more than one memory.
+        """
+        if len(memory_id) >= MEMORY_ID_LENGTH:
+            return memory_id
+        return resolve_memory_id_prefix(conn, memory_id)
+
     def get(self, memory_id: str) -> Optional[MemoryObject]:
         """
         Get a specific memory by ID or unique prefix.
 
-        Accepts a full 32-char memory ID or a prefix of at least 4
-        characters. A unique prefix resolves to the matching memory. The
-        minimum-length gate and ambiguous-prefix surfacing are enforced by
-        the storage-layer resolver via exceptions.
+        Accepts a full 32-char memory ID or a prefix of at least
+        MIN_PREFIX_LENGTH characters. A unique prefix resolves to the
+        matching memory; ambiguity and too-short input surface as
+        exceptions from the storage-layer resolver.
 
         Args:
-            memory_id: Full 32-char ID or a prefix >= 4 chars.
+            memory_id: Full 32-char ID or a prefix >= MIN_PREFIX_LENGTH.
 
         Returns:
             MemoryObject if found, None if no match.
@@ -553,11 +583,10 @@ class PACTMemory:
         with db_connection(self._db_path) as conn:
             ensure_initialized(conn)
 
-            if len(memory_id) < MEMORY_ID_LENGTH:
-                resolved = resolve_memory_id_prefix(conn, memory_id)
-                if resolved is None:
-                    return None
-                memory_id = resolved
+            resolved = self._resolve_id_or_full(conn, memory_id)
+            if resolved is None:
+                return None
+            memory_id = resolved
 
             memory_dict = get_memory(conn, memory_id)
             if memory_dict is None:
@@ -577,10 +606,15 @@ class PACTMemory:
         replace: bool = False,
     ) -> bool:
         """
-        Update an existing memory.
+        Update an existing memory by ID or unique prefix.
+
+        Accepts a full 32-char memory ID or a prefix of at least
+        MIN_PREFIX_LENGTH characters. A unique prefix resolves to the
+        matching memory; ambiguous prefixes are refused (the update is
+        rejected via AmbiguousPrefixError so the caller can disambiguate).
 
         Args:
-            memory_id: The memory ID.
+            memory_id: Full 32-char ID or a prefix >= MIN_PREFIX_LENGTH.
             updates: Dictionary of fields to update.
             replace: If True, list-valued fields are replaced wholesale
                 instead of merged additively (default False = additive merge
@@ -592,12 +626,19 @@ class PACTMemory:
         Raises:
             ValueError: If updates contains unknown field names, or if any
                 dict-list item contains unknown sub-object keys.
+            PrefixTooShortError: prefix is shorter than the minimum.
+            AmbiguousPrefixError: prefix matches more than one memory.
         """
         # Ensure memory system is ready (lazy initialization)
         _ensure_ready()
 
         with db_connection(self._db_path) as conn:
             ensure_initialized(conn)
+
+            resolved = self._resolve_id_or_full(conn, memory_id)
+            if resolved is None:
+                return False
+            memory_id = resolved
 
             # M7 (#374 remediation): snapshot CONTENT_FIELDS before the
             # update so we can detect whether the merge actually changed
@@ -625,19 +666,33 @@ class PACTMemory:
 
     def delete(self, memory_id: str) -> bool:
         """
-        Delete a memory.
+        Delete a memory by ID or unique prefix.
+
+        Accepts a full 32-char memory ID or a prefix of at least
+        MIN_PREFIX_LENGTH characters. A unique prefix resolves to the
+        matching memory; ambiguous prefixes are refused (the delete is
+        rejected via AmbiguousPrefixError so the caller can disambiguate).
 
         Args:
-            memory_id: The memory ID.
+            memory_id: Full 32-char ID or a prefix >= MIN_PREFIX_LENGTH.
 
         Returns:
             True if deleted, False if not found.
+
+        Raises:
+            PrefixTooShortError: prefix is shorter than the minimum.
+            AmbiguousPrefixError: prefix matches more than one memory.
         """
         # Ensure memory system is ready (lazy initialization)
         _ensure_ready()
 
         with db_connection(self._db_path) as conn:
             ensure_initialized(conn)
+
+            resolved = self._resolve_id_or_full(conn, memory_id)
+            if resolved is None:
+                return False
+            memory_id = resolved
 
             # Also remove from vector table
             try:

--- a/pact-plugin/skills/pact-memory/scripts/memory_api.py
+++ b/pact-plugin/skills/pact-memory/scripts/memory_api.py
@@ -707,14 +707,21 @@ class PACTMemory:
                 return None
             memory_id = resolved
 
-            # Also remove from vector table
+            # Also remove from vector table. vec_memories is created lazily
+            # by the FTS extension; absence is expected when FTS is
+            # unavailable, and the "no such table" OperationalError is
+            # silently swallowed in that case. All other OperationalErrors
+            # (lock contention, corruption, schema violations) and every
+            # other exception class must propagate so the caller sees the
+            # real failure instead of a silent orphan-vector.
             try:
                 conn.execute(
                     "DELETE FROM vec_memories WHERE memory_id = ?",
                     (memory_id,)
                 )
-            except Exception:
-                pass  # Vector table might not exist
+            except sqlite3.OperationalError as exc:
+                if "no such table" not in str(exc):
+                    raise
 
             return memory_id if delete_memory(conn, memory_id) else None
 

--- a/pact-plugin/skills/pact-memory/scripts/memory_api.py
+++ b/pact-plugin/skills/pact-memory/scripts/memory_api.py
@@ -43,6 +43,10 @@ from .database import (
     ensure_initialized,
     get_db_path,
     generate_id,
+    resolve_memory_id_prefix,
+    AmbiguousPrefixError,
+    PrefixTooShortError,
+    MEMORY_ID_LENGTH,
     SQLITE_EXTENSIONS_ENABLED
 )
 from .embeddings import (
@@ -526,19 +530,34 @@ class PACTMemory:
 
     def get(self, memory_id: str) -> Optional[MemoryObject]:
         """
-        Get a specific memory by ID.
+        Get a specific memory by ID or unique prefix.
+
+        Accepts a full 32-char memory ID or a prefix of at least 4
+        characters. A unique prefix resolves to the matching memory. The
+        minimum-length gate and ambiguous-prefix surfacing are enforced by
+        the storage-layer resolver via exceptions.
 
         Args:
-            memory_id: The memory ID.
+            memory_id: Full 32-char ID or a prefix >= 4 chars.
 
         Returns:
-            MemoryObject if found, None otherwise.
+            MemoryObject if found, None if no match.
+
+        Raises:
+            PrefixTooShortError: prefix is shorter than the minimum.
+            AmbiguousPrefixError: prefix matches more than one memory.
         """
         # Ensure memory system is ready (lazy initialization)
         _ensure_ready()
 
         with db_connection(self._db_path) as conn:
             ensure_initialized(conn)
+
+            if len(memory_id) < MEMORY_ID_LENGTH:
+                resolved = resolve_memory_id_prefix(conn, memory_id)
+                if resolved is None:
+                    return None
+                memory_id = resolved
 
             memory_dict = get_memory(conn, memory_id)
             if memory_dict is None:

--- a/pact-plugin/skills/pact-memory/scripts/memory_api.py
+++ b/pact-plugin/skills/pact-memory/scripts/memory_api.py
@@ -604,7 +604,7 @@ class PACTMemory:
         updates: Dict[str, Any],
         *,
         replace: bool = False,
-    ) -> bool:
+    ) -> Optional[str]:
         """
         Update an existing memory by ID or unique prefix.
 
@@ -621,7 +621,10 @@ class PACTMemory:
                 with content-hash dedup).
 
         Returns:
-            True if updated, False if memory not found.
+            The resolved full 32-char memory ID on successful update, or
+            None when the input matched no row. Callers that invoked with a
+            prefix get the canonical ID back so downstream operations key off
+            the storage form.
 
         Raises:
             ValueError: If updates contains unknown field names, or if any
@@ -637,7 +640,7 @@ class PACTMemory:
 
             resolved = self._resolve_id_or_full(conn, memory_id)
             if resolved is None:
-                return False
+                return None
             memory_id = resolved
 
             # M7 (#374 remediation): snapshot CONTENT_FIELDS before the
@@ -662,9 +665,9 @@ class PACTMemory:
                 ):
                     self._store_embedding(conn, memory_id, memory_dict)
 
-            return success
+            return memory_id if success else None
 
-    def delete(self, memory_id: str) -> bool:
+    def delete(self, memory_id: str) -> Optional[str]:
         """
         Delete a memory by ID or unique prefix.
 
@@ -677,7 +680,10 @@ class PACTMemory:
             memory_id: Full 32-char ID or a prefix >= MIN_PREFIX_LENGTH.
 
         Returns:
-            True if deleted, False if not found.
+            The resolved full 32-char memory ID on successful delete, or
+            None when the input matched no row. Callers that invoked with a
+            prefix get the canonical ID back so downstream operations key off
+            the storage form.
 
         Raises:
             PrefixTooShortError: prefix is shorter than the minimum.
@@ -691,7 +697,7 @@ class PACTMemory:
 
             resolved = self._resolve_id_or_full(conn, memory_id)
             if resolved is None:
-                return False
+                return None
             memory_id = resolved
 
             # Also remove from vector table
@@ -703,7 +709,7 @@ class PACTMemory:
             except Exception:
                 pass  # Vector table might not exist
 
-            return delete_memory(conn, memory_id)
+            return memory_id if delete_memory(conn, memory_id) else None
 
     def list(
         self,

--- a/pact-plugin/tests/test_memory_cli.py
+++ b/pact-plugin/tests/test_memory_cli.py
@@ -905,6 +905,33 @@ class TestCliUpdateCommand:
         err_output = json.loads(captured.err)
         assert err_output["error"] == "NOT_FOUND"
 
+    def test_update_too_short_prefix_returns_error(self, mock_pact_memory, capsys):
+        """Locks the PrefixTooShortError-IS-A-ValueError except-clause precedence.
+
+        cmd_update catches PrefixTooShortError BEFORE the generic ValueError
+        handler that surfaces field-validation failures. Since
+        PrefixTooShortError is a ValueError subclass, the order matters:
+        a swap would silently route prefix-too-short to the ValueError
+        envelope (with allowed_fields list and exit_code=2) instead of the
+        intended PREFIX_TOO_SHORT envelope.
+        """
+        from scripts.database import PrefixTooShortError
+        mock_pact_memory.update.side_effect = PrefixTooShortError("abc", minimum=7)
+        parser = build_parser()
+        args = parser.parse_args(["update", "abc", '{"context": "x"}'])
+
+        with patch("scripts.cli.PACTMemory", return_value=mock_pact_memory):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_update(args)
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        err_output = json.loads(captured.err)
+        assert err_output["error"] == "PREFIX_TOO_SHORT"
+        assert err_output["minimum"] == 7
+        # Negative assertion: the ValueError envelope shape would have
+        # this key; PREFIX_TOO_SHORT must NOT.
+        assert "allowed_fields" not in err_output
+
     def test_update_with_stdin(self, mock_pact_memory, monkeypatch):
         mock_pact_memory.update.return_value = _FAKE_RESOLVED_ID
         monkeypatch.setattr("sys.stdin", StringIO('{"context": "from stdin"}'))
@@ -1185,6 +1212,28 @@ class TestCliDeleteCommand:
         captured = capsys.readouterr()
         err_output = json.loads(captured.err)
         assert err_output["error"] == "NOT_FOUND"
+
+    def test_delete_too_short_prefix_returns_error(self, mock_pact_memory, capsys):
+        """cmd_delete surfaces PREFIX_TOO_SHORT envelope, not a generic error.
+
+        cmd_delete has no field-validation ValueError path, but the
+        explicit `except PrefixTooShortError` clause still matters: it
+        carries the `minimum` field through to the envelope rather than
+        falling through to a generic exception handler.
+        """
+        from scripts.database import PrefixTooShortError
+        mock_pact_memory.delete.side_effect = PrefixTooShortError("abc", minimum=7)
+        parser = build_parser()
+        args = parser.parse_args(["delete", "abc"])
+
+        with patch("scripts.cli.PACTMemory", return_value=mock_pact_memory):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_delete(args)
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        err_output = json.loads(captured.err)
+        assert err_output["error"] == "PREFIX_TOO_SHORT"
+        assert err_output["minimum"] == 7
 
     def test_delete_passes_db_path(self, mock_pact_memory):
         mock_pact_memory.delete.return_value = _FAKE_RESOLVED_ID
@@ -1515,7 +1564,7 @@ class TestCliSubprocess:
         err = json.loads(update_result.stderr)
         assert err["error"] == "AMBIGUOUS_PREFIX"
         assert err["prefix"] == "updambi"
-        assert err["truncated"] is False
+        assert err["matches_capped"] is False
         assert err["total_matches"] == 2
         match_ids = sorted(m["id"] for m in err["matches"])
         assert match_ids == sorted([id_a, id_b])
@@ -1589,7 +1638,7 @@ class TestCliSubprocess:
         err = json.loads(delete_result.stderr)
         assert err["error"] == "AMBIGUOUS_PREFIX"
         assert err["prefix"] == "delambi"
-        assert err["truncated"] is False
+        assert err["matches_capped"] is False
         assert err["total_matches"] == 2
 
         # Verify BOTH rows survive

--- a/pact-plugin/tests/test_memory_cli.py
+++ b/pact-plugin/tests/test_memory_cli.py
@@ -39,6 +39,14 @@ from scripts.memory_api import PACTMemory
 # Fixtures
 # ---------------------------------------------------------------------------
 
+# Stable 32-char fake memory ID used by mock_pact_memory defaults so tests
+# asserting on the success envelope's `memory_id` field have a known value
+# to compare against. Distinct from any prefix used in test args so that
+# assertions catch regressions where the user-supplied prefix is echoed
+# instead of the resolved full ID.
+_FAKE_RESOLVED_ID = "fa1ce1d" + "0" * 25  # 32 chars, lowercase hex pattern
+
+
 @pytest.fixture
 def mock_pact_memory():
     """Create a mock PACTMemory instance with standard return values."""
@@ -49,6 +57,10 @@ def mock_pact_memory():
     # Non-None default so save verification in PACTMemory.save() passes;
     # override to None in tests that need NOT_FOUND behavior.
     mock.get.return_value = MagicMock()
+    # update/delete return Optional[str] (resolved full ID). Explicit defaults
+    # match the API contract; tests for not-found paths override to None.
+    mock.update.return_value = _FAKE_RESOLVED_ID
+    mock.delete.return_value = _FAKE_RESOLVED_ID
     mock.get_status.return_value = {
         "project_id": "test-project",
         "memory_count": 5,
@@ -862,24 +874,26 @@ class TestCliUpdateCommand:
     """Test the update subcommand handler."""
 
     def test_update_existing_memory(self, mock_pact_memory, capsys):
-        mock_pact_memory.update.return_value = True
+        mock_pact_memory.update.return_value = _FAKE_RESOLVED_ID
         parser = build_parser()
-        args = parser.parse_args(["update", "abc123", '{"context": "updated"}'])
+        args = parser.parse_args(["update", "abc1234", '{"context": "updated"}'])
 
         with patch("scripts.cli.PACTMemory", return_value=mock_pact_memory):
             with pytest.raises(SystemExit) as exc_info:
                 cmd_update(args)
         assert exc_info.value.code == 0
         mock_pact_memory.update.assert_called_once_with(
-            "abc123", {"context": "updated"}, replace=False
+            "abc1234", {"context": "updated"}, replace=False
         )
         captured = capsys.readouterr()
         output = json.loads(captured.out)
         assert output["ok"] is True
-        assert output["result"]["memory_id"] == "abc123"
+        # Envelope echoes the RESOLVED full ID returned by the API, not the
+        # user-supplied prefix — locks the cycle-2 echo fix.
+        assert output["result"]["memory_id"] == _FAKE_RESOLVED_ID
 
     def test_update_not_found(self, mock_pact_memory, capsys):
-        mock_pact_memory.update.return_value = False
+        mock_pact_memory.update.return_value = None
         parser = build_parser()
         args = parser.parse_args(["update", "nonexistent", '{"context": "x"}'])
 
@@ -892,7 +906,7 @@ class TestCliUpdateCommand:
         assert err_output["error"] == "NOT_FOUND"
 
     def test_update_with_stdin(self, mock_pact_memory, monkeypatch):
-        mock_pact_memory.update.return_value = True
+        mock_pact_memory.update.return_value = _FAKE_RESOLVED_ID
         monkeypatch.setattr("sys.stdin", StringIO('{"context": "from stdin"}'))
         parser = build_parser()
         args = parser.parse_args(["update", "abc123", "--stdin"])
@@ -939,7 +953,7 @@ class TestCliUpdateCommand:
         assert err_output["error"] == "MISSING_INPUT"
 
     def test_update_passes_db_path(self, mock_pact_memory):
-        mock_pact_memory.update.return_value = True
+        mock_pact_memory.update.return_value = _FAKE_RESOLVED_ID
         parser = build_parser()
         args = parser.parse_args(["update", "abc123", '{"context": "x"}', "--db-path", "/tmp/t.db"])
 
@@ -953,7 +967,7 @@ class TestCliUpdateReplaceFlag:
     """Test the --replace flag and ValueError envelope on the update subcommand."""
 
     def test_replace_flag_forwards_true(self, mock_pact_memory):
-        mock_pact_memory.update.return_value = True
+        mock_pact_memory.update.return_value = _FAKE_RESOLVED_ID
         parser = build_parser()
         args = parser.parse_args(
             ["update", "abc123", '{"lessons": ["x"]}', "--replace"]
@@ -968,7 +982,7 @@ class TestCliUpdateReplaceFlag:
         )
 
     def test_replace_default_is_false(self, mock_pact_memory):
-        mock_pact_memory.update.return_value = True
+        mock_pact_memory.update.return_value = _FAKE_RESOLVED_ID
         parser = build_parser()
         args = parser.parse_args(["update", "abc123", '{"lessons": ["x"]}'])
 
@@ -1143,23 +1157,24 @@ class TestCliDeleteCommand:
     """Test the delete subcommand handler."""
 
     def test_delete_existing_memory(self, mock_pact_memory, capsys):
-        mock_pact_memory.delete.return_value = True
+        mock_pact_memory.delete.return_value = _FAKE_RESOLVED_ID
         parser = build_parser()
-        args = parser.parse_args(["delete", "abc123"])
+        args = parser.parse_args(["delete", "abc1234"])
 
         with patch("scripts.cli.PACTMemory", return_value=mock_pact_memory):
             with pytest.raises(SystemExit) as exc_info:
                 cmd_delete(args)
         assert exc_info.value.code == 0
-        mock_pact_memory.delete.assert_called_once_with("abc123")
+        mock_pact_memory.delete.assert_called_once_with("abc1234")
         captured = capsys.readouterr()
         output = json.loads(captured.out)
         assert output["ok"] is True
         assert output["result"]["deleted"] is True
-        assert output["result"]["memory_id"] == "abc123"
+        # Envelope echoes the RESOLVED full ID, not the user-supplied prefix.
+        assert output["result"]["memory_id"] == _FAKE_RESOLVED_ID
 
     def test_delete_not_found(self, mock_pact_memory, capsys):
-        mock_pact_memory.delete.return_value = False
+        mock_pact_memory.delete.return_value = None
         parser = build_parser()
         args = parser.parse_args(["delete", "nonexistent"])
 
@@ -1172,7 +1187,7 @@ class TestCliDeleteCommand:
         assert err_output["error"] == "NOT_FOUND"
 
     def test_delete_passes_db_path(self, mock_pact_memory):
-        mock_pact_memory.delete.return_value = True
+        mock_pact_memory.delete.return_value = _FAKE_RESOLVED_ID
         parser = build_parser()
         args = parser.parse_args(["delete", "abc123", "--db-path", "/tmp/t.db"])
 
@@ -1605,6 +1620,53 @@ class TestCliSubprocess:
         )
         assert get_result.returncode == 1
         assert json.loads(get_result.stderr)["error"] == "NOT_FOUND"
+
+    # ----- Cycle 2: echo-fix regression — envelope must echo resolved full ID -----
+
+    def test_update_success_envelope_returns_resolved_full_id(self, cli_script_path, cli_db):
+        """E2E: update success envelope echoes the resolved full ID, not the user prefix.
+
+        Calling `pact-memory update <prefix>` and then chaining a follow-up
+        operation against the returned ID must work without re-running prefix
+        resolution. Locks the cycle-2 echo fix.
+        """
+        full_id = "ech0upd" + "1" + "0" * 24  # 32 chars
+        self._seed_memory(cli_db, full_id, "before")
+
+        prefix = "ech0upd"
+        assert prefix != full_id  # The whole point: caller passed a prefix
+        update_result = subprocess.run(
+            [sys.executable, cli_script_path, "update", prefix,
+             json.dumps({"context": "after"}),
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert update_result.returncode == 0, f"stderr: {update_result.stderr}"
+        out = json.loads(update_result.stdout)
+        assert out["ok"] is True
+        # Regression assertion: envelope must surface the RESOLVED full ID,
+        # not the user-supplied prefix.
+        assert out["result"]["memory_id"] == full_id
+        assert out["result"]["memory_id"] != prefix
+
+    def test_delete_success_envelope_returns_resolved_full_id(self, cli_script_path, cli_db):
+        """E2E: delete success envelope echoes the resolved full ID, not the user prefix."""
+        full_id = "ech0del" + "1" + "0" * 24
+        self._seed_memory(cli_db, full_id, "to-go")
+
+        prefix = "ech0del"
+        assert prefix != full_id
+        delete_result = subprocess.run(
+            [sys.executable, cli_script_path, "delete", prefix,
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert delete_result.returncode == 0, f"stderr: {delete_result.stderr}"
+        out = json.loads(delete_result.stdout)
+        assert out["ok"] is True
+        assert out["result"]["deleted"] is True
+        assert out["result"]["memory_id"] == full_id
+        assert out["result"]["memory_id"] != prefix
 
     def test_save_via_stdin(self, cli_script_path, cli_db):
         memory_dict = make_cli_memory_dict(context="stdin test")

--- a/pact-plugin/tests/test_memory_cli.py
+++ b/pact-plugin/tests/test_memory_cli.py
@@ -1668,6 +1668,126 @@ class TestCliSubprocess:
         assert out["result"]["memory_id"] == full_id
         assert out["result"]["memory_id"] != prefix
 
+    # ----- Cycle 3 H1: case-insensitive matching extends to FULL-32-char branch -----
+
+    def test_uppercase_full_id_resolves_to_lowercase_stored_get(self, cli_script_path, cli_db):
+        """E2E: passing the full ID in UPPERCASE to `get` still resolves the lowercase-stored row.
+
+        The 32-char branch bypasses prefix resolution entirely; case-normalization
+        must apply on this branch too, otherwise an uppercase full ID misses
+        despite being byte-identical-after-lower() to the stored ID.
+        """
+        full_id_lower = "abcdef0" + "1" + "0" * 24
+        self._seed_memory(cli_db, full_id_lower, "case-roundtrip")
+
+        full_id_upper = full_id_lower.upper()
+        assert full_id_upper != full_id_lower  # confirm the input differs
+
+        result = subprocess.run(
+            [sys.executable, cli_script_path, "get", full_id_upper,
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        out = json.loads(result.stdout)
+        assert out["ok"] is True
+        assert out["result"]["id"] == full_id_lower
+        assert out["result"]["context"] == "case-roundtrip"
+
+    def test_uppercase_full_id_resolves_to_lowercase_stored_update(self, cli_script_path, cli_db):
+        """E2E: passing the full ID in UPPERCASE to `update` mutates the lowercase-stored row."""
+        full_id_lower = "abcdef0" + "2" + "0" * 24
+        self._seed_memory(cli_db, full_id_lower, "before-case")
+
+        update_result = subprocess.run(
+            [sys.executable, cli_script_path, "update", full_id_lower.upper(),
+             json.dumps({"context": "after-case"}),
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert update_result.returncode == 0, f"stderr: {update_result.stderr}"
+        out = json.loads(update_result.stdout)
+        assert out["ok"] is True
+        # Resolved-id echo must be the lowercase storage form, not the uppercase input.
+        assert out["result"]["memory_id"] == full_id_lower
+
+        # Verify mutation actually landed via lowercase GET
+        get_result = subprocess.run(
+            [sys.executable, cli_script_path, "get", full_id_lower,
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert json.loads(get_result.stdout)["result"]["context"] == "after-case"
+
+    def test_uppercase_full_id_resolves_to_lowercase_stored_delete(self, cli_script_path, cli_db):
+        """E2E: passing the full ID in UPPERCASE to `delete` removes the lowercase-stored row."""
+        full_id_lower = "abcdef0" + "3" + "0" * 24
+        self._seed_memory(cli_db, full_id_lower, "case-doomed")
+
+        delete_result = subprocess.run(
+            [sys.executable, cli_script_path, "delete", full_id_lower.upper(),
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert delete_result.returncode == 0, f"stderr: {delete_result.stderr}"
+        out = json.loads(delete_result.stdout)
+        assert out["ok"] is True
+        assert out["result"]["memory_id"] == full_id_lower
+
+        # Verify removal via lowercase GET → NOT_FOUND
+        get_result = subprocess.run(
+            [sys.executable, cli_script_path, "get", full_id_lower,
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert get_result.returncode == 1
+        assert json.loads(get_result.stderr)["error"] == "NOT_FOUND"
+
+    # ----- Cycle 3 H3: AMBIGUOUS_PREFIX envelope scrubs $HOME from match contexts -----
+
+    def test_ambiguous_prefix_scrubs_context_in_envelope(self, cli_script_path, cli_db):
+        """E2E: AMBIGUOUS_PREFIX envelope replaces user $HOME path with '~' in each match context.
+
+        Contexts may carry absolute paths from agent notes; piping the envelope
+        to a log file would otherwise leak the operating user's home directory.
+        Scrub is applied per-match in cli.py at all 3 ambiguous-prefix call
+        sites (cmd_get, cmd_update, cmd_delete); this test exercises cmd_get
+        as representative.
+        """
+        home = str(Path.home())
+        # Guard against an unresolved tilde — _scrub no-ops if HOME is unset
+        # or returns the literal '~', and this test would not be exercising
+        # the scrub path in that case.
+        assert home and home != "~", f"HOME must be a real path for this test (got {home!r})"
+
+        sensitive_path = f"{home}/Sites/secret-project/file.py"
+        id_a = "scrub00" + "a" + "0" * 24
+        id_b = "scrub00" + "b" + "0" * 24
+        self._seed_memory(cli_db, id_a, f"Note about {sensitive_path}")
+        self._seed_memory(cli_db, id_b, f"Other note also at {sensitive_path}")
+
+        result = subprocess.run(
+            [sys.executable, cli_script_path, "get", "scrub00",
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert result.returncode == 1, f"stdout: {result.stdout}"
+        err = json.loads(result.stderr)
+        assert err["error"] == "AMBIGUOUS_PREFIX"
+        assert err["prefix"] == "scrub00"
+
+        # Per-match contexts must NOT contain the literal $HOME expansion.
+        for match in err["matches"]:
+            assert home not in match["context"], (
+                f"$HOME ({home!r}) leaked into match context: {match['context']!r}"
+            )
+            # Positive assertion: the substituted form is present.
+            assert "~/Sites/secret-project/file.py" in match["context"]
+            # IDs are hex and must NOT be scrubbed; they should be the
+            # untouched 32-char storage form. Per backend H3 contract.
+            assert match["id"] in (id_a, id_b)
+            assert len(match["id"]) == 32
+
     def test_save_via_stdin(self, cli_script_path, cli_db):
         memory_dict = make_cli_memory_dict(context="stdin test")
         json_str = json.dumps(memory_dict)

--- a/pact-plugin/tests/test_memory_cli.py
+++ b/pact-plugin/tests/test_memory_cli.py
@@ -732,12 +732,12 @@ class TestCliGetPrefixResolution:
     def test_get_ambiguous_prefix_returns_match_list(self, mock_pact_memory, capsys):
         from scripts.database import AmbiguousPrefixError
         matches = [
-            {"id": "abcd0001" + "0" * 24, "context": "first"},
-            {"id": "abcd0002" + "0" * 24, "context": "second"},
+            {"id": "abcd123" + "1" + "0" * 24, "context": "first"},
+            {"id": "abcd123" + "2" + "0" * 24, "context": "second"},
         ]
-        mock_pact_memory.get.side_effect = AmbiguousPrefixError("abcd", matches)
+        mock_pact_memory.get.side_effect = AmbiguousPrefixError("abcd123", matches)
         parser = build_parser()
-        args = parser.parse_args(["get", "abcd"])
+        args = parser.parse_args(["get", "abcd123"])
 
         with patch("scripts.cli.PACTMemory", return_value=mock_pact_memory):
             with pytest.raises(SystemExit) as exc_info:
@@ -747,14 +747,16 @@ class TestCliGetPrefixResolution:
         err_output = json.loads(captured.err)
         assert err_output["ok"] is False
         assert err_output["error"] == "AMBIGUOUS_PREFIX"
-        assert err_output["prefix"] == "abcd"
+        assert err_output["prefix"] == "abcd123"
         assert err_output["matches"] == matches
 
     def test_get_too_short_prefix_returns_error(self, mock_pact_memory, capsys):
-        from scripts.database import PrefixTooShortError
-        mock_pact_memory.get.side_effect = PrefixTooShortError("abc", minimum=4)
+        from scripts.database import PrefixTooShortError, MIN_PREFIX_LENGTH
+        mock_pact_memory.get.side_effect = PrefixTooShortError(
+            "abc123", minimum=MIN_PREFIX_LENGTH
+        )
         parser = build_parser()
-        args = parser.parse_args(["get", "abc"])
+        args = parser.parse_args(["get", "abc123"])
 
         with patch("scripts.cli.PACTMemory", return_value=mock_pact_memory):
             with pytest.raises(SystemExit) as exc_info:
@@ -763,7 +765,7 @@ class TestCliGetPrefixResolution:
         captured = capsys.readouterr()
         err_output = json.loads(captured.err)
         assert err_output["error"] == "PREFIX_TOO_SHORT"
-        assert err_output["minimum"] == 4
+        assert err_output["minimum"] == MIN_PREFIX_LENGTH
 
     def test_get_full_hash_unchanged(self, mock_pact_memory, capsys):
         """Full 32-char IDs continue to work unchanged."""
@@ -1362,6 +1364,247 @@ class TestCliSubprocess:
         get_output = json.loads(get_result.stdout)
         assert get_output["ok"] is True
         assert get_output["result"]["context"] == memory_dict["context"]
+
+    def test_get_unique_prefix_resolves_via_subprocess(self, cli_script_path, cli_db):
+        """E2E: real cli.py → memory_api → database → SQL roundtrip on a unique prefix."""
+        from scripts.database import create_memory
+        try:
+            import pysqlite3 as sqlite3
+        except ImportError:
+            import sqlite3
+
+        full_id = "fa11ce5" + "1" + "0" * 24  # 32 chars; prefix "fa11ce5" is 7 chars
+        conn = sqlite3.connect(str(cli_db))
+        conn.row_factory = sqlite3.Row
+        with patch("scripts.database.ensure_initialized"):
+            create_memory(conn, {"id": full_id, "context": "unique-prefix-roundtrip"})
+        conn.commit()
+        conn.close()
+
+        result = subprocess.run(
+            [sys.executable, cli_script_path, "get", "fa11ce5",
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert output["ok"] is True
+        assert output["result"]["id"] == full_id
+        assert output["result"]["context"] == "unique-prefix-roundtrip"
+
+    def test_get_ambiguous_prefix_envelope_via_subprocess(self, cli_script_path, cli_db):
+        """E2E: ambiguous prefix returns AMBIGUOUS_PREFIX envelope with full match list."""
+        from scripts.database import create_memory
+        try:
+            import pysqlite3 as sqlite3
+        except ImportError:
+            import sqlite3
+
+        id_a = "ambig00" + "a" + "0" * 24
+        id_b = "ambig00" + "b" + "0" * 24
+        conn = sqlite3.connect(str(cli_db))
+        conn.row_factory = sqlite3.Row
+        with patch("scripts.database.ensure_initialized"):
+            create_memory(conn, {"id": id_a, "context": "first"})
+            create_memory(conn, {"id": id_b, "context": "second"})
+        conn.commit()
+        conn.close()
+
+        result = subprocess.run(
+            [sys.executable, cli_script_path, "get", "ambig00",
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert result.returncode == 1, f"stdout: {result.stdout}, stderr: {result.stderr}"
+        err_output = json.loads(result.stderr)
+        assert err_output["ok"] is False
+        assert err_output["error"] == "AMBIGUOUS_PREFIX"
+        assert err_output["prefix"] == "ambig00"
+        match_ids = sorted(m["id"] for m in err_output["matches"])
+        assert match_ids == sorted([id_a, id_b])
+
+    def test_get_too_short_prefix_envelope_via_subprocess(self, cli_script_path, cli_db):
+        """E2E: prefix shorter than minimum returns PREFIX_TOO_SHORT envelope.
+
+        Uses a 6-char prefix — exactly MIN_PREFIX_LENGTH - 1 — to exercise
+        the gate at its sharpest boundary rather than a trivially-short input.
+        """
+        from scripts.database import MIN_PREFIX_LENGTH
+        too_short = "abcdef"  # exactly MIN_PREFIX_LENGTH - 1
+        assert len(too_short) == MIN_PREFIX_LENGTH - 1
+
+        result = subprocess.run(
+            [sys.executable, cli_script_path, "get", too_short,
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert result.returncode == 1, f"stdout: {result.stdout}, stderr: {result.stderr}"
+        err_output = json.loads(result.stderr)
+        assert err_output["ok"] is False
+        assert err_output["error"] == "PREFIX_TOO_SHORT"
+        assert err_output["minimum"] == MIN_PREFIX_LENGTH
+
+    # ----- F7: update/delete prefix resolution (subprocess E2E) -----
+
+    def _seed_memory(self, db_path, memory_id, context):
+        """Helper: insert one memory via storage primitive (bypasses CLI ingress strip)."""
+        from scripts.database import create_memory
+        try:
+            import pysqlite3 as sqlite3
+        except ImportError:
+            import sqlite3
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        with patch("scripts.database.ensure_initialized"):
+            create_memory(conn, {"id": memory_id, "context": context})
+        conn.commit()
+        conn.close()
+
+    def test_update_unique_prefix_resolves_and_mutates(self, cli_script_path, cli_db):
+        """E2E: update by unique prefix resolves to full ID and mutates the memory."""
+        full_id = "upd1nfo" + "1" + "0" * 24
+        self._seed_memory(cli_db, full_id, "before-update")
+
+        update_payload = json.dumps({"context": "after-update"})
+        update_result = subprocess.run(
+            [sys.executable, cli_script_path, "update", "upd1nfo", update_payload,
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert update_result.returncode == 0, f"stderr: {update_result.stderr}"
+        assert json.loads(update_result.stdout)["ok"] is True
+
+        # Verify the mutation landed by reading the FULL ID
+        get_result = subprocess.run(
+            [sys.executable, cli_script_path, "get", full_id,
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert get_result.returncode == 0
+        assert json.loads(get_result.stdout)["result"]["context"] == "after-update"
+
+    def test_update_ambiguous_prefix_refuses_with_envelope(self, cli_script_path, cli_db):
+        """E2E: ambiguous prefix on update refuses with AMBIGUOUS_PREFIX, leaves both rows untouched."""
+        id_a = "updambi" + "a" + "0" * 24
+        id_b = "updambi" + "b" + "0" * 24
+        self._seed_memory(cli_db, id_a, "original-a")
+        self._seed_memory(cli_db, id_b, "original-b")
+
+        update_result = subprocess.run(
+            [sys.executable, cli_script_path, "update", "updambi",
+             json.dumps({"context": "should-not-land"}),
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert update_result.returncode == 1, f"stdout: {update_result.stdout}"
+        err = json.loads(update_result.stderr)
+        assert err["error"] == "AMBIGUOUS_PREFIX"
+        assert err["prefix"] == "updambi"
+        assert err["truncated"] is False
+        assert err["total_matches"] == 2
+        match_ids = sorted(m["id"] for m in err["matches"])
+        assert match_ids == sorted([id_a, id_b])
+
+        # Verify NEITHER row was mutated
+        for fid, original in [(id_a, "original-a"), (id_b, "original-b")]:
+            get_result = subprocess.run(
+                [sys.executable, cli_script_path, "get", fid,
+                 "--db-path", str(cli_db)],
+                capture_output=True, text=True, timeout=60,
+            )
+            assert json.loads(get_result.stdout)["result"]["context"] == original
+
+    def test_update_full_hash_unchanged(self, cli_script_path, cli_db):
+        """E2E: full 32-char ID on update bypasses resolver and works as before."""
+        full_id = "fu11upd0" + "0" * 24
+        self._seed_memory(cli_db, full_id, "pre")
+
+        update_result = subprocess.run(
+            [sys.executable, cli_script_path, "update", full_id,
+             json.dumps({"context": "post"}),
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert update_result.returncode == 0, f"stderr: {update_result.stderr}"
+
+        get_result = subprocess.run(
+            [sys.executable, cli_script_path, "get", full_id,
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert json.loads(get_result.stdout)["result"]["context"] == "post"
+
+    def test_delete_unique_prefix_resolves_and_removes(self, cli_script_path, cli_db):
+        """E2E: delete by unique prefix resolves to full ID and removes the memory."""
+        full_id = "del1nfo" + "1" + "0" * 24
+        self._seed_memory(cli_db, full_id, "to-be-deleted")
+
+        delete_result = subprocess.run(
+            [sys.executable, cli_script_path, "delete", "del1nfo",
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert delete_result.returncode == 0, f"stderr: {delete_result.stderr}"
+        out = json.loads(delete_result.stdout)
+        assert out["ok"] is True
+        assert out["result"]["deleted"] is True
+
+        # Verify it's actually gone via full ID
+        get_result = subprocess.run(
+            [sys.executable, cli_script_path, "get", full_id,
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert get_result.returncode == 1
+        assert json.loads(get_result.stderr)["error"] == "NOT_FOUND"
+
+    def test_delete_ambiguous_prefix_refuses_with_envelope(self, cli_script_path, cli_db):
+        """E2E: ambiguous prefix on delete refuses, leaves both rows present."""
+        id_a = "delambi" + "a" + "0" * 24
+        id_b = "delambi" + "b" + "0" * 24
+        self._seed_memory(cli_db, id_a, "stays-a")
+        self._seed_memory(cli_db, id_b, "stays-b")
+
+        delete_result = subprocess.run(
+            [sys.executable, cli_script_path, "delete", "delambi",
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert delete_result.returncode == 1, f"stdout: {delete_result.stdout}"
+        err = json.loads(delete_result.stderr)
+        assert err["error"] == "AMBIGUOUS_PREFIX"
+        assert err["prefix"] == "delambi"
+        assert err["truncated"] is False
+        assert err["total_matches"] == 2
+
+        # Verify BOTH rows survive
+        for fid in (id_a, id_b):
+            get_result = subprocess.run(
+                [sys.executable, cli_script_path, "get", fid,
+                 "--db-path", str(cli_db)],
+                capture_output=True, text=True, timeout=60,
+            )
+            assert get_result.returncode == 0, f"row {fid} was unexpectedly deleted"
+
+    def test_delete_full_hash_unchanged(self, cli_script_path, cli_db):
+        """E2E: full 32-char ID on delete bypasses resolver and works as before."""
+        full_id = "fu11del0" + "0" * 24
+        self._seed_memory(cli_db, full_id, "doomed")
+
+        delete_result = subprocess.run(
+            [sys.executable, cli_script_path, "delete", full_id,
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert delete_result.returncode == 0, f"stderr: {delete_result.stderr}"
+
+        get_result = subprocess.run(
+            [sys.executable, cli_script_path, "get", full_id,
+             "--db-path", str(cli_db)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert get_result.returncode == 1
+        assert json.loads(get_result.stderr)["error"] == "NOT_FOUND"
 
     def test_save_via_stdin(self, cli_script_path, cli_db):
         memory_dict = make_cli_memory_dict(context="stdin test")

--- a/pact-plugin/tests/test_memory_cli.py
+++ b/pact-plugin/tests/test_memory_cli.py
@@ -705,6 +705,86 @@ class TestCliGetCommand:
         mock_cls.assert_called_once_with(db_path=Path("/tmp/t.db"))
 
 
+class TestCliGetPrefixResolution:
+    """CLI-layer tests for git-style prefix resolution on `get`."""
+
+    def test_get_unique_prefix_returns_memory(self, mock_pact_memory, capsys):
+        from scripts.database import MEMORY_ID_LENGTH
+        full_id = "a" * MEMORY_ID_LENGTH
+        mock_obj = MagicMock()
+        mock_obj.to_dict.return_value = {"id": full_id, "context": "match"}
+        # Simulate API-layer prefix resolution: short input still returns the obj
+        mock_pact_memory.get.return_value = mock_obj
+        parser = build_parser()
+        args = parser.parse_args(["get", "aaaa1234"])
+
+        with patch("scripts.cli.PACTMemory", return_value=mock_pact_memory):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_get(args)
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+        assert output["ok"] is True
+        assert output["result"]["id"] == full_id
+        # CLI passed the prefix through to the API layer unchanged
+        mock_pact_memory.get.assert_called_once_with("aaaa1234")
+
+    def test_get_ambiguous_prefix_returns_match_list(self, mock_pact_memory, capsys):
+        from scripts.database import AmbiguousPrefixError
+        matches = [
+            {"id": "abcd0001" + "0" * 24, "context": "first"},
+            {"id": "abcd0002" + "0" * 24, "context": "second"},
+        ]
+        mock_pact_memory.get.side_effect = AmbiguousPrefixError("abcd", matches)
+        parser = build_parser()
+        args = parser.parse_args(["get", "abcd"])
+
+        with patch("scripts.cli.PACTMemory", return_value=mock_pact_memory):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_get(args)
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        err_output = json.loads(captured.err)
+        assert err_output["ok"] is False
+        assert err_output["error"] == "AMBIGUOUS_PREFIX"
+        assert err_output["prefix"] == "abcd"
+        assert err_output["matches"] == matches
+
+    def test_get_too_short_prefix_returns_error(self, mock_pact_memory, capsys):
+        from scripts.database import PrefixTooShortError
+        mock_pact_memory.get.side_effect = PrefixTooShortError("abc", minimum=4)
+        parser = build_parser()
+        args = parser.parse_args(["get", "abc"])
+
+        with patch("scripts.cli.PACTMemory", return_value=mock_pact_memory):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_get(args)
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        err_output = json.loads(captured.err)
+        assert err_output["error"] == "PREFIX_TOO_SHORT"
+        assert err_output["minimum"] == 4
+
+    def test_get_full_hash_unchanged(self, mock_pact_memory, capsys):
+        """Full 32-char IDs continue to work unchanged."""
+        from scripts.database import MEMORY_ID_LENGTH
+        full_id = "a" * MEMORY_ID_LENGTH
+        mock_obj = MagicMock()
+        mock_obj.to_dict.return_value = {"id": full_id, "context": "found"}
+        mock_pact_memory.get.return_value = mock_obj
+        parser = build_parser()
+        args = parser.parse_args(["get", full_id])
+
+        with patch("scripts.cli.PACTMemory", return_value=mock_pact_memory):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_get(args)
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+        assert output["result"]["id"] == full_id
+        mock_pact_memory.get.assert_called_once_with(full_id)
+
+
 # ---------------------------------------------------------------------------
 # Status Command
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_memory_database.py
+++ b/pact-plugin/tests/test_memory_database.py
@@ -196,6 +196,61 @@ class TestGetMemory:
         assert get_memory(db_conn, "nonexistent") is None
 
 
+class TestResolveMemoryIdPrefix:
+    """Storage-layer tests for resolve_memory_id_prefix."""
+
+    def test_unique_prefix_returns_full_id(self, db_conn):
+        from scripts.database import create_memory, resolve_memory_id_prefix
+        mem_id = create_memory(
+            db_conn,
+            {"id": "abc12345" + "0" * 24, "context": "unique"},
+        )
+        assert resolve_memory_id_prefix(db_conn, "abc12345") == mem_id
+
+    def test_ambiguous_prefix_raises(self, db_conn):
+        from scripts.database import (
+            create_memory,
+            resolve_memory_id_prefix,
+            AmbiguousPrefixError,
+        )
+        id_a = "abcd0001" + "0" * 24
+        id_b = "abcd0002" + "0" * 24
+        create_memory(db_conn, {"id": id_a, "context": "first match"})
+        create_memory(db_conn, {"id": id_b, "context": "second match"})
+
+        with pytest.raises(AmbiguousPrefixError) as exc_info:
+            resolve_memory_id_prefix(db_conn, "abcd")
+
+        match_ids = sorted(m["id"] for m in exc_info.value.matches)
+        assert match_ids == sorted([id_a, id_b])
+        # Descriptor snippet attached for terse disambiguation
+        contexts = {m["id"]: m["context"] for m in exc_info.value.matches}
+        assert contexts[id_a] == "first match"
+        assert contexts[id_b] == "second match"
+
+    def test_no_match_returns_none(self, db_conn):
+        from scripts.database import resolve_memory_id_prefix
+        assert resolve_memory_id_prefix(db_conn, "ffff") is None
+
+    def test_too_short_prefix_raises(self, db_conn):
+        from scripts.database import (
+            resolve_memory_id_prefix,
+            PrefixTooShortError,
+        )
+        with pytest.raises(PrefixTooShortError) as exc_info:
+            resolve_memory_id_prefix(db_conn, "abc")
+        assert exc_info.value.prefix == "abc"
+        assert exc_info.value.minimum == 4
+
+    def test_like_wildcard_in_prefix_is_escaped(self, db_conn):
+        """A literal '%' in the prefix must not expand as a SQL wildcard."""
+        from scripts.database import create_memory, resolve_memory_id_prefix
+        # Real memory whose ID does NOT contain '%' (IDs are hex)
+        create_memory(db_conn, {"id": "deadbeef" + "0" * 24, "context": "x"})
+        # '%dead' would match 'deadbeef...' if '%' were not escaped
+        assert resolve_memory_id_prefix(db_conn, "%dead") is None
+
+
 class TestUpdateMemory:
     def test_updates_fields(self, db_conn):
         from scripts.database import create_memory, update_memory, get_memory

--- a/pact-plugin/tests/test_memory_database.py
+++ b/pact-plugin/tests/test_memory_database.py
@@ -475,6 +475,117 @@ class TestDeleteMemory:
         assert delete_memory(db_conn, "nonexistent") is False
 
 
+class TestPACTMemoryDeleteVecTableHandling:
+    """Locks the narrowed-except contract on PACTMemory.delete's vec_memories cleanup.
+
+    PACTMemory.delete attempts `DELETE FROM vec_memories WHERE memory_id = ?`
+    AFTER deleting the row from the primary memories table. The vec_memories
+    table only exists when sqlite-vec is loaded; absence is the legitimate
+    common case. A bare `except Exception: pass` here would also swallow
+    "database is locked", "disk I/O error", and other surface-or-surface-this
+    failures. The narrowed `except sqlite3.OperationalError if "no such table"
+    in str(e)` lets the legitimate-FTS-absent path stay silent while
+    surfacing every other operational error.
+    """
+
+    def test_delete_silently_handles_missing_vec_memories_table(self, tmp_path):
+        """Real-DB path: schema has no vec_memories table; delete must succeed."""
+        sys.path.insert(
+            0,
+            os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'),
+        )
+        from scripts.memory_api import PACTMemory
+
+        db_path = tmp_path / "vec_absent.db"
+        conn = sqlite3.connect(str(db_path))
+        create_test_schema(conn)
+        conn.close()
+        # Schema does NOT include vec_memories — DELETE FROM vec_memories will
+        # raise sqlite3.OperationalError("no such table: vec_memories"), which
+        # the narrowed except must swallow.
+
+        with patch("scripts.memory_api._ensure_ready"), \
+             patch("scripts.memory_api.sync_to_claude_md"), \
+             patch.object(PACTMemory, "_store_embedding", autospec=True):
+            memory = PACTMemory(
+                project_id="vec-absent-test",
+                session_id="s1",
+                db_path=db_path,
+            )
+            mem_id = memory.save({"context": "row to delete"})
+            # Delete must succeed despite vec_memories being absent.
+            resolved = memory.delete(mem_id)
+            assert resolved == mem_id
+            # Verify the primary-table delete actually landed.
+            assert memory.get(mem_id) is None
+
+    def test_delete_propagates_other_operational_errors(self, tmp_path):
+        """Bug-surfacing: non-"no such table" OperationalError must propagate.
+
+        Wraps conn.execute so the vec_memories DELETE raises a controlled
+        OperationalError ("database is locked") instead of the natural
+        no-such-table error. The narrowed except must NOT swallow this —
+        propagating it surfaces real problems (lock contention, disk I/O,
+        etc.) instead of silently leaving stale vector entries.
+        """
+        sys.path.insert(
+            0,
+            os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'),
+        )
+        from scripts.memory_api import PACTMemory
+        import scripts.memory_api as memory_api_mod
+
+        db_path = tmp_path / "vec_locked.db"
+        conn = sqlite3.connect(str(db_path))
+        create_test_schema(conn)
+        conn.close()
+
+        from contextlib import contextmanager
+        real_db_connection = memory_api_mod.db_connection
+
+        class _ConnProxy:
+            """Delegates everything to real_conn, intercepts execute()."""
+            def __init__(self, real_conn):
+                self._real = real_conn
+
+            def execute(self, sql, *args, **kwargs):
+                # Inject a non-"no such table" OperationalError on the
+                # vec_memories DELETE only. All other queries (resolver,
+                # primary-table delete, ensure_initialized) pass through.
+                if "vec_memories" in sql and sql.lstrip().upper().startswith("DELETE"):
+                    raise sqlite3.OperationalError("database is locked")
+                return self._real.execute(sql, *args, **kwargs)
+
+            def __getattr__(self, name):
+                # Delegate any other attribute (commit, close, row_factory, etc.)
+                return getattr(self._real, name)
+
+        @contextmanager
+        def db_connection_locking_vec(path):
+            with real_db_connection(path) as real_conn:
+                yield _ConnProxy(real_conn)
+
+        with patch("scripts.memory_api._ensure_ready"), \
+             patch("scripts.memory_api.sync_to_claude_md"), \
+             patch.object(PACTMemory, "_store_embedding", autospec=True):
+            memory = PACTMemory(
+                project_id="vec-locked-test",
+                session_id="s1",
+                db_path=db_path,
+            )
+            mem_id = memory.save({"context": "row delete will lock-fail"})
+
+            # Now patch db_connection so the SUBSEQUENT delete uses the
+            # locking wrapper. (save() above used the real db_connection.)
+            with patch.object(
+                memory_api_mod, "db_connection", db_connection_locking_vec
+            ):
+                with pytest.raises(sqlite3.OperationalError) as exc_info:
+                    memory.delete(mem_id)
+                assert "database is locked" in str(exc_info.value)
+                assert "no such table" not in str(exc_info.value)
+
+
 class TestListMemories:
     def test_lists_all(self, db_conn):
         from scripts.database import create_memory, list_memories

--- a/pact-plugin/tests/test_memory_database.py
+++ b/pact-plugin/tests/test_memory_database.py
@@ -213,16 +213,20 @@ class TestResolveMemoryIdPrefix:
             resolve_memory_id_prefix,
             AmbiguousPrefixError,
         )
-        id_a = "abcd0001" + "0" * 24
-        id_b = "abcd0002" + "0" * 24
-        create_memory(db_conn, {"id": id_a, "context": "first match"})
+        id_a = "abcd123" + "1" + "0" * 24
+        id_b = "abcd123" + "2" + "0" * 24
+        # Inserted in REVERSE lexicographic order to verify ORDER BY id sorts
+        # the matches independently of insert order.
         create_memory(db_conn, {"id": id_b, "context": "second match"})
+        create_memory(db_conn, {"id": id_a, "context": "first match"})
 
         with pytest.raises(AmbiguousPrefixError) as exc_info:
-            resolve_memory_id_prefix(db_conn, "abcd")
+            resolve_memory_id_prefix(db_conn, "abcd123")
 
-        match_ids = sorted(m["id"] for m in exc_info.value.matches)
-        assert match_ids == sorted([id_a, id_b])
+        # Direct list equality preserves the ORDER BY id contract — sorting
+        # both sides would mask a regression that drops the ORDER BY clause.
+        match_ids = [m["id"] for m in exc_info.value.matches]
+        assert match_ids == [id_a, id_b]
         # Descriptor snippet attached for terse disambiguation
         contexts = {m["id"]: m["context"] for m in exc_info.value.matches}
         assert contexts[id_a] == "first match"
@@ -230,7 +234,7 @@ class TestResolveMemoryIdPrefix:
 
     def test_no_match_returns_none(self, db_conn):
         from scripts.database import resolve_memory_id_prefix
-        assert resolve_memory_id_prefix(db_conn, "ffff") is None
+        assert resolve_memory_id_prefix(db_conn, "fffffff") is None
 
     def test_too_short_prefix_raises(self, db_conn):
         from scripts.database import (
@@ -238,17 +242,113 @@ class TestResolveMemoryIdPrefix:
             PrefixTooShortError,
         )
         with pytest.raises(PrefixTooShortError) as exc_info:
-            resolve_memory_id_prefix(db_conn, "abc")
-        assert exc_info.value.prefix == "abc"
-        assert exc_info.value.minimum == 4
+            resolve_memory_id_prefix(db_conn, "abc123")
+        assert exc_info.value.prefix == "abc123"
+        assert exc_info.value.minimum == 7
 
     def test_like_wildcard_in_prefix_is_escaped(self, db_conn):
         """A literal '%' in the prefix must not expand as a SQL wildcard."""
         from scripts.database import create_memory, resolve_memory_id_prefix
         # Real memory whose ID does NOT contain '%' (IDs are hex)
         create_memory(db_conn, {"id": "deadbeef" + "0" * 24, "context": "x"})
-        # '%dead' would match 'deadbeef...' if '%' were not escaped
-        assert resolve_memory_id_prefix(db_conn, "%dead") is None
+        # '%deadbe' would match 'deadbeef...' if '%' were not escaped
+        assert resolve_memory_id_prefix(db_conn, "%deadbe") is None
+
+    def test_empty_string_prefix_raises_too_short(self, db_conn):
+        """Empty input hits the minimum-length gate before the SQL query."""
+        from scripts.database import (
+            resolve_memory_id_prefix,
+            PrefixTooShortError,
+        )
+        with pytest.raises(PrefixTooShortError) as exc_info:
+            resolve_memory_id_prefix(db_conn, "")
+        assert exc_info.value.prefix == ""
+        assert exc_info.value.minimum == 7
+
+    def test_exactly_min_length_unique_match(self, db_conn):
+        """A 7-char prefix (the boundary) resolves when the match is unique."""
+        from scripts.database import (
+            create_memory,
+            resolve_memory_id_prefix,
+            MIN_PREFIX_LENGTH,
+        )
+        mem_id = create_memory(
+            db_conn,
+            {"id": "feed123" + "0" * 25, "context": "boundary"},
+        )
+        # Exactly MIN_PREFIX_LENGTH chars — no padding above the floor
+        prefix = "feed123"
+        assert len(prefix) == MIN_PREFIX_LENGTH
+        assert resolve_memory_id_prefix(db_conn, prefix) == mem_id
+
+    def test_exactly_full_length_no_match_returns_none(self, db_conn):
+        """A 32-char input bypasses the resolver but still returns None on miss.
+
+        Guards against an off-by-one regression in the `len < MEMORY_ID_LENGTH`
+        gate: a 32-char nonexistent ID must not raise, must return None.
+        """
+        from scripts.database import resolve_memory_id_prefix
+        full_length_miss = "f" * 32
+        assert resolve_memory_id_prefix(db_conn, full_length_miss) is None
+
+    def test_uppercase_prefix_resolves_to_lowercase_stored_id(self, db_conn):
+        """Prefix lookup is case-insensitive; the returned ID is the stored form.
+
+        Memory IDs are produced by secrets.token_hex (lowercase). A user
+        typing an uppercase prefix must still resolve to the canonical
+        lowercase ID — disambiguation, downstream API calls, and CLI
+        envelopes all key off the storage form.
+        """
+        from scripts.database import create_memory, resolve_memory_id_prefix
+        stored_id = "abcd1234" + "0" * 24
+        create_memory(db_conn, {"id": stored_id, "context": "case test"})
+        resolved = resolve_memory_id_prefix(db_conn, "ABCD1234")
+        assert resolved == stored_id
+
+    def test_ambiguous_small_set_not_truncated(self, db_conn):
+        """Ambiguous match below the cap reports truncated=False, exact total."""
+        from scripts.database import (
+            create_memory,
+            resolve_memory_id_prefix,
+            AmbiguousPrefixError,
+        )
+        ids = [f"smalset{i}" + "0" * 24 for i in range(3)]  # 7-char shared prefix
+        for mid in ids:
+            create_memory(db_conn, {"id": mid, "context": f"row-{mid[-25]}"})
+
+        with pytest.raises(AmbiguousPrefixError) as exc_info:
+            resolve_memory_id_prefix(db_conn, "smalset")
+
+        assert exc_info.value.truncated is False
+        assert exc_info.value.total_matches == 3
+        assert len(exc_info.value.matches) == 3
+
+    def test_ambiguous_pathological_set_truncated_at_cap(self, db_conn):
+        """When matches exceed AMBIGUOUS_MATCH_CAP, list is capped + truncated=True.
+
+        total_matches reflects the actual COUNT(*) from the storage layer,
+        not len(matches). Guards regression where the cap query and the
+        count query diverge.
+        """
+        from scripts.database import (
+            create_memory,
+            resolve_memory_id_prefix,
+            AmbiguousPrefixError,
+            AMBIGUOUS_MATCH_CAP,
+        )
+        # Seed AMBIGUOUS_MATCH_CAP + 1 rows under shared 7-char prefix "patho00"
+        seeded = AMBIGUOUS_MATCH_CAP + 1
+        for i in range(seeded):
+            mid = f"patho00{i:025d}"  # 7-char prefix + 25-char numeric pad = 32
+            assert len(mid) == 32
+            create_memory(db_conn, {"id": mid, "context": f"row-{i}"})
+
+        with pytest.raises(AmbiguousPrefixError) as exc_info:
+            resolve_memory_id_prefix(db_conn, "patho00")
+
+        assert exc_info.value.truncated is True
+        assert exc_info.value.total_matches == seeded
+        assert len(exc_info.value.matches) == AMBIGUOUS_MATCH_CAP
 
 
 class TestUpdateMemory:

--- a/pact-plugin/tests/test_memory_database.py
+++ b/pact-plugin/tests/test_memory_database.py
@@ -246,12 +246,19 @@ class TestResolveMemoryIdPrefix:
         assert exc_info.value.prefix == "abc123"
         assert exc_info.value.minimum == 7
 
-    def test_like_wildcard_in_prefix_is_escaped(self, db_conn):
-        """A literal '%' in the prefix must not expand as a SQL wildcard."""
+    def test_non_hex_prefix_returns_none(self, db_conn):
+        """Non-hex prefix characters (e.g., punctuation) yield no match.
+
+        The range scan operates on a literal `id >= prefix AND id < prefix+'g'`
+        bound; a prefix outside the lowercase-hex alphabet falls outside the
+        range of any real ID, so the lookup correctly returns None. Guards
+        against attempts to inject SQL metacharacters via the prefix arg.
+        """
         from scripts.database import create_memory, resolve_memory_id_prefix
-        # Real memory whose ID does NOT contain '%' (IDs are hex)
         create_memory(db_conn, {"id": "deadbeef" + "0" * 24, "context": "x"})
-        # '%deadbe' would match 'deadbeef...' if '%' were not escaped
+        # '%' < '0' in ASCII; a prefix starting with '%' falls outside any
+        # hex ID's range. Same outcome a literal-meta-char attempt would have
+        # produced under the prior LIKE-with-escape implementation.
         assert resolve_memory_id_prefix(db_conn, "%deadbe") is None
 
     def test_empty_string_prefix_raises_too_short(self, db_conn):
@@ -349,6 +356,51 @@ class TestResolveMemoryIdPrefix:
         assert exc_info.value.truncated is True
         assert exc_info.value.total_matches == seeded
         assert len(exc_info.value.matches) == AMBIGUOUS_MATCH_CAP
+
+    def test_range_scan_does_not_overmatch_at_boundary(self, db_conn):
+        """Range scan must NOT match rows where the next char exceeds the prefix.
+
+        Locks the H2 contract independent of internals (LIKE vs range): a
+        prefix `abcdef0` should match `abcdef0...` but NOT `abcdef1...`,
+        even though both share the same first 6 chars. A buggy
+        upper-bound construction (e.g., open-ended scan, off-by-one cap)
+        would over-match here.
+        """
+        from scripts.database import (
+            create_memory,
+            resolve_memory_id_prefix,
+        )
+        id_at_prefix = "abcdef0" + "0" * 25  # matches prefix "abcdef0"
+        id_above_prefix = "abcdef1" + "0" * 25  # one char higher at the boundary
+        create_memory(db_conn, {"id": id_at_prefix, "context": "in-range"})
+        create_memory(db_conn, {"id": id_above_prefix, "context": "above-range"})
+
+        # Unique match — only the in-range row resolves
+        assert resolve_memory_id_prefix(db_conn, "abcdef0") == id_at_prefix
+
+    def test_generate_id_alphabet_invariant(self):
+        """Every generate_id() output must stay within the lowercase-hex alphabet.
+
+        The resolver's range-scan upper bound is `prefix + _PREFIX_UPPER_BOUND_CHAR`
+        (currently 'g' — the smallest ASCII char above 'f'). That bound is
+        correct ONLY if generate_id produces strictly lowercase hex [0-9a-f].
+        If the alphabet ever broadens (e.g., to base32 or full alphanumeric),
+        the upper-bound constant must be revisited; this test fails loudly
+        in that case.
+        """
+        from scripts.database import generate_id, _PREFIX_UPPER_BOUND_CHAR
+
+        # 100 IDs is enough to surface a misconfigured charset without
+        # making the test slow; secrets.token_hex is uniform over [0-9a-f].
+        for _ in range(100):
+            mid = generate_id()
+            for ch in mid:
+                assert ch < _PREFIX_UPPER_BOUND_CHAR, (
+                    f"generate_id produced char {ch!r} (in {mid!r}) outside the "
+                    f"strictly-below-{_PREFIX_UPPER_BOUND_CHAR!r} alphabet that "
+                    "the range-scan upper bound depends on. If charset broadened "
+                    "intentionally, update _PREFIX_UPPER_BOUND_CHAR."
+                )
 
 
 class TestUpdateMemory:

--- a/pact-plugin/tests/test_memory_database.py
+++ b/pact-plugin/tests/test_memory_database.py
@@ -313,7 +313,7 @@ class TestResolveMemoryIdPrefix:
         assert resolved == stored_id
 
     def test_ambiguous_small_set_not_truncated(self, db_conn):
-        """Ambiguous match below the cap reports truncated=False, exact total."""
+        """Ambiguous match below the cap reports matches_capped=False, exact total."""
         from scripts.database import (
             create_memory,
             resolve_memory_id_prefix,
@@ -326,12 +326,12 @@ class TestResolveMemoryIdPrefix:
         with pytest.raises(AmbiguousPrefixError) as exc_info:
             resolve_memory_id_prefix(db_conn, "smalset")
 
-        assert exc_info.value.truncated is False
+        assert exc_info.value.matches_capped is False
         assert exc_info.value.total_matches == 3
         assert len(exc_info.value.matches) == 3
 
     def test_ambiguous_pathological_set_truncated_at_cap(self, db_conn):
-        """When matches exceed AMBIGUOUS_MATCH_CAP, list is capped + truncated=True.
+        """When matches exceed AMBIGUOUS_MATCH_CAP, list is capped + matches_capped=True.
 
         total_matches reflects the actual COUNT(*) from the storage layer,
         not len(matches). Guards regression where the cap query and the
@@ -353,7 +353,7 @@ class TestResolveMemoryIdPrefix:
         with pytest.raises(AmbiguousPrefixError) as exc_info:
             resolve_memory_id_prefix(db_conn, "patho00")
 
-        assert exc_info.value.truncated is True
+        assert exc_info.value.matches_capped is True
         assert exc_info.value.total_matches == seeded
         assert len(exc_info.value.matches) == AMBIGUOUS_MATCH_CAP
 
@@ -401,6 +401,39 @@ class TestResolveMemoryIdPrefix:
                     "the range-scan upper bound depends on. If charset broadened "
                     "intentionally, update _PREFIX_UPPER_BOUND_CHAR."
                 )
+
+    def test_long_context_marked_truncated_per_match(self, db_conn):
+        """Per-match `context_truncated` flag distinguishes long vs short contexts.
+
+        Long contexts (> descriptor_chars) are truncated to descriptor_chars
+        and flagged `context_truncated=True`; short contexts pass through
+        unchanged with `context_truncated=False`. The flag is per-match,
+        not per-list — guards a regression where the flag gets set globally
+        based on any-row-truncated.
+        """
+        from scripts.database import (
+            create_memory,
+            resolve_memory_id_prefix,
+            AmbiguousPrefixError,
+        )
+        descriptor_chars = 60  # default arg of resolve_memory_id_prefix
+        long_id = "trunca0" + "1" + "0" * 24
+        short_id = "trunca0" + "2" + "0" * 24
+        long_context = "x" * 200
+        short_context = "short"
+        create_memory(db_conn, {"id": long_id, "context": long_context})
+        create_memory(db_conn, {"id": short_id, "context": short_context})
+
+        with pytest.raises(AmbiguousPrefixError) as exc_info:
+            resolve_memory_id_prefix(db_conn, "trunca0")
+
+        by_id = {m["id"]: m for m in exc_info.value.matches}
+        assert by_id[long_id]["context_truncated"] is True
+        assert len(by_id[long_id]["context"]) == descriptor_chars
+        assert by_id[long_id]["context"] == "x" * descriptor_chars
+
+        assert by_id[short_id]["context_truncated"] is False
+        assert by_id[short_id]["context"] == short_context
 
 
 class TestUpdateMemory:


### PR DESCRIPTION
## Summary
- `pact-memory get <prefix>` now resolves any prefix ≥4 chars to the matching full memory (git-style), instead of returning NOT_FOUND for anything shorter than the full 32-char hash.
- Ambiguous prefixes return a structured disambiguation list (`AMBIGUOUS_PREFIX` envelope with `matches: [{id, context_snippet}]`) instead of silently picking one.
- Full 32-char hashes keep their existing exact-match path unchanged.

## Why
Pointer memories across the codebase cite 8-char short IDs (e.g., `7210031c`, `4bc90569`) because they fit pin budgets. Today's CLI silently falls through to semantic search on those, masking retrieval failures as "search miss." This unblocks #519 AC-B3 demotion-not-loss validation, which depends on direct short-ID retrieval.

## Design
- Resolver `resolve_memory_id_prefix()` lives in the storage layer (reusable for future `delete`/`update` adoption) but composition happens at the API layer (`PACTMemory.get`). Storage `get_memory()` stays as the exact-match primitive — extending prefix resolution to `update_memory`/`delete_memory` is intentionally out of scope.
- New exception types `PrefixTooShortError` and `AmbiguousPrefixError`. The latter carries `.matches` so the CLI can emit a structured envelope.
- SQL `LIKE` with `ESCAPE '\\'` and prefix-escape; `LIMIT 2` short-circuits the unique-match common case.

Closes #520.

## Test plan
- [x] Unit tests for storage resolver — unique, ambiguous, no-match, prefix-too-short, LIKE-wildcard escape (5 tests in `TestResolveMemoryIdPrefix`)
- [x] CLI integration — unique-prefix, ambiguous, too-short, full-hash unchanged (4 tests in `TestCliGetPrefixResolution`)
- [x] Existing `TestCliGetCommand` cases still pass (no regression on full-hash path)
- [x] Full memory test suite passes (228 tests across the two modules)