### PR TITLE
fix(peer-review): pre-state recommendation in Step A gate + Step C per-finding questions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.2.1/      # Plugin version
+│               └── 4.2.2/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.2.1
+> **Version**: 4.2.2
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/commands/peer-review.md
+++ b/pact-plugin/commands/peer-review.md
@@ -288,7 +288,7 @@ JSON
      **Step A — Initial Gate Question** (Yes/No only):
 
      **Pre-form a gate-level recommendation BEFORE constructing the AskUserQuestion call.** The gate recommendation is BINARY (Yes or No across the entire minor+future population) — distinct from Step C's per-finding recommendations. Apply these POPULATION-LEVEL criteria:
-       - **Substance of findings** — Are the minors/futures substantive (convention violations, latent risks, real ergonomic wins) or cosmetic-only (whitespace, naming preference, stylistic nits)? Substantive → recommend Yes. Cosmetic-only → recommend No.
+       - **Aggregate Substance** — Are the minors/futures substantive (convention violations, latent risks, real ergonomic wins) or cosmetic-only (whitespace, naming preference, stylistic nits)? Substantive → recommend Yes. Cosmetic-only → recommend No.
        - **PR size + scope-tightness signals from the session** — If the user has expressed scope-tight preferences earlier and findings are cosmetic, recommend No. If PR is small and findings are substantive, recommend Yes.
        - **Time/cost of remediation** — If minors batch cleanly into one remediation cycle (Yes path is cheap), lean Yes. If each minor would require its own dispatch + verify cycle (Yes path is expensive) AND findings are not high-substance, lean No.
 
@@ -321,13 +321,13 @@ JSON
 
      **Step C — Per-Recommendation Questions** (after context presented):
 
-     **C.1 — Pre-form a recommendation BEFORE constructing the AskUserQuestion call.** For every minor and future finding, you MUST decide which option you would recommend BEFORE you call `AskUserQuestion`. Asking the user "what do you recommend?" or constructing an option set where no option carries a `(recommended)` suffix is a protocol violation — the user-facing checkpoint surfaces your prior, it does not elicit one. Apply these criteria when forming the recommendation:
+     **C.1 — Pre-form a recommendation BEFORE constructing the AskUserQuestion call.** <!-- ANCHOR-STABLE: C.1 --> For every minor and future finding, you MUST decide which option you would recommend BEFORE you call `AskUserQuestion`. Asking the user "what do you recommend?" or constructing an option set where no option carries a `(recommended)` suffix is a protocol violation — the user-facing checkpoint surfaces your prior, it does not elicit one. Apply these criteria when forming the recommendation:
        - **Scope** — Does fixing now stay inside this PR's stated scope, or does it expand the diff into adjacent concerns? In-scope → lean toward fix now; out-of-scope → lean toward defer/issue.
        - **Convention alignment** — Does the finding flag a divergence from an established project convention (pinned rules, repeated patterns, audit anchors)? Convention violation → lean toward fix now even if minor.
        - **Risk** — What is the cost of NOT addressing? Latent correctness, security, or data-integrity risk → lean toward fix now; pure ergonomics with no failure mode → lean toward defer.
        - **Substance** — Is the change a real behavioral or contract improvement, or a stylistic/cosmetic preference? Substantive → lean toward fix now; cosmetic → lean toward defer or skip.
 
-     **C.2 — Bake the recommendation into the option set.** The recommended option's label MUST carry the `(recommended)` suffix (plugin-wide convention; precedent in `wrap-up.md` and `rePACT.md`). The option's description MUST carry a one-line rationale grounded in the criteria above. Exactly ONE option per question carries the suffix.
+     **C.2 — Bake the recommendation into the option set.** <!-- ANCHOR-STABLE: C.2 --> The recommended option's label MUST carry the `(recommended)` suffix (plugin-wide convention; precedent in `comPACT.md`). The option's description MUST carry a one-line rationale grounded in the criteria above. Exactly ONE option per question carries the suffix.
 
      - For each **minor** recommendation, ask "Address [recommendation] now?" with options:
        - **Yes** — Fix it in this PR
