### PR TITLE
feat: exempt pact-secretary from teachback-gated dispatch (#716)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.1.8",
+      "version": "4.1.9",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.1.8/     # Plugin version
+│               └── 4.1.9/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.1.8",
+  "version": "4.1.9",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.1.8
+> **Version**: 4.1.9
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/agents/pact-orchestrator.md
+++ b/pact-plugin/agents/pact-orchestrator.md
@@ -367,7 +367,7 @@ For full detail, `Read(file_path="../protocols/pact-variety.md")` when calibrati
 
 Every specialist dispatch is a Task A (TEACHBACK) + Task B (primary work, `blockedBy=[A]`) pair. Both tasks must exist with the teammate as owner BEFORE the `Agent()` spawn. The mission lives in Task B's `description`, never in the spawn prompt.
 
-**Exemption**: teammates whose `agentType` is in `TEACHBACK_EXEMPT_AGENT_TYPES` (`shared/intentional_wait.py`) dispatch via Task B only — currently `pact-secretary`. The secretary's task-system work is rote and skill-defined (session briefing at spawn, HANDOFF harvest at fixed workflow boundaries, memory saves); no teachback round-trip. Resolution via team-config `member.agentType` lookup — `is_teachback_exempt(owner, team_name)` in `shared/intentional_wait.py`. The exemption is permissive: a team-lead may still dispatch with a teachback gate if the work is genuinely novel.
+**Exemption**: teammates whose `agentType` is in `TEACHBACK_EXEMPT_AGENT_TYPES` (`shared/intentional_wait.py`) dispatch via Task B only — currently `pact-secretary`. The secretary's tasks are rote and skill-defined (session briefing, HANDOFF harvest, memory saves); no teachback round-trip. The exemption is permissive: a team-lead may still dispatch with a teachback gate if the work is genuinely novel.
 
 For non-exempt teammates (everyone except `pact-secretary`):
 

--- a/pact-plugin/agents/pact-orchestrator.md
+++ b/pact-plugin/agents/pact-orchestrator.md
@@ -367,6 +367,10 @@ For full detail, `Read(file_path="../protocols/pact-variety.md")` when calibrati
 
 Every specialist dispatch is a Task A (TEACHBACK) + Task B (primary work, `blockedBy=[A]`) pair. Both tasks must exist with the teammate as owner BEFORE the `Agent()` spawn. The mission lives in Task B's `description`, never in the spawn prompt.
 
+**Exemption**: teammates whose `agentType` is in `TEACHBACK_EXEMPT_AGENT_TYPES` (`shared/intentional_wait.py`) dispatch via Task B only — currently `pact-secretary`. The secretary's task-system work is rote and skill-defined (session briefing at spawn, HANDOFF harvest at fixed workflow boundaries, memory saves); no teachback round-trip. Resolution via team-config `member.agentType` lookup — `is_teachback_exempt(owner, team_name)` in `shared/intentional_wait.py`. The exemption is permissive: a team-lead may still dispatch with a teachback gate if the work is genuinely novel.
+
+For non-exempt teammates (everyone except `pact-secretary`):
+
 1. `TaskCreate(subject="{name}: TEACHBACK for {topic}", description="<teachback gate brief; cross-ref to Task B for the mission>")` — create Task A (teachback gate).
 2. `TaskCreate(subject="{name}: {primary work subject}", description="<full mission: CONTEXT / MISSION / INSTRUCTIONS / GUIDELINES per §13 Recommended Agent Prompting Structure>")` — create Task B (primary work).
 3. `TaskUpdate(A_id, owner="{name}", addBlocks=[B_id])` — assign Task A to the teammate and wire it as the gate that unblocks Task B.

--- a/pact-plugin/agents/pact-orchestrator.md
+++ b/pact-plugin/agents/pact-orchestrator.md
@@ -367,7 +367,7 @@ For full detail, `Read(file_path="../protocols/pact-variety.md")` when calibrati
 
 Every specialist dispatch is a Task A (TEACHBACK) + Task B (primary work, `blockedBy=[A]`) pair. Both tasks must exist with the teammate as owner BEFORE the `Agent()` spawn. The mission lives in Task B's `description`, never in the spawn prompt.
 
-**Exemption**: teammates whose `agentType` is in `TEACHBACK_EXEMPT_AGENT_TYPES` (`shared/intentional_wait.py`) dispatch via Task B only — currently `pact-secretary`. The secretary's tasks are mostly skill-defined (session briefing, HANDOFF harvest, memory saves); no teachback needed. The exemption is permissive: a team-lead may still dispatch with a teachback gate if the work is genuinely novel.
+**Exemption**: teammates whose `agentType` is in `TEACHBACK_EXEMPT_AGENT_TYPES` (`shared/intentional_wait.py`) dispatch via Task B only — currently `pact-secretary`. The secretary's tasks are usually skill-defined (session briefing, HANDOFF harvest, memory saves); no teachback needed. The exemption is permissive: a team-lead may still dispatch with a teachback gate if the work is genuinely novel.
 
 For non-exempt teammates (everyone except `pact-secretary`):
 

--- a/pact-plugin/agents/pact-orchestrator.md
+++ b/pact-plugin/agents/pact-orchestrator.md
@@ -367,7 +367,7 @@ For full detail, `Read(file_path="../protocols/pact-variety.md")` when calibrati
 
 Every specialist dispatch is a Task A (TEACHBACK) + Task B (primary work, `blockedBy=[A]`) pair. Both tasks must exist with the teammate as owner BEFORE the `Agent()` spawn. The mission lives in Task B's `description`, never in the spawn prompt.
 
-**Exemption**: teammates whose `agentType` is in `TEACHBACK_EXEMPT_AGENT_TYPES` (`shared/intentional_wait.py`) dispatch via Task B only — currently `pact-secretary`. The secretary's tasks are rote and skill-defined (session briefing, HANDOFF harvest, memory saves); no teachback round-trip. The exemption is permissive: a team-lead may still dispatch with a teachback gate if the work is genuinely novel.
+**Exemption**: teammates whose `agentType` is in `TEACHBACK_EXEMPT_AGENT_TYPES` (`shared/intentional_wait.py`) dispatch via Task B only — currently `pact-secretary`. The secretary's tasks are mostly skill-defined (session briefing, HANDOFF harvest, memory saves); no teachback needed. The exemption is permissive: a team-lead may still dispatch with a teachback gate if the work is genuinely novel.
 
 For non-exempt teammates (everyone except `pact-secretary`):
 

--- a/pact-plugin/agents/pact-secretary.md
+++ b/pact-plugin/agents/pact-secretary.md
@@ -208,6 +208,16 @@ When the team-lead sends a consolidation request (typically during `/PACT:wrap-u
 
 # COMMUNICATION PROTOCOL
 
+## Dispatch Shape (teachback exemption)
+
+You are exempt from the teachback-gated dispatch pattern. The team-lead dispatches you with a single work task (no Task A teachback). The carve-out is encoded as `pact-secretary` in `TEACHBACK_EXEMPT_AGENT_TYPES` (`shared/intentional_wait.py`) and resolved via team-config lookup on `member.agentType` — so the carve-out attaches to your agentType, not your spawn name. A spawn under `secretary`, `session-secretary`, or any other name still reaches the carve-out as long as the team config records your `agentType`.
+
+When you receive a dispatch:
+- **No Task A (teachback)**: proceed directly to claiming the work task and executing.
+- **If a team-lead does dispatch you with a teachback gate anyway**: honor it. The exemption is permissive, not prohibitive — the lead may genuinely want a teachback for novel work.
+
+Predicate: `is_teachback_exempt(owner, team_name)` in `shared/intentional_wait.py`. Parallel structure to the self-completion carve-out below (and to `WAKE_EXCLUDED_AGENT_TYPES` in the same module).
+
 ## Task Completion Signal (memory-save self-complete carve-out)
 
 You are exempt from the team-lead-only-completion rule for memory-save tasks. The team-lead has no acceptance criteria for memory bookkeeping — judging memory-save quality is your domain. The carve-out is encoded as `pact-secretary` in `SELF_COMPLETE_EXEMPT_AGENT_TYPES` (`shared/intentional_wait.py`) and resolved via team-config lookup on `member.agentType` — so the carve-out attaches to your agentType, not your spawn name. The canonical spawn name is `secretary` (used by `bootstrap_marker_writer` and the housekeeping dispatch sites' `TaskUpdate(owner="secretary")` literal); a spawn under any other name still reaches the carve-out as long as the team config records your `agentType`. See [pact-completion-authority.md](../protocols/pact-completion-authority.md).

--- a/pact-plugin/agents/pact-secretary.md
+++ b/pact-plugin/agents/pact-secretary.md
@@ -210,17 +210,15 @@ When the team-lead sends a consolidation request (typically during `/PACT:wrap-u
 
 ## Dispatch Shape (teachback exemption)
 
-You are exempt from the teachback-gated dispatch pattern. The team-lead dispatches you with a single work task (no Task A teachback). The carve-out is encoded as `pact-secretary` in `TEACHBACK_EXEMPT_AGENT_TYPES` (`shared/intentional_wait.py`) and resolved via team-config lookup on `member.agentType` — so the carve-out attaches to your agentType, not your spawn name. A spawn under `secretary`, `session-secretary`, or any other name still reaches the carve-out as long as the team config records your `agentType`.
+You are exempt from the teachback-gated dispatch pattern. The team-lead dispatches you with a single work task (no Task A teachback).
 
 When you receive a dispatch:
 - **No Task A (teachback)**: proceed directly to claiming the work task and executing.
 - **If a team-lead does dispatch you with a teachback gate anyway**: honor it. The exemption is permissive, not prohibitive — the lead may genuinely want a teachback for novel work.
 
-Predicate: `is_teachback_exempt(owner, team_name)` in `shared/intentional_wait.py`. Parallel structure to the self-completion carve-out below (and to `WAKE_EXCLUDED_AGENT_TYPES` in the same module).
-
 ## Task Completion Signal (memory-save self-complete carve-out)
 
-You are exempt from the team-lead-only-completion rule for memory-save tasks. The team-lead has no acceptance criteria for memory bookkeeping — judging memory-save quality is your domain. The carve-out is encoded as `pact-secretary` in `SELF_COMPLETE_EXEMPT_AGENT_TYPES` (`shared/intentional_wait.py`) and resolved via team-config lookup on `member.agentType` — so the carve-out attaches to your agentType, not your spawn name. The canonical spawn name is `secretary` (used by `bootstrap_marker_writer` and the housekeeping dispatch sites' `TaskUpdate(owner="secretary")` literal); a spawn under any other name still reaches the carve-out as long as the team config records your `agentType`. See [pact-completion-authority.md](../protocols/pact-completion-authority.md).
+You are exempt from the team-lead-only-completion rule for memory-save tasks. The team-lead has no acceptance criteria for memory bookkeeping — judging memory-save quality is your domain. See [pact-completion-authority.md](../protocols/pact-completion-authority.md).
 
 > Memory-save self-complete bypasses the team-lead inspection window by design — judging memory-save quality is the secretary's domain (per pact-completion-authority.md carve-out rationale).
 

--- a/pact-plugin/commands/bootstrap.md
+++ b/pact-plugin/commands/bootstrap.md
@@ -17,13 +17,11 @@ Read `team_name` from the **Current Session** block in the project's `CLAUDE.md`
 
 ## Step 2 — Spawn `pact-secretary`
 
-Spawn the session secretary using the Teachback-Gated Dispatch below (See persona §Agent Teams Dispatch for the canonical pattern applied to other dispatches):
+Spawn the session secretary using single-task dispatch — the `pact-secretary` agentType is exempt from the teachback gate via `TEACHBACK_EXEMPT_AGENT_TYPES` (`shared/intentional_wait.py`). No Task A teachback round-trip; the secretary's work is rote and skill-defined (session briefing at spawn, HANDOFF harvest at workflow boundaries per pact-handoff-harvest skill, memory queries via SendMessage).
 
-1. `TaskCreate(subject="secretary: TEACHBACK for session briefing", description="<teachback gate brief; cross-ref to Task B for the mission>")` — Task A
-2. `TaskCreate(subject="secretary: Session briefing + HANDOFF readiness", description="<full mission: deliver session briefing on spawn, answer memory queries during the session, process HANDOFFs at workflow boundaries; CONTEXT / MISSION / INSTRUCTIONS / GUIDELINES per the orchestrator persona §13 Recommended Agent Prompting Structure>")` — Task B
-3. `TaskUpdate(A_id, owner="secretary", addBlocks=[B_id])`
-4. `TaskUpdate(B_id, owner="secretary", addBlockedBy=[A_id])`
-5. `Agent(name="secretary", team_name="{team_name}", subagent_type="pact-secretary", prompt="YOUR PACT ROLE: teammate (secretary).\n\nYou are joining team {team_name}. Check `TaskList` for tasks assigned to you.")`
+1. `TaskCreate(subject="secretary: Session briefing + HANDOFF readiness", description="<full mission: deliver session briefing on spawn, answer memory queries during the session, process HANDOFFs at workflow boundaries; CONTEXT / MISSION / INSTRUCTIONS / GUIDELINES per the orchestrator persona §13 Recommended Agent Prompting Structure>")` — single work task
+2. `TaskUpdate(task_id, owner="secretary")` — assign to the secretary; no `addBlockedBy` (no teachback gate)
+3. `Agent(name="secretary", team_name="{team_name}", subagent_type="pact-secretary", prompt="YOUR PACT ROLE: teammate (secretary).\n\nYou are joining team {team_name}. Check `TaskList` for tasks assigned to you.")`
     - **Use `subagent_type="pact-secretary"` and the canonical `name="secretary"` — the literal name is load-bearing**.
 
 The secretary delivers the session briefing at spawn, answers memory queries during the session, and processes HANDOFFs at workflow boundaries. Memory queries from any other agent are blocked until the secretary is alive.

--- a/pact-plugin/commands/bootstrap.md
+++ b/pact-plugin/commands/bootstrap.md
@@ -17,7 +17,7 @@ Read `team_name` from the **Current Session** block in the project's `CLAUDE.md`
 
 ## Step 2 — Spawn `pact-secretary`
 
-Spawn the session secretary using single-task dispatch — the `pact-secretary` agentType is exempt from the teachback gate via `TEACHBACK_EXEMPT_AGENT_TYPES` (`shared/intentional_wait.py`). No Task A teachback round-trip; the secretary's work is rote and skill-defined (session briefing at spawn, HANDOFF harvest at workflow boundaries per pact-handoff-harvest skill, memory queries via SendMessage).
+Spawn the session secretary using single-task dispatch — the `pact-secretary` agentType is exempt from the teachback gate. No Task A teachback round-trip.
 
 1. `TaskCreate(subject="secretary: Session briefing + HANDOFF readiness", description="<full mission: deliver session briefing on spawn, answer memory queries during the session, process HANDOFFs at workflow boundaries; CONTEXT / MISSION / INSTRUCTIONS / GUIDELINES per the orchestrator persona §13 Recommended Agent Prompting Structure>")` — single work task
 2. `TaskUpdate(task_id, owner="secretary")` — assign to the secretary; no `addBlockedBy` (no teachback gate)

--- a/pact-plugin/commands/comPACT.md
+++ b/pact-plugin/commands/comPACT.md
@@ -198,7 +198,7 @@ The `Agent()` `prompt` does NOT change shape — the Teachback-Gated Dispatch is
 **Carve-outs** — single-task dispatch still applies for:
 
 - **Auditor signal-tasks** (`metadata.completion_type="signal"`): no TEACHBACK, no Task B; self-completes tasks.
-- **Secretary** (`member.agentType="pact-secretary"`): no TEACHBACK (single-task dispatch); can self-complete memory-save tasks. Resolves on agentType, not spawn name.
+- **Secretary** (`member.agentType="pact-secretary"`): no TEACHBACK (single-task dispatch); self-completes memory-save tasks.
 
 ---
 

--- a/pact-plugin/commands/comPACT.md
+++ b/pact-plugin/commands/comPACT.md
@@ -197,7 +197,7 @@ The `Agent()` `prompt` does NOT change shape — the Teachback-Gated Dispatch is
 
 **Carve-outs** — single-task dispatch still applies for:
 
-- **Auditor signal-tasks** (`metadata.completion_type="signal"`): no TEACHBACK, no Task B.
+- **Auditor signal-tasks** (`metadata.completion_type="signal"`): no TEACHBACK, no Task B; self-completes tasks.
 - **Secretary** (`member.agentType="pact-secretary"`): no TEACHBACK (single-task dispatch); can self-complete memory-save tasks. Resolves on agentType, not spawn name.
 
 ---

--- a/pact-plugin/commands/comPACT.md
+++ b/pact-plugin/commands/comPACT.md
@@ -198,7 +198,7 @@ The `Agent()` `prompt` does NOT change shape — the Teachback-Gated Dispatch is
 **Carve-outs** — single-task dispatch still applies for:
 
 - **Auditor signal-tasks** (`metadata.completion_type="signal"`): no TEACHBACK, no Task B.
-- **Secretary memory-save tasks**: secretary self-completes via the team-config-keyed `SELF_COMPLETE_EXEMPT_AGENT_TYPES` set in `shared/intentional_wait.py` (resolved on `member.agentType`, so the carve-out applies regardless of spawn name).
+- **Secretary dispatches**: owner's team-config `agentType` ∈ `TEACHBACK_EXEMPT_AGENT_TYPES` (`shared/intentional_wait.py`) — predicate `is_teachback_exempt(owner, team_name)` suppresses the Task A teachback gate. Completion-side companion: secretary self-completes memory-save tasks via `SELF_COMPLETE_EXEMPT_AGENT_TYPES` and `is_self_complete_exempt(task, team_name)`. Both resolve via team-config `member.agentType`, so the carve-outs apply regardless of spawn name.
 
 ---
 

--- a/pact-plugin/commands/comPACT.md
+++ b/pact-plugin/commands/comPACT.md
@@ -198,7 +198,7 @@ The `Agent()` `prompt` does NOT change shape — the Teachback-Gated Dispatch is
 **Carve-outs** — single-task dispatch still applies for:
 
 - **Auditor signal-tasks** (`metadata.completion_type="signal"`): no TEACHBACK, no Task B.
-- **Secretary dispatches**: owner's team-config `agentType` ∈ `TEACHBACK_EXEMPT_AGENT_TYPES` (`shared/intentional_wait.py`) — predicate `is_teachback_exempt(owner, team_name)` suppresses the Task A teachback gate. Completion-side companion: secretary self-completes memory-save tasks via `SELF_COMPLETE_EXEMPT_AGENT_TYPES` and `is_self_complete_exempt(task, team_name)`. Both resolve via team-config `member.agentType`, so the carve-outs apply regardless of spawn name.
+- **Secretary** (`member.agentType="pact-secretary"`): no TEACHBACK (single-task dispatch); can self-complete memory-save tasks. Resolves on agentType, not spawn name.
 
 ---
 

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -103,7 +103,7 @@ The `Agent()` `prompt` does NOT change shape — the Teachback-Gated Dispatch is
 
 **Carve-outs** — single-task dispatch still applies for:
 
-- **Auditor signal-tasks** (`metadata.completion_type="signal"`): no TEACHBACK, no Task B. The auditor IS observing; their task IS the signal.
+- **Auditor signal-tasks** (`metadata.completion_type="signal"`): no TEACHBACK, no Task B; self-completes tasks.
 - **Secretary** (`member.agentType="pact-secretary"`): no TEACHBACK (single-task dispatch); can self-complete memory-save tasks. Resolves on agentType, not spawn name.
 - **imPACT force-termination**: `TaskStop` + team-lead-set `metadata.terminated=true` is its own out-of-band path. See [imPACT.md](imPACT.md).
 

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -104,7 +104,7 @@ The `Agent()` `prompt` does NOT change shape — the Teachback-Gated Dispatch is
 **Carve-outs** — single-task dispatch still applies for:
 
 - **Auditor signal-tasks** (`metadata.completion_type="signal"`): no TEACHBACK, no Task B; self-completes tasks.
-- **Secretary** (`member.agentType="pact-secretary"`): no TEACHBACK (single-task dispatch); can self-complete memory-save tasks. Resolves on agentType, not spawn name.
+- **Secretary** (`member.agentType="pact-secretary"`): no TEACHBACK (single-task dispatch); self-completes memory-save tasks.
 - **imPACT force-termination**: `TaskStop` + team-lead-set `metadata.terminated=true` is its own out-of-band path. See [imPACT.md](imPACT.md).
 
 **Skipped phases**: Mark directly `completed` (no `in_progress` — no work occurs):

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -104,7 +104,7 @@ The `Agent()` `prompt` does NOT change shape — the Teachback-Gated Dispatch is
 **Carve-outs** — single-task dispatch still applies for:
 
 - **Auditor signal-tasks** (`metadata.completion_type="signal"`): no TEACHBACK, no Task B. The auditor IS observing; their task IS the signal.
-- **Secretary dispatches**: owner's team-config `agentType` ∈ `TEACHBACK_EXEMPT_AGENT_TYPES` (`shared/intentional_wait.py`) — predicate `is_teachback_exempt(owner, team_name)` suppresses the Task A teachback gate. Completion-side companion: secretary self-completes memory-save tasks via `SELF_COMPLETE_EXEMPT_AGENT_TYPES` and `is_self_complete_exempt(task, team_name)`. Both resolve via team-config `member.agentType`, so the carve-outs apply regardless of spawn name.
+- **Secretary** (`member.agentType="pact-secretary"`): no TEACHBACK (single-task dispatch); can self-complete memory-save tasks. Resolves on agentType, not spawn name.
 - **imPACT force-termination**: `TaskStop` + team-lead-set `metadata.terminated=true` is its own out-of-band path. See [imPACT.md](imPACT.md).
 
 **Skipped phases**: Mark directly `completed` (no `in_progress` — no work occurs):

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -104,7 +104,7 @@ The `Agent()` `prompt` does NOT change shape — the Teachback-Gated Dispatch is
 **Carve-outs** — single-task dispatch still applies for:
 
 - **Auditor signal-tasks** (`metadata.completion_type="signal"`): no TEACHBACK, no Task B. The auditor IS observing; their task IS the signal.
-- **Secretary memory-save tasks**: secretary self-completes; the standard On Completion flow applies via the team-config-keyed `SELF_COMPLETE_EXEMPT_AGENT_TYPES` set in `shared/intentional_wait.py` (resolved on `member.agentType`, so the carve-out applies regardless of spawn name).
+- **Secretary dispatches**: owner's team-config `agentType` ∈ `TEACHBACK_EXEMPT_AGENT_TYPES` (`shared/intentional_wait.py`) — predicate `is_teachback_exempt(owner, team_name)` suppresses the Task A teachback gate. Completion-side companion: secretary self-completes memory-save tasks via `SELF_COMPLETE_EXEMPT_AGENT_TYPES` and `is_self_complete_exempt(task, team_name)`. Both resolve via team-config `member.agentType`, so the carve-outs apply regardless of spawn name.
 - **imPACT force-termination**: `TaskStop` + team-lead-set `metadata.terminated=true` is its own out-of-band path. See [imPACT.md](imPACT.md).
 
 **Skipped phases**: Mark directly `completed` (no `in_progress` — no work occurs):

--- a/pact-plugin/hooks/shared/intentional_wait.py
+++ b/pact-plugin/hooks/shared/intentional_wait.py
@@ -33,6 +33,11 @@ Public surface:
   lead must receive promptly via wake. Semantically distinct from
   SELF_COMPLETE_EXEMPT_AGENT_TYPES (different consumers ask different
   questions); see constant docstring for the divergence rationale.
+- TEACHBACK_EXEMPT_AGENT_TYPES — agentType tokens whose owners are
+  exempt from the teachback-gated dispatch pattern (no Task A
+  teachback gate; single-task dispatch). Consumed by
+  task_lifecycle_gate.work_addblockedby_missing via is_teachback_exempt.
+  Same team-config agentType lookup as the prior two constants.
 - canonical_since() — ISO-8601 UTC timestamp helper for the `since` field.
 - validate_wait(wait_metadata) — True iff the flag is well-formed.
 - wait_stale(wait_metadata) — True iff the flag has aged past threshold.
@@ -121,6 +126,35 @@ SELF_COMPLETE_EXEMPT_AGENT_TYPES: frozenset = frozenset({
 # window failure the next time SELF_COMPLETE_EXEMPT_AGENT_TYPES gains a
 # member.
 WAKE_EXCLUDED_AGENT_TYPES: frozenset = frozenset()
+
+
+# AgentType tokens whose owners are exempt from the teachback-gated
+# dispatch pattern. Semantically distinct from the two prior surfaces:
+# - SELF_COMPLETE_EXEMPT_AGENT_TYPES answers "may this owner self-complete?"
+# - WAKE_EXCLUDED_AGENT_TYPES answers "should this owner's tasks count toward
+#   the lead's inbox-watch Monitor lifecycle?"
+# - TEACHBACK_EXEMPT_AGENT_TYPES answers "should the team-lead dispatch this
+#   owner via the Task A (teachback) + Task B (work) pair, or skip Task A?"
+#
+# `pact-secretary` is included because the secretary's task-system work
+# is uniformly rote and skill-defined (session briefing at spawn, HANDOFF
+# harvest at fixed workflow boundaries per pact-handoff-harvest skill,
+# memory saves). The teachback round-trip catches no real misunderstanding
+# for these workflows; the ceremony is overhead.
+#
+# Resolution is by team-config agentType lookup (see
+# `_is_teachback_exempt_agent_type` below + `_iter_members` upstream), NOT
+# owner name. A secretary spawned under any name (`session-secretary`,
+# `team-secretary`, etc.) still reaches the carve-out as long as the
+# team-config records its agentType as `pact-secretary`.
+#
+# Future divergence is supported: a hypothetical rote-only agentType
+# joins the set with a one-line change. Three frozensets, three
+# operational surfaces, fully decoupled — DO NOT recouple by aliasing to
+# either of the prior two constants.
+TEACHBACK_EXEMPT_AGENT_TYPES: frozenset = frozenset({
+    "pact-secretary",
+})
 
 
 def _is_exempt_agent_type(

--- a/pact-plugin/hooks/shared/intentional_wait.py
+++ b/pact-plugin/hooks/shared/intentional_wait.py
@@ -44,6 +44,9 @@ Public surface:
 - is_self_complete_exempt(task, team_name="", teams_dir=None) — True iff
   the task is exempt from the team-lead-only-completion rule (by
   team-config-resolved agentType, or signal-task pattern).
+- is_teachback_exempt(owner, team_name="", teams_dir=None) — True iff
+  the owner's team-config agentType is in TEACHBACK_EXEMPT_AGENT_TYPES.
+  Consumed by task_lifecycle_gate.work_addblockedby_missing.
 """
 
 from datetime import datetime, timezone
@@ -248,6 +251,77 @@ def _is_wake_excluded_agent_type(
                 and agent_type in WAKE_EXCLUDED_AGENT_TYPES
             )
     return False
+
+
+def _is_teachback_exempt_agent_type(
+    owner: str,
+    team_name: str,
+    teams_dir: str | None = None,
+) -> bool:
+    """Return True iff the team-config member matching `owner` has an
+    agentType in TEACHBACK_EXEMPT_AGENT_TYPES.
+
+    Parallel to `_is_exempt_agent_type` and `_is_wake_excluded_agent_type`
+    but keyed on a different constant so the dispatch-exemption policy
+    can diverge from the self-completion and wake-counting policies
+    without coupling. See the TEACHBACK_EXEMPT_AGENT_TYPES constant
+    docstring for the semantic distinction.
+
+    Same fail-closed semantics as the sibling predicates: returns False
+    on every error path. Conservative posture — a non-exempt owner
+    falsely exempted via a corrupt config would skip the teachback
+    round-trip the team-lead might genuinely have wanted.
+
+    Consumed by `task_lifecycle_gate.evaluate_lifecycle` via the public
+    `is_teachback_exempt` predicate.
+
+    NOT a hook predicate — pure helper.
+
+    Args:
+        owner: Task owner name (matched against member.name).
+        team_name: Team name for config path. Empty string returns False.
+        teams_dir: Override teams directory (for testing). When omitted,
+                   _iter_members uses ``~/.claude/teams/``.
+    """
+    if not isinstance(owner, str) or not owner:
+        return False
+    if not isinstance(team_name, str) or not team_name:
+        return False
+    for member in pact_context._iter_members(team_name, teams_dir):
+        if member.get("name") == owner:
+            agent_type = member.get("agentType")
+            return (
+                isinstance(agent_type, str)
+                and agent_type in TEACHBACK_EXEMPT_AGENT_TYPES
+            )
+    return False
+
+
+def is_teachback_exempt(
+    owner: str,
+    team_name: str = "",
+    teams_dir: str | None = None,
+) -> bool:
+    """Return True iff this owner is exempt from teachback-gated dispatch.
+
+    Single exemption surface: team-config agentType lookup. Unlike
+    `is_self_complete_exempt(task, team_name)`, there is no signal-task
+    analog for the dispatch surface — dispatch is a per-spawn decision
+    keyed on agentType only.
+
+    Resolution via `_is_teachback_exempt_agent_type(owner, team_name,
+    teams_dir)`. Fail-closed on every error path.
+
+    Used by `task_lifecycle_gate.evaluate_lifecycle` to suppress the
+    `work_addblockedby_missing` advisory when the work task's owner is
+    teachback-exempt.
+
+    Args:
+        owner: Task owner name (matched against team-config member.name).
+        team_name: Team name for config path. Empty string returns False.
+        teams_dir: Override teams directory (for testing).
+    """
+    return _is_teachback_exempt_agent_type(owner, team_name, teams_dir)
 
 
 def canonical_since() -> str:

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -113,6 +113,9 @@ PAIRED_SENDMESSAGE_WINDOW_S = 120
 # the name perimeter blocks teammates from spawning under reserved
 # names that could shadow legitimate secretary spawn).
 
+# Teachback-exempt dispatch carve-out resolution is delegated entirely to
+# is_teachback_exempt(owner, team_name) in shared.intentional_wait.
+
 # Required handoff schema fields (advisory if present-but-malformed).
 _HANDOFF_REQUIRED_FIELDS = (
     "produced",
@@ -359,6 +362,14 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
                 "the work task (per pact-completion-authority).",
             ))
 
+        # Clause order is intentional: the cheap checks
+        # (is_teachback dict-lookup, owner.startswith string-prefix,
+        # tool_input.get dict-lookup) precede the disk-reading
+        # is_teachback_exempt predicate. Common path (well-formed
+        # dispatch with addBlockedBy provided) short-circuits at the
+        # 3rd clause and never hits disk. Failure path (missing
+        # addBlockedBy) does hit disk via _iter_members, but this is
+        # the rare misconfiguration path — amortized cost near zero.
         if (
             not is_teachback
             and owner.startswith("pact-")

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -83,7 +83,7 @@ try:
 
     import shared.pact_context as pact_context
     from shared.dispatch_helpers import trustworthy_actor_name
-    from shared.intentional_wait import is_self_complete_exempt
+    from shared.intentional_wait import is_self_complete_exempt, is_teachback_exempt
     from shared.session_journal import append_event, make_event
     from shared.task_utils import read_task_json
     from shared.tool_response import extract_tool_response
@@ -331,6 +331,18 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
     if isinstance(incoming_metadata, dict) and incoming_metadata.get("gate_writeback") is True:
         return []
 
+    # Resolve team_name once at function scope. Both branches need it:
+    # TaskCreate's work_addblockedby_missing rule consumes it via
+    # is_teachback_exempt; TaskUpdate's self-completion carve-out consumes
+    # it via is_self_complete_exempt; and the TaskUpdate disk-fallback read
+    # uses it for the team-scoped task path. Empty string on failure
+    # (fail-closed downstream: both predicates return False on empty
+    # team_name).
+    try:
+        team_name = pact_context.get_pact_context().get("team_name", "")
+    except Exception:
+        team_name = ""
+
     # ② TaskCreate rules — teachback addBlocks + work-task addBlockedBy
     if tool_name == "TaskCreate":
         subject = (tool_input.get("subject") or "")
@@ -351,6 +363,7 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
             not is_teachback
             and owner.startswith("pact-")
             and not tool_input.get("addBlockedBy")
+            and not is_teachback_exempt(owner, team_name)
         ):
             advisories.append((
                 "work_addblockedby_missing",
@@ -363,13 +376,9 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
     # handoff schema, self-completion
     if tool_name == "TaskUpdate" and tool_input.get("status") == "completed":
         task_id = tool_input.get("taskId", "") or ""
-        # Resolve team_name from pact_context once for use by both the
+        # team_name resolved at function scope above; consumed here by the
         # disk-fallback read and the self-completion carve-out predicate
-        # (is_self_complete_exempt now keys on team-config agentType).
-        try:
-            team_name = pact_context.get_pact_context().get("team_name", "")
-        except Exception:
-            team_name = ""
+        # (is_self_complete_exempt keys on team-config agentType).
         # Final post-state — prefer tool_response.task; fallback to bare dict.
         task = tool_response.get("task") if isinstance(tool_response, dict) else None
         if not isinstance(task, dict):

--- a/pact-plugin/protocols/pact-completion-authority.md
+++ b/pact-plugin/protocols/pact-completion-authority.md
@@ -31,6 +31,8 @@ Both calls are **required**, and the ordering matches Acceptance for the same li
 
 The canonical predicate `is_self_complete_exempt(task, team_name)` in `shared/intentional_wait.py` witnesses ONLY these two surfaces — pure function for your TaskGet inspection and audit tooling. No hook reads it. Pass `team_name` (read from session context) to get accurate exemption signal for surface 1; surface 2 is independent of `team_name`.
 
+**Related (dispatch surface)**: A parallel agentType-keyed predicate `is_teachback_exempt(owner, team_name)` in `shared/intentional_wait.py` governs the **dispatch-shape** exemption — owners whose team-config `agentType` is in `TEACHBACK_EXEMPT_AGENT_TYPES` (currently `{pact-secretary}`) dispatch via single-task (no Task A teachback gate). This is the third agentType-keyed carve-out, parallel to `SELF_COMPLETE_EXEMPT_AGENT_TYPES` (completion, above) and `WAKE_EXCLUDED_AGENT_TYPES` (wake counting). Three frozensets, three behavioral surfaces, fully decoupled. See `agents/pact-orchestrator.md` §11 for the dispatch-side rule and `commands/bootstrap.md` for the canonical single-task dispatch shape.
+
 **Lead-driven force-completion (separate path, not predicate-witnessed)**:
 
 | Path | Trigger | Rule |

--- a/pact-plugin/protocols/pact-completion-authority.md
+++ b/pact-plugin/protocols/pact-completion-authority.md
@@ -31,7 +31,7 @@ Both calls are **required**, and the ordering matches Acceptance for the same li
 
 The canonical predicate `is_self_complete_exempt(task, team_name)` in `shared/intentional_wait.py` witnesses ONLY these two surfaces — pure function for your TaskGet inspection and audit tooling. No hook reads it. Pass `team_name` (read from session context) to get accurate exemption signal for surface 1; surface 2 is independent of `team_name`.
 
-**Related (dispatch surface)**: A parallel agentType-keyed predicate `is_teachback_exempt(owner, team_name)` in `shared/intentional_wait.py` governs the **dispatch-shape** exemption — owners whose team-config `agentType` is in `TEACHBACK_EXEMPT_AGENT_TYPES` (currently `{pact-secretary}`) dispatch via single-task (no Task A teachback gate). This is the third agentType-keyed carve-out, parallel to `SELF_COMPLETE_EXEMPT_AGENT_TYPES` (completion, above) and `WAKE_EXCLUDED_AGENT_TYPES` (wake counting). Three frozensets, three behavioral surfaces, fully decoupled. See `agents/pact-orchestrator.md` §11 for the dispatch-side rule and `commands/bootstrap.md` for the canonical single-task dispatch shape.
+**Related (dispatch surface)**: `member.agentType="pact-secretary"` also gets a dispatch carve-out — no TEACHBACK (single-task dispatch). Third agentType-keyed carve-out, parallel to `SELF_COMPLETE_EXEMPT_AGENT_TYPES` (completion, above) and `WAKE_EXCLUDED_AGENT_TYPES` (wake counting); three frozensets, three behavioral surfaces, fully decoupled. See `agents/pact-orchestrator.md` §11 + `commands/bootstrap.md`.
 
 **Lead-driven force-completion (separate path, not predicate-witnessed)**:
 

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -1982,7 +1982,7 @@ Both calls are **required**, and the ordering matches Acceptance for the same li
 
 The canonical predicate `is_self_complete_exempt(task, team_name)` in `shared/intentional_wait.py` witnesses ONLY these two surfaces — pure function for your TaskGet inspection and audit tooling. No hook reads it. Pass `team_name` (read from session context) to get accurate exemption signal for surface 1; surface 2 is independent of `team_name`.
 
-**Related (dispatch surface)**: A parallel agentType-keyed predicate `is_teachback_exempt(owner, team_name)` in `shared/intentional_wait.py` governs the **dispatch-shape** exemption — owners whose team-config `agentType` is in `TEACHBACK_EXEMPT_AGENT_TYPES` (currently `{pact-secretary}`) dispatch via single-task (no Task A teachback gate). This is the third agentType-keyed carve-out, parallel to `SELF_COMPLETE_EXEMPT_AGENT_TYPES` (completion, above) and `WAKE_EXCLUDED_AGENT_TYPES` (wake counting). Three frozensets, three behavioral surfaces, fully decoupled. See `agents/pact-orchestrator.md` §11 for the dispatch-side rule and `commands/bootstrap.md` for the canonical single-task dispatch shape.
+**Related (dispatch surface)**: `member.agentType="pact-secretary"` also gets a dispatch carve-out — no TEACHBACK (single-task dispatch). Third agentType-keyed carve-out, parallel to `SELF_COMPLETE_EXEMPT_AGENT_TYPES` (completion, above) and `WAKE_EXCLUDED_AGENT_TYPES` (wake counting); three frozensets, three behavioral surfaces, fully decoupled. See `agents/pact-orchestrator.md` §11 + `commands/bootstrap.md`.
 
 **Lead-driven force-completion (separate path, not predicate-witnessed)**:
 

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -1982,6 +1982,8 @@ Both calls are **required**, and the ordering matches Acceptance for the same li
 
 The canonical predicate `is_self_complete_exempt(task, team_name)` in `shared/intentional_wait.py` witnesses ONLY these two surfaces — pure function for your TaskGet inspection and audit tooling. No hook reads it. Pass `team_name` (read from session context) to get accurate exemption signal for surface 1; surface 2 is independent of `team_name`.
 
+**Related (dispatch surface)**: A parallel agentType-keyed predicate `is_teachback_exempt(owner, team_name)` in `shared/intentional_wait.py` governs the **dispatch-shape** exemption — owners whose team-config `agentType` is in `TEACHBACK_EXEMPT_AGENT_TYPES` (currently `{pact-secretary}`) dispatch via single-task (no Task A teachback gate). This is the third agentType-keyed carve-out, parallel to `SELF_COMPLETE_EXEMPT_AGENT_TYPES` (completion, above) and `WAKE_EXCLUDED_AGENT_TYPES` (wake counting). Three frozensets, three behavioral surfaces, fully decoupled. See `agents/pact-orchestrator.md` §11 for the dispatch-side rule and `commands/bootstrap.md` for the canonical single-task dispatch shape.
+
 **Lead-driven force-completion (separate path, not predicate-witnessed)**:
 
 | Path | Trigger | Rule |

--- a/pact-plugin/tests/test_intentional_wait.py
+++ b/pact-plugin/tests/test_intentional_wait.py
@@ -817,12 +817,29 @@ class TestTeachbackExemptAgentTypesConstant:
 
         assert "pact-secretary" in TEACHBACK_EXEMPT_AGENT_TYPES
 
-    def test_excludes_other_agent_types(self):
+    @pytest.mark.parametrize("agent_type", [
+        "pact-architect",
+        "pact-auditor",
+        "pact-backend-coder",
+        "pact-frontend-coder",
+        "pact-test-engineer",
+        "pact-security-engineer",
+        "pact-database-engineer",
+        "pact-preparer",
+        "pact-orchestrator",
+        "pact-devops-engineer",
+        "pact-n8n",
+        "pact-qa-engineer",
+    ])
+    def test_excludes_other_agent_types(self, agent_type):
+        """Exclusivity invariant pinned over the full canonical PACT roster
+        (everyone except pact-secretary). A future agentType addition that
+        accidentally widens the exempt set surfaces as a parametrize-row
+        failure, not silent privilege drift.
+        """
         from shared.intentional_wait import TEACHBACK_EXEMPT_AGENT_TYPES
 
-        assert "pact-auditor" not in TEACHBACK_EXEMPT_AGENT_TYPES
-        assert "pact-backend-coder" not in TEACHBACK_EXEMPT_AGENT_TYPES
-        assert "pact-test-engineer" not in TEACHBACK_EXEMPT_AGENT_TYPES
+        assert agent_type not in TEACHBACK_EXEMPT_AGENT_TYPES
 
 
 class TestTeachbackExemptAgentTypesImmutability:
@@ -845,6 +862,35 @@ class TestTeachbackExemptAgentTypesImmutability:
 
         with pytest.raises(AttributeError):
             TEACHBACK_EXEMPT_AGENT_TYPES.clear()
+
+
+class TestThreeFrozensetsAreSeparateObjects:
+    """Phantom-green guard: the module docstring forbids aliasing the three
+    agentType-keyed carve-out frozensets (`SELF_COMPLETE_EXEMPT_AGENT_TYPES`,
+    `WAKE_EXCLUDED_AGENT_TYPES`, `TEACHBACK_EXEMPT_AGENT_TYPES`) because
+    each governs an independent operational surface (self-completion,
+    wake-counting, dispatch). Same-contents aliasing — e.g.
+    `TEACHBACK_EXEMPT_AGENT_TYPES = SELF_COMPLETE_EXEMPT_AGENT_TYPES` — is a
+    silent-recouple defect: membership and immutability tests stay GREEN
+    because the alias preserves contents; the docstring prohibition has no
+    CI teeth. This test pins the three as separate objects via `is not`
+    identity checks so a future aliasing refactor fails loudly.
+
+    When divergence lands (one frozenset gains a member the others don't),
+    contents-based tests will catch it. But during the equal-contents
+    window — which is the current state — only identity checks discriminate.
+    """
+
+    def test_three_frozensets_are_separate_objects(self):
+        from shared.intentional_wait import (
+            SELF_COMPLETE_EXEMPT_AGENT_TYPES,
+            TEACHBACK_EXEMPT_AGENT_TYPES,
+            WAKE_EXCLUDED_AGENT_TYPES,
+        )
+
+        assert TEACHBACK_EXEMPT_AGENT_TYPES is not SELF_COMPLETE_EXEMPT_AGENT_TYPES
+        assert TEACHBACK_EXEMPT_AGENT_TYPES is not WAKE_EXCLUDED_AGENT_TYPES
+        assert SELF_COMPLETE_EXEMPT_AGENT_TYPES is not WAKE_EXCLUDED_AGENT_TYPES
 
 
 class TestIsTeachbackExempt:
@@ -1010,6 +1056,67 @@ class TestIsExemptAgentTypeDefaultTeamsDir:
         # Both teams_dir omitted; `team_name` provided.
         task = {"owner": "session-secretary", "metadata": {}}
         assert is_self_complete_exempt(task, "default-path-team") is True
+
+
+class TestIsTeachbackExemptDefaultTeamsDir:
+    """teams_dir=None default-path coverage for is_teachback_exempt: when
+    the override is omitted, the underlying `_iter_members` must resolve
+    via Path.home()/.claude/teams/. TestIsTeachbackExempt above passes
+    teams_dir explicitly; this class exercises the production default path
+    so a future regression that bypasses `_iter_members` (e.g. inlines its
+    own path) fails loudly.
+
+    Mirror of TestIsExemptAgentTypeDefaultTeamsDir for the self-complete
+    surface — same shape, different predicate.
+    """
+
+    def test_default_teams_dir_resolves_via_path_home(self, tmp_path, monkeypatch):
+        from shared.intentional_wait import is_teachback_exempt
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        team_dir = tmp_path / ".claude" / "teams" / "default-path-team"
+        team_dir.mkdir(parents=True)
+        (team_dir / "config.json").write_text(
+            json.dumps({"team_name": "default-path-team", "members": [
+                {"name": "session-secretary", "agentType": "pact-secretary"},
+            ]}),
+            encoding="utf-8",
+        )
+        # teams_dir omitted → exercises _iter_members default branch.
+        assert is_teachback_exempt(
+            "session-secretary", "default-path-team"
+        ) is True
+
+    def test_default_teams_dir_missing_config_fails_closed(
+        self, tmp_path, monkeypatch
+    ):
+        from shared.intentional_wait import is_teachback_exempt
+
+        # Path.home() points to tmp_path with no .claude/teams set up.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        # Default-path resolution must fail-closed without raising.
+        assert is_teachback_exempt(
+            "session-secretary", "ghost-team"
+        ) is False
+
+    def test_default_teams_dir_non_exempt_agent_type(
+        self, tmp_path, monkeypatch
+    ):
+        from shared.intentional_wait import is_teachback_exempt
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        team_dir = tmp_path / ".claude" / "teams" / "default-path-team"
+        team_dir.mkdir(parents=True)
+        (team_dir / "config.json").write_text(
+            json.dumps({"team_name": "default-path-team", "members": [
+                {"name": "backend-coder-1", "agentType": "pact-backend-coder"},
+            ]}),
+            encoding="utf-8",
+        )
+        # Default-path resolves member but agentType is non-exempt.
+        assert is_teachback_exempt(
+            "backend-coder-1", "default-path-team"
+        ) is False
 
 
 class TestIsExemptAgentTypeMixedTeamConfig:
@@ -1210,6 +1317,14 @@ class TestDocSurfaceStalenessSweep:
     import re
 
     OLD_NAME_PATTERN = re.compile(r"\bSELF_COMPLETE_EXEMPT_AGENTS\b")
+    # Preventive guard for the dispatch-exemption frozenset: forbid the
+    # `_TYPES`-less typo variant of TEACHBACK_EXEMPT_AGENT_TYPES. Currently
+    # zero occurrences exist; this pattern catches a future rename-typo
+    # before it lands in agent-facing instruction.
+    TEACHBACK_OLD_NAME_PATTERN = re.compile(r"\bTEACHBACK_EXEMPT_AGENTS\b")
+    # All patterns scanned for staleness — extended via tuple so adding a
+    # third constant-rename guard is a one-line change.
+    ALL_OLD_NAME_PATTERNS = (OLD_NAME_PATTERN, TEACHBACK_OLD_NAME_PATTERN)
     # `> Deprecated:` blockquote marker, leading whitespace tolerated.
     DEPRECATION_BLOCKQUOTE_PATTERN = re.compile(r"^\s*>\s*Deprecated:")
     # `<!-- old name:` HTML comment marker (case-insensitive on `old name`),
@@ -1254,11 +1369,15 @@ class TestDocSurfaceStalenessSweep:
                     continue
                 if self._skipped_line(line, in_fence):
                     continue
-                if self.OLD_NAME_PATTERN.search(line):
-                    violations.append(f"{md_path.relative_to(root.parent)}:{line_no}: {line.strip()}")
+                for pattern in self.ALL_OLD_NAME_PATTERNS:
+                    if pattern.search(line):
+                        violations.append(
+                            f"{md_path.relative_to(root.parent)}:{line_no}: "
+                            f"[{pattern.pattern}] {line.strip()}"
+                        )
         assert not violations, (
-            "Stale `SELF_COMPLETE_EXEMPT_AGENTS` references found in doc "
-            "surface — must be retargeted to `SELF_COMPLETE_EXEMPT_AGENT_TYPES`:\n"
+            "Stale typo-variant references found in doc surface — must be "
+            "retargeted to the canonical `_AGENT_TYPES`-suffixed name:\n"
             + "\n".join(violations)
         )
 
@@ -1278,7 +1397,7 @@ class TestDocSurfaceStalenessSweep:
                 continue
             if self._skipped_line(line, in_fence):
                 continue
-            if self.OLD_NAME_PATTERN.search(line):
+            if any(p.search(line) for p in self.ALL_OLD_NAME_PATTERNS):
                 violations.append(line_no)
         return violations
 
@@ -1364,6 +1483,41 @@ class TestDocSurfaceStalenessSweep:
         # predicate accidentally suppressing the NEW name.
         lines = [
             "Reference SELF_COMPLETE_EXEMPT_AGENT_TYPES in shared module.",
+        ]
+        assert self._scan_lines(lines) == []
+
+    # ---- TEACHBACK_EXEMPT_AGENTS typo-variant counter-tests ----
+
+    def test_teachback_typo_variant_caught(self):
+        # Bare prose mention of the TEACHBACK typo variant in a plain
+        # doc line MUST fire. Currently zero occurrences exist in the
+        # repo; this pin catches a future rename-typo before it lands.
+        lines = [
+            "## Dispatch carve-out",
+            "",
+            "Owners listed in TEACHBACK_EXEMPT_AGENTS skip the gate.",
+        ]
+        assert self._scan_lines(lines) == [3]
+
+    def test_teachback_typo_in_deprecation_blockquote_skipped(self):
+        # Same exclusion logic applies to the new pattern.
+        lines = [
+            "## Dispatch carve-out",
+            "",
+            "> Deprecated: TEACHBACK_EXEMPT_AGENTS (pre-rename). See "
+            "TEACHBACK_EXEMPT_AGENT_TYPES below.",
+            "",
+            "Carve-out is keyed on agentType.",
+        ]
+        assert self._scan_lines(lines) == []
+
+    def test_teachback_typo_in_fenced_block_skipped(self):
+        # Snippets quoting historical-typo code inside fences must NOT fire.
+        lines = [
+            "```python",
+            "if owner in TEACHBACK_EXEMPT_AGENTS:",
+            "    return True",
+            "```",
         ]
         assert self._scan_lines(lines) == []
 

--- a/pact-plugin/tests/test_intentional_wait.py
+++ b/pact-plugin/tests/test_intentional_wait.py
@@ -847,6 +847,77 @@ class TestTeachbackExemptAgentTypesImmutability:
             TEACHBACK_EXEMPT_AGENT_TYPES.clear()
 
 
+class TestIsTeachbackExempt:
+    """Direct unit tests on is_teachback_exempt — the public predicate that
+    backs task_lifecycle_gate.work_addblockedby_missing carve-out. Parallel
+    structure to TestIsExemptAgentType; fail-closed on every error path.
+    """
+
+    def test_secretary_owner_is_exempt(self, teams_dir):
+        from shared.intentional_wait import is_teachback_exempt
+
+        _write_team_config(teams_dir, "test-team", [
+            {"name": "secretary", "agentType": "pact-secretary"},
+        ])
+        assert is_teachback_exempt("secretary", "test-team", teams_dir) is True
+
+    def test_non_canonical_spawn_name_with_secretary_agenttype_is_exempt(self, teams_dir):
+        """Resolution via team-config agentType, NOT spawn name."""
+        from shared.intentional_wait import is_teachback_exempt
+
+        _write_team_config(teams_dir, "test-team", [
+            {"name": "session-secretary", "agentType": "pact-secretary"},
+        ])
+        assert is_teachback_exempt("session-secretary", "test-team", teams_dir) is True
+
+    def test_non_secretary_agenttype_not_exempt(self, teams_dir):
+        from shared.intentional_wait import is_teachback_exempt
+
+        _write_team_config(teams_dir, "test-team", [
+            {"name": "coder", "agentType": "pact-backend-coder"},
+        ])
+        assert is_teachback_exempt("coder", "test-team", teams_dir) is False
+
+    def test_empty_owner_fails_closed(self, teams_dir):
+        from shared.intentional_wait import is_teachback_exempt
+
+        assert is_teachback_exempt("", "test-team", teams_dir) is False
+
+    def test_empty_team_name_fails_closed(self, teams_dir):
+        from shared.intentional_wait import is_teachback_exempt
+
+        assert is_teachback_exempt("secretary", "", teams_dir) is False
+
+    def test_missing_team_config_fails_closed(self, teams_dir):
+        from shared.intentional_wait import is_teachback_exempt
+
+        # No config written — _iter_members returns []; no match; fail-closed.
+        assert is_teachback_exempt("secretary", "ghost-team", teams_dir) is False
+
+    def test_owner_not_in_members_fails_closed(self, teams_dir):
+        from shared.intentional_wait import is_teachback_exempt
+
+        _write_team_config(teams_dir, "test-team", [
+            {"name": "other", "agentType": "pact-secretary"},
+        ])
+        assert is_teachback_exempt("secretary", "test-team", teams_dir) is False
+
+    def test_empty_agent_type_field_fails_closed(self, teams_dir):
+        from shared.intentional_wait import is_teachback_exempt
+
+        _write_team_config(teams_dir, "test-team", [
+            {"name": "secretary", "agentType": ""},
+        ])
+        assert is_teachback_exempt("secretary", "test-team", teams_dir) is False
+
+    def test_non_string_inputs_fail_closed(self, teams_dir):
+        from shared.intentional_wait import is_teachback_exempt
+
+        assert is_teachback_exempt(None, "test-team", teams_dir) is False  # type: ignore[arg-type]
+        assert is_teachback_exempt("secretary", None, teams_dir) is False  # type: ignore[arg-type]
+        assert is_teachback_exempt(123, "test-team", teams_dir) is False  # type: ignore[arg-type]
+
+
 class TestKnownReasonsLiteralRegressionGuard:
     """Pin the exact set of known reasons. Any silent removal/rename must fail loudly.
 

--- a/pact-plugin/tests/test_intentional_wait.py
+++ b/pact-plugin/tests/test_intentional_wait.py
@@ -801,6 +801,52 @@ class TestSelfCompleteExemptAgentTypesImmutability:
             KNOWN_REASONS.add("awaiting_something_new")
 
 
+class TestTeachbackExemptAgentTypesConstant:
+    """Third agentType-keyed carve-out frozenset, parallel structure to
+    SELF_COMPLETE_EXEMPT_AGENT_TYPES and WAKE_EXCLUDED_AGENT_TYPES. Membership:
+    {pact-secretary}. Surface: teachback-gated dispatch (Task A skipped).
+    """
+
+    def test_is_frozenset(self):
+        from shared.intentional_wait import TEACHBACK_EXEMPT_AGENT_TYPES
+
+        assert isinstance(TEACHBACK_EXEMPT_AGENT_TYPES, frozenset)
+
+    def test_contains_pact_secretary(self):
+        from shared.intentional_wait import TEACHBACK_EXEMPT_AGENT_TYPES
+
+        assert "pact-secretary" in TEACHBACK_EXEMPT_AGENT_TYPES
+
+    def test_excludes_other_agent_types(self):
+        from shared.intentional_wait import TEACHBACK_EXEMPT_AGENT_TYPES
+
+        assert "pact-auditor" not in TEACHBACK_EXEMPT_AGENT_TYPES
+        assert "pact-backend-coder" not in TEACHBACK_EXEMPT_AGENT_TYPES
+        assert "pact-test-engineer" not in TEACHBACK_EXEMPT_AGENT_TYPES
+
+
+class TestTeachbackExemptAgentTypesImmutability:
+    """frozenset chosen specifically to prevent accidental mutation; pin that."""
+
+    def test_add_raises_attribute_error(self):
+        from shared.intentional_wait import TEACHBACK_EXEMPT_AGENT_TYPES
+
+        with pytest.raises(AttributeError):
+            TEACHBACK_EXEMPT_AGENT_TYPES.add("new-agent-type")
+
+    def test_remove_raises_attribute_error(self):
+        from shared.intentional_wait import TEACHBACK_EXEMPT_AGENT_TYPES
+
+        with pytest.raises(AttributeError):
+            TEACHBACK_EXEMPT_AGENT_TYPES.remove("pact-secretary")
+
+    def test_clear_raises_attribute_error(self):
+        from shared.intentional_wait import TEACHBACK_EXEMPT_AGENT_TYPES
+
+        with pytest.raises(AttributeError):
+            TEACHBACK_EXEMPT_AGENT_TYPES.clear()
+
+
 class TestKnownReasonsLiteralRegressionGuard:
     """Pin the exact set of known reasons. Any silent removal/rename must fail loudly.
 

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -252,11 +252,11 @@ def test_teachback_addblocks_missing_still_fires_for_stray_secretary_teachback(
     assert any(rule == "teachback_addblocks_missing" for rule, _ in advisories)
 
 
-def test_advisory_when_owner_not_in_team_config_members(tmp_path, monkeypatch, pact_context):
+def test_advisory_when_pact_owner_not_in_members_fails_closed(tmp_path, monkeypatch, pact_context):
     """Fail-closed: owner doesn't match any member.name in team config →
-    is_teachback_exempt returns False → advisory still fires. Defense
-    against a teammate spoofing the secretary name without the team config
-    recording the privileged agentType."""
+    is_teachback_exempt returns False → advisory still fires. The pinned
+    property is fail-closed-on-member-miss; the spoof-defense framing is
+    one motivation, not the property itself."""
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     pact_context(team_name="test-team", session_id="test-session")
     team_dir = tmp_path / ".claude" / "teams" / "test-team"

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -127,6 +127,161 @@ def test_silent_when_owner_is_not_pact_specialist(pact_context):
     assert not any(rule == "work_addblockedby_missing" for rule, _ in advisories)
 
 
+def test_silent_when_owner_is_teachback_exempt_secretary(tmp_path, monkeypatch, pact_context):
+    """Secretary owner with agentType in TEACHBACK_EXEMPT_AGENT_TYPES → no
+    work_addblockedby_missing advisory even without addBlockedBy. Resolution
+    via team-config agentType lookup (mirrors the self-completion carve-out
+    fixture pattern at test_silent_when_secretary_self_completes)."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    pact_context(team_name="test-team", session_id="test-session")
+    team_dir = tmp_path / ".claude" / "teams" / "test-team"
+    team_dir.mkdir(parents=True)
+    (team_dir / "config.json").write_text(
+        json.dumps({
+            "team_name": "test-team",
+            "members": [
+                {"name": "pact-secretary", "agentType": "pact-secretary"},
+            ],
+        }),
+        encoding="utf-8",
+    )
+    payload = {
+        "tool_name": "TaskCreate",
+        "tool_input": {
+            "subject": "secretary: session briefing + HANDOFF readiness",
+            "owner": "pact-secretary",
+            # no addBlockedBy — single-task dispatch shape
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert not any(rule == "work_addblockedby_missing" for rule, _ in advisories)
+
+
+def test_advisory_when_pact_owner_is_not_teachback_exempt(tmp_path, monkeypatch, pact_context):
+    """A pact-* owner whose team-config agentType is NOT in
+    TEACHBACK_EXEMPT_AGENT_TYPES still fires work_addblockedby_missing —
+    regression protection for the unchanged majority path."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    pact_context(team_name="test-team", session_id="test-session")
+    team_dir = tmp_path / ".claude" / "teams" / "test-team"
+    team_dir.mkdir(parents=True)
+    (team_dir / "config.json").write_text(
+        json.dumps({
+            "team_name": "test-team",
+            "members": [
+                {"name": "pact-backend-coder", "agentType": "pact-backend-coder"},
+            ],
+        }),
+        encoding="utf-8",
+    )
+    payload = {
+        "tool_name": "TaskCreate",
+        "tool_input": {
+            "subject": "implement feature X",
+            "owner": "pact-backend-coder",
+            # no addBlockedBy
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert any(rule == "work_addblockedby_missing" for rule, _ in advisories)
+
+
+def test_silent_when_teachback_exempt_resolves_via_team_config_agent_type(
+    tmp_path, monkeypatch, pact_context
+):
+    """Spawn-name independence: owner='session-secretary' (non-canonical
+    spawn name) with team-config agentType='pact-secretary' still reaches
+    the exemption. The carve-out keys on agentType, not owner-name match."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    pact_context(team_name="test-team", session_id="test-session")
+    team_dir = tmp_path / ".claude" / "teams" / "test-team"
+    team_dir.mkdir(parents=True)
+    (team_dir / "config.json").write_text(
+        json.dumps({
+            "team_name": "test-team",
+            "members": [
+                {"name": "pact-session-secretary", "agentType": "pact-secretary"},
+            ],
+        }),
+        encoding="utf-8",
+    )
+    payload = {
+        "tool_name": "TaskCreate",
+        "tool_input": {
+            "subject": "session-secretary: harvest HANDOFFs",
+            "owner": "pact-session-secretary",
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert not any(rule == "work_addblockedby_missing" for rule, _ in advisories)
+
+
+def test_teachback_addblocks_missing_still_fires_for_stray_secretary_teachback(
+    tmp_path, monkeypatch, pact_context
+):
+    """Defensive: the teachback_addblocks_missing rule is independent of the
+    new exemption. A stray teachback-subject task for the secretary still
+    triggers the addBlocks advisory — exemption applies only to the
+    work_addblockedby_missing rule."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    pact_context(team_name="test-team", session_id="test-session")
+    team_dir = tmp_path / ".claude" / "teams" / "test-team"
+    team_dir.mkdir(parents=True)
+    (team_dir / "config.json").write_text(
+        json.dumps({
+            "team_name": "test-team",
+            "members": [
+                {"name": "pact-secretary", "agentType": "pact-secretary"},
+            ],
+        }),
+        encoding="utf-8",
+    )
+    payload = {
+        "tool_name": "TaskCreate",
+        "tool_input": {
+            "subject": "secretary: TEACHBACK for some task",
+            "owner": "pact-secretary",
+            # no addBlocks
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert any(rule == "teachback_addblocks_missing" for rule, _ in advisories)
+
+
+def test_advisory_when_owner_not_in_team_config_members(tmp_path, monkeypatch, pact_context):
+    """Fail-closed: owner doesn't match any member.name in team config →
+    is_teachback_exempt returns False → advisory still fires. Defense
+    against a teammate spoofing the secretary name without the team config
+    recording the privileged agentType."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    pact_context(team_name="test-team", session_id="test-session")
+    team_dir = tmp_path / ".claude" / "teams" / "test-team"
+    team_dir.mkdir(parents=True)
+    (team_dir / "config.json").write_text(
+        json.dumps({
+            "team_name": "test-team",
+            "members": [
+                {"name": "other-agent", "agentType": "pact-secretary"},
+            ],
+        }),
+        encoding="utf-8",
+    )
+    payload = {
+        "tool_name": "TaskCreate",
+        "tool_input": {
+            "subject": "spoof: pact-secretary work",
+            "owner": "pact-secretary",  # owner doesn't match any member.name
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert any(rule == "work_addblockedby_missing" for rule, _ in advisories)
+
+
 # =============================================================================
 # completion_no_paired_send — teachback completion without paired SendMessage (120s window)
 # =============================================================================


### PR DESCRIPTION
## Summary

Adds `TEACHBACK_EXEMPT_AGENT_TYPES` frozenset (`shared/intentional_wait.py`) — third agentType-keyed carve-out, parallel to `SELF_COMPLETE_EXEMPT_AGENT_TYPES` (completion) and `WAKE_EXCLUDED_AGENT_TYPES` (wake counting). Membership: `{pact-secretary}`. Resolves via team-config `member.agentType`.

Wired into `task_lifecycle_gate.py` `work_addblockedby_missing` rule: `pact-secretary`-typed owners no longer require an `addBlockedBy` gate link on `TaskCreate`. Bootstrap command, persona §11, and secretary agent body all aligned to single-task dispatch for the secretary.

The secretary's task-system work is uniformly rote and skill-defined (session briefing, HANDOFF harvest at fixed workflow boundaries, memory saves). The teachback round-trip caught no real misunderstanding for these workflows; this PR removes the ceremony.

Closes #716.

## Design alternatives considered

| Shape | Decision |
|---|---|
| Frozenset + gate update + persona/agent-body updates (V1) | **Chosen.** Architecturally consistent; single SSOT predicate; both operational surfaces aligned. |
| Persona-only update, accept gate noise (V2) | Rejected — "lying gate" anti-pattern. |
| Subject-pattern exemption (V3) | Rejected — subject strings not a stable schema. |

## Test plan

- [x] 7652 passed, 10 skipped, 0 failures (worktree pact-plugin/, `--ignore=skills/pact-handoff-harvest/test_skill_loading.py`)
- [x] Pre-PR baseline 7642, delta +20 tests exactly (source-only revert verification by test-engineer)
- [x] 15 new tests in `test_intentional_wait.py` (3 frozenset shape + 3 immutability + 9 predicate covering positive-secretary, spawn-name-independence, 6 fail-closed paths)
- [x] 5 new tests in `test_task_lifecycle_gate.py` (suppression, positive-fires, spawn-name-independence-via-agentType, defensive `teachback_addblocks_missing` independence, fail-closed when owner-not-in-members)
- [x] Dedup invariant verified: `test_advisory_when_pact_owner_is_not_teachback_exempt` coexists with pre-existing `test_silent_when_owner_is_not_pact_specialist`
- [x] `team_name`-lift regression check: 0 existing tests broke on the lift

## Post-merge

- Tag `v4.1.9` + `gh release create v4.1.9` (per "Tag + GitHub release after every plugin-version bump" pin)
- Pin update: third row in the "Lead-only completion: carve-outs + naming nuance" frozenset table
- Auto-memory `feedback_teachback_required_even_on_reuse` update: reference the new exemption set

## Migration & back-compat

Permissive change — old teachback-gated secretary dispatches still work; the exemption is "allowed to skip," not "required to skip." No data migration.