### PR TITLE
fix(merge-guard): pair #665 + #676 fixes; bump to 4.1.8 (#677 PR #1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.1.7",
+      "version": "4.1.8",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.1.7/     # Plugin version
+│               └── 4.1.8/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.1.7",
+  "version": "4.1.8",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -74,7 +74,7 @@ Environment variables that tune hook behavior:
 
 | Variable | Default | Allowed values | Effect |
 |---|---|---|---|
-| `PACT_DISPATCH_INLINE_MISSION_MODE` | `warn` | `warn` / `deny` / `shadow` | Disposition of the dispatch-gate inline-mission heuristic (flags dispatchers inlining mission text into `prompt=` instead of using the canonical "check TaskList" form; F7 in the #662 failure-mode index). `warn` emits an advisory `additionalContext`; `deny` blocks the spawn (flip after the F22 counter-test in `tests/runbooks/662-dispatch-gate.md` confirms `additionalContext` is silently dropped under PreToolUse); `shadow` journals only — the trigger is observable but neither WARNs nor DENYs (calibration / first-session safety net). F1-F6, F14, F15 are unaffected. Unknown values fall back to `warn`. |
+| `PACT_DISPATCH_INLINE_MISSION_MODE` | `warn` | `warn` / `deny` / `shadow` | Disposition of the dispatch-gate inline-mission heuristic (flags dispatchers inlining mission text into `prompt=` instead of using the canonical "check TaskList" form). `warn` emits an advisory `additionalContext`; `deny` blocks the spawn (flip only after empirically confirming `additionalContext` injection is reliable under PreToolUse — see `pact-plugin/hooks/dispatch_gate.py` for the matcher-fidelity discussion); `shadow` journals only — the trigger is observable but neither WARNs nor DENYs (calibration / first-session safety net). The other dispatch-gate rules (name/team presence, name validation, specialist registry, session-team match, member uniqueness, task-assignment) are unaffected by this env-var. Unknown values fall back to `warn`. |
 
 ## Full Documentation
 

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.1.7
+> **Version**: 4.1.8
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/auditor_reminder.py
+++ b/pact-plugin/hooks/auditor_reminder.py
@@ -12,7 +12,7 @@ explicit justification to skip.
 
 This is a non-blocking reminder (always exits 0), not a gate.
 
-Input: JSON from stdin with tool_name, tool_input, tool_output
+Input: JSON from stdin with tool_name, tool_input, tool_response
 Output: JSON systemMessage on stdout if reminder needed, nothing otherwise
 """
 

--- a/pact-plugin/hooks/file_size_check.py
+++ b/pact-plugin/hooks/file_size_check.py
@@ -7,7 +7,7 @@ Used by: Claude Code settings.json PostToolUse hook (Edit, Write tools)
 Monitors file sizes after edits and provides guidance when files grow too large,
 encouraging SOLID/DRY principles and architectural refactoring.
 
-Input: JSON from stdin with tool_name, tool_input, tool_output
+Input: JSON from stdin with tool_name, tool_input, tool_response
 Output: JSON with `hookSpecificOutput.additionalContext` when file exceeds threshold
 """
 

--- a/pact-plugin/hooks/merge_guard_post.py
+++ b/pact-plugin/hooks/merge_guard_post.py
@@ -35,6 +35,7 @@ from shared.merge_guard_common import (
     TOKEN_DIR,
     cleanup_consumed_tokens as _cleanup_consumed_tokens,
 )
+from shared.tool_response import extract_tool_response
 
 # When the hook allows a command (exits 0), output this JSON so the Claude Code
 # UI suppresses the hook display instead of showing "hook error (No output)".
@@ -196,7 +197,10 @@ def main():
 
         pact_context.init(input_data)
         tool_input = input_data.get("tool_input", {})
-        tool_response = input_data.get("tool_response", {})
+        # Defense-in-depth via SSOT helper: prefers canonical `tool_response`,
+        # falls back to legacy `tool_output` for envelope-rename robustness,
+        # warns on dual-envelope payloads (envelope-confusion smell).
+        tool_response = extract_tool_response(input_data)
 
         # Extract question from AskUserQuestion schema:
         # tool_input: {"questions": [{"question": "...", ...}]}
@@ -212,9 +216,6 @@ def main():
 
         # Extract answer from AskUserQuestion schema:
         # tool_response: {"answers": {"question_text": "answer_text"}, ...}
-        if not isinstance(tool_response, dict):
-            print(_SUPPRESS_OUTPUT)
-            sys.exit(0)
         answers = tool_response.get("answers", {})
         if isinstance(answers, dict) and answers:
             # Look up answer by exact question text; fall back to first value

--- a/pact-plugin/hooks/merge_guard_post.py
+++ b/pact-plugin/hooks/merge_guard_post.py
@@ -109,12 +109,19 @@ def extract_context(question: str) -> dict:
     if branch_match:
         context["branch"] = branch_match.group(1) or branch_match.group(2)
 
-    # Detect operation type for token scoping
+    # Detect operation type for token scoping. The order matters — close
+    # is more specific than merge (close can mention "merge"), and
+    # force-push / branch-delete are independent operation classes whose
+    # AskUserQuestion text typically does not mention "merge" or "close".
     question_lower = question.lower()
     if re.search(r"\bclose\b.*(?:pr|pull\s*request)|(?:pr|pull\s*request).*\bclose\b|gh\s+pr\s+close", question_lower):
         context["operation_type"] = "close"
     elif re.search(r"\bmerge\b", question_lower):
         context["operation_type"] = "merge"
+    elif re.search(r"force[\s-]?push|push\s+--force|push\s+-f\b|push\s+-[a-z]*f", question_lower):
+        context["operation_type"] = "force-push"
+    elif re.search(r"delete[\s-]?branch|branch\s+(?:-D|--delete)\b", question_lower):
+        context["operation_type"] = "branch-delete"
 
     return context
 
@@ -127,8 +134,36 @@ def write_token(context: dict, token_dir: Path | None = None) -> str | None:
         token_dir: Override token directory (for testing)
 
     Returns:
-        Path to the created token file, or None on failure
+        Path to the created token file, or None on failure or refusal
     """
+    # Sparse-context guard: refuse to write a token whose context — as
+    # produced by `extract_context()` on a vague AskUserQuestion text —
+    # carries NONE of the three concrete anchor keys (pr_number, branch,
+    # operation_type). The realistic shape of such a wildcard context is
+    # `{question_snippet: "<vague text>"}` with no extracted anchors; a
+    # token written from it would match ANY destructive command via the
+    # PRE-side `_token_matches_command` ladder's ambiguous-permissive
+    # fallback. Fail closed at the WRITE side so the wildcard token never
+    # reaches the PRE-side ladder. Any one concrete anchor is sufficient.
+    if not isinstance(context, dict):
+        print(
+            "[security] sparse context: non-dict context, refusing token write",
+            file=sys.stderr,
+        )
+        return None
+    has_pr = bool(context.get("pr_number"))
+    has_branch = bool(context.get("branch"))
+    has_op = bool(context.get("operation_type"))
+    if not (has_pr or has_branch or has_op):
+        print(
+            "[security] sparse context: AskUserQuestion text yielded no "
+            "extractable pr_number, branch, or operation_type — refusing "
+            "token write to avoid wildcard-allow against subsequent "
+            "destructive commands.",
+            file=sys.stderr,
+        )
+        return None
+
     if token_dir is None:
         token_dir = TOKEN_DIR
 

--- a/pact-plugin/hooks/merge_guard_post.py
+++ b/pact-plugin/hooks/merge_guard_post.py
@@ -12,7 +12,7 @@ and the user answers affirmatively, a token file is written to ~/.claude/. The
 companion hook (merge_guard_pre.py) checks for this token before allowing
 dangerous commands.
 
-Input: JSON from stdin with tool_input (AskUserQuestion questions array) and tool_output (answers dict)
+Input: JSON from stdin with tool_input (AskUserQuestion questions array) and tool_response (answers dict)
 Output: None (side effect: writes token file on approval)
 """
 
@@ -196,7 +196,7 @@ def main():
 
         pact_context.init(input_data)
         tool_input = input_data.get("tool_input", {})
-        tool_output = input_data.get("tool_output", {})
+        tool_response = input_data.get("tool_response", {})
 
         # Extract question from AskUserQuestion schema:
         # tool_input: {"questions": [{"question": "...", ...}]}
@@ -211,11 +211,11 @@ def main():
             question = ""
 
         # Extract answer from AskUserQuestion schema:
-        # tool_output: {"answers": {"question_text": "answer_text"}, ...}
-        if not isinstance(tool_output, dict):
+        # tool_response: {"answers": {"question_text": "answer_text"}, ...}
+        if not isinstance(tool_response, dict):
             print(_SUPPRESS_OUTPUT)
             sys.exit(0)
-        answers = tool_output.get("answers", {})
+        answers = tool_response.get("answers", {})
         if isinstance(answers, dict) and answers:
             # Look up answer by exact question text; fall back to first value
             answer = str(answers.get(question, next(iter(answers.values()), "")))

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -433,6 +433,45 @@ def _strip_non_executable_content(command: str) -> str:
     return result
 
 
+def _has_eval_with_heredoc(command: str) -> bool:
+    """Detect eval (or backtick) command-substitution that wraps a heredoc.
+
+    The strip pipeline removes heredoc bodies BEFORE the regex-match phase.
+    An eval-wrapped destructive command inside a heredoc body is therefore
+    invisible to DANGEROUS_PATTERNS by the time matching runs:
+
+        eval $(cat <<HEREDOC
+        gh pr merge 999 --admin
+        HEREDOC
+        )
+
+    After ``_strip_non_executable_content``, the inner ``gh pr merge 999``
+    is gone. The outer eval invokes the heredoc body as a command, which
+    is exactly the destructive operation the merge guard is supposed to
+    intercept. Treat the eval+heredoc shape as categorically dangerous —
+    legitimate operator command flows do not use eval-wrapped heredoc as
+    a delivery mechanism, so the false-positive risk is low.
+
+    Detects both the modern ``$(...)`` substitution form and the legacy
+    backtick form.
+    """
+    # eval $(...) with a heredoc anywhere within the substitution
+    if re.search(r"\beval\s+\$\(", command) and "<<" in command:
+        return True
+    # eval `...` (backtick) wrapping a heredoc
+    if re.search(r"\beval\s+`[^`]*<<", command):
+        return True
+    return False
+
+
+# Compound-command detection: shell control-flow operators that split a
+# command line into multiple independent operations. When a destructive
+# operation appears inside a compound, the merge-guard token model breaks
+# down — a single AskUserQuestion approval is presumed by the operator to
+# authorize ONE operation, but the compound runs many.
+_COMPOUND_OPS_RE = re.compile(r"[&;|\n]")
+
+
 def is_dangerous_command(command: str) -> bool:
     """Check if a bash command is a dangerous git operation.
 
@@ -446,10 +485,41 @@ def is_dangerous_command(command: str) -> bool:
     Returns:
         True if the command matches a dangerous pattern
     """
+    # Pre-strip detection: eval+heredoc shape obscures destructive ops via
+    # the heredoc-strip pipeline. Treat as dangerous before the strip runs.
+    if _has_eval_with_heredoc(command):
+        return True
+
     # Normalize bash line continuations (\<newline>) before any matching.
     # Without this, patterns split across lines bypass all regex detection.
     command = command.replace("\\\n", " ")
     stripped = _strip_non_executable_content(command)
+    for pattern in DANGEROUS_PATTERNS:
+        if pattern.search(stripped):
+            return True
+    return False
+
+
+def is_compound_destructive_command(command: str) -> bool:
+    """Detect destructive operations chained inside a shell compound shape.
+
+    Returns True iff the stripped command contains BOTH (a) a compound-shape
+    character (``&&``, ``||``, ``;``, ``|``, newline) AND (b) a
+    DANGEROUS_PATTERNS match. Safe compounds (``ls && pwd``) are NOT flagged.
+
+    Operator-side review of AskUserQuestion text typically focuses on the
+    headline command and may miss a chained second destructive op, e.g.:
+
+        gh pr merge 100 && gh pr merge 999 --admin
+
+    Single-token authorization for the headline command would otherwise
+    let the second op execute unauthorized. Reject compound destructive
+    shapes outright; force one-op-at-a-time with one checkpoint each.
+    """
+    normalized = command.replace("\\\n", " ")
+    stripped = _strip_non_executable_content(normalized)
+    if not _COMPOUND_OPS_RE.search(stripped):
+        return False
     for pattern in DANGEROUS_PATTERNS:
         if pattern.search(stripped):
             return True
@@ -658,6 +728,19 @@ def check_merge_authorization(command: str, token_dir: Path | None = None) -> st
     """
     if not is_dangerous_command(command):
         return None
+
+    # Compound destructive shapes are categorically denied — a single
+    # token cannot authorize multiple chained ops. The operator must run
+    # one destructive op per checkpoint. Checked BEFORE the token lookup
+    # so a valid token for the headline op cannot accidentally authorize
+    # the chained second op.
+    if is_compound_destructive_command(command):
+        return (
+            "Compound destructive command rejected — `&&`, `||`, `;`, `|`, and "
+            "newlines cannot be authorized atomically. A single AskUserQuestion "
+            "approval can only authorize ONE destructive operation. Run each "
+            "destructive op separately with its own approval."
+        )
 
     token, token_path = find_valid_token(token_dir)
     if token is not None:

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -181,11 +181,31 @@ try:
     _GH_PR_CLOSE_RE = re.compile(_GH_PREFIX + r"pr\s+close\b")
     # PR number extraction: allows optional subcommand flags (e.g., --admin, --squash)
     # between merge/close and the PR number.
-    # #665: use _GH_FLAG_TOKENS (flag-shaped only) for the post-subcommand
-    # token walk, and \b after (\d+) so the capture is a standalone digit
-    # token (not the suffix of a longer token like `7352-tests`).
+    #
+    # Both flag-walks (between `gh` and `pr`, AND between subcommand and PR
+    # number) use the tight `_GH_FLAG_TOKENS` form. The earlier broad
+    # `_GH_GLOBAL_FLAGS` form on the pre-subcommand walk allowed greedy
+    # consumption past a `gh pr <subcmd> <PR>` substring inside `--body
+    # "..."` text, then re-anchoring at a SECOND `gh pr <subcmd>` occurrence
+    # embedded in the body. That re-anchor permitted an authorization-bypass
+    # attack where the body text contained `gh pr merge <fake_PR>` and the
+    # token-context check matched against the embedded fake PR number rather
+    # than the real positional. Restricting both walks to flag-shaped tokens
+    # only prevents the engine from walking past the real positional into
+    # quoted body content.
+    #
+    # The trailing `(?![\w-])` rejects BOTH alphanumeric-suffix tokens
+    # (e.g., `7352abc`) AND hyphen-suffix tokens (e.g., `7352-tests`).
+    # Python `\b` is a word-boundary that DOES match at digit-to-hyphen
+    # (because `-` is a non-word character), so a plain `\b` would
+    # incorrectly capture `7352` from `7352-tests` (a branch-name argument
+    # to `gh pr merge`). The negative-lookahead form `(?![\w-])` is
+    # strictly stronger: it rejects any continuation that is a word char
+    # OR a hyphen, which closes the branch-name suffix-match case while
+    # preserving rejection of the alphanumeric-suffix case.
     _GH_PR_NUMBER_RE = re.compile(
-        _GH_PREFIX + r"pr\s+(?:merge|close)\s+" + _GH_FLAG_TOKENS + r"(\d+)\b"
+        r"\bgh\s+" + _GH_FLAG_TOKENS + r"pr\s+(?:merge|close)\s+"
+        + _GH_FLAG_TOKENS + r"(\d+)(?![\w-])"
     )
 except BaseException as _pattern_compile_error:  # noqa: BLE001 — fail-closed catch-all
     _emit_load_failure_deny("pattern compilation", _pattern_compile_error)

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -645,15 +645,137 @@ def _consume_token(token_path: str) -> bool:
 def _detect_command_operation_type(command: str) -> str | None:
     """Detect the operation type of a dangerous command.
 
+    Symmetric with `extract_context()` in merge_guard_post.py: both must
+    recognize the SAME four operation classes so write-side tokens and
+    read-side commands compare on a common axis.
+
     Returns:
-        "merge" for gh pr merge, "close" for gh pr close (any variant),
-        or None for other operation types (force push, branch delete, etc.)
+        "merge"         — gh pr merge
+        "close"         — gh pr close (any variant)
+        "force-push"    — git push --force / git push -f (excludes --force-with-lease)
+        "branch-delete" — git branch -D / git branch --delete --force / gh pr close --delete-branch
+        None            — destructive shape not in the recognized set
+                          (caller treats None as "untyped command", which the
+                          tightened token-match semantic now treats as a
+                          deny-on-typed-token signal rather than permissive)
     """
+    # Order matters: gh pr close --delete-branch is BOTH a close and a
+    # branch-delete operation; the AskUserQuestion-side classifier
+    # (extract_context) tags it as "close" in priority order, so match
+    # the same precedence here for write/read symmetry.
     if _GH_PR_MERGE_RE.search(command):
         return "merge"
     if _GH_PR_CLOSE_RE.search(command):
+        # gh pr close --delete-branch is a close-type operation per the
+        # write-side classifier. Branch-delete-via-pr-close is folded into
+        # the close class on both sides for symmetric authorization.
         return "close"
+    # force-push: git push ... --force (excludes --force-with-lease which
+    # the existing DANGEROUS_PATTERNS treats as safe). The negative
+    # lookahead matches the DANGEROUS_PATTERNS L127 form.
+    if re.search(_GIT_PREFIX + r"push\s+.*--force(?!-with-lease)\b", command):
+        return "force-push"
+    if re.search(_GIT_PREFIX + r"push\s+.*-f\b", command):
+        return "force-push"
+    if re.search(_GIT_PREFIX + r"push\s+-[a-zA-Z]*f", command):
+        return "force-push"
+    # Direct push to default branch is force-push-class (bypasses PR
+    # review). Match the existing DANGEROUS_PATTERNS forms but require
+    # the dangerous shape to actually fire — the negative-lookahead-free
+    # pattern `git push X main` would over-match safer flows. Use the
+    # same `(?!:)` refspec exclusion as DANGEROUS_PATTERNS L175-176.
+    if re.search(_GIT_PREFIX + r"push\s+\S+\s+HEAD:(?:main|master)\b", command):
+        return "force-push"
+    if re.search(
+        _GIT_PREFIX + r"push\s+(?:-(?!-force-with-lease\b)\S+\s+)*\S+\s+(?:main|master)(?!:)\b",
+        command,
+    ):
+        return "force-push"
+    # API-based ref-mutation forms (gh api / curl / wget targeting
+    # /git/refs with mutating HTTP methods) classify by HTTP semantic:
+    # DELETE → branch-delete class (removes a ref)
+    # PATCH/POST/PUT → force-push class (rewrites a ref without PR review)
+    # Symmetric with how a force-push or branch-delete token from
+    # extract_context() would authorize the equivalent CLI form.
+    _is_api_form = re.search(r"\b(?:gh\s+api|curl|wget)\b", command, re.IGNORECASE)
+    if _is_api_form and "git/refs" in command:
+        if re.search(r"\bDELETE\b", command):
+            return "branch-delete"
+        if re.search(r"\b(?:PATCH|POST|PUT)\b", command):
+            return "force-push"
+    # branch-delete: git branch -D, git branch --delete --force,
+    # or git branch --force --delete (matches DANGEROUS_PATTERNS L131-133).
+    if re.search(_GIT_PREFIX + r"branch\s+.*-D\b", command):
+        return "branch-delete"
+    if re.search(_GIT_PREFIX + r"branch\s+.*--delete\s+--force\b", command):
+        return "branch-delete"
+    if re.search(_GIT_PREFIX + r"branch\s+--force\s+--delete\b", command):
+        return "branch-delete"
     return None
+
+
+# Allowlist of `gh pr merge|close` long-form flags KNOWN to take a value.
+# The F3 defensive check only rejects digits preceded by one of these
+# value-taking flags (avoiding false-positives on value-less flags like
+# `--admin`, `--auto`, `--squash` whose positional digit IS the PR).
+#
+# As of `gh` v2 (2026-04 baseline), no real `gh pr merge|close` flag
+# takes a digit value; this allowlist is a forward-compatible defense
+# for hypothetical future flags. `--max-retries` is the canonical
+# example cited in the F3 review (test-engineer-2). Extend this list
+# when `gh` ships a flag that takes a numeric value.
+_GH_PR_VALUE_TAKING_FLAGS = frozenset({
+    # Known string/path-value flags from `gh pr merge --help` /
+    # `gh pr close --help`. Listed here for forward-compat: if any of
+    # these were given a digit value (e.g. `--subject 123`), the
+    # defensive check correctly rejects the digit-as-flag-value capture.
+    "--body",
+    "--body-file",
+    "--subject",
+    "--author-email",
+    "--match-head-commit",
+    "--comment",
+    # Hypothetical future flags. Add here when gh ships one.
+    "--max-retries",
+    "--retry-count",
+    "--timeout",
+})
+
+
+def _extract_pr_number(command: str) -> str | None:
+    """Extract the PR number positional from a `gh pr merge|close` command.
+
+    Wraps `_GH_PR_NUMBER_RE.search()` with a defensive post-extract check
+    that rejects digits which are actually the VALUE of an immediately-
+    preceding value-taking long-form flag (e.g., `--max-retries 5`).
+
+    The defensive check is narrowly scoped to flags in
+    `_GH_PR_VALUE_TAKING_FLAGS`. Value-less flags like `--admin`,
+    `--auto`, `--squash` do NOT trigger the check — a digit immediately
+    after one of them IS the PR positional. This avoids the false-
+    negative class where a real PR positional after a value-less flag
+    would be incorrectly rejected.
+
+    No current `gh pr merge|close` flag takes a digit value, so the
+    realistic risk is theoretical — but this is defense-in-depth post
+    the cycle-3 strict-match enforcement: a typed token would otherwise
+    compare against the wrong digit and emit a confusing
+    "does-not-match" deny. Returning None here lets the comparison fall
+    through to the ambiguous-permissive path on the pr_number axis
+    (op_type strict-match still applies).
+    """
+    match = _GH_PR_NUMBER_RE.search(command)
+    if not match:
+        return None
+    pr_pos = match.start(1)
+    # Inspect the immediately-preceding token for a known value-taking
+    # long-form flag. Match captures the flag name (without trailing
+    # whitespace) so we can look it up in the allowlist.
+    preceding = command[:pr_pos].rstrip()
+    flag_match = re.search(r"(--[\w-]+)$", preceding)
+    if flag_match and flag_match.group(1) in _GH_PR_VALUE_TAKING_FLAGS:
+        return None
+    return match.group(1)
 
 
 def _token_matches_command(token: dict, command: str) -> bool:
@@ -678,19 +800,33 @@ def _token_matches_command(token: dict, command: str) -> bool:
     branch = context.get("branch")
     token_op_type = context.get("operation_type")
 
-    # Check operation type: a merge token should not authorize a close and
-    # vice versa. If either side has no operation_type, skip the check
-    # (ambiguous is permissive for backward compatibility with old tokens).
+    # Cross-operation authorization guard: a typed token (one with a known
+    # operation_type) MUST match the command's detected operation type, OR
+    # the command shape is unrecognized. Symmetric coverage —
+    # `_detect_command_operation_type` recognizes all four classes
+    # (merge / close / force-push / branch-delete) so a missing cmd_op_type
+    # means the destructive shape is outside the recognized set, not a
+    # legitimate "untyped" path. Refuse the cross-op authorization rather
+    # than fall through permissively (the prior fall-through let
+    # token{op=merge} authorize `git push --force` because cmd_op_type was
+    # None — closed by extending the detector + tightening this check).
+    #
+    # Untyped tokens (no operation_type — only shipped pre-cycle-2; should
+    # not occur post-#700 sparse-context guard at write time) still fall
+    # through to the pr_number/branch checks for backward compatibility.
     if token_op_type:
         cmd_op_type = _detect_command_operation_type(command)
-        if cmd_op_type and token_op_type != cmd_op_type:
+        if cmd_op_type is None or token_op_type != cmd_op_type:
             return False
 
-    # If token has a PR number, check gh pr merge/close commands match
+    # If token has a PR number, check gh pr merge/close commands match.
+    # Use _extract_pr_number for the defensive long-flag-value check so a
+    # token's pr_number is not compared against a flag-value digit
+    # (e.g., the `5` in `gh pr merge --max-retries 5 --auto`).
     if pr_number:
-        pr_match = _GH_PR_NUMBER_RE.search(command)
-        if pr_match:
-            return pr_match.group(1) == str(pr_number)
+        cmd_pr = _extract_pr_number(command)
+        if cmd_pr is not None:
+            return cmd_pr == str(pr_number)
 
     # If token has a branch, check branch deletion commands match
     if branch:

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -72,7 +72,12 @@ except BaseException as _module_load_error:  # noqa: BLE001 — fail-closed catc
 
 # Optional global flags between CLI tool and subcommand.
 # (?:\S+\s+)* matches zero or more flag+value tokens (e.g., --repo owner/repo).
-_GH_GLOBAL_FLAGS = r"(?:\S+\s+)*"
+_GH_GLOBAL_FLAGS = r"(?:\S+\s+)*"  # broad — keep for DANGEROUS_PATTERNS (matches any token)
+# Tight variant for PR-number extraction (#665): only flag-shaped tokens
+# (`-x`, `--long`, optionally `--flag value`). Prevents the capture group
+# from greedily walking past the PR positional into heredoc body content,
+# 2>&1 redirects, or trailing positional-digit tokens.
+_GH_FLAG_TOKENS = r"(?:-\S*(?:\s+\S+)?\s+)*"
 _GIT_GLOBAL_FLAGS = r"(?:\S+\s+)*"
 
 # Composed prefixes for DRY usage across all patterns.
@@ -176,7 +181,12 @@ try:
     _GH_PR_CLOSE_RE = re.compile(_GH_PREFIX + r"pr\s+close\b")
     # PR number extraction: allows optional subcommand flags (e.g., --admin, --squash)
     # between merge/close and the PR number.
-    _GH_PR_NUMBER_RE = re.compile(_GH_PREFIX + r"pr\s+(?:merge|close)\s+" + _GH_GLOBAL_FLAGS + r"(\d+)")
+    # #665: use _GH_FLAG_TOKENS (flag-shaped only) for the post-subcommand
+    # token walk, and \b after (\d+) so the capture is a standalone digit
+    # token (not the suffix of a longer token like `7352-tests`).
+    _GH_PR_NUMBER_RE = re.compile(
+        _GH_PREFIX + r"pr\s+(?:merge|close)\s+" + _GH_FLAG_TOKENS + r"(\d+)\b"
+    )
 except BaseException as _pattern_compile_error:  # noqa: BLE001 — fail-closed catch-all
     _emit_load_failure_deny("pattern compilation", _pattern_compile_error)
 

--- a/pact-plugin/hooks/shared/tool_response.py
+++ b/pact-plugin/hooks/shared/tool_response.py
@@ -1,0 +1,60 @@
+"""
+Location: pact-plugin/hooks/shared/tool_response.py
+Summary: SSOT helper for extracting the platform's tool-response payload from
+         hook stdin, with a defensive fallback for the legacy `tool_output`
+         envelope name and a security warning when both fields are present.
+Used by: hooks that consume PostToolUse / SubagentStop / TaskCompleted stdin
+         (task_lifecycle_gate.py, wake_lifecycle_emitter.py, merge_guard_post.py).
+
+The platform's canonical field is `tool_response`. Pre-rename payloads (and
+captured-from-production test fixtures from that era) carry `tool_output`.
+This helper centralizes the "prefer canonical, fall back to legacy" pattern
+so that all consumer hooks share one defensive read — preventing the kind
+of asymmetry that existed pre-#677-PR-#1 where only one hook had the
+fallback while siblings did not.
+
+When BOTH fields are present in the same payload, that is a categorically
+suspicious shape (no legitimate platform fire emits both). The helper logs
+a SECURITY warning to stderr identifying it as a possible
+envelope-confusion attack, and returns the canonical `tool_response` value.
+"""
+
+import sys
+
+
+def extract_tool_response(input_data: dict) -> dict:
+    """Return the tool-response payload, preferring canonical over legacy.
+
+    Args:
+        input_data: The hook stdin dict.
+
+    Returns:
+        The tool-response payload as a dict. Returns `{}` when neither
+        field is present, when the value is non-dict, or when the field
+        is present but empty.
+
+    Side effect:
+        Emits a stderr warning when BOTH `tool_response` AND `tool_output`
+        are present in the same payload (envelope-confusion shape).
+    """
+    if not isinstance(input_data, dict):
+        return {}
+
+    canonical = input_data.get("tool_response")
+    legacy = input_data.get("tool_output")
+
+    if canonical and legacy:
+        # Categorically suspicious: no legitimate platform fire emits both.
+        # Warn for forensic visibility; return canonical (the trustworthy
+        # field per current platform contract).
+        print(
+            "[security] dual-envelope payload detected: both tool_response "
+            "AND tool_output present — possible envelope-confusion attack. "
+            "Using tool_response (canonical).",
+            file=sys.stderr,
+        )
+
+    chosen = canonical or legacy or {}
+    if not isinstance(chosen, dict):
+        return {}
+    return chosen

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -86,6 +86,7 @@ try:
     from shared.intentional_wait import is_self_complete_exempt
     from shared.session_journal import append_event, make_event
     from shared.task_utils import read_task_json
+    from shared.tool_response import extract_tool_response
 except BaseException as _module_load_error:  # noqa: BLE001 — fail-closed catch-all
     _emit_load_failure_advisory("module imports", _module_load_error)
 
@@ -312,17 +313,16 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
     advisories: list[tuple[str, str]] = []
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input") or {}
-    # Defense-in-depth: prefer canonical `tool_response` (platform contract — see
-    # wake_lifecycle_emitter.py:255). The `or tool_output` fallback covers (a)
-    # legacy/captured-from-production test fixtures whose envelope predates the
-    # canonical name, and (b) any future platform envelope rename. This hook
-    # fires on every Task-tool use, so a missed read here would silently disable
-    # lifecycle advisories. DO NOT remove the fallback.
-    tool_response = input_data.get("tool_response") or input_data.get("tool_output") or {}
+    # Defense-in-depth: extract_tool_response is the SSOT helper that prefers
+    # the canonical `tool_response` field, falls back to legacy `tool_output`
+    # (covers captured-from-production test fixtures predating the rename and
+    # any future platform envelope rename), and warns to stderr on
+    # dual-envelope payloads (categorically suspicious — no legitimate platform
+    # fire emits both). This hook fires on every Task-tool use, so a missed
+    # read here would silently disable lifecycle advisories. DO NOT remove.
+    tool_response = extract_tool_response(input_data)
     if not isinstance(tool_input, dict):
         tool_input = {}
-    if not isinstance(tool_response, dict):
-        tool_response = {}
 
     # ① Recursion guard (self-completion writeback self-trigger): skip
     # silently if THIS update is the gate's own writeback. Checked FIRST

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -312,6 +312,12 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
     advisories: list[tuple[str, str]] = []
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input") or {}
+    # Defense-in-depth: prefer canonical `tool_response` (platform contract — see
+    # wake_lifecycle_emitter.py:255). The `or tool_output` fallback covers (a)
+    # legacy/captured-from-production test fixtures whose envelope predates the
+    # canonical name, and (b) any future platform envelope rename. This hook
+    # fires on every Task-tool use, so a missed read here would silently disable
+    # lifecycle advisories. DO NOT remove the fallback.
     tool_response = input_data.get("tool_response") or input_data.get("tool_output") or {}
     if not isinstance(tool_input, dict):
         tool_input = {}

--- a/pact-plugin/hooks/teachback_check.py
+++ b/pact-plugin/hooks/teachback_check.py
@@ -19,7 +19,7 @@ Non-PACT agents and the orchestrator (no agent identity resolvable) are skipped.
 Exit codes:
     0 — always (non-blocking; this is a warning layer, not a gate)
 
-Input: JSON from stdin with tool_name, tool_input, tool_output
+Input: JSON from stdin with tool_name, tool_input, tool_response
 Output: JSON systemMessage on stdout if warning needed, suppressOutput otherwise
 """
 

