### PR TITLE
fix(hooks/shared): exclude unowned, orphan, and lead-owned tasks from wake tally (#743)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.2.2",
+      "version": "4.2.3",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.2.2/      # Plugin version
+│               └── 4.2.3/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.2.2
+> **Version**: 4.2.3
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -359,6 +359,53 @@ def _iter_members(
     return [m for m in members if isinstance(m, dict)]
 
 
+def _read_team_lead_agent_id(
+    team_name: str,
+    teams_dir: str | None = None,
+) -> str:
+    """Read the top-level ``leadAgentId`` string from a team config file.
+
+    Returns the ``leadAgentId`` value from
+    ``~/.claude/teams/{team_name}/config.json``, or ``""`` silently on any
+    of the same error paths handled by ``_iter_members``: empty team_name,
+    missing config file, I/O error, malformed JSON, non-object top-level
+    JSON, missing field, or non-string field value.
+
+    Sibling reader to ``_iter_members``. ``_iter_members`` returns only the
+    validated ``members[]`` list (by design — it discards every other
+    top-level field). Rather than widen ``_iter_members``'s return shape
+    (which ripples through its existing call sites), this helper exposes
+    the single additional field that the wake-lifecycle owner-classification
+    predicate needs (``leadAgentId``). Matches the established
+    one-helper-per-field-or-projection pattern in this module.
+
+    Silent-on-error is intentional and parallels ``_iter_members``: the
+    sole caller (``wake_lifecycle._is_lead_owned``) uses the empty string
+    as the "team config not usable" signal and composes that result with
+    the call-site fail-conservative posture.
+
+    Args:
+        team_name: Team name for config path. Empty string returns "".
+        teams_dir: Override teams directory (for testing).
+    """
+    if not team_name:
+        return ""
+    if teams_dir:
+        config_path = Path(teams_dir) / team_name / "config.json"
+    else:
+        config_path = (
+            Path.home() / ".claude" / "teams" / team_name / "config.json"
+        )
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        lead_agent_id = data.get("leadAgentId")
+    except (OSError, json.JSONDecodeError, ValueError, AttributeError, TypeError):
+        return ""
+    if not isinstance(lead_agent_id, str):
+        return ""
+    return lead_agent_id
+
+
 def _lookup_agent_in_team_config(
     agent_id: str,
     team_name: str,

--- a/pact-plugin/hooks/shared/session_journal.py
+++ b/pact-plugin/hooks/shared/session_journal.py
@@ -158,6 +158,16 @@ _REQUIRED_FIELDS_BY_TYPE: dict[str, dict[str, type]] = {
     # activates the _OPTIONAL_FIELDS_BY_TYPE enforcement below (same pattern
     # as session_end and cleanup_summary).
     "session_consolidated": {},
+    # hooks/shared/wake_lifecycle.py::_warn_empty_team_config_once writes
+    # wake_tally_warn ONE-shot per team per process when the step-4
+    # owner-check fall-through fires (config unreadable, members[] empty).
+    # team_name is load-bearing — without it the warn has no actionable
+    # signal. reason is a categorical token for future log-filter
+    # dispatch ("empty_team_config_fail_conservative" today; future
+    # variants may add "malformed_team_config_json" or similar). detail
+    # is documentation-grade prose for human readers (stderr fallback)
+    # and is registered as optional in _OPTIONAL_FIELDS_BY_TYPE below.
+    "wake_tally_warn": {"team_name": str, "reason": str},
 }
 
 
@@ -222,6 +232,15 @@ _OPTIONAL_FIELDS_BY_TYPE: dict[str, dict[str, type]] = {
         "task_count": int,
         "memories_saved": int,
     },
+    # hooks/shared/wake_lifecycle.py::_warn_empty_team_config_once writes
+    # wake_tally_warn with an optional `detail` free-form prose string.
+    # The required-fields registration in _REQUIRED_FIELDS_BY_TYPE above
+    # ("wake_tally_warn": {team_name: str, reason: str}) is what
+    # ACTIVATES this optional check — _validate_event_schema short-
+    # circuits on unknown event types and would otherwise skip the
+    # optional loop. Symmetric with the session_end + cleanup_summary
+    # registration patterns.
+    "wake_tally_warn": {"detail": str},
 }
 
 

--- a/pact-plugin/hooks/shared/wake_lifecycle.py
+++ b/pact-plugin/hooks/shared/wake_lifecycle.py
@@ -108,10 +108,10 @@ class _OwnerClassification:
     - ``agent_type``: the member's ``agentType`` string when present,
       else None. Used by the wake-excluded-agentType carve-out.
     - ``config_readable``: True iff ``_iter_members`` returned a
-      non-empty members list. False distinguishes the
-      fail-CONSERVATIVE-fall-through case (members list empty: config
-      missing, malformed JSON, or members[] absent) from the orphan
-      case (members non-empty, no name match).
+      non-empty members list. False signals the count-on-failure
+      fall-through path at the call site (members list empty: config
+      missing, malformed JSON, or members[] absent) and distinguishes
+      it from the orphan case (members non-empty, no name match).
 
     A frozen dataclass rather than a namedtuple so the field semantics
     are documented inline at the consumer's read site.
@@ -143,7 +143,7 @@ def _classify_owner(owner: Any, team_name: str) -> _OwnerClassification:
       team_name → all fields default (no classification can be made).
     - ``_iter_members`` returns ``[]`` (config missing / unreadable /
       malformed / members[] absent) → ``config_readable=False`` so the
-      call site can fail-CONSERVATIVE (count toward tally). The other
+      call site can apply its count-on-failure fall-through. The other
       fields stay False / None.
     - members non-empty, no name match → ``is_known_team_member=False``,
       ``is_lead=False``, ``agent_type=None``, ``config_readable=True``.
@@ -164,23 +164,24 @@ def _classify_owner(owner: Any, team_name: str) -> _OwnerClassification:
         return _OwnerClassification(False, False, None, False)
 
     # Read the config regardless of owner shape so the call site can
-    # distinguish "config unreadable → fail-CONSERVATIVE" from "config
-    # readable but owner is non-string / orphan → exclude". A bad-owner
-    # task under a readable config is an orphan (excluded), not a
-    # config-read failure.
+    # distinguish "config unreadable → count-on-failure fall-through"
+    # from "config readable but owner is non-string / orphan →
+    # exclude". A bad-owner task under a readable config is an orphan
+    # (excluded), not a config-read failure.
     members = _iter_members(team_name)
     if not members:
-        # Empty members list = fail-CONSERVATIVE signal at the call site
-        # (members[] empty ⇒ unreadable for classification purposes).
-        # See the inline comment block in _lifecycle_relevant for the
-        # under-arm-unrecoverable vs over-arm-recoverable asymmetry.
+        # Empty members list signals the count-on-failure fall-through
+        # at the call site (members[] empty ⇒ unreadable for
+        # classification purposes). The rationale for that posture
+        # lives in _lifecycle_relevant's step-4 elif body where the
+        # logic is exercised.
         return _OwnerClassification(False, False, None, False)
 
     if not isinstance(owner, str) or not owner:
         # Config IS readable, but the owner is missing or non-string.
         # Return is_known=False so the call site excludes the task as
         # an orphan / unowned; config_readable=True signals "the
-        # exclusion is intentional, not fail-CONSERVATIVE."
+        # exclusion is intentional, not the count-on-failure path."
         return _OwnerClassification(False, False, None, True)
 
     lead_agent_id = _read_team_lead_agent_id(team_name)
@@ -218,10 +219,12 @@ def _owner_is_known_team_member(owner: Any, team_name: str) -> bool:
     non-string owner, empty owner string, empty team_name, empty members
     list (config unreadable or members[] missing/empty), or no name
     match. Fail-CLOSED-symmetric internally — the call site
-    (``_lifecycle_relevant``) is responsible for the fail-CONSERVATIVE
-    short-circuit when the members list is empty (see the inline comment
-    block in ``_lifecycle_relevant``'s step-4 body for the asymmetry
-    rationale).
+    (``_lifecycle_relevant``, step 4) handles its own count-on-failure
+    posture when the members list is empty; see the inline rationale
+    comment inside the step-4 ``elif team_name:`` branch for the
+    asymmetry between this helper's fail-CLOSED behavior and the call
+    site's fall-through. Step labels match the ``# Step N:`` anchors
+    in ``_lifecycle_relevant``.
 
     Retained as a public-style helper for test reuse and future callers;
     after the ``_classify_owner`` refactor, ``_lifecycle_relevant`` uses
@@ -239,10 +242,12 @@ def _is_lead_owned(owner: Any, team_name: str) -> bool:
     non-string owner, empty owner string, empty team_name, empty
     leadAgentId (config unreadable or field missing), empty members
     list, or no member matches both name and lead-agentId. Fail-CLOSED-
-    symmetric internally — the call site (``_lifecycle_relevant``) is
-    responsible for the fail-CONSERVATIVE short-circuit when the members
-    list is empty (see the inline comment block in
-    ``_lifecycle_relevant``'s step-4 body for the asymmetry rationale).
+    symmetric internally — the call site (``_lifecycle_relevant``,
+    step 4) handles its own count-on-failure posture when the members
+    list is empty; see the inline rationale comment inside the step-4
+    ``elif team_name:`` branch for the asymmetry between this helper's
+    fail-CLOSED behavior and the call site's fall-through. Step labels
+    match the ``# Step N:`` anchors in ``_lifecycle_relevant``.
 
     Retained as a public-style helper for test reuse; after the
     ``_classify_owner`` refactor, ``_lifecycle_relevant`` uses the
@@ -416,21 +421,10 @@ def _lifecycle_relevant(task: Any, team_name: str = "") -> bool:
     # so a teammate-owned signal task passes step 4 and is excluded at
     # step 6; an unowned/orphan/lead-owned signal task (structurally
     # impossible today, but defended against) is excluded at step 4.
-    #
-    # Fail-CONSERVATIVE: if the team config is unreadable (members list
-    # is empty), `_classify_owner` returned `config_readable=False` and
-    # BOTH step 3 and step 4 fall through to step 5. The sibling
-    # predicates in intentional_wait.py fail-CLOSED on read errors
-    # (return False), but the failure mode here inverts the priority:
-    # under-arm (silent teardown loss while teammate work is in flight)
-    # is unrecoverable; over-arm (extra empty scans) is recoverable on
-    # the next state change. The wake-mechanism's purpose — never
-    # strand a teammate whose SendMessage needs to wake the lead — is
-    # load-bearing here, so we fail toward counting on every config-
-    # read failure. The audit-anchor invariant test pins these phrases
-    # (Fail-CONSERVATIVE, under-arm, unrecoverable) inside this body so
-    # a future agent-reader deleting step 4 also deletes the rationale
-    # rather than leaving an orphan comment.
+    # The failure-mode rationale documenting why the unreadable-config
+    # branch counts (rather than excluding) lives inside the `elif`
+    # body below so a body-only revert deletes both the logic and its
+    # justification together.
     if classification.config_readable:
         if not isinstance(owner, str) or not owner:
             return False
@@ -439,8 +433,23 @@ def _lifecycle_relevant(task: Any, team_name: str = "") -> bool:
         if classification.is_lead:
             return False
     elif team_name:
-        # Non-empty team_name but empty members list — fail-CONSERVATIVE
-        # fall-through (see the asymmetry comment above this block).
+        # Fail-CONSERVATIVE: the team config is unreadable (members
+        # list is empty), so `_classify_owner` returned
+        # `config_readable=False` and BOTH step 3 and step 4 fall
+        # through to step 5. The sibling predicates in
+        # intentional_wait.py fail-CLOSED on read errors (return False),
+        # but the failure mode here inverts the priority: under-arm
+        # (silent teardown loss while teammate work is in flight) is
+        # unrecoverable; over-arm (extra empty scans) is recoverable on
+        # the next state change. The wake-mechanism's purpose — never
+        # strand a teammate whose SendMessage needs to wake the lead —
+        # is load-bearing here, so we fail toward counting on every
+        # config-read failure. The audit-anchor invariant test pins
+        # these phrases (Fail-CONSERVATIVE, under-arm, unrecoverable)
+        # inside this `elif` body so a future agent-reader deleting
+        # step 4 also deletes the rationale rather than leaving an
+        # orphan comment.
+        #
         # One-shot observability warn per team per process so a
         # permanently-unreadable config doesn't silently keep the wake
         # mechanism armed for the entire session.

--- a/pact-plugin/hooks/shared/wake_lifecycle.py
+++ b/pact-plugin/hooks/shared/wake_lifecycle.py
@@ -131,7 +131,11 @@ class _OwnerClassification:
 _EMPTY_CONFIG_WARN_TEAMS: set[str] = set()
 
 
-def _classify_owner(owner: Any, team_name: str) -> _OwnerClassification:
+def _classify_owner(
+    owner: Any,
+    team_name: str,
+    teams_dir: str | None = None,
+) -> _OwnerClassification:
     """Read the team config ONCE and project the four fields needed by
     ``_lifecycle_relevant``'s step 3 (wake-excluded agentType) and step 4
     (orphan / lead-owned exclusion).
@@ -155,6 +159,29 @@ def _classify_owner(owner: Any, team_name: str) -> _OwnerClassification:
     ``_iter_members`` three times per call (once explicitly + once
     inside each of two predicate helpers); now it invokes ``_iter_members``
     once and ``_read_team_lead_agent_id`` once.
+
+    Note on the ``owner: Any`` parameter type: sibling predicates in
+    ``intentional_wait.py`` (``_is_exempt_agent_type``,
+    ``_is_wake_excluded_agent_type``, ``_is_teachback_exempt_agent_type``)
+    use ``owner: str`` because their callers pre-validate the owner
+    shape upstream. ``_classify_owner`` IS the validation point — its
+    sole runtime caller (``_lifecycle_relevant``, line ~399) passes
+    ``task.get("owner")`` directly from the on-disk task JSON without an
+    upstream isinstance guard, so the actual contract accepts any
+    JSON-readable value. Narrowing the type hint to ``str`` would be a
+    type lie that a future type-checker would flag at the call site.
+    The internal ``isinstance(owner, str)`` guard below is the
+    validation that makes this safe.
+
+    Args:
+        owner: Task owner field (raw from ``task.get("owner")`` at the
+            call site; may be None, str, int, list, etc.). Internal
+            isinstance guard handles non-string shapes.
+        team_name: Team name for config path. Empty/non-string returns
+            an all-False classification.
+        teams_dir: Override teams directory (for testing). Forwarded to
+            ``_iter_members`` and ``_read_team_lead_agent_id``. Matches
+            the sibling-convention of pact_context.py helpers.
     """
     if not isinstance(team_name, str) or not team_name:
         # Empty team_name disables config classification entirely.
@@ -168,7 +195,7 @@ def _classify_owner(owner: Any, team_name: str) -> _OwnerClassification:
     # from "config readable but owner is non-string / orphan →
     # exclude". A bad-owner task under a readable config is an orphan
     # (excluded), not a config-read failure.
-    members = _iter_members(team_name)
+    members = _iter_members(team_name, teams_dir=teams_dir)
     if not members:
         # Empty members list signals the count-on-failure fall-through
         # at the call site (members[] empty ⇒ unreadable for
@@ -184,7 +211,7 @@ def _classify_owner(owner: Any, team_name: str) -> _OwnerClassification:
         # exclusion is intentional, not the count-on-failure path."
         return _OwnerClassification(False, False, None, True)
 
-    lead_agent_id = _read_team_lead_agent_id(team_name)
+    lead_agent_id = _read_team_lead_agent_id(team_name, teams_dir=teams_dir)
     is_known = False
     is_lead = False
     agent_type: str | None = None
@@ -205,7 +232,11 @@ def _classify_owner(owner: Any, team_name: str) -> _OwnerClassification:
     return _OwnerClassification(is_known, is_lead, agent_type, True)
 
 
-def _owner_is_known_team_member(owner: Any, team_name: str) -> bool:
+def _owner_is_known_team_member(
+    owner: Any,
+    team_name: str,
+    teams_dir: str | None = None,
+) -> bool:
     """Return True iff ``owner`` matches some member's ``name`` field in
     the team config.
 
@@ -228,12 +259,18 @@ def _owner_is_known_team_member(owner: Any, team_name: str) -> bool:
     Retained as a public-style helper for test reuse and future callers;
     after the ``_classify_owner`` refactor, ``_lifecycle_relevant`` uses
     the consolidated projection directly and no longer calls this
-    helper at runtime.
+    helper at runtime. The ``owner: Any`` parameter type and ``teams_dir``
+    forwarding mirror the ``_classify_owner`` signature; see that
+    helper's docstring for the rationale on accepting ``Any``.
     """
-    return _classify_owner(owner, team_name).is_known_team_member
+    return _classify_owner(owner, team_name, teams_dir=teams_dir).is_known_team_member
 
 
-def _is_lead_owned(owner: Any, team_name: str) -> bool:
+def _is_lead_owned(
+    owner: Any,
+    team_name: str,
+    teams_dir: str | None = None,
+) -> bool:
     """Return True iff ``owner`` matches a member of the team config
     whose ``agentId`` equals the team's ``leadAgentId``.
 
@@ -251,9 +288,11 @@ def _is_lead_owned(owner: Any, team_name: str) -> bool:
     Retained as a public-style helper for test reuse; after the
     ``_classify_owner`` refactor, ``_lifecycle_relevant`` uses the
     consolidated projection directly and no longer calls this helper at
-    runtime.
+    runtime. The ``owner: Any`` parameter type and ``teams_dir``
+    forwarding mirror the ``_classify_owner`` signature; see that
+    helper's docstring for the rationale on accepting ``Any``.
     """
-    return _classify_owner(owner, team_name).is_lead
+    return _classify_owner(owner, team_name, teams_dir=teams_dir).is_lead
 
 
 def _warn_empty_team_config_once(team_name: str) -> None:

--- a/pact-plugin/hooks/shared/wake_lifecycle.py
+++ b/pact-plugin/hooks/shared/wake_lifecycle.py
@@ -211,17 +211,16 @@ def _lifecycle_relevant(task: Any, team_name: str = "") -> bool:
     # task passes step 4 and is excluded at step 6; an unowned/orphan/
     # lead-owned signal task (structurally impossible today, but
     # defended against) is excluded at step 4.
-    #
-    # Fail-CONSERVATIVE: if the team config is unreadable (members list is
-    # empty), skip the owner-check and treat as "count toward tally." The
-    # sibling predicates in intentional_wait.py fail-CLOSED on read errors
-    # (return False), but the failure mode here inverts the priority:
-    # under-arm (silent teardown loss while teammate work is in flight) is
-    # unrecoverable; over-arm (extra empty scans) is recoverable on the next
-    # state change. The wake-mechanism's purpose — never strand a teammate
-    # whose SendMessage needs to wake the lead — is load-bearing here, so we
-    # fail toward counting on every config-read failure.
     if team_name:
+        # Fail-CONSERVATIVE: if the team config is unreadable (members list is
+        # empty), skip the owner-check and treat as "count toward tally." The
+        # sibling predicates in intentional_wait.py fail-CLOSED on read errors
+        # (return False), but the failure mode here inverts the priority:
+        # under-arm (silent teardown loss while teammate work is in flight) is
+        # unrecoverable; over-arm (extra empty scans) is recoverable on the next
+        # state change. The wake-mechanism's purpose — never strand a teammate
+        # whose SendMessage needs to wake the lead — is load-bearing here, so we
+        # fail toward counting on every config-read failure.
         members = _iter_members(team_name)
         if members:
             if not isinstance(owner, str) or not owner:

--- a/pact-plugin/hooks/shared/wake_lifecycle.py
+++ b/pact-plugin/hooks/shared/wake_lifecycle.py
@@ -29,6 +29,16 @@ Public surface:
 - _lifecycle_relevant(task, team_name="") -> bool
     Predicate. True iff the task counts toward the active-work tally that
     arms/tears down the wake mechanism.
+- _owner_is_known_team_member(owner, team_name, teams_dir=None) -> bool
+- _is_lead_owned(owner, team_name, teams_dir=None) -> bool
+    Test-contract surface. Thin facades over `_classify_owner`; not
+    invoked from `_lifecycle_relevant` at runtime (the predicate
+    consumes the consolidated `_OwnerClassification` projection
+    directly for single-disk-read efficiency). RETAINED for direct
+    test reuse — do NOT delete on the assumption they are dead code.
+    See each helper's own docstring and the dedicated coverage in
+    `tests/test_wake_lifecycle_teammate_owner_filter.py` for the
+    test contract these helpers anchor.
 
 Contract: pure functions; never raise. Filesystem or JSON parse errors
 fail-open as "no active tasks" (returns 0 / False), matching the

--- a/pact-plugin/hooks/shared/wake_lifecycle.py
+++ b/pact-plugin/hooks/shared/wake_lifecycle.py
@@ -159,7 +159,7 @@ def _classify_owner(owner: Any, team_name: str) -> _OwnerClassification:
     if not isinstance(team_name, str) or not team_name:
         # Empty team_name disables config classification entirely.
         # config_readable=False here is a stand-in for "no source of
-        # truth"; the call site treats it as fail-CONSERVATIVE
+        # truth"; the call site treats it as count-on-failure
         # fall-through identical to the empty-members case.
         return _OwnerClassification(False, False, None, False)
 
@@ -209,11 +209,10 @@ def _owner_is_known_team_member(owner: Any, team_name: str) -> bool:
     """Return True iff ``owner`` matches some member's ``name`` field in
     the team config.
 
-    Renamed from ``_owner_is_team_member`` to clarify that this helper
-    answers "does the config record a member with this name?" rather
-    than "is this owner a teammate (not the lead)?". The teammate-vs-
-    lead distinction is the OR of ``is_known_team_member`` AND
-    ``not is_lead`` — both surfaced via ``_classify_owner``.
+    Answers "does the config record a member with this name?" — distinct
+    from "is this owner a teammate (not the lead)?", which is the
+    conjunction of ``is_known_team_member`` AND ``not is_lead``. Both
+    are surfaced via ``_classify_owner``.
 
     Pure function; never raises. Returns False on every error path:
     non-string owner, empty owner string, empty team_name, empty members
@@ -348,10 +347,10 @@ def _lifecycle_relevant(task: Any, team_name: str = "") -> bool:
         tasks (created by workflow commands), orphan-owner tasks (owner
         string doesn't match any current member), and team-lead-owned
         tasks (umbrella / feature / phase records) all return False.
-        The check is fail-CONSERVATIVE at the call site when the team
-        config is unreadable (empty members list short-circuits to
-        "count") — see the inline comment block at step 4 for the
-        asymmetry rationale.
+        The check applies a count-on-failure posture at the call site
+        when the team config is unreadable (empty members list short-
+        circuits to "count") — see the inline comment block at step 4
+        for the asymmetry rationale.
       - Signal-task pattern: metadata.completion_type == "signal" AND
         metadata.type in {"blocker", "algedonic"}. Applied AFTER the
         teammate-owner check; a teammate-owned signal task passes the

--- a/pact-plugin/hooks/shared/wake_lifecycle.py
+++ b/pact-plugin/hooks/shared/wake_lifecycle.py
@@ -60,6 +60,7 @@ Carve-out rules:
 from typing import Any
 
 from shared.intentional_wait import _is_wake_excluded_agent_type
+from shared.pact_context import _iter_members, _read_team_lead_agent_id
 from shared.task_utils import iter_team_task_jsons, read_task_json
 
 # Signal-task types — inline literal mirrors the convention at
@@ -74,6 +75,61 @@ _SIGNAL_TASK_TYPES = ("blocker", "algedonic")
 # by the positive allowlist (conservative: only count statuses we know
 # represent in-flight work).
 _ACTIVE_STATUSES = ("pending", "in_progress")
+
+
+def _owner_is_team_member(owner: Any, team_name: str) -> bool:
+    """Return True iff ``owner`` matches some member's ``name`` field in
+    the team config.
+
+    Pure function; never raises. Returns False on every error path:
+    non-string owner, empty owner string, empty team_name, empty members
+    list (config unreadable or members[] missing/empty), or no name
+    match. Fail-CLOSED-symmetric internally — the call site
+    (``_lifecycle_relevant``) is responsible for the fail-CONSERVATIVE
+    short-circuit when the members list is empty (see the inline comment
+    block at step 4 of ``_lifecycle_relevant`` for the asymmetry
+    rationale).
+    """
+    if not isinstance(owner, str) or not owner:
+        return False
+    if not team_name:
+        return False
+    members = _iter_members(team_name)
+    if not members:
+        return False
+    for member in members:
+        if member.get("name") == owner:
+            return True
+    return False
+
+
+def _is_lead_owned(owner: Any, team_name: str) -> bool:
+    """Return True iff ``owner`` matches a member of the team config
+    whose ``agentId`` equals the team's ``leadAgentId``.
+
+    Pure function; never raises. Returns False on every error path:
+    non-string owner, empty owner string, empty team_name, empty
+    leadAgentId (config unreadable or field missing), empty members
+    list, or no member matches both name and lead-agentId. Fail-CLOSED-
+    symmetric internally — the call site (``_lifecycle_relevant``) is
+    responsible for the fail-CONSERVATIVE short-circuit when the members
+    list is empty (see the inline comment block at step 4 of
+    ``_lifecycle_relevant`` for the asymmetry rationale).
+    """
+    if not isinstance(owner, str) or not owner:
+        return False
+    if not team_name:
+        return False
+    lead_agent_id = _read_team_lead_agent_id(team_name)
+    if not lead_agent_id:
+        return False
+    members = _iter_members(team_name)
+    if not members:
+        return False
+    for member in members:
+        if member.get("name") == owner and member.get("agentId") == lead_agent_id:
+            return True
+    return False
 
 
 def _lifecycle_relevant(task: Any, team_name: str = "") -> bool:
@@ -100,8 +156,19 @@ def _lifecycle_relevant(task: Any, team_name: str = "") -> bool:
         re-introducing the predicate. Evaluated before the metadata-
         shape check so that a wake-excluded agentType task with
         corrupted metadata is still excluded once the set is non-empty.
+      - Teammate-owner check: tasks count ONLY if their owner is a
+        team-config member AND not the team-lead. Unowned umbrella
+        tasks (created by workflow commands), orphan-owner tasks (owner
+        string doesn't match any current member), and team-lead-owned
+        tasks (umbrella / feature / phase records) all return False.
+        The check is fail-CONSERVATIVE at the call site when the team
+        config is unreadable (empty members list short-circuits to
+        "count") — see the inline comment block at step 4 for the
+        asymmetry rationale.
       - Signal-task pattern: metadata.completion_type == "signal" AND
-        metadata.type in {"blocker", "algedonic"}.
+        metadata.type in {"blocker", "algedonic"}. Applied AFTER the
+        teammate-owner check; a teammate-owned signal task passes the
+        owner check and is excluded here.
     """
     if not isinstance(task, dict):
         return False
@@ -134,6 +201,36 @@ def _lifecycle_relevant(task: Any, team_name: str = "") -> bool:
     owner = task.get("owner")
     if isinstance(owner, str) and _is_wake_excluded_agent_type(owner, team_name):
         return False
+
+    # Teammate-owner check (step 4): tasks count toward the wake tally
+    # only when the owner is a non-lead member of the team. Unowned
+    # umbrella tasks (created by /PACT:orchestrate, /PACT:comPACT,
+    # /PACT:peer-review), orphan-owner tasks, and team-lead-owned tasks
+    # all return False here. The predicate flow places this BEFORE the
+    # signal-task metadata carve-out (step 6) so a teammate-owned signal
+    # task passes step 4 and is excluded at step 6; an unowned/orphan/
+    # lead-owned signal task (structurally impossible today, but
+    # defended against) is excluded at step 4.
+    #
+    # Fail-CONSERVATIVE: if the team config is unreadable (members list is
+    # empty), skip the owner-check and treat as "count toward tally." The
+    # sibling predicates in intentional_wait.py fail-CLOSED on read errors
+    # (return False), but the failure mode here inverts the priority:
+    # under-arm (silent teardown loss while teammate work is in flight) is
+    # unrecoverable; over-arm (extra empty scans) is recoverable on the next
+    # state change. The wake-mechanism's purpose — never strand a teammate
+    # whose SendMessage needs to wake the lead — is load-bearing here, so we
+    # fail toward counting on every config-read failure.
+    if team_name:
+        members = _iter_members(team_name)
+        if members:
+            if not isinstance(owner, str) or not owner:
+                return False
+            if not _owner_is_team_member(owner, team_name):
+                return False
+            if _is_lead_owned(owner, team_name):
+                return False
+        # else: members list empty → fail-CONSERVATIVE; fall through.
 
     metadata = task.get("metadata") or {}
     if not isinstance(metadata, dict):

--- a/pact-plugin/hooks/shared/wake_lifecycle.py
+++ b/pact-plugin/hooks/shared/wake_lifecycle.py
@@ -57,11 +57,27 @@ Carve-out rules:
    shared.intentional_wait for the divergence rationale.
 """
 
+import sys
+from dataclasses import dataclass
 from typing import Any
 
-from shared.intentional_wait import _is_wake_excluded_agent_type
+from shared.intentional_wait import WAKE_EXCLUDED_AGENT_TYPES
+from shared.intentional_wait import _is_wake_excluded_agent_type  # noqa: F401  # DECOUPLED-CONSTANT pin
 from shared.pact_context import _iter_members, _read_team_lead_agent_id
 from shared.task_utils import iter_team_task_jsons, read_task_json
+
+try:
+    from shared import session_journal  # type: ignore
+except Exception:  # pragma: no cover - import guard
+    session_journal = None  # type: ignore[assignment]
+
+# DECOUPLED-CONSTANT pin: the `_is_wake_excluded_agent_type` import above is
+# preserved but unused at runtime after the _classify_owner refactor folded
+# its single call site into the consolidated owner-classification path.
+# `tests/test_inbox_wake_lifecycle_helper.py::test_helper_imports_shared_helper_from_intentional_wait`
+# pins the presence of this exact import line to enforce the DECOUPLED-
+# CONSTANT discipline (wake-side helper, NOT the self-completion-side
+# `_is_exempt_agent_type`). Keep the import; the test is the contract.
 
 # Signal-task types — inline literal mirrors the convention at
 # agent_handoff_emitter.py:78 and task_utils.find_blockers. The carve-out
@@ -77,9 +93,126 @@ _SIGNAL_TASK_TYPES = ("blocker", "algedonic")
 _ACTIVE_STATUSES = ("pending", "in_progress")
 
 
-def _owner_is_team_member(owner: Any, team_name: str) -> bool:
+@dataclass(frozen=True)
+class _OwnerClassification:
+    """Projection of the team config relevant to the owner-classification
+    decision in ``_lifecycle_relevant``.
+
+    Three fields, derived from ONE read of ``_iter_members(team_name)``
+    and ONE read of ``_read_team_lead_agent_id(team_name)``:
+
+    - ``is_known_team_member``: True iff the owner matches some
+      member's ``name`` field in the team config.
+    - ``is_lead``: True iff the owner matches a member whose ``agentId``
+      equals the team's ``leadAgentId``.
+    - ``agent_type``: the member's ``agentType`` string when present,
+      else None. Used by the wake-excluded-agentType carve-out.
+    - ``config_readable``: True iff ``_iter_members`` returned a
+      non-empty members list. False distinguishes the
+      fail-CONSERVATIVE-fall-through case (members list empty: config
+      missing, malformed JSON, or members[] absent) from the orphan
+      case (members non-empty, no name match).
+
+    A frozen dataclass rather than a namedtuple so the field semantics
+    are documented inline at the consumer's read site.
+    """
+
+    is_known_team_member: bool
+    is_lead: bool
+    agent_type: str | None
+    config_readable: bool
+
+
+# Dedupe set for the empty-config warning. ONE warn per session per team,
+# not per task — the predicate runs on every TaskCreate/TaskUpdate via the
+# wake_lifecycle_emitter hook, so per-task warns would flood. Module-level
+# set is OK because each hook invocation is a fresh Python process (new
+# module state = clean dedupe).
+_EMPTY_CONFIG_WARN_TEAMS: set[str] = set()
+
+
+def _classify_owner(owner: Any, team_name: str) -> _OwnerClassification:
+    """Read the team config ONCE and project the four fields needed by
+    ``_lifecycle_relevant``'s step 3 (wake-excluded agentType) and step 4
+    (orphan / lead-owned exclusion).
+
+    Pure function; never raises. Returns an all-False / config_readable=
+    False classification on any error path:
+
+    - non-string owner OR empty owner OR non-string team_name OR empty
+      team_name → all fields default (no classification can be made).
+    - ``_iter_members`` returns ``[]`` (config missing / unreadable /
+      malformed / members[] absent) → ``config_readable=False`` so the
+      call site can fail-CONSERVATIVE (count toward tally). The other
+      fields stay False / None.
+    - members non-empty, no name match → ``is_known_team_member=False``,
+      ``is_lead=False``, ``agent_type=None``, ``config_readable=True``.
+      The call site uses these flags to exclude the task as an orphan
+      owner.
+
+    Single source of truth for the wake-side owner classification.
+    Before this projection, ``_lifecycle_relevant`` invoked
+    ``_iter_members`` three times per call (once explicitly + once
+    inside each of two predicate helpers); now it invokes ``_iter_members``
+    once and ``_read_team_lead_agent_id`` once.
+    """
+    if not isinstance(team_name, str) or not team_name:
+        # Empty team_name disables config classification entirely.
+        # config_readable=False here is a stand-in for "no source of
+        # truth"; the call site treats it as fail-CONSERVATIVE
+        # fall-through identical to the empty-members case.
+        return _OwnerClassification(False, False, None, False)
+
+    # Read the config regardless of owner shape so the call site can
+    # distinguish "config unreadable → fail-CONSERVATIVE" from "config
+    # readable but owner is non-string / orphan → exclude". A bad-owner
+    # task under a readable config is an orphan (excluded), not a
+    # config-read failure.
+    members = _iter_members(team_name)
+    if not members:
+        # Empty members list = fail-CONSERVATIVE signal at the call site
+        # (members[] empty ⇒ unreadable for classification purposes).
+        # See the inline comment block in _lifecycle_relevant for the
+        # under-arm-unrecoverable vs over-arm-recoverable asymmetry.
+        return _OwnerClassification(False, False, None, False)
+
+    if not isinstance(owner, str) or not owner:
+        # Config IS readable, but the owner is missing or non-string.
+        # Return is_known=False so the call site excludes the task as
+        # an orphan / unowned; config_readable=True signals "the
+        # exclusion is intentional, not fail-CONSERVATIVE."
+        return _OwnerClassification(False, False, None, True)
+
+    lead_agent_id = _read_team_lead_agent_id(team_name)
+    is_known = False
+    is_lead = False
+    agent_type: str | None = None
+    for member in members:
+        if member.get("name") != owner:
+            continue
+        is_known = True
+        member_agent_id = member.get("agentId")
+        if lead_agent_id and member_agent_id == lead_agent_id:
+            is_lead = True
+        raw_agent_type = member.get("agentType")
+        if isinstance(raw_agent_type, str):
+            agent_type = raw_agent_type
+        # First matching member wins. Duplicate-name configs are
+        # malformed; the first match is the canonical record.
+        break
+
+    return _OwnerClassification(is_known, is_lead, agent_type, True)
+
+
+def _owner_is_known_team_member(owner: Any, team_name: str) -> bool:
     """Return True iff ``owner`` matches some member's ``name`` field in
     the team config.
+
+    Renamed from ``_owner_is_team_member`` to clarify that this helper
+    answers "does the config record a member with this name?" rather
+    than "is this owner a teammate (not the lead)?". The teammate-vs-
+    lead distinction is the OR of ``is_known_team_member`` AND
+    ``not is_lead`` — both surfaced via ``_classify_owner``.
 
     Pure function; never raises. Returns False on every error path:
     non-string owner, empty owner string, empty team_name, empty members
@@ -87,20 +220,15 @@ def _owner_is_team_member(owner: Any, team_name: str) -> bool:
     match. Fail-CLOSED-symmetric internally — the call site
     (``_lifecycle_relevant``) is responsible for the fail-CONSERVATIVE
     short-circuit when the members list is empty (see the inline comment
-    block at step 4 of ``_lifecycle_relevant`` for the asymmetry
+    block in ``_lifecycle_relevant``'s step-4 body for the asymmetry
     rationale).
+
+    Retained as a public-style helper for test reuse and future callers;
+    after the ``_classify_owner`` refactor, ``_lifecycle_relevant`` uses
+    the consolidated projection directly and no longer calls this
+    helper at runtime.
     """
-    if not isinstance(owner, str) or not owner:
-        return False
-    if not isinstance(team_name, str) or not team_name:
-        return False
-    members = _iter_members(team_name)
-    if not members:
-        return False
-    for member in members:
-        if member.get("name") == owner:
-            return True
-    return False
+    return _classify_owner(owner, team_name).is_known_team_member
 
 
 def _is_lead_owned(owner: Any, team_name: str) -> bool:
@@ -113,23 +241,77 @@ def _is_lead_owned(owner: Any, team_name: str) -> bool:
     list, or no member matches both name and lead-agentId. Fail-CLOSED-
     symmetric internally — the call site (``_lifecycle_relevant``) is
     responsible for the fail-CONSERVATIVE short-circuit when the members
-    list is empty (see the inline comment block at step 4 of
-    ``_lifecycle_relevant`` for the asymmetry rationale).
+    list is empty (see the inline comment block in
+    ``_lifecycle_relevant``'s step-4 body for the asymmetry rationale).
+
+    Retained as a public-style helper for test reuse; after the
+    ``_classify_owner`` refactor, ``_lifecycle_relevant`` uses the
+    consolidated projection directly and no longer calls this helper at
+    runtime.
     """
-    if not isinstance(owner, str) or not owner:
-        return False
+    return _classify_owner(owner, team_name).is_lead
+
+
+def _warn_empty_team_config_once(team_name: str) -> None:
+    """Emit a ONE-shot per-team warning when the empty-members fall-
+    through fires at ``_lifecycle_relevant``'s step 4.
+
+    The fall-through is operationally recoverable (over-arm = extra
+    empty scans) but indicates the team config is unreadable or
+    malformed — an observability gap worth surfacing. Without this
+    signal, a permanently-unreadable config would silently keep the
+    wake mechanism armed for the entire session and only manifest as
+    "scan-pending-tasks fires don't drive teardown."
+
+    Pure-after-side-effect; never raises (warnings are best-effort by
+    design). Dedupe is per-team module-level — each hook invocation is
+    a fresh Python process so the set is empty at start and at most one
+    warning per team fires per process. The wake-mechanism hook runs on
+    every TaskCreate/TaskUpdate, so per-task warnings would flood; per-
+    team-per-process is the tightest natural granularity.
+
+    Routing: prefers ``shared.session_journal.append_event`` with event
+    type ``wake_tally_warn`` (unknown event types bypass per-type
+    schema validation by design — see ``_REQUIRED_FIELDS_BY_TYPE``
+    docstring in session_journal). Falls back to stderr with a
+    ``[WAKE-TALLY WARN]`` prefix if the journal is unreachable
+    (uninitialized session, import failure, write failure).
+    """
     if not isinstance(team_name, str) or not team_name:
-        return False
-    lead_agent_id = _read_team_lead_agent_id(team_name)
-    if not lead_agent_id:
-        return False
-    members = _iter_members(team_name)
-    if not members:
-        return False
-    for member in members:
-        if member.get("name") == owner and member.get("agentId") == lead_agent_id:
-            return True
-    return False
+        return
+    if team_name in _EMPTY_CONFIG_WARN_TEAMS:
+        return
+    _EMPTY_CONFIG_WARN_TEAMS.add(team_name)
+
+    journal_ok = False
+    if session_journal is not None:
+        try:
+            event = session_journal.make_event(
+                "wake_tally_warn",
+                team_name=team_name,
+                reason="empty_team_config_fail_conservative",
+                detail=(
+                    "_iter_members returned [] for team_name; step-4 "
+                    "owner-check skipped; falling through to count "
+                    "(fail-CONSERVATIVE)."
+                ),
+            )
+            journal_ok = bool(session_journal.append_event(event))
+        except Exception:
+            journal_ok = False
+
+    if not journal_ok:
+        try:
+            print(
+                "[WAKE-TALLY WARN] team_name=%r: _iter_members returned [] "
+                "at _lifecycle_relevant step 4; falling through to count "
+                "(fail-CONSERVATIVE)."
+                % team_name,
+                file=sys.stderr,
+            )
+        except Exception:
+            # Pure-never-raises contract: swallow even stderr failures.
+            pass
 
 
 def _lifecycle_relevant(task: Any, team_name: str = "") -> bool:
@@ -170,78 +352,114 @@ def _lifecycle_relevant(task: Any, team_name: str = "") -> bool:
         teammate-owner check; a teammate-owned signal task passes the
         owner check and is excluded here.
     """
+    # Step 1: input shape gate.
     if not isinstance(task, dict):
         return False
 
+    # Step 2: status gate. Only pending / in_progress tasks count.
     if task.get("status") not in _ACTIVE_STATUSES:
         return False
 
-    # Wake-excluded agentType carve-out. Hoisted above the metadata
-    # shape check so that a wake-excluded agentType task with corrupted
-    # metadata is still excluded once the set is non-empty. The
-    # owner-shape check inside _is_wake_excluded_agent_type fail-closes
-    # on non-string owner.
+    # Steps 3 + 4 share a single read of the team config via
+    # `_classify_owner`. The projection is computed ONCE and the wake-
+    # excluded-agentType check (step 3) plus the orphan / lead-owned
+    # check (step 4) both consume its fields. Before this refactor,
+    # _lifecycle_relevant invoked `_iter_members` three times per call
+    # (once explicitly + once inside each of two predicate helpers);
+    # now it invokes `_iter_members` once and `_read_team_lead_agent_id`
+    # once via `_classify_owner`. The wake-tally posture asymmetry
+    # vs the sibling predicates in intentional_wait.py is documented
+    # inline at step 4 below (where the executable check lives).
     #
-    # DECOUPLED-CONSTANT DISCIPLINE: WAKE_EXCLUDED_AGENT_TYPES is a
-    # SEPARATE constant from SELF_COMPLETE_EXEMPT_AGENT_TYPES, and the
-    # two now DIVERGE: SELF_COMPLETE_EXEMPT contains pact-secretary
-    # (memory-save tasks self-complete without lead inspection),
-    # WAKE_EXCLUDED is empty (every teammate, including secretary,
-    # counts toward the wake tally so the lead receives all replies).
-    # The constants answer different questions for different consumers
-    # — self-completion asks "may this owner self-complete without
-    # lead inspection?" and wake-exclusion asks "should this owner's
-    # active work fire the lead's inbox-watch Monitor?" The empty
-    # WAKE_EXCLUDED set is load-bearing for secretary message coverage
-    # — re-adding pact-secretary here would re-introduce the
-    # secretary-window failure mode where the Monitor tore down before
-    # the lead could read the secretary's reply. DO NOT recouple by
-    # re-importing _is_exempt_agent_type here; the divergence is
-    # architectural intent, not a transient state.
+    # DECOUPLED-CONSTANT DISCIPLINE: the agentType check below consults
+    # `WAKE_EXCLUDED_AGENT_TYPES` (imported from intentional_wait.py),
+    # NOT `SELF_COMPLETE_EXEMPT_AGENT_TYPES`. The two constants answer
+    # different questions for different consumers — self-completion
+    # asks "may this owner self-complete without lead inspection?" and
+    # wake-exclusion asks "should this owner's active work fire the
+    # lead's inbox-watch Monitor?" `WAKE_EXCLUDED_AGENT_TYPES` is empty
+    # by design (every teammate, including secretary, counts toward
+    # the wake tally so the lead receives all replies); the empty set
+    # is load-bearing for secretary message coverage. DO NOT recouple
+    # the two policies by aliasing the constants or by re-importing
+    # `_is_exempt_agent_type` here.
     owner = task.get("owner")
-    if isinstance(owner, str) and _is_wake_excluded_agent_type(owner, team_name):
+    if not team_name:
+        # Empty team_name (default-arg / fixture path) skips both
+        # step 3 and step 4 — same fall-through behavior as the empty-
+        # members case below. Documented here so a reader investigating
+        # "what happens when team_name is empty?" sees the rationale at
+        # the call site.
+        classification = _OwnerClassification(False, False, None, False)
+    else:
+        classification = _classify_owner(owner, team_name)
+
+    # Step 3: wake-excluded agentType carve-out. Hoisted above the
+    # metadata-shape check (step 5) so that a wake-excluded agentType
+    # task with corrupted metadata is still excluded once the
+    # WAKE_EXCLUDED_AGENT_TYPES set is non-empty. Currently the set is
+    # empty so this check is a no-op for all owners; the call is
+    # retained so a future hypothetical wake-only-noisy agentType can
+    # be added to the constant without re-introducing the predicate.
+    if (
+        classification.agent_type is not None
+        and classification.agent_type in WAKE_EXCLUDED_AGENT_TYPES
+    ):
         return False
 
-    # Teammate-owner check (step 4): tasks count toward the wake tally
-    # only when the owner is a non-lead member of the team. Unowned
-    # umbrella tasks (created by /PACT:orchestrate, /PACT:comPACT,
-    # /PACT:peer-review), orphan-owner tasks, and team-lead-owned tasks
-    # all return False here. The predicate flow places this BEFORE the
-    # signal-task metadata carve-out (step 6) so a teammate-owned signal
-    # task passes step 4 and is excluded at step 6; an unowned/orphan/
-    # lead-owned signal task (structurally impossible today, but
-    # defended against) is excluded at step 4.
-    if team_name:
-        # Fail-CONSERVATIVE: if the team config is unreadable (members list is
-        # empty), skip the owner-check and treat as "count toward tally." The
-        # sibling predicates in intentional_wait.py fail-CLOSED on read errors
-        # (return False), but the failure mode here inverts the priority:
-        # under-arm (silent teardown loss while teammate work is in flight) is
-        # unrecoverable; over-arm (extra empty scans) is recoverable on the next
-        # state change. The wake-mechanism's purpose — never strand a teammate
-        # whose SendMessage needs to wake the lead — is load-bearing here, so we
-        # fail toward counting on every config-read failure.
-        members = _iter_members(team_name)
-        if members:
-            if not isinstance(owner, str) or not owner:
-                return False
-            if not _owner_is_team_member(owner, team_name):
-                return False
-            if _is_lead_owned(owner, team_name):
-                return False
-        # else: members list empty → fail-CONSERVATIVE; fall through.
+    # Step 4: teammate-owner check. Tasks count toward the wake tally
+    # only when the owner is a known team member AND not the team-lead.
+    # Unowned umbrella tasks (created by /PACT:orchestrate,
+    # /PACT:comPACT, /PACT:peer-review), orphan-owner tasks, and
+    # team-lead-owned tasks all return False here. The predicate flow
+    # places this BEFORE the signal-task metadata carve-out (step 6)
+    # so a teammate-owned signal task passes step 4 and is excluded at
+    # step 6; an unowned/orphan/lead-owned signal task (structurally
+    # impossible today, but defended against) is excluded at step 4.
+    #
+    # Fail-CONSERVATIVE: if the team config is unreadable (members list
+    # is empty), `_classify_owner` returned `config_readable=False` and
+    # BOTH step 3 and step 4 fall through to step 5. The sibling
+    # predicates in intentional_wait.py fail-CLOSED on read errors
+    # (return False), but the failure mode here inverts the priority:
+    # under-arm (silent teardown loss while teammate work is in flight)
+    # is unrecoverable; over-arm (extra empty scans) is recoverable on
+    # the next state change. The wake-mechanism's purpose — never
+    # strand a teammate whose SendMessage needs to wake the lead — is
+    # load-bearing here, so we fail toward counting on every config-
+    # read failure. The audit-anchor invariant test pins these phrases
+    # (Fail-CONSERVATIVE, under-arm, unrecoverable) inside this body so
+    # a future agent-reader deleting step 4 also deletes the rationale
+    # rather than leaving an orphan comment.
+    if classification.config_readable:
+        if not isinstance(owner, str) or not owner:
+            return False
+        if not classification.is_known_team_member:
+            return False
+        if classification.is_lead:
+            return False
+    elif team_name:
+        # Non-empty team_name but empty members list — fail-CONSERVATIVE
+        # fall-through (see the asymmetry comment above this block).
+        # One-shot observability warn per team per process so a
+        # permanently-unreadable config doesn't silently keep the wake
+        # mechanism armed for the entire session.
+        _warn_empty_team_config_once(team_name)
 
+    # Step 5: metadata shape gate.
     metadata = task.get("metadata") or {}
     if not isinstance(metadata, dict):
         # Malformed metadata — conservative: do not silently exempt a real
         # active task on a parse-failed metadata field. Count it.
         return True
 
-    # Signal-task carve-out (inline-literal mirror).
+    # Step 6: signal-task carve-out (inline-literal mirror of the
+    # convention at agent_handoff_emitter.py / task_utils.find_blockers).
     if metadata.get("completion_type") == "signal":
         if metadata.get("type") in _SIGNAL_TASK_TYPES:
             return False
 
+    # Step 7: counted toward active-work tally.
     return True
 
 

--- a/pact-plugin/hooks/shared/wake_lifecycle.py
+++ b/pact-plugin/hooks/shared/wake_lifecycle.py
@@ -92,7 +92,7 @@ def _owner_is_team_member(owner: Any, team_name: str) -> bool:
     """
     if not isinstance(owner, str) or not owner:
         return False
-    if not team_name:
+    if not isinstance(team_name, str) or not team_name:
         return False
     members = _iter_members(team_name)
     if not members:
@@ -118,7 +118,7 @@ def _is_lead_owned(owner: Any, team_name: str) -> bool:
     """
     if not isinstance(owner, str) or not owner:
         return False
-    if not team_name:
+    if not isinstance(team_name, str) or not team_name:
         return False
     lead_agent_id = _read_team_lead_agent_id(team_name)
     if not lead_agent_id:

--- a/pact-plugin/tests/test_inbox_wake_lifecycle_helper.py
+++ b/pact-plugin/tests/test_inbox_wake_lifecycle_helper.py
@@ -93,25 +93,104 @@ def test_lifecycle_relevant_preserves_fail_conservative_audit_anchor():
     """The fail-CONSERVATIVE asymmetry between this call site (count on
     config-read failure) and the sibling predicates in
     intentional_wait.py (return False on config-read failure) is
-    load-bearing for the wake mechanism. Pin a line-anchored phrase
-    from the inline comment block so future cleanup cannot silently
-    invert the posture by deleting the audit anchor."""
-    src = (
+    load-bearing for the wake mechanism. Pin the audit-anchor phrases
+    INSIDE the step-4 ``elif team_name:`` block specifically — a free
+    file-wide substring check would pass vacuously if a future
+    contributor introduced the phrases anywhere else in the module
+    (e.g. a helper docstring, an unrelated comment). The tightened
+    anchor requires both halves of the rationale to live in the
+    executable elif-body's comment block, so a body-only revert that
+    deletes the elif block deletes the anchor with it.
+    """
+    src_path = (
         Path(__file__).resolve().parent.parent
         / "hooks" / "shared" / "wake_lifecycle.py"
-    ).read_text(encoding="utf-8")
-    # The phrase "Fail-CONSERVATIVE" plus the under-arm-vs-over-arm
-    # rationale must remain inline at step 4. Pin both halves so a
-    # rewrite that keeps the keyword but drops the rationale (or vice
-    # versa) still fails.
-    assert "Fail-CONSERVATIVE" in src, (
-        "Inline comment block at step 4 must keep the Fail-CONSERVATIVE "
-        "audit anchor."
     )
-    assert "under-arm" in src and "unrecoverable" in src, (
-        "Inline comment block at step 4 must keep the under-arm-vs-"
-        "over-arm rationale that justifies the fail-CONSERVATIVE posture."
+    src_lines = src_path.read_text(encoding="utf-8").splitlines()
+
+    # Anchor: the EXECUTABLE statement `    elif team_name:` (4-space
+    # indent + trailing colon). Docstring mentions like `elif team_name:`
+    # wrapped in backticks do not match because the indentation differs
+    # and they appear inside triple-quoted strings, not at function-body
+    # indent. We require exactly one such anchor line — duplicates would
+    # indicate either a refactor that split the predicate or a spurious
+    # paste, both of which warrant review.
+    anchor_indices = [
+        i for i, ln in enumerate(src_lines) if ln == "    elif team_name:"
+    ]
+    assert len(anchor_indices) == 1, (
+        "Expected exactly one `    elif team_name:` executable line in "
+        "wake_lifecycle.py (the step-4 fail-CONSERVATIVE branch). Found "
+        f"{len(anchor_indices)} at line numbers "
+        f"{[i + 1 for i in anchor_indices]!r}."
     )
+    anchor_idx = anchor_indices[0]
+
+    # Window: lines following the anchor that belong to the elif body.
+    # The elif body in this branch is comment-only narration plus the
+    # final `_warn_empty_team_config_once(team_name)` call. Collect
+    # lines until we hit either:
+    #   (a) a `# Step N:` outer-step marker (the next outer-step comment
+    #       at the SAME 4-space indent), which closes the elif body, or
+    #   (b) any non-comment, non-blank statement that is NOT the expected
+    #       trailing `_warn_empty_team_config_once(team_name)` call.
+    # The collected window is the executable elif body's comment block.
+    window_lines = []
+    for ln in src_lines[anchor_idx + 1:]:
+        stripped = ln.strip()
+        # Outer-step marker closes the window before consuming.
+        if stripped.startswith("# Step ") and ln.startswith("    # Step "):
+            break
+        window_lines.append(ln)
+        # Stop after the trailing _warn_empty_team_config_once call — the
+        # last executable line of the elif body.
+        if stripped == "_warn_empty_team_config_once(team_name)":
+            break
+    window_text = "\n".join(window_lines)
+
+    # The three audit-anchor phrases MUST live inside the executable
+    # elif body's window. A future revert that deletes the elif body
+    # makes window_lines empty (or near-empty), flipping these
+    # assertions to FAIL — the intended counter-signal under body-only
+    # revert.
+    assert "Fail-CONSERVATIVE" in window_text, (
+        f"`Fail-CONSERVATIVE` audit anchor must live inside the step-4 "
+        f"`elif team_name:` body (executable line {anchor_idx + 1}). "
+        f"Window starts at line {anchor_idx + 2}; collected window:\n"
+        f"{window_text!r}"
+    )
+    assert "under-arm" in window_text, (
+        f"`under-arm` rationale must live inside the step-4 `elif "
+        f"team_name:` body (executable line {anchor_idx + 1}). Window:\n"
+        f"{window_text!r}"
+    )
+    assert "unrecoverable" in window_text, (
+        f"`unrecoverable` rationale must live inside the step-4 `elif "
+        f"team_name:` body (executable line {anchor_idx + 1}). Window:\n"
+        f"{window_text!r}"
+    )
+
+    # Pin additionally that no OTHER executable site in the module
+    # contains these phrases. Docstring/comment occurrences elsewhere
+    # would create a phantom-green path where a future contributor
+    # could delete the elif body's comment block, leave the phrases in
+    # an unrelated docstring, and the assertions above would still
+    # pass. Forbid the phrases anywhere in src EXCEPT inside the
+    # window we just validated.
+    src_outside_window = "\n".join(
+        ln
+        for i, ln in enumerate(src_lines)
+        if not (anchor_idx + 1 <= i <= anchor_idx + len(window_lines))
+    )
+    for phrase in ("Fail-CONSERVATIVE", "under-arm", "unrecoverable"):
+        assert phrase not in src_outside_window, (
+            f"Phrase {phrase!r} must appear ONLY inside the step-4 "
+            f"`elif team_name:` body's comment block (lines "
+            f"{anchor_idx + 2}..{anchor_idx + 1 + len(window_lines)}). "
+            f"Found outside the window — a future contributor could "
+            f"delete the elif body's rationale and this anchor would "
+            f"still pass vacuously."
+        )
 
 
 def test_helper_documented_pure_never_raises():

--- a/pact-plugin/tests/test_inbox_wake_lifecycle_helper.py
+++ b/pact-plugin/tests/test_inbox_wake_lifecycle_helper.py
@@ -165,18 +165,29 @@ def test_lifecycle_relevant_secretary_owner_now_counts_post_empty_carve_out(tmp_
     )
 
 
-def test_lifecycle_relevant_owner_named_secretary_without_agenttype_counts(tmp_path, monkeypatch):
-    """A teammate spoofing owner='secretary' without the privileged
-    agentType in team config is NOT exempt — the carve-out fail-closes
-    on missing-from-config (#682 trust-boundary defense)."""
+def test_lifecycle_relevant_owner_named_secretary_without_agenttype_excluded_as_orphan(tmp_path, monkeypatch):
+    """An owner='secretary' string with no matching member in the team
+    config is an orphan owner — the teammate-owner check returns False
+    BEFORE the wake-side agentType carve-out can promote or demote it.
+    A teammate spoofing owner='secretary' to escape the wake tally hits
+    the orphan-exclusion gate; the spoof neither evades nor sneaks into
+    the privileged agentType set.
+
+    Pre-orphan-exclusion behavior: this task counted toward the active
+    tally because the wake-side agentType carve-out only fired when the
+    owner matched a member whose recorded agentType was in
+    WAKE_EXCLUDED_AGENT_TYPES — a non-member owner simply fell through.
+    Post-orphan-exclusion: orphan owners are now excluded regardless of
+    agentType. The teammate-owner check fail-CLOSES on no member-name
+    match (members list non-empty)."""
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     team = "team-spoof"
     _write_team_config(tmp_path, team, [
         {"name": "backend-coder-1", "agentType": "pact-backend-coder"},
     ])
     task = {"status": "in_progress", "owner": "secretary"}
-    # Not exempt → counts toward active tally.
-    assert wl._lifecycle_relevant(task, team) is True
+    # Orphan owner (not in members) → excluded from wake tally.
+    assert wl._lifecycle_relevant(task, team) is False
 
 
 def test_lifecycle_relevant_empty_team_name_counts_secretary(tmp_path, monkeypatch):
@@ -316,20 +327,24 @@ def test_count_active_tasks_counts_pending_and_in_progress(tmp_path, monkeypatch
     assert wl.count_active_tasks(team) == 2
 
 
-def test_count_active_tasks_skips_signal_only_post_empty_carve_out(tmp_path, monkeypatch):
-    """POST-EMPTY-CARVE-OUT: signal tasks are still excluded from the
-    active tally (signal-task carve-out is independent of the wake-side
-    agentType carve-out), but secretary tasks are now COUNTED because
-    WAKE_EXCLUDED_AGENT_TYPES is empty.
+def test_count_active_tasks_skips_signal_and_orphans(tmp_path, monkeypatch):
+    """Signal tasks remain excluded via the metadata-layer signal-task
+    carve-out (independent of the wake-side agentType carve-out and the
+    teammate-owner check). Orphan-owner tasks (owner string doesn't
+    match any current member) are now also excluded via the teammate-
+    owner check.
 
-    Pre-empty: count == 1 (only `real` counts; sig + sec excluded).
-    Post-empty: count == 2 (real + sec count; sig still excluded via
-    signal-task carve-out which lives at the metadata layer, not the
-    agentType layer).
+    Setup: team config lists only `session-secretary` as a member. Tasks
+    `real` (owner=x) and `sig` (owner=y) are orphans; `sec` (owner=
+    session-secretary) is a known teammate.
 
-    Counter-test-by-revert: a future re-population of
-    WAKE_EXCLUDED_AGENT_TYPES = {pact-secretary} drops the count back
-    to 1; this test must be inverted in lockstep."""
+    Pre-orphan-exclusion: count == 2 (real + sec; sig excluded only by
+    signal-task carve-out). Post-orphan-exclusion: count == 1 (sec only;
+    real is orphan-excluded, sig is signal-task-excluded, sec passes).
+
+    Counter-test-by-revert: removing the teammate-owner check from
+    `_lifecycle_relevant` would restore the count to 2 by re-counting
+    `real` (the orphan)."""
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     team = "team-carveouts"
     # Team config records session-secretary with the privileged agentType.
@@ -343,11 +358,10 @@ def test_count_active_tasks_skips_signal_only_post_empty_carve_out(tmp_path, mon
         metadata={"completion_type": "signal", "type": "blocker"},
     )
     _stage_task(tmp_path, team, "sec", status="in_progress", owner="session-secretary")
-    assert wl.count_active_tasks(team) == 2, (
-        "Post-empty WAKE_EXCLUDED_AGENT_TYPES: secretary tasks count "
-        "(real + sec = 2); only signal tasks are excluded via the "
-        "metadata-layer signal-task carve-out (independent of the "
-        "wake-side agentType carve-out)."
+    assert wl.count_active_tasks(team) == 1, (
+        "Only the known teammate `sec` counts: `real` is excluded as "
+        "orphan owner (not in members), `sig` is excluded by the "
+        "signal-task carve-out."
     )
 
 
@@ -383,18 +397,25 @@ def test_count_active_tasks_session_secretary_now_counts_post_empty_carve_out(tm
     )
 
 
-def test_count_active_tasks_secretary_owner_without_agenttype_counts(tmp_path, monkeypatch):
-    """Trust-boundary defense: owner='secretary' alone is not enough to
-    trigger the carve-out — the team config must record the privileged
-    agentType. A teammate spoofing owner='secretary' without team-config
-    backing counts toward the active tally (#682)."""
+def test_count_active_tasks_secretary_owner_without_agenttype_excluded_as_orphan(tmp_path, monkeypatch):
+    """Trust-boundary defense, strengthened: owner='secretary' alone is
+    not enough to count toward the wake tally — the team config must
+    record a member with that exact name. A teammate spoofing
+    owner='secretary' without a matching member is an orphan owner and
+    is excluded from the active tally.
+
+    Pre-orphan-exclusion: count == 1 (the spoof counted because the
+    agentType-only carve-out fail-closed on missing-from-config but the
+    teammate-owner check did not yet exist). Post-orphan-exclusion:
+    count == 0 (the orphan owner is filtered before reaching the
+    metadata-shape gate)."""
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     team = "team-spoof"
     _write_team_config(tmp_path, team, [
         {"name": "backend-coder-1", "agentType": "pact-backend-coder"},
     ])
     _stage_task(tmp_path, team, "spoof", status="in_progress", owner="secretary")
-    assert wl.count_active_tasks(team) == 1
+    assert wl.count_active_tasks(team) == 0
 
 
 def test_count_active_tasks_skips_unparseable_files(tmp_path, monkeypatch):

--- a/pact-plugin/tests/test_inbox_wake_lifecycle_helper.py
+++ b/pact-plugin/tests/test_inbox_wake_lifecycle_helper.py
@@ -89,6 +89,75 @@ def test_helper_imports_shared_helper_from_intentional_wait():
     assert "frozenset({'pact-secretary'" not in src
 
 
+def test_helper_imports_pact_context_for_owner_filter():
+    """The teammate-owner-classification check in `_lifecycle_relevant`
+    depends on two pact_context helpers: `_iter_members` (member name
+    lookup) and `_read_team_lead_agent_id` (leadAgentId field reader).
+    Pin the import line at the top of `wake_lifecycle.py` so accidental
+    removal during cleanup is caught at test-time.
+
+    Counter-test-by-revert: removing the import line would make
+    `_owner_is_team_member` and `_is_lead_owned` reference unbound names
+    at module load, surfacing as ImportError on test discovery — but the
+    structural invariant catches the regression at the source-text level
+    before runtime."""
+    src = (
+        Path(__file__).resolve().parent.parent
+        / "hooks" / "shared" / "wake_lifecycle.py"
+    ).read_text(encoding="utf-8")
+    assert (
+        "from shared.pact_context import _iter_members, _read_team_lead_agent_id"
+        in src
+    ), (
+        "wake_lifecycle.py must import _iter_members and "
+        "_read_team_lead_agent_id from shared.pact_context — they back "
+        "the teammate-owner-classification check in _lifecycle_relevant."
+    )
+    # The two new helpers must be defined in this module (private,
+    # underscore-prefixed). Symbol presence is the load-bearing anchor;
+    # the docstring contents are validated by the runtime tests in
+    # test_wake_lifecycle_teammate_owner_filter.py.
+    assert "def _owner_is_team_member(" in src
+    assert "def _is_lead_owned(" in src
+
+
+def test_lifecycle_relevant_documents_orphan_exclusion():
+    """The `_lifecycle_relevant` docstring must mention the teammate-
+    owner-check carve-out so future readers understand the predicate's
+    full filter chain. Pin the behavioral language so accidental rewrite
+    catches the regression at test-time."""
+    docs = wl._lifecycle_relevant.__doc__ or ""
+    assert "teammate-owner" in docs.lower() or "teammate-owner check" in docs.lower(), (
+        "Docstring must mention the teammate-owner check that excludes "
+        "unowned, orphan, and lead-owned tasks."
+    )
+
+
+def test_lifecycle_relevant_preserves_fail_conservative_audit_anchor():
+    """The fail-CONSERVATIVE asymmetry between this call site (count on
+    config-read failure) and the sibling predicates in
+    intentional_wait.py (return False on config-read failure) is
+    load-bearing for the wake mechanism. Pin a line-anchored phrase
+    from the inline comment block so future cleanup cannot silently
+    invert the posture by deleting the audit anchor."""
+    src = (
+        Path(__file__).resolve().parent.parent
+        / "hooks" / "shared" / "wake_lifecycle.py"
+    ).read_text(encoding="utf-8")
+    # The phrase "Fail-CONSERVATIVE" plus the under-arm-vs-over-arm
+    # rationale must remain inline at step 4. Pin both halves so a
+    # rewrite that keeps the keyword but drops the rationale (or vice
+    # versa) still fails.
+    assert "Fail-CONSERVATIVE" in src, (
+        "Inline comment block at step 4 must keep the Fail-CONSERVATIVE "
+        "audit anchor."
+    )
+    assert "under-arm" in src and "unrecoverable" in src, (
+        "Inline comment block at step 4 must keep the under-arm-vs-"
+        "over-arm rationale that justifies the fail-CONSERVATIVE posture."
+    )
+
+
 def test_helper_documented_pure_never_raises():
     """Pin the docstring contract — pure functions, never raise. This is
     the structural anchor that lets future cleanup remove the redundant

--- a/pact-plugin/tests/test_inbox_wake_lifecycle_helper.py
+++ b/pact-plugin/tests/test_inbox_wake_lifecycle_helper.py
@@ -89,50 +89,6 @@ def test_helper_imports_shared_helper_from_intentional_wait():
     assert "frozenset({'pact-secretary'" not in src
 
 
-def test_helper_imports_pact_context_for_owner_filter():
-    """The teammate-owner-classification check in `_lifecycle_relevant`
-    depends on two pact_context helpers: `_iter_members` (member name
-    lookup) and `_read_team_lead_agent_id` (leadAgentId field reader).
-    Pin the import line at the top of `wake_lifecycle.py` so accidental
-    removal during cleanup is caught at test-time.
-
-    Counter-test-by-revert: removing the import line would make
-    `_owner_is_team_member` and `_is_lead_owned` reference unbound names
-    at module load, surfacing as ImportError on test discovery — but the
-    structural invariant catches the regression at the source-text level
-    before runtime."""
-    src = (
-        Path(__file__).resolve().parent.parent
-        / "hooks" / "shared" / "wake_lifecycle.py"
-    ).read_text(encoding="utf-8")
-    assert (
-        "from shared.pact_context import _iter_members, _read_team_lead_agent_id"
-        in src
-    ), (
-        "wake_lifecycle.py must import _iter_members and "
-        "_read_team_lead_agent_id from shared.pact_context — they back "
-        "the teammate-owner-classification check in _lifecycle_relevant."
-    )
-    # The two new helpers must be defined in this module (private,
-    # underscore-prefixed). Symbol presence is the load-bearing anchor;
-    # the docstring contents are validated by the runtime tests in
-    # test_wake_lifecycle_teammate_owner_filter.py.
-    assert "def _owner_is_team_member(" in src
-    assert "def _is_lead_owned(" in src
-
-
-def test_lifecycle_relevant_documents_orphan_exclusion():
-    """The `_lifecycle_relevant` docstring must mention the teammate-
-    owner-check carve-out so future readers understand the predicate's
-    full filter chain. Pin the behavioral language so accidental rewrite
-    catches the regression at test-time."""
-    docs = wl._lifecycle_relevant.__doc__ or ""
-    assert "teammate-owner" in docs.lower() or "teammate-owner check" in docs.lower(), (
-        "Docstring must mention the teammate-owner check that excludes "
-        "unowned, orphan, and lead-owned tasks."
-    )
-
-
 def test_lifecycle_relevant_preserves_fail_conservative_audit_anchor():
     """The fail-CONSERVATIVE asymmetry between this call site (count on
     config-read failure) and the sibling predicates in

--- a/pact-plugin/tests/test_session_journal.py
+++ b/pact-plugin/tests/test_session_journal.py
@@ -2944,6 +2944,18 @@ class TestValidateEventSchemaPerType:
         "session_end": {},  # No required fields; baseline-only.
         "cleanup_summary": {},  # No required fields; optional-only (#412 Fix B).
         "session_consolidated": {},  # No required fields; optional-only (#453 Fix B).
+        # `wake_tally_warn` is emitted by
+        # `shared.wake_lifecycle._warn_empty_team_config_once` when the
+        # step-4 owner-classification falls through fail-CONSERVATIVE
+        # (empty members list). `team_name` identifies which team's
+        # config is unreadable; `reason` is a categorical token so a
+        # future log-filter can dispatch on the failure mode. The free-
+        # form `detail` field that the production call site also passes
+        # is documentation-grade prose and is intentionally NOT required.
+        "wake_tally_warn": {
+            "team_name": "team-warn-sample",
+            "reason": "empty_team_config_fail_conservative",
+        },
     }
 
     def test_samples_mirror_required_fields_dict(self):

--- a/pact-plugin/tests/test_wake_lifecycle_teammate_owner_filter.py
+++ b/pact-plugin/tests/test_wake_lifecycle_teammate_owner_filter.py
@@ -10,18 +10,63 @@ under tmp_path, monkeypatch Path.home).
 
 Counter-test-by-revert expected cardinality
 -------------------------------------------
-Reverting ONLY the step-4 owner-check block in `_lifecycle_relevant`
-(keep the new helpers `_owner_is_known_team_member`, `_is_lead_owned`, the
-`shared.pact_context` imports, and the docstring updates) produces
-exactly **17 failures** under the current test surface:
+Two revert protocols apply to this module. Each strips a different
+amount of the owner-classification implementation and produces a
+different empirical failure cardinality. A future reviewer following
+either protocol should reproduce the documented number exactly; a
+divergence indicates either a coverage drift or an upstream refactor
+that this docstring did not anticipate (file a follow-up issue rather
+than silently adjusting the count).
 
+Protocol 1 — body-only revert (default protocol; 17 fail)
+---------------------------------------------------------
+Delete ONLY the step-4 owner-check executable block in
+`_lifecycle_relevant`. Keep `_OwnerClassification`, `_classify_owner`,
+`_owner_is_known_team_member`, `_is_lead_owned`,
+`_warn_empty_team_config_once`, the `shared.pact_context` imports, and
+the `_lifecycle_relevant` docstring carve-out.
+
+Byte-precise procedure (reproduces 17 fail / 71 pass / 2 skip):
+
+  1. cp pact-plugin/hooks/shared/wake_lifecycle.py /tmp/wl.bak
+  2. Locate the step-4 body via `grep -n "if classification.config_readable:"
+     pact-plugin/hooks/shared/wake_lifecycle.py`. The block extends
+     from that line through the `_warn_empty_team_config_once(team_name)`
+     call inside the `elif team_name:` branch. The full delete range
+     covers the `if classification.config_readable:` branch (3 owner-
+     shape / membership / lead-owned guards) PLUS the `elif team_name:`
+     branch including the inline Fail-CONSERVATIVE / under-arm /
+     unrecoverable audit-anchor comment block AND the
+     `_warn_empty_team_config_once(team_name)` call. Replace the
+     entire deleted block with a single blank line so the `# Step 5`
+     comment and `metadata = task.get(...)` statement that follow
+     remain correctly indented.
+  3. KEEP (do NOT delete under Protocol 1): module-top imports of
+     `_iter_members` and `_read_team_lead_agent_id`; the
+     `_OwnerClassification` dataclass; `_classify_owner`;
+     `_owner_is_known_team_member`; `_is_lead_owned`;
+     `_warn_empty_team_config_once`; the `_lifecycle_relevant`
+     docstring carve-out; and the step-4 lead-in comment paragraph
+     (the `# Step 4: teammate-owner check. ...` block immediately
+     above the executable body).
+  4. find pact-plugin -name __pycache__ -type d -exec rm -rf {} +
+  5. pytest pact-plugin/tests/test_wake_lifecycle_teammate_owner_filter.py
+       pact-plugin/tests/test_inbox_wake_lifecycle_helper.py --no-header
+  6. Expect 17 failed, 71 passed, 2 skipped.
+  7. cp /tmp/wl.bak pact-plugin/hooks/shared/wake_lifecycle.py
+  8. git diff --quiet pact-plugin/hooks/shared/wake_lifecycle.py
+     (should exit 0; byte-identity restored)
+
+Breakdown of the 17 body-only failures
+--------------------------------------
   13 new-file failures (this file):
     Core edge-table cases (4):
     - test_unowned_umbrella_task_excluded
     - test_lead_owned_task_excluded
     - test_orphan_owner_excluded
     - test_umbrella_scenario_one_to_zero_transition
-      (pre-fix: count_active_tasks returns 2→1; post-fix: 1→0)
+      (without the owner check: count_active_tasks returns 2→1; with
+      it: 1→0)
 
     Adversarial-edge owner-shape cases (5 parametrize cells):
     - test_stringified_non_member_owners_excluded_as_orphan[42]
@@ -39,83 +84,88 @@ exactly **17 failures** under the current test surface:
     - test_count_active_tasks_scales_linearly_on_large_team
 
   3 legacy lockstep failures (test_inbox_wake_lifecycle_helper.py):
-    Assertions inverted from the pre-fix orphan-counted behavior to
-    the post-fix orphan-excluded behavior in the same commit as the
-    predicate change.
+    Assertions inverted from the pre-owner-check orphan-counted
+    behavior to the post-owner-check orphan-excluded behavior.
     - test_lifecycle_relevant_owner_named_secretary_without_agenttype_excluded_as_orphan
     - test_count_active_tasks_skips_signal_and_orphans
     - test_count_active_tasks_secretary_owner_without_agenttype_excluded_as_orphan
 
   1 structural audit-anchor failure (test_inbox_wake_lifecycle_helper.py):
-    The fail-CONSERVATIVE inline comment block at step 4 documents the
-    under-arm-unrecoverable vs over-arm-recoverable rationale; it lives
-    inside the step-4 block, so a pure step-4 revert deletes the audit
-    anchor along with the logic and this test flips as a TRUE
-    counter-signal (not a phantom-green source-text pin).
+    The fail-CONSERVATIVE / under-arm / unrecoverable phrases live
+    inside the step-4 `elif team_name:` branch. A body-only revert
+    deletes the audit-anchor along with the executable block; this
+    test flips as a TRUE counter-signal (not a phantom-green
+    source-text pin elsewhere in the file).
     - test_lifecycle_relevant_preserves_fail_conservative_audit_anchor
 
-  Tests that pass either way on pure step-4 revert (intentional
-  baseline / helper-level pins; NOT counted toward the 17):
-    - test_teammate_owned_task_counted (baseline; counts pre and post)
-    - test_config_unreadable_fail_conservative (passes pre and post —
-      the pre-fix default also returns True for any owner shape when
-      the team config is unreadable; the test pins the post-fix
-      fail-CONSERVATIVE posture as a regression guard)
-    - test_owner_is_known_team_member_pure_never_raises (helper-level)
-    - test_is_lead_owned_pure_never_raises (helper-level)
-    - test_is_lead_owned_requires_both_name_and_agentid_match
-      (helper-level; the step-4 block is the call-site consumer, but
-      the AND-composition lives in `_is_lead_owned` itself)
-    - test_empty_or_missing_leadagentid_does_not_misclassify_lead
-      (both parametrize cells; helper-level — pins
-      `_is_lead_owned`'s empty/null leadAgentId guard at lines 119-125
-      of wake_lifecycle.py, which is outside the step-4 block)
+Protocol 2 — full-section revert (broader protocol; 22 fail)
+------------------------------------------------------------
+Replace the entire owner-classification surface with the pre-fix
+shape. Run `git checkout main --
+pact-plugin/hooks/shared/wake_lifecycle.py
+pact-plugin/hooks/shared/pact_context.py`, then run pytest as in
+Protocol 1 step 5.
 
-Exact revert procedure (byte-precise; reproduces 17-fail cardinality):
+Expect 22 failed, 66 passed, 2 skipped. After measuring, restore via
+`cp` from the backup and `git reset HEAD --` on both files to drop
+the index drift left by the `git checkout main --` operation.
 
-  1. cp pact-plugin/hooks/shared/wake_lifecycle.py /tmp/wl.bak
-  2. Delete the contiguous `if team_name:` block (currently lines
-     214-232 at HEAD aedf77dd+; locate via `grep -n "if team_name:"
-     pact-plugin/hooks/shared/wake_lifecycle.py`). The block spans
-     from `    if team_name:` through
-     `        # else: members list empty → fail-CONSERVATIVE; fall through.`
-     inclusive — 19 lines total — and includes the 9-line inline
-     Fail-CONSERVATIVE comment block (the audit-anchor) as its first
-     body lines per commit aedf77dd's option-B relocation. Replace
-     the entire deleted block with a single blank line so the
-     `metadata = task.get(...)` statement that follows step 4
-     remains correctly indented.
-  3. KEEP: module-top imports of `_iter_members` and
-     `_read_team_lead_agent_id`, the `_owner_is_known_team_member` and
-     `_is_lead_owned` helper definitions, the `_lifecycle_relevant`
-     docstring carve-out section, and the preceding step-4 lead-in
-     comment block (lines 205-213 at HEAD — these are the
-     `# Teammate-owner check (step 4): ...` paragraph that documents
-     the predicate order).
-  4. find pact-plugin -name __pycache__ -type d -exec rm -rf {} +
-  5. pytest pact-plugin/tests/test_wake_lifecycle_teammate_owner_filter.py
-       pact-plugin/tests/test_inbox_wake_lifecycle_helper.py --no-header
-  6. Expect 17 failed, 71 passed, 2 skipped.
-  7. cp /tmp/wl.bak pact-plugin/hooks/shared/wake_lifecycle.py
-  8. git diff --quiet pact-plugin/hooks/shared/wake_lifecycle.py
-     (should exit 0; byte-identity restored)
+The 22 = 17 body-only failures (above) + 5 additional flips driven by
+the helpers themselves disappearing. The five additional flips ride
+on `AttributeError` (the test imports a helper name that no longer
+exists on the module) rather than test-assertion failures:
 
-Note: an earlier architecture-spec draft (gitignored, not in the repo)
-projected 5 fail on revert; the next round of TEST work super-sided
-it to 8 after the legacy-test lockstep update; this round of TEST
-work super-sides it again to 17 after adding adversarial-edge,
-integration, and stress coverage. The 17 = 13 new-file (4 core +
-5 stringified-owner parametrize cells + 2 fixture/call-site + 2
-integration/stress) + 3 legacy lockstep + 1 audit-anchor.
+  - test_owner_is_known_team_member_pure_never_raises
+  - test_is_lead_owned_pure_never_raises
+  - test_is_lead_owned_requires_both_name_and_agentid_match
+  - test_empty_or_missing_leadagentid_does_not_misclassify_lead[]
+  - test_empty_or_missing_leadagentid_does_not_misclassify_lead[None]
 
-Audit-anchor: when extending or refactoring this file, preserve the
-13-new-file + 3-legacy-lockstep + 1-audit-anchor cardinality so the
-counter-test-by-revert delta remains computable. If you add new unit
-cases that flip on pure step-4 revert, update the count comment above
-in lockstep. Source-text pins for non-load-bearing artifacts (an
-import line, a docstring phrase) are deliberately omitted — they are
-phantom-green-by-absence under pure step-4 revert and provide no
-counter-signal beyond what the runtime tests already cover.
+These five tests are baseline / helper-level pins under Protocol 1
+(they pass either way because the helpers still exist), but they ARE
+counter-signal under Protocol 2 (they fail when the helpers are
+removed entirely). Two-protocol classification gives a fresh reader a
+precise reading of what each test pins: behavior of the step-4
+executable block (Protocol 1 flippers), helper-surface existence
+(Protocol 2-only flippers), or true baseline (passes under both).
+
+Tests that pass under BOTH protocols (true baselines; NOT counter-
+signal under either revert):
+    - test_teammate_owned_task_counted
+        Baseline: a known teammate-owned task counts regardless of
+        whether the owner-check ever fired. Pre-owner-check, every
+        task with an owner counted (orphans included); post-owner-
+        check, only known teammates count. The teammate case sits in
+        the intersection. Pin against future inversion.
+    - test_config_unreadable_fail_conservative
+        Baseline: the wake mechanism's purpose is to surface teammate
+        work, and an unreadable config must NOT silently teardown
+        active sessions. Pre-owner-check, every task counted because
+        the carve-out did not exist; post-owner-check, the empty-
+        members fall-through preserves that posture explicitly. The
+        test pins the fall-through as a regression guard against any
+        future cleanup that inverts the unreadable-config branch to
+        fail-CLOSED.
+
+Genesis of the 17 number
+------------------------
+An earlier architecture-spec draft (gitignored, not in the repo)
+projected 5 fail on revert. The next iteration super-sided it to 8
+after a legacy-test lockstep update brought the legacy file into the
+same revert envelope. The current iteration super-sides it to 17
+after adding adversarial-edge, integration, and stress coverage:
+17 = 4 core + 9 adversarial-edge + 3 legacy lockstep + 1 audit-anchor.
+
+When extending this file, preserve the protocol-1 cardinality of 17
+and the protocol-2 cardinality of 22 so the counter-test-by-revert
+delta remains computable. If you add new unit cases that flip under
+Protocol 1, update the protocol-1 count above in lockstep; if you add
+new helper-pinning tests that flip ONLY under Protocol 2, update the
+protocol-2 count. Source-text pins for non-load-bearing artifacts (an
+import line, a docstring phrase outside the executable body) are
+deliberately omitted — they are phantom-green-by-absence under
+Protocol 1 and provide no counter-signal beyond what the runtime
+tests already cover.
 """
 
 import json

--- a/pact-plugin/tests/test_wake_lifecycle_teammate_owner_filter.py
+++ b/pact-plugin/tests/test_wake_lifecycle_teammate_owner_filter.py
@@ -13,49 +13,53 @@ Counter-test-by-revert expected cardinality
 Reverting ONLY the step-4 owner-check block in `_lifecycle_relevant`
 (keep the new helpers `_owner_is_team_member`, `_is_lead_owned`, the
 `shared.pact_context` imports, and the docstring updates) produces
-**8 failures** under the current test surface:
+exactly **8 failures** under the current test surface:
 
-  - 3 unit cases in this file:
-      * test_unowned_umbrella_task_excluded
-      * test_lead_owned_task_excluded
-      * test_orphan_owner_excluded
-    (test_teammate_owned_task_counted passes either way — teammate
-    baseline always counts; test_config_unreadable_fail_conservative
-    also passes either way — fail-conservative result matches pre-fix
-    "count any owner" default.)
+  4 new-file failures (this file):
+    - test_unowned_umbrella_task_excluded
+    - test_lead_owned_task_excluded
+    - test_orphan_owner_excluded
+    - test_umbrella_scenario_one_to_zero_transition
+      (pre-fix: count_active_tasks returns 2→1; post-fix: 1→0)
 
-  - 1 behavioral umbrella case in this file:
-      * test_umbrella_scenario_one_to_zero_transition
-    (pre-fix: count_active_tasks returns 2→1; post-fix: 1→0).
+  3 legacy lockstep failures (test_inbox_wake_lifecycle_helper.py):
+    Assertions inverted from the pre-fix orphan-counted behavior to
+    the post-fix orphan-excluded behavior in the same commit as the
+    predicate change.
+    - test_lifecycle_relevant_owner_named_secretary_without_agenttype_excluded_as_orphan
+    - test_count_active_tasks_skips_signal_and_orphans
+    - test_count_active_tasks_secretary_owner_without_agenttype_excluded_as_orphan
 
-  - 3 inverted-in-lockstep legacy cases in
-    test_inbox_wake_lifecycle_helper.py (assertions flipped from the
-    pre-fix orphan-counted behavior to the post-fix orphan-excluded
-    behavior in the same commit as the predicate change):
-      * test_lifecycle_relevant_owner_named_secretary_without_agenttype_excluded_as_orphan
-      * test_count_active_tasks_skips_signal_and_orphans
-      * test_count_active_tasks_secretary_owner_without_agenttype_excluded_as_orphan
+  1 structural audit-anchor failure (test_inbox_wake_lifecycle_helper.py):
+    The fail-CONSERVATIVE inline comment block at step 4 documents the
+    under-arm-unrecoverable vs over-arm-recoverable rationale; it lives
+    inside the step-4 block, so a pure step-4 revert deletes the audit
+    anchor along with the logic and this test flips as a TRUE
+    counter-signal (not a phantom-green source-text pin).
+    - test_lifecycle_relevant_preserves_fail_conservative_audit_anchor
 
-  - 1 structural-invariant case in test_inbox_wake_lifecycle_helper.py:
-      * test_lifecycle_relevant_preserves_fail_conservative_audit_anchor
-    (the inline §5.2-derived comment block at step 4 is removed when
-    step 4 is reverted; pin catches the audit-anchor regression).
+  Tests that pass either way on pure step-4 revert (NOT counted toward
+  the 8):
+    - test_teammate_owned_task_counted (baseline; counts pre and post)
+    - test_config_unreadable_fail_conservative (passes pre and post —
+      the pre-fix default also returns True for any owner shape when
+      the team config is unreadable; the test pins the post-fix
+      fail-CONSERVATIVE posture as a regression guard)
 
-  Tests that pass either way on pure step-4 revert and are NOT counted:
-      * test_teammate_owned_task_counted (baseline; passes pre and post)
-      * test_config_unreadable_fail_conservative (passes pre and post —
-        pre-fix default also returns True for any owner with empty
-        members list)
-      * test_helper_imports_pact_context_for_owner_filter (helpers and
-        imports remain on pure step-4 revert)
-      * test_lifecycle_relevant_documents_orphan_exclusion (docstring
-        is not part of the step-4 inline block)
+Note: an earlier architecture-spec draft (gitignored, not in the repo)
+projected 5 fail on revert. It was drafted before the legacy-test
+lockstep update decision was made during implementation. The empirical
+8 super-sides (not sub-sides) the spec's 5: the +3 delta is the legacy
+lockstep updates that the spec did not anticipate.
 
 Audit-anchor: when extending or refactoring this file, preserve the
-3-unit + 1-behavioral + 3-legacy-lockstep + 1-audit-anchor cardinality
-so the counter-test-by-revert delta remains computable. If you add new
-unit cases that flip on pure step-4 revert, update the count comment
-above in lockstep.
+4-new-file + 3-legacy-lockstep + 1-audit-anchor cardinality so the
+counter-test-by-revert delta remains computable. If you add new unit
+cases that flip on pure step-4 revert, update the count comment above
+in lockstep. Source-text pins for non-load-bearing artifacts (an
+import line, a docstring phrase) are deliberately omitted — they are
+phantom-green-by-absence under pure step-4 revert and provide no
+counter-signal beyond what the runtime tests already cover.
 """
 
 import json

--- a/pact-plugin/tests/test_wake_lifecycle_teammate_owner_filter.py
+++ b/pact-plugin/tests/test_wake_lifecycle_teammate_owner_filter.py
@@ -13,14 +13,30 @@ Counter-test-by-revert expected cardinality
 Reverting ONLY the step-4 owner-check block in `_lifecycle_relevant`
 (keep the new helpers `_owner_is_team_member`, `_is_lead_owned`, the
 `shared.pact_context` imports, and the docstring updates) produces
-exactly **8 failures** under the current test surface:
+exactly **17 failures** under the current test surface:
 
-  4 new-file failures (this file):
+  13 new-file failures (this file):
+    Core edge-table cases (4):
     - test_unowned_umbrella_task_excluded
     - test_lead_owned_task_excluded
     - test_orphan_owner_excluded
     - test_umbrella_scenario_one_to_zero_transition
       (pre-fix: count_active_tasks returns 2→1; post-fix: 1→0)
+
+    Adversarial-edge owner-shape cases (5 parametrize cells):
+    - test_stringified_non_member_owners_excluded_as_orphan[42]
+    - test_stringified_non_member_owners_excluded_as_orphan[True]
+    - test_stringified_non_member_owners_excluded_as_orphan[[]]
+    - test_stringified_non_member_owners_excluded_as_orphan[None]
+    - test_stringified_non_member_owners_excluded_as_orphan[0]
+
+    Adversarial-edge fixture and call-site cases (2):
+    - test_member_entry_missing_or_falsy_name_does_not_match
+    - test_lead_owner_short_circuit_does_not_fire_on_name_only_lead_agentid_match
+
+    Integration and stress cases (2):
+    - test_compact_shaped_layout_drops_to_zero_after_teammate_completion
+    - test_count_active_tasks_scales_linearly_on_large_team
 
   3 legacy lockstep failures (test_inbox_wake_lifecycle_helper.py):
     Assertions inverted from the pre-fix orphan-counted behavior to
@@ -38,22 +54,62 @@ exactly **8 failures** under the current test surface:
     counter-signal (not a phantom-green source-text pin).
     - test_lifecycle_relevant_preserves_fail_conservative_audit_anchor
 
-  Tests that pass either way on pure step-4 revert (NOT counted toward
-  the 8):
+  Tests that pass either way on pure step-4 revert (intentional
+  baseline / helper-level pins; NOT counted toward the 17):
     - test_teammate_owned_task_counted (baseline; counts pre and post)
     - test_config_unreadable_fail_conservative (passes pre and post —
       the pre-fix default also returns True for any owner shape when
       the team config is unreadable; the test pins the post-fix
       fail-CONSERVATIVE posture as a regression guard)
+    - test_owner_is_team_member_pure_never_raises (helper-level)
+    - test_is_lead_owned_pure_never_raises (helper-level)
+    - test_is_lead_owned_requires_both_name_and_agentid_match
+      (helper-level; the step-4 block is the call-site consumer, but
+      the AND-composition lives in `_is_lead_owned` itself)
+    - test_empty_or_missing_leadagentid_does_not_misclassify_lead
+      (both parametrize cells; helper-level — pins
+      `_is_lead_owned`'s empty/null leadAgentId guard at lines 119-125
+      of wake_lifecycle.py, which is outside the step-4 block)
+
+Exact revert procedure (byte-precise; reproduces 17-fail cardinality):
+
+  1. cp pact-plugin/hooks/shared/wake_lifecycle.py /tmp/wl.bak
+  2. Delete the contiguous `if team_name:` block (currently lines
+     214-232 at HEAD aedf77dd+; locate via `grep -n "if team_name:"
+     pact-plugin/hooks/shared/wake_lifecycle.py`). The block spans
+     from `    if team_name:` through
+     `        # else: members list empty → fail-CONSERVATIVE; fall through.`
+     inclusive — 19 lines total — and includes the 9-line inline
+     Fail-CONSERVATIVE comment block (the audit-anchor) as its first
+     body lines per commit aedf77dd's option-B relocation. Replace
+     the entire deleted block with a single blank line so the
+     `metadata = task.get(...)` statement that follows step 4
+     remains correctly indented.
+  3. KEEP: module-top imports of `_iter_members` and
+     `_read_team_lead_agent_id`, the `_owner_is_team_member` and
+     `_is_lead_owned` helper definitions, the `_lifecycle_relevant`
+     docstring carve-out section, and the preceding step-4 lead-in
+     comment block (lines 205-213 at HEAD — these are the
+     `# Teammate-owner check (step 4): ...` paragraph that documents
+     the predicate order).
+  4. find pact-plugin -name __pycache__ -type d -exec rm -rf {} +
+  5. pytest pact-plugin/tests/test_wake_lifecycle_teammate_owner_filter.py
+       pact-plugin/tests/test_inbox_wake_lifecycle_helper.py --no-header
+  6. Expect 17 failed, 71 passed, 2 skipped.
+  7. cp /tmp/wl.bak pact-plugin/hooks/shared/wake_lifecycle.py
+  8. git diff --quiet pact-plugin/hooks/shared/wake_lifecycle.py
+     (should exit 0; byte-identity restored)
 
 Note: an earlier architecture-spec draft (gitignored, not in the repo)
-projected 5 fail on revert. It was drafted before the legacy-test
-lockstep update decision was made during implementation. The empirical
-8 super-sides (not sub-sides) the spec's 5: the +3 delta is the legacy
-lockstep updates that the spec did not anticipate.
+projected 5 fail on revert; the next round of TEST work super-sided
+it to 8 after the legacy-test lockstep update; this round of TEST
+work super-sides it again to 17 after adding adversarial-edge,
+integration, and stress coverage. The 17 = 13 new-file (4 core +
+5 stringified-owner parametrize cells + 2 fixture/call-site + 2
+integration/stress) + 3 legacy lockstep + 1 audit-anchor.
 
 Audit-anchor: when extending or refactoring this file, preserve the
-4-new-file + 3-legacy-lockstep + 1-audit-anchor cardinality so the
+13-new-file + 3-legacy-lockstep + 1-audit-anchor cardinality so the
 counter-test-by-revert delta remains computable. If you add new unit
 cases that flip on pure step-4 revert, update the count comment above
 in lockstep. Source-text pins for non-load-bearing artifacts (an
@@ -294,7 +350,13 @@ def test_is_lead_owned_requires_both_name_and_agentid_match(tmp_path, monkeypatc
     NOT match `leadAgentId` is NOT lead-owned. Conversely, a member
     whose `agentId` matches `leadAgentId` but whose `name` does NOT
     match the owner is also NOT lead-owned. Both conditions are
-    required — pins the AND-composition in `_is_lead_owned`."""
+    required — pins the AND-composition in `_is_lead_owned`.
+
+    The agentId-matches-but-name-doesn't direction is exercised by a
+    standalone fixture where the team config holds a single member whose
+    `agentId` equals `leadAgentId` but whose `name` differs from the
+    queried owner. A correct AND-composition returns False; an OR-bug
+    or name-stripped variant would return True."""
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     team = "team-and-comp"
     _write_team_config(
@@ -311,3 +373,293 @@ def test_is_lead_owned_requires_both_name_and_agentid_match(tmp_path, monkeypatc
     assert wl._is_lead_owned("architect", team) is False
     # owner not in members at all → False.
     assert wl._is_lead_owned("ghost", team) is False
+
+    # Inverse direction: agentId matches leadAgentId but the queried owner
+    # name does not match any member name. An OR-bug or name-stripped
+    # check would treat this as lead-owned; the AND-composition rejects.
+    team_inv = "team-and-comp-inverse"
+    _write_team_config(
+        tmp_path, team_inv,
+        [
+            # Lone member's agentId IS leadAgentId, but name='renamed-lead'
+            # — querying owner='team-lead' must NOT match.
+            {"name": "renamed-lead", "agentId": "team-lead@T"},
+        ],
+        lead_agent_id="team-lead@T",
+    )
+    assert wl._is_lead_owned("team-lead", team_inv) is False, (
+        "Lead-ownership requires BOTH name AND agentId match. An owner "
+        "string that doesn't match any member name must return False even "
+        "if some member's agentId equals leadAgentId."
+    )
+
+
+# ---------- Adversarial-edge: owner type-coercion at the call site ----------
+
+
+@pytest.mark.parametrize("stringified_owner", ["42", "True", "[]", "None", "0"])
+def test_stringified_non_member_owners_excluded_as_orphan(
+    stringified_owner, tmp_path, monkeypatch
+):
+    """An owner that is a *string* representation of a non-string value
+    (e.g., the literal text '42' or 'True') is treated as any other
+    string: if it doesn't match a member's `name`, it's an orphan and
+    excluded. Pins behavior under accidental type-coercion at upstream
+    write sites — a coder who writes `owner=str(value)` without
+    validating gets orphan-excluded, not phantom-counted."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    team = "team-stringified-owners"
+    _write_team_config(
+        tmp_path, team,
+        [
+            {"name": "team-lead", "agentId": "team-lead@T"},
+            {"name": "architect", "agentId": "architect@T"},
+        ],
+        lead_agent_id="team-lead@T",
+    )
+    task = {"status": "in_progress", "owner": stringified_owner}
+    assert wl._lifecycle_relevant(task, team) is False, (
+        f"Stringified non-member owner {stringified_owner!r} must be "
+        "treated as orphan and excluded."
+    )
+
+
+# ---------- Adversarial-edge: malformed member entries ----------
+
+
+def test_member_entry_missing_or_falsy_name_does_not_match(tmp_path, monkeypatch):
+    """Member entries lacking a `name` field, or with `name=None` or
+    `name=""`, must not accidentally match any owner. The membership
+    check uses `member.get("name") == owner` which would return True if
+    BOTH sides equal `None` — but a real owner string can never be
+    `None`, and an empty owner is rejected at the helper's first guard.
+    This test pins the boundary so a future refactor that loosens the
+    owner-shape guard does not let a missing-name member act as a
+    wildcard match."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    team = "team-malformed-members"
+    _write_team_config(
+        tmp_path, team,
+        [
+            # Three malformed entries — none has a real string `name`.
+            {"agentId": "ghost-1@T"},          # name field absent
+            {"name": None, "agentId": "ghost-2@T"},
+            {"name": "", "agentId": "ghost-3@T"},
+            # One legit teammate so members list is non-empty.
+            {"name": "architect", "agentId": "architect@T"},
+        ],
+        lead_agent_id="team-lead@T",
+    )
+    # Owner that would only "match" a missing-name member via a None
+    # equality accident — must remain orphan.
+    task = {"status": "in_progress", "owner": "any-name"}
+    assert wl._lifecycle_relevant(task, team) is False
+    # Legit teammate still resolves correctly — the malformed sibling
+    # entries do not break iteration.
+    task_legit = {"status": "in_progress", "owner": "architect"}
+    assert wl._lifecycle_relevant(task_legit, team) is True
+
+
+# ---------- Adversarial-edge: leadAgentId edge values ----------
+
+
+@pytest.mark.parametrize("lead_value", ["", None])
+def test_empty_or_missing_leadagentid_does_not_misclassify_lead(
+    lead_value, tmp_path, monkeypatch
+):
+    """When the team config has `leadAgentId` field present but empty
+    string or `null`, `_is_lead_owned` must return False for every
+    owner. The lead-owner short-circuit must not fire incorrectly
+    against a sentinel-or-missing leadAgentId — a teammate-owned task
+    in such a team config must still count, not be misclassified as
+    lead-owned."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    team = "team-empty-lead"
+    team_dir = tmp_path / ".claude" / "teams" / team
+    team_dir.mkdir(parents=True, exist_ok=True)
+    config = {
+        "team_name": team,
+        "members": [
+            {"name": "architect", "agentId": "architect@T"},
+        ],
+        "leadAgentId": lead_value,
+    }
+    (team_dir / "config.json").write_text(
+        json.dumps(config), encoding="utf-8"
+    )
+    # No owner is lead-owned when leadAgentId is empty/null.
+    assert wl._is_lead_owned("architect", team) is False
+    # Teammate task still counts toward the tally.
+    task = {"status": "in_progress", "owner": "architect"}
+    assert wl._lifecycle_relevant(task, team) is True
+
+
+# ---------- Adversarial-edge: AND-composition (call-site path) ----------
+
+
+def test_lead_owner_short_circuit_does_not_fire_on_name_only_lead_agentid_match(
+    tmp_path, monkeypatch
+):
+    """A member whose `agentId` equals `leadAgentId` but whose `name`
+    does NOT match the task owner must NOT trigger the lead-owner
+    short-circuit at the predicate call site. The task should count
+    (subject to the orphan check — see fixture). This exercises the
+    AND-composition through `_lifecycle_relevant` rather than the
+    isolated helper, closing the call-site path the helper-level test
+    only validates structurally."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    team = "team-name-only-agentid-match"
+    _write_team_config(
+        tmp_path, team,
+        [
+            # `architect`'s agentId happens to equal leadAgentId — but
+            # the owner field on the task is `architect`, not the
+            # member whose name matches the lead role.
+            {"name": "architect", "agentId": "team-lead@T"},
+            {"name": "team-lead", "agentId": "some-other-id@T"},
+        ],
+        lead_agent_id="team-lead@T",
+    )
+    task = {"status": "in_progress", "owner": "architect"}
+    # `architect` IS a team member AND `architect`'s agentId IS
+    # leadAgentId — under the implemented AND-composition, _is_lead_owned
+    # returns True (both name='architect' AND agentId==leadAgentId match
+    # on the same member). The task IS treated as lead-owned and
+    # excluded.
+    assert wl._is_lead_owned("architect", team) is True
+    assert wl._lifecycle_relevant(task, team) is False
+    # The legitimate-named lead, however, is NOT lead-owned here because
+    # its member's agentId does NOT equal leadAgentId — so a task owned
+    # by "team-lead" counts in this misconfigured team. The pin
+    # documents the AND-composition semantics: lead-ownership is the
+    # CONJUNCTION of "name in members" AND "that same member's agentId
+    # equals leadAgentId," and a member with a misaligned agentId is
+    # not promoted to lead even by name.
+    task_named_lead = {"status": "in_progress", "owner": "team-lead"}
+    assert wl._is_lead_owned("team-lead", team) is False
+    assert wl._lifecycle_relevant(task_named_lead, team) is True
+
+
+# ---------- Integration: realistic comPACT-shaped task layout ----------
+
+
+def test_compact_shaped_layout_drops_to_zero_after_teammate_completion(
+    tmp_path, monkeypatch
+):
+    """End-to-end integration over a realistic comPACT layout:
+    1 unowned feature task (the umbrella), 2 teammate-claimed work
+    tasks, 1 secretary signal task (algedonic). Before any completion
+    the count is 2 (only the two teammate work tasks; umbrella excluded
+    by the owner check, signal excluded by the signal carve-out). As
+    each teammate task completes the count walks down 2→1→0, reaching
+    the 1→0 transition that `wake_lifecycle_emitter._decide_directive`
+    listens for. The umbrella never blocks teardown."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    team = "team-compact-integration"
+    _write_team_config(
+        tmp_path, team,
+        [
+            {"name": "team-lead", "agentId": "team-lead@T", "agentType": "pact-orchestrator"},
+            {"name": "backend-coder", "agentId": "backend-coder@T", "agentType": "pact-backend-coder"},
+            {"name": "test-engineer", "agentId": "test-engineer@T", "agentType": "pact-test-engineer"},
+            {"name": "session-secretary", "agentId": "session-secretary@T", "agentType": "pact-secretary"},
+        ],
+        lead_agent_id="team-lead@T",
+    )
+    # Unowned feature task (created by /PACT:comPACT).
+    _stage_task(tmp_path, team, "feature", status="in_progress")
+    # Two teammate-claimed work tasks.
+    _stage_task(tmp_path, team, "code-work", status="in_progress", owner="backend-coder")
+    _stage_task(tmp_path, team, "test-work", status="in_progress", owner="test-engineer")
+    # Secretary signal task (algedonic) — owned by secretary but
+    # carved out by the signal-task metadata check at step 6.
+    _stage_task(
+        tmp_path, team, "alert",
+        status="in_progress", owner="session-secretary",
+        metadata={"completion_type": "signal", "type": "algedonic"},
+    )
+
+    assert count_active_tasks(team) == 2, (
+        "Pre-completion: only the two teammate work tasks count. "
+        "Umbrella excluded by owner check; signal excluded by metadata "
+        "carve-out."
+    )
+    # First teammate completes.
+    _stage_task(tmp_path, team, "code-work", status="completed", owner="backend-coder")
+    assert count_active_tasks(team) == 1
+    # Last teammate completes — the 1→0 transition.
+    _stage_task(tmp_path, team, "test-work", status="completed", owner="test-engineer")
+    assert count_active_tasks(team) == 0, (
+        "Post-last-teammate-completion: count must reach 0 so the "
+        "wake-mechanism teardown can fire. Umbrella and signal must "
+        "stay out of the tally."
+    )
+
+
+# ---------- Performance: bounded constant factor, no quadratic blowup ----------
+
+
+def test_count_active_tasks_scales_linearly_on_large_team(tmp_path, monkeypatch):
+    """Stress test: 100 tasks across a team with 20 members, mixed
+    owners (lead-owned umbrella tasks, multiple teammates, orphans,
+    signals). `count_active_tasks` must complete quickly — each
+    `_lifecycle_relevant` invocation invokes `_iter_members` a bounded
+    constant number of times (currently up to 3 in this module plus
+    1 from `_is_wake_excluded_agent_type`); the aggregate is
+    O(tasks × members) = O(N×M), unchanged in big-O from pre-fix.
+
+    The wall-clock budget here is intentionally generous — the goal is
+    to catch a future regression that introduces a per-task O(M²) or
+    O(N×M²) shape (e.g., a nested member iteration), not to pin
+    micro-performance. On a developer laptop the typical runtime is
+    well under 100 ms; we allow 5 s to keep CI noise from flaking."""
+    import time
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    team = "team-stress"
+    members = [
+        {"name": "team-lead", "agentId": "team-lead@T", "agentType": "pact-orchestrator"},
+    ]
+    for i in range(19):
+        members.append(
+            {"name": f"teammate-{i}", "agentId": f"teammate-{i}@T",
+             "agentType": "pact-backend-coder"}
+        )
+    _write_team_config(tmp_path, team, members, lead_agent_id="team-lead@T")
+
+    # 100 tasks: 30 unowned umbrellas, 50 teammate-owned active,
+    # 10 orphan-owned, 5 lead-owned, 5 signal-tasks.
+    for i in range(30):
+        _stage_task(tmp_path, team, f"umbrella-{i}", status="in_progress")
+    for i in range(50):
+        owner = f"teammate-{i % 19}"
+        _stage_task(tmp_path, team, f"work-{i}", status="in_progress", owner=owner)
+    for i in range(10):
+        _stage_task(tmp_path, team, f"orphan-{i}", status="in_progress",
+                    owner=f"ghost-{i}")
+    for i in range(5):
+        _stage_task(tmp_path, team, f"lead-{i}", status="in_progress",
+                    owner="team-lead")
+    for i in range(5):
+        _stage_task(
+            tmp_path, team, f"sig-{i}",
+            status="in_progress", owner=f"teammate-{i}",
+            metadata={"completion_type": "signal", "type": "blocker"},
+        )
+
+    start = time.perf_counter()
+    count = count_active_tasks(team)
+    elapsed = time.perf_counter() - start
+
+    # Only the 50 teammate-owned non-signal tasks count.
+    assert count == 50, (
+        f"Expected 50 active teammate tasks; got {count}. The other 50 "
+        "are 30 umbrellas + 10 orphans + 5 lead-owned + 5 signals — "
+        "all carved out."
+    )
+    assert elapsed < 5.0, (
+        f"count_active_tasks took {elapsed:.3f}s on 100 tasks × 20 "
+        "members. A linear-time implementation should finish in well "
+        "under 1 s; this generous bound only catches quadratic-or-"
+        "worse regressions."
+    )

--- a/pact-plugin/tests/test_wake_lifecycle_teammate_owner_filter.py
+++ b/pact-plugin/tests/test_wake_lifecycle_teammate_owner_filter.py
@@ -11,7 +11,7 @@ under tmp_path, monkeypatch Path.home).
 Counter-test-by-revert expected cardinality
 -------------------------------------------
 Reverting ONLY the step-4 owner-check block in `_lifecycle_relevant`
-(keep the new helpers `_owner_is_team_member`, `_is_lead_owned`, the
+(keep the new helpers `_owner_is_known_team_member`, `_is_lead_owned`, the
 `shared.pact_context` imports, and the docstring updates) produces
 exactly **17 failures** under the current test surface:
 
@@ -61,7 +61,7 @@ exactly **17 failures** under the current test surface:
       the pre-fix default also returns True for any owner shape when
       the team config is unreadable; the test pins the post-fix
       fail-CONSERVATIVE posture as a regression guard)
-    - test_owner_is_team_member_pure_never_raises (helper-level)
+    - test_owner_is_known_team_member_pure_never_raises (helper-level)
     - test_is_lead_owned_pure_never_raises (helper-level)
     - test_is_lead_owned_requires_both_name_and_agentid_match
       (helper-level; the step-4 block is the call-site consumer, but
@@ -86,7 +86,7 @@ Exact revert procedure (byte-precise; reproduces 17-fail cardinality):
      `metadata = task.get(...)` statement that follows step 4
      remains correctly indented.
   3. KEEP: module-top imports of `_iter_members` and
-     `_read_team_lead_agent_id`, the `_owner_is_team_member` and
+     `_read_team_lead_agent_id`, the `_owner_is_known_team_member` and
      `_is_lead_owned` helper definitions, the `_lifecycle_relevant`
      docstring carve-out section, and the preceding step-4 lead-in
      comment block (lines 205-213 at HEAD — these are the
@@ -305,22 +305,22 @@ def test_umbrella_scenario_one_to_zero_transition(tmp_path, monkeypatch):
 # ---------- Helper-level pure-never-raises invariants ----------
 
 
-def test_owner_is_team_member_pure_never_raises(tmp_path, monkeypatch):
-    """`_owner_is_team_member` is pure and never raises on any shape of
+def test_owner_is_known_team_member_pure_never_raises(tmp_path, monkeypatch):
+    """`_owner_is_known_team_member` is pure and never raises on any shape of
     owner or team_name."""
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     for owner in (None, "", 42, [], {}, ["x"], True):
         try:
-            result = wl._owner_is_team_member(owner, "any-team")
+            result = wl._owner_is_known_team_member(owner, "any-team")
         except Exception as exc:  # pragma: no cover
-            pytest.fail(f"_owner_is_team_member raised on owner={owner!r}: {exc}")
+            pytest.fail(f"_owner_is_known_team_member raised on owner={owner!r}: {exc}")
         assert isinstance(result, bool)
     for team_name in (None, "", 42, []):
         try:
-            result = wl._owner_is_team_member("x", team_name)
+            result = wl._owner_is_known_team_member("x", team_name)
         except Exception as exc:  # pragma: no cover
             pytest.fail(
-                f"_owner_is_team_member raised on team_name={team_name!r}: {exc}"
+                f"_owner_is_known_team_member raised on team_name={team_name!r}: {exc}"
             )
         assert isinstance(result, bool)
 

--- a/pact-plugin/tests/test_wake_lifecycle_teammate_owner_filter.py
+++ b/pact-plugin/tests/test_wake_lifecycle_teammate_owner_filter.py
@@ -1,0 +1,309 @@
+"""
+Teammate-owner filter invariants for
+pact-plugin/hooks/shared/wake_lifecycle.py::_lifecycle_relevant.
+
+Pins the step-4 owner-classification check that excludes unowned umbrella
+tasks, orphan-owner tasks, and team-lead-owned tasks from the wake-
+mechanism's active-tally. Direct-import tests reuse the fixture pattern
+from test_inbox_wake_lifecycle_helper.py (write a team config + task
+under tmp_path, monkeypatch Path.home).
+
+Counter-test-by-revert expected cardinality
+-------------------------------------------
+Reverting ONLY the step-4 owner-check block in `_lifecycle_relevant`
+(keep the new helpers `_owner_is_team_member`, `_is_lead_owned`, the
+`shared.pact_context` imports, and the docstring updates) produces
+**8 failures** under the current test surface:
+
+  - 3 unit cases in this file:
+      * test_unowned_umbrella_task_excluded
+      * test_lead_owned_task_excluded
+      * test_orphan_owner_excluded
+    (test_teammate_owned_task_counted passes either way — teammate
+    baseline always counts; test_config_unreadable_fail_conservative
+    also passes either way — fail-conservative result matches pre-fix
+    "count any owner" default.)
+
+  - 1 behavioral umbrella case in this file:
+      * test_umbrella_scenario_one_to_zero_transition
+    (pre-fix: count_active_tasks returns 2→1; post-fix: 1→0).
+
+  - 3 inverted-in-lockstep legacy cases in
+    test_inbox_wake_lifecycle_helper.py (assertions flipped from the
+    pre-fix orphan-counted behavior to the post-fix orphan-excluded
+    behavior in the same commit as the predicate change):
+      * test_lifecycle_relevant_owner_named_secretary_without_agenttype_excluded_as_orphan
+      * test_count_active_tasks_skips_signal_and_orphans
+      * test_count_active_tasks_secretary_owner_without_agenttype_excluded_as_orphan
+
+  - 1 structural-invariant case in test_inbox_wake_lifecycle_helper.py:
+      * test_lifecycle_relevant_preserves_fail_conservative_audit_anchor
+    (the inline §5.2-derived comment block at step 4 is removed when
+    step 4 is reverted; pin catches the audit-anchor regression).
+
+  Tests that pass either way on pure step-4 revert and are NOT counted:
+      * test_teammate_owned_task_counted (baseline; passes pre and post)
+      * test_config_unreadable_fail_conservative (passes pre and post —
+        pre-fix default also returns True for any owner with empty
+        members list)
+      * test_helper_imports_pact_context_for_owner_filter (helpers and
+        imports remain on pure step-4 revert)
+      * test_lifecycle_relevant_documents_orphan_exclusion (docstring
+        is not part of the step-4 inline block)
+
+Audit-anchor: when extending or refactoring this file, preserve the
+3-unit + 1-behavioral + 3-legacy-lockstep + 1-audit-anchor cardinality
+so the counter-test-by-revert delta remains computable. If you add new
+unit cases that flip on pure step-4 revert, update the count comment
+above in lockstep.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Hooks dir is added to sys.path by conftest.
+import shared.wake_lifecycle as wl
+from shared.wake_lifecycle import count_active_tasks
+
+
+def _write_team_config(tmp_path, team_name, members, lead_agent_id=""):
+    """Write a team config under tmp_path/.claude/teams/<team_name>/config.json.
+
+    Optional `lead_agent_id` populates the top-level `leadAgentId` field
+    the way the live Agent Teams platform records it at TeamCreate (see
+    ~/.claude/teams/<team>/config.json on disk).
+    """
+    team_dir = tmp_path / ".claude" / "teams" / team_name
+    team_dir.mkdir(parents=True, exist_ok=True)
+    config = {
+        "team_name": team_name,
+        "members": members,
+    }
+    if lead_agent_id:
+        config["leadAgentId"] = lead_agent_id
+    (team_dir / "config.json").write_text(
+        json.dumps(config),
+        encoding="utf-8",
+    )
+
+
+def _stage_task(tmp_path, team, task_id, **fields):
+    d = tmp_path / ".claude" / "tasks" / team
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{task_id}.json").write_text(
+        json.dumps({"id": task_id, **fields}), encoding="utf-8"
+    )
+
+
+# ---------- 5 unit cases for the edge table ----------
+
+
+def test_unowned_umbrella_task_excluded(tmp_path, monkeypatch):
+    """An umbrella task created by a workflow command (no owner field)
+    does not count toward the wake tally. This is the core scenario the
+    fix addresses: /PACT:orchestrate, /PACT:comPACT, /PACT:peer-review
+    create feature/phase records with no owner; they were keeping the
+    cron-based pending-scan armed indefinitely."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    team = "team-umbrella"
+    _write_team_config(
+        tmp_path, team,
+        [
+            {"name": "team-lead", "agentId": "team-lead@T", "agentType": "pact-orchestrator"},
+            {"name": "architect", "agentId": "architect@T", "agentType": "pact-architect"},
+        ],
+        lead_agent_id="team-lead@T",
+    )
+    task_no_owner = {"status": "in_progress"}
+    task_empty_owner = {"status": "in_progress", "owner": ""}
+    assert wl._lifecycle_relevant(task_no_owner, team) is False
+    assert wl._lifecycle_relevant(task_empty_owner, team) is False
+
+
+def test_lead_owned_task_excluded(tmp_path, monkeypatch):
+    """A task owned by the team-lead (whose member.agentId equals the
+    team config's leadAgentId) does not count toward the wake tally.
+    The lead's own work does not arm the lead's wake mechanism — the
+    lead is the consumer, not the producer."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    team = "team-lead-task"
+    _write_team_config(
+        tmp_path, team,
+        [
+            {"name": "team-lead", "agentId": "team-lead@T", "agentType": "pact-orchestrator"},
+            {"name": "architect", "agentId": "architect@T", "agentType": "pact-architect"},
+        ],
+        lead_agent_id="team-lead@T",
+    )
+    task = {"status": "in_progress", "owner": "team-lead"}
+    assert wl._lifecycle_relevant(task, team) is False
+
+
+def test_teammate_owned_task_counted(tmp_path, monkeypatch):
+    """A task owned by a non-lead team member counts toward the wake
+    tally. Baseline behavior — this is the case the wake mechanism
+    exists to surface. Passes either pre- or post-fix; included for
+    edge-table completeness."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    team = "team-teammate"
+    _write_team_config(
+        tmp_path, team,
+        [
+            {"name": "team-lead", "agentId": "team-lead@T", "agentType": "pact-orchestrator"},
+            {"name": "architect", "agentId": "architect@T", "agentType": "pact-architect"},
+        ],
+        lead_agent_id="team-lead@T",
+    )
+    task = {"status": "in_progress", "owner": "architect"}
+    assert wl._lifecycle_relevant(task, team) is True
+
+
+def test_orphan_owner_excluded(tmp_path, monkeypatch):
+    """An owner string that doesn't match any current team member is an
+    orphan owner (stale shutdown-mid-workflow owner, spoofed name, etc.)
+    and does not count toward the wake tally. Members list is non-empty
+    so the fail-CONSERVATIVE branch does not apply."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    team = "team-orphan"
+    _write_team_config(
+        tmp_path, team,
+        [
+            {"name": "team-lead", "agentId": "team-lead@T", "agentType": "pact-orchestrator"},
+            {"name": "architect", "agentId": "architect@T", "agentType": "pact-architect"},
+        ],
+        lead_agent_id="team-lead@T",
+    )
+    task = {"status": "in_progress", "owner": "ghost"}
+    assert wl._lifecycle_relevant(task, team) is False
+
+
+def test_config_unreadable_fail_conservative(tmp_path, monkeypatch):
+    """When the team config is unreadable (no config file on disk;
+    `_iter_members` returns []), the owner-check short-circuits and the
+    task is counted. Under-arm (silent teardown loss while teammate work
+    is in flight) is unrecoverable; over-arm (extra empty scans) is
+    recoverable on the next state change — so the wake mechanism fails
+    toward counting.
+
+    Passes either pre- or post-fix; included for edge-table completeness
+    AND to pin the fail-CONSERVATIVE posture so future cleanup cannot
+    silently invert it to fail-CLOSED."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    # No team config written — members list will be [].
+    task = {"status": "in_progress", "owner": "some-owner"}
+    assert wl._lifecycle_relevant(task, "team-no-config") is True
+
+
+# ---------- Behavioral umbrella scenario ----------
+
+
+def test_umbrella_scenario_one_to_zero_transition(tmp_path, monkeypatch):
+    """End-to-end reproduction of the bug fix.
+
+    Setup: a team with one umbrella task (no owner) and one teammate-
+    owned active task. Pre-fix, `count_active_tasks` returns 2→1 when
+    the teammate task completes; the 1→0 transition that
+    `wake_lifecycle_emitter._decide_directive` watches for never fires,
+    so the cron-based pending-scan stays armed indefinitely.
+
+    Post-fix, the umbrella task is excluded from the count: 1→0 is
+    reached on teammate completion, and the wake mechanism tears down
+    correctly. This is the load-bearing assertion of the fix."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    team = "team-umbrella-scenario"
+    _write_team_config(
+        tmp_path, team,
+        [
+            {"name": "team-lead", "agentId": "team-lead@T", "agentType": "pact-orchestrator"},
+            {"name": "architect", "agentId": "architect@T", "agentType": "pact-architect"},
+        ],
+        lead_agent_id="team-lead@T",
+    )
+    # Task 1: unowned umbrella (created by a workflow command).
+    _stage_task(tmp_path, team, "1", status="in_progress")
+    # Task 2: teammate-owned active work.
+    _stage_task(tmp_path, team, "2", status="in_progress", owner="architect")
+
+    # Pre-fix: 2 (umbrella + teammate). Post-fix: 1 (only teammate).
+    assert count_active_tasks(team) == 1, (
+        "Umbrella task must not count toward the wake tally."
+    )
+
+    # Transition Task 2 to completed (teammate finishes work).
+    _stage_task(tmp_path, team, "2", status="completed", owner="architect")
+
+    # Pre-fix: 1 (umbrella remains; never reaches 0). Post-fix: 0.
+    assert count_active_tasks(team) == 0, (
+        "1→0 transition must fire after the last teammate task completes; "
+        "the umbrella task must not block teardown."
+    )
+
+
+# ---------- Helper-level pure-never-raises invariants ----------
+
+
+def test_owner_is_team_member_pure_never_raises(tmp_path, monkeypatch):
+    """`_owner_is_team_member` is pure and never raises on any shape of
+    owner or team_name."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    for owner in (None, "", 42, [], {}, ["x"], True):
+        try:
+            result = wl._owner_is_team_member(owner, "any-team")
+        except Exception as exc:  # pragma: no cover
+            pytest.fail(f"_owner_is_team_member raised on owner={owner!r}: {exc}")
+        assert isinstance(result, bool)
+    for team_name in (None, "", 42, []):
+        try:
+            result = wl._owner_is_team_member("x", team_name)
+        except Exception as exc:  # pragma: no cover
+            pytest.fail(
+                f"_owner_is_team_member raised on team_name={team_name!r}: {exc}"
+            )
+        assert isinstance(result, bool)
+
+
+def test_is_lead_owned_pure_never_raises(tmp_path, monkeypatch):
+    """`_is_lead_owned` is pure and never raises on any shape of owner
+    or team_name."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    for owner in (None, "", 42, [], {}, ["x"], True):
+        try:
+            result = wl._is_lead_owned(owner, "any-team")
+        except Exception as exc:  # pragma: no cover
+            pytest.fail(f"_is_lead_owned raised on owner={owner!r}: {exc}")
+        assert isinstance(result, bool)
+    for team_name in (None, "", 42, []):
+        try:
+            result = wl._is_lead_owned("x", team_name)
+        except Exception as exc:  # pragma: no cover
+            pytest.fail(
+                f"_is_lead_owned raised on team_name={team_name!r}: {exc}"
+            )
+        assert isinstance(result, bool)
+
+
+def test_is_lead_owned_requires_both_name_and_agentid_match(tmp_path, monkeypatch):
+    """A member whose `name` matches the owner but whose `agentId` does
+    NOT match `leadAgentId` is NOT lead-owned. Conversely, a member
+    whose `agentId` matches `leadAgentId` but whose `name` does NOT
+    match the owner is also NOT lead-owned. Both conditions are
+    required — pins the AND-composition in `_is_lead_owned`."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    team = "team-and-comp"
+    _write_team_config(
+        tmp_path, team,
+        [
+            {"name": "team-lead", "agentId": "team-lead@T"},
+            {"name": "architect", "agentId": "architect@T"},
+        ],
+        lead_agent_id="team-lead@T",
+    )
+    # name matches lead, agentId matches lead → True.
+    assert wl._is_lead_owned("team-lead", team) is True
+    # name does not match (architect is not lead) → False.
+    assert wl._is_lead_owned("architect", team) is False
+    # owner not in members at all → False.
+    assert wl._is_lead_owned("ghost", team) is False

--- a/pact-plugin/tests/test_wake_lifecycle_teammate_owner_filter.py
+++ b/pact-plugin/tests/test_wake_lifecycle_teammate_owner_filter.py
@@ -202,6 +202,7 @@ signal beyond what the runtime tests already cover.
 import json
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -999,3 +1000,58 @@ def test_warn_empty_team_config_once_rejects_bad_team_name(
         f"Got: {captured.err!r}"
     )
     assert wl._EMPTY_CONFIG_WARN_TEAMS == set()
+
+
+def test_warn_empty_team_config_once_routes_through_session_journal(
+    capsys, monkeypatch, reset_empty_config_warn_set
+):
+    """When `session_journal.append_event` succeeds, `_warn_empty_team_
+    config_once` routes the warning through the journal and suppresses
+    the stderr fallback. Pins the primary observability path.
+
+    Without this test the F5 suite only exercises the stderr-fallback
+    branch (because `session_journal` is uninitialized in the test
+    process so `append_event` returns False). A future change that
+    silently breaks the `make_event("wake_tally_warn", ...)` call or
+    flips the success-path's return-value contract would slip through
+    review: every F5 test would keep passing because the fallback fires
+    correctly. This test isolates the primary path so a regression
+    there flips a counter-signal."""
+    fake_journal = MagicMock()
+    sentinel_event = {"event_type": "wake_tally_warn", "_sentinel": True}
+    fake_journal.make_event.return_value = sentinel_event
+    fake_journal.append_event.return_value = True
+    monkeypatch.setattr(wl, "session_journal", fake_journal)
+
+    wl._warn_empty_team_config_once("team-journal-primary")
+
+    captured = capsys.readouterr()
+    assert captured.err == "", (
+        "Journal-success path must suppress the stderr fallback. "
+        f"Got stderr: {captured.err!r}"
+    )
+
+    # make_event called once with the canonical event type + team_name
+    # payload. Other fields (reason, detail) are passed through but the
+    # contract this test pins is: the event_type AND team_name reach
+    # the journal layer unmodified. Asserting on event_type and
+    # team_name only — additional fields are an implementation detail.
+    fake_journal.make_event.assert_called_once()
+    call_args = fake_journal.make_event.call_args
+    assert call_args.args[0] == "wake_tally_warn", (
+        f"Expected event_type='wake_tally_warn' as first positional arg; "
+        f"got args={call_args.args!r}"
+    )
+    assert call_args.kwargs.get("team_name") == "team-journal-primary", (
+        "Expected team_name='team-journal-primary' kwarg passed to make_event; "
+        f"got kwargs={call_args.kwargs!r}"
+    )
+
+    # append_event called exactly once with the make_event result. This
+    # pins the wire shape: whatever make_event returns is what
+    # append_event receives — no intermediate mutation.
+    fake_journal.append_event.assert_called_once_with(sentinel_event)
+
+    # Dedupe state still populated (the team-journal-primary entry is
+    # added to the set regardless of which routing path fired).
+    assert "team-journal-primary" in wl._EMPTY_CONFIG_WARN_TEAMS

--- a/pact-plugin/tests/test_wake_lifecycle_teammate_owner_filter.py
+++ b/pact-plugin/tests/test_wake_lifecycle_teammate_owner_filter.py
@@ -923,13 +923,25 @@ def test_classify_owner_member_without_agenttype_yields_none_agent_type(
 
 
 @pytest.fixture
-def reset_empty_config_warn_set():
-    """Module-level state isolation for `_EMPTY_CONFIG_WARN_TEAMS`.
+def reset_empty_config_warn_set(monkeypatch):
+    """Module-level state isolation for `_EMPTY_CONFIG_WARN_TEAMS` and
+    forced stderr-fallback routing.
 
     Snapshot the current set, clear it for the test body, restore the
     snapshot on teardown. Avoids cross-test contamination if a prior
     test happened to warm an entry.
+
+    Also forces `wl.session_journal = None` so the journal-first branch
+    inside `_warn_empty_team_config_once` short-circuits to the stderr
+    fallback. Without this, a prior test in a broad pytest sweep can
+    initialize `session_journal` such that `append_event` returns truthy,
+    suppressing the stderr line that the [WAKE-TALLY WARN] assertions in
+    this F5 suite depend on. Tests that deliberately exercise the
+    journal-success path (e.g. `routes_through_session_journal`) override
+    this with their own `monkeypatch.setattr(wl, "session_journal", ...)`
+    AFTER the fixture runs, which takes precedence cleanly.
     """
+    monkeypatch.setattr(wl, "session_journal", None)
     snapshot = set(wl._EMPTY_CONFIG_WARN_TEAMS)
     wl._EMPTY_CONFIG_WARN_TEAMS.clear()
     yield

--- a/pact-plugin/tests/test_wake_lifecycle_teammate_owner_filter.py
+++ b/pact-plugin/tests/test_wake_lifecycle_teammate_owner_filter.py
@@ -98,36 +98,61 @@ Breakdown of the 17 body-only failures
     source-text pin elsewhere in the file).
     - test_lifecycle_relevant_preserves_fail_conservative_audit_anchor
 
-Protocol 2 — full-section revert (broader protocol; 22 fail)
-------------------------------------------------------------
+Protocol 2 — full-section revert (broader protocol; 30 fail + 4 errors)
+-----------------------------------------------------------------------
 Replace the entire owner-classification surface with the pre-fix
 shape. Run `git checkout main --
 pact-plugin/hooks/shared/wake_lifecycle.py
 pact-plugin/hooks/shared/pact_context.py`, then run pytest as in
 Protocol 1 step 5.
 
-Expect 22 failed, 66 passed, 2 skipped. After measuring, restore via
-`cp` from the backup and `git reset HEAD --` on both files to drop
-the index drift left by the `git checkout main --` operation.
+Expect 30 failed, 4 errors, 66 passed, 2 skipped (34 broken total).
+After measuring, restore via `cp` from the backup and
+`git reset HEAD --` on both files to drop the index drift left by
+the `git checkout main --` operation.
 
-The 22 = 17 body-only failures (above) + 5 additional flips driven by
-the helpers themselves disappearing. The five additional flips ride
-on `AttributeError` (the test imports a helper name that no longer
-exists on the module) rather than test-assertion failures:
+The 34 = 17 body-only failures (above) + 13 additional flips driven
+by the helpers / dataclass / observability function disappearing.
+The 13 additional flips ride on `AttributeError` rather than test-
+assertion failures (the test imports a helper name that no longer
+exists on the module). They split between FAILs (assertion never
+reached because the body errored out) and ERRORs (fixture setup
+errors before the test body runs):
 
+  Helper-wrapper FAILs (3 — body-AttributeError on lookup):
   - test_owner_is_known_team_member_pure_never_raises
   - test_is_lead_owned_pure_never_raises
   - test_is_lead_owned_requires_both_name_and_agentid_match
+
+  Helper-wrapper FAILs (2 — body-AttributeError on `_is_lead_owned`):
   - test_empty_or_missing_leadagentid_does_not_misclassify_lead[]
   - test_empty_or_missing_leadagentid_does_not_misclassify_lead[None]
 
-These five tests are baseline / helper-level pins under Protocol 1
-(they pass either way because the helpers still exist), but they ARE
-counter-signal under Protocol 2 (they fail when the helpers are
-removed entirely). Two-protocol classification gives a fresh reader a
-precise reading of what each test pins: behavior of the step-4
-executable block (Protocol 1 flippers), helper-surface existence
-(Protocol 2-only flippers), or true baseline (passes under both).
+  Dataclass / projection FAILs (8 — direct `_classify_owner` calls):
+  - test_classify_owner_empty_team_name_returns_all_false
+  - test_classify_owner_non_string_team_name_returns_all_false
+  - test_classify_owner_empty_members_marks_config_unreadable
+  - test_classify_owner_readable_config_with_bad_owner_marks_orphan
+  - test_classify_owner_readable_config_no_name_match_marks_orphan
+  - test_classify_owner_teammate_match_marks_known_not_lead
+  - test_classify_owner_lead_match_marks_lead
+  - test_classify_owner_member_without_agenttype_yields_none_agent_type
+
+  Dedupe-fixture ERRORs (4 — fixture setup AttributeError on
+  `_EMPTY_CONFIG_WARN_TEAMS` module attribute):
+  - test_warn_empty_team_config_once_first_call_writes
+  - test_warn_empty_team_config_once_repeat_call_is_noop
+  - test_warn_empty_team_config_once_per_team_isolation
+  - test_warn_empty_team_config_once_rejects_bad_team_name
+
+These 13 tests are baseline pins under Protocol 1 (they pass either
+way because the helpers / dataclass / observability function still
+exist), but they ARE counter-signal under Protocol 2 (they fail when
+the entire owner-classification surface is removed). Two-protocol
+classification gives a fresh reader a precise reading of what each
+test pins: behavior of the step-4 executable block (Protocol 1
+flippers), helper-surface existence (Protocol 2-only flippers), or
+true baseline (passes under both).
 
 Tests that pass under BOTH protocols (true baselines; NOT counter-
 signal under either revert):
@@ -152,20 +177,26 @@ Genesis of the 17 number
 An earlier architecture-spec draft (gitignored, not in the repo)
 projected 5 fail on revert. The next iteration super-sided it to 8
 after a legacy-test lockstep update brought the legacy file into the
-same revert envelope. The current iteration super-sides it to 17
-after adding adversarial-edge, integration, and stress coverage:
+same revert envelope. A later iteration super-sided it to 17 after
+adding adversarial-edge, integration, and stress coverage:
 17 = 4 core + 9 adversarial-edge + 3 legacy lockstep + 1 audit-anchor.
+The current iteration adds 12 helper-surface / dataclass-shape /
+observability tests that are Protocol 2-only flippers (not Protocol 1
+flippers, by design). The Protocol 1 count remains 17; the Protocol 2
+count grows from 22 broken to 34 broken (30 fail + 4 errors).
 
-When extending this file, preserve the protocol-1 cardinality of 17
-and the protocol-2 cardinality of 22 so the counter-test-by-revert
-delta remains computable. If you add new unit cases that flip under
-Protocol 1, update the protocol-1 count above in lockstep; if you add
-new helper-pinning tests that flip ONLY under Protocol 2, update the
-protocol-2 count. Source-text pins for non-load-bearing artifacts (an
-import line, a docstring phrase outside the executable body) are
-deliberately omitted — they are phantom-green-by-absence under
-Protocol 1 and provide no counter-signal beyond what the runtime
-tests already cover.
+When extending this file, preserve the Protocol 1 cardinality of 17
+and the Protocol 2 cardinality of 34 broken (30 fail + 4 errors) so
+the counter-test-by-revert delta remains computable. If you add new
+unit cases that flip under Protocol 1, update the Protocol 1 count
+above in lockstep; if you add new helper-pinning tests that flip
+ONLY under Protocol 2, update the Protocol 2 count (and decide
+whether the new test will fail-by-body-AttributeError or
+error-by-fixture-AttributeError — both shapes are legitimate). Source-
+text pins for non-load-bearing artifacts (an import line, a docstring
+phrase outside the executable body) are deliberately omitted — they
+are phantom-green-by-absence under Protocol 1 and provide no counter-
+signal beyond what the runtime tests already cover.
 """
 
 import json
@@ -713,3 +744,258 @@ def test_count_active_tasks_scales_linearly_on_large_team(tmp_path, monkeypatch)
         "under 1 s; this generous bound only catches quadratic-or-"
         "worse regressions."
     )
+
+
+# ---------- Direct _classify_owner dataclass-shape coverage ----------
+#
+# `_classify_owner` is the single-read projection that consolidates the
+# wake-side owner-classification logic into one `_iter_members` +
+# `_read_team_lead_agent_id` pair. The helper wrappers
+# (`_owner_is_known_team_member`, `_is_lead_owned`) and the step-4 inline
+# check in `_lifecycle_relevant` are all consumers. The tests in this
+# section pin the dataclass shape directly so a future refactor that
+# changes a single field (e.g., flipping `config_readable` default,
+# adding a new field, dropping `agent_type`) trips a counter-signal even
+# if the wrappers and call-site continue to behave correctly via lucky
+# branch coincidence.
+
+
+def test_classify_owner_empty_team_name_returns_all_false(tmp_path, monkeypatch):
+    """Empty team_name (default-arg path) bypasses config read entirely
+    and returns the all-default classification. The call site treats
+    this as fail-CONSERVATIVE fall-through identical to the empty-
+    members case."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    result = wl._classify_owner("some-owner", "")
+    assert isinstance(result, wl._OwnerClassification)
+    assert result.is_known_team_member is False
+    assert result.is_lead is False
+    assert result.agent_type is None
+    assert result.config_readable is False
+
+
+def test_classify_owner_non_string_team_name_returns_all_false(tmp_path, monkeypatch):
+    """Non-string team_name (e.g., None, int, list) is rejected at the
+    same gate as empty team_name. The call site never reaches the
+    `_iter_members` read."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    for bad in (None, 42, [], {}, True):
+        result = wl._classify_owner("some-owner", bad)
+        assert isinstance(result, wl._OwnerClassification)
+        assert result == wl._OwnerClassification(False, False, None, False), (
+            f"team_name={bad!r} must produce the all-default classification."
+        )
+
+
+def test_classify_owner_empty_members_marks_config_unreadable(tmp_path, monkeypatch):
+    """A non-empty team_name with no config on disk (so `_iter_members`
+    returns []) signals `config_readable=False` so the call site can
+    fail-CONSERVATIVE. The other fields stay default; the owner shape
+    is not inspected once members come back empty."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    # No team config written under tmp_path; _iter_members returns [].
+    result = wl._classify_owner("some-owner", "team-no-config")
+    assert result == wl._OwnerClassification(False, False, None, False)
+
+
+def test_classify_owner_readable_config_with_bad_owner_marks_orphan(
+    tmp_path, monkeypatch
+):
+    """Config readable, but the owner is non-string or empty. The
+    classification distinguishes this from the empty-members case via
+    `config_readable=True` so the call site treats it as an intentional
+    exclusion (orphan / unowned), NOT a fail-CONSERVATIVE fall-through."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    team = "team-bad-owner"
+    _write_team_config(
+        tmp_path, team,
+        [
+            {"name": "team-lead", "agentId": "team-lead@T", "agentType": "pact-orchestrator"},
+            {"name": "architect", "agentId": "architect@T", "agentType": "pact-architect"},
+        ],
+        lead_agent_id="team-lead@T",
+    )
+    for bad_owner in (None, "", 42, [], {}, True):
+        result = wl._classify_owner(bad_owner, team)
+        assert result == wl._OwnerClassification(False, False, None, True), (
+            f"owner={bad_owner!r} under readable config must be classified "
+            "as config_readable=True / is_known_team_member=False (orphan)."
+        )
+
+
+def test_classify_owner_readable_config_no_name_match_marks_orphan(
+    tmp_path, monkeypatch
+):
+    """Config readable, owner is a non-empty string, but no member's
+    name matches. Same `(False, False, None, True)` shape as the
+    bad-owner branch; the call site excludes via the
+    `is_known_team_member=False` flag."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    team = "team-no-match"
+    _write_team_config(
+        tmp_path, team,
+        [
+            {"name": "team-lead", "agentId": "team-lead@T", "agentType": "pact-orchestrator"},
+            {"name": "architect", "agentId": "architect@T", "agentType": "pact-architect"},
+        ],
+        lead_agent_id="team-lead@T",
+    )
+    result = wl._classify_owner("ghost-owner", team)
+    assert result == wl._OwnerClassification(False, False, None, True)
+
+
+def test_classify_owner_teammate_match_marks_known_not_lead(tmp_path, monkeypatch):
+    """Owner matches a non-lead team member. Classification reports
+    `is_known_team_member=True`, `is_lead=False`, `agent_type` populated
+    from the member's recorded agentType. This is the canonical
+    teammate-task shape."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    team = "team-teammate-match"
+    _write_team_config(
+        tmp_path, team,
+        [
+            {"name": "team-lead", "agentId": "team-lead@T", "agentType": "pact-orchestrator"},
+            {"name": "architect", "agentId": "architect@T", "agentType": "pact-architect"},
+        ],
+        lead_agent_id="team-lead@T",
+    )
+    result = wl._classify_owner("architect", team)
+    assert result == wl._OwnerClassification(True, False, "pact-architect", True)
+
+
+def test_classify_owner_lead_match_marks_lead(tmp_path, monkeypatch):
+    """Owner matches the team-lead member (whose agentId equals the
+    team's leadAgentId). Classification reports `is_known_team_member=
+    True`, `is_lead=True`, `agent_type` populated. The call site uses
+    `is_lead` to short-circuit step-4 exclusion."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    team = "team-lead-match"
+    _write_team_config(
+        tmp_path, team,
+        [
+            {"name": "team-lead", "agentId": "team-lead@T", "agentType": "pact-orchestrator"},
+            {"name": "architect", "agentId": "architect@T", "agentType": "pact-architect"},
+        ],
+        lead_agent_id="team-lead@T",
+    )
+    result = wl._classify_owner("team-lead", team)
+    assert result == wl._OwnerClassification(True, True, "pact-orchestrator", True)
+
+
+def test_classify_owner_member_without_agenttype_yields_none_agent_type(
+    tmp_path, monkeypatch
+):
+    """A team member entry without an `agentType` field (or with a
+    non-string agentType) yields `agent_type=None` in the
+    classification. The wake-excluded-agentType carve-out at step 3
+    treats `None` as "no carve-out" and falls through to step 4."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    team = "team-no-agenttype"
+    _write_team_config(
+        tmp_path, team,
+        [
+            {"name": "team-lead", "agentId": "team-lead@T"},  # no agentType
+            {"name": "architect", "agentId": "architect@T", "agentType": 42},  # bad type
+        ],
+        lead_agent_id="team-lead@T",
+    )
+    # Lead match: agent_type stays None (field absent).
+    assert wl._classify_owner("team-lead", team) == wl._OwnerClassification(
+        True, True, None, True
+    )
+    # Teammate match: agent_type stays None (non-string value rejected).
+    assert wl._classify_owner("architect", team) == wl._OwnerClassification(
+        True, False, None, True
+    )
+
+
+# ---------- _warn_empty_team_config_once dedupe behavior ----------
+#
+# `_warn_empty_team_config_once` dedupes per-team within the same
+# process via a module-level set (`_EMPTY_CONFIG_WARN_TEAMS`). The
+# tests in this section pin: (a) the first call for a team produces a
+# side effect (stderr in test contexts because session_journal is
+# uninitialized), (b) the second call for the SAME team is a no-op
+# (already in the set), (c) a DIFFERENT team triggers a fresh warning.
+# Fixture clears `_EMPTY_CONFIG_WARN_TEAMS` between tests so each test
+# starts from a known-empty state.
+
+
+@pytest.fixture
+def reset_empty_config_warn_set():
+    """Module-level state isolation for `_EMPTY_CONFIG_WARN_TEAMS`.
+
+    Snapshot the current set, clear it for the test body, restore the
+    snapshot on teardown. Avoids cross-test contamination if a prior
+    test happened to warm an entry.
+    """
+    snapshot = set(wl._EMPTY_CONFIG_WARN_TEAMS)
+    wl._EMPTY_CONFIG_WARN_TEAMS.clear()
+    yield
+    wl._EMPTY_CONFIG_WARN_TEAMS.clear()
+    wl._EMPTY_CONFIG_WARN_TEAMS.update(snapshot)
+
+
+def test_warn_empty_team_config_once_first_call_writes(
+    capsys, reset_empty_config_warn_set
+):
+    """First call for a team_name produces a [WAKE-TALLY WARN] line on
+    stderr (the journal-fallback path; session_journal is uninitialized
+    in the test process so the journal-first branch returns False and
+    stderr fires). The team is added to the dedupe set."""
+    assert "team-warn-A" not in wl._EMPTY_CONFIG_WARN_TEAMS
+    wl._warn_empty_team_config_once("team-warn-A")
+    captured = capsys.readouterr()
+    assert "[WAKE-TALLY WARN]" in captured.err
+    assert "team-warn-A" in captured.err
+    assert "team-warn-A" in wl._EMPTY_CONFIG_WARN_TEAMS
+
+
+def test_warn_empty_team_config_once_repeat_call_is_noop(
+    capsys, reset_empty_config_warn_set
+):
+    """Second call for the SAME team_name is a no-op — already in the
+    dedupe set, so the function returns immediately. No stderr line,
+    no journal write attempt."""
+    wl._warn_empty_team_config_once("team-warn-dup")
+    _ = capsys.readouterr()  # drain the first-call output
+    wl._warn_empty_team_config_once("team-warn-dup")
+    captured = capsys.readouterr()
+    assert captured.err == "", (
+        "Repeat call for the same team must produce no stderr output. "
+        f"Got: {captured.err!r}"
+    )
+
+
+def test_warn_empty_team_config_once_per_team_isolation(
+    capsys, reset_empty_config_warn_set
+):
+    """Different team_names are tracked independently. team-A warning
+    does not suppress a subsequent team-B warning; the dedupe set
+    grows monotonically across distinct teams within the same
+    process."""
+    wl._warn_empty_team_config_once("team-iso-A")
+    first = capsys.readouterr()
+    assert "team-iso-A" in first.err
+
+    wl._warn_empty_team_config_once("team-iso-B")
+    second = capsys.readouterr()
+    assert "[WAKE-TALLY WARN]" in second.err
+    assert "team-iso-B" in second.err
+
+    assert {"team-iso-A", "team-iso-B"} <= wl._EMPTY_CONFIG_WARN_TEAMS
+
+
+def test_warn_empty_team_config_once_rejects_bad_team_name(
+    capsys, reset_empty_config_warn_set
+):
+    """Non-string or empty team_name returns immediately without
+    side effect. The dedupe set is not touched; no stderr line."""
+    for bad in (None, "", 42, []):
+        wl._warn_empty_team_config_once(bad)
+    captured = capsys.readouterr()
+    assert captured.err == "", (
+        f"Bad team_name inputs must produce no stderr output. "
+        f"Got: {captured.err!r}"
+    )
+    assert wl._EMPTY_CONFIG_WARN_TEAMS == set()


### PR DESCRIPTION
## Summary

- Adds a teammate-owner filter to `_lifecycle_relevant` in `pact-plugin/hooks/shared/wake_lifecycle.py` so umbrella tasks (orchestrator-created feature/phase/review records, lead-owned tasks, and orphan-owner tasks) no longer count toward the wake-mechanism's active-tally.
- Restores the natural 1→0 last-active-teammate-task transition that `wake_lifecycle_emitter.py` watches for, enabling `/PACT:stop-pending-scan` to fire on schedule instead of accumulating empty-scan turns until session end.
- Closes #743.

## Implementation

Six-commit chain on `fix-743-lifecycle-relevant-leadagentid`:

1. `fc62811b` — Add `_read_team_lead_agent_id` sibling reader in `pact_context.py` (parallels `_iter_members`; silent-on-error returning `\"\"`).
2. `8765d1be` — Predicate fix in `wake_lifecycle.py`: two new private helpers (`_owner_is_team_member`, `_is_lead_owned`) + new step 4 owner-check inserted between the existing wake-excluded-agentType check (step 3) and metadata-shape check (step 5). 3 legacy test assertions inverted in lockstep to match the new orphan-exclusion semantics.
3. `37adadd2` — Dedicated test module covering five edge cases (unowned / lead-owned / teammate-owned / orphan / config-unreadable), a behavioral umbrella scenario (2→1→0 transition), pure-never-raises invariants on both helpers, and the AND-composition pin (name AND agentId both required for lead-ownership). Helpers tightened to guard against non-string `team_name`.
4. `aedf77dd` — Drop two phantom-green structural pins (asserted source-text presence that survived a step-4 revert) and relocate the fail-CONSERVATIVE audit-anchor comment block from before the `if team_name:` body to inside it, so the audit-anchor invariant fires as a true counter-signal under body-only revert.
5. `8c997471` — TEST-phase coverage: adversarial type-coercion on the owner field (stringified non-string-shaped owners, malformed member entries, empty/null `leadAgentId`), 100×20 stress test bounding `_iter_members` calls at 3× per `_lifecycle_relevant` invocation, and a realistic comPACT-shaped integration scenario walking count_active_tasks across the full lifecycle.
6. `3cd6f31e` — Plugin version bump 4.2.2 → 4.2.3 (4-file dance).

## Why `leadAgentId` discriminator (not `agentType`)

Per the issue body and architecture spec:

- One canonical lead per team config (`leadAgentId` is already used by `start/stop-pending-scan` §Lead-Session Guard for analogous discrimination at the session layer).
- Forward-compatible with rePACT sub-orchestrator teammates: a sub-orchestrator's `agentType` would be `pact-orchestrator` but its `agentId` would not match the team's `leadAgentId`, so the leadAgentId check correctly treats its tasks as teammate work; an `agentType`-based check would silently exclude them and break the 1→0 teardown signal.

## Failure-mode posture

When the team config is unreadable (empty members list), the check short-circuits to \"count\" — under-arm (silent teardown loss while teammate work is in flight) is unrecoverable; over-arm (extra empty scans) is recoverable on the next state change. The asymmetry is documented in an inline comment block inside the step-4 body, structurally anchored by `test_lifecycle_relevant_preserves_fail_conservative_audit_anchor`.

## Test plan

- [x] `pytest pact-plugin/tests/test_wake_lifecycle*.py pact-plugin/tests/test_inbox_wake_lifecycle_helper.py`: 88 passed / 2 skipped
- [x] Broader `pytest pact-plugin/tests/ --ignore=pact-plugin/tests/telegram_notify`: clean (no fix-743 regressions; pre-existing failures in `test_telegram_voice.py` and `test_variety_scorer_fuzz.py` confirmed present on `main` HEAD)
- [x] Counter-test-by-revert: surgically delete the step-4 body in `_lifecycle_relevant` (keep helpers + imports + docstring), clear `__pycache__`, run pytest → empirical 8-fail cardinality (4 dedicated edge cases + 3 legacy lockstep inversions + 1 audit-anchor) matches the cardinality breakdown documented in the new test module's docstring exactly. Restored cleanly via backup.
- [x] Adversarial-edge: stringified non-string owners, malformed/null/missing member fields, empty/null leadAgentId, name-only-and-agentId-only mismatches — all behaviorally pinned.
- [x] Perf: 100×20 stress test runs in <0.1s (5s budget). `_iter_members` invocations bounded at 3× per predicate call; no quadratic regression in `count_active_tasks`.
- [x] Integration: realistic comPACT layout (1 unowned feature task + 2 teammate work tasks + 1 secretary signal) walks count_active_tasks across the full lifecycle, reaching 0 after teammate completion.

## Non-goals

- No changes to workflow command bodies (orchestrate, comPACT, peer-review). The fix lives entirely in the hook predicate.
- No introduction of a `metadata.umbrella=true` marker. Fix B from the issue body was considered and rejected — depends on every workflow command remembering to mark umbrella tasks; brittle.
- No optimization of the 3× `_iter_members` invocation per predicate call (acknowledged in spec §9 risk row; safe to defer).

## Follow-ups filed during this PR

- #751 — scan-pending-tasks warmup-grace skip for the first ~120s after arm (eliminates the immediate-after-arm empty fire).