### PR TITLE
fix(hooks): wake_lifecycle_emitter Arm starvation (#754) — asymmetric guard + wake_inbox drain

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.2.4",
+      "version": "4.2.5",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.2.4/      # Plugin version
+│               └── 4.2.5/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.2.4
+> **Version**: 4.2.5
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/hooks.json
+++ b/pact-plugin/hooks/hooks.json
@@ -16,6 +16,14 @@
             "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/bootstrap_prompt_gate.py\""
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/wake_inbox_drain.py\""
+          }
+        ]
       }
     ],
     "SessionStart": [

--- a/pact-plugin/hooks/shared/wake_lifecycle.py
+++ b/pact-plugin/hooks/shared/wake_lifecycle.py
@@ -26,6 +26,15 @@ Public surface:
     the 1->0 Teardown emit when a same-teammate continuation is staged
     for handoff. Pure function; never raises; fail-closed (returns
     False on every error path so Teardown emits unchanged).
+- is_lead_session(input_data, team_name) -> bool
+    Predicate. True iff the current PostToolUse/UserPromptSubmit
+    session's `session_id` matches the team's `leadSessionId` from
+    team_config.json. Lifted from wake_lifecycle_emitter.py to enable
+    reuse by wake_inbox_drain.py (single SSOT). Pure function; never
+    raises; silent fail-open (returns False) on missing/empty
+    session_id, missing/unsafe team_name, missing config.json,
+    malformed JSON, or filesystem error — the teammate session is the
+    expected non-lead path so no UI noise on every Task-tool fire.
 - _lifecycle_relevant(task, team_name="") -> bool
     Predicate. True iff the task counts toward the active-work tally that
     arms/tears down the wake mechanism.
@@ -67,13 +76,16 @@ Carve-out rules:
    shared.intentional_wait for the divergence rationale.
 """
 
+import json
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from shared.intentional_wait import WAKE_EXCLUDED_AGENT_TYPES
 from shared.intentional_wait import _is_wake_excluded_agent_type  # noqa: F401  # DECOUPLED-CONSTANT pin
 from shared.pact_context import _iter_members, _read_team_lead_agent_id
+from shared.session_state import is_safe_path_component
 from shared.task_utils import iter_team_task_jsons, read_task_json
 
 try:
@@ -634,3 +646,50 @@ def has_same_teammate_continuation(completed_task: Any, team_name: str) -> bool:
         return False
     except Exception:
         return False
+
+
+def is_lead_session(input_data: Any, team_name: str) -> bool:
+    """
+    Return True iff the current session is the team's lead session.
+
+    Reads `session_id` from the hook stdin payload and `leadSessionId`
+    from ~/.claude/teams/{team_name}/config.json. Single source of truth
+    for the wake-mechanism's lead-session locality check; consumed by
+    `wake_lifecycle_emitter._decide_directive` (PostToolUse) and by
+    `wake_inbox_drain.main` (UserPromptSubmit). Mirrors the Lead-Session
+    Guard pattern used by the start-pending-scan / stop-pending-scan
+    skill bodies (Layer 1 of the defense-in-depth model); this
+    hook-level check is Layer 0, preventing directive emission to
+    teammate sessions at the emission source. team_config is the
+    single source of truth for lead identity.
+
+    Pure function; never raises. Returns False on missing/empty
+    session_id, missing/unsafe team_name, missing config.json,
+    malformed JSON, or filesystem error. The teammate session is the
+    expected non-lead path; silent fail-open avoids UI noise on every
+    teammate hook fire.
+    """
+    if not isinstance(input_data, dict):
+        return False
+    raw_session_id = input_data.get("session_id")
+    if not isinstance(raw_session_id, str) or not raw_session_id:
+        return False
+    if not isinstance(team_name, str) or not team_name:
+        return False
+    if not is_safe_path_component(team_name):
+        return False
+    try:
+        config_path = (
+            Path.home() / ".claude" / "teams" / team_name / "config.json"
+        )
+        if not config_path.exists():
+            return False
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    lead_session_id = data.get("leadSessionId")
+    if not isinstance(lead_session_id, str) or not lead_session_id:
+        return False
+    return raw_session_id == lead_session_id

--- a/pact-plugin/hooks/wake_inbox_drain.py
+++ b/pact-plugin/hooks/wake_inbox_drain.py
@@ -45,9 +45,11 @@ Single-emit discipline:
   count → emit Arm. Zero count → suppressOutput.
 
 Performance hygiene:
-- Empty inbox AND non-lead session short-circuits to suppressOutput
-  before any task-store I/O. Cost on every teammate prompt: one
-  directory glob + one config.json read + one session_id compare.
+- Non-lead session short-circuits to suppressOutput before any
+  task-store I/O. Per-prompt cost on the hot teammate path: one
+  team_config.json read (inside `is_lead_session`) + one session_id
+  compare. Task-store I/O (inbox glob + `count_active_tasks`) only
+  runs in the lead session.
 
 SACROSANCT module-load failure pattern:
 - Module-load failures emit a fail-closed advisory via the stdlib-only
@@ -131,6 +133,12 @@ _SUPPRESS_OUTPUT = json.dumps({
 # defense-in-depth against parser amplification.
 _MAX_PAYLOAD_BYTES = 1024 * 1024
 
+# Bound per-marker body read at 8 KiB. The canonical marker schema is
+# 7 fields well under 1 KiB; 8 KiB is generous headroom against schema
+# growth while still capping parser-amplification risk on a corrupted
+# or hostile file under the inbox path.
+_MAX_MARKER_BYTES = 8192
+
 
 def _wake_inbox_path(team_name: str) -> Path | None:
     """Resolve the team's wake-inbox directory or return None on
@@ -163,6 +171,14 @@ def _drain_markers(inbox_dir: Path) -> int:
     Forensic value only; the drain side consumes file PRESENCE not the
     timestamp.
 
+    Size cap on marker read: the writer schema is tiny (7 fields,
+    well under 1 KiB). An attacker (or a corrupted FS) producing a
+    multi-MB file under the inbox path could amplify the drain read
+    cost on every prompt. Pre-check via `os.path.getsize` and skip
+    oversize markers (>8 KiB) — log to stderr and unlink without
+    reading. The wake intent still stands (PRESENCE is the signal)
+    so the unlink + count-as-consumed posture is preserved.
+
     Pure-after-side-effect; never raises.
     """
     if not inbox_dir.exists():
@@ -174,15 +190,31 @@ def _drain_markers(inbox_dir: Path) -> int:
     consumed = 0
     for marker in markers:
         try:
-            # Read for forensic logging only — fail-conservative on
-            # malformed JSON: still treat as a wake signal (delete +
-            # count). A truncated / corrupted marker file MEANS a
-            # teammate session attempted to write and was interrupted;
-            # the wake intent stands.
+            # Size-cap pre-check: 8 KiB is generous against the
+            # canonical 7-field payload. Oversize markers are treated
+            # as wake signals (delete + count) but the body is NOT
+            # read — protects against parser-amplification on a
+            # corrupted or hostile file.
             try:
-                marker.read_text(encoding="utf-8")
+                size = os.path.getsize(str(marker))
             except OSError:
-                pass
+                size = -1
+            if size > _MAX_MARKER_BYTES:
+                print(
+                    f"wake_inbox_drain: oversize marker "
+                    f"({size} bytes); skipping body read, unlinking",
+                    file=sys.stderr,
+                )
+            else:
+                # Read for forensic logging only — fail-conservative
+                # on malformed JSON: still treat as a wake signal
+                # (delete + count). A truncated / corrupted marker
+                # file MEANS a teammate session attempted to write
+                # and was interrupted; the wake intent stands.
+                try:
+                    marker.read_text(encoding="utf-8")
+                except OSError:
+                    pass
             os.unlink(str(marker))
             consumed += 1
         except OSError:
@@ -235,11 +267,12 @@ def _decide_and_emit(input_data: dict) -> None:
         print(_SUPPRESS_OUTPUT)
         return
 
-    # Performance hygiene: empty-inbox + non-lead-session early-out.
-    # The non-lead path is the hot common case (every teammate prompt
-    # fires this hook); short-circuit before any further I/O. Note we
-    # MUST still evaluate is_lead_session even on empty inbox for the
-    # lead-side B-1 fallback path below.
+    # Performance hygiene: non-lead-session early-out before any
+    # task-store I/O. The non-lead path is the hot common case (every
+    # teammate prompt fires this hook); short-circuit before the drain
+    # glob and the count_active_tasks fallback. `is_lead_session`
+    # itself reads team_config.json (one disk read on every prompt),
+    # which is the per-prompt cost on the hot path.
     if not is_lead_session(input_data, team_name):
         print(_SUPPRESS_OUTPUT)
         return

--- a/pact-plugin/hooks/wake_inbox_drain.py
+++ b/pact-plugin/hooks/wake_inbox_drain.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""
+Location: pact-plugin/hooks/wake_inbox_drain.py
+Summary: UserPromptSubmit hook that drains the team's wake-inbox markers
+         (cross-session teammate-Arm signals) on the lead's prompts and
+         emits a single _ARM_DIRECTIVE via hookSpecificOutput.additionalContext
+         when either (a) markers are present OR (b) the count_active_tasks
+         fallback shows at least one lifecycle-relevant teammate task.
+Used by: hooks.json UserPromptSubmit hook (third entry, after
+         bootstrap_marker_writer + bootstrap_prompt_gate).
+
+Role in the asymmetric-guard Arm/Teardown model:
+- wake_lifecycle_emitter.py's teammate-Arm pre-branch writes per-marker
+  JSON files to ~/.claude/teams/{team_name}/wake_inbox/ when a teammate
+  self-claims a task (TaskUpdate(status='in_progress')) or when a
+  TaskCreate carries a teammate owner-at-create. PostToolUse
+  `additionalContext` targets the teammate's session — wrong session
+  for an Arm directive — so the filesystem marker IS the cross-session
+  signal.
+- This hook (UserPromptSubmit) runs on every lead prompt. It drains
+  markers + falls back to a count_active_tasks(team_name) >= 1
+  predicate that covers the lead-side unowned-create-then-owner-update
+  dispatch pattern surface (where no teammate-side write opportunity
+  ever exists — the lead's TaskCreate is unowned, the subsequent
+  TaskUpdate(owner) carries no status transition).
+- Either trigger emits exactly one _ARM_DIRECTIVE block per prompt
+  (combined drain + fallback single-emit discipline). The skill body's
+  CronList exact-suffix-match is the single idempotency truth — a
+  redundant Arm directive is benign because start-pending-scan no-ops
+  if its cron entry already exists.
+
+Lead-Session Guard (Layer 0 — defense-in-depth):
+- The drain hook ONLY emits in the lead session. A teammate's
+  UserPromptSubmit fires this hook too, but `is_lead_session` returns
+  False there and the hook short-circuits to suppressOutput. The skill
+  body's Layer 1 lead-session guard remains as backstop.
+
+Single-emit discipline:
+- Drain path consumed → emit Arm; do NOT also run the fallback. Fallback
+  is the LEAD-side unowned-dispatch recovery path; if markers were
+  drained, the teammate-side signal already covered the surface and a
+  second emit would be redundant (still benign under skill-body
+  idempotency, but the single-emit shape is cleaner).
+- Drain path empty → run the count_active_tasks fallback. Positive
+  count → emit Arm. Zero count → suppressOutput.
+
+Performance hygiene:
+- Empty inbox AND non-lead session short-circuits to suppressOutput
+  before any task-store I/O. Cost on every teammate prompt: one
+  directory glob + one config.json read + one session_id compare.
+
+SACROSANCT module-load failure pattern:
+- Module-load failures emit a fail-closed advisory via the stdlib-only
+  `_emit_load_failure_advisory` sentinel (mirrors
+  bootstrap_marker_writer.py / bootstrap_prompt_gate.py). Runtime
+  exceptions in main logic suppressOutput at exit 0 — the wake
+  mechanism is opportunistic; a crashed drain degrades to baseline
+  user-invoked /PACT:start-pending-scan, not a hard failure.
+
+Input: JSON from stdin with session_id, hook_event_name, etc.
+Output: hookSpecificOutput with additionalContext on Arm trigger;
+        {"suppressOutput": true} on every other path.
+"""
+
+# ─── stdlib first (used by _emit_load_failure_advisory BEFORE wrapped imports) ─
+import json
+import sys
+from typing import NoReturn
+
+
+def _emit_load_failure_advisory(stage: str, error: BaseException) -> NoReturn:
+    """Emit fail-closed advisory for module-load failure.
+
+    UserPromptSubmit cannot DENY the prompt; the strongest available
+    signal is `additionalContext` injection. Uses ONLY stdlib (json,
+    sys) so it remains functional even when every wrapped import below
+    fails. Audit anchor: hookEventName must be present in any structured
+    output.
+    """
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": (
+                f"PACT wake_inbox_drain {stage} failure — the hook could "
+                f"not drain the wake-inbox. {type(error).__name__}: "
+                f"{error}. The pending-scan mechanism degrades to "
+                f"user-invoked /PACT:start-pending-scan; teammate-Arm "
+                f"signals may be missed until the underlying error is "
+                f"resolved."
+            ),
+        }
+    }))
+    print(
+        f"Hook load error (wake_inbox_drain / {stage}): {error}",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+
+
+# ─── fail-closed wrapper around cross-package imports ───────────────────────
+try:
+    import os
+    from pathlib import Path
+
+    # Ensure shared package import resolves under the hooks directory.
+    _hooks_dir = Path(__file__).parent
+    if str(_hooks_dir) not in sys.path:
+        sys.path.insert(0, str(_hooks_dir))
+
+    import shared.pact_context as pact_context
+    from shared.pact_context import get_team_name
+    from shared.session_state import is_safe_path_component
+    from shared.wake_lifecycle import count_active_tasks, is_lead_session
+    # Reuse the canonical _ARM_DIRECTIVE literal from the emitter so the
+    # directive prose has a single source of truth. The audit-anchor
+    # literal-prose pin (test in test_wake_lifecycle_bug_b_rearm.py)
+    # covers the emitter side; this import makes any future drift
+    # immediately break the drain hook too.
+    from wake_lifecycle_emitter import _ARM_DIRECTIVE
+except BaseException as _module_load_error:  # noqa: BLE001 — fail-closed catch-all
+    _emit_load_failure_advisory("module imports", _module_load_error)
+
+
+_SUPPRESS_OUTPUT = json.dumps({
+    "suppressOutput": True,
+    "hookSpecificOutput": {"hookEventName": "UserPromptSubmit"},
+})
+
+# Bound stdin payload at 1 MB. UserPromptSubmit payloads carry the user's
+# prompt text + session metadata; a 1 MB cap is generous and serves as
+# defense-in-depth against parser amplification.
+_MAX_PAYLOAD_BYTES = 1024 * 1024
+
+
+def _wake_inbox_path(team_name: str) -> Path | None:
+    """Resolve the team's wake-inbox directory or return None on
+    path-safety failure.
+
+    Path-traversal defense: `is_safe_path_component(team_name)` is the
+    same allowlist applied by `is_lead_session` and the teammate-Arm
+    pre-branch in the emitter. team_name is read from
+    pact-session-context.json which is itself written by trusted
+    plugin code; this re-check is belt-and-suspenders.
+    """
+    if not isinstance(team_name, str) or not team_name:
+        return None
+    if not is_safe_path_component(team_name):
+        return None
+    return Path.home() / ".claude" / "teams" / team_name / "wake_inbox"
+
+
+def _drain_markers(inbox_dir: Path) -> int:
+    """Drain every JSON marker in the inbox directory.
+
+    Returns the count of markers successfully consumed (read + deleted).
+    Read failures and unlink failures are silently swallowed — the drain
+    is best-effort; a stuck marker stays on disk and gets re-drained
+    next prompt. The skill body's CronList match makes redundant Arm
+    emits benign.
+
+    Sorted-glob iteration: the marker filename schema starts with an
+    ISO-8601 compact UTC timestamp, so lexical order IS chronological.
+    Forensic value only; the drain side consumes file PRESENCE not the
+    timestamp.
+
+    Pure-after-side-effect; never raises.
+    """
+    if not inbox_dir.exists():
+        return 0
+    try:
+        markers = sorted(inbox_dir.glob("*.json"))
+    except OSError:
+        return 0
+    consumed = 0
+    for marker in markers:
+        try:
+            # Read for forensic logging only — fail-conservative on
+            # malformed JSON: still treat as a wake signal (delete +
+            # count). A truncated / corrupted marker file MEANS a
+            # teammate session attempted to write and was interrupted;
+            # the wake intent stands.
+            try:
+                marker.read_text(encoding="utf-8")
+            except OSError:
+                pass
+            os.unlink(str(marker))
+            consumed += 1
+        except OSError:
+            # Couldn't unlink — leave the marker on disk; next drain
+            # will retry. Do NOT count this marker as consumed so the
+            # fallback can still fire if needed.
+            continue
+    return consumed
+
+
+def _emit_arm() -> None:
+    """Print the _ARM_DIRECTIVE additionalContext payload with the
+    required hookEventName field. Caller is responsible for sys.exit(0).
+    """
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": _ARM_DIRECTIVE,
+        }
+    }
+    print(json.dumps(output))
+
+
+def _decide_and_emit(input_data: dict) -> None:
+    """Run the drain + fallback decision tree and emit at most one
+    _ARM_DIRECTIVE block.
+
+    Decision order:
+      1. Resolve team_name from session context. No team → suppressOutput.
+      2. Resolve inbox_dir from team_name. Path-safety failure →
+         suppressOutput.
+      3. Lead-session guard. Non-lead session → suppressOutput
+         (regardless of inbox state — teammate sessions never emit
+         the Arm directive; the directive is lead-targeted).
+      4. Drain markers. If drained count > 0 → emit Arm and return
+         (single-emit discipline; skip the fallback).
+      5. Fallback: count_active_tasks(team_name) >= 1 → emit Arm.
+         Otherwise → suppressOutput.
+
+    Pure-after-side-effect; outer main() handles exception fail-open.
+    """
+    pact_context.init(input_data)
+    team_name = get_team_name()
+    if not team_name:
+        print(_SUPPRESS_OUTPUT)
+        return
+
+    inbox_dir = _wake_inbox_path(team_name)
+    if inbox_dir is None:
+        print(_SUPPRESS_OUTPUT)
+        return
+
+    # Performance hygiene: empty-inbox + non-lead-session early-out.
+    # The non-lead path is the hot common case (every teammate prompt
+    # fires this hook); short-circuit before any further I/O. Note we
+    # MUST still evaluate is_lead_session even on empty inbox for the
+    # lead-side B-1 fallback path below.
+    if not is_lead_session(input_data, team_name):
+        print(_SUPPRESS_OUTPUT)
+        return
+
+    drained = _drain_markers(inbox_dir)
+    if drained > 0:
+        _emit_arm()
+        return
+
+    # B-1 fallback: lead-side unowned-create-then-owner-update dispatch
+    # pattern produces no teammate-side write opportunity. Cover it via
+    # count_active_tasks — any lifecycle-relevant teammate task on disk
+    # warrants the scan being armed.
+    if count_active_tasks(team_name) >= 1:
+        _emit_arm()
+        return
+
+    print(_SUPPRESS_OUTPUT)
+
+
+def main() -> None:
+    # Outer catch-all preserves the exit-0 fail-open contract against
+    # any unexpected exception. UserPromptSubmit hooks fire on every
+    # prompt; a raise here would surface as a hook-error UI on every
+    # turn. The wake mechanism is opportunistic — a crashed drain
+    # degrades to user-invoked /PACT:start-pending-scan.
+    try:
+        try:
+            buffer = sys.stdin.read(_MAX_PAYLOAD_BYTES + 1)
+        except (IOError, OSError):
+            print(_SUPPRESS_OUTPUT)
+            sys.exit(0)
+        if len(buffer) > _MAX_PAYLOAD_BYTES:
+            print(_SUPPRESS_OUTPUT)
+            sys.exit(0)
+        try:
+            input_data = json.loads(buffer)
+        except json.JSONDecodeError:
+            print(_SUPPRESS_OUTPUT)
+            sys.exit(0)
+
+        if not isinstance(input_data, dict):
+            print(_SUPPRESS_OUTPUT)
+            sys.exit(0)
+
+        _decide_and_emit(input_data)
+        sys.exit(0)
+    except SystemExit:
+        raise
+    except Exception:
+        print(_SUPPRESS_OUTPUT)
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/pact-plugin/hooks/wake_lifecycle_emitter.py
+++ b/pact-plugin/hooks/wake_lifecycle_emitter.py
@@ -389,11 +389,24 @@ _TEAMMATE_SELF_CLAIM_TRIGGER = "teammate_self_claim_in_progress"
 
 
 def _maybe_write_teammate_arm_marker(
-    input_data: dict[str, Any], team_name: str
+    input_data: dict[str, Any],
+    team_name: str,
+    is_lead: bool | None = None,
 ) -> None:
     """
     Write a wake-inbox marker iff the 6-clause asymmetric-guard
     predicate ladder holds for this PostToolUse fire.
+
+    `is_lead` is the pre-computed result of
+    `is_lead_session(input_data, team_name)`, passed in by
+    `_decide_directive` so the team_config.json read happens at most
+    ONCE per fire (instead of twice: once here at clause 5, once at
+    the lead-session outer gate). When `is_lead is None` (the test
+    direct-invocation path), clause 5 falls back to computing the
+    check in-helper — preserves behavior for callers that don't have
+    the memoized value pre-computed. Behavior-preserving: clause 5
+    still skips the marker write when this fire originates from the
+    lead session.
 
     The predicate ladder evaluates in ORDER below; ALL six clauses must
     hold to write a marker. Order matters: cheap predicates first
@@ -479,8 +492,17 @@ def _maybe_write_teammate_arm_marker(
 
         # Clause 5: positive teammate-session check. The lead-session
         # branch handles the lead-side Arm path directly below; only
-        # teammate-side fires write the cross-session marker.
-        if is_lead_session(input_data, team_name):
+        # teammate-side fires write the cross-session marker. The
+        # `is_lead` argument is the memoized result of
+        # `is_lead_session(input_data, team_name)` computed once by
+        # `_decide_directive` and reused at the outer-gate check below.
+        # When `is_lead is None` (direct-invocation path), fall back
+        # to computing the check in-helper — the structural pin
+        # (test_emitter_guards_on_lead_session_id_structural) requires
+        # the guard call to appear on a control-flow line.
+        if is_lead is None and is_lead_session(input_data, team_name):
+            return
+        if is_lead:
             return
 
         # Clause 6: task_id present.
@@ -516,9 +538,20 @@ def _maybe_write_teammate_arm_marker(
         # component safety: session_id is platform-generated UUID,
         # task_id is platform-generated short id; both are restricted by
         # the platform's task-id alphabet. Use a defensive replace of
-        # path separators as belt-and-suspenders.
-        safe_task_id = task_id.replace("/", "_").replace("\\", "_")
-        safe_session_id = session_id_raw.replace("/", "_").replace("\\", "_")
+        # path separators AND embedded NUL bytes as belt-and-suspenders.
+        # NUL byte handling: a `\x00` in either field would raise
+        # `ValueError` from `os.open` (NOT `OSError`); the outer
+        # `except Exception` still catches it but the explicit NUL-strip
+        # here makes the defense visible at the sanitization step and
+        # avoids opening a fd just to have it rejected by the kernel.
+        safe_task_id = (
+            task_id.replace("/", "_").replace("\\", "_").replace("\x00", "_")
+        )
+        safe_session_id = (
+            session_id_raw.replace("/", "_")
+            .replace("\\", "_")
+            .replace("\x00", "_")
+        )
         marker_filename = (
             f"{timestamp}-{safe_session_id}-{safe_task_id}.json"
         )
@@ -598,6 +631,13 @@ def _decide_directive(input_data: dict[str, Any], team_name: str) -> str | None:
     sequential-first-create emit case together rule out predicates
     above (e.g. > 1) and below (e.g. >= 0).
     """