--- a/pact-plugin/hooks/track_files.py
+++ b/pact-plugin/hooks/track_files.py
@@ -7,7 +7,7 @@ Used by: Claude Code settings.json PostToolUse hook (Edit, Write tools)
 Extracts file paths from Edit/Write tool usage and records them
 for the memory system's graph network.
 
-Input: JSON from stdin with tool_name, tool_input, tool_output
+Input: JSON from stdin with tool_name, tool_input, tool_response
 Output: None (writes to tracking file for later memory association)
 """
 

--- a/pact-plugin/hooks/wake_lifecycle_emitter.py
+++ b/pact-plugin/hooks/wake_lifecycle_emitter.py
@@ -119,6 +119,7 @@ import shared.pact_context as pact_context
 from shared.pact_context import get_team_name
 from shared.session_state import is_safe_path_component
 from shared.task_utils import read_task_json
+from shared.tool_response import extract_tool_response
 from shared.wake_lifecycle import count_active_tasks, has_same_teammate_continuation
 
 # Suppress the false "hook error" UI surface on bare exit paths.
@@ -252,7 +253,7 @@ def _extract_task_id(input_data: dict[str, Any]) -> str | None:
         if isinstance(tid, str) and tid.strip():
             return tid.strip()
 
-    tool_response = input_data.get("tool_response") or {}
+    tool_response = extract_tool_response(input_data)
     if isinstance(tool_response, dict):
         nested_task = tool_response.get("task") or {}
         if isinstance(nested_task, dict):
@@ -353,7 +354,7 @@ def _is_terminal_status_update(input_data: dict[str, Any]) -> bool:
         if tool_input.get("status") in _TERMINAL_STATUSES:
             return True
 
-    tool_response = input_data.get("tool_response") or {}
+    tool_response = extract_tool_response(input_data)
     if isinstance(tool_response, dict):
         status_change = tool_response.get("statusChange")
         if isinstance(status_change, dict) and status_change.get("to") in _TERMINAL_STATUSES:

--- a/pact-plugin/tests/test_error_output.py
+++ b/pact-plugin/tests/test_error_output.py
@@ -491,7 +491,7 @@ class TestMergeGuardPostErrorOutput:
             "tool_input": {
                 "questions": [{"question": "Merge PR #42?"}]
             },
-            "tool_output": {
+            "tool_response": {
                 "answers": {"Merge PR #42?": "yes"}
             },
         })
@@ -539,7 +539,7 @@ class TestMergeGuardPostErrorOutput:
             "tool_input": {
                 "questions": [{"question": "What color?"}]
             },
-            "tool_output": {
+            "tool_response": {
                 "answers": {"What color?": "blue"}
             },
         })

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -3554,7 +3554,7 @@ class TestAPIBypassAuthorizationFlow:
         from merge_guard_post import write_token
         from merge_guard_pre import check_merge_authorization
 
-        write_token({"operation_type": "api-delete-ref"}, token_dir=tmp_path)
+        write_token({"operation_type": "branch-delete"}, token_dir=tmp_path)
 
         result = check_merge_authorization(
             "gh api -X DELETE repos/owner/repo/git/refs/heads/feature",
@@ -3567,7 +3567,7 @@ class TestAPIBypassAuthorizationFlow:
         from merge_guard_post import write_token
         from merge_guard_pre import check_merge_authorization
 
-        write_token({"operation_type": "api-patch-main"}, token_dir=tmp_path)
+        write_token({"operation_type": "force-push"}, token_dir=tmp_path)
 
         result = check_merge_authorization(
             "gh api -X PATCH repos/owner/repo/git/refs/heads/main -f sha=abc",
@@ -3580,7 +3580,7 @@ class TestAPIBypassAuthorizationFlow:
         from merge_guard_post import write_token
         from merge_guard_pre import check_merge_authorization
 
-        write_token({"operation_type": "api-patch-ref"}, token_dir=tmp_path)
+        write_token({"operation_type": "force-push"}, token_dir=tmp_path)
 
         result = check_merge_authorization(
             "curl -X PATCH https://api.github.com/repos/owner/repo/git/refs/heads/feature",
@@ -4433,7 +4433,7 @@ class TestDirectPushToDefaultBranch:
         from merge_guard_post import write_token
         from merge_guard_pre import check_merge_authorization
 
-        write_token({"operation_type": "push-main"}, token_dir=tmp_path)
+        write_token({"operation_type": "force-push"}, token_dir=tmp_path)
 
         result = check_merge_authorization("git push origin main", token_dir=tmp_path)
         assert result is None  # Allowed
@@ -7448,15 +7448,68 @@ class TestDetectCommandOperationType:
 
         assert _detect_command_operation_type("gh pr close 42") == "close"
 
-    def test_force_push_returns_none(self):
+    def test_force_push_returns_force_push(self):
         from merge_guard_pre import _detect_command_operation_type
 
-        assert _detect_command_operation_type("git push --force origin main") is None
+        assert _detect_command_operation_type("git push --force origin main") == "force-push"
 
-    def test_branch_delete_returns_none(self):
+    def test_branch_delete_returns_branch_delete(self):
         from merge_guard_pre import _detect_command_operation_type
 
-        assert _detect_command_operation_type("git branch -D feature") is None
+        assert _detect_command_operation_type("git branch -D feature") == "branch-delete"
+
+    def test_force_push_short_flag(self):
+        from merge_guard_pre import _detect_command_operation_type
+
+        assert _detect_command_operation_type("git push -f origin main") == "force-push"
+
+    def test_force_push_with_lease_to_topic_branch_returns_none(self):
+        """git push --force-with-lease (without main/master target) is the SAFE form.
+
+        The detector classifies bare --force / -f as force-push but
+        deliberately excludes --force-with-lease (matches the safe-form
+        carve-out in DANGEROUS_PATTERNS). Direct push to main is dangerous
+        but not classified by the op-type detector — only explicit
+        --force / -f forms produce a force-push tag for token-authorization
+        purposes.
+        """
+        from merge_guard_pre import _detect_command_operation_type
+
+        assert _detect_command_operation_type("git push --force-with-lease origin feature") is None
+
+    def test_api_ref_delete_classified_as_branch_delete(self):
+        """API DELETE on git/refs is a branch-delete class operation."""
+        from merge_guard_pre import _detect_command_operation_type
+
+        assert _detect_command_operation_type(
+            "gh api -X DELETE repos/owner/repo/git/refs/heads/feature"
+        ) == "branch-delete"
+
+    def test_api_ref_patch_classified_as_force_push(self):
+        from merge_guard_pre import _detect_command_operation_type
+
+        assert _detect_command_operation_type(
+            "gh api -X PATCH repos/owner/repo/git/refs/heads/main -f sha=abc"
+        ) == "force-push"
+
+    def test_curl_ref_patch_classified_as_force_push(self):
+        from merge_guard_pre import _detect_command_operation_type
+
+        assert _detect_command_operation_type(
+            "curl -X PATCH https://api.github.com/repos/o/r/git/refs/heads/main"
+        ) == "force-push"
+
+    def test_branch_delete_force_long_form(self):
+        from merge_guard_pre import _detect_command_operation_type
+
+        assert _detect_command_operation_type("git branch --delete --force feature") == "branch-delete"
+
+    def test_unknown_command_returns_none(self):
+        """Non-destructive shapes correctly return None."""
+        from merge_guard_pre import _detect_command_operation_type
+
+        assert _detect_command_operation_type("ls -la") is None
+        assert _detect_command_operation_type("git status") is None
 
 
 # =============================================================================
@@ -8825,3 +8878,195 @@ class TestEvalHeredocRejection:
         cmd = "eval $(cat <<HEREDOC\ngh pr merge 999 --admin\nHEREDOC\n)"
         result = check_merge_authorization(cmd, token_dir=tmp_path)
         assert result is not None, "eval+heredoc must be denied without token"
+
+
+class TestCrossOperationAuthorizationDenied:
+    """Pin the F-1 cross-operation authorization closure.
+
+    Cycle-2 added force-push and branch-delete to extract_context() (the
+    write side). Cycle-3 mirrors the symmetric coverage in
+    _detect_command_operation_type (the read side) and tightens the
+    cross-op comparison so a typed token CANNOT authorize a command of a
+    different operation class. Pre-fix, the read-side detector returned
+    None for force-push/branch-delete, and the comparison fell through
+    permissively (cmd_op_type=None → no comparison), allowing any typed
+    token to authorize any destructive command in those classes.
+    """
+
+    def test_merge_token_does_not_authorize_force_push(self, tmp_path):
+        """The empirical bypass: merge-token + force-push command → deny.
+
+        Pre-fix: cmd_op_type was None for `git push --force`, so the
+        token's `operation_type=merge` comparison was skipped, and the
+        merge token authorized the force-push. Post-fix: cmd_op_type is
+        `force-push`, the comparison fires, and the typed-mismatch denies.
+        """
+        from merge_guard_post import write_token
+        from merge_guard_pre import check_merge_authorization
+
+        write_token({"operation_type": "merge", "pr_number": "100"}, token_dir=tmp_path)
+        result = check_merge_authorization(
+            "git push --force origin main", token_dir=tmp_path
+        )
+        assert result is not None
+        assert "does not match" in result.lower() or "approval" in result.lower()
+
+    def test_force_push_token_does_not_authorize_merge(self, tmp_path):
+        """Symmetric inverse: force-push token + gh pr merge → deny."""
+        from merge_guard_post import write_token
+        from merge_guard_pre import check_merge_authorization
+
+        write_token({"operation_type": "force-push"}, token_dir=tmp_path)
+        result = check_merge_authorization(
+            "gh pr merge 42 --squash", token_dir=tmp_path
+        )
+        assert result is not None
+        assert "does not match" in result.lower() or "approval" in result.lower()
+
+    def test_branch_delete_token_does_not_authorize_close(self, tmp_path):
+        """branch-delete token + gh pr close → deny.
+
+        gh pr close (without --delete-branch) is the close op-class;
+        a branch-delete token cannot authorize it.
+        """
+        from merge_guard_post import write_token
+        from merge_guard_pre import check_merge_authorization
+
+        write_token({"operation_type": "branch-delete"}, token_dir=tmp_path)
+        # bare close is not a DANGEROUS_PATTERNS hit; use --delete-branch
+        # which IS dangerous and is classified as "close" per the
+        # extract_context precedence. The token op_type=branch-delete
+        # mismatches the cmd op_type=close.
+        result = check_merge_authorization(
+            "gh pr close 42 --delete-branch", token_dir=tmp_path
+        )
+        assert result is not None
+        assert "does not match" in result.lower() or "approval" in result.lower()
+
+    def test_unknown_op_command_with_typed_token_denied(self, tmp_path):
+        """Typed token + dangerous-but-unrecognized command shape → deny.
+
+        The strict-match semantic: if the token has an operation_type but
+        the command's shape doesn't match any of the known op classes, the
+        comparison fails closed rather than falling through permissively.
+        """
+        from merge_guard_post import write_token
+        from merge_guard_pre import check_merge_authorization
+
+        write_token({"operation_type": "merge"}, token_dir=tmp_path)
+        # gh api PATCH on /merge endpoint is dangerous (DANGEROUS_PATTERNS L142)
+        # but my detector classifies it as None (only git/refs API forms map
+        # to force-push/branch-delete). Typed token vs untyped cmd → deny.
+        result = check_merge_authorization(
+            "gh api -X PATCH repos/o/r/merges -f base=main -f head=feature",
+            token_dir=tmp_path,
+        )
+        assert result is not None
+
+    def test_matching_op_type_still_authorizes(self, tmp_path):
+        """Regression-protection: matching op_type still allows execution."""
+        from merge_guard_post import write_token
+        from merge_guard_pre import check_merge_authorization
+
+        write_token({"operation_type": "force-push"}, token_dir=tmp_path)
+        result = check_merge_authorization(
+            "git push --force origin feature", token_dir=tmp_path
+        )
+        assert result is None, "matching force-push token must authorize git push --force"
+
+
+class TestExtractPRNumberLongFlagValueGuard:
+    """Pin the F3 long-flag-value defensive check.
+
+    `_GH_PR_NUMBER_RE` matches `gh pr merge --max-retries 5 --auto` and
+    captures `5` as the PR number — but `5` is the value of `--max-retries`,
+    not a positional. The wrapper `_extract_pr_number()` rejects digits
+    that are immediately preceded by a long-form flag, returning None
+    (which the caller treats as ambiguous-permissive on the pr_number
+    axis). No current `gh pr merge|close` flag takes a digit value, so
+    the realistic risk is theoretical — this is defense-in-depth post the
+    cycle-3 strict-match enforcement.
+    """
+
+    def test_long_flag_numeric_value_not_captured(self):
+        """`--max-retries 5 --auto`: `5` is the flag's value, not a PR number."""
+        from merge_guard_pre import _extract_pr_number
+
+        cmd = "gh pr merge --max-retries 5 --auto"
+        assert _extract_pr_number(cmd) is None
+
+    def test_long_flag_then_real_positional_captures_positional(self):
+        """`--max-retries 5 999`: `999` is the real positional, captured correctly."""
+        from merge_guard_pre import _extract_pr_number
+
+        cmd = "gh pr merge --max-retries 5 999 --squash"
+        assert _extract_pr_number(cmd) == "999"
+
+    def test_value_less_long_flag_before_positional_captures_positional(self):
+        """`--auto 999`: `--auto` is value-less, so `999` IS the positional.
+
+        The allowlist `_GH_PR_VALUE_TAKING_FLAGS` excludes value-less
+        flags like `--admin`, `--auto`, `--squash`. A digit immediately
+        following one of those flags IS the PR positional and is
+        captured correctly.
+        """
+        from merge_guard_pre import _extract_pr_number
+
+        cmd = "gh pr merge --auto 999"
+        assert _extract_pr_number(cmd) == "999"
+
+    def test_admin_flag_then_positional_unchanged(self):
+        """Regression-protection: `--admin 99` still captures 99 (--admin is value-less)."""
+        from merge_guard_pre import _extract_pr_number
+
+        assert _extract_pr_number("gh pr merge --admin 99") == "99"
+
+    def test_known_value_taking_flag_blocks_capture(self):
+        """`--body 123 --auto`: `--body` IS in the allowlist; `123` rejected."""
+        from merge_guard_pre import _extract_pr_number
+
+        cmd = "gh pr merge --body 123 --auto"
+        assert _extract_pr_number(cmd) is None
+
+    def test_subject_flag_blocks_capture(self):
+        """`--subject 999`: `--subject` is in the allowlist."""
+        from merge_guard_pre import _extract_pr_number
+
+        cmd = "gh pr merge --subject 999"
+        assert _extract_pr_number(cmd) is None
+
+    def test_positional_then_long_flag_with_numeric_value_captures_positional(self):
+        """`999 --max-retries 5`: `999` is the positional (matched first)."""
+        from merge_guard_pre import _extract_pr_number
+
+        cmd = "gh pr merge 999 --max-retries 5"
+        assert _extract_pr_number(cmd) == "999"
+
+    def test_short_flag_with_numeric_value_not_blocked(self):
+        """Short flags (`-n 5`) are not checked by the defensive guard.
+
+        The guard is narrowly scoped to long-form flags. Short flags are
+        combinable and rarely take numeric values; if a real `gh` short
+        flag emerges that takes a digit value, this test pins the
+        current narrow-scope behavior so any future widening is
+        reviewed in lockstep.
+        """
+        from merge_guard_pre import _extract_pr_number
+
+        cmd = "gh pr merge -n 5 999"
+        # 999 is captured as the positional; the regex's _GH_FLAG_TOKENS
+        # walk consumed `-n 5` as a flag pair, leaving 999 to capture.
+        assert _extract_pr_number(cmd) == "999"
+
+    def test_simple_positional_unchanged(self):
+        """Regression-protection: simple `gh pr merge 999` still works."""
+        from merge_guard_pre import _extract_pr_number
+
+        assert _extract_pr_number("gh pr merge 999 --squash") == "999"
+
+    def test_no_pr_match_returns_none(self):
+        """No PR-number match → None (regression-protection)."""
+        from merge_guard_pre import _extract_pr_number
+
+        assert _extract_pr_number("ls -la") is None
+        assert _extract_pr_number("gh pr merge --auto") is None  # no positional

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -247,7 +247,7 @@ class TestPostMainEntryPoint:
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"question": "Should I merge #42?"}]},
-            "tool_output": {"answers": {"Should I merge #42?": "yes"}},
+            "tool_response": {"answers": {"Should I merge #42?": "yes"}},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -267,7 +267,7 @@ class TestPostMainEntryPoint:
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"question": "Should I add logging?"}]},
-            "tool_output": {"answers": {"Should I add logging?": "yes"}},
+            "tool_response": {"answers": {"Should I add logging?": "yes"}},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -285,7 +285,7 @@ class TestPostMainEntryPoint:
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"question": "Should I merge #42?"}]},
-            "tool_output": {"answers": {"Should I merge #42?": "no"}},
+            "tool_response": {"answers": {"Should I merge #42?": "no"}},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -306,23 +306,29 @@ class TestPostMainEntryPoint:
 
         assert exc_info.value.code == 0
 
