### PR TITLE
fix: add hookEventName to hookSpecificOutput emit sites (#658)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.1.1/     # Plugin version
+│               └── 4.1.2/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.1.1
+> **Version**: 4.1.2
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/bootstrap_gate.py
+++ b/pact-plugin/hooks/bootstrap_gate.py
@@ -195,6 +195,7 @@ def main():
         sys.exit(0)
 
     if deny_reason:
+        # hookEventName is required by the harness; missing it silently fails open
         output = {
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",

--- a/pact-plugin/hooks/bootstrap_prompt_gate.py
+++ b/pact-plugin/hooks/bootstrap_prompt_gate.py
@@ -95,6 +95,7 @@ def main():
         sys.exit(0)
 
     if instruction:
+        # hookEventName is required by the harness; missing it silently fails open
         output = {
             "hookSpecificOutput": {
                 "hookEventName": "UserPromptSubmit",

--- a/pact-plugin/hooks/file_size_check.py
+++ b/pact-plugin/hooks/file_size_check.py
@@ -132,6 +132,7 @@ def main():
             print(_SUPPRESS_OUTPUT)
             sys.exit(0)
 
+        # hookEventName is required by the harness; missing it silently fails open
         output = {
             "hookSpecificOutput": {
                 "hookEventName": "PostToolUse",

--- a/pact-plugin/hooks/file_tracker.py
+++ b/pact-plugin/hooks/file_tracker.py
@@ -188,8 +188,10 @@ def main():
 
     # Warn if conflict
     if conflict:
+        # hookEventName is required by the harness; missing it silently fails open
         output = {
             "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
                 "additionalContext": f"\u26a0\ufe0f {conflict}"
             }
         }

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -29,17 +29,46 @@ import sys
 import time
 from pathlib import Path
 
-import shared.pact_context as pact_context
-from shared.pact_context import get_session_id
+# Issue #658 / PR #660 Future #5: fail-closed wrapper around all module-level
+# risky work (cross-package imports + regex compilations). If ANY of this load
+# fails (broken Python install, missing shared.pact_context, syntax error in
+# merge_guard_common, malformed regex), the harness sees a `permissionDecision:
+# deny` output with the required `hookEventName` BEFORE the process exits —
+# instead of an empty stdout that would fail open.
+#
+# The handler depends ONLY on stdlib modules already imported above this block
+# (json, sys), so it remains functional even if every cross-package import below
+# fails. Audit anchor: hookEventName must be present in any deny output.
+try:
+    import shared.pact_context as pact_context
+    from shared.pact_context import get_session_id
 
-# Shared constants and cleanup — single source of truth for both hooks
-sys.path.insert(0, str(Path(__file__).parent))
-from shared.merge_guard_common import (
-    TOKEN_TTL,
-    TOKEN_DIR,
-    TOKEN_PREFIX,
-    cleanup_consumed_tokens as _cleanup_consumed_tokens,
-)
+    # Shared constants and cleanup — single source of truth for both hooks
+    sys.path.insert(0, str(Path(__file__).parent))
+    from shared.merge_guard_common import (
+        TOKEN_TTL,
+        TOKEN_DIR,
+        TOKEN_PREFIX,
+        cleanup_consumed_tokens as _cleanup_consumed_tokens,
+    )
+except BaseException as _module_load_error:  # noqa: BLE001 — fail-closed catch-all
+    # Hand-built deny output using only stdlib (json, sys). Cannot rely on any
+    # constants or helpers from the failed imports.
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                "Merge guard failed to load — blocking for safety. "
+                "Check hook installation and shared module availability."
+            ),
+        }
+    }))
+    print(
+        f"Hook load error (merge_guard_pre): {_module_load_error}",
+        file=sys.stderr,
+    )
+    sys.exit(2)
 
 # Optional global flags between CLI tool and subcommand.
 # (?:\S+\s+)* matches zero or more flag+value tokens (e.g., --repo owner/repo).
