### PR TITLE
Rename marketplace handle to pact-plugin + version bump 3.20.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "3.20.0",
+      "version": "3.20.1",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ PACT turns one AI into a coordinated dev team. Instead of a single Claude guessi
 
 **1. Install the plugin**
 ```
-/plugin marketplace add Synaptic-Labs-AI/PACT-prompt
+/plugin marketplace add Synaptic-Labs-AI/PACT-Plugin
 /plugin install PACT@pact-plugin
 ```
 
@@ -293,7 +293,7 @@ pip install sqlite-vec
 **Quick version** — give Claude this prompt:
 
 ```
-Read the PACT setup instructions at https://github.com/Synaptic-Labs-AI/PACT-prompt/blob/main/README.md
+Read the PACT setup instructions at https://github.com/Synaptic-Labs-AI/PACT-Plugin/blob/main/README.md
 and help me install the PACT plugin with auto-updates enabled.
 ```
 
@@ -302,7 +302,7 @@ and help me install the PACT plugin with auto-updates enabled.
 ```
 Help me install the PACT plugin for Claude Code:
 
-1. Add the marketplace: /plugin marketplace add Synaptic-Labs-AI/PACT-prompt
+1. Add the marketplace: /plugin marketplace add Synaptic-Labs-AI/PACT-Plugin
 2. Install the plugin: /plugin install PACT@pact-plugin
 3. Enable auto-updates via /plugin → Marketplaces → pact-plugin → Enable auto-update
 4. Set up the orchestrator by appending PACT's CLAUDE.md to my existing ~/.claude/CLAUDE.md
@@ -316,7 +316,7 @@ Help me install the PACT plugin for Claude Code:
 
 **Step 1: Add the marketplace**
 ```bash
-/plugin marketplace add Synaptic-Labs-AI/PACT-prompt
+/plugin marketplace add Synaptic-Labs-AI/PACT-Plugin
 ```
 
 **Step 2: Install the plugin**
@@ -359,8 +359,8 @@ claude
 If you want to contribute or customize PACT:
 
 ```bash
-git clone https://github.com/Synaptic-Labs-AI/PACT-prompt.git
-cd PACT-prompt
+git clone https://github.com/Synaptic-Labs-AI/PACT-Plugin.git
+cd PACT-Plugin
 claude
 ```
 
@@ -502,7 +502,7 @@ your-project/
 If you cloned this repo for development/contribution:
 
 ```
-PACT-prompt/
+PACT-Plugin/
 ├── .claude-plugin/
 │   └── marketplace.json        # Self-hosted marketplace definition
 ├── pact-plugin/                # Plugin source (canonical)