-    def test_main_rejects_string_tool_output(self, tmp_path):
-        """Non-dict tool_output exits early — no token created."""
+    def test_main_rejects_string_tool_response(self, tmp_path):
+        """Non-dict tool_response exits early — no token created."""
         from merge_guard_post import main
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"question": "Should I merge?"}]},
-            "tool_output": "yes",
+            "tool_response": "yes",
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
-             patch("sys.stdin", io.StringIO(input_data)):
+             patch("sys.stdin", io.StringIO(input_data)), \
+             patch("merge_guard_post.write_token") as mock_write_token:
             with pytest.raises(SystemExit) as exc_info:
                 main()
 
         assert exc_info.value.code == 0
-        # Non-dict tool_output rejected — only dict format trusted
+        # Non-dict tool_response rejected — only dict format trusted
         assert len(list(tmp_path.glob("merge-authorized-*"))) == 0
+        # Cause-of-no-token: malformed tool_response triggered early-exit
+        # before the merge-question branch could reach write_token. Without
+        # this, the test would still pass if a silent regression caused
+        # tool_response reading to degrade to empty-dict + happy-path skip.
+        mock_write_token.assert_not_called()
 
 
 # =============================================================================
@@ -680,7 +686,7 @@ class TestIntegration:
         # Step 1: Post hook processes merge approval
         post_input = json.dumps({
             "tool_input": {"questions": [{"question": "Should I merge PR #99?"}]},
-            "tool_output": {"answers": {"Should I merge PR #99?": "yes"}},
+            "tool_response": {"answers": {"Should I merge PR #99?": "yes"}},
         })
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
              patch("sys.stdin", io.StringIO(post_input)):