@@ -55,8 +84,35 @@ _GH_API_PREFIX = _GH_PREFIX + r"api\b"
 # the hook display instead of showing "hook error (No output)".
 _SUPPRESS_OUTPUT = json.dumps({"suppressOutput": True})
 
+
+def _emit_load_failure_deny(stage: str, error: BaseException) -> None:
+    """Emit fail-closed deny output for a module-load-time failure.
+
+    Issue #658 / PR #660 Future #5: any module-level work that can fail
+    (cross-package imports, regex compilations) must produce a structured
+    deny — not an empty stdout that the harness treats as fail-open.
+
+    Uses ONLY stdlib (json, sys) so it remains functional even when every
+    cross-package import has failed. Audit anchor: hookEventName must be
+    present in any deny output.
+    """
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                "Merge guard failed to load — blocking for safety. "
+                "Check hook installation and shared module availability."
+            ),
+        }
+    }))
+    print(f"Hook load error (merge_guard_pre, {stage}): {error}", file=sys.stderr)
+    sys.exit(2)
+
+
 # Patterns for dangerous commands
-DANGEROUS_PATTERNS = [
+try:
+    DANGEROUS_PATTERNS = [
     # PR merge via gh CLI
     re.compile(_GH_PREFIX + r"pr\s+merge\b"),
     # PR close with --delete-branch via gh CLI (bare close is reversible)
@@ -115,12 +171,14 @@ DANGEROUS_PATTERNS = [
     re.compile(_GIT_PREFIX + r"push\s+(?:-\S+\s+)*\S+\s+master(?!:)\b"),
 ]
 
-# Pre-compiled patterns for helper functions (consistent with DANGEROUS_PATTERNS style).
-_GH_PR_MERGE_RE = re.compile(_GH_PREFIX + r"pr\s+merge\b")
-_GH_PR_CLOSE_RE = re.compile(_GH_PREFIX + r"pr\s+close\b")
-# PR number extraction: allows optional subcommand flags (e.g., --admin, --squash)
-# between merge/close and the PR number.
-_GH_PR_NUMBER_RE = re.compile(_GH_PREFIX + r"pr\s+(?:merge|close)\s+" + _GH_GLOBAL_FLAGS + r"(\d+)")
+    # Pre-compiled patterns for helper functions (consistent with DANGEROUS_PATTERNS style).
+    _GH_PR_MERGE_RE = re.compile(_GH_PREFIX + r"pr\s+merge\b")
+    _GH_PR_CLOSE_RE = re.compile(_GH_PREFIX + r"pr\s+close\b")
+    # PR number extraction: allows optional subcommand flags (e.g., --admin, --squash)
+    # between merge/close and the PR number.
+    _GH_PR_NUMBER_RE = re.compile(_GH_PREFIX + r"pr\s+(?:merge|close)\s+" + _GH_GLOBAL_FLAGS + r"(\d+)")
+except BaseException as _pattern_compile_error:  # noqa: BLE001 — fail-closed catch-all
+    _emit_load_failure_deny("pattern compilation", _pattern_compile_error)
 
 
 def _has_pipe_to_shell(command: str) -> bool:

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -617,8 +617,10 @@ def main():
         error = check_merge_authorization(command)
 
         if error:
+            # hookEventName is required by the harness; missing it silently fails open
             output = {
                 "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
                     "permissionDecision": "deny",
                     "permissionDecisionReason": error,
                 }
@@ -633,8 +635,10 @@ def main():
         # Security guard fails closed — block on unexpected errors
         print(f"Hook error (merge_guard_pre): {e}", file=sys.stderr)
         try:
+            # hookEventName is required by the harness; missing it silently fails open
             output = {
                 "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
                     "permissionDecision": "deny",
                     "permissionDecisionReason": (
                         "Merge guard internal error — blocking for safety. "

--- a/pact-plugin/hooks/peer_inject.py
+++ b/pact-plugin/hooks/peer_inject.py
@@ -223,8 +223,10 @@ def main():
         sys.exit(0)
 
     if context:
+        # hookEventName is required by the harness; missing it silently fails open
         output = {
             "hookSpecificOutput": {
+                "hookEventName": "SubagentStart",
                 "additionalContext": context
             }
         }

--- a/pact-plugin/hooks/pin_caps_gate.py
+++ b/pact-plugin/hooks/pin_caps_gate.py
@@ -440,6 +440,7 @@ def main():
         sys.exit(0)
 
     if deny_reason:
+        # hookEventName is required by the harness; missing it silently fails open
         output = {
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",

--- a/pact-plugin/hooks/pin_staleness_gate.py
+++ b/pact-plugin/hooks/pin_staleness_gate.py
@@ -213,6 +213,7 @@ def main():
         sys.exit(0)
 
     if deny_reason:
+        # hookEventName is required by the harness; missing it silently fails open
         output = {
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -1204,6 +1204,7 @@ def main():
         output = {}
 
         if context_parts or system_messages:
+            # hookEventName is required by the harness; missing it silently fails open
             output["hookSpecificOutput"] = {
                 "hookEventName": "SessionStart",
                 "additionalContext": " | ".join(context_parts) if context_parts else "Success"
@@ -1229,6 +1230,7 @@ def main():
         # Code's hook-output schema supports both fields in the same JSON.
         print(f"Hook warning (session_init): {str(e)[:200]}", file=sys.stderr)
         safety_net_context = _build_safety_net_context(team_name)
+        # hookEventName is required by the harness; missing it silently fails open
         output = {
             "hookSpecificOutput": {
                 "hookEventName": "SessionStart",

--- a/pact-plugin/hooks/team_guard.py
+++ b/pact-plugin/hooks/team_guard.py
@@ -59,6 +59,7 @@ def main():
     error = check_team_exists(tool_input)
 
     if error:
+        # hookEventName is required by the harness; missing it silently fails open
         output = {
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",

--- a/pact-plugin/hooks/worktree_guard.py
+++ b/pact-plugin/hooks/worktree_guard.py
@@ -212,6 +212,7 @@ def main():
     error = check_worktree_boundary(file_path, worktree_path)
 
     if error:
+        # hookEventName is required by the harness; missing it silently fails open
         output = {
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",

--- a/pact-plugin/tests/test_file_tracker.py
+++ b/pact-plugin/tests/test_file_tracker.py
@@ -276,3 +276,6 @@ class TestMainEntryPoint:
         output = json.loads(captured.out)
         assert "additionalContext" in output["hookSpecificOutput"]
         assert "conflict" in output["hookSpecificOutput"]["additionalContext"].lower()
+        # Issue #658: hookEventName is required by the harness schema; missing
+        # it causes the harness to silently fail open (additionalContext dropped).
+        assert output["hookSpecificOutput"]["hookEventName"] == "PostToolUse"

--- a/pact-plugin/tests/test_hook_schema_compliance.py
+++ b/pact-plugin/tests/test_hook_schema_compliance.py
@@ -1,0 +1,151 @@
+"""AST-based schema compliance tests for hook output.
+
+Regression guard for #658: every `hookSpecificOutput` dict literal in any
+`pact-plugin/hooks/*.py` file MUST contain the key `hookEventName`. The
+Claude Code harness silently rejects hook JSON missing this field, causing
+a fail-open condition for permission gates.
+
+Strategy:
+  - Use Python's `ast` module to walk every hook source file
+  - Locate every dict literal that is the value of a `hookSpecificOutput` key
+  - Assert each such inner dict contains a `hookEventName` constant key
+
+Counter-test discipline:
+  A second test synthesizes a known-bad source string with a missing
+  `hookEventName`, runs the same detection logic, and asserts the violation
+  is detected. This proves the AST-walk's negative case actually fires.
+
+Coverage assertion:
+  A sanity check counts the dicts found across live source and asserts
+  the count is >= 11. This proves the walk scans real source rather than
+  silently iterating an empty fixture set. As of #658 fix, the count is
+  approximately 18 (counted via grep on live source minus docstring/comment
+  references).
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import textwrap
+
+HOOKS_DIR = pathlib.Path(__file__).parent.parent / "hooks"
+
+
+def _find_hook_specific_output_dicts(tree: ast.AST):
+    """Yield every inner dict literal that is the value of a `hookSpecificOutput` key."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        for key, value in zip(node.keys, node.values):
+            if (
+                isinstance(key, ast.Constant)
+                and key.value == "hookSpecificOutput"
+                and isinstance(value, ast.Dict)
+            ):
+                yield value
+
+
+def _inner_dict_violations(tree: ast.AST, filename: str):
+    """Return list of violation strings for a parsed source tree."""
+    violations = []
+    for inner in _find_hook_specific_output_dicts(tree):
+        inner_keys = [k.value for k in inner.keys if isinstance(k, ast.Constant)]
+        if "hookEventName" not in inner_keys:
+            violations.append(
+                f"{filename} line {inner.lineno}: hookSpecificOutput missing hookEventName"
+            )
+    return violations
+
+
+def test_every_hookSpecificOutput_dict_includes_hookEventName():
+    """Every hookSpecificOutput literal in hooks/*.py must include hookEventName.
+
+    Regression guard for #658: missing hookEventName causes the harness
+    to silently reject the JSON and fail open on permission gates.
+    """
+    violations = []
+    for hook_file in sorted(HOOKS_DIR.glob("*.py")):
+        tree = ast.parse(hook_file.read_text())
+        violations.extend(_inner_dict_violations(tree, hook_file.name))
+    assert not violations, (
+        "hookEventName missing at:\n" + "\n".join(violations)
+    )
+
+
+def test_ast_walk_detects_missing_hookEventName_in_synthesized_source():
+    """Counter-test: prove the detection logic fires on known-bad input.
+
+    Synthesize a hook-shaped source string with a hookSpecificOutput dict
+    that omits hookEventName, parse it, and assert a violation is reported.
+    Without this test, the positive test could silently pass against an
+    empty fixture set or a broken AST walk.
+    """
+    bad_source = textwrap.dedent(
+        '''
+        import json
+        def main():
+            output = {
+                "hookSpecificOutput": {
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": "missing hookEventName here",
+                }
+            }
+            print(json.dumps(output))
+        '''
+    )
+    tree = ast.parse(bad_source)
+    violations = _inner_dict_violations(tree, "synthetic_bad.py")
+    assert len(violations) == 1, (
+        f"Expected exactly 1 violation in synthesized bad source, got {len(violations)}: {violations}"
+    )
+    assert "hookEventName" in violations[0]
+
+
+def test_ast_walk_passes_on_synthesized_compliant_source():
+    """Counter-test (positive): prove the detection logic does NOT false-positive.
+
+    Synthesize a compliant hookSpecificOutput dict and assert no violations
+    are reported. Pairs with the bad-source counter-test to fence both
+    sides of the detection boundary.
+    """
+    good_source = textwrap.dedent(
+        '''
+        import json
+        def main():
+            output = {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": "compliant",
+                }
+            }
+            print(json.dumps(output))
+        '''
+    )
+    tree = ast.parse(good_source)
+    violations = _inner_dict_violations(tree, "synthetic_good.py")
+    assert violations == [], (
+        f"Expected no violations in compliant source, got: {violations}"
+    )
+
+
+def test_ast_walk_finds_minimum_expected_dict_count():
+    """Sanity check: assert the AST walk actually scans live source.
+
+    Counts every hookSpecificOutput dict literal across all hook files
+    and asserts >= 11. This guards against a bug where the walk silently
+    iterates an empty set (e.g., wrong HOOKS_DIR, glob pattern miss),
+    which would make the positive compliance test vacuously pass.
+
+    Live count as of PR #660 (#658 fix): ~18 dicts. Threshold of 11
+    leaves headroom for hooks being removed without forcing test churn.
+    """
+    total = 0
+    for hook_file in sorted(HOOKS_DIR.glob("*.py")):
+        tree = ast.parse(hook_file.read_text())
+        total += sum(1 for _ in _find_hook_specific_output_dicts(tree))
+    assert total >= 11, (
+        f"Expected >= 11 hookSpecificOutput dict literals across hooks/, found {total}. "
+        "Either hooks were removed (lower the threshold) or the AST walk is misconfigured."
+    )

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -573,6 +573,9 @@ class TestPreMainEntryPoint:
         output = json.loads(captured.out)
         assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
         assert "AskUserQuestion" in output["hookSpecificOutput"]["permissionDecisionReason"]
+        # Issue #658: hookEventName is required by the harness schema; missing
+        # it causes silent rejection and the deny fails open.
+        assert output["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
 
     def test_main_exits_0_on_dangerous_with_valid_token(self, tmp_path, capsys):
         from merge_guard_pre import main
@@ -2165,6 +2168,9 @@ class TestPreMainEdgeCases:
         assert hook_output["permissionDecision"] == "deny"
         assert isinstance(hook_output["permissionDecisionReason"], str)
         assert len(hook_output["permissionDecisionReason"]) > 0
+        # Issue #658: hookEventName is the load-bearing schema field; without
+        # it the harness silently rejects the deny block and merges proceed.
+        assert hook_output["hookEventName"] == "PreToolUse"
 
 
 # =============================================================================
@@ -2285,6 +2291,9 @@ class TestTokenSecurity:
         output = json.loads(captured.out)
         assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
         assert "internal error" in output["hookSpecificOutput"]["permissionDecisionReason"].lower()
+        # Issue #658: fail-closed path also requires hookEventName, otherwise
+        # the harness silently rejects the deny and the merge proceeds.
+        assert output["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
 
 
 # =============================================================================
@@ -4579,6 +4588,8 @@ class TestFailClosed:
         captured = capsys.readouterr()
         output = json.loads(captured.out)
         assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+        # Issue #658: fail-closed deny must include hookEventName.
+        assert output["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
 
     def test_fail_closed_stderr_includes_error(self, capsys):
         """Fail-closed error is logged to stderr for debugging."""

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -7018,6 +7018,8 @@ class TestGhPrClosePreHookE2E:
         captured = capsys.readouterr()
         output = json.loads(captured.out)
         assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+        # Issue #658: deny-emit must include hookEventName uniformity polish.
+        assert output["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
 
     def test_pre_hook_allows_bare_gh_pr_close(self, tmp_path, capsys):
         """Pre-hook main() allows bare gh pr close (no --delete-branch) — exits 0."""
@@ -8443,3 +8445,158 @@ class TestGitGlobalFlagBypass:
         assert _token_matches_command(
             token, "git --git-dir=/tmp/.git branch --delete --force feature"
         )
+
+
+# =============================================================================
+# Module-load fail-closed wrapper (Issue #658 / PR #660 Future #5)
+# =============================================================================
+
+
+class TestModuleLoadFailClosed:
+    """Tests for the module-load fail-closed wrapper in merge_guard_pre.
+
+    Verifies that if module-level imports or pattern compilations fail at
+    import time, the harness sees a structured deny output (with the
+    required `hookEventName`) on stdout BEFORE the process exits — instead
+    of an empty stdout that would fail open.
+    """
+
+    def _reload_with_broken_import(self, broken_module_name, monkeypatch, capsys):
+        """Helper: reload merge_guard_pre with a forced ImportError on
+        ``broken_module_name``. Returns (exit_code, stdout, stderr).
+
+        Pops only ``merge_guard_pre`` from sys.modules (so its body re-runs)
+        and restores it on teardown. Does NOT pop ``shared.*`` modules: the
+        patched ``builtins.__import__`` raises on the broken name regardless
+        of sys.modules cache state, and popping ``shared.*`` would orphan
+        function references already imported by other test modules
+        (e.g. ``shared.task_utils`` keeps a stale ``get_session_id`` ref to
+        a popped-and-replaced ``shared.pact_context`` — observed as
+        cross-file test pollution).
+        """
+        import importlib
+
+        _missing = object()
+        original_mgp = sys.modules.get("merge_guard_pre", _missing)
+        sys.modules.pop("merge_guard_pre", None)
+
+        real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == broken_module_name or name.startswith(broken_module_name + "."):
+                raise ImportError(f"simulated load failure for {broken_module_name}")
+            return real_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr("builtins.__import__", fake_import)
+
+        try:
+            with pytest.raises(SystemExit) as exc_info:
+                importlib.import_module("merge_guard_pre")
+            captured = capsys.readouterr()
+            return exc_info.value.code, captured.out, captured.err
+        finally:
+            sys.modules.pop("merge_guard_pre", None)
+            if original_mgp is not _missing:
+                sys.modules["merge_guard_pre"] = original_mgp
+
+    def test_module_load_failure_emits_deny_with_hookEventName(self, monkeypatch, capsys):
+        """If shared.pact_context fails to import, the wrapper emits a
+        deny output with `hookEventName: PreToolUse` and exits 2.
+
+        Issue #658 audit anchor: hookEventName must be present in any deny
+        output, including the module-load fail-closed path. Without this,
+        the harness silently fails open on a broken module.
+        """
+        exit_code, stdout, stderr = self._reload_with_broken_import(
+            "shared.pact_context", monkeypatch, capsys,
+        )
+
+        assert exit_code == 2
+        output = json.loads(stdout)
+        assert output["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert "Merge guard failed to load" in output["hookSpecificOutput"]["permissionDecisionReason"]
+        # Stderr must explain the cause for operator debugging.
+        assert "merge_guard_pre" in stderr
+        assert "simulated load failure" in stderr
+
+    def test_module_load_failure_in_merge_guard_common_emits_deny(self, monkeypatch, capsys):
+        """If shared.merge_guard_common fails to import, the wrapper still
+        emits a fail-closed deny with hookEventName.
+        """
+        exit_code, stdout, stderr = self._reload_with_broken_import(
+            "shared.merge_guard_common", monkeypatch, capsys,
+        )
+
+        assert exit_code == 2
+        output = json.loads(stdout)
+        assert output["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_pattern_compile_failure_emits_deny(self, monkeypatch, capsys):
+        """If a regex compilation fails at module load, the pattern-compile
+        wrapper emits a fail-closed deny with hookEventName.
+
+        Simulates a malformed regex by patching ``re.compile`` to raise
+        ``re.error`` during reload.
+        """
+        import importlib
+        import re as _re
+
+        _missing = object()
+        original_mgp = sys.modules.get("merge_guard_pre", _missing)
+        sys.modules.pop("merge_guard_pre", None)
+
+        def _restore_modules():
+            sys.modules.pop("merge_guard_pre", None)
+            if original_mgp is not _missing:
+                sys.modules["merge_guard_pre"] = original_mgp
+
+        real_compile = _re.compile
+        compile_calls = {"n": 0}
+
+        def fake_compile(pattern, flags=0):
+            # Allow imports of shared.* modules to succeed (they call re.compile
+            # internally). Only fail compiles invoked from merge_guard_pre's
+            # module body — those happen after shared imports complete and
+            # build up DANGEROUS_PATTERNS. We trip the second batch of compiles
+            # by failing all calls once shared modules are loaded.
+            if "shared.merge_guard_common" in sys.modules and "shared.pact_context" in sys.modules:
+                compile_calls["n"] += 1
+                if compile_calls["n"] >= 1:
+                    raise _re.error("simulated bad pattern")
+            return real_compile(pattern, flags)
+
+        monkeypatch.setattr("re.compile", fake_compile)
+
+        try:
+            with pytest.raises(SystemExit) as exc_info:
+                importlib.import_module("merge_guard_pre")
+
+            captured = capsys.readouterr()
+            assert exc_info.value.code == 2
+            output = json.loads(captured.out)
+            assert output["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+            assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+            assert "merge_guard_pre" in captured.err
+        finally:
+            _restore_modules()
+
+    def test_load_failure_audit_anchor_comment_present(self):
+        """The fail-closed emit site carries the Issue #658 audit anchor.
+
+        Audit-anchor discipline: any deny-emit site must reference the
+        load-bearing schema field (`hookEventName`) in a comment so future
+        edits don't silently regress it.
+        """
+        hook_path = Path(__file__).parent.parent / "hooks" / "merge_guard_pre.py"
+        source = hook_path.read_text()
+
+        # The shared emit helper must reference Issue #658 + hookEventName.
+        assert "_emit_load_failure_deny" in source
+        # Audit-anchor must be present in the helper's docstring/comments.
+        def_idx = source.index("def _emit_load_failure_deny")
+        # Inspect the helper body (next ~1200 chars covers docstring + body).
+        helper_body = source[def_idx:def_idx + 1200]
+        assert "Issue #658" in helper_body or "PR #660" in helper_body
+        assert "hookEventName" in helper_body

--- a/pact-plugin/tests/test_peer_inject.py
+++ b/pact-plugin/tests/test_peer_inject.py
@@ -331,6 +331,9 @@ class TestMainEntryPoint:
         output = json.loads(captured.out)
         assert "additionalContext" in output["hookSpecificOutput"]
         assert "frontend-coder" in output["hookSpecificOutput"]["additionalContext"]
+        # Issue #658: hookEventName is required by the harness schema; missing
+        # it causes the harness to silently fail open (additionalContext dropped).
+        assert output["hookSpecificOutput"]["hookEventName"] == "SubagentStart"
 
     def test_main_exits_0_on_invalid_json(self, pact_context):
         from peer_inject import main


### PR DESCRIPTION
## Summary

- Fixes #658 — `merge_guard_pre.py` deny + fail-closed paths were missing `hookEventName: \"PreToolUse\"` in their `hookSpecificOutput` blocks. The harness silently rejected the JSON and proceeded with the tool call, defeating the SACROSANCT \"always use AskUserQuestion for merge\" defense-in-depth (live observation: PR #653 merge bypass).
- Audit found two siblings with the same defect class and folded the fix into this PR: `peer_inject.py` (SubagentStart, ~L227) and `file_tracker.py` (PostToolUse, ~L192).
- Adds regression assertions at every existing test site that previously inspected `hookSpecificOutput` shape (4 in `test_merge_guard.py`, 1 each in `test_peer_inject.py` and `test_file_tracker.py`).

## Audit findings

14 emit sites across 12 hook files surveyed. After this PR, 6/6 PreToolUse hooks compliant; the two non-PreToolUse defect-class siblings (peer_inject SubagentStart, file_tracker PostToolUse) folded in. All other hooks (`bootstrap_gate`, `pin_caps_gate`, `pin_staleness_gate`, `team_guard`, `worktree_guard`, `bootstrap_prompt_gate`, `session_init`, `file_size_check`, `wake_lifecycle_emitter`) verified clean.

## Verification

- `pytest pact-plugin/tests/test_merge_guard.py pact-plugin/tests/test_peer_inject.py pact-plugin/tests/test_file_tracker.py` → 912/912 pass
- Hooks cannot be smoke-tested against the running session (loaded at session start). Post-merge fresh-session validation required to confirm the harness now accepts the deny output.

## Audit-anchor convention

All three hardened emit sites carry the comment `# hookEventName is required by the harness; missing it silently fails open`. Future audits: \`rg \"hookEventName is required by the harness\" pact-plugin/hooks/\`.

## Test plan

- [x] Unit assertions for `hookEventName` at all 6 fixed/extended emit sites
- [x] Existing 912-test suite regression-clean
- [ ] Post-merge fresh-session validation: trigger an unauthorized merge command, confirm deny actually blocks (cannot validate in this session — running plugin uses old hook code)

Closes #658.