@@ -340,7 +340,7 @@ JSON
        - **More context** — Get additional details (if more detail is needed)
      - > **Tool mapping**: Every option listed above MUST appear as a named `option` in the `AskUserQuestion` call. For minor recommendations: **Yes**, **No**, **More context**. For future recommendations: **Create GitHub issue**, **Skip**, **Address now**, **More context**. Do not omit any option and rely on the tool's built-in "Other" freeform input — each is a first-class option, not a fallback. On the option you selected as recommended, append `(recommended)` to the label and replace the generic description with a one-line rationale (e.g., "In-scope convention fix, low diff cost" or "Out-of-scope; track to avoid PR sprawl"). Do NOT append the suffix to more than one option per question.
 
-     **C.3 — Worked example.** Concrete pattern for a minor finding "Inconsistent error-log prefix across two helpers":
+     **C.3 — Worked example.** <!-- ANCHOR-STABLE: C.3 --> Concrete pattern for a minor finding "Inconsistent error-log prefix across two helpers":
 
      > **Before** (elicits "what do you recommend?"):
      > - **Yes** — Fix it in this PR
@@ -352,11 +352,11 @@ JSON
      > - **No** — Defer; cosmetic-only inconsistency
      > - **More context** — Get additional details
 
-     **C.4 — When no clear recommendation exists.** You MUST still construct the question with the full option set — never short-circuit by skipping the question. Two acceptable shapes:
+     **C.4 — When no clear recommendation exists.** <!-- ANCHOR-STABLE: C.4 --> You MUST still construct the question with the full option set — never short-circuit by skipping the question. Two acceptable shapes:
        - Mark the **most-defensible** option as `(recommended)` and write a description that names the uncertainty (e.g., "Tentative — scope is on the boundary; lean defer if PR is already large").
        - OR omit the `(recommended)` suffix entirely and state "No clear recommendation; user judgment" in the question prose. Use this shape sparingly; it shifts cognitive load back to the user and should appear only when the criteria genuinely don't converge.
 
-     **C.5 — Edge cases.**
+     **C.5 — Edge cases.** <!-- ANCHOR-STABLE: C.5 -->
        - **Conflict with earlier session signals** — If your pre-formed recommendation contradicts a stance the user took earlier in the session (e.g., user previously said "keep this PR tight" and you now recommend "fix now"), surface the conflict explicitly in the option description (e.g., "Recommend fix now despite earlier scope-tight signal — convention violation tips balance"). Do not silently invert the signal.
        - **Batching when shape aligns** — When multiple findings share recommendation shape (same recommended option, same rationale class, comparable scope/cost), batch them into a single `AskUserQuestion` question (e.g., "Address findings A, B, C now?") rather than asking three near-identical questions. Only batch when the rationale legitimately collapses; do NOT batch to save tool calls if findings diverge in cost or convention weight.
      - Note: Tool supports 2-4 options per question and 1-4 questions per call. If >4 recommendations exist, make multiple `AskUserQuestion` calls to cover all items.

--- a/pact-plugin/commands/peer-review.md
+++ b/pact-plugin/commands/peer-review.md
@@ -302,7 +302,15 @@ JSON
      - After presenting all context, proceed to Step C.
 
      **Step C — Per-Recommendation Questions** (after context presented):
-     - Use `AskUserQuestion` tool with one question per recommendation
+
+     **C.1 — Pre-form a recommendation BEFORE constructing the AskUserQuestion call.** For every minor and future finding, you MUST decide which option you would recommend BEFORE you call `AskUserQuestion`. Asking the user "what do you recommend?" or constructing an option set where no option carries a `(recommended)` suffix is a protocol violation — the user-facing checkpoint surfaces your prior, it does not elicit one. Apply these criteria when forming the recommendation:
+       - **Scope** — Does fixing now stay inside this PR's stated scope, or does it expand the diff into adjacent concerns? In-scope → lean toward fix now; out-of-scope → lean toward defer/issue.
+       - **Convention alignment** — Does the finding flag a divergence from an established project convention (pinned rules, repeated patterns, audit anchors)? Convention violation → lean toward fix now even if minor.
+       - **Risk** — What is the cost of NOT addressing? Latent correctness, security, or data-integrity risk → lean toward fix now; pure ergonomics with no failure mode → lean toward defer.
+       - **Substance** — Is the change a real behavioral or contract improvement, or a stylistic/cosmetic preference? Substantive → lean toward fix now; cosmetic → lean toward defer or skip.
+
+     **C.2 — Bake the recommendation into the option set.** The recommended option's label MUST carry the `(recommended)` suffix (plugin-wide convention; precedent in `wrap-up.md` and `rePACT.md`). The option's description MUST carry a one-line rationale grounded in the criteria above. Exactly ONE option per question carries the suffix.
+
      - For each **minor** recommendation, ask "Address [recommendation] now?" with options:
        - **Yes** — Fix it in this PR
        - **No** — Skip for now