@@ -1998,30 +2004,34 @@ class TestTokenEdgeCases:
 class TestPostMainEdgeCases:
     """Edge cases for merge_guard_post.main()."""
 
-    def test_tool_output_empty_dict(self, tmp_path):
-        """tool_output as empty dict — no token created."""
+    def test_tool_response_empty_dict(self, tmp_path):
+        """tool_response as empty dict — no token created."""
         from merge_guard_post import main
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"question": "Should I merge?"}]},
-            "tool_output": {},
+            "tool_response": {},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
-             patch("sys.stdin", io.StringIO(input_data)):
+             patch("sys.stdin", io.StringIO(input_data)), \
+             patch("merge_guard_post.write_token") as mock_write_token:
             with pytest.raises(SystemExit) as exc_info:
                 main()
 
         assert exc_info.value.code == 0
         assert len(list(tmp_path.glob("merge-authorized-*"))) == 0
+        # Cause-of-no-token: empty answers dict produced empty answer string,
+        # which is falsy, so the merge-question branch did not reach write_token.
+        mock_write_token.assert_not_called()
 
-    def test_tool_output_with_answers_key(self, tmp_path):
-        """tool_output dict with 'answers' key (actual AskUserQuestion format)."""
+    def test_tool_response_with_answers_key(self, tmp_path):
+        """tool_response dict with 'answers' key (actual AskUserQuestion format)."""
         from merge_guard_post import main
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"question": "Merge PR #10?"}]},
-            "tool_output": {"answers": {"Merge PR #10?": "yes"}},
+            "tool_response": {"answers": {"Merge PR #10?": "yes"}},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -2038,7 +2048,7 @@ class TestPostMainEdgeCases:
 
         input_data = json.dumps({
             "tool_input": {},
-            "tool_output": {"answers": {"anything": "yes"}},
+            "tool_response": {"answers": {"anything": "yes"}},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -2049,39 +2059,47 @@ class TestPostMainEdgeCases:
         assert exc_info.value.code == 0
         assert len(list(tmp_path.glob("merge-authorized-*"))) == 0
 
-    def test_tool_output_none(self, tmp_path):
-        """tool_output as None — non-dict, exits early, no token."""
+    def test_tool_response_none(self, tmp_path):
+        """tool_response as None — non-dict, exits early, no token."""
         from merge_guard_post import main
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"question": "Merge?"}]},
-            "tool_output": None,
+            "tool_response": None,
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
-             patch("sys.stdin", io.StringIO(input_data)):
+             patch("sys.stdin", io.StringIO(input_data)), \
+             patch("merge_guard_post.write_token") as mock_write_token:
             with pytest.raises(SystemExit) as exc_info:
                 main()
 
         assert exc_info.value.code == 0
         assert len(list(tmp_path.glob("merge-authorized-*"))) == 0
+        # Cause-of-no-token: non-dict tool_response triggered isinstance early-exit
+        # before the merge-question branch could reach write_token.
+        mock_write_token.assert_not_called()
 
-    def test_tool_output_integer(self, tmp_path):
-        """tool_output as integer — non-dict, exits early, no token."""
+    def test_tool_response_integer(self, tmp_path):
+        """tool_response as integer — non-dict, exits early, no token."""
         from merge_guard_post import main
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"question": "Merge?"}]},
-            "tool_output": 42,
+            "tool_response": 42,
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
-             patch("sys.stdin", io.StringIO(input_data)):
+             patch("sys.stdin", io.StringIO(input_data)), \
+             patch("merge_guard_post.write_token") as mock_write_token:
             with pytest.raises(SystemExit) as exc_info:
                 main()
 
         assert exc_info.value.code == 0
         assert len(list(tmp_path.glob("merge-authorized-*"))) == 0
+        # Cause-of-no-token: non-dict tool_response triggered isinstance early-exit
+        # before the merge-question branch could reach write_token.
+        mock_write_token.assert_not_called()
 
     def test_empty_stdin(self, tmp_path):
         """Empty stdin — exits 0 without error."""
@@ -2256,7 +2274,7 @@ class TestTokenSecurity:
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"question": "Merge PR #1?"}]},
-            "tool_output": {"answers": {"Merge PR #1?": "yes"}},
+            "tool_response": {"answers": {"Merge PR #1?": "yes"}},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", bad_dir), \
@@ -4692,40 +4710,48 @@ class TestTokenWriteExceptionHandling:
         # path (FileExistsError) is not triggered (different exception type)
         assert result is None
 
-    def test_tool_output_as_boolean_true(self, tmp_path):
-        """tool_output as boolean True — non-dict, exits early, no token."""
+    def test_tool_response_as_boolean_true(self, tmp_path):
+        """tool_response as boolean True — non-dict, exits early, no token."""
         from merge_guard_post import main
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"question": "Merge?"}]},
-            "tool_output": True,
+            "tool_response": True,
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
-             patch("sys.stdin", io.StringIO(input_data)):
+             patch("sys.stdin", io.StringIO(input_data)), \
+             patch("merge_guard_post.write_token") as mock_write_token:
             with pytest.raises(SystemExit) as exc_info:
                 main()
 
         assert exc_info.value.code == 0
         # "True" does not match affirmative patterns
         assert len(list(tmp_path.glob("merge-authorized-*"))) == 0
+        # Cause-of-no-token: non-dict tool_response triggered isinstance early-exit
+        # before the merge-question branch could reach write_token.
+        mock_write_token.assert_not_called()
 
-    def test_tool_output_as_boolean_false(self, tmp_path):
-        """tool_output as boolean False — non-dict, exits early, no token."""
+    def test_tool_response_as_boolean_false(self, tmp_path):
+        """tool_response as boolean False — non-dict, exits early, no token."""
         from merge_guard_post import main
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"question": "Merge?"}]},
-            "tool_output": False,
+            "tool_response": False,
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
-             patch("sys.stdin", io.StringIO(input_data)):
+             patch("sys.stdin", io.StringIO(input_data)), \
+             patch("merge_guard_post.write_token") as mock_write_token:
             with pytest.raises(SystemExit) as exc_info:
                 main()
 
         assert exc_info.value.code == 0
         assert len(list(tmp_path.glob("merge-authorized-*"))) == 0
+        # Cause-of-no-token: non-dict tool_response triggered isinstance early-exit
+        # before the merge-question branch could reach write_token.
+        mock_write_token.assert_not_called()
 
 
 # =============================================================================
@@ -4747,7 +4773,7 @@ class TestQuestionExtractionEdgeCases:
 
         input_data = json.dumps({
             "tool_input": {"questions": "Should I merge?"},
-            "tool_output": {"answers": {"Should I merge?": "yes"}},
+            "tool_response": {"answers": {"Should I merge?": "yes"}},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -4764,7 +4790,7 @@ class TestQuestionExtractionEdgeCases:
 
         input_data = json.dumps({
             "tool_input": {"questions": 42},
-            "tool_output": {"answers": {"q": "yes"}},
+            "tool_response": {"answers": {"q": "yes"}},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -4781,7 +4807,7 @@ class TestQuestionExtractionEdgeCases:
 
         input_data = json.dumps({
             "tool_input": {"questions": None},
-            "tool_output": {"answers": {"q": "yes"}},
+            "tool_response": {"answers": {"q": "yes"}},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -4798,7 +4824,7 @@ class TestQuestionExtractionEdgeCases:
 
         input_data = json.dumps({
             "tool_input": {"questions": []},
-            "tool_output": {"answers": {"q": "yes"}},
+            "tool_response": {"answers": {"q": "yes"}},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -4815,7 +4841,7 @@ class TestQuestionExtractionEdgeCases:
 
         input_data = json.dumps({
             "tool_input": {"questions": ["Should I merge?"]},
-            "tool_output": {"answers": {"Should I merge?": "yes"}},
+            "tool_response": {"answers": {"Should I merge?": "yes"}},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -4832,7 +4858,7 @@ class TestQuestionExtractionEdgeCases:
 
         input_data = json.dumps({
             "tool_input": {"questions": [123]},
-            "tool_output": {"answers": {"q": "yes"}},
+            "tool_response": {"answers": {"q": "yes"}},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -4849,7 +4875,7 @@ class TestQuestionExtractionEdgeCases:
 
         input_data = json.dumps({
             "tool_input": {"questions": [None]},
-            "tool_output": {"answers": {"q": "yes"}},
+            "tool_response": {"answers": {"q": "yes"}},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -4866,7 +4892,7 @@ class TestQuestionExtractionEdgeCases:
 
         input_data = json.dumps({
             "tool_input": {"questions": [["nested", "list"]]},
-            "tool_output": {"answers": {"q": "yes"}},
+            "tool_response": {"answers": {"q": "yes"}},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -4883,7 +4909,7 @@ class TestQuestionExtractionEdgeCases:
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"header": "Merge", "options": []}]},
-            "tool_output": {"answers": {"q": "yes"}},
+            "tool_response": {"answers": {"q": "yes"}},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -4898,7 +4924,7 @@ class TestQuestionExtractionEdgeCases:
 class TestAnswerExtractionEdgeCases:
     """Tests for isinstance guards on the answers dict extraction path.
 
-    The fix extracts answer from tool_output["answers"] dict using
+    The fix extracts answer from tool_response["answers"] dict using
     next(iter(values())). Every malformed input must result in
     answer="" which prevents token creation (fail-closed).
     """
@@ -4909,7 +4935,7 @@ class TestAnswerExtractionEdgeCases:
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"question": "Should I merge?"}]},
-            "tool_output": {"answers": ["yes"]},
+            "tool_response": {"answers": ["yes"]},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -4926,7 +4952,7 @@ class TestAnswerExtractionEdgeCases:
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"question": "Should I merge?"}]},
-            "tool_output": {"answers": "yes"},
+            "tool_response": {"answers": "yes"},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -4943,7 +4969,7 @@ class TestAnswerExtractionEdgeCases:
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"question": "Should I merge?"}]},
-            "tool_output": {"answers": 1},
+            "tool_response": {"answers": 1},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -4955,12 +4981,12 @@ class TestAnswerExtractionEdgeCases:
         assert len(list(tmp_path.glob("merge-authorized-*"))) == 0
 
     def test_answers_is_none(self, tmp_path):
-        """answers is None inside tool_output dict — no token."""
+        """answers is None inside tool_response dict — no token."""
         from merge_guard_post import main
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"question": "Should I merge?"}]},
-            "tool_output": {"answers": None},
+            "tool_response": {"answers": None},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -4977,7 +5003,7 @@ class TestAnswerExtractionEdgeCases:
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"question": "Should I merge?"}]},
-            "tool_output": {"answers": {}},
+            "tool_response": {"answers": {}},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -4994,7 +5020,7 @@ class TestAnswerExtractionEdgeCases:
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"question": "Should I merge?"}]},
-            "tool_output": {"answers": {"Should I merge?": 42}},
+            "tool_response": {"answers": {"Should I merge?": 42}},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -5011,7 +5037,7 @@ class TestAnswerExtractionEdgeCases:
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"question": "Should I merge?"}]},
-            "tool_output": {"answers": {"Should I merge?": True}},
+            "tool_response": {"answers": {"Should I merge?": True}},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -5028,7 +5054,7 @@ class TestAnswerExtractionEdgeCases:
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"question": "Should I merge?"}]},
-            "tool_output": {"answers": {"Should I merge?": None}},
+            "tool_response": {"answers": {"Should I merge?": None}},
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -5040,16 +5066,16 @@ class TestAnswerExtractionEdgeCases:
         assert len(list(tmp_path.glob("merge-authorized-*"))) == 0
 
     def test_formatted_string_rejected_as_non_dict(self, tmp_path):
-        """tool_output is the formatted string from AskUserQuestion.
+        """tool_response is the formatted string from AskUserQuestion.
 
