### PR TITLE
docs(#559): extend Charter Part I with SendMessage discipline gaps

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "3.19.3",
+      "version": "3.19.4",
       "author": {
         "name": "ProfSynapse"
       },

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-marketplace/
 │           └── PACT/
-│               └── 3.19.3/    # Plugin version
+│               └── 3.19.4/    # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "3.19.3",
+  "version": "3.19.4",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "ProfSynapse",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 3.19.3
+> **Version**: 3.19.4
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/protocols/pact-communication-charter.md
+++ b/pact-plugin/protocols/pact-communication-charter.md
@@ -22,9 +22,24 @@ The rules below govern how messages delivered via this tool actually behave.
 ### Lead-Side Discipline — Verify Before Dispatching
 - Before sending a course-correction, check actual state (`git status`, `TaskList`, read files). The lead's mental model of teammate state diverges every time the teammate takes a tool action.
 - Do not rapid-fire corrections while a teammate is mid-turn. Each queues and executes in order at their idle boundary, by which point the earlier message's premise may be stale.
-- Supersede-the-last-message does not exist. If message A is wrong and you send B, both will execute.
-- For in-flight damage that is unacceptable, escalate to the user for manual interrupt — do not attempt to fake sync interrupt via rapid-fire SendMessage.
-- Treat task creation + `TaskUpdate(owner)` as the dispatch commit point; SendMessage is supplemental context.
+
+#### No Supersede Primitive
+
+Supersede-the-last-message does not exist. If message A is wrong and you send B, both will execute at the recipient's idle in FIFO order.
+
+*Failure shape: lead sends dispatch A based on a stale mental model; sends correction B before the teammate idles. The teammate processes A first, takes an action B's correction would have prevented, then reads B against the post-A state where the correction no longer fits.*
+
+#### Escalation for In-Flight Halt
+
+For in-flight damage that is unacceptable, escalate to the user for manual interrupt — do not attempt to fake sync interrupt via rapid-fire SendMessage.
+
+*Failure shape: lead detects a teammate executing destructive work mid-turn; queues rapid-fire HALT messages instead of asking the user to press Escape. Each HALT lands at the teammate's next idle; the destructive tool call completes before any HALT is read.*
+
+#### Dispatch Commit Point
+
+Treat task creation + `TaskUpdate(owner)` as the dispatch commit point; SendMessage is supplemental context.
+
+*Failure shape: lead sends a SendMessage with task instructions but skips the TaskUpdate(owner) step. The teammate's TaskList shows no assigned task; the SendMessage lands as orphan context with no work-tracking anchor, no teachback gate, and no completion handle.*
 
 #### Wait for In-Flight Context
 
@@ -51,6 +66,12 @@ If teammate A produces info teammate B needs, prefer direct A→B SendMessage wi
 
 ### Teammate-Side Discipline — Verify Before Acting + Assume Eventually-Seen
 
+#### Wait for In-Flight Context
+
+Before composing any outbound SendMessage (peer-to-peer or to lead), wait for your own pending inputs. If you have an unread Read/Bash result, an outstanding peer query, or a dispatch you yourself issued that has not yet completed, hold the outbound until inputs land. Same **premature-dispatch** failure shape as lead-side — see [the lead-side rule](#wait-for-in-flight-context).
+
+*Failure shape: backend-coder mid-task with a pending Bash result; a peer pings; backend-coder drafts a peer-to-peer reply now and an addendum after the Bash returns. Two messages queue at the peer's idle; the first is composed against framing the Bash result would have shaped.*
+
 #### Inbound — Verify Before Acting
 - On receiving a state-dependent message, check actual state before executing. If state has advanced past the message's premise, no-op and report.
 - When a follow-up message updates earlier context, mentally diff and incorporate. Do NOT assume the earlier message is superseded — additive updates extend rather than replace prior framing. If the new message contradicts the prior, it's a lead-side rapid-fire-correction violation; surface it to the lead rather than silently picking one. Ambiguous middle: "investigate auth flow" followed by "start with the session-token path" — narrower-additive (a starting point) or different-assumption-contradictory (auth flow ≠ session-token path)? Default to surfacing.
@@ -60,6 +81,7 @@ If teammate A produces info teammate B needs, prefer direct A→B SendMessage wi
 - Before resending an apparently-unacknowledged message, verify the addressee has reached idle at least once since the original send. Otherwise the original is still queued and resending just duplicates it.
 - Peer-to-peer: do not assume a peer saw your message before their next tool call. Peer's in-flight action runs to completion before they read inbound.
 - Prefer peer-to-peer for context forwarding. If your work produces info another teammate would benefit from, send directly to them with a brief CC-summary to the lead — don't route through the lead unless the lead specifically owns the routing decision. Reduces total idle-boundary latency.
+- Apply the **Pre-Send Self-Check** above before any outbound SendMessage — the questions are universal to any sender, not lead-only.
 
 ### Algedonic-Signal Latency Caveat
 - HALT signals via SendMessage have idle-boundary latency like any other message.

--- a/pact-plugin/protocols/pact-communication-charter.md
+++ b/pact-plugin/protocols/pact-communication-charter.md
@@ -25,27 +25,35 @@ The rules below govern how messages delivered via this tool actually behave.
 - Supersede-the-last-message does not exist. If message A is wrong and you send B, both will execute.
 - For in-flight damage that is unacceptable, escalate to the user for manual interrupt — do not attempt to fake sync interrupt via rapid-fire SendMessage.
 - Treat task creation + `TaskUpdate(owner)` as the dispatch commit point; SendMessage is supplemental context.
-- Wait for in-flight context before composing your dispatch. If a peer is gathering info you'll need (query in flight, dispatch pending, tool result imminent), wait for delivery and send one consolidated message. Sending early-and-supplementing is rapid-fire by another name. Example: a preparer's secretary query is outstanding — hold the dispatch until the response lands rather than sending an initial brief and a follow-up addendum.
+
+#### Wait for In-Flight Context
+
+Wait for in-flight context before composing your dispatch. If a peer has an outstanding query you can see in the team thread, an unfulfilled dispatch you yourself issued, or your own pending Read/Bash result you have not yet read, wait for delivery and send one consolidated message. This is a distinct anti-pattern from rapid-fire correction (concurrent corrections during teammate execution); call it **premature-dispatch** — the message is composed before the inputs that would shape it have arrived.
+
+*Failure shape: a preparer's secretary query is outstanding. Sending a dispatch brief now and an addendum after the response lands queues two messages where one would have sufficed; the teammate processes the stale framing first.*
 
 #### Pre-Send Self-Check
 
 Before every SendMessage, run through:
 
 1. **Is the teammate idle?** If not, my message queues; accept that or wait.
-2. **Is more context likely incoming?** Query in flight, peer working on related task, pending tool result — wait for it.
+2. **Is more context likely incoming?** A peer's outstanding query, an unfulfilled dispatch I issued, or my own pending Read/Bash result I have not yet read — wait for it.
 3. **Would this message *supersede* an earlier one I sent?** If yes, escalate to user-interrupt; both will execute regardless.
 4. **Could this be a peer-to-peer message**, avoiding a routing hop through me?
-5. **Have I verified my framing against the final phase output** (the doc, the HANDOFF, the diagnostic file), or am I working from an interim progress signal? Progress signals are pre-revision snapshots; post-progress information the agent absorbed before completion may have superseded them.
+5. **Have I verified my framing against the final phase output** (the doc, the HANDOFF, the diagnostic file), or am I working from an interim progress signal? Progress signals are pre-revision snapshots; post-progress information the agent absorbed before completion may have superseded them. *(Failure shape: a teammate's mid-task progress signal flags concern X; their final HANDOFF resolves X; a course-correction dispatched off the progress signal lands as obsolete instruction.)*
 
 #### Forwarding-Chain Hygiene
 
 If teammate A produces info teammate B needs, prefer direct A→B SendMessage with a brief CC-summary to the lead, rather than A→lead→B routing. Halves idle-boundary latency. Reserve lead-routing for cases where the lead specifically owns the routing decision (priority arbitration, scope reassignment).
 
+- **DON'T** relay design notes, query results, or HANDOFF excerpts from one teammate to another — that's a routing hop with no lead-owned decision in it. Send direct.
+- **DO** ask the lead to choose which of two teammates should take a task, or to arbitrate a scope conflict — those are decisions the lead owns.
+
 ### Teammate-Side Discipline — Verify Before Acting + Assume Eventually-Seen
 
 #### Inbound — Verify Before Acting
 - On receiving a state-dependent message, check actual state before executing. If state has advanced past the message's premise, no-op and report.
-- When a follow-up message updates earlier context, mentally diff and incorporate. Do NOT assume the earlier message is superseded — additive updates extend rather than replace prior framing. If the new message contradicts the prior, it's a lead-side rapid-fire-correction violation; surface it to the lead rather than silently picking one.
+- When a follow-up message updates earlier context, mentally diff and incorporate. Do NOT assume the earlier message is superseded — additive updates extend rather than replace prior framing. If the new message contradicts the prior, it's a lead-side rapid-fire-correction violation; surface it to the lead rather than silently picking one. Ambiguous middle: "investigate auth flow" followed by "start with the session-token path" — narrower-additive (a starting point) or different-assumption-contradictory (auth flow ≠ session-token path)? Default to surfacing.
 
 #### Outbound — Assume Eventually-Seen
 - Your outbound messages are delivered at the recipient's idle — not immediately. `intentional_wait` means "nothing advances until a resolver arrives," not "my message was read."

--- a/pact-plugin/protocols/pact-communication-charter.md
+++ b/pact-plugin/protocols/pact-communication-charter.md
@@ -20,8 +20,18 @@ The rules below govern how messages delivered via this tool actually behave.
 - The only mid-turn interrupt mechanism is user-side (Escape). Agent-to-agent SendMessage has no equivalent.
 
 ### Lead-Side Discipline — Verify Before Dispatching
-- Before sending a course-correction, check actual state (`git status`, `TaskList`, read files). The lead's mental model of teammate state diverges every time the teammate takes a tool action.
-- Do not rapid-fire corrections while a teammate is mid-turn. Each queues and executes in order at their idle boundary, by which point the earlier message's premise may be stale.
+
+#### Verify State Before Correction
+
+Before sending a course-correction, check actual state (`git status`, `TaskList`, read files). The lead's mental model of teammate state diverges every time the teammate takes a tool action.
+
+*Failure shape: lead corrects against a `git status` snapshot from three tool calls ago; the teammate has committed and moved on since. The correction targets a no-longer-existing diff, and the teammate must surface the mismatch instead of acting on it.*
+
+#### Hold Fire During Mid-Turn
+
+Do not rapid-fire corrections while a teammate is mid-turn. Each queues and executes in order at their idle boundary, by which point the earlier message's premise may be stale.
+
+*Failure shape: lead fires correction B before correction A has cleared; A and B both queue. Distinct from the No-Supersede rule (which governs what happens once corrections collide); this is the upstream discipline of not firing them in the first place.*
 
 #### No Supersede Primitive
 
@@ -72,15 +82,30 @@ Before composing any outbound SendMessage (peer-to-peer or to lead), wait for yo
 
 *Failure shape: backend-coder mid-task with a pending Bash result; a peer pings; backend-coder drafts a peer-to-peer reply now and an addendum after the Bash returns. Two messages queue at the peer's idle; the first is composed against framing the Bash result would have shaped.*
 
-#### Inbound — Verify Before Acting
-- On receiving a state-dependent message, check actual state before executing. If state has advanced past the message's premise, no-op and report.
-- When a follow-up message updates earlier context, mentally diff and incorporate. Do NOT assume the earlier message is superseded — additive updates extend rather than replace prior framing. If the new message contradicts the prior, it's a lead-side rapid-fire-correction violation; surface it to the lead rather than silently picking one. Ambiguous middle: "investigate auth flow" followed by "start with the session-token path" — narrower-additive (a starting point) or different-assumption-contradictory (auth flow ≠ session-token path)? Default to surfacing.
+#### Verify Before Executing
 
-#### Outbound — Assume Eventually-Seen
-- Your outbound messages are delivered at the recipient's idle — not immediately. `intentional_wait` means "nothing advances until a resolver arrives," not "my message was read."
-- Before resending an apparently-unacknowledged message, verify the addressee has reached idle at least once since the original send. Otherwise the original is still queued and resending just duplicates it.
+On receiving a state-dependent message, check actual state before executing. If state has advanced past the message's premise, no-op and report.
+
+*Failure shape: teammate receives "fix foo.py:42" at idle; their last action already routed past that location (a refactor moved it; tests passed). Without the state-check, the teammate runs a redundant or conflicting operation, undoing prior valid work.*
+
+#### Additive vs Corrective
+
+When a follow-up message updates earlier context, mentally diff and incorporate. Do NOT assume the earlier message is superseded — additive updates extend rather than replace prior framing. If the new message contradicts the prior, it's a lead-side rapid-fire-correction violation; surface it to the lead rather than silently picking one. Ambiguous middle: "investigate auth flow" followed by "start with the session-token path" — narrower-additive (a starting point) or different-assumption-contradictory (auth flow ≠ session-token path)? Default to surfacing.
+
+#### Eventually-Seen, Not Read
+
+Your outbound messages are delivered at the recipient's idle — not immediately. `intentional_wait` means "nothing advances until a resolver arrives," not "my message was read."
+
+*Failure shape: teammate sets `intentional_wait` expecting the addressee to read and respond. The addressee hasn't idled since the message was sent (still mid-turn, stuck, or shut down); the wait stalls on a message the addressee literally hasn't seen yet.*
+
+#### Resend Only After Addressee Idles
+
+Before resending an apparently-unacknowledged message, verify the addressee has reached idle at least once since the original send. Otherwise the original is still queued and resending just duplicates it.
+
+*Failure shape: peer is busy mid-task; their idle hasn't fired since the original send. The resend queues a second identical message that lands at their first idle alongside the original — peer reads two copies in FIFO order.*
+
 - Peer-to-peer: do not assume a peer saw your message before their next tool call. Peer's in-flight action runs to completion before they read inbound.
-- Prefer peer-to-peer for context forwarding. If your work produces info another teammate would benefit from, send directly to them with a brief CC-summary to the lead — don't route through the lead unless the lead specifically owns the routing decision. Reduces total idle-boundary latency.
+- Prefer peer-to-peer for context forwarding — see [the lead-side Forwarding-Chain Hygiene rule](#forwarding-chain-hygiene). If your work produces info another teammate would benefit from, send directly to them with a brief CC-summary to the lead.
 - Apply the **Pre-Send Self-Check** above before any outbound SendMessage — the questions are universal to any sender, not lead-only.
 
 ### Algedonic-Signal Latency Caveat

--- a/pact-plugin/protocols/pact-communication-charter.md
+++ b/pact-plugin/protocols/pact-communication-charter.md
@@ -25,16 +25,33 @@ The rules below govern how messages delivered via this tool actually behave.
 - Supersede-the-last-message does not exist. If message A is wrong and you send B, both will execute.
 - For in-flight damage that is unacceptable, escalate to the user for manual interrupt — do not attempt to fake sync interrupt via rapid-fire SendMessage.
 - Treat task creation + `TaskUpdate(owner)` as the dispatch commit point; SendMessage is supplemental context.
+- Wait for in-flight context before composing your dispatch. If a peer is gathering info you'll need (query in flight, dispatch pending, tool result imminent), wait for delivery and send one consolidated message. Sending early-and-supplementing is rapid-fire by another name. Example: a preparer's secretary query is outstanding — hold the dispatch until the response lands rather than sending an initial brief and a follow-up addendum.
+
+#### Pre-Send Self-Check
+
+Before every SendMessage, run through:
+
+1. **Is the teammate idle?** If not, my message queues; accept that or wait.
+2. **Is more context likely incoming?** Query in flight, peer working on related task, pending tool result — wait for it.
+3. **Would this message *supersede* an earlier one I sent?** If yes, escalate to user-interrupt; both will execute regardless.
+4. **Could this be a peer-to-peer message**, avoiding a routing hop through me?
+5. **Have I verified my framing against the final phase output** (the doc, the HANDOFF, the diagnostic file), or am I working from an interim progress signal? Progress signals are pre-revision snapshots; post-progress information the agent absorbed before completion may have superseded them.
+
+#### Forwarding-Chain Hygiene
+
+If teammate A produces info teammate B needs, prefer direct A→B SendMessage with a brief CC-summary to the lead, rather than A→lead→B routing. Halves idle-boundary latency. Reserve lead-routing for cases where the lead specifically owns the routing decision (priority arbitration, scope reassignment).
 
 ### Teammate-Side Discipline — Verify Before Acting + Assume Eventually-Seen
 
 #### Inbound — Verify Before Acting
 - On receiving a state-dependent message, check actual state before executing. If state has advanced past the message's premise, no-op and report.
+- When a follow-up message updates earlier context, mentally diff and incorporate. Do NOT assume the earlier message is superseded — additive updates extend rather than replace prior framing. If the new message contradicts the prior, it's a lead-side rapid-fire-correction violation; surface it to the lead rather than silently picking one.
 
 #### Outbound — Assume Eventually-Seen
 - Your outbound messages are delivered at the recipient's idle — not immediately. `intentional_wait` means "nothing advances until a resolver arrives," not "my message was read."
 - Before resending an apparently-unacknowledged message, verify the addressee has reached idle at least once since the original send. Otherwise the original is still queued and resending just duplicates it.
 - Peer-to-peer: do not assume a peer saw your message before their next tool call. Peer's in-flight action runs to completion before they read inbound.
+- Prefer peer-to-peer for context forwarding. If your work produces info another teammate would benefit from, send directly to them with a brief CC-summary to the lead — don't route through the lead unless the lead specifically owns the routing decision. Reduces total idle-boundary latency.
 
 ### Algedonic-Signal Latency Caveat
 - HALT signals via SendMessage have idle-boundary latency like any other message.


### PR DESCRIPTION
## Summary

Extends Communication Charter Part I with five well-specified discipline rules surfaced during dogfooding of PR #553. Both lead-side and teammate-side surfaces receive parallel coverage per the agent-reader-primary axiom's planning corollary.

**Lead-Side Discipline — Verify Before Dispatching** (extended):
- **L1**: Wait-for-in-flight-context rule — hold dispatch until pending peer queries / tool results land; send one consolidated message rather than early-and-supplementing.
- **L2**: New `Pre-Send Self-Check` subsection — 5-question positive checklist (idle / incoming-context / supersession / peer-to-peer-eligible / framing-verified-against-final-output-vs-interim-progress-signal). The fifth question integrates the comment-added progress-signal-vs-final-output drift case.
- **L3**: New `Forwarding-Chain Hygiene` subsection — prefer A→B direct with CC-summary to lead over A→lead→B routing.

**Teammate-Side Discipline** (extended):
- **T1** (Outbound): Peer-to-peer preferred for context forwarding.
- **T2** (Inbound): Additive vs corrective receive-side handling — diff and incorporate follow-ups; surface contradictions as lead-side rapid-fire-correction violations rather than silently picking one.

## Test plan
- [x] Doc-only change (+17 lines, single file). No executable behavior; no new tests.
- [x] Existing charter/communication structural tests pass (7/7).
- [ ] Multi-reviewer peer review (architect / test / backend) — dispatched concurrently with this PR.

Closes #559.