### PR TITLE
Add Pre-Response Channel Check gate to teammate + lead skills (#574)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "3.20.3",
+      "version": "3.20.4",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 3.20.3/    # Plugin version
+│               └── 3.20.4/    # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "3.20.3",
+  "version": "3.20.4",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 3.20.3
+> **Version**: 3.20.4
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/protocols/pact-communication-charter.md
+++ b/pact-plugin/protocols/pact-communication-charter.md
@@ -68,6 +68,8 @@ Before every SendMessage, run through:
 4. **Could this be a peer-to-peer message**, avoiding a routing hop through me?
 5. **Have I verified my framing against the final phase output** (the doc, the HANDOFF, the diagnostic file), or am I working from an interim progress signal? Progress signals are pre-revision snapshots; post-progress information the agent absorbed before completion may have superseded them. *(Failure shape: a teammate's mid-task progress signal flags concern X; their final HANDOFF resolves X; a course-correction dispatched off the progress signal lands as obsolete instruction.)*
 
+*Pre-decision sibling: see [Pre-Response Channel Check](../skills/pact-agent-teams/SKILL.md#pre-response-channel-check) (also in [orchestration/SKILL.md](../skills/orchestration/SKILL.md#pre-response-channel-check)) for the response-START gate that runs before this check.*
+
 #### Forwarding-Chain Hygiene
 
 If teammate A produces info teammate B needs, prefer direct A→B SendMessage with a brief CC-summary to the team-lead, rather than A→lead→B routing. Halves idle-boundary latency. Reserve team-lead-routing for cases where the team-lead specifically owns the routing decision (priority arbitration, scope reassignment).

--- a/pact-plugin/skills/orchestration/SKILL.md
+++ b/pact-plugin/skills/orchestration/SKILL.md
@@ -101,7 +101,7 @@ Workflow commands handle recovery automatically. Your context window doesn't sur
 
 ### Pre-Response Channel Check
 
-Before any response output, identify the addressee and pick the channel (post-decision sibling: [Pre-Send Self-Check](../../protocols/pact-communication-charter.md#pre-send-self-check)):
+Before any response output, identify the addressee and pick the channel (post-channel-choice complement: [Pre-Send Self-Check](../../protocols/pact-communication-charter.md#pre-send-self-check)):
 
 - Addressee is **user** (or self-narration) → text output is appropriate.
 - Addressee is **team-lead or teammate** → SendMessage is REQUIRED. Plain text is invisible to other agents.

--- a/pact-plugin/skills/orchestration/SKILL.md
+++ b/pact-plugin/skills/orchestration/SKILL.md
@@ -101,24 +101,22 @@ Workflow commands handle recovery automatically. Your context window doesn't sur
 
 ### Pre-Response Channel Check
 
-Before any response output, identify the addressee and pick the channel:
+Before any response output, identify the addressee and pick the channel (post-decision sibling: [Pre-Send Self-Check](../../protocols/pact-communication-charter.md#pre-send-self-check)):
 
 - Addressee is **user** (or self-narration) → text output is appropriate.
 - Addressee is **lead, peer, or any other agent** → SendMessage is REQUIRED. Plain text is invisible to other agents.
 - Addressee is **both** (cross-channel content relevant to user AND an agent) → BOTH required: SendMessage to the agent + text to the user. Neither alone delivers the content to both audiences.
 
-This gate fires at response START, not at SendMessage decision time. It complements (does not duplicate) the post-decision Pre-Send Self-Check in [Communication Charter Part I](../../protocols/pact-communication-charter.md#pre-send-self-check), which runs after the channel has already been chosen.
-
 #### Failure modes this gate catches
 
-- **Format-cue hijack.** Inbound `<teammate-message>` blocks framed as `[sender→recipient]` visually resemble a user turn; the response generator's "answer the speaker" reflex defaults to plain text. The speaker is an agent and the channel back is SendMessage — text replies are invisible to them.
-- **Candor-question / conversational-register pull.** Personal-shaped or candor-framed questions ("did you run X?", "reply candidly") pull toward prose register. A structured tool-call feels stilted; a candid prose admission feels natural. Social register does not override channel discipline — if the addressee is an agent, SendMessage is still required.
+- **Format-cue hijack.** Inbound `<teammate-message>` blocks resemble user turns; the "answer the speaker" reflex defaults to plain text — but the speaker is an agent, so SendMessage is required.
+- **Candor-question / conversational-register pull.** Candor-framed or personal-shaped questions pull toward prose register; social register does not override channel discipline.
 
 If you are unsure who the addressee is, choose **both**.
 
 #### Lead-side gray-area trap
 
-A status update to the user that substantively answers a teammate's question lands in user view but NOT the teammate's inbox unless ALSO sent via SendMessage. The teammate is then stuck on a question you have already answered — invisibly, from the teammate's perspective. If your text output to the user contains content that resolves an outstanding teammate question, the addressee is **both** — send the resolution to the teammate via SendMessage in the same turn.
+A status update to the user that resolves an outstanding teammate question requires also sending via SendMessage — the teammate's inbox does not see your text. Cross-channel content is **both**.
 
 ### Communication
 - Start every response with "🛠️:" to maintain consistent identity

--- a/pact-plugin/skills/orchestration/SKILL.md
+++ b/pact-plugin/skills/orchestration/SKILL.md
@@ -104,7 +104,7 @@ Workflow commands handle recovery automatically. Your context window doesn't sur
 Before any response output, identify the addressee and pick the channel (post-decision sibling: [Pre-Send Self-Check](../../protocols/pact-communication-charter.md#pre-send-self-check)):
 
 - Addressee is **user** (or self-narration) → text output is appropriate.
-- Addressee is **lead, peer, or any other agent** → SendMessage is REQUIRED. Plain text is invisible to other agents.
+- Addressee is **team-lead or teammate** → SendMessage is REQUIRED. Plain text is invisible to other agents.
 - Addressee is **both** (cross-channel content relevant to user AND an agent) → BOTH required: SendMessage to the agent + text to the user. Neither alone delivers the content to both audiences.
 
 #### Failure modes this gate catches

--- a/pact-plugin/skills/orchestration/SKILL.md
+++ b/pact-plugin/skills/orchestration/SKILL.md
@@ -99,6 +99,27 @@ Reconstruct state:
 
 Workflow commands handle recovery automatically. Your context window doesn't survive compaction — the *session journal* does. Full State Recovery Protocol: `pact-state-recovery.md` (loaded at bootstrap).
 
+### Pre-Response Channel Check
+
+Before any response output, identify the addressee and pick the channel:
+
+- Addressee is **user** (or self-narration) → text output is appropriate.
+- Addressee is **lead, peer, or any other agent** → SendMessage is REQUIRED. Plain text is invisible to other agents.
+- Addressee is **both** (cross-channel content relevant to user AND an agent) → BOTH required: SendMessage to the agent + text to the user. Neither alone delivers the content to both audiences.
+
+This gate fires at response START, not at SendMessage decision time. It complements (does not duplicate) the post-decision Pre-Send Self-Check in [Communication Charter Part I](../../protocols/pact-communication-charter.md#pre-send-self-check), which runs after the channel has already been chosen.
+
+#### Failure modes this gate catches
+
+- **Format-cue hijack.** Inbound `<teammate-message>` blocks framed as `[sender→recipient]` visually resemble a user turn; the response generator's "answer the speaker" reflex defaults to plain text. The speaker is an agent and the channel back is SendMessage — text replies are invisible to them.
+- **Candor-question / conversational-register pull.** Personal-shaped or candor-framed questions ("did you run X?", "reply candidly") pull toward prose register. A structured tool-call feels stilted; a candid prose admission feels natural. Social register does not override channel discipline — if the addressee is an agent, SendMessage is still required.
+
+If you are unsure who the addressee is, choose **both**.
+
+#### Lead-side gray-area trap
+
+A status update to the user that substantively answers a teammate's question lands in user view but NOT the teammate's inbox unless ALSO sent via SendMessage. The teammate is then stuck on a question you have already answered — invisibly, from the teammate's perspective. If your text output to the user contains content that resolves an outstanding teammate question, the addressee is **both** — send the resolution to the teammate via SendMessage in the same turn.
+
 ### Communication
 - Start every response with "🛠️:" to maintain consistent identity
 - **Be concise**: State decisions, not reasoning process. Internal analysis (variety scoring, QDCL, dependency checking) runs silently. Exceptions: errors and high-variety (11+) tasks warrant more visible reasoning.

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -13,6 +13,23 @@ description: |
 
 You are a member of a PACT Agent Team. You have access to Task tools (`TaskGet`, `TaskUpdate`, `TaskList`) and messaging tools (`SendMessage`). Use them to coordinate with the team.
 
+## Pre-Response Channel Check
+
+Before any response output, identify the addressee and pick the channel:
+
+- Addressee is **user** (or self-narration) → text output is appropriate.
+- Addressee is **lead, peer, or any other agent** → SendMessage is REQUIRED. Plain text is invisible to other agents.
+- Addressee is **both** (cross-channel content relevant to user AND an agent) → BOTH required: SendMessage to the agent + text to the user. Neither alone delivers the content to both audiences.
+
+This gate fires at response START, not at SendMessage decision time. It complements (does not duplicate) the post-decision Pre-Send Self-Check in [Communication Charter Part I](../../protocols/pact-communication-charter.md#pre-send-self-check), which runs after the channel has already been chosen.
+
+### Failure modes this gate catches
+
+- **Format-cue hijack.** Inbound `<teammate-message>` blocks framed as `[sender→recipient]` visually resemble a user turn; the response generator's "answer the speaker" reflex defaults to plain text. The speaker is an agent and the channel back is SendMessage — text replies are invisible to them.
+- **Candor-question / conversational-register pull.** Personal-shaped or candor-framed questions ("did you run X?", "reply candidly") pull toward prose register. A structured tool-call feels stilted; a candid prose admission feels natural. Social register does not override channel discipline — if the addressee is an agent, SendMessage is still required.
+
+If you are unsure who the addressee is, choose **both**.
+
 ## On Start
 
 1. Check `TaskList` for tasks assigned to you (by your name)

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -18,7 +18,7 @@ You are a member of a PACT Agent Team. You have access to Task tools (`TaskGet`,
 Before any response output, identify the addressee and pick the channel (post-decision sibling: [Pre-Send Self-Check](../../protocols/pact-communication-charter.md#pre-send-self-check)):
 
 - Addressee is **user** (or self-narration) → text output is appropriate.
-- Addressee is **lead, peer, or any other agent** → SendMessage is REQUIRED. Plain text is invisible to other agents.
+- Addressee is **team-lead or teammate** → SendMessage is REQUIRED. Plain text is invisible to other agents.
 - Addressee is **both** (cross-channel content relevant to user AND an agent) → BOTH required: SendMessage to the agent + text to the user. Neither alone delivers the content to both audiences.
 
 ### Failure modes this gate catches

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -15,18 +15,16 @@ You are a member of a PACT Agent Team. You have access to Task tools (`TaskGet`,
 
 ## Pre-Response Channel Check
 
-Before any response output, identify the addressee and pick the channel:
+Before any response output, identify the addressee and pick the channel (post-decision sibling: [Pre-Send Self-Check](../../protocols/pact-communication-charter.md#pre-send-self-check)):
 
 - Addressee is **user** (or self-narration) → text output is appropriate.
 - Addressee is **lead, peer, or any other agent** → SendMessage is REQUIRED. Plain text is invisible to other agents.
 - Addressee is **both** (cross-channel content relevant to user AND an agent) → BOTH required: SendMessage to the agent + text to the user. Neither alone delivers the content to both audiences.
 
-This gate fires at response START, not at SendMessage decision time. It complements (does not duplicate) the post-decision Pre-Send Self-Check in [Communication Charter Part I](../../protocols/pact-communication-charter.md#pre-send-self-check), which runs after the channel has already been chosen.
-
 ### Failure modes this gate catches
 
-- **Format-cue hijack.** Inbound `<teammate-message>` blocks framed as `[sender→recipient]` visually resemble a user turn; the response generator's "answer the speaker" reflex defaults to plain text. The speaker is an agent and the channel back is SendMessage — text replies are invisible to them.
-- **Candor-question / conversational-register pull.** Personal-shaped or candor-framed questions ("did you run X?", "reply candidly") pull toward prose register. A structured tool-call feels stilted; a candid prose admission feels natural. Social register does not override channel discipline — if the addressee is an agent, SendMessage is still required.
+- **Format-cue hijack.** Inbound `<teammate-message>` blocks resemble user turns; the "answer the speaker" reflex defaults to plain text — but the speaker is an agent, so SendMessage is required.
+- **Candor-question / conversational-register pull.** Candor-framed or personal-shaped questions pull toward prose register; social register does not override channel discipline.
 
 If you are unsure who the addressee is, choose **both**.
 

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -15,7 +15,7 @@ You are a member of a PACT Agent Team. You have access to Task tools (`TaskGet`,
 
 ## Pre-Response Channel Check
 
-Before any response output, identify the addressee and pick the channel (post-decision sibling: [Pre-Send Self-Check](../../protocols/pact-communication-charter.md#pre-send-self-check)):
+Before any response output, identify the addressee and pick the channel (post-channel-choice complement: [Pre-Send Self-Check](../../protocols/pact-communication-charter.md#pre-send-self-check)):
 
 - Addressee is **user** (or self-narration) → text output is appropriate.
 - Addressee is **team-lead or teammate** → SendMessage is REQUIRED. Plain text is invisible to other agents.
@@ -27,6 +27,10 @@ Before any response output, identify the addressee and pick the channel (post-de
 - **Candor-question / conversational-register pull.** Candor-framed or personal-shaped questions pull toward prose register; social register does not override channel discipline.
 
 If you are unsure who the addressee is, choose **both**.
+
+### Teammate-side gray-area trap
+
+A reply to the user that contains content the team-lead needs to act on (a blocker, partial result, scope flag) requires also sending via SendMessage — the team-lead's inbox does not see your text. Cross-channel content is **both**.
 
 ## On Start
 

--- a/pact-plugin/tests/test_skills_structure.py
+++ b/pact-plugin/tests/test_skills_structure.py
@@ -157,3 +157,12 @@ class TestPreResponseChannelCheckGate:
         assert self.LEAD_GRAY_AREA_PHRASE not in text, (
             "lead-side gray-area trap belongs only in orchestration/SKILL.md"
         )
+
+    def test_gate_appears_before_anchor_section(self):
+        teammate = self.AGENT_TEAMS_PATH.read_text(encoding="utf-8")
+        assert teammate.index("## Pre-Response Channel Check") < teammate.index("## On Start"), \
+            "pact-agent-teams: gate must appear before On Start"
+
+        lead = self.ORCHESTRATION_PATH.read_text(encoding="utf-8")
+        assert lead.index("### Pre-Response Channel Check") < lead.index("### Communication"), \
+            "orchestration: gate must appear before Communication"

--- a/pact-plugin/tests/test_skills_structure.py
+++ b/pact-plugin/tests/test_skills_structure.py
@@ -116,7 +116,7 @@ class TestPreResponseChannelCheckGate:
 
     INVARIANT_HEADER = "Pre-Response Channel Check"
     INVARIANT_USER_ADDRESSEE = "Addressee is **user**"
-    INVARIANT_AGENT_ADDRESSEE = "Addressee is **lead, peer, or any other agent**"
+    INVARIANT_AGENT_ADDRESSEE = "Addressee is **team-lead or teammate**"
     INVARIANT_BOTH_ADDRESSEE = "Addressee is **both**"
     INVARIANT_FORMAT_CUE = "Format-cue hijack"
     INVARIANT_CANDOR = "Candor-question"

--- a/pact-plugin/tests/test_skills_structure.py
+++ b/pact-plugin/tests/test_skills_structure.py
@@ -125,6 +125,7 @@ class TestPreResponseChannelCheckGate:
     INVARIANT_CHOOSE_BOTH_FALLBACK = "If you are unsure who the addressee is, choose **both**"
     INVARIANT_CHARTER_LINK = "../../protocols/pact-communication-charter.md#pre-send-self-check"
     LEAD_GRAY_AREA_PHRASE = "Lead-side gray-area trap"
+    TEAMMATE_GRAY_AREA_PHRASE = "Teammate-side gray-area trap"
 
     def test_teammate_side_has_gate(self):
         text = self.AGENT_TEAMS_PATH.read_text(encoding="utf-8")
@@ -168,6 +169,18 @@ class TestPreResponseChannelCheckGate:
         text = self.AGENT_TEAMS_PATH.read_text(encoding="utf-8")
         assert self.LEAD_GRAY_AREA_PHRASE not in text, (
             "lead-side gray-area trap belongs only in orchestration/SKILL.md"
+        )
+
+    def test_teammate_side_has_gray_area_addendum(self):
+        text = self.AGENT_TEAMS_PATH.read_text(encoding="utf-8")
+        assert self.TEAMMATE_GRAY_AREA_PHRASE in text, (
+            "pact-agent-teams must include the teammate-side gray-area trap addendum"
+        )
+
+    def test_lead_side_does_not_have_teammate_addendum(self):
+        text = self.ORCHESTRATION_PATH.read_text(encoding="utf-8")
+        assert self.TEAMMATE_GRAY_AREA_PHRASE not in text, (
+            "teammate-side gray-area trap belongs only in pact-agent-teams/SKILL.md"
         )
 
     def test_teammate_gate_appears_before_on_start(self):

--- a/pact-plugin/tests/test_skills_structure.py
+++ b/pact-plugin/tests/test_skills_structure.py
@@ -105,3 +105,55 @@ class TestSkillMdFiles:
             _, _, body = text.partition("---")
             _, _, body = body.partition("---")
             assert len(body.strip()) > 100, f"{d.name}/SKILL.md body too short"
+
+
+class TestPreResponseChannelCheckGate:
+    """Both pact-agent-teams and orchestration skills carry the
+    Pre-Response Channel Check gate (issue family: instruction-surface-leak)."""
+
+    AGENT_TEAMS_PATH = SKILLS_DIR / "pact-agent-teams" / "SKILL.md"
+    ORCHESTRATION_PATH = SKILLS_DIR / "orchestration" / "SKILL.md"
+
+    INVARIANT_HEADER = "Pre-Response Channel Check"
+    INVARIANT_USER_ADDRESSEE = "Addressee is **user**"
+    INVARIANT_AGENT_ADDRESSEE = "Addressee is **lead, peer, or any other agent**"
+    INVARIANT_BOTH_ADDRESSEE = "Addressee is **both**"
+    INVARIANT_FORMAT_CUE = "Format-cue hijack"
+    INVARIANT_CANDOR = "Candor-question"
+    LEAD_GRAY_AREA_PHRASE = "Lead-side gray-area trap"
+
+    def test_teammate_side_has_gate(self):
+        text = self.AGENT_TEAMS_PATH.read_text(encoding="utf-8")
+        for phrase in (
+            self.INVARIANT_HEADER,
+            self.INVARIANT_USER_ADDRESSEE,
+            self.INVARIANT_AGENT_ADDRESSEE,
+            self.INVARIANT_BOTH_ADDRESSEE,
+            self.INVARIANT_FORMAT_CUE,
+            self.INVARIANT_CANDOR,
+        ):
+            assert phrase in text, f"pact-agent-teams missing gate phrase: {phrase!r}"
+
+    def test_lead_side_has_gate(self):
+        text = self.ORCHESTRATION_PATH.read_text(encoding="utf-8")
+        for phrase in (
+            self.INVARIANT_HEADER,
+            self.INVARIANT_USER_ADDRESSEE,
+            self.INVARIANT_AGENT_ADDRESSEE,
+            self.INVARIANT_BOTH_ADDRESSEE,
+            self.INVARIANT_FORMAT_CUE,
+            self.INVARIANT_CANDOR,
+        ):
+            assert phrase in text, f"orchestration missing gate phrase: {phrase!r}"
+
+    def test_lead_side_has_gray_area_addendum(self):
+        text = self.ORCHESTRATION_PATH.read_text(encoding="utf-8")
+        assert self.LEAD_GRAY_AREA_PHRASE in text, (
+            "orchestration must include the lead-side gray-area trap addendum"
+        )
+
+    def test_teammate_side_does_not_have_lead_addendum(self):
+        text = self.AGENT_TEAMS_PATH.read_text(encoding="utf-8")
+        assert self.LEAD_GRAY_AREA_PHRASE not in text, (
+            "lead-side gray-area trap belongs only in orchestration/SKILL.md"
+        )

--- a/pact-plugin/tests/test_skills_structure.py
+++ b/pact-plugin/tests/test_skills_structure.py
@@ -120,6 +120,10 @@ class TestPreResponseChannelCheckGate:
     INVARIANT_BOTH_ADDRESSEE = "Addressee is **both**"
     INVARIANT_FORMAT_CUE = "Format-cue hijack"
     INVARIANT_CANDOR = "Candor-question"
+    INVARIANT_SENDMESSAGE_REQUIRED = "SendMessage is REQUIRED"
+    INVARIANT_PLAIN_TEXT_INVISIBLE = "Plain text is invisible to other agents"
+    INVARIANT_CHOOSE_BOTH_FALLBACK = "If you are unsure who the addressee is, choose **both**"
+    INVARIANT_CHARTER_LINK = "../../protocols/pact-communication-charter.md#pre-send-self-check"
     LEAD_GRAY_AREA_PHRASE = "Lead-side gray-area trap"
 
     def test_teammate_side_has_gate(self):
@@ -131,6 +135,10 @@ class TestPreResponseChannelCheckGate:
             self.INVARIANT_BOTH_ADDRESSEE,
             self.INVARIANT_FORMAT_CUE,
             self.INVARIANT_CANDOR,
+            self.INVARIANT_SENDMESSAGE_REQUIRED,
+            self.INVARIANT_PLAIN_TEXT_INVISIBLE,
+            self.INVARIANT_CHOOSE_BOTH_FALLBACK,
+            self.INVARIANT_CHARTER_LINK,
         ):
             assert phrase in text, f"pact-agent-teams missing gate phrase: {phrase!r}"
 
@@ -143,6 +151,10 @@ class TestPreResponseChannelCheckGate:
             self.INVARIANT_BOTH_ADDRESSEE,
             self.INVARIANT_FORMAT_CUE,
             self.INVARIANT_CANDOR,
+            self.INVARIANT_SENDMESSAGE_REQUIRED,
+            self.INVARIANT_PLAIN_TEXT_INVISIBLE,
+            self.INVARIANT_CHOOSE_BOTH_FALLBACK,
+            self.INVARIANT_CHARTER_LINK,
         ):
             assert phrase in text, f"orchestration missing gate phrase: {phrase!r}"
 
@@ -158,11 +170,12 @@ class TestPreResponseChannelCheckGate:
             "lead-side gray-area trap belongs only in orchestration/SKILL.md"
         )
 
-    def test_gate_appears_before_anchor_section(self):
+    def test_teammate_gate_appears_before_on_start(self):
         teammate = self.AGENT_TEAMS_PATH.read_text(encoding="utf-8")
         assert teammate.index("## Pre-Response Channel Check") < teammate.index("## On Start"), \
             "pact-agent-teams: gate must appear before On Start"
 
+    def test_lead_gate_appears_before_communication(self):
         lead = self.ORCHESTRATION_PATH.read_text(encoding="utf-8")
         assert lead.index("### Pre-Response Channel Check") < lead.index("### Communication"), \
             "orchestration: gate must appear before Communication"


### PR DESCRIPTION
## Summary

Closes #574 (`family: instruction-surface-leak`).

Adds a structural gate — §Pre-Response Channel Check — that fires at response START, BEFORE the response generator commits to a reply shape. Forces an explicit channel choice (text / SendMessage / both). Symmetric coverage on both surfaces:

- **Teammate-side** (`pact-plugin/skills/pact-agent-teams/SKILL.md`): new `## Pre-Response Channel Check` section above `## On Start`.
- **Lead-side** (`pact-plugin/skills/orchestration/SKILL.md`): new `### Pre-Response Channel Check` subsection inside `## GUIDELINES`, above `### Communication`. Body byte-identical to teammate-side apart from heading depth, plus an appended `#### Lead-side gray-area trap` addendum that explicitly names the failure mode where a status update to the user substantively answers a teammate's question without ALSO sending via SendMessage.

Gate text names the **Format-cue hijack** and **Candor-question** failure modes inline, distinguishes addressee (user / agent / both), and cross-references Charter Part I §Pre-Send Self-Check (the post-decision complement) via verified slug-link.

## Test plan

- [x] New `TestPreResponseChannelCheckGate` class in `pact-plugin/tests/test_skills_structure.py` — methods enforcing gate symmetry (both files have shared phrases) + addendum-asymmetry (only lead-side has the gray-area-trap heading) + anchor-based position-enforcement
- [x] `pytest pact-plugin/tests/test_skills_structure.py::TestPreResponseChannelCheckGate -v` — all pass
- [x] `pytest pact-plugin/tests/test_skills_structure.py -v` — full file pass, no regressions
- [x] Charter slug `#pre-send-self-check` verified at `protocols/pact-communication-charter.md:61`
- [x] Side-by-side hunk diff confirms shared-body byte-identity (heading-level chars + lead-only addendum the only diffs)