-        When tool_output is a string like 'User has answered your questions:
+        When tool_response is a string like 'User has answered your questions:
         "Confirm merge?"="yes"', it is rejected as non-dict — no token.
         """
         from merge_guard_post import main
 
         input_data = json.dumps({
             "tool_input": {"questions": [{"question": "Confirm merge of PR #252?"}]},
-            "tool_output": 'User has answered your questions: "Confirm merge of PR #252?"="Yes, merge".',
+            "tool_response": 'User has answered your questions: "Confirm merge of PR #252?"="Yes, merge".',
         })
 
         with patch("merge_guard_post.TOKEN_DIR", tmp_path), \
@@ -5058,7 +5084,7 @@ class TestAnswerExtractionEdgeCases:
                 main()
 
         assert exc_info.value.code == 0
-        # Non-dict tool_output rejected entirely — no token
+        # Non-dict tool_response rejected entirely — no token
         assert len(list(tmp_path.glob("merge-authorized-*"))) == 0
 
 
@@ -5090,7 +5116,7 @@ class TestSchemaFixEndToEnd:
                     "multiSelect": False,
                 }]
             },
-            "tool_output": {
+            "tool_response": {
                 "questions": [{
                     "question": "Confirm merge of PR #252 to main?",
                     "header": "Merge",
@@ -5154,7 +5180,7 @@ class TestSchemaFixEndToEnd:
                     "question": "Force push to origin/main? This will overwrite remote history.",
                 }]
             },
-            "tool_output": {
+            "tool_response": {
                 "answers": {
                     "Force push to origin/main? This will overwrite remote history.": "yes",
                 },
@@ -5188,7 +5214,7 @@ class TestSchemaFixEndToEnd:
                     "question": "Delete branch feat/old-feature?",
                 }]
             },
-            "tool_output": {
+            "tool_response": {
                 "answers": {
                     "Delete branch feat/old-feature?": "go ahead",
                 },
@@ -5226,7 +5252,7 @@ class TestSchemaFixEndToEnd:
                     ],
                 }]
             },
-            "tool_output": {
+            "tool_response": {
                 "answers": {
                     "Merge PR #100 to main?": "Cancel",
                 },
@@ -5259,7 +5285,7 @@ class TestSchemaFixEndToEnd:
             "tool_input": {
                 "questions": [{"question": "Should I merge PR #42?"}]
             },
-            "tool_output": {
+            "tool_response": {
                 "answers": {"Should I merge PR #42?": "yes"}
             },
         })
@@ -5286,7 +5312,7 @@ class TestSchemaFixEndToEnd:
                     {"question": "Also update the changelog?"},
                 ]
             },
-            "tool_output": {
+            "tool_response": {
                 "answers": {
                     "Should I merge PR #42?": "yes",
                     "Also update the changelog?": "yes",
@@ -5313,7 +5339,7 @@ class TestSchemaFixEndToEnd:
                     {"question": "Then merge PR #42?"},
                 ]
             },
-            "tool_output": {
+            "tool_response": {
                 "answers": {
                     "Update the changelog?": "yes",
                     "Then merge PR #42?": "yes",
@@ -5347,7 +5373,7 @@ class TestSchemaFixEndToEnd:
                     {"question": "Update the changelog?"},
                 ]
             },
-            "tool_output": {
+            "tool_response": {
                 "answers": {
                     "Update the changelog?": "yes",
                     "Merge PR #42 to main?": "no",
@@ -5380,7 +5406,7 @@ class TestSchemaFixEndToEnd:
             "tool_input": {
                 "questions": [{"question": "Merge PR #42?"}]
             },
-            "tool_output": {
+            "tool_response": {
                 "answers": {
                     "Merge PR #42? ": "Yes, merge",
                 },
@@ -7086,7 +7112,7 @@ class TestGhPrClosePostHookE2E:
             "tool_input": {
                 "questions": [{"question": "Should I close PR #42?"}]
             },
-            "tool_output": {
+            "tool_response": {
                 "answers": {"Should I close PR #42?": "yes"}
             },
         }
@@ -7117,7 +7143,7 @@ class TestGhPrClosePostHookE2E:
             "tool_input": {
                 "questions": [{"question": "Run gh pr close 99?"}]
             },
-            "tool_output": {
+            "tool_response": {
                 "answers": {"Run gh pr close 99?": "yes"}
             },
         }
@@ -7142,7 +7168,7 @@ class TestGhPrClosePostHookE2E:
             "tool_input": {
                 "questions": [{"question": "Should I close PR #42?"}]
             },
-            "tool_output": {
+            "tool_response": {
                 "answers": {"Should I close PR #42?": "no"}
             },
         }
@@ -7167,7 +7193,7 @@ class TestGhPrClosePostHookE2E:
             "tool_input": {
                 "questions": [{"question": "Should I close issue #42?"}]
             },
-            "tool_output": {
+            "tool_response": {
                 "answers": {"Should I close issue #42?": "yes"}
             },
         }

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -195,19 +195,28 @@ class TestExtractContext:
 
 
 class TestWriteToken:
-    """Tests for merge_guard_post.write_token()."""
+    """Tests for merge_guard_post.write_token().
+
+    Per the sparse-context guard, write_token requires the context dict
+    to carry at least one concrete anchor (pr_number OR operation_type).
+    Tests that exercise the file-write side use a minimal-but-valid
+    context (operation_type alone is sufficient).
+    """
+
+    # Minimal context that satisfies the sparse-context guard (one anchor).
+    _MIN_CTX = {"operation_type": "merge"}
 
     def test_creates_token_file(self, tmp_path):
         from merge_guard_post import write_token
 
-        result = write_token({"test": True}, token_dir=tmp_path)
+        result = write_token({"test": True, **self._MIN_CTX}, token_dir=tmp_path)
         assert result is not None
         assert Path(result).exists()
 
     def test_token_has_correct_structure(self, tmp_path):
         from merge_guard_post import write_token
 
-        result = write_token({"test": True}, token_dir=tmp_path)
+        result = write_token({"test": True, **self._MIN_CTX}, token_dir=tmp_path)
         with open(result) as f:
             data = json.load(f)
 
@@ -219,7 +228,7 @@ class TestWriteToken:
     def test_token_has_correct_ttl(self, tmp_path):
         from merge_guard_post import write_token, TOKEN_TTL
 
-        result = write_token({}, token_dir=tmp_path)
+        result = write_token(dict(self._MIN_CTX), token_dir=tmp_path)
         with open(result) as f:
             data = json.load(f)
 
@@ -228,15 +237,76 @@ class TestWriteToken:
     def test_token_file_permissions(self, tmp_path):
         from merge_guard_post import write_token
 
-        result = write_token({}, token_dir=tmp_path)
+        result = write_token(dict(self._MIN_CTX), token_dir=tmp_path)
         mode = os.stat(result).st_mode & 0o777
         assert mode == 0o600
 
     def test_token_filename_prefix(self, tmp_path):
         from merge_guard_post import write_token
 
-        result = write_token({}, token_dir=tmp_path)
+        result = write_token(dict(self._MIN_CTX), token_dir=tmp_path)
         assert "merge-authorized-" in Path(result).name
+
+
+class TestWriteTokenSparseContextGuard:
+    """Pin the F-2 sparse-context refusal at the write boundary.
+
+    Refusing to write tokens whose context lacks BOTH pr_number AND
+    operation_type prevents wildcard-permissive matches in
+    `_token_matches_command`: a `{pr_number: None, operation_type: None}`
+    token would otherwise be authorized against ANY destructive command
+    via the ladder's "ambiguous-permissive" fallback.
+    """
+
+    def test_write_token_rejects_no_pr_number_no_op_type(self, tmp_path, capsys):
+        from merge_guard_post import write_token
+
+        result = write_token({}, token_dir=tmp_path)
+        assert result is None
+        # No file should have been created
+        assert list(Path(tmp_path).glob("merge-authorized-*")) == []
+        # Stderr warning emitted (forensic visibility)
+        captured = capsys.readouterr()
+        assert "[security]" in captured.err
+        assert "sparse context" in captured.err
+
+    def test_write_token_rejects_only_question_snippet(self, tmp_path, capsys):
+        """Realistic shape from extract_context() on vague question text.
+
+        `extract_context("Merge?")` returns `{question_snippet: "Merge?"}`
+        with neither pr_number nor operation_type. The guard refuses.
+        """
+        from merge_guard_post import write_token
+
+        result = write_token({"question_snippet": "Merge?"}, token_dir=tmp_path)
+        assert result is None
+        captured = capsys.readouterr()
+        assert "[security]" in captured.err
+
+    def test_write_token_accepts_pr_number_alone(self, tmp_path):
+        """One concrete anchor is sufficient — pr_number alone allows write."""
+        from merge_guard_post import write_token
+
+        result = write_token({"pr_number": "663"}, token_dir=tmp_path)
+        assert result is not None
+        assert Path(result).exists()
+
+    def test_write_token_accepts_op_type_alone(self, tmp_path):
+        """One concrete anchor is sufficient — operation_type alone allows write."""
+        from merge_guard_post import write_token
+
+        result = write_token({"operation_type": "merge"}, token_dir=tmp_path)
+        assert result is not None
+        assert Path(result).exists()
+
+    def test_write_token_rejects_non_dict_context(self, tmp_path, capsys):
+        from merge_guard_post import write_token
+
+        result = write_token("not_a_dict", token_dir=tmp_path)
+        assert result is None
+        captured = capsys.readouterr()
+        assert "[security]" in captured.err
+        assert "non-dict" in captured.err
 
 
 class TestPostMainEntryPoint:
@@ -709,29 +779,35 @@ class TestIntegration:
         assert exc_info.value.code == 0  # Allowed
 
     def test_multiple_valid_tokens(self, tmp_path):
-        """Multiple valid tokens: each authorizes one operation (consumed on use)."""
+        """Multiple valid tokens: each authorizes one matching operation.
+
+        Each token's operation_type is matched against the consuming
+        command. Two compatible-class operations succeed (one merge token
+        consumed by `gh pr merge`, one merge token consumed by another
+        `gh pr merge`); a third operation with no matching token blocks.
+        """
         from merge_guard_post import write_token
         from merge_guard_pre import check_merge_authorization
 
-        write_token({"op": "merge"}, token_dir=tmp_path)
+        write_token({"operation_type": "merge"}, token_dir=tmp_path)
         # Force a different filename by manipulating time
         with patch("merge_guard_post.time") as mock_time:
             mock_time.time.return_value = time.time() + 1
-            write_token({"op": "force-push"}, token_dir=tmp_path)
+            write_token({"operation_type": "merge"}, token_dir=tmp_path)
 
         tokens = list(tmp_path.glob("merge-authorized-*"))
         assert len(tokens) >= 2
 
-        # First operation: consumes one token
+        # First operation: consumes one merge token
         result1 = check_merge_authorization("gh pr merge 1", token_dir=tmp_path)
         assert result1 is None
 
-        # Second operation: consumes the other token
-        result2 = check_merge_authorization("git push --force origin main", token_dir=tmp_path)
+        # Second operation: consumes the other merge token
+        result2 = check_merge_authorization("gh pr merge 2", token_dir=tmp_path)
         assert result2 is None
 
         # Third operation: blocked (all tokens consumed)
-        result3 = check_merge_authorization("git branch -D old", token_dir=tmp_path)
+        result3 = check_merge_authorization("gh pr merge 3", token_dir=tmp_path)
         assert result3 is not None
 
     def test_expired_token_does_not_authorize(self, tmp_path):
@@ -765,7 +841,7 @@ class TestSingleUseToken:
         from merge_guard_post import write_token
         from merge_guard_pre import check_merge_authorization
 
-        token_path = write_token({"pr": "42"}, token_dir=tmp_path)
+        token_path = write_token({"pr_number": "42"}, token_dir=tmp_path)
         assert token_path is not None
         assert Path(token_path).exists()
 
@@ -780,7 +856,7 @@ class TestSingleUseToken:
         from merge_guard_post import write_token
         from merge_guard_pre import check_merge_authorization
 
-        write_token({"pr": "42"}, token_dir=tmp_path)
+        write_token({"pr_number": "42"}, token_dir=tmp_path)
 
         # First command: allowed
         result1 = check_merge_authorization("gh pr merge 42", token_dir=tmp_path)
@@ -796,7 +872,7 @@ class TestSingleUseToken:
         from merge_guard_post import write_token
         from merge_guard_pre import check_merge_authorization
 
-        token_path = write_token({"pr": "42"}, token_dir=tmp_path)
+        token_path = write_token({"pr_number": "42"}, token_dir=tmp_path)
 
         # Safe command: allowed without consuming token
         result = check_merge_authorization("git status", token_dir=tmp_path)
@@ -820,7 +896,7 @@ class TestSingleUseToken:
         expired_file.write_text(json.dumps(expired_data))
 
         # Create a valid token
-        valid_path = write_token({"pr": "99"}, token_dir=tmp_path)
+        valid_path = write_token({"pr_number": "99"}, token_dir=tmp_path)
 
         # Authorize: expired cleaned up, valid consumed (renamed to .consumed)
         result = check_merge_authorization("gh pr merge 99", token_dir=tmp_path)
@@ -835,7 +911,7 @@ class TestSingleUseToken:
         from merge_guard_pre import check_merge_authorization
 
         # First approval
-        write_token({"op": "merge"}, token_dir=tmp_path)
+        write_token({"operation_type": "merge"}, token_dir=tmp_path)
         result1 = check_merge_authorization("gh pr merge 42", token_dir=tmp_path)
         assert result1 is None  # Allowed
 
@@ -846,7 +922,7 @@ class TestSingleUseToken:
         # Second approval
         with patch("merge_guard_post.time") as mock_time:
             mock_time.time.return_value = time.time() + 1
-            write_token({"op": "force-push"}, token_dir=tmp_path)
+            write_token({"operation_type": "force-push"}, token_dir=tmp_path)
         result3 = check_merge_authorization("git push --force origin main", token_dir=tmp_path)
         assert result3 is None  # Allowed
 
@@ -859,7 +935,7 @@ class TestSingleUseToken:
         from merge_guard_post import write_token
         from merge_guard_pre import check_merge_authorization
 
-        token_path = write_token({"pr": "42"}, token_dir=tmp_path)
+        token_path = write_token({"pr_number": "42"}, token_dir=tmp_path)
 
         # Simulate external deletion: remove the token before
         # check_merge_authorization can consume it. Since neither the
@@ -875,7 +951,7 @@ class TestSingleUseToken:
         from merge_guard_post import write_token
         from merge_guard_pre import _consume_token, check_merge_authorization
 
-        token_path = write_token({"pr": "42"}, token_dir=tmp_path)
+        token_path = write_token({"pr_number": "42"}, token_dir=tmp_path)
 
         # First consumption: rename to .consumed
         assert _consume_token(token_path) is True
@@ -1971,7 +2047,9 @@ class TestTokenEdgeCases:
         os.chmod(str(readonly_dir), 0o444)
 
         try:
-            result = write_token({}, token_dir=readonly_dir)
+            # Use a valid context (operation_type satisfies sparse-context guard);
+            # the test exercises the readonly-dir failure path, not the guard.
+            result = write_token({"operation_type": "merge"}, token_dir=readonly_dir)
             assert result is None
         finally:
             os.chmod(str(readonly_dir), 0o755)
@@ -1988,7 +2066,7 @@ class TestTokenEdgeCases:
 
         with patch("merge_guard_post.time") as mock_time:
             mock_time.time.return_value = now
-            result = write_token({"test": True}, token_dir=tmp_path)
+            result = write_token({"test": True, "operation_type": "merge"}, token_dir=tmp_path)
 
         # Must succeed with fallback name (not None)
         assert result is not None
@@ -2203,7 +2281,7 @@ class TestTokenSecurity:
         """Token file must be 0o600 — not readable by others."""
         from merge_guard_post import write_token
 
-        result = write_token({"sensitive": True}, token_dir=tmp_path)
+        result = write_token({"sensitive": True, "operation_type": "merge"}, token_dir=tmp_path)
         assert result is not None
 
         mode = os.stat(result).st_mode
@@ -2219,7 +2297,7 @@ class TestTokenSecurity:
         """Token file content must be parseable JSON with expected fields."""
         from merge_guard_post import write_token
 
-        result = write_token({"pr": "42"}, token_dir=tmp_path)
+        result = write_token({"pr_number": "42"}, token_dir=tmp_path)
         with open(result) as f:
             data = json.load(f)
 
@@ -2255,7 +2333,7 @@ class TestTokenSecurity:
         from merge_guard_post import write_token
         from merge_guard_pre import find_valid_token
 
-        large_context = {"data": "x" * 10000}
+        large_context = {"data": "x" * 10000, "operation_type": "merge"}
         result = write_token(large_context, token_dir=tmp_path)
         assert result is not None
 
@@ -3476,7 +3554,7 @@ class TestAPIBypassAuthorizationFlow:
         from merge_guard_post import write_token
         from merge_guard_pre import check_merge_authorization
 
-        write_token({"op": "api-delete-ref"}, token_dir=tmp_path)
+        write_token({"operation_type": "api-delete-ref"}, token_dir=tmp_path)
 
         result = check_merge_authorization(
             "gh api -X DELETE repos/owner/repo/git/refs/heads/feature",
@@ -3489,7 +3567,7 @@ class TestAPIBypassAuthorizationFlow:
         from merge_guard_post import write_token
         from merge_guard_pre import check_merge_authorization
 
-        write_token({"op": "api-patch-main"}, token_dir=tmp_path)
+        write_token({"operation_type": "api-patch-main"}, token_dir=tmp_path)
 
         result = check_merge_authorization(
             "gh api -X PATCH repos/owner/repo/git/refs/heads/main -f sha=abc",
@@ -3502,7 +3580,7 @@ class TestAPIBypassAuthorizationFlow:
         from merge_guard_post import write_token
         from merge_guard_pre import check_merge_authorization
 
-        write_token({"op": "api-patch-ref"}, token_dir=tmp_path)
+        write_token({"operation_type": "api-patch-ref"}, token_dir=tmp_path)
 
         result = check_merge_authorization(
             "curl -X PATCH https://api.github.com/repos/owner/repo/git/refs/heads/feature",
@@ -4355,7 +4433,7 @@ class TestDirectPushToDefaultBranch:
         from merge_guard_post import write_token
         from merge_guard_pre import check_merge_authorization
 
-        write_token({"op": "push-main"}, token_dir=tmp_path)
+        write_token({"operation_type": "push-main"}, token_dir=tmp_path)
 
         result = check_merge_authorization("git push origin main", token_dir=tmp_path)
         assert result is None  # Allowed
@@ -4493,7 +4571,7 @@ class TestSessionScoping:
         from merge_guard_post import write_token
 
         with patch("merge_guard_post.get_session_id", return_value="session-abc"):
-            result = write_token({"test": True}, token_dir=tmp_path)
+            result = write_token({"test": True, "operation_type": "merge"}, token_dir=tmp_path)
 
         with open(result) as f:
             data = json.load(f)
@@ -4504,7 +4582,7 @@ class TestSessionScoping:
         from merge_guard_post import write_token
 
         with patch("merge_guard_post.get_session_id", return_value=""):
-            result = write_token({"test": True}, token_dir=tmp_path)
+            result = write_token({"test": True, "operation_type": "merge"}, token_dir=tmp_path)
 
         with open(result) as f:
             data = json.load(f)
@@ -4683,7 +4761,7 @@ class TestTokenWriteExceptionHandling:
 
         with patch("merge_guard_post.time") as mock_time:
             mock_time.time.return_value = now
-            result = write_token({"test": True}, token_dir=tmp_path)
+            result = write_token({"test": True, "operation_type": "merge"}, token_dir=tmp_path)
 
         assert result is None
 
@@ -4704,7 +4782,7 @@ class TestTokenWriteExceptionHandling:
             return original_fdopen(fd, *args, **kwargs)
 
         with patch("merge_guard_post.os.fdopen", side_effect=failing_fdopen):
-            result = write_token({"test": True}, token_dir=tmp_path)
+            result = write_token({"test": True, "operation_type": "merge"}, token_dir=tmp_path)
 
         # Should return None because the primary write failed and the retry
         # path (FileExistsError) is not triggered (different exception type)
@@ -5867,7 +5945,7 @@ class TestIdempotentTokenConsumption:
         os.utime(str(stale), (old_mtime, old_mtime))
 
         # Create a new token — should clean up stale consumed files
-        token_path = write_token({"pr": "42"}, token_dir=tmp_path)
+        token_path = write_token({"pr_number": "42"}, token_dir=tmp_path)
 
         assert token_path is not None
         assert not stale.exists()  # Stale consumed cleaned up
@@ -5880,7 +5958,7 @@ class TestIdempotentTokenConsumption:
         fresh = tmp_path / "merge-authorized-00001.consumed"
         fresh.write_text('{}')
 
-        token_path = write_token({"pr": "42"}, token_dir=tmp_path)
+        token_path = write_token({"pr_number": "42"}, token_dir=tmp_path)
 
         assert token_path is not None
         assert fresh.exists()  # Fresh consumed preserved
@@ -6009,7 +6087,7 @@ class TestIdempotentTokenConsumption:
         from merge_guard_post import write_token
         from merge_guard_pre import check_merge_authorization
 
-        token_path = write_token({"pr": "42"}, token_dir=tmp_path)
+        token_path = write_token({"pr_number": "42"}, token_dir=tmp_path)
         assert token_path is not None
 
         # First: allowed, token consumed
@@ -6032,7 +6110,7 @@ class TestIdempotentTokenConsumption:
         from merge_guard_post import write_token
         from merge_guard_pre import _consume_token, check_merge_authorization
 
-        token_path = write_token({"pr": "42"}, token_dir=tmp_path)
+        token_path = write_token({"pr_number": "42"}, token_dir=tmp_path)
 
         # First invocation: consume via rename
         assert _consume_token(token_path) is True
@@ -6095,7 +6173,7 @@ class TestIdempotentTokenConsumption:
         from merge_guard_post import write_token
         from merge_guard_pre import check_merge_authorization
 
-        token_path = write_token({"pr": "42"}, token_dir=tmp_path)
+        token_path = write_token({"pr_number": "42"}, token_dir=tmp_path)
         assert token_path is not None
 
         # Verify original has secure permissions
@@ -6124,7 +6202,7 @@ class TestIdempotentTokenConsumption:
         )
 
         # 1. Create token
-        token_path = write_token({"pr": "42"}, token_dir=tmp_path)
+        token_path = write_token({"pr_number": "42"}, token_dir=tmp_path)
         assert token_path is not None
         assert Path(token_path).exists()
 
@@ -8626,3 +8704,124 @@ class TestModuleLoadFailClosed:
         helper_body = source[def_idx:def_idx + 1200]
         assert "Issue #658" in helper_body or "PR #660" in helper_body
         assert "hookEventName" in helper_body
+
+
+class TestCompoundDestructiveCommandRejection:
+    """Pin the compound-command rejection that closes the chained-bypass class.
+
+    A single AskUserQuestion approval can authorize ONE destructive op.
+    Chained shapes (``&&``, ``||``, ``;``, ``|``, newline) hide secondary
+    destructive ops past the operator's headline-command review of the
+    AskUserQuestion text. Categorically reject compound destructive
+    shapes; force the operator to run one destructive op per checkpoint.
+    """
+
+    def test_compound_with_destructive_denied(self, tmp_path):
+        """gh pr merge 100 && gh pr merge 999 → denied even with token for 100."""
+        from merge_guard_post import write_token
+        from merge_guard_pre import check_merge_authorization
+
+        # Token for the headline op exists
+        write_token(
+            {"pr_number": "100", "operation_type": "merge"},
+            token_dir=tmp_path,
+        )
+        cmd = "gh pr merge 100 && gh pr merge 999 --admin"
+        result = check_merge_authorization(cmd, token_dir=tmp_path)
+        assert result is not None, "compound destructive must be denied"
+        assert "Compound destructive" in result
+        assert "&&" in result or "||" in result or ";" in result
+
+    def test_pipe_with_destructive_denied(self, tmp_path):
+        from merge_guard_pre import check_merge_authorization
+
+        cmd = "gh pr merge 100 | tee /tmp/out"
+        result = check_merge_authorization(cmd, token_dir=tmp_path)
+        assert result is not None
+        assert "Compound destructive" in result
+
+    def test_semicolon_with_destructive_denied(self, tmp_path):
+        from merge_guard_pre import check_merge_authorization
+
+        cmd = "echo go ; git push --force origin main"
+        result = check_merge_authorization(cmd, token_dir=tmp_path)
+        assert result is not None
+        assert "Compound destructive" in result
+
+    def test_newline_with_destructive_denied(self, tmp_path):
+        from merge_guard_pre import check_merge_authorization
+
+        cmd = "ls\ngh pr merge 99"
+        result = check_merge_authorization(cmd, token_dir=tmp_path)
+        assert result is not None
+        assert "Compound destructive" in result
+
+    def test_compound_safe_commands_allowed(self, tmp_path):
+        """Safe compounds without DANGEROUS_PATTERNS are NOT rejected.
+
+        ``ls && pwd`` contains a compound shape but no destructive sub-op,
+        so check_merge_authorization returns None (allow).
+        """
+        from merge_guard_pre import check_merge_authorization
+
+        result = check_merge_authorization("ls && pwd", token_dir=tmp_path)
+        assert result is None, "safe compound must be allowed"
+
+    def test_single_destructive_with_token_still_works(self, tmp_path):
+        """Regression-protection: single destructive op + valid token = allow."""
+        from merge_guard_post import write_token
+        from merge_guard_pre import check_merge_authorization
+
+        write_token(
+            {"pr_number": "100", "operation_type": "merge"},
+            token_dir=tmp_path,
+        )
+        result = check_merge_authorization("gh pr merge 100", token_dir=tmp_path)
+        assert result is None, "single destructive with token must be allowed"
+
+
+class TestEvalHeredocRejection:
+    """Pin the eval+heredoc detection that closes the strip-pipeline-bypass class.
+
+    The strip pipeline removes heredoc bodies BEFORE the regex-match phase.
+    An eval-wrapped destructive command inside a heredoc body becomes
+    invisible to DANGEROUS_PATTERNS by the time matching runs. Treat
+    eval+heredoc shapes as categorically dangerous via a pre-strip check.
+    """
+
+    def test_eval_dollar_paren_heredoc_denied(self, tmp_path):
+        """eval $(cat <<HEREDOC ... HEREDOC) form denied as dangerous."""
+        from merge_guard_pre import is_dangerous_command
+
+        cmd = "eval $(cat <<HEREDOC\ngh pr merge 999 --admin\nHEREDOC\n)"
+        assert is_dangerous_command(cmd) is True
+
+    def test_eval_backtick_heredoc_denied(self, tmp_path):
+        """eval `cat <<HEREDOC ... HEREDOC` (legacy backtick form) denied."""
+        from merge_guard_pre import is_dangerous_command
+
+        cmd = "eval `cat <<HEREDOC\ngh pr merge 999\nHEREDOC\n`"
+        assert is_dangerous_command(cmd) is True
+
+    def test_eval_without_heredoc_not_flagged_by_helper(self):
+        """Plain eval (no heredoc) is not caught by the eval+heredoc helper.
+
+        A plain ``eval "$VAR"`` may still be dangerous via other paths
+        (the eval-or-source variable-expansion guards in
+        ``_strip_non_executable_content``), but the categorical
+        eval+heredoc helper specifically targets the strip-pipeline
+        bypass class. Pin the helper's narrow scope.
+        """
+        from merge_guard_pre import _has_eval_with_heredoc
+
+        assert _has_eval_with_heredoc('eval "$VAR"') is False
+        assert _has_eval_with_heredoc("eval $(echo hi)") is False  # $() but no heredoc
+        assert _has_eval_with_heredoc("cat <<EOF\nhi\nEOF") is False  # heredoc but no eval
+
+    def test_eval_heredoc_routes_through_check_authorization(self, tmp_path):
+        """End-to-end: eval+heredoc with no token is denied via standard flow."""
+        from merge_guard_pre import check_merge_authorization
+
+        cmd = "eval $(cat <<HEREDOC\ngh pr merge 999 --admin\nHEREDOC\n)"
+        result = check_merge_authorization(cmd, token_dir=tmp_path)
+        assert result is not None, "eval+heredoc must be denied without token"

--- a/pact-plugin/tests/test_merge_guard_pre.py
+++ b/pact-plugin/tests/test_merge_guard_pre.py
@@ -3,32 +3,34 @@ Tests for merge_guard_pre._GH_PR_NUMBER_RE — PR-number extraction.
 
 Pins the regex behavior: `_GH_FLAG_TOKENS` restricts BOTH flag-walks (between
 `gh` and `pr`, AND between subcommand and PR number) to flag-shaped tokens
-only (`-x`, `--long`, optionally `--flag value`). The `\\b` boundary on the
-(\\d+) capture rejects suffix matches inside longer alphanumeric tokens.
+only (`-x`, `--long`, optionally `--flag value`). The `(?![\\w-])` negative-
+lookahead on the (\\d+) capture rejects suffix matches inside longer
+alphanumeric-or-hyphenated tokens.
 
 Each TRUE-GAIN test below cites the exact OLD-vs-NEW behavioral delta — these
 are the cases that were broken on main (regex captured a non-PR digit token
-from heredoc body / 2>&1 redirect / trailing positional) and now correctly
-extract the PR number.
+from heredoc body / 2>&1 redirect / trailing positional / branch-name suffix)
+and now correctly extract the PR number or return None.
 
-The remaining limitation:
+Two previously-xfail-strict cases are now FIXED in this file:
 
-  Branch-name suffix `7352-tests`: Python `\\b` IS a word boundary at
-  digit-to-hyphen (word char `2` to non-word char `-`). The original
-  spec claimed `\\b` would reject this; that claim was wrong about
-  Python regex semantics. Fixing requires `(?![\\w-])` instead. The
-  test is marked xfail(strict=True) so a future tightening that fixes
-  it will fail the test (signaling the marker should be removed in lockstep).
+  1. "heredoc body containing a fully-formed `gh pr merge <N>` substring":
+     `_GH_PR_NUMBER_RE` uses the tight `_GH_FLAG_TOKENS` form for BOTH the
+     pre-subcommand AND post-subcommand flag walks (rather than reusing the
+     broad `_GH_GLOBAL_FLAGS` for the pre-subcommand walk). This eliminates
+     the re-anchor-at-second-occurrence authorization-bypass class.
 
-The previously-xfail "heredoc body containing a fully-formed `gh pr merge
-<N>` substring" case is now FIXED: `_GH_PR_NUMBER_RE` uses the tight
-`_GH_FLAG_TOKENS` form for BOTH the pre-subcommand AND post-subcommand
-flag walks (rather than reusing the broad `_GH_GLOBAL_FLAGS` for the
-pre-subcommand walk). This eliminates the re-anchor-at-second-occurrence
-authorization-bypass class. The `test_heredoc_body_with_embedded_gh_pr_merge`
-test below is now a regular passing test pinning the fix; the new
-`test_authorization_mismatch_attack` test pins the end-to-end attack
-shape that the fix prevents.
+  2. "branch-name suffix `7352-tests`": Python `\\b` IS a word boundary at
+     digit-to-hyphen (word char `2` to non-word char `-`). The earlier spec
+     assumed `\\b` would reject this; that assumption was wrong about Python
+     regex semantics. The fix replaces the trailing `\\b` with `(?![\\w-])`
+     (negative lookahead) — strictly stronger: rejects any continuation that
+     is a word char OR a hyphen.
+
+Both `test_heredoc_body_with_embedded_gh_pr_merge` and
+`test_branch_name_with_digit_prefix_suffix_match` are now regular passing
+tests pinning the fixes; the new `test_authorization_mismatch_attack` test
+pins the end-to-end attack shape that the heredoc-side fix prevents.
 """
 
 import re
