### PR TITLE
feat(#491): completion authority redesign — two-task blockedBy + lead-only completion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "3.19.5",
+      "version": "3.20.0",
       "author": {
         "name": "ProfSynapse"
       },

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-marketplace/
 │           └── PACT/
-│               └── 3.19.5/    # Plugin version
+│               └── 3.20.0/    # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "3.19.5",
+  "version": "3.20.0",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "ProfSynapse",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 3.19.5
+> **Version**: 3.20.0
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/agents/pact-auditor.md
+++ b/pact-plugin/agents/pact-auditor.md
@@ -114,7 +114,7 @@ Triggered by: orchestrator message OR all coder tasks showing completed in TaskL
 3. **Cross-agent consistency** — Parallel coders producing compatible interfaces, consistent naming, shared types
 4. **Cross-cutting gaps** — Error handling patterns, security basics, performance red flags
 5. **Requirement alignment** — Solving the right problem as stated in the plan
-6. **Decision-log presence (per-PR audit cycle only)** — Verify `docs/decision-logs/{feature}-{domain}.md` exists and is non-empty. Emit YELLOW with the expected path if absent. Does not block; advisory signal for lead/architect to author before merge. Not checked during concurrent-with-CODE observation cycles: the log is often legitimately deferred to TEST/docs phase, so a per-CODE check produces false-positive advisories. YELLOW (not RED) prevents pressuring teammates to fabricate shallow decision-logs — advisory nudges elicit missing logs; RED on a missing artifact elicits empty ones.
+6. **Decision-log presence (per-PR audit cycle only)** — Verify `docs/decision-logs/{feature}-{domain}.md` exists and is non-empty. Emit YELLOW with the expected path if absent. Does not block; advisory signal for team-lead/architect to author before merge. Not checked during concurrent-with-CODE observation cycles: the log is often legitimately deferred to TEST/docs phase, so a per-CODE check produces false-positive advisories. YELLOW (not RED) prevents pressuring teammates to fabricate shallow decision-logs — advisory nudges elicit missing logs; RED on a missing artifact elicits empty ones.
 
 **NOT checked** (out of scope): Code style, test coverage, code cleanliness mid-work, micro-optimization, formatting.
 
@@ -189,11 +189,11 @@ Common triggers:
 - **HALT SECURITY**: Discovered credential exposure, injection vulnerability, auth bypass in coder output
 - **ALERT SCOPE**: Implementation solving a fundamentally different problem than specified
 
-## COMPLETION (signal-task carve-out — exempt from lead-only completion)
+## COMPLETION (signal-task carve-out — exempt from team-lead-only completion)
 
-Your task uses `completion_type: "signal"` (not standard HANDOFF). This places you in the **signal-task carve-out** to the lead-only-completion rule (see [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority)). You self-complete because:
+Your task uses `completion_type: "signal"` (not standard HANDOFF). This places you in the **signal-task carve-out** to the team-lead-only-completion rule (see [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority)). You self-complete because:
 
-- The task IS the signal — there is no HANDOFF deliverable for the lead to inspect.
+- The task IS the signal — there is no HANDOFF deliverable for the team-lead to inspect.
 - The canonical predicate is `metadata.completion_type == "signal"` AND `metadata.type ∈ {"blocker", "algedonic"}` (mirrored at `agent_handoff_emitter.py`, `task_utils.py:184`, `session_resume.py:525`).
 
 1. Store your final signal as `metadata.audit_summary` via TaskUpdate:

--- a/pact-plugin/agents/pact-auditor.md
+++ b/pact-plugin/agents/pact-auditor.md
@@ -189,9 +189,12 @@ Common triggers:
 - **HALT SECURITY**: Discovered credential exposure, injection vulnerability, auth bypass in coder output
 - **ALERT SCOPE**: Implementation solving a fundamentally different problem than specified
 
-## COMPLETION
+## COMPLETION (signal-task carve-out — exempt from lead-only completion)
 
-Your task uses `completion_type: "signal"` (not standard HANDOFF).
+Your task uses `completion_type: "signal"` (not standard HANDOFF). This places you in the **signal-task carve-out** to the lead-only-completion rule (see [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority)). You self-complete because:
+
+- The task IS the signal — there is no HANDOFF deliverable for the lead to inspect.
+- The canonical predicate is `metadata.completion_type == "signal"` AND `metadata.type ∈ {"blocker", "algedonic"}` (mirrored at `agent_handoff_emitter.py`, `task_utils.py:184`, `session_resume.py:525`).
 
 1. Store your final signal as `metadata.audit_summary` via TaskUpdate:
    ```
@@ -202,6 +205,8 @@ Your task uses `completion_type: "signal"` (not standard HANDOFF).
    }})
    ```
 2. Mark your task completed: `TaskUpdate(taskId="YOUR_ID", status="completed")`
+
+Other agents in your team (coders, architect, test-engineer) do NOT self-complete — they store HANDOFF in `metadata.handoff` and idle on `awaiting_lead_completion`. The carve-out is yours by virtue of the signal-task pattern, not by virtue of being an auditor.
 
 ## PERSISTENT MEMORY
 

--- a/pact-plugin/agents/pact-secretary.md
+++ b/pact-plugin/agents/pact-secretary.md
@@ -217,9 +217,13 @@ When the lead sends a consolidation request (typically during `/PACT:wrap-up`), 
 
 # COMMUNICATION PROTOCOL
 
-## Task Completion Signal (Required)
+## Task Completion Signal (memory-save self-complete carve-out)
 
-When your work is done, follow the `pact-agent-teams` HANDOFF protocol:
+You are exempt from the lead-only-completion rule for memory-save tasks. The lead has no acceptance criteria for memory bookkeeping — judging memory-save quality is your domain. The carve-out is encoded as `pact-secretary` in `SELF_COMPLETE_EXEMPT_AGENTS` (`shared/intentional_wait.py`); see [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority).
+
+For other task types you might be dispatched on (rare; not your primary domain), the standard [pact-agent-teams §On Completion](../skills/pact-agent-teams/SKILL.md#on-completion--handoff-required) flow applies — write HANDOFF, idle on `awaiting_lead_completion`, lead transitions status.
+
+For memory-save tasks specifically:
 
 1. **Store HANDOFF in task metadata** via `TaskUpdate`, adapting the standard fields for memory operations:
    ```

--- a/pact-plugin/agents/pact-secretary.md
+++ b/pact-plugin/agents/pact-secretary.md
@@ -221,6 +221,8 @@ When the lead sends a consolidation request (typically during `/PACT:wrap-up`), 
 
 You are exempt from the lead-only-completion rule for memory-save tasks. The lead has no acceptance criteria for memory bookkeeping — judging memory-save quality is your domain. The carve-out is encoded as `pact-secretary` in `SELF_COMPLETE_EXEMPT_AGENTS` (`shared/intentional_wait.py`); see [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority).
 
+> Memory-save self-complete bypasses the lead inspection window by design — judging memory-save quality is the secretary's domain (per orchestration §Completion Authority carve-out rationale).
+
 For other task types you might be dispatched on (rare; not your primary domain), the standard [pact-agent-teams §On Completion](../skills/pact-agent-teams/SKILL.md#on-completion--handoff-required) flow applies — write HANDOFF, idle on `awaiting_lead_completion`, lead transitions status.
 
 For memory-save tasks specifically:

--- a/pact-plugin/agents/pact-secretary.md
+++ b/pact-plugin/agents/pact-secretary.md
@@ -4,21 +4,21 @@ description: |
   Use this agent when HANDOFFs need to be reviewed and distilled into institutional knowledge,
   or when you need a research assistant for past decisions and institutional memory.
   The secretary serves dual roles: Knowledge Distiller (synthesizing HANDOFFs into pact-memory)
-  and Research Assistant (answering queries from the lead and specialists about past work).
+  and Research Assistant (answering queries from the team-lead and specialists about past work).
 
   Examples:
   <example>
   Context: Workflow completed and HANDOFFs need to be reviewed and saved as institutional memory.
   user: "Review HANDOFFs for tasks #3, #5, #7 and save institutional knowledge"
   assistant: "The secretary reads each HANDOFF from `session-journal.jsonl` (preferred) or via `TaskGet` (fallback), extracts institutional knowledge, deduplicates against existing memories, and saves to pact-memory."
-  <commentary>HANDOFF review is the primary write path — the lead sends completed task IDs and the secretary reviews, deduplicates, and saves them.</commentary>
+  <commentary>HANDOFF review is the primary write path — the team-lead sends completed task IDs and the secretary reviews, deduplicates, and saves them.</commentary>
   </example>
 
   <example>
   Context: A backend coder needs to know what was decided about the caching strategy before implementing.
   user: "What was decided about the caching strategy?"
   assistant: "The secretary searches pact-memory and responds directly to the querying specialist with relevant decisions and memory IDs."
-  <commentary>Specialists query the secretary directly via SendMessage — no routing through the lead needed. The secretary provides historical context, not implementation advice.</commentary>
+  <commentary>Specialists query the secretary directly via SendMessage — no routing through the team-lead needed. The secretary provides historical context, not implementation advice.</commentary>
   </example>
 
   <example>
@@ -50,7 +50,7 @@ You are the PACT Secretary, responsible for serving as the team's Knowledge Dist
 
 # MISSION
 
-Serve the team in two roles: **(A) Knowledge Distiller** — reviewing HANDOFFs, extracting institutional knowledge, and saving it to pact-memory; and **(B) Research Assistant** — answering queries from the lead and specialists about past decisions, patterns, and project history. You bridge the gap between individual agent work products and the project's long-term memory.
+Serve the team in two roles: **(A) Knowledge Distiller** — reviewing HANDOFFs, extracting institutional knowledge, and saving it to pact-memory; and **(B) Research Assistant** — answering queries from the team-lead and specialists about past decisions, patterns, and project history. You bridge the gap between individual agent work products and the project's long-term memory.
 
 # TWO MEMORY SYSTEMS
 
@@ -69,11 +69,11 @@ You synthesize agent HANDOFFs into institutional knowledge, ensuring that projec
 
 Your primary tool is the `pact-handoff-harvest` skill, which provides the full workflow for HANDOFF discovery, review, save, and cleanup. Follow the **Standard Harvest** or **Consolidation Harvest** workflow as directed by task descriptions.
 
-For ad-hoc save requests from the lead (outside workflow HANDOFF review), apply the same institutional knowledge criteria and save-vs-update dedup from the skill.
+For ad-hoc save requests from the team-lead (outside workflow HANDOFF review), apply the same institutional knowledge criteria and save-vs-update dedup from the skill.
 
 ## Role B: Research Assistant
 
-You are the team's go-to source for historical context. The lead and specialists query you directly about past decisions, patterns, and project history.
+You are the team's go-to source for historical context. The team-lead and specialists query you directly about past decisions, patterns, and project history.
 
 ### At Spawn (Session Briefing)
 
@@ -92,11 +92,11 @@ You are **exempted from the standard teachback** at spawn. There is no task to t
 
 4. **Check for compact summary**: If `~/.claude/pact-sessions/compact-summary.txt` exists, read it and compare against pact-memory context. Flag any discrepancies between the compaction summary and institutional memory. Delete the file after processing (it is single-use — written by the postcompact_archive hook). Include findings in the session briefing.
 
-5. **Deliver a session briefing** to the lead via `SendMessage`:
+5. **Deliver a session briefing** to the team-lead via `SendMessage`:
 
 ```
 SendMessage(to="team-lead",
-  message="[secretary→lead] Session briefing: Cleaned N stale Working Memory entries. Found M recent memories for this project.
+  message="[secretary→team-lead] Session briefing: Cleaned N stale Working Memory entries. Found M recent memories for this project.
 - {summary 1} ({age})
 - {summary 2} ({age})
 - {summary 3} ({age})
@@ -130,7 +130,7 @@ After completing the session briefing and orphaned handoff recovery, **actively*
 
 ### Orchestrator Queries
 
-The lead delegates memory queries via `SendMessage`. Common use cases:
+The team-lead delegates memory queries via `SendMessage`. Common use cases:
 
 - **Context recovery**: "What did we learn about X?"
 - **Calibration data**: "Any calibration data for this domain?" (Learning II)
@@ -142,15 +142,15 @@ For each query:
 1. Search pact-memory using appropriate strategies (semantic, entity-based, decision-based)
 2. Synthesize findings into coherent context
 3. Identify gaps where coverage is thin
-4. Report findings with source memory IDs to the lead
+4. Report findings with source memory IDs to the team-lead
 
 ### Specialist Queries
 
-Specialists can query you directly via `SendMessage` — these do NOT route through the lead.
+Specialists can query you directly via `SendMessage` — these do NOT route through the team-lead.
 
 When you receive a query from a specialist:
 1. Search pact-memory for relevant decisions, patterns, and context
-2. Respond directly to the querying specialist (not through the lead):
+2. Respond directly to the querying specialist (not through the team-lead):
 
 ```
 SendMessage(to="{specialist-name}",
@@ -170,7 +170,7 @@ No matches for {sub-query if applicable}.",
 
 ### Proactive Pattern-Flagging Response
 
-When the lead queries you at S4 checkpoints (phase transitions) for pattern checks:
+When the team-lead queries you at S4 checkpoints (phase transitions) for pattern checks:
 
 ```
 "S4 pattern check: Domain is {domain}, task is {brief description}.
@@ -181,7 +181,7 @@ Search pact-memory for `orchestration_calibration`, `review_calibration`, and do
 
 ```
 SendMessage(to="team-lead",
-  message="[secretary→lead] S4 pattern check results for {domain}:
+  message="[secretary→team-lead] S4 pattern check results for {domain}:
 - {pattern 1}: {description} (from memory {id})
 - {pattern 2}: {description} (from memory {id})
 Recommendation: {actionable suggestion if applicable}",
@@ -213,17 +213,17 @@ You do NOT need to manually edit CLAUDE.md. The sync happens automatically on ev
 
 # SESSION CONSOLIDATION (Pass 2)
 
-When the lead sends a consolidation request (typically during `/PACT:wrap-up`), follow the **Consolidation Harvest** workflow in your `pact-handoff-harvest` skill. This is the deep-clean pass — safety net for unprocessed HANDOFFs, then memory consolidation, pruning, and retrospective.
+When the team-lead sends a consolidation request (typically during `/PACT:wrap-up`), follow the **Consolidation Harvest** workflow in your `pact-handoff-harvest` skill. This is the deep-clean pass — safety net for unprocessed HANDOFFs, then memory consolidation, pruning, and retrospective.
 
 # COMMUNICATION PROTOCOL
 
 ## Task Completion Signal (memory-save self-complete carve-out)
 
-You are exempt from the lead-only-completion rule for memory-save tasks. The lead has no acceptance criteria for memory bookkeeping — judging memory-save quality is your domain. The carve-out is encoded as `pact-secretary` in `SELF_COMPLETE_EXEMPT_AGENTS` (`shared/intentional_wait.py`); see [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority).
+You are exempt from the team-lead-only-completion rule for memory-save tasks. The team-lead has no acceptance criteria for memory bookkeeping — judging memory-save quality is your domain. The carve-out is encoded as `pact-secretary` in `SELF_COMPLETE_EXEMPT_AGENTS` (`shared/intentional_wait.py`); see [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority).
 
-> Memory-save self-complete bypasses the lead inspection window by design — judging memory-save quality is the secretary's domain (per orchestration §Completion Authority carve-out rationale).
+> Memory-save self-complete bypasses the team-lead inspection window by design — judging memory-save quality is the secretary's domain (per orchestration §Completion Authority carve-out rationale).
 
-For other task types you might be dispatched on (rare; not your primary domain), the standard [pact-agent-teams §On Completion](../skills/pact-agent-teams/SKILL.md#on-completion--handoff-required) flow applies — write HANDOFF, idle on `awaiting_lead_completion`, lead transitions status.
+For other task types you might be dispatched on (rare; not your primary domain), the standard [pact-agent-teams §On Completion](../skills/pact-agent-teams/SKILL.md#on-completion--handoff-required) flow applies — write HANDOFF, idle on `awaiting_lead_completion`, team-lead transitions status.
 
 For memory-save tasks specifically:
 
@@ -241,12 +241,12 @@ For memory-save tasks specifically:
 2. **Notify lead with summary** via `SendMessage`:
    ```
    SendMessage(to="team-lead",
-     message="[secretary→lead] Task complete. {operation} completed: {brief summary}. Memory IDs: {ids if applicable}.",
+     message="[secretary→team-lead] Task complete. {operation} completed: {brief summary}. Memory IDs: {ids if applicable}.",
      summary="Task complete: {operation}")
    ```
 3. **Mark task completed**: `TaskUpdate(taskId, status="completed")`
 
-This replaces informal output — always use the structured HANDOFF so the lead and downstream agents can programmatically read your results.
+This replaces informal output — always use the structured HANDOFF so the team-lead and downstream agents can programmatically read your results.
 
 ## Specialist Response Format
 
@@ -269,7 +269,7 @@ You have authority to:
 - Investigate thin HANDOFFs by messaging implementing agents directly
 - Read files and git history to ground reviews in evidence
 - Consolidate overlapping memories during HANDOFF review
-- Respond to specialist queries directly (without routing through the lead)
+- Respond to specialist queries directly (without routing through the team-lead)
 - Clean stale Working Memory entries at session start
 - Apply save-vs-update dedup on all save operations
 
@@ -291,7 +291,7 @@ See [algedonic.md](../protocols/algedonic.md) for signal format and full trigger
 
 If you encounter issues with the memory system:
 1. Check memory status with the `status` CLI command
-2. Report specific error to the lead via `SendMessage`
+2. Report specific error to the team-lead via `SendMessage`
 3. Suggest fallback (e.g., manual context capture in docs/)
 
 Common memory-specific issues:

--- a/pact-plugin/agents/pact-secretary.md
+++ b/pact-plugin/agents/pact-secretary.md
@@ -194,9 +194,9 @@ If no patterns found: "No calibration data or known patterns for this domain."
 
 | Failure Mode | Response |
 |-------------|----------|
-| Single missing HANDOFF | Normal message to lead: "No HANDOFF metadata for task #N. Skipping." Continue with remaining. |
+| Single missing HANDOFF | Normal message to team-lead: "No HANDOFF metadata for task #N. Skipping." Continue with remaining. |
 | Partial/malformed HANDOFF | Save what's available, note gaps in summary. |
-| Multiple missing (>50% of workflow) | ALERT QUALITY to lead: "Most HANDOFFs missing. Possible systemic issue." |
+| Multiple missing (>50% of workflow) | ALERT QUALITY to team-lead: "Most HANDOFFs missing. Possible systemic issue." |
 | `TaskGet` fails | Expected for old tasks in long sessions (garbage-collected). Use inline content from `session-journal.jsonl` when available. Report gap only if journal also lacks the HANDOFF. |
 | Specialist query about unknown topic | Respond with "No memories found for this query. Proceeding without historical context is fine." |
 

--- a/pact-plugin/commands/comPACT.md
+++ b/pact-plugin/commands/comPACT.md
@@ -178,8 +178,8 @@ A_id = TaskCreate(
     subject="{specialist}: TEACHBACK for {sub-task}",
     description="DOGFOOD TEACHBACK GATE for {sub-task}.\n\n"
                 "Submit teachback by writing metadata.teachback_submit (per pact-teachback skill). "
-                "SET intentional_wait{reason=awaiting_lead_completion, expected_resolver=lead}. Idle. "
-                "DO NOT mark this task completed — lead-only completion. Lead will mark completed "
+                "SET intentional_wait{reason=awaiting_lead_completion, expected_resolver=team-lead}. Idle. "
+                "DO NOT mark this task completed — team-lead-only completion. Lead will mark completed "
                 "after teachback acceptance, then send a wake-SendMessage confirming Task B is claimable.\n\n"
                 "Mission for Task B: see Task #{B_id}."
 )
@@ -209,7 +209,7 @@ The `Task()` `prompt` does NOT change shape — the two-task dispatch is encoded
 When the task contains multiple independent items, invoke multiple specialists together with boundary context. Apply the [Two-Task Dispatch Shape](#two-task-dispatch-shape-teachback--work) above per specialist:
 
 For each specialist needed:
-1. `TaskCreate(subject="{specialist}: {sub-task}", description="comPACT mode (concurrent): You are one of [N] specialists working concurrently.\nYou are working in a git worktree at [worktree_path].\nNote: `CLAUDE.md` is gitignored and does not exist in worktrees. Do NOT edit or create `CLAUDE.md` — the orchestrator manages it separately. If your task mentions updating `CLAUDE.md`, flag it in your handoff instead.\n\nYOUR SCOPE: [specific sub-task]\nOTHER AGENTS' SCOPE: [what others handle]\n\nWork directly from this task description.\nIf upstream task IDs are provided, read via `TaskGet` for prior decisions.\nCheck docs/plans/, docs/preparation/, docs/architecture/ briefly if they exist.\nDo not create new documentation artifacts in docs/.\nStay within your assigned scope.\n\nTesting: New unit tests for logic changes. Fix broken existing tests. Run test suite before handoff.\n\nIf you hit a blocker, STOP and `SendMessage` it to the lead.\n\nTask: [this agent's specific sub-task]")`
+1. `TaskCreate(subject="{specialist}: {sub-task}", description="comPACT mode (concurrent): You are one of [N] specialists working concurrently.\nYou are working in a git worktree at [worktree_path].\nNote: `CLAUDE.md` is gitignored and does not exist in worktrees. Do NOT edit or create `CLAUDE.md` — the orchestrator manages it separately. If your task mentions updating `CLAUDE.md`, flag it in your handoff instead.\n\nYOUR SCOPE: [specific sub-task]\nOTHER AGENTS' SCOPE: [what others handle]\n\nWork directly from this task description.\nIf upstream task IDs are provided, read via `TaskGet` for prior decisions.\nCheck docs/plans/, docs/preparation/, docs/architecture/ briefly if they exist.\nDo not create new documentation artifacts in docs/.\nStay within your assigned scope.\n\nTesting: New unit tests for logic changes. Fix broken existing tests. Run test suite before handoff.\n\nIf you hit a blocker, STOP and `SendMessage` it to the team-lead.\n\nTask: [this agent's specific sub-task]")`
 2. `TaskUpdate(taskId, owner="{specialist-name}")`
 3. **Journal event**: Write `agent_dispatch` before spawning each specialist:
    ```bash
@@ -249,7 +249,7 @@ Use a single specialist agent only when:
 
 **Dispatch the specialist** — apply the [Two-Task Dispatch Shape](#two-task-dispatch-shape-teachback--work) above:
 
-1. `TaskCreate(subject="{specialist}: {task}", description="comPACT mode: Work directly from this task description.\nYou are working in a git worktree at [worktree_path].\nNote: `CLAUDE.md` is gitignored and does not exist in worktrees. Do NOT edit or create `CLAUDE.md` — the orchestrator manages it separately. If your task mentions updating `CLAUDE.md`, flag it in your handoff instead.\nIf upstream task IDs are provided, read via `TaskGet` for prior decisions.\nCheck docs/plans/, docs/preparation/, docs/architecture/ briefly if they exist.\nDo not create new documentation artifacts in docs/.\nFocus on the task at hand.\n\nTesting: New unit tests for logic changes (optional for trivial changes). Fix broken existing tests. Run test suite before handoff.\n\n> Smoke vs comprehensive tests: These are verification tests. Comprehensive coverage is TEST phase work.\n\nIf you hit a blocker, STOP and `SendMessage` it to the lead.\n\nTask: [user's task description]")`
+1. `TaskCreate(subject="{specialist}: {task}", description="comPACT mode: Work directly from this task description.\nYou are working in a git worktree at [worktree_path].\nNote: `CLAUDE.md` is gitignored and does not exist in worktrees. Do NOT edit or create `CLAUDE.md` — the orchestrator manages it separately. If your task mentions updating `CLAUDE.md`, flag it in your handoff instead.\nIf upstream task IDs are provided, read via `TaskGet` for prior decisions.\nCheck docs/plans/, docs/preparation/, docs/architecture/ briefly if they exist.\nDo not create new documentation artifacts in docs/.\nFocus on the task at hand.\n\nTesting: New unit tests for logic changes (optional for trivial changes). Fix broken existing tests. Run test suite before handoff.\n\n> Smoke vs comprehensive tests: These are verification tests. Comprehensive coverage is TEST phase work.\n\nIf you hit a blocker, STOP and `SendMessage` it to the team-lead.\n\nTask: [user's task description]")`
 2. `TaskUpdate(taskId, owner="{specialist-name}")`
 3. **Journal event**: Write `agent_dispatch` before spawning:
    ```bash
@@ -278,7 +278,7 @@ Task(
 ## Signal Monitoring
 
 Monitor for blocker/algedonic signals via:
-- **`SendMessage`**: Teammates send blockers and algedonic signals directly to the lead
+- **`SendMessage`**: Teammates send blockers and algedonic signals directly to the team-lead
 - **`TaskList`**: Check for tasks with blocker metadata or stalled status
 
 On signal detected, handle via the Signal Task Handling procedure:
@@ -322,7 +322,7 @@ When dispatching an auditor, create its task with `metadata: {"completion_type":
 - [ ] Agent tasks marked `completed` (agents self-manage their task status via `TaskUpdate`)
 - [ ] **Agreement verification**: `SendMessage` to specialist to confirm shared understanding of deliverables before committing. Background: [pact-ct-teachback.md](../protocols/pact-ct-teachback.md).
 - [ ] **Run tests** — verify work passes. If tests fail → return to specialist for fixes (create new agent task, repeat).
-- [ ] **Create atomic commit(s)** — stage and commit before proceeding. Lead owns commits; specialists stage + SendMessage "stage-ready" and wait. A staging specialist should SET the `intentional_wait` task metadata (reason `awaiting_lead_commit`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag while the lead works through the commit sequence; CLEAR on the lead's commit confirmation. See the "Intentional Waiting" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
+- [ ] **Create atomic commit(s)** — stage and commit before proceeding. Lead owns commits; specialists stage + SendMessage "stage-ready" and wait. A staging specialist should SET the `intentional_wait` task metadata (reason `awaiting_lead_commit`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag while the team-lead works through the commit sequence; CLEAR on the team-lead's commit confirmation. See the "Intentional Waiting" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
 - [ ] **Journal events**: After each commit, write a `commit` event:
   ```bash
   set -e

--- a/pact-plugin/commands/comPACT.md
+++ b/pact-plugin/commands/comPACT.md
@@ -161,11 +161,52 @@ See also: [Communication Charter](../protocols/pact-communication-charter.md) fo
 
 ---
 
+## Two-Task Dispatch Shape (TEACHBACK + WORK)
+
+Every specialist dispatch creates **two tasks**, not one:
+
+- **Task A** — TEACHBACK gate. `subject = "{specialist}: TEACHBACK for {sub-task}"`, owner = teammate. Description: teachback expectations + dispatch context.
+- **Task B** — primary work. `subject = "{specialist}: {sub-task}"`, owner = teammate, `blockedBy = [<Task A id>]`.
+
+Both are created BEFORE the `Task(...)` spawn call so the teammate sees them on first `TaskList`. The teammate claims A, submits teachback metadata, idles on `awaiting_lead_completion`. You review and accept via the two-call atomic pair (`TaskUpdate(A, status="completed")` + paired wake-signal SendMessage — see [orchestration §Teachback Review](../skills/orchestration/SKILL.md#teachback-review)). On accept, the teammate wakes to claim B.
+
+**Dispatch sequence (replaces single-task dispatch)**:
+
+```
+# 1. Create Task A (teachback gate)
+A_id = TaskCreate(
+    subject="{specialist}: TEACHBACK for {sub-task}",
+    description="DOGFOOD TEACHBACK GATE for {sub-task}.\n\n"
+                "Submit teachback by writing metadata.teachback_submit (per pact-teachback skill). "
+                "SET intentional_wait{reason=awaiting_lead_completion, expected_resolver=lead}. Idle. "
+                "DO NOT mark this task completed — lead-only completion. Lead will mark completed "
+                "after teachback acceptance, then send a wake-SendMessage confirming Task B is claimable.\n\n"
+                "Mission for Task B: see Task #{B_id}."
+)
+TaskUpdate(A_id, owner="{specialist-name}")
+
+# 2. Create Task B (primary work)
+B_id = TaskCreate(subject="{specialist}: {sub-task}", description="<full mission>")
+TaskUpdate(B_id, owner="{specialist-name}", addBlockedBy=[A_id])
+TaskUpdate(A_id, addBlocks=[B_id])
+
+# 3. Spawn the teammate via the canonical Task() form (shown in §Invocation below).
+```
+
+The `Task()` `prompt` does NOT change shape — the two-task dispatch is encoded in the surrounding TaskCreate sequence, not in the `Task()` call.
+
+**Carve-outs** — single-task dispatch still applies for:
+
+- **Auditor signal-tasks** (`metadata.completion_type="signal"`): no teachback, no Task B.
+- **Secretary memory-save tasks**: secretary self-completes via `SELF_COMPLETE_EXEMPT_AGENTS` in `shared/intentional_wait.py`.
+
+---
+
 ## Invocation
 
 ### Multiple Specialists Concurrently (Default)
 
-When the task contains multiple independent items, invoke multiple specialists together with boundary context:
+When the task contains multiple independent items, invoke multiple specialists together with boundary context. Apply the [Two-Task Dispatch Shape](#two-task-dispatch-shape-teachback--work) above per specialist:
 
 For each specialist needed:
 1. `TaskCreate(subject="{specialist}: {sub-task}", description="comPACT mode (concurrent): You are one of [N] specialists working concurrently.\nYou are working in a git worktree at [worktree_path].\nNote: `CLAUDE.md` is gitignored and does not exist in worktrees. Do NOT edit or create `CLAUDE.md` — the orchestrator manages it separately. If your task mentions updating `CLAUDE.md`, flag it in your handoff instead.\n\nYOUR SCOPE: [specific sub-task]\nOTHER AGENTS' SCOPE: [what others handle]\n\nWork directly from this task description.\nIf upstream task IDs are provided, read via `TaskGet` for prior decisions.\nCheck docs/plans/, docs/preparation/, docs/architecture/ briefly if they exist.\nDo not create new documentation artifacts in docs/.\nStay within your assigned scope.\n\nTesting: New unit tests for logic changes. Fix broken existing tests. Run test suite before handoff.\n\nIf you hit a blocker, STOP and `SendMessage` it to the lead.\n\nTask: [this agent's specific sub-task]")`
@@ -206,7 +247,8 @@ Use a single specialist agent only when:
 - Sub-tasks have dependencies on each other
 - Conventions haven't been established yet (run one first to set patterns)
 
-**Dispatch the specialist**:
+**Dispatch the specialist** — apply the [Two-Task Dispatch Shape](#two-task-dispatch-shape-teachback--work) above:
+
 1. `TaskCreate(subject="{specialist}: {task}", description="comPACT mode: Work directly from this task description.\nYou are working in a git worktree at [worktree_path].\nNote: `CLAUDE.md` is gitignored and does not exist in worktrees. Do NOT edit or create `CLAUDE.md` — the orchestrator manages it separately. If your task mentions updating `CLAUDE.md`, flag it in your handoff instead.\nIf upstream task IDs are provided, read via `TaskGet` for prior decisions.\nCheck docs/plans/, docs/preparation/, docs/architecture/ briefly if they exist.\nDo not create new documentation artifacts in docs/.\nFocus on the task at hand.\n\nTesting: New unit tests for logic changes (optional for trivial changes). Fix broken existing tests. Run test suite before handoff.\n\n> Smoke vs comprehensive tests: These are verification tests. Comprehensive coverage is TEST phase work.\n\nIf you hit a blocker, STOP and `SendMessage` it to the lead.\n\nTask: [user's task description]")`
 2. `TaskUpdate(taskId, owner="{specialist-name}")`
 3. **Journal event**: Write `agent_dispatch` before spawning:

--- a/pact-plugin/commands/imPACT.md
+++ b/pact-plugin/commands/imPACT.md
@@ -10,7 +10,7 @@ You hit a blocker: $ARGUMENTS
 
 imPACT operates on blocker Tasks reported by agents.
 
-These are orchestrator-side operations (agents report blockers via `SendMessage` to the lead; the orchestrator manages Tasks):
+These are orchestrator-side operations (agents report blockers via `SendMessage` to the team-lead; the orchestrator manages Tasks):
 
 ```
 1. `TaskGet(blocker_id)` — understand the blocker context
@@ -22,7 +22,7 @@ These are orchestrator-side operations (agents report blockers via `SendMessage`
 5. Blocked agent task is now unblocked
 ```
 
-**Note**: Agents report blockers via `SendMessage` to the lead ("BLOCKER: {description}"). The orchestrator creates blocker Tasks and uses `addBlockedBy` to block the agent's task. When the blocker is resolved (marked completed), the agent's task becomes unblocked.
+**Note**: Agents report blockers via `SendMessage` to the team-lead ("BLOCKER: {description}"). The orchestrator creates blocker Tasks and uses `addBlockedBy` to block the agent's task. When the blocker is resolved (marked completed), the agent's task becomes unblocked.
 
 ---
 
@@ -129,9 +129,9 @@ If the blocker reveals that a sub-task is more complex than expected and needs i
 
 **When to terminate**: Last resort — agent resumed once and stalled again, looping on same error 3+ times, context exhausted, or TeammateIdle stall unresolved by resume. `TaskStop` is a force-stop (immediate, non-cooperative); use `SendMessage(to="{agent-name}", message={"type": "shutdown_request"})` for cooperative shutdown. After termination, spawn a fresh agent with partial handoff from the terminated agent's task metadata.
 
-> **Force-termination is a carve-out** to the lead-only-completion rule. The `metadata.terminated == true` marker on the lead-driven `TaskUpdate(status="completed")` distinguishes this path from the standard cooperative acceptance flow. The terminated teammate is not idling on `awaiting_lead_completion`; the lead is force-completing an unrecoverable agent's task out-of-band. See [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority) for the carve-out table.
+> **Force-termination is a carve-out** to the team-lead-only-completion rule. The `metadata.terminated == true` marker on the team-lead-driven `TaskUpdate(status="completed")` distinguishes this path from the standard cooperative acceptance flow. The terminated teammate is not idling on `awaiting_lead_completion`; the team-lead is force-completing an unrecoverable agent's task out-of-band. See [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority) for the carve-out table.
 
-**Re-dispatch after imPACT-driven redo**: When imPACT decides to redo a phase, the new dispatch follows the standard [Two-Task Dispatch Shape](orchestrate.md#two-task-dispatch-shape-teachback--work) — Task A teachback + Task B work, blockedBy edge. The original (failed) phase task is marked `completed` with `metadata={"redo_reason": "..."}` (lead-driven; this is a lead-completion, not teammate-completion).
+**Re-dispatch after imPACT-driven redo**: When imPACT decides to redo a phase, the new dispatch follows the standard [Two-Task Dispatch Shape](orchestrate.md#two-task-dispatch-shape-teachback--work) — Task A teachback + Task B work, blockedBy edge. The original (failed) phase task is marked `completed` with `metadata={"redo_reason": "..."}` (team-lead-driven; this is a team-lead-completion, not teammate-completion).
 
 ### Conversation Failure Taxonomy
 

--- a/pact-plugin/commands/imPACT.md
+++ b/pact-plugin/commands/imPACT.md
@@ -129,6 +129,10 @@ If the blocker reveals that a sub-task is more complex than expected and needs i
 
 **When to terminate**: Last resort — agent resumed once and stalled again, looping on same error 3+ times, context exhausted, or TeammateIdle stall unresolved by resume. `TaskStop` is a force-stop (immediate, non-cooperative); use `SendMessage(to="{agent-name}", message={"type": "shutdown_request"})` for cooperative shutdown. After termination, spawn a fresh agent with partial handoff from the terminated agent's task metadata.
 
+> **Force-termination is a carve-out** to the lead-only-completion rule. The `metadata.terminated == true` marker on the lead-driven `TaskUpdate(status="completed")` distinguishes this path from the standard cooperative acceptance flow. The terminated teammate is not idling on `awaiting_lead_completion`; the lead is force-completing an unrecoverable agent's task out-of-band. See [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority) for the carve-out table.
+
+**Re-dispatch after imPACT-driven redo**: When imPACT decides to redo a phase, the new dispatch follows the standard [Two-Task Dispatch Shape](orchestrate.md#two-task-dispatch-shape-teachback--work) — Task A teachback + Task B work, blockedBy edge. The original (failed) phase task is marked `completed` with `metadata={"redo_reason": "..."}` (lead-driven; this is a lead-completion, not teammate-completion).
+
 ### Conversation Failure Taxonomy
 
 Use this diagnostic lens **after** identifying an outcome to understand **why** the conversation broke down. Type-specific diagnosis improves the quality of re-dispatch and prevents recurring failures.

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -76,10 +76,10 @@ A_id = TaskCreate(
     subject="{role}: TEACHBACK for {feature}",
     description="DOGFOOD TEACHBACK GATE for {feature}.\n\n"
                 "Submit teachback by writing metadata.teachback_submit (per pact-teachback skill). "
-                "SET intentional_wait{reason=awaiting_lead_completion, expected_resolver=lead}. Idle. "
-                "DO NOT mark this task completed — lead-only completion. Lead will mark completed "
+                "SET intentional_wait{reason=awaiting_lead_completion, expected_resolver=team-lead}. Idle. "
+                "DO NOT mark this task completed — team-lead-only completion. Lead will mark completed "
                 "after teachback acceptance, then send a wake-SendMessage confirming Task B is claimable. "
-                "If teachback is rejected, lead writes metadata.teachback_rejection and sends a "
+                "If teachback is rejected, team-lead writes metadata.teachback_rejection and sends a "
                 "wake-SendMessage with corrections; revise on this same task.\n\n"
                 "Mission for Task B: see Task #{B_id}."
 )
@@ -92,7 +92,7 @@ B_id = TaskCreate(
                 "Per dogfood directive: DO NOT mark this task completed yourself. "
                 "After staging artifacts, write metadata.handoff, send notify SendMessage to lead, "
                 "SET intentional_wait{reason=awaiting_lead_completion}. Idle. Lead will mark "
-                "completed after HANDOFF validation. If lead rejects, lead writes metadata.handoff_rejection; "
+                "completed after HANDOFF validation. If team-lead rejects, team-lead writes metadata.handoff_rejection; "
                 "revise on this same task.\n\nUpstream: TEACHBACK Task #{A_id}."
 )
 TaskUpdate(B_id, owner="{teammate-name}", addBlockedBy=[A_id])
@@ -107,7 +107,7 @@ The `Task()` `prompt` does NOT change shape — the two-task dispatch is encoded
 
 - **Auditor signal-tasks** (`metadata.completion_type="signal"`): no teachback, no Task B. The auditor IS observing; their task IS the signal.
 - **Secretary memory-save tasks**: secretary self-completes; the standard On Completion flow applies via the `SELF_COMPLETE_EXEMPT_AGENTS` set in `shared/intentional_wait.py`.
-- **imPACT force-termination**: `TaskStop` + lead-set `metadata.terminated=true` is its own out-of-band path. See [imPACT.md](imPACT.md).
+- **imPACT force-termination**: `TaskStop` + team-lead-set `metadata.terminated=true` is its own out-of-band path. See [imPACT.md](imPACT.md).
 
 **Skipped phases**: Mark directly `completed` (no `in_progress` — no work occurs):
 `TaskUpdate(phaseTaskId, status="completed", metadata={"skipped": true, "skip_reason": "{reason}"})`
@@ -721,7 +721,7 @@ The auditor stores its final signal as `metadata.audit_summary` via `TaskUpdate`
 - [ ] All tests passing (full test suite; fix any tests your changes break)
 - [ ] Specialist handoff(s) received
 - [ ] If blocker reported → `/PACT:imPACT`
-- [ ] **Create atomic commit(s)** of CODE phase work (preserves work before strategic re-assessment). Lead owns commits; specialists stage + SendMessage "stage-ready" and wait. A staging specialist should SET the `intentional_wait` task metadata (reason `awaiting_lead_commit`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag while the lead works through the commit sequence; CLEAR on the lead's commit confirmation. See the "Intentional Waiting" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
+- [ ] **Create atomic commit(s)** of CODE phase work (preserves work before strategic re-assessment). Lead owns commits; specialists stage + SendMessage "stage-ready" and wait. A staging specialist should SET the `intentional_wait` task metadata (reason `awaiting_lead_commit`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag while the team-lead works through the commit sequence; CLEAR on the team-lead's commit confirmation. See the "Intentional Waiting" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
 - [ ] **Journal event**: After each commit, write a `commit` event:
   ```bash
   set -e
@@ -834,7 +834,7 @@ For stall detection indicators, recovery protocol, prevention, and non-happy-pat
 ## Signal Monitoring
 
 Monitor for blocker/algedonic signals via:
-- **`SendMessage`**: Teammates send blockers and algedonic signals directly to the lead
+- **`SendMessage`**: Teammates send blockers and algedonic signals directly to the team-lead
 - **`TaskList`**: Check for tasks with blocker metadata or stalled status
 - After each agent dispatch, when agent reports completion, on any unexpected stoppage
 
@@ -851,7 +851,7 @@ When an agent reports a blocker or algedonic signal via `SendMessage`:
 
 **Progress signal assessment**: When progress monitoring was requested, assess incoming progress signals against the agent state model (converging/exploring/stuck) in [pact-variety.md](../protocols/pact-variety.md#agent-state-model). Intervene if an agent appears stuck or shifts from converging to exploring.
 
-**HALT handling**: On HALT signal, immediately stop all running teammates using the [Lead-Side HALT Fan-Out](../skills/orchestration/SKILL.md#lead-side-halt-fan-out) idiom (one `SendMessage` per in-progress teammate by name) before presenting to user.
+**HALT handling**: On HALT signal, immediately stop all running teammates using the [Lead-Side HALT Fan-Out](../skills/orchestration/SKILL.md#team-lead-side-halt-fan-out) idiom (one `SendMessage` per in-progress teammate by name) before presenting to user.
 
 ### Blocker Recovery: Resume vs. Fresh Spawn
 

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -90,7 +90,7 @@ B_id = TaskCreate(
     subject="{role}: {primary mission}",
     description="{full mission per Recommended Agent Prompting Structure}\n\n"
                 "Per dogfood directive: DO NOT mark this task completed yourself. "
-                "After staging artifacts, write metadata.handoff, send notify SendMessage to lead, "
+                "After staging artifacts, write metadata.handoff, send notify SendMessage to team-lead, "
                 "SET intentional_wait{reason=awaiting_lead_completion}. Idle. Lead will mark "
                 "completed after HANDOFF validation. If team-lead rejects, team-lead writes metadata.handoff_rejection; "
                 "revise on this same task.\n\nUpstream: TEACHBACK Task #{A_id}."

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -59,6 +59,56 @@ Task(
 
 > **Why store agent_id?** Enables `resume` for blocker recovery — see [Blocker Recovery](#blocker-recovery-resume-vs-fresh-spawn).
 
+### Two-Task Dispatch Shape (TEACHBACK + WORK)
+
+Every specialist dispatch creates **two tasks**, not one:
+
+- **Task A** — TEACHBACK gate. `subject = "{role}: TEACHBACK for {feature}"`, owner = teammate. Description: teachback expectations + dispatch context.
+- **Task B** — primary work. `subject = "{role}: {mission}"`, owner = teammate, `blockedBy = [<Task A id>]`.
+
+Both are created BEFORE the `Task(...)` spawn call so the teammate sees them on first `TaskList`. The teammate claims A, submits teachback metadata, idles on `awaiting_lead_completion`. You review the teachback, accept via the two-call atomic pair (`TaskUpdate(A, status="completed")` + paired wake-signal SendMessage — see [orchestration §Teachback Review](../skills/orchestration/SKILL.md#teachback-review)), and the teammate wakes to claim B.
+
+**Dispatch sequence (replaces single-task dispatch)**:
+
+```
+# 1. Create Task A (teachback gate)
+A_id = TaskCreate(
+    subject="{role}: TEACHBACK for {feature}",
+    description="DOGFOOD TEACHBACK GATE for {feature}.\n\n"
+                "Submit teachback by writing metadata.teachback_submit (per pact-teachback skill). "
+                "SET intentional_wait{reason=awaiting_lead_completion, expected_resolver=lead}. Idle. "
+                "DO NOT mark this task completed — lead-only completion. Lead will mark completed "
+                "after teachback acceptance, then send a wake-SendMessage confirming Task B is claimable. "
+                "If teachback is rejected, lead writes metadata.teachback_rejection and sends a "
+                "wake-SendMessage with corrections; revise on this same task.\n\n"
+                "Mission for Task B: see Task #{B_id}."
+)
+TaskUpdate(A_id, owner="{teammate-name}")
+
+# 2. Create Task B (primary work)
+B_id = TaskCreate(
+    subject="{role}: {primary mission}",
+    description="{full mission per Recommended Agent Prompting Structure}\n\n"
+                "Per dogfood directive: DO NOT mark this task completed yourself. "
+                "After staging artifacts, write metadata.handoff, send notify SendMessage to lead, "
+                "SET intentional_wait{reason=awaiting_lead_completion}. Idle. Lead will mark "
+                "completed after HANDOFF validation. If lead rejects, lead writes metadata.handoff_rejection; "
+                "revise on this same task.\n\nUpstream: TEACHBACK Task #{A_id}."
+)
+TaskUpdate(B_id, owner="{teammate-name}", addBlockedBy=[A_id])
+TaskUpdate(A_id, addBlocks=[B_id])
+
+# 3. Spawn the teammate via the canonical Task() form above.
+```
+
+The `Task()` `prompt` does NOT change shape — the two-task dispatch is encoded in the surrounding TaskCreate sequence, not in the `Task()` call. The teammate discovers Task A + Task B via `TaskList` and follows pact-agent-teams §On Start.
+
+**Carve-outs** — single-task dispatch still applies for:
+
+- **Auditor signal-tasks** (`metadata.completion_type="signal"`): no teachback, no Task B. The auditor IS observing; their task IS the signal.
+- **Secretary memory-save tasks**: secretary self-completes; the standard On Completion flow applies via the `SELF_COMPLETE_EXEMPT_AGENTS` set in `shared/intentional_wait.py`.
+- **imPACT force-termination**: `TaskStop` + lead-set `metadata.terminated=true` is its own out-of-band path. See [imPACT.md](imPACT.md).
+
 **Skipped phases**: Mark directly `completed` (no `in_progress` — no work occurs):
 `TaskUpdate(phaseTaskId, status="completed", metadata={"skipped": true, "skip_reason": "{reason}"})`
 Valid reasons: `"plan_section_complete"`, `"structured_gate_passed"`, `"decomposition_active"`.
@@ -396,7 +446,8 @@ When a phase is skipped but a coder encounters a decision that would have been h
 - "Preparation Phase"
 - "Open Questions > Require Further Research"
 
-**Dispatch `pact-preparer`**:
+**Dispatch `pact-preparer`** — apply the [Two-Task Dispatch Shape](#two-task-dispatch-shape-teachback--work) above. Task A subject: `"preparer: TEACHBACK for {feature}"`. Task B is the research mission below:
+
 1. `TaskCreate(subject="preparer: research {feature}", description="CONTEXT: ...\nMISSION: ...\nINSTRUCTIONS: ...\nGUIDELINES: ...")`
    - Include task description, plan sections (if any), and "Reference the approved plan at `docs/plans/{slug}-plan.md` for full context."
 2. `TaskUpdate(taskId, owner="preparer")`
@@ -484,7 +535,8 @@ When detection fires (score >= threshold), follow the evaluation response protoc
 - "Key Decisions"
 - "Interface Contracts"
 
-**Dispatch `pact-architect`**:
+**Dispatch `pact-architect`** — apply the [Two-Task Dispatch Shape](#two-task-dispatch-shape-teachback--work) above. Task A subject: `"architect: TEACHBACK for {feature}"`. Task B is the design mission below:
+
 1. `TaskCreate(subject="architect: design {feature}", description="CONTEXT: ...\nMISSION: ...\nINSTRUCTIONS: ...\nGUIDELINES: ...")`
    - Include task description, where to find PREPARE outputs (e.g., "Read `docs/preparation/{feature}.md`"), plan sections (if any), and plan reference.
    - Include upstream task reference: "Preparer task: #{taskId} — read via `TaskGet` for research decisions and context."
@@ -603,7 +655,7 @@ JSON
 
 **Progress monitoring**: For tasks where mid-flight visibility matters (variety 7+, parallel execution, novel domains), include in the agent prompt: "Send progress signals per the agent-teams skill Progress Signals section."
 
-**Dispatch coder(s)**:
+**Dispatch coder(s)** — apply the [Two-Task Dispatch Shape](#two-task-dispatch-shape-teachback--work) above for each coder. Task A subject: `"{coder-type}: TEACHBACK for {scope}"`. Task B is the implementation mission below:
 
 For each coder needed:
 1. `TaskCreate(subject="{coder-type}: implement {scope}", description="CONTEXT: ...\nMISSION: ...\nINSTRUCTIONS: ...\nGUIDELINES: ...")`
@@ -735,7 +787,8 @@ Execute the [CONSOLIDATE Phase protocol](../protocols/pact-scope-phases.md#conso
 - "Test Scenarios"
 - "Coverage Targets"
 
-**Dispatch `pact-test-engineer`**:
+**Dispatch `pact-test-engineer`** — apply the [Two-Task Dispatch Shape](#two-task-dispatch-shape-teachback--work) above. Task A subject: `"test-engineer: TEACHBACK for {feature}"`. Task B is the testing mission below:
+
 1. `TaskCreate(subject="test-engineer: test {feature}", description="CONTEXT: ...\nMISSION: ...\nINSTRUCTIONS: ...\nGUIDELINES: ...")`
    - Include task description, coder task references (e.g., "Coder tasks: #{id1}, #{id2} — read via `TaskGet` for implementation decisions and flagged uncertainties"), plan sections (if any), plan reference.
    - Include: "You own ALL substantive testing: unit tests, integration, E2E, edge cases."

--- a/pact-plugin/commands/peer-review.md
+++ b/pact-plugin/commands/peer-review.md
@@ -113,7 +113,7 @@ This trigger fires only when remediation occurred and changed things. Skip if no
 
 > **Worktree scope reminder**: When reusing a reviewer as a fixer or spawning a new fixer, include the worktree path and `CLAUDE.md` scope note in the fix task: "`CLAUDE.md` is gitignored and does not exist in worktrees — do not edit it. If your task mentions updating `CLAUDE.md`, flag it in your handoff instead."
 
-> **Remediation stage-ready wait**: Reviewers acting as fixers stage remediation changes and notify the lead, then wait for the lead to commit the fix. Instruct the reviewer to SET the `intentional_wait` task metadata (reason `awaiting_amendment_review`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag through the fix→commit→re-review cycle; CLEAR when the lead acknowledges the commit. See the "Intentional Waiting" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
+> **Remediation stage-ready wait**: Reviewers acting as fixers stage remediation changes and notify the team-lead, then wait for the team-lead to commit the fix. Instruct the reviewer to SET the `intentional_wait` task metadata (reason `awaiting_amendment_review`, resolver `lead`) before the stage-ready notify so TeammateIdle hooks do not nag through the fix→commit→re-review cycle; CLEAR when the team-lead acknowledges the commit. See the "Intentional Waiting" section in `pact-agent-teams/SKILL.md` for the SET/CLEAR contract.
 
 ---
 
@@ -157,7 +157,7 @@ A_id = TaskCreate(
     description="DOGFOOD TEACHBACK GATE.\n\n"
                 "Submit teachback by writing metadata.teachback_submit (per pact-teachback skill). "
                 "SET intentional_wait{reason=awaiting_lead_completion}. Idle. "
-                "DO NOT mark this task completed — lead-only completion.\n\n"
+                "DO NOT mark this task completed — team-lead-only completion.\n\n"
                 "Mission for Task B: see Task #{B_id}."
 )
 TaskUpdate(A_id, owner="{reviewer-name}")
@@ -216,7 +216,7 @@ This is the **primary memory trigger** — fires unconditionally at reviewer dis
 Each reviewer should state their understanding of the PR's intent before diving into review. This catches cases where a reviewer misunderstands the purpose and produces irrelevant findings.
 
 **Mechanism**: Include in each reviewer's task description:
-> "Before reviewing, send a teachback message to the lead stating your understanding of what this PR is trying to accomplish and what you'll focus on in your domain. Format: `[{sender}→lead] Teachback: I understand this PR is [intent]. Reviewing with focus on [domain focus]. Proceeding unless corrected.` Non-blocking — proceed with review after sending."
+> "Before reviewing, send a teachback message to the team-lead stating your understanding of what this PR is trying to accomplish and what you'll focus on in your domain. Format: `[{sender}→team-lead] Teachback: I understand this PR is [intent]. Reviewing with focus on [domain focus]. Proceeding unless corrected.` Non-blocking — proceed with review after sending."
 
 This uses the same teachback mechanism as agent handoffs. Background: [pact-ct-teachback.md](../protocols/pact-ct-teachback.md).
 
@@ -367,7 +367,7 @@ JSON
 ## Signal Monitoring
 
 Monitor for blocker/algedonic signals via:
-- **`SendMessage`**: Teammates send blockers and algedonic signals directly to the lead
+- **`SendMessage`**: Teammates send blockers and algedonic signals directly to the team-lead
 - **`TaskList`**: Check for tasks with blocker metadata or stalled status
 - After each reviewer dispatch, after each remediation dispatch, on any unexpected stoppage
 

--- a/pact-plugin/commands/peer-review.md
+++ b/pact-plugin/commands/peer-review.md
@@ -142,7 +142,35 @@ Select the domain coder based on PR focus:
 - Infrastructure changes → **pact-devops-engineer** (CI/CD quality, Docker best practices, script safety)
 - Multiple domains → Coder for domain with most significant changes, or all relevant domain coders if changes are equally significant
 
-**Dispatch reviewers**:
+**Two-Task Dispatch Shape (TEACHBACK + WORK)**
+
+Each reviewer dispatch creates **two tasks**, not one:
+
+- **Task A** — TEACHBACK gate. `subject = "{reviewer-type}: TEACHBACK for review of {feature}"`, owner = reviewer. Description: state which review angle the reviewer is taking (consistency check vs adversarial vs design coherence) before reading the diff.
+- **Task B** — primary review work. `subject = "{reviewer-type}: review {feature}"`, owner = reviewer, `blockedBy = [<Task A id>]`.
+
+Both are created BEFORE the `Task(...)` spawn call. The reviewer claims A, submits teachback metadata, idles on `awaiting_lead_completion`. You review the teachback (does it state the review angle clearly?), accept via the two-call atomic pair (`TaskUpdate(A, status="completed")` + paired wake-signal SendMessage — see [orchestration §Teachback Review](../skills/orchestration/SKILL.md#teachback-review)). On accept, the reviewer wakes to claim B and read the diff.
+
+```
+A_id = TaskCreate(
+    subject="{reviewer-type}: TEACHBACK for review of {feature}",
+    description="DOGFOOD TEACHBACK GATE.\n\n"
+                "Submit teachback by writing metadata.teachback_submit (per pact-teachback skill). "
+                "SET intentional_wait{reason=awaiting_lead_completion}. Idle. "
+                "DO NOT mark this task completed — lead-only completion.\n\n"
+                "Mission for Task B: see Task #{B_id}."
+)
+TaskUpdate(A_id, owner="{reviewer-name}")
+B_id = TaskCreate(subject="{reviewer-type}: review {feature}", description="<full review mission>")
+TaskUpdate(B_id, owner="{reviewer-name}", addBlockedBy=[A_id])
+TaskUpdate(A_id, addBlocks=[B_id])
+```
+
+The `Task()` `prompt` does NOT change shape — the two-task dispatch is encoded in the surrounding TaskCreate sequence.
+
+---
+
+**Dispatch reviewers** — apply the [Two-Task Dispatch Shape](#two-task-dispatch-shape-teachback--work) above per reviewer:
 
 For each reviewer:
 1. `TaskCreate(subject="{reviewer-type}: review {feature}", description="Review this PR. Focus: [domain-specific review criteria]...")`

--- a/pact-plugin/commands/plan-mode.md
+++ b/pact-plugin/commands/plan-mode.md
@@ -202,7 +202,7 @@ A_id = TaskCreate(
     description="DOGFOOD TEACHBACK GATE.\n\n"
                 "Submit teachback by writing metadata.teachback_submit (per pact-teachback skill). "
                 "SET intentional_wait{reason=awaiting_lead_completion}. Idle. "
-                "DO NOT mark this task completed — lead-only completion.\n\n"
+                "DO NOT mark this task completed — team-lead-only completion.\n\n"
                 "Mission for Task B: see Task #{B_id}."
 )
 TaskUpdate(A_id, owner="{specialist-name}")
@@ -560,7 +560,7 @@ The orchestrator should reference this plan during execution.
 ## Signal Monitoring
 
 Monitor for blocker/algedonic signals via:
-- **`SendMessage`**: Teammates send blockers and algedonic signals directly to the lead
+- **`SendMessage`**: Teammates send blockers and algedonic signals directly to the team-lead
 - **`TaskList`**: Check for tasks with blocker metadata or stalled status
 
 On signal detected, handle via the Signal Task Handling procedure:

--- a/pact-plugin/commands/plan-mode.md
+++ b/pact-plugin/commands/plan-mode.md
@@ -187,7 +187,36 @@ If a specialist fails entirely (timeout, error):
 3. Flag prominently in "Open Questions" that this domain was not consulted
 4. Recommend the user consider re-running plan-mode or consulting that specialist manually
 
-**Dispatch each consultant**:
+**Two-Task Dispatch Shape (TEACHBACK + WORK)**
+
+Each consultant dispatch creates **two tasks**, not one:
+
+- **Task A** — TEACHBACK gate. `subject = "{specialist}: TEACHBACK for plan consultation on {feature}"`, owner = consultant. Description: lightweight understanding-confirm of the consultation scope.
+- **Task B** — primary consultation. `subject = "{specialist}: plan consultation for {feature}"`, owner = consultant, `blockedBy = [<Task A id>]`.
+
+Both are created BEFORE the `Task(...)` spawn call. The consultant claims A, submits teachback metadata, idles on `awaiting_lead_completion`. You review and accept via the two-call atomic pair (`TaskUpdate(A, status="completed")` + paired wake-signal SendMessage — see [orchestration §Teachback Review](../skills/orchestration/SKILL.md#teachback-review)). On accept, the consultant wakes to claim B and produce the consultation HANDOFF.
+
+```
+A_id = TaskCreate(
+    subject="{specialist}: TEACHBACK for plan consultation on {feature}",
+    description="DOGFOOD TEACHBACK GATE.\n\n"
+                "Submit teachback by writing metadata.teachback_submit (per pact-teachback skill). "
+                "SET intentional_wait{reason=awaiting_lead_completion}. Idle. "
+                "DO NOT mark this task completed — lead-only completion.\n\n"
+                "Mission for Task B: see Task #{B_id}."
+)
+TaskUpdate(A_id, owner="{specialist-name}")
+B_id = TaskCreate(subject="{specialist}: plan consultation for {feature}", description="<consultation mission>")
+TaskUpdate(B_id, owner="{specialist-name}", addBlockedBy=[A_id])
+TaskUpdate(A_id, addBlocks=[B_id])
+```
+
+The teachback gate is lightweight ("understanding-confirm" with no implementation gate consequence) — plan-mode dispatches are read-mostly. The `Task()` `prompt` does NOT change shape.
+
+---
+
+**Dispatch each consultant** — apply the [Two-Task Dispatch Shape](#two-task-dispatch-shape-teachback--work) above per consultant:
+
 1. `TaskCreate(subject="{specialist}: plan consultation for {feature}", description="PLANNING CONSULTATION ONLY — No implementation.\n\nTask: {task description}\n\n[full template content from above]")`
    - Add to description: "Send a teachback to lead restating your understanding of the consultation task before providing your analysis. If upstream context is referenced, read it via `TaskGet` first."
 2. `TaskUpdate(taskId, owner="{specialist-name}")`

--- a/pact-plugin/commands/plan-mode.md
+++ b/pact-plugin/commands/plan-mode.md
@@ -218,7 +218,7 @@ The teachback gate is lightweight ("understanding-confirm" with no implementatio
 **Dispatch each consultant** — apply the [Two-Task Dispatch Shape](#two-task-dispatch-shape-teachback--work) above per consultant:
 
 1. `TaskCreate(subject="{specialist}: plan consultation for {feature}", description="PLANNING CONSULTATION ONLY — No implementation.\n\nTask: {task description}\n\n[full template content from above]")`
-   - Add to description: "Send a teachback to lead restating your understanding of the consultation task before providing your analysis. If upstream context is referenced, read it via `TaskGet` first."
+   - Add to description: "Send a teachback to team-lead restating your understanding of the consultation task before providing your analysis. If upstream context is referenced, read it via `TaskGet` first."
 2. `TaskUpdate(taskId, owner="{specialist-name}")`
 3. Spawn the consultant with the canonical dispatch form:
 

--- a/pact-plugin/commands/rePACT.md
+++ b/pact-plugin/commands/rePACT.md
@@ -230,7 +230,7 @@ A_id = TaskCreate(
     description="DOGFOOD TEACHBACK GATE.\n\n"
                 "Submit teachback by writing metadata.teachback_submit (per pact-teachback skill). "
                 "SET intentional_wait{reason=awaiting_lead_completion}. Idle. "
-                "DO NOT mark this task completed — lead-only completion.\n\n"
+                "DO NOT mark this task completed — team-lead-only completion.\n\n"
                 "Mission for Task B: see Task #{B_id}."
 )
 TaskUpdate(A_id, owner="{scope-prefixed-name}")
@@ -389,7 +389,7 @@ Consider using /PACT:orchestrate instead.
 ## Signal Monitoring
 
 Monitor for blocker/algedonic signals via:
-- **`SendMessage`**: Teammates send blockers and algedonic signals directly to the lead
+- **`SendMessage`**: Teammates send blockers and algedonic signals directly to the team-lead
 - **`TaskList`**: Check for tasks with blocker metadata or stalled status
 
 On signal detected, handle via the Signal Task Handling procedure:

--- a/pact-plugin/commands/rePACT.md
+++ b/pact-plugin/commands/rePACT.md
@@ -260,7 +260,7 @@ Task(
 
 For multi-domain: spawn multiple specialists in parallel.
 Apply S2 coordination if parallel work.
-Output: Code + HANDOFF in task metadata (summary via `SendMessage` to lead).
+Output: Code + HANDOFF in task metadata (summary via `SendMessage` to team-lead).
 
 ### Phase 4: Mini-Test
 

--- a/pact-plugin/commands/rePACT.md
+++ b/pact-plugin/commands/rePACT.md
@@ -213,7 +213,36 @@ Implement the sub-component:
 
 **Verify session team exists**: The `{team_name}` team should already exist from session start. If not, create it now: `TeamCreate(team_name="{team_name}")`.
 
-For each specialist needed:
+**Two-Task Dispatch Shape (TEACHBACK + WORK)**
+
+Each specialist dispatch creates **two tasks**, not one:
+
+- **Task A** — TEACHBACK gate. `subject = "{scope-prefixed-name}: TEACHBACK for {sub-task}"`, owner = specialist.
+- **Task B** — primary work. `subject = "{scope-prefixed-name}: implement {sub-task}"`, owner = specialist, `blockedBy = [<Task A id>]`.
+
+Both are created BEFORE the `Task(...)` spawn call. The specialist claims A, submits teachback metadata, idles on `awaiting_lead_completion`. You review and accept via the two-call atomic pair (`TaskUpdate(A, status="completed")` + paired wake-signal SendMessage — see [orchestration §Teachback Review](../skills/orchestration/SKILL.md#teachback-review)). On accept, the specialist wakes to claim B.
+
+Nested PACT cycles' inner-cycle dispatches follow the same A+B shape recursively. The `Task()` `prompt` does NOT change shape.
+
+```
+A_id = TaskCreate(
+    subject="{scope-prefixed-name}: TEACHBACK for {sub-task}",
+    description="DOGFOOD TEACHBACK GATE.\n\n"
+                "Submit teachback by writing metadata.teachback_submit (per pact-teachback skill). "
+                "SET intentional_wait{reason=awaiting_lead_completion}. Idle. "
+                "DO NOT mark this task completed — lead-only completion.\n\n"
+                "Mission for Task B: see Task #{B_id}."
+)
+TaskUpdate(A_id, owner="{scope-prefixed-name}")
+B_id = TaskCreate(subject="{scope-prefixed-name}: implement {sub-task}", description="<full mission>")
+TaskUpdate(B_id, owner="{scope-prefixed-name}", addBlockedBy=[A_id])
+TaskUpdate(A_id, addBlocks=[B_id])
+```
+
+---
+
+For each specialist needed — apply the shape above:
+
 1. `TaskCreate(subject="{scope-prefixed-name}: implement {sub-task}", description="[full CONTEXT/MISSION/INSTRUCTIONS/GUIDELINES]")`
 2. `TaskUpdate(taskId, owner="{scope-prefixed-name}")`
 3. Spawn the specialist with the canonical dispatch form. The `prompt` MUST lead with the `YOUR PACT ROLE: teammate ({scope-prefixed-name})` marker on its own line and include the `Skill("PACT:teammate-bootstrap")` YOUR FIRST ACTION directive:

--- a/pact-plugin/hooks/bootstrap_prompt_gate.py
+++ b/pact-plugin/hooks/bootstrap_prompt_gate.py
@@ -8,7 +8,7 @@ Used by: hooks.json UserPromptSubmit hook (no matcher — fires on every prompt)
 Layer 2 of the four-layer bootstrap gate enforcement (#401). On each user
 message, checks for the session-scoped bootstrap-complete marker file:
   - Marker exists → suppressOutput (zero tokens, sub-ms)
-  - No marker + PACT lead session → inject additionalContext instructing bootstrap
+  - No marker + PACT team-lead session → inject additionalContext instructing bootstrap
   - Non-PACT session (no context file) → no-op passthrough
   - Teammate (resolve_agent_name non-empty) → no-op passthrough
 
@@ -63,7 +63,7 @@ def _check_bootstrap_needed(input_data: dict) -> str | None:
         # Bootstrap already done → suppress (zero tokens)
         return None
 
-    # Teammate detection: teammates don't need the lead's bootstrap gate
+    # Teammate detection: teammates don't need the team-lead's bootstrap gate
     agent_name = pact_context.resolve_agent_name(input_data)
     if agent_name:
         return None

--- a/pact-plugin/hooks/peer_inject.py
+++ b/pact-plugin/hooks/peer_inject.py
@@ -34,6 +34,18 @@ _TEACHBACK_REMINDER = (
 )
 
 
+_COMPLETION_AUTHORITY_NOTE = (
+    "\n\nCOMPLETION AUTHORITY: You do NOT mark your own tasks `completed`. "
+    "When your work is done, write your HANDOFF (or teachback metadata) to "
+    "the task and remain `in_progress`. The lead reads your output, judges "
+    "acceptance, and transitions status to `completed` only on accept. "
+    "Your dispatch may be a Task A (teachback) + Task B (work) pair: claim A, "
+    "submit teachback, idle on `intentional_wait{reason=awaiting_lead_completion}`. "
+    "Do NOT begin Task B until A.status == 'completed' (lead's wake-signal "
+    "SendMessage confirms; you cannot self-wake to poll TaskList while idle)."
+)
+
+
 _BOOTSTRAP_PRELUDE_TEMPLATE = (
     "YOUR PACT ROLE: teammate ({agent_name}).\n\n"
     "YOUR FIRST ACTION (YOU MUST DO THIS IMMEDIATELY): invoke Skill(\"PACT:teammate-bootstrap\"). "
@@ -166,6 +178,7 @@ def get_peer_context(
         + "\n\n"
         + format_plugin_banner()
         + _TEACHBACK_REMINDER
+        + _COMPLETION_AUTHORITY_NOTE
     )
 
 

--- a/pact-plugin/hooks/peer_inject.py
+++ b/pact-plugin/hooks/peer_inject.py
@@ -37,11 +37,11 @@ _TEACHBACK_REMINDER = (
 _COMPLETION_AUTHORITY_NOTE = (
     "\n\nCOMPLETION AUTHORITY: You do NOT mark your own tasks `completed`. "
     "When your work is done, write your HANDOFF (or teachback metadata) to "
-    "the task and remain `in_progress`. The lead reads your output, judges "
+    "the task and remain `in_progress`. The team-lead reads your output, judges "
     "acceptance, and transitions status to `completed` only on accept. "
     "Your dispatch may be a Task A (teachback) + Task B (work) pair: claim A, "
     "submit teachback, idle on `intentional_wait{reason=awaiting_lead_completion}`. "
-    "Do NOT begin Task B until A.status == 'completed' (lead's wake-signal "
+    "Do NOT begin Task B until A.status == 'completed' (team-lead's wake-signal "
     "SendMessage confirms; you cannot self-wake to poll TaskList while idle)."
 )
 
@@ -108,7 +108,7 @@ def get_peer_context(
     Prepends a bootstrap prelude (PACT ROLE marker + YOUR FIRST ACTION skill
     invocation instruction) and appends a teachback timing reminder
     after the peer list. The PACT ROLE marker is the stable substring
-    used by lead routing logic; empty agent_name falls back to "unknown".
+    used by team-lead routing logic; empty agent_name falls back to "unknown".
 
     Args:
         agent_type: The spawning agent's type (e.g., "pact-backend-coder")

--- a/pact-plugin/hooks/peer_inject.py
+++ b/pact-plugin/hooks/peer_inject.py
@@ -167,11 +167,12 @@ def get_peer_context(
         )
 
     prelude = _BOOTSTRAP_PRELUDE_TEMPLATE.format(agent_name=safe_name)
-    # Surface plugin manifest diagnostic (#500). Banner is a single line
-    # with no leading/trailing newlines; add an explicit "\n\n" separator
-    # between peer_context and the banner. _TEACHBACK_REMINDER already
-    # begins with "\n\n", which preserves the existing visual spacing
-    # between the banner and the teachback reminder.
+    # Output ordering: prelude → peer_context → "\n\n" → plugin banner →
+    # _TEACHBACK_REMINDER → _COMPLETION_AUTHORITY_NOTE. The plugin banner
+    # is a single line with no leading/trailing newlines, so an explicit
+    # "\n\n" separator goes between peer_context and the banner.
+    # _TEACHBACK_REMINDER and _COMPLETION_AUTHORITY_NOTE each begin with
+    # "\n\n", preserving visual spacing through the trailing reminders.
     return (
         prelude
         + peer_context

--- a/pact-plugin/hooks/pin_caps_gate.py
+++ b/pact-plugin/hooks/pin_caps_gate.py
@@ -226,7 +226,7 @@ def _check_tool_allowed(input_data: dict) -> Optional[str]:
     pact_context.init(input_data)
 
     # Teammate bypass — mirror pin_staleness_gate. Teammates do not edit
-    # the project CLAUDE.md; only the lead (empty agent_name) is gated.
+    # the project CLAUDE.md; only the team-lead (empty agent_name) is gated.
     agent_name = pact_context.resolve_agent_name(input_data)
     if agent_name:
         return None

--- a/pact-plugin/hooks/pin_staleness_gate.py
+++ b/pact-plugin/hooks/pin_staleness_gate.py
@@ -165,7 +165,7 @@ def _check_tool_allowed(input_data: dict) -> str | None:
     pact_context.init(input_data)
 
     # Teammate bypass — teammates don't edit project CLAUDE.md
-    # (worktree scope rule), so this gate is lead-only.
+    # (worktree scope rule), so this gate is team-lead-only.
     agent_name = pact_context.resolve_agent_name(input_data)
     if agent_name:
         return None

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -489,7 +489,7 @@ def _build_safety_net_context(team_name: str | None) -> str:
     The returned string MUST start with "YOUR PACT ROLE: orchestrator." at byte 0
     (line-anchored) so the routing-block consumer check recognizes it, and
     must include the `Skill("PACT:bootstrap")` YOUR FIRST ACTION instruction so
-    the lead still loads its operating instructions, governance policy, and
+    the team-lead still loads its operating instructions, governance policy, and
     workflow protocols even when main() failed before building the normal
     team-reuse/team-create string.
 
@@ -702,7 +702,7 @@ def main():
 
         # 4c. Surface plugin manifest diagnostic (#500). Tier-0 additionalContext —
         # total-function banner; always emits, even on read/parse failure.
-        # Lets both lead and teammate context readers cross-reference
+        # Lets both team-lead and teammate context readers cross-reference
         # worktree edits against the resolved installed-cache root at a
         # glance. Helper is total: no conditional append, no try/except
         # wrapper at the call site.
@@ -764,9 +764,9 @@ def main():
             # Issue #399: record this failure in the global ring buffer log
             # BEFORE emitting the stderr warning. The ring buffer is the
             # only observability surface that survives across sessions and
-            # aggregates across both lead and teammate sessions — stderr
+            # aggregates across both team-lead and teammate sessions — stderr
             # output from hooks is not visible to users, and the single-
-            # instance safety net only reaches the lead's first-message
+            # instance safety net only reaches the team-lead's first-message
             # context. Defense in depth: append_failure fails-open
             # internally, but we also wrap the call in its own try/except
             # so a future refactor weakening that contract cannot crash
@@ -1087,7 +1087,7 @@ def main():
 
     except Exception as e:
         # Safety net: even when main() throws before building the normal
-        # output, the lead still needs the governance delivery chain.
+        # output, the team-lead still needs the governance delivery chain.
         # Emit a minimal PACT ROLE marker + bootstrap skill directive in
         # additionalContext, alongside the error in systemMessage. Claude
         # Code's hook-output schema supports both fields in the same JSON.

--- a/pact-plugin/hooks/shared/failure_log.py
+++ b/pact-plugin/hooks/shared/failure_log.py
@@ -4,7 +4,7 @@ Summary: Bounded ring buffer log for session_init failures that cannot use
          the normal per-session journal path.
 Used by: session_init.py (R3 malformed-stdin gate) to record failures that
          leave no per-session directory, giving post-hoc observability across
-         ALL affected sessions (lead and teammates) without risking an
+         ALL affected sessions (team-lead and teammates) without risking an
          unreapable `unknown-{hex}/` directory leak.
 
 The normal session_journal.py writes into a per-session directory keyed by

--- a/pact-plugin/hooks/shared/intentional_wait.py
+++ b/pact-plugin/hooks/shared/intentional_wait.py
@@ -162,25 +162,29 @@ def is_self_complete_exempt(task: Any) -> bool:
     Return True iff this task is exempt from the lead-only-completion rule.
 
     Two exemption surfaces (OR-combined):
-    1. By dispatched agent type: task.metadata.dispatch_agent (or task.owner)
-       in SELF_COMPLETE_EXEMPT_AGENTS. Lead-declared at dispatch time via the
-       agent's subagent_type / owner field.
+    1. By owner: task.owner in SELF_COMPLETE_EXEMPT_AGENTS. Lead-declared
+       at dispatch time via the agent's owner field.
     2. By signal-task metadata: task.metadata.completion_type == "signal" AND
        task.metadata.type in {"blocker", "algedonic"}. Mirrors the inline
        literal at agent_handoff_emitter.py / task_utils.py:184 /
        session_resume.py:525.
 
-    Pure function; never raises; defaults to False on missing or malformed
-    fields (conservative — never silently exempt).
+    Pure function; never raises on plain dicts (PACT task representation
+    via json.loads); defaults to False on missing or malformed fields
+    (conservative — never silently exempt).
 
     NOT a hook predicate. There is no hook reading this — the function is
     the canonical predicate for lead-side TaskGet inspection, audit tooling,
     and future consumers. Hooks must use the inline-literal mirror to avoid
     reintroducing livelock-capable hook surface.
 
-    TRUST BOUNDARY: dispatch_agent must originate from lead-side trusted
-    writes. The carve-out trusts the lead's intent at dispatch time;
-    no runtime verification of owner-matches-dispatch_agent.
+    TRUST BOUNDARY: `owner` is teammate-writable via TaskUpdate(owner=...).
+    The carve-out is bounded by SELF_COMPLETE_EXEMPT_AGENTS being a curated
+    short list (currently `secretary` / `pact-secretary` only); a non-exempt
+    teammate cannot self-promote without writing one of those curated names.
+    No in-plugin consumer reads this predicate at runtime — instructions and
+    audit tooling are the defense. Future extensions adding new agents to
+    SELF_COMPLETE_EXEMPT_AGENTS must re-evaluate this boundary.
     """
     if not isinstance(task, dict):
         return False
@@ -189,10 +193,7 @@ def is_self_complete_exempt(task: Any) -> bool:
     if not isinstance(metadata, dict):
         return False
 
-    # Surface 1: dispatched agent type.
-    dispatch_agent = metadata.get("dispatch_agent")
-    if isinstance(dispatch_agent, str) and dispatch_agent in SELF_COMPLETE_EXEMPT_AGENTS:
-        return True
+    # Surface 1: owner in curated exempt set.
     owner = task.get("owner")
     if isinstance(owner, str) and owner in SELF_COMPLETE_EXEMPT_AGENTS:
         return True

--- a/pact-plugin/hooks/shared/intentional_wait.py
+++ b/pact-plugin/hooks/shared/intentional_wait.py
@@ -2,28 +2,31 @@
 Location: pact-plugin/hooks/shared/intentional_wait.py
 Summary: `intentional_wait` metadata schema — the teammate-facing contract
          for signalling a legitimate wait on an in_progress task (teachback
-         approval, inter-commit hold, peer reply, etc.).
-Used by: teammate-authored metadata on Task records. No in-plugin consumers
-         post-#538; the schema primitives are retained as the teammate-facing
-         metadata contract documented in skills/pact-agent-teams/SKILL.md.
+         approval, inter-commit hold, peer reply, etc.). Also the canonical
+         self-complete-exemption predicate for lead-side TaskGet inspection
+         and audit tooling.
+Used by: teammate-authored metadata on Task records, lead inspection, and
+         audit tooling. The exemption predicate (is_self_complete_exempt)
+         is NOT a hook — it is a pure function consumed by lead instructions
+         and future audit consumers. See skills/pact-agent-teams/SKILL.md
+         and skills/orchestration/SKILL.md for the contract.
 
 Contract: pure functions; never raise. Malformed flags fail loud — e.g.
 `wait_stale` returns True on any parse error so a broken flag cannot
-silently be interpreted as a fresh wait.
+silently be interpreted as a fresh wait. is_self_complete_exempt defaults
+to False on malformed input (conservative: never silently exempt).
 
 Public surface:
 - KNOWN_REASONS / KNOWN_RESOLVERS — vocabulary hints (free-form strings
   still accepted by validate_wait).
 - DEFAULT_THRESHOLD_MINUTES — staleness horizon (30 min).
+- SELF_COMPLETE_EXEMPT_AGENTS — agent names whose tasks may self-complete
+  (memory-save, etc.). Companion predicate: is_self_complete_exempt.
 - canonical_since() — ISO-8601 UTC timestamp helper for the `since` field.
 - validate_wait(wait_metadata) — True iff the flag is well-formed.
 - wait_stale(wait_metadata) — True iff the flag has aged past threshold.
-
-Removed in #538 C3 (with detect_stall in teammate_idle.py):
-- is_signal_task(task) — agent_handoff_emitter uses the inline literal
-  `metadata.type in ("blocker", "algedonic")` (matches task_utils.py:184
-  and session_resume.py:525 convention).
-- should_silence_stall_nag(task) — stall-nag removed entirely.
+- is_self_complete_exempt(task) — True iff the task is exempt from the
+  lead-only-completion rule (by agent type or signal-task pattern).
 """
 
 from datetime import datetime, timezone
@@ -41,11 +44,34 @@ KNOWN_REASONS = frozenset({
     "awaiting_peer_response",
     "awaiting_user_decision",
     "awaiting_blocker_resolution",
+    "awaiting_lead_completion",
 })
 
 KNOWN_RESOLVERS = frozenset({"lead", "peer", "user", "external"})
 
 DEFAULT_THRESHOLD_MINUTES = 30
+
+
+# Agents whose tasks may be self-completed because the lead has no
+# acceptance criteria to judge. Exemption is narrow by design: each
+# entry must have a documented rationale.
+#
+# `pact-secretary` (memory-save tasks): purely internal bookkeeping.
+#   The secretary writes a HANDOFF describing what was saved; the lead
+#   has no acceptance criteria — judging memory-save quality is the
+#   secretary's domain. Lead-as-gate would add 12-18 transitions per
+#   session with zero quality signal.
+#
+# Auditor signal-tasks are NOT in this set — they self-complete via
+# `metadata.completion_type == "signal"` + `metadata.type in {"blocker",
+# "algedonic"}` (the inline-literal pattern at task_utils.py:184 /
+# session_resume.py:525). Two distinct exemption surfaces:
+# - SELF_COMPLETE_EXEMPT_AGENTS: by agent type, declared at dispatch.
+# - signal-task pattern: by task metadata, applies to any agent.
+SELF_COMPLETE_EXEMPT_AGENTS: frozenset = frozenset({
+    "pact-secretary",
+    "secretary",
+})
 
 
 def canonical_since() -> str:
@@ -129,3 +155,48 @@ def wait_stale(
     now = _now or datetime.now(timezone.utc)
     age_minutes = (now - since).total_seconds() / 60
     return age_minutes >= threshold_minutes
+
+
+def is_self_complete_exempt(task: Any) -> bool:
+    """
+    Return True iff this task is exempt from the lead-only-completion rule.
+
+    Two exemption surfaces (OR-combined):
+    1. By dispatched agent type: task.metadata.dispatch_agent (or task.owner)
+       in SELF_COMPLETE_EXEMPT_AGENTS. Lead-declared at dispatch time via the
+       agent's subagent_type / owner field.
+    2. By signal-task metadata: task.metadata.completion_type == "signal" AND
+       task.metadata.type in {"blocker", "algedonic"}. Mirrors the inline
+       literal at agent_handoff_emitter.py / task_utils.py:184 /
+       session_resume.py:525.
+
+    Pure function; never raises; defaults to False on missing or malformed
+    fields (conservative — never silently exempt).
+
+    NOT a hook predicate. There is no hook reading this — the function is
+    the canonical predicate for lead-side TaskGet inspection, audit tooling,
+    and future consumers. Hooks must use the inline-literal mirror to avoid
+    reintroducing livelock-capable hook surface.
+    """
+    if not isinstance(task, dict):
+        return False
+
+    metadata = task.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        return False
+
+    # Surface 1: dispatched agent type.
+    dispatch_agent = metadata.get("dispatch_agent")
+    if isinstance(dispatch_agent, str) and dispatch_agent in SELF_COMPLETE_EXEMPT_AGENTS:
+        return True
+    owner = task.get("owner")
+    if isinstance(owner, str) and owner in SELF_COMPLETE_EXEMPT_AGENTS:
+        return True
+
+    # Surface 2: signal-task pattern (inline-literal mirror).
+    if metadata.get("completion_type") == "signal":
+        signal_type = metadata.get("type")
+        if signal_type in ("blocker", "algedonic"):
+            return True
+
+    return False

--- a/pact-plugin/hooks/shared/intentional_wait.py
+++ b/pact-plugin/hooks/shared/intentional_wait.py
@@ -177,6 +177,10 @@ def is_self_complete_exempt(task: Any) -> bool:
     the canonical predicate for lead-side TaskGet inspection, audit tooling,
     and future consumers. Hooks must use the inline-literal mirror to avoid
     reintroducing livelock-capable hook surface.
+
+    TRUST BOUNDARY: dispatch_agent must originate from lead-side trusted
+    writes. The carve-out trusts the lead's intent at dispatch time;
+    no runtime verification of owner-matches-dispatch_agent.
     """
     if not isinstance(task, dict):
         return False

--- a/pact-plugin/hooks/shared/intentional_wait.py
+++ b/pact-plugin/hooks/shared/intentional_wait.py
@@ -3,11 +3,11 @@ Location: pact-plugin/hooks/shared/intentional_wait.py
 Summary: `intentional_wait` metadata schema — the teammate-facing contract
          for signalling a legitimate wait on an in_progress task (teachback
          approval, inter-commit hold, peer reply, etc.). Also the canonical
-         self-complete-exemption predicate for lead-side TaskGet inspection
+         self-complete-exemption predicate for team-lead-side TaskGet inspection
          and audit tooling.
-Used by: teammate-authored metadata on Task records, lead inspection, and
+Used by: teammate-authored metadata on Task records, team-lead inspection, and
          audit tooling. The exemption predicate (is_self_complete_exempt)
-         is NOT a hook — it is a pure function consumed by lead instructions
+         is NOT a hook — it is a pure function consumed by team-lead instructions
          and future audit consumers. See skills/pact-agent-teams/SKILL.md
          and skills/orchestration/SKILL.md for the contract.
 
@@ -26,7 +26,7 @@ Public surface:
 - validate_wait(wait_metadata) — True iff the flag is well-formed.
 - wait_stale(wait_metadata) — True iff the flag has aged past threshold.
 - is_self_complete_exempt(task) — True iff the task is exempt from the
-  lead-only-completion rule (by agent type or signal-task pattern).
+  team-lead-only-completion rule (by agent type or signal-task pattern).
 """
 
 from datetime import datetime, timezone
@@ -52,12 +52,12 @@ KNOWN_RESOLVERS = frozenset({"lead", "peer", "user", "external"})
 DEFAULT_THRESHOLD_MINUTES = 30
 
 
-# Agents whose tasks may be self-completed because the lead has no
+# Agents whose tasks may be self-completed because the team-lead has no
 # acceptance criteria to judge. Exemption is narrow by design: each
 # entry must have a documented rationale.
 #
 # `pact-secretary` (memory-save tasks): purely internal bookkeeping.
-#   The secretary writes a HANDOFF describing what was saved; the lead
+#   The secretary writes a HANDOFF describing what was saved; the team-lead
 #   has no acceptance criteria — judging memory-save quality is the
 #   secretary's domain. Lead-as-gate would add 12-18 transitions per
 #   session with zero quality signal.
@@ -159,7 +159,7 @@ def wait_stale(
 
 def is_self_complete_exempt(task: Any) -> bool:
     """
-    Return True iff this task is exempt from the lead-only-completion rule.
+    Return True iff this task is exempt from the team-lead-only-completion rule.
 
     Two exemption surfaces (OR-combined):
     1. By owner: task.owner in SELF_COMPLETE_EXEMPT_AGENTS. Lead-declared
@@ -174,7 +174,7 @@ def is_self_complete_exempt(task: Any) -> bool:
     (conservative — never silently exempt).
 
     NOT a hook predicate. There is no hook reading this — the function is
-    the canonical predicate for lead-side TaskGet inspection, audit tooling,
+    the canonical predicate for team-lead-side TaskGet inspection, audit tooling,
     and future consumers. Hooks must use the inline-literal mirror to avoid
     reintroducing livelock-capable hook surface.
 

--- a/pact-plugin/hooks/teammate_idle.py
+++ b/pact-plugin/hooks/teammate_idle.py
@@ -10,7 +10,7 @@ Used by: hooks.json TeammateIdle hook
 # livelock-safe: threshold-escalation, not a nag. Message emissions
 # transition only at the IDLE_SUGGEST_THRESHOLD and IDLE_FORCE_THRESHOLD
 # boundaries — not every idle tick. Above IDLE_FORCE_THRESHOLD a
-# shutdown_request is re-emitted per tick until the lead processes it and
+# shutdown_request is re-emitted per tick until the team-lead processes it and
 # the platform terminates the agent (safety is protocol-level, not a
 # structural cap). Exits deterministically on every code path. Does NOT
 # consume intentional_wait.

--- a/pact-plugin/hooks/validate_handoff.py
+++ b/pact-plugin/hooks/validate_handoff.py
@@ -10,7 +10,7 @@ Validates that PACT agents complete with proper handoff information
 
 Note: Task protocol compliance (status, metadata) is NOT validated here.
 Task state may still be in flux at SubagentStop time (agents self-manage
-status under Agent Teams, and the lead may process output after this hook
+status under Agent Teams, and the team-lead may process output after this hook
 fires), so Task state cannot be reliably checked here.
 
 Input: JSON from stdin with `last_assistant_message` (preferred, SDK v2.1.47+),

--- a/pact-plugin/protocols/algedonic.md
+++ b/pact-plugin/protocols/algedonic.md
@@ -95,7 +95,7 @@ Under Agent Teams, teammates have access to Task tools (`TaskGet`, `TaskUpdate`,
 1. Stop work immediately
 2. Send the signal to the lead via `SendMessage` (using the Signal Format above):
    ```
-   SendMessage(to="lead",
+   SendMessage(to="team-lead",
      message="[{sender}→lead] ⚠️ ALGEDONIC [HALT|ALERT]: {Category}\n\nIssue: ...\nEvidence: ...\nImpact: ...\nRecommended Action: ...\n\nPartial HANDOFF:\n...",
      summary="ALGEDONIC [HALT|ALERT]: [category]")
    ```

--- a/pact-plugin/protocols/algedonic.md
+++ b/pact-plugin/protocols/algedonic.md
@@ -130,7 +130,7 @@ Agent detects trigger condition
     ↓
 Agent stops work immediately
     ↓
-Agent sends algedonic signal via `SendMessage` to lead + provides partial handoff
+Agent sends algedonic signal via `SendMessage` to team-lead + provides partial handoff
     ↓
 Orchestrator creates algedonic Task + blocks agent's task (addBlockedBy)
     ↓

--- a/pact-plugin/protocols/algedonic.md
+++ b/pact-plugin/protocols/algedonic.md
@@ -83,7 +83,7 @@ Apply the S5 Decision Framing Protocol (see [pact-s5-policy.md](pact-s5-policy.m
 
 ### Latency Caveat
 
-See [Communication Charter Part I — Algedonic-Signal Latency Caveat](pact-communication-charter.md#algedonic-signal-latency-caveat) for the delivery-model implications (idle-boundary HALT latency; immediate in-flight halt needs user interrupt; lead's "surface immediately" = lead's next idle).
+See [Communication Charter Part I — Algedonic-Signal Latency Caveat](pact-communication-charter.md#algedonic-signal-latency-caveat) for the delivery-model implications (idle-boundary HALT latency; immediate in-flight halt needs user interrupt; team-lead's "surface immediately" = team-lead's next idle).
 
 ### Task System Integration
 
@@ -93,15 +93,15 @@ With PACT Task integration, algedonic signals create **signal Tasks** that persi
 
 Under Agent Teams, teammates have access to Task tools (`TaskGet`, `TaskUpdate`, `TaskList`) and messaging (`SendMessage`). When an agent detects a viability threat:
 1. Stop work immediately
-2. Send the signal to the lead via `SendMessage` (using the Signal Format above):
+2. Send the signal to the team-lead via `SendMessage` (using the Signal Format above):
    ```
    SendMessage(to="team-lead",
-     message="[{sender}→lead] ⚠️ ALGEDONIC [HALT|ALERT]: {Category}\n\nIssue: ...\nEvidence: ...\nImpact: ...\nRecommended Action: ...\n\nPartial HANDOFF:\n...",
+     message="[{sender}→team-lead] ⚠️ ALGEDONIC [HALT|ALERT]: {Category}\n\nIssue: ...\nEvidence: ...\nImpact: ...\nRecommended Action: ...\n\nPartial HANDOFF:\n...",
      summary="ALGEDONIC [HALT|ALERT]: [category]")
    ```
 3. Provide a partial handoff with whatever work was completed
 
-The lead receives the `SendMessage` signal and handles algedonic Task creation and scope amplification.
+The team-lead receives the `SendMessage` signal and handles algedonic Task creation and scope amplification.
 
 **Orchestrator creates and manages the algedonic Task:**
 1. `TaskCreate(subject="[HALT|ALERT]: {category}", metadata={"type": "algedonic", "level": "...", "category": "..."})` — creates the signal Task
@@ -152,14 +152,14 @@ Work resumes (or stops) based on user decision
 On receiving an algedonic signal:
 
 1. **IMMEDIATELY** present signal to user (do not continue other work first)
-2. For **HALT**: Stop all in-progress teammates by sending HALT individually to each (see lead-side fan-out idiom in [Lead-Side HALT Fan-Out](../skills/orchestration/SKILL.md#lead-side-halt-fan-out)). Then await user acknowledgment.
+2. For **HALT**: Stop all in-progress teammates by sending HALT individually to each (see team-lead-side fan-out idiom in [Lead-Side HALT Fan-Out](../skills/orchestration/SKILL.md#team-lead-side-halt-fan-out)). Then await user acknowledgment.
 3. For **ALERT**: Pause current work, present options to user
 4. **Log** the signal in session record
 
 **Handling parallel agents on HALT**:
 
 When multiple agents are running and HALT is triggered:
-1. **Stop in-progress teammates by name** — for each teammate with `status="in_progress"`, send the HALT individually (see [Lead-Side HALT Fan-Out](../skills/orchestration/SKILL.md#lead-side-halt-fan-out)). Each message lands at that teammate's next idle boundary; for immediate halt of in-flight work, user-side manual interrupt is required (see [Algedonic-Signal Latency Caveat](pact-communication-charter.md#algedonic-signal-latency-caveat)).
+1. **Stop in-progress teammates by name** — for each teammate with `status="in_progress"`, send the HALT individually (see [Lead-Side HALT Fan-Out](../skills/orchestration/SKILL.md#team-lead-side-halt-fan-out)). Each message lands at that teammate's next idle boundary; for immediate halt of in-flight work, user-side manual interrupt is required (see [Algedonic-Signal Latency Caveat](pact-communication-charter.md#algedonic-signal-latency-caveat)).
 2. **Preserve work-in-progress** — do NOT discard uncommitted changes
 3. **Do NOT commit partial work** — leave changes staged/unstaged as-is
 4. **Document agent states** — note which agents were interrupted and their progress

--- a/pact-plugin/protocols/pact-audit.md
+++ b/pact-plugin/protocols/pact-audit.md
@@ -130,7 +130,7 @@ The auditor uses signal-based completion rather than standard HANDOFF:
 1. Task is created with `metadata: {"completion_type": "signal"}`
 2. Auditor stores final signal as `metadata.audit_summary` via `TaskUpdate`
 3. Auditor marks task completed
-4. Completion gate accepts `audit_summary` as the completion artifact (the `audit_summary` field in task metadata; no hook validates it; the lead verifies presence directly via `TaskGet`).
+4. Completion gate accepts `audit_summary` as the completion artifact (the `audit_summary` field in task metadata; no hook validates it; the team-lead verifies presence directly via `TaskGet`).
 
 **audit_summary format**:
 ```json

--- a/pact-plugin/protocols/pact-communication-charter.md
+++ b/pact-plugin/protocols/pact-communication-charter.md
@@ -18,39 +18,39 @@ The rules below govern how messages delivered via this tool actually behave.
 - Agents read queued messages in FIFO order on reaching idle.
 - No cancellation primitive exists — a follow-up message cannot supersede a queued earlier one.
 - The only mid-turn interrupt mechanism is user-side (Escape). Agent-to-agent SendMessage has no equivalent.
-- `SendMessage` requires a specific `to=` recipient name. There is no broadcast addressing mode; reaching multiple teammates means iterating and sending one message per recipient (see [Lead-Side HALT Fan-Out](../skills/orchestration/SKILL.md#lead-side-halt-fan-out) for the canonical pattern).
+- `SendMessage` requires a specific `to=` recipient name. There is no broadcast addressing mode; reaching multiple teammates means iterating and sending one message per recipient (see [Lead-Side HALT Fan-Out](../skills/orchestration/SKILL.md#team-lead-side-halt-fan-out) for the canonical pattern).
 
 ### Lead-Side Discipline — Verify Before Dispatching
 
 #### Verify State Before Correction
 
-Before sending a course-correction, check actual state (`git status`, `TaskList`, read files). The lead's mental model of teammate state diverges every time the teammate takes a tool action.
+Before sending a course-correction, check actual state (`git status`, `TaskList`, read files). The team-lead's mental model of teammate state diverges every time the teammate takes a tool action.
 
-*Failure shape: lead corrects against a `git status` snapshot from three tool calls ago; the teammate has committed and moved on since. The correction targets a no-longer-existing diff, and the teammate must surface the mismatch instead of acting on it.*
+*Failure shape: team-lead corrects against a `git status` snapshot from three tool calls ago; the teammate has committed and moved on since. The correction targets a no-longer-existing diff, and the teammate must surface the mismatch instead of acting on it.*
 
 #### Hold Fire During Mid-Turn
 
 Do not rapid-fire corrections while a teammate is mid-turn. Each queues and executes in order at their idle boundary, by which point the earlier message's premise may be stale.
 
-*Failure shape: lead fires correction B before correction A has cleared; A and B both queue. Distinct from the No-Supersede rule (which governs what happens once corrections collide); this is the upstream discipline of not firing them in the first place.*
+*Failure shape: team-lead fires correction B before correction A has cleared; A and B both queue. Distinct from the No-Supersede rule (which governs what happens once corrections collide); this is the upstream discipline of not firing them in the first place.*
 
 #### No Supersede Primitive
 
 Supersede-the-last-message does not exist. If message A is wrong and you send B, both will execute at the recipient's idle in FIFO order.
 
-*Failure shape: lead sends dispatch A based on a stale mental model; sends correction B before the teammate idles. The teammate processes A first, takes an action B's correction would have prevented, then reads B against the post-A state where the correction no longer fits.*
+*Failure shape: team-lead sends dispatch A based on a stale mental model; sends correction B before the teammate idles. The teammate processes A first, takes an action B's correction would have prevented, then reads B against the post-A state where the correction no longer fits.*
 
 #### Escalation for In-Flight Halt
 
 For in-flight damage that is unacceptable, escalate to the user for manual interrupt — do not attempt to fake sync interrupt via rapid-fire SendMessage.
 
-*Failure shape: lead detects a teammate executing destructive work mid-turn; queues rapid-fire HALT messages instead of asking the user to press Escape. Each HALT lands at the teammate's next idle; the destructive tool call completes before any HALT is read.*
+*Failure shape: team-lead detects a teammate executing destructive work mid-turn; queues rapid-fire HALT messages instead of asking the user to press Escape. Each HALT lands at the teammate's next idle; the destructive tool call completes before any HALT is read.*
 
 #### Dispatch Commit Point
 
 Treat task creation + `TaskUpdate(owner)` as the dispatch commit point; SendMessage is supplemental context.
 
-*Failure shape: lead sends a SendMessage with task instructions but skips the TaskUpdate(owner) step. The teammate's TaskList shows no assigned task; the SendMessage lands as orphan context with no work-tracking anchor, no teachback gate, and no completion handle.*
+*Failure shape: team-lead sends a SendMessage with task instructions but skips the TaskUpdate(owner) step. The teammate's TaskList shows no assigned task; the SendMessage lands as orphan context with no work-tracking anchor, no teachback gate, and no completion handle.*
 
 #### Wait for In-Flight Context
 
@@ -70,16 +70,16 @@ Before every SendMessage, run through:
 
 #### Forwarding-Chain Hygiene
 
-If teammate A produces info teammate B needs, prefer direct A→B SendMessage with a brief CC-summary to the lead, rather than A→lead→B routing. Halves idle-boundary latency. Reserve lead-routing for cases where the lead specifically owns the routing decision (priority arbitration, scope reassignment).
+If teammate A produces info teammate B needs, prefer direct A→B SendMessage with a brief CC-summary to the team-lead, rather than A→lead→B routing. Halves idle-boundary latency. Reserve team-lead-routing for cases where the team-lead specifically owns the routing decision (priority arbitration, scope reassignment).
 
-- **DON'T** relay design notes, query results, or HANDOFF excerpts from one teammate to another — that's a routing hop with no lead-owned decision in it. Send direct.
-- **DO** ask the lead to choose which of two teammates should take a task, or to arbitrate a scope conflict — those are decisions the lead owns.
+- **DON'T** relay design notes, query results, or HANDOFF excerpts from one teammate to another — that's a routing hop with no team-lead-owned decision in it. Send direct.
+- **DO** ask the team-lead to choose which of two teammates should take a task, or to arbitrate a scope conflict — those are decisions the team-lead owns.
 
 ### Teammate-Side Discipline — Verify Before Acting + Assume Eventually-Seen
 
 #### Wait for In-Flight Context
 
-Before composing any outbound SendMessage (peer-to-peer or to lead), wait for your own pending inputs. If you have an unread Read/Bash result, an outstanding peer query, or a dispatch you yourself issued that has not yet completed, hold the outbound until inputs land. Same **premature-dispatch** failure shape as lead-side — see [the lead-side rule](#wait-for-in-flight-context).
+Before composing any outbound SendMessage (peer-to-peer or to lead), wait for your own pending inputs. If you have an unread Read/Bash result, an outstanding peer query, or a dispatch you yourself issued that has not yet completed, hold the outbound until inputs land. Same **premature-dispatch** failure shape as team-lead-side — see [the team-lead-side rule](#wait-for-in-flight-context).
 
 *Failure shape: backend-coder mid-task with a pending Bash result; a peer pings; backend-coder drafts a peer-to-peer reply now and an addendum after the Bash returns. Two messages queue at the peer's idle; the first is composed against framing the Bash result would have shaped.*
 
@@ -91,7 +91,7 @@ On receiving a state-dependent message, check actual state before executing. If 
 
 #### Additive vs Corrective
 
-When a follow-up message updates earlier context, mentally diff and incorporate. Do NOT assume the earlier message is superseded — additive updates extend rather than replace prior framing. If the new message contradicts the prior, it's a lead-side rapid-fire-correction violation; surface it to the lead rather than silently picking one. Ambiguous middle: "investigate auth flow" followed by "start with the session-token path" — narrower-additive (a starting point) or different-assumption-contradictory (auth flow ≠ session-token path)? Default to surfacing.
+When a follow-up message updates earlier context, mentally diff and incorporate. Do NOT assume the earlier message is superseded — additive updates extend rather than replace prior framing. If the new message contradicts the prior, it's a team-lead-side rapid-fire-correction violation; surface it to the team-lead rather than silently picking one. Ambiguous middle: "investigate auth flow" followed by "start with the session-token path" — narrower-additive (a starting point) or different-assumption-contradictory (auth flow ≠ session-token path)? Default to surfacing.
 
 #### Eventually-Seen, Not Read
 
@@ -106,13 +106,13 @@ Before resending an apparently-unacknowledged message, verify the addressee has 
 *Failure shape: peer is busy mid-task; their idle hasn't fired since the original send. The resend queues a second identical message that lands at their first idle alongside the original — peer reads two copies in FIFO order.*
 
 - Peer-to-peer: do not assume a peer saw your message before their next tool call. Peer's in-flight action runs to completion before they read inbound.
-- Prefer peer-to-peer for context forwarding — see [the lead-side Forwarding-Chain Hygiene rule](#forwarding-chain-hygiene). If your work produces info another teammate would benefit from, send directly to them with a brief CC-summary to the lead.
-- Apply the **Pre-Send Self-Check** above before any outbound SendMessage — the questions are universal to any sender, not lead-only.
+- Prefer peer-to-peer for context forwarding — see [the team-lead-side Forwarding-Chain Hygiene rule](#forwarding-chain-hygiene). If your work produces info another teammate would benefit from, send directly to them with a brief CC-summary to the team-lead.
+- Apply the **Pre-Send Self-Check** above before any outbound SendMessage — the questions are universal to any sender, not team-lead-only.
 
 ### Algedonic-Signal Latency Caveat
 - HALT signals via SendMessage have idle-boundary latency like any other message.
 - For immediate halt of in-flight teammate work, user-side manual interrupt is required.
-- The lead's responsibility to "surface immediately" means at the lead's next idle, not at arbitrary real-time.
+- The team-lead's responsibility to "surface immediately" means at the team-lead's next idle, not at arbitrary real-time.
 
 ## Part II — Written Output
 

--- a/pact-plugin/protocols/pact-completion-authority.md
+++ b/pact-plugin/protocols/pact-completion-authority.md
@@ -26,15 +26,20 @@ Both calls are **required**. Skipping the SendMessage strands the teammate idle 
 
 Both calls are **required**. Skipping the SendMessage leaves the teammate idle on stale `awaiting_lead_completion`, never seeing the corrections — symmetric failure to skipping wake on acceptance. The teammate's `intentional_wait` does not auto-clear when you write rejection metadata; only the wake-signal triggers their CLEAR-and-revise flow. **3+ rejection cycles** on the same task is an imPACT META-BLOCK signal.
 
-**Carve-outs** (rare, narrow):
+**Teammate self-completion carve-outs (predicate-witnessed)** — narrow exemptions where the teammate marks `completed` themselves:
 
 | Carve-out | Trigger | Rule |
 |---|---|---|
 | Signal-tasks | `metadata.completion_type == "signal"` AND `metadata.type ∈ {"blocker", "algedonic"}` | Auditor + algedonic-emitting agents self-complete; the task IS the signal, no HANDOFF to judge. |
 | Memory-save | Owner is `secretary` (or `pact-secretary`) | Secretary self-completes memory-save tasks; lead has no acceptance criteria for memory bookkeeping. |
-| imPACT termination | `metadata.terminated == true` | You force-complete an unrecoverable agent's task via `TaskStop` + `TaskUpdate(status="completed", metadata={"terminated": true, "reason": "..."})`. See [imPACT.md](../commands/imPACT.md). |
 
-The canonical predicate is `is_self_complete_exempt(task)` in `shared/intentional_wait.py` — pure function for your TaskGet inspection and audit tooling. No hook reads it.
+The canonical predicate `is_self_complete_exempt(task)` in `shared/intentional_wait.py` witnesses ONLY these two surfaces — pure function for your TaskGet inspection and audit tooling. No hook reads it.
+
+**Lead-driven force-completion (separate path, not predicate-witnessed)**:
+
+| Path | Trigger | Rule |
+|---|---|---|
+| imPACT termination | `metadata.terminated == true` | You force-complete an unrecoverable agent's task via `TaskStop` + `TaskUpdate(status="completed", metadata={"terminated": true, "reason": "..."})`. See [imPACT.md](../commands/imPACT.md). The `terminated` marker is recognized directly by audit/inspection; `is_self_complete_exempt` does NOT cover this surface (the lead writes status=completed directly). |
 
 **TaskGet metadata-blindness reminder**: `TaskGet` does NOT surface `metadata.handoff`. Read directly:
 
@@ -65,13 +70,20 @@ cat ~/.claude/tasks/{team_name}/{A_id}.json | jq .metadata.teachback_submit
 
 Compare against the dispatched task description. Apply the validation discipline from [orchestration §Validating Incoming Teachbacks](../skills/orchestration/SKILL.md#validating-incoming-teachbacks) — check for both misstatements AND omissions.
 
-**Approving the teachback — two-call atomic pair (BOTH required)**:
+**Optional audit step** — write a `teachback_resolution` record before flipping status:
 
 ```
 TaskUpdate(A_id, metadata={"teachback_resolution": {
     "conditions_met": true,
     "resolution_comment": "<optional one-line rationale>"
 }})
+```
+
+This write is optional but recommended for audit. It is NOT one of the required calls below.
+
+**Approving the teachback — two-call atomic pair (BOTH required)**:
+
+```
 TaskUpdate(A_id, status="completed")
 SendMessage(
     to="<teammate>",
@@ -83,7 +95,7 @@ SendMessage(
 )
 ```
 
-The `teachback_resolution` write is optional but recommended for audit. The status flip is the load-bearing approval action; the SendMessage is the load-bearing wake.
+The status flip is the load-bearing approval action; the SendMessage is the load-bearing wake.
 
 **Rejecting the teachback** — see [Rejection Flow](#rejection-flow) below.
 

--- a/pact-plugin/protocols/pact-completion-authority.md
+++ b/pact-plugin/protocols/pact-completion-authority.md
@@ -8,20 +8,23 @@
 
 ## Completion Authority
 
-You — the lead — are the **only** actor who marks teammate-owned tasks `completed`. Teammates write HANDOFFs to `metadata.handoff`, idle on `intentional_wait{reason=awaiting_lead_completion}`, and wait for your acceptance. The `TaskUpdate(status="completed")` flip is the load-bearing approval action; the wake-signal SendMessage is the load-bearing wake.
+You — the lead — are the **only** actor who marks teammate-owned tasks `completed`. Teammates write HANDOFFs to `metadata.handoff`, idle on `intentional_wait{reason=awaiting_lead_completion}`, and wait for your acceptance. The `TaskUpdate(status="completed")` flip is the load-bearing approval action; the paired wake-signal SendMessage is the load-bearing wake.
 
-**Acceptance recipe — two-call atomic pair (BOTH required)**:
+`blockedBy` is pull-only at the platform level — the platform does NOT push a wake on blocker resolution; `blockedBy` is computed at TaskList query time. Idle teammates cannot self-wake to re-poll, so the wake-signal SendMessage is paired with each metadata or status write that resolves their wait.
 
-```
-TaskUpdate(taskId, status="completed")
-SendMessage(
-    to="<teammate>",
-    message="[lead→<teammate>] Task #<id> accepted. Work complete.",
-    summary="Task accepted"
-)
-```
+### Acceptance — two-call atomic pair (BOTH required)
 
-Both calls are **required**. The `TaskUpdate` flips status (which auto-unblocks any tasks with `blockedBy=[<id>]`); the `SendMessage` wakes the idle teammate so they can claim the next task. The platform does NOT push a wake on blocker resolution — `blockedBy` is computed at TaskList query time. An idle teammate cannot self-wake to re-poll. Skipping the SendMessage strands the teammate idle until something else (peer message, your next dispatch) wakes them.
+1. `TaskUpdate(taskId, status="completed")` — status flip; auto-unblocks any tasks with `blockedBy=[<id>]`
+2. `SendMessage(to="<teammate>", "[lead→<teammate>] Task #<id> accepted. Work complete.", summary="Task accepted")` — wakes the idle teammate so they can claim the next task
+
+Both calls are **required**. Skipping the SendMessage strands the teammate idle on `awaiting_lead_completion` until something else (peer message, your next dispatch) wakes them; `blockedBy` resolution is invisible without the wake.
+
+### Rejection — two-call atomic pair (BOTH required)
+
+1. `TaskUpdate(taskId, metadata={"teachback_rejection": {...}})` (Task A) OR `TaskUpdate(taskId, metadata={"handoff_rejection": {...}})` (Task B) — payload `{reason, corrections, since, revision_number}`
+2. `SendMessage(to="<teammate>", "[lead→<teammate>] Rejected on Task #<id>. See metadata.{teachback,handoff}_rejection. Revise.", summary="Rejected; revise")` — wakes the teammate so they read the corrections
+
+Both calls are **required**. Skipping the SendMessage leaves the teammate idle on stale `awaiting_lead_completion`, never seeing the corrections — symmetric failure to skipping wake on acceptance. The teammate's `intentional_wait` does not auto-clear when you write rejection metadata; only the wake-signal triggers their CLEAR-and-revise flow. **3+ rejection cycles** on the same task is an imPACT META-BLOCK signal.
 
 **Carve-outs** (rare, narrow):
 

--- a/pact-plugin/protocols/pact-completion-authority.md
+++ b/pact-plugin/protocols/pact-completion-authority.md
@@ -2,27 +2,27 @@
 
 > **Purpose**: Lead-only completion of teammate-owned tasks. Acceptance is a two-call atomic pair (status flip + wake-signal SendMessage); rejection is dual-channel (metadata + wake-signal SendMessage).
 >
-> **Audience**: PACT lead (orchestrator). Teammate-side rules live in [pact-agent-teams §On Completion](../skills/pact-agent-teams/SKILL.md#on-completion--handoff-required) and [pact-agent-teams §On Rejection](../skills/pact-agent-teams/SKILL.md#on-rejection-wake-signal-receipt).
+> **Audience**: PACT team-lead (orchestrator). Teammate-side rules live in [pact-agent-teams §On Completion](../skills/pact-agent-teams/SKILL.md#on-completion--handoff-required) and [pact-agent-teams §On Rejection](../skills/pact-agent-teams/SKILL.md#on-rejection-wake-signal-receipt).
 
 ---
 
 ## Completion Authority
 
-You — the lead — are the **only** actor who marks teammate-owned tasks `completed`. Teammates write HANDOFFs to `metadata.handoff`, idle on `intentional_wait{reason=awaiting_lead_completion}`, and wait for your acceptance. The `TaskUpdate(status="completed")` flip is the load-bearing approval action; the paired wake-signal SendMessage is the load-bearing wake.
+You — the team-lead — are the **only** actor who marks teammate-owned tasks `completed`. Teammates write HANDOFFs to `metadata.handoff`, idle on `intentional_wait{reason=awaiting_lead_completion}`, and wait for your acceptance. The `TaskUpdate(status="completed")` flip is the load-bearing approval action; the paired wake-signal SendMessage is the load-bearing wake.
 
 `blockedBy` is pull-only at the platform level — the platform does NOT push a wake on blocker resolution; `blockedBy` is computed at TaskList query time. Idle teammates cannot self-wake to re-poll, so the wake-signal SendMessage is paired with each metadata or status write that resolves their wait.
 
 ### Acceptance — two-call atomic pair (BOTH required)
 
 1. `TaskUpdate(taskId, status="completed")` — status flip; auto-unblocks any tasks with `blockedBy=[<id>]`
-2. `SendMessage(to="<teammate>", "[lead→<teammate>] Task #<id> accepted. Work complete.", summary="Task accepted")` — wakes the idle teammate so they can claim the next task
+2. `SendMessage(to="<teammate>", "[team-lead→<teammate>] Task #<id> accepted. Work complete.", summary="Task accepted")` — wakes the idle teammate so they can claim the next task
 
 Both calls are **required**. Skipping the SendMessage strands the teammate idle on `awaiting_lead_completion` until something else (peer message, your next dispatch) wakes them; `blockedBy` resolution is invisible without the wake.
 
 ### Rejection — two-call atomic pair (BOTH required)
 
 1. `TaskUpdate(taskId, metadata={"teachback_rejection": {...}})` (Task A) OR `TaskUpdate(taskId, metadata={"handoff_rejection": {...}})` (Task B) — payload `{reason, corrections, since, revision_number}`
-2. `SendMessage(to="<teammate>", "[lead→<teammate>] Rejected on Task #<id>. See metadata.{teachback,handoff}_rejection. Revise.", summary="Rejected; revise")` — wakes the teammate so they read the corrections
+2. `SendMessage(to="<teammate>", "[team-lead→<teammate>] Rejected on Task #<id>. See metadata.{teachback,handoff}_rejection. Revise.", summary="Rejected; revise")` — wakes the teammate so they read the corrections
 
 Both calls are **required**. Skipping the SendMessage leaves the teammate idle on stale `awaiting_lead_completion`, never seeing the corrections — symmetric failure to skipping wake on acceptance. The teammate's `intentional_wait` does not auto-clear when you write rejection metadata; only the wake-signal triggers their CLEAR-and-revise flow. **3+ rejection cycles** on the same task is an imPACT META-BLOCK signal.
 
@@ -31,7 +31,7 @@ Both calls are **required**. Skipping the SendMessage leaves the teammate idle o
 | Carve-out | Trigger | Rule |
 |---|---|---|
 | Signal-tasks | `metadata.completion_type == "signal"` AND `metadata.type ∈ {"blocker", "algedonic"}` | Auditor + algedonic-emitting agents self-complete; the task IS the signal, no HANDOFF to judge. |
-| Memory-save | Owner is `secretary` (or `pact-secretary`) | Secretary self-completes memory-save tasks; lead has no acceptance criteria for memory bookkeeping. |
+| Memory-save | Owner is `secretary` (or `pact-secretary`) | Secretary self-completes memory-save tasks; team-lead has no acceptance criteria for memory bookkeeping. |
 
 The canonical predicate `is_self_complete_exempt(task)` in `shared/intentional_wait.py` witnesses ONLY these two surfaces — pure function for your TaskGet inspection and audit tooling. No hook reads it.
 
@@ -39,7 +39,7 @@ The canonical predicate `is_self_complete_exempt(task)` in `shared/intentional_w
 
 | Path | Trigger | Rule |
 |---|---|---|
-| imPACT termination | `metadata.terminated == true` | You force-complete an unrecoverable agent's task via `TaskStop` + `TaskUpdate(status="completed", metadata={"terminated": true, "reason": "..."})`. See [imPACT.md](../commands/imPACT.md). The `terminated` marker is recognized directly by audit/inspection; `is_self_complete_exempt` does NOT cover this surface (the lead writes status=completed directly). |
+| imPACT termination | `metadata.terminated == true` | You force-complete an unrecoverable agent's task via `TaskStop` + `TaskUpdate(status="completed", metadata={"terminated": true, "reason": "..."})`. See [imPACT.md](../commands/imPACT.md). The `terminated` marker is recognized directly by audit/inspection; `is_self_complete_exempt` does NOT cover this surface (the team-lead writes status=completed directly). |
 
 **TaskGet metadata-blindness reminder**: `TaskGet` does NOT surface `metadata.handoff`. Read directly:
 
@@ -88,7 +88,7 @@ TaskUpdate(A_id, status="completed")
 SendMessage(
     to="<teammate>",
     message=(
-        "[lead→<teammate>] Teachback accepted on Task #<A_id>. "
+        "[team-lead→<teammate>] Teachback accepted on Task #<A_id>. "
         "Task B (#<B_id>) is now claimable."
     ),
     summary="Teachback accepted; Task B claimable"
@@ -119,7 +119,7 @@ TaskUpdate(A_id, metadata={"teachback_rejection": {
 SendMessage(
     to="<teammate>",
     message=(
-        "[lead→<teammate>] Teachback rejected on Task #<A_id>. "
+        "[team-lead→<teammate>] Teachback rejected on Task #<A_id>. "
         "See metadata.teachback_rejection. Revise and re-submit. "
         "Task A remains in_progress."
     ),
@@ -139,7 +139,7 @@ TaskUpdate(B_id, metadata={"handoff_rejection": {
 SendMessage(
     to="<teammate>",
     message=(
-        "[lead→<teammate>] HANDOFF rejected on Task #<B_id>. "
+        "[team-lead→<teammate>] HANDOFF rejected on Task #<B_id>. "
         "See metadata.handoff_rejection. Revise."
     ),
     summary="HANDOFF rejected; revise"
@@ -153,7 +153,7 @@ SendMessage(
 1. Lead writes rejection metadata + sends wake-signal.
 2. Teammate wakes, CLEARs `intentional_wait`, reads rejection metadata.
 3. Teammate revises (`metadata.teachback_submit` for A, or revises deliverable + `metadata.handoff` for B).
-4. Teammate re-SETs `intentional_wait` with fresh `since`, increments `metadata.revision_number`, SendMessage notifies lead "revised."
+4. Teammate re-SETs `intentional_wait` with fresh `since`, increments `metadata.revision_number`, SendMessage notifies team-lead "revised."
 5. Lead reviews; either accepts (per [Completion Authority](#completion-authority)) or rejects again (revision_number = N+1).
 
 > **Cycle limit**: 3+ rejection cycles on the same task is an imPACT META-BLOCK signal. See [imPACT.md](../commands/imPACT.md).

--- a/pact-plugin/protocols/pact-completion-authority.md
+++ b/pact-plugin/protocols/pact-completion-authority.md
@@ -1,0 +1,144 @@
+# Completion Authority Protocol
+
+> **Purpose**: Lead-only completion of teammate-owned tasks. Acceptance is a two-call atomic pair (status flip + wake-signal SendMessage); rejection is dual-channel (metadata + wake-signal SendMessage).
+>
+> **Audience**: PACT lead (orchestrator). Teammate-side rules live in [pact-agent-teams §On Completion](../skills/pact-agent-teams/SKILL.md#on-completion--handoff-required) and [pact-agent-teams §On Rejection](../skills/pact-agent-teams/SKILL.md#on-rejection-wake-signal-receipt).
+
+---
+
+## Completion Authority
+
+You — the lead — are the **only** actor who marks teammate-owned tasks `completed`. Teammates write HANDOFFs to `metadata.handoff`, idle on `intentional_wait{reason=awaiting_lead_completion}`, and wait for your acceptance. The `TaskUpdate(status="completed")` flip is the load-bearing approval action; the wake-signal SendMessage is the load-bearing wake.
+
+**Acceptance recipe — two-call atomic pair (BOTH required)**:
+
+```
+TaskUpdate(taskId, status="completed")
+SendMessage(
+    to="<teammate>",
+    message="[lead→<teammate>] Task #<id> accepted. Work complete.",
+    summary="Task accepted"
+)
+```
+
+Both calls are **required**. The `TaskUpdate` flips status (which auto-unblocks any tasks with `blockedBy=[<id>]`); the `SendMessage` wakes the idle teammate so they can claim the next task. The platform does NOT push a wake on blocker resolution — `blockedBy` is computed at TaskList query time. An idle teammate cannot self-wake to re-poll. Skipping the SendMessage strands the teammate idle until something else (peer message, your next dispatch) wakes them.
+
+**Carve-outs** (rare, narrow):
+
+| Carve-out | Trigger | Rule |
+|---|---|---|
+| Signal-tasks | `metadata.completion_type == "signal"` AND `metadata.type ∈ {"blocker", "algedonic"}` | Auditor + algedonic-emitting agents self-complete; the task IS the signal, no HANDOFF to judge. |
+| Memory-save | Owner is `secretary` (or `pact-secretary`) | Secretary self-completes memory-save tasks; lead has no acceptance criteria for memory bookkeeping. |
+| imPACT termination | `metadata.terminated == true` | You force-complete an unrecoverable agent's task via `TaskStop` + `TaskUpdate(status="completed", metadata={"terminated": true, "reason": "..."})`. See [imPACT.md](../commands/imPACT.md). |
+
+The canonical predicate is `is_self_complete_exempt(task)` in `shared/intentional_wait.py` — pure function for your TaskGet inspection and audit tooling. No hook reads it.
+
+**TaskGet metadata-blindness reminder**: `TaskGet` does NOT surface `metadata.handoff`. Read directly:
+
+```
+cat ~/.claude/tasks/{team_name}/{taskId}.json | jq .metadata.handoff
+```
+
+Inspect the HANDOFF before flipping status. If `metadata.handoff` is missing or empty, do NOT mark the task completed — request the teammate write the HANDOFF first.
+
+---
+
+## Teachback Review
+
+The Task A + Task B dispatch shape gates implementation work behind teachback approval. When dispatching, you create:
+
+- **Task A**: `subject="<role>: TEACHBACK for <feature>"`, owner = teammate. Description states: "Submit teachback via `metadata.teachback_submit`. SET `intentional_wait{reason=awaiting_lead_completion}`. Do NOT begin Task B."
+- **Task B**: `subject="<role>: <primary mission>"`, owner = teammate, `blockedBy=[<Task A id>]`.
+
+Both tasks are created at dispatch time; the teammate receives both in their initial TaskList view, with B greyed out by `blockedBy`.
+
+**Reviewing the teachback**:
+
+Read `metadata.teachback_submit` directly:
+
+```
+cat ~/.claude/tasks/{team_name}/{A_id}.json | jq .metadata.teachback_submit
+```
+
+Compare against the dispatched task description. Apply the validation discipline from [orchestration §Validating Incoming Teachbacks](../skills/orchestration/SKILL.md#validating-incoming-teachbacks) — check for both misstatements AND omissions.
+
+**Approving the teachback — two-call atomic pair (BOTH required)**:
+
+```
+TaskUpdate(A_id, metadata={"teachback_resolution": {
+    "conditions_met": true,
+    "resolution_comment": "<optional one-line rationale>"
+}})
+TaskUpdate(A_id, status="completed")
+SendMessage(
+    to="<teammate>",
+    message=(
+        "[lead→<teammate>] Teachback accepted on Task #<A_id>. "
+        "Task B (#<B_id>) is now claimable."
+    ),
+    summary="Teachback accepted; Task B claimable"
+)
+```
+
+The `teachback_resolution` write is optional but recommended for audit. The status flip is the load-bearing approval action; the SendMessage is the load-bearing wake.
+
+**Rejecting the teachback** — see [Rejection Flow](#rejection-flow) below.
+
+> ⚠️ DO NOT mark Task B `completed` and DO NOT mark Task B `pending`. Task B stays `pending` (its initial state) until the teammate claims it (`status=in_progress`) after wake. Your acceptance affects Task A only; Task B's lifecycle is the teammate's to drive (claim → work → submit HANDOFF → idle for your HANDOFF acceptance).
+
+---
+
+## Rejection Flow
+
+Teachback or HANDOFF inadequate? Reject with **dual-channel delivery** (metadata + SendMessage). Same shape for both rejection types:
+
+**Teachback rejection**:
+
+```
+TaskUpdate(A_id, metadata={"teachback_rejection": {
+    "reason": "<one-line summary>",
+    "corrections": ["<correction 1>", "<correction 2>", ...],
+    "since": "<canonical_since() output>",
+    "revision_number": 1
+}})
+SendMessage(
+    to="<teammate>",
+    message=(
+        "[lead→<teammate>] Teachback rejected on Task #<A_id>. "
+        "See metadata.teachback_rejection. Revise and re-submit. "
+        "Task A remains in_progress."
+    ),
+    summary="Teachback rejected; revise"
+)
+```
+
+**HANDOFF rejection** (Task B):
+
+```
+TaskUpdate(B_id, metadata={"handoff_rejection": {
+    "reason": "...",
+    "corrections": [...],
+    "since": "<canonical_since() output>",
+    "revision_number": 1
+}})
+SendMessage(
+    to="<teammate>",
+    message=(
+        "[lead→<teammate>] HANDOFF rejected on Task #<B_id>. "
+        "See metadata.handoff_rejection. Revise."
+    ),
+    summary="HANDOFF rejected; revise"
+)
+```
+
+**Why dual-channel**: metadata gives the durable revision spec the teammate reads on wake; SendMessage gives the wake itself. Single-channel via metadata only fails because the idle teammate can't self-wake to read it. Single-channel via SendMessage only loses durability — the corrections need to survive teammate compaction or agent restart.
+
+**Recovery flow on rejection**:
+
+1. Lead writes rejection metadata + sends wake-signal.
+2. Teammate wakes, CLEARs `intentional_wait`, reads rejection metadata.
+3. Teammate revises (`metadata.teachback_submit` for A, or revises deliverable + `metadata.handoff` for B).
+4. Teammate re-SETs `intentional_wait` with fresh `since`, increments `metadata.revision_number`, SendMessage notifies lead "revised."
+5. Lead reviews; either accepts (per [Completion Authority](#completion-authority)) or rejects again (revision_number = N+1).
+
+> **Cycle limit**: 3+ rejection cycles on the same task is an imPACT META-BLOCK signal. See [imPACT.md](../commands/imPACT.md).

--- a/pact-plugin/protocols/pact-ct-teachback.md
+++ b/pact-plugin/protocols/pact-ct-teachback.md
@@ -29,7 +29,7 @@ When a downstream agent receives an upstream handoff (via `TaskGet`), their firs
 ```
 1. Agent dispatched with upstream task reference (e.g., "Architect task: #5")
 2. Agent reads upstream handoff via `TaskGet(#5)`
-3. Agent sends teachback to lead via `SendMessage`:
+3. Agent sends teachback to team-lead via `SendMessage`:
    "[{sender}→team-lead] Teachback: My understanding is... [key decisions restated]. Proceeding unless corrected."
 4. Agent proceeds with work (non-blocking)
 5. If orchestrator spots misunderstanding, they must `SendMessage` to agent to correct it

--- a/pact-plugin/protocols/pact-ct-teachback.md
+++ b/pact-plugin/protocols/pact-ct-teachback.md
@@ -30,7 +30,7 @@ When a downstream agent receives an upstream handoff (via `TaskGet`), their firs
 1. Agent dispatched with upstream task reference (e.g., "Architect task: #5")
 2. Agent reads upstream handoff via `TaskGet(#5)`
 3. Agent sends teachback to lead via `SendMessage`:
-   "[{sender}→lead] Teachback: My understanding is... [key decisions restated]. Proceeding unless corrected."
+   "[{sender}→team-lead] Teachback: My understanding is... [key decisions restated]. Proceeding unless corrected."
 4. Agent proceeds with work (non-blocking)
 5. If orchestrator spots misunderstanding, they must `SendMessage` to agent to correct it
 ```
@@ -42,7 +42,7 @@ Blocking teachback (wait for confirmation before working) would serialize everyt
 #### Teachback Format
 
 ```
-[{sender}→lead] Teachback:
+[{sender}→team-lead] Teachback:
 - Building: {what I understand I'm building}
 - Key constraints: {constraints I'm working within}
 - Interfaces: {interfaces I'll produce or consume}
@@ -67,7 +67,7 @@ One extra `SendMessage` per agent dispatch (~100-200 tokens). Cheap insurance ag
 
 ### Agreement Verification (Orchestrator-Side)
 
-Teachback verifies understanding **downstream** (next agent → lead). Agreement verification verifies understanding **upstream** (lead → previous agent).
+Teachback verifies understanding **downstream** (next agent → team-lead). Agreement verification verifies understanding **upstream** (team-lead → previous agent).
 
 #### When to Verify
 

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -407,7 +407,7 @@ When a downstream agent receives an upstream handoff (via `TaskGet`), their firs
 1. Agent dispatched with upstream task reference (e.g., "Architect task: #5")
 2. Agent reads upstream handoff via `TaskGet(#5)`
 3. Agent sends teachback to lead via `SendMessage`:
-   "[{sender}→lead] Teachback: My understanding is... [key decisions restated]. Proceeding unless corrected."
+   "[{sender}→team-lead] Teachback: My understanding is... [key decisions restated]. Proceeding unless corrected."
 4. Agent proceeds with work (non-blocking)
 5. If orchestrator spots misunderstanding, they must `SendMessage` to agent to correct it
 ```
@@ -419,7 +419,7 @@ Blocking teachback (wait for confirmation before working) would serialize everyt
 #### Teachback Format
 
 ```
-[{sender}→lead] Teachback:
+[{sender}→team-lead] Teachback:
 - Building: {what I understand I'm building}
 - Key constraints: {constraints I'm working within}
 - Interfaces: {interfaces I'll produce or consume}
@@ -444,7 +444,7 @@ One extra `SendMessage` per agent dispatch (~100-200 tokens). Cheap insurance ag
 
 ### Agreement Verification (Orchestrator-Side)
 
-Teachback verifies understanding **downstream** (next agent → lead). Agreement verification verifies understanding **upstream** (lead → previous agent).
+Teachback verifies understanding **downstream** (next agent → team-lead). Agreement verification verifies understanding **upstream** (team-lead → previous agent).
 
 #### When to Verify
 
@@ -750,7 +750,7 @@ For full protocol details, see [algedonic.md](algedonic.md).
 - **Any agent** can emit algedonic signals when they recognize trigger conditions
 - Orchestrator **MUST** surface signals to user immediately—cannot suppress or delay
 - HALT requires user acknowledgment before ANY work resumes
-- For **HALT** with parallel agents: send stop individually to each in-progress teammate (see [Lead-Side HALT Fan-Out](../skills/orchestration/SKILL.md#lead-side-halt-fan-out)), preserve work-in-progress, do NOT commit partial work
+- For **HALT** with parallel agents: send stop individually to each in-progress teammate (see [Lead-Side HALT Fan-Out](../skills/orchestration/SKILL.md#team-lead-side-halt-fan-out)), preserve work-in-progress, do NOT commit partial work
 - ALERT allows user to choose: Investigate / Continue / Stop
 
 ### Relationship to imPACT
@@ -856,7 +856,7 @@ Derive agent state from progress signals (see agent-teams skill, Progress Signal
 > **Cybernetic basis**: Bateson's deutero-learning — the system learns to learn by comparing
 > predicted difficulty against actual outcomes, creating a feedback loop for scoring accuracy.
 
-At workflow completion (orchestrate wrap-up or comPACT completion), the secretary gathers calibration metrics during HANDOFF processing, asks the lead for a brief difficulty assessment, and saves the calibration record to pact-memory. Records feed back into Learning II pattern matching.
+At workflow completion (orchestrate wrap-up or comPACT completion), the secretary gathers calibration metrics during HANDOFF processing, asks the team-lead for a brief difficulty assessment, and saves the calibration record to pact-memory. Records feed back into Learning II pattern matching.
 
 **Schema**:
 
@@ -881,7 +881,7 @@ CalibrationRecord:
 **Post-cycle comparison**: During HANDOFF processing, the secretary:
 1. Reads feature task metadata for initial_variety_score
 2. Scans TaskList for blocker count and phase rerun count
-3. Asks the lead for a brief difficulty assessment (higher, lower, or about the same)
+3. Asks the team-lead for a brief difficulty assessment (higher, lower, or about the same)
 4. Computes the full CalibrationRecord and saves to pact-memory
 5. If drift exceeds 2 in any dimension, notes as significant for future Learning II queries
 
@@ -909,7 +909,7 @@ CalibrationRecord:
 | `/PACT:plan-mode` | None (consultant writes consultation HANDOFF, idles) | All consultant tasks; the plan-mode parent task |
 | `/PACT:imPACT` | None (triage agent writes triage HANDOFF, idles) | All triage tasks; the imPACT parent task |
 
-Carve-outs apply across all workflows: signal-tasks (auditor), memory-save (secretary), force-termination (imPACT). See [pact-completion-authority.md](pact-completion-authority.md) for the full acceptance + rejection recipes and carve-out rationale; [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority) holds the slim lead-side summary.
+Carve-outs apply across all workflows: signal-tasks (auditor), memory-save (secretary), force-termination (imPACT). See [pact-completion-authority.md](pact-completion-authority.md) for the full acceptance + rejection recipes and carve-out rationale; [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority) holds the slim team-lead-side summary.
 
 ---
 
@@ -1125,7 +1125,7 @@ Tasks progress through: `pending` → `in_progress` → `completed`
 
 - **pending**: Created but not started
 - **in_progress**: Active work underway (also covers "done-awaiting-review" — teammate has stored HANDOFF and idles on `awaiting_lead_completion`)
-- **completed**: Work finished (success or documented failure); transition is **lead-only** on teammate-owned tasks
+- **completed**: Work finished (success or documented failure); transition is **team-lead-only** on teammate-owned tasks
 
 ### Status-by-Actor
 
@@ -1139,7 +1139,7 @@ Tasks progress through: `pending` → `in_progress` → `completed`
 
 ### Task A + Task B Dispatch Shape
 
-Every specialist dispatch creates a Task A (teachback) + Task B (primary work) pair. Task B has `blockedBy=[A]`. Lead-completion of Task A auto-unblocks Task B in the task graph; the lead pairs the status flip with a wake-signal SendMessage so the idle teammate (on `intentional_wait{reason=awaiting_lead_completion}`) wakes to claim B. The platform does not push a wake on blocker resolution — `blockedBy` is computed at TaskList query time, so the wake-signal SendMessage is required.
+Every specialist dispatch creates a Task A (teachback) + Task B (primary work) pair. Task B has `blockedBy=[A]`. Lead-completion of Task A auto-unblocks Task B in the task graph; the team-lead pairs the status flip with a wake-signal SendMessage so the idle teammate (on `intentional_wait{reason=awaiting_lead_completion}`) wakes to claim B. The platform does not push a wake on blocker resolution — `blockedBy` is computed at TaskList query time, so the wake-signal SendMessage is required.
 
 ### Blocking Relationships
 
@@ -1671,7 +1671,7 @@ When Claude Code Agent Teams reaches stable release, it could serve as an altern
 | **Output: handoff** | `SendMessage` (type: `"message"`) from teammate to lead |
 | **Output: commits** | Teammate commits directly to the feature branch |
 | **Output: status** | `TaskUpdate` via shared task list (`TaskCreate`/`TaskUpdate`/`TaskList`/`TaskGet`) |
-| **Delivery mechanism** | Asynchronous — teammates operate independently; lead receives messages and task updates automatically |
+| **Delivery mechanism** | Asynchronous — teammates operate independently; team-lead receives messages and task updates automatically |
 
 **Key Agent Teams tools**:
 
@@ -1686,7 +1686,7 @@ When Claude Code Agent Teams reaches stable release, it could serve as an altern
 
 **Architectural notes**:
 
-- Teammates load CLAUDE.md, MCP servers, and skills automatically but do **not** inherit the lead's conversation history — they receive only the spawn prompt (scope contract + feature context).
+- Teammates load CLAUDE.md, MCP servers, and skills automatically but do **not** inherit the team-lead's conversation history — they receive only the spawn prompt (scope contract + feature context).
 - No nested teams are allowed. This parallels PACT's 1-level nesting limit but is enforced architecturally by Agent Teams rather than by convention.
 - Agent Teams supports peer-to-peer messaging between teammates (`SendMessage` type: `"message"` with `recipient`), which goes beyond PACT's current hub-and-spoke model. Scoped orchestration would use this for sibling scope coordination during the CONSOLIDATE phase.
 
@@ -1913,7 +1913,7 @@ The auditor uses signal-based completion rather than standard HANDOFF:
 1. Task is created with `metadata: {"completion_type": "signal"}`
 2. Auditor stores final signal as `metadata.audit_summary` via `TaskUpdate`
 3. Auditor marks task completed
-4. Completion gate accepts `audit_summary` as the completion artifact (the `audit_summary` field in task metadata; no hook validates it; the lead verifies presence directly via `TaskGet`).
+4. Completion gate accepts `audit_summary` as the completion artifact (the `audit_summary` field in task metadata; no hook validates it; the team-lead verifies presence directly via `TaskGet`).
 
 **audit_summary format**:
 ```json

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -909,7 +909,7 @@ CalibrationRecord:
 | `/PACT:plan-mode` | None (consultant writes consultation HANDOFF, idles) | All consultant tasks; the plan-mode parent task |
 | `/PACT:imPACT` | None (triage agent writes triage HANDOFF, idles) | All triage tasks; the imPACT parent task |
 
-Carve-outs apply across all workflows: signal-tasks (auditor), memory-save (secretary), force-termination (imPACT). See [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority) for the canonical table.
+Carve-outs apply across all workflows: signal-tasks (auditor), memory-save (secretary), force-termination (imPACT). See [pact-completion-authority.md](pact-completion-authority.md) for the full acceptance + rejection recipes and carve-out rationale; [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority) holds the slim lead-side summary.
 
 ---
 

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -406,7 +406,7 @@ When a downstream agent receives an upstream handoff (via `TaskGet`), their firs
 ```
 1. Agent dispatched with upstream task reference (e.g., "Architect task: #5")
 2. Agent reads upstream handoff via `TaskGet(#5)`
-3. Agent sends teachback to lead via `SendMessage`:
+3. Agent sends teachback to team-lead via `SendMessage`:
    "[{sender}→team-lead] Teachback: My understanding is... [key decisions restated]. Proceeding unless corrected."
 4. Agent proceeds with work (non-blocking)
 5. If orchestrator spots misunderstanding, they must `SendMessage` to agent to correct it
@@ -1668,7 +1668,7 @@ When Claude Code Agent Teams reaches stable release, it could serve as an altern
 | **Input: feature_context** | Inherited via CLAUDE.md (auto-loaded by teammates) plus the spawn prompt |
 | **Input: worktree_path** | Worktree working directory (teammate operates in the assigned worktree) |
 | **Input: nesting_depth** | Communicated in the spawn prompt; no nested teams allowed (enforced by Agent Teams) |
-| **Output: handoff** | `SendMessage` (type: `"message"`) from teammate to lead |
+| **Output: handoff** | `SendMessage` (type: `"message"`) from teammate to team-lead |
 | **Output: commits** | Teammate commits directly to the feature branch |
 | **Output: status** | `TaskUpdate` via shared task list (`TaskCreate`/`TaskUpdate`/`TaskList`/`TaskGet`) |
 | **Delivery mechanism** | Asynchronous — teammates operate independently; team-lead receives messages and task updates automatically |
@@ -1679,7 +1679,7 @@ When Claude Code Agent Teams reaches stable release, it could serve as an altern
 |------|---------|--------------|
 | `TeamCreate` | Create a team (with `team_name`, optional `description`) | One team per scoped orchestration |
 | `Task` (with `team_name`, `name`) | Spawn a teammate into the team | One teammate per sub-scope |
-| `SendMessage` (type: `"message"`) | Direct message from teammate to lead | Handoff delivery, blocker reporting |
+| `SendMessage` (type: `"message"`) | Direct message from teammate to team-lead | Handoff delivery, blocker reporting |
 | `SendMessage` (type: `"shutdown_request"`) | Request teammate graceful exit | Sub-scope completion acknowledgment |
 | `TaskCreate`/`TaskUpdate` | Shared task list management | Status tracking across sub-scopes |
 | `TeamDelete` | Remove team and task directories | Cleanup after scoped orchestration completes |

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -898,6 +898,19 @@ CalibrationRecord:
 | **imPACT** | When blocked or need to iterate | Triage: Redo prior phase? Additional agents needed? |
 | **pause** | PR open, not ready to merge | Consolidate memory, persist state, shut down teammates |
 
+### Lead-vs-Teammate Completion Responsibilities (per workflow)
+
+| Workflow | Teammate completion authority | Lead completion authority |
+|---|---|---|
+| `/PACT:orchestrate` | None (write HANDOFF, idle on `awaiting_lead_completion`) | All teammate-owned phase tasks; the feature task |
+| `/PACT:comPACT` | None for normal specialists; auditor self-completes signal-tasks | All teammate-owned tasks; the parent comPACT task |
+| `/PACT:rePACT` | None (write HANDOFF, idle) | All sub-scope tasks; the parent rePACT task |
+| `/PACT:peer-review` | None (reviewer writes review HANDOFF, idles) | All reviewer tasks; the peer-review parent task |
+| `/PACT:plan-mode` | None (consultant writes consultation HANDOFF, idles) | All consultant tasks; the plan-mode parent task |
+| `/PACT:imPACT` | None (triage agent writes triage HANDOFF, idles) | All triage tasks; the imPACT parent task |
+
+Carve-outs apply across all workflows: signal-tasks (auditor), memory-save (secretary), force-termination (imPACT). See [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority) for the canonical table.
+
 ---
 
 ## plan-mode Protocol
@@ -1102,17 +1115,31 @@ Feature Task (created by orchestrator)
 |-------|------------|----------|-----------|
 | Feature | Orchestrator | Orchestrator | Spans entire workflow |
 | Phase | Orchestrator | Orchestrator | Active during phase |
-| Agent | Orchestrator | Specialist (self-managed) | Specialist claims via `TaskUpdate(status="in_progress")`, completes via `TaskUpdate(status="completed")` |
+| Agent | Orchestrator | Specialist (claim-only); Orchestrator (completion authority) | Specialist claims via `TaskUpdate(status="in_progress")`; orchestrator completes via `TaskUpdate(status="completed")` paired with a wake-signal SendMessage |
 
-Under Agent Teams, specialists self-manage their agent task lifecycle. The orchestrator creates tasks via `TaskCreate` and assigns ownership, but the specialist teammate claims the task (sets `in_progress`) and marks it `completed` upon finishing. This differs from the background task model where the orchestrator managed all task state transitions.
+Under Agent Teams, specialists claim agent tasks (`pending → in_progress`) and store HANDOFFs in `metadata.handoff`, but the orchestrator transitions agent tasks to `completed` after inspecting the HANDOFF. Two narrow carve-outs (signal-tasks; secretary memory-save) self-complete; see [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority).
 
 ### Task States
 
 Tasks progress through: `pending` → `in_progress` → `completed`
 
 - **pending**: Created but not started
-- **in_progress**: Active work underway
-- **completed**: Work finished (success or documented failure)
+- **in_progress**: Active work underway (also covers "done-awaiting-review" — teammate has stored HANDOFF and idles on `awaiting_lead_completion`)
+- **completed**: Work finished (success or documented failure); transition is **lead-only** on teammate-owned tasks
+
+### Status-by-Actor
+
+| Transition | Actor | Conditions |
+|---|---|---|
+| `pending → in_progress` (claim) | Teammate | Owns the task; `blockedBy` is empty |
+| `in_progress → in_progress` (metadata work) | Teammate | Writes `metadata.handoff` / `metadata.teachback_submit` |
+| `in_progress → in_progress` (rejection metadata) | Lead | Writes `metadata.teachback_rejection` / `metadata.handoff_rejection` + sends wake-signal SendMessage |
+| `in_progress → completed` | **LEAD ONLY** on teammate-owned tasks | Pairs with wake-signal SendMessage; carve-outs: signal-tasks, secretary memory-save, imPACT force-term |
+| `pending → completed` (skip) | Lead | Phase-skip with `metadata.skipped = true` |
+
+### Task A + Task B Dispatch Shape
+
+Every specialist dispatch creates a Task A (teachback) + Task B (primary work) pair. Task B has `blockedBy=[A]`. Lead-completion of Task A auto-unblocks Task B in the task graph; the lead pairs the status flip with a wake-signal SendMessage so the idle teammate (on `intentional_wait{reason=awaiting_lead_completion}`) wakes to claim B. The platform does not push a wake on blocker resolution — `blockedBy` is computed at TaskList query time, so the wake-signal SendMessage is required.
 
 ### Blocking Relationships
 

--- a/pact-plugin/protocols/pact-scope-contract.md
+++ b/pact-plugin/protocols/pact-scope-contract.md
@@ -127,7 +127,7 @@ When Claude Code Agent Teams reaches stable release, it could serve as an altern
 | **Input: feature_context** | Inherited via CLAUDE.md (auto-loaded by teammates) plus the spawn prompt |
 | **Input: worktree_path** | Worktree working directory (teammate operates in the assigned worktree) |
 | **Input: nesting_depth** | Communicated in the spawn prompt; no nested teams allowed (enforced by Agent Teams) |
-| **Output: handoff** | `SendMessage` (type: `"message"`) from teammate to lead |
+| **Output: handoff** | `SendMessage` (type: `"message"`) from teammate to team-lead |
 | **Output: commits** | Teammate commits directly to the feature branch |
 | **Output: status** | `TaskUpdate` via shared task list (`TaskCreate`/`TaskUpdate`/`TaskList`/`TaskGet`) |
 | **Delivery mechanism** | Asynchronous — teammates operate independently; team-lead receives messages and task updates automatically |
@@ -138,7 +138,7 @@ When Claude Code Agent Teams reaches stable release, it could serve as an altern
 |------|---------|--------------|
 | `TeamCreate` | Create a team (with `team_name`, optional `description`) | One team per scoped orchestration |
 | `Task` (with `team_name`, `name`) | Spawn a teammate into the team | One teammate per sub-scope |
-| `SendMessage` (type: `"message"`) | Direct message from teammate to lead | Handoff delivery, blocker reporting |
+| `SendMessage` (type: `"message"`) | Direct message from teammate to team-lead | Handoff delivery, blocker reporting |
 | `SendMessage` (type: `"shutdown_request"`) | Request teammate graceful exit | Sub-scope completion acknowledgment |
 | `TaskCreate`/`TaskUpdate` | Shared task list management | Status tracking across sub-scopes |
 | `TeamDelete` | Remove team and task directories | Cleanup after scoped orchestration completes |

--- a/pact-plugin/protocols/pact-scope-contract.md
+++ b/pact-plugin/protocols/pact-scope-contract.md
@@ -130,7 +130,7 @@ When Claude Code Agent Teams reaches stable release, it could serve as an altern
 | **Output: handoff** | `SendMessage` (type: `"message"`) from teammate to lead |
 | **Output: commits** | Teammate commits directly to the feature branch |
 | **Output: status** | `TaskUpdate` via shared task list (`TaskCreate`/`TaskUpdate`/`TaskList`/`TaskGet`) |
-| **Delivery mechanism** | Asynchronous — teammates operate independently; lead receives messages and task updates automatically |
+| **Delivery mechanism** | Asynchronous — teammates operate independently; team-lead receives messages and task updates automatically |
 
 **Key Agent Teams tools**:
 
@@ -145,7 +145,7 @@ When Claude Code Agent Teams reaches stable release, it could serve as an altern
 
 **Architectural notes**:
 
-- Teammates load CLAUDE.md, MCP servers, and skills automatically but do **not** inherit the lead's conversation history — they receive only the spawn prompt (scope contract + feature context).
+- Teammates load CLAUDE.md, MCP servers, and skills automatically but do **not** inherit the team-lead's conversation history — they receive only the spawn prompt (scope contract + feature context).
 - No nested teams are allowed. This parallels PACT's 1-level nesting limit but is enforced architecturally by Agent Teams rather than by convention.
 - Agent Teams supports peer-to-peer messaging between teammates (`SendMessage` type: `"message"` with `recipient`), which goes beyond PACT's current hub-and-spoke model. Scoped orchestration would use this for sibling scope coordination during the CONSOLIDATE phase.
 

--- a/pact-plugin/protocols/pact-task-hierarchy.md
+++ b/pact-plugin/protocols/pact-task-hierarchy.md
@@ -19,17 +19,31 @@ Feature Task (created by orchestrator)
 |-------|------------|----------|-----------|
 | Feature | Orchestrator | Orchestrator | Spans entire workflow |
 | Phase | Orchestrator | Orchestrator | Active during phase |
-| Agent | Orchestrator | Specialist (self-managed) | Specialist claims via `TaskUpdate(status="in_progress")`, completes via `TaskUpdate(status="completed")` |
+| Agent | Orchestrator | Specialist (claim-only); Orchestrator (completion authority) | Specialist claims via `TaskUpdate(status="in_progress")`; orchestrator completes via `TaskUpdate(status="completed")` paired with a wake-signal SendMessage |
 
-Under Agent Teams, specialists self-manage their agent task lifecycle. The orchestrator creates tasks via `TaskCreate` and assigns ownership, but the specialist teammate claims the task (sets `in_progress`) and marks it `completed` upon finishing. This differs from the background task model where the orchestrator managed all task state transitions.
+Under Agent Teams, specialists claim agent tasks (`pending → in_progress`) and store HANDOFFs in `metadata.handoff`, but the orchestrator transitions agent tasks to `completed` after inspecting the HANDOFF. Two narrow carve-outs (signal-tasks; secretary memory-save) self-complete; see [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority).
 
 ### Task States
 
 Tasks progress through: `pending` → `in_progress` → `completed`
 
 - **pending**: Created but not started
-- **in_progress**: Active work underway
-- **completed**: Work finished (success or documented failure)
+- **in_progress**: Active work underway (also covers "done-awaiting-review" — teammate has stored HANDOFF and idles on `awaiting_lead_completion`)
+- **completed**: Work finished (success or documented failure); transition is **lead-only** on teammate-owned tasks
+
+### Status-by-Actor
+
+| Transition | Actor | Conditions |
+|---|---|---|
+| `pending → in_progress` (claim) | Teammate | Owns the task; `blockedBy` is empty |
+| `in_progress → in_progress` (metadata work) | Teammate | Writes `metadata.handoff` / `metadata.teachback_submit` |
+| `in_progress → in_progress` (rejection metadata) | Lead | Writes `metadata.teachback_rejection` / `metadata.handoff_rejection` + sends wake-signal SendMessage |
+| `in_progress → completed` | **LEAD ONLY** on teammate-owned tasks | Pairs with wake-signal SendMessage; carve-outs: signal-tasks, secretary memory-save, imPACT force-term |
+| `pending → completed` (skip) | Lead | Phase-skip with `metadata.skipped = true` |
+
+### Task A + Task B Dispatch Shape
+
+Every specialist dispatch creates a Task A (teachback) + Task B (primary work) pair. Task B has `blockedBy=[A]`. Lead-completion of Task A auto-unblocks Task B in the task graph; the lead pairs the status flip with a wake-signal SendMessage so the idle teammate (on `intentional_wait{reason=awaiting_lead_completion}`) wakes to claim B. The platform does not push a wake on blocker resolution — `blockedBy` is computed at TaskList query time, so the wake-signal SendMessage is required.
 
 ### Blocking Relationships
 

--- a/pact-plugin/protocols/pact-task-hierarchy.md
+++ b/pact-plugin/protocols/pact-task-hierarchy.md
@@ -29,7 +29,7 @@ Tasks progress through: `pending` → `in_progress` → `completed`
 
 - **pending**: Created but not started
 - **in_progress**: Active work underway (also covers "done-awaiting-review" — teammate has stored HANDOFF and idles on `awaiting_lead_completion`)
-- **completed**: Work finished (success or documented failure); transition is **lead-only** on teammate-owned tasks
+- **completed**: Work finished (success or documented failure); transition is **team-lead-only** on teammate-owned tasks
 
 ### Status-by-Actor
 
@@ -43,7 +43,7 @@ Tasks progress through: `pending` → `in_progress` → `completed`
 
 ### Task A + Task B Dispatch Shape
 
-Every specialist dispatch creates a Task A (teachback) + Task B (primary work) pair. Task B has `blockedBy=[A]`. Lead-completion of Task A auto-unblocks Task B in the task graph; the lead pairs the status flip with a wake-signal SendMessage so the idle teammate (on `intentional_wait{reason=awaiting_lead_completion}`) wakes to claim B. The platform does not push a wake on blocker resolution — `blockedBy` is computed at TaskList query time, so the wake-signal SendMessage is required.
+Every specialist dispatch creates a Task A (teachback) + Task B (primary work) pair. Task B has `blockedBy=[A]`. Lead-completion of Task A auto-unblocks Task B in the task graph; the team-lead pairs the status flip with a wake-signal SendMessage so the idle teammate (on `intentional_wait{reason=awaiting_lead_completion}`) wakes to claim B. The platform does not push a wake on blocker resolution — `blockedBy` is computed at TaskList query time, so the wake-signal SendMessage is required.
 
 ### Blocking Relationships
 

--- a/pact-plugin/protocols/pact-variety.md
+++ b/pact-plugin/protocols/pact-variety.md
@@ -91,7 +91,7 @@ Derive agent state from progress signals (see agent-teams skill, Progress Signal
 > **Cybernetic basis**: Bateson's deutero-learning — the system learns to learn by comparing
 > predicted difficulty against actual outcomes, creating a feedback loop for scoring accuracy.
 
-At workflow completion (orchestrate wrap-up or comPACT completion), the secretary gathers calibration metrics during HANDOFF processing, asks the lead for a brief difficulty assessment, and saves the calibration record to pact-memory. Records feed back into Learning II pattern matching.
+At workflow completion (orchestrate wrap-up or comPACT completion), the secretary gathers calibration metrics during HANDOFF processing, asks the team-lead for a brief difficulty assessment, and saves the calibration record to pact-memory. Records feed back into Learning II pattern matching.
 
 **Schema**:
 
@@ -116,7 +116,7 @@ CalibrationRecord:
 **Post-cycle comparison**: During HANDOFF processing, the secretary:
 1. Reads feature task metadata for initial_variety_score
 2. Scans TaskList for blocker count and phase rerun count
-3. Asks the lead for a brief difficulty assessment (higher, lower, or about the same)
+3. Asks the team-lead for a brief difficulty assessment (higher, lower, or about the same)
 4. Computes the full CalibrationRecord and saves to pact-memory
 5. If drift exceeds 2 in any dimension, notes as significant for future Learning II queries
 

--- a/pact-plugin/protocols/pact-workflows.md
+++ b/pact-plugin/protocols/pact-workflows.md
@@ -9,6 +9,19 @@
 | **imPACT** | When blocked or need to iterate | Triage: Redo prior phase? Additional agents needed? |
 | **pause** | PR open, not ready to merge | Consolidate memory, persist state, shut down teammates |
 
+### Lead-vs-Teammate Completion Responsibilities (per workflow)
+
+| Workflow | Teammate completion authority | Lead completion authority |
+|---|---|---|
+| `/PACT:orchestrate` | None (write HANDOFF, idle on `awaiting_lead_completion`) | All teammate-owned phase tasks; the feature task |
+| `/PACT:comPACT` | None for normal specialists; auditor self-completes signal-tasks | All teammate-owned tasks; the parent comPACT task |
+| `/PACT:rePACT` | None (write HANDOFF, idle) | All sub-scope tasks; the parent rePACT task |
+| `/PACT:peer-review` | None (reviewer writes review HANDOFF, idles) | All reviewer tasks; the peer-review parent task |
+| `/PACT:plan-mode` | None (consultant writes consultation HANDOFF, idles) | All consultant tasks; the plan-mode parent task |
+| `/PACT:imPACT` | None (triage agent writes triage HANDOFF, idles) | All triage tasks; the imPACT parent task |
+
+Carve-outs apply across all workflows: signal-tasks (auditor), memory-save (secretary), force-termination (imPACT). See [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority) for the canonical table.
+
 ---
 
 ## plan-mode Protocol

--- a/pact-plugin/protocols/pact-workflows.md
+++ b/pact-plugin/protocols/pact-workflows.md
@@ -20,7 +20,7 @@
 | `/PACT:plan-mode` | None (consultant writes consultation HANDOFF, idles) | All consultant tasks; the plan-mode parent task |
 | `/PACT:imPACT` | None (triage agent writes triage HANDOFF, idles) | All triage tasks; the imPACT parent task |
 
-Carve-outs apply across all workflows: signal-tasks (auditor), memory-save (secretary), force-termination (imPACT). See [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority) for the canonical table.
+Carve-outs apply across all workflows: signal-tasks (auditor), memory-save (secretary), force-termination (imPACT). See [pact-completion-authority.md](pact-completion-authority.md) for the full acceptance + rejection recipes and carve-out rationale; [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority) holds the slim lead-side summary.
 
 ---
 

--- a/pact-plugin/protocols/pact-workflows.md
+++ b/pact-plugin/protocols/pact-workflows.md
@@ -20,7 +20,7 @@
 | `/PACT:plan-mode` | None (consultant writes consultation HANDOFF, idles) | All consultant tasks; the plan-mode parent task |
 | `/PACT:imPACT` | None (triage agent writes triage HANDOFF, idles) | All triage tasks; the imPACT parent task |
 
-Carve-outs apply across all workflows: signal-tasks (auditor), memory-save (secretary), force-termination (imPACT). See [pact-completion-authority.md](pact-completion-authority.md) for the full acceptance + rejection recipes and carve-out rationale; [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority) holds the slim lead-side summary.
+Carve-outs apply across all workflows: signal-tasks (auditor), memory-save (secretary), force-termination (imPACT). See [pact-completion-authority.md](pact-completion-authority.md) for the full acceptance + rejection recipes and carve-out rationale; [orchestration §Completion Authority](../skills/orchestration/SKILL.md#completion-authority) holds the slim team-lead-side summary.
 
 ---
 

--- a/pact-plugin/skills/orchestration/SKILL.md
+++ b/pact-plugin/skills/orchestration/SKILL.md
@@ -478,136 +478,13 @@ inspection and session review. Your responsibilities:
 
 ### Completion Authority
 
-You — the lead — are the **only** actor who marks teammate-owned tasks `completed`. Teammates write HANDOFFs to `metadata.handoff`, idle on `intentional_wait{reason=awaiting_lead_completion}`, and wait for your acceptance. The `TaskUpdate(status="completed")` flip is the load-bearing approval action; the wake-signal SendMessage is the load-bearing wake.
+You — the lead — are the **only** actor who marks teammate-owned tasks `completed`. Acceptance is a **two-call atomic pair (BOTH required)**: `TaskUpdate(taskId, status="completed")` + paired wake-signal SendMessage. Rejection is dual-channel: write `metadata.{teachback,handoff}_rejection` `{reason, corrections, since, revision_number}` + paired wake-signal SendMessage. Skipping the SendMessage strands the idle teammate — `blockedBy` is pull-only at the platform level, so the wake is load-bearing. 3+ rejection cycles on the same task is an imPACT META-BLOCK signal. Carve-outs (rare, narrow): signal-tasks (`metadata.completion_type == "signal"` AND `metadata.type ∈ {"blocker", "algedonic"}`); secretary memory-save (owner in `SELF_COMPLETE_EXEMPT_AGENTS`); imPACT force-termination (`metadata.terminated == true`). Canonical predicate: `is_self_complete_exempt(task)` in `shared/intentional_wait.py`.
 
-**Acceptance recipe — two-call atomic pair (BOTH required)**:
-
-```
-TaskUpdate(taskId, status="completed")
-SendMessage(
-    to="<teammate>",
-    message="[lead→<teammate>] Task #<id> accepted. Work complete.",
-    summary="Task accepted"
-)
-```
-
-Both calls are **required**. The `TaskUpdate` flips status (which auto-unblocks any tasks with `blockedBy=[<id>]`); the `SendMessage` wakes the idle teammate so they can claim the next task. The platform does NOT push a wake on blocker resolution — `blockedBy` is computed at TaskList query time. An idle teammate cannot self-wake to re-poll. Skipping the SendMessage strands the teammate idle until something else (peer message, your next dispatch) wakes them.
-
-**Carve-outs** (rare, narrow):
-
-| Carve-out | Trigger | Rule |
-|---|---|---|
-| Signal-tasks | `metadata.completion_type == "signal"` AND `metadata.type ∈ {"blocker", "algedonic"}` | Auditor + algedonic-emitting agents self-complete; the task IS the signal, no HANDOFF to judge. |
-| Memory-save | Owner is `secretary` (or `pact-secretary`) | Secretary self-completes memory-save tasks; lead has no acceptance criteria for memory bookkeeping. |
-| imPACT termination | `metadata.terminated == true` | You force-complete an unrecoverable agent's task via `TaskStop` + `TaskUpdate(status="completed", metadata={"terminated": true, "reason": "..."})`. See [imPACT.md](../../commands/imPACT.md). |
-
-The canonical predicate is `is_self_complete_exempt(task)` in `shared/intentional_wait.py` — pure function for your TaskGet inspection and audit tooling. No hook reads it.
-
-**TaskGet metadata-blindness reminder**: `TaskGet` does NOT surface `metadata.handoff`. Read directly:
-
-```
-cat ~/.claude/tasks/{team_name}/{taskId}.json | jq .metadata.handoff
-```
-
-Inspect the HANDOFF before flipping status. If `metadata.handoff` is missing or empty, do NOT mark the task completed — request the teammate write the HANDOFF first.
+**TaskGet metadata-blindness reminder**: `TaskGet` does NOT surface `metadata.handoff`. Read directly via `cat ~/.claude/tasks/{team_name}/{taskId}.json | jq .metadata.handoff`; do NOT mark completed if missing or empty. See [pact-completion-authority.md](../../protocols/pact-completion-authority.md) for the full recipes and recovery semantics.
 
 ### Teachback Review
 
-The Task A + Task B dispatch shape gates implementation work behind teachback approval. When dispatching, you create:
-
-- **Task A**: `subject="<role>: TEACHBACK for <feature>"`, owner = teammate. Description states: "Submit teachback via `metadata.teachback_submit`. SET `intentional_wait{reason=awaiting_lead_completion}`. Do NOT begin Task B."
-- **Task B**: `subject="<role>: <primary mission>"`, owner = teammate, `blockedBy=[<Task A id>]`.
-
-Both tasks are created at dispatch time; the teammate receives both in their initial TaskList view, with B greyed out by `blockedBy`.
-
-**Reviewing the teachback**:
-
-Read `metadata.teachback_submit` directly:
-
-```
-cat ~/.claude/tasks/{team_name}/{A_id}.json | jq .metadata.teachback_submit
-```
-
-Compare against the dispatched task description. Apply the validation discipline from [Validating Incoming Teachbacks](#validating-incoming-teachbacks) below — check for both misstatements AND omissions.
-
-**Approving the teachback — two-call atomic pair (BOTH required)**:
-
-```
-TaskUpdate(A_id, metadata={"teachback_resolution": {
-    "conditions_met": true,
-    "resolution_comment": "<optional one-line rationale>"
-}})
-TaskUpdate(A_id, status="completed")
-SendMessage(
-    to="<teammate>",
-    message=(
-        "[lead→<teammate>] Teachback accepted on Task #<A_id>. "
-        "Task B (#<B_id>) is now claimable."
-    ),
-    summary="Teachback accepted; Task B claimable"
-)
-```
-
-The `teachback_resolution` write is optional but recommended for audit. The status flip is the load-bearing approval action; the SendMessage is the load-bearing wake.
-
-**Rejecting the teachback** — see [Rejection Flow](#rejection-flow) below.
-
-> ⚠️ DO NOT mark Task B `completed` and DO NOT mark Task B `pending`. Task B stays `pending` (its initial state) until the teammate claims it (`status=in_progress`) after wake. Your acceptance affects Task A only; Task B's lifecycle is the teammate's to drive (claim → work → submit HANDOFF → idle for your HANDOFF acceptance).
-
-### Rejection Flow
-
-Teachback or HANDOFF inadequate? Reject with **dual-channel delivery** (metadata + SendMessage). Same shape for both rejection types:
-
-**Teachback rejection**:
-
-```
-TaskUpdate(A_id, metadata={"teachback_rejection": {
-    "reason": "<one-line summary>",
-    "corrections": ["<correction 1>", "<correction 2>", ...],
-    "since": "<canonical_since() output>",
-    "revision_number": 1
-}})
-SendMessage(
-    to="<teammate>",
-    message=(
-        "[lead→<teammate>] Teachback rejected on Task #<A_id>. "
-        "See metadata.teachback_rejection. Revise and re-submit. "
-        "Task A remains in_progress."
-    ),
-    summary="Teachback rejected; revise"
-)
-```
-
-**HANDOFF rejection** (Task B):
-
-```
-TaskUpdate(B_id, metadata={"handoff_rejection": {
-    "reason": "...",
-    "corrections": [...],
-    "since": "<canonical_since() output>",
-    "revision_number": 1
-}})
-SendMessage(
-    to="<teammate>",
-    message=(
-        "[lead→<teammate>] HANDOFF rejected on Task #<B_id>. "
-        "See metadata.handoff_rejection. Revise."
-    ),
-    summary="HANDOFF rejected; revise"
-)
-```
-
-**Why dual-channel**: metadata gives the durable revision spec the teammate reads on wake; SendMessage gives the wake itself. Single-channel via metadata only fails because the idle teammate can't self-wake to read it. Single-channel via SendMessage only loses durability — the corrections need to survive teammate compaction or agent restart.
-
-**Recovery flow on rejection**:
-
-1. Lead writes rejection metadata + sends wake-signal.
-2. Teammate wakes, CLEARs `intentional_wait`, reads rejection metadata.
-3. Teammate revises (`metadata.teachback_submit` for A, or revises deliverable + `metadata.handoff` for B).
-4. Teammate re-SETs `intentional_wait` with fresh `since`, increments `metadata.revision_number`, SendMessage notifies lead "revised."
-5. Lead reviews; either accepts (per [Completion Authority](#completion-authority)) or rejects again (revision_number = N+1).
-
-> **Cycle limit**: 3+ rejection cycles on the same task is an imPACT META-BLOCK signal. See [imPACT.md](../../commands/imPACT.md).
+Each specialist dispatch creates a Task A (teachback) + Task B (primary work) pair with `blockedBy=[A]`. The teammate claims A, writes `metadata.teachback_submit` (4 fields: understanding / most_likely_wrong / least_confident_item / first_action), idles on `awaiting_lead_completion`. You read the payload (`cat ~/.claude/tasks/{team}/{A_id}.json | jq .metadata.teachback_submit`), apply the validation discipline from [Validating Incoming Teachbacks](#validating-incoming-teachbacks) below, then accept via the two-call atomic pair from §Completion Authority above. Acceptance auto-unblocks Task B; do NOT mark Task B `completed` or `pending` yourself — the teammate claims it on wake. See [pact-completion-authority.md §Teachback Review](../../protocols/pact-completion-authority.md#teachback-review) for the complete approval recipe.
 
 ### Recommended Agent Prompting Structure
 

--- a/pact-plugin/skills/orchestration/SKILL.md
+++ b/pact-plugin/skills/orchestration/SKILL.md
@@ -474,6 +474,140 @@ inspection and session review. Your responsibilities:
   the wait has hung and you should investigate and drive resolution.
 - **Don't SET the `intentional_wait` task metadata on your own lead task.**
   TeammateIdle hooks filter by task owner; they don't inspect lead state.
+- **`awaiting_lead_completion` is the most common wait you'll see** — set by every teammate after they store HANDOFF or teachback metadata. Resolution = your two-call acceptance pair (or rejection dual-channel pair). See [Completion Authority](#completion-authority) below.
+
+### Completion Authority
+
+You — the lead — are the **only** actor who marks teammate-owned tasks `completed`. Teammates write HANDOFFs to `metadata.handoff`, idle on `intentional_wait{reason=awaiting_lead_completion}`, and wait for your acceptance. The `TaskUpdate(status="completed")` flip is the load-bearing approval action; the wake-signal SendMessage is the load-bearing wake.
+
+**Acceptance recipe — two-call atomic pair (BOTH required)**:
+
+```
+TaskUpdate(taskId, status="completed")
+SendMessage(
+    to="<teammate>",
+    message="[lead→<teammate>] Task #<id> accepted. Work complete.",
+    summary="Task accepted"
+)
+```
+
+Both calls are **required**. The `TaskUpdate` flips status (which auto-unblocks any tasks with `blockedBy=[<id>]`); the `SendMessage` wakes the idle teammate so they can claim the next task. The platform does NOT push a wake on blocker resolution — `blockedBy` is computed at TaskList query time. An idle teammate cannot self-wake to re-poll. Skipping the SendMessage strands the teammate idle until something else (peer message, your next dispatch) wakes them.
+
+**Carve-outs** (rare, narrow):
+
+| Carve-out | Trigger | Rule |
+|---|---|---|
+| Signal-tasks | `metadata.completion_type == "signal"` AND `metadata.type ∈ {"blocker", "algedonic"}` | Auditor + algedonic-emitting agents self-complete; the task IS the signal, no HANDOFF to judge. |
+| Memory-save | Owner is `secretary` (or `pact-secretary`) | Secretary self-completes memory-save tasks; lead has no acceptance criteria for memory bookkeeping. |
+| imPACT termination | `metadata.terminated == true` | You force-complete an unrecoverable agent's task via `TaskStop` + `TaskUpdate(status="completed", metadata={"terminated": true, "reason": "..."})`. See [imPACT.md](../../commands/imPACT.md). |
+
+The canonical predicate is `is_self_complete_exempt(task)` in `shared/intentional_wait.py` — pure function for your TaskGet inspection and audit tooling. No hook reads it.
+
+**TaskGet metadata-blindness reminder**: `TaskGet` does NOT surface `metadata.handoff`. Read directly:
+
+```
+cat ~/.claude/tasks/{team_name}/{taskId}.json | jq .metadata.handoff
+```
+
+Inspect the HANDOFF before flipping status. If `metadata.handoff` is missing or empty, do NOT mark the task completed — request the teammate write the HANDOFF first.
+
+### Teachback Review
+
+The Task A + Task B dispatch shape gates implementation work behind teachback approval. When dispatching, you create:
+
+- **Task A**: `subject="<role>: TEACHBACK for <feature>"`, owner = teammate. Description states: "Submit teachback via `metadata.teachback_submit`. SET `intentional_wait{reason=awaiting_lead_completion}`. Do NOT begin Task B."
+- **Task B**: `subject="<role>: <primary mission>"`, owner = teammate, `blockedBy=[<Task A id>]`.
+
+Both tasks are created at dispatch time; the teammate receives both in their initial TaskList view, with B greyed out by `blockedBy`.
+
+**Reviewing the teachback**:
+
+Read `metadata.teachback_submit` directly:
+
+```
+cat ~/.claude/tasks/{team_name}/{A_id}.json | jq .metadata.teachback_submit
+```
+
+Compare against the dispatched task description. Apply the validation discipline from [Validating Incoming Teachbacks](#validating-incoming-teachbacks) below — check for both misstatements AND omissions.
+
+**Approving the teachback — two-call atomic pair (BOTH required)**:
+
+```
+TaskUpdate(A_id, metadata={"teachback_resolution": {
+    "conditions_met": true,
+    "resolution_comment": "<optional one-line rationale>"
+}})
+TaskUpdate(A_id, status="completed")
+SendMessage(
+    to="<teammate>",
+    message=(
+        "[lead→<teammate>] Teachback accepted on Task #<A_id>. "
+        "Task B (#<B_id>) is now claimable."
+    ),
+    summary="Teachback accepted; Task B claimable"
+)
+```
+
+The `teachback_resolution` write is optional but recommended for audit. The status flip is the load-bearing approval action; the SendMessage is the load-bearing wake.
+
+**Rejecting the teachback** — see [Rejection Flow](#rejection-flow) below.
+
+> ⚠️ DO NOT mark Task B `completed` and DO NOT mark Task B `pending`. Task B stays `pending` (its initial state) until the teammate claims it (`status=in_progress`) after wake. Your acceptance affects Task A only; Task B's lifecycle is the teammate's to drive (claim → work → submit HANDOFF → idle for your HANDOFF acceptance).
+
+### Rejection Flow
+
+Teachback or HANDOFF inadequate? Reject with **dual-channel delivery** (metadata + SendMessage). Same shape for both rejection types:
+
+**Teachback rejection**:
+
+```
+TaskUpdate(A_id, metadata={"teachback_rejection": {
+    "reason": "<one-line summary>",
+    "corrections": ["<correction 1>", "<correction 2>", ...],
+    "since": "<canonical_since() output>",
+    "revision_number": 1
+}})
+SendMessage(
+    to="<teammate>",
+    message=(
+        "[lead→<teammate>] Teachback rejected on Task #<A_id>. "
+        "See metadata.teachback_rejection. Revise and re-submit. "
+        "Task A remains in_progress."
+    ),
+    summary="Teachback rejected; revise"
+)
+```
+
+**HANDOFF rejection** (Task B):
+
+```
+TaskUpdate(B_id, metadata={"handoff_rejection": {
+    "reason": "...",
+    "corrections": [...],
+    "since": "<canonical_since() output>",
+    "revision_number": 1
+}})
+SendMessage(
+    to="<teammate>",
+    message=(
+        "[lead→<teammate>] HANDOFF rejected on Task #<B_id>. "
+        "See metadata.handoff_rejection. Revise."
+    ),
+    summary="HANDOFF rejected; revise"
+)
+```
+
+**Why dual-channel**: metadata gives the durable revision spec the teammate reads on wake; SendMessage gives the wake itself. Single-channel via metadata only fails because the idle teammate can't self-wake to read it. Single-channel via SendMessage only loses durability — the corrections need to survive teammate compaction or agent restart.
+
+**Recovery flow on rejection**:
+
+1. Lead writes rejection metadata + sends wake-signal.
+2. Teammate wakes, CLEARs `intentional_wait`, reads rejection metadata.
+3. Teammate revises (`metadata.teachback_submit` for A, or revises deliverable + `metadata.handoff` for B).
+4. Teammate re-SETs `intentional_wait` with fresh `since`, increments `metadata.revision_number`, SendMessage notifies lead "revised."
+5. Lead reviews; either accepts (per [Completion Authority](#completion-authority)) or rejects again (revision_number = N+1).
+
+> **Cycle limit**: 3+ rejection cycles on the same task is an imPACT META-BLOCK signal. See [imPACT.md](../../commands/imPACT.md).
 
 ### Recommended Agent Prompting Structure
 
@@ -505,6 +639,8 @@ A list of things that include the following:
 
 When an agent sends a teachback, **compare it against the task as you dispatched it — check for both misstatements AND omissions of the objective, constraints, or success criteria**. If you spot a misunderstanding, reply with a correction via `SendMessage` before any other action — the agent is already working, so the correction window is short. Prevents **misunderstanding disguised as agreement** from going undetected until TEST phase.
 
+Once you've reviewed and decided, follow the [Teachback Review](#teachback-review) acceptance recipe. Do NOT mark Task A `completed` without the paired wake-signal SendMessage — see [Completion Authority](#completion-authority) for the two-call atomic pair.
+
 #### Expected Agent HANDOFF Format
 
 Every agent delivers a structured HANDOFF stored in task metadata. Read via `TaskGet(taskId).metadata.handoff` when needed:
@@ -526,7 +662,7 @@ Items 1-2 and 4-6 are required. Item 3 (reasoning chain) is recommended — incl
 
 If the `validate_handoff` hook warns about a missing HANDOFF, extract available context from the agent's response and update the Task accordingly.
 
-On HANDOFF receipt, verify task completion via `TaskList` before dispatching downstream phases — mechanical gates catch missed completions later, but `TaskList` is the gate-truth at receipt time. If the task is not marked completed, ask the agent to update task status via `SendMessage` before dispatching downstream phases.
+On HANDOFF receipt, inspect `metadata.handoff` (raw JSON read; `TaskGet` does not surface metadata) and follow the [Completion Authority](#completion-authority) two-call atomic pair to flip the task to `completed` and wake the teammate. Do NOT dispatch downstream phases against a teammate-owned task that you have not yet marked completed — the teammate is idle awaiting your acceptance, and the task graph has not unblocked dependents.
 
 ### How to Delegate
 

--- a/pact-plugin/skills/orchestration/SKILL.md
+++ b/pact-plugin/skills/orchestration/SKILL.md
@@ -516,7 +516,7 @@ Use this structure in the `prompt` field to ensure agents have adequate context:
 1. [Step 1]
 2. [Step 2 - explicit skill usage if needed, e.g., "Use pact-security-patterns"]
 3. [Step 3]
-4. **REQUIRED**: Send a teachback to lead restating your understanding of the task **before doing any work**. If upstream task references are provided, read them via `TaskGet` first. (See agent-teams skill for format)
+4. **REQUIRED**: Send a teachback to team-lead restating your understanding of the task **before doing any work**. If upstream task references are provided, read them via `TaskGet` first. (See agent-teams skill for format)
 
 **GUIDELINES**
 A list of things that include the following:

--- a/pact-plugin/skills/orchestration/SKILL.md
+++ b/pact-plugin/skills/orchestration/SKILL.md
@@ -478,13 +478,27 @@ inspection and session review. Your responsibilities:
 
 ### Completion Authority
 
-You — the lead — are the **only** actor who marks teammate-owned tasks `completed`. Acceptance is a **two-call atomic pair (BOTH required)**: `TaskUpdate(taskId, status="completed")` + paired wake-signal SendMessage. Rejection is dual-channel: write `metadata.{teachback,handoff}_rejection` `{reason, corrections, since, revision_number}` + paired wake-signal SendMessage. Skipping the SendMessage strands the idle teammate — `blockedBy` is pull-only at the platform level, so the wake is load-bearing. 3+ rejection cycles on the same task is an imPACT META-BLOCK signal. Carve-outs (rare, narrow): signal-tasks (`metadata.completion_type == "signal"` AND `metadata.type ∈ {"blocker", "algedonic"}`); secretary memory-save (owner in `SELF_COMPLETE_EXEMPT_AGENTS`); imPACT force-termination (`metadata.terminated == true`). Canonical predicate: `is_self_complete_exempt(task)` in `shared/intentional_wait.py`.
+You — the lead — are the **only** actor who marks teammate-owned tasks `completed`. `blockedBy` is pull-only at the platform level — idle teammates cannot self-wake to re-poll, so the wake-signal SendMessage paired with each metadata/status write is load-bearing.
 
-**TaskGet metadata-blindness reminder**: `TaskGet` does NOT surface `metadata.handoff`. Read directly via `cat ~/.claude/tasks/{team_name}/{taskId}.json | jq .metadata.handoff`; do NOT mark completed if missing or empty. See [pact-completion-authority.md](../../protocols/pact-completion-authority.md) for the full recipes and recovery semantics.
+**Acceptance — two-call atomic pair (BOTH required)**
+1. `TaskUpdate(taskId, status="completed")`
+2. `SendMessage(to=<teammate>, "[lead→<teammate>] Task #<id> accepted...", summary="Task accepted")`
+
+Both calls are required. Skipping the SendMessage leaves the teammate idle on `awaiting_lead_completion`; `blockedBy` resolution is invisible without the wake.
+
+**Rejection — two-call atomic pair (BOTH required)**
+1. `TaskUpdate(taskId, metadata={"teachback_rejection": {...}})` OR `metadata={"handoff_rejection": {...}}` — payload `{reason, corrections, since, revision_number}`
+2. `SendMessage(to=<teammate>, "[lead→<teammate>] Rejected on Task #<id>. See metadata...; revise.")`
+
+Both calls are required. Skipping the SendMessage leaves the teammate idle on stale `awaiting_lead_completion`, never seeing the corrections — symmetric failure to skipping wake on acceptance. 3+ rejection cycles on the same task is an imPACT META-BLOCK signal.
+
+Carve-outs (rare, narrow): signal-tasks (`metadata.completion_type == "signal"` AND `metadata.type ∈ {"blocker", "algedonic"}`); secretary memory-save (owner in `SELF_COMPLETE_EXEMPT_AGENTS`); imPACT force-termination (`metadata.terminated == true`). Canonical predicate: `is_self_complete_exempt(task)` in `shared/intentional_wait.py`.
+
+**TaskGet metadata-blindness reminder**: `TaskGet` does NOT surface `metadata.handoff`. Read directly via `cat ~/.claude/tasks/{team_name}/{taskId}.json | jq .metadata.handoff`; do NOT mark completed if missing or empty. See [pact-completion-authority.md](../../protocols/pact-completion-authority.md) for full recipes (teachback review flow, rejection corrections schema, carve-out rationale).
 
 ### Teachback Review
 
-Each specialist dispatch creates a Task A (teachback) + Task B (primary work) pair with `blockedBy=[A]`. The teammate claims A, writes `metadata.teachback_submit` (4 fields: understanding / most_likely_wrong / least_confident_item / first_action), idles on `awaiting_lead_completion`. You read the payload (`cat ~/.claude/tasks/{team}/{A_id}.json | jq .metadata.teachback_submit`), apply the validation discipline from [Validating Incoming Teachbacks](#validating-incoming-teachbacks) below, then accept via the two-call atomic pair from §Completion Authority above. Acceptance auto-unblocks Task B; do NOT mark Task B `completed` or `pending` yourself — the teammate claims it on wake. See [pact-completion-authority.md §Teachback Review](../../protocols/pact-completion-authority.md#teachback-review) for the complete approval recipe.
+Each specialist dispatch creates a Task A (teachback) + Task B (primary work) pair with `blockedBy=[A]`. Teammate claims A, writes `metadata.teachback_submit` (4 fields per [pact-teachback](../pact-teachback/SKILL.md)), idles on `awaiting_lead_completion`. Read the payload via raw JSON (TaskGet is metadata-blind), apply [Validating Incoming Teachbacks](#validating-incoming-teachbacks) below, then accept via the Acceptance two-call atomic pair above; acceptance auto-unblocks Task B. Do NOT mark Task B `completed` or `pending` yourself — the teammate claims on wake. See [pact-completion-authority.md §Teachback Review](../../protocols/pact-completion-authority.md#teachback-review) for the full review flow.
 
 ### Recommended Agent Prompting Structure
 
@@ -514,32 +528,11 @@ A list of things that include the following:
 
 #### Validating Incoming Teachbacks
 
-When an agent sends a teachback, **compare it against the task as you dispatched it — check for both misstatements AND omissions of the objective, constraints, or success criteria**. If you spot a misunderstanding, reply with a correction via `SendMessage` before any other action — the agent is already working, so the correction window is short. Prevents **misunderstanding disguised as agreement** from going undetected until TEST phase.
-
-Once you've reviewed and decided, follow the [Teachback Review](#teachback-review) acceptance recipe. Do NOT mark Task A `completed` without the paired wake-signal SendMessage — see [Completion Authority](#completion-authority) for the two-call atomic pair.
+When an agent sends a teachback, **compare it against the task as you dispatched it — check for both misstatements AND omissions of the objective, constraints, or success criteria**. If you spot a misunderstanding, reply with a correction via `SendMessage` before any other action — the agent is already working, so the correction window is short. Prevents **misunderstanding disguised as agreement** from going undetected until TEST phase. Once decided, follow the [Acceptance or Rejection two-call atomic pair](#completion-authority).
 
 #### Expected Agent HANDOFF Format
 
-Every agent delivers a structured HANDOFF stored in task metadata. Read via `TaskGet(taskId).metadata.handoff` when needed:
-
-```
-HANDOFF:
-1. Produced: Files created/modified
-2. Key decisions: Decisions with rationale, assumptions that could be wrong
-3. Reasoning chain (optional): How key decisions connect — "X because Y, which required Z"
-4. Areas of uncertainty (PRIORITIZED):
-   - [HIGH] {description} — Why risky, suggested test focus
-   - [MEDIUM] {description}
-   - [LOW] {description}
-5. Integration points: Other components touched
-6. Open questions: Unresolved items
-```
-
-Items 1-2 and 4-6 are required. Item 3 (reasoning chain) is recommended — include it unless the task is trivial. Use this to update Task metadata and inform subsequent phases.
-
-If the `validate_handoff` hook warns about a missing HANDOFF, extract available context from the agent's response and update the Task accordingly.
-
-On HANDOFF receipt, inspect `metadata.handoff` (raw JSON read; `TaskGet` does not surface metadata) and follow the [Completion Authority](#completion-authority) two-call atomic pair to flip the task to `completed` and wake the teammate. Do NOT dispatch downstream phases against a teammate-owned task that you have not yet marked completed — the teammate is idle awaiting your acceptance, and the task graph has not unblocked dependents.
+Every agent delivers a structured HANDOFF (6 fields: `produced`, `decisions`, `reasoning_chain`, `uncertainty`, `integration`, `open_questions`) stored in `metadata.handoff`. See [pact-agent-teams §HANDOFF Format](../pact-agent-teams/SKILL.md#handoff-format) for the full schema. If `validate_handoff` warns about a missing HANDOFF, extract available context from the agent's response and update the task. On receipt, inspect `metadata.handoff` (raw JSON read; `TaskGet` is metadata-blind) and follow the [Completion Authority](#completion-authority) two-call atomic pair. Do NOT dispatch downstream phases against a teammate-owned task you have not yet marked completed — the teammate is idle awaiting your acceptance, and dependents have not unblocked.
 
 ### How to Delegate
 

--- a/pact-plugin/skills/orchestration/SKILL.md
+++ b/pact-plugin/skills/orchestration/SKILL.md
@@ -111,7 +111,7 @@ Workflow commands handle recovery automatically. Your context window doesn't sur
 - **Challenge, don't comply**: When you believe a different approach is better, say so with evidence. Propose the alternative and ask the user if they agree. Do not default to compliance — default to the strongest recommendation you can make.
 - **Adopt specialist pushback**: When a specialist argues for a different approach, engage with the argument. If their case is stronger, adopt it. You have authority to change course based on specialist input without escalating to the user.
 - **No empty affirmations**: Never open with "Great idea" or restate what the user just said. Start with substance. Follow the Communication Charter. Full protocol: `pact-communication-charter.md` (loaded at bootstrap).
-- **Verify before dispatching a course-correction**: before you SendMessage a teammate to change direction, check the filesystem, task metadata, or journal against your mental model — a stale model produces stale instructions. See [Communication Charter Part I — Lead-Side Discipline — Verify Before Dispatching](../../protocols/pact-communication-charter.md#lead-side-discipline--verify-before-dispatching) for the full rule.
+- **Verify before dispatching a course-correction**: before you SendMessage a teammate to change direction, check the filesystem, task metadata, or journal against your mental model — a stale model produces stale instructions. See [Communication Charter Part I — Lead-Side Discipline — Verify Before Dispatching](../../protocols/pact-communication-charter.md#team-lead-side-discipline--verify-before-dispatching) for the full rule.
 
 ### Git Branching
 - Create a feature branch before any new workstream begins
@@ -162,7 +162,7 @@ The secretary answers queries about prior project knowledge from pact-memory —
 
 ```
 SendMessage(to="secretary",
-  message="[lead→secretary] Query: {specific question}",
+  message="[team-lead→secretary] Query: {specific question}",
   summary="Query: {topic}")
 ```
 
@@ -179,7 +179,7 @@ At these workflow boundaries, create a task for the secretary referencing the `p
 
 These triggers are idempotent — safe to fire even if HANDOFFs were already processed.
 
-NOTE: For ad-hoc work outside defined PACT workflows → `SendMessage(to="secretary", message="[lead→secretary] Save: {what and why}", summary="Save request: {topic}")`
+NOTE: For ad-hoc work outside defined PACT workflows → `SendMessage(to="secretary", message="[team-lead→secretary] Save: {what and why}", summary="Save request: {topic}")`
 
 ### S3/S4 Operational Modes
 
@@ -329,7 +329,7 @@ Explicit user override ("you code this, don't delegate") should be honored; casu
 | Agent reports blocker | `TaskCreate(subject: "BLOCKER: ...", metadata={"type": "blocker"})` then `TaskUpdate(agent_taskId, addBlockedBy: [blocker_taskId])`. **`metadata.type` is required** — `agent_handoff_emitter.py` inline-checks `metadata.type in ("blocker", "algedonic")` and SUPPRESSES journal emission for signal tasks; `shared/task_utils.py` and `shared/session_resume.py` use the same literal to CATEGORIZE signal tasks for recovery display (they do not suppress anything). The three sites share the literal as a convention, not a common suppression mechanism. The subject prefix has no special meaning. |
 | Agent reports algedonic signal | `TaskCreate(subject: "[HALT\|ALERT]: ...", metadata={"type": "algedonic", "level": "halt"\|"alert", "category": "..."})` then amplify scope via `addBlockedBy` on phase/feature task. **`metadata.type` is required** — same three-site behavior as the blocker row (emitter suppresses; task_utils + session_resume categorize). |
 
-**Key principle**: Under Agent Teams, teammates self-manage their task status (claim via `TaskUpdate(status="in_progress")`, complete via `TaskUpdate(status="completed")`) and communicate via `SendMessage` (HANDOFFs, blockers, algedonic signals, progress signals). You create tasks and monitor via `TaskList` and incoming `SendMessage` signals. Agents can send brief mid-task status updates (`[sender→lead] Progress: {done}/{remaining}, {status}`) when requested.
+**Key principle**: Under Agent Teams, teammates self-manage their task status (claim via `TaskUpdate(status="in_progress")`, complete via `TaskUpdate(status="completed")`) and communicate via `SendMessage` (HANDOFFs, blockers, algedonic signals, progress signals). You create tasks and monitor via `TaskList` and incoming `SendMessage` signals. Agents can send brief mid-task status updates (`[sender→team-lead] Progress: {done}/{remaining}, {status}`) when requested.
 
 ##### Signal Task Handling
 When an agent reports a blocker or algedonic signal via `SendMessage`:
@@ -430,23 +430,23 @@ Exceptions:
 - rePACT sub-scope specialists shut down after their nested cycle (orchestrator relays handoff details to subsequent sub-scopes)
 - comPACT specialists shut down when user chooses "Pause work for now"
 
-**Inter-teammate messages always go individually by name.** `SendMessage` requires a specific `to=` recipient — there is no broadcast addressing mode. To reach multiple teammates (HALT, shutdown, plan approval, structured protocol messages, plain-text announcements), iterate over the relevant teammates and send one `SendMessage` per recipient. Use the [Lead-Side HALT Fan-Out](#lead-side-halt-fan-out) idiom as the canonical pattern.
+**Inter-teammate messages always go individually by name.** `SendMessage` requires a specific `to=` recipient — there is no broadcast addressing mode. To reach multiple teammates (HALT, shutdown, plan approval, structured protocol messages, plain-text announcements), iterate over the relevant teammates and send one `SendMessage` per recipient. Use the [Lead-Side HALT Fan-Out](#team-lead-side-halt-fan-out) idiom as the canonical pattern.
 
 #### Lead-Side HALT Fan-Out
 
-To stop all in-progress teammates (HALT, shutdown, or any other lead-to-many signal), iterate `TaskList` for tasks with `status="in_progress"` and send the signal individually to each owner:
+To stop all in-progress teammates (HALT, shutdown, or any other team-lead-to-many signal), iterate `TaskList` for tasks with `status="in_progress"` and send the signal individually to each owner:
 
     in_progress = [t for t in TaskList() if t["status"] == "in_progress" and t["owner"]]
     for task in in_progress:
         SendMessage(
             to=task["owner"],
-            message=f"[lead→{task['owner']}] ⚠️ HALT: {category}. Stop all work immediately. Preserve current state and await further instructions.",
+            message=f"[team-lead→{task['owner']}] ⚠️ HALT: {category}. Stop all work immediately. Preserve current state and await further instructions.",
             summary=f"HALT: {category}",
         )
 
 Each message lands at the teammate's next idle boundary (see [Algedonic-Signal Latency Caveat](../../protocols/pact-communication-charter.md#algedonic-signal-latency-caveat)). For immediate halt of in-flight teammate work, escalate to user for manual interrupt — `SendMessage` cannot interrupt a mid-turn teammate.
 
-Use the same iterate-by-name pattern for any other lead-to-many signal (graceful shutdown via `shutdown_request`, `plan_approval_request`, plain-text announcements). There is no broadcast addressing mode.
+Use the same iterate-by-name pattern for any other team-lead-to-many signal (graceful shutdown via `shutdown_request`, `plan_approval_request`, plain-text announcements). There is no broadcast addressing mode.
 
 ### Intentional Waiting (orchestrator responsibilities)
 
@@ -472,27 +472,27 @@ inspection and session review. Your responsibilities:
   inspection purposes; no hook fires on expiry. If a flagged wait has been
   pending past 30 min, the teammate should re-SET with a fresh `since` — or
   the wait has hung and you should investigate and drive resolution.
-- **Don't SET the `intentional_wait` task metadata on your own lead task.**
-  TeammateIdle hooks filter by task owner; they don't inspect lead state.
+- **Don't SET the `intentional_wait` task metadata on your own team-lead task.**
+  TeammateIdle hooks filter by task owner; they don't inspect team-lead state.
 - **`awaiting_lead_completion` is the most common wait you'll see** — set by every teammate after they store HANDOFF or teachback metadata. Resolution = your two-call acceptance pair (or rejection dual-channel pair). See [Completion Authority](#completion-authority) below.
 
 ### Completion Authority
 
-You — the lead — are the **only** actor who marks teammate-owned tasks `completed`. `blockedBy` is pull-only at the platform level — idle teammates cannot self-wake to re-poll, so the wake-signal SendMessage paired with each metadata/status write is load-bearing.
+You — the team-lead — are the **only** actor who marks teammate-owned tasks `completed`. `blockedBy` is pull-only at the platform level — idle teammates cannot self-wake to re-poll, so the wake-signal SendMessage paired with each metadata/status write is load-bearing.
 
 **Acceptance — two-call atomic pair (BOTH required)**
 1. `TaskUpdate(taskId, status="completed")`
-2. `SendMessage(to=<teammate>, "[lead→<teammate>] Task #<id> accepted...", summary="Task accepted")`
+2. `SendMessage(to=<teammate>, "[team-lead→<teammate>] Task #<id> accepted...", summary="Task accepted")`
 
 Both calls are required. Skipping the SendMessage leaves the teammate idle on `awaiting_lead_completion`; `blockedBy` resolution is invisible without the wake.
 
 **Rejection — two-call atomic pair (BOTH required)**
 1. `TaskUpdate(taskId, metadata={"teachback_rejection": {...}})` OR `metadata={"handoff_rejection": {...}}` — payload `{reason, corrections, since, revision_number}`
-2. `SendMessage(to=<teammate>, "[lead→<teammate>] Rejected on Task #<id>. See metadata...; revise.")`
+2. `SendMessage(to=<teammate>, "[team-lead→<teammate>] Rejected on Task #<id>. See metadata...; revise.")`
 
 Both calls are required. Skipping the SendMessage leaves the teammate idle on stale `awaiting_lead_completion`, never seeing the corrections — symmetric failure to skipping wake on acceptance. 3+ rejection cycles on the same task is an imPACT META-BLOCK signal.
 
-Teammate self-completion carve-outs (predicate-witnessed): signal-tasks (`metadata.completion_type == "signal"` AND `metadata.type ∈ {"blocker", "algedonic"}`); secretary memory-save (owner in `SELF_COMPLETE_EXEMPT_AGENTS`). Canonical predicate: `is_self_complete_exempt(task)` in `shared/intentional_wait.py` — covers ONLY these two surfaces. Separate path: imPACT force-termination (`metadata.terminated == true`) is lead-driven (you write `status=completed` directly via `TaskStop` + `TaskUpdate`); the `terminated` marker is recognized by audit/inspection, NOT by the predicate.
+Teammate self-completion carve-outs (predicate-witnessed): signal-tasks (`metadata.completion_type == "signal"` AND `metadata.type ∈ {"blocker", "algedonic"}`); secretary memory-save (owner in `SELF_COMPLETE_EXEMPT_AGENTS`). Canonical predicate: `is_self_complete_exempt(task)` in `shared/intentional_wait.py` — covers ONLY these two surfaces. Separate path: imPACT force-termination (`metadata.terminated == true`) is team-lead-driven (you write `status=completed` directly via `TaskStop` + `TaskUpdate`); the `terminated` marker is recognized by audit/inspection, NOT by the predicate.
 
 **TaskGet metadata-blindness reminder**: `TaskGet` does NOT surface `metadata.handoff`. Read directly via `cat ~/.claude/tasks/{team_name}/{taskId}.json | jq .metadata.handoff`; do NOT mark completed if missing or empty. See [pact-completion-authority.md](../../protocols/pact-completion-authority.md) for full recipes (teachback review flow, rejection corrections schema, carve-out rationale).
 

--- a/pact-plugin/skills/orchestration/SKILL.md
+++ b/pact-plugin/skills/orchestration/SKILL.md
@@ -492,7 +492,7 @@ Both calls are required. Skipping the SendMessage leaves the teammate idle on `a
 
 Both calls are required. Skipping the SendMessage leaves the teammate idle on stale `awaiting_lead_completion`, never seeing the corrections — symmetric failure to skipping wake on acceptance. 3+ rejection cycles on the same task is an imPACT META-BLOCK signal.
 
-Carve-outs (rare, narrow): signal-tasks (`metadata.completion_type == "signal"` AND `metadata.type ∈ {"blocker", "algedonic"}`); secretary memory-save (owner in `SELF_COMPLETE_EXEMPT_AGENTS`); imPACT force-termination (`metadata.terminated == true`). Canonical predicate: `is_self_complete_exempt(task)` in `shared/intentional_wait.py`.
+Teammate self-completion carve-outs (predicate-witnessed): signal-tasks (`metadata.completion_type == "signal"` AND `metadata.type ∈ {"blocker", "algedonic"}`); secretary memory-save (owner in `SELF_COMPLETE_EXEMPT_AGENTS`). Canonical predicate: `is_self_complete_exempt(task)` in `shared/intentional_wait.py` — covers ONLY these two surfaces. Separate path: imPACT force-termination (`metadata.terminated == true`) is lead-driven (you write `status=completed` directly via `TaskStop` + `TaskUpdate`); the `terminated` marker is recognized by audit/inspection, NOT by the predicate.
 
 **TaskGet metadata-blindness reminder**: `TaskGet` does NOT surface `metadata.handoff`. Read directly via `cat ~/.claude/tasks/{team_name}/{taskId}.json | jq .metadata.handoff`; do NOT mark completed if missing or empty. See [pact-completion-authority.md](../../protocols/pact-completion-authority.md) for full recipes (teachback review flow, rejection corrections schema, carve-out rationale).
 

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -108,7 +108,7 @@ For consequence-level disagreements:
 
 ## On Completion — HANDOFF (Required)
 
-When your work is done:
+When your work is done, you store the HANDOFF and remain `in_progress`. **You do NOT mark your own tasks `completed`** — the lead is the authoritative completion signal.
 
 1. **Store HANDOFF in task metadata**:
    ```
@@ -122,15 +122,59 @@ When your work is done:
    }})
    ```
    If `TaskUpdate` fails, include the full HANDOFF in your `SendMessage` content as a fallback.
-2. **Complete task — BOTH actions required, in this order**:
-   a. `SendMessage(to="lead", message="[{sender}→lead] Task complete. [1-2 sentences: what was done + any HIGH uncertainties]", summary="Task complete: [brief]")`
-   b. `TaskUpdate(taskId, status="completed")`
 
-   > ⚠️ Your task is NOT complete until BOTH calls succeed. SendMessage alone is insufficient — the `TaskUpdate(status="completed")` call is required to fire the TaskCompleted event. The lead's `TaskGet` verification is the primary HANDOFF-presence check; a missing or empty `metadata.handoff` will be flagged and your completion rejected until you store the HANDOFF. The `agent_handoff_emitter.py` hook that journals the completion is a pure journal-writer — it does NOT block, so your metadata.handoff content is load-bearing for both the lead's gate and institutional memory.
+2. **Notify the lead**:
+   ```
+   SendMessage(to="team-lead",
+     message="[{sender}→lead] Task complete. [1-2 sentences: what was done + any HIGH uncertainties]",
+     summary="Task complete: [brief]")
+   ```
 
-3. **Self-claim follow-up work**: Check `TaskList` for unassigned, unblocked tasks matching your domain
-4. If found: `TaskUpdate(taskId, owner="your-name", status="in_progress")` and begin
-5. If none: idle (you may be consulted or shut down)
+3. **SET `intentional_wait` and idle**:
+   ```
+   TaskUpdate(taskId, metadata={"intentional_wait": {
+       "reason": "awaiting_lead_completion",
+       "expected_resolver": "lead",
+       "since": "<canonical_since() output: tz-aware ISO-8601 UTC>"
+   }})
+   ```
+
+4. **Idle.** The lead reads `metadata.handoff`, judges acceptance, and either:
+   - **Accepts**: `TaskUpdate(taskId, status="completed")` plus a wake-signal SendMessage. On wake, CLEAR `intentional_wait` and check `TaskList` for follow-up work.
+   - **Rejects**: writes `metadata.handoff_rejection = {reason, corrections, since, revision_number}` plus a wake-signal SendMessage. Follow §On Rejection below.
+
+> ⚠️ Do NOT call `TaskUpdate(taskId, status="completed")` on your own task. The lead-as-completion-gate is the discipline; teammate self-completion bypasses HANDOFF inspection. Two narrow exemptions (signal-tasks; secretary memory-save) are documented at the relevant agent bodies — those carve-outs apply only to those agents, not to you unless your agent body says so.
+
+> **Why idle, not poll?** You cannot self-wake while idle. The lead's wake-signal SendMessage brings you back to read the acceptance/rejection. Trust the wake; do not poll TaskList speculatively.
+
+After wake on acceptance, check `TaskList` for unassigned, unblocked tasks matching your domain (Task B from your dispatch pair, or other follow-up work). If found, claim via `TaskUpdate(taskId, owner="your-name", status="in_progress")` and begin. If none, idle (you may be consulted or shut down).
+
+## On Rejection (Wake-Signal Receipt)
+
+If the lead rejects your teachback or HANDOFF, you wake on the inbound SendMessage. Your task remains `in_progress`; the lead has written rejection details to metadata.
+
+**On wake**:
+
+1. **CLEAR your existing `intentional_wait`**:
+   ```
+   TaskUpdate(taskId, metadata={"intentional_wait": None})
+   ```
+
+2. **Read the rejection metadata**:
+   - For Task A (teachback): `TaskGet(taskId).metadata.teachback_rejection`
+   - For Task B (work): `TaskGet(taskId).metadata.handoff_rejection`
+
+   The shape is `{"reason": str, "corrections": [str, ...], "since": ISO8601, "revision_number": int}`.
+
+3. **Revise**. For teachback rejection: rewrite `metadata.teachback_submit` per the corrections. For HANDOFF rejection: revise the deliverable (re-edit files, re-run tests, etc.) and rewrite `metadata.handoff`.
+
+4. **Re-submit on the SAME task** (do NOT create a new task):
+   - Increment `metadata.revision_number` (start at 1 on first revision; the lead writes `revision_number` into the rejection record, you increment to N+1 on each subsequent revision).
+   - SendMessage the lead: `"[{sender}→lead] Revised teachback/HANDOFF on Task #{id}. See metadata.{teachback_submit|handoff} (revision {N})."`
+   - Re-SET `intentional_wait{reason=awaiting_lead_completion, since=<fresh canonical_since() output>}`.
+   - Idle.
+
+> **Revision visibility**: on revision (`revision_number > 1`), the journal `agent_handoff` event from your *first* completion is preserved (one event per task lifetime). The secretary's harvest path reads `metadata.handoff` directly when `revision_number > 1`, so your revised content reaches institutional memory. The metadata write is sufficient.
 
 ### HANDOFF Format
 
@@ -182,6 +226,7 @@ output (even zero-content) blocks the next inbox delivery.
 - **Idle-waiting for a protocol-defined resolution** (teachback, lead commit,
   peer reply, user decision)? Use the `intentional_wait` task metadata per
   the Intentional Waiting section below.
+- **Awaiting lead completion?** SET `intentional_wait{reason=awaiting_lead_completion, expected_resolver=lead, since=<canonical_since() output>}` after storing your HANDOFF or teachback metadata. Do NOT poll TaskList while idle — you cannot self-wake to do so. The lead's wake-signal SendMessage is the resolver.
 - **Genuinely stuck**? Follow the On Blocker section.
 
 If you have nothing to say that advances the work, say nothing.
@@ -336,8 +381,6 @@ When you receive a `shutdown_request`:
 
 ## Completion Integrity (SACROSANCT)
 
-Only report work as completed if you actually performed the changes. Never fabricate
-a completion HANDOFF. If files don't exist, can't be edited, or tools fail, report
-a BLOCKER via `SendMessage` -- never invent results.
+Only report work as ready for lead-review if you actually performed the changes. Never fabricate a completion HANDOFF; the lead inspects `metadata.handoff` before transitioning status to `completed`. If files don't exist, can't be edited, or tools fail, report a BLOCKER via `SendMessage` — never invent results.
 
 **Do not create git commits.** All staging and committing is the lead's responsibility. Your job ends at the HANDOFF.

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -21,12 +21,12 @@ You are a member of a PACT Agent Team. You have access to Task tools (`TaskGet`,
 4. **GATE — Send teachback**: Send a teachback to lead restating your understanding of the task. Nothing proceeds until this is sent. (See [Teachback](#teachback-conversation-verification) below)
    - **DO NOT** call `Edit`, `Write`, or `Bash` before sending your teachback
    - After sending, record it: `TaskUpdate(taskId, metadata={"teachback_sent": true})`
-   - Non-blocking: proceed immediately after sending — do not wait for the lead's reply
+   - Non-blocking: proceed immediately after sending — do not wait for the team-lead's reply
 5. Begin work — check your agent memory (`~/.claude/agent-memory/<your-name>/`) for relevant patterns and knowledge as part of your working process
 
 > **Worktree Scope**: If you are working in a worktree, files that are gitignored (e.g., `CLAUDE.md`) do not exist there. Do not edit or create `CLAUDE.md` — the orchestrator manages it separately. If you need to reference `CLAUDE.md` content, it is auto-loaded into your context. If your task mentions updating `CLAUDE.md`, flag it in your handoff instead of editing it directly.
 
-> **Note**: The lead stores your `agent_id` in task metadata after dispatch. This enables `resume` if you hit a blocker — the lead can resume your process with preserved context instead of spawning fresh.
+> **Note**: The team-lead stores your `agent_id` in task metadata after dispatch. This enables `resume` if you hit a blocker — the team-lead can resume your process with preserved context instead of spawning fresh.
 
 > **Custom start flows**: If your agent definition specifies a custom On Start sequence (e.g., the secretary's session briefing), you must explicitly re-enter this standard lifecycle after your custom flow completes — call `TaskList`, claim assigned tasks, and follow the teachback protocol from the teachback step onward.
 
@@ -34,7 +34,7 @@ You are a member of a PACT Agent Team. You have access to Task tools (`TaskGet`,
 
 Your task description may reference upstream task IDs (e.g., "Architect task: #5").
 Use `TaskGet(taskId)` to read their metadata for design decisions, HANDOFF data, and
-integration points — rather than relying on the lead to relay this information.
+integration points — rather than relying on the team-lead to relay this information.
 
 Common chain-reads:
 - **Coders** → read architect's task for design decisions and interface contracts
@@ -70,9 +70,9 @@ Report progress naturally in your responses. For significant milestones, update 
 
 ### Progress Signals
 
-When the lead requests progress monitoring in your dispatch, send brief progress updates at natural breakpoints during your work.
+When the team-lead requests progress monitoring in your dispatch, send brief progress updates at natural breakpoints during your work.
 
-**Format**: `[sender→lead] Progress: {what's done}/{what's remaining}, {current status}`
+**Format**: `[sender→team-lead] Progress: {what's done}/{what's remaining}, {current status}`
 
 **Natural breakpoints**:
 - After modifying a file
@@ -108,7 +108,7 @@ For consequence-level disagreements:
 
 ## On Completion — HANDOFF (Required)
 
-When your work is done, you store the HANDOFF and remain `in_progress`. **You do NOT mark your own tasks `completed`** — the lead is the authoritative completion signal.
+When your work is done, you store the HANDOFF and remain `in_progress`. **You do NOT mark your own tasks `completed`** — the team-lead is the authoritative completion signal.
 
 1. **Store HANDOFF in task metadata**:
    ```
@@ -123,10 +123,10 @@ When your work is done, you store the HANDOFF and remain `in_progress`. **You do
    ```
    If `TaskUpdate` fails, include the full HANDOFF in your `SendMessage` content as a fallback.
 
-2. **Notify the lead**:
+2. **Notify the team-lead**:
    ```
    SendMessage(to="team-lead",
-     message="[{sender}→lead] Task complete. [1-2 sentences: what was done + any HIGH uncertainties]",
+     message="[{sender}→team-lead] Task complete. [1-2 sentences: what was done + any HIGH uncertainties]",
      summary="Task complete: [brief]")
    ```
 
@@ -139,19 +139,19 @@ When your work is done, you store the HANDOFF and remain `in_progress`. **You do
    }})
    ```
 
-4. **Idle.** The lead reads `metadata.handoff`, judges acceptance, and either:
+4. **Idle.** The team-lead reads `metadata.handoff`, judges acceptance, and either:
    - **Accepts**: `TaskUpdate(taskId, status="completed")` plus a wake-signal SendMessage. On wake, CLEAR `intentional_wait` and check `TaskList` for follow-up work.
    - **Rejects**: writes `metadata.handoff_rejection = {reason, corrections, since, revision_number}` plus a wake-signal SendMessage. Follow §On Rejection below.
 
-> ⚠️ Do NOT call `TaskUpdate(taskId, status="completed")` on your own task. The lead-as-completion-gate is the discipline; teammate self-completion bypasses HANDOFF inspection. Two narrow exemptions (signal-tasks; secretary memory-save) are documented at the relevant agent bodies — those carve-outs apply only to those agents, not to you unless your agent body says so.
+> ⚠️ Do NOT call `TaskUpdate(taskId, status="completed")` on your own task. The team-lead-as-completion-gate is the discipline; teammate self-completion bypasses HANDOFF inspection. Two narrow exemptions (signal-tasks; secretary memory-save) are documented at the relevant agent bodies — those carve-outs apply only to those agents, not to you unless your agent body says so.
 
-> **Why idle, not poll?** You cannot self-wake while idle. The lead's wake-signal SendMessage brings you back to read the acceptance/rejection. Trust the wake; do not poll TaskList speculatively.
+> **Why idle, not poll?** You cannot self-wake while idle. The team-lead's wake-signal SendMessage brings you back to read the acceptance/rejection. Trust the wake; do not poll TaskList speculatively.
 
 After wake on acceptance, check `TaskList` for unassigned, unblocked tasks matching your domain (Task B from your dispatch pair, or other follow-up work). If found, claim via `TaskUpdate(taskId, owner="your-name", status="in_progress")` and begin. If none, idle (you may be consulted or shut down).
 
 ## On Rejection (Wake-Signal Receipt)
 
-If the lead rejects your teachback or HANDOFF, you wake on the inbound SendMessage. Your task remains `in_progress`; the lead has written rejection details to metadata.
+If the team-lead rejects your teachback or HANDOFF, you wake on the inbound SendMessage. Your task remains `in_progress`; the team-lead has written rejection details to metadata.
 
 **On wake**:
 
@@ -169,8 +169,8 @@ If the lead rejects your teachback or HANDOFF, you wake on the inbound SendMessa
 3. **Revise**. For teachback rejection: rewrite `metadata.teachback_submit` per the corrections. For HANDOFF rejection: revise the deliverable (re-edit files, re-run tests, etc.) and rewrite `metadata.handoff`.
 
 4. **Re-submit on the SAME task** (do NOT create a new task):
-   - Increment `metadata.revision_number`. The lead writes `revision_number=1` in the rejection record. On your first revision, increment to `2`. On each subsequent revision, increment again. The harvest path reads `metadata.handoff` directly when `revision_number > 1` to surface revised content; setting `revision_number=1` would route harvest to the rejected journal event and silently lose the revised content.
-   - SendMessage the lead: `"[{sender}→lead] Revised teachback/HANDOFF on Task #{id}. See metadata.{teachback_submit|handoff} (revision {N})."`
+   - Increment `metadata.revision_number`. The team-lead writes `revision_number=1` in the rejection record. On your first revision, increment to `2`. On each subsequent revision, increment again. The harvest path reads `metadata.handoff` directly when `revision_number > 1` to surface revised content; setting `revision_number=1` would route harvest to the rejected journal event and silently lose the revised content.
+   - SendMessage the team-lead: `"[{sender}→team-lead] Revised teachback/HANDOFF on Task #{id}. See metadata.{teachback_submit|handoff} (revision {N})."`
    - Re-SET `intentional_wait{reason=awaiting_lead_completion, since=<fresh canonical_since() output>}`.
    - Idle.
 
@@ -204,17 +204,17 @@ in your task description.
 
 **Message a peer when:**
 - Your work produces something an active peer needs (API schema, interface contract, shared config)
-- You have a question another specialist can answer better than the lead
+- You have a question another specialist can answer better than the team-lead
 - You discover something affecting a peer's scope (breaking change, shared dependency)
 
-**Message the lead when:**
+**Message the team-lead when:**
 - Blockers, algedonic signals, completion summaries (always)
 - Questions about scope, priorities, or requirements
 - Anything requiring a decision above your authority
 
 Keep messages actionable — state what you did/found, what they need to know, and
 any action needed from them.
-Message each peer at most once per task — share your output when complete, not progress updates. If you need ongoing coordination, route through the lead.
+Message each peer at most once per task — share your output when complete, not progress updates. If you need ongoing coordination, route through the team-lead.
 
 ## Idle Discipline
 
@@ -223,10 +223,10 @@ When you wake with no new work, return to idle silently — no "standing by" or
 output (even zero-content) blocks the next inbox delivery.
 
 - **No new `SendMessage` and no new dispatch instructions?** Do not emit.
-- **Idle-waiting for a protocol-defined resolution** (teachback, lead commit,
+- **Idle-waiting for a protocol-defined resolution** (teachback, team-lead commit,
   peer reply, user decision)? Use the `intentional_wait` task metadata per
   the Intentional Waiting section below.
-- **Awaiting lead completion?** SET `intentional_wait{reason=awaiting_lead_completion, expected_resolver=lead, since=<canonical_since() output>}` after storing your HANDOFF or teachback metadata. Do NOT poll TaskList while idle — you cannot self-wake to do so. The lead's wake-signal SendMessage is the resolver.
+- **Awaiting lead completion?** SET `intentional_wait{reason=awaiting_lead_completion, expected_resolver=lead, since=<canonical_since() output>}` after storing your HANDOFF or teachback metadata. Do NOT poll TaskList while idle — you cannot self-wake to do so. The team-lead's wake-signal SendMessage is the resolver.
 - **Genuinely stuck**? Follow the On Blocker section.
 
 If you have nothing to say that advances the work, say nothing.
@@ -245,7 +245,7 @@ resolution), signal it via the `intentional_wait` task metadata BEFORE going idl
 There are no in-plugin consumers of this flag; the schema primitives
 (`KNOWN_REASONS`, `KNOWN_RESOLVERS`, `wait_stale`) in `shared.intentional_wait`
 are retained as the teammate-facing metadata contract for protocol-defined
-waits. Using the flag documents the wait intent for the lead's TaskGet
+waits. Using the flag documents the wait intent for the team-lead's TaskGet
 inspection and for post-hoc session review.
 
 ### SET — before going idle
@@ -261,7 +261,7 @@ TaskUpdate(taskId=taskId, metadata={
 })
 ```
 
-`since` must be tz-aware ISO-8601. A naive timestamp fails `validate_wait` and will be surfaced as malformed to any reader of the flag (lead TaskGet, audit, future consumers). Fail-loud.
+`since` must be tz-aware ISO-8601. A naive timestamp fails `validate_wait` and will be surfaced as malformed to any reader of the flag (team-lead TaskGet, audit, future consumers). Fail-loud.
 
 ### CLEAR — when the wait resolves
 
@@ -284,7 +284,7 @@ Unknown keys are preserved (forward-compat).
 ### Staleness safeguard
 
 The `wait_stale` primitive in `shared.intentional_wait` considers the flag stale after 30
-minutes from `since`. No hook currently enforces this — it's advisory metadata the lead may
+minutes from `since`. No hook currently enforces this — it's advisory metadata the team-lead may
 inspect via TaskGet. If your wait genuinely takes longer, re-SET with a fresh `since` so
 later inspection reflects the real duration.
 
@@ -292,7 +292,7 @@ later inspection reflects the real duration.
 
 - **Consultant mode** (no owned `in_progress` task): the flag has no current consumer for consultants anyway.
 - **Waits < 30 seconds**: SET+CLEAR bookkeeping isn't worth it for brief waits.
-- **Completion gating**: the flag does NOT suppress the lead's HANDOFF-presence check. An empty or missing `metadata.handoff` will be flagged by the lead's TaskGet verification — store your HANDOFF before marking the task completed, regardless of intentional_wait state.
+- **Completion gating**: the flag does NOT suppress the team-lead's HANDOFF-presence check. An empty or missing `metadata.handoff` will be flagged by the team-lead's TaskGet verification — store your HANDOFF before marking the task completed, regardless of intentional_wait state.
 
 ## Consultant Mode
 
@@ -307,14 +307,14 @@ When your active task is done and no follow-up tasks are available:
 If you cannot proceed:
 
 1. **Stop work immediately**
-2. **`SendMessage`** the blocker to the lead:
+2. **`SendMessage`** the blocker to the team-lead:
    ```
    SendMessage(to="team-lead",
-     message="[{sender}→lead] BLOCKER: {description of what is blocking you}\n\nPartial HANDOFF:\n...",
+     message="[{sender}→team-lead] BLOCKER: {description of what is blocking you}\n\nPartial HANDOFF:\n...",
      summary="BLOCKER: [brief description]")
    ```
 3. Provide a partial HANDOFF with whatever work you completed
-4. Wait for lead's response or new instructions
+4. Wait for team-lead's response or new instructions
 
 Do not attempt to work around the blocker.
 
@@ -323,10 +323,10 @@ Do not attempt to work around the blocker.
 When you detect a viability threat (security, data integrity, ethics):
 
 1. **Stop work immediately**
-2. **`SendMessage`** the signal to the lead:
+2. **`SendMessage`** the signal to the team-lead:
    ```
    SendMessage(to="team-lead",
-     message="[{sender}→lead] ⚠️ ALGEDONIC [HALT|ALERT]: {Category}\n\nIssue: ...\nEvidence: ...\nImpact: ...\nRecommended Action: ...\n\nPartial HANDOFF:\n...",
+     message="[{sender}→team-lead] ⚠️ ALGEDONIC [HALT|ALERT]: {Category}\n\nIssue: ...\nEvidence: ...\nImpact: ...\nRecommended Action: ...\n\nPartial HANDOFF:\n...",
      summary="ALGEDONIC [HALT|ALERT]: [category]")
    ```
 3. Provide a partial HANDOFF with whatever work you completed
@@ -336,8 +336,8 @@ These bypass normal triage. See the [algedonic protocol](../../protocols/algedon
 ## Variety Signals
 
 If task complexity differs significantly from what was delegated:
-- "Simpler than expected" — Note in handoff; lead may simplify remaining work
-- "More complex than expected" — Escalate if scope change >20%, or note for lead
+- "Simpler than expected" — Note in handoff; team-lead may simplify remaining work
+- "More complex than expected" — Escalate if scope change >20%, or note for team-lead
 
 ## Bash Commands in ~/.claude/ Paths
 
@@ -381,6 +381,6 @@ When you receive a `shutdown_request`:
 
 ## Completion Integrity (SACROSANCT)
 
-Only report work as ready for lead-review if you actually performed the changes. Never fabricate a completion HANDOFF; the lead inspects `metadata.handoff` before transitioning status to `completed`. If files don't exist, can't be edited, or tools fail, report a BLOCKER via `SendMessage` — never invent results.
+Only report work as ready for team-lead-review if you actually performed the changes. Never fabricate a completion HANDOFF; the team-lead inspects `metadata.handoff` before transitioning status to `completed`. If files don't exist, can't be edited, or tools fail, report a BLOCKER via `SendMessage` — never invent results.
 
-**Do not create git commits.** All staging and committing is the lead's responsibility. Your job ends at the HANDOFF.
+**Do not create git commits.** All staging and committing is the team-lead's responsibility. Your job ends at the HANDOFF.

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -18,7 +18,7 @@ You are a member of a PACT Agent Team. You have access to Task tools (`TaskGet`,
 1. Check `TaskList` for tasks assigned to you (by your name)
 2. Claim your assigned task: `TaskUpdate(taskId, status="in_progress")`
 3. Read the task description — it contains your full mission (CONTEXT, MISSION, INSTRUCTIONS, GUIDELINES). If upstream tasks are referenced, read them via `TaskGet`.
-4. **GATE — Send teachback**: Send a teachback to lead restating your understanding of the task. Nothing proceeds until this is sent. (See [Teachback](#teachback-conversation-verification) below)
+4. **GATE — Send teachback**: Send a teachback to team-lead restating your understanding of the task. Nothing proceeds until this is sent. (See [Teachback](#teachback-conversation-verification) below)
    - **DO NOT** call `Edit`, `Write`, or `Bash` before sending your teachback
    - After sending, record it: `TaskUpdate(taskId, metadata={"teachback_sent": true})`
    - Non-blocking: proceed immediately after sending — do not wait for the team-lead's reply

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -169,7 +169,7 @@ If the lead rejects your teachback or HANDOFF, you wake on the inbound SendMessa
 3. **Revise**. For teachback rejection: rewrite `metadata.teachback_submit` per the corrections. For HANDOFF rejection: revise the deliverable (re-edit files, re-run tests, etc.) and rewrite `metadata.handoff`.
 
 4. **Re-submit on the SAME task** (do NOT create a new task):
-   - Increment `metadata.revision_number` (start at 1 on first revision; the lead writes `revision_number` into the rejection record, you increment to N+1 on each subsequent revision).
+   - Increment `metadata.revision_number`. The lead writes `revision_number=1` in the rejection record. On your first revision, increment to `2`. On each subsequent revision, increment again. The harvest path reads `metadata.handoff` directly when `revision_number > 1` to surface revised content; setting `revision_number=1` would route harvest to the rejected journal event and silently lose the revised content.
    - SendMessage the lead: `"[{sender}→lead] Revised teachback/HANDOFF on Task #{id}. See metadata.{teachback_submit|handoff} (revision {N})."`
    - Re-SET `intentional_wait{reason=awaiting_lead_completion, since=<fresh canonical_since() output>}`.
    - Idle.
@@ -309,7 +309,7 @@ If you cannot proceed:
 1. **Stop work immediately**
 2. **`SendMessage`** the blocker to the lead:
    ```
-   SendMessage(to="lead",
+   SendMessage(to="team-lead",
      message="[{sender}→lead] BLOCKER: {description of what is blocking you}\n\nPartial HANDOFF:\n...",
      summary="BLOCKER: [brief description]")
    ```
@@ -325,7 +325,7 @@ When you detect a viability threat (security, data integrity, ethics):
 1. **Stop work immediately**
 2. **`SendMessage`** the signal to the lead:
    ```
-   SendMessage(to="lead",
+   SendMessage(to="team-lead",
      message="[{sender}→lead] ⚠️ ALGEDONIC [HALT|ALERT]: {Category}\n\nIssue: ...\nEvidence: ...\nImpact: ...\nRecommended Action: ...\n\nPartial HANDOFF:\n...",
      summary="ALGEDONIC [HALT|ALERT]: [category]")
    ```

--- a/pact-plugin/skills/pact-handoff-harvest/SKILL.md
+++ b/pact-plugin/skills/pact-handoff-harvest/SKILL.md
@@ -169,7 +169,7 @@ Triggered after remediation completes — processes only the delta since the las
 6. **Update processed task tracking** — append new task IDs to the processed set (do NOT overwrite — preserves the full session history)
 7. **Do NOT delete the session journal** — it may still be accumulating entries from ongoing work
 8. **Update existing memories** if remediation superseded prior decisions (use `update` CLI command, not `save`). Remember: default `update` is additive merge — pass `--replace` only when the prior list items need to be discarded, not amended.
-9. **Report delta summary** to lead — only report what changed in this incremental pass
+9. **Report delta summary** to team-lead — only report what changed in this incremental pass
 
 ---
 
@@ -288,7 +288,7 @@ For direct save requests from the team-lead outside of workflow HANDOFF review (
 This is the Layer 4 fallback for completed handoffs left behind by sessions that ended without wrap-up or where Layer 2 triggers were missed.
 
 1. Look for `session-journal.jsonl` in `~/.claude/pact-sessions/*/*/` directories. **Exclude the current session's directory** (available from the session context file at `~/.claude/pact-sessions/{slug}/{session_id}/pact-session-context.json`, or the session dir provided in your dispatch prompt) — that session's data is active, not orphaned.
-2. If found: report to lead "Found N orphaned HANDOFFs from prior session {session_dir}"
+2. If found: report to team-lead "Found N orphaned HANDOFFs from prior session {session_dir}"
 3. Attempt to process them — prefer `agent_handoff` events from the session journal (full HANDOFF inline, read via `read_events_from(session_dir, 'agent_handoff')`); fall back to `TaskGet` (may fail for garbage-collected tasks)
 4. Delete processed files after recovery (use `python3 -c "from pathlib import Path; Path(...).unlink(missing_ok=True)"` — not shell `rm`, to avoid sensitive-file permission prompts)
 5. Report summary of recovered knowledge (or gaps where all sources failed)

--- a/pact-plugin/skills/pact-handoff-harvest/SKILL.md
+++ b/pact-plugin/skills/pact-handoff-harvest/SKILL.md
@@ -43,10 +43,10 @@ Read your processed task list from agent memory (`~/.claude/agent-memory/pact-se
 
 For each discovered task, read the HANDOFF using this revision-aware fallback:
 
-1. **Revision-aware metadata read**: Read the task's `metadata` (raw JSON; `TaskGet` is metadata-blind for `handoff` content). If `metadata.revision_number` is set and `> 1`, prefer `metadata.handoff` over the journal event. The journal `agent_handoff` event captured the FIRST (rejected) submission only — `agent_handoff_emitter.py` writes one journal event per task lifetime via an O_EXCL marker. On revision, the lead-completion of the revised task does NOT emit a second journal event, so the revised content lives in `metadata.handoff` only.
+1. **Revision-aware metadata read**: Read the task's `metadata` (raw JSON; `TaskGet` is metadata-blind for `handoff` content). If `metadata.revision_number` is set and `> 1`, prefer `metadata.handoff` over the journal event. The journal `agent_handoff` event captured the FIRST (rejected) submission only — `agent_handoff_emitter.py` writes one journal event per task lifetime via an O_EXCL marker. On revision, the team-lead-completion of the revised task does NOT emit a second journal event, so the revised content lives in `metadata.handoff` only.
 2. **Session journal** (preferred for revision_number == 1 or unset, GC-proof): If the task was discovered via `agent_handoff` journal events and `revision_number` is unset or 1, the journal event's `handoff` field contains the full HANDOFF content inline — use it directly. This is the most reliable source for first-pass acceptance flows.
 3. **`TaskGet` fallback**: If both above fail (no journal event AND no `metadata.handoff`), fall back to `TaskGet(taskId).metadata.handoff`. May fail for garbage-collected tasks.
-4. **Report gap**: If all sources fail, report the gap to lead — note the task_id, agent name, and timestamp so the lead has context.
+4. **Report gap**: If all sources fail, report the gap to lead — note the task_id, agent name, and timestamp so the team-lead has context.
 
 Pseudocode for the revision-aware branch:
 
@@ -128,11 +128,11 @@ Last processed: {timestamp}
 
 ### Step 9: Report Summary
 
-Report to the lead:
+Report to the team-lead:
 
 ```
 SendMessage(to="team-lead",
-  message="[secretary→lead] HANDOFF review complete. Saved N memories from M HANDOFFs.
+  message="[secretary→team-lead] HANDOFF review complete. Saved N memories from M HANDOFFs.
 - {memory summary 1}
 - {memory summary 2}
 Gaps: {any HANDOFFs that were thin or missing}",
@@ -142,18 +142,18 @@ Gaps: {any HANDOFFs that were thin or missing}",
 ### Step 10: Gather Calibration Data
 
 After processing HANDOFFs, gather calibration metrics for the orchestrator's variety scoring feedback loop:
-- Read the feature task metadata for `initial_variety_score` (stored during variety assessment). If `TaskGet` fails (garbage-collected), ask the lead for the variety score instead.
+- Read the feature task metadata for `initial_variety_score` (stored during variety assessment). If `TaskGet` fails (garbage-collected), ask the team-lead for the variety score instead.
 - Scan `TaskList` for blocker count (tasks with "BLOCKER:" in subject). Note: `TaskList` may be incomplete in long sessions due to garbage collection — report what's available.
 - Scan `TaskList` for phase rerun count (retry/redo phase tasks)
 - Note domain from feature task description
 - Infer specialist fit from HANDOFF content (scope mismatch signals, blocker patterns)
-- Send a calibration check to the lead:
+- Send a calibration check to the team-lead:
   ```
   SendMessage(to="team-lead",
-    message="[secretary→lead] Calibration: variety was scored {X}. Blockers: {N}, reruns: {N}. Was actual difficulty higher, lower, or about the same? Any dimensions that surprised you?",
+    message="[secretary→team-lead] Calibration: variety was scored {X}. Blockers: {N}, reruns: {N}. Was actual difficulty higher, lower, or about the same? Any dimensions that surprised you?",
     summary="Calibration check: variety {X}")
   ```
-- On lead's response, compute the full CalibrationRecord and save to pact-memory with entities `['orchestration_calibration', '{domain}']`
+- On team-lead's response, compute the full CalibrationRecord and save to pact-memory with entities `['orchestration_calibration', '{domain}']`
 
 ---
 
@@ -200,7 +200,7 @@ Save orchestration retrospective as calibration data (see Standard Harvest Step 
 
 ### Step 6: Report Summary
 
-Report consolidation results to the lead, including:
+Report consolidation results to the team-lead, including:
 - Memories consolidated (merged count)
 - Memories pruned (deleted/superseded count)
 - Calibration data saved
@@ -253,7 +253,7 @@ HANDOFFs are agent-written summaries — they may omit implicit learnings (faile
 
 ### Investigation Techniques
 
-**Direct teammate communication**: Message implementing agents **directly** — not through the lead. The lead does not need to be in the loop for these exchanges.
+**Direct teammate communication**: Message implementing agents **directly** — not through the team-lead. The team-lead does not need to be in the loop for these exchanges.
 
 ```
 SendMessage(to="{agent-name}",
@@ -279,7 +279,7 @@ SendMessage(to="{agent-name}",
 
 ## Ad-Hoc Save Requests
 
-For direct save requests from the lead outside of workflow HANDOFF review (ad-hoc saves), apply the same institutional knowledge criteria and save-vs-update dedup — save decisions, lessons, and cross-cutting concerns to pact-memory.
+For direct save requests from the team-lead outside of workflow HANDOFF review (ad-hoc saves), apply the same institutional knowledge criteria and save-vs-update dedup — save decisions, lessons, and cross-cutting concerns to pact-memory.
 
 ---
 

--- a/pact-plugin/skills/pact-handoff-harvest/SKILL.md
+++ b/pact-plugin/skills/pact-handoff-harvest/SKILL.md
@@ -41,11 +41,29 @@ Read your processed task list from agent memory (`~/.claude/agent-memory/pact-se
 
 ### Step 3: Read All HANDOFFs
 
-For each discovered task, read the HANDOFF using this two-tier fallback:
+For each discovered task, read the HANDOFF using this revision-aware fallback:
 
-1. **Session journal** (preferred, GC-proof): If the task was discovered via `agent_handoff` journal events, the `handoff` field contains the full HANDOFF content inline — use it directly. This is the most reliable source.
-2. **`TaskGet` fallback**: If the journal event lacks inline content, fall back to `TaskGet(taskId).metadata.handoff`. This may fail for garbage-collected tasks.
-3. **Report gap**: If both sources fail, report the gap to lead — note the task_id, agent name, and timestamp so the lead has context.
+1. **Revision-aware metadata read**: Read the task's `metadata` (raw JSON; `TaskGet` is metadata-blind for `handoff` content). If `metadata.revision_number` is set and `> 1`, prefer `metadata.handoff` over the journal event. The journal `agent_handoff` event captured the FIRST (rejected) submission only — `agent_handoff_emitter.py` writes one journal event per task lifetime via an O_EXCL marker. On revision, the lead-completion of the revised task does NOT emit a second journal event, so the revised content lives in `metadata.handoff` only.
+2. **Session journal** (preferred for revision_number == 1 or unset, GC-proof): If the task was discovered via `agent_handoff` journal events and `revision_number` is unset or 1, the journal event's `handoff` field contains the full HANDOFF content inline — use it directly. This is the most reliable source for first-pass acceptance flows.
+3. **`TaskGet` fallback**: If both above fail (no journal event AND no `metadata.handoff`), fall back to `TaskGet(taskId).metadata.handoff`. May fail for garbage-collected tasks.
+4. **Report gap**: If all sources fail, report the gap to lead — note the task_id, agent name, and timestamp so the lead has context.
+
+Pseudocode for the revision-aware branch:
+
+```python
+for task_id in unprocessed:
+    journal_event = next((e for e in journal_events if e.task_id == task_id), None)
+    task_meta = read_task_metadata(task_id) or {}  # raw JSON read; TaskGet is metadata-blind
+    revision_n = task_meta.get("revision_number", 1)
+    if revision_n > 1:
+        # Revised HANDOFF; journal event captured only the first (rejected) submission.
+        handoff = task_meta.get("handoff")
+    elif journal_event:
+        handoff = journal_event.handoff
+    else:
+        handoff = task_meta.get("handoff")
+    # ...process handoff...
+```
 
 Read all HANDOFFs before proceeding to extraction.
 

--- a/pact-plugin/skills/pact-teachback/SKILL.md
+++ b/pact-plugin/skills/pact-teachback/SKILL.md
@@ -1,67 +1,78 @@
 ---
 name: pact-teachback
-description: Command-style teachback protocol for PACT teammates. Invoking this skill directly instructs you to construct and send a teachback SendMessage in the canonical format before any implementation work.
+description: Command-style teachback protocol for PACT teammates. Invoking this skill directly instructs you to store your teachback in task metadata and idle on awaiting_lead_completion before any implementation work.
 ---
 
-# Teachback — Send Now
+# Teachback — Store Now
 
-Invoking this skill means you are about to send a teachback SendMessage to
-the lead. Do not proceed to implementation work until you have sent it.
+Invoking this skill means you are about to submit a teachback for your
+current task. Do not proceed to implementation work until you have stored
+it AND received the lead's acceptance.
 
 ## What a teachback is
 
 A teachback is a Pask Conversation Theory verification gate. Before you
 start implementing, you restate your understanding of the task so the
-orchestrator can catch misunderstandings early, before you burn context on
-a wrong implementation.
+lead can catch misunderstandings early, before you burn context on a
+wrong implementation.
 
-## Action: send this SendMessage now
+Under the Task A + Task B dispatch shape, your teachback is the deliverable
+of Task A. Task B (the primary work) is `blockedBy=[A]` and stays hidden
+in your TaskList until the lead accepts your teachback by transitioning
+Task A to `completed`.
 
-Construct the following SendMessage call with your understanding of the
-current task substituted into the placeholders. Send it now, before any
-Edit, Write, or Bash tool call:
+## Action: store teachback now
+
+**Step 1 — write the teachback to task metadata** (4 fields: the structured payload):
+
+```
+TaskUpdate(taskId, metadata={"teachback_submit": {
+    "understanding": "<what you understand you're building, key constraints, interfaces>",
+    "most_likely_wrong": "<the part of your understanding you are least confident about>",
+    "least_confident_item": "<one specific assumption you'd like the lead to confirm>",
+    "first_action": "<the first concrete step you will take after teachback approval>"
+}})
+```
+
+**Step 2 — notify the lead** (lightweight prose, NOT the full payload):
 
 ```
 SendMessage(
-  to="team-lead",
-  message=(
-    "[<your-agent-name>→lead] Teachback:\n"
-    "- Building: <what you understand you're building>\n"
-    "- Key constraints: <constraints you're working within>\n"
-    "- Interfaces: <interfaces you'll produce or consume>\n"
-    "- Approach: <your intended approach, briefly>\n"
-    "Proceeding unless corrected."
-  ),
-  summary="Teachback: <1-line summary>"
+    to="team-lead",
+    message=(
+        "[<your-agent-name>→lead] Teachback submitted on Task #<A_id>. "
+        "See metadata.teachback_submit. Idling on awaiting_lead_completion."
+    ),
+    summary="Teachback submitted: <topic>"
 )
 ```
 
-After sending, record the teachback as metadata on your task:
+**Step 3 — SET `intentional_wait` and idle**:
 
 ```
-TaskUpdate(taskId, metadata={"teachback_sent": true})
+TaskUpdate(taskId, metadata={"intentional_wait": {
+    "reason": "awaiting_lead_completion",
+    "expected_resolver": "lead",
+    "since": "<canonical_since() output: tz-aware ISO-8601 UTC>"
+}})
 ```
 
-If you will idle-wait for the lead's correction, SET the `intentional_wait`
-task metadata (reason `awaiting_teachback_approved`, resolver `lead`) before
-going idle and CLEAR it on resume. See "Intentional Waiting" in `pact-agent-teams`
-for the SET/CLEAR snippets and full contract.
+Do NOT begin Task B until Task A's status transitions to `completed`. The lead's wake-signal SendMessage confirms acceptance — you cannot self-wake to poll TaskList while idle.
+
+**On rejection** (lead writes `metadata.teachback_rejection`): see [pact-agent-teams §On Rejection](../pact-agent-teams/SKILL.md#on-rejection-wake-signal-receipt).
 
 ## Ordering rule
 
-You must send the teachback before any Edit/Write/Bash call used for
-implementation work. Reading files to understand the task (via Read, Glob,
-Grep) is permitted before teachback; those are understanding actions, not
-implementation actions.
+You must store your teachback (`metadata.teachback_submit` write) before any Edit/Write/Bash call used for implementation work. Reading files to understand the task (Read, Glob, Grep) is permitted before teachback; those are understanding actions, not implementation actions.
 
-## Post-send behavior
+Under the Task A + Task B dispatch shape, this ordering is structurally reinforced: Task B is hidden behind `blockedBy=[A]` until Task A's status transitions to `completed`. The `metadata.teachback_submit` write IS your teachback delivery; the lead's `TaskUpdate(A, status="completed")` paired with a wake-signal SendMessage IS approval.
 
-After sending the teachback, proceed with your work immediately. Do not
-wait for the lead to confirm — the protocol is non-blocking by design.
-If the lead sends a correction via SendMessage, adjust your approach
-as soon as you see it.
+## Post-store behavior
+
+Idle on `awaiting_lead_completion` until the lead's wake-signal arrives. Do NOT speculatively begin Task B; the lead's status flip is the gate.
+
+If you have other claimable, unblocked tasks unrelated to this dispatch (a separate Task A from a different mission), you may claim and work them. The wait is per-task, not per-agent.
 
 ## Exception
 
-Consultant questions (a peer asks you something) do not require a teachback.
-You only teachback on task dispatches.
+Consultant questions (a peer asks you something) do not require a teachback. You only teachback on task dispatches.

--- a/pact-plugin/skills/pact-teachback/SKILL.md
+++ b/pact-plugin/skills/pact-teachback/SKILL.md
@@ -7,18 +7,18 @@ description: Command-style teachback protocol for PACT teammates. Invoking this 
 
 Invoking this skill means you are about to submit a teachback for your
 current task. Do not proceed to implementation work until you have stored
-it AND received the lead's acceptance.
+it AND received the team-lead's acceptance.
 
 ## What a teachback is
 
 A teachback is a Pask Conversation Theory verification gate. Before you
 start implementing, you restate your understanding of the task so the
-lead can catch misunderstandings early, before you burn context on a
+team-lead can catch misunderstandings early, before you burn context on a
 wrong implementation.
 
 Under the Task A + Task B dispatch shape, your teachback is the deliverable
 of Task A. Task B (the primary work) is `blockedBy=[A]` and stays hidden
-in your TaskList until the lead accepts your teachback by transitioning
+in your TaskList until the team-lead accepts your teachback by transitioning
 Task A to `completed`.
 
 ## Action: store teachback now
@@ -29,18 +29,18 @@ Task A to `completed`.
 TaskUpdate(taskId, metadata={"teachback_submit": {
     "understanding": "<what you understand you're building, key constraints, interfaces>",
     "most_likely_wrong": "<the part of your understanding you are least confident about>",
-    "least_confident_item": "<one specific assumption you'd like the lead to confirm>",
+    "least_confident_item": "<one specific assumption you'd like the team-lead to confirm>",
     "first_action": "<the first concrete step you will take after teachback approval>"
 }})
 ```
 
-**Step 2 — notify the lead** (lightweight prose, NOT the full payload):
+**Step 2 — notify the team-lead** (lightweight prose, NOT the full payload):
 
 ```
 SendMessage(
     to="team-lead",
     message=(
-        "[<your-agent-name>→lead] Teachback submitted on Task #<A_id>. "
+        "[<your-agent-name>→team-lead] Teachback submitted on Task #<A_id>. "
         "See metadata.teachback_submit. Idling on awaiting_lead_completion."
     ),
     summary="Teachback submitted: <topic>"
@@ -57,19 +57,19 @@ TaskUpdate(taskId, metadata={"intentional_wait": {
 }})
 ```
 
-Do NOT begin Task B until Task A's status transitions to `completed`. The lead's wake-signal SendMessage confirms acceptance — you cannot self-wake to poll TaskList while idle.
+Do NOT begin Task B until Task A's status transitions to `completed`. The team-lead's wake-signal SendMessage confirms acceptance — you cannot self-wake to poll TaskList while idle.
 
-**On rejection** (lead writes `metadata.teachback_rejection`): see [pact-agent-teams §On Rejection](../pact-agent-teams/SKILL.md#on-rejection-wake-signal-receipt).
+**On rejection** (team-lead writes `metadata.teachback_rejection`): see [pact-agent-teams §On Rejection](../pact-agent-teams/SKILL.md#on-rejection-wake-signal-receipt).
 
 ## Ordering rule
 
 You must store your teachback (`metadata.teachback_submit` write) before any Edit/Write/Bash call used for implementation work. Reading files to understand the task (Read, Glob, Grep) is permitted before teachback; those are understanding actions, not implementation actions.
 
-Under the Task A + Task B dispatch shape, this ordering is structurally reinforced: Task B is hidden behind `blockedBy=[A]` until Task A's status transitions to `completed`. The `metadata.teachback_submit` write IS your teachback delivery; the lead's `TaskUpdate(A, status="completed")` paired with a wake-signal SendMessage IS approval.
+Under the Task A + Task B dispatch shape, this ordering is structurally reinforced: Task B is hidden behind `blockedBy=[A]` until Task A's status transitions to `completed`. The `metadata.teachback_submit` write IS your teachback delivery; the team-lead's `TaskUpdate(A, status="completed")` paired with a wake-signal SendMessage IS approval.
 
 ## Post-store behavior
 
-Idle on `awaiting_lead_completion` until the lead's wake-signal arrives. Do NOT speculatively begin Task B; the lead's status flip is the gate.
+Idle on `awaiting_lead_completion` until the team-lead's wake-signal arrives. Do NOT speculatively begin Task B; the team-lead's status flip is the gate.
 
 If you have other claimable, unblocked tasks unrelated to this dispatch (a separate Task A from a different mission), you may claim and work them. The wait is per-task, not per-agent.
 

--- a/pact-plugin/tests/conftest.py
+++ b/pact-plugin/tests/conftest.py
@@ -158,7 +158,7 @@ def make_send_message_call(
     Create a SendMessage tool call block for Agent Teams communication.
 
     Args:
-        recipient: Target teammate name (e.g., "lead", "backend-coder")
+        recipient: Target teammate name (e.g., "team-lead", "backend-coder")
         content: Message content
         summary: Short summary for UI preview
         msg_type: Message type ("message", "shutdown_request")

--- a/pact-plugin/tests/helpers.py
+++ b/pact-plugin/tests/helpers.py
@@ -238,7 +238,7 @@ def make_send_message_call(
     Create a SendMessage tool call block for Agent Teams communication.
 
     Args:
-        recipient: Target teammate name (e.g., "lead", "backend-coder")
+        recipient: Target teammate name (e.g., "team-lead", "backend-coder")
         content: Message content
         summary: Short summary for UI preview
         msg_type: Message type ("message", "shutdown_request")

--- a/pact-plugin/tests/test_agent_handoff_emitter.py
+++ b/pact-plugin/tests/test_agent_handoff_emitter.py
@@ -117,7 +117,7 @@ class TestHappyPath:
         _run_main(
             stdin_payload={
                 "task_id": "6",
-                "task_subject": "handed off from lead",
+                "task_subject": "handed off from team-lead",
                 "teammate_name": "platform-placeholder",
                 "team_name": "pact-test",
             },

--- a/pact-plugin/tests/test_agents_structure.py
+++ b/pact-plugin/tests/test_agents_structure.py
@@ -426,7 +426,7 @@ class TestTeachbackMicroSkillExtraction:
     # the skill has shed a load-bearing piece of the protocol.
     REQUIRED_PROTOCOL_ELEMENTS = [
         "SendMessage",                  # Communication tool reference (notify path)
-        "teachback_submit",             # Metadata field name (lead-readable payload)
+        "teachback_submit",             # Metadata field name (team-lead-readable payload)
         "gate",                         # Gate semantics (teachback is a gate)
         "Teachback submitted",          # Notify-message marker
         "before any Edit/Write/Bash",   # Ordering rule literal
@@ -1321,7 +1321,7 @@ class TestDispatchTemplatePrelude:
     skills/orchestration/SKILL.md must embed the teammate bootstrap prelude
     inside the `prompt=` parameter.
 
-    This is load-bearing because the dispatch template is what the lead
+    This is load-bearing because the dispatch template is what the team-lead
     reads when spawning a specialist — if the template is missing the
     `YOUR PACT ROLE: teammate (` marker or the `Skill("PACT:teammate-bootstrap")`
     call, spawned teammates will not self-bootstrap and will lack the
@@ -1355,7 +1355,7 @@ class TestDispatchTemplatePrelude:
         """Spec Section 6.6 / Section 8: the dispatch template must
         contain the literal placeholder form `YOUR PACT ROLE: teammate ({name})`
         — not just the prefix. The `{name}` placeholder is load-bearing
-        because at dispatch time the lead substitutes the teammate's
+        because at dispatch time the team-lead substitutes the teammate's
         actual name, which is what the routing block searches for and
         what appears in the spawned teammate's context.
         """
@@ -1368,7 +1368,7 @@ class TestDispatchTemplatePrelude:
         assert "YOUR PACT ROLE: teammate ({name})" in region, (
             "Agent Teams Dispatch template in skills/orchestration/SKILL.md "
             "must contain literal `YOUR PACT ROLE: teammate ({name})` (with "
-            "the exact placeholder form) so the lead substitutes the "
+            "the exact placeholder form) so the team-lead substitutes the "
             "teammate's name at dispatch time. Spec Section 6.6."
         )
 

--- a/pact-plugin/tests/test_agents_structure.py
+++ b/pact-plugin/tests/test_agents_structure.py
@@ -413,26 +413,24 @@ class TestTeachbackMicroSkillExtraction:
     AGENTS_DIR = Path(__file__).parent.parent / "agents"
 
     # Micro-skill size budget: teachback protocol should be compact.
-    # Measured in characters (not bytes). Bumped from 1500 to 2500 post-#366
-    # because the skill was rewritten in command-style form (it now contains
-    # the full SendMessage template, ordering rule, post-send behavior, and
-    # consultant-question exception). The previous stub form was too terse to
-    # function as the standalone teachback gate it now serves.
-    MAX_SKILL_CHARS = 2500
+    # Measured in characters (not bytes). Budget tracks legitimate growth
+    # of the protocol surface. Current value (4000) accommodates the
+    # 4-field structured payload (understanding / most_likely_wrong /
+    # least_confident_item / first_action), the Task A / Task B dispatch
+    # framing, and the idle-on-awaiting_lead_completion contract that
+    # replaced the prior SendMessage-prose teachback delivery.
+    MAX_SKILL_CHARS = 4000
 
     # Key protocol elements that must be in the extracted skill.
-    # Cycle 2 minor item 4: added literal ordering rule and TaskUpdate
-    # follow-up to close spec Section 6.14 coverage gap. The previous
-    # presence-only checks would have passed even if the skill dropped
-    # the ordering rule entirely.
+    # Presence-only checks are deliberately strict — any drop indicates
+    # the skill has shed a load-bearing piece of the protocol.
     REQUIRED_PROTOCOL_ELEMENTS = [
-        "SendMessage",           # Communication tool reference
-        "teachback_sent",        # Metadata flag
-        "gate",                  # Gate semantics (teachback is a gate)
-        "Teachback:",            # Format template marker
-        # Cycle 2 item 4 additions:
-        "before any Edit/Write/Bash",  # Ordering rule literal
-        'TaskUpdate(taskId, metadata={"teachback_sent": true})',  # Follow-up literal
+        "SendMessage",                  # Communication tool reference (notify path)
+        "teachback_submit",             # Metadata field name (lead-readable payload)
+        "gate",                         # Gate semantics (teachback is a gate)
+        "Teachback submitted",          # Notify-message marker
+        "before any Edit/Write/Bash",   # Ordering rule literal
+        'TaskUpdate(taskId, metadata={"teachback_submit":',  # Storage literal
     ]
 
     # Lines that indicate full protocol content (not a stub).

--- a/pact-plugin/tests/test_bootstrap_prompt_gate.py
+++ b/pact-plugin/tests/test_bootstrap_prompt_gate.py
@@ -4,7 +4,7 @@ bootstrap-first instructions until bootstrap-complete marker exists.
 
 Tests cover:
 1. Marker exists → suppressOutput (fast path, zero tokens)
-2. No marker + PACT lead session → inject additionalContext with bootstrap instruction
+2. No marker + PACT team-lead session → inject additionalContext with bootstrap instruction
 3. Non-PACT session (no session dir) → suppressOutput (no-op passthrough)
 4. Teammate (agent_name non-empty) → suppressOutput (no-op passthrough)
 5. Malformed stdin JSON → fail-open (suppressOutput, exit 0)
@@ -117,7 +117,7 @@ class TestCheckBootstrapNeeded:
         assert result is None
 
     def test_returns_instruction_when_no_marker(self, monkeypatch, tmp_path):
-        """No marker + lead session → bootstrap instruction string with session dir."""
+        """No marker + team-lead session → bootstrap instruction string with session dir."""
         from bootstrap_prompt_gate import _check_bootstrap_needed
 
         session_dir = _setup_pact_session(monkeypatch, tmp_path, with_marker=False)

--- a/pact-plugin/tests/test_claude_md_manager.py
+++ b/pact-plugin/tests/test_claude_md_manager.py
@@ -205,7 +205,7 @@ class TestPactRoutingBlock:
         assert required_substring in PACT_ROUTING_BLOCK, (
             f"PACT_ROUTING_BLOCK is missing the per-turn reminder "
             f"substring {required_substring!r}. Per #452, the orchestrator "
-            f"line must instruct the lead to treat the orchestration "
+            f"line must instruct the team-lead to treat the orchestration "
             f"skill's content as its per-turn operating reference. "
             f"Without this, the Tier-0 per-turn-discipline layer of the "
             f"governance-delivery architecture is silently absent."
@@ -237,7 +237,7 @@ class TestPactRoutingBlock:
             "\n"
             "## Working Memory\n"
             "- 2026-04-12: The session_init hook injects YOUR PACT ROLE: orchestrator "
-            "into additionalContext for the lead session.\n"
+            "into additionalContext for the team-lead session.\n"
             "- Architecture note: YOUR PACT ROLE: teammate markers are injected by "
             "peer_inject.py.\n"
             "\n"
@@ -1976,7 +1976,7 @@ class TestMarkerConsistency:
     Meanwhile, three production sites emit these markers:
 
       - session_init.py `_team_create` / `_team_reuse` emit the
-        orchestrator marker to fresh and resumed lead sessions.
+        orchestrator marker to fresh and resumed team-lead sessions.
       - peer_inject.py `_BOOTSTRAP_PRELUDE_TEMPLATE` emits the teammate
         marker to every newly spawned teammate via SubagentStart hook.
 
@@ -2060,7 +2060,7 @@ class TestMarkerConsistency:
         create_region = source[create_idx : create_idx + 2000]
         assert self.ORCHESTRATOR_MARKER in create_region, (
             f"session_init.py `_team_create` string literal must contain "
-            f"`{self.ORCHESTRATOR_MARKER}` so fresh lead sessions are "
+            f"`{self.ORCHESTRATOR_MARKER}` so fresh team-lead sessions are "
             f"routed to the orchestrator bootstrap. Routing-block search "
             f"pattern drift."
         )
@@ -2079,7 +2079,7 @@ class TestMarkerConsistency:
         reuse_region = source[reuse_idx : reuse_idx + 2000]
         assert self.ORCHESTRATOR_MARKER in reuse_region, (
             f"session_init.py `_team_reuse` string literal must contain "
-            f"`{self.ORCHESTRATOR_MARKER}` so resumed lead sessions are "
+            f"`{self.ORCHESTRATOR_MARKER}` so resumed team-lead sessions are "
             f"routed to the orchestrator bootstrap. Routing-block search "
             f"pattern drift."
         )
@@ -2106,7 +2106,7 @@ class TestMarkerConsistency:
         peer_inject.py _BOOTSTRAP_PRELUDE_TEMPLATE — though session_init
         emits the orchestrator marker, not the teammate marker).
 
-        The dispatch template is how the lead spawns specialists as
+        The dispatch template is how the team-lead spawns specialists as
         teammates: the `prompt=` parameter of the `Task(...)` call embeds
         `YOUR PACT ROLE: teammate ({name})` so the spawned teammate's context
         carries the marker the routing block searches for. If the
@@ -2150,7 +2150,7 @@ class TestMarkerConsistency:
               emitters still hold the line.
 
         The (b) case matters because the PACT routing architecture is
-        multi-layer: the lead session path (session_init), the spawned
+        multi-layer: the team-lead session path (session_init), the spawned
         teammate path via hook injection (peer_inject), and the spawned
         teammate path via dispatch template (skills/orchestration/SKILL.md)
         are all independently load-bearing. A silent drop in any one of
@@ -2158,7 +2158,7 @@ class TestMarkerConsistency:
         other paths noticing — which is exactly the kind of drift this
         tripwire exists to catch.
 
-        Note that session_init emits the ORCHESTRATOR marker (to lead
+        Note that session_init emits the ORCHESTRATOR marker (to team-lead
         sessions), while peer_inject and skills/orchestration/SKILL.md emit
         the TEAMMATE marker prefix (to spawned teammates). That split is
         intentional — the routing block uses each marker to dispatch to
@@ -2205,7 +2205,7 @@ class TestMarkerConsistency:
                 f"production emission site(s) do not contain it: "
                 f"{missing}. Registered emitters: "
                 f"{[name for name, _ in emitters]}. Routing is broken "
-                f"for this code path — a teammate or lead reaching the "
+                f"for this code path — a teammate or team-lead reaching the "
                 f"broken emitter will not self-bootstrap."
             )
 

--- a/pact-plugin/tests/test_commands_structure.py
+++ b/pact-plugin/tests/test_commands_structure.py
@@ -195,3 +195,58 @@ class TestPactRoleTeammateInConsumerCommands:
             "'Canonical Task() dispatch is mirrored inline at every consumer "
             "site' pinned-context entry for context."
         )
+
+
+class TestTwoTaskDispatchShapeInConsumerCommands:
+    """The Task A + Task B dispatch shape must be encoded in every consumer
+    command file that spawns teammates.
+
+    Why this is structural, not behavioral: the dispatch shape is described
+    in skills/orchestration/SKILL.md but consumer commands inline it because
+    LLM readers under token pressure don't follow cross-references reliably
+    (same rationale as the canonical PACT ROLE marker test above). If a
+    consumer command silently drops the inline anchor, lead-side dispatch
+    for that workflow degrades to single-task form and the teachback gate
+    becomes optional rather than mandatory.
+
+    Pinned literals:
+    - "Two-Task Dispatch Shape" — the section heading anchor in each file.
+    - "addBlockedBy" — the API call shape that creates the blockedBy chain.
+
+    Distinct from `addBlockedBy=[A]` which the architect spec used as
+    illustrative shorthand; production form is the API call name itself
+    (e.g. `addBlockedBy=[A_id]` or `addBlockedBy=[<Task A id>]`).
+    """
+
+    CONSUMER_COMMANDS = [
+        "orchestrate",
+        "peer-review",
+        "comPACT",
+        "rePACT",
+        "plan-mode",
+    ]
+
+    @pytest.mark.parametrize("name", CONSUMER_COMMANDS)
+    def test_contains_two_task_dispatch_shape_anchor(self, name):
+        path = COMMANDS_DIR / f"{name}.md"
+        text = path.read_text(encoding="utf-8")
+        assert "Two-Task Dispatch Shape" in text, (
+            f"{name}.md must contain 'Two-Task Dispatch Shape' section anchor "
+            "(inline per architect D7 — canonical Task() prompt preserved, "
+            "dispatch shape mirrored at consumer sites). Drop signals "
+            "either reverted #491 work or a refactor that compressed the "
+            "anchor into a cross-reference; both fail the agent-reader-primary "
+            "axiom (LLM readers under token pressure don't follow xrefs)."
+        )
+
+    @pytest.mark.parametrize("name", CONSUMER_COMMANDS)
+    def test_contains_add_blocked_by_call(self, name):
+        path = COMMANDS_DIR / f"{name}.md"
+        text = path.read_text(encoding="utf-8")
+        assert "addBlockedBy" in text, (
+            f"{name}.md must contain 'addBlockedBy' (the API call that wires "
+            "Task B's blockedBy=[A] dependency). Without this, the data-layer "
+            "unblock that resolves on Task A completion is never created — "
+            "Task B becomes immediately claimable and the teachback gate "
+            "is bypassed."
+        )

--- a/pact-plugin/tests/test_commands_structure.py
+++ b/pact-plugin/tests/test_commands_structure.py
@@ -205,7 +205,7 @@ class TestTwoTaskDispatchShapeInConsumerCommands:
     in skills/orchestration/SKILL.md but consumer commands inline it because
     LLM readers under token pressure don't follow cross-references reliably
     (same rationale as the canonical PACT ROLE marker test above). If a
-    consumer command silently drops the inline anchor, lead-side dispatch
+    consumer command silently drops the inline anchor, team-lead-side dispatch
     for that workflow degrades to single-task form and the teachback gate
     becomes optional rather than mandatory.
 

--- a/pact-plugin/tests/test_cross_references.py
+++ b/pact-plugin/tests/test_cross_references.py
@@ -263,11 +263,11 @@ class TestDeadReferencesToMovedOrchestratorCore:
 
 
 class TestLeadSideHaltFanOutSlugStability:
-    """L10: Stability of the `lead-side-halt-fan-out` slug.
+    """L10: Stability of the `team-lead-side-halt-fan-out` slug.
 
     The canonical `#### Lead-Side HALT Fan-Out` heading lives in
     skills/orchestration/SKILL.md and is referenced from 4 distinct
-    consumer files via the GitHub-rendered slug `lead-side-halt-fan-out`
+    consumer files via the GitHub-rendered slug `team-lead-side-halt-fan-out`
     (algedonic.md hosts 2 link occurrences, the other three each host 1,
     for 5 link occurrences across 4 files). Renaming the heading
     silently breaks every cross-reference (link still resolves to the
@@ -283,7 +283,7 @@ class TestLeadSideHaltFanOutSlugStability:
     """
 
     CANONICAL_HEADING = "#### Lead-Side HALT Fan-Out"
-    SLUG = "lead-side-halt-fan-out"
+    SLUG = "team-lead-side-halt-fan-out"
 
     CROSS_REF_FILES = [
         ("protocols/algedonic.md", ALGEDONIC_PATH),
@@ -304,9 +304,9 @@ class TestLeadSideHaltFanOutSlugStability:
 
     def test_canonical_heading_renders_to_expected_slug(self):
         """GitHub auto-slugs `#### Lead-Side HALT Fan-Out` to
-        `lead-side-halt-fan-out` (lowercased, spaces → hyphens, special
+        `team-lead-side-halt-fan-out` (lowercased, spaces → hyphens, special
         chars stripped). Verify the canonical site itself contains the
-        slug as a self-anchor in its consumer body — `[…](#lead-side-halt-fan-out)` —
+        slug as a self-anchor in its consumer body — `[…](#team-lead-side-halt-fan-out)` —
         which transitively confirms the lower-casing/hyphenation rule
         the consumers rely on.
         """

--- a/pact-plugin/tests/test_dogfood_livelock_invariant.py
+++ b/pact-plugin/tests/test_dogfood_livelock_invariant.py
@@ -653,7 +653,7 @@ class TestR1bRuntimeFailOpen:
         # The critical structural invariant: no systemMessage on stdout.
         # Claude Code treats stdout-JSON as a hook signal; if python's
         # own error output leaked there, every missing-hook path would
-        # surface in the lead's prompt.
+        # surface in the team-lead's prompt.
         assert "systemMessage" not in result.stdout, (
             f"python3 emitted systemMessage to stdout on missing file — "
             f"this would incorrectly surface as a Claude Code hook signal. "

--- a/pact-plugin/tests/test_intentional_wait.py
+++ b/pact-plugin/tests/test_intentional_wait.py
@@ -362,12 +362,6 @@ class TestIsSelfCompleteExempt:
         assert is_self_complete_exempt({"owner": "secretary", "metadata": {}}) is True
         assert is_self_complete_exempt({"owner": "pact-secretary", "metadata": {}}) is True
 
-    def test_dispatch_agent_metadata_is_exempt(self):
-        from shared.intentional_wait import is_self_complete_exempt
-
-        task = {"owner": "secretary-3", "metadata": {"dispatch_agent": "pact-secretary"}}
-        assert is_self_complete_exempt(task) is True
-
     def test_backend_coder_is_not_exempt(self):
         from shared.intentional_wait import is_self_complete_exempt
 
@@ -451,27 +445,6 @@ class TestIsSelfCompleteExemptMalformedTaskShapes:
 
         # Empty string is not in SELF_COMPLETE_EXEMPT_AGENTS → no exemption.
         assert is_self_complete_exempt({"owner": "", "metadata": {}}) is False
-
-    def test_dispatch_agent_none_falls_through_to_owner(self):
-        from shared.intentional_wait import is_self_complete_exempt
-
-        # dispatch_agent=None → not str → skip; owner=secretary → exempt.
-        task = {"owner": "secretary", "metadata": {"dispatch_agent": None}}
-        assert is_self_complete_exempt(task) is True
-
-    def test_dispatch_agent_non_str_falls_through_to_owner(self):
-        from shared.intentional_wait import is_self_complete_exempt
-
-        # dispatch_agent=int → not str → skip; owner=secretary → exempt.
-        task = {"owner": "secretary", "metadata": {"dispatch_agent": 42}}
-        assert is_self_complete_exempt(task) is True
-
-    def test_dispatch_agent_empty_string_returns_false(self):
-        from shared.intentional_wait import is_self_complete_exempt
-
-        # Empty string is not in SELF_COMPLETE_EXEMPT_AGENTS; non-exempt owner.
-        task = {"owner": "backend-coder", "metadata": {"dispatch_agent": ""}}
-        assert is_self_complete_exempt(task) is False
 
 
 class TestIsSelfCompleteExemptDualCarveOutIndependence:

--- a/pact-plugin/tests/test_intentional_wait.py
+++ b/pact-plugin/tests/test_intentional_wait.py
@@ -418,3 +418,173 @@ class TestIsSelfCompleteExempt:
         assert is_self_complete_exempt({"owner": 42, "metadata": {}}) is False
 
 
+class TestIsSelfCompleteExemptMalformedTaskShapes:
+    """Edge cases for malformed task dicts — defensive defaults must hold."""
+
+    def test_no_metadata_key_returns_false(self):
+        from shared.intentional_wait import is_self_complete_exempt
+
+        # `metadata` key absent entirely. owner is non-exempt.
+        assert is_self_complete_exempt({"owner": "backend-coder"}) is False
+
+    def test_metadata_explicit_none_returns_false(self):
+        from shared.intentional_wait import is_self_complete_exempt
+
+        # metadata=None coalesces to {} via `metadata = task.get("metadata") or {}`.
+        # Owner is non-exempt → returns False.
+        assert is_self_complete_exempt({"owner": "backend-coder", "metadata": None}) is False
+
+    def test_metadata_none_with_secretary_owner_still_exempt(self):
+        from shared.intentional_wait import is_self_complete_exempt
+
+        # Surface 1 (owner) still triggers even with metadata=None.
+        assert is_self_complete_exempt({"owner": "secretary", "metadata": None}) is True
+
+    def test_owner_none_returns_false(self):
+        from shared.intentional_wait import is_self_complete_exempt
+
+        # owner=None is not a string → isinstance check fails → no exemption.
+        assert is_self_complete_exempt({"owner": None, "metadata": {}}) is False
+
+    def test_owner_empty_string_returns_false(self):
+        from shared.intentional_wait import is_self_complete_exempt
+
+        # Empty string is not in SELF_COMPLETE_EXEMPT_AGENTS → no exemption.
+        assert is_self_complete_exempt({"owner": "", "metadata": {}}) is False
+
+    def test_dispatch_agent_none_falls_through_to_owner(self):
+        from shared.intentional_wait import is_self_complete_exempt
+
+        # dispatch_agent=None → not str → skip; owner=secretary → exempt.
+        task = {"owner": "secretary", "metadata": {"dispatch_agent": None}}
+        assert is_self_complete_exempt(task) is True
+
+    def test_dispatch_agent_non_str_falls_through_to_owner(self):
+        from shared.intentional_wait import is_self_complete_exempt
+
+        # dispatch_agent=int → not str → skip; owner=secretary → exempt.
+        task = {"owner": "secretary", "metadata": {"dispatch_agent": 42}}
+        assert is_self_complete_exempt(task) is True
+
+    def test_dispatch_agent_empty_string_returns_false(self):
+        from shared.intentional_wait import is_self_complete_exempt
+
+        # Empty string is not in SELF_COMPLETE_EXEMPT_AGENTS; non-exempt owner.
+        task = {"owner": "backend-coder", "metadata": {"dispatch_agent": ""}}
+        assert is_self_complete_exempt(task) is False
+
+
+class TestIsSelfCompleteExemptDualCarveOutIndependence:
+    """Both exemption surfaces must work independently AND together.
+
+    Surface 1: SELF_COMPLETE_EXEMPT_AGENTS membership (by agent type).
+    Surface 2: signal-task pattern (completion_type=signal + type in {blocker, algedonic}).
+
+    Reverting EITHER surface in production must surface as independent test failures.
+    """
+
+    def test_only_signal_task_path_no_exempt_agent(self):
+        # Auditor signal-task: agent NOT in exempt set, but signal pattern exempts.
+        from shared.intentional_wait import is_self_complete_exempt
+
+        task = {
+            "owner": "pact-auditor",
+            "metadata": {"completion_type": "signal", "type": "algedonic"},
+        }
+        assert is_self_complete_exempt(task) is True
+
+    def test_only_exempt_agent_path_no_signal_task(self):
+        # Secretary memory-save: agent in exempt set, no signal-task metadata.
+        from shared.intentional_wait import is_self_complete_exempt
+
+        task = {"owner": "secretary", "metadata": {"completion_type": "regular"}}
+        assert is_self_complete_exempt(task) is True
+
+    def test_both_paths_match_still_exempt(self):
+        # Defense-in-depth: secretary on a signal-task is exempt via either surface.
+        from shared.intentional_wait import is_self_complete_exempt
+
+        task = {
+            "owner": "secretary",
+            "metadata": {"completion_type": "signal", "type": "blocker"},
+        }
+        assert is_self_complete_exempt(task) is True
+
+    def test_neither_path_matches_not_exempt(self):
+        # Backend-coder doing regular work is NOT exempt via either surface.
+        from shared.intentional_wait import is_self_complete_exempt
+
+        task = {
+            "owner": "backend-coder",
+            "metadata": {"completion_type": "regular", "type": "feature"},
+        }
+        assert is_self_complete_exempt(task) is False
+
+
+class TestSelfCompleteExemptAgentsImmutability:
+    """frozenset chosen specifically to prevent accidental mutation; pin that."""
+
+    def test_add_raises_attribute_error(self):
+        from shared.intentional_wait import SELF_COMPLETE_EXEMPT_AGENTS
+
+        with pytest.raises(AttributeError):
+            SELF_COMPLETE_EXEMPT_AGENTS.add("new-agent")
+
+    def test_remove_raises_attribute_error(self):
+        from shared.intentional_wait import SELF_COMPLETE_EXEMPT_AGENTS
+
+        with pytest.raises(AttributeError):
+            SELF_COMPLETE_EXEMPT_AGENTS.remove("secretary")
+
+    def test_clear_raises_attribute_error(self):
+        from shared.intentional_wait import SELF_COMPLETE_EXEMPT_AGENTS
+
+        with pytest.raises(AttributeError):
+            SELF_COMPLETE_EXEMPT_AGENTS.clear()
+
+    def test_known_reasons_immutable(self):
+        # KNOWN_REASONS must also be frozen — same accidental-mutation concern.
+        from shared.intentional_wait import KNOWN_REASONS
+
+        with pytest.raises(AttributeError):
+            KNOWN_REASONS.add("awaiting_something_new")
+
+
+class TestKnownReasonsLiteralRegressionGuard:
+    """Pin the exact set of known reasons. Any silent removal/rename must fail loudly.
+
+    This is a documentation-in-code test: the contract published to teammates
+    via the pact-agent-teams skill names these strings. Silent renaming would
+    break in-flight teammate metadata writes without surfacing a build error.
+    """
+
+    EXPECTED_REASONS = {
+        "awaiting_teachback_approved",
+        "awaiting_lead_commit",
+        "awaiting_amendment_review",
+        "awaiting_post_handoff_decision",
+        "awaiting_peer_response",
+        "awaiting_user_decision",
+        "awaiting_blocker_resolution",
+        "awaiting_lead_completion",
+    }
+
+    def test_exact_set(self):
+        from shared.intentional_wait import KNOWN_REASONS
+
+        assert set(KNOWN_REASONS) == self.EXPECTED_REASONS
+
+    @pytest.mark.parametrize("reason", sorted(EXPECTED_REASONS))
+    def test_each_reason_validates(self, reason):
+        from shared.intentional_wait import validate_wait
+
+        payload = _fresh_wait(reason=reason)
+        assert validate_wait(payload) is True
+
+    def test_awaiting_lead_completion_is_present(self):
+        # Specifically pin the new addition — guards against revert.
+        from shared.intentional_wait import KNOWN_REASONS
+
+        assert "awaiting_lead_completion" in KNOWN_REASONS
+
+

--- a/pact-plugin/tests/test_intentional_wait.py
+++ b/pact-plugin/tests/test_intentional_wait.py
@@ -320,3 +320,101 @@ class TestSkillMdProseSnippetConformance:
         assert wait_stale(payload) is False
 
 
+# --- self-complete exemption -----------------------------------------------
+
+class TestKnownReasonsCompletionAddition:
+    def test_awaiting_lead_completion_in_known_reasons(self):
+        from shared.intentional_wait import KNOWN_REASONS
+
+        assert "awaiting_lead_completion" in KNOWN_REASONS
+
+    def test_awaiting_lead_completion_passes_validate_wait(self):
+        from shared.intentional_wait import validate_wait
+
+        payload = _fresh_wait(reason="awaiting_lead_completion")
+        assert validate_wait(payload) is True
+
+
+class TestSelfCompleteExemptAgentsConstant:
+    def test_is_frozenset(self):
+        from shared.intentional_wait import SELF_COMPLETE_EXEMPT_AGENTS
+
+        assert isinstance(SELF_COMPLETE_EXEMPT_AGENTS, frozenset)
+
+    def test_contains_secretary_aliases(self):
+        from shared.intentional_wait import SELF_COMPLETE_EXEMPT_AGENTS
+
+        assert "pact-secretary" in SELF_COMPLETE_EXEMPT_AGENTS
+        assert "secretary" in SELF_COMPLETE_EXEMPT_AGENTS
+
+    def test_does_not_contain_auditor(self):
+        # Auditor exemption is signal-task pattern, NOT agent-type.
+        from shared.intentional_wait import SELF_COMPLETE_EXEMPT_AGENTS
+
+        assert "auditor" not in SELF_COMPLETE_EXEMPT_AGENTS
+        assert "pact-auditor" not in SELF_COMPLETE_EXEMPT_AGENTS
+
+
+class TestIsSelfCompleteExempt:
+    def test_secretary_owner_is_exempt(self):
+        from shared.intentional_wait import is_self_complete_exempt
+
+        assert is_self_complete_exempt({"owner": "secretary", "metadata": {}}) is True
+        assert is_self_complete_exempt({"owner": "pact-secretary", "metadata": {}}) is True
+
+    def test_dispatch_agent_metadata_is_exempt(self):
+        from shared.intentional_wait import is_self_complete_exempt
+
+        task = {"owner": "secretary-3", "metadata": {"dispatch_agent": "pact-secretary"}}
+        assert is_self_complete_exempt(task) is True
+
+    def test_backend_coder_is_not_exempt(self):
+        from shared.intentional_wait import is_self_complete_exempt
+
+        assert is_self_complete_exempt({"owner": "backend-coder-1", "metadata": {}}) is False
+
+    def test_signal_task_blocker_is_exempt(self):
+        from shared.intentional_wait import is_self_complete_exempt
+
+        task = {
+            "owner": "auditor-1",
+            "metadata": {"completion_type": "signal", "type": "blocker"},
+        }
+        assert is_self_complete_exempt(task) is True
+
+    def test_signal_task_algedonic_is_exempt(self):
+        from shared.intentional_wait import is_self_complete_exempt
+
+        task = {
+            "owner": "any-agent",
+            "metadata": {"completion_type": "signal", "type": "algedonic"},
+        }
+        assert is_self_complete_exempt(task) is True
+
+    def test_signal_task_other_type_is_not_exempt(self):
+        from shared.intentional_wait import is_self_complete_exempt
+
+        task = {
+            "owner": "any-agent",
+            "metadata": {"completion_type": "signal", "type": "progress"},
+        }
+        assert is_self_complete_exempt(task) is False
+
+    def test_completion_type_without_signal_marker_not_exempt(self):
+        # type=blocker alone (without completion_type=signal) is NOT a signal-task.
+        from shared.intentional_wait import is_self_complete_exempt
+
+        task = {"owner": "any-agent", "metadata": {"type": "blocker"}}
+        assert is_self_complete_exempt(task) is False
+
+    def test_malformed_input_no_raise_returns_false(self):
+        from shared.intentional_wait import is_self_complete_exempt
+
+        assert is_self_complete_exempt(None) is False
+        assert is_self_complete_exempt("not a dict") is False
+        assert is_self_complete_exempt([]) is False
+        assert is_self_complete_exempt({}) is False
+        assert is_self_complete_exempt({"metadata": "not a dict"}) is False
+        assert is_self_complete_exempt({"owner": 42, "metadata": {}}) is False
+
+

--- a/pact-plugin/tests/test_peer_inject.py
+++ b/pact-plugin/tests/test_peer_inject.py
@@ -29,7 +29,11 @@ class TestPeerInject:
     """Tests for peer_inject.get_peer_context()."""
 
     def test_injects_peer_names(self, tmp_path):
-        from peer_inject import get_peer_context, _TEACHBACK_REMINDER
+        from peer_inject import (
+            get_peer_context,
+            _TEACHBACK_REMINDER,
+            _COMPLETION_AUTHORITY_NOTE,
+        )
 
         team_dir = tmp_path / "teams" / "pact-test"
         team_dir.mkdir(parents=True)
@@ -51,10 +55,14 @@ class TestPeerInject:
         assert "frontend-coder" in result
         assert "database-engineer" in result
         assert "backend-coder" not in result
-        assert result.endswith(_TEACHBACK_REMINDER)
+        assert result.endswith(_COMPLETION_AUTHORITY_NOTE)
 
     def test_excludes_spawning_agent(self, tmp_path):
-        from peer_inject import get_peer_context, _TEACHBACK_REMINDER
+        from peer_inject import (
+            get_peer_context,
+            _TEACHBACK_REMINDER,
+            _COMPLETION_AUTHORITY_NOTE,
+        )
 
         team_dir = tmp_path / "teams" / "pact-test"
         team_dir.mkdir(parents=True)
@@ -74,7 +82,7 @@ class TestPeerInject:
 
         assert "backend-coder" in result
         assert "architect" not in result
-        assert result.endswith(_TEACHBACK_REMINDER)
+        assert result.endswith(_COMPLETION_AUTHORITY_NOTE)
 
     def test_returns_none_when_no_team_config(self, tmp_path):
         from peer_inject import get_peer_context
@@ -88,7 +96,11 @@ class TestPeerInject:
         assert result is None
 
     def test_alone_message_when_only_member(self, tmp_path):
-        from peer_inject import get_peer_context, _TEACHBACK_REMINDER
+        from peer_inject import (
+            get_peer_context,
+            _TEACHBACK_REMINDER,
+            _COMPLETION_AUTHORITY_NOTE,
+        )
 
         team_dir = tmp_path / "teams" / "pact-test"
         team_dir.mkdir(parents=True)
@@ -106,7 +118,7 @@ class TestPeerInject:
         )
 
         assert "only active teammate" in result.lower()
-        assert result.endswith(_TEACHBACK_REMINDER)
+        assert result.endswith(_COMPLETION_AUTHORITY_NOTE)
 
     def test_noop_when_no_team_name(self, tmp_path):
         from peer_inject import get_peer_context
@@ -176,7 +188,11 @@ class TestTeachbackReminder:
     """Tests for _TEACHBACK_REMINDER injection into peer context."""
 
     def test_reminder_appended_when_peers_exist(self, tmp_path):
-        from peer_inject import get_peer_context, _TEACHBACK_REMINDER
+        from peer_inject import (
+            get_peer_context,
+            _TEACHBACK_REMINDER,
+            _COMPLETION_AUTHORITY_NOTE,
+        )
 
         team_dir = tmp_path / "teams" / "pact-test"
         team_dir.mkdir(parents=True)
@@ -194,11 +210,15 @@ class TestTeachbackReminder:
             teams_dir=str(tmp_path / "teams")
         )
 
-        assert result.endswith(_TEACHBACK_REMINDER)
+        assert result.endswith(_COMPLETION_AUTHORITY_NOTE)
         assert "TEACHBACK TIMING" in result
 
     def test_reminder_appended_when_alone(self, tmp_path):
-        from peer_inject import get_peer_context, _TEACHBACK_REMINDER
+        from peer_inject import (
+            get_peer_context,
+            _TEACHBACK_REMINDER,
+            _COMPLETION_AUTHORITY_NOTE,
+        )
 
         team_dir = tmp_path / "teams" / "pact-test"
         team_dir.mkdir(parents=True)
@@ -216,7 +236,7 @@ class TestTeachbackReminder:
         )
 
         assert "only active teammate" in result.lower()
-        assert result.endswith(_TEACHBACK_REMINDER)
+        assert result.endswith(_COMPLETION_AUTHORITY_NOTE)
 
     def test_reminder_contains_key_instructions(self):
         """The teachback reminder must mention the key instructions:
@@ -257,7 +277,11 @@ class TestTeachbackReminder:
         therefore targets the peer-list segment only — the slice between the
         prelude and the teachback reminder.
         """
-        from peer_inject import get_peer_context, _TEACHBACK_REMINDER
+        from peer_inject import (
+            get_peer_context,
+            _TEACHBACK_REMINDER,
+            _COMPLETION_AUTHORITY_NOTE,
+        )
 
         team_dir = tmp_path / "teams" / "pact-test"
         team_dir.mkdir(parents=True)
@@ -277,12 +301,13 @@ class TestTeachbackReminder:
         )
 
         assert "coder-2" in result
-        assert result.endswith(_TEACHBACK_REMINDER)
+        assert result.endswith(_COMPLETION_AUTHORITY_NOTE)
 
         # Slice out the peer-list segment: drop the prelude (everything up to
         # and including the first blank-line gap before "Active teammates")
-        # and drop the teachback reminder.
-        before_reminder = result[: -len(_TEACHBACK_REMINDER)]
+        # and drop the trailing reminders.
+        suffix_len = len(_TEACHBACK_REMINDER) + len(_COMPLETION_AUTHORITY_NOTE)
+        before_reminder = result[:-suffix_len]
         peer_list_section = before_reminder.split("Active teammates on your team:", 1)[1]
         assert "coder-1" not in peer_list_section
 
@@ -501,7 +526,11 @@ class TestBootstrapPreludeAgentName:
 
     def test_prelude_precedes_peer_list(self, tmp_path):
         """Order is: prelude, then peer context, then teachback reminder."""
-        from peer_inject import get_peer_context, _TEACHBACK_REMINDER
+        from peer_inject import (
+            get_peer_context,
+            _TEACHBACK_REMINDER,
+            _COMPLETION_AUTHORITY_NOTE,
+        )
 
         team_dir = tmp_path / "teams" / "pact-test"
         team_dir.mkdir(parents=True)
@@ -975,3 +1004,53 @@ class TestCounterTestByPeerInjectRevert:
         assert hasattr(peer_inject, "format_plugin_banner"), (
             "peer_inject must import format_plugin_banner at module scope"
         )
+
+
+class TestCompletionAuthorityNote:
+    """Tests for the completion-authority directive appended to peer context."""
+
+    def test_constant_exists_and_non_empty(self):
+        from peer_inject import _COMPLETION_AUTHORITY_NOTE
+
+        assert isinstance(_COMPLETION_AUTHORITY_NOTE, str)
+        assert len(_COMPLETION_AUTHORITY_NOTE) > 0
+
+    def test_note_contains_load_bearing_phrases(self):
+        from peer_inject import _COMPLETION_AUTHORITY_NOTE
+
+        assert "do NOT mark your own tasks" in _COMPLETION_AUTHORITY_NOTE
+        assert "awaiting_lead_completion" in _COMPLETION_AUTHORITY_NOTE
+        assert "Task A" in _COMPLETION_AUTHORITY_NOTE
+        assert "Task B" in _COMPLETION_AUTHORITY_NOTE
+        assert "lead" in _COMPLETION_AUTHORITY_NOTE.lower()
+
+    def test_note_appears_after_teachback_reminder(self, tmp_path):
+        """Ordering: prelude → peer_context → banner → teachback → completion-note."""
+        from peer_inject import (
+            get_peer_context,
+            _TEACHBACK_REMINDER,
+            _COMPLETION_AUTHORITY_NOTE,
+        )
+
+        team_dir = tmp_path / "teams" / "pact-test"
+        team_dir.mkdir(parents=True)
+        config = {
+            "members": [
+                {"name": "architect", "agentType": "pact-architect"},
+                {"name": "backend-coder", "agentType": "pact-backend-coder"},
+            ]
+        }
+        (team_dir / "config.json").write_text(json.dumps(config))
+
+        result = get_peer_context(
+            agent_type="pact-architect",
+            team_name="pact-test",
+            agent_name="architect",
+            teams_dir=str(tmp_path / "teams"),
+        )
+
+        assert _COMPLETION_AUTHORITY_NOTE in result
+        assert result.endswith(_COMPLETION_AUTHORITY_NOTE)
+        # Teachback reminder precedes completion-authority note.
+        assert result.index(_TEACHBACK_REMINDER) < result.index(_COMPLETION_AUTHORITY_NOTE)
+

--- a/pact-plugin/tests/test_peer_inject.py
+++ b/pact-plugin/tests/test_peer_inject.py
@@ -1022,7 +1022,7 @@ class TestCompletionAuthorityNote:
         assert "awaiting_lead_completion" in _COMPLETION_AUTHORITY_NOTE
         assert "Task A" in _COMPLETION_AUTHORITY_NOTE
         assert "Task B" in _COMPLETION_AUTHORITY_NOTE
-        assert "lead" in _COMPLETION_AUTHORITY_NOTE.lower()
+        assert "team-lead" in _COMPLETION_AUTHORITY_NOTE.lower()
 
     def test_note_appears_after_teachback_reminder(self, tmp_path):
         """Ordering: prelude → peer_context → banner → teachback → completion-note."""
@@ -1196,7 +1196,7 @@ class TestCompletionAuthorityLiteralPhraseRegressionGuard:
 
         # The directive must name the team-lead explicitly as the actor that
         # transitions status — not vague "the team" or "someone".
-        assert "lead" in _COMPLETION_AUTHORITY_NOTE.lower()
+        assert "team-lead" in _COMPLETION_AUTHORITY_NOTE.lower()
         assert "transitions status" in _COMPLETION_AUTHORITY_NOTE.lower() \
             or "completed" in _COMPLETION_AUTHORITY_NOTE
 

--- a/pact-plugin/tests/test_peer_inject.py
+++ b/pact-plugin/tests/test_peer_inject.py
@@ -1054,3 +1054,138 @@ class TestCompletionAuthorityNote:
         # Teachback reminder precedes completion-authority note.
         assert result.index(_TEACHBACK_REMINDER) < result.index(_COMPLETION_AUTHORITY_NOTE)
 
+
+# Spawn-able teammate agent types — these are the surfaces that should
+# receive the completion-authority directive when a peer is injected.
+# Sourced from agents/ directory; if a new pact-* agent is added, this
+# list should grow to match.
+_PACT_AGENT_TYPES = [
+    "pact-architect",
+    "pact-backend-coder",
+    "pact-frontend-coder",
+    "pact-database-engineer",
+    "pact-devops-engineer",
+    "pact-test-engineer",
+    "pact-auditor",
+    "pact-preparer",
+    "pact-secretary",
+]
+
+
+class TestCompletionAuthorityNoteParametrizedAgents:
+    """The completion-authority directive must reach EVERY spawnable pact-*
+    agent type. Single-shape mistake = one role gets phantom-approved
+    self-completion authority.
+    """
+
+    @pytest.mark.parametrize("agent_type", _PACT_AGENT_TYPES)
+    def test_note_present_for_each_agent_type(self, agent_type, tmp_path):
+        from peer_inject import get_peer_context, _COMPLETION_AUTHORITY_NOTE
+
+        team_dir = tmp_path / "teams" / "pact-test"
+        team_dir.mkdir(parents=True)
+        agent_name = agent_type.replace("pact-", "")
+        config = {
+            "members": [
+                {"name": agent_name, "agentType": agent_type},
+                {"name": "other-peer", "agentType": "pact-architect"},
+            ]
+        }
+        (team_dir / "config.json").write_text(json.dumps(config))
+
+        result = get_peer_context(
+            agent_type=agent_type,
+            team_name="pact-test",
+            agent_name=agent_name,
+            teams_dir=str(tmp_path / "teams"),
+        )
+
+        assert _COMPLETION_AUTHORITY_NOTE in result, (
+            f"Completion-authority directive missing for agent_type={agent_type}; "
+            "every spawnable pact-* role must receive it via peer_inject."
+        )
+
+    @pytest.mark.parametrize("agent_type", _PACT_AGENT_TYPES)
+    def test_ordering_invariant_for_each_agent_type(self, agent_type, tmp_path):
+        # For every agent type, completion-note still trails teachback-reminder.
+        # Index-based comparison: catches a swap that endswith would phantom-pass.
+        from peer_inject import (
+            get_peer_context,
+            _TEACHBACK_REMINDER,
+            _COMPLETION_AUTHORITY_NOTE,
+        )
+
+        team_dir = tmp_path / "teams" / "pact-test"
+        team_dir.mkdir(parents=True)
+        agent_name = agent_type.replace("pact-", "")
+        config = {
+            "members": [
+                {"name": agent_name, "agentType": agent_type},
+                {"name": "other-peer", "agentType": "pact-architect"},
+            ]
+        }
+        (team_dir / "config.json").write_text(json.dumps(config))
+
+        result = get_peer_context(
+            agent_type=agent_type,
+            team_name="pact-test",
+            agent_name=agent_name,
+            teams_dir=str(tmp_path / "teams"),
+        )
+
+        teachback_pos = result.index(_TEACHBACK_REMINDER)
+        completion_pos = result.index(_COMPLETION_AUTHORITY_NOTE)
+        assert teachback_pos < completion_pos, (
+            f"Ordering invariant broken for agent_type={agent_type}: "
+            f"teachback at {teachback_pos}, completion-note at {completion_pos}. "
+            "Completion-note must trail teachback-reminder."
+        )
+
+
+class TestCompletionAuthorityLiteralPhraseRegressionGuard:
+    """Pin the load-bearing phrases against silent softening.
+
+    Background: a prior session shipped completion-authority guidance
+    using softer wording ("teammates should generally...") that LLM
+    readers parsed as advisory rather than mandatory. Pinning the
+    "do NOT mark your own tasks" literal at the test level prevents
+    a future "improve clarity" rewrite from accidentally softening it.
+    """
+
+    def test_directive_says_do_not_mark_own_tasks(self):
+        from peer_inject import _COMPLETION_AUTHORITY_NOTE
+
+        # Exact case-sensitive phrase. NOT "should not", NOT "shouldn't",
+        # NOT "avoid marking". The capitalized "NOT" is load-bearing for
+        # LLM-reader emphasis under token pressure.
+        assert "do NOT mark your own tasks" in _COMPLETION_AUTHORITY_NOTE, (
+            "_COMPLETION_AUTHORITY_NOTE must contain the literal capitalized "
+            "phrase 'do NOT mark your own tasks' — softening to 'should not' "
+            "or 'avoid' has been observed to lose enforcement weight."
+        )
+
+    def test_directive_names_lead_as_completion_authority(self):
+        from peer_inject import _COMPLETION_AUTHORITY_NOTE
+
+        # The directive must name the lead explicitly as the actor that
+        # transitions status — not vague "the team" or "someone".
+        assert "lead" in _COMPLETION_AUTHORITY_NOTE.lower()
+        assert "transitions status" in _COMPLETION_AUTHORITY_NOTE.lower() \
+            or "completed" in _COMPLETION_AUTHORITY_NOTE
+
+    def test_directive_references_intentional_wait_completion_reason(self):
+        from peer_inject import _COMPLETION_AUTHORITY_NOTE
+
+        # The directive instructs teammates to use the new
+        # `awaiting_lead_completion` reason. Pin the literal so a
+        # rename in shared.intentional_wait surfaces here.
+        assert "awaiting_lead_completion" in _COMPLETION_AUTHORITY_NOTE
+
+    def test_directive_describes_two_task_pair(self):
+        from peer_inject import _COMPLETION_AUTHORITY_NOTE
+
+        # Both halves of the dispatch pair must be named — single-half
+        # phrasing has been observed to leave Task B context under-described.
+        assert "Task A" in _COMPLETION_AUTHORITY_NOTE
+        assert "Task B" in _COMPLETION_AUTHORITY_NOTE
+

--- a/pact-plugin/tests/test_peer_inject.py
+++ b/pact-plugin/tests/test_peer_inject.py
@@ -1058,7 +1058,8 @@ class TestCompletionAuthorityNote:
 # Spawn-able teammate agent types — these are the surfaces that should
 # receive the completion-authority directive when a peer is injected.
 # Sourced from agents/ directory; if a new pact-* agent is added, this
-# list should grow to match.
+# list should grow to match. The drift-detection test below asserts the
+# list ⊇ agents/ directory listing so additions are caught at test-time.
 _PACT_AGENT_TYPES = [
     "pact-architect",
     "pact-backend-coder",
@@ -1069,6 +1070,9 @@ _PACT_AGENT_TYPES = [
     "pact-auditor",
     "pact-preparer",
     "pact-secretary",
+    "pact-n8n",
+    "pact-qa-engineer",
+    "pact-security-engineer",
 ]
 
 
@@ -1139,6 +1143,24 @@ class TestCompletionAuthorityNoteParametrizedAgents:
             f"Ordering invariant broken for agent_type={agent_type}: "
             f"teachback at {teachback_pos}, completion-note at {completion_pos}. "
             "Completion-note must trail teachback-reminder."
+        )
+
+    def test_pact_agent_types_list_covers_agents_directory(self):
+        """Drift guard: _PACT_AGENT_TYPES must cover every pact-*.md in agents/.
+
+        Catches new agent additions that forget to update the parametrize list.
+        Without this, a new role would silently miss the parametrized sweep
+        and could ship without verified completion-authority directive
+        delivery. Set comparison (⊇) tolerates the list being a superset
+        if a future agent type is registered before its file lands.
+        """
+        agents_dir = Path(__file__).parent.parent / "agents"
+        files = sorted(p.stem for p in agents_dir.glob("pact-*.md"))
+        missing = set(files) - set(_PACT_AGENT_TYPES)
+        assert not missing, (
+            f"_PACT_AGENT_TYPES is missing agents present in {agents_dir}: "
+            f"{sorted(missing)}. Add them to the list so the parametrized "
+            "sweep covers every spawnable role."
         )
 
 

--- a/pact-plugin/tests/test_peer_inject.py
+++ b/pact-plugin/tests/test_peer_inject.py
@@ -1194,7 +1194,7 @@ class TestCompletionAuthorityLiteralPhraseRegressionGuard:
     def test_directive_names_lead_as_completion_authority(self):
         from peer_inject import _COMPLETION_AUTHORITY_NOTE
 
-        # The directive must name the lead explicitly as the actor that
+        # The directive must name the team-lead explicitly as the actor that
         # transitions status — not vague "the team" or "someone".
         assert "lead" in _COMPLETION_AUTHORITY_NOTE.lower()
         assert "transitions status" in _COMPLETION_AUTHORITY_NOTE.lower() \

--- a/pact-plugin/tests/test_peer_inject.py
+++ b/pact-plugin/tests/test_peer_inject.py
@@ -1145,22 +1145,27 @@ class TestCompletionAuthorityNoteParametrizedAgents:
             "Completion-note must trail teachback-reminder."
         )
 
-    def test_pact_agent_types_list_covers_agents_directory(self):
-        """Drift guard: _PACT_AGENT_TYPES must cover every pact-*.md in agents/.
+    def test_pact_agent_types_list_matches_agents_directory(self):
+        """Drift guard: _PACT_AGENT_TYPES must equal the set of pact-*.md in agents/.
 
-        Catches new agent additions that forget to update the parametrize list.
-        Without this, a new role would silently miss the parametrized sweep
-        and could ship without verified completion-authority directive
-        delivery. Set comparison (⊇) tolerates the list being a superset
-        if a future agent type is registered before its file lands.
+        Bidirectional check:
+        - Catches NEW agents added to agents/ but missing from _PACT_AGENT_TYPES
+          (parametrized sweep would silently skip them, shipping a new role
+          without verified completion-authority directive delivery).
+        - Catches TYPOS or stale entries in _PACT_AGENT_TYPES (e.g.,
+          `pact-architecte`) that parametrize against non-existent agent
+          files and silently pass.
         """
         agents_dir = Path(__file__).parent.parent / "agents"
-        files = sorted(p.stem for p in agents_dir.glob("pact-*.md"))
-        missing = set(files) - set(_PACT_AGENT_TYPES)
-        assert not missing, (
-            f"_PACT_AGENT_TYPES is missing agents present in {agents_dir}: "
-            f"{sorted(missing)}. Add them to the list so the parametrized "
-            "sweep covers every spawnable role."
+        files = set(p.stem for p in agents_dir.glob("pact-*.md"))
+        listed = set(_PACT_AGENT_TYPES)
+        missing = files - listed
+        unexpected = listed - files
+        assert not (missing or unexpected), (
+            f"_PACT_AGENT_TYPES drift vs {agents_dir}: "
+            f"missing (in agents/ but not list): {sorted(missing)}; "
+            f"unexpected (in list but no agent file): {sorted(unexpected)}. "
+            "Update _PACT_AGENT_TYPES to match the agents/ directory exactly."
         )
 
 

--- a/pact-plugin/tests/test_pin_caps.py
+++ b/pact-plugin/tests/test_pin_caps.py
@@ -249,7 +249,7 @@ class TestCheckAddAllowed_EmbeddedHeading:
     level-3 heading (`### `) are rejected because parse_pins on reload
     would count them as additional pins, defeating the count cap.
 
-    Conservative by design (per lead direction 2026-04-21): rejects ANY
+    Conservative by design (per team-lead direction 2026-04-21): rejects ANY
     embedded pin structure detected by parse_pins, whether accompanied
     by a date-comment or not. Legitimate pin bodies can use `#### ` or
     bold/italic for in-body structure.

--- a/pact-plugin/tests/test_pin_caps_gate_matrix.py
+++ b/pact-plugin/tests/test_pin_caps_gate_matrix.py
@@ -13,7 +13,7 @@ Matrix axes:
   baseline:  fresh (existing CLAUDE.md with N < cap pins)
              missing (no CLAUDE.md on disk)
              corrupt (CLAUDE.md exists but no Pinned Context section)
-  bypass:    lead (agent_name empty)
+  bypass:    team-lead (agent_name empty)
              teammate (agent_name non-empty)
 
 Full 2 * 6 * 3 * 2 = 72 logical cells. Not every combination produces a

--- a/pact-plugin/tests/test_pin_staleness_gate.py
+++ b/pact-plugin/tests/test_pin_staleness_gate.py
@@ -5,7 +5,7 @@ CLAUDE.md Pinned Context edits under stale-pins-pending state.
 Risk tier: CRITICAL (auth-adjacent — gate blocks user tool calls). All
 I/O failure paths MUST fail-open (SACROSANCT: gate bugs never block).
 
-Matrix: marker absence/present × CLAUDE.md path match/miss × teammate/lead
+Matrix: marker absence/present × CLAUDE.md path match/miss × teammate/team-lead
         × Edit/Write → 16 cells minimum, plus fail-open assertions.
 """
 
@@ -82,10 +82,10 @@ def _call_gate(input_data):
 
 
 # Matrix coverage note: the full matrix is (marker absent/present) × (path match/miss) ×
-# (teammate/lead) × (Edit/Write) = 16 cells. Three cells are NOT exercised explicitly
+# (teammate/team-lead) × (Edit/Write) = 16 cells. Three cells are NOT exercised explicitly
 # because they reduce to tested paths: (marker-absent × teammate × {Edit,Write,path-miss})
 # all short-circuit at the same marker-check before any teammate/path logic runs —
-# TestPinStalenessGate_MarkerAbsent already covers that short-circuit for lead callers,
+# TestPinStalenessGate_MarkerAbsent already covers that short-circuit for team-lead callers,
 # and the marker-absent return is agent-name-independent by construction.
 
 

--- a/pact-plugin/tests/test_progress_signals.py
+++ b/pact-plugin/tests/test_progress_signals.py
@@ -27,7 +27,7 @@ class TestProgressSignals:
         assert "### Progress Signals" in skill_content
 
     def test_format_specification_present(self, skill_content):
-        assert "[sender→lead] Progress:" in skill_content
+        assert "[sender→team-lead] Progress:" in skill_content
 
     def test_natural_breakpoints_defined(self, skill_content):
         assert "Natural breakpoints" in skill_content

--- a/pact-plugin/tests/test_project_id.py
+++ b/pact-plugin/tests/test_project_id.py
@@ -52,6 +52,12 @@ def _isolate_walkup_to(monkeypatch, tmp_path):
     for any path that is NOT inside `tmp_path`. Within tmp_path, the
     original behavior is preserved. Effect: walk-up across ancestors above
     tmp_path always sees "no markers" regardless of ambient state.
+
+    Caveat: patches `Path.exists` and `Path.is_dir` at the CLASS level via
+    monkeypatch — affects ALL Path operations in the test's scope, not just
+    `_find_project_root_under_test` walks. Bounded by monkeypatch teardown.
+    Future test authors extending tests that rely on Path methods for
+    non-walk purposes should be aware.
     """
     tmp_resolved = tmp_path.resolve()
     original_exists = Path.exists

--- a/pact-plugin/tests/test_project_id.py
+++ b/pact-plugin/tests/test_project_id.py
@@ -38,6 +38,46 @@ def clean_env_no_claude_project_dir():
         yield
 
 
+def _isolate_walkup_to(monkeypatch, tmp_path):
+    """Confine the walk-up search to the test's tmp_path subtree.
+
+    `_find_project_root_under_test` walks Path.parents up to "/" looking
+    for project markers. On macOS, pytest's tmp_path lives under
+    /private/var/folders/.../T/, and unrelated processes can leak markers
+    (e.g., a stray `.claude/` dir) into that shared parent. The walk-up
+    correctly returns the leaked marker, but the test loses isolation
+    against ambient state.
+
+    This helper monkeypatches Path.exists and Path.is_dir to return False
+    for any path that is NOT inside `tmp_path`. Within tmp_path, the
+    original behavior is preserved. Effect: walk-up across ancestors above
+    tmp_path always sees "no markers" regardless of ambient state.
+    """
+    tmp_resolved = tmp_path.resolve()
+    original_exists = Path.exists
+    original_is_dir = Path.is_dir
+
+    def _is_inside(p):
+        try:
+            resolved = p.resolve()
+        except (OSError, RuntimeError):
+            return False
+        return resolved == tmp_resolved or tmp_resolved in resolved.parents
+
+    def _patched_exists(self):
+        if _is_inside(self):
+            return original_exists(self)
+        return False
+
+    def _patched_is_dir(self):
+        if _is_inside(self):
+            return original_is_dir(self)
+        return False
+
+    monkeypatch.setattr(Path, "exists", _patched_exists)
+    monkeypatch.setattr(Path, "is_dir", _patched_is_dir)
+
+
 # Path to the actual source file for equivalence checking
 _MEMORY_API_PATH = (
     Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts" / "memory_api.py"
@@ -337,11 +377,15 @@ class TestDetectProjectId:
 class TestFindProjectRoot:
     """Tests for PACTMemory._find_project_root() walk-up helper."""
 
-    def test_returns_start_when_no_markers(self, tmp_path):
+    def test_returns_start_when_no_markers(self, tmp_path, monkeypatch):
         """No markers anywhere on the path → returns start unchanged."""
         nested = tmp_path / "a" / "b" / "c"
         nested.mkdir(parents=True)
-        # tmp_path is a clean isolated directory — no .git, .claude, CLAUDE.md
+        # tmp_path is a clean isolated directory — no .git, .claude, CLAUDE.md.
+        # Confine the walk-up to tmp_path so ambient markers above (e.g., a
+        # stray .claude/ leaked into macOS /var/folders/.../T/ by an unrelated
+        # process) cannot win the walk-up.
+        _isolate_walkup_to(monkeypatch, tmp_path)
         result = _find_project_root_under_test(nested)
         # Walk-up found nothing → falls back to start
         assert result == nested
@@ -477,12 +521,16 @@ class TestCwdSubdirectoryDetection:
         assert result == "root-project"
 
     def test_cwd_no_markers_falls_back_to_cwd_basename(
-        self, clean_env_no_claude_project_dir, tmp_path
+        self, clean_env_no_claude_project_dir, tmp_path, monkeypatch
     ):
         """No markers found walking up → fall back to cwd basename (legacy behavior)."""
-        # tmp_path is clean: no .git, .claude, CLAUDE.md anywhere
+        # tmp_path is clean: no .git, .claude, CLAUDE.md anywhere.
+        # Confine the walk-up to tmp_path so ambient markers above (e.g., a
+        # stray .claude/ leaked into macOS /var/folders/.../T/ by an unrelated
+        # process) cannot win the walk-up.
         leaf = tmp_path / "orphan-dir"
         leaf.mkdir()
+        _isolate_walkup_to(monkeypatch, tmp_path)
 
         with patch("subprocess.run", side_effect=FileNotFoundError()), \
              patch("pathlib.Path.cwd", return_value=leaf):

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -281,7 +281,7 @@ class TestTeamResumeDetection:
         # The team instruction uses insert(0, ...) so it should be first
         # additionalContext is " | ".join(context_parts), so team instruction
         # should be at the start. Post #366 Phase 1 the prelude leads with the
-        # PACT ROLE marker to anchor role detection for the lead session.
+        # PACT ROLE marker to anchor role detection for the team-lead session.
         # Post #444 the directive is the unconditional 4-sentence form.
         assert additional.startswith("YOUR PACT ROLE: orchestrator")
         assert 'Invoke Skill("PACT:bootstrap") immediately' in additional
@@ -1766,7 +1766,7 @@ class TestFailureLogIntegration:
     create an unreapable `unknown-{hex}/` directory. That design choice
     costs visibility into hook failures (stderr is not user-visible, and
     teammate sessions never surface their first-message context to the
-    lead). The global ring buffer at ~/.claude/pact-sessions/_session_init_failures.log
+    team-lead). The global ring buffer at ~/.claude/pact-sessions/_session_init_failures.log
     is the post-hoc record that closes that gap.
 
     The integration contract verified here:
@@ -2915,7 +2915,7 @@ class TestPluginRootEnvWiring:
 #
 # These classes pin the post-refactor session_init contract:
 #   1. _team_create / _team_reuse strings now lead with `YOUR PACT ROLE: orchestrator`
-#      and instruct the lead to invoke `Skill("PACT:bootstrap")` as its FIRST
+#      and instruct the team-lead to invoke `Skill("PACT:bootstrap")` as its FIRST
 #      action.
 #   2. session_init.main() calls remove_stale_kernel_block() unconditionally
 #      on every SessionStart (not gated by is_context_reset).
@@ -2997,7 +2997,7 @@ class TestTeamCreateStringFreshSession:
         assert 'TeamCreate(team_name="pact-aabb1122")' in additional
 
     def test_blocks_premature_action(self, monkeypatch, tmp_path):
-        """The fresh prelude must instruct the lead not to act before bootstrap."""
+        """The fresh prelude must instruct the team-lead not to act before bootstrap."""
         additional, _, _ = _run_session_init_for_path(
             monkeypatch, tmp_path, source="startup", team_exists=False
         )
@@ -3212,10 +3212,10 @@ class TestHappyPathOutputInvariant:
 # for the PACT ROLE marker + Skill("PACT:bootstrap") YOUR FIRST ACTION directive.
 #
 # If session_init.main() throws BEFORE it has built the team_create/team_reuse
-# block, the lead would previously get only {"systemMessage": "..."} back and
+# block, the team-lead would previously get only {"systemMessage": "..."} back and
 # the governance delivery chain would be broken for that one session. The F2
 # safety net in the outer except block rebuilds a minimal PACT ROLE block so
-# the lead still knows how to bootstrap even on the failure path.
+# the team-lead still knows how to bootstrap even on the failure path.
 # ---------------------------------------------------------------------------
 
 
@@ -3247,7 +3247,7 @@ class TestBuildSafetyNetContext:
         assert 'You must invoke Skill("PACT:bootstrap") on every session start.' in result
 
     def test_none_team_mentions_not_generated(self):
-        """With team_name=None the message should tell the lead the team is not yet created."""
+        """With team_name=None the message should tell the team-lead the team is not yet created."""
         from session_init import _build_safety_net_context
 
         result = _build_safety_net_context(None)
@@ -3264,7 +3264,7 @@ class TestBuildSafetyNetContext:
         assert result.startswith("YOUR PACT ROLE: orchestrator.")
 
     def test_with_team_contains_team_name(self):
-        """With a team_name the string must embed the team name so the lead can reuse it."""
+        """With a team_name the string must embed the team name so the team-lead can reuse it."""
         from session_init import _build_safety_net_context
 
         result = _build_safety_net_context("pact-abc123")
@@ -3312,7 +3312,7 @@ class TestReadOnlyHomeScenario:
     and writes to ~/.claude/CLAUDE.md. If the .claude parent directory is
     read-only, the write fails — but the hook must still deliver the
     governance chain: exit 0, valid JSON on stdout, and additionalContext
-    starting with "YOUR PACT ROLE: orchestrator." so the lead can load bootstrap.
+    starting with "YOUR PACT ROLE: orchestrator." so the team-lead can load bootstrap.
 
     Unlike the unit-level OSError mocks, this test uses a real chmod on a
     real temp directory and exercises the full migration code path end to
@@ -3383,7 +3383,7 @@ class TestReadOnlyHomeScenario:
 
             assert exc_info.value.code == 0, (
                 "session_init must exit 0 even when the home .claude "
-                "directory is read-only — the hook fails open so the lead "
+                "directory is read-only — the hook fails open so the team-lead "
                 "still receives the governance delivery chain."
             )
 
@@ -3394,7 +3394,7 @@ class TestReadOnlyHomeScenario:
             assert additional.startswith("YOUR PACT ROLE: orchestrator."), (
                 "Read-only home scenario regressed: additionalContext must "
                 "still start with the PACT ROLE marker so the routing block "
-                "consumer identifies the lead's role."
+                "consumer identifies the team-lead's role."
             )
             assert 'Invoke Skill("PACT:bootstrap") immediately' in additional, (
                 "#444 unconditional directive must survive the readonly scenario."
@@ -3412,7 +3412,7 @@ class TestMainExceptionSafetyNet:
       - hookSpecificOutput.additionalContext starting with "YOUR PACT ROLE: orchestrator."
       - systemMessage reporting the original exception
 
-    The key invariant: even on the failure path, the lead still receives the
+    The key invariant: even on the failure path, the team-lead still receives the
     governance delivery chain (PACT ROLE marker + Skill bootstrap directive).
     """
 
@@ -3466,7 +3466,7 @@ class TestMainExceptionSafetyNet:
     ):
         """When an exception fires AFTER generate_team_name(), the except block
         must see the captured team_name and emit it in the safety net so the
-        lead can reuse it instead of creating a new one."""
+        team-lead can reuse it instead of creating a new one."""
         from session_init import main
 
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
@@ -3506,7 +3506,7 @@ class TestMainExceptionSafetyNet:
         assert 'Invoke Skill("PACT:bootstrap") immediately' in additional
 
         # The team name captured before the exception must be in the safety net
-        # so the lead can reuse it rather than creating a second team.
+        # so the team-lead can reuse it rather than creating a second team.
         assert "pact-aabb1122" in additional
         assert "partially failed" in additional
         assert "NOT GENERATED" not in additional, (

--- a/pact-plugin/tests/test_spawn_overhead_benchmark.py
+++ b/pact-plugin/tests/test_spawn_overhead_benchmark.py
@@ -6,7 +6,7 @@ Used by: pytest CI / local test runs.
 The PR #390 / v3.17.0 release eliminated ~17KB of orchestrator content from
 the per-teammate spawn path by moving it out of ~/.claude/CLAUDE.md (always
 loaded) and into pact-plugin/commands/bootstrap.md (lazy-loaded via
-Skill("PACT:bootstrap") only when the lead needs it). This test pins that
+Skill("PACT:bootstrap") only when the team-lead needs it). This test pins that
 reduction as a byte-level regression gate: any change that re-introduces
 CLAUDE.md-scale content into the spawn path will blow past the threshold.
 
@@ -134,7 +134,7 @@ class TestSpawnOverheadRegression:
         SessionStart / SubagentStart and whose output lands in
         additionalContext. Neither should Read or embed bootstrap.md
         content — bootstrap.md must only be reachable via the
-        Skill("PACT:bootstrap") invocation instruction the lead is
+        Skill("PACT:bootstrap") invocation instruction the team-lead is
         told to issue.
         """
         session_init_src = (
@@ -147,12 +147,12 @@ class TestSpawnOverheadRegression:
         assert "bootstrap.md" not in session_init_src, (
             "session_init.py references bootstrap.md directly — this is a "
             "spawn-path regression. bootstrap.md must only be loaded lazily "
-            "via the Skill(\"PACT:bootstrap\") invocation by the lead."
+            "via the Skill(\"PACT:bootstrap\") invocation by the team-lead."
         )
         assert "bootstrap.md" not in peer_inject_src, (
             "peer_inject.py references bootstrap.md directly — this is a "
             "spawn-path regression. bootstrap.md must only be loaded lazily "
-            "via the Skill(\"PACT:bootstrap\") invocation by the lead."
+            "via the Skill(\"PACT:bootstrap\") invocation by the team-lead."
         )
 
     def test_home_claude_md_template_has_no_pact_content_after_migration(

--- a/pact-plugin/tests/test_teachback_check.py
+++ b/pact-plugin/tests/test_teachback_check.py
@@ -1268,7 +1268,7 @@ class TestAllMatchEdgeCases:
         only the new task (without teachback) visible to the scanner.
 
         This is the benign race condition from the prep doc. The hook reads a
-        point-in-time snapshot, so if the lead marks the old task completed
+        point-in-time snapshot, so if the team-lead marks the old task completed
         before the scan reaches it, only the new task is visible.
         """
         from teachback_check import check_teachback_sent
@@ -1328,7 +1328,7 @@ class TestAllMatchEdgeCases:
         assert task_id == "25"
 
     def test_self_claim_followup_both_in_progress(self, tmp_path):
-        """Self-claim follow-up: agent claims task B before lead marks task A
+        """Self-claim follow-up: agent claims task B before team-lead marks task A
         completed. Both are in_progress. Task A has teachback; task B does not.
 
         Per prep doc scenario 1, there's a timing window where both tasks

--- a/pact-plugin/tests/test_teammate_idle.py
+++ b/pact-plugin/tests/test_teammate_idle.py
@@ -577,7 +577,7 @@ class TestMainEdgeCases:
 
     def test_shutdown_message_includes_action_required(self, capsys, tmp_path):
         """At force threshold, output must include ACTION REQUIRED +
-        shutdown_request wording for the lead to act on."""
+        shutdown_request wording for the team-lead to act on."""
         import io
         from teammate_idle import main, write_idle_counts
 


### PR DESCRIPTION
Closes #491.
Closes #576 (folded in via commit a31a52a).

## Summary

Implements the #491 PACT task-completion authority redesign: two-task blockedBy dispatch shape (Task A teachback + Task B primary, `blockedBy=[A]`) + lead-only completion authority (teammates do not self-complete; lead transitions tasks to `completed` after inspecting metadata) + dual-channel rejection (lead writes `metadata.{teachback,handoff}_rejection` + sends paired wake-SendMessage).

The redesign closes the residual livelock-vulnerability that #543's hook removal didn't fully address: blockedBy is pull-only at the platform level (`TaskListTool.ts:73-82`), so a teammate that idles after writing HANDOFF needs a wake-SendMessage from the lead, not just a `TaskUpdate(status=completed)`. The two-call atomic pair (TaskUpdate + paired SendMessage) is the canonical acceptance recipe; the same shape applies to rejection (metadata + wake-SendMessage).

## Plugin version: 3.19.5 → 3.20.0 (minor — new dispatch primitive)

## Acceptance criteria

### From #491

- [x] `shared/intentional_wait.py` adds `awaiting_lead_completion` to `KNOWN_REASONS`
- [x] `shared/intentional_wait.py` adds `SELF_COMPLETE_EXEMPT_AGENTS = frozenset({"pact-secretary", "secretary"})`
- [x] `shared/intentional_wait.py` adds `is_self_complete_exempt(task) -> bool` as a pure function (NOT a hook predicate, per architect D2 — honors #538 categorical standard)
- [x] `peer_inject.py` adds `_COMPLETION_AUTHORITY_NOTE` carrying the unconditional "MUST NOT self-complete" clause + Task A/B reminder, appended after `_TEACHBACK_REMINDER` in `get_peer_context`
- [x] `skills/orchestration/SKILL.md` includes §Completion Authority (parallel acceptance/rejection blocks, BOTH-required two-call atomic pair) + §Teachback Review
- [x] `skills/pact-agent-teams/SKILL.md` rewrites §On Completion (idle on awaiting_lead_completion, NEVER self-complete) + adds §On Rejection
- [x] `skills/pact-teachback/SKILL.md` consolidates to 4-field structured payload via `metadata.teachback_submit`
- [x] `skills/pact-handoff-harvest/SKILL.md` adds revision-aware HANDOFF read (revision_number > 1 → prefer metadata.handoff over journal event) — N1 mitigation
- [x] All 5 commands files (orchestrate, comPACT, peer-review, plan-mode, rePACT) gain inline §Two-Task Dispatch Shape blocks
- [x] `commands/imPACT.md` preserves force-termination carve-out (metadata.terminated)
- [x] `agents/pact-auditor.md` + `pact-secretary.md` document self-complete carve-outs
- [x] SSOT mirror in `protocols/pact-protocols.md` (§Status-by-Actor, §Task A+B, §Lead-vs-Teammate Completion Responsibilities)
- [x] Plugin version bumped to 3.20.0 across 4 canonical files
- [x] `verify-protocol-extracts.sh`: 18/18

### From #576 (folded in via a31a52a)

- [x] §Completion Authority presents acceptance + rejection as parallel labeled two-call blocks
- [x] Each block carries the literal "BOTH required" callout
- [x] Each block names the symmetric failure mode (skipping wake leaves teammate idle on stale awaiting_lead_completion)
- [x] `protocols/pact-completion-authority.md` mirrors the same structure
- [x] skills/orchestration/SKILL.md stays under 600-line compaction-durability boundary (591 lines, 9 under)

## Test plan

- [x] Full pytest sweep: 6980 passed, 8 skipped, 2 pre-existing test_project_id failures persist (unrelated to #491; see follow-up note below)
- [x] `verify-protocol-extracts.sh`: 18/18
- [x] Counter-test-by-revert applied to all critical guards (cardinalities {3, 5, 1, 2, 1} on revert experiments — every new assertion proven load-bearing)
- [x] 74 collected tests added (43 method definitions; the 31 additional come from parametrize expansion) across `test_intentional_wait.py`, `test_peer_inject.py`, `test_commands_structure.py`
- [ ] **D6 Dogfood Verification Runbook** (manual, pre-merge gate) — see runbook below

### D6 Dogfood Verification Runbook

Automated end-to-end testing of the dispatch + intentional_wait + wake-signal flow is infeasible (`/PACT:orchestrate` is a user-only command, hooks/CI cannot invoke it; teammate idle-boundary semantics are platform-internal). The unit-test layer covers static contract surfaces (constants, helpers, ordering invariants, structural anchors); this runbook covers dynamic behavior that closes the gap between static contract and live system.

#### Scenario D6.1 — Positive: wake-signal works

Open a fresh session: `/PACT:orchestrate research and document something trivial — pick two unrelated micro-tasks for two architects in parallel`

Both architects spawn, claim Task A1/A2, send teachback, write `metadata.teachback_submit`, SET `intentional_wait{reason=awaiting_lead_completion}`, idle.

Lead executes the two-call atomic pair on architect-1 only:
```
TaskUpdate(A1_id, status="completed")
SendMessage(to="architect-1", message="[lead→architect-1] Teachback accepted on Task #<A1_id>. Task B (#<B1_id>) is now claimable.")
```

**Expected**: architect-1 wakes within ~1 idle boundary (<30s), claims B1, CLEARS its intentional_wait. architect-2 stays idle (untouched).

**Pass criteria**: All assertions hold for architect-1; latency <30s.

#### Scenario D6.2 — Negative: omitting wake reproduces stall

Same session as D6.1. architect-2 still idle.

Lead deliberately omits the SendMessage — only executes:
```
TaskUpdate(A2_id, status="completed")
```

Wait 5 minutes (well above ~30s idle-tick, well below 30-min wait_stale horizon).

**Expected**: architect-2 remains idle; intentional_wait still SET; B2 is data-layer-unblocked but observability-locked.

Recovery: send the missing SendMessage. architect-2 should wake within ~30s.

**Pass criteria**: Stall during 5-min window; recovery on belated SendMessage.

**Fail criteria** (would invalidate #491 premise): architect-2 wakes spontaneously without wake-signal → PREPARE finding P0-4 was wrong; the platform DOES push wake on blocker resolution.

This runbook MUST be executed pre-merge per the architect's §7.1 D6 contract.

## Commits

15 atomic commits ahead of main:

1. `7da9d58` chore(#491): bump plugin version 3.19.5 → 3.20.0
2. `1bbfcb5` feat(#491): add lead-only completion authority primitives to intentional_wait
3. `285a9c8` feat(#491): add completion-authority directive to peer_inject
4. `c1b15b3` feat(#491): rewrite pact-agent-teams §On Completion + add §On Rejection
5. `19a9804` feat(#491): consolidate pact-teachback to two-task shape
6. `6204a72` feat(#491): add Completion Authority + Teachback Review + Rejection Flow to orchestration skill
7. `d97359c` feat(#491): inline §Two-Task Dispatch Shape in 5 commands files
8. `199f02f` feat(#491): preserve imPACT force-term carve-out + redo-after-imPACT note
9. `3ecad30` docs(#491): document self-complete carve-outs in pact-auditor + pact-secretary
10. `cc11b88` docs(#491): SSOT mirror — Status-by-Actor + Task A+B + per-workflow completion table
11. `6563894` feat(#491): pact-handoff-harvest revision-aware HANDOFF read
12. `5787216` test(#491): tighten test_agents_structure for new teachback convention (CODE remediation)
13. `51804b7` refactor(#491): extract Completion Authority sections to protocol file (CODE remediation)
14. `5896af4` test(#491): add 58 comprehensive tests for completion authority primitives
15. `a31a52a` refactor: parallel acceptance/rejection blocks under Completion Authority (#576 fold-in)

## Follow-up issues filed during this PR's dogfood session

All four are members of the `family: instruction-surface-leak` failure-mode family — agent-instruction surfaces don't fully gate against predictable LLM-reader failure modes (token pressure, format cues, propagation lag, scope assumptions):

- **#574** — Channel-discipline pre-response gate (both teammate-side + lead-side). Surfaced when test-engineer replied to a candor-question SendMessage with plain text instead of via SendMessage.
- **#575** — CODE-phase smoke-test scope ambiguity. Surfaced when 3 META-test regressions slipped through CODE phase smoke (scoped pytest) and only surfaced in TEST phase (full pytest). Same shape as #574: rule documented as guidance, not gated at decision-point.
- **#576** — Acceptance/rejection symmetry (closed in this PR via a31a52a — folded in rather than separate-PR after architect amendment arrived post-CODE-phase close).
- **#577** — TaskUpdate→TaskGet propagation lag. Surfaced twice in the dispatch cycles (#18→#19 + #21→#22). Documented as expected platform behavior with prescribed handling, not as a defect.

GitHub label `family: instruction-surface-leak` applied to all four. Meta-memory saved as queryable knowledge for future sessions.

## Pre-existing failures (NOT this PR's scope)

`test_project_id.py::TestFindProjectRoot::test_returns_start_when_no_markers` and `TestCwdSubdirectoryDetection::test_cwd_no_markers_falls_back_to_cwd_basename` fail on `main` and on this branch identically. Environment-related (orphan-dir vs T value). Should be filed as a separate issue if not already tracked.