+    # Compute `is_lead_session` ONCE per fire and thread the result
+    # through both the teammate-Arm pre-branch (clause 5) and the
+    # outer lead-session gate. team_config.json is the single source
+    # of truth; reading it twice on the same fire wastes a disk read
+    # and the lead-status cannot legitimately change mid-fire.
+    is_lead = bool(is_lead_session(input_data, team_name))
+
     # Teammate-Arm pre-branch — runs BEFORE the lead-session early-return
     # so the teammate self-claim signal escapes the symmetric guard via
     # an inbox marker (the cross-session signal). Returns None in all
@@ -605,9 +645,13 @@ def _decide_directive(input_data: dict[str, Any], team_name: str) -> str | None:
     # session, not the lead's. The lead-side drain hook
     # (`wake_inbox_drain.py`, UserPromptSubmit) consumes the marker on
     # the lead's next prompt.
-    _maybe_write_teammate_arm_marker(input_data, team_name)
+    _maybe_write_teammate_arm_marker(input_data, team_name, is_lead)
 
-    if not is_lead_session(input_data, team_name):
+    # Outer lead-session gate. Layer 0 of the defense-in-depth model;
+    # teammate sessions never reach the directive emission paths below.
+    # Uses the memoized `is_lead` from above; semantically identical
+    # to `if not is_lead_session(input_data, team_name): return None`.
+    if not is_lead:
         return None
 
     tool_name = input_data.get("tool_name")

--- a/pact-plugin/hooks/wake_lifecycle_emitter.py
+++ b/pact-plugin/hooks/wake_lifecycle_emitter.py
@@ -42,15 +42,38 @@ Lifecycle automation:
   emitted.
 
 Lead-Session Guard (Layer 0 — defense-in-depth):