@@ -132,16 +134,14 @@ class TestGH_PR_NumberRE_AcceptableNone:
 
 
 # =============================================================================
-# KNOWN LIMITATIONS — pinned with strict xfail
+# AUTHORIZATION-BYPASS FIXES — regression-protection for prior xfail cases
 # =============================================================================
-# These tests document cases the #665 fix does NOT solve. They are marked
-# strict=True so a future tightening that resolves either one will FAIL the
-# test (signaling the xfail marker should be removed in the follow-up PR).
-#
-# Without strict=True, an accidental fix would silently flip xfail→xpass and
-# the limitation would be re-rediscovered later. With strict=True, the test
-# acts as a tripwire: the limitation is honestly documented as a current
-# behavior, and any change to that behavior is forced through review.
+# Two cases that were previously pinned as xfail-strict are now passing
+# tests after the regex tightening:
+#   1. heredoc body containing embedded `gh pr merge <N>` — fixed by tight
+#      flag-walks on BOTH sides of `pr <subcmd>`.
+#   2. branch-name argument with digit prefix (e.g., `7352-tests`) — fixed
+#      by replacing `\b` with `(?![\w-])` (rejects hyphen continuation).
 
 class TestGH_PR_NumberRE_AuthorizationBypassFixed:
     """Fixed authorization-bypass class — pinned as regression-protection.
@@ -191,26 +191,18 @@ class TestGH_PR_NumberRE_AuthorizationBypassFixed:
         assert _capture(cmd) == "663"
 
 
-class TestGH_PR_NumberRE_KnownLimitations:
-    """Documented limitations — see module docstring + follow-up issue."""
-
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Python `\\b` IS a word boundary at digit-to-hyphen "
-            "(word char `2` to non-word char `-`). The earlier spec assumed \\b "
-            "would reject `7352-tests` as a suffix match; that assumption was "
-            "wrong about Python regex semantics. Fix requires `(?![\\w-])` "
-            "instead of `\\b`. Tracked for follow-up."
-        ),
-    )
     def test_branch_name_with_digit_prefix_suffix_match(self):
-        # If a user passes a branch name (instead of PR number) like `7352-tests`,
-        # the regex captures the leading digit run. Whether this is dangerous
-        # depends on the AskUserQuestion authorization flow, which is itself
-        # PR-number-oriented (so a branch-name merge is already an unusual path).
+        """Branch-name argument with digit prefix no longer captures the digit.
+
+        Previously xfail-strict (Python `\\b` IS a word boundary at
+        digit-to-hyphen, so `\\b` after `(\\d+)` allowed `7352` to match
+        from `7352-tests`). After replacing `\\b` with `(?![\\w-])` the
+        trailing-hyphen continuation is rejected and the regex returns
+        None, which the caller treats as ambiguous-and-permissive (the
+        intended degradation when no clean digit token can be extracted).
+        """
         cmd = "gh pr merge 7352-tests --squash"
-        assert _capture(cmd) is None  # Fix would return None (no clean digit token)
+        assert _capture(cmd) is None
 
 
 # =============================================================================

--- a/pact-plugin/tests/test_merge_guard_pre.py
+++ b/pact-plugin/tests/test_merge_guard_pre.py
@@ -90,8 +90,11 @@ class TestGH_PR_NumberRE_TrueGains:
         assert _capture(cmd) == "663"
 
     def test_body_file_with_versioned_path(self):
-        # OLD captured "7352" from path filename.
-        # NEW correctly captures "663".
+        # Regression-protection only: empirical probe shows OLD ALSO captured
+        # "663" here (the path's slashes/hyphens are non-word and `\S+\s+`
+        # requires whitespace separation, so the broad walk consumes the path
+        # and backtracks to the positional). Pinned as a no-op canary so a
+        # future regex change cannot regress this case to capturing "7352".
         cmd = "gh pr merge 663 --body-file /tmp/release-notes-v4.1.7-7352.md --squash"
         assert _capture(cmd) == "663"
 

--- a/pact-plugin/tests/test_merge_guard_pre.py
+++ b/pact-plugin/tests/test_merge_guard_pre.py
@@ -1,0 +1,196 @@
+"""
+Tests for merge_guard_pre._GH_PR_NUMBER_RE — PR-number extraction (#665).
+
+Pins the regex behavior introduced by the #665 fix: the new `_GH_FLAG_TOKENS`
+constant restricts the post-subcommand token walk to flag-shaped tokens only
+(`-x`, `--long`, optionally `--flag value`). The `\\b` boundary on the (\\d+)
+capture rejects suffix matches inside longer alphanumeric tokens.
+
+Each TRUE-GAIN test below cites the exact OLD-vs-NEW behavioral delta — these
+are the cases that were broken on main (regex captured a non-PR digit token
+from heredoc body / 2>&1 redirect / trailing positional) and now correctly
+extract the PR number.
+
+The KNOWN LIMITATIONS section pins two cases the #665 fix does NOT solve.
+They are marked xfail(strict=True) so a future tightening that fixes either
+one will fail the test (signaling the marker should be removed in lockstep).
+Without the strict-xfail marker, fixing the limitation would silently pass
+the test and the limitation would be re-rediscovered later.
+
+The two limitations:
+
+  1. Heredoc body containing a fully-formed `gh pr merge <N>` substring:
+     `_GH_PREFIX` (line 79 of merge_guard_pre.py) still uses the broad
+     `_GH_GLOBAL_FLAGS` because DANGEROUS_PATTERNS shares it. The PR-number
+     regex re-anchors at the SECOND `gh pr merge` inside the heredoc body
+     and captures the embedded digit. Fixing requires duplicating
+     `_GH_PREFIX` into a tighter `_GH_PR_NUMBER_PREFIX` (does not affect
+     DANGEROUS_PATTERNS).
+
+  2. Branch-name suffix `7352-tests`: Python `\\b` IS a word boundary at
+     digit-to-hyphen (word char `2` to non-word char `-`). The original
+     architect spec claimed `\\b` would reject this; that claim was wrong
+     about Python regex semantics. Fixing requires `(?![\\w-])` instead.
+
+Both limitations are tracked for follow-up post-merge.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+from merge_guard_pre import _GH_PR_NUMBER_RE  # noqa: E402
+
+
+def _capture(command: str):
+    """Helper: run the regex and return the captured PR number, or None."""
+    m = _GH_PR_NUMBER_RE.search(command)
+    return m.group(1) if m else None
+
+
+# =============================================================================
+# TRUE GAINS — cases broken on main, fixed by #665
+# =============================================================================
+# Each test documents the OLD-vs-NEW delta. On main, the regex used the broad
+# `_GH_GLOBAL_FLAGS` for the post-subcommand walk, which greedily consumed
+# tokens past the PR positional and captured the LAST digit reachable.
+
+class TestGH_PR_NumberRE_TrueGains:
+    """The behavioral delta that resolves #665."""
+
+    def test_subject_with_version_digits_captures_pr(self):
+        # OLD captured "7352" (last digit in subject string).
+        # NEW correctly captures the PR positional "663".
+        cmd = 'gh pr merge 663 --squash --subject "v4.1.7 release notes ships 7352 tests"'
+        assert _capture(cmd) == "663"
+
+    def test_body_with_version_digits_captures_pr(self):
+        # OLD captured "7352" (last digit in body content).
+        # NEW correctly captures "663".
+        cmd = (
+            'gh pr merge 663 --squash --subject foo '
+            '--body "v4.1.7 ships 7352 tests passing"'
+        )
+        assert _capture(cmd) == "663"
+
+    def test_stderr_redirect_captures_pr(self):
+        # OLD captured "2" (the "2" of "2>&1" redirect).
+        # NEW correctly captures "663".
+        cmd = "gh pr merge 663 --squash 2>&1"
+        assert _capture(cmd) == "663"
+
+    def test_trailing_positional_text_with_digits(self):
+        # OLD captured "7352" from trailing positional text.
+        # NEW correctly captures "663".
+        cmd = "gh pr merge 663 with 7352 tests passing"
+        assert _capture(cmd) == "663"
+
+    def test_body_file_with_versioned_path(self):
+        # OLD captured "7352" from path filename.
+        # NEW correctly captures "663".
+        cmd = "gh pr merge 663 --body-file /tmp/release-notes-v4.1.7-7352.md --squash"
+        assert _capture(cmd) == "663"
+
+    def test_simple_squash_unaffected(self):
+        # No regression: simple case still works.
+        cmd = "gh pr merge 663 --squash"
+        assert _capture(cmd) == "663"
+
+    def test_pre_subcommand_flag_unaffected(self):
+        # No regression: --admin between merge subcommand and PR number.
+        cmd = "gh pr merge --admin 663 --squash"
+        assert _capture(cmd) == "663"
+
+    def test_global_flag_before_subcommand_unaffected(self):
+        # No regression: --repo owner/repo as a gh global flag.
+        cmd = "gh --repo owner/repo pr merge 663 --squash"
+        assert _capture(cmd) == "663"
+
+    def test_close_with_delete_branch_captures_pr(self):
+        # No regression: gh pr close form with --delete-branch.
+        cmd = "gh pr close 663 --delete-branch"
+        assert _capture(cmd) == "663"
+
+
+# =============================================================================
+# ACCEPTABLE-NONE — degradation to permissive behavior
+# =============================================================================
+# When the PR number cannot be unambiguously located, the regex returns None.
+# The caller (_token_authorizes_command) treats None as ambiguous and falls
+# back to permissive (returns True). This preserves the existing semantic.
+
+class TestGH_PR_NumberRE_AcceptableNone:
+    """Cases where the regex correctly returns None (permissive degradation)."""
+
+    def test_no_positional_pr_number(self):
+        # gh pr merge --auto has no positional PR number; None is correct.
+        cmd = "gh pr merge --auto"
+        assert _capture(cmd) is None
+
+
+# =============================================================================
+# KNOWN LIMITATIONS — pinned with strict xfail
+# =============================================================================
+# These tests document cases the #665 fix does NOT solve. They are marked
+# strict=True so a future tightening that resolves either one will FAIL the
+# test (signaling the xfail marker should be removed in the follow-up PR).
+#
+# Without strict=True, an accidental fix would silently flip xfail→xpass and
+# the limitation would be re-rediscovered later. With strict=True, the test
+# acts as a tripwire: the limitation is honestly documented as a current
+# behavior, and any change to that behavior is forced through review.
+
+class TestGH_PR_NumberRE_KnownLimitations:
+    """Documented limitations — see module docstring + follow-up issue."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Limitation 1: heredoc body containing a fully-formed `gh pr merge <N>` "
+            "substring re-anchors the regex at the second occurrence and captures "
+            "the embedded digit. Root cause: _GH_PREFIX uses broad _GH_GLOBAL_FLAGS "
+            "(shared with DANGEROUS_PATTERNS). Fix requires duplicating _GH_PREFIX "
+            "into a tighter _GH_PR_NUMBER_PREFIX. Tracked for follow-up."
+        ),
+    )
+    def test_heredoc_body_with_embedded_gh_pr_merge(self):
+        cmd = 'gh pr merge 663 --body "see also gh pr merge 999 example"'
+        # Expected behavior under fix: capture 663 (the real positional).
+        # Current behavior: captures 999 (the embedded substring).
+        assert _capture(cmd) == "663"
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Limitation 2: Python `\\b` IS a word boundary at digit-to-hyphen "
+            "(word char `2` to non-word char `-`). Architect spec assumed \\b "
+            "would reject `7352-tests` as a suffix match; that assumption was "
+            "wrong about Python regex semantics. Fix requires `(?![\\w-])` "
+            "instead of `\\b`. Tracked for follow-up."
+        ),
+    )
+    def test_branch_name_with_digit_prefix_suffix_match(self):
+        # If a user passes a branch name (instead of PR number) like `7352-tests`,
+        # the regex captures the leading digit run. Whether this is dangerous
+        # depends on the AskUserQuestion authorization flow, which is itself
+        # PR-number-oriented (so a branch-name merge is already an unusual path).
+        cmd = "gh pr merge 7352-tests --squash"
+        assert _capture(cmd) is None  # Fix would return None (no clean digit token)
+
+
+# =============================================================================
+# Boundary verification — `\b` semantics that DO work
+# =============================================================================
+# Document what `\b` correctly rejects, complementing the limitation above.
+
+class TestGH_PR_NumberRE_BoundaryCorrect:
+    """The `\\b` boundary correctly rejects alphanumeric suffix matches."""
+
+    def test_no_match_when_followed_by_alpha(self):
+        # `\b` works correctly between digit and letter.
+        cmd = "gh pr merge 7352abc --squash"
+        assert _capture(cmd) is None

--- a/pact-plugin/tests/test_merge_guard_pre.py
+++ b/pact-plugin/tests/test_merge_guard_pre.py
@@ -1,38 +1,34 @@
 """
-Tests for merge_guard_pre._GH_PR_NUMBER_RE — PR-number extraction (#665).
+Tests for merge_guard_pre._GH_PR_NUMBER_RE — PR-number extraction.
 
-Pins the regex behavior introduced by the #665 fix: the new `_GH_FLAG_TOKENS`
-constant restricts the post-subcommand token walk to flag-shaped tokens only
-(`-x`, `--long`, optionally `--flag value`). The `\\b` boundary on the (\\d+)
-capture rejects suffix matches inside longer alphanumeric tokens.
+Pins the regex behavior: `_GH_FLAG_TOKENS` restricts BOTH flag-walks (between
+`gh` and `pr`, AND between subcommand and PR number) to flag-shaped tokens
+only (`-x`, `--long`, optionally `--flag value`). The `\\b` boundary on the
+(\\d+) capture rejects suffix matches inside longer alphanumeric tokens.
 
 Each TRUE-GAIN test below cites the exact OLD-vs-NEW behavioral delta — these
 are the cases that were broken on main (regex captured a non-PR digit token
 from heredoc body / 2>&1 redirect / trailing positional) and now correctly
 extract the PR number.
 
-The KNOWN LIMITATIONS section pins two cases the #665 fix does NOT solve.
-They are marked xfail(strict=True) so a future tightening that fixes either
-one will fail the test (signaling the marker should be removed in lockstep).
-Without the strict-xfail marker, fixing the limitation would silently pass
-the test and the limitation would be re-rediscovered later.
+The remaining limitation:
 
-The two limitations:
+  Branch-name suffix `7352-tests`: Python `\\b` IS a word boundary at
+  digit-to-hyphen (word char `2` to non-word char `-`). The original
+  spec claimed `\\b` would reject this; that claim was wrong about
+  Python regex semantics. Fixing requires `(?![\\w-])` instead. The
+  test is marked xfail(strict=True) so a future tightening that fixes
+  it will fail the test (signaling the marker should be removed in lockstep).
 
-  1. Heredoc body containing a fully-formed `gh pr merge <N>` substring:
-     `_GH_PREFIX` (line 79 of merge_guard_pre.py) still uses the broad
-     `_GH_GLOBAL_FLAGS` because DANGEROUS_PATTERNS shares it. The PR-number
-     regex re-anchors at the SECOND `gh pr merge` inside the heredoc body
-     and captures the embedded digit. Fixing requires duplicating
-     `_GH_PREFIX` into a tighter `_GH_PR_NUMBER_PREFIX` (does not affect
-     DANGEROUS_PATTERNS).
-
-  2. Branch-name suffix `7352-tests`: Python `\\b` IS a word boundary at
-     digit-to-hyphen (word char `2` to non-word char `-`). The original
-     architect spec claimed `\\b` would reject this; that claim was wrong
-     about Python regex semantics. Fixing requires `(?![\\w-])` instead.
-
-Both limitations are tracked for follow-up post-merge.
+The previously-xfail "heredoc body containing a fully-formed `gh pr merge
+<N>` substring" case is now FIXED: `_GH_PR_NUMBER_RE` uses the tight
+`_GH_FLAG_TOKENS` form for BOTH the pre-subcommand AND post-subcommand
+flag walks (rather than reusing the broad `_GH_GLOBAL_FLAGS` for the
+pre-subcommand walk). This eliminates the re-anchor-at-second-occurrence
+authorization-bypass class. The `test_heredoc_body_with_embedded_gh_pr_merge`
+test below is now a regular passing test pinning the fix; the new
+`test_authorization_mismatch_attack` test pins the end-to-end attack
+shape that the fix prevents.
 """
 
 import re
@@ -147,30 +143,62 @@ class TestGH_PR_NumberRE_AcceptableNone:
 # acts as a tripwire: the limitation is honestly documented as a current
 # behavior, and any change to that behavior is forced through review.
 
+class TestGH_PR_NumberRE_AuthorizationBypassFixed:
+    """Fixed authorization-bypass class — pinned as regression-protection.
+
+    These tests pin the regex tightening that closed an authorization-bypass
+    where a body string containing `gh pr merge <fake_PR>` could re-anchor
+    the regex past the real positional and cause the token-context check
+    to compare against the embedded fake PR rather than the real one.
+    """
+
+    def test_heredoc_body_with_embedded_gh_pr_merge(self):
+        """Body string with embedded `gh pr merge <N>` no longer re-anchors.
+
+        Previously xfail-strict (the regex captured 999 because the broad
+        pre-subcommand flag walk consumed past `663 --body "see also gh `
+        and re-anchored at the second `pr merge`). After tightening BOTH
+        flag-walks to flag-shaped tokens only, the broad walk cannot
+        consume past quoted body content, so the first-occurrence anchor
+        sticks and the real positional is captured.
+        """
+        cmd = 'gh pr merge 663 --body "see also gh pr merge 999 example"'
+        assert _capture(cmd) == "663"
+
+    def test_authorization_mismatch_attack(self):
+        """End-to-end shape of the authorization-bypass attack now blocked.
+
+        Resolves the BLOCKING finding from PR #697 review.
+
+        Attack shape: an attacker (or an honest user with a verbose body)
+        constructs `gh pr merge <real> --body "...gh pr merge <fake>..."`.
+        Pre-fix, the AskUserQuestion authorization issued for `<real>`
+        would be matched against `<fake>` extracted by the regex and
+        REJECTED with "Authorization token exists but does not match this
+        operation" — masking the real merge. Worse, an attacker could craft
+        the body so that the AskUserQuestion-issued token (for `<fake>`,
+        a non-existent PR they mention in the body of a different merge)
+        authorizes the actual `<real>` merge they intended to bypass.
+
+        Post-fix: the regex always extracts the real positional regardless
+        of body content, so the token-context check matches correctly.
+        """
+        cmd = (
+            'gh pr merge 663 --body "$(cat <<EOF\\n'
+            'Fixes #999. See related: gh pr merge 999 --admin\\n'
+            'EOF\\n)" --squash'
+        )
+        assert _capture(cmd) == "663"
+
+
 class TestGH_PR_NumberRE_KnownLimitations:
     """Documented limitations — see module docstring + follow-up issue."""
 
     @pytest.mark.xfail(
         strict=True,
         reason=(
-            "Limitation 1: heredoc body containing a fully-formed `gh pr merge <N>` "
-            "substring re-anchors the regex at the second occurrence and captures "
-            "the embedded digit. Root cause: _GH_PREFIX uses broad _GH_GLOBAL_FLAGS "
-            "(shared with DANGEROUS_PATTERNS). Fix requires duplicating _GH_PREFIX "
-            "into a tighter _GH_PR_NUMBER_PREFIX. Tracked for follow-up."
-        ),
-    )
-    def test_heredoc_body_with_embedded_gh_pr_merge(self):
-        cmd = 'gh pr merge 663 --body "see also gh pr merge 999 example"'
-        # Expected behavior under fix: capture 663 (the real positional).
-        # Current behavior: captures 999 (the embedded substring).
-        assert _capture(cmd) == "663"
-
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Limitation 2: Python `\\b` IS a word boundary at digit-to-hyphen "
-            "(word char `2` to non-word char `-`). Architect spec assumed \\b "
+            "Python `\\b` IS a word boundary at digit-to-hyphen "
+            "(word char `2` to non-word char `-`). The earlier spec assumed \\b "
             "would reject `7352-tests` as a suffix match; that assumption was "
             "wrong about Python regex semantics. Fix requires `(?![\\w-])` "
             "instead of `\\b`. Tracked for follow-up."

--- a/pact-plugin/tests/test_merge_guard_pre.py
+++ b/pact-plugin/tests/test_merge_guard_pre.py
@@ -51,14 +51,33 @@ def _capture(command: str):
 
 
 # =============================================================================
-# TRUE GAINS — cases broken on main, fixed by #665
+# TRUE GAINS — cases broken on main, fixed by the regex tightening
 # =============================================================================
-# Each test documents the OLD-vs-NEW delta. On main, the regex used the broad
-# `_GH_GLOBAL_FLAGS` for the post-subcommand walk, which greedily consumed
-# tokens past the PR positional and captured the LAST digit reachable.
+# Each test in this class documents the OLD-vs-NEW behavioral delta. On main,
+# the regex used the broad `_GH_GLOBAL_FLAGS` for the post-subcommand walk,
+# which greedily consumed tokens past the PR positional and captured the LAST
+# digit reachable. After tightening to `_GH_FLAG_TOKENS`, each of these cases
+# now captures the real positional PR number.
+#
+# Selection criterion: a test belongs in TrueGains iff source-only revert of
+# the regex tightening commit causes the test to FAIL. Cases that pass on
+# both pre-fix and post-fix source belong in NoRegressionCanaries (sibling
+# class below) instead.
+#
+# Counter-test cardinality: source-only revert of the regex tightening
+# (`git checkout <pre-fix-sha> -- pact-plugin/hooks/merge_guard_pre.py`)
+# causes ALL 4 tests in this class to FAIL with the regex capturing the
+# wrong digit. Empirically verified during PR #697 review.
 
 class TestGH_PR_NumberRE_TrueGains:
-    """The behavioral delta that resolves #665."""
+    """Cases broken on main, fixed by the regex tightening.
+
+    Each test fails on source-only revert of the fix commit. This is the
+    discriminating criterion: TRUE GAINS cause failures when the fix is
+    reverted. Compare with `TestGH_PR_NumberRE_NoRegressionCanaries`
+    (sibling class) where the cases pass on both pre-fix and post-fix
+    source — those are no-op protection canaries, not behavioral deltas.
+    """
 
     def test_subject_with_version_digits_captures_pr(self):
         # OLD captured "7352" (last digit in subject string).
@@ -87,32 +106,59 @@ class TestGH_PR_NumberRE_TrueGains:
         cmd = "gh pr merge 663 with 7352 tests passing"
         assert _capture(cmd) == "663"
 
+
+# =============================================================================
+# NO-REGRESSION CANARIES — cases unchanged by the fix; pinned as protection
+# =============================================================================
+# These tests pass on BOTH pre-fix and post-fix source. They do not demonstrate
+# behavioral gain from the fix; instead they pin currently-correct behavior so
+# a future regex change cannot silently regress these working cases.
+#
+# Selection criterion: a test belongs in NoRegressionCanaries iff source-only
+# revert of the regex tightening commit leaves the test PASSING. The fix is
+# orthogonal to these inputs.
+#
+# Counter-test cardinality: source-only revert of the regex tightening leaves
+# ALL 5 tests in this class PASSING. Empirically verified during PR #697
+# review. If a future regression causes any of these to fail under the
+# current source, the canary fires loudly.
+
+class TestGH_PR_NumberRE_NoRegressionCanaries:
+    """Cases unchanged by the fix — pinned as future-regression tripwires.
+
+    Distinct from `TestGH_PR_NumberRE_TrueGains` (sibling class above)
+    where source-only revert of the fix causes failure: these cases pass
+    regardless of whether the fix is in place. Their value is forward-
+    looking — a future "cleanup" or refactor of the regex that broke any
+    of these inputs would be caught by the canary firing.
+    """
+
     def test_body_file_with_versioned_path(self):
-        # Regression-protection only: empirical probe shows OLD ALSO captured
-        # "663" here (the path's slashes/hyphens are non-word and `\S+\s+`
-        # requires whitespace separation, so the broad walk consumes the path
-        # and backtracks to the positional). Pinned as a no-op canary so a
-        # future regex change cannot regress this case to capturing "7352".
+        # Empirical probe: OLD captured "663" here (the path's slashes/
+        # hyphens are non-word and `\S+\s+` requires whitespace separation,
+        # so the broad walk consumes the path and backtracks to the
+        # positional). Pinned as a no-op canary so a future regex change
+        # cannot regress this case to capturing "7352".
         cmd = "gh pr merge 663 --body-file /tmp/release-notes-v4.1.7-7352.md --squash"
         assert _capture(cmd) == "663"
 
     def test_simple_squash_unaffected(self):
-        # No regression: simple case still works.
+        # Simple case: no flags between subcommand and PR positional.
         cmd = "gh pr merge 663 --squash"
         assert _capture(cmd) == "663"
 
     def test_pre_subcommand_flag_unaffected(self):
-        # No regression: --admin between merge subcommand and PR number.
+        # `--admin` between merge subcommand and PR number.
         cmd = "gh pr merge --admin 663 --squash"
         assert _capture(cmd) == "663"
 
     def test_global_flag_before_subcommand_unaffected(self):
-        # No regression: --repo owner/repo as a gh global flag.
+        # `--repo owner/repo` as a gh global flag (pre-subcommand).
         cmd = "gh --repo owner/repo pr merge 663 --squash"
         assert _capture(cmd) == "663"
 
     def test_close_with_delete_branch_captures_pr(self):
-        # No regression: gh pr close form with --delete-branch.
+        # `gh pr close` form with `--delete-branch` (sibling subcommand).
         cmd = "gh pr close 663 --delete-branch"
         assert _capture(cmd) == "663"
 

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -694,3 +694,92 @@ def test_main_no_op_on_malformed_stdin(capsys):
     assert exc.value.code == 0
     out = capsys.readouterr().out.strip()
     assert json.loads(out) == {"suppressOutput": True}
+
+
+# =============================================================================
+# Defensive fallback: `tool_response or tool_output or {}`
+# =============================================================================
+#
+# evaluate_lifecycle reads the post-state task via:
+#     tool_response = input_data.get("tool_response") or input_data.get("tool_output") or {}
+#
+# The `or tool_output` fallback covers (a) legacy/captured-from-production
+# fixtures whose envelope predates the canonical `tool_response` rename,
+# and (b) any future platform envelope rename. The 4-line comment in
+# task_lifecycle_gate.py documents the intent; this test enforces it.
+#
+# If a future "cleanup" PR removes the `or tool_output` branch, the
+# test_legacy_envelope_extracts_via_fallback case fails — which is the
+# enforcement-mechanism prose alone cannot provide.
+
+
+def test_legacy_envelope_extracts_via_fallback():
+    """Legacy `tool_output` envelope (no `tool_response`) → handoff_missing fires.
+
+    Constructs a payload with NO `tool_response` field and the task data
+    under `tool_output` (the pre-rename envelope shape). evaluate_lifecycle
+    must extract the task via the `or tool_output` fallback; the
+    handoff_missing rule then fires because the work task carries no
+    metadata.handoff.
+
+    A regression that strips the `or tool_output` branch causes
+    tool_response to resolve to {}, task.get("subject") to be empty, and
+    handoff_missing to NOT fire (the rule is gated on subject + owner
+    being a pact-* work task) — which would leak past this assertion.
+    """
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": "1", "status": "completed"},
+        # Legacy envelope shape — pre-rename. NO `tool_response` key.
+        "tool_output": {
+            "task": {
+                "id": "1",
+                "subject": "pact-backend-coder: implement foo",
+                "owner": "pact-backend-coder",
+                "metadata": {},
+            }
+        },
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert any(rule == "handoff_missing" for rule, _ in advisories), (
+        f"expected handoff_missing via tool_output fallback, got: {advisories}"
+    )
+
+
+def test_canonical_tool_response_takes_precedence_over_legacy():
+    """Both `tool_response` and `tool_output` present → canonical wins.
+
+    The `or` short-circuits: when `tool_response` is a truthy dict, the
+    fallback is never consulted. This pins the precedence so a refactor
+    that swapped the operands (e.g., to `tool_output or tool_response`)
+    would silently make legacy data shadow canonical data — caught here
+    by injecting DIFFERENT subjects in each envelope and asserting the
+    advisory reflects the canonical one.
+    """
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": "1", "status": "completed"},
+        # Canonical envelope: pact-* work task, no handoff → handoff_missing fires.
+        "tool_response": {
+            "task": {
+                "id": "1",
+                "subject": "pact-backend-coder: implement canonical",
+                "owner": "pact-backend-coder",
+                "metadata": {},
+            }
+        },
+        # Legacy envelope: non-pact owner → handoff_missing would NOT fire if read.
+        "tool_output": {
+            "task": {
+                "id": "1",
+                "subject": "user: random task",
+                "owner": "user",
+                "metadata": {},
+            }
+        },
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    # Canonical was read → backend-coder pact-* work task → handoff_missing fires.
+    assert any(rule == "handoff_missing" for rule, _ in advisories), (
+        "canonical tool_response must take precedence over legacy tool_output"
+    )

--- a/pact-plugin/tests/test_tool_response.py
+++ b/pact-plugin/tests/test_tool_response.py
@@ -1,0 +1,135 @@
+"""Tests for shared.tool_response.extract_tool_response — SSOT helper.
+
+Pins the helper's three behavioral contracts:
+
+1. Canonical-prefer: when `tool_response` is present, return it.
+2. Legacy-fallback: when only `tool_output` is present, return it.
+3. Dual-envelope warning: when BOTH are present, warn to stderr and
+   return the canonical `tool_response` value (not legacy).
+
+Also pins defensive shapes (non-dict input, non-dict field values, empty
+fields, missing fields).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+from shared.tool_response import extract_tool_response  # noqa: E402
+
+
+# =============================================================================
+# Canonical-prefer behavior
+# =============================================================================
+
+
+def test_canonical_tool_response_returned_when_present():
+    payload = {"tool_response": {"task": {"id": "1"}}}
+    assert extract_tool_response(payload) == {"task": {"id": "1"}}
+
+
+def test_canonical_returned_even_when_legacy_missing():
+    payload = {"tool_response": {"status": "completed"}}
+    assert extract_tool_response(payload) == {"status": "completed"}
+
+
+# =============================================================================
+# Legacy-fallback behavior
+# =============================================================================
+
+
+def test_legacy_tool_output_returned_when_canonical_missing():
+    payload = {"tool_output": {"task": {"id": "1"}}}
+    assert extract_tool_response(payload) == {"task": {"id": "1"}}
+
+
+def test_legacy_returned_when_canonical_is_empty():
+    # `or` short-circuits on falsy — empty dict triggers fallback to legacy.
+    payload = {"tool_response": {}, "tool_output": {"id": "from_legacy"}}
+    # NOTE: empty dict is falsy → legacy wins. Document this so a future
+    # refactor that uses `is not None` instead of `or` would change the
+    # contract and break this test.
+    assert extract_tool_response(payload) == {"id": "from_legacy"}
+
+
+# =============================================================================
+# Dual-envelope warning
+# =============================================================================
+
+
+def test_dual_envelope_warns_to_stderr(capsys):
+    """Both fields present and truthy → SECURITY warning + canonical wins.
+
+    Pins the envelope-confusion-attack defense: no legitimate platform
+    fire emits both fields; a same-payload pair is categorically
+    suspicious. Helper emits a stderr warning and returns canonical.
+    """
+    payload = {
+        "tool_response": {"id": "from_canonical"},
+        "tool_output": {"id": "from_legacy"},
+    }
+    result = extract_tool_response(payload)
+    assert result == {"id": "from_canonical"}, "canonical must win the precedence"
+
+    captured = capsys.readouterr()
+    assert "[security]" in captured.err
+    assert "dual-envelope" in captured.err
+    assert "envelope-confusion" in captured.err
+    assert "tool_response" in captured.err  # warns it's using canonical
+
+
+def test_dual_envelope_no_warn_when_canonical_is_empty(capsys):
+    """Empty canonical + present legacy → fallback fires, no warning.
+
+    Empty dict is falsy → not a dual-envelope race. The warning fires
+    only when BOTH are truthy (which is the actual confusion shape).
+    """
+    payload = {"tool_response": {}, "tool_output": {"id": "1"}}
+    result = extract_tool_response(payload)
+    assert result == {"id": "1"}
+    captured = capsys.readouterr()
+    assert captured.err == "", "no warning when canonical is empty"
+
+
+# =============================================================================
+# Defensive shapes
+# =============================================================================
+
+
+def test_neither_field_present_returns_empty_dict():
+    assert extract_tool_response({}) == {}
+    assert extract_tool_response({"tool_input": {"foo": "bar"}}) == {}
+
+
+def test_non_dict_input_returns_empty_dict():
+    assert extract_tool_response(None) == {}
+    assert extract_tool_response("string") == {}
+    assert extract_tool_response(42) == {}
+    assert extract_tool_response([]) == {}
+
+
+def test_non_dict_field_values_return_empty_dict():
+    """Field present but non-dict → return {} rather than propagate the bad value."""
+    assert extract_tool_response({"tool_response": "not a dict"}) == {}
+    assert extract_tool_response({"tool_response": 42}) == {}
+    assert extract_tool_response({"tool_response": ["list"]}) == {}
+    assert extract_tool_response({"tool_output": "not a dict"}) == {}
+
+
+def test_canonical_takes_precedence_when_present_and_truthy(capsys):
+    """Re-pin the precedence semantics from a different angle.
+
+    A refactor that flipped the operands (`tool_output or tool_response`)
+    would silently make legacy data shadow canonical data — caught here
+    with strict equality on canonical's payload.
+    """
+    payload = {
+        "tool_response": {"canonical_marker": True},
+        "tool_output": {"legacy_marker": True},
+    }
+    result = extract_tool_response(payload)
+    assert "canonical_marker" in result
+    assert "legacy_marker" not in result


### PR DESCRIPTION
## Summary

PR #1 of #677 umbrella — fixes the merge guard end-to-end. Closes #665, #676, #700, #701, #702.

The merge-guard mechanism had two distinct bugs preventing it from working as designed:
- **#665**: `merge_guard_pre._GH_PR_NUMBER_RE` greedy-quantifier picked the wrong PR number from heredoc-style `--body` arguments
- **#676**: `merge_guard_post.py` read stdin field `tool_output` while Claude Code sends `tool_response`. Authorization tokens were never written automatically by the post-hook

Plus 4 cycles of peer-review-driven hardening: cycle-1 closed authorization-bypass classes surfaced by adversarial security review (F-5, F-7); cycle-2 closed 3 pre-existing authorization-model bypasses (F-2, F-3, F-4 Option A) per defense-in-depth argument (post-PR the merge guard works for the first time, exposing these as operationally exploitable).

## Commits (13)

1. `b74ec540` — fix(merge_guard_post): rename tool_output to tool_response (3 files: merge_guard_post.py + 66 fixture renames + 6 cause-of-no-token assertions)
2. `d771af27` — fix(hooks): sweep tool_output docstring drift across PostToolUse hooks (4 sibling hooks)
3. `14379853` — fix(task_lifecycle_gate): document tool_output defensive fallback (4-line comment above L321)
4. `73410afb` — fix(merge_guard_pre): tighten PR-number regex to skip flag-shaped tokens only
5. `b551c951` — chore: bump plugin version to 4.1.8 (4-file dance)
6. `a0977c95` — docs(test_merge_guard_pre): correct phantom-green docstring
7. `680b74b3` — test(task_lifecycle_gate): add defensive-fallback tests for tool_output legacy envelope
8. `04e63dd1` — fix(merge_guard_pre): tighten _GH_PR_NUMBER_RE to use _GH_FLAG_TOKENS for BOTH flag-walks (closes F-5 authorization-bypass)
9. `e6ae33ee` — refactor(hooks): extract shared _extract_tool_response helper with dual-envelope warning (closes BC-M1 + S2)
10. `33c927d2` — docs(README): rewrite dispatch-matcher row using behavioral names (closes S3)
11. `d188e1af` — test(merge_guard_pre): convert second xfail to passing test + update module docstring (closes F-7 + xfail #2)
12. `c017710d` — refactor(test_merge_guard_pre): split TrueGains class by counter-test cardinality (closes architect-2 M1 + test-engineer-2 F2)
13. `e1ba7ea0` — fix(merge_guard): close F-2 + F-3 + F-4 pre-existing authorization-model bypasses (closes #700, #701, #702)

## What was deferred

**Phase B planning-artifacts check** was originally folded into this PR but deferred mid-flight to follow-up issue **#696**. The Path-1 "extend exclusion lists" approach surfaced an unbounded bootstrap cascade. Proper bootstrap-aware design (likely git-diff-scoped scanning or AST-level detection) needs to land before that work can ship cleanly.

## Security findings — final status

**ADDRESSED IN PR (closed by cycle-1 + cycle-2)**:
- F-5 MEDIUM (heredoc bypass) → CLOSED in C9
- F-7 LOW (boundary semantics) → CLOSED in C9/C12
- S2 MINOR (dual-envelope tolerance) → CLOSED in C10
- S3 MINOR (README F-row refs) → CLOSED in C11
- F-2 HIGH (sparse-context wildcard tokens) → CLOSED in e1ba7ea0 (#700)
- F-3 HIGH (compound-command bypass) → CLOSED in e1ba7ea0 (#701) — was IMPROVED-but-RESIDUAL post-cycle-1, now FULLY CLOSED structurally
- F-4 MEDIUM (eval+heredoc strip-pipeline ordering) → CLOSED in e1ba7ea0 (#702)

**REMAINING DEFERRED (filed as follow-up)**:
- **#699** F-1 HIGH (cross-operation token-class mismatch) — cycle-2 fixed WRITE side (extract_context recognizes force-push/branch-delete) but NOT READ side (_detect_command_operation_type still returns None). Symmetric closure requires the matching _detect change. Token format extension is the recommended approach. Should be next merge-guard-hardening PR.
- **#703** F-8 LOW (defense-in-depth gaps inventory) — TRACKING issue, 5 sub-gaps (TTL, actor binding, HMAC, audit log, rate limiting)

## Behavioral-change comms (operator-impact)

- The merge guard NOW works as designed — `gh pr merge` after `AskUserQuestion` + "Yes, merge" succeeds without manual intervention. Operators with muscle memory of "manually `touch ~/.claude/merge-authorized-{ts}` to bypass the broken post-hook" will hit unexpected denials.
- **NEW: compound destructive commands cannot be authorized atomically.** `gh pr merge 999 | tee log.txt`, `echo done && gh pr merge 999`, etc. are now denied. Run each destructive operation separately with its own AskUserQuestion approval.
- **NEW: eval+heredoc combinations are denied** as a security defense (eval $(... <<HEREDOC...HEREDOC) and backtick variants). Acceptable false-positive surface for legitimate eval+heredoc workflows; rare in operator command flows.
- **Schema change**: token contexts now use canonical `{operation_type, pr_number}` field names (was: ad-hoc `{op, pr}` mix). 30+ existing test fixtures rebased to canonical schema.
- The CLAUDE.md `#665` and `#676` workaround pins document approaches that no longer apply post-merge — orchestrator will retire them in wrap-up phase.

## Test results

- **7589 passed**, 10 skipped, **0 xfailed** (was 7561 + 2 xfailed pre-cycle-1; both KnownLimitations resolved in cycle-1 + 15 new tests added in cycle-2)

## Test coverage

Per architect's commit sequence, comprehensive tests were bundled with each fix commit (an architect-spec deviation that the orchestrator caught mid-flight + course-corrected via test-engineer dispatch for retro review). Test-engineer audit confirmed ZERO load-bearing coverage gaps; cycle-2 added 15 more tests with full counter-test-by-revert verification.

## Known limitations: NONE

All 14 tests in test_merge_guard_pre.py now pass; 0 xfails remain.

Closes #665, #676, #700, #701, #702. Refs #677. Filed during review: #696 (deferred Phase B), #698 (test-strategy planning gap), #699 (F-1 deferred), #703 (F-8 inventory).