@@ -596,5 +596,5 @@ MIT License - See [LICENSE](LICENSE) for details.
 ## Links
 
 - [Claude Code Documentation](https://code.claude.com/docs)
-- [Report Issues](https://github.com/ProfSynapse/PACT-prompt/issues)
+- [Report Issues](https://github.com/Synaptic-Labs-AI/PACT-Plugin/issues)
 - [VSM Background](https://en.wikipedia.org/wiki/Viable_system_model)

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ PACT turns one AI into a coordinated dev team. Instead of a single Claude guessi
 **1. Install the plugin**
 ```
 /plugin marketplace add Synaptic-Labs-AI/PACT-prompt
-/plugin install PACT@pact-marketplace
+/plugin install PACT@pact-plugin
 ```
 
 **2. Set up the orchestrator** ([detailed options below](#installation))
 ```bash
-cp ~/.claude/plugins/cache/pact-marketplace/PACT/*/CLAUDE.md ~/.claude/CLAUDE.md
+cp ~/.claude/plugins/cache/pact-plugin/PACT/*/CLAUDE.md ~/.claude/CLAUDE.md
 ```
 
 **3. Allow team file access** (prevents permission prompts during agent operations)
@@ -303,8 +303,8 @@ and help me install the PACT plugin with auto-updates enabled.
 Help me install the PACT plugin for Claude Code:
 
 1. Add the marketplace: /plugin marketplace add Synaptic-Labs-AI/PACT-prompt
-2. Install the plugin: /plugin install PACT@pact-marketplace
-3. Enable auto-updates via /plugin → Marketplaces → pact-marketplace → Enable auto-update
+2. Install the plugin: /plugin install PACT@pact-plugin
+3. Enable auto-updates via /plugin → Marketplaces → pact-plugin → Enable auto-update
 4. Set up the orchestrator by appending PACT's CLAUDE.md to my existing ~/.claude/CLAUDE.md
    (or create it if I don't have one)
 5. Configure my settings.json per the "Enabling Agent Teams" section of this README
@@ -321,13 +321,13 @@ Help me install the PACT plugin for Claude Code:
 
 **Step 2: Install the plugin**
 ```bash
-/plugin install PACT@pact-marketplace
+/plugin install PACT@pact-plugin
 ```
 
 **Step 3: Enable auto-updates**
 - Run `/plugin`
 - Select **Marketplaces**
-- Select **pact-marketplace**
+- Select **pact-plugin**
 - Enable **Auto-update**
 
 **Step 4: Set up the Orchestrator**
@@ -336,10 +336,10 @@ The PACT Orchestrator needs to be in your global `CLAUDE.md`:
 
 ```bash
 # If you DON'T have an existing ~/.claude/CLAUDE.md:
-cp ~/.claude/plugins/cache/pact-marketplace/PACT/*/CLAUDE.md ~/.claude/CLAUDE.md
+cp ~/.claude/plugins/cache/pact-plugin/PACT/*/CLAUDE.md ~/.claude/CLAUDE.md
 
 # If you DO have an existing ~/.claude/CLAUDE.md, append PACT to it:
-cat ~/.claude/plugins/cache/pact-marketplace/PACT/*/CLAUDE.md >> ~/.claude/CLAUDE.md
+cat ~/.claude/plugins/cache/pact-plugin/PACT/*/CLAUDE.md >> ~/.claude/CLAUDE.md
 ```
 
 **Step 5: Allow team file access**
@@ -469,7 +469,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 ├── CLAUDE.md                   # Orchestrator (copy from plugin)
 ├── plugins/
 │   └── cache/
-│       └── pact-marketplace/
+│       └── pact-plugin/
 │           └── PACT/
 │               └── 3.20.0/    # Plugin version
 │                   ├── agents/
@@ -570,7 +570,7 @@ PACT v3.0 is a **breaking change**. The agent execution model migrated from suba
    # Back up your existing CLAUDE.md first
    cp ~/.claude/CLAUDE.md ~/.claude/CLAUDE.md.bak
    # Then re-copy from the updated plugin
-   cp ~/.claude/plugins/cache/pact-marketplace/PACT/*/CLAUDE.md ~/.claude/CLAUDE.md
+   cp ~/.claude/plugins/cache/pact-plugin/PACT/*/CLAUDE.md ~/.claude/CLAUDE.md
    ```
    If you have custom content in `~/.claude/CLAUDE.md`, manually merge the updated PACT section (between `<!-- PACT_START -->` and `<!-- PACT_END -->` markers) instead of overwriting.
 3. **Restart Claude Code**

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 3.20.0/    # Plugin version
+│               └── 3.20.1/    # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "3.20.0",
+  "version": "3.20.1",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -10,8 +10,8 @@ Turn a single Claude Code session into a managed team of specialist AI agents th
 
 ```bash
 /plugin marketplace add ProfSynapse/PACT-prompt
-/plugin install PACT@pact-marketplace
-cp ~/.claude/plugins/cache/pact-marketplace/PACT/*/CLAUDE.md ~/.claude/CLAUDE.md
+/plugin install PACT@pact-plugin
+cp ~/.claude/plugins/cache/pact-plugin/PACT/*/CLAUDE.md ~/.claude/CLAUDE.md
 ```
 
 Then add `~/.claude/teams` and `~/.claude/pact-sessions` to your `additionalDirectories` and PACT allow rules in `~/.claude/settings.json` to prevent permission prompts during agent operations:

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 3.20.0
+> **Version**: 3.20.1
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -4,12 +4,12 @@
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 
-> **Breaking change in v3.0:** PACT now uses [Agent Teams](https://code.claude.com/docs/en/agent-teams) instead of subagents. You must [enable Agent Teams](https://github.com/ProfSynapse/PACT-prompt#enabling-agent-teams) in your `settings.json`. See the [upgrade guide](https://github.com/ProfSynapse/PACT-prompt#upgrading-from-v2x-to-v30) for details.
+> **Breaking change in v3.0:** PACT now uses [Agent Teams](https://code.claude.com/docs/en/agent-teams) instead of subagents. You must [enable Agent Teams](https://github.com/Synaptic-Labs-AI/PACT-Plugin#enabling-agent-teams) in your `settings.json`. See the [upgrade guide](https://github.com/Synaptic-Labs-AI/PACT-Plugin#upgrading-from-v2x-to-v30) for details.
 
 ## Install in 30 Seconds
 
 ```bash
-/plugin marketplace add ProfSynapse/PACT-prompt
+/plugin marketplace add Synaptic-Labs-AI/PACT-Plugin
 /plugin install PACT@pact-plugin
 cp ~/.claude/plugins/cache/pact-plugin/PACT/*/CLAUDE.md ~/.claude/CLAUDE.md
 ```
@@ -43,7 +43,7 @@ Then add `~/.claude/teams` and `~/.claude/pact-sessions` to your `additionalDire
 
 > **Note:** Bash allow rules are intentionally omitted — they are [fragile](https://docs.anthropic.com/en/docs/claude-code/settings#permission-settings) for commands with arguments. When agents run `mkdir` or `rm` in `~/.claude/` paths, select **"Yes, and always allow from this project"** to add the rule automatically.
 
-Then restart Claude Code. Requires [Agent Teams enabled](https://github.com/ProfSynapse/PACT-prompt#enabling-agent-teams).
+Then restart Claude Code. Requires [Agent Teams enabled](https://github.com/Synaptic-Labs-AI/PACT-Plugin#enabling-agent-teams).
 
 ## What You Get
 
@@ -70,7 +70,7 @@ Then restart Claude Code. Requires [Agent Teams enabled](https://github.com/Prof
 ## Full Documentation
 
 For installation options, detailed features, examples, and technical reference:
-**[github.com/ProfSynapse/PACT-prompt](https://github.com/ProfSynapse/PACT-prompt)**
+**[github.com/Synaptic-Labs-AI/PACT-Plugin](https://github.com/Synaptic-Labs-AI/PACT-Plugin)**
 
 ## Reference
 

--- a/pact-plugin/hooks/refresh/checkpoint_builder.py
+++ b/pact-plugin/hooks/refresh/checkpoint_builder.py
@@ -166,9 +166,9 @@ def get_encoded_project_path(transcript_path: str) -> str:
         transcript_path: Full path to the transcript file
 
     Returns:
-        Encoded project path segment (e.g., "-Users-mj-Sites-project")
+        Encoded project path segment (e.g., "-Users-example-Sites-project")
         Note: The leading dash is intentional - it matches Claude Code's folder
-        naming convention where /Users/mj/Sites/project becomes -Users-mj-Sites-project
+        naming convention where /Users/example/Sites/project becomes -Users-example-Sites-project
     """
     parts = transcript_path.split("/")
     try:

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -351,7 +351,7 @@ def _extract_prev_session_dir(project_dir: str) -> str | None:
 
     Reads the "## Current Session" block written by update_session_info()
     and extracts the session dir from lines like
-    "- Session dir: `~/.claude/pact-sessions/PACT-prompt/abc12345-...`".
+    "- Session dir: `~/.claude/pact-sessions/PACT-Plugin/abc12345-...`".
 
     Honors both supported project CLAUDE.md locations
     ($project_dir/.claude/CLAUDE.md preferred, $project_dir/CLAUDE.md legacy).

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -104,7 +104,7 @@ def init(input_data: dict) -> None:
     session-scoped context file path:
         ~/.claude/pact-sessions/{project-slug}/{session-id}/pact-session-context.json
 
-    Where project-slug is Path(project_dir).name (e.g., "PACT-prompt").
+    Where project-slug is Path(project_dir).name (e.g., "PACT-Plugin").
 
     If session_id or project_dir is unavailable, leaves _context_path as None.
     Readers will return _EMPTY_CONTEXT without attempting any file I/O.

--- a/pact-plugin/skills/pact-agent-teams/test_skill_loading.py
+++ b/pact-plugin/skills/pact-agent-teams/test_skill_loading.py
@@ -1,5 +1,5 @@
 """
-/Users/mj/Sites/collab/PACT-prompt/pact-plugin/skills/pact-agent-teams/test_skill_loading.py
+pact-plugin/skills/pact-agent-teams/test_skill_loading.py
 
 Tests for verifying the pact-agent-teams skill file structure and content.
 Ensures SKILL.md exists, has valid YAML frontmatter, and includes key sections

--- a/pact-plugin/skills/pact-memory/scripts/pact_session.py
+++ b/pact-plugin/skills/pact-memory/scripts/pact_session.py
@@ -28,7 +28,7 @@ def _context_file_path(session_id: str, project_dir: str) -> Path | None:
 
     Returns the session-scoped path when both identifiers are provided:
         ~/.claude/pact-sessions/{project-slug}/{session-id}/pact-session-context.json
-    where project-slug is Path(project_dir).name (e.g., "PACT-prompt").
+    where project-slug is Path(project_dir).name (e.g., "PACT-Plugin").
 
     Returns None when either identifier is missing — callers should treat
     this as "no context file available" and return a safe default.

--- a/pact-plugin/telegram/notify.py
+++ b/pact-plugin/telegram/notify.py
@@ -141,7 +141,7 @@ def _get_project_name() -> str:
     """
     Get the project name from CLAUDE_PROJECT_DIR environment variable.
 
-    Returns the basename of the project directory (e.g. 'PACT-prompt'),
+    Returns the basename of the project directory (e.g. 'PACT-Plugin'),
     falling back to the basename of the current working directory when
     CLAUDE_PROJECT_DIR is not available (e.g. in MCP server processes),
     and finally to 'unknown' if neither yields a useful name.

--- a/pact-plugin/telegram/tools.py
+++ b/pact-plugin/telegram/tools.py
@@ -34,9 +34,8 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
-from telegram.config import load_config_safe
 from telegram.telegram_client import TelegramClient, TelegramAPIError
-from telegram.voice import VoiceTranscriber, VoiceTranscriptionError
+from telegram.voice import VoiceTranscriber
 
 logger = logging.getLogger("pact-telegram.tools")
 
@@ -365,7 +364,7 @@ class ToolContext:
             await self.voice.close()
 
         # Cancel any pending futures
-        for msg_id, future in self.pending_replies.items():
+        for future in self.pending_replies.values():
             if not future.done():
                 future.cancel()
         self.pending_replies.clear()

--- a/pact-plugin/telegram/tools.py
+++ b/pact-plugin/telegram/tools.py
@@ -93,7 +93,7 @@ def _get_project_name() -> str:
     """
     Get the project name from CLAUDE_PROJECT_DIR environment variable.
 
-    Returns the basename of the project directory (e.g. 'PACT-prompt'),
+    Returns the basename of the project directory (e.g. 'PACT-Plugin'),
     falling back to the basename of the current working directory when
     CLAUDE_PROJECT_DIR is not available (e.g. in MCP server processes),
     and finally to 'unknown' if neither yields a useful name.

--- a/pact-plugin/tests/test_agent_handoff_emitter.py
+++ b/pact-plugin/tests/test_agent_handoff_emitter.py
@@ -41,10 +41,10 @@ PLATFORM_STDIN_SHAPE = {
     "session_id": "1fb6500d-25ba-48c6-af00-5f92024644d0",
     "transcript_path": (
         "/Users/mj/.claude/projects/"
-        "-Users-mj-Sites-collab-PACT-prompt/"
+        "-Users-mj-Sites-collab-PACT-Plugin/"
         "1fb6500d-25ba-48c6-af00-5f92024644d0.jsonl"
     ),
-    "cwd": "/Users/mj/Sites/collab/PACT-prompt",
+    "cwd": "/Users/mj/Sites/collab/PACT-Plugin",
     "hook_event_name": "TaskCompleted",
     "task_id": "12",
     "task_subject": "PROBE: capture real TaskCompleted stdin shape",

--- a/pact-plugin/tests/test_agent_handoff_emitter.py
+++ b/pact-plugin/tests/test_agent_handoff_emitter.py
@@ -40,11 +40,11 @@ VALID_HANDOFF = {
 PLATFORM_STDIN_SHAPE = {
     "session_id": "1fb6500d-25ba-48c6-af00-5f92024644d0",
     "transcript_path": (
-        "/Users/mj/.claude/projects/"
-        "-Users-mj-Sites-collab-PACT-Plugin/"
+        "/Users/example/.claude/projects/"
+        "-Users-example-Sites-collab-PACT-Plugin/"
         "1fb6500d-25ba-48c6-af00-5f92024644d0.jsonl"
     ),
-    "cwd": "/Users/mj/Sites/collab/PACT-Plugin",
+    "cwd": "/Users/example/Sites/collab/PACT-Plugin",
     "hook_event_name": "TaskCompleted",
     "task_id": "12",
     "task_subject": "PROBE: capture real TaskCompleted stdin shape",

--- a/pact-plugin/tests/test_checkpoint_builder.py
+++ b/pact-plugin/tests/test_checkpoint_builder.py
@@ -53,11 +53,11 @@ class TestGetEncodedProjectPath:
 
     def test_extract_from_transcript_path(self):
         """Test extracting encoded path from transcript path."""
-        transcript_path = "/Users/test/.claude/projects/-Users-test-myproject/session-123/session.jsonl"
+        transcript_path = "/Users/example/.claude/projects/-Users-example-myproject/session-123/session.jsonl"
 
         encoded = get_encoded_project_path(transcript_path)
 
-        assert encoded == "-Users-test-myproject"
+        assert encoded == "-Users-example-myproject"
 
     def test_extract_nested_project_path(self):
         """Test extracting deeply nested project path."""
@@ -71,11 +71,11 @@ class TestGetEncodedProjectPath:
         """Test fallback to CLAUDE_PROJECT_DIR when extraction fails."""
         transcript_path = "/invalid/path/without/projects"
 
-        with patch.dict(os.environ, {"CLAUDE_PROJECT_DIR": "/Users/test/myproject"}):
+        with patch.dict(os.environ, {"CLAUDE_PROJECT_DIR": "/Users/example/myproject"}):
             encoded = get_encoded_project_path(transcript_path)
 
         # Now keeps the leading dash to match Claude Code's folder naming convention
-        assert encoded == "-Users-test-myproject"
+        assert encoded == "-Users-example-myproject"
 
     def test_fallback_unknown_project(self):
         """Test fallback to 'unknown-project' when all else fails."""

--- a/pact-plugin/tests/test_claude_md_manager.py
+++ b/pact-plugin/tests/test_claude_md_manager.py
@@ -881,7 +881,7 @@ class TestUpdatePactRoutingSessionStartIsolation:
         "## Current Session\n"
         "- Resume: `claude --resume deadbeef-dead-beef-dead-beefdeadbeef`\n"
         "- Team: `pact-deadbeef`\n"
-        "- Session dir: `/Users/test/.claude/pact-sessions/proj/deadbeef`\n"
+        "- Session dir: `/Users/example/.claude/pact-sessions/proj/deadbeef`\n"
         "- Started: 2026-04-11 00:00:00 UTC\n"
         "<!-- SESSION_END -->\n"
     )

--- a/pact-plugin/tests/test_pact_context.py
+++ b/pact-plugin/tests/test_pact_context.py
@@ -1163,7 +1163,7 @@ class TestPathSync:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         session_id = "abc-12345"
-        project_dir = "/Users/test/PACT-prompt"
+        project_dir = "/Users/test/PACT-Plugin"
         slug = Path(project_dir).name
 
         expected = (
@@ -1386,7 +1386,7 @@ class TestSessionScopedPathE2E:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         session_id = "e2e-session-42"
-        project_dir = "/Users/test/PACT-prompt"
+        project_dir = "/Users/test/PACT-Plugin"
 
         # write_context with _context_path=None computes session-scoped path
         ctx_module.write_context(
@@ -1396,7 +1396,7 @@ class TestSessionScopedPathE2E:
         )
 
         # Verify file exists at expected session-scoped path
-        slug = "PACT-prompt"  # Path(project_dir).name
+        slug = "PACT-Plugin"  # Path(project_dir).name
         expected_path = (
             tmp_path / ".claude" / "pact-sessions"
             / slug / session_id / "pact-session-context.json"
@@ -1450,12 +1450,12 @@ class TestPactSessionPath:
 
         result = _context_file_path(
             session_id="abc-session-123",
-            project_dir="/Users/test/PACT-prompt",
+            project_dir="/Users/test/PACT-Plugin",
         )
 
         expected = (
             tmp_path / ".claude" / "pact-sessions"
-            / "PACT-prompt" / "abc-session-123" / "pact-session-context.json"
+            / "PACT-Plugin" / "abc-session-123" / "pact-session-context.json"
         )
         assert result == expected
 

--- a/pact-plugin/tests/test_pact_context.py
+++ b/pact-plugin/tests/test_pact_context.py
@@ -154,14 +154,14 @@ class TestGetPactContext:
         pact_context(
             team_name="pact-abc12345",
             session_id="abc12345-0000-1111-2222-333344445555",
-            project_dir="/Users/test/project",
+            project_dir="/Users/example/project",
         )
 
         result = get_pact_context()
 
         assert result["team_name"] == "pact-abc12345"
         assert result["session_id"] == "abc12345-0000-1111-2222-333344445555"
-        assert result["project_dir"] == "/Users/test/project"
+        assert result["project_dir"] == "/Users/example/project"
         assert result["started_at"] == "2026-01-01T00:00:00Z"
 
     def test_returns_empty_strings_when_file_missing(self, monkeypatch, tmp_path):
@@ -283,9 +283,9 @@ class TestGetProjectDir:
         """Should return project_dir from context file."""
         from shared.pact_context import get_project_dir
 
-        pact_context(project_dir="/Users/test/my-project")
+        pact_context(project_dir="/Users/example/my-project")
 
-        assert get_project_dir() == "/Users/test/my-project"
+        assert get_project_dir() == "/Users/example/my-project"
 
 
 class TestGetPluginRoot:
@@ -317,7 +317,7 @@ class TestGetSessionDir:
 
         pact_context(
             session_id="abc-123-def",
-            project_dir="/Users/test/my-project",
+            project_dir="/Users/example/my-project",
         )
 
         result = get_session_dir()
@@ -328,7 +328,7 @@ class TestGetSessionDir:
         """Should return '' when session_id is unavailable."""
         from shared.pact_context import get_session_dir
 
-        pact_context(session_id="", project_dir="/Users/test/my-project")
+        pact_context(session_id="", project_dir="/Users/example/my-project")
 
         assert get_session_dir() == ""
 
@@ -549,14 +549,14 @@ class TestWriteContext:
         ctx_module.write_context(
             team_name="pact-abc12345",
             session_id="abc12345-0000-1111-2222-333344445555",
-            project_dir="/Users/test/project",
+            project_dir="/Users/example/project",
         )
 
         assert ctx_file.exists()
         data = json.loads(ctx_file.read_text(encoding="utf-8"))
         assert data["team_name"] == "pact-abc12345"
         assert data["session_id"] == "abc12345-0000-1111-2222-333344445555"
-        assert data["project_dir"] == "/Users/test/project"
+        assert data["project_dir"] == "/Users/example/project"
         assert "started_at" in data  # ISO timestamp, not empty
 
     def test_writes_plugin_root_when_provided(self, monkeypatch, tmp_path):
@@ -1010,14 +1010,14 @@ class TestWriteReadRoundTrip:
         ctx_module.write_context(
             team_name="pact-roundtrip",
             session_id="roundtrip-session-123",
-            project_dir="/Users/test/roundtrip",
+            project_dir="/Users/example/roundtrip",
         )
 
         result = ctx_module.get_pact_context()
 
         assert result["team_name"] == "pact-roundtrip"
         assert result["session_id"] == "roundtrip-session-123"
-        assert result["project_dir"] == "/Users/test/roundtrip"
+        assert result["project_dir"] == "/Users/example/roundtrip"
         assert result["started_at"] != ""
 
     def test_write_then_convenience_accessors(self, monkeypatch, tmp_path):
@@ -1053,7 +1053,7 @@ class TestCategoryC_MemoryScriptFallback:
         from scripts.pact_session import get_session_id_from_context_file
 
         session_id = "init-session-xyz"
-        project_dir = "/Users/test/my-project"
+        project_dir = "/Users/example/my-project"
         slug = Path(project_dir).name
         ctx_dir = tmp_path / ".claude" / "pact-sessions" / slug / session_id
         ctx_dir.mkdir(parents=True)
@@ -1079,7 +1079,7 @@ class TestCategoryC_MemoryScriptFallback:
 
         result = get_session_id_from_context_file(
             session_id="nonexistent-session",
-            project_dir="/Users/test/project",
+            project_dir="/Users/example/project",
         )
 
         assert result == ""
@@ -1097,7 +1097,7 @@ class TestCategoryC_MemoryScriptFallback:
         from scripts.pact_session import get_session_id_from_context_file
 
         session_id = "corrupt-session"
-        project_dir = "/Users/test/project"
+        project_dir = "/Users/example/project"
         slug = Path(project_dir).name
         ctx_dir = tmp_path / ".claude" / "pact-sessions" / slug / session_id
         ctx_dir.mkdir(parents=True)
@@ -1163,7 +1163,7 @@ class TestPathSync:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         session_id = "abc-12345"
-        project_dir = "/Users/test/PACT-Plugin"
+        project_dir = "/Users/example/PACT-Plugin"
         slug = Path(project_dir).name
 
         expected = (
@@ -1344,7 +1344,7 @@ class TestInitOrdering:
         monkeypatch.setattr(ctx_module, "_context_path", None)
         monkeypatch.setattr(ctx_module, "_cache", None)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/test/my-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/my-project")
 
         # Write context file at the session-scoped path
         session_id = "sess-abc12345"
@@ -1355,7 +1355,7 @@ class TestInitOrdering:
         ctx_file.write_text(json.dumps({
             "team_name": "pact-abc12345",
             "session_id": session_id,
-            "project_dir": "/Users/test/my-project",
+            "project_dir": "/Users/example/my-project",
             "started_at": "2026-01-01T00:00:00Z",
         }), encoding="utf-8")
 
@@ -1386,7 +1386,7 @@ class TestSessionScopedPathE2E:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         session_id = "e2e-session-42"
-        project_dir = "/Users/test/PACT-Plugin"
+        project_dir = "/Users/example/PACT-Plugin"
 
         # write_context with _context_path=None computes session-scoped path
         ctx_module.write_context(
@@ -1450,7 +1450,7 @@ class TestPactSessionPath:
 
         result = _context_file_path(
             session_id="abc-session-123",
-            project_dir="/Users/test/PACT-Plugin",
+            project_dir="/Users/example/PACT-Plugin",
         )
 
         expected = (

--- a/pact-plugin/tests/test_plugin_manifest.py
+++ b/pact-plugin/tests/test_plugin_manifest.py
@@ -803,7 +803,7 @@ class TestDogfoodPathWorktreeVsInstalledCache:
     """The #500 dogfood motivation: teammate edits worktree source at
     /Users/.../worktrees/feat-X/pact-plugin/hooks/, but the runtime
     resolves hooks against ${CLAUDE_PLUGIN_ROOT}, which is the installed
-    cache at ~/.claude/plugins/cache/pact-marketplace/PACT/3.x.y. The
+    cache at ~/.claude/plugins/cache/pact-plugin/PACT/3.x.y. The
     banner must surface the INSTALLED-CACHE version/root — not whatever
     is in the worktree source tree.
 

--- a/pact-plugin/tests/test_session_end.py
+++ b/pact-plugin/tests/test_session_end.py
@@ -32,7 +32,7 @@ class TestGetProjectSlug:
     def test_returns_basename_from_project_dir(self):
         from session_end import get_project_slug
 
-        with patch("session_end.get_project_dir", return_value="/Users/mj/Sites/my-project"):
+        with patch("session_end.get_project_dir", return_value="/Users/example/Sites/my-project"):
             assert get_project_slug() == "my-project"
 
     def test_returns_empty_when_no_project_dir(self):
@@ -60,7 +60,7 @@ class TestMainEntryPoint:
         defaults = {
             "pact_context_init": patch("session_end.pact_context.init"),
             "get_project_dir": patch("session_end.get_project_dir",
-                                     return_value="/Users/mj/Sites/my-project"),
+                                     return_value="/Users/example/Sites/my-project"),
             "get_session_dir": patch("session_end.get_session_dir", return_value=""),
             "get_session_id": patch("session_end.get_session_id", return_value=""),
             "get_team_name": patch("session_end.get_team_name", return_value="pact-abc12345"),

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -193,7 +193,7 @@ class TestTeamResumeDetection:
         """
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         if stdin_data is None:
@@ -239,7 +239,7 @@ class TestTeamResumeDetection:
 
     def test_oserror_falls_back_to_team_create(self, monkeypatch, tmp_path):
         """When filesystem check raises OSError, should fall back to TeamCreate."""
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
 
         # Make Path.home() raise OSError indirectly by patching Path.exists
         original_exists = Path.exists
@@ -308,7 +308,7 @@ class TestSourceAwareness:
         """
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         if team_exists:
@@ -551,7 +551,7 @@ class TestSourceAwareness:
         """Missing source field should default to startup behavior."""
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         # stdin_data without "source" key
@@ -634,7 +634,7 @@ class TestMainPausedStateIntegration:
 
         paused_msg = "Paused work detected: PR #42 (feat/login) — awaiting merge."
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
 
         # Provide valid JSON on stdin with a session_id
         stdin_data = json.dumps({"session_id": "aabb1122-0000-0000-0000-000000000000"})
@@ -664,7 +664,7 @@ class TestMainPausedStateIntegration:
         """None check_paused_state result should not appear in additionalContext."""
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
 
         stdin_data = json.dumps({"session_id": "aabb1122-0000-0000-0000-000000000000"})
 
@@ -849,7 +849,7 @@ class TestCompactSummaryCleanup:
         """
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         # Create compact-summary.txt
@@ -1135,7 +1135,7 @@ class TestCheckAdditionalDirectoriesMainIntegration:
         """Tip should appear in systemMessage when teams dir not configured."""
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         # Create settings.json WITHOUT ~/.claude/teams in additionalDirectories
@@ -1173,7 +1173,7 @@ class TestCheckAdditionalDirectoriesMainIntegration:
         """No tip should appear when both required dirs are configured."""
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         # Create settings.json WITH both dirs in additionalDirectories
@@ -1213,7 +1213,7 @@ class TestCheckAdditionalDirectoriesMainIntegration:
         """Tip should NOT be checked on compact/clear sources (context resets)."""
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         # Create settings.json WITHOUT ~/.claude/teams — tip would fire on startup
@@ -1354,7 +1354,7 @@ class TestWriteContextIntegration:
         """write_context should be called with team_name, session_id, project_dir."""
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         stdin_data = json.dumps({
@@ -1380,7 +1380,7 @@ class TestWriteContextIntegration:
         mock_write_ctx.assert_called_once_with(
             "pact-aabb1122",
             "aabb1122-0000-0000-0000-000000000000",
-            "/Users/mj/Sites/test-project",
+            "/Users/example/Sites/test-project",
             "",  # plugin_root: CLAUDE_PLUGIN_ROOT not set in this test
         )
 
@@ -1401,7 +1401,7 @@ class TestWriteContextIntegration:
         """
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         stdin_data = json.dumps({})  # No session_id in stdin
@@ -1466,7 +1466,7 @@ class TestWriteContextIntegration:
         """
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         stdin_data = json.dumps({})  # No session_id in stdin
@@ -1530,7 +1530,7 @@ class TestWriteContextIntegration:
         """
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         stdin_data = json.dumps({})  # No session_id in stdin
@@ -1579,7 +1579,7 @@ class TestWriteContextIntegration:
         """
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         stdin_data = json.dumps({})  # No session_id in stdin
@@ -1651,7 +1651,7 @@ class TestWriteContextIntegration:
         """
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         stdin_data = json.dumps({})  # No session_id in stdin
@@ -1689,7 +1689,7 @@ class TestWriteContextIntegration:
         """
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         real_session_id = "aabb1122-0000-0000-0000-000000000000"
@@ -1720,7 +1720,7 @@ class TestWriteContextIntegration:
         """write_context failure should not prevent session_init from completing."""
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         stdin_data = json.dumps({
@@ -1788,7 +1788,7 @@ class TestFailureLogIntegration:
         """
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         stdin_data = "{ not valid json at all"
@@ -1837,7 +1837,7 @@ class TestFailureLogIntegration:
         """
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         stdin_data = json.dumps({})  # valid JSON, no session_id
@@ -1876,7 +1876,7 @@ class TestFailureLogIntegration:
         """
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         # Integer, not a string — triggers the non_string_session_id branch.
@@ -1918,7 +1918,7 @@ class TestFailureLogIntegration:
         """
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         stdin_data = json.dumps({"session_id": "   "})  # whitespace only
@@ -1959,7 +1959,7 @@ class TestFailureLogIntegration:
         """
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         stdin_data = json.dumps({"session_id": "unknown-deadbeef"})
@@ -2001,7 +2001,7 @@ class TestFailureLogIntegration:
         """
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         stdin_data = json.dumps({})  # missing session_id → R3 gate fires
@@ -2078,7 +2078,7 @@ class TestFailureLogIntegration:
         """
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         # The attack payload: embedded newline + a forged PACT ROLE marker.
@@ -2145,7 +2145,7 @@ class TestFailureLogIntegration:
         """
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         # A valid UUID — would normally pass _is_unknown_or_missing_session.
@@ -2936,7 +2936,7 @@ def _run_session_init_for_path(
     and returns (additionalContext, kernel_call_count, routing_call_count)."""
     from session_init import main
 
-    monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
     if team_exists:
@@ -3424,7 +3424,7 @@ class TestMainExceptionSafetyNet:
         branch and the original error must still surface via systemMessage."""
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         stdin_data = json.dumps({
@@ -3469,7 +3469,7 @@ class TestMainExceptionSafetyNet:
         team-lead can reuse it instead of creating a new one."""
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         stdin_data = json.dumps({
@@ -3542,7 +3542,7 @@ class TestBootstrapMarkerCleanup:
         """
         from session_init import main
 
-        project_dir = "/Users/mj/Sites/test-project"
+        project_dir = "/Users/example/Sites/test-project"
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", project_dir)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
@@ -3606,7 +3606,7 @@ class TestBootstrapMarkerCleanup:
         """clear with no marker should not raise (unlink(missing_ok=True))."""
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         session_id = "aabb1122-0000-0000-0000-000000000000"
@@ -3643,7 +3643,7 @@ class TestBootstrapMarkerCleanup:
         """No session_id in input → marker cleanup is skipped (no crash)."""
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         stdin_data = json.dumps({
@@ -3726,7 +3726,7 @@ class TestSessionStartSourceField:
         return the dict that was passed to append_event for session_start."""
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         stdin_data = json.dumps(stdin_payload)
@@ -3861,7 +3861,7 @@ class TestSessionStartSourceField:
         assert event.get("session_id") == (
             "aabb1122-0000-0000-0000-000000000000"
         )
-        assert event.get("project_dir") == "/Users/mj/Sites/test-project"
+        assert event.get("project_dir") == "/Users/example/Sites/test-project"
         assert event.get("team") == "pact-aabb1122"
         # `worktree` is always written as "" at this point in the hook —
         # the worktree is not yet created. The empty string is the
@@ -3903,7 +3903,7 @@ def _run_session_init_compact(
     """
     from session_init import main
 
-    monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
     if team_exists:
@@ -4185,7 +4185,7 @@ class TestSessionInitCompactPhantomWorkflow:
         # _run_session_init_compact since it hard-codes source.
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         team_dir = tmp_path / ".claude" / "teams" / "pact-aabb1122"
@@ -4248,7 +4248,7 @@ class TestSessionInitCompactPhantomWorkflow:
 
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         team_dir = tmp_path / ".claude" / "teams" / "pact-aabb1122"
@@ -4303,7 +4303,7 @@ class TestSessionInitCompactBranchExceptions:
         from session_init import main
 
         pact_context(session_id="aabb1122-0000-0000-0000-000000000000")
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         team_dir = tmp_path / ".claude" / "teams" / "pact-aabb1122"
@@ -4349,7 +4349,7 @@ class TestSessionInitCompactBranchExceptions:
         test_main_with_invalid_json_input."""
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         stdout = io.StringIO()
@@ -4397,7 +4397,7 @@ class TestSessionInitCompactBranchExceptions:
 
         session_id = "aabb1122-0000-0000-0000-000000000000"
         pact_context(session_id=session_id)
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         team_dir = tmp_path / ".claude" / "teams" / "pact-aabb1122"
@@ -4477,7 +4477,7 @@ class TestSessionInitCompactBranchExceptions:
 
         session_id = "aabb1122-0000-0000-0000-000000000000"
         pact_context(session_id=session_id)
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         team_dir = tmp_path / ".claude" / "teams" / "pact-aabb1122"
@@ -4528,7 +4528,7 @@ class TestSessionInitDirectiveAcrossAllSources:
         """Minimal driver for a compact/clear run with team_exists=True."""
         from session_init import main
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         team_dir = tmp_path / ".claude" / "teams" / "pact-aabb1122"
@@ -4610,7 +4610,7 @@ class TestSessionInitDirectiveAcrossAllSources:
 
         session_id = "aabb1122-0000-0000-0000-000000000000"
         pact_context(session_id=session_id)
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/mj/Sites/test-project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         team_dir = tmp_path / ".claude" / "teams" / "pact-aabb1122"

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -2240,7 +2240,7 @@ class TestExtractPrevSessionDirDualLocation:
         dot_claude_dir.mkdir()
         expected = str(
             (tmp_path / "home") / ".claude" / "pact-sessions"
-            / "PACT-prompt" / "aaaaaaaa-1111-2222-3333-444444444444"
+            / "PACT-Plugin" / "aaaaaaaa-1111-2222-3333-444444444444"
         )
         (dot_claude_dir / "CLAUDE.md").write_text(
             self._make_content("aaaaaaaa-1111-2222-3333-444444444444", expected),
@@ -2261,7 +2261,7 @@ class TestExtractPrevSessionDirDualLocation:
 
         expected = str(
             (tmp_path / "home") / ".claude" / "pact-sessions"
-            / "PACT-prompt" / "bbbbbbbb-1111-2222-3333-444444444444"
+            / "PACT-Plugin" / "bbbbbbbb-1111-2222-3333-444444444444"
         )
         (tmp_path / "CLAUDE.md").write_text(
             self._make_content("bbbbbbbb-1111-2222-3333-444444444444", expected),
@@ -2284,10 +2284,10 @@ class TestExtractPrevSessionDirDualLocation:
         dot_claude_dir.mkdir()
         sessions_root = (tmp_path / "home") / ".claude" / "pact-sessions"
         preferred = str(
-            sessions_root / "PACT-prompt" / "cccccccc-1111-2222-3333-444444444444"
+            sessions_root / "PACT-Plugin" / "cccccccc-1111-2222-3333-444444444444"
         )
         legacy = str(
-            sessions_root / "PACT-prompt" / "dddddddd-1111-2222-3333-444444444444"
+            sessions_root / "PACT-Plugin" / "dddddddd-1111-2222-3333-444444444444"
         )
 
         (dot_claude_dir / "CLAUDE.md").write_text(
@@ -2616,7 +2616,7 @@ class TestExtractPrevSessionDirDualLocation:
         prefix = str(tmp_path / "home" / ".claude" / "pact-sessions")
 
         # Inside the prefix — should pass.
-        good = f"{prefix}/PACT-prompt/aaaa"
+        good = f"{prefix}/PACT-Plugin/aaaa"
         assert _validate_under_pact_sessions(good) == good
 
         # Exactly the prefix root — should pass (edge case).
@@ -2682,7 +2682,7 @@ class TestExtractPrevSessionDirDualLocation:
         monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
 
         prefix = str(tmp_path / "home" / ".claude" / "pact-sessions")
-        legitimate = f"{prefix}/PACT-prompt/aaaaaaaa-1111-2222-3333-444444444444"
+        legitimate = f"{prefix}/PACT-Plugin/aaaaaaaa-1111-2222-3333-444444444444"
         assert _validate_under_pact_sessions(legitimate) == legitimate
 
     def test_validator_rejects_sibling_prefix_collision_regression(

--- a/pact-plugin/tests/test_worktree_guard.py
+++ b/pact-plugin/tests/test_worktree_guard.py
@@ -42,7 +42,7 @@ class TestWorktreeGuard:
         from worktree_guard import check_worktree_boundary
 
         result = check_worktree_boundary(
-            file_path="/Users/mj/project/src/auth.ts",
+            file_path="/Users/example/project/src/auth.ts",
             worktree_path="/tmp/worktrees/feat-auth"
         )
         assert result is not None
@@ -72,7 +72,7 @@ class TestWorktreeGuard:
         from worktree_guard import check_worktree_boundary
 
         result = check_worktree_boundary(
-            file_path="/Users/mj/.claude/CLAUDE.md",
+            file_path="/Users/example/.claude/CLAUDE.md",
             worktree_path="/tmp/worktrees/feat-auth"
         )
         assert result is None
@@ -81,7 +81,7 @@ class TestWorktreeGuard:
         from worktree_guard import check_worktree_boundary
 
         result = check_worktree_boundary(
-            file_path="/Users/mj/project/docs/architecture/design.md",
+            file_path="/Users/example/project/docs/architecture/design.md",
             worktree_path="/tmp/worktrees/feat-auth"
         )
         assert result is None
@@ -90,7 +90,7 @@ class TestWorktreeGuard:
         from worktree_guard import check_worktree_boundary
 
         result = check_worktree_boundary(
-            file_path="/Users/mj/project/src/auth.ts",
+            file_path="/Users/example/project/src/auth.ts",
             worktree_path=""
         )
         assert result is None
@@ -99,7 +99,7 @@ class TestWorktreeGuard:
         from worktree_guard import check_worktree_boundary
 
         result = check_worktree_boundary(
-            file_path="/Users/mj/project/CLAUDE.md",
+            file_path="/Users/example/project/CLAUDE.md",
             worktree_path="/tmp/worktrees/feat-auth"
         )
         assert result is None
@@ -261,10 +261,10 @@ class TestMainEntryPoint:
         from worktree_guard import main
 
         input_data = json.dumps({
-            "tool_input": {"file_path": "/Users/mj/project/src/auth.ts"}
+            "tool_input": {"file_path": "/Users/example/project/src/auth.ts"}
         })
 
-        error_msg = "Edit blocked: /Users/mj/project/src/auth.ts is outside the active worktree"
+        error_msg = "Edit blocked: /Users/example/project/src/auth.ts is outside the active worktree"
         with patch.dict("os.environ", {"PACT_WORKTREE_PATH": "/tmp/worktrees/feat-auth"}), \
              patch("worktree_guard.check_worktree_boundary", return_value=error_msg), \
              patch("sys.stdin", io.StringIO(input_data)):
@@ -311,20 +311,20 @@ class TestIsAllowedPathEdgeCases:
         """Deeply nested .claude path should still be allowed."""
         from worktree_guard import is_allowed_path
 
-        assert is_allowed_path("/Users/mj/.claude/some/deep/path/file.md") is True
+        assert is_allowed_path("/Users/example/.claude/some/deep/path/file.md") is True
 
     def test_docs_nested_deep(self):
         """Deeply nested docs path should still be allowed."""
         from worktree_guard import is_allowed_path
 
-        assert is_allowed_path("/Users/mj/project/docs/architecture/v2/design.md") is True
+        assert is_allowed_path("/Users/example/project/docs/architecture/v2/design.md") is True
 
     def test_gitignore_anywhere(self):
         """'.gitignore' file should be allowed regardless of location."""
         from worktree_guard import is_allowed_path
 
-        assert is_allowed_path("/Users/mj/project/.gitignore") is True
-        assert is_allowed_path("/Users/mj/project/subdir/.gitignore") is True
+        assert is_allowed_path("/Users/example/project/.gitignore") is True
+        assert is_allowed_path("/Users/example/project/subdir/.gitignore") is True
 
     def test_docs_as_substring_not_matched(self):
         """A path component 'mydocs' should NOT match the 'docs' pattern
@@ -332,13 +332,13 @@ class TestIsAllowedPathEdgeCases:
         from worktree_guard import is_allowed_path
 
         # 'mydocs' should NOT match 'docs' pattern
-        assert is_allowed_path("/Users/mj/project/mydocs/file.md") is False
+        assert is_allowed_path("/Users/example/project/mydocs/file.md") is False
 
     def test_claude_as_substring_not_matched(self):
         """A directory named 'not-claude' should NOT match '.claude' pattern."""
         from worktree_guard import is_allowed_path
 
-        assert is_allowed_path("/Users/mj/not-claude/file.md") is False
+        assert is_allowed_path("/Users/example/not-claude/file.md") is False
 
     def test_claude_md_in_any_directory(self):
         """CLAUDE.md should be allowed anywhere."""
@@ -395,7 +395,7 @@ class TestCheckWorktreeBoundaryEdgeCases:
         from worktree_guard import check_worktree_boundary
 
         result = check_worktree_boundary(
-            file_path="/Users/mj/project/notes.txt",
+            file_path="/Users/example/project/notes.txt",
             worktree_path="/tmp/worktrees/feat-auth"
         )
         assert result is None  # Not blocked
@@ -425,7 +425,7 @@ class TestCheckWorktreeBoundaryEdgeCases:
         from worktree_guard import check_worktree_boundary
 
         result = check_worktree_boundary(
-            file_path="/Users/mj/project/hooks/session_init.py",
+            file_path="/Users/example/project/hooks/session_init.py",
             worktree_path="/tmp/worktrees/feat-auth"
         )
         assert result is not None

--- a/testing/scenario-standard-orchestration.md
+++ b/testing/scenario-standard-orchestration.md
@@ -10,7 +10,7 @@ Verify the full PACT orchestration lifecycle: PREPARE, ARCHITECT, CODE, TEST pha
 
 ## Prerequisites
 
-1. PACT plugin installed at `~/.claude/plugins/cache/pact-marketplace/PACT/`
+1. PACT plugin installed at `~/.claude/plugins/cache/pact-plugin/PACT/`
 2. A git repository with `CLAUDE.md` containing the PACT orchestrator configuration
 3. No active worktrees for the test feature branch (run `git worktree list` to verify)
 4. All four verification scripts passing: `bash scripts/verify-scope-integrity.sh`, `bash scripts/verify-protocol-extracts.sh`, `bash scripts/verify-task-hierarchy.sh`, `bash scripts/verify-worktree-protocol.sh`


### PR DESCRIPTION
## Summary

- **Rename**: marketplace handle `pact-marketplace` → `pact-plugin` across 14 doc references in 4 files. The `.claude-plugin/marketplace.json` SSOT was already updated; this catches the stale instructional-surface references.
- **Version bump**: `3.20.0` → `3.20.1` (patch) in the four canonical version sites: `pact-plugin/.claude-plugin/plugin.json` (authoritative), `.claude-plugin/marketplace.json`, `pact-plugin/README.md` header, and the `README.md` path-tree diagram.

Plugin name remains `PACT` (all caps). Install command becomes `/plugin install PACT@pact-plugin`; cache path becomes `~/.claude/plugins/cache/pact-plugin/PACT/<version>/`.

## Commits

1. `32c73be` — Rename marketplace handle pact-marketplace → pact-plugin in docs (4 files, 14+/14-)
2. `5ff1db4` — Bump plugin version 3.20.0 → 3.20.1 (4 files, 4+/4-)

## Test plan

- [x] `pytest pact-plugin/tests/test_plugin_manifest.py` → 56/56 passed
- [x] `grep -rn "pact-marketplace" --include="*.md" --include="*.json" --include="*.py"` → zero hits across the 4 target files
- [x] `grep -rn "3\.20\.0" --include="*.md" --include="*.json"` → zero hits (all 4 sites bumped symmetrically)
- [x] Peer review: architect GREEN, devops-coder GREEN, test-engineer YELLOW (1 Future item: no cross-file version invariant test exists — pre-existing coverage gap, not introduced by this PR; tracked as a follow-up issue under family:instruction-surface-leak)