### PR TITLE
v4.1.5: republish to invalidate marketplace cache for #682

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.1.4",
+      "version": "4.1.5",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.1.4/     # Plugin version
+│               └── 4.1.5/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.1.4
+> **Version**: 4.1.5
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 


### PR DESCRIPTION
## Summary

- Patch-bump 4.1.4 → 4.1.5 across the canonical 4-file dance to invalidate the marketplace cache for users running cached 4.1.4
- No source changes — this PR exists solely to ship the changes from #682 (commit 1f20c886) under a new version string
- Surfaces a process gap: PR #683 merged into the same `4.1.4` version label, so the marketplace cache (keyed on version) silently buried the relax

## Background

Plugin version is the cache key for marketplace installs. PR #683 (1f20c886, "Decouple secretary self-completion carve-out from spawn name to agent type") merged the `RESERVED_NAMES` relax — removing `secretary` and `pact-secretary` so the canonical bootstrap ritual could spawn the secretary by name. But #683 didn't bump `plugin.json` from 4.1.4, so installations that pulled 4.1.4 before #683's merge are stuck on the pre-merge `dispatch_gate.py` where `secretary` is still reserved.

Live symptom (this session, 2026-05-08): bootstrap ritual called `Agent(name="secretary", ...)` → `dispatch_gate` refused with `reserved-token set` — even though source on `main` explicitly removed it.

## What this changes

| File | Change |
|------|--------|
| `pact-plugin/.claude-plugin/plugin.json` | `"version": "4.1.4"` → `"4.1.5"` |
| `.claude-plugin/marketplace.json` | `"version": "4.1.4"` → `"4.1.5"` |
| `README.md` | path doc `4.1.4/` → `4.1.5/` |
| `pact-plugin/README.md` | `> **Version**: 4.1.4` → `4.1.5` |

## Post-merge actions

Per the pinned "Tag + GitHub release after every plugin-version bump" memory:

1. `git tag -a v4.1.5 {merge_sha} -m "v4.1.5 — republish for #682 carve-out relax"` then `git push origin v4.1.5`
2. `gh release create v4.1.5 --title "v4.1.5 — republish for #682 carve-out relax" --notes "..."` covering the cache-invalidation reason, the #682 changes now reaching users, and the process gap surfaced.

## Follow-up

Recommend filing a follow-up issue: **"PR review checklist: require plugin-version bump if hooks/skills/commands changed"**. The 4-file dance is documented in pinned memory but isn't gate-enforced; a review-time checkpoint or a hook that diffs `plugin/` against the version field would prevent recurrence.

## Test plan

- [ ] CI passes (no source changes, so test cardinality should be unchanged from main)
- [ ] After merge: tag + release, then verify `~/.claude/plugins/cache/pact-plugin/PACT/4.1.5/hooks/dispatch_gate.py` shows the post-#682 `RESERVED_NAMES` (no `secretary`)
- [ ] Fresh-session bootstrap ritual successfully spawns `Agent(name="secretary", ...)` without dispatch_gate refusal