@@ -312,7 +320,27 @@ JSON
        - **Skip** — Don't track or address
        - **Address now** — Fix it in this PR
        - **More context** — Get additional details (if more detail is needed)
-     - > **Tool mapping**: Every option listed above MUST appear as a named `option` in the `AskUserQuestion` call. For minor recommendations: **Yes**, **No**, **More context**. For future recommendations: **Create GitHub issue**, **Skip**, **Address now**, **More context**. Do not omit any option and rely on the tool's built-in "Other" freeform input — each is a first-class option, not a fallback.
+     - > **Tool mapping**: Every option listed above MUST appear as a named `option` in the `AskUserQuestion` call. For minor recommendations: **Yes**, **No**, **More context**. For future recommendations: **Create GitHub issue**, **Skip**, **Address now**, **More context**. Do not omit any option and rely on the tool's built-in "Other" freeform input — each is a first-class option, not a fallback. On the option you selected as recommended, append `(recommended)` to the label and replace the generic description with a one-line rationale (e.g., "In-scope convention fix, low diff cost" or "Out-of-scope; track to avoid PR sprawl"). Do NOT append the suffix to more than one option per question.
+
+     **C.3 — Worked example.** Concrete pattern for a minor finding "Inconsistent error-log prefix across two helpers":
+
+     > **Before** (elicits "what do you recommend?"):
+     > - **Yes** — Fix it in this PR
+     > - **No** — Skip for now
+     > - **More context** — Get additional details
+     >
+     > **After** (surfaces orchestrator's prior):
+     > - **Yes (recommended)** — In-scope convention alignment; 2-line diff, no behavioral risk
+     > - **No** — Defer; cosmetic-only inconsistency
+     > - **More context** — Get additional details
+
+     **C.4 — When no clear recommendation exists.** You MUST still construct the question with the full option set — never short-circuit by skipping the question. Two acceptable shapes:
+       - Mark the **most-defensible** option as `(recommended)` and write a description that names the uncertainty (e.g., "Tentative — scope is on the boundary; lean defer if PR is already large").
+       - OR omit the `(recommended)` suffix entirely and state "No clear recommendation; user judgment" in the question prose. Use this shape sparingly; it shifts cognitive load back to the user and should appear only when the criteria genuinely don't converge.
+
+     **C.5 — Edge cases.**
+       - **Conflict with earlier session signals** — If your pre-formed recommendation contradicts a stance the user took earlier in the session (e.g., user previously said "keep this PR tight" and you now recommend "fix now"), surface the conflict explicitly in the option description (e.g., "Recommend fix now despite earlier scope-tight signal — convention violation tips balance"). Do not silently invert the signal.
+       - **Batching when shape aligns** — When multiple findings share recommendation shape (same recommended option, same rationale class, comparable scope/cost), batch them into a single `AskUserQuestion` question (e.g., "Address findings A, B, C now?") rather than asking three near-identical questions. Only batch when the rationale legitimately collapses; do NOT batch to save tool calls if findings diverge in cost or convention weight.
      - Note: Tool supports 2-4 options per question and 1-4 questions per call. If >4 recommendations exist, make multiple `AskUserQuestion` calls to cover all items.
        - **Handling "More context" responses**:
          - When user selects "More context", provide deeper explanation beyond the preemptive context (e.g., implementation specifics, examples, related patterns)

--- a/pact-plugin/commands/peer-review.md
+++ b/pact-plugin/commands/peer-review.md
@@ -296,16 +296,16 @@ JSON
 
      **Worked example.** Concrete pattern when findings are 2 substantive minors (convention alignment) on a small PR:
 
-     > **Before** (no orchestrator prior):
+     > **Before**:
      > - **Yes** — review each item
      > - **No** — skip to merge readiness
      >
-     > **After** (surfaces orchestrator's prior):
+     > **After**:
      > - **Yes (recommended)** — Two substantive convention-alignment minors; small PR, low remediation cost
      > - **No** — Skip to merge readiness
 
      - Use `AskUserQuestion` tool: "Would you like to review the minor and future recommendations?"
-       - Options: **Yes** (review each item) / **No** (skip to merge readiness) — exactly one option labeled with `(recommended)` suffix and a one-line rationale per the criteria above.
+       - Options: **Yes** (review each item) / **No** (skip to merge readiness)
      - If **No**: Skip to step 4 directly
      - If **Yes**: Continue to Step B
 
@@ -338,16 +338,16 @@ JSON
        - **Skip** — Don't track or address
        - **Address now** — Fix it in this PR
        - **More context** — Get additional details (if more detail is needed)
-     - > **Tool mapping**: Every option listed above MUST appear as a named `option` in the `AskUserQuestion` call. For minor recommendations: **Yes**, **No**, **More context**. For future recommendations: **Create GitHub issue**, **Skip**, **Address now**, **More context**. Do not omit any option and rely on the tool's built-in "Other" freeform input — each is a first-class option, not a fallback. On the option you selected as recommended, append `(recommended)` to the label and replace the generic description with a one-line rationale (e.g., "In-scope convention fix, low diff cost" or "Out-of-scope; track to avoid PR sprawl"). Do NOT append the suffix to more than one option per question.
+     - > **Tool mapping**: Every option listed above MUST appear as a named `option` in the `AskUserQuestion` call. For minor recommendations: **Yes**, **No**, **More context**. For future recommendations: **Create GitHub issue**, **Skip**, **Address now**, **More context**. Do not omit any option and rely on the tool's built-in "Other" freeform input — each is a first-class option, not a fallback. Apply the `(recommended)` suffix + rationale per C.2 to exactly one option per question.
 
      **C.3 — Worked example.** <!-- ANCHOR-STABLE: C.3 --> Concrete pattern for a minor finding "Inconsistent error-log prefix across two helpers":
 
-     > **Before** (elicits "what do you recommend?"):
+     > **Before**:
      > - **Yes** — Fix it in this PR
      > - **No** — Skip for now
      > - **More context** — Get additional details
      >
-     > **After** (surfaces orchestrator's prior):
+     > **After**:
      > - **Yes (recommended)** — In-scope convention alignment; 2-line diff, no behavioral risk
      > - **No** — Defer; cosmetic-only inconsistency
      > - **More context** — Get additional details

--- a/pact-plugin/commands/peer-review.md
+++ b/pact-plugin/commands/peer-review.md
@@ -292,7 +292,7 @@ JSON
        - **PR size + scope-tightness signals from the session** — If the user has expressed scope-tight preferences earlier and findings are cosmetic, recommend No. If PR is small and findings are substantive, recommend Yes.
        - **Time/cost of remediation** — If minors batch cleanly into one remediation cycle (Yes path is cheap), lean Yes. If each minor would require its own dispatch + verify cycle (Yes path is expensive) AND findings are not high-substance, lean No.
 
-     **Bake the recommendation into the option set** using the same `(recommended)` suffix + one-line rationale convention as Step C (see C.2). Exactly ONE of Yes / No carries the suffix; its description carries a one-line rationale grounded in the criteria above. When no clear recommendation exists, apply the C.4 carve-out (mark the most-defensible option as recommended with uncertainty named in the rationale, OR omit the suffix and state "No clear recommendation; user judgment" in the question prose).
+     **Bake the recommendation into the option set** using the same `(recommended)` suffix + one-line rationale convention as Step C (see C.2). When no clear recommendation exists, apply the C.4 carve-out (mark the most-defensible option as recommended with uncertainty named in the rationale, OR omit the suffix and state "No clear recommendation; user judgment" in the question prose).
 
      **Worked example.** Concrete rationale shape for 2 substantive minors on a small PR: `Yes (recommended) — Two substantive convention-alignment minors; small PR, low remediation cost`. See C.3 for the full option-block convention.
 

--- a/pact-plugin/commands/peer-review.md
+++ b/pact-plugin/commands/peer-review.md
@@ -286,8 +286,26 @@ JSON
    - **Minor + Future**:
 
      **Step A — Initial Gate Question** (Yes/No only):
+
+     **Pre-form a gate-level recommendation BEFORE constructing the AskUserQuestion call.** The gate recommendation is BINARY (Yes or No across the entire minor+future population) — distinct from Step C's per-finding recommendations. Apply these POPULATION-LEVEL criteria:
+       - **Substance of findings** — Are the minors/futures substantive (convention violations, latent risks, real ergonomic wins) or cosmetic-only (whitespace, naming preference, stylistic nits)? Substantive → recommend Yes. Cosmetic-only → recommend No.
+       - **PR size + scope-tightness signals from the session** — If the user has expressed scope-tight preferences earlier and findings are cosmetic, recommend No. If PR is small and findings are substantive, recommend Yes.
+       - **Time/cost of remediation** — If minors batch cleanly into one remediation cycle (Yes path is cheap), lean Yes. If each minor would require its own dispatch + verify cycle (Yes path is expensive) AND findings are not high-substance, lean No.
+
+     **Bake the recommendation into the option set** using the same `(recommended)` suffix + one-line rationale convention as Step C (see C.2). Exactly ONE of Yes / No carries the suffix; its description carries a one-line rationale grounded in the criteria above. When no clear recommendation exists, apply the C.4 carve-out (mark the most-defensible option as recommended with uncertainty named in the rationale, OR omit the suffix and state "No clear recommendation; user judgment" in the question prose).
+
+     **Worked example.** Concrete pattern when findings are 2 substantive minors (convention alignment) on a small PR:
+
+     > **Before** (no orchestrator prior):
+     > - **Yes** — review each item
+     > - **No** — skip to merge readiness
+     >
+     > **After** (surfaces orchestrator's prior):
+     > - **Yes (recommended)** — Two substantive convention-alignment minors; small PR, low remediation cost
+     > - **No** — Skip to merge readiness
+
      - Use `AskUserQuestion` tool: "Would you like to review the minor and future recommendations?"
-       - Options: **Yes** (review each item) / **No** (skip to merge readiness)
+       - Options: **Yes** (review each item) / **No** (skip to merge readiness) — exactly one option labeled with `(recommended)` suffix and a one-line rationale per the criteria above.
      - If **No**: Skip to step 4 directly
      - If **Yes**: Continue to Step B
 

--- a/pact-plugin/commands/peer-review.md
+++ b/pact-plugin/commands/peer-review.md
@@ -294,15 +294,7 @@ JSON
 
      **Bake the recommendation into the option set** using the same `(recommended)` suffix + one-line rationale convention as Step C (see C.2). Exactly ONE of Yes / No carries the suffix; its description carries a one-line rationale grounded in the criteria above. When no clear recommendation exists, apply the C.4 carve-out (mark the most-defensible option as recommended with uncertainty named in the rationale, OR omit the suffix and state "No clear recommendation; user judgment" in the question prose).
 
-     **Worked example.** Concrete pattern when findings are 2 substantive minors (convention alignment) on a small PR:
-
-     > **Before**:
-     > - **Yes** — review each item
-     > - **No** — skip to merge readiness
-     >
-     > **After**:
-     > - **Yes (recommended)** — Two substantive convention-alignment minors; small PR, low remediation cost
-     > - **No** — Skip to merge readiness
+     **Worked example.** Concrete rationale shape for 2 substantive minors on a small PR: `Yes (recommended) — Two substantive convention-alignment minors; small PR, low remediation cost`. See C.3 for the full option-block convention.
 
      - Use `AskUserQuestion` tool: "Would you like to review the minor and future recommendations?"
        - Options: **Yes** (review each item) / **No** (skip to merge readiness)
@@ -342,12 +334,7 @@ JSON
 
      **C.3 — Worked example.** <!-- ANCHOR-STABLE: C.3 --> Concrete pattern for a minor finding "Inconsistent error-log prefix across two helpers":
 
-     > **Before**:
-     > - **Yes** — Fix it in this PR
-     > - **No** — Skip for now
-     > - **More context** — Get additional details
-     >
-     > **After**:
+     > **Example**:
      > - **Yes (recommended)** — In-scope convention alignment; 2-line diff, no behavioral risk
      > - **No** — Defer; cosmetic-only inconsistency
      > - **More context** — Get additional details


### PR DESCRIPTION
## Summary

Closes #659. Bundles Step A gate-level recommendation per user direction during dogfooding.

`commands/peer-review.md` Step C (per-recommendation questions) and Step A (initial Yes/No gate) previously elicited user answers without surfacing the orchestrator's prior. Empirical instance: PR #653 review, where the user repeatedly typed "what do you recommend?" to extract the orchestrator's view — forcing two round-trips per finding instead of one.

This PR makes the orchestrator MUST pre-form a recommendation BEFORE constructing each `AskUserQuestion` call, and bake the recommendation into the option set via the existing `(recommended)` suffix convention with a one-line rationale in the option description.

## Changes

| Commit | Subject |
|--------|---------|
| `bda058c8` | fix(peer-review): pre-state recommendation in Step C per-finding questions |
| `12f2a8ca` | fix(peer-review): pre-state recommendation in Step A gate question |
| `ba697f94` | chore(version): bump plugin version 4.2.1 -> 4.2.2 for PR #659 |

### Step C — per-finding (commit 1, +30/-2)

New sub-steps C.1–C.5:
- **C.1**: Pre-form per-finding recommendation BEFORE the AskUserQuestion call. Criteria: scope, convention alignment, risk, substance.
- **C.2**: Bake recommendation into option set. Exactly ONE option carries `(recommended)` suffix; description carries one-line rationale.
- **C.3**: Worked Before/After example for a minor finding.
- **C.4**: "When no clear recommendation exists" carve-out — still construct the question; two acceptable shapes (mark most-defensible as recommended OR omit suffix and state "No clear recommendation; user judgment").
- **C.5**: Edge cases — conflict with earlier session signals (surface in description, do not silently invert); batching when shape aligns.

### Step A — gate-level (commit 2, +19/-1)

Flat-bolded-section structure (Step A is short; sub-step numbering would bloat):
- **Pre-form a gate-level recommendation** — binary (Yes/No across the entire minor+future population). Population-level criteria (distinct from C.1's per-finding criteria):
  - Substance of findings (substantive → Yes; cosmetic-only → No)
  - PR size + scope-tightness signals
  - Time/cost of remediation
- **Bake recommendation into option set** — cross-references C.2 for suffix mechanics + C.4 for no-clear-recommendation carve-out.
- **Worked example** — Before/After blockquote for substantive-minors-on-small-PR scenario.

If-No → step 4 / If-Yes → Step B branching preserved verbatim. Step B and Step C untouched.

### Plugin version

**4.2.1 → 4.2.2** (patch — workflow-discipline refinement, no new capability surface). Tag + GitHub release after merge per pinned distribution discipline.

## Why bundle Step A with Step C

Same convention, same file, same UX motivation, same agent-reader-primary class. The two are tightly related and trying to split would produce one tiny diff plus a follow-up that's substantively the same fix at a different scope. Bundle keeps the workflow discipline atomic.

## Test plan

- [x] All 78 structural tests in `pact-plugin/tests/test_commands_structure.py` + `test_cross_references.py` pass
- [x] Step B and Step D (which I initially referenced as if it existed — corrected mid-session: no Step D exists; the flow returns to top-level item 4 "State merge readiness" after Step C) are untouched
- [x] Branching logic ("If No: skip to step 4" / "If Yes: continue to Step B") preserved verbatim
- [ ] Post-merge dogfood: next peer-review session should show orchestrator pre-forming recommendations and surfacing them in option labels
- [ ] Post-merge: tag v4.2.2 + GitHub release per pinned distribution discipline

## Related follow-ups (filed this session)

- #740 — handoff-side Step 0 verification precondition (same agent-reader-primary class)
- #741 — umbrella for deferred Phase 2 follow-ups (schema field, hook enforcement, lead-side verification)
- #742 — teachback-side SendMessage elision in pact-agent-teams summary (sibling of #740)
- #743 — wake_lifecycle predicate counts umbrella tasks (independent hook bug with rePACT forward-compat rationale)