### PR TITLE
feat(#552): async-at-idle-boundary communication charter

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "3.19.1",
+      "version": "3.19.2",
       "author": {
         "name": "ProfSynapse"
       },

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-marketplace/
 │           └── PACT/
-│               └── 3.19.1/    # Plugin version
+│               └── 3.19.2/    # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "3.19.1",
+  "version": "3.19.2",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "ProfSynapse",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 3.19.1
+> **Version**: 3.19.2
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/commands/bootstrap.md
+++ b/pact-plugin/commands/bootstrap.md
@@ -16,15 +16,15 @@ To orchestrate is to delegate. To act alone is to fail. Your context is sacred.
 
 **REQUIRED**: Read ALL of the following protocol files now using the Read tool. Construct absolute paths by resolving `{plugin_root}` from your session context (the `- Plugin root:` line in CLAUDE.md, or the session_init hook value if still visible). These files auto-reload after compaction via the Read tracker.
 
-1. `{plugin_root}/skills/orchestration/SKILL.md` — Full orchestrator instructions
-2. `{plugin_root}/protocols/pact-s5-policy.md` — Governance non-negotiables
-3. `{plugin_root}/protocols/pact-s4-checkpoints.md` — Strategic assessment
+1. `{plugin_root}/protocols/algedonic.md` — Emergency bypass protocol
+2. `{plugin_root}/protocols/pact-state-recovery.md` — Recovery procedures
+3. `{plugin_root}/protocols/pact-variety.md` — Task complexity assessment
 4. `{plugin_root}/protocols/pact-s4-tension.md` — S3/S4 conflict resolution
-5. `{plugin_root}/protocols/pact-variety.md` — Task complexity assessment
-6. `{plugin_root}/protocols/pact-workflows.md` — Workflow family mechanics
-7. `{plugin_root}/protocols/pact-communication-charter.md` — Communication norms
-8. `{plugin_root}/protocols/pact-state-recovery.md` — Recovery procedures
-9. `{plugin_root}/protocols/algedonic.md` — Emergency bypass protocol
+5. `{plugin_root}/protocols/pact-s4-checkpoints.md` — Strategic assessment
+6. `{plugin_root}/protocols/pact-s5-policy.md` — Governance non-negotiables
+7. `{plugin_root}/protocols/pact-workflows.md` — Workflow family mechanics
+8. `{plugin_root}/protocols/pact-communication-charter.md` — Communication norms
+9. `{plugin_root}/skills/orchestration/SKILL.md` — Full orchestrator instructions
 
 ---
 

--- a/pact-plugin/commands/teammate-bootstrap.md
+++ b/pact-plugin/commands/teammate-bootstrap.md
@@ -8,7 +8,8 @@ description: Teammate bootstrap — loads team protocol, teachback, memory retri
 
 Load the following before any other work:
 
-@${CLAUDE_PLUGIN_ROOT}/skills/pact-agent-teams/SKILL.md
-@${CLAUDE_PLUGIN_ROOT}/skills/pact-teachback/SKILL.md
-@${CLAUDE_PLUGIN_ROOT}/skills/request-more-context/SKILL.md
 @${CLAUDE_PLUGIN_ROOT}/protocols/algedonic.md
+@${CLAUDE_PLUGIN_ROOT}/skills/request-more-context/SKILL.md
+@${CLAUDE_PLUGIN_ROOT}/skills/pact-teachback/SKILL.md
+@${CLAUDE_PLUGIN_ROOT}/protocols/pact-communication-charter.md
+@${CLAUDE_PLUGIN_ROOT}/skills/pact-agent-teams/SKILL.md

--- a/pact-plugin/protocols/algedonic.md
+++ b/pact-plugin/protocols/algedonic.md
@@ -81,6 +81,20 @@ Apply the S5 Decision Framing Protocol (see [pact-s5-policy.md](pact-s5-policy.m
 
 **Protocol-level, not architectural**: Agents emit algedonic signals through the same communication channel (to orchestrator), but the SIGNAL FORMAT itself demands immediate user escalation. The orchestrator is **REQUIRED** to surface algedonic signals to user immediately—it cannot triage, delay, or suppress them.
 
+### Latency Caveat
+
+Algedonic signals travel over `SendMessage` and are subject to the standard
+delivery model: messages land in the recipient's inbox at their next idle
+boundary, not instantaneously.
+
+- **Lead's "surface to user immediately"** means at the lead's next idle — the lead cannot preempt itself mid-tool-call to deliver the signal.
+- **HALT broadcast to teammates** via `SendMessage(to="*", ...)` reaches each teammate at that teammate's next idle boundary; a teammate currently mid-tool-call continues until their tool returns and they next check inbox.
+- **Immediate halt of in-flight teammate work** requires user-side manual interrupt (Esc / stop in the host UI). The in-band broadcast cannot stop work that is already executing a tool call.
+
+When emitting a HALT, assume non-zero latency before affected teammates see
+it and act on it. Plan recovery on the assumption that some in-flight work
+may complete before the HALT is observed.
+
 ### Task System Integration
 
 With PACT Task integration, algedonic signals create **signal Tasks** that persist and block affected work.
@@ -160,7 +174,7 @@ On receiving an algedonic signal:
 **Handling parallel agents on HALT**:
 
 When multiple agents are running and HALT is triggered:
-1. **Broadcast stop** — `SendMessage(to="*", ...)` ensures all teammates receive the HALT simultaneously (see step 2 above)
+1. **Broadcast stop** — `SendMessage(to="*", ...)` delivers the HALT to each teammate's inbox at their next idle boundary (see step 2 above and the Latency Caveat under Signal Delivery Mechanism); for immediate halt of in-flight work, user-side manual interrupt is required
 2. **Preserve work-in-progress** — do NOT discard uncommitted changes
 3. **Do NOT commit partial work** — leave changes staged/unstaged as-is
 4. **Document agent states** — note which agents were interrupted and their progress

--- a/pact-plugin/protocols/algedonic.md
+++ b/pact-plugin/protocols/algedonic.md
@@ -83,17 +83,7 @@ Apply the S5 Decision Framing Protocol (see [pact-s5-policy.md](pact-s5-policy.m
 
 ### Latency Caveat
 
-Algedonic signals travel over `SendMessage` and are subject to the standard
-delivery model: messages land in the recipient's inbox at their next idle
-boundary, not instantaneously.
-
-- **Lead's "surface to user immediately"** means at the lead's next idle — the lead cannot preempt itself mid-tool-call to deliver the signal.
-- **HALT broadcast to teammates** via `SendMessage(to="*", ...)` reaches each teammate at that teammate's next idle boundary; a teammate currently mid-tool-call continues until their tool returns and they next check inbox.
-- **Immediate halt of in-flight teammate work** requires user-side manual interrupt (Esc / stop in the host UI). The in-band broadcast cannot stop work that is already executing a tool call.
-
-When emitting a HALT, assume non-zero latency before affected teammates see
-it and act on it. Plan recovery on the assumption that some in-flight work
-may complete before the HALT is observed.
+See the Communication Charter Part I — Algedonic-Signal Latency Caveat ([pact-communication-charter.md](pact-communication-charter.md)) for the delivery-model implications (idle-boundary HALT latency; immediate in-flight halt needs user interrupt; lead's "surface immediately" = lead's next idle).
 
 ### Task System Integration
 

--- a/pact-plugin/protocols/algedonic.md
+++ b/pact-plugin/protocols/algedonic.md
@@ -83,7 +83,7 @@ Apply the S5 Decision Framing Protocol (see [pact-s5-policy.md](pact-s5-policy.m
 
 ### Latency Caveat
 
-See the Communication Charter Part I — Algedonic-Signal Latency Caveat ([pact-communication-charter.md](pact-communication-charter.md)) for the delivery-model implications (idle-boundary HALT latency; immediate in-flight halt needs user interrupt; lead's "surface immediately" = lead's next idle).
+See [Communication Charter Part I — Algedonic-Signal Latency Caveat](pact-communication-charter.md#algedonic-signal-latency-caveat) for the delivery-model implications (idle-boundary HALT latency; immediate in-flight halt needs user interrupt; lead's "surface immediately" = lead's next idle).
 
 ### Task System Integration
 

--- a/pact-plugin/protocols/pact-communication-charter.md
+++ b/pact-plugin/protocols/pact-communication-charter.md
@@ -27,7 +27,11 @@ The rules below govern how messages delivered via this tool actually behave.
 - Treat task creation + `TaskUpdate(owner)` as the dispatch commit point; SendMessage is supplemental context.
 
 ### Teammate-Side Discipline — Verify Before Acting + Assume Eventually-Seen
+
+#### Inbound — Verify Before Acting
 - On receiving a state-dependent message, check actual state before executing. If state has advanced past the message's premise, no-op and report.
+
+#### Outbound — Assume Eventually-Seen
 - Your outbound messages are delivered at the recipient's idle — not immediately. `intentional_wait` means "nothing advances until a resolver arrives," not "my message was read."
 - Before resending an apparently-unacknowledged message, verify the addressee has reached idle at least once since the original send. Otherwise the original is still queued and resending just duplicates it.
 - Peer-to-peer: do not assume a peer saw your message before their next tool call. Peer's in-flight action runs to completion before they read inbound.

--- a/pact-plugin/protocols/pact-communication-charter.md
+++ b/pact-plugin/protocols/pact-communication-charter.md
@@ -1,8 +1,43 @@
 # Communication Charter
 
-These norms apply to all PACT agents and the orchestrator. They govern all written output: code comments, documentation, inter-agent messages, user-facing text, GitHub PRs, issues, commit messages, and review comments.
+These norms govern how PACT agents communicate. Part I covers the
+mechanics of how messages are delivered between agents. Part II covers
+how written output — messages, comments, docs, PRs, issues — should
+read. Both apply to all PACT agents and the orchestrator.
 
----
+## Part I — Message Delivery Mechanics
+
+Inter-agent communication uses the `SendMessage` tool. Basic call shape:
+
+    SendMessage(to="teammate-name", message="[sender→recipient] ...", summary="5-10 word preview")
+
+The rules below govern how messages delivered via this tool actually behave.
+
+### Delivery Model
+- Messages are queued-async, delivered at the recipient's next idle boundary.
+- Agents read queued messages in FIFO order on reaching idle.
+- No cancellation primitive exists — a follow-up message cannot supersede a queued earlier one.
+- The only mid-turn interrupt mechanism is user-side (Escape). Agent-to-agent SendMessage has no equivalent.
+
+### Lead-Side Discipline — Verify Before Dispatching
+- Before sending a course-correction, check actual state (`git status`, `TaskList`, read files). The lead's mental model of teammate state diverges every time the teammate takes a tool action.
+- Do not rapid-fire corrections while a teammate is mid-turn. Each queues and executes in order at their idle boundary, by which point the earlier message's premise may be stale.
+- Supersede-the-last-message does not exist. If message A is wrong and you send B, both will execute.
+- For in-flight damage that is unacceptable, escalate to the user for manual interrupt — do not attempt to fake sync interrupt via rapid-fire SendMessage.
+- Treat task creation + `TaskUpdate(owner)` as the dispatch commit point; SendMessage is supplemental context.
+
+### Teammate-Side Discipline — Verify Before Acting + Assume Eventually-Seen
+- On receiving a state-dependent message, check actual state before executing. If state has advanced past the message's premise, no-op and report.
+- Your outbound messages are delivered at the recipient's idle — not immediately. `intentional_wait` means "nothing advances until a resolver arrives," not "my message was read."
+- Before resending an apparently-unacknowledged message, verify the addressee has reached idle at least once since the original send. Otherwise the original is still queued and resending just duplicates it.
+- Peer-to-peer: do not assume a peer saw your message before their next tool call. Peer's in-flight action runs to completion before they read inbound.
+
+### Algedonic-Signal Latency Caveat
+- HALT signals via SendMessage have idle-boundary latency like any other message.
+- For immediate halt of in-flight teammate work, user-side manual interrupt is required.
+- The lead's responsibility to "surface immediately" means at the lead's next idle, not at arbitrary real-time.
+
+## Part II — Written Output
 
 ## Pillar 1 — Plain English
 

--- a/pact-plugin/skills/orchestration/SKILL.md
+++ b/pact-plugin/skills/orchestration/SKILL.md
@@ -109,6 +109,7 @@ Workflow commands handle recovery automatically. Your context window doesn't sur
 - **Challenge, don't comply**: When you believe a different approach is better, say so with evidence. Propose the alternative and ask the user if they agree. Do not default to compliance — default to the strongest recommendation you can make.
 - **Adopt specialist pushback**: When a specialist argues for a different approach, engage with the argument. If their case is stronger, adopt it. You have authority to change course based on specialist input without escalating to the user.
 - **No empty affirmations**: Never open with "Great idea" or restate what the user just said. Start with substance. Follow the Communication Charter. Full protocol: `pact-communication-charter.md` (loaded at bootstrap).
+- **Verify before dispatching a course-correction**: before you SendMessage a teammate to change direction, check the filesystem, task metadata, or journal against your mental model — a stale model produces stale instructions. See the Communication Charter Part I (Lead-Side Discipline — Verify Before Dispatching) for the full rule.
 
 ### Git Branching
 - Create a feature branch before any new workstream begins

--- a/pact-plugin/skills/orchestration/SKILL.md
+++ b/pact-plugin/skills/orchestration/SKILL.md
@@ -86,6 +86,8 @@ Full protocol, trigger conditions, and signal format: `algedonic.md` (loaded at 
 
 When waiting for teammates to complete their tasks, **do not narrate waiting** — saying "Waiting on X..." is a waste of your context window. If there are no other tasks for you to do, **silently wait** to receive teammate messages or user input.
 
+Idle notifications arrive as conversation turns. When a turn carries no actionable content — no blocker, no stage-ready, no question, no user input — emit no reply. Acknowledging every incoming turn is the reflex that produces narrate-the-wait noise. The next meaningful transition triggers the next meaningful reply.
+
 #### State Recovery (After Compaction or Session Resume)
 
 Reconstruct state:

--- a/pact-plugin/skills/orchestration/SKILL.md
+++ b/pact-plugin/skills/orchestration/SKILL.md
@@ -109,7 +109,7 @@ Workflow commands handle recovery automatically. Your context window doesn't sur
 - **Challenge, don't comply**: When you believe a different approach is better, say so with evidence. Propose the alternative and ask the user if they agree. Do not default to compliance — default to the strongest recommendation you can make.
 - **Adopt specialist pushback**: When a specialist argues for a different approach, engage with the argument. If their case is stronger, adopt it. You have authority to change course based on specialist input without escalating to the user.
 - **No empty affirmations**: Never open with "Great idea" or restate what the user just said. Start with substance. Follow the Communication Charter. Full protocol: `pact-communication-charter.md` (loaded at bootstrap).
-- **Verify before dispatching a course-correction**: before you SendMessage a teammate to change direction, check the filesystem, task metadata, or journal against your mental model — a stale model produces stale instructions. See the Communication Charter Part I (Lead-Side Discipline — Verify Before Dispatching) for the full rule.
+- **Verify before dispatching a course-correction**: before you SendMessage a teammate to change direction, check the filesystem, task metadata, or journal against your mental model — a stale model produces stale instructions. See [Communication Charter Part I — Lead-Side Discipline — Verify Before Dispatching](../../protocols/pact-communication-charter.md#lead-side-discipline-—-verify-before-dispatching) for the full rule.
 
 ### Git Branching
 - Create a feature branch before any new workstream begins

--- a/pact-plugin/skills/orchestration/SKILL.md
+++ b/pact-plugin/skills/orchestration/SKILL.md
@@ -109,7 +109,7 @@ Workflow commands handle recovery automatically. Your context window doesn't sur
 - **Challenge, don't comply**: When you believe a different approach is better, say so with evidence. Propose the alternative and ask the user if they agree. Do not default to compliance — default to the strongest recommendation you can make.
 - **Adopt specialist pushback**: When a specialist argues for a different approach, engage with the argument. If their case is stronger, adopt it. You have authority to change course based on specialist input without escalating to the user.
 - **No empty affirmations**: Never open with "Great idea" or restate what the user just said. Start with substance. Follow the Communication Charter. Full protocol: `pact-communication-charter.md` (loaded at bootstrap).
-- **Verify before dispatching a course-correction**: before you SendMessage a teammate to change direction, check the filesystem, task metadata, or journal against your mental model — a stale model produces stale instructions. See [Communication Charter Part I — Lead-Side Discipline — Verify Before Dispatching](../../protocols/pact-communication-charter.md#lead-side-discipline-—-verify-before-dispatching) for the full rule.
+- **Verify before dispatching a course-correction**: before you SendMessage a teammate to change direction, check the filesystem, task metadata, or journal against your mental model — a stale model produces stale instructions. See [Communication Charter Part I — Lead-Side Discipline — Verify Before Dispatching](../../protocols/pact-communication-charter.md#lead-side-discipline--verify-before-dispatching) for the full rule.
 
 ### Git Branching
 - Create a feature branch before any new workstream begins

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -186,6 +186,13 @@ output (even zero-content) blocks the next inbox delivery.
 
 If you have nothing to say that advances the work, say nothing.
 
+**Outbound direction**: a `SendMessage` you send lands in the recipient's
+inbox at their next idle boundary, not instantaneously. See the Communication
+Charter Part I (Teammate-Side Discipline — Verify Before Acting + Assume
+Eventually-Seen) in [pact-communication-charter.md](../../protocols/pact-communication-charter.md)
+for verify-before-acting and assume-eventually-seen rules that follow from
+this delivery model.
+
 ## Intentional Waiting
 
 When your task is `in_progress` but you are legitimately idle awaiting a message

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -187,9 +187,8 @@ output (even zero-content) blocks the next inbox delivery.
 If you have nothing to say that advances the work, say nothing.
 
 **Outbound direction**: a `SendMessage` you send lands in the recipient's
-inbox at their next idle boundary, not instantaneously. See the Communication
-Charter Part I (Teammate-Side Discipline — Verify Before Acting + Assume
-Eventually-Seen) in [pact-communication-charter.md](../../protocols/pact-communication-charter.md)
+inbox at their next idle boundary, not instantaneously. See
+[Communication Charter Part I — Teammate-Side Discipline — Verify Before Acting + Assume Eventually-Seen](../../protocols/pact-communication-charter.md#teammate-side-discipline-—-verify-before-acting--assume-eventually-seen)
 for verify-before-acting and assume-eventually-seen rules that follow from
 this delivery model.
 

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -188,7 +188,7 @@ If you have nothing to say that advances the work, say nothing.
 
 **Outbound direction**: a `SendMessage` you send lands in the recipient's
 inbox at their next idle boundary, not instantaneously. See
-[Communication Charter Part I — Teammate-Side Discipline — Verify Before Acting + Assume Eventually-Seen](../../protocols/pact-communication-charter.md#teammate-side-discipline-—-verify-before-acting--assume-eventually-seen)
+[Communication Charter Part I — Teammate-Side Discipline — Verify Before Acting + Assume Eventually-Seen](../../protocols/pact-communication-charter.md#teammate-side-discipline--verify-before-acting--assume-eventually-seen)
 for verify-before-acting and assume-eventually-seen rules that follow from
 this delivery model.
 

--- a/pact-plugin/tests/test_agents_structure.py
+++ b/pact-plugin/tests/test_agents_structure.py
@@ -1100,14 +1100,18 @@ class TestTeammateBootstrapCommand:
     PLUGIN_ROOT = Path(__file__).parent.parent
     COMMAND_PATH = PLUGIN_ROOT / "commands" / "teammate-bootstrap.md"
 
-    # Required @-references — at least these four must be present so the
-    # spawned teammate gets team-tools, teachback, on-demand context, and
-    # algedonic content loaded into context at command-invocation time.
+    # Required @-references — each of these must be present so the spawned
+    # teammate gets team-tools, teachback, on-demand context, algedonic
+    # content, and the communication charter loaded into context at
+    # command-invocation time. The charter is eager-loaded because every
+    # teammate turn involves SendMessage and the delivery-model discipline
+    # must be available without a follow-up Read hop.
     REQUIRED_REFS = (
         "skills/pact-agent-teams/SKILL.md",
         "skills/pact-teachback/SKILL.md",
         "skills/request-more-context/SKILL.md",
         "protocols/algedonic.md",
+        "protocols/pact-communication-charter.md",
     )
 
     def test_command_file_exists(self):
@@ -1138,8 +1142,8 @@ class TestTeammateBootstrapCommand:
         assert not missing, (
             f"teammate-bootstrap.md missing eager-load references: "
             f"{missing}. Required for the teammate to receive the team "
-            f"protocol, teachback, request-more-context, and algedonic "
-            f"content at command invocation."
+            f"protocol, teachback, request-more-context, algedonic, and "
+            f"communication-charter content at command invocation."
         )
 
     def test_command_referenced_files_exist(self):
@@ -1151,23 +1155,28 @@ class TestTeammateBootstrapCommand:
                 f"does not exist at {path}."
             )
 
-    def test_command_contains_exactly_four_at_references(self):
-        """Spec Section 6.8 requires exactly 4 @${CLAUDE_PLUGIN_ROOT}/ references
-        in teammate-bootstrap.md — no more, no less.
+    def test_command_contains_exactly_five_at_references(self):
+        """teammate-bootstrap.md must contain exactly 5
+        @${CLAUDE_PLUGIN_ROOT}/ references — no more, no less.
 
         Presence-only checks (test_command_contains_required_at_references)
-        would silently accept the addition of a 5th or 6th ref, which would
+        would silently accept the addition of a 6th or 7th ref, which would
         cost every spawned teammate extra context tokens on every bootstrap
         call. The cardinality pin locks the eager-load footprint.
+
+        The five accepted eager-loads are: pact-agent-teams (team protocol),
+        pact-teachback (verification gate), request-more-context (on-demand
+        secretary queries), algedonic (emergency bypass), and
+        pact-communication-charter (SendMessage delivery-model discipline,
+        load-bearing for every teammate turn that sends a message).
         """
         text = self.COMMAND_PATH.read_text(encoding="utf-8")
         count = text.count("@${CLAUDE_PLUGIN_ROOT}/")
-        assert count == 4, (
-            f"teammate-bootstrap.md must contain exactly 4 "
-            f"@${{CLAUDE_PLUGIN_ROOT}}/ references (spec Section 6.8). "
-            f"Found {count}. The eager-load footprint is load-bearing — "
-            f"every spawned teammate pays the cost of each extra ref on "
-            f"every invocation."
+        assert count == 5, (
+            f"teammate-bootstrap.md must contain exactly 5 "
+            f"@${{CLAUDE_PLUGIN_ROOT}}/ references. Found {count}. "
+            f"The eager-load footprint is load-bearing — every spawned "
+            f"teammate pays the cost of each extra ref on every invocation."
         )
 
 

--- a/pact-plugin/tests/test_orchestration_skill.py
+++ b/pact-plugin/tests/test_orchestration_skill.py
@@ -3,7 +3,7 @@ Tests for #452 — dual-purpose orchestration skill invariants.
 
 skills/orchestration/SKILL.md is a dual-purpose file:
   - Readable as markdown via the Read tool (bootstrap.md Reads it as
-    its first Read target; Tier-2 Read-tracker durability).
+    its last Read target; tail-biased Tier-2 Read-tracker durability).
   - Invokable as a skill via Skill("PACT:orchestration") (Tier-1
     Skills-restored durability, backup only).
 
@@ -12,7 +12,7 @@ skill must be auto-discoverable via plugin.json's directory-reference
 skill schema.
 
 Test coverage (plan doc row IDs):
-  T6  bootstrap.md first Read target path equals skills/orchestration/SKILL.md
+  T6  bootstrap.md last Read target path equals skills/orchestration/SKILL.md
   T7  Skill body byte-identical to what bootstrap.md Reads (SSOT byte-diff)
   T8  PACT:orchestration resolvable via plugin.json skill auto-discovery
   T9  End-to-end Skill("PACT:orchestration") returns skill body
@@ -35,29 +35,33 @@ PLUGIN_JSON_PATH = PLUGIN_ROOT / ".claude-plugin" / "plugin.json"
 
 
 class TestDualPurposeInvariants:
-    """T6 + T7: Bootstrap.md's first Read target must point to the same
-    file that Skill("PACT:orchestration") loads. The two delivery paths
-    have zero content divergence tolerance — any drift is a dead-on-arrival
-    contract violation."""
+    """Bootstrap.md's tail Read target must point to the same file that
+    Skill("PACT:orchestration") loads. The two delivery paths have zero
+    content divergence tolerance — any drift is a dead-on-arrival contract
+    violation. The tail slot (not head) carries the skill body because the
+    5-slot Read/@-ref tracker is tail-biased: the most-load-bearing file
+    gets the best post-compaction survival slot by appearing last."""
 
-    def test_bootstrap_first_read_target_path(self):
-        """Bootstrap.md's first numbered Read target must be the
-        orchestration skill file (by path)."""
+    def test_bootstrap_last_read_target_path(self):
+        """Bootstrap.md's last numbered Read target must be the
+        orchestration skill file (by path). Tail-biased tracker durability
+        places the heaviest operating content at the end of the list."""
         text = BOOTSTRAP_MD.read_text(encoding="utf-8")
-        # Find the numbered list: item 1 should reference the skill file.
+        # Find every numbered Read entry and pick the highest-numbered one.
         pattern = re.compile(
-            r"1\.\s+`\{plugin_root\}/((?:protocols|skills)/[\w\-/]+\.md)`"
+            r"(\d+)\.\s+`\{plugin_root\}/((?:protocols|skills)/[\w\-/]+\.md)`"
         )
-        match = pattern.search(text)
-        assert match is not None, (
-            "bootstrap.md has no numbered Read instruction #1"
+        matches = pattern.findall(text)
+        assert matches, (
+            "bootstrap.md has no numbered Read instructions"
         )
-        assert match.group(1) == "skills/orchestration/SKILL.md", (
-            f"bootstrap.md first Read target is '{match.group(1)}', "
-            f"expected 'skills/orchestration/SKILL.md'. The dual-purpose "
-            f"contract requires the first Read target to point at the "
-            f"skill body file; diverging paths break the Tier-2 durability "
-            f"path for orchestration content."
+        last_index, last_path = max(matches, key=lambda m: int(m[0]))
+        assert last_path == "skills/orchestration/SKILL.md", (
+            f"bootstrap.md last Read target is '{last_path}' "
+            f"(entry #{last_index}), expected 'skills/orchestration/SKILL.md'. "
+            f"The dual-purpose contract requires the tail Read target to "
+            f"point at the skill body file; diverging paths break the "
+            f"tail-biased Tier-2 durability path for orchestration content."
         )
 
     def test_skill_file_readable_and_substantial(self):

--- a/pact-plugin/tests/test_orchestration_skill_structure.py
+++ b/pact-plugin/tests/test_orchestration_skill_structure.py
@@ -33,32 +33,35 @@ BOOTSTRAP_MD = COMMANDS_DIR / "bootstrap.md"
 CORE_FILE = SKILLS_DIR / "orchestration" / "SKILL.md"
 
 # The 9 mandatory Read targets, in the order listed in bootstrap.md.
-# Entry 1 is the orchestration skill (under skills/); entries 2-9 are
-# supplementary protocols under protocols/. Paths are relative to plugin root.
+# The list is tail-biased: the most-load-bearing file (skills/orchestration/SKILL.md,
+# consulted every turn) sits last so it occupies the best-surviving slot in the
+# 5-slot path-agnostic Read/@-ref tracker after compaction. Situationally-invoked
+# protocols (algedonic, state-recovery, variety) head the list; they are cheap
+# to re-Read on demand at the moment of need. Paths are relative to plugin root.
 MANDATORY_READ_TARGETS = [
-    "skills/orchestration/SKILL.md",
-    "protocols/pact-s5-policy.md",
-    "protocols/pact-s4-checkpoints.md",
-    "protocols/pact-s4-tension.md",
+    "protocols/algedonic.md",
+    "protocols/pact-state-recovery.md",
     "protocols/pact-variety.md",
+    "protocols/pact-s4-tension.md",
+    "protocols/pact-s4-checkpoints.md",
+    "protocols/pact-s5-policy.md",
     "protocols/pact-workflows.md",
     "protocols/pact-communication-charter.md",
-    "protocols/pact-state-recovery.md",
-    "protocols/algedonic.md",
+    "skills/orchestration/SKILL.md",
 ]
 
 # The 8 supplementary protocols (filenames only). Retained separately for
 # forward-reference tests within the core skill body — the core file cannot
 # forward-reference itself.
 SUPPLEMENTARY_PROTOCOL_FILES = [
-    "pact-s5-policy.md",
-    "pact-s4-checkpoints.md",
-    "pact-s4-tension.md",
+    "algedonic.md",
+    "pact-state-recovery.md",
     "pact-variety.md",
+    "pact-s4-tension.md",
+    "pact-s4-checkpoints.md",
+    "pact-s5-policy.md",
     "pact-workflows.md",
     "pact-communication-charter.md",
-    "pact-state-recovery.md",
-    "algedonic.md",
 ]
 
 
@@ -173,10 +176,12 @@ class TestBootstrapStructure:
         """Read instructions must appear in the first 30 lines for truncation resilience."""
         first_30 = "\n".join(bootstrap_lines[:30])
         assert "skills/orchestration/SKILL.md" in first_30, (
-            "skills/orchestration/SKILL.md Read instruction not found in first 30 lines"
+            "skills/orchestration/SKILL.md Read instruction (tail slot) "
+            "not referenced in first 30 lines"
         )
         assert "algedonic.md" in first_30, (
-            "Last protocol file (algedonic.md) not referenced in first 30 lines"
+            "algedonic.md Read instruction (head slot) not referenced in "
+            "first 30 lines"
         )
 
     def test_bootstrap_body_size_reduced(self, bootstrap_lines):
@@ -186,17 +191,29 @@ class TestBootstrapStructure:
             f"bootstrap.md is {count} lines — exceeds 100-line target for stub"
         )
 
-    def test_core_file_is_first_read_target(self, bootstrap_text):
-        """skills/orchestration/SKILL.md must be listed as the FIRST Read target."""
-        # Find the numbered list: item 1 should reference the orchestration skill
+    def test_core_file_is_last_read_target(self, bootstrap_text):
+        """skills/orchestration/SKILL.md must be listed as the LAST Read target.
+
+        Tail-bias compaction durability: the 5-slot path-agnostic Read/@-ref
+        tracker is tail-biased, so the most-load-bearing file gets the best
+        post-compaction survival slot by appearing last. The orchestration
+        skill body is consulted every turn by the Agent Team lead; it gets
+        the tail slot. Situationally-invoked protocols head the list because
+        they can be re-Read on demand at the moment of need.
+        """
+        # Find every numbered Read entry and pick the highest-numbered one.
         pattern = re.compile(
-            r"1\.\s+`\{plugin_root\}/((?:protocols|skills)/[\w\-/]+\.md)`"
+            r"(\d+)\.\s+`\{plugin_root\}/((?:protocols|skills)/[\w\-/]+\.md)`"
         )
-        match = pattern.search(bootstrap_text)
-        assert match is not None, "No numbered Read instruction #1 found"
-        assert match.group(1) == "skills/orchestration/SKILL.md", (
-            f"First Read target is '{match.group(1)}', "
-            f"expected 'skills/orchestration/SKILL.md'"
+        matches = pattern.findall(bootstrap_text)
+        assert matches, "No numbered Read instructions found"
+        last_index, last_path = max(matches, key=lambda m: int(m[0]))
+        assert last_path == "skills/orchestration/SKILL.md", (
+            f"Last Read target is '{last_path}' (entry #{last_index}), "
+            f"expected 'skills/orchestration/SKILL.md'. The tail slot in "
+            f"the bootstrap Read list is reserved for the most-load-bearing "
+            f"file so tail-biased tracker durability preserves it across "
+            f"compaction."
         )
 
     def test_load_operating_instructions_heading(self, bootstrap_text):


### PR DESCRIPTION
## Summary

Closes #552.

- Expand `pact-communication-charter.md` into Part I (Message Delivery Mechanics) + Part II (Written Output). Part I covers the queued-async-at-idle-boundary delivery model, lead-side verify-before-dispatching discipline, teammate-side verify-before-acting discipline, and the algedonic-signal latency caveat.
- Tail-bias both bootstrap files (`commands/bootstrap.md` + `commands/teammate-bootstrap.md`) so the most-load-bearing files land last in the 5-slot Read/@-ref tracker — primary operating skills get best post-compaction survival.
- Load `pact-communication-charter.md` in the teammate bootstrap (previously lead-only).
- Thin-reference the charter from `algedonic.md`, `skills/orchestration/SKILL.md`, and `skills/pact-agent-teams/SKILL.md` — point at the canonical rules, don't duplicate.
- Patch-bump plugin 3.19.1 → 3.19.2.

Charter is now the single source of truth for delivery-model discipline; downstream files point at it. An auditor verified: Part II pillars byte-identical to pre-edit; all downstream cross-references match charter subsection names verbatim; no verify-before-X duplication; no historical-narrative leakage.

## Test plan

- [x] Protocol extracts verification (`scripts/verify-protocol-extracts.sh`): 18/18 MATCH
- [x] Markdown parses across all 6 edited files
- [ ] Reviewer confirmation: bootstrap reorder semantics align with the pinned 4-tier compaction-durability model
- [ ] Reviewer confirmation: POINT-not-COPY discipline holds across all 3 downstream cross-references