-- Every directive emission is gated by `_is_lead_session`, which
-  verifies that the current PostToolUse session's `session_id`
-  matches the team's `leadSessionId` from team_config.json.
-  Teammate sessions never receive the Arm/Teardown directives —
-  hook-level filtering at the emission source, correct-by-
-  construction rather than relying on the skill body's
-  Lead-Session Guard (Layer 1) as the primary defense. The skill-
-  body guard remains as backstop for user-typed manual invocation
-  from a teammate session.
+- Every Teardown directive emission is gated by `is_lead_session`,
+  which verifies that the current PostToolUse session's `session_id`
+  matches the team's `leadSessionId` from team_config.json. Teammate
+  sessions never receive the Teardown directive — hook-level filtering
+  at the emission source, correct-by-construction rather than relying
+  on the skill body's Lead-Session Guard (Layer 1) as the primary
+  defense. The skill-body guard remains as backstop for user-typed
+  manual invocation from a teammate session.
+
+Asymmetric Arm vs Teardown Guard:
+- Teardown's natural trigger source IS the lead session: terminal-status
+  TaskUpdates run under the Completion Authority model in the lead's
+  session. Suppressing teammate-side Teardown emit at the lead-session
+  guard is correct because there is no legitimate teammate-side
+  Teardown signal to preserve.
+- Arm has TWO natural trigger sources with different session locality.
+  (a) Teammate self-claim TaskUpdate(status="in_progress") per
+  pact-agent-teams §On Start lives in the TEAMMATE session — a symmetric
+  lead-session guard starves this signal entirely. (b) Lead-side
+  unowned-TaskCreate-then-TaskUpdate(owner) dispatch pattern produces
+  no in_progress transition the lead-session sees, so the lead-session
+  branch also misses it.
+- The asymmetric guard is realised by branch PLACEMENT: a teammate-Arm
+  pre-branch (`_maybe_write_teammate_arm_marker`) sits ABOVE the
+  `is_lead_session` early-return and writes a per-marker JSON file to
+  the team's `wake_inbox/` directory (the cross-session signal — the
+  in-session PostToolUse `additionalContext` targets the WRONG session
+  for the teammate path). The lead-session branch and Teardown stay
+  BELOW the lead-session guard. Lead-side drain + count-fallback lives
+  in `hooks/wake_inbox_drain.py` (UserPromptSubmit). Together they
+  cover both Arm trigger sources without re-coupling Teardown's
+  lead-only correctness (#737 Layer 0 preserved).
 
 Transition detection (post-only):
 - post = count_active_tasks(team_name) — the count AFTER the tool's
@@ -117,7 +140,9 @@ Output: hookSpecificOutput with additionalContext on transitions;
 """
 
 import json
+import os
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -131,7 +156,12 @@ from shared.pact_context import get_team_name
 from shared.session_state import is_safe_path_component
 from shared.task_utils import read_task_json
 from shared.tool_response import extract_tool_response
-from shared.wake_lifecycle import count_active_tasks, has_same_teammate_continuation
+from shared.wake_lifecycle import (
+    count_active_tasks,
+    has_same_teammate_continuation,
+    is_lead_session,
+)
+from shared.wake_lifecycle import _classify_owner  # noqa: F401 — owner classification for teammate-Arm pre-branch
 
 # Suppress the false "hook error" UI surface on bare exit paths.
 _SUPPRESS_OUTPUT = json.dumps({"suppressOutput": True})
@@ -169,46 +199,6 @@ _TEARDOWN_DIRECTIVE = (
 # other tools at the platform layer; this in-hook check is
 # belt-and-suspenders against future matcher widening.
 _TASK_MUTATING_TOOLS = ("TaskCreate", "TaskUpdate")
-
-
-def _is_lead_session(input_data: dict[str, Any], team_name: str) -> bool:
-    """
-    Return True iff the current session is the team's lead session.
-
-    Reads `session_id` from the PostToolUse stdin payload and
-    `leadSessionId` from ~/.claude/teams/{team_name}/config.json.
-    Mirrors the Lead-Session Guard pattern used by the start-pending-scan /
-    stop-pending-scan skill bodies (Layer 1 of the defense-in-depth model);
-    this hook-level check is Layer 0, preventing directive emission to
-    teammate sessions at the emission source. team_config is the single
-    source of truth for lead identity.
-
-    Pure function; never raises. Returns False on missing/empty
-    session_id, missing/unsafe team_name, missing config.json, malformed
-    JSON, or filesystem error. The teammate session is the expected
-    non-lead path; silent fail-open avoids UI noise on every
-    teammate Task-tool fire.
-    """
-    raw_session_id = input_data.get("session_id")
-    if not isinstance(raw_session_id, str) or not raw_session_id:
-        return False
-    if not team_name or not is_safe_path_component(team_name):
-        return False
-    try:
-        config_path = (
-            Path.home() / ".claude" / "teams" / team_name / "config.json"
-        )
-        if not config_path.exists():
-            return False
-        data = json.loads(config_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return False
-    if not isinstance(data, dict):
-        return False
-    lead_session_id = data.get("leadSessionId")
-    if not isinstance(lead_session_id, str) or not lead_session_id:
-        return False
-    return raw_session_id == lead_session_id
 
 
 def _extract_task_id(input_data: dict[str, Any]) -> str | None:
@@ -387,6 +377,197 @@ def _emit_directive(prose: str) -> None:
     print(json.dumps(output))
 
 
+# Schema version for inbox marker JSON payloads. Bump on
+# breaking-shape changes; drain side tolerates unknown fields and
+# treats malformed JSON as a fail-conservative wake signal.
+_WAKE_INBOX_MARKER_SCHEMA_VERSION = 1
+
+# Trigger sentinel written into the marker payload for forensics. The
+# drain side consumes the file PRESENCE, not the field content, but
+# the field documents the trigger class for debug/triage.
+_TEAMMATE_SELF_CLAIM_TRIGGER = "teammate_self_claim_in_progress"
+
+
+def _maybe_write_teammate_arm_marker(
+    input_data: dict[str, Any], team_name: str
+) -> None:
+    """
+    Write a wake-inbox marker iff the 6-clause asymmetric-guard
+    predicate ladder holds for this PostToolUse fire.
+
+    The predicate ladder evaluates in ORDER below; ALL six clauses must
+    hold to write a marker. Order matters: cheap predicates first
+    (string/shape checks) before any filesystem I/O; the lead-session
+    check is clause 5 so a non-lead match still pays the predicate cost
+    but no more (clauses 1-4 are pure dict reads).
+
+      Clause 1 — team_name path-safe: non-empty AND
+                 is_safe_path_component(team_name). Mirrors the same
+                 defense already applied by `is_lead_session`.
+      Clause 2 — tool_name allowlist: tool_name in TaskCreate|TaskUpdate.
+                 Belt-and-suspenders against future hooks.json matcher
+                 widening; current matcher already filters.
+      Clause 3 — trigger semantics: for TaskUpdate, the fire is a
+                 pending->in_progress self-claim transition. For
+                 TaskCreate, the just-created task carries a teammate
+                 owner-at-create (excludes unowned umbrella TaskCreates).
+                 Status-only TaskUpdates (teachback_submit,
+                 intentional_wait, metadata-only edits) fail this clause.
+      Clause 4 — owner classification: the owner field resolves to a
+                 known team member who is NOT the team lead. Defends
+                 against hypothetical re-assignment to the lead.
+      Clause 5 — NOT lead session: positive teammate-session check.
+                 The lead-session counterpart to this path is the
+                 existing TaskCreate branch (which fires Arm directly
+                 below) and the new lead-side drain hook fallback.
+      Clause 6 — task_id present: non-empty string for the marker
+                 filename's uniqueness component.
+
+    On all six clauses passing, write the marker via O_CREAT|O_EXCL
+    atomic open. On any failure to write (FileExistsError,
+    PermissionError, any OSError), silently swallow — the wake mechanism
+    is opportunistic; a missed marker degrades to the lead-side B-1
+    count-based fallback in `wake_inbox_drain.py`, not a hard failure.
+
+    Pure side-effect helper. Never raises (outer except swallows every
+    OSError + Exception class). Returns None unconditionally — caller
+    must NOT branch on a return value.
+    """
+    try:
+        # Clause 1: team_name path-safety.
+        if not isinstance(team_name, str) or not team_name:
+            return
+        if not is_safe_path_component(team_name):
+            return
+
+        # Clause 2: tool_name allowlist.
+        tool_name = input_data.get("tool_name")
+        if tool_name not in _TASK_MUTATING_TOOLS:
+            return
+
+        tool_input = input_data.get("tool_input") or {}
+        if not isinstance(tool_input, dict):
+            return
+
+        # Clause 3: trigger semantics. For TaskUpdate, require
+        # pending->in_progress transition. For TaskCreate, require a
+        # non-empty owner-at-create field — unowned umbrella TaskCreates
+        # (per /PACT:orchestrate dispatch pattern) fail this clause.
+        if tool_name == "TaskUpdate":
+            if not _is_pending_to_in_progress_transition(input_data):
+                return
+            owner = tool_input.get("owner")
+        else:  # tool_name == "TaskCreate"
+            owner = tool_input.get("owner")
+            if not isinstance(owner, str) or not owner:
+                return
+
+        # Clause 4: owner classification. Owner must be a known team
+        # member AND NOT the lead. Reuses the consolidated owner
+        # projection from shared/wake_lifecycle.py.
+        if not isinstance(owner, str) or not owner:
+            return
+        classification = _classify_owner(owner, team_name)
+        if not classification.config_readable:
+            # Config unreadable: cannot positively classify; fail-open
+            # to "skip marker." Lead-side B-1 fallback covers the gap.
+            return
+        if not classification.is_known_team_member:
+            return
+        if classification.is_lead:
+            return
+
+        # Clause 5: positive teammate-session check. The lead-session
+        # branch handles the lead-side Arm path directly below; only
+        # teammate-side fires write the cross-session marker.
+        if is_lead_session(input_data, team_name):
+            return
+
+        # Clause 6: task_id present.
+        task_id = _extract_task_id(input_data)
+        if not task_id:
+            return
+
+        # All six clauses hold — write the marker atomically.
+        session_id_raw = input_data.get("session_id")
+        if not isinstance(session_id_raw, str) or not session_id_raw:
+            return
+
+        now = datetime.now(timezone.utc)
+        timestamp = now.strftime("%Y%m%dT%H%M%SZ")
+        written_at = now.isoformat(timespec="milliseconds").replace(
+            "+00:00", "Z"
+        )
+
+        inbox_dir = (
+            Path.home()
+            / ".claude"
+            / "teams"
+            / team_name
+            / "wake_inbox"
+        )
+        try:
+            inbox_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        except OSError:
+            return
+
+        # Filename: {timestamp}-{session_id}-{task_id}.json — natural
+        # lexical order is chronological for the drain side. Path
+        # component safety: session_id is platform-generated UUID,
+        # task_id is platform-generated short id; both are restricted by
+        # the platform's task-id alphabet. Use a defensive replace of
+        # path separators as belt-and-suspenders.
+        safe_task_id = task_id.replace("/", "_").replace("\\", "_")
+        safe_session_id = session_id_raw.replace("/", "_").replace("\\", "_")
+        marker_filename = (
+            f"{timestamp}-{safe_session_id}-{safe_task_id}.json"
+        )
+        marker_path = inbox_dir / marker_filename
+
+        marker_payload = {
+            "schema_version": _WAKE_INBOX_MARKER_SCHEMA_VERSION,
+            "written_at": written_at,
+            "writer_session_id": session_id_raw,
+            "tool_name": tool_name,
+            "task_id": task_id,
+            "owner": owner,
+            "trigger": _TEAMMATE_SELF_CLAIM_TRIGGER,
+        }
+
+        # O_CREAT|O_EXCL atomic write. FileExistsError on collision is
+        # silently swallowed — another writer already signalled, no
+        # second signal needed (collisions are structurally impossible
+        # under the {timestamp, session_id, task_id} encoding but
+        # O_EXCL is belt-and-suspenders).
+        try:
+            fd = os.open(
+                str(marker_path),
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+            )
+        except FileExistsError:
+            return
+        except OSError:
+            return
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(marker_payload, handle)
+        except OSError:
+            # Write failure after open — best-effort cleanup; the file
+            # may be empty but the drain side treats malformed/empty
+            # markers as wake signals (fail-conservative).
+            try:
+                os.unlink(str(marker_path))
+            except OSError:
+                pass
+            return
+    except Exception:
+        # Outer catch-all preserves the never-raises contract; teammate
+        # sessions emit on every Task-tool fire, a raise here would
+        # surface as a hook-error UI on every fire.
+        return
+
+
 def _decide_directive(input_data: dict[str, Any], team_name: str) -> str | None:
     """
     Return the directive prose to emit, or None for no-op.
@@ -417,7 +598,16 @@ def _decide_directive(input_data: dict[str, Any], team_name: str) -> str | None:
     sequential-first-create emit case together rule out predicates
     above (e.g. > 1) and below (e.g. >= 0).
     """
-    if not _is_lead_session(input_data, team_name):
+    # Teammate-Arm pre-branch — runs BEFORE the lead-session early-return
+    # so the teammate self-claim signal escapes the symmetric guard via
+    # an inbox marker (the cross-session signal). Returns None in all
+    # paths: PostToolUse `additionalContext` would target the teammate's
+    # session, not the lead's. The lead-side drain hook
+    # (`wake_inbox_drain.py`, UserPromptSubmit) consumes the marker on
+    # the lead's next prompt.
+    _maybe_write_teammate_arm_marker(input_data, team_name)
+
+    if not is_lead_session(input_data, team_name):
         return None
 
     tool_name = input_data.get("tool_name")

--- a/pact-plugin/tests/fixtures/wake_lifecycle/teammate_metadata_only_update_shape.json
+++ b/pact-plugin/tests/fixtures/wake_lifecycle/teammate_metadata_only_update_shape.json
@@ -1,0 +1,26 @@
+{
+  "_meta": {
+    "capture_session_id": "synthesized",
+    "capture_date": "2026-05-14",
+    "capture_method": "synthesized",
+    "issue_ref": "wake-lifecycle-arm-starvation",
+    "notes": "Synthesized TaskUpdate PostToolUse stdin shape representing a metadata-only TaskUpdate (e.g. teachback_submit, intentional_wait, handoff, progress, memory_saved). tool_input carries taskId + metadata fields but NO status field. Pins the negative-case trigger semantics for the teammate-Arm pre-branch: the predicate ladder's transition clause must reject this shape (no pending->in_progress status transition) and write NO inbox marker. Counterpart positive fixture: teammate_claim_in_progress_shape.json."
+  },
+  "tool_name": "TaskUpdate",
+  "session_id": "synthesized-teammate-session-id",
+  "cwd": "/Users/mj/Sites/collab/PACT-prompt",
+  "tool_input": {
+    "taskId": "42",
+    "metadata": {
+      "teachback_submit": {
+        "role": "backend-coder",
+        "mission": "Implement metadata-only-no-transition smoke fixture"
+      }
+    }
+  },
+  "tool_response": {
+    "id": "42",
+    "subject": "metadata-only TaskUpdate fixture for clause-3 negative case",
+    "owner": "backend-coder"
+  }
+}

--- a/pact-plugin/tests/runbooks/wake-lifecycle-arm-starvation.md
+++ b/pact-plugin/tests/runbooks/wake-lifecycle-arm-starvation.md
@@ -40,28 +40,68 @@ cd "$WORKTREE"
 
 ## Expected cardinality on revert
 
-Targets pending test-engineer's empirical measurement against the merge-
-parent. Architect targets:
+### Architect §8.4 targets
 
-- **`tests/test_wake_lifecycle_arm_starvation.py`** (10 tests):
-  - Tests 1, 2, 3, 8, 9 FAIL — the teammate-Arm pre-branch is gone, so no
-    marker is written; tests asserting marker presence or filename schema
-    raise AssertionError; the O_EXCL collision test fails because
-    `_maybe_write_teammate_arm_marker` is undefined.
-  - Tests 4, 5, 6, 7 PASS — these exercise the pre-existing lead-session
-    branches (Arm on TaskCreate, re-Arm on TaskUpdate(in_progress),
-    Teardown on terminal-status, teammate-suppression on terminal-
-    status). They survive the revert because the branches below the
-    lead-session early-return are unchanged.
-  - Test 10 PASSES — the `_ARM_DIRECTIVE` literal is in the unchanged
-    pre-revert source.
-- **`tests/test_wake_inbox_drain.py`** (6 tests):
-  - Full collection error — the module file is missing. All 6 tests
-    fail at collection time.
+- `test_wake_lifecycle_arm_starvation.py`: tests 1, 2, 3, 8, 9 fail;
+  tests 4–7 + 10 pass. ~5 fail + 5 pass.
+- `test_wake_inbox_drain.py`: full collection error; all 6 fail.
 
-Total on this scope's revert: ~5 test failures + 1 collection error in
-the arm_starvation file + 1 collection error in the drain file. (4
-arm_starvation tests survive; 6 drain tests fail at collection.)
+### Empirical (test-engineer, 2026-05-14, revert against HEAD~2 = main parent)
+
+Measured by `cp`-snapshot + `git checkout HEAD~2 -- <source files>` +
+`rm wake_inbox_drain.py`, then re-running the full new-test scope.
+
+**Total: 14 failed + 7 passed.**
+
+- **`test_wake_lifecycle_arm_starvation.py` (10 tests): 3 fail + 7 pass.**
+  - FAIL: test 1 (`test_teammate_self_claim_writes_inbox_marker`),
+    test 8 (`test_marker_filename_schema`),
+    test 9 (`test_marker_o_excl_collision_silent`).
+  - PASS: tests 2, 3, 4, 5, 6, 7, 10.
+  - Architect target said tests 2 and 3 would fail on revert.
+    Empirically they pass: tests 2 (lead-owner negative) and 3
+    (metadata-only negative) assert NO marker is written, which is
+    also true on the reverted (no-marker-writer-at-all) source.
+    This is documented PHANTOM-GREEN on revert — the tests are
+    correctly coupled to the negative-case contract under the fix
+    but pass trivially on revert. They retain value as future-
+    regression guards (a hypothetical buggy implementation that
+    accidentally wrote markers for the lead-owner or metadata-only
+    cases would be caught). Same shape for test 7 (teammate-side
+    Teardown still suppressed) — pre-existing #737 symmetric guard
+    already suppresses on revert.
+- **`test_wake_inbox_drain.py` (6 tests): 6 fail (not 1 collection error).**
+  - All 6 subprocess fires return RC=2 with stderr "can't open file …
+    wake_inbox_drain.py: No such file or directory". The test
+    harness uses subprocess invocation rather than module import,
+    so the missing module surfaces as runtime subprocess-error
+    AssertionError (`assert rc == 0`) rather than pytest collection
+    error. Functionally equivalent — all 6 tests are coupled to the
+    fix.
+- **`test_wake_lifecycle_arm_edge_cases.py` (5 tests): 5 fail.**
+  - Test-engineer additions covering: drain hook fail-open on missing
+    team config; emitter path-traversal rejection (clause 1); empty
+    task_id rejection (clause 6); empty session_id rejection;
+    separator-bearing id sanitization. All 5 fail on revert because
+    `_maybe_write_teammate_arm_marker` is undefined and the drain
+    hook file is missing.
+
+### Interpretation
+
+The fix's load-bearing protection is the 14-test surface that fails on
+revert. The 7 phantom-green tests (2, 3, 4, 5, 6, 7, 10) split into:
+
+- Tests 4, 5, 6 — lead-session regression guards. Correctly pass on
+  revert (the lead-session branches below the guard are unchanged);
+  their value is forward-protection against any future Arm-path
+  refactor that breaks lead-session emit.
+- Tests 2, 3, 7 — teammate-side negative cases. Phantom-green on
+  revert (the entire teammate-side write path is gone). They will
+  catch future regressions where a buggy implementation accidentally
+  writes markers in these negative cases.
+- Test 10 — audit-anchor literal-prose pin. Passes on revert because
+  the `_ARM_DIRECTIVE` literal exists in the pre-fix emitter source
+  (the lift was a refactor; the literal itself was always present).
 
 ## Restore
 
@@ -145,11 +185,13 @@ on unowned-create-then-owner-update.
 
 ## Verification matrix
 
-| Test scope | Pass criteria | Counter-test cardinality on revert |
+| Test scope | Pass criteria | Counter-test cardinality on revert (empirical 2026-05-14) |
 |-----------|----------------|-------------------------------------|
-| `test_wake_lifecycle_arm_starvation.py` (10 tests) | All pass on fix | ~5 fail, 5 pass on revert (tests 1, 2, 3, 8, 9 fail; tests 4–7 + 10 pass — lead-session paths and audit-anchor literal survive) |
-| `test_wake_inbox_drain.py` (6 tests) | All pass on fix | Collection error on revert (module file missing); all 6 tests fail at collection |
+| `test_wake_lifecycle_arm_starvation.py` (10 tests) | All pass on fix | 3 fail (1, 8, 9), 7 pass (2, 3, 4, 5, 6, 7, 10) — negative-case tests phantom-green on revert (see Interpretation above) |
+| `test_wake_inbox_drain.py` (6 tests) | All pass on fix | 6 fail via subprocess RC=2 "No such file" (test harness uses subprocess, not import, so this surfaces as test failure rather than collection error) |
+| `test_wake_lifecycle_arm_edge_cases.py` (5 tests) | All pass on fix | 5 fail — drain fail-open, path-traversal, empty task_id, empty session_id, separator sanitization all fail on revert |
 | Existing `test_wake_lifecycle_bug_*.py` (full) | All pass on fix; no regressions | N/A — orthogonal to this PR's surface |
+| Full suite (`pytest tests/`) | 7669 passed, 10 skipped post-fix (7664 baseline + 5 edge-case additions) | — |
 
 ## Known limitations
 

--- a/pact-plugin/tests/runbooks/wake-lifecycle-arm-starvation.md
+++ b/pact-plugin/tests/runbooks/wake-lifecycle-arm-starvation.md
@@ -1,0 +1,168 @@
+# Counter-test-by-revert runbook: wake-lifecycle Arm starvation fix
+
+> **Why this runbook exists** — per the pinned constraint "Hooks cannot be
+> smoke-tested against the running plugin in-session" (`CLAUDE.md`), every
+> wake-lifecycle hook fix requires CI + counter-test-by-revert verification.
+> The running session uses the OLD hook code at the moment of the fix; in-
+> session observability is structurally limited. Counter-test-by-revert
+> proves the new tests would FAIL on the unfixed source — falsifying the
+> tests-pass-because-the-bug-was-never-real failure mode.
+
+## SOURCE-ONLY revert procedure
+
+The fix is a bundled commit (production source + new tests + runbook +
+fixture). Counter-test-by-revert uses a SOURCE-ONLY revert via `cp` and
+`git checkout` — `git revert -n` would re-revert the new tests too and
+mask the protection cardinality.
+
+```sh
+cd <repo-root>
+WORKTREE=$(pwd)
+
+# Snapshot current (fix) source.
+cp pact-plugin/hooks/wake_lifecycle_emitter.py /tmp/emitter.bak
+cp pact-plugin/hooks/shared/wake_lifecycle.py /tmp/shared.bak
+cp pact-plugin/hooks/hooks.json /tmp/hooks.bak
+
+# Revert source-only — drain hook is a NEW file, so move it aside.
+git checkout HEAD~1 -- pact-plugin/hooks/wake_lifecycle_emitter.py \
+                       pact-plugin/hooks/shared/wake_lifecycle.py \
+                       pact-plugin/hooks/hooks.json
+mv pact-plugin/hooks/wake_inbox_drain.py /tmp/drain.bak
+
+# Run the affected test scope and record cardinality.
+cd pact-plugin && /Users/mj/.pyenv/versions/3.12.7/bin/python -m pytest \
+    tests/test_wake_lifecycle_arm_starvation.py \
+    tests/test_wake_inbox_drain.py \
+    -v 2>&1 | tail -40
+cd "$WORKTREE"
+```
+
+## Expected cardinality on revert
+
+Targets pending test-engineer's empirical measurement against the merge-
+parent. Architect targets:
+
+- **`tests/test_wake_lifecycle_arm_starvation.py`** (10 tests):
+  - Tests 1, 2, 3, 8, 9 FAIL — the teammate-Arm pre-branch is gone, so no
+    marker is written; tests asserting marker presence or filename schema
+    raise AssertionError; the O_EXCL collision test fails because
+    `_maybe_write_teammate_arm_marker` is undefined.
+  - Tests 4, 5, 6, 7 PASS — these exercise the pre-existing lead-session
+    branches (Arm on TaskCreate, re-Arm on TaskUpdate(in_progress),
+    Teardown on terminal-status, teammate-suppression on terminal-
+    status). They survive the revert because the branches below the
+    lead-session early-return are unchanged.
+  - Test 10 PASSES — the `_ARM_DIRECTIVE` literal is in the unchanged
+    pre-revert source.
+- **`tests/test_wake_inbox_drain.py`** (6 tests):
+  - Full collection error — the module file is missing. All 6 tests
+    fail at collection time.
+
+Total on this scope's revert: ~5 test failures + 1 collection error in
+the arm_starvation file + 1 collection error in the drain file. (4
+arm_starvation tests survive; 6 drain tests fail at collection.)
+
+## Restore
+
+```sh
+cp /tmp/emitter.bak pact-plugin/hooks/wake_lifecycle_emitter.py
+cp /tmp/shared.bak pact-plugin/hooks/shared/wake_lifecycle.py
+cp /tmp/hooks.bak pact-plugin/hooks/hooks.json
+cp /tmp/drain.bak pact-plugin/hooks/wake_inbox_drain.py
+
+git diff --quiet -- pact-plugin/hooks/wake_lifecycle_emitter.py \
+                    pact-plugin/hooks/shared/wake_lifecycle.py \
+                    pact-plugin/hooks/hooks.json \
+                    pact-plugin/hooks/wake_inbox_drain.py
+echo "exit code: $?"  # MUST be 0 — clean restore.
+git status --porcelain -- pact-plugin/hooks/wake_lifecycle_emitter.py \
+                          pact-plugin/hooks/shared/wake_lifecycle.py \
+                          pact-plugin/hooks/hooks.json \
+                          pact-plugin/hooks/wake_inbox_drain.py
+# MUST print nothing.
+```
+
+## Post-merge fresh-session validation
+
+In a NEW Claude Code session (so the platform reloads the merged hook
+code), confirm the live behavior covers both dual-starvation surfaces.
+
+### V1 — Teammate self-claim surface (issue body acceptance criterion)
+
+```
+Setup: Start a fresh session in a PACT-Plugin worktree. Trigger
+       /PACT:orchestrate or /PACT:comPACT with any non-trivial task that
+       dispatches a teammate (e.g. backend-coder, architect).
+
+Sequence:
+  1. Lead dispatches the teammate via Agent + TaskCreate.
+  2. Teammate session starts; per pact-agent-teams §On Start, teammate
+     calls TaskUpdate(taskId, status="in_progress").
+  3. Within ONE lead-prompt cycle of the teammate self-claim:
+     - Lead receives _ARM_DIRECTIVE additionalContext in next prompt.
+     - Lead invokes Skill("PACT:start-pending-scan").
+     - CronList shows a fresh /PACT:scan-pending-tasks entry.
+
+Pass criteria:
+  - CronList output contains a line with suffix ": /PACT:scan-pending-tasks"
+    within ≤ 2 lead prompts of the teammate self-claim transition.
+  - Inspect ~/.claude/teams/{team}/wake_inbox/ — expect empty (markers
+    were drained on the lead's prompt).
+
+Failure mode (Arm starvation bug back):
+  - No CronList entry; wake_inbox/ contains stale markers; lead must
+    /PACT:start-pending-scan manually.
+```
+
+### V2 — Lead-side unowned-create-then-owner-update surface (B-1 fallback)
+
+```
+Setup: Same as V1, but observe the lead's dispatch pattern carefully.
+       The lead's /PACT:orchestrate flow creates tasks with TaskCreate
+       (initially unowned), then TaskUpdate(owner=teammate) to assign
+       — NO status transition. Empirically (per architect §1 / current
+       session pact-fb3423e5), this surface ALSO fails without the fix:
+       the TaskCreate sees count=0 (unowned excluded); the subsequent
+       TaskUpdate(owner=...) carries no status change → no Arm trigger.
+
+Sequence:
+  1. Lead's next prompt after the dispatch fires
+     wake_inbox_drain.py UserPromptSubmit hook.
+  2. Drain inbox: typically empty for this surface (teammate-side write
+     happens only on status=in_progress claim).
+  3. B-1 fallback: count_active_tasks(team) >= 1 because the task on
+     disk is teammate-owned. Emit Arm.
+
+Pass criteria:
+  - Lead's first prompt after dispatch carries the Arm directive
+    additionalContext.
+  - CronList shows a fresh /PACT:scan-pending-tasks entry.
+
+Failure mode: B-1 fallback predicate broken; lead never re-arms scan
+on unowned-create-then-owner-update.
+```
+
+## Verification matrix
+
+| Test scope | Pass criteria | Counter-test cardinality on revert |
+|-----------|----------------|-------------------------------------|
+| `test_wake_lifecycle_arm_starvation.py` (10 tests) | All pass on fix | ~5 fail, 5 pass on revert (tests 1, 2, 3, 8, 9 fail; tests 4–7 + 10 pass — lead-session paths and audit-anchor literal survive) |
+| `test_wake_inbox_drain.py` (6 tests) | All pass on fix | Collection error on revert (module file missing); all 6 tests fail at collection |
+| Existing `test_wake_lifecycle_bug_*.py` (full) | All pass on fix; no regressions | N/A — orthogonal to this PR's surface |
+
+## Known limitations
+
+1. **Smoke-test of the running session is impossible.** Per CLAUDE.md
+   pinned context: the running session uses the OLD hook code. V1 and
+   V2 validation must run in a fresh post-merge session.
+
+2. **#738 prose bug is co-resident, not co-fixed.** The architecture
+   spec §6 resolved the apparent #738 contradiction by source walk
+   (`_lifecycle_relevant` step 4 correctly excludes lead-owned tasks).
+   The "First active teammate task created" prose is provably-false on
+   re-fires; that's a separate prose-bug ticket and does NOT block #754.
+
+3. **Counter-test cardinality is a target, not a measurement.** Test-
+   engineer empirically records the actual revert cardinality in the
+   PR before merge.

--- a/pact-plugin/tests/runbooks/wake-lifecycle-arm-starvation.md
+++ b/pact-plugin/tests/runbooks/wake-lifecycle-arm-starvation.md
@@ -25,9 +25,15 @@ cp pact-plugin/hooks/shared/wake_lifecycle.py /tmp/shared.bak
 cp pact-plugin/hooks/hooks.json /tmp/hooks.bak
 
 # Revert source-only — drain hook is a NEW file, so move it aside.
-git checkout HEAD~1 -- pact-plugin/hooks/wake_lifecycle_emitter.py \
-                       pact-plugin/hooks/shared/wake_lifecycle.py \
-                       pact-plugin/hooks/hooks.json
+# Anchor MUST resolve to the pre-fix commit. The branch carries the
+# bundled fix commit PLUS follow-on version-bump and test-additions
+# commits, so HEAD~N varies with branch state. Use `git merge-base`
+# against origin/main to resolve the pre-fix anchor independent of
+# subsequent commit count.
+PRE_FIX=$(git merge-base HEAD origin/main)
+git checkout "$PRE_FIX" -- pact-plugin/hooks/wake_lifecycle_emitter.py \
+                           pact-plugin/hooks/shared/wake_lifecycle.py \
+                           pact-plugin/hooks/hooks.json
 mv pact-plugin/hooks/wake_inbox_drain.py /tmp/drain.bak
 
 # Run the affected test scope and record cardinality.
@@ -46,10 +52,11 @@ cd "$WORKTREE"
   tests 4–7 + 10 pass. ~5 fail + 5 pass.
 - `test_wake_inbox_drain.py`: full collection error; all 6 fail.
 
-### Empirical (test-engineer, 2026-05-14, revert against HEAD~2 = main parent)
+### Empirical (test-engineer, 2026-05-14, revert against `git merge-base HEAD origin/main`)
 
-Measured by `cp`-snapshot + `git checkout HEAD~2 -- <source files>` +
-`rm wake_inbox_drain.py`, then re-running the full new-test scope.
+Measured by `cp`-snapshot + `git checkout "$PRE_FIX" -- <source files>`
+(where `PRE_FIX=$(git merge-base HEAD origin/main)`) + `rm
+wake_inbox_drain.py`, then re-running the full new-test scope.
 
 **Total: 14 failed + 7 passed.**
 

--- a/pact-plugin/tests/test_inbox_wake_lifecycle_emitter.py
+++ b/pact-plugin/tests/test_inbox_wake_lifecycle_emitter.py
@@ -83,7 +83,7 @@ def _write_session_context(
         }),
         encoding="utf-8",
     )
-    # Team config drives the emitter's _is_lead_session guard. Default
+    # Team config drives the emitter's is_lead_session guard. Default
     # behavior: caller's session_id IS the lead (the standard test
     # framing for these tests, which exercise lead-side behavior). Pass
     # `lead_session_id="some-other-id"` to simulate a teammate session.
@@ -495,10 +495,11 @@ def test_is_terminal_status_update_matches_completed_and_deleted():
 
 def test_emitter_guards_on_lead_session_id_structural():
     """Source-level structural pin (commit-9 tightened from substring-
-    anywhere to regex-in-code-line): the emitter must CALL `_is_lead_session`
-    (or equivalent guard against team_config.leadSessionId) before any
-    directive emit. Without this structural anchor, the emitter would
-    fire Arm/Teardown directives in teammate sessions (where they're
+    anywhere to regex-in-code-line): the emitter must CALL `is_lead_session`
+    (the public symbol lifted into shared.wake_lifecycle, or equivalent
+    guard against team_config.leadSessionId) before any Teardown directive
+    emit. Without this structural anchor, the emitter would fire
+    Arm/Teardown directives in teammate sessions (where they're
     inert at best, attacker-weaponizable at worst — a teammate session
     that arms a cron scan would scan the lead's task store from the wrong
     process).
@@ -507,11 +508,16 @@ def test_emitter_guards_on_lead_session_id_structural():
     construct (if/return/elif/while/assert), NOT just anywhere in source.
     A hostile edit removing the actual guard call but leaving a docstring
     mention would pass the prior substring check; the regex-in-code-line
-    check catches the wiring-disconnect."""
+    check catches the wiring-disconnect.
+
+    Accepts both the lifted public name `is_lead_session` and the
+    historical underscore-prefixed `_is_lead_session` for forward-compat;
+    `leadSessionId` (the config key) matches if a future refactor inlines
+    the check at the call site."""
     import re as _re
     src = (HOOK_DIR / "wake_lifecycle_emitter.py").read_text(encoding="utf-8")
     code_line_pattern = _re.compile(
-        r"^\s*(if|return|elif|while|assert)\b.*(_is_lead_session|leadSessionId)",
+        r"^\s*(if|return|elif|while|assert)\b.*(is_lead_session|leadSessionId)",
         _re.MULTILINE,
     )
     assert code_line_pattern.search(src) is not None, (
@@ -549,7 +555,7 @@ def test_no_emit_when_session_id_does_not_match_lead(tmp_path):
 
 
 def test_no_emit_when_team_config_missing(tmp_path):
-    """If team config.json is missing, _is_lead_session fail-closes —
+    """If team config.json is missing, is_lead_session fail-closes —
     no emit. Documenting the fail-closed behavior so an editing LLM
     cannot 'simplify' the guard into fail-open during refactor."""
     home = tmp_path / "home"; home.mkdir()
@@ -601,13 +607,13 @@ def test_count_active_tasks_not_called_on_metadata_only_taskupdate():
         }, "team-x")
         # Without a lead-session guard pass, _decide_directive returns
         # early; we want to specifically exercise the post-tool-name +
-        # post-task-id + non-terminal path. Bypass _is_lead_session by
+        # post-task-id + non-terminal path. Bypass is_lead_session by
         # patching it to True for this perf-invariant probe.
         # (The lead-session guard's correctness is covered separately
         # above; here we isolate the count_active_tasks ordering.)
 
     # Re-run with lead-guard bypassed to isolate the perf ordering invariant.
-    with patch.object(emitter, "_is_lead_session", return_value=True), \
+    with patch.object(emitter, "is_lead_session", return_value=True), \
          patch.object(emitter, "count_active_tasks") as mock_count:
         result = emitter._decide_directive({
             "tool_name": "TaskUpdate",
@@ -630,7 +636,7 @@ def test_count_active_tasks_called_on_terminal_status_taskupdate():
     import wake_lifecycle_emitter as emitter
 
     from unittest.mock import patch
-    with patch.object(emitter, "_is_lead_session", return_value=True), \
+    with patch.object(emitter, "is_lead_session", return_value=True), \
          patch.object(emitter, "count_active_tasks", return_value=0) as mock_count:
         emitter._decide_directive({
             "tool_name": "TaskUpdate",
@@ -650,7 +656,7 @@ def test_count_active_tasks_called_on_taskcreate():
     import wake_lifecycle_emitter as emitter
 
     from unittest.mock import patch
-    with patch.object(emitter, "_is_lead_session", return_value=True), \
+    with patch.object(emitter, "is_lead_session", return_value=True), \
          patch.object(emitter, "_extract_task_id", return_value="1"), \
          patch.object(emitter, "count_active_tasks", return_value=1) as mock_count:
         emitter._decide_directive({

--- a/pact-plugin/tests/test_wake_inbox_drain.py
+++ b/pact-plugin/tests/test_wake_inbox_drain.py
@@ -1,0 +1,323 @@
+"""
+Integration tests for hooks/wake_inbox_drain.py — the lead-side
+UserPromptSubmit hook that drains wake_inbox markers and emits a single
+_ARM_DIRECTIVE additionalContext block per prompt.
+
+Combined drain + B-1 count-fallback path. Lead-only gated; teammate
+sessions short-circuit to suppressOutput regardless of inbox or count
+state. Single-emit discipline: if drain consumed markers, the
+count-fallback is NOT run (drain wins; second emit would be redundant).
+
+Counter-test-by-revert: see
+tests/runbooks/wake-lifecycle-arm-starvation.md.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HOOK_DIR = Path(__file__).resolve().parent.parent / "hooks"
+DRAIN = HOOK_DIR / "wake_inbox_drain.py"
+
+
+def _run_drain(stdin_payload, env_extra=None):
+    env = {k: v for k, v in os.environ.items() if not k.startswith("CLAUDE_")}
+    if env_extra:
+        env.update(env_extra)
+    payload_bytes = (
+        stdin_payload if isinstance(stdin_payload, bytes)
+        else stdin_payload.encode("utf-8")
+    )
+    proc = subprocess.run(
+        [sys.executable, str(DRAIN)],
+        input=payload_bytes,
+        capture_output=True,
+        env=env,
+        timeout=10,
+    )
+    return proc.returncode, proc.stdout.decode("utf-8"), proc.stderr.decode("utf-8")
+
+
+def _write_session_context(
+    home,
+    session_id,
+    project_dir,
+    team_name,
+    *,
+    lead_session_id=None,
+    members=None,
+    lead_agent_id=None,
+):
+    slug = Path(project_dir).name
+    sess_dir = home / ".claude" / "pact-sessions" / slug / session_id
+    sess_dir.mkdir(parents=True, exist_ok=True)
+    (sess_dir / "pact-session-context.json").write_text(
+        json.dumps({
+            "team_name": team_name,
+            "session_id": session_id,
+            "project_dir": project_dir,
+            "plugin_root": "",
+            "started_at": "2026-05-14T00:00:00Z",
+        }),
+        encoding="utf-8",
+    )
+    team_dir = home / ".claude" / "teams" / team_name
+    team_dir.mkdir(parents=True, exist_ok=True)
+    effective_lead = (
+        lead_session_id if lead_session_id is not None else session_id
+    )
+    config_data = {"leadSessionId": effective_lead}
+    if lead_agent_id is not None:
+        config_data["leadAgentId"] = lead_agent_id
+    if members:
+        config_data["members"] = list(members)
+    (team_dir / "config.json").write_text(
+        json.dumps(config_data), encoding="utf-8",
+    )
+
+
+def _write_task(home, team_name, task_id, **fields):
+    tasks_dir = home / ".claude" / "tasks" / team_name
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    payload = {"id": task_id, **fields}
+    (tasks_dir / f"{task_id}.json").write_text(
+        json.dumps(payload), encoding="utf-8",
+    )
+
+
+def _write_marker(home, team_name, filename, payload):
+    inbox = home / ".claude" / "teams" / team_name / "wake_inbox"
+    inbox.mkdir(parents=True, exist_ok=True)
+    target = inbox / filename
+    target.write_text(json.dumps(payload), encoding="utf-8")
+    return target
+
+
+def _drain_out(payload, home):
+    rc, out, err = _run_drain(
+        json.dumps(payload),
+        env_extra={
+            "HOME": str(home),
+            "CLAUDE_PROJECT_DIR": payload.get("cwd", ""),
+        },
+    )
+    assert rc == 0, f"non-zero exit; stderr={err}"
+    return json.loads(out)
+
+
+# ─── Drain path tests ──────────────────────────────────────────────────
+
+
+def test_drain_emits_arm_when_marker_present(tmp_path):
+    """Test 11 — Drain primary path. With a marker present in the lead's
+    wake_inbox/, the hook emits _ARM_DIRECTIVE via additionalContext and
+    deletes the marker.
+    """
+    home = tmp_path / "home"; home.mkdir()
+    lead_sid = "lead-sid"
+    pdir = "/tmp/p"
+    team = "team-drain-emits"
+    _write_session_context(home, lead_sid, pdir, team)
+    marker_path = _write_marker(
+        home, team, "20260514T160526Z-some-session-X.json",
+        {
+            "schema_version": 1,
+            "written_at": "2026-05-14T16:05:26.123Z",
+            "writer_session_id": "some-session",
+            "tool_name": "TaskUpdate",
+            "task_id": "X",
+            "owner": "backend-coder",
+            "trigger": "teammate_self_claim_in_progress",
+        },
+    )
+
+    out = _drain_out({
+        "session_id": lead_sid, "cwd": pdir,
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "go",
+    }, home)
+    hso = out.get("hookSpecificOutput")
+    assert hso is not None, f"Drain must emit Arm; got {out!r}"
+    assert hso["hookEventName"] == "UserPromptSubmit"
+    assert 'Skill("PACT:start-pending-scan")' in hso["additionalContext"]
+    assert not marker_path.exists(), (
+        "Drain must unlink the consumed marker"
+    )
+
+
+def test_drain_no_emit_when_inbox_empty_and_count_zero(tmp_path):
+    """Test 12 — Negative case. Empty inbox and count=0 → suppressOutput.
+    """
+    home = tmp_path / "home"; home.mkdir()
+    lead_sid = "lead-sid"
+    pdir = "/tmp/p"
+    team = "team-drain-empty"
+    _write_session_context(home, lead_sid, pdir, team)
+    # No tasks, no markers.
+
+    out = _drain_out({
+        "session_id": lead_sid, "cwd": pdir,
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "go",
+    }, home)
+    assert out.get("suppressOutput") is True, (
+        f"Empty inbox + count=0 must suppressOutput; got {out!r}"
+    )
+
+
+def test_fallback_emits_arm_when_count_positive_and_no_marker(tmp_path):
+    """Test 13 — B-1 fallback path. Empty inbox but a lifecycle-relevant
+    teammate task is on disk → count_active_tasks >= 1 → emit Arm.
+    Covers the lead-side unowned-create-then-owner-update dispatch
+    pattern surface where no teammate-side write opportunity exists.
+    """
+    home = tmp_path / "home"; home.mkdir()
+    lead_sid = "lead-sid"
+    pdir = "/tmp/p"
+    team = "team-drain-fallback"
+    teammate_owner = "backend-coder"
+    _write_session_context(
+        home, lead_sid, pdir, team,
+        members=[
+            {"name": teammate_owner, "agentId": "agent-bc"},
+            {"name": "lead", "agentId": "agent-lead"},
+        ],
+        lead_agent_id="agent-lead",
+    )
+    _write_task(home, team, "Q", status="in_progress", owner=teammate_owner)
+
+    out = _drain_out({
+        "session_id": lead_sid, "cwd": pdir,
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "go",
+    }, home)
+    hso = out.get("hookSpecificOutput")
+    assert hso is not None, (
+        f"Fallback must emit Arm when count >= 1; got {out!r}"
+    )
+    assert hso["hookEventName"] == "UserPromptSubmit"
+    assert 'Skill("PACT:start-pending-scan")' in hso["additionalContext"]
+
+
+def test_fallback_suppressed_in_teammate_session(tmp_path):
+    """Test 14 — Lead-only gate. A teammate-session UserPromptSubmit
+    with markers on disk AND a positive count must STILL suppressOutput
+    because the drain hook is lead-targeted.
+    """
+    home = tmp_path / "home"; home.mkdir()
+    teammate_sid = "teammate-sid"
+    lead_sid = "lead-sid"
+    pdir = "/tmp/p"
+    team = "team-drain-teammate"
+    teammate_owner = "backend-coder"
+    _write_session_context(
+        home, teammate_sid, pdir, team,
+        lead_session_id=lead_sid,
+        members=[
+            {"name": teammate_owner, "agentId": "agent-bc"},
+            {"name": "lead", "agentId": "agent-lead"},
+        ],
+        lead_agent_id="agent-lead",
+    )
+    _write_task(home, team, "R", status="in_progress", owner=teammate_owner)
+    marker_path = _write_marker(
+        home, team, "20260514T160600Z-other-R.json",
+        {
+            "schema_version": 1, "trigger": "teammate_self_claim_in_progress",
+            "tool_name": "TaskUpdate", "task_id": "R", "owner": teammate_owner,
+        },
+    )
+
+    out = _drain_out({
+        "session_id": teammate_sid, "cwd": pdir,
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "go",
+    }, home)
+    assert out.get("suppressOutput") is True, (
+        f"Teammate-session drain must suppressOutput; got {out!r}"
+    )
+    # Marker must remain on disk — only the lead session is authorized
+    # to drain it.
+    assert marker_path.exists(), (
+        "Teammate-session drain must NOT consume markers"
+    )
+
+
+def test_drain_handles_malformed_marker_as_signal(tmp_path):
+    """Test 15 — Fail-conservative on malformed marker. A non-JSON file
+    in the inbox is still treated as a wake signal: emit Arm AND delete
+    the file. Rationale: a truncated/corrupted marker indicates a
+    teammate-session writer attempted the signal and was interrupted;
+    the wake intent stands.
+    """
+    home = tmp_path / "home"; home.mkdir()
+    lead_sid = "lead-sid"
+    pdir = "/tmp/p"
+    team = "team-drain-malformed"
+    _write_session_context(home, lead_sid, pdir, team)
+    inbox = home / ".claude" / "teams" / team / "wake_inbox"
+    inbox.mkdir(parents=True, exist_ok=True)
+    malformed = inbox / "20260514T160700Z-x-y.json"
+    malformed.write_text("{ this is not json ", encoding="utf-8")
+
+    out = _drain_out({
+        "session_id": lead_sid, "cwd": pdir,
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "go",
+    }, home)
+    hso = out.get("hookSpecificOutput")
+    assert hso is not None, (
+        f"Malformed marker must still emit Arm; got {out!r}"
+    )
+    assert 'Skill("PACT:start-pending-scan")' in hso["additionalContext"]
+    assert not malformed.exists(), (
+        "Drain must unlink the malformed marker"
+    )
+
+
+def test_drain_single_emit_when_both_paths_trigger(tmp_path):
+    """Test 16 — Single-emit discipline. With BOTH a marker present AND
+    count >= 1, the hook emits exactly one _ARM_DIRECTIVE block (drain
+    path consumes; fallback is skipped).
+    """
+    home = tmp_path / "home"; home.mkdir()
+    lead_sid = "lead-sid"
+    pdir = "/tmp/p"
+    team = "team-drain-single-emit"
+    teammate_owner = "backend-coder"
+    _write_session_context(
+        home, lead_sid, pdir, team,
+        members=[
+            {"name": teammate_owner, "agentId": "agent-bc"},
+            {"name": "lead", "agentId": "agent-lead"},
+        ],
+        lead_agent_id="agent-lead",
+    )
+    _write_task(home, team, "S", status="in_progress", owner=teammate_owner)
+    marker_path = _write_marker(
+        home, team, "20260514T160800Z-some-S.json",
+        {
+            "schema_version": 1, "trigger": "teammate_self_claim_in_progress",
+            "tool_name": "TaskUpdate", "task_id": "S", "owner": teammate_owner,
+        },
+    )
+
+    rc, out_str, err = _run_drain(
+        json.dumps({
+            "session_id": lead_sid, "cwd": pdir,
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "go",
+        }),
+        env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+    )
+    assert rc == 0, f"non-zero exit; stderr={err}"
+    # Exactly one additionalContext block: the JSON stdout contains
+    # _ARM_DIRECTIVE prose exactly once.
+    arm_count = out_str.count("First active teammate task created")
+    assert arm_count == 1, (
+        f"Expected exactly 1 _ARM_DIRECTIVE emit; got {arm_count} in "
+        f"stdout={out_str!r}"
+    )
+    assert not marker_path.exists(), "Marker must be drained"

--- a/pact-plugin/tests/test_wake_lifecycle_arm_edge_cases.py
+++ b/pact-plugin/tests/test_wake_lifecycle_arm_edge_cases.py
@@ -162,15 +162,9 @@ def test_emitter_rejects_path_traversal_team_name(tmp_path):
             f"Path-traversal team_name must not write any marker; got "
             f"{[str(m) for m in markers]}"
         )
-    # And nothing escaped to higher directories under tmp_path either.
-    escaped = [
-        p for p in tmp_path.rglob("*.json")
-        if "wake_inbox" in p.parts and "..wake_inbox" not in str(p)
-        and "passwd" in str(p) or "etc" in str(p)
-    ]
-    assert escaped == [], (
-        f"Marker writer must not escape via path traversal; got {escaped}"
-    )
+    # Primary assertion above (teams_root.rglob empty) is the load-bearing
+    # falsifiable check; this earlier non-falsifiable belt-and-suspenders
+    # assertion was removed in favor of the clean rglob check.
 
 
 # ─── Emitter teammate-Arm: boundary task_id / session_id ─────────────
@@ -336,3 +330,130 @@ def test_emitter_sanitizes_separators_in_task_id_and_session_id(tmp_path):
             assert "/" not in m.name and "\\" not in m.name, (
                 f"Separators in filename {m.name!r}"
             )
+
+
+# ─── Clause-2: tool_name allowlist falsifiable coverage ─────────────
+
+
+def test_emitter_rejects_disallowed_tool_name(tmp_path):
+    """Clause 2 of the predicate ladder: tool_name must be in
+    {TaskCreate, TaskUpdate}. A PostToolUse fire from any other tool
+    (Bash, Read, Write, Edit, etc.) must NOT write a marker even if
+    every other clause would otherwise hold.
+
+    Falsifiability: stripping the clause-2 early-return in
+    `_maybe_write_teammate_arm_marker` flips this test RED while
+    leaving all other tests GREEN. Closes the coverage gap where
+    every other fixture happens to use TaskCreate or TaskUpdate,
+    leaving clause 2 belt-and-suspenders without a test.
+    """
+    sys.path.insert(0, str(HOOK_DIR))
+    import wake_lifecycle_emitter as emitter
+
+    home = tmp_path / "home"; home.mkdir()
+    os.environ["HOME"] = str(home)
+    teammate_sid = "teammate-sid"
+    team = "team-disallowed-tool"
+    teammate_owner = "backend-coder"
+    _write_session_context(
+        home, teammate_sid, "/tmp/p", team,
+        lead_session_id="lead-sid",
+        members=[
+            {"name": teammate_owner, "agentId": "agent-bc"},
+            {"name": "lead", "agentId": "agent-lead"},
+        ],
+        lead_agent_id="agent-lead",
+    )
+    tasks_dir = home / ".claude" / "tasks" / team
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / "X.json").write_text(json.dumps(
+        {"id": "X", "status": "in_progress", "owner": teammate_owner}
+    ), encoding="utf-8")
+
+    # Shape mirrors a passing teammate self-claim BUT with tool_name=Bash.
+    # All other predicate-ladder fields are populated to ensure clause 2
+    # is the ONLY discriminator under test.
+    payload = {
+        "tool_name": "Bash",
+        "session_id": teammate_sid,
+        "cwd": "/tmp/p",
+        "tool_input": {
+            "taskId": "X", "status": "in_progress", "owner": teammate_owner,
+        },
+        "tool_response": {
+            "id": "X", "status": "in_progress", "owner": teammate_owner,
+        },
+    }
+    emitter._maybe_write_teammate_arm_marker(payload, team)
+
+    inbox = home / ".claude" / "teams" / team / "wake_inbox"
+    if inbox.exists():
+        markers = list(inbox.glob("*.json"))
+        assert markers == [], (
+            f"Disallowed tool_name must not produce a marker; got {markers}"
+        )
+
+
+# ─── Clause-3: pending->in_progress transition discriminator ────────
+
+
+def test_emitter_rejects_taskupdate_without_status_transition(tmp_path):
+    """Clause 3 discriminator: a TaskUpdate WITHOUT a `status` field but
+    WITH a teammate `owner` in tool_input must NOT write a marker. Pins
+    that the transition check is load-bearing independent of the
+    owner-empty-string check in clause 4.
+
+    Falsifiability: stripping clause 3 (the pending->in_progress
+    transition check) flips this test RED. The sibling test 3
+    (`test_teammate_metadata_only_update_no_marker`) does NOT discriminate
+    clause 3 alone because its fixture has no `tool_input.owner`, so
+    clause 4 also rejects — the metadata-only fixture is doubly-guarded.
+    This test fills that gap with a non-status payload that DOES carry
+    an owner.
+    """
+    sys.path.insert(0, str(HOOK_DIR))
+    import wake_lifecycle_emitter as emitter
+
+    home = tmp_path / "home"; home.mkdir()
+    os.environ["HOME"] = str(home)
+    teammate_sid = "teammate-sid"
+    team = "team-no-status-with-owner"
+    teammate_owner = "backend-coder"
+    _write_session_context(
+        home, teammate_sid, "/tmp/p", team,
+        lead_session_id="lead-sid",
+        members=[
+            {"name": teammate_owner, "agentId": "agent-bc"},
+            {"name": "lead", "agentId": "agent-lead"},
+        ],
+        lead_agent_id="agent-lead",
+    )
+    tasks_dir = home / ".claude" / "tasks" / team
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / "X.json").write_text(json.dumps(
+        {"id": "X", "status": "in_progress", "owner": teammate_owner}
+    ), encoding="utf-8")
+
+    # TaskUpdate with NO status field but WITH owner. Represents a
+    # metadata-only update (e.g. owner reassignment, intentional_wait
+    # set) that nonetheless carries an owner string in tool_input.
+    payload = {
+        "tool_name": "TaskUpdate",
+        "session_id": teammate_sid,
+        "cwd": "/tmp/p",
+        "tool_input": {
+            "taskId": "X", "owner": teammate_owner,
+        },
+        "tool_response": {
+            "id": "X", "owner": teammate_owner,
+        },
+    }
+    emitter._maybe_write_teammate_arm_marker(payload, team)
+
+    inbox = home / ".claude" / "teams" / team / "wake_inbox"
+    if inbox.exists():
+        markers = list(inbox.glob("*.json"))
+        assert markers == [], (
+            f"TaskUpdate without status transition must not produce a "
+            f"marker; got {markers}"
+        )

--- a/pact-plugin/tests/test_wake_lifecycle_arm_edge_cases.py
+++ b/pact-plugin/tests/test_wake_lifecycle_arm_edge_cases.py
@@ -1,0 +1,338 @@
+"""
+Edge-case coverage for the wake-lifecycle Arm starvation fix.
+
+These tests probe gaps not covered by the primary 10+6 surface in
+test_wake_lifecycle_arm_starvation.py + test_wake_inbox_drain.py:
+
+- Drain hook fail-open when team config is missing (no team_name
+  resolvable) → suppressOutput, no crash, no false-positive Arm emit.
+- Drain hook path-traversal defense: a team_name that fails
+  is_safe_path_component is rejected at _wake_inbox_path resolution.
+  (Emitter-side path-traversal defense is via clause 1 of the
+  predicate ladder, tested via the marker-not-written contract.)
+- Marker writer boundary inputs on task_id and session_id (empty
+  string, path-separator-bearing) — verify clause 6 (task_id) +
+  pre-marker session_id guard reject without raising.
+
+These are HIGH-tier additions per the test-engineer risk assessment
+(novel cross-session filesystem-bridge primitive). They probe failure
+modes the spec acknowledged as fail-open but did not pin in tests.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HOOK_DIR = Path(__file__).resolve().parent.parent / "hooks"
+EMITTER = HOOK_DIR / "wake_lifecycle_emitter.py"
+DRAIN = HOOK_DIR / "wake_inbox_drain.py"
+
+
+def _run(target, stdin_payload, env_extra=None):
+    env = {k: v for k, v in os.environ.items() if not k.startswith("CLAUDE_")}
+    if env_extra:
+        env.update(env_extra)
+    payload_bytes = (
+        stdin_payload if isinstance(stdin_payload, bytes)
+        else stdin_payload.encode("utf-8")
+    )
+    proc = subprocess.run(
+        [sys.executable, str(target)],
+        input=payload_bytes,
+        capture_output=True,
+        env=env,
+        timeout=10,
+    )
+    return proc.returncode, proc.stdout.decode("utf-8"), proc.stderr.decode("utf-8")
+
+
+def _write_session_context(
+    home, session_id, project_dir, team_name,
+    *, lead_session_id=None, members=None, lead_agent_id=None,
+):
+    slug = Path(project_dir).name
+    sess_dir = home / ".claude" / "pact-sessions" / slug / session_id
+    sess_dir.mkdir(parents=True, exist_ok=True)
+    (sess_dir / "pact-session-context.json").write_text(
+        json.dumps({
+            "team_name": team_name,
+            "session_id": session_id,
+            "project_dir": project_dir,
+            "plugin_root": "",
+            "started_at": "2026-05-14T00:00:00Z",
+        }),
+        encoding="utf-8",
+    )
+    team_dir = home / ".claude" / "teams" / team_name
+    team_dir.mkdir(parents=True, exist_ok=True)
+    effective_lead = lead_session_id if lead_session_id is not None else session_id
+    config_data = {"leadSessionId": effective_lead}
+    if lead_agent_id is not None:
+        config_data["leadAgentId"] = lead_agent_id
+    if members:
+        config_data["members"] = list(members)
+    (team_dir / "config.json").write_text(
+        json.dumps(config_data), encoding="utf-8",
+    )
+
+
+# ─── Drain hook: missing/unreadable team config ──────────────────────
+
+
+def test_drain_suppresses_when_team_name_unresolvable(tmp_path):
+    """Drain hook fail-open guard: when get_team_name() returns empty
+    (no pact-session-context.json on disk), the hook MUST suppressOutput
+    silently — no crash, no Arm emit, no advisory.
+
+    This pins the documented degradation posture for sessions that
+    have lost their session context mid-run (or for non-PACT Claude
+    Code sessions where this hook still fires per hooks.json
+    UserPromptSubmit registration).
+    """
+    home = tmp_path / "home"; home.mkdir()
+    # Deliberately NOT writing pact-session-context.json or team config.
+
+    rc, out, err = _run(DRAIN, json.dumps({
+        "session_id": "any-sid",
+        "cwd": "/tmp/p",
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "go",
+    }), env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": "/tmp/p"})
+    assert rc == 0, f"non-zero exit; stderr={err}"
+    payload = json.loads(out)
+    assert payload.get("suppressOutput") is True, (
+        f"Missing team config must suppressOutput; got {payload!r}"
+    )
+    # Must NOT carry an additionalContext with Arm prose.
+    hso = payload.get("hookSpecificOutput", {})
+    if "additionalContext" in hso:
+        assert "First active teammate task created" not in (
+            hso["additionalContext"]
+        ), "Missing team config must not emit a false-positive Arm"
+
+
+# ─── Emitter teammate-Arm: path-traversal on team_name ───────────────
+
+
+def test_emitter_rejects_path_traversal_team_name(tmp_path):
+    """Clause 1 of the predicate ladder: a team_name containing path
+    separators or relative-path tokens must NOT result in a marker
+    written outside the wake_inbox directory.
+
+    Setup: write a session context with a deliberately-unsafe
+    team_name. The session_init path-safety guard would normally
+    reject this upstream, but the emitter's clause 1 is the defense-
+    in-depth pin we want.
+
+    Test invokes the helper directly (subprocess would require a
+    valid team_name to even reach _decide_directive without short-
+    circuiting elsewhere; the helper's clause-1 contract is the
+    falsifiable target).
+    """
+    sys.path.insert(0, str(HOOK_DIR))
+    import wake_lifecycle_emitter as emitter
+
+    home = tmp_path / "home"; home.mkdir()
+    os.environ["HOME"] = str(home)
+
+    payload = {
+        "tool_name": "TaskUpdate",
+        "session_id": "teammate-sid",
+        "cwd": "/tmp/p",
+        "tool_input": {
+            "taskId": "X", "status": "in_progress", "owner": "backend-coder",
+        },
+        "tool_response": {
+            "id": "X", "status": "in_progress", "owner": "backend-coder",
+        },
+    }
+
+    # Path-traversal attempts.
+    for unsafe in ("../etc", "../../passwd", "team/with/slash",
+                   "team\\with\\backslash", ".", ".."):
+        emitter._maybe_write_teammate_arm_marker(payload, unsafe)
+
+    # No marker file written anywhere under ~/.claude/teams/.
+    teams_root = home / ".claude" / "teams"
+    if teams_root.exists():
+        markers = list(teams_root.rglob("*.json"))
+        assert markers == [], (
+            f"Path-traversal team_name must not write any marker; got "
+            f"{[str(m) for m in markers]}"
+        )
+    # And nothing escaped to higher directories under tmp_path either.
+    escaped = [
+        p for p in tmp_path.rglob("*.json")
+        if "wake_inbox" in p.parts and "..wake_inbox" not in str(p)
+        and "passwd" in str(p) or "etc" in str(p)
+    ]
+    assert escaped == [], (
+        f"Marker writer must not escape via path traversal; got {escaped}"
+    )
+
+
+# ─── Emitter teammate-Arm: boundary task_id / session_id ─────────────
+
+
+def test_emitter_rejects_empty_task_id(tmp_path):
+    """Clause 6 of the predicate ladder: missing or empty task_id
+    blocks marker write.
+
+    Setup: full fixture-shape teammate self-claim TaskUpdate but with
+    taskId mutated to an empty string. The helper must return without
+    writing any marker and without raising.
+    """
+    sys.path.insert(0, str(HOOK_DIR))
+    import wake_lifecycle_emitter as emitter
+
+    home = tmp_path / "home"; home.mkdir()
+    os.environ["HOME"] = str(home)
+    teammate_sid = "teammate-sid"
+    team = "team-empty-task-id"
+    _write_session_context(
+        home, teammate_sid, "/tmp/p", team,
+        lead_session_id="lead-sid",
+        members=[
+            {"name": "backend-coder", "agentId": "agent-bc"},
+            {"name": "lead", "agentId": "agent-lead"},
+        ],
+        lead_agent_id="agent-lead",
+    )
+    tasks_dir = home / ".claude" / "tasks" / team
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / "X.json").write_text(json.dumps(
+        {"id": "X", "status": "in_progress", "owner": "backend-coder"}
+    ), encoding="utf-8")
+
+    payload = {
+        "tool_name": "TaskUpdate",
+        "session_id": teammate_sid,
+        "cwd": "/tmp/p",
+        "tool_input": {
+            "taskId": "", "status": "in_progress", "owner": "backend-coder",
+        },
+        "tool_response": {
+            "id": "", "status": "in_progress", "owner": "backend-coder",
+        },
+    }
+    # Must not raise.
+    emitter._maybe_write_teammate_arm_marker(payload, team)
+
+    inbox = home / ".claude" / "teams" / team / "wake_inbox"
+    if inbox.exists():
+        markers = list(inbox.glob("*.json"))
+        assert markers == [], (
+            f"Empty taskId must not produce a marker; got {markers}"
+        )
+
+
+def test_emitter_rejects_empty_session_id(tmp_path):
+    """Pre-marker guard: an empty/missing session_id blocks marker
+    write. Defense-in-depth against malformed PostToolUse stdin
+    payloads.
+    """
+    sys.path.insert(0, str(HOOK_DIR))
+    import wake_lifecycle_emitter as emitter
+
+    home = tmp_path / "home"; home.mkdir()
+    os.environ["HOME"] = str(home)
+    team = "team-empty-session-id"
+    _write_session_context(
+        home, "real-sid", "/tmp/p", team,
+        lead_session_id="lead-sid",
+        members=[
+            {"name": "backend-coder", "agentId": "agent-bc"},
+            {"name": "lead", "agentId": "agent-lead"},
+        ],
+        lead_agent_id="agent-lead",
+    )
+    tasks_dir = home / ".claude" / "tasks" / team
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / "X.json").write_text(json.dumps(
+        {"id": "X", "status": "in_progress", "owner": "backend-coder"}
+    ), encoding="utf-8")
+
+    # session_id missing entirely.
+    payload_missing = {
+        "tool_name": "TaskUpdate",
+        "cwd": "/tmp/p",
+        "tool_input": {
+            "taskId": "X", "status": "in_progress", "owner": "backend-coder",
+        },
+        "tool_response": {
+            "id": "X", "status": "in_progress", "owner": "backend-coder",
+        },
+    }
+    emitter._maybe_write_teammate_arm_marker(payload_missing, team)
+
+    # session_id empty string.
+    payload_empty = dict(payload_missing, session_id="")
+    emitter._maybe_write_teammate_arm_marker(payload_empty, team)
+
+    inbox = home / ".claude" / "teams" / team / "wake_inbox"
+    if inbox.exists():
+        markers = list(inbox.glob("*.json"))
+        assert markers == [], (
+            f"Empty/missing session_id must not produce a marker; got "
+            f"{markers}"
+        )
+
+
+def test_emitter_sanitizes_separators_in_task_id_and_session_id(tmp_path):
+    """Defense-in-depth pin: the helper replaces path separators in
+    task_id and session_id before forming the marker filename. Even
+    if upstream guards somehow let a separator-bearing id through,
+    the resulting filename must NOT escape the wake_inbox directory.
+    """
+    sys.path.insert(0, str(HOOK_DIR))
+    import wake_lifecycle_emitter as emitter
+
+    home = tmp_path / "home"; home.mkdir()
+    os.environ["HOME"] = str(home)
+    team = "team-separator-sanitize"
+    _write_session_context(
+        home, "weird/sid", "/tmp/p", team,
+        lead_session_id="lead-sid",
+        members=[
+            {"name": "backend-coder", "agentId": "agent-bc"},
+            {"name": "lead", "agentId": "agent-lead"},
+        ],
+        lead_agent_id="agent-lead",
+    )
+    tasks_dir = home / ".claude" / "tasks" / team
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    weird_task_id = "weird/task\\id"
+    (tasks_dir / "weird_task_id.json").write_text(json.dumps(
+        {"id": weird_task_id, "status": "in_progress", "owner": "backend-coder"}
+    ), encoding="utf-8")
+
+    payload = {
+        "tool_name": "TaskUpdate",
+        "session_id": "weird/sid",
+        "cwd": "/tmp/p",
+        "tool_input": {
+            "taskId": weird_task_id, "status": "in_progress",
+            "owner": "backend-coder",
+        },
+        "tool_response": {
+            "id": weird_task_id, "status": "in_progress",
+            "owner": "backend-coder",
+        },
+    }
+    emitter._maybe_write_teammate_arm_marker(payload, team)
+
+    inbox = home / ".claude" / "teams" / team / "wake_inbox"
+    # If a marker was written at all, it must be inside inbox/ — no
+    # escape via separators in the filename.
+    if inbox.exists():
+        markers = list(inbox.iterdir())
+        for m in markers:
+            assert m.parent == inbox, (
+                f"Marker {m} escaped the inbox directory"
+            )
+            # No '/' or '\\' in the filename itself.
+            assert "/" not in m.name and "\\" not in m.name, (
+                f"Separators in filename {m.name!r}"
+            )

--- a/pact-plugin/tests/test_wake_lifecycle_arm_starvation.py
+++ b/pact-plugin/tests/test_wake_lifecycle_arm_starvation.py
@@ -1,0 +1,516 @@
+"""
+Integration tests for the teammate-Arm pre-branch in
+wake_lifecycle_emitter._decide_directive.
+
+Surface: under v4.2.4, the lead-session early-return at the top of
+_decide_directive symmetrically suppressed BOTH teammate-side Teardown
+emit (correct) AND teammate-side Arm signaling (wrong — starves the
+natural trigger source for teammate self-claim transitions). The fix
+inserts a pre-branch ABOVE the lead-session early-return that, when the
+6-clause asymmetric-guard predicate ladder holds, writes a per-marker
+JSON file to ~/.claude/teams/{team}/wake_inbox/ via O_CREAT|O_EXCL
+atomic write. The lead-side wake_inbox_drain.py UserPromptSubmit hook
+consumes the marker on the next lead prompt.
+
+Teardown stays lead-only-gated (the existing branches BELOW the
+lead-session early-return are unchanged), preserving the #737 Layer 0
+correctness for Teardown emission.
+
+Counter-test-by-revert: see
+tests/runbooks/wake-lifecycle-arm-starvation.md.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+HOOK_DIR = Path(__file__).resolve().parent.parent / "hooks"
+EMITTER = HOOK_DIR / "wake_lifecycle_emitter.py"
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "wake_lifecycle"
+
+
+def _run_emitter(stdin_payload, env_extra=None):
+    env = {k: v for k, v in os.environ.items() if not k.startswith("CLAUDE_")}
+    if env_extra:
+        env.update(env_extra)
+    payload_bytes = (
+        stdin_payload if isinstance(stdin_payload, bytes)
+        else stdin_payload.encode("utf-8")
+    )
+    proc = subprocess.run(
+        [sys.executable, str(EMITTER)],
+        input=payload_bytes,
+        capture_output=True,
+        env=env,
+        timeout=10,
+    )
+    return proc.returncode, proc.stdout.decode("utf-8"), proc.stderr.decode("utf-8")
+
+
+def _write_session_context(
+    home,
+    session_id,
+    project_dir,
+    team_name,
+    *,
+    lead_session_id=None,
+    members=None,
+    lead_agent_id=None,
+):
+    slug = Path(project_dir).name
+    sess_dir = home / ".claude" / "pact-sessions" / slug / session_id
+    sess_dir.mkdir(parents=True, exist_ok=True)
+    (sess_dir / "pact-session-context.json").write_text(
+        json.dumps({
+            "team_name": team_name,
+            "session_id": session_id,
+            "project_dir": project_dir,
+            "plugin_root": "",
+            "started_at": "2026-05-14T00:00:00Z",
+        }),
+        encoding="utf-8",
+    )
+    team_dir = home / ".claude" / "teams" / team_name
+    team_dir.mkdir(parents=True, exist_ok=True)
+    effective_lead_session = (
+        lead_session_id if lead_session_id is not None else session_id
+    )
+    config_data = {"leadSessionId": effective_lead_session}
+    if lead_agent_id is not None:
+        config_data["leadAgentId"] = lead_agent_id
+    if members:
+        config_data["members"] = list(members)
+    (team_dir / "config.json").write_text(
+        json.dumps(config_data), encoding="utf-8",
+    )
+
+
+def _write_task(home, team_name, task_id, **fields):
+    tasks_dir = home / ".claude" / "tasks" / team_name
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    payload = {"id": task_id, **fields}
+    (tasks_dir / f"{task_id}.json").write_text(
+        json.dumps(payload), encoding="utf-8",
+    )
+
+
+def _emit_output(payload, home):
+    rc, out, err = _run_emitter(
+        json.dumps(payload),
+        env_extra={
+            "HOME": str(home),
+            "CLAUDE_PROJECT_DIR": payload.get("cwd", ""),
+        },
+    )
+    assert rc == 0, f"non-zero exit; stderr={err}"
+    return json.loads(out)
+
+
+def _load_fixture(name):
+    """Load a fixture and strip the diagnostic _meta sibling."""
+    data = json.loads((FIXTURES_DIR / name).read_text(encoding="utf-8"))
+    data.pop("_meta", None)
+    return data
+
+
+def _wake_inbox_dir(home, team):
+    return home / ".claude" / "teams" / team / "wake_inbox"
+
+
+# ─── Teammate-Arm pre-branch: positive + negative cases ────────────────
+
+
+def test_teammate_self_claim_writes_inbox_marker(tmp_path):
+    """Test 1 — Symmetric-guard regression guard. Captured teammate
+    self-claim TaskUpdate(status=in_progress) shape fires in a teammate
+    session (session_id != leadSessionId). The pre-branch writes
+    exactly one inbox marker; the lead-session-gated branches return
+    suppressOutput; nothing reaches stdout but the marker is on disk.
+    """
+    fixture = _load_fixture("teammate_claim_in_progress_shape.json")
+    home = tmp_path / "home"; home.mkdir()
+    teammate_sid = fixture["session_id"]
+    lead_sid = "lead-session-id"
+    team = "team-arm-self-claim"
+    pdir = fixture["cwd"]
+    teammate_owner = fixture["tool_input"]["owner"]
+    _write_session_context(
+        home, teammate_sid, pdir, team,
+        lead_session_id=lead_sid,
+        members=[
+            {"name": teammate_owner, "agentId": "agent-teammate"},
+            {"name": "lead", "agentId": "agent-lead"},
+        ],
+        lead_agent_id="agent-lead",
+    )
+    _write_task(
+        home, team, fixture["tool_input"]["taskId"],
+        status="in_progress", owner=teammate_owner,
+    )
+
+    out = _emit_output(fixture, home)
+    assert out == {"suppressOutput": True}, (
+        f"Teammate session must not emit any PostToolUse directive; "
+        f"got {out!r}"
+    )
+
+    inbox_dir = _wake_inbox_dir(home, team)
+    assert inbox_dir.exists(), "wake_inbox directory must be created"
+    markers = list(inbox_dir.glob("*.json"))
+    assert len(markers) == 1, (
+        f"Expected exactly 1 inbox marker; got {len(markers)}: "
+        f"{[m.name for m in markers]}"
+    )
+    payload = json.loads(markers[0].read_text(encoding="utf-8"))
+    assert payload["trigger"] == "teammate_self_claim_in_progress"
+    assert payload["tool_name"] == "TaskUpdate"
+    assert payload["task_id"] == fixture["tool_input"]["taskId"]
+    assert payload["owner"] == teammate_owner
+    assert payload["writer_session_id"] == teammate_sid
+
+
+def test_teammate_self_claim_no_marker_when_owner_is_lead(tmp_path):
+    """Test 2 — Clause 4 defense: even if a TaskUpdate carries
+    status=in_progress, an owner equal to the team's lead must NOT
+    trigger a marker write. Defends against hypothetical re-assignment
+    to the lead and against lead self-claim.
+    """
+    home = tmp_path / "home"; home.mkdir()
+    teammate_sid = "teammate-sid"
+    lead_sid = "lead-sid"
+    team = "team-arm-lead-owner"
+    pdir = "/tmp/p"
+    _write_session_context(
+        home, teammate_sid, pdir, team,
+        lead_session_id=lead_sid,
+        members=[
+            {"name": "the-lead", "agentId": "agent-lead"},
+            {"name": "backend-coder", "agentId": "agent-bc"},
+        ],
+        lead_agent_id="agent-lead",
+    )
+    _write_task(home, team, "L", status="in_progress", owner="the-lead")
+
+    out = _emit_output({
+        "tool_name": "TaskUpdate",
+        "session_id": teammate_sid,
+        "cwd": pdir,
+        "tool_input": {
+            "taskId": "L", "status": "in_progress", "owner": "the-lead",
+        },
+        "tool_response": {
+            "id": "L", "status": "in_progress", "owner": "the-lead",
+        },
+    }, home)
+    assert out == {"suppressOutput": True}
+
+    inbox_dir = _wake_inbox_dir(home, team)
+    if inbox_dir.exists():
+        markers = list(inbox_dir.glob("*.json"))
+        assert markers == [], (
+            f"Lead-owned TaskUpdate must not write a marker; got "
+            f"{[m.name for m in markers]}"
+        )
+
+
+def test_teammate_metadata_only_update_no_marker(tmp_path):
+    """Test 3 — Clause 3 defense: TaskUpdate with no status field
+    (metadata-only edit such as teachback_submit, intentional_wait,
+    handoff) must NOT trigger a marker write. The pending->in_progress
+    transition is the load-bearing trigger.
+    """
+    fixture = _load_fixture("teammate_metadata_only_update_shape.json")
+    home = tmp_path / "home"; home.mkdir()
+    teammate_sid = fixture["session_id"]
+    lead_sid = "lead-sid"
+    team = "team-arm-metadata-only"
+    pdir = fixture["cwd"]
+    _write_session_context(
+        home, teammate_sid, pdir, team,
+        lead_session_id=lead_sid,
+        members=[
+            {"name": "backend-coder", "agentId": "agent-bc"},
+            {"name": "lead", "agentId": "agent-lead"},
+        ],
+        lead_agent_id="agent-lead",
+    )
+
+    out = _emit_output(fixture, home)
+    assert out == {"suppressOutput": True}
+
+    inbox_dir = _wake_inbox_dir(home, team)
+    if inbox_dir.exists():
+        markers = list(inbox_dir.glob("*.json"))
+        assert markers == [], (
+            f"Metadata-only TaskUpdate must not write a marker; got "
+            f"{[m.name for m in markers]}"
+        )
+
+
+# ─── Lead-session regression guards: existing emit paths still fire ────
+
+
+def test_lead_session_arm_still_fires_on_taskcreate(tmp_path):
+    """Test 4 — Lead-session Arm path not broken by the new pre-branch.
+    A lead-session TaskCreate with count >= 1 still emits _ARM_DIRECTIVE
+    via additionalContext.
+    """
+    home = tmp_path / "home"; home.mkdir()
+    sid = "lead-sid"
+    pdir = "/tmp/p"
+    team = "team-lead-arm-create"
+    _write_session_context(home, sid, pdir, team)
+    _write_task(home, team, "X", status="in_progress", owner="backend-coder")
+
+    out = _emit_output({
+        "tool_name": "TaskCreate",
+        "session_id": sid, "cwd": pdir,
+        "tool_input": {"taskId": "X"},
+        "tool_response": {"task": {"id": "X"}},
+    }, home)
+    hso = out.get("hookSpecificOutput")
+    assert hso is not None, (
+        f"Lead-session TaskCreate must emit Arm; got {out!r}"
+    )
+    assert hso["hookEventName"] == "PostToolUse"
+    assert 'Skill("PACT:start-pending-scan")' in hso["additionalContext"]
+
+
+def test_lead_session_arm_still_fires_on_taskupdate_in_progress(tmp_path):
+    """Test 5 — Lead-session re-Arm on TaskUpdate(in_progress) path not
+    broken by the new pre-branch. Mirrors Bug B re-Arm semantics under
+    the asymmetric-guard rewrite.
+    """
+    home = tmp_path / "home"; home.mkdir()
+    sid = "lead-sid"
+    pdir = "/tmp/p"
+    team = "team-lead-arm-update"
+    _write_session_context(home, sid, pdir, team)
+    _write_task(home, team, "Y", status="in_progress", owner="backend-coder")
+
+    out = _emit_output({
+        "tool_name": "TaskUpdate",
+        "session_id": sid, "cwd": pdir,
+        "tool_input": {"taskId": "Y", "status": "in_progress"},
+        "tool_response": {
+            "id": "Y", "status": "in_progress", "owner": "backend-coder",
+        },
+    }, home)
+    hso = out.get("hookSpecificOutput")
+    assert hso is not None, (
+        f"Lead-session TaskUpdate(in_progress) must emit Arm; got {out!r}"
+    )
+    assert hso["hookEventName"] == "PostToolUse"
+    assert 'Skill("PACT:start-pending-scan")' in hso["additionalContext"]
+
+
+def test_lead_session_teardown_still_fires_on_terminal_status(tmp_path):
+    """Test 6 — Teardown lead-only gate preserved (#737 Layer 0). Lead-
+    session TaskUpdate(status=completed) with count=0 emits Teardown.
+    """
+    home = tmp_path / "home"; home.mkdir()
+    sid = "lead-sid"
+    pdir = "/tmp/p"
+    team = "team-lead-teardown"
+    _write_session_context(home, sid, pdir, team)
+    # Task on disk reflects post-state (completed) so count == 0.
+    _write_task(home, team, "Z", status="completed", owner="backend-coder")
+
+    out = _emit_output({
+        "tool_name": "TaskUpdate",
+        "session_id": sid, "cwd": pdir,
+        "tool_input": {"taskId": "Z", "status": "completed"},
+        "tool_response": {
+            "id": "Z", "status": "completed", "owner": "backend-coder",
+        },
+    }, home)
+    hso = out.get("hookSpecificOutput")
+    assert hso is not None, (
+        f"Lead-session terminal TaskUpdate must emit Teardown; got {out!r}"
+    )
+    assert hso["hookEventName"] == "PostToolUse"
+    assert 'Skill("PACT:stop-pending-scan")' in hso["additionalContext"]
+
+
+def test_teammate_terminal_status_no_marker_and_no_directive(tmp_path):
+    """Test 7 — Teammate-side Teardown still suppressed by lead-session
+    early-return; pre-branch's clause-3 also rejects terminal-status
+    TaskUpdates so no marker is written either.
+    """
+    home = tmp_path / "home"; home.mkdir()
+    teammate_sid = "teammate-sid"
+    lead_sid = "lead-sid"
+    team = "team-teammate-terminal"
+    pdir = "/tmp/p"
+    _write_session_context(
+        home, teammate_sid, pdir, team,
+        lead_session_id=lead_sid,
+        members=[
+            {"name": "backend-coder", "agentId": "agent-bc"},
+            {"name": "lead", "agentId": "agent-lead"},
+        ],
+        lead_agent_id="agent-lead",
+    )
+    _write_task(home, team, "T", status="completed", owner="backend-coder")
+
+    out = _emit_output({
+        "tool_name": "TaskUpdate",
+        "session_id": teammate_sid, "cwd": pdir,
+        "tool_input": {
+            "taskId": "T", "status": "completed", "owner": "backend-coder",
+        },
+        "tool_response": {
+            "id": "T", "status": "completed", "owner": "backend-coder",
+        },
+    }, home)
+    assert out == {"suppressOutput": True}
+
+    inbox_dir = _wake_inbox_dir(home, team)
+    if inbox_dir.exists():
+        markers = list(inbox_dir.glob("*.json"))
+        assert markers == [], (
+            f"Teammate terminal-status update must not write a marker; "
+            f"got {[m.name for m in markers]}"
+        )
+
+
+# ─── Marker shape / atomicity pins ─────────────────────────────────────
+
+
+def test_marker_filename_schema(tmp_path):
+    """Test 8 — Filename encoding pin. The marker filename matches
+    {ISO-8601 compact UTC}-{session_id}-{task_id}.json so lexical sort
+    is chronological order for the drain side.
+    """
+    fixture = _load_fixture("teammate_claim_in_progress_shape.json")
+    home = tmp_path / "home"; home.mkdir()
+    teammate_sid = fixture["session_id"]
+    team = "team-marker-schema"
+    pdir = fixture["cwd"]
+    teammate_owner = fixture["tool_input"]["owner"]
+    _write_session_context(
+        home, teammate_sid, pdir, team,
+        lead_session_id="lead-sid",
+        members=[
+            {"name": teammate_owner, "agentId": "agent-bc"},
+            {"name": "lead", "agentId": "agent-lead"},
+        ],
+        lead_agent_id="agent-lead",
+    )
+    _write_task(
+        home, team, fixture["tool_input"]["taskId"],
+        status="in_progress", owner=teammate_owner,
+    )
+
+    _emit_output(fixture, home)
+
+    inbox_dir = _wake_inbox_dir(home, team)
+    markers = list(inbox_dir.glob("*.json"))
+    assert len(markers) == 1
+    # {timestamp}-{session_id}-{task_id}.json — timestamp YYYYMMDDTHHMMSSZ
+    # session_id is a UUID; allow the general session_id alphabet
+    # (hex + dashes); task_id allows the platform's compact alphabet.
+    pattern = re.compile(
+        r"^\d{8}T\d{6}Z-[A-Za-z0-9_-]+-[A-Za-z0-9_-]+\.json$"
+    )
+    assert pattern.match(markers[0].name), (
+        f"Marker filename {markers[0].name!r} does not match expected "
+        f"schema {pattern.pattern!r}"
+    )
+
+
+def test_marker_o_excl_collision_silent(tmp_path):
+    """Test 9 — O_EXCL discipline. Pre-create a marker file at a path
+    the helper would write to, then invoke the helper. The collision
+    must be silently swallowed (FileExistsError fail-open); no raise,
+    no duplicate.
+
+    Implementation: invoke the helper directly via import (faster +
+    more focused than a subprocess fire that re-derives the timestamp
+    on its own).
+    """
+    sys.path.insert(0, str(HOOK_DIR))
+    import wake_lifecycle_emitter as emitter
+
+    home = tmp_path / "home"; home.mkdir()
+    teammate_sid = "teammate-sid"
+    team = "team-o-excl"
+    pdir = "/tmp/p"
+    teammate_owner = "backend-coder"
+    _write_session_context(
+        home, teammate_sid, pdir, team,
+        lead_session_id="lead-sid",
+        members=[
+            {"name": teammate_owner, "agentId": "agent-bc"},
+            {"name": "lead", "agentId": "agent-lead"},
+        ],
+        lead_agent_id="agent-lead",
+    )
+    _write_task(home, team, "ABC", status="in_progress", owner=teammate_owner)
+
+    # Pre-populate the wake_inbox directory with a placeholder file at
+    # a path the helper will compute via the same timestamp — to force
+    # a collision deterministically we monkeypatch datetime.now to
+    # return a fixed instant.
+    from datetime import datetime, timezone
+    fixed = datetime(2026, 5, 14, 16, 5, 26, tzinfo=timezone.utc)
+
+    class _FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed
+
+    original_dt = emitter.datetime
+    emitter.datetime = _FixedDateTime
+    try:
+        os.environ["HOME"] = str(home)
+        payload = {
+            "tool_name": "TaskUpdate",
+            "session_id": teammate_sid,
+            "cwd": pdir,
+            "tool_input": {
+                "taskId": "ABC", "status": "in_progress",
+                "owner": teammate_owner,
+            },
+            "tool_response": {
+                "id": "ABC", "status": "in_progress",
+                "owner": teammate_owner,
+            },
+        }
+        # First call writes the marker.
+        emitter._maybe_write_teammate_arm_marker(payload, team)
+        inbox_dir = _wake_inbox_dir(home, team)
+        markers_after_first = list(inbox_dir.glob("*.json"))
+        assert len(markers_after_first) == 1
+
+        # Second call MUST silently no-op via O_EXCL collision.
+        emitter._maybe_write_teammate_arm_marker(payload, team)
+        markers_after_second = list(inbox_dir.glob("*.json"))
+        assert len(markers_after_second) == 1, (
+            f"Second invocation must collision-no-op; got "
+            f"{[m.name for m in markers_after_second]}"
+        )
+    finally:
+        emitter.datetime = original_dt
+
+
+# ─── Audit-anchor regression guards ────────────────────────────────────
+
+
+def test_arm_directive_audit_anchor_literal_prose():
+    """Test 10 — Audit-anchor pin for the _ARM_DIRECTIVE literal prose.
+    The directive prose is the user-visible contract; a future agent
+    renaming it silently must trip this pin. Mirrors the existing
+    test_wake_lifecycle_bug_b_rearm.py audit-anchor coverage; this pin
+    is needed here because wake_inbox_drain.py imports _ARM_DIRECTIVE
+    from the emitter (single SSOT) and the drain hook's behavior
+    depends on the literal being stable.
+    """
+    sys.path.insert(0, str(HOOK_DIR))
+    import wake_lifecycle_emitter as emitter
+    assert "First active teammate task created" in emitter._ARM_DIRECTIVE
+    assert 'Skill("PACT:start-pending-scan")' in emitter._ARM_DIRECTIVE
+    assert "Idempotent" in emitter._ARM_DIRECTIVE

--- a/pact-plugin/tests/test_wake_lifecycle_arm_starvation.py
+++ b/pact-plugin/tests/test_wake_lifecycle_arm_starvation.py
@@ -431,6 +431,19 @@ def test_marker_o_excl_collision_silent(tmp_path):
     Implementation: invoke the helper directly via import (faster +
     more focused than a subprocess fire that re-derives the timestamp
     on its own).
+
+    SCOPE TRADEOFF (test-engineer note): this test is intra-process
+    and monkeypatches `emitter.datetime` to force a deterministic
+    timestamp collision. It pins the FileExistsError fail-open
+    contract in os.open(O_CREAT|O_EXCL), which IS the correct
+    falsifiable target for this helper. It does NOT directly probe
+    the scenario of two concurrent teammate subprocess fires racing
+    on the same wall-clock second. The intra-process approach was
+    chosen over subprocess concurrency because the latter is flaky
+    on slow CI. The cross-process race is structurally impossible
+    under the {timestamp, session_id, task_id} encoding (each
+    teammate session has a unique session_id) — O_EXCL is
+    belt-and-suspenders, this test pins the belt.
     """
     sys.path.insert(0, str(HOOK_DIR))
     import wake_lifecycle_emitter as emitter


### PR DESCRIPTION
Closes #754.

## Summary

Resolves wake_lifecycle_emitter Arm starvation: the symmetric `_is_lead_session` guard suppressed the Arm directive on the structurally-correct trigger source (teammate self-claim `TaskUpdate(status=in_progress)`, which runs in the teammate's session). The fix is **asymmetric** — Teardown stays lead-only gated (preserves #737 Layer 0 directive-noise suppression); Arm relaxes via a pre-branch above the guard.

**Dual-starvation insight (architect-phase contribution):** the lead's own dispatch pattern (`TaskCreate` unowned → `TaskUpdate(owner=...)`) also fails to arm because the per-event `count_active_tasks` is 0 at TaskCreate time. The fix covers both surfaces.

## Approach

**Teammate-side** (`wake_lifecycle_emitter.py`): new `_maybe_write_teammate_arm_marker` pre-branch above `is_lead_session` early-return. Six-clause predicate ladder (path safety / tool allowlist / self-claim transition / owner-is-known-teammate-not-lead / NOT lead-session / non-empty task_id) gates the marker write. On pass, writes a per-marker JSON via `os.open(O_CREAT|O_EXCL, 0o600)` to `~/.claude/teams/{team}/wake_inbox/{ISO-8601-UTC}-{session_id}-{task_id}.json`. `FileExistsError` fails open.

**Lead-side** (`wake_inbox_drain.py`, NEW): UserPromptSubmit hook (third entry, after `bootstrap_marker_writer` + `bootstrap_prompt_gate`). Lead-session guard short-circuits non-lead sessions before any disk I/O. Drains markers; if drained → emit `_ARM_DIRECTIVE` and return (skips fallback). If drain empty, **B-1 fallback**: `count_active_tasks(team) >= 1` → emit. Structurally single-emit per prompt.

**Refactor** (`shared/wake_lifecycle.py`): `_is_lead_session` lifted to public `is_lead_session` for shared use; defensive `isinstance` guard added (fail-open hardening within the existing contract).

**Cross-session primitive** reframing: `~/.claude/teams/{team}/wake_inbox/` is a sibling of the existing `inboxes/` convention (SendMessage path), not a brand-new mechanism.

**#738 dissolved:** the apparent contradiction (lead-owned Task #14 triggering Arm despite `_lifecycle_relevant` step-4) was verified against `shared/wake_lifecycle.py:476-482` to be the **total count_active_tasks** firing the emit (Task #13 secretary-owned counts), not a filter bug. #754 does not block on #738.

## Empirical anchor

This session (`pact-fb3423e5`) reproduced the bug in real-time: every teammate dispatch required manual `/PACT:start-pending-scan` arm. The fix targets the exact reproducer.

## Test cardinality

- 16 primary tests (10 arm-starvation + 6 drain) at architect §8.1 / §8.2.
- 5 edge-case tests (`test_wake_lifecycle_arm_edge_cases.py`): drain config fail-open, clause-1 path-traversal, clause-6 empty task_id, pre-marker empty session_id, separator sanitization defense-in-depth.
- Full suite: **7669 passed, 10 skipped, 0 failed** (was 7664 baseline; +5 edge cases).
- Counter-test-by-revert against main: 14 failed + 7 passed (3 phantom-greens retained as forward-regression guards; drain RC=2 vs collection-error divergence explained in runbook Interpretation section).

## Verification plan

- **Pre-merge** (this PR): pytest suite + audit-anchor literal-prose pins (`_ARM_DIRECTIVE` byte-identical, single SSOT via import in drain) + counter-test-by-revert.
- **Post-merge** (fresh session per pinned constraint "Hooks cannot be smoke-tested in-session"): the issue body's falsifiability test — spawn architect, wait for teachback claim, `CronList` shows `/PACT:scan-pending-tasks` within one lead-prompt cycle.

## Version

v4.2.4 → v4.2.5 patch bump (4 files: `plugin.json` authoritative, `marketplace.json`, both READMEs).

## Commits

- `4d6c8606` fix(hooks): asymmetric Arm/Teardown guard + wake_inbox drain hook (#754) — 9 files, +1657/-63
- `ecbf8f2c` chore(version): bump plugin version 4.2.4 -> 4.2.5 for #754
- `4ecf4038` test(hooks): edge-case coverage + counter-test runbook for #754

## Test plan

- [x] pytest pact-plugin/tests/ → 7669 passed
- [x] Counter-test-by-revert empirical cardinality recorded in runbook
- [x] `_ARM_DIRECTIVE` byte-identical literal preserved (single SSOT via import)
- [x] wake_inbox_drain registered as third UserPromptSubmit entry in hooks.json
- [x] No regression in #737 symmetric Teardown lead-session guard
- [ ] Post-merge fresh-session falsifiability test (manual)

## Follow-ups

- #738 (open) — Arm directive prose bug on lead-owned tasks; pure prose, no filter bug. Independent.
- File post-merge: maintainability refactor for `shared/wake_lifecycle.py` (695 lines) and `wake_lifecycle_emitter.py` (731 lines) — accepted consequence of single-SSOT consolidation.
- File post-merge: explicit clause-2 (tool_name allowlist) test — LOW priority follow-up flagged by test-engineer.