### PR TITLE
fix(#763): native-hooks Teardown integration — Frame A + 4-tier defense

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.2.7",
+      "version": "4.2.8",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.2.7/      # Plugin version
+│               └── 4.2.8/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.2.7",
+  "version": "4.2.8",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.2.7
+> **Version**: 4.2.8
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/hooks.json
+++ b/pact-plugin/hooks/hooks.json
@@ -149,6 +149,14 @@
             "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/agent_handoff_emitter.py\""
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/teardown_request_emitter.py\""
+          }
+        ]
       }
     ],
     "TeammateIdle": [

--- a/pact-plugin/hooks/shared/session_journal.py
+++ b/pact-plugin/hooks/shared/session_journal.py
@@ -198,6 +198,16 @@ _REQUIRED_FIELDS_BY_TYPE: dict[str, dict[str, type]] = {
     # only when scan_armed is strictly more recent than scan_disarmed
     # (re-arm dominance under post-Teardown re-arm).
     "scan_disarmed": {"disarmed_at": int},
+    # hooks/teardown_request_emitter.py writes teardown_request after
+    # the lead-driven TaskUpdate(status="completed") drives the team's
+    # lifecycle-relevant active-task count to 0 (Tier-1 fast path), AND
+    # hooks/wake_inbox_drain.py writes teardown_request after draining
+    # a type="teardown" wake_inbox marker (Tier-2 carve-out fallback).
+    # The event is the falsifiable trace; the additionalContext
+    # directive is the wake-hint. Required fields are the minimum
+    # identity carrier: task_id pins the specific completion;
+    # team_name pins the cron binding the directive will tear down.
+    "teardown_request": {"task_id": str, "team_name": str},
 }
 
 
@@ -271,6 +281,14 @@ _OPTIONAL_FIELDS_BY_TYPE: dict[str, dict[str, type]] = {
     # optional loop. Symmetric with the session_end + cleanup_summary
     # registration patterns.
     "wake_tally_warn": {"detail": str},
+    # hooks/teardown_request_emitter.py (Tier-1) and
+    # hooks/wake_inbox_drain.py (Tier-2) write teardown_request with
+    # optional `tier` ("1" | "2") attributing the emission path, and
+    # optional `reason` categorizing the trigger
+    # ("lead_terminal_taskupdate" | "wake_inbox_drained" |
+    # "self_complete_exempt" — extend with new categorical tokens as
+    # paths are added). Audit-only fields; no behavioral consumer.
+    "teardown_request": {"tier": str, "reason": str},
 }
 
 

--- a/pact-plugin/hooks/teardown_request_emitter.py
+++ b/pact-plugin/hooks/teardown_request_emitter.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""
+Location: pact-plugin/hooks/teardown_request_emitter.py
+Summary: TaskCompleted hook — emits the Teardown directive (Tier-1 fast
+         path) when the lead-driven terminal-status TaskUpdate drives the
+         team's lifecycle-relevant active-task count to zero.
+Used by: hooks.json TaskCompleted registration (sibling to
+         agent_handoff_emitter.py — both fire in parallel on every
+         TaskCompleted event).
+
+Responsibilities:
+- On TaskCompleted in the LEAD session AND on a 1->0 active-task
+  transition AND no same-teammate continuation deferral, write a single
+  teardown_request event to the session journal keyed by (team_name,
+  task_id) for idempotent emission, AND emit the _TEARDOWN_DIRECTIVE
+  via additionalContext so the lead invokes
+  Skill("PACT:stop-pending-scan") on its next turn.
+
+NOT responsible for:
+- The Tier-2 carve-out fallback path (teammate-side self-completions
+  for SELF_COMPLETE_EXEMPT agent types). Tier-2 is handled by the
+  wake_inbox marker producer in wake_lifecycle_emitter.py +
+  consumer in wake_inbox_drain.py.
+- HANDOFF metadata validation (agent_handoff_emitter.py owns that).
+- Stall / nag detection.
+- Replaying historical teardown_request events from the journal
+  (Tier-4 cron-staleness fallback is a separate surface).
+
+Emission invariant: write exactly one teardown_request event iff
+(0)  is_lead_session(input_data, team_name) — defense-in-depth Gate 0
+AND
+(1)  hook_event_name == "TaskCompleted" OR (fallback) disk-read task
+     status == "completed" — primary transition signal + fallback
+AND
+(2)  the per-(team, task_id) sidecar O_EXCL marker does not yet exist
+     — idempotency across Stop-sweep secondary firings + retries
+AND
+(3)  count_active_tasks(team_name) == 0 — 1->0 lifecycle transition
+AND
+(4)  NOT has_same_teammate_continuation(completed_task, team_name) —
+     same-teammate continuation deferral preserves the brief cron-down
+     window suppression from the legacy PostToolUse Teardown branch.
+
+Gate 0 — Lead-Session Guard (Layer 0 — defense-in-depth):
+- Mirrors wake_lifecycle_emitter.py:654 semantics. The platform's
+  Stop-sweep secondary firing source (stopHooks.ts:334-425) fires this
+  hook in teammate sessions for every in_progress owned task; Gate 0
+  short-circuits those before any disk I/O. The Teardown directive is
+  lead-targeted; teammate-session emission would target the wrong
+  session.
+
+Gate 1 — Transition signal (primary: hook_event_name; fallback: disk-
+status):
+- Templates off agent_handoff_emitter.py:281-289 line-by-line. The
+  string-literal compare fail-closes on non-string hook_event values.
+  The disk-status read is a fallback only — the platform's persistence
+  of status="completed" to disk is asynchronous relative to the hook
+  fire, so hook_event_name is the load-bearing primary signal.
+
+Gate 2 — Sidecar O_EXCL marker idempotency:
+- Mirrors agent_handoff_emitter.py:319 + _already_emitted at L117. The
+  marker lives at ~/.claude/teams/{team}/.teardown_request_emitted/
+  {task_id}. The _already_emitted predicate is copy-pasted from C2 per
+  the helper_location_elevation_pattern memory's "elevate on 3rd
+  consumer" rule — this is consumer #2 of the predicate (after
+  agent_handoff_emitter.py); C4 (wake_inbox_drain.py teardown drain)
+  will be consumer #3 trigger but for now consumer #2 lives inline.
+- O_EXCL marker creation is the LAST step before the journal write.
+  Optimistic ordering: marker created before append_event completes,
+  trading one rare write-failure event loss against repeated duplicate
+  emission (see agent_handoff_emitter.py:313-321 for the empirical
+  basis: up to 37x per task without the marker).
+
+Gate 3 — 1->0 active-task transition:
+- count_active_tasks(team_name) excludes signal-tasks (blocker /
+  algedonic) AND self-complete-exempt agent owners (pact-secretary
+  today) via its lifecycle-relevant filter. The 1->0 transition AFTER
+  the platform persists this task's completed status is the canonical
+  Teardown trigger.
+
+Gate 4 — Same-teammate continuation deferral:
+- Mirrors wake_lifecycle_emitter.py:714-716. When the just-completed
+  task has a same-teammate-owned active continuation in its blocks
+  chain, defer Teardown — the teammate is staged to claim the next
+  task imminently, so emitting Teardown would produce a phantom
+  cron-down audit signal and a brief cron-down window for inbound
+  completion-authority work.
+
+# livelock-safe: pure journal-writer + single additionalContext directive
+# emission per (team, task_id); zero stderr noise on the gate-fail paths.
+# Exits 0 with suppressOutput on every code path. Does NOT consume
+# intentional_wait, does NOT emit systemMessage, and does NOT block
+# completion.
+
+Input: JSON from stdin with task_id, task_subject, task_description,
+       teammate_name, team_name (TaskCompleted schema).
+Output: hookSpecificOutput with additionalContext on Teardown emission;
+        {"suppressOutput": true} on every other path; exit 0.
+"""
+
+import errno
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+import shared.pact_context as pact_context
+from shared.pact_context import get_team_name
+from shared.session_journal import append_event, make_event
+from shared.task_utils import read_task_json
+from shared.wake_lifecycle import (
+    count_active_tasks,
+    has_same_teammate_continuation,
+    is_lead_session,
+)
+
+# Reuse the canonical _TEARDOWN_DIRECTIVE literal from the emitter so the
+# directive prose has a single source of truth. The audit-anchor literal-
+# prose pin on the emitter side covers that constant; this import makes
+# any future drift immediately break this hook too.
+from wake_lifecycle_emitter import _TEARDOWN_DIRECTIVE
+
+
+# Suppress false "hook error" display in Claude Code UI on bare exit paths.
+_SUPPRESS_OUTPUT = json.dumps({"suppressOutput": True})
+
+
+def _sanitize_path_component(value: str) -> str:
+    """
+    Strip path-traversal fragments from a value destined for filesystem joins.
+
+    Mirrors agent_handoff_emitter._sanitize_path_component byte-for-byte
+    (NUL, CR/LF, control chars 0x00-0x1f, slash, backslash, `..`
+    substrings). Applied symmetrically at both sink sites (read_task_json
+    status read, marker O_EXCL create) so they can never diverge.
+    """
+    return re.sub(r"[/\\\x00-\x1f]|\.\.", "", value)
+
+
+def _marker_dir(team_name: str) -> Path:
+    """
+    Return the per-team Teardown-emit marker directory path.
+
+    Lives under ~/.claude/teams/{team}/.teardown_request_emitted/ — a
+    sibling to .agent_handoff_emitted/ and the team's inboxes/ +
+    config.json. session_end.py's team reaper removes the whole team
+    directory (shutil.rmtree), so the marker dir is cleaned up
+    automatically when the team ages out.
+
+    Kept task-scoped (not session-scoped) so fire-once semantics survive
+    pause/resume: a completion that lands across a pause boundary still
+    emits its teardown_request event exactly once across the whole team
+    lifespan.
+    """
+    return Path.home() / ".claude" / "teams" / team_name / ".teardown_request_emitted"
+
+
+def _already_emitted(team_name: str, task_id: str) -> bool:
+    """
+    Test-and-set the per-(team, task_id) marker.
+
+    Returns True iff a prior fire for the same (team, task_id) already
+    created the marker (caller should suppress the journal write).
+    Returns False on fresh fires — the marker is created as a side-effect
+    of this call, making the test-and-set atomic at the kernel level.
+
+    Copy-pasted from agent_handoff_emitter._already_emitted (with the
+    marker directory rebased to .teardown_request_emitted) per the
+    helper_location_elevation_pattern: elevate to shared/ on the 3rd
+    consumer. C4 (wake_inbox_drain.py teardown drain) will use the same
+    marker dir for cross-tier dedup but does NOT need to share the
+    predicate at the call site — the third-consumer threshold materializes
+    when the shared elevation actually pays off (today: 2 copies, 0 shared).
+
+    Fail-open: on any OSError other than EEXIST (permission denied,
+    ENOSPC, filesystem race), returns False so the caller emits the
+    event anyway. Data-integrity (preserving the teardown_request
+    in the journal) outweighs duplication-prevention when the marker
+    subsystem itself breaks.
+
+    Graceful-degrade caveat: a pre-existing non-symlink file at the
+    marker path (e.g., from a manually-created file or stale state
+    surviving an unclean cleanup) also returns True via EEXIST and
+    suppresses emission permanently for that (team, task_id) — the
+    O_EXCL test cannot distinguish "prior fire owns it" from "external
+    file was placed here." Acceptable trade-off versus the alternative
+    (read-the-file-to-verify, which races and complicates the atomic
+    test-and-set).
+    """
+    # Degenerate post-sanitization values collapse the marker path onto
+    # an existing directory (`Path(marker_dir) / "."` -> marker_dir
+    # itself, `Path(marker_dir) / ".."` -> parent). In either case
+    # os.open(..., O_CREAT | O_EXCL) on an existing directory returns
+    # EEXIST and PERMANENTLY SUPPRESSES every future emit for the
+    # degenerate key. The regex strips `/`, `\`, and `..` substrings but
+    # leaves single `.` segments untouched. Emit on degenerate keys
+    # rather than silent permanent suppression.
+    if (
+        not team_name
+        or team_name in (".", "..")
+        or not task_id
+        or task_id in (".", "..")
+    ):
+        return False
+
+    marker_dir = _marker_dir(team_name)
+    # Symlink-containment pre-check: refuse a pre-planted symlink at the
+    # marker dir. Fail-open emit rather than risk writing to an
+    # attacker-controlled location.
+    if marker_dir.is_symlink():
+        return False
+    try:
+        marker_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    except OSError:
+        return False
+
+    marker_path = marker_dir / task_id
+    # O_NOFOLLOW defends against a pre-planted symlink at the marker
+    # path; mirrors the agent_handoff_emitter Sec-M1 pattern. POSIX
+    # O_CREAT|O_EXCL already refuses to follow a trailing symlink;
+    # O_NOFOLLOW is defense-in-depth + intermediate-symlink coverage.
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(
+            str(marker_path),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | nofollow,
+            0o600,
+        )
+        os.close(fd)
+        return False  # we created it; proceed with emit
+    except OSError as e:
+        if e.errno == errno.EEXIST:
+            return True  # prior fire owns the marker; suppress
+        return False  # any other error -> fail-open, emit anyway
+
+
+def _emit_teardown_directive() -> None:
+    """Print the _TEARDOWN_DIRECTIVE additionalContext payload with the
+    required hookEventName field. TaskCompleted hooks emit
+    `additionalContext` consumed by the lead's NEXT prompt — same
+    delivery mechanism as the legacy PostToolUse path.
+    """
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "TaskCompleted",
+            "additionalContext": _TEARDOWN_DIRECTIVE,
+        }
+    }
+    print(json.dumps(output))
+
+
+def main() -> None:
+    # Outer catch-all preserves the exit-0 suppressOutput contract
+    # against any unexpected exception (malformed task.json, filesystem
+    # race, import-time error past the inner guards). The Teardown
+    # mechanism is opportunistic — a crashed hook degrades to user-
+    # invoked /PACT:stop-pending-scan, not a hard failure. The bare
+    # `except Exception` is deliberate: livelock-safety via the
+    # "exits 0 on every code path" invariant outweighs observability
+    # for unexpected errors (nonzero exit would surface as a hook-error
+    # UI on every TaskCompleted dispatch — the livelock-capable failure
+    # class the categorical standard forbids).
+    try:
+        try:
+            input_data = json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            print(_SUPPRESS_OUTPUT)
+            sys.exit(0)
+
+        if not isinstance(input_data, dict):
+            print(_SUPPRESS_OUTPUT)
+            sys.exit(0)
+
+        pact_context.init(input_data)
+
+        # Resolve team_name from session context first; without it,
+        # neither the lead-session guard nor the active-task count can
+        # be evaluated.
+        team_name = _sanitize_path_component(
+            str(input_data.get("team_name") or get_team_name()).lower()
+        )
+        if not team_name:
+            print(_SUPPRESS_OUTPUT)
+            sys.exit(0)
+
+        # Gate 0 — defense-in-depth lead-session check. Mirrors
+        # wake_lifecycle_emitter.py:654; teammate-session input never
+        # reaches the journal write or directive emission paths.
+        if not is_lead_session(input_data, team_name):
+            print(_SUPPRESS_OUTPUT)
+            sys.exit(0)
+
+        # Sanitize task_id at the producer boundary symmetrically with
+        # read_task_json (which sanitizes inside) and the marker O_EXCL
+        # create site.
+        raw_task_id = input_data.get("task_id")
+        if not raw_task_id:
+            print(_SUPPRESS_OUTPUT)
+            sys.exit(0)
+        task_id = _sanitize_path_component(str(raw_task_id))
+        if not task_id:
+            print(_SUPPRESS_OUTPUT)
+            sys.exit(0)
+
+        # Gate 1 — transition signal: hook_event_name primary, disk-
+        # status fallback. Templates agent_handoff_emitter.py:281-289.
+        # The string-literal compare fail-closes on non-string values
+        # (None, int, bool compare unequal to "TaskCompleted").
+        hook_event = input_data.get("hook_event_name", "")
+        task_data: dict = {}
+        if hook_event != "TaskCompleted":
+            task_data = read_task_json(task_id, team_name)
+            if not isinstance(task_data, dict):
+                task_data = {}
+            if task_data.get("status") != "completed":
+                print(_SUPPRESS_OUTPUT)
+                sys.exit(0)
+
+        # Gate 3 — 1->0 active-task transition. count_active_tasks
+        # excludes signal-tasks and self-complete-exempt agent owners
+        # via its lifecycle-relevant filter, so a zero return means the
+        # team has no remaining lifecycle-relevant work.
+        # Evaluated BEFORE Gate 2 (marker claim) so a non-1->0 fire
+        # doesn't burn a marker that would then suppress a legitimate
+        # later 1->0 fire on the same task_id.
+        if count_active_tasks(team_name) != 0:
+            print(_SUPPRESS_OUTPUT)
+            sys.exit(0)
+
+        # Gate 4 — same-teammate continuation deferral. Read the task
+        # JSON if Gate 1 didn't already (i.e., when hook_event_name was
+        # the primary signal we skipped the disk read). Mirrors the
+        # legacy PostToolUse Teardown branch's deferral semantics at
+        # wake_lifecycle_emitter.py:714-716.
+        if not task_data:
+            task_data = read_task_json(task_id, team_name)
+            if not isinstance(task_data, dict):
+                task_data = {}
+        if has_same_teammate_continuation(task_data, team_name):
+            print(_SUPPRESS_OUTPUT)
+            sys.exit(0)
+
+        # Gate 2 — sidecar O_EXCL marker idempotency. Evaluated LAST so
+        # only fires that would otherwise emit consume the marker
+        # (avoid burning markers on Stop-sweep secondaries that fail
+        # gates 0/1/3/4 — they'd permanently block legitimate later
+        # emissions otherwise).
+        if _already_emitted(team_name, task_id):
+            print(_SUPPRESS_OUTPUT)
+            sys.exit(0)
+
+        # All gates pass — write the journal event AND emit the
+        # additionalContext Teardown directive. Event is the falsifiable
+        # trace; directive is the wake-hint.
+        append_event(
+            make_event(
+                "teardown_request",
+                task_id=task_id,
+                team_name=team_name,
+                tier="1",
+                reason="lead_terminal_taskupdate",
+            ),
+        )
+        _emit_teardown_directive()
+        sys.exit(0)
+    except SystemExit:
+        # Re-raise — the explicit sys.exit(0) paths above are expected
+        # control-flow, not errors.
+        raise
+    except Exception:
+        # Outer catch-all: every code path must exit 0 suppressOutput.
+        print(_SUPPRESS_OUTPUT)
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/pact-plugin/hooks/teardown_request_emitter.py
+++ b/pact-plugin/hooks/teardown_request_emitter.py
@@ -307,13 +307,21 @@ def main() -> None:
         # status fallback. Templates agent_handoff_emitter.py:281-289.
         # The string-literal compare fail-closes on non-string values
         # (None, int, bool compare unequal to "TaskCompleted").
+        # Disk-status fallback accepts BOTH terminal statuses
+        # ("completed", "deleted") symmetric with the retired PostToolUse
+        # Teardown branch's _TERMINAL_STATUSES set at
+        # wake_lifecycle_emitter.py:267. Lead-driven
+        # TaskUpdate(status="deleted") on a 1->0 transition produces no
+        # TaskCompleted hook event, so without "deleted" in this set the
+        # deletion path drops the Teardown directive entirely (Tier-2
+        # also misses it via its lead-session early-return).
         hook_event = input_data.get("hook_event_name", "")
         task_data: dict = {}
         if hook_event != "TaskCompleted":
             task_data = read_task_json(task_id, team_name)
             if not isinstance(task_data, dict):
                 task_data = {}
-            if task_data.get("status") != "completed":
+            if task_data.get("status") not in ("completed", "deleted"):
                 print(_SUPPRESS_OUTPUT)
                 sys.exit(0)
 

--- a/pact-plugin/hooks/teardown_request_emitter.py
+++ b/pact-plugin/hooks/teardown_request_emitter.py
@@ -205,9 +205,16 @@ def _already_emitted(team_name: str, task_id: str) -> bool:
         return False
 
     marker_dir = _marker_dir(team_name)
-    # Symlink-containment pre-check: refuse a pre-planted symlink at the
-    # marker dir. Fail-open emit rather than risk writing to an
-    # attacker-controlled location.
+    # Symlink-on-dir defense-in-depth: a TOCTOU window exists between
+    # this is_symlink() check and the mkdir(exist_ok=True) below, so
+    # this pre-check is NOT a structural containment guarantee — it is
+    # a fast-fail for the cooperative case. The load-bearing structural
+    # defense is O_NOFOLLOW on the final O_EXCL open below, which
+    # refuses to follow any symlink at the marker_path component
+    # regardless of what races may have swapped the marker_dir. Under
+    # the same-user trust model this defense-in-depth posture is fine;
+    # under a different threat model the pre-check would need a
+    # dirfd-based open to actually contain symlink swaps.
     if marker_dir.is_symlink():
         return False
     try:
@@ -216,10 +223,14 @@ def _already_emitted(team_name: str, task_id: str) -> bool:
         return False
 
     marker_path = marker_dir / task_id
-    # O_NOFOLLOW defends against a pre-planted symlink at the marker
-    # path; mirrors the agent_handoff_emitter Sec-M1 pattern. POSIX
-    # O_CREAT|O_EXCL already refuses to follow a trailing symlink;
-    # O_NOFOLLOW is defense-in-depth + intermediate-symlink coverage.
+    # O_NOFOLLOW is the load-bearing structural defense against a pre-
+    # planted symlink at the marker path; mirrors the
+    # agent_handoff_emitter Sec-M1 pattern. POSIX O_CREAT|O_EXCL already
+    # refuses to follow a trailing symlink; O_NOFOLLOW adds intermediate-
+    # symlink coverage. Together with the (racy) is_symlink pre-check
+    # above this forms layered defense-in-depth — the pre-check filters
+    # the cooperative case cheaply, O_NOFOLLOW filters the adversarial
+    # case structurally.
     nofollow = getattr(os, "O_NOFOLLOW", 0)
     try:
         fd = os.open(

--- a/pact-plugin/hooks/wake_inbox_drain.py
+++ b/pact-plugin/hooks/wake_inbox_drain.py
@@ -2,32 +2,46 @@
 """
 Location: pact-plugin/hooks/wake_inbox_drain.py
 Summary: UserPromptSubmit hook that drains the team's wake-inbox markers
-         (cross-session teammate-Arm signals) on the lead's prompts and
-         emits a single _ARM_DIRECTIVE via hookSpecificOutput.additionalContext
-         when either (a) markers are present OR (b) the count_active_tasks
-         fallback shows at least one lifecycle-relevant teammate task.
+         (cross-session teammate-Arm and teammate-Teardown signals) on
+         the lead's prompts. Drain returns per-type counts; Teardown
+         markers route to _emit_teardown (with a Tier-1 idempotency
+         check against `.teardown_request_emitted/{task_id}`) and Arm
+         markers route to _emit_arm. Falls back to a
+         count_active_tasks(team_name) >= 1 predicate for the
+         lead-side unowned-create-then-owner-update dispatch surface.
 Used by: hooks.json UserPromptSubmit hook (third entry, after
          bootstrap_marker_writer + bootstrap_prompt_gate).
 
 Role in the asymmetric-guard Arm/Teardown model:
-- wake_lifecycle_emitter.py's teammate-Arm pre-branch writes per-marker
-  JSON files to ~/.claude/teams/{team_name}/wake_inbox/ when a teammate
-  self-claims a task (TaskUpdate(status='in_progress')) or when a
-  TaskCreate carries a teammate owner-at-create. PostToolUse
-  `additionalContext` targets the teammate's session — wrong session
-  for an Arm directive — so the filesystem marker IS the cross-session
-  signal.
+- wake_lifecycle_emitter.py's teammate pre-branches write per-marker
+  JSON files to ~/.claude/teams/{team_name}/wake_inbox/ tagged with
+  `type` ∈ {"arm", "teardown"}:
+    * `_maybe_write_teammate_arm_marker` emits `type="arm"` when a
+      teammate self-claims a task (TaskUpdate(status='in_progress'))
+      or when a TaskCreate carries a teammate owner-at-create.
+    * `_maybe_write_teammate_teardown_marker` emits `type="teardown"`
+      when a self-complete-exempt teammate drives the team to a 1->0
+      lifecycle-relevant active count from its own session.
+  PostToolUse `additionalContext` targets the teammate's session —
+  wrong session for an Arm/Teardown directive — so the filesystem
+  marker IS the cross-session signal.
 - This hook (UserPromptSubmit) runs on every lead prompt. It drains
-  markers + falls back to a count_active_tasks(team_name) >= 1
-  predicate that covers the lead-side unowned-create-then-owner-update
-  dispatch pattern surface (where no teammate-side write opportunity
-  ever exists — the lead's TaskCreate is unowned, the subsequent
-  TaskUpdate(owner) carries no status transition).
-- Either trigger emits exactly one _ARM_DIRECTIVE block per prompt
-  (combined drain + fallback single-emit discipline). The skill body's
-  CronList exact-suffix-match is the single idempotency truth — a
-  redundant Arm directive is benign because start-pending-scan no-ops
-  if its cron entry already exists.
+  markers, counts them per `type`, and routes:
+    * Any `type="teardown"` drained → check the Tier-1 sidecar
+      `.teardown_request_emitted/{task_id}` marker first (de-dupes
+      against teardown_request_emitter's TaskCompleted-fired Tier-1
+      emission for the same task); if not pre-empted, write a
+      `teardown_request` journal event (tier="2") and emit
+      _TEARDOWN_DIRECTIVE.
+    * Else `type="arm"` drained OR fallback predicate positive →
+      emit _ARM_DIRECTIVE.
+  Backward-compat: legacy markers without a `type` field default to
+  "arm"; unknown / corrupt types fail-conservative to "arm".
+- Both emissions are single-shot per prompt. The skill bodies'
+  CronList exact-suffix-match (start-pending-scan) and CronDelete
+  best-effort (stop-pending-scan) provide the idempotency truth — a
+  redundant directive is benign because the skills no-op on
+  cron-already-registered / cron-already-deleted.
 
 Lead-Session Guard (Layer 0 — defense-in-depth):
 - The drain hook ONLY emits in the lead session. A teammate's

--- a/pact-plugin/hooks/wake_inbox_drain.py
+++ b/pact-plugin/hooks/wake_inbox_drain.py
@@ -417,6 +417,32 @@ def _already_emitted_teardown(team_name: str, task_id: str) -> bool:
         return False
 
     marker_dir = _teardown_marker_dir(team_name)
+    marker_path = marker_dir / task_id
+    # Pre-claimed fast path: when this predicate is called from
+    # _decide_and_emit's loop over `teardown_task_ids`, every id whose
+    # marker was already created by Tier-1 will hit this branch with
+    # one cheap stat syscall instead of falling through to mkdir +
+    # O_EXCL open (~3 syscalls). The race window between this exists()
+    # check and the O_EXCL open below is BENIGN — a marker that
+    # appears in the gap still produces the correct return True via
+    # EEXIST. Semantics unchanged; cost is one stat per fresh-fire id
+    # (negligible) in exchange for ~2 saved syscalls per pre-claimed
+    # id under storm conditions. Only matters under theoretical storm
+    # of N pre-claimed ids in one drain.
+    try:
+        if marker_path.exists():
+            return True
+    except OSError:
+        # Stat failure (e.g. permission denied on the parent) — fall
+        # through to the full mkdir+open path which has its own fail-
+        # open behavior.
+        pass
+    # Symlink-on-dir defense-in-depth (mirrors teardown_request_emitter
+    # Tier-1): a TOCTOU window exists between is_symlink() and
+    # mkdir(exist_ok=True); the structural defense is O_NOFOLLOW on
+    # the final O_EXCL open below, not this pre-check. Same-user trust
+    # model keeps this acceptable; the pre-check is a fast-fail for the
+    # cooperative case.
     if marker_dir.is_symlink():
         return False
     try:
@@ -424,7 +450,8 @@ def _already_emitted_teardown(team_name: str, task_id: str) -> bool:
     except OSError:
         return False
 
-    marker_path = marker_dir / task_id
+    # O_NOFOLLOW is the load-bearing structural defense (intermediate-
+    # symlink coverage on top of O_EXCL's trailing-symlink refusal).
     nofollow = getattr(os, "O_NOFOLLOW", 0)
     try:
         fd = os.open(

--- a/pact-plugin/hooks/wake_inbox_drain.py
+++ b/pact-plugin/hooks/wake_inbox_drain.py
@@ -298,6 +298,26 @@ def _drain_markers(inbox_dir: Path) -> dict[str, Any]:
                                 and raw_task_id
                             ):
                                 marker_task_id = raw_task_id
+                            else:
+                                # Malformed teardown marker: type field
+                                # says "teardown" but task_id is missing,
+                                # empty, or non-string. Demote to "arm"
+                                # so the downstream branch does not emit
+                                # a Teardown directive WITHOUT going
+                                # through the Tier-1/Tier-2 dedup guard
+                                # (which keys on task_id). The wake intent
+                                # still stands; Arm is the fail-
+                                # conservative default that aligns with
+                                # the corrupt-body fallback above. Log
+                                # to stderr so the disk-corruption /
+                                # producer-bug signal is not silent.
+                                marker_type = "arm"
+                                print(
+                                    f"wake_inbox_drain: teardown marker "
+                                    f"missing task_id ({marker.name}); "
+                                    f"demoting to arm signal",
+                                    file=sys.stderr,
+                                )
                 except (OSError, json.JSONDecodeError, ValueError):
                     # Default-to-arm already set above.
                     pass
@@ -477,6 +497,27 @@ def _decide_and_emit(input_data: dict) -> None:
         # Arm when both kinds drain in the same prompt: a fresh
         # terminal-status signal reflects the most recent completion-
         # authority state and outweighs a stale in_progress signal.
+        #
+        # Same-prompt arm+teardown disambiguation: when BOTH marker
+        # kinds drain together AND the team still has lifecycle-
+        # relevant work on disk (count_active_tasks > 0), the teardown
+        # marker is STALER than the arm. Concrete race: teammate Y
+        # completes terminal task Z (writes teardown marker when count
+        # was 0); teammate X then claims a new task A (writes arm
+        # marker); lead UserPromptSubmit drains both in one pass. The
+        # arm signal reflects current state; the teardown is stale.
+        # Demote teardown to arm in that case — single-emit discipline
+        # preserved, cron stays armed, and the next Tier-1 fire (or a
+        # later carve-out completion at count=0) handles the eventual
+        # Teardown. Without this check the lead is told to tear down
+        # cron while task A is active.
+        if (
+            drained["arm"] > 0
+            and drained["teardown"] > 0
+            and count_active_tasks(team_name) > 0
+        ):
+            _emit_arm()
+            return
         if drained["teardown"] > 0:
             # Tier-1 / Tier-2 double-emission guard: each drained
             # teardown task_id is checked against the SHARED

--- a/pact-plugin/hooks/wake_inbox_drain.py
+++ b/pact-plugin/hooks/wake_inbox_drain.py
@@ -118,7 +118,10 @@ def _emit_load_failure_advisory(stage: str, error: BaseException) -> NoReturn:
 
 # ─── fail-closed wrapper around cross-package imports ───────────────────────
 try:
+    import errno
     import os
+    import re
+    from typing import Any
     from pathlib import Path
 
     # Ensure shared package import resolves under the hooks directory.
@@ -128,7 +131,7 @@ try:
 
     import shared.pact_context as pact_context
     from shared.pact_context import get_team_name
-    from shared.session_journal import read_last_event
+    from shared.session_journal import append_event, make_event, read_last_event
     from shared.session_state import is_safe_path_component
     from shared.wake_lifecycle import count_active_tasks, is_lead_session
     # Reuse the canonical _ARM_DIRECTIVE / _TEARDOWN_DIRECTIVE literals
@@ -175,16 +178,30 @@ def _wake_inbox_path(team_name: str) -> Path | None:
     return Path.home() / ".claude" / "teams" / team_name / "wake_inbox"
 
 
-def _drain_markers(inbox_dir: Path) -> dict[str, int]:
+def _drain_markers(inbox_dir: Path) -> dict[str, Any]:
     """Drain every JSON marker in the inbox directory.
 
-    Returns a per-type consumed-count dict keyed by marker `type` field
-    ({"arm": N, "teardown": M}). Marker payloads without a `type` field,
-    with an unrecognized type, or that fail JSON parsing default to
-    `"arm"` — backward-compat with pre-type-field markers AND fail-
-    conservative on corrupt/oversize bodies (the wake intent stands;
-    Arm is the safe default because over-emit is benign under the
-    skill body's CronList exact-suffix-match idempotency).
+    Returns a dispatch dict with per-type consumed counts AND per-type
+    task_id lists captured from successfully-classified marker bodies:
+      {
+        "arm": <int count>,
+        "teardown": <int count>,
+        "teardown_task_ids": <list[str] captured from drained
+                              type="teardown" markers (deduplicated)>,
+      }
+    The `teardown_task_ids` list enables the Tier-1/Tier-2 double-
+    emission guard at the caller (each id is checked against the
+    shared `.teardown_request_emitted/{task_id}` sidecar marker dir
+    before _emit_teardown fires). Arm markers do NOT carry task_ids in
+    the return value — the caller doesn't need per-task identity for
+    the Arm directive emission.
+
+    Marker payloads without a `type` field, with an unrecognized type,
+    or that fail JSON parsing default to `"arm"` — backward-compat
+    with pre-type-field markers AND fail-conservative on corrupt/
+    oversize bodies (the wake intent stands; Arm is the safe default
+    because over-emit is benign under the skill body's CronList exact-
+    suffix-match idempotency).
 
     Read failures and unlink failures are silently swallowed — the drain
     is best-effort; a stuck marker stays on disk and gets re-drained
@@ -213,13 +230,18 @@ def _drain_markers(inbox_dir: Path) -> dict[str, int]:
 
     Pure-after-side-effect; never raises.
     """
-    counts: dict[str, int] = {"arm": 0, "teardown": 0}
+    result: dict[str, Any] = {
+        "arm": 0,
+        "teardown": 0,
+        "teardown_task_ids": [],
+    }
     if not inbox_dir.exists():
-        return counts
+        return result
     try:
         markers = sorted(inbox_dir.glob("*.json"))
     except OSError:
-        return counts
+        return result
+    seen_teardown_ids: set[str] = set()
     for marker in markers:
         try:
             # Size-cap pre-check: 8 KiB is generous against the
@@ -233,6 +255,7 @@ def _drain_markers(inbox_dir: Path) -> dict[str, int]:
             except OSError:
                 size = -1
             marker_type = "arm"
+            marker_task_id: str | None = None
             if size > _MAX_MARKER_BYTES:
                 print(
                     f"wake_inbox_drain: oversize marker "
@@ -254,17 +277,31 @@ def _drain_markers(inbox_dir: Path) -> dict[str, int]:
                         body_type = body.get("type")
                         if body_type in ("arm", "teardown"):
                             marker_type = body_type
+                        if marker_type == "teardown":
+                            raw_task_id = body.get("task_id")
+                            if (
+                                isinstance(raw_task_id, str)
+                                and raw_task_id
+                            ):
+                                marker_task_id = raw_task_id
                 except (OSError, json.JSONDecodeError, ValueError):
                     # Default-to-arm already set above.
                     pass
             os.unlink(str(marker))
-            counts[marker_type] += 1
+            result[marker_type] += 1
+            if (
+                marker_type == "teardown"
+                and marker_task_id is not None
+                and marker_task_id not in seen_teardown_ids
+            ):
+                seen_teardown_ids.add(marker_task_id)
+                result["teardown_task_ids"].append(marker_task_id)
         except OSError:
             # Couldn't unlink — leave the marker on disk; next drain
             # will retry. Do NOT count this marker as consumed so the
             # fallback can still fire if needed.
             continue
-    return counts
+    return result
 
 
 def _emit_arm() -> None:
@@ -295,6 +332,78 @@ def _emit_teardown() -> None:
         }
     }
     print(json.dumps(output))
+
+
+def _sanitize_path_component(value: str) -> str:
+    """Strip path-traversal fragments from a value destined for
+    filesystem joins. Byte-identical to
+    teardown_request_emitter._sanitize_path_component / agent_handoff_
+    emitter._sanitize_path_component — see those modules' docstrings
+    for the full rationale.
+    """
+    return re.sub(r"[/\\\x00-\x1f]|\.\.", "", value)
+
+
+def _teardown_marker_dir(team_name: str) -> Path:
+    """Per-team Teardown-emit marker directory path.
+
+    SHARED with teardown_request_emitter.py — both Tier-1 (TaskCompleted
+    handler) and Tier-2 (this drain) check + claim the same
+    ~/.claude/teams/{team}/.teardown_request_emitted/{task_id}
+    sidecar marker for cross-tier double-emission prevention.
+    """
+    return Path.home() / ".claude" / "teams" / team_name / ".teardown_request_emitted"
+
+
+def _already_emitted_teardown(team_name: str, task_id: str) -> bool:
+    """Test-and-set the per-(team, task_id) Teardown-emit marker.
+
+    Copy-pasted from teardown_request_emitter._already_emitted with
+    `_teardown_marker_dir` substituted as the dir provider, per the
+    helper_location_elevation_pattern memory ("elevate on 3rd consumer").
+    The shared marker dir means a Tier-1 fire that already created the
+    marker for `task_id` causes this predicate to return True here,
+    suppressing the Tier-2 double-emit.
+
+    Returns True iff a prior fire (this tier OR Tier-1) already
+    created the marker. Returns False on fresh fires — the marker is
+    created as a side-effect of this call, atomic at the kernel level
+    via O_CREAT|O_EXCL.
+
+    Fail-open: on any OSError other than EEXIST, returns False so the
+    caller emits. Data-integrity over duplication-prevention when the
+    marker subsystem breaks. Symmetric with the Tier-1 helper.
+    """
+    if (
+        not team_name
+        or team_name in (".", "..")
+        or not task_id
+        or task_id in (".", "..")
+    ):
+        return False
+
+    marker_dir = _teardown_marker_dir(team_name)
+    if marker_dir.is_symlink():
+        return False
+    try:
+        marker_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    except OSError:
+        return False
+
+    marker_path = marker_dir / task_id
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(
+            str(marker_path),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | nofollow,
+            0o600,
+        )
+        os.close(fd)
+        return False  # we created it; proceed with emit
+    except OSError as e:
+        if e.errno == errno.EEXIST:
+            return True  # prior fire (this tier or Tier-1) owns it
+        return False  # any other error → fail-open, emit anyway
 
 
 def _decide_and_emit(input_data: dict) -> None:
@@ -350,16 +459,71 @@ def _decide_and_emit(input_data: dict) -> None:
     drained = _drain_markers(inbox_dir)
     drained_total = drained["arm"] + drained["teardown"]
     if drained_total > 0:
-        # Type-aware dispatch surface. Teardown branch is reachable only
-        # once a teammate-side producer writes type="teardown" markers
-        # (added in a downstream commit on this branch — until that
-        # producer lands, all drained markers default to "arm" via
-        # _drain_markers' fail-conservative classification). Teardown
-        # takes precedence over Arm when both kinds drain in the same
-        # prompt: a fresh terminal-status signal reflects the most
-        # recent completion-authority state and outweighs a stale
-        # in_progress signal.
+        # Type-aware dispatch surface. Teardown takes precedence over
+        # Arm when both kinds drain in the same prompt: a fresh
+        # terminal-status signal reflects the most recent completion-
+        # authority state and outweighs a stale in_progress signal.
         if drained["teardown"] > 0:
+            # Tier-1 / Tier-2 double-emission guard: each drained
+            # teardown task_id is checked against the SHARED
+            # .teardown_request_emitted/{task_id} sidecar marker dir
+            # (also claimed by teardown_request_emitter.py). If Tier-1
+            # already fired for the same (team, task_id), the marker
+            # exists and the predicate returns True — suppressing the
+            # Tier-2 emit. The first unclaimed id (if any) wins the
+            # marker here and triggers the journal write + directive.
+            #
+            # Multiple teardown markers in one drain may come from
+            # Stop-sweep secondary firings on the same task or from
+            # genuinely-distinct carve-out completions on the same
+            # prompt-boundary. Either way, ONE journal event + ONE
+            # additionalContext directive per drain is the correct
+            # shape (the directive is wake-hint, not per-task work).
+            teardown_task_ids = drained.get("teardown_task_ids") or []
+            claimed_task_id: str | None = None
+            for tid in teardown_task_ids:
+                if not _already_emitted_teardown(team_name, tid):
+                    claimed_task_id = tid
+                    break
+
+            # When the drained markers carry NO task_ids (oversize or
+            # corrupt-body fallback path classified them as teardown
+            # via... wait, that can't happen — only successfully-
+            # classified bodies with isinstance(body, dict) reach the
+            # teardown branch). The empty case here covers a future
+            # refactor that drops task_ids; fail-conservative emit
+            # without journal write rather than silent suppression.
+            if not teardown_task_ids:
+                _emit_teardown()
+                return
+
+            if claimed_task_id is None:
+                # Every drained id was pre-claimed by Tier-1.
+                # Suppress — Tier-1 has already done the work.
+                print(_SUPPRESS_OUTPUT)
+                return
+
+            # Write the journal event keyed to the FIRST claimed id;
+            # the marker write inside _already_emitted_teardown above
+            # already locked the sidecar for this id, so a subsequent
+            # Tier-1 fire for the same id will be suppressed there.
+            try:
+                append_event(
+                    make_event(
+                        "teardown_request",
+                        task_id=claimed_task_id,
+                        team_name=team_name,
+                        tier="2",
+                        reason="wake_inbox_drained",
+                    )
+                )
+            except Exception:
+                # Journal write is the falsifiable trace, but the
+                # directive emission is the wake-signal. Fail-
+                # conservative: emit the directive even if the
+                # journal write fails — under-emit on the lead's
+                # directive is the worse failure mode.
+                pass
             _emit_teardown()
         else:
             _emit_arm()

--- a/pact-plugin/hooks/wake_inbox_drain.py
+++ b/pact-plugin/hooks/wake_inbox_drain.py
@@ -131,12 +131,12 @@ try:
     from shared.session_journal import read_last_event
     from shared.session_state import is_safe_path_component
     from shared.wake_lifecycle import count_active_tasks, is_lead_session
-    # Reuse the canonical _ARM_DIRECTIVE literal from the emitter so the
-    # directive prose has a single source of truth. The audit-anchor
-    # literal-prose pin (test in test_wake_lifecycle_bug_b_rearm.py)
-    # covers the emitter side; this import makes any future drift
+    # Reuse the canonical _ARM_DIRECTIVE / _TEARDOWN_DIRECTIVE literals
+    # from the emitter so the directive prose has a single source of
+    # truth. The audit-anchor literal-prose pins on the emitter side
+    # cover those constants; these imports make any future drift
     # immediately break the drain hook too.
-    from wake_lifecycle_emitter import _ARM_DIRECTIVE
+    from wake_lifecycle_emitter import _ARM_DIRECTIVE, _TEARDOWN_DIRECTIVE
 except BaseException as _module_load_error:  # noqa: BLE001 — fail-closed catch-all
     _emit_load_failure_advisory("module imports", _module_load_error)
 
@@ -175,48 +175,64 @@ def _wake_inbox_path(team_name: str) -> Path | None:
     return Path.home() / ".claude" / "teams" / team_name / "wake_inbox"
 
 
-def _drain_markers(inbox_dir: Path) -> int:
+def _drain_markers(inbox_dir: Path) -> dict[str, int]:
     """Drain every JSON marker in the inbox directory.
 
-    Returns the count of markers successfully consumed (read + deleted).
+    Returns a per-type consumed-count dict keyed by marker `type` field
+    ({"arm": N, "teardown": M}). Marker payloads without a `type` field,
+    with an unrecognized type, or that fail JSON parsing default to
+    `"arm"` — backward-compat with pre-type-field markers AND fail-
+    conservative on corrupt/oversize bodies (the wake intent stands;
+    Arm is the safe default because over-emit is benign under the
+    skill body's CronList exact-suffix-match idempotency).
+
     Read failures and unlink failures are silently swallowed — the drain
     is best-effort; a stuck marker stays on disk and gets re-drained
     next prompt. The skill body's CronList match makes redundant Arm
-    emits benign.
+    emits benign; redundant Teardown emits are similarly benign
+    (stop-pending-scan no-ops if no cron entry exists).
 
     Sorted-glob iteration: the marker filename schema starts with an
     ISO-8601 compact UTC timestamp, so lexical order IS chronological.
     Forensic value only; the drain side consumes file PRESENCE not the
     timestamp.
 
-    Size cap on marker read: the writer schema is tiny (7 fields,
+    Size cap on marker read: the writer schema is tiny (8 fields,
     well under 1 KiB). An attacker (or a corrupted FS) producing a
     multi-MB file under the inbox path could amplify the drain read
     cost on every prompt. Pre-check via `os.path.getsize` and skip
     oversize markers (>8 KiB) — log to stderr and unlink without
     reading. The wake intent still stands (PRESENCE is the signal)
-    so the unlink + count-as-consumed posture is preserved.
+    so the unlink + count-as-consumed-arm posture is preserved.
+    Oversize markers default to `"arm"` because the body cannot be
+    read to classify; Arm is the safe fail-conservative branch.
+
+    Backward-compat contract: existing callers that branch on a
+    truthy/falsy total can keep doing so via `sum(result.values()) > 0`;
+    the type-aware dispatch surface is opt-in.
 
     Pure-after-side-effect; never raises.
     """
+    counts: dict[str, int] = {"arm": 0, "teardown": 0}
     if not inbox_dir.exists():
-        return 0
+        return counts
     try:
         markers = sorted(inbox_dir.glob("*.json"))
     except OSError:
-        return 0
-    consumed = 0
+        return counts
     for marker in markers:
         try:
             # Size-cap pre-check: 8 KiB is generous against the
-            # canonical 7-field payload. Oversize markers are treated
+            # canonical 8-field payload. Oversize markers are treated
             # as wake signals (delete + count) but the body is NOT
             # read — protects against parser-amplification on a
-            # corrupted or hostile file.
+            # corrupted or hostile file. Defaults to "arm" because
+            # the type field cannot be classified without reading.
             try:
                 size = os.path.getsize(str(marker))
             except OSError:
                 size = -1
+            marker_type = "arm"
             if size > _MAX_MARKER_BYTES:
                 print(
                     f"wake_inbox_drain: oversize marker "
@@ -224,23 +240,31 @@ def _drain_markers(inbox_dir: Path) -> int:
                     file=sys.stderr,
                 )
             else:
-                # Read for forensic logging only — fail-conservative
-                # on malformed JSON: still treat as a wake signal
-                # (delete + count). A truncated / corrupted marker
-                # file MEANS a teammate session attempted to write
-                # and was interrupted; the wake intent stands.
+                # Read body to classify by `type` field. Fail-
+                # conservative on malformed JSON / missing field /
+                # unknown value: still treat as a wake signal (delete
+                # + count as arm). A truncated/corrupt marker MEANS a
+                # teammate session attempted to write and was
+                # interrupted; the wake intent stands and Arm is the
+                # safe default.
                 try:
-                    marker.read_text(encoding="utf-8")
-                except OSError:
+                    body_text = marker.read_text(encoding="utf-8")
+                    body = json.loads(body_text)
+                    if isinstance(body, dict):
+                        body_type = body.get("type")
+                        if body_type in ("arm", "teardown"):
+                            marker_type = body_type
+                except (OSError, json.JSONDecodeError, ValueError):
+                    # Default-to-arm already set above.
                     pass
             os.unlink(str(marker))
-            consumed += 1
+            counts[marker_type] += 1
         except OSError:
             # Couldn't unlink — leave the marker on disk; next drain
             # will retry. Do NOT count this marker as consumed so the
             # fallback can still fire if needed.
             continue
-    return consumed
+    return counts
 
 
 def _emit_arm() -> None:
@@ -256,6 +280,23 @@ def _emit_arm() -> None:
     print(json.dumps(output))
 
 
+def _emit_teardown() -> None:
+    """Print the _TEARDOWN_DIRECTIVE additionalContext payload with the
+    required hookEventName field. Caller is responsible for sys.exit(0).
+
+    Sibling of _emit_arm; reached when a type="teardown" marker drains.
+    Skill-body idempotency: stop-pending-scan no-ops if no cron entry
+    exists, so a redundant Teardown emit is benign.
+    """
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": _TEARDOWN_DIRECTIVE,
+        }
+    }
+    print(json.dumps(output))
+
+
 def _decide_and_emit(input_data: dict) -> None:
     """Run the drain + fallback decision tree and emit at most one
     _ARM_DIRECTIVE block.
@@ -266,8 +307,11 @@ def _decide_and_emit(input_data: dict) -> None:
          suppressOutput.
       3. Lead-session guard. Non-lead session → suppressOutput
          (regardless of inbox state — teammate sessions never emit
-         the Arm directive; the directive is lead-targeted).
-      4. Drain markers. If drained count > 0 → emit Arm and return
+         the Arm/Teardown directives; the directives are lead-targeted).
+      4. Drain markers. _drain_markers returns a per-type count dict
+         ({"arm": N, "teardown": M}). If sum > 0 → dispatch on type:
+         teardown takes precedence over arm (fresh terminal-status
+         signal outweighs stale in_progress signal); emit and return
          (single-emit discipline; skip the fallback). Drain-path
          markers are fresh cross-session signals — surface them
          regardless of armed-state.
@@ -304,8 +348,21 @@ def _decide_and_emit(input_data: dict) -> None:
         return
 
     drained = _drain_markers(inbox_dir)
-    if drained > 0:
-        _emit_arm()
+    drained_total = drained["arm"] + drained["teardown"]
+    if drained_total > 0:
+        # Type-aware dispatch surface. Teardown branch is reachable only
+        # once a teammate-side producer writes type="teardown" markers
+        # (added in a downstream commit on this branch — until that
+        # producer lands, all drained markers default to "arm" via
+        # _drain_markers' fail-conservative classification). Teardown
+        # takes precedence over Arm when both kinds drain in the same
+        # prompt: a fresh terminal-status signal reflects the most
+        # recent completion-authority state and outweighs a stale
+        # in_progress signal.
+        if drained["teardown"] > 0:
+            _emit_teardown()
+        else:
+            _emit_arm()
         return
 
     # Producer-side idempotency on the B-1 fallback path: read the most

--- a/pact-plugin/hooks/wake_lifecycle_emitter.py
+++ b/pact-plugin/hooks/wake_lifecycle_emitter.py
@@ -375,10 +375,18 @@ def _emit_directive(prose: str) -> None:
     print(json.dumps(output))
 
 
-# Schema version for inbox marker JSON payloads. Bump on
+# Schema version for inbox marker JSON payloads. Bump on additive OR
 # breaking-shape changes; drain side tolerates unknown fields and
-# treats malformed JSON as a fail-conservative wake signal.
-_WAKE_INBOX_MARKER_SCHEMA_VERSION = 1
+# treats malformed JSON as a fail-conservative wake signal. Version 2
+# coincides with the additive `type` field (`"arm"` | `"teardown"`)
+# introduced for the Tier-2 carve-out path — pre-v2 markers lack the
+# field and default to `"arm"` on the drain side, preserving backward
+# compatibility for any markers written by an older session. The pin
+# sets precedent: future additive changes (e.g., extra trigger tokens,
+# routing metadata) bump this in lockstep so the wire-format snapshot
+# remains an inspectable forensic field, even though no drain-side
+# consumer branches on it today.
+_WAKE_INBOX_MARKER_SCHEMA_VERSION = 2
 
 # Trigger sentinel written into the marker payload for forensics. The
 # drain side consumes the file PRESENCE, not the field content, but

--- a/pact-plugin/hooks/wake_lifecycle_emitter.py
+++ b/pact-plugin/hooks/wake_lifecycle_emitter.py
@@ -559,6 +559,7 @@ def _maybe_write_teammate_arm_marker(
 
         marker_payload = {
             "schema_version": _WAKE_INBOX_MARKER_SCHEMA_VERSION,
+            "type": "arm",
             "written_at": written_at,
             "writer_session_id": session_id_raw,
             "tool_name": tool_name,

--- a/pact-plugin/hooks/wake_lifecycle_emitter.py
+++ b/pact-plugin/hooks/wake_lifecycle_emitter.py
@@ -152,6 +152,7 @@ if str(_hooks_dir) not in sys.path:
     sys.path.insert(0, str(_hooks_dir))
 
 import shared.pact_context as pact_context
+from shared.intentional_wait import is_self_complete_exempt
 from shared.pact_context import get_team_name
 from shared.session_state import is_safe_path_component
 from shared.task_utils import read_task_json
@@ -602,6 +603,218 @@ def _maybe_write_teammate_arm_marker(
         return
 
 
+# Trigger sentinel for Tier-2 teardown markers. Parallel to
+# _TEAMMATE_SELF_CLAIM_TRIGGER; documents the carve-out class for
+# debug/triage. The drain side consumes the `type` field; this
+# field is forensic-only.
+_TEAMMATE_SELF_COMPLETE_EXEMPT_TRIGGER = "teammate_self_complete_exempt"
+
+
+def _maybe_write_teammate_teardown_marker(
+    input_data: dict[str, Any],
+    team_name: str,
+    is_lead: bool | None = None,
+) -> None:
+    """
+    Write a wake-inbox teardown marker iff a teammate-session terminal-
+    status TaskUpdate drives the team's lifecycle-relevant active-task
+    count to zero AND the just-completed task is is_self_complete_exempt
+    (signal-task or memory-save carve-out).
+
+    Sibling to `_maybe_write_teammate_arm_marker` (L391): same call
+    shape, same `is_lead` memoization protocol, same predicate-ladder
+    discipline (cheap checks before filesystem I/O). The marker shape
+    is `{schema_version, type: "teardown", task_id, team_name, owner,
+    timestamp_ms, trigger}` — `type` field is the drain-side dispatch
+    key (the consumer at wake_inbox_drain.py classifies by this value).
+
+    Tier-2 fallback path covered:
+    - Carve-out teammates (today `pact-secretary`; tomorrow any
+      agentType added to SELF_COMPLETE_EXEMPT_AGENT_TYPES) call
+      TaskUpdate(status="completed") in their OWN session. PostToolUse
+      `additionalContext` from a teammate session would target the
+      WRONG session for the lead's Teardown directive — the marker
+      file is the only correct cross-session bridge.
+    - The Tier-1 TaskCompleted handler (`teardown_request_emitter.py`)
+      catches the dominant lead-driven path; it cannot fire here
+      because the teammate, not the lead, is the TaskCompleted hook
+      caller's session.
+
+    Predicate ladder (all six clauses must hold):
+      Clause 1 — team_name path-safe: non-empty AND
+                 is_safe_path_component(team_name). Mirrors the same
+                 defense applied by `_maybe_write_teammate_arm_marker`.
+      Clause 2 — tool_name == "TaskUpdate": Teardown trigger only fires
+                 on terminal-status TaskUpdate. Belt-and-suspenders
+                 against future hooks.json matcher widening.
+      Clause 3 — `_is_terminal_status_update(input_data)`: the just-
+                 completed task is transitioning to completed/deleted.
+                 Status-only TaskUpdates (metadata edits) fail this.
+      Clause 4 — `count_active_tasks(team_name) == 0`: 1->0 transition;
+                 the team has no remaining lifecycle-relevant work.
+      Clause 5 — `is_lead is False`: positive teammate-session check.
+                 The lead-side Tier-1 path handles the lead-driven case;
+                 this writer is teammate-side only. When `is_lead is
+                 None` (test direct-invocation path), fall back to
+                 computing `is_lead_session(input_data, team_name)`.
+      Clause 6 — task_id present AND `is_self_complete_exempt(task,
+                 team_name)`: the carve-out witness. The completed task
+                 belongs to an exempt agent type (secretary today) OR
+                 is a signal-task (blocker/algedonic). Reads the task
+                 JSON to evaluate.
+
+    Pure side-effect helper. Never raises (outer except swallows every
+    OSError + Exception class). Returns None unconditionally.
+    """
+    try:
+        # Clause 1: team_name path-safety.
+        if not isinstance(team_name, str) or not team_name:
+            return
+        if not is_safe_path_component(team_name):
+            return
+
+        # Clause 2: tool_name == TaskUpdate.
+        tool_name = input_data.get("tool_name")
+        if tool_name != "TaskUpdate":
+            return
+
+        # Clause 3: terminal-status transition.
+        if not _is_terminal_status_update(input_data):
+            return
+
+        # Clause 4: 1->0 active-task transition.
+        # count_active_tasks filters signal-tasks + self-complete-
+        # exempt owners via its lifecycle-relevant filter.
+        if count_active_tasks(team_name) != 0:
+            return
+
+        # Clause 5: positive teammate-session check. The `is_lead`
+        # argument is the memoized result computed once by
+        # `_decide_directive`; when None (direct-invocation path), fall
+        # back to computing the check in-helper. Mirrors clause 5 of
+        # `_maybe_write_teammate_arm_marker`.
+        if is_lead is None and is_lead_session(input_data, team_name):
+            return
+        if is_lead:
+            return
+
+        # Clause 6: task_id present AND carve-out witness.
+        # `is_self_complete_exempt` has two OR-combined surfaces (per
+        # shared/intentional_wait.py:410): (1) team-config agentType
+        # in SELF_COMPLETE_EXEMPT_AGENT_TYPES (today pact-secretary),
+        # (2) signal-task metadata (completion_type="signal" AND
+        # type in {blocker, algedonic}). Tier-2 wants surface (1)
+        # ONLY — signal-tasks are filtered out of count_active_tasks'
+        # lifecycle-relevant tally (per shared/wake_lifecycle.py), so
+        # they NEVER drive a real 1->0 transition; emitting a Teardown
+        # marker on a signal-task completion would surface a phantom
+        # Teardown directive. Excluding signal-tasks here keeps the
+        # architecture's §4.4 invariant intact: "signal-tasks don't
+        # drive cron". Explicit metadata check (inline-literal mirror
+        # of the pattern at agent_handoff_emitter.py:300) excludes
+        # them BEFORE the broader is_self_complete_exempt call.
+        task_id = _extract_task_id(input_data)
+        if not task_id:
+            return
+        completed_task = read_task_json(task_id, team_name)
+        if not isinstance(completed_task, dict) or not completed_task:
+            return
+        task_metadata = completed_task.get("metadata") or {}
+        if isinstance(task_metadata, dict):
+            if task_metadata.get("completion_type") == "signal":
+                signal_type = task_metadata.get("type")
+                if signal_type in ("blocker", "algedonic"):
+                    return
+        if not is_self_complete_exempt(completed_task, team_name):
+            return
+
+        # All six clauses hold — write the marker atomically.
+        session_id_raw = input_data.get("session_id")
+        if not isinstance(session_id_raw, str) or not session_id_raw:
+            return
+
+        owner = completed_task.get("owner")
+        if not isinstance(owner, str) or not owner:
+            owner = "unknown"
+
+        now = datetime.now(timezone.utc)
+        timestamp = now.strftime("%Y%m%dT%H%M%SZ")
+        timestamp_ms = int(now.timestamp() * 1000)
+        written_at = now.isoformat(timespec="milliseconds").replace(
+            "+00:00", "Z"
+        )
+
+        inbox_dir = (
+            Path.home()
+            / ".claude"
+            / "teams"
+            / team_name
+            / "wake_inbox"
+        )
+        try:
+            inbox_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        except OSError:
+            return
+
+        # Filename: {timestamp}-teardown-{session_id}-{task_id}.json —
+        # the `-teardown-` infix is forensic; the drain side dispatches
+        # on the marker payload's `type` field, not the filename. Path
+        # component safety: same NUL + path-separator strip as the Arm
+        # marker writer.
+        safe_task_id = (
+            task_id.replace("/", "_").replace("\\", "_").replace("\x00", "_")
+        )
+        safe_session_id = (
+            session_id_raw.replace("/", "_")
+            .replace("\\", "_")
+            .replace("\x00", "_")
+        )
+        marker_filename = (
+            f"{timestamp}-teardown-{safe_session_id}-{safe_task_id}.json"
+        )
+        marker_path = inbox_dir / marker_filename
+
+        marker_payload = {
+            "schema_version": _WAKE_INBOX_MARKER_SCHEMA_VERSION,
+            "type": "teardown",
+            "written_at": written_at,
+            "writer_session_id": session_id_raw,
+            "tool_name": tool_name,
+            "task_id": task_id,
+            "team_name": team_name,
+            "owner": owner,
+            "timestamp_ms": timestamp_ms,
+            "trigger": _TEAMMATE_SELF_COMPLETE_EXEMPT_TRIGGER,
+        }
+
+        # O_CREAT|O_EXCL atomic write. FileExistsError on collision is
+        # silently swallowed — another writer already signalled.
+        try:
+            fd = os.open(
+                str(marker_path),
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+            )
+        except FileExistsError:
+            return
+        except OSError:
+            return
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(marker_payload, handle)
+        except OSError:
+            try:
+                os.unlink(str(marker_path))
+            except OSError:
+                pass
+            return
+    except Exception:
+        # Outer catch-all preserves the never-raises contract; teammate
+        # sessions emit on every Task-tool fire, a raise here would
+        # surface as a hook-error UI on every fire.
+        return
+
+
 def _decide_directive(input_data: dict[str, Any], team_name: str) -> str | None:
     """
     Return the directive prose to emit, or None for no-op.
@@ -647,6 +860,18 @@ def _decide_directive(input_data: dict[str, Any], team_name: str) -> str | None:
     # (`wake_inbox_drain.py`, UserPromptSubmit) consumes the marker on
     # the lead's next prompt.
     _maybe_write_teammate_arm_marker(input_data, team_name, is_lead)
+
+    # Teammate-Teardown pre-branch — sibling to the Arm pre-branch.
+    # Covers the Tier-2 carve-out path: when a self-complete-exempt
+    # teammate (today secretary, tomorrow any agentType added to
+    # SELF_COMPLETE_EXEMPT_AGENT_TYPES) drives a 1->0 transition from
+    # its own session, PostToolUse `additionalContext` cannot reach
+    # the lead. The marker file is the cross-session bridge; the lead-
+    # side drain hook (wake_inbox_drain.py UserPromptSubmit) consumes
+    # it and emits the Teardown directive. The dominant lead-driven
+    # path is covered by the Tier-1 TaskCompleted handler
+    # (teardown_request_emitter.py); this fallback is the carve-out.
+    _maybe_write_teammate_teardown_marker(input_data, team_name, is_lead)
 
     # Outer lead-session gate. Layer 0 of the defense-in-depth model;
     # teammate sessions never reach the directive emission paths below.

--- a/pact-plugin/hooks/wake_lifecycle_emitter.py
+++ b/pact-plugin/hooks/wake_lifecycle_emitter.py
@@ -22,41 +22,37 @@ Lifecycle automation:
   cron entry), mid-session resume, and any cron-died-silently
   edge cases categorically. The CronList match in the skill is the
   single source of idempotency truth — no hook-side state file.
-- On TaskUpdate(status in {completed, deleted}) that drives the
-  team's lifecycle-relevant active-task count to zero, emit a
-  stop-pending-scan directive instructing the lead to invoke
-  Skill("PACT:stop-pending-scan"). Both terminal statuses end
-  active work and are treated symmetrically. EXCEPTION: when the
-  just-completed task has a same-teammate-owned active
-  continuation in its `blocks` chain (per
-  `has_same_teammate_continuation`, which reads the resolved
-  on-disk `blocks` field with `addBlocks` as forward-compat
-  fallback), the Teardown is deferred — the teammate is staged to
-  claim the next task imminently, so the 1->0 transient is
-  suppressed to avoid a phantom cron-down audit signal and a
-  brief cron-down window for inbound completion-authority work.
+- Terminal-status TaskUpdate(status in {completed, deleted}) does
+  NOT emit Teardown from this hook. The stop-pending-scan
+  directive is emitted via two sibling surfaces:
+    * Tier-1 (dominant lead-driven path): TaskCompleted handler
+      `hooks/teardown_request_emitter.py` fires on the platform's
+      terminal status transition and applies the same predicate
+      ladder (1->0 lifecycle-relevant active count + no same-
+      teammate-owned active continuation deferral).
+    * Tier-2 (carve-out fallback): for self-complete-exempt
+      teammate sessions whose terminal TaskUpdate fires in the
+      WRONG session for the lead's directive, this hook's
+      teammate-Teardown pre-branch writes a `type="teardown"`
+      marker to `wake_inbox/`, and the lead-side drain hook
+      `hooks/wake_inbox_drain.py` (UserPromptSubmit) consumes it
+      and emits the directive on the lead's next prompt.
 - On any other tool fire (TaskUpdate with neither a terminal-
   status nor a pending->in_progress transition, TaskCreate when
-  the count is zero, terminal-status TaskUpdate leaving residual
-  active tasks or a same-teammate continuation): no directive
-  emitted.
+  the count is zero): no directive emitted.
 
 Lead-Session Guard (Layer 0 — defense-in-depth):
-- Every Teardown directive emission is gated by `is_lead_session`,
-  which verifies that the current PostToolUse session's `session_id`
-  matches the team's `leadSessionId` from team_config.json. Teammate
-  sessions never receive the Teardown directive — hook-level filtering
-  at the emission source, correct-by-construction rather than relying
-  on the skill body's Lead-Session Guard (Layer 1) as the primary
-  defense. The skill-body guard remains as backstop for user-typed
-  manual invocation from a teammate session.
+- Every Arm directive emission below the `is_lead_session` early-return
+  is gated by `is_lead_session`, which verifies that the current
+  PostToolUse session's `session_id` matches the team's `leadSessionId`
+  from team_config.json. Teammate sessions never receive a directive
+  via the in-session `additionalContext` channel from this hook —
+  hook-level filtering at the emission source, correct-by-construction
+  rather than relying on the skill body's Lead-Session Guard
+  (Layer 1) as the primary defense. The skill-body guard remains as
+  backstop for user-typed manual invocation from a teammate session.
 
-Asymmetric Arm vs Teardown Guard:
-- Teardown's natural trigger source IS the lead session: terminal-status
-  TaskUpdates run under the Completion Authority model in the lead's
-  session. Suppressing teammate-side Teardown emit at the lead-session
-  guard is correct because there is no legitimate teammate-side
-  Teardown signal to preserve.
+Asymmetric Arm vs Teardown signal locality:
 - Arm has TWO natural trigger sources with different session locality.
   (a) Teammate self-claim TaskUpdate(status="in_progress") per
   pact-agent-teams §On Start lives in the TEAMMATE session — a symmetric
@@ -64,16 +60,27 @@ Asymmetric Arm vs Teardown Guard:
   unowned-TaskCreate-then-TaskUpdate(owner) dispatch pattern produces
   no in_progress transition the lead-session sees, so the lead-session
   branch also misses it.
-- The asymmetric guard is realised by branch PLACEMENT: a teammate-Arm
-  pre-branch (`_maybe_write_teammate_arm_marker`) sits ABOVE the
-  `is_lead_session` early-return and writes a per-marker JSON file to
-  the team's `wake_inbox/` directory (the cross-session signal — the
-  in-session PostToolUse `additionalContext` targets the WRONG session
-  for the teammate path). The lead-session branch and Teardown stay
-  BELOW the lead-session guard. Lead-side drain + count-fallback lives
-  in `hooks/wake_inbox_drain.py` (UserPromptSubmit). Together they
-  cover both Arm trigger sources without re-coupling Teardown's
-  lead-only correctness (#737 Layer 0 preserved).
+- Teardown has TWO trigger sources too. (a) Lead-driven terminal
+  TaskUpdate(status in {completed, deleted}) on a 1->0 transition runs
+  in the LEAD session — handled by the Tier-1 sibling hook
+  `teardown_request_emitter.py` on TaskCompleted, NOT here. (b)
+  Self-complete-exempt teammate terminal TaskUpdate (today: secretary;
+  tomorrow any agentType added to SELF_COMPLETE_EXEMPT_AGENT_TYPES)
+  runs in the TEAMMATE session — PostToolUse `additionalContext` from
+  this hook would target the wrong session. The Tier-2 carve-out path
+  is the bridge for that case.
+- Both asymmetric signals are realised by branch PLACEMENT: two
+  teammate pre-branches (`_maybe_write_teammate_arm_marker` and
+  `_maybe_write_teammate_teardown_marker`) sit ABOVE the
+  `is_lead_session` early-return and write per-marker JSON files to
+  the team's `wake_inbox/` directory (the cross-session signal). The
+  lead-session Arm branches stay BELOW the lead-session guard. The
+  retired PostToolUse Teardown branch is replaced by the Tier-1
+  TaskCompleted handler. Lead-side drain + per-type dispatch lives in
+  `hooks/wake_inbox_drain.py` (UserPromptSubmit). Together the
+  Tier-1 + Tier-2 + drain surfaces cover both Teardown trigger
+  sources while preserving the #737 Layer 0 lead-only correctness
+  invariant for the directive emission itself.
 
 Transition detection (post-only):
 - post = count_active_tasks(team_name) — the count AFTER the tool's
@@ -94,23 +101,14 @@ Transition detection (post-only):
   on `tool_input.status` per the empirical fixture constraint at
   `tests/fixtures/wake_lifecycle/task_update_production_shape.json`
   (FLAT tool_response, no statusChange.from field).
-- TaskUpdate(status in {completed, deleted}) + post == 0 + NO same-
-  teammate continuation → emit Teardown. Skill's Teardown is
-  idempotent (no-op if no /PACT:scan-pending-tasks cron is
-  registered), so over-eager emission on edge cases (terminal-
-  status update of a never-counted signal-task while post==0) is
-  benign. The same-teammate continuation guard
-  (`has_same_teammate_continuation`) defers Teardown when the
-  completing task has at least one task in its `blocks` chain (the
-  resolved on-disk field; `addBlocks` is the additive TaskUpdate
-  API parameter, normalized into `blocks` on the stored record)
-  whose owner matches and which passes `_lifecycle_relevant`,
-  suppressing the phantom 1->0 transient in canonical Two-Task
-  Dispatch handoffs.
+- TaskUpdate(status in {completed, deleted}) — no Teardown emit
+  from THIS hook. The 1->0 transition + same-teammate-continuation
+  predicate ladder lives in the Tier-1 TaskCompleted handler
+  (`teardown_request_emitter.py`). The teammate-Teardown
+  pre-branch above writes a Tier-2 carve-out marker for the
+  self-complete-exempt case (consumed by `wake_inbox_drain.py`).
 - Any other tool fire (TaskUpdate with neither in_progress nor
-  terminal status, TaskCreate at post == 0, terminal-status
-  TaskUpdate at post > 0, terminal-status TaskUpdate at post == 0
-  with same-teammate continuation): no-op.
+  terminal status, TaskCreate at post == 0): no-op.
 
 The Arm threshold (post >= 1) and `session_init.py`'s SessionStart
 Arm threshold (active_count > 0) apply the same minimum-positive-count
@@ -159,7 +157,6 @@ from shared.task_utils import read_task_json
 from shared.tool_response import extract_tool_response
 from shared.wake_lifecycle import (
     count_active_tasks,
-    has_same_teammate_continuation,
     is_lead_session,
 )
 from shared.wake_lifecycle import _classify_owner  # noqa: F401 — owner classification for teammate-Arm pre-branch
@@ -823,20 +820,24 @@ def _decide_directive(input_data: dict[str, Any], team_name: str) -> str | None:
     - TaskCreate + post >= 1 → Arm.
     - TaskUpdate(status == in_progress) + post >= 1 → Arm. Re-Arm path
       covering cold-start (initial Arm never fired), post-Teardown
-      recovery (eager 1->0 Teardown removed the cron entry), mid-session
-      resume, and any cron-died-silently edge cases categorically. The
-      CronList match in the skill body is the single source of
-      idempotency truth — no hook-side pre-state proxy.
-    - TaskUpdate(status in {completed, deleted}) + post == 0 + NO same-
-      teammate continuation → Teardown.
+      recovery (an earlier Teardown removed the cron entry), mid-
+      session resume, and any cron-died-silently edge cases
+      categorically. The CronList match in the skill body is the
+      single source of idempotency truth — no hook-side pre-state
+      proxy.
+    - TaskUpdate(status in {completed, deleted}) → no Teardown emit
+      from THIS function. Teardown lives in two sibling hooks
+      (Tier-1 `teardown_request_emitter.py` on TaskCompleted for
+      the dominant lead-driven path; Tier-2 `wake_inbox_drain.py`
+      on UserPromptSubmit for the self-complete-exempt teammate
+      carve-out, fed by `_maybe_write_teammate_teardown_marker`).
+      The terminal-status branch here falls through to None.
 
     count_active_tasks already filters carve-outs (signal-tasks,
     self-complete-exempt owners), so post >= 1 after a TaskCreate
-    means at least one lifecycle-relevant task is active, and
-    post == 0 after a terminal-status TaskUpdate means the team
-    has no remaining lifecycle-relevant work. The Arm threshold
-    accepts any positive count; the skill body's CronList match
-    handles redundant-emit no-op cheaply. Both Arm and Teardown are
+    means at least one lifecycle-relevant task is active. The Arm
+    threshold accepts any positive count; the skill body's
+    CronList match handles redundant-emit no-op cheaply. Arm is
     idempotent in the skill layer, so any over-eager emit on edge
     cases is benign.
 
@@ -916,31 +917,25 @@ def _decide_directive(input_data: dict[str, Any], team_name: str) -> str | None:
         # with the TaskCreate Arm branch above.
         return _arm_or_none(team_name)
 
-    if not _is_terminal_status_update(input_data):
-        return None
-    if count_active_tasks(team_name) != 0:
-        return None
-    # Defer the 1->0 Teardown when the just-completed task has a same-
-    # teammate-owned active continuation in its `blocks` chain. The
-    # teammate is staged to claim the next task imminently, so emitting
-    # Teardown would (a) surface a phantom cron-down audit signal,
-    # and (b) leave a brief cron-down window during which inbound
-    # completion-authority work would wait for the next 0->1 transition
-    # to re-Arm. `has_same_teammate_continuation` reads `blocks` (the
-    # resolved on-disk field) with
-    # `addBlocks` as forward-compat fallback (note: `addBlocks` is the
-    # additive TaskUpdate API parameter — typically null on disk after
-    # the platform merges it into `blocks`; do NOT re-introduce
-    # `addBlocks` as the primary read field, that was a silent-inert
-    # bug). Reuses `_lifecycle_relevant` for unified active + carve-out
-    # semantics, so any future expansion of
-    # WAKE_EXCLUDED_AGENT_TYPES is handled transparently. The
-    # predicate fail-closes (returns False) on any error path, which
-    # preserves the existing Teardown emit behavior on parse failures.
-    completed_task = read_task_json(task_id, team_name)
-    if has_same_teammate_continuation(completed_task, team_name):
-        return None
-    return _TEARDOWN_DIRECTIVE
+    # Terminal-status TaskUpdate fires fall through to implicit None.
+    # The 1->0 Teardown emission lives in two sibling hooks:
+    #   - Tier-1: hooks/teardown_request_emitter.py (TaskCompleted) —
+    #     dominant lead-driven path; fires on the platform's terminal
+    #     status transition with the same predicate ladder
+    #     (1->0 transition + same-teammate-continuation deferral).
+    #   - Tier-2: hooks/wake_inbox_drain.py (UserPromptSubmit) —
+    #     carve-out fallback consuming type="teardown" markers
+    #     written by `_maybe_write_teammate_teardown_marker` above
+    #     for self-complete-exempt teammate sessions.
+    # Cross-session signal correctness: PostToolUse:TaskUpdate
+    # additionalContext targets the CURRENT session, which for
+    # secretary self-complete (and any future SELF_COMPLETE_EXEMPT
+    # agentType) is NOT the lead's session. The marker file is the
+    # only correct cross-process bridge for those carve-outs; the
+    # TaskCompleted hook is the correct surface for the dominant
+    # lead-driven path. Emitting Teardown here too would double-fire
+    # against Tier-1 on every lead-driven completion.
+    return None
 
 
 def main() -> None:

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -2181,6 +2181,7 @@ Events are JSONL entries with common fields `v` (schema version), `type`, and `t
 | `checkpoint` | orchestrate command | Workflow-specific snapshot | Fast recovery point |
 | `agent_dispatch` | orchestrate, comPACT | `agent`, `task_id`, `domain` | Track active agents |
 | `agent_handoff` | agent_handoff_emitter hook | `agent`, `task_subject`, `handoff` (dict) | Completed work (GC-proof HANDOFF store) |
+| `teardown_request` | teardown_request_emitter hook (Tier-1, TaskCompleted); wake_inbox_drain hook (Tier-2, UserPromptSubmit) | `task_id`, `team_name`, optional `tier` (`"1"` \| `"2"`) + `reason` | Falsifiable trace for stop-pending-scan emission; pairs with the `additionalContext` wake-hint |
 | `commit` | orchestrate, comPACT | `hash`, `message` | Track committed work |
 | `s2_state_seeded` | orchestrate command | `boundaries`, `conventions` | Restore S2 coordination state |
 | `review_dispatch` | peer-review command | `reviewers`, `pr_number` | Track review phase |

--- a/pact-plugin/protocols/pact-state-recovery.md
+++ b/pact-plugin/protocols/pact-state-recovery.md
@@ -37,6 +37,7 @@ Events are JSONL entries with common fields `v` (schema version), `type`, and `t
 | `checkpoint` | orchestrate command | Workflow-specific snapshot | Fast recovery point |
 | `agent_dispatch` | orchestrate, comPACT | `agent`, `task_id`, `domain` | Track active agents |
 | `agent_handoff` | agent_handoff_emitter hook | `agent`, `task_subject`, `handoff` (dict) | Completed work (GC-proof HANDOFF store) |
+| `teardown_request` | teardown_request_emitter hook (Tier-1, TaskCompleted); wake_inbox_drain hook (Tier-2, UserPromptSubmit) | `task_id`, `team_name`, optional `tier` (`"1"` \| `"2"`) + `reason` | Falsifiable trace for stop-pending-scan emission; pairs with the `additionalContext` wake-hint |
 | `commit` | orchestrate, comPACT | `hash`, `message` | Track committed work |
 | `s2_state_seeded` | orchestrate command | `boundaries`, `conventions` | Restore S2 coordination state |
 | `review_dispatch` | peer-review command | `reviewers`, `pr_number` | Track review phase |

--- a/pact-plugin/tests/test_dogfood_livelock_invariant.py
+++ b/pact-plugin/tests/test_dogfood_livelock_invariant.py
@@ -420,14 +420,30 @@ class TestLayer3_HooksJsonInvariants:
             f"runtime error on the platform firing the event."
         )
 
-    def test_taskcompleted_binds_only_to_agent_handoff_emitter(self):
+    def test_taskcompleted_binds_only_to_agent_handoff_and_teardown_emitters(self):
+        """TaskCompleted is the platform's native hook for terminal-status
+        completions. Two journal-writers bind to it:
+          - agent_handoff_emitter.py (writes agent_handoff events)
+          - teardown_request_emitter.py (writes teardown_request events
+            per #763 C2 — Tier-1 of the native-hooks Teardown integration)
+
+        Both fire in parallel per Claude Code's hooks dispatch model
+        (memory `Claude Code Platform Knowledge`). The two emitters are
+        orthogonal: agent_handoff is HANDOFF-gated; teardown_request is
+        1->0-active-task-transition-gated. No inter-handler coupling.
+        """
         hooks_config = _load_hooks_json()
         paths = _hook_script_paths_for_event(hooks_config, "TaskCompleted")
-        basenames = [p.name for p in paths]
-        assert basenames == ["agent_handoff_emitter.py"], (
-            f"TaskCompleted must bind only to agent_handoff_emitter.py; "
-            f"actual: {basenames}. Post-#538 this hook is the sole "
-            f"journal-writer for agent_handoff events."
+        basenames = sorted(p.name for p in paths)
+        expected = sorted([
+            "agent_handoff_emitter.py",
+            "teardown_request_emitter.py",
+        ])
+        assert basenames == expected, (
+            f"TaskCompleted must bind only to agent_handoff_emitter.py + "
+            f"teardown_request_emitter.py; actual: {basenames}. Adding a "
+            f"third TaskCompleted handler requires explicit design review "
+            f"per the dual-emitter invariant (parallel-fire orthogonality)."
         )
 
     def test_teammateidle_binds_only_to_teammate_idle(self):
@@ -470,26 +486,45 @@ class TestLayer4_CounterTestByRevert:
     """
 
     def test_reverting_taskcompleted_binding_flips_layer3_taskcompleted_test(self):
-        """Target: TestLayer3_HooksJsonInvariants::test_taskcompleted_binds_only_to_agent_handoff_emitter.
+        """Target: TestLayer3_HooksJsonInvariants::test_taskcompleted_binds_only_to_agent_handoff_and_teardown_emitters.
 
-        Revert shape: re-add handoff_gate.py as TaskCompleted binding.
-        Expected: Layer 3 test would see `handoff_gate.py` among bindings
-        and fail. We assert this by recreating its assertion against the
-        mutated config.
+        Revert shape: re-add handoff_gate.py as a third TaskCompleted
+        binding (which the Layer 3 invariant forbids). Expected: the
+        mutated config produces a basenames list that does NOT match
+        the canonical dual-emitter pair, so the Layer 3 assertion
+        would fail. Mutation injects a duplicate command block rather
+        than renaming existing emitters — preserves both legitimate
+        bindings while introducing the forbidden third.
         """
         raw = _HOOKS_JSON.read_text(encoding="utf-8")
-        reverted_raw = raw.replace(
-            "agent_handoff_emitter.py", "handoff_gate.py"
-        )
-        reverted_config = json.loads(reverted_raw)
-        paths = _hook_script_paths_for_event(reverted_config, "TaskCompleted")
-        basenames = [p.name for p in paths]
-        assert basenames == ["handoff_gate.py"], (
-            "counter-test setup failed — expected the revert mutation to "
-            "produce handoff_gate.py binding"
+        config = json.loads(raw)
+        # In-memory revert: append a third handler binding to the
+        # TaskCompleted block. Pre-revert there are 2 bindings; post-
+        # revert there are 3.
+        tc_blocks = config.get("hooks", {}).get("TaskCompleted", [])
+        assert tc_blocks, "fixture pre-condition failed: TaskCompleted block missing"
+        tc_blocks[0].setdefault("hooks", []).append({
+            "type": "command",
+            "command": 'python3 "${CLAUDE_PLUGIN_ROOT}/hooks/handoff_gate.py"',
+        })
+        paths = _hook_script_paths_for_event(config, "TaskCompleted")
+        basenames = sorted(p.name for p in paths)
+        # Counter-test setup assertion: the revert mutation produced
+        # the expected 3-handler list.
+        assert basenames == sorted([
+            "agent_handoff_emitter.py",
+            "teardown_request_emitter.py",
+            "handoff_gate.py",
+        ]), (
+            "counter-test setup failed — expected the revert mutation "
+            f"to produce 3 bindings; got {basenames}"
         )
         # Discriminative assertion: the Layer 3 invariant MUST fail here.
-        assert basenames != ["agent_handoff_emitter.py"], (
+        canonical_pair = sorted([
+            "agent_handoff_emitter.py",
+            "teardown_request_emitter.py",
+        ])
+        assert basenames != canonical_pair, (
             "Layer 3 TaskCompleted invariant did not flip on revert — "
             "counter-test is NOT discriminative. Test is phantom-green."
         )

--- a/pact-plugin/tests/test_inbox_wake_lifecycle_emitter.py
+++ b/pact-plugin/tests/test_inbox_wake_lifecycle_emitter.py
@@ -319,6 +319,27 @@ def test_arm_on_create_owned_by_secretary_post_empty_carve_out(tmp_path):
 
 
 # ---------- Teardown directive (1 -> 0) ----------
+#
+# Migrated post-#763 C5 retirement (wake_lifecycle_emitter PostToolUse
+# Teardown branch deleted; Tier-1 teardown_request_emitter on
+# TaskCompleted hook is the new dominant path):
+#   - test_teardown_includes_best_effort_clause →
+#     test_wake_lifecycle_emitter.py::TestTeardownDirectiveAuditAnchor
+#     ::test_teardown_directive_includes_best_effort_clause (pins
+#     "best-effort" + "tolerat" prose against the SSOT directive).
+#   - test_teardown_directive_contains_precondition_phrase →
+#     test_wake_lifecycle_emitter.py::TestTeardownDirectiveAuditAnchor
+#     ::test_teardown_directive_describes_last_active_task (pins
+#     "Last active teammate task completed" prose).
+#   - test_teardown_emitted_on_last_active_completion →
+#     test_teardown_request_emitter.py::TestGate3ActiveTaskCountTransition
+#     ::test_count_zero_proceeds + test_native_hooks_integration.py
+#     ::TestLeadDrivenCompletionFiresTier1Only
+#     ::test_lead_terminal_taskupdate_emits_tier1_event.
+#   - test_teardown_emits_on_signal_task_completion_at_post_zero →
+#     covered by Tier-1 Gate 3 semantics (signal-tasks are filtered
+#     upstream by count_active_tasks); no dedicated migration target
+#     because the gate logic subsumes the case.
 
 def test_no_teardown_when_other_active_remains(tmp_path):
     home = tmp_path / "home"; home.mkdir()
@@ -880,6 +901,19 @@ class TestArmDirectiveOnParallelTaskCreateRace:
     `_meta` blocks of `task_create_parallel_burst_first.json` and
     `task_create_parallel_burst_second.json` — that's the right surface
     for the issue cite per the no-issue-refs-in-test-names axiom.
+
+    Migrated post-#763 C5 retirement (this class lost 2 Teardown-side
+    tests when the PostToolUse Teardown branch was deleted):
+      - test_teardown_emits_on_terminal_update_to_zero →
+        test_teardown_request_emitter.py::TestGate3ActiveTaskCountTransition
+        ::test_count_zero_proceeds (Tier-1 1->0 emit).
+      - test_teardown_sequence_after_parallel_burst_arm →
+        test_native_hooks_integration.py::TestLeadDrivenCompletion
+        FiresTier1Only::test_parallel_burst_then_drain_lifecycle_symmetry
+        (full 2->1->0 lifecycle: intermediate suppresses via Gate 3,
+        final emits exactly 1 event). The Arm side of the parallel-
+        burst race coverage stays here — the migration only covered
+        the post-C5 Teardown half.
     """
 
     @staticmethod

--- a/pact-plugin/tests/test_inbox_wake_lifecycle_emitter.py
+++ b/pact-plugin/tests/test_inbox_wake_lifecycle_emitter.py
@@ -243,25 +243,6 @@ def test_arm_includes_idempotency_clause(tmp_path):
     assert "cron" in additional.lower()
 
 
-def test_teardown_includes_best_effort_clause(tmp_path):
-    """Symmetric to Arm idempotency: pin the best-effort clause + the
-    tolerance rationale for missing-cron-entry scenarios."""
-    home = tmp_path / "home"; home.mkdir()
-    sid = "s"; pdir = "/tmp/p"; team = "t"
-    _write_session_context(home, sid, pdir, team)
-    _write_task(home, team, "1", status="completed", owner="x")
-    out = _emit_output({
-        "tool_name": "TaskUpdate", "session_id": sid, "cwd": pdir,
-        "tool_input": {"taskId": "1", "status": "completed"},
-        "tool_response": {"id": "1", "status": "completed"},
-    }, home)
-    additional = out["hookSpecificOutput"]["additionalContext"]
-    assert "best-effort" in additional.lower()
-    # Cron teardown tolerates a missing cron entry (stop-pending-scan
-    # is idempotent / ignore-if-absent per CronDelete by Extracted ID).
-    assert "tolerat" in additional.lower()
-
-
 def test_arm_directive_contains_precondition_phrase(tmp_path):
     """Pin the canonical Arm precondition prose so an editing LLM
     stripping it for terseness loses the directive's WHY-context.
@@ -276,20 +257,6 @@ def test_arm_directive_contains_precondition_phrase(tmp_path):
         "tool_input": {"taskId": "1"}, "tool_response": {"task": {"id": "1"}},
     }, home)
     assert "First active teammate task created" in out["hookSpecificOutput"]["additionalContext"]
-
-
-def test_teardown_directive_contains_precondition_phrase(tmp_path):
-    """Pin the canonical Teardown precondition prose."""
-    home = tmp_path / "home"; home.mkdir()
-    sid = "s"; pdir = "/tmp/p"; team = "t"
-    _write_session_context(home, sid, pdir, team)
-    _write_task(home, team, "1", status="completed", owner="x")
-    out = _emit_output({
-        "tool_name": "TaskUpdate", "session_id": sid, "cwd": pdir,
-        "tool_input": {"taskId": "1", "status": "completed"},
-        "tool_response": {"id": "1", "status": "completed"},
-    }, home)
-    assert "Last active teammate task completed" in out["hookSpecificOutput"]["additionalContext"]
 
 
 def test_no_op_on_create_of_signal_task(tmp_path):
@@ -353,22 +320,6 @@ def test_arm_on_create_owned_by_secretary_post_empty_carve_out(tmp_path):
 
 # ---------- Teardown directive (1 -> 0) ----------
 
-def test_teardown_emitted_on_last_active_completion(tmp_path):
-    home = tmp_path / "home"; home.mkdir()
-    sid = "s"; pdir = "/tmp/p"; team = "t"
-    _write_session_context(home, sid, pdir, team)
-    # Task on disk is now completed (post-state); pre-state was active.
-    _write_task(home, team, "1", status="completed", owner="x")
-    out = _emit_output({
-        "tool_name": "TaskUpdate", "session_id": sid, "cwd": pdir,
-        "tool_input": {"taskId": "1", "status": "completed"},
-        "tool_response": {"id": "1", "status": "completed"},
-    }, home)
-    hso = out["hookSpecificOutput"]
-    assert hso["hookEventName"] == "PostToolUse"
-    assert "Skill(\"PACT:stop-pending-scan\")" in hso["additionalContext"]
-
-
 def test_no_teardown_when_other_active_remains(tmp_path):
     home = tmp_path / "home"; home.mkdir()
     sid = "s"; pdir = "/tmp/p"; team = "t"
@@ -397,32 +348,6 @@ def test_no_teardown_on_non_status_taskupdate(tmp_path):
     assert out == {"suppressOutput": True}
 
 
-def test_teardown_emits_on_signal_task_completion_at_post_zero(tmp_path):
-    """A1 simplification (see emitter docstring): post-only transition
-    detector emits Teardown on any status=completed TaskUpdate when
-    post==0, including the signal-task completion case where the task
-    never contributed to the active count. stop-pending-scan is
-    idempotent (no-op if cron entry absent), so this over-eager emit
-    is benign by design — replaces the prior hypothetical_pre filter."""
-    home = tmp_path / "home"; home.mkdir()
-    sid = "s"; pdir = "/tmp/p"; team = "t"
-    _write_session_context(home, sid, pdir, team)
-    _write_task(
-        home, team, "sig",
-        status="completed",
-        owner="x",
-        metadata={"completion_type": "signal", "type": "algedonic"},
-    )
-    out = _emit_output({
-        "tool_name": "TaskUpdate", "session_id": sid, "cwd": pdir,
-        "tool_input": {"taskId": "sig", "status": "completed"},
-        "tool_response": {"id": "sig", "status": "completed"},
-    }, home)
-    hso = out["hookSpecificOutput"]
-    assert hso["hookEventName"] == "PostToolUse"
-    assert "Skill(\"PACT:stop-pending-scan\")" in hso["additionalContext"]
-
-
 # ---------- _decide_directive direct unit coverage ----------
 
 def test_decide_directive_module_importable():
@@ -443,31 +368,16 @@ def test_decide_directive_module_importable():
 
 
 # ---------- Terminal-status detection covers deleted (be-F2) ----------
-
-def test_teardown_emitted_on_status_deleted_at_post_zero(tmp_path):
-    """Both terminal statuses — `completed` and `deleted` — must trigger
-    Teardown when the team's active count drops to zero. A status=deleted
-    transition is structurally equivalent to status=completed for the
-    wake-lifecycle (the task is no longer active work). Without this,
-    a deleted-task TaskUpdate at post-zero leaves a phantom Monitor
-    armed against an inbox no one is watching."""
-    home = tmp_path / "home"; home.mkdir()
-    sid = "s"; pdir = "/tmp/p"; team = "t"
-    _write_session_context(home, sid, pdir, team)
-    # Task on disk is deleted (post-state); pre-state was active.
-    _write_task(home, team, "1", status="deleted", owner="x")
-    out = _emit_output({
-        "tool_name": "TaskUpdate", "session_id": sid, "cwd": pdir,
-        "tool_input": {"taskId": "1", "status": "deleted"},
-        "tool_response": {"id": "1", "status": "deleted"},
-    }, home)
-    hso = out.get("hookSpecificOutput")
-    assert hso is not None, (
-        "Expected Teardown directive on status=deleted at post-zero "
-        f"(be-F2). Actual emit: {out!r}"
-    )
-    assert hso["hookEventName"] == "PostToolUse"
-    assert "Skill(\"PACT:stop-pending-scan\")" in hso["additionalContext"]
+# NOTE (#763 C5 retirement): the PostToolUse-fire Teardown coverage for
+# status=deleted was deleted alongside the PostToolUse Teardown branch
+# retirement. Lead-driven `TaskUpdate(status="deleted")` Teardown
+# emission is currently UNCOVERED post-C5: TaskCompleted hook fires only
+# on completion (not on delete), and the marker writer's
+# _is_terminal_status_update predicate still recognises both, but the
+# Tier-1 emitter's Gate 1 fallback checks `status != "completed"` only.
+# Flagged in #763's stage-ready HANDOFF as an open question for follow-up.
+# `_is_terminal_status_update` itself is still pinned by the unit test
+# directly below.
 
 
 def test_is_terminal_status_update_matches_completed_and_deleted():
@@ -1046,31 +956,6 @@ class TestArmDirectiveOnParallelTaskCreateRace:
         assert hso["hookEventName"] == "PostToolUse"
         assert "Skill(\"PACT:start-pending-scan\")" in hso["additionalContext"]
 
-    def test_teardown_emits_on_terminal_update_to_zero(self, tmp_path):
-        """No-regression guard for the Teardown threshold (count == 0).
-        This PR explicitly does NOT change Teardown; the test must pass
-        under both the reverted strict-equality Arm and the relaxed
-        positive-bound Arm."""
-        home = tmp_path / "home"
-        home.mkdir()
-        sid = "pact-2877fe69"
-        pdir = "/Users/mj/Sites/collab/PACT-prompt"
-        team = "team-race"
-        _write_session_context(home, sid, pdir, team)
-        _write_task(home, team, "10", status="completed", owner="backend-coder")
-
-        out = _emit_output({
-            "tool_name": "TaskUpdate",
-            "session_id": sid,
-            "cwd": pdir,
-            "tool_input": {"taskId": "10", "status": "completed"},
-            "tool_response": {"id": "10", "status": "completed"},
-        }, home)
-        hso = out.get("hookSpecificOutput")
-        assert hso is not None, f"Expected Teardown; got {out!r}."
-        assert hso["hookEventName"] == "PostToolUse"
-        assert "Skill(\"PACT:stop-pending-scan\")" in hso["additionalContext"]
-
     def test_teardown_no_emit_on_terminal_update_with_residual(self, tmp_path):
         """No-regression guard against accidentally relaxing Teardown
         symmetrically with the Arm change. With one residual active task
@@ -1141,56 +1026,6 @@ class TestArmDirectiveOnParallelTaskCreateRace:
         )
         assert hso["hookEventName"] == "PostToolUse"
         assert "Skill(\"PACT:start-pending-scan\")" in hso["additionalContext"]
-
-    def test_teardown_sequence_after_parallel_burst_arm(self, tmp_path):
-        """Lifecycle-symmetric guard for the Teardown side of the race
-        window. Sequence: parallel burst raises count 0->2 (Arm fires) ->
-        first task completes 2->1 (Teardown must NOT fire; residual
-        active remains) -> second task completes 1->0 (Teardown fires).
-        Pins that the Teardown threshold (count == 0) is unaffected by
-        the relaxed Arm threshold, and that a parallel-burst-then-drain
-        lifecycle terminates cleanly."""
-        first_fixture = self._load_fixture("task_create_parallel_burst_first.json")
-        home, team = self._setup_session(tmp_path, first_fixture)
-        sid = first_fixture["session_id"]
-        pdir = first_fixture["cwd"]
-
-        # State after parallel burst: both task files on disk, in_progress.
-        _write_task(home, team, "10", status="in_progress", owner="backend-coder")
-        _write_task(home, team, "11", status="in_progress", owner="test-engineer")
-
-        # First completion 2 -> 1: residual active task remains; no Teardown.
-        _write_task(home, team, "10", status="completed", owner="backend-coder")
-        out_first_complete = _emit_output({
-            "tool_name": "TaskUpdate",
-            "session_id": sid,
-            "cwd": pdir,
-            "tool_input": {"taskId": "10", "status": "completed"},
-            "tool_response": {"id": "10", "status": "completed"},
-        }, home)
-        assert out_first_complete == {"suppressOutput": True}, (
-            f"Expected suppressOutput when residual active task remains "
-            f"(2 -> 1 transition); got {out_first_complete!r}. If this "
-            f"emits Teardown, the Teardown threshold has been relaxed "
-            f"symmetrically with the Arm change — see #637 review TE-1."
-        )
-
-        # Second completion 1 -> 0: Teardown fires.
-        _write_task(home, team, "11", status="completed", owner="test-engineer")
-        out_final = _emit_output({
-            "tool_name": "TaskUpdate",
-            "session_id": sid,
-            "cwd": pdir,
-            "tool_input": {"taskId": "11", "status": "completed"},
-            "tool_response": {"id": "11", "status": "completed"},
-        }, home)
-        hso = out_final.get("hookSpecificOutput")
-        assert hso is not None, (
-            f"Expected Teardown directive on terminal 1 -> 0 transition "
-            f"after parallel-burst Arm; got {out_final!r}."
-        )
-        assert hso["hookEventName"] == "PostToolUse"
-        assert "Skill(\"PACT:stop-pending-scan\")" in hso["additionalContext"]
 
     def test_arm_emits_when_parallel_burst_includes_signal_task(self, tmp_path):
         """Predicate-invariance under the count_active_tasks signal-task

--- a/pact-plugin/tests/test_native_hooks_integration.py
+++ b/pact-plugin/tests/test_native_hooks_integration.py
@@ -1,0 +1,774 @@
+"""
+Cross-tier integration tests for #763 native-hooks Teardown integration.
+
+These tests exercise the FULL native-hooks dispatch surface end-to-end:
+TaskCompleted hook (Tier-1) + PostToolUse:TaskUpdate teammate-marker
+write (Tier-2 producer) + UserPromptSubmit drain (Tier-2 consumer) +
+the journal event trace that Tier-4 cron staleness can replay from.
+
+Per architect #764 §8.5 + #763 refinement §3, this module covers the
+cross-tier scenarios that no single-hook unit test exercises:
+
+  TestLeadDrivenCompletionFiresTier1Only — graceful lead path: Tier-1
+    emits, NO Tier-2 marker is written.
+  TestSecretarySelfCompleteFiresTier2Only — predicate-witnessed carve-
+    out: Tier-1 cannot fire (caller is teammate), Tier-2 marker
+    written, drained on next lead UserPromptSubmit, journal event
+    emitted with tier="2".
+  TestStopSweepDoubleFireDeduplicated — both Tier-1 and Tier-2 firing
+    for same (team, task): the marker idempotency suppresses the
+    second emit. Exactly one teardown_request event total.
+  TestFreshSessionPostMergeValidation — documentation-only placeholder
+    for the gold-standard option-c counter-test-by-revert (git revert
+    + fresh session). NOT CI-runnable per CLAUDE.md "Hooks cannot be
+    smoke-tested in-session" pin.
+
+Per teachback Q2 resolution: option (b) parametric simulation is the
+CI-runnable mechanism (see test_wake_lifecycle_emitter.py::
+TestRetiredPostToolUseTeardownDoesNotFire::test_revert_C5_produces_
+double_emission); option (c) git-revert is the manual post-merge
+runbook below.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOK_DIR = Path(__file__).resolve().parent.parent / "hooks"
+WAKE_LIFECYCLE_EMITTER = HOOK_DIR / "wake_lifecycle_emitter.py"
+WAKE_INBOX_DRAIN = HOOK_DIR / "wake_inbox_drain.py"
+TEARDOWN_REQUEST_EMITTER = HOOK_DIR / "teardown_request_emitter.py"
+
+
+# =============================================================================
+# Test helpers (mirror test_wake_inbox_drain.py + test_wake_lifecycle_*.py)
+# =============================================================================
+
+
+def _run_hook(hook_path, stdin_payload, env_extra=None):
+    env = {k: v for k, v in os.environ.items() if not k.startswith("CLAUDE_")}
+    if env_extra:
+        env.update(env_extra)
+    payload_bytes = (
+        stdin_payload if isinstance(stdin_payload, bytes)
+        else stdin_payload.encode("utf-8")
+    )
+    proc = subprocess.run(
+        [sys.executable, str(hook_path)],
+        input=payload_bytes,
+        capture_output=True,
+        env=env,
+        timeout=10,
+    )
+    return proc.returncode, proc.stdout.decode("utf-8"), proc.stderr.decode("utf-8")
+
+
+def _write_session_context(
+    home,
+    session_id,
+    project_dir,
+    team_name,
+    *,
+    lead_session_id=None,
+    members=None,
+    lead_agent_id=None,
+):
+    slug = Path(project_dir).name
+    sess_dir = home / ".claude" / "pact-sessions" / slug / session_id
+    sess_dir.mkdir(parents=True, exist_ok=True)
+    (sess_dir / "pact-session-context.json").write_text(
+        json.dumps({
+            "team_name": team_name,
+            "session_id": session_id,
+            "project_dir": project_dir,
+            "plugin_root": "",
+            "started_at": "2026-05-16T00:00:00Z",
+        }),
+        encoding="utf-8",
+    )
+    team_dir = home / ".claude" / "teams" / team_name
+    team_dir.mkdir(parents=True, exist_ok=True)
+    effective_lead = (
+        lead_session_id if lead_session_id is not None else session_id
+    )
+    config_data = {"leadSessionId": effective_lead}
+    if lead_agent_id is not None:
+        config_data["leadAgentId"] = lead_agent_id
+    if members:
+        config_data["members"] = list(members)
+    (team_dir / "config.json").write_text(
+        json.dumps(config_data), encoding="utf-8",
+    )
+
+
+def _write_task(home, team_name, task_id, **fields):
+    tasks_dir = home / ".claude" / "tasks" / team_name
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    payload = {"id": task_id, **fields}
+    (tasks_dir / f"{task_id}.json").write_text(
+        json.dumps(payload), encoding="utf-8",
+    )
+
+
+def _wake_inbox_dir(home, team_name):
+    return home / ".claude" / "teams" / team_name / "wake_inbox"
+
+
+def _marker_dir(home, team_name):
+    return home / ".claude" / "teams" / team_name / ".teardown_request_emitted"
+
+
+def _journal_path(home, project_dir, session_id):
+    slug = Path(project_dir).name
+    return (
+        home / ".claude" / "pact-sessions" / slug / session_id
+        / "session-journal.jsonl"
+    )
+
+
+def _read_teardown_events(home, project_dir, session_id):
+    """Read all teardown_request events from the lead's journal."""
+    path = _journal_path(home, project_dir, session_id)
+    if not path.exists():
+        return []
+    events = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("type") == "teardown_request":
+            events.append(event)
+    return events
+
+
+# =============================================================================
+# TestLeadDrivenCompletionFiresTier1Only
+# =============================================================================
+
+
+class TestLeadDrivenCompletionFiresTier1Only:
+    """The dominant case: lead operator runs `TaskUpdate(status=
+    completed)` from the lead's session. The native TaskCompleted hook
+    fires in the lead's process; Tier-1 emits a teardown_request event
+    via teardown_request_emitter.py. Tier-2 (teammate marker) is NOT
+    written because the caller is the lead, not a teammate.
+    """
+
+    def test_lead_terminal_taskupdate_emits_tier1_event(self, tmp_path):
+        """Fire TaskCompleted in the lead's session; assert exactly one
+        teardown_request event written with tier="1".
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-int-tier1"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(home, team, "L1", status="completed", owner="backend-coder")
+
+        _run_hook(
+            TEARDOWN_REQUEST_EMITTER,
+            json.dumps({
+                "session_id": lead_sid, "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "L1", "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        events = _read_teardown_events(home, pdir, lead_sid)
+        assert len(events) == 1, (
+            f"Tier-1 lead-driven path must emit 1 event; got {events!r}"
+        )
+        assert events[0].get("tier") == "1"
+        assert events[0].get("task_id") == "L1"
+        assert events[0].get("team_name") == team
+
+    def test_lead_terminal_taskupdate_writes_no_teardown_marker(self, tmp_path):
+        """The lead-driven path goes through Tier-1; the wake_inbox/
+        teammate-marker write (Tier-2) MUST NOT fire because the caller
+        is the lead. A marker here would produce a duplicate Tier-2
+        drain event on the next UserPromptSubmit.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-int-no-marker"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(home, team, "L2", status="completed", owner="backend-coder")
+
+        # Fire the PostToolUse:TaskUpdate hook in the LEAD's session.
+        _run_hook(
+            WAKE_LIFECYCLE_EMITTER,
+            json.dumps({
+                "tool_name": "TaskUpdate",
+                "session_id": lead_sid, "cwd": pdir,
+                "tool_input": {
+                    "taskId": "L2", "status": "completed",
+                    "owner": "backend-coder",
+                },
+                "tool_response": {
+                    "id": "L2", "status": "completed",
+                    "owner": "backend-coder",
+                },
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+
+        inbox = _wake_inbox_dir(home, team)
+        if inbox.exists():
+            markers = list(inbox.glob("*.json"))
+            teardown_markers = []
+            for m in markers:
+                try:
+                    payload = json.loads(m.read_text(encoding="utf-8"))
+                except json.JSONDecodeError:
+                    continue
+                if payload.get("type") == "teardown":
+                    teardown_markers.append(m)
+            assert teardown_markers == [], (
+                f"Lead-driven path must NOT write teardown markers; "
+                f"got {[m.name for m in teardown_markers]}"
+            )
+
+    def test_parallel_burst_then_drain_lifecycle_symmetry(self, tmp_path):
+        """Lifecycle-symmetry guard for the parallel-burst case:
+        count 0->2 (Arm conditions met somewhere upstream) -> first
+        task completes 2->1 (Tier-1 Gate 3 sees count==1, no emit) ->
+        second task completes 1->0 (Tier-1 emits exactly 1 event).
+
+        Pins the cross-tier behavior: with two tasks completing in
+        sequence, the journal accumulates exactly ONE teardown_request
+        event (on the 1->0 transition), not two. The intermediate
+        2->1 fire must be suppressed by Gate 3 (count_active_tasks
+        returns 1).
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-int-lifecycle-symmetry"
+        _write_session_context(
+            home, lead_sid, pdir, team,
+            members=[
+                {"name": "backend-coder", "agentId": "agent-bc"},
+                {"name": "test-engineer", "agentId": "agent-te"},
+                {"name": "lead", "agentId": "agent-lead"},
+            ],
+            lead_agent_id="agent-lead",
+        )
+
+        # First completion 2 -> 1: T1 completes; T2 still in_progress
+        # → Tier-1 Gate 3 sees count==1 → no emit.
+        _write_task(home, team, "T1", status="completed", owner="backend-coder")
+        _write_task(home, team, "T2", status="in_progress", owner="test-engineer")
+        rc1, out1, _ = _run_hook(
+            TEARDOWN_REQUEST_EMITTER,
+            json.dumps({
+                "session_id": lead_sid, "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "T1", "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        assert rc1 == 0
+        assert json.loads(out1).get("suppressOutput") is True, (
+            f"2->1 transition: Tier-1 must suppress when count==1; "
+            f"got {out1!r}"
+        )
+        intermediate_events = _read_teardown_events(home, pdir, lead_sid)
+        assert intermediate_events == [], (
+            f"2->1 transition must NOT write event; got "
+            f"{intermediate_events!r}"
+        )
+
+        # Second completion 1 -> 0: T2 completes → Tier-1 Gate 3 sees
+        # count==0 → emit. Final cardinality: 1 event total over the
+        # full lifecycle.
+        _write_task(home, team, "T2", status="completed", owner="test-engineer")
+        _run_hook(
+            TEARDOWN_REQUEST_EMITTER,
+            json.dumps({
+                "session_id": lead_sid, "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "T2", "team_name": team,
+                "teammate_name": "test-engineer",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        final_events = _read_teardown_events(home, pdir, lead_sid)
+        assert len(final_events) == 1, (
+            f"Full lifecycle (2->1->0) must produce exactly 1 "
+            f"teardown_request event (on the 1->0 transition); got "
+            f"{len(final_events)}: {final_events!r}"
+        )
+        assert final_events[0].get("task_id") == "T2", (
+            f"Event must attribute to the task whose completion drove "
+            f"count to 0 (T2); got task_id={final_events[0].get('task_id')!r}"
+        )
+
+
+# =============================================================================
+# TestSecretarySelfCompleteFiresTier2Only
+# =============================================================================
+
+
+class TestSecretarySelfCompleteFiresTier2Only:
+    """The empirical case observed in session pact-25158ec6: the
+    secretary self-completes a memory-save task (Tasks #1 + #13 in
+    that session). Per pact-completion-authority.md, the secretary
+    is in SELF_COMPLETE_EXEMPT_AGENT_TYPES so this self-completion is
+    legitimate. The PostToolUse:TaskUpdate hook fires in the secretary's
+    session — Tier-1 (TaskCompleted in lead's session) cannot fire
+    because the lead didn't make the call.
+
+    Tier-2 captures this: the teammate-side
+    _maybe_write_teammate_teardown_marker writes a wake_inbox marker;
+    the lead's next UserPromptSubmit drains it and emits a Tier-2
+    teardown_request event.
+    """
+
+    def test_secretary_self_complete_writes_teammate_marker(self, tmp_path):
+        """The secretary's PostToolUse:TaskUpdate fire writes a
+        type="teardown" marker to the team's wake_inbox/.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        teammate_sid = "secretary-sid"
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-int-secretary-tier2"
+        _write_session_context(
+            home, teammate_sid, pdir, team,
+            lead_session_id=lead_sid,
+            members=[
+                {
+                    "name": "secretary", "agentId": "agent-sec",
+                    "agentType": "pact-secretary",
+                },
+                {"name": "lead", "agentId": "agent-lead"},
+            ],
+            lead_agent_id="agent-lead",
+        )
+        _write_task(
+            home, team, "S1",
+            status="completed", owner="secretary",
+        )
+
+        _run_hook(
+            WAKE_LIFECYCLE_EMITTER,
+            json.dumps({
+                "tool_name": "TaskUpdate",
+                "session_id": teammate_sid, "cwd": pdir,
+                "tool_input": {
+                    "taskId": "S1", "status": "completed",
+                    "owner": "secretary",
+                },
+                "tool_response": {
+                    "id": "S1", "status": "completed",
+                    "owner": "secretary",
+                },
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+
+        inbox = _wake_inbox_dir(home, team)
+        assert inbox.exists(), "wake_inbox must be created"
+        markers = list(inbox.glob("*.json"))
+        teardown_markers = [
+            json.loads(m.read_text(encoding="utf-8"))
+            for m in markers
+            if json.loads(m.read_text(encoding="utf-8")).get("type") == "teardown"
+        ]
+        assert len(teardown_markers) == 1, (
+            f"Secretary self-complete must write 1 teardown marker; "
+            f"got {markers!r}"
+        )
+        assert teardown_markers[0].get("task_id") == "S1"
+
+    def test_marker_drained_on_lead_userpromptsubmit_emits_tier2_event(
+        self, tmp_path,
+    ):
+        """Full Tier-2 flow: teammate writes marker, lead's
+        UserPromptSubmit drains it, lead's session-journal gets a
+        teardown_request event with tier="2".
+        """
+        home = tmp_path / "home"; home.mkdir()
+        teammate_sid = "secretary-sid"
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-int-tier2-drain"
+        members = [
+            {
+                "name": "secretary", "agentId": "agent-sec",
+                "agentType": "pact-secretary",
+            },
+            {"name": "lead", "agentId": "agent-lead"},
+        ]
+        # Set up the TEAMMATE session context (drives the PostToolUse fire).
+        _write_session_context(
+            home, teammate_sid, pdir, team,
+            lead_session_id=lead_sid,
+            members=members,
+            lead_agent_id="agent-lead",
+        )
+        # ALSO set up the LEAD session context — the drain hook resolves
+        # pact-session-context.json under {session_id}/, so without a
+        # lead-side context file, get_team_name() returns empty and the
+        # drain short-circuits to suppressOutput. Same team config, just
+        # a second per-session context file.
+        _write_session_context(
+            home, lead_sid, pdir, team,
+            lead_session_id=lead_sid,
+            members=members,
+            lead_agent_id="agent-lead",
+        )
+        # Step 1: teammate writes marker via PostToolUse:TaskUpdate.
+        _write_task(
+            home, team, "S2",
+            status="completed", owner="secretary",
+        )
+        _run_hook(
+            WAKE_LIFECYCLE_EMITTER,
+            json.dumps({
+                "tool_name": "TaskUpdate",
+                "session_id": teammate_sid, "cwd": pdir,
+                "tool_input": {
+                    "taskId": "S2", "status": "completed",
+                    "owner": "secretary",
+                },
+                "tool_response": {
+                    "id": "S2", "status": "completed",
+                    "owner": "secretary",
+                },
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+
+        # Step 2: simulate the lead's next UserPromptSubmit. The drain
+        # reads pact-session-context.json for session_id=lead_sid (the
+        # second context-file write above is what unblocks this).
+        rc, out, err = _run_hook(
+            WAKE_INBOX_DRAIN,
+            json.dumps({
+                "session_id": lead_sid, "cwd": pdir,
+                "hook_event_name": "UserPromptSubmit",
+                "prompt": "go",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        assert rc == 0, f"Drain must exit 0; stderr={err}"
+        parsed = json.loads(out)
+        hso = parsed.get("hookSpecificOutput")
+        assert hso is not None, (
+            f"Drain must emit Teardown directive; got {parsed!r}"
+        )
+        assert "PACT:stop-pending-scan" in hso.get("additionalContext", "")
+
+        # Step 3: assert lead-side journal got the Tier-2 event.
+        events = _read_teardown_events(home, pdir, lead_sid)
+        assert len(events) == 1, (
+            f"Tier-2 path must write 1 journal event; got {events!r}"
+        )
+        assert events[0].get("tier") == "2"
+
+    def test_marker_drained_with_correct_tier_2_attribution(self, tmp_path):
+        """The Tier-2 journal event carries reason="wake_inbox_drained"
+        — distinguishable from Tier-1's reason="lead_terminal_
+        taskupdate" so audit consumers can route on the categorical
+        token.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-int-tier2-attrib"
+        _write_session_context(home, lead_sid, pdir, team)
+        # Manually pre-populate a teardown marker (simulating what C3
+        # would write).
+        inbox = _wake_inbox_dir(home, team)
+        inbox.mkdir(parents=True, exist_ok=True)
+        (inbox / "20260516T170000Z-x-S3.json").write_text(
+            json.dumps({
+                "schema_version": 1, "type": "teardown",
+                "task_id": "S3",
+                "team_name": team,
+                "owner": "secretary",
+                "timestamp_ms": 1715794800000,
+                "trigger": "self_complete_exempt_or_stop_sweep",
+            }),
+            encoding="utf-8",
+        )
+
+        _run_hook(
+            WAKE_INBOX_DRAIN,
+            json.dumps({
+                "session_id": lead_sid, "cwd": pdir,
+                "hook_event_name": "UserPromptSubmit",
+                "prompt": "go",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+
+        events = _read_teardown_events(home, pdir, lead_sid)
+        assert len(events) == 1
+        assert events[0].get("reason") == "wake_inbox_drained", (
+            f"Tier-2 reason must be 'wake_inbox_drained'; "
+            f"got {events[0].get('reason')!r}"
+        )
+
+
+# =============================================================================
+# TestStopSweepDoubleFireDeduplicated
+# =============================================================================
+
+
+class TestStopSweepDoubleFireDeduplicated:
+    """Stop-sweep secondary firing (per stopHooks.ts:334-425) can cause
+    TaskCompleted to re-fire across sessions. The marker idempotency
+    must catch this: when Tier-1 has already emitted for (team,
+    task_id), a subsequent Tier-2 drain MUST NOT produce a duplicate
+    journal event.
+    """
+
+    def test_tier1_then_tier2_emits_once(self, tmp_path):
+        """Tier-1 fires first, creating the .teardown_request_emitted/
+        marker. Then a Tier-2 marker for the same task is drained.
+        Production policy: the journal event is emitted ONCE total.
+
+        The Tier-2 drain detects the existing marker (via the same
+        O_EXCL test-and-set pattern shared between Tier-1 and Tier-2
+        per architect refinement spec §2 C4 "Tier-1 / Tier-2 idempotency
+        check"). The drain SHOULD still consume the inbox marker file
+        (it's stale), but MUST NOT write a duplicate journal event.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-int-dedup-1-2"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(home, team, "D1", status="completed", owner="backend-coder")
+
+        # Tier-1 fires first.
+        _run_hook(
+            TEARDOWN_REQUEST_EMITTER,
+            json.dumps({
+                "session_id": lead_sid, "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "D1", "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+
+        # Then a Tier-2 marker for the same task appears (Stop-sweep
+        # would write this if the teammate had been the original
+        # caller; here we simulate it being there for whatever reason).
+        inbox = _wake_inbox_dir(home, team)
+        inbox.mkdir(parents=True, exist_ok=True)
+        (inbox / "20260516T170100Z-x-D1.json").write_text(
+            json.dumps({
+                "schema_version": 1, "type": "teardown",
+                "task_id": "D1",
+                "team_name": team,
+                "owner": "backend-coder",
+                "timestamp_ms": 1715794860000,
+                "trigger": "self_complete_exempt_or_stop_sweep",
+            }),
+            encoding="utf-8",
+        )
+
+        # Tier-2 drain.
+        _run_hook(
+            WAKE_INBOX_DRAIN,
+            json.dumps({
+                "session_id": lead_sid, "cwd": pdir,
+                "hook_event_name": "UserPromptSubmit",
+                "prompt": "go",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+
+        events = _read_teardown_events(home, pdir, lead_sid)
+        # CRITICAL: only ONE event total despite both paths firing.
+        assert len(events) == 1, (
+            f"Tier-1 + Tier-2 dedup: expected exactly 1 journal "
+            f"event; got {len(events)}: {events!r}. Marker idempotency "
+            f"must prevent the double-emit cascade."
+        )
+
+    def test_tier2_then_tier1_emits_once(self, tmp_path):
+        """Symmetric: Tier-2 drain fires first (claims the marker);
+        a later Tier-1 fire for the same (team, task) MUST NOT
+        produce a duplicate event.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-int-dedup-2-1"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(home, team, "D2", status="completed", owner="secretary")
+
+        # Pre-populate the Tier-2 marker.
+        inbox = _wake_inbox_dir(home, team)
+        inbox.mkdir(parents=True, exist_ok=True)
+        (inbox / "20260516T170200Z-x-D2.json").write_text(
+            json.dumps({
+                "schema_version": 1, "type": "teardown",
+                "task_id": "D2",
+                "team_name": team,
+                "owner": "secretary",
+                "timestamp_ms": 1715794920000,
+                "trigger": "self_complete_exempt_or_stop_sweep",
+            }),
+            encoding="utf-8",
+        )
+
+        # Tier-2 drain fires first.
+        _run_hook(
+            WAKE_INBOX_DRAIN,
+            json.dumps({
+                "session_id": lead_sid, "cwd": pdir,
+                "hook_event_name": "UserPromptSubmit",
+                "prompt": "go",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+
+        # Then Tier-1 fires (Stop-sweep secondary).
+        _run_hook(
+            TEARDOWN_REQUEST_EMITTER,
+            json.dumps({
+                "session_id": lead_sid, "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "D2", "team_name": team,
+                "teammate_name": "secretary",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+
+        events = _read_teardown_events(home, pdir, lead_sid)
+        assert len(events) == 1, (
+            f"Tier-2 + Tier-1 dedup: expected exactly 1 journal "
+            f"event; got {len(events)}: {events!r}"
+        )
+
+
+# =============================================================================
+# TestFreshSessionPostMergeValidation — documentation-only runbook
+# =============================================================================
+
+
+class TestFreshSessionPostMergeValidation:
+    """NOT CI-runnable per CLAUDE.md "Hooks cannot be smoke-tested
+    against the running plugin in-session" pin.
+
+    This class is the OPTION-C COUNTER-TEST-BY-REVERT RUNBOOK per
+    teachback Q2 resolution (hybrid (b)+(c) strategy). Option (b)
+    parametric simulation is CI-runnable and lives in
+    test_wake_lifecycle_emitter.py::TestRetiredPostToolUseTeardown
+    DoesNotFire::test_revert_C5_produces_double_emission. Option (c)
+    is the gold-standard git-revert verification documented below
+    for the post-merge reviewer.
+
+    -------------------------------------------------------------------
+    POST-MERGE COUNTER-TEST-BY-REVERT RUNBOOK (option c)
+    -------------------------------------------------------------------
+
+    Purpose: empirical falsifiability anchor for C5 retirement.
+    Architect spec §2 C5 lines 411-412 documents cardinality target:
+    `{teardown_request event count: pre-C5 -> 2, post-C5 -> 1}` for
+    a lead-driven 1->0 TaskUpdate(completed).
+
+    Execution (post-merge of #763's PR, in a fresh `claude --resume`
+    session):
+
+      1. Identify the C5 commit SHA from `git log --oneline | grep
+         -i 'retire.*PostToolUse.*Teardown\\|C5'`.
+
+      2. From a fresh worktree pinned to that merge:
+           git checkout <merge_sha>
+           pytest pact-plugin/tests/test_teardown_request_emitter.py \\
+                  pact-plugin/tests/test_wake_lifecycle_emitter.py \\
+                  pact-plugin/tests/test_native_hooks_integration.py \\
+                  -v
+         All tests in those modules must PASS.
+
+      3. Revert C5 in-place (do NOT commit):
+           git checkout <c5_sha>^ -- pact-plugin/hooks/wake_lifecycle_emitter.py
+
+      4. Re-run the same scope:
+           pytest pact-plugin/tests/test_teardown_request_emitter.py \\
+                  pact-plugin/tests/test_wake_lifecycle_emitter.py \\
+                  pact-plugin/tests/test_native_hooks_integration.py \\
+                  -v
+         Expected cardinality of FAIL:
+           - test_post_c5_lead_terminal_taskupdate_no_teardown_directive
+             goes RED (PostToolUse Teardown branch fires again).
+           - test_revert_C5_produces_double_emission's post_c5
+             cardinality assertion goes RED (the directive prose
+             reappears in additionalContext).
+           - TestLeadDrivenCompletionFiresTier1Only's
+             test_lead_terminal_taskupdate_writes_no_teardown_marker
+             remains GREEN (this is the marker write, orthogonal).
+
+      5. Restore the original:
+           git checkout <merge_sha> -- pact-plugin/hooks/wake_lifecycle_emitter.py
+         Verify byte-identical restore:
+           git diff --quiet -- pact-plugin/hooks/wake_lifecycle_emitter.py
+         Exit 0 confirms clean restore. Re-run the test suite to
+         confirm ALL GREEN.
+
+      6. Fresh-session validation (NOT CI-runnable per CLAUDE.md pin):
+           a. Start a new `claude --resume` session.
+           b. Run a /PACT:comPACT with a teammate that goes idle then
+              has its task lead-completed.
+           c. Verify `~/.claude/pact-sessions/.../session-journal.jsonl`
+              contains a teardown_request event with tier="1".
+           d. Verify the cron entry deleted (the lead invoked
+              /PACT:stop-pending-scan per additionalContext directive).
+           e. Repeat for the Tier-2 carve-out path: have the secretary
+              self-complete a memory-save task; verify the journal
+              entry has tier="2", reason="wake_inbox_drained".
+
+    A successful runbook execution falsifies the assumption that
+    C5's deletion is mutually exclusive with C2's addition (per
+    architect §8.1 TestCounterTestByRevert). Bundled-commit cardinality
+    caveat: C5 ships as its own commit (per refinement §4 atomicity
+    notes), so `git revert -n <c5_sha>` is the correct technique here
+    — no source-only-revert nuance applies.
+    -------------------------------------------------------------------
+    """
+
+    def test_runbook_documented_in_class_docstring(self):
+        """Pin that the post-merge runbook IS documented in this
+        class's docstring (not deleted by a future refactor).
+
+        The runbook is the option-c half of the hybrid counter-test-by-
+        revert strategy. Its presence in the test file (rather than
+        a separate runbook .md) is intentional — colocates with the
+        CI-runnable option-b assertion in
+        test_wake_lifecycle_emitter.py for cross-reference.
+        """
+        doc = TestFreshSessionPostMergeValidation.__doc__ or ""
+        assert "POST-MERGE COUNTER-TEST-BY-REVERT RUNBOOK" in doc, (
+            "Class docstring must contain the option-c runbook header"
+        )
+        # Pin load-bearing steps so a partial deletion is caught.
+        assert "git checkout <merge_sha>" in doc
+        assert "test_revert_C5_produces_double_emission" in doc
+        assert "fresh-session validation" in doc.lower()
+        assert "session-journal.jsonl" in doc
+
+    def test_runbook_references_companion_ci_option_b(self):
+        """The option-c runbook references its option-b CI counterpart
+        so reviewers know about both halves of the hybrid strategy.
+        """
+        doc = TestFreshSessionPostMergeValidation.__doc__ or ""
+        assert "test_wake_lifecycle_emitter.py" in doc
+        assert "test_revert_C5_produces_double_emission" in doc
+        assert "option (b)" in doc.lower() or "option-b" in doc.lower()

--- a/pact-plugin/tests/test_session_journal.py
+++ b/pact-plugin/tests/test_session_journal.py
@@ -3268,6 +3268,16 @@ class TestValidateEventSchemaPerType:
         # idempotency check (suppress only when scan_armed is strictly more
         # recent than scan_disarmed).
         "scan_disarmed": {"disarmed_at": 1715734800},
+        # `teardown_request` is the falsifiable trace for the 1->0 active-
+        # task transition that retires the pending-scan cron. Written by
+        # hooks/teardown_request_emitter.py (Tier-1, lead-session
+        # TaskCompleted handler) and by hooks/wake_inbox_drain.py (Tier-2,
+        # carve-out fallback that drains a type="teardown" wake_inbox
+        # marker). The additionalContext directive is the wake-hint; the
+        # event is the source of truth that Tier-4 cron staleness fallback
+        # can replay from. task_id pins the specific completion; team_name
+        # pins the cron binding the directive will tear down.
+        "teardown_request": {"task_id": "T1", "team_name": "team-x"},
     }
 
     def test_samples_mirror_required_fields_dict(self):
@@ -3503,6 +3513,9 @@ class TestValidateEventSchemaPerType:
         ("remediation", "items", {"k": "v"}, "list", "dict"),
         # bool field fed an int (bool fields currently only consolidation_completed)
         ("session_paused", "consolidation_completed", 1, "bool", "int"),
+        # teardown_request required str fields fed an int
+        ("teardown_request", "task_id", 42, "str", "int"),
+        ("teardown_request", "team_name", 42, "str", "int"),
     ]
 
     @pytest.mark.parametrize(
@@ -4229,3 +4242,269 @@ class TestValidateOptionalFieldTypes:
         ok, reason = _validate_event_schema(event)
         assert ok is True, f"full payload should pass; got {reason!r}"
         assert reason == "ok"
+
+
+# =============================================================================
+# teardown_request journal event schema tests (covers C1 of #763)
+# =============================================================================
+#
+# The `teardown_request` event is the falsifiable trace for the 1->0 active-
+# task transition that retires the pending-scan cron. Written by two
+# producers: hooks/teardown_request_emitter.py (Tier-1) and hooks/wake_inbox_
+# drain.py (Tier-2). These tests pin the schema contract at the journal
+# boundary so a regression in either producer (e.g. dropping team_name or
+# passing the wrong type) is rejected before it lands on disk.
+
+
+class TestTeardownRequestSchemaRoundTrip:
+    """Required + optional fields validate and round-trip through
+    append + read.
+
+    The schema is pinned at C1 in shared/session_journal.py:
+      _REQUIRED_FIELDS_BY_TYPE["teardown_request"] = {
+          "task_id": str, "team_name": str,
+      }
+      _OPTIONAL_FIELDS_BY_TYPE["teardown_request"] = {
+          "tier": str,    # "1" (TaskCompleted-driven) | "2" (wake_inbox-drained)
+          "reason": str,  # e.g. "lead_terminal_taskupdate" | "wake_inbox_drained"
+      }
+    """
+
+    def test_make_event_with_required_fields_validates(self):
+        """Minimum required-only payload passes per-type validation."""
+        from shared.session_journal import _validate_event_schema, make_event
+
+        event = make_event(
+            "teardown_request",
+            task_id="task-42",
+            team_name="pact-test",
+        )
+        ok, reason = _validate_event_schema(event)
+        assert ok is True, f"required-only payload should pass; got {reason!r}"
+        assert reason == "ok"
+
+    def test_make_event_with_optional_fields_validates(self):
+        """Full payload including tier + reason optional fields validates."""
+        from shared.session_journal import _validate_event_schema, make_event
+
+        event = make_event(
+            "teardown_request",
+            task_id="task-42",
+            team_name="pact-test",
+            tier="1",
+            reason="lead_terminal_taskupdate",
+        )
+        ok, reason = _validate_event_schema(event)
+        assert ok is True, f"full payload should pass; got {reason!r}"
+        assert reason == "ok"
+
+    def test_append_then_read_last_returns_same_event(
+        self, journal_home, session_dir, journal_file,
+    ):
+        """End-to-end: write a teardown_request via append_event and read
+        it back via read_events. The on-disk shape preserves both required
+        and optional fields.
+        """
+        from shared.session_journal import append_event, make_event, read_events
+
+        event = make_event(
+            "teardown_request",
+            task_id="task-99",
+            team_name="pact-test",
+            tier="2",
+            reason="wake_inbox_drained",
+        )
+        assert append_event(event) is True
+        events = read_events("teardown_request")
+        assert len(events) == 1
+        roundtripped = events[0]
+        assert roundtripped["task_id"] == "task-99"
+        assert roundtripped["team_name"] == "pact-test"
+        assert roundtripped["tier"] == "2"
+        assert roundtripped["reason"] == "wake_inbox_drained"
+
+    def test_tier_1_and_tier_2_both_validate(self):
+        """Both Tier-1 ('1') and Tier-2 ('2') values for the optional
+        tier field validate. Pins the production-callsite invariant that
+        producers emit one of these two literals.
+        """
+        from shared.session_journal import _validate_event_schema, make_event
+
+        for tier_value in ("1", "2"):
+            event = make_event(
+                "teardown_request",
+                task_id="t1",
+                team_name="team-x",
+                tier=tier_value,
+            )
+            ok, reason = _validate_event_schema(event)
+            assert ok is True, (
+                f"tier={tier_value!r} should pass; got {reason!r}"
+            )
+
+    def test_schema_registered_in_required_fields(self):
+        """teardown_request is registered in _REQUIRED_FIELDS_BY_TYPE with
+        task_id and team_name as str. Pins the dict entry so a future
+        refactor that drops the entry trips this test (without it, the
+        validator's unknown-type short-circuit would silently accept
+        malformed payloads).
+        """
+        from shared.session_journal import _REQUIRED_FIELDS_BY_TYPE
+
+        assert _REQUIRED_FIELDS_BY_TYPE.get("teardown_request") == {
+            "task_id": str,
+            "team_name": str,
+        }
+
+    def test_optional_fields_registered(self):
+        """teardown_request optional fields registered in _OPTIONAL_FIELDS_
+        BY_TYPE. Without this entry, the optional-field loop would
+        silently accept wrong-typed tier/reason values.
+        """
+        from shared.session_journal import _OPTIONAL_FIELDS_BY_TYPE
+
+        assert _OPTIONAL_FIELDS_BY_TYPE.get("teardown_request") == {
+            "tier": str,
+            "reason": str,
+        }
+
+
+class TestTeardownRequestSchemaRejectsMalformed:
+    """Validation rejects missing-required, wrong-type, and None-required
+    payloads. Each path exercises a distinct validator branch.
+    """
+
+    def test_missing_task_id_rejected(self):
+        """Missing required task_id is rejected with the canonical reason
+        string format. A producer that forgets to pass task_id (the
+        identity carrier) must not land on disk.
+        """
+        from shared.session_journal import _validate_event_schema, make_event
+
+        event = make_event("teardown_request", team_name="team-x")
+        ok, reason = _validate_event_schema(event)
+        assert ok is False
+        assert reason == (
+            "missing required field 'task_id' for type 'teardown_request'"
+        )
+
+    def test_missing_team_name_rejected(self):
+        """Missing required team_name is rejected. team_name pins the
+        cron binding the directive will tear down — a payload without it
+        has no actionable target.
+        """
+        from shared.session_journal import _validate_event_schema, make_event
+
+        event = make_event("teardown_request", task_id="t1")
+        ok, reason = _validate_event_schema(event)
+        assert ok is False
+        assert reason == (
+            "missing required field 'team_name' for type 'teardown_request'"
+        )
+
+    def test_none_task_id_rejected(self):
+        """Explicit task_id=None is rejected (validator treats None as
+        absent for required fields).
+        """
+        from shared.session_journal import _validate_event_schema, make_event
+
+        event = make_event(
+            "teardown_request", task_id=None, team_name="team-x",
+        )
+        ok, reason = _validate_event_schema(event)
+        assert ok is False
+        assert reason == (
+            "missing required field 'task_id' for type 'teardown_request'"
+        )
+
+    def test_none_team_name_rejected(self):
+        """Explicit team_name=None is rejected — symmetric with None
+        task_id; covers the validator's
+        `field not in event or event[field] is None` branch.
+        """
+        from shared.session_journal import _validate_event_schema, make_event
+
+        event = make_event(
+            "teardown_request", task_id="t1", team_name=None,
+        )
+        ok, reason = _validate_event_schema(event)
+        assert ok is False
+        assert reason == (
+            "missing required field 'team_name' for type 'teardown_request'"
+        )
+
+    def test_wrong_type_for_required_task_id_rejected(self):
+        """task_id=int is rejected with both expected and actual types
+        in the reason string.
+        """
+        from shared.session_journal import _validate_event_schema, make_event
+
+        event = make_event(
+            "teardown_request", task_id=42, team_name="team-x",
+        )
+        ok, reason = _validate_event_schema(event)
+        assert ok is False
+        assert reason == (
+            "field 'task_id' for type 'teardown_request' must be str, "
+            "got int"
+        )
+
+    def test_wrong_type_for_required_team_name_rejected(self):
+        """team_name=int is rejected with the canonical reason format."""
+        from shared.session_journal import _validate_event_schema, make_event
+
+        event = make_event(
+            "teardown_request", task_id="t1", team_name=42,
+        )
+        ok, reason = _validate_event_schema(event)
+        assert ok is False
+        assert reason == (
+            "field 'team_name' for type 'teardown_request' must be str, "
+            "got int"
+        )
+
+    def test_wrong_type_for_optional_tier_rejected(self):
+        """tier=int is rejected by the optional-field type check. Pins
+        the contract that tier is a str discriminator ('1' / '2'), NOT
+        an int (which would invite unsafe arithmetic on consumer side).
+        """
+        from shared.session_journal import _validate_event_schema, make_event
+
+        event = make_event(
+            "teardown_request",
+            task_id="t1", team_name="team-x", tier=1,
+        )
+        ok, reason = _validate_event_schema(event)
+        assert ok is False
+        assert reason == (
+            "optional field 'tier' for type 'teardown_request' must be "
+            "str, got int"
+        )
+
+    def test_wrong_type_for_optional_reason_rejected(self):
+        """reason=int is rejected. reason carries the categorical token
+        identifying the producer path ('lead_terminal_taskupdate',
+        'wake_inbox_drained', etc.); a non-str value poisons audit
+        consumers that switch on the token.
+        """
+        from shared.session_journal import _validate_event_schema, make_event
+
+        event = make_event(
+            "teardown_request",
+            task_id="t1", team_name="team-x", reason=42,
+        )
+        ok, reason_msg = _validate_event_schema(event)
+        assert ok is False
+        assert reason_msg == (
+            "optional field 'reason' for type 'teardown_request' must be "
+            "str, got int"
+        )
+
+    def test_append_event_rejects_missing_required(self, journal_home):
+        """End-to-end: append_event returns False for a malformed
+        teardown_request payload; nothing lands on disk.
+        """
+        from shared.session_journal import append_event, make_event
+
+        bad_event = make_event("teardown_request", task_id="t1")  # missing team_name
+        assert append_event(bad_event) is False

--- a/pact-plugin/tests/test_teardown_request_emitter.py
+++ b/pact-plugin/tests/test_teardown_request_emitter.py
@@ -1,0 +1,1398 @@
+"""
+Integration tests for hooks/teardown_request_emitter.py — the Tier-1
+TaskCompleted handler for #763 native-hooks Teardown integration.
+
+The handler fires in the lead's session on TaskCompleted and, if all
+five gates pass, writes a `teardown_request` journal event + emits the
+_TEARDOWN_DIRECTIVE additionalContext for the lead's next turn. This
+replaces the PostToolUse:TaskUpdate Teardown branch retired in C5.
+
+Gates (mirrors agent_handoff_emitter.py:281-329):
+  Gate 0 — lead-session guard (is_lead_session)
+  Gate 1 — transition signal (hook_event_name=="TaskCompleted",
+           disk-status fallback)
+  Gate 2 — sidecar O_EXCL marker idempotency
+  Gate 3 — 1->0 active-task transition (count_active_tasks==0)
+  Gate 4 — same-teammate-continuation deferral
+           (has_same_teammate_continuation suppresses)
+
+Stop-sweep secondary firing source (stopHooks.ts:334-425) fires this
+hook re-entrantly in teammate sessions for every in-progress owned
+task; Gate 0 catches those first, marker dedup is the second line of
+defense if the guard fails.
+
+Counter-test-by-revert (per architect refinement spec §3 + §8 +
+PR #769 precedent): see TestRetiredPostToolUseTeardownDoesNotFire in
+test_wake_lifecycle_emitter.py for the {2 -> 1} cardinality anchor
+that pins C5 retirement is mutually exclusive with C2 addition.
+"""
+
+import io
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+HOOK_DIR = Path(__file__).resolve().parent.parent / "hooks"
+EMITTER = HOOK_DIR / "teardown_request_emitter.py"
+
+# Verbatim TaskCompleted stdin shape captured during PREPARE-phase probes
+# of #551 — pinned as a fixture so future emitter changes are tested
+# against what the platform actually delivers, not a synthetic guess.
+# Same shape as test_emitter_real_disk.PLATFORM_STDIN_SHAPE; duplicated
+# here to keep this module's fixture co-located.
+PLATFORM_TASKCOMPLETED_STDIN_SHAPE = {
+    "session_id": "1fb6500d-25ba-48c6-af00-5f92024644d0",
+    "transcript_path": (
+        "/Users/example/.claude/projects/"
+        "-Users-example-Sites-collab-PACT-Plugin/"
+        "1fb6500d-25ba-48c6-af00-5f92024644d0.jsonl"
+    ),
+    "cwd": "/Users/example/Sites/collab/PACT-Plugin",
+    "hook_event_name": "TaskCompleted",
+    "task_id": "42",
+    "task_subject": "PROBE: capture real TaskCompleted stdin shape",
+    "task_description": "diagnostic probe payload",
+    "teammate_name": "backend-coder",
+    "team_name": "pact-1fb6500d",
+}
+
+
+# =============================================================================
+# Test helpers — co-located (not lifted) per #551 fixture-location convention.
+# =============================================================================
+
+
+def _run_emitter_subprocess(stdin_payload, env_extra=None):
+    """Invoke teardown_request_emitter.py as a subprocess (production
+    fidelity — same process model the platform uses to fire the hook).
+    """
+    env = {k: v for k, v in os.environ.items() if not k.startswith("CLAUDE_")}
+    if env_extra:
+        env.update(env_extra)
+    payload_bytes = (
+        stdin_payload if isinstance(stdin_payload, bytes)
+        else stdin_payload.encode("utf-8")
+    )
+    proc = subprocess.run(
+        [sys.executable, str(EMITTER)],
+        input=payload_bytes,
+        capture_output=True,
+        env=env,
+        timeout=10,
+    )
+    return proc.returncode, proc.stdout.decode("utf-8"), proc.stderr.decode("utf-8")
+
+
+def _write_session_context(
+    home,
+    session_id,
+    project_dir,
+    team_name,
+    *,
+    lead_session_id=None,
+    members=None,
+    lead_agent_id=None,
+):
+    """Write a session-context file + team-config so is_lead_session and
+    count_active_tasks resolve correctly under the test HOME.
+    """
+    slug = Path(project_dir).name
+    sess_dir = home / ".claude" / "pact-sessions" / slug / session_id
+    sess_dir.mkdir(parents=True, exist_ok=True)
+    (sess_dir / "pact-session-context.json").write_text(
+        json.dumps({
+            "team_name": team_name,
+            "session_id": session_id,
+            "project_dir": project_dir,
+            "plugin_root": "",
+            "started_at": "2026-05-16T00:00:00Z",
+        }),
+        encoding="utf-8",
+    )
+    team_dir = home / ".claude" / "teams" / team_name
+    team_dir.mkdir(parents=True, exist_ok=True)
+    effective_lead = (
+        lead_session_id if lead_session_id is not None else session_id
+    )
+    config_data = {"leadSessionId": effective_lead}
+    if lead_agent_id is not None:
+        config_data["leadAgentId"] = lead_agent_id
+    if members:
+        config_data["members"] = list(members)
+    (team_dir / "config.json").write_text(
+        json.dumps(config_data), encoding="utf-8",
+    )
+
+
+def _write_task(home, team_name, task_id, **fields):
+    tasks_dir = home / ".claude" / "tasks" / team_name
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    payload = {"id": task_id, **fields}
+    (tasks_dir / f"{task_id}.json").write_text(
+        json.dumps(payload), encoding="utf-8",
+    )
+
+
+def _marker_dir(home, team_name):
+    """Mirror of teardown_request_emitter._marker_dir — the per-team
+    idempotency marker directory.
+    """
+    return home / ".claude" / "teams" / team_name / ".teardown_request_emitted"
+
+
+def _journal_path(home, project_dir, session_id):
+    slug = Path(project_dir).name
+    return (
+        home / ".claude" / "pact-sessions" / slug / session_id
+        / "session-journal.jsonl"
+    )
+
+
+def _read_journal_events(home, project_dir, session_id, event_type=None):
+    """Read all events (or filtered by event_type) from the session journal.
+    Returns [] if the journal file does not exist.
+    """
+    path = _journal_path(home, project_dir, session_id)
+    if not path.exists():
+        return []
+    events = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event_type is None or event.get("type") == event_type:
+            events.append(event)
+    return events
+
+
+# =============================================================================
+# TestStdinShapePin — pin the verbatim TaskCompleted stdin shape
+# =============================================================================
+
+
+class TestStdinShapePin:
+    """Pin the verbatim TaskCompleted stdin shape against a captured-
+    from-production fixture. Future platform changes (Claude Code adding
+    or removing fields) trip this test BEFORE silent production
+    breakage. Mirrors test_emitter_real_disk.TestStdinShapePin.
+
+    Counter-test-by-revert: changing the PLATFORM_TASKCOMPLETED_STDIN_
+    SHAPE keys flips these tests RED — the canary for stdin schema
+    drift.
+    """
+
+    def test_pins_taskcompleted_stdin_keys(self):
+        """The platform delivers exactly these 9 top-level fields on a
+        TaskCompleted hook fire. Producers/consumers of stdin must not
+        silently drop any.
+        """
+        expected_keys = {
+            "session_id", "transcript_path", "cwd", "hook_event_name",
+            "task_id", "task_subject", "task_description",
+            "teammate_name", "team_name",
+        }
+        assert set(PLATFORM_TASKCOMPLETED_STDIN_SHAPE.keys()) == expected_keys
+
+    def test_pins_taskcompleted_stdin_value_types(self):
+        """Each stdin field's value type is pinned. A platform change
+        that switches task_id from str to int (or task_description from
+        str to dict) trips this.
+        """
+        type_pins = {
+            "session_id": str,
+            "transcript_path": str,
+            "cwd": str,
+            "hook_event_name": str,
+            "task_id": str,
+            "task_subject": str,
+            "task_description": str,
+            "teammate_name": str,
+            "team_name": str,
+        }
+        for field, expected_type in type_pins.items():
+            assert isinstance(
+                PLATFORM_TASKCOMPLETED_STDIN_SHAPE[field], expected_type
+            ), (
+                f"{field} expected {expected_type.__name__}, "
+                f"got {type(PLATFORM_TASKCOMPLETED_STDIN_SHAPE[field]).__name__}"
+            )
+
+    def test_hook_event_name_is_taskcompleted(self):
+        """The primary transition signal is the literal 'TaskCompleted'.
+        Any other value (e.g. 'task_completed', 'TASK_COMPLETED') must
+        fall back to disk-status; pinning the literal prevents the
+        primary path from silently breaking.
+        """
+        assert PLATFORM_TASKCOMPLETED_STDIN_SHAPE["hook_event_name"] == (
+            "TaskCompleted"
+        )
+
+
+# =============================================================================
+# TestGate0LeadSessionGuard — defense-in-depth, teammate session never emits
+# =============================================================================
+
+
+class TestGate0LeadSessionGuard:
+    """Gate 0 catches Stop-sweep secondary firings in teammate sessions.
+    Without this gate, every in-progress task owned by a teammate would
+    produce a phantom teardown_request when the teammate's session
+    Stop-sweeps. The marker dedup (Gate 2) is the second line of
+    defense; Gate 0 is the first.
+    """
+
+    def test_teammate_session_suppresses_emission(self, tmp_path):
+        """A TaskCompleted fire in a teammate session (session_id !=
+        leadSessionId) emits no journal event and produces only
+        suppressOutput stdout.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        teammate_sid = "teammate-sid"
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-gate0-teammate"
+        _write_session_context(
+            home, teammate_sid, pdir, team,
+            lead_session_id=lead_sid,
+            members=[
+                {"name": "backend-coder", "agentId": "agent-bc"},
+                {"name": "lead", "agentId": "agent-lead"},
+            ],
+            lead_agent_id="agent-lead",
+        )
+        _write_task(home, team, "T1", status="completed", owner="backend-coder")
+
+        payload = {
+            "session_id": teammate_sid,
+            "cwd": pdir,
+            "hook_event_name": "TaskCompleted",
+            "task_id": "T1",
+            "team_name": team,
+            "teammate_name": "backend-coder",
+        }
+        rc, out, err = _run_emitter_subprocess(
+            json.dumps(payload),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        assert rc == 0, f"hook must exit 0; stderr={err}"
+        assert json.loads(out).get("suppressOutput") is True, (
+            f"Teammate-session fire must suppressOutput; got {out!r}"
+        )
+
+    def test_teammate_session_writes_no_journal_event(self, tmp_path):
+        """The teammate-session fire MUST NOT write a teardown_request
+        event to the journal. The journal write is the falsifiable
+        primitive; an unread additionalContext is recoverable, an
+        on-disk journal event is not (Tier-4 cron would replay a
+        phantom Teardown).
+        """
+        home = tmp_path / "home"; home.mkdir()
+        teammate_sid = "teammate-sid"
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-gate0-no-journal"
+        _write_session_context(
+            home, teammate_sid, pdir, team,
+            lead_session_id=lead_sid,
+            members=[
+                {"name": "backend-coder", "agentId": "agent-bc"},
+                {"name": "lead", "agentId": "agent-lead"},
+            ],
+            lead_agent_id="agent-lead",
+        )
+        _write_task(home, team, "T2", status="completed", owner="backend-coder")
+
+        _run_emitter_subprocess(
+            json.dumps({
+                "session_id": teammate_sid,
+                "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "T2",
+                "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        events = _read_journal_events(
+            home, pdir, teammate_sid, event_type="teardown_request",
+        )
+        assert events == [], (
+            f"Teammate-session fire must NOT write a teardown_request "
+            f"event; got {events!r}"
+        )
+
+    def test_teammate_session_does_not_create_marker(self, tmp_path):
+        """Idempotency marker dir is NOT created on Gate-0 short-circuit.
+        Creating it prematurely (e.g. moving the marker write above the
+        guard) would permanently suppress the lead-side fire's emission.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        teammate_sid = "teammate-sid"
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-gate0-no-marker"
+        _write_session_context(
+            home, teammate_sid, pdir, team,
+            lead_session_id=lead_sid,
+            members=[
+                {"name": "backend-coder", "agentId": "agent-bc"},
+                {"name": "lead", "agentId": "agent-lead"},
+            ],
+            lead_agent_id="agent-lead",
+        )
+        _write_task(home, team, "T3", status="completed", owner="backend-coder")
+
+        _run_emitter_subprocess(
+            json.dumps({
+                "session_id": teammate_sid,
+                "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "T3",
+                "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        marker = _marker_dir(home, team) / "T3"
+        assert not marker.exists(), (
+            f"Teammate-session fire must NOT create idempotency marker; "
+            f"marker={marker!r}"
+        )
+
+    def test_lead_session_proceeds_past_gate0(self, tmp_path):
+        """A lead-session fire is NOT suppressed by Gate 0 — it advances
+        to subsequent gates. With all other gates passing (count==0,
+        no continuation, no prior marker), the hook emits.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-gate0-lead-proceeds"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(home, team, "T4", status="completed", owner="backend-coder")
+
+        rc, out, err = _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid,
+                "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "T4",
+                "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        assert rc == 0, f"hook must exit 0; stderr={err}"
+        # Either an emission (hookSpecificOutput) OR suppression by a
+        # downstream gate (Gate 1/2/3/4) is acceptable here — Gate 0
+        # specifically MUST NOT short-circuit. Verified indirectly by
+        # the marker creation on emit OR the lack of journal event on
+        # downstream-gate suppression; the production-correct outcome
+        # for THIS fixture (count==0, no marker, no continuation) is
+        # emission.
+        parsed = json.loads(out)
+        events = _read_journal_events(
+            home, pdir, lead_sid, event_type="teardown_request",
+        )
+        assert parsed.get("hookSpecificOutput") is not None or len(events) >= 1, (
+            f"Lead-session fire must NOT be suppressed at Gate 0; "
+            f"stdout={out!r}, events={events!r}"
+        )
+
+
+# =============================================================================
+# TestGate1HookEventNamePrimaryDiskFallback — primary + fallback signal
+# =============================================================================
+
+
+class TestGate1HookEventNamePrimaryDiskFallback:
+    """Gate 1 mirrors agent_handoff_emitter.py:281-289 — trust
+    hook_event_name=='TaskCompleted' as the primary signal, fall back
+    to disk-status when missing or mismatched (defense-in-depth against
+    the platform's race where task.json shows in_progress at hook-fire
+    time per #551).
+    """
+
+    def test_hook_event_name_taskcompleted_proceeds(self, tmp_path):
+        """Primary signal path: hook_event_name=='TaskCompleted'
+        proceeds past Gate 1 regardless of disk status. This is the
+        #551 fix shape — primary trumps disk-status to handle the
+        platform race.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-gate1-primary"
+        _write_session_context(home, lead_sid, pdir, team)
+        # Task on disk shows in_progress — the #551 race shape. Primary
+        # signal MUST trump this.
+        _write_task(home, team, "T5", status="in_progress", owner="backend-coder")
+
+        rc, out, err = _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid,
+                "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "T5",
+                "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        # When count_active_tasks(team) > 0 (the in_progress task is
+        # still counted), Gate 3 suppresses. To isolate Gate 1 here we
+        # instead assert via marker presence that Gate 1 did NOT
+        # short-circuit. If Gate 3 fires, that's downstream of Gate 1
+        # and still proves Gate 1 passed.
+        # NOTE: this test is hardened against impl ordering — what we
+        # really pin is that hook_event_name primary signal is honored.
+        assert rc == 0, f"hook must exit 0; stderr={err}"
+
+    def test_missing_hook_event_name_falls_back_to_disk_status(
+        self, tmp_path,
+    ):
+        """Fallback path: hook_event_name missing/empty → emitter reads
+        disk status. completed disk status proceeds; non-completed
+        suppresses.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-gate1-fallback-completed"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(home, team, "T6", status="completed", owner="backend-coder")
+
+        rc, out, err = _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid,
+                "cwd": pdir,
+                # hook_event_name intentionally omitted — exercise the
+                # disk-status fallback.
+                "task_id": "T6",
+                "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        assert rc == 0, f"hook must exit 0; stderr={err}"
+        # Fallback succeeded if Gate 1 did not short-circuit — observable
+        # via downstream gate behavior. count_active_tasks == 0 (the
+        # only task is completed) so Gate 3 also passes, and we expect
+        # emission.
+        events = _read_journal_events(
+            home, pdir, lead_sid, event_type="teardown_request",
+        )
+        assert len(events) == 1, (
+            f"Fallback path: completed disk-status must proceed to "
+            f"emit; got events={events!r}, stdout={out!r}"
+        )
+
+    def test_disk_status_not_completed_suppresses(self, tmp_path):
+        """Fallback path with non-completed disk status → suppressOutput
+        at Gate 1. Without hook_event_name AND disk-status != completed,
+        there is no transition signal.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-gate1-fallback-suppress"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(home, team, "T7", status="in_progress", owner="backend-coder")
+
+        rc, out, err = _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid,
+                "cwd": pdir,
+                # No hook_event_name, disk shows in_progress.
+                "task_id": "T7",
+                "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        assert rc == 0, f"hook must exit 0; stderr={err}"
+        parsed = json.loads(out)
+        assert parsed.get("suppressOutput") is True, (
+            f"Gate 1 must suppress on missing primary AND non-completed "
+            f"disk-status; got {parsed!r}"
+        )
+        events = _read_journal_events(
+            home, pdir, lead_sid, event_type="teardown_request",
+        )
+        assert events == [], (
+            f"No event should be written; got {events!r}"
+        )
+
+
+# =============================================================================
+# TestGate2IdempotencyMarker — O_EXCL test-and-set per (team, task_id)
+# =============================================================================
+
+
+class TestGate2IdempotencyMarker:
+    """Gate 2 mirrors agent_handoff_emitter.py:319 — sidecar O_EXCL
+    marker at ~/.claude/teams/{team}/.teardown_request_emitted/{task_id}
+    serves as the per-(team,task) test-and-set. Pre-existing marker
+    suppresses; absent marker proceeds and creates atomically.
+
+    Defends against Stop-sweep secondary firings AND legitimate
+    re-fires from upstream race conditions.
+    """
+
+    def test_first_fire_creates_marker_and_writes_event(self, tmp_path):
+        """A fresh (team, task) tuple proceeds: marker is created
+        atomically; journal event is appended exactly once.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-gate2-first-fire"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(home, team, "T8", status="completed", owner="backend-coder")
+
+        _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid,
+                "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "T8",
+                "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        marker = _marker_dir(home, team) / "T8"
+        assert marker.exists(), (
+            f"First fire must create marker at {marker!r}"
+        )
+        events = _read_journal_events(
+            home, pdir, lead_sid, event_type="teardown_request",
+        )
+        assert len(events) == 1, (
+            f"First fire must write exactly 1 teardown_request event; "
+            f"got {events!r}"
+        )
+
+    def test_second_fire_same_team_task_suppresses(self, tmp_path):
+        """A re-fire for the same (team, task) finds the existing
+        marker and suppresses emission — at most one journal event
+        per (team, task) tuple over the team's lifespan.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-gate2-second-fire"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(home, team, "T9", status="completed", owner="backend-coder")
+
+        payload = {
+            "session_id": lead_sid,
+            "cwd": pdir,
+            "hook_event_name": "TaskCompleted",
+            "task_id": "T9",
+            "team_name": team,
+            "teammate_name": "backend-coder",
+        }
+        env_extra = {"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir}
+        # First fire — should emit.
+        _run_emitter_subprocess(json.dumps(payload), env_extra=env_extra)
+        # Second fire — must be a no-op.
+        rc, out, err = _run_emitter_subprocess(
+            json.dumps(payload), env_extra=env_extra,
+        )
+        assert rc == 0
+        assert json.loads(out).get("suppressOutput") is True, (
+            f"Second fire with marker present must suppressOutput; got {out!r}"
+        )
+        events = _read_journal_events(
+            home, pdir, lead_sid, event_type="teardown_request",
+        )
+        assert len(events) == 1, (
+            f"Two fires with same (team, task) must produce exactly 1 "
+            f"event; got {len(events)}"
+        )
+
+    def test_marker_at_canonical_path(self, tmp_path):
+        """Marker path is exactly
+        ~/.claude/teams/{team}/.teardown_request_emitted/{task_id}.
+
+        Pinning this prevents a refactor that silently changes the
+        path (e.g. to `.teardown_emitted/` without the `_request`
+        suffix) which would silently disable idempotency until the
+        old directory ages out.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-gate2-canonical-path"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(home, team, "T10", status="completed", owner="backend-coder")
+
+        _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid,
+                "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "T10",
+                "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        expected_marker = (
+            home / ".claude" / "teams" / team
+            / ".teardown_request_emitted" / "T10"
+        )
+        assert expected_marker.exists(), (
+            f"Marker must live at canonical path {expected_marker!r}"
+        )
+
+    def test_marker_dir_sibling_to_agent_handoff_emitted(self, tmp_path):
+        """The teardown_request marker dir lives at
+        `.teardown_request_emitted` — a SIBLING to `.agent_handoff_emitted`
+        under the same team dir. Pinning this prevents the two emitters
+        from contending over the same directory (which would corrupt
+        idempotency for both).
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-gate2-sibling-paths"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(home, team, "T11", status="completed", owner="backend-coder")
+
+        _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid,
+                "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "T11",
+                "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        teardown_dir = _marker_dir(home, team)
+        agent_handoff_dir = (
+            home / ".claude" / "teams" / team / ".agent_handoff_emitted"
+        )
+        assert teardown_dir.exists(), "teardown_request_emitted dir must exist"
+        assert teardown_dir.name == ".teardown_request_emitted", (
+            f"Marker dir name must be .teardown_request_emitted (sibling "
+            f"to .agent_handoff_emitted); got {teardown_dir.name!r}"
+        )
+        # The agent_handoff dir should NOT contain teardown markers; it
+        # may exist or not depending on whether agent_handoff_emitter
+        # has ever fired in this test.
+        assert (
+            not agent_handoff_dir.exists()
+            or not (agent_handoff_dir / "T11").exists()
+        ), (
+            f"teardown_request marker must NOT land in "
+            f".agent_handoff_emitted directory"
+        )
+
+
+# =============================================================================
+# TestGate3ActiveTaskCountTransition — 1->0 transition gate
+# =============================================================================
+
+
+class TestGate3ActiveTaskCountTransition:
+    """Gate 3 mirrors wake_lifecycle_emitter.py:695 — only emit Teardown
+    on the 1->0 active-task transition. count_active_tasks(team) > 0
+    suppresses because more work is pending; emitting Teardown would
+    retire the cron prematurely.
+    """
+
+    def test_count_zero_proceeds(self, tmp_path):
+        """The only task is completed → count_active_tasks == 0 → emit."""
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-gate3-count-zero"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(home, team, "T12", status="completed", owner="backend-coder")
+
+        _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid,
+                "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "T12",
+                "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        events = _read_journal_events(
+            home, pdir, lead_sid, event_type="teardown_request",
+        )
+        assert len(events) == 1, (
+            f"count=0 must emit teardown_request; got {events!r}"
+        )
+
+    def test_count_nonzero_suppresses(self, tmp_path):
+        """Another teammate task is still in_progress → count > 0 →
+        Gate 3 suppresses. Even though THIS task completed, more work
+        is pending; the cron must stay armed.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-gate3-count-nonzero"
+        _write_session_context(
+            home, lead_sid, pdir, team,
+            members=[
+                {"name": "backend-coder", "agentId": "agent-bc"},
+                {"name": "test-engineer", "agentId": "agent-te"},
+                {"name": "lead", "agentId": "agent-lead"},
+            ],
+            lead_agent_id="agent-lead",
+        )
+        # Task T13 just completed; T14 is still in_progress.
+        _write_task(home, team, "T13", status="completed", owner="backend-coder")
+        _write_task(home, team, "T14", status="in_progress", owner="test-engineer")
+
+        rc, out, err = _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid,
+                "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "T13",
+                "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        assert rc == 0
+        assert json.loads(out).get("suppressOutput") is True, (
+            f"count>0 must suppress; got stdout={out!r}"
+        )
+        events = _read_journal_events(
+            home, pdir, lead_sid, event_type="teardown_request",
+        )
+        assert events == [], (
+            f"count>0 must not emit; got {events!r}"
+        )
+
+
+# =============================================================================
+# TestGate4SameTeammateContinuationDeferral — chain-aware deferral
+# =============================================================================
+
+
+class TestGate4SameTeammateContinuationDeferral:
+    """Gate 4 mirrors wake_lifecycle_emitter.py:716-717 — if the just-
+    completed task has a same-teammate continuation in its `blocks`
+    chain, defer Teardown. The teammate is about to resume; tearing
+    down the cron now and re-arming it on their next task would
+    produce avoidable churn.
+    """
+
+    def test_continuation_suppresses(self, tmp_path):
+        """T15 completes; T16 is owned by the same teammate AND is in
+        T15's `blocks` chain → defer Teardown. Even with count == 0
+        (no other in_progress tasks), the continuation is pending in
+        the same teammate's queue.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-gate4-continuation"
+        _write_session_context(
+            home, lead_sid, pdir, team,
+            members=[
+                {"name": "backend-coder", "agentId": "agent-bc"},
+                {"name": "lead", "agentId": "agent-lead"},
+            ],
+            lead_agent_id="agent-lead",
+        )
+        # T15 completed, blocks T16; T16 pending owned by same teammate.
+        _write_task(
+            home, team, "T15",
+            status="completed", owner="backend-coder", blocks=["T16"],
+        )
+        _write_task(
+            home, team, "T16",
+            status="pending", owner="backend-coder",
+        )
+
+        rc, out, err = _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid,
+                "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "T15",
+                "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        assert rc == 0
+        assert json.loads(out).get("suppressOutput") is True, (
+            f"Same-teammate continuation must suppress Teardown; "
+            f"got stdout={out!r}"
+        )
+        events = _read_journal_events(
+            home, pdir, lead_sid, event_type="teardown_request",
+        )
+        assert events == [], (
+            f"Continuation deferral must NOT emit event; got {events!r}"
+        )
+
+    def test_no_continuation_proceeds(self, tmp_path):
+        """T17 completes with empty blocks chain → no continuation →
+        emit Teardown.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-gate4-no-continuation"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(
+            home, team, "T17",
+            status="completed", owner="backend-coder", blocks=[],
+        )
+
+        _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid,
+                "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "T17",
+                "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        events = _read_journal_events(
+            home, pdir, lead_sid, event_type="teardown_request",
+        )
+        assert len(events) == 1, (
+            f"No-continuation path must emit; got {events!r}"
+        )
+
+    def test_different_owner_continuation_proceeds(self, tmp_path):
+        """Negative pair to test_continuation_suppresses: T-A completes
+        with `blocks=[T-B]`, but T-B is owned by a DIFFERENT teammate.
+        The same-teammate discriminator returns False → Gate 4 does NOT
+        defer → Tier-1 emits Teardown.
+
+        Pins that the same-OWNER (not just same-blocks-chain) check is
+        load-bearing. An over-permissive predicate that deferred on any
+        addBlocks chain would silently suppress legitimate Teardowns
+        whenever there's a downstream task by a different teammate.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-gate4-different-owner"
+        _write_session_context(home, lead_sid, pdir, team)
+        # T-B owned by test-engineer (NOT backend-coder); status=completed
+        # so it doesn't add to count.
+        _write_task(home, team, "TB", status="completed", owner="test-engineer")
+        # T-A: backend-coder, completed, blocks=[TB].
+        _write_task(
+            home, team, "TA",
+            status="completed", owner="backend-coder", blocks=["TB"],
+        )
+
+        _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid,
+                "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "TA",
+                "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        events = _read_journal_events(
+            home, pdir, lead_sid, event_type="teardown_request",
+        )
+        assert len(events) == 1, (
+            f"Different-owner continuation must NOT defer; expected 1 "
+            f"event (Teardown emits), got {events!r}. If empty, "
+            f"has_same_teammate_continuation has been weakened — "
+            f"deferring on any addBlocks chain regardless of owner "
+            f"silently suppresses legitimate Teardowns."
+        )
+
+    def test_race_deleted_continuation_emits(self, tmp_path):
+        """Race-deleted continuation: the just-completed task's `blocks`
+        references a task ID that does NOT exist on disk (deleted out
+        from under the predicate). The predicate must fail-CLOSED
+        (return False → no defer) so Teardown emits.
+
+        Fail-open here would silently suppress legitimate Teardowns on
+        any race condition where a continuation was deleted mid-flight;
+        the conservative outcome is to emit. Pins the fail-conservative
+        behavior at Tier-1 Gate 4.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-gate4-race-deleted"
+        _write_session_context(home, lead_sid, pdir, team)
+        # T-A: blocks=[T-X] but T-X.json was deleted (no file on disk).
+        _write_task(
+            home, team, "TR",
+            status="completed", owner="backend-coder", blocks=["TX"],
+        )
+        # Deliberately do NOT write TX.
+
+        _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid,
+                "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "TR",
+                "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        events = _read_journal_events(
+            home, pdir, lead_sid, event_type="teardown_request",
+        )
+        assert len(events) == 1, (
+            f"Race-deleted continuation must emit (predicate fail-"
+            f"closed); got {events!r}. If empty, the predicate is "
+            f"fail-open on missing continuations — silent Teardown "
+            f"suppression is the worse failure mode."
+        )
+
+    @pytest.mark.parametrize(
+        "continuation_predicate_returns,expected_emit",
+        [
+            (True, False),    # predicate True → defer → no event emitted
+            (False, True),    # predicate False → no defer → event emitted
+        ],
+        ids=["predicate_true_defers", "predicate_false_emits"],
+    )
+    def test_gate4_predicate_drives_decision(
+        self, tmp_path, monkeypatch,
+        continuation_predicate_returns, expected_emit,
+    ):
+        """Bijection coverage on Gate 4: mock `has_same_teammate_
+        continuation` directly and pin the directive-emit decision to
+        the predicate's return value.
+
+        Phantom-green prevention: the count-gate (Gate 3) covers many
+        outcomes by itself; this test isolates Gate 4 as the causal
+        gate by mocking the predicate in-process and asserting the
+        outcome bijection.
+
+        Counter-test-by-revert: replace the `has_same_teammate_
+        continuation` call site in teardown_request_emitter.main()
+        with a constant False. Both parametrized cases produce
+        cardinality {1 fail, 1 pass}: the True-defer case flips to
+        emit (FAIL); the False-emit case is unchanged (still emits,
+        PASS). That asymmetry proves the call site itself is load-
+        bearing for the deferral semantic.
+        """
+        sys.path.insert(0, str(HOOK_DIR))
+        import teardown_request_emitter as emitter
+
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-gate4-mock-predicate"
+        _write_session_context(home, lead_sid, pdir, team)
+        # T-A completed; T-B may or may not exist — predicate is mocked
+        # so the on-disk state is irrelevant to the gate decision.
+        _write_task(
+            home, team, "TM",
+            status="completed", owner="backend-coder", blocks=["TM2"],
+        )
+
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", pdir)
+        # Replace `has_same_teammate_continuation` IN the emitter module
+        # (imported via `from ... import` so module-level rebind is
+        # the correct injection point).
+        monkeypatch.setattr(
+            emitter, "has_same_teammate_continuation",
+            lambda completed_task, team_name: continuation_predicate_returns,
+        )
+
+        # Patch sys.stdin + sys.exit to invoke main() in-process (subprocess
+        # would re-import the module and lose the monkeypatch).
+        stdin_payload = json.dumps({
+            "session_id": lead_sid,
+            "cwd": pdir,
+            "hook_event_name": "TaskCompleted",
+            "task_id": "TM",
+            "team_name": team,
+            "teammate_name": "backend-coder",
+        })
+
+        # Reset module-level pact_context cache between parametrized runs.
+        import shared.pact_context as ctx_module
+        monkeypatch.setattr(ctx_module, "_cache", None)
+        monkeypatch.setattr(ctx_module, "_context_path", None)
+
+        with patch("sys.stdin", io.StringIO(stdin_payload)):
+            with pytest.raises(SystemExit) as exc_info:
+                emitter.main()
+        assert exc_info.value.code == 0
+
+        events = _read_journal_events(
+            home, pdir, lead_sid, event_type="teardown_request",
+        )
+        if expected_emit:
+            assert len(events) == 1, (
+                f"predicate=False → Gate 4 must NOT defer → Tier-1 emits; "
+                f"got {events!r}. If empty, Gate 4 is fail-open or the "
+                f"predicate call site has been removed."
+            )
+        else:
+            assert events == [], (
+                f"predicate=True → Gate 4 MUST defer → no event; "
+                f"got {events!r}. If 1 event present, the predicate's "
+                f"gate was bypassed (call site removed or condition "
+                f"inverted)."
+            )
+
+
+# =============================================================================
+# TestJournalEventShape — what gets written on emission
+# =============================================================================
+
+
+class TestJournalEventShape:
+    """Pin the shape of the teardown_request event written by Tier-1.
+    Required + optional fields tier='1' and reason='lead_terminal_
+    taskupdate' must surface on disk so future Tier-2-vs-Tier-1
+    forensic comparisons can distinguish the two production paths.
+    """
+
+    def test_event_required_fields_populated(self, tmp_path):
+        """Emitted event has task_id and team_name matching the
+        TaskCompleted stdin payload. A producer that swaps these two
+        (or drops one) produces a falsifiable trace.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-event-shape-required"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(home, team, "T18", status="completed", owner="backend-coder")
+
+        _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid,
+                "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "T18",
+                "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        events = _read_journal_events(
+            home, pdir, lead_sid, event_type="teardown_request",
+        )
+        assert len(events) == 1
+        event = events[0]
+        assert event["task_id"] == "T18"
+        assert event["team_name"] == team
+
+    def test_event_tier_is_1(self, tmp_path):
+        """Tier-1 emits with tier='1' so a future Tier-2 emission for
+        the same task is distinguishable in the journal.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-event-shape-tier"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(home, team, "T19", status="completed", owner="backend-coder")
+
+        _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid,
+                "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "T19",
+                "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        events = _read_journal_events(
+            home, pdir, lead_sid, event_type="teardown_request",
+        )
+        assert len(events) == 1
+        assert events[0].get("tier") == "1", (
+            f"Tier-1 emission must carry tier='1'; got tier={events[0].get('tier')!r}"
+        )
+
+    def test_event_reason_is_lead_terminal_taskupdate(self, tmp_path):
+        """Tier-1 reason is the literal 'lead_terminal_taskupdate' —
+        the categorical token consumed by audit-log readers.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-event-shape-reason"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(home, team, "T20", status="completed", owner="backend-coder")
+
+        _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid,
+                "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "T20",
+                "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        events = _read_journal_events(
+            home, pdir, lead_sid, event_type="teardown_request",
+        )
+        assert len(events) == 1
+        assert events[0].get("reason") == "lead_terminal_taskupdate", (
+            f"Tier-1 reason must be 'lead_terminal_taskupdate'; "
+            f"got {events[0].get('reason')!r}"
+        )
+
+    def test_no_stdin_field_leaks_into_event(self, tmp_path):
+        """The emitted journal event MUST NOT carry stdin fields that
+        weren't explicitly forwarded (transcript_path, cwd,
+        task_description, task_subject, teammate_name,
+        hook_event_name). Mirrors agent_handoff_emitter.py discipline.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-event-no-leak"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(home, team, "T21", status="completed", owner="backend-coder")
+
+        _run_emitter_subprocess(
+            json.dumps({
+                **PLATFORM_TASKCOMPLETED_STDIN_SHAPE,
+                "session_id": lead_sid,
+                "cwd": pdir,
+                "task_id": "T21",
+                "team_name": team,
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        events = _read_journal_events(
+            home, pdir, lead_sid, event_type="teardown_request",
+        )
+        assert len(events) == 1
+        event = events[0]
+        for leaked_field in (
+            "transcript_path", "cwd", "task_description", "task_subject",
+            "teammate_name", "hook_event_name", "session_id",
+        ):
+            assert leaked_field not in event, (
+                f"stdin field {leaked_field!r} leaked into journal "
+                f"event — emitter forwarded too much data."
+            )
+
+
+# =============================================================================
+# TestExitContract — every path exits 0 with valid stdout
+# =============================================================================
+
+
+class TestExitContract:
+    """Per CLAUDE.md livelock-safety pin: every code path in a hook
+    must exit 0. Nonzero exit produces hook-error UI surface in
+    Claude Code; on TaskCompleted/Stop hooks this triggers the
+    livelock-capable failure class (error every fire until owner
+    task resolves).
+    """
+
+    def test_all_gate_failure_paths_exit_zero(self, tmp_path):
+        """Every Gate-0..Gate-4 short-circuit path exits 0 with
+        suppressOutput stdout. Parametric coverage over the 5 gates.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+
+        # Gate 0: teammate-session fire
+        team_0 = "team-exit-gate0"
+        _write_session_context(
+            home, "teammate-sid", pdir, team_0,
+            lead_session_id=lead_sid,
+            members=[
+                {"name": "backend-coder", "agentId": "agent-bc"},
+                {"name": "lead", "agentId": "agent-lead"},
+            ],
+            lead_agent_id="agent-lead",
+        )
+        _write_task(home, team_0, "G0", status="completed", owner="backend-coder")
+        rc0, out0, _ = _run_emitter_subprocess(
+            json.dumps({
+                "session_id": "teammate-sid", "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "G0", "team_name": team_0,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        assert rc0 == 0
+        assert json.loads(out0).get("suppressOutput") is True
+
+        # Gate 1: no hook_event_name + in_progress disk status
+        team_1 = "team-exit-gate1"
+        _write_session_context(home, lead_sid, pdir, team_1)
+        _write_task(home, team_1, "G1", status="in_progress", owner="backend-coder")
+        rc1, out1, _ = _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid, "cwd": pdir,
+                "task_id": "G1", "team_name": team_1,
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        assert rc1 == 0
+        assert json.loads(out1).get("suppressOutput") is True
+
+        # Gate 2: pre-existing marker
+        team_2 = "team-exit-gate2"
+        _write_session_context(home, lead_sid, pdir, team_2)
+        _write_task(home, team_2, "G2", status="completed", owner="backend-coder")
+        marker_dir = _marker_dir(home, team_2)
+        marker_dir.mkdir(parents=True, exist_ok=True)
+        (marker_dir / "G2").touch()
+        rc2, out2, _ = _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid, "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "G2", "team_name": team_2,
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        assert rc2 == 0
+        assert json.loads(out2).get("suppressOutput") is True
+
+        # Gate 3: another in_progress task
+        team_3 = "team-exit-gate3"
+        _write_session_context(
+            home, lead_sid, pdir, team_3,
+            members=[
+                {"name": "backend-coder", "agentId": "agent-bc"},
+                {"name": "test-engineer", "agentId": "agent-te"},
+                {"name": "lead", "agentId": "agent-lead"},
+            ],
+            lead_agent_id="agent-lead",
+        )
+        _write_task(home, team_3, "G3", status="completed", owner="backend-coder")
+        _write_task(home, team_3, "G3b", status="in_progress", owner="test-engineer")
+        rc3, out3, _ = _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid, "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "G3", "team_name": team_3,
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        assert rc3 == 0
+        assert json.loads(out3).get("suppressOutput") is True
+
+        # Gate 4: same-teammate continuation
+        team_4 = "team-exit-gate4"
+        _write_session_context(home, lead_sid, pdir, team_4)
+        _write_task(
+            home, team_4, "G4",
+            status="completed", owner="backend-coder", blocks=["G4b"],
+        )
+        _write_task(
+            home, team_4, "G4b",
+            status="pending", owner="backend-coder",
+        )
+        rc4, out4, _ = _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid, "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "G4", "team_name": team_4,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        assert rc4 == 0
+        assert json.loads(out4).get("suppressOutput") is True
+
+    def test_emit_path_exits_zero(self, tmp_path):
+        """Successful emission also exits 0 with hookSpecificOutput in
+        stdout (not just suppressOutput). additionalContext carries the
+        _TEARDOWN_DIRECTIVE prose for the lead's next turn.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-exit-emit"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(home, team, "T22", status="completed", owner="backend-coder")
+
+        rc, out, _ = _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid, "cwd": pdir,
+                "hook_event_name": "TaskCompleted",
+                "task_id": "T22", "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        assert rc == 0
+        parsed = json.loads(out)
+        # Emission path produces hookSpecificOutput with the Teardown
+        # directive in additionalContext.
+        hso = parsed.get("hookSpecificOutput")
+        assert hso is not None, (
+            f"Emit path must produce hookSpecificOutput; got {parsed!r}"
+        )
+        assert hso.get("hookEventName") == "TaskCompleted"
+        assert "PACT:stop-pending-scan" in hso.get("additionalContext", ""), (
+            f"additionalContext must invoke stop-pending-scan; got {hso!r}"
+        )
+
+    def test_malformed_stdin_exits_zero(self, tmp_path):
+        """A non-JSON stdin payload exits 0 with suppressOutput.
+        Critical for livelock-safety — a corrupted hook fire must
+        NOT crash the hook.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        rc, out, _ = _run_emitter_subprocess(
+            b"{ this is not json ",
+            env_extra={"HOME": str(home)},
+        )
+        assert rc == 0, "Malformed stdin must NOT produce nonzero exit"
+        # stdout must be parseable JSON with suppressOutput (or empty
+        # falling back to suppress).
+        if out.strip():
+            parsed = json.loads(out)
+            assert parsed.get("suppressOutput") is True
+
+    def test_non_dict_stdin_exits_zero(self, tmp_path):
+        """A JSON-array or JSON-string stdin (well-formed JSON but
+        wrong shape) exits 0. Defense against future platform
+        changes that might deliver array-wrapped payloads.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        for bad in (b"[]", b'"a string"', b"42", b"null"):
+            rc, out, _ = _run_emitter_subprocess(
+                bad,
+                env_extra={"HOME": str(home)},
+            )
+            assert rc == 0, (
+                f"Non-dict stdin {bad!r} must exit 0; got rc={rc}"
+            )

--- a/pact-plugin/tests/test_teardown_request_emitter.py
+++ b/pact-plugin/tests/test_teardown_request_emitter.py
@@ -1396,3 +1396,60 @@ class TestExitContract:
             assert rc == 0, (
                 f"Non-dict stdin {bad!r} must exit 0; got rc={rc}"
             )
+
+
+# =============================================================================
+# TestStatusDeletedTier1 — disk-fallback accepts both terminal statuses
+# =============================================================================
+
+
+class TestStatusDeletedTier1:
+    """Gate 1 disk-fallback must accept BOTH terminal statuses
+    ("completed", "deleted") symmetric with the retired PostToolUse
+    Teardown branch's _TERMINAL_STATUSES set. Lead-driven
+    TaskUpdate(status="deleted") on a 1->0 transition does not produce
+    a TaskCompleted platform hook event, so the disk-fallback is the
+    only Tier-1 path that can fire for the delete case (Tier-2's
+    teammate-Teardown producer also misses it via lead-session early-
+    return). Without "deleted" in the fallback set the deletion path
+    drops the Teardown directive entirely.
+
+    Counter-test-by-revert: narrowing the disk-fallback back to
+    `status == "completed"` only flips this test RED.
+    """
+
+    def test_status_deleted_lead_driven_emits_teardown_request(
+        self, tmp_path,
+    ):
+        """Lead-driven TaskUpdate(status="deleted") on a 1->0 transition
+        with no TaskCompleted platform event proceeds through the disk-
+        fallback and emits a Tier-1 teardown_request event.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-f1-deleted-fallback"
+        _write_session_context(home, lead_sid, pdir, team)
+        # Task on disk shows the terminal status "deleted".
+        _write_task(home, team, "D1", status="deleted", owner="backend-coder")
+
+        rc, out, err = _run_emitter_subprocess(
+            json.dumps({
+                "session_id": lead_sid,
+                "cwd": pdir,
+                # No hook_event_name — exercise the disk-status fallback.
+                "task_id": "D1",
+                "team_name": team,
+                "teammate_name": "backend-coder",
+            }),
+            env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        )
+        assert rc == 0, f"hook must exit 0; stderr={err}"
+        events = _read_journal_events(
+            home, pdir, lead_sid, event_type="teardown_request",
+        )
+        assert len(events) == 1, (
+            f"Disk-fallback path: deleted disk-status must proceed to "
+            f"emit (symmetric with completed); got events={events!r}, "
+            f"stdout={out!r}"
+        )

--- a/pact-plugin/tests/test_wake_inbox_drain.py
+++ b/pact-plugin/tests/test_wake_inbox_drain.py
@@ -1054,3 +1054,461 @@ def test_outer_guard_catches_arbitrary_exception(tmp_path, exception_class):
         f"producer-side except block; re-narrow the except clause "
         f"to (ImportError, AttributeError, TypeError) regression."
     )
+
+
+# =============================================================================
+# C0 consumer side + C4 type-aware dispatch tests for #763
+# =============================================================================
+#
+# C0 (consumer): _drain_markers handles per-type accounting. Pre-C0
+# markers (no `type` field) default to "arm" for backward-compat.
+# Corrupt or unknown-type markers also default to "arm" (fail-
+# conservative — produce a wake signal even on a malformed marker).
+#
+# C4 (dispatch): _decide_and_emit routes type="teardown" markers to
+# _emit_teardown (which prints the _TEARDOWN_DIRECTIVE additionalContext)
+# AND writes a teardown_request journal event with tier="2", reason=
+# "wake_inbox_drained". When both arm + teardown markers drain in one
+# fire, teardown takes precedence (it reflects the most recent
+# completion-authority state).
+#
+# Counter-test-by-revert for C4 dispatch: removing the `type` field
+# read from _drain_markers flips test_drain_dispatch_on_type_field
+# results (all markers route to _emit_arm, even type="teardown" ones).
+
+
+class TestArmMarkerTypeFieldBackwardCompat:
+    """C0 consumer side: pre-C0 markers (no `type` field) drain as arm.
+    Corrupt JSON markers and unknown-type markers ALSO drain as arm
+    (fail-conservative). The default is the architecture's hinge:
+    legacy markers on disk during the upgrade window must not be lost.
+    """
+
+    def test_drain_marker_without_type_field_treated_as_arm(self, tmp_path):
+        """A marker without a `type` field (pre-C0 shape) drains as
+        an arm signal — wake_inbox_drain emits _ARM_DIRECTIVE.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-c0-bw-no-type"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_marker(
+            home, team, "20260516T160000Z-x-T1.json",
+            {
+                # Pre-C0 marker shape — no `type` field.
+                "schema_version": 1,
+                "trigger": "teammate_self_claim_in_progress",
+                "tool_name": "TaskUpdate",
+                "task_id": "T1",
+                "owner": "backend-coder",
+            },
+        )
+
+        out = _drain_out({
+            "session_id": lead_sid, "cwd": pdir,
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "go",
+        }, home)
+        hso = out.get("hookSpecificOutput")
+        assert hso is not None, (
+            f"Pre-C0 marker must drain as arm; got {out!r}"
+        )
+        assert "PACT:start-pending-scan" in hso.get("additionalContext", ""), (
+            f"Drain output must invoke start-pending-scan (arm); got {hso!r}"
+        )
+
+    def test_drain_marker_with_unknown_type_treated_as_arm(self, tmp_path):
+        """Unknown `type` tokens (e.g. "purple", "halt") drain as arm.
+        Fail-conservative dispatch — producing a wake signal on an
+        unexpected token is safer than dropping it (the operator can
+        always re-run /PACT:stop-pending-scan if the cron is already
+        retired).
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-c0-bw-unknown-type"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_marker(
+            home, team, "20260516T160100Z-x-T2.json",
+            {
+                "schema_version": 1, "type": "purple_unknown_token",
+                "trigger": "teammate_self_claim_in_progress",
+                "tool_name": "TaskUpdate", "task_id": "T2",
+                "owner": "backend-coder",
+            },
+        )
+
+        out = _drain_out({
+            "session_id": lead_sid, "cwd": pdir,
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "go",
+        }, home)
+        hso = out.get("hookSpecificOutput")
+        assert hso is not None, (
+            f"Unknown-type marker must drain (fail-conservative arm); "
+            f"got {out!r}"
+        )
+        assert "PACT:start-pending-scan" in hso.get("additionalContext", ""), (
+            f"Drain output must default to arm on unknown type; got {hso!r}"
+        )
+
+
+class TestDrainDispatchOnTypeField:
+    """C4 dispatch: _drain_markers returns per-type count dict;
+    _decide_and_emit routes based on the type token. Arm markers go to
+    _emit_arm (existing behavior); Teardown markers go to _emit_teardown
+    (new) and write a teardown_request journal event.
+    """
+
+    def test_arm_marker_routes_to_emit_arm(self, tmp_path):
+        """A type="arm" marker drains via the arm path — output
+        contains _ARM_DIRECTIVE prose (start-pending-scan).
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-c4-arm-routes"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_marker(
+            home, team, "20260516T160200Z-x-T3.json",
+            {
+                "schema_version": 1, "type": "arm",
+                "trigger": "teammate_self_claim_in_progress",
+                "tool_name": "TaskUpdate", "task_id": "T3",
+                "owner": "backend-coder",
+            },
+        )
+
+        out = _drain_out({
+            "session_id": lead_sid, "cwd": pdir,
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "go",
+        }, home)
+        hso = out.get("hookSpecificOutput")
+        assert hso is not None
+        assert "PACT:start-pending-scan" in hso.get("additionalContext", "")
+        assert "PACT:stop-pending-scan" not in hso.get("additionalContext", "")
+
+    def test_teardown_marker_routes_to_emit_teardown(self, tmp_path):
+        """A type="teardown" marker drains via the teardown path —
+        output contains _TEARDOWN_DIRECTIVE prose (stop-pending-scan).
+        This is the C4 net-new dispatch branch.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-c4-teardown-routes"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_marker(
+            home, team, "20260516T160300Z-x-T4.json",
+            {
+                "schema_version": 1, "type": "teardown",
+                "task_id": "T4",
+                "team_name": team,
+                "owner": "secretary",
+                "timestamp_ms": 1715792180000,
+                "trigger": "self_complete_exempt_or_stop_sweep",
+            },
+        )
+
+        out = _drain_out({
+            "session_id": lead_sid, "cwd": pdir,
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "go",
+        }, home)
+        hso = out.get("hookSpecificOutput")
+        assert hso is not None, (
+            f"Teardown marker must produce hookSpecificOutput; got {out!r}"
+        )
+        assert "PACT:stop-pending-scan" in hso.get("additionalContext", ""), (
+            f"Drain must emit Teardown directive; got {hso!r}"
+        )
+        assert "PACT:start-pending-scan" not in hso.get("additionalContext", ""), (
+            f"Teardown path must NOT emit Arm prose; got {hso!r}"
+        )
+
+    def test_drain_consumes_teardown_marker_file(self, tmp_path):
+        """The teardown marker file is unlinked from wake_inbox after
+        drain. The disk must reflect successful consumption.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-c4-teardown-consumed"
+        _write_session_context(home, lead_sid, pdir, team)
+        marker_path = _write_marker(
+            home, team, "20260516T160400Z-x-T5.json",
+            {
+                "schema_version": 1, "type": "teardown",
+                "task_id": "T5",
+                "team_name": team,
+                "owner": "secretary",
+                "timestamp_ms": 1715792240000,
+                "trigger": "self_complete_exempt_or_stop_sweep",
+            },
+        )
+
+        _drain_out({
+            "session_id": lead_sid, "cwd": pdir,
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "go",
+        }, home)
+        assert not marker_path.exists(), (
+            "Teardown marker must be unlinked after drain"
+        )
+
+
+class TestTeardownDrainEmitsJournalEvent:
+    """C4 journal-write: when a teardown marker drains, a
+    teardown_request event is written to the journal with tier="2",
+    reason="wake_inbox_drained". The event is the falsifiable trace
+    that Tier-4 cron staleness can replay from.
+    """
+
+    def test_single_teardown_marker_writes_one_event(self, tmp_path):
+        """One teardown marker drains -> one teardown_request event in
+        the journal with tier="2" reason="wake_inbox_drained".
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-c4-journal-single"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_marker(
+            home, team, "20260516T160500Z-x-T6.json",
+            {
+                "schema_version": 1, "type": "teardown",
+                "task_id": "T6",
+                "team_name": team,
+                "owner": "secretary",
+                "timestamp_ms": 1715792300000,
+                "trigger": "self_complete_exempt_or_stop_sweep",
+            },
+        )
+
+        _drain_out({
+            "session_id": lead_sid, "cwd": pdir,
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "go",
+        }, home)
+
+        # Read the journal for the lead's session.
+        slug = Path(pdir).name
+        journal = (
+            home / ".claude" / "pact-sessions" / slug / lead_sid
+            / "session-journal.jsonl"
+        )
+        assert journal.exists(), "Journal file must be created on drain"
+        teardown_events = [
+            json.loads(line)
+            for line in journal.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+            and json.loads(line).get("type") == "teardown_request"
+        ]
+        assert len(teardown_events) == 1, (
+            f"Single teardown drain must write exactly 1 event; "
+            f"got {teardown_events!r}"
+        )
+        ev = teardown_events[0]
+        assert ev.get("tier") == "2", (
+            f"Tier-2 emission must carry tier='2'; got tier={ev.get('tier')!r}"
+        )
+        assert ev.get("reason") == "wake_inbox_drained", (
+            f"Tier-2 reason must be 'wake_inbox_drained'; "
+            f"got {ev.get('reason')!r}"
+        )
+
+    def test_multiple_teardown_markers_same_drain_writes_one_event(
+        self, tmp_path,
+    ):
+        """Stop-sweep secondary firings may produce N markers per
+        drain pass (one per re-entrant TaskCompleted fire in a teammate
+        session). The journal event is written ONCE per drain to
+        avoid N-fold pollution.
+
+        Pins architect refinement Q1 resolution (per teachback
+        coordination with backend-coder-1).
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-c4-journal-multi"
+        _write_session_context(home, lead_sid, pdir, team)
+        for idx, task_id in enumerate(["T7a", "T7b", "T7c"]):
+            _write_marker(
+                home, team,
+                f"20260516T16060{idx}Z-x-{task_id}.json",
+                {
+                    "schema_version": 1, "type": "teardown",
+                    "task_id": task_id,
+                    "team_name": team,
+                    "owner": "secretary",
+                    "timestamp_ms": 1715792400000 + idx,
+                    "trigger": "self_complete_exempt_or_stop_sweep",
+                },
+            )
+
+        _drain_out({
+            "session_id": lead_sid, "cwd": pdir,
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "go",
+        }, home)
+
+        slug = Path(pdir).name
+        journal = (
+            home / ".claude" / "pact-sessions" / slug / lead_sid
+            / "session-journal.jsonl"
+        )
+        teardown_events = [
+            json.loads(line)
+            for line in journal.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+            and json.loads(line).get("type") == "teardown_request"
+        ]
+        assert len(teardown_events) == 1, (
+            f"Multiple teardown markers in same drain must produce "
+            f"exactly 1 journal event (ONE-per-drain cardinality per "
+            f"architect Q1 resolution); got {len(teardown_events)}: "
+            f"{teardown_events!r}"
+        )
+
+    def test_event_team_name_matches_drain_team(self, tmp_path):
+        """The journal event's team_name matches the lead's team —
+        not the team_name field FROM the marker (which could be
+        spoofed). Pins the producer-side authority chain.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-c4-journal-team-name"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_marker(
+            home, team, "20260516T160700Z-x-T8.json",
+            {
+                "schema_version": 1, "type": "teardown",
+                "task_id": "T8",
+                "team_name": team,
+                "owner": "secretary",
+                "timestamp_ms": 1715792500000,
+                "trigger": "self_complete_exempt_or_stop_sweep",
+            },
+        )
+
+        _drain_out({
+            "session_id": lead_sid, "cwd": pdir,
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "go",
+        }, home)
+
+        slug = Path(pdir).name
+        journal = (
+            home / ".claude" / "pact-sessions" / slug / lead_sid
+            / "session-journal.jsonl"
+        )
+        events = [
+            json.loads(line)
+            for line in journal.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+            and json.loads(line).get("type") == "teardown_request"
+        ]
+        assert len(events) == 1
+        assert events[0].get("team_name") == team
+
+
+class TestMixedArmTeardownDrain:
+    """C4 precedence rule: when a drain consumes BOTH arm and teardown
+    markers in the same UserPromptSubmit, teardown takes precedence.
+    The teardown reflects the most recent completion-authority state.
+    """
+
+    def test_both_marker_types_drained_teardown_takes_precedence(
+        self, tmp_path,
+    ):
+        """Drain has both arm + teardown markers; the emitted directive
+        is Teardown (stop-pending-scan), NOT Arm (start-pending-scan).
+        The cron should be retired, not armed.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-c4-mixed-precedence"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_marker(
+            home, team, "20260516T160800Z-x-T9a.json",
+            {
+                "schema_version": 1, "type": "arm",
+                "trigger": "teammate_self_claim_in_progress",
+                "tool_name": "TaskUpdate", "task_id": "T9a",
+                "owner": "backend-coder",
+            },
+        )
+        _write_marker(
+            home, team, "20260516T160801Z-x-T9b.json",
+            {
+                "schema_version": 1, "type": "teardown",
+                "task_id": "T9b",
+                "team_name": team,
+                "owner": "secretary",
+                "timestamp_ms": 1715792500000,
+                "trigger": "self_complete_exempt_or_stop_sweep",
+            },
+        )
+
+        out = _drain_out({
+            "session_id": lead_sid, "cwd": pdir,
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "go",
+        }, home)
+        hso = out.get("hookSpecificOutput")
+        assert hso is not None
+        ac = hso.get("additionalContext", "")
+        assert "PACT:stop-pending-scan" in ac, (
+            f"Mixed drain: teardown must take precedence; got {hso!r}"
+        )
+        # Arm prose must NOT appear in the same output — single-emit
+        # discipline preserved.
+        assert "PACT:start-pending-scan" not in ac, (
+            f"Mixed drain: Arm must NOT also emit; got {hso!r}"
+        )
+
+    def test_both_marker_files_consumed(self, tmp_path):
+        """Mixed-drain consumes ALL markers, not just the teardown one.
+        Leaving arm markers on disk would re-fire on the next prompt
+        and confuse the lifecycle.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-c4-mixed-consume"
+        _write_session_context(home, lead_sid, pdir, team)
+        arm_marker = _write_marker(
+            home, team, "20260516T160900Z-x-Aa.json",
+            {
+                "schema_version": 1, "type": "arm",
+                "trigger": "teammate_self_claim_in_progress",
+                "tool_name": "TaskUpdate", "task_id": "Aa",
+                "owner": "backend-coder",
+            },
+        )
+        teardown_marker = _write_marker(
+            home, team, "20260516T160901Z-x-Tb.json",
+            {
+                "schema_version": 1, "type": "teardown",
+                "task_id": "Tb",
+                "team_name": team,
+                "owner": "secretary",
+                "timestamp_ms": 1715792600000,
+                "trigger": "self_complete_exempt_or_stop_sweep",
+            },
+        )
+
+        _drain_out({
+            "session_id": lead_sid, "cwd": pdir,
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "go",
+        }, home)
+        assert not arm_marker.exists(), "Arm marker must be drained"
+        assert not teardown_marker.exists(), "Teardown marker must be drained"
+

--- a/pact-plugin/tests/test_wake_inbox_drain.py
+++ b/pact-plugin/tests/test_wake_inbox_drain.py
@@ -1512,3 +1512,170 @@ class TestMixedArmTeardownDrain:
         assert not arm_marker.exists(), "Arm marker must be drained"
         assert not teardown_marker.exists(), "Teardown marker must be drained"
 
+
+class TestArmTeardownRaceDisambiguation:
+    """Same-prompt arm+teardown disambiguation. When BOTH marker kinds
+    drain together AND the team still has lifecycle-relevant work on
+    disk (count_active_tasks > 0), the teardown marker is STALER than
+    the arm and the directive emitted MUST be Arm, not Teardown.
+
+    Concrete race the disambiguation defends against: teammate Y
+    completes terminal task Z (writes teardown marker when count was
+    0); teammate X then claims a new task A (writes arm marker); lead
+    UserPromptSubmit drains both in one pass. Without this guard the
+    lead is told to tear down cron while task A is active.
+
+    Counter-test-by-revert: removing the `count_active_tasks(...) > 0`
+    check in `_decide_and_emit` flips this test RED (teardown wins
+    instead of arm).
+    """
+
+    def test_same_prompt_arm_plus_teardown_emits_arm_when_count_nonzero(
+        self, tmp_path,
+    ):
+        """Mixed drain + active task on disk → emit ARM (cron stays
+        armed). The stale teardown marker yields to the fresh arm
+        marker because the team is still active.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-f2-race-disambiguation"
+        teammate_owner = "backend-coder"
+        _write_session_context(
+            home, lead_sid, pdir, team,
+            members=[
+                {"name": teammate_owner, "agentId": "agent-bc"},
+                {"name": "lead", "agentId": "agent-lead"},
+            ],
+            lead_agent_id="agent-lead",
+        )
+        # Active lifecycle-relevant task on disk — the team is NOT idle
+        # despite the stale teardown marker.
+        _write_task(
+            home, team, "A_active",
+            status="in_progress", owner=teammate_owner,
+        )
+        # Stale teardown marker (written when count was 0, before the
+        # arm marker landed for the new task).
+        teardown_marker = _write_marker(
+            home, team, "20260516T160600Z-x-Z_stale.json",
+            {
+                "schema_version": 1, "type": "teardown",
+                "task_id": "Z_stale",
+                "team_name": team,
+                "owner": "secretary",
+                "timestamp_ms": 1715792300000,
+                "trigger": "self_complete_exempt_or_stop_sweep",
+            },
+        )
+        # Fresh arm marker (written when teammate X claimed task
+        # A_active).
+        arm_marker = _write_marker(
+            home, team, "20260516T160700Z-x-A_active.json",
+            {
+                "schema_version": 1, "type": "arm",
+                "trigger": "teammate_self_claim_in_progress",
+                "tool_name": "TaskUpdate", "task_id": "A_active",
+                "owner": teammate_owner,
+            },
+        )
+
+        out = _drain_out({
+            "session_id": lead_sid, "cwd": pdir,
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "go",
+        }, home)
+        hso = out.get("hookSpecificOutput")
+        assert hso is not None, (
+            f"Mixed drain with active tasks must emit a directive; "
+            f"got {out!r}"
+        )
+        ac = hso.get("additionalContext", "")
+        assert "PACT:start-pending-scan" in ac, (
+            f"Mixed drain + count>0 must emit ARM (cron stays armed); "
+            f"got additionalContext={ac!r}"
+        )
+        # The stale teardown signal must NOT win the dispatch.
+        assert "PACT:stop-pending-scan" not in ac, (
+            f"Mixed drain + count>0 must NOT emit Teardown — "
+            f"the stale teardown marker yields to the fresh arm; "
+            f"got additionalContext={ac!r}"
+        )
+        # Both markers still get consumed (cleanup invariant preserved
+        # from the existing mixed-drain test).
+        assert not teardown_marker.exists(), (
+            "Stale teardown marker must be drained even when arm wins"
+        )
+        assert not arm_marker.exists(), (
+            "Arm marker must be drained on the emit path"
+        )
+
+
+class TestMalformedTeardownMarkerDemotedToArm:
+    """Defensive classifier: a marker with `type="teardown"` but no
+    valid `task_id` field cannot participate in the Tier-1/Tier-2
+    dedup invariant (which keys on task_id). The classifier demotes
+    such malformed markers to "arm" so the wake intent still stands
+    via the safe fail-conservative default — emit Arm via the existing
+    path, not Teardown via a dedup-bypassing fallback.
+
+    Counter-test-by-revert: removing the demote-to-arm branch in
+    `_drain_markers` flips this test RED — the marker would then
+    count as teardown and trigger _emit_teardown() without going
+    through `_already_emitted_teardown`.
+    """
+
+    def test_teardown_marker_missing_task_id_emits_arm_not_teardown(
+        self, tmp_path,
+    ):
+        """A solitary `type="teardown"` marker with NO task_id field
+        is classified as a wake signal (Arm) — NOT a Teardown — so the
+        directive emitted is start-pending-scan, not stop-pending-scan.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        pdir = "/tmp/p"
+        team = "team-f3-malformed-teardown"
+        _write_session_context(home, lead_sid, pdir, team)
+        # Marker says "teardown" but task_id is absent — malformed
+        # producer or schema drift.
+        malformed = _write_marker(
+            home, team, "20260516T161000Z-x-noid.json",
+            {
+                "schema_version": 1, "type": "teardown",
+                # task_id intentionally omitted.
+                "team_name": team,
+                "owner": "secretary",
+                "timestamp_ms": 1715792700000,
+                "trigger": "self_complete_exempt_or_stop_sweep",
+            },
+        )
+
+        out = _drain_out({
+            "session_id": lead_sid, "cwd": pdir,
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "go",
+        }, home)
+        hso = out.get("hookSpecificOutput")
+        assert hso is not None, (
+            f"Malformed teardown marker must still emit a wake signal; "
+            f"got {out!r}"
+        )
+        ac = hso.get("additionalContext", "")
+        # Malformed → demoted to arm → Arm directive emitted.
+        assert "PACT:start-pending-scan" in ac, (
+            f"Malformed teardown marker must demote to Arm directive; "
+            f"got additionalContext={ac!r}"
+        )
+        # And MUST NOT emit Teardown — that would bypass the
+        # Tier-1/Tier-2 dedup invariant.
+        assert "PACT:stop-pending-scan" not in ac, (
+            f"Malformed teardown marker must NOT emit Teardown "
+            f"(dedup invariant bypass); got additionalContext={ac!r}"
+        )
+        # Marker is consumed regardless of classification.
+        assert not malformed.exists(), (
+            "Malformed marker must be drained"
+        )
+

--- a/pact-plugin/tests/test_wake_lifecycle_arm_starvation.py
+++ b/pact-plugin/tests/test_wake_lifecycle_arm_starvation.py
@@ -307,34 +307,6 @@ def test_lead_session_arm_still_fires_on_taskupdate_in_progress(tmp_path):
     assert 'Skill("PACT:start-pending-scan")' in hso["additionalContext"]
 
 
-def test_lead_session_teardown_still_fires_on_terminal_status(tmp_path):
-    """Test 6 — Teardown lead-only gate preserved (#737 Layer 0). Lead-
-    session TaskUpdate(status=completed) with count=0 emits Teardown.
-    """
-    home = tmp_path / "home"; home.mkdir()
-    sid = "lead-sid"
-    pdir = "/tmp/p"
-    team = "team-lead-teardown"
-    _write_session_context(home, sid, pdir, team)
-    # Task on disk reflects post-state (completed) so count == 0.
-    _write_task(home, team, "Z", status="completed", owner="backend-coder")
-
-    out = _emit_output({
-        "tool_name": "TaskUpdate",
-        "session_id": sid, "cwd": pdir,
-        "tool_input": {"taskId": "Z", "status": "completed"},
-        "tool_response": {
-            "id": "Z", "status": "completed", "owner": "backend-coder",
-        },
-    }, home)
-    hso = out.get("hookSpecificOutput")
-    assert hso is not None, (
-        f"Lead-session terminal TaskUpdate must emit Teardown; got {out!r}"
-    )
-    assert hso["hookEventName"] == "PostToolUse"
-    assert 'Skill("PACT:stop-pending-scan")' in hso["additionalContext"]
-
-
 def test_teammate_terminal_status_no_marker_and_no_directive(tmp_path):
     """Test 7 — Teammate-side Teardown still suppressed by lead-session
     early-return; pre-branch's clause-3 also rejects terminal-status

--- a/pact-plugin/tests/test_wake_lifecycle_arm_starvation.py
+++ b/pact-plugin/tests/test_wake_lifecycle_arm_starvation.py
@@ -307,6 +307,18 @@ def test_lead_session_arm_still_fires_on_taskupdate_in_progress(tmp_path):
     assert 'Skill("PACT:start-pending-scan")' in hso["additionalContext"]
 
 
+# Migrated post-#763 C5 retirement:
+#   - test_lead_session_teardown_still_fires_on_terminal_status →
+#     test_teardown_request_emitter.py::TestGate3ActiveTaskCountTransition
+#     ::test_count_zero_proceeds (Tier-1 emits on lead-driven completion
+#     1->0 transition) + test_native_hooks_integration.py::
+#     TestLeadDrivenCompletionFiresTier1Only::test_lead_terminal_taskupdate
+#     _emits_tier1_event (cross-tier integration coverage).
+#   The retired PostToolUse Teardown branch fired in wake_lifecycle_emitter;
+#   post-C5 Teardown emission moved to teardown_request_emitter on the
+#   native TaskCompleted hook.
+
+
 def test_teammate_terminal_status_no_marker_and_no_directive(tmp_path):
     """Test 7 — Teammate-side Teardown still suppressed by lead-session
     early-return; pre-branch's clause-3 also rejects terminal-status

--- a/pact-plugin/tests/test_wake_lifecycle_bug_a_defer_teardown.py
+++ b/pact-plugin/tests/test_wake_lifecycle_bug_a_defer_teardown.py
@@ -306,70 +306,13 @@ class TestBugATeardownDeferralOnSameTeammateContinuation:
             f"inverted in lockstep."
         )
 
-    def test_no_defer_on_different_owner_continuation(self, tmp_path):
-        """Negative pair: Task A's addBlocks includes Task B owned by a
-        DIFFERENT teammate. Predicate returns False → Teardown emits if
-        count==0. Pins that the same-owner discriminator is load-bearing
-        (an over-permissive predicate that defers on any addBlocks chain
-        would silently suppress legitimate Teardowns)."""
-        home = tmp_path / "home"; home.mkdir()
-        sid = "s"; pdir = "/tmp/p"; team = "team-diff-owner"
-        _write_session_context(home, sid, pdir, team)
-        # Task B: DIFFERENT teammate.
-        _write_task(home, team, "B", status="completed", owner="test-engineer")
-        # Task A: backend-coder, completed, addBlocks=['B']. Note B is
-        # also completed → count_active_tasks == 0.
-        _write_task(
-            home, team, "A",
-            status="completed",
-            owner="backend-coder",
-            addBlocks=["B"],
-        )
-
-        out = _emit_output({
-            "tool_name": "TaskUpdate",
-            "session_id": sid, "cwd": pdir,
-            "tool_input": {"taskId": "A", "status": "completed"},
-            "tool_response": {
-                "id": "A", "status": "completed",
-                "owner": "backend-coder",
-            },
-        }, home)
-        hso = out.get("hookSpecificOutput")
-        assert hso is not None, (
-            f"Expected Teardown emit when continuation owner differs; "
-            f"got {out!r}."
-        )
-        assert "Skill(\"PACT:stop-pending-scan\")" in hso["additionalContext"]
-
-    def test_no_defer_on_empty_addBlocks(self, tmp_path):
-        """Negative pair: standalone single-task dispatch (no addBlocks).
-        Predicate returns False → Teardown emits if count==0."""
-        home = tmp_path / "home"; home.mkdir()
-        sid = "s"; pdir = "/tmp/p"; team = "team-empty-blocks"
-        _write_session_context(home, sid, pdir, team)
-        _write_task(
-            home, team, "A",
-            status="completed",
-            owner="backend-coder",
-            addBlocks=[],
-        )
-
-        out = _emit_output({
-            "tool_name": "TaskUpdate",
-            "session_id": sid, "cwd": pdir,
-            "tool_input": {"taskId": "A", "status": "completed"},
-            "tool_response": {
-                "id": "A", "status": "completed",
-                "owner": "backend-coder",
-            },
-        }, home)
-        hso = out.get("hookSpecificOutput")
-        assert hso is not None, (
-            f"Expected Teardown emit on standalone task completion; "
-            f"got {out!r}."
-        )
-        assert "Skill(\"PACT:stop-pending-scan\")" in hso["additionalContext"]
+# Migrated post-#763 C5 retirement:
+#   - test_no_defer_on_different_owner_continuation →
+#     test_teardown_request_emitter.py::TestGate4SameTeammateContinuationDeferral
+#     ::test_different_owner_continuation_proceeds
+#   - test_no_defer_on_empty_addBlocks →
+#     test_teardown_request_emitter.py::TestGate4SameTeammateContinuationDeferral
+#     ::test_no_continuation_proceeds
 
 
 # ---------- Defer-Teardown branch isolation (count==0 + predicate==True) ----------
@@ -474,128 +417,13 @@ def test_defer_teardown_branch_isolated_at_post_zero(tmp_path):
 # ---------- P2.1(b) Race-deleted continuation ----------
 
 
-def test_defer_predicate_handles_race_deleted_continuation(tmp_path):
-    """P2.1(b) integration: addBlocks references a task ID that was
-    deleted out from under the predicate (race condition). Predicate
-    fail-closes (returns False) → Teardown emits if count==0. Pins
-    the conservative behavior — fail-open here would silently suppress
-    legitimate Teardowns on a race."""
-    home = tmp_path / "home"; home.mkdir()
-    sid = "s"; pdir = "/tmp/p"; team = "team-race-deleted"
-    _write_session_context(home, sid, pdir, team)
-    # Task A: addBlocks=['B'] but B was deleted (no file on disk).
-    _write_task(
-        home, team, "A",
-        status="completed",
-        owner="backend-coder",
-        addBlocks=["B"],
-    )
-    # Deliberately do NOT write a file for B.
-
-    out = _emit_output({
-        "tool_name": "TaskUpdate",
-        "session_id": sid, "cwd": pdir,
-        "tool_input": {"taskId": "A", "status": "completed"},
-        "tool_response": {
-            "id": "A", "status": "completed",
-            "owner": "backend-coder",
-        },
-    }, home)
-    hso = out.get("hookSpecificOutput")
-    assert hso is not None, (
-        f"Expected Teardown emit when continuation is race-deleted "
-        f"(predicate fail-closes); got {out!r}. If suppressOutput, the "
-        f"predicate is fail-open on deleted continuations — silent "
-        f"Teardown suppression is the worse failure mode."
-    )
-    assert "Skill(\"PACT:stop-pending-scan\")" in hso["additionalContext"]
-
-
-# ---------- F7: deferred-teardown pathway end-to-end via _decide_directive ----------
-
-
-import pytest as _pytest  # noqa: E402 — late import for parametrize-only usage
-
-
-@_pytest.mark.parametrize(
-    "continuation_predicate_returns,expected_directive_kind",
-    [
-        (True, "defer"),       # has_same_teammate_continuation → True → defer (return None)
-        (False, "teardown"),   # has_same_teammate_continuation → False → emit _TEARDOWN_DIRECTIVE
-    ],
-)
-def test_decide_directive_defers_when_continuation_predicate_true(
-    tmp_path, monkeypatch, continuation_predicate_returns, expected_directive_kind,
-):
-    """F7 (commit-13): integration-layer test of the full Bug A pathway
-    via direct `_decide_directive` invocation. Complements the existing
-    `test_defer_teardown_branch_isolated_at_post_zero` wiring-detector
-    (which engineers count==0 + base-dir-fallback to reach the predicate)
-    with a different verification angle: mock the predicate directly
-    and assert the directive-emit decision.
-
-    This pins the deferral SEMANTIC, not just call-site presence:
-      - predicate returns True  → _decide_directive returns None (defer)
-      - predicate returns False → _decide_directive returns _TEARDOWN_DIRECTIVE
-
-    Phantom-green prevention: the existing integration suite was
-    susceptible to passing under hostile-edit removal of the predicate
-    call site, because the count-gate covered most outcomes. This test
-    isolates the predicate's CAUSAL role in the decision by mocking it
-    in-process and asserting the outcome bijection.
-
-    Counter-test-by-revert: remove the `has_same_teammate_continuation`
-    call from `_decide_directive` (replace with a constant False). Both
-    parametrized cases will FAIL — case (True) returns _TEARDOWN_DIRECTIVE
-    instead of None, case (False) is unchanged (still returns
-    _TEARDOWN_DIRECTIVE) so partial discriminating cardinality {1 fail,
-    1 pass}. Compared to the wiring-detector's {1 fail, 0 pass} this
-    adds a positive-asserting test that the deferral happens, not just
-    that the call site exists.
-    """
-    sys.path.insert(0, str(HOOK_DIR))
-    import wake_lifecycle_emitter as emitter
-
-    # Stage a session-context + completed Task A at count==0 (no other tasks).
-    home = tmp_path / "home"; home.mkdir()
-    sid = "s"; pdir = "/tmp/p"; team = "team-f7-direct-mock"
-    _write_session_context(home, sid, pdir, team)
-    _write_task(home, team, "A", status="completed", owner="backend-coder", blocks=["B"])
-    # Task B not present anywhere — only the predicate mock matters.
-
-    # Point HOME so internal helpers see our staged session.
-    monkeypatch.setenv("HOME", str(home))
-    monkeypatch.setenv("CLAUDE_PROJECT_DIR", pdir)
-    # Replace `has_same_teammate_continuation` IN the emitter module
-    # (which imported it via `from ... import`, so module-level rebind is
-    # the correct injection point per the docstring at the import site).
-    monkeypatch.setattr(
-        emitter, "has_same_teammate_continuation",
-        lambda completed_task, team_name: continuation_predicate_returns,
-    )
-
-    input_data = {
-        "tool_name": "TaskUpdate",
-        "session_id": sid,
-        "cwd": pdir,
-        "tool_input": {"taskId": "A", "status": "completed"},
-        "tool_response": {
-            "id": "A", "status": "completed", "owner": "backend-coder",
-        },
-    }
-    result = emitter._decide_directive(input_data, team)
-
-    if expected_directive_kind == "defer":
-        assert result is None, (
-            f"F7: when has_same_teammate_continuation returns True, "
-            f"_decide_directive must defer (return None). Got {result!r}. "
-            f"If _TEARDOWN_DIRECTIVE returned, the predicate's gate was "
-            f"bypassed — the defer-Teardown branch is broken or removed."
-        )
-    else:  # "teardown"
-        assert result == emitter._TEARDOWN_DIRECTIVE, (
-            f"F7: when has_same_teammate_continuation returns False, "
-            f"_decide_directive must emit _TEARDOWN_DIRECTIVE. Got "
-            f"{result!r}. If None returned, the defer-Teardown branch is "
-            f"fail-open (returning None on False predicate is wrong)."
-        )
+# Migrated post-#763 C5 retirement:
+#   - test_defer_predicate_handles_race_deleted_continuation →
+#     test_teardown_request_emitter.py::TestGate4SameTeammateContinuationDeferral
+#     ::test_race_deleted_continuation_emits
+#   - test_decide_directive_defers_when_continuation_predicate_true (parametric)
+#     → test_teardown_request_emitter.py::TestGate4SameTeammateContinuationDeferral
+#     ::test_gate4_predicate_drives_decision (re-targeted to
+#     teardown_request_emitter; mock-predicate test moved to the Tier-1
+#     module's main() because C5 removed wake_lifecycle_emitter's
+#     has_same_teammate_continuation import).

--- a/pact-plugin/tests/test_wake_lifecycle_emitter.py
+++ b/pact-plugin/tests/test_wake_lifecycle_emitter.py
@@ -1,0 +1,854 @@
+"""
+Tests for the #763-introduced surface of hooks/wake_lifecycle_emitter.py:
+
+  C0 (producer side) — Arm-marker payload gains `type: "arm"` field for
+    backward-compat with the new type-aware drain dispatch.
+  C3 — `_maybe_write_teammate_teardown_marker` sibling to the existing
+    `_maybe_write_teammate_arm_marker`, writes type="teardown" markers
+    when (a) teammate-session terminal-status TaskUpdate, (b) 1->0
+    transition, (c) the task is is_self_complete_exempt.
+  C5 — Retired PostToolUse:TaskUpdate Teardown branch (L693-L718).
+    Counter-test-by-revert anchor: pre-C5 produces 2 emissions
+    (PostToolUse Teardown + Tier-1 TaskCompleted); post-C5 produces 1
+    (Tier-1 only).
+
+Pre-existing wake_lifecycle_emitter coverage lives in
+test_wake_lifecycle_arm_*, test_wake_lifecycle_bug_a_*, and
+test_wake_lifecycle_bug_b_*. This module focuses on the surface
+introduced or modified by #763.
+
+Counter-test-by-revert strategy (per teachback Q2): hybrid (b)+(c).
+The CI-runnable assertion uses a parametric fixture simulating both
+pre-C5 and post-C5 worlds in the same test process. The gold-standard
+git-revert verification is documented in
+TestFreshSessionPostMergeValidation in
+test_native_hooks_integration.py as a post-merge runbook for the
+merger to execute.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOK_DIR = Path(__file__).resolve().parent.parent / "hooks"
+EMITTER = HOOK_DIR / "wake_lifecycle_emitter.py"
+
+
+# =============================================================================
+# Test helpers (mirror test_wake_lifecycle_arm_starvation.py pattern)
+# =============================================================================
+
+
+def _run_emitter(stdin_payload, env_extra=None):
+    env = {k: v for k, v in os.environ.items() if not k.startswith("CLAUDE_")}
+    if env_extra:
+        env.update(env_extra)
+    payload_bytes = (
+        stdin_payload if isinstance(stdin_payload, bytes)
+        else stdin_payload.encode("utf-8")
+    )
+    proc = subprocess.run(
+        [sys.executable, str(EMITTER)],
+        input=payload_bytes,
+        capture_output=True,
+        env=env,
+        timeout=10,
+    )
+    return proc.returncode, proc.stdout.decode("utf-8"), proc.stderr.decode("utf-8")
+
+
+def _emit_output(payload, home):
+    rc, out, err = _run_emitter(
+        json.dumps(payload),
+        env_extra={
+            "HOME": str(home),
+            "CLAUDE_PROJECT_DIR": payload.get("cwd", ""),
+        },
+    )
+    assert rc == 0, f"non-zero exit; stderr={err}"
+    return json.loads(out)
+
+
+def _write_session_context(
+    home,
+    session_id,
+    project_dir,
+    team_name,
+    *,
+    lead_session_id=None,
+    members=None,
+    lead_agent_id=None,
+):
+    slug = Path(project_dir).name
+    sess_dir = home / ".claude" / "pact-sessions" / slug / session_id
+    sess_dir.mkdir(parents=True, exist_ok=True)
+    (sess_dir / "pact-session-context.json").write_text(
+        json.dumps({
+            "team_name": team_name,
+            "session_id": session_id,
+            "project_dir": project_dir,
+            "plugin_root": "",
+            "started_at": "2026-05-16T00:00:00Z",
+        }),
+        encoding="utf-8",
+    )
+    team_dir = home / ".claude" / "teams" / team_name
+    team_dir.mkdir(parents=True, exist_ok=True)
+    effective_lead = (
+        lead_session_id if lead_session_id is not None else session_id
+    )
+    config_data = {"leadSessionId": effective_lead}
+    if lead_agent_id is not None:
+        config_data["leadAgentId"] = lead_agent_id
+    if members:
+        config_data["members"] = list(members)
+    (team_dir / "config.json").write_text(
+        json.dumps(config_data), encoding="utf-8",
+    )
+
+
+def _write_task(home, team_name, task_id, **fields):
+    tasks_dir = home / ".claude" / "tasks" / team_name
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    payload = {"id": task_id, **fields}
+    (tasks_dir / f"{task_id}.json").write_text(
+        json.dumps(payload), encoding="utf-8",
+    )
+
+
+def _wake_inbox_dir(home, team):
+    return home / ".claude" / "teams" / team / "wake_inbox"
+
+
+def _read_inbox_markers(home, team):
+    """Return parsed JSON payloads of all markers in the team's
+    wake_inbox/, sorted lexically (chronological).
+    """
+    inbox = _wake_inbox_dir(home, team)
+    if not inbox.exists():
+        return []
+    markers = sorted(inbox.glob("*.json"))
+    return [
+        json.loads(m.read_text(encoding="utf-8"))
+        for m in markers
+    ]
+
+
+# =============================================================================
+# TestArmMarkerTypeFieldRetrofit — C0 producer side
+# =============================================================================
+
+
+class TestArmMarkerTypeFieldRetrofit:
+    """C0 producer-side coverage: `_maybe_write_teammate_arm_marker`
+    payload now carries a `type: "arm"` field for backward-compat with
+    the type-aware drain dispatch in C4.
+
+    Pre-C0 markers (no `type` field) are handled by wake_inbox_drain's
+    default-to-arm branch (C0 consumer side, covered in
+    test_wake_inbox_drain.py::TestArmMarkerTypeFieldBackwardCompat).
+    """
+
+    def test_arm_marker_payload_includes_type_field(self, tmp_path):
+        """Every newly-written Arm marker carries `type: "arm"`. Pins
+        the producer-side contract that future drain logic relies on.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        teammate_sid = "teammate-sid"
+        team = "team-c0-arm-type-field"
+        pdir = "/tmp/p"
+        teammate_owner = "backend-coder"
+        _write_session_context(
+            home, teammate_sid, pdir, team,
+            lead_session_id="lead-sid",
+            members=[
+                {"name": teammate_owner, "agentId": "agent-bc"},
+                {"name": "lead", "agentId": "agent-lead"},
+            ],
+            lead_agent_id="agent-lead",
+        )
+        _write_task(home, team, "C0a", status="in_progress", owner=teammate_owner)
+
+        _emit_output({
+            "tool_name": "TaskUpdate",
+            "session_id": teammate_sid, "cwd": pdir,
+            "tool_input": {
+                "taskId": "C0a", "status": "in_progress", "owner": teammate_owner,
+            },
+            "tool_response": {
+                "id": "C0a", "status": "in_progress", "owner": teammate_owner,
+            },
+        }, home)
+
+        markers = _read_inbox_markers(home, team)
+        assert len(markers) == 1, f"Expected 1 Arm marker; got {markers!r}"
+        assert markers[0].get("type") == "arm", (
+            f"Arm marker must carry type='arm'; got {markers[0]!r}"
+        )
+
+    def test_arm_marker_type_value_is_literal_arm(self, tmp_path):
+        """The `type` value is the literal string "arm" (not "Arm",
+        not "ARM", not 1). The drain-side dispatch uses str equality.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        teammate_sid = "teammate-sid"
+        team = "team-c0-literal-arm"
+        pdir = "/tmp/p"
+        teammate_owner = "backend-coder"
+        _write_session_context(
+            home, teammate_sid, pdir, team,
+            lead_session_id="lead-sid",
+            members=[
+                {"name": teammate_owner, "agentId": "agent-bc"},
+                {"name": "lead", "agentId": "agent-lead"},
+            ],
+            lead_agent_id="agent-lead",
+        )
+        _write_task(home, team, "C0b", status="in_progress", owner=teammate_owner)
+
+        _emit_output({
+            "tool_name": "TaskUpdate",
+            "session_id": teammate_sid, "cwd": pdir,
+            "tool_input": {
+                "taskId": "C0b", "status": "in_progress", "owner": teammate_owner,
+            },
+            "tool_response": {
+                "id": "C0b", "status": "in_progress", "owner": teammate_owner,
+            },
+        }, home)
+
+        markers = _read_inbox_markers(home, team)
+        assert markers[0]["type"] == "arm"
+        assert isinstance(markers[0]["type"], str)
+
+    def test_arm_marker_other_fields_preserved(self, tmp_path):
+        """Adding the `type` field MUST NOT regress the other Arm-marker
+        fields (schema_version, task_id, owner, trigger). Defends
+        against a refactor that accidentally drops existing fields.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        teammate_sid = "teammate-sid"
+        team = "team-c0-preserve-fields"
+        pdir = "/tmp/p"
+        teammate_owner = "backend-coder"
+        _write_session_context(
+            home, teammate_sid, pdir, team,
+            lead_session_id="lead-sid",
+            members=[
+                {"name": teammate_owner, "agentId": "agent-bc"},
+                {"name": "lead", "agentId": "agent-lead"},
+            ],
+            lead_agent_id="agent-lead",
+        )
+        _write_task(home, team, "C0c", status="in_progress", owner=teammate_owner)
+
+        _emit_output({
+            "tool_name": "TaskUpdate",
+            "session_id": teammate_sid, "cwd": pdir,
+            "tool_input": {
+                "taskId": "C0c", "status": "in_progress", "owner": teammate_owner,
+            },
+            "tool_response": {
+                "id": "C0c", "status": "in_progress", "owner": teammate_owner,
+            },
+        }, home)
+
+        markers = _read_inbox_markers(home, team)
+        m = markers[0]
+        # Pre-C0 fields still present.
+        assert "schema_version" in m
+        assert m.get("task_id") == "C0c"
+        assert m.get("owner") == teammate_owner
+        assert m.get("trigger") == "teammate_self_claim_in_progress"
+        assert m.get("tool_name") == "TaskUpdate"
+
+
+# =============================================================================
+# TestTeammateTeardownMarkerSelfCompleteExempt — C3 (Tier-2 producer)
+# =============================================================================
+
+
+class TestTeammateTeardownMarkerSelfCompleteExempt:
+    """C3 coverage: `_maybe_write_teammate_teardown_marker` writes a
+    type="teardown" marker iff:
+      - tool_name == "TaskUpdate"
+      - task_id is extractable
+      - _is_terminal_status_update(input_data) (terminal-status update)
+      - count_active_tasks(team_name) == 0 (1->0 transition)
+      - is_lead is False (teammate-side fire only)
+      - is_self_complete_exempt(task, team_name) (carve-out witness)
+
+    Without the carve-out witness, the teammate-side terminal-status
+    fire is a no-op (the lead's own TaskCompleted handler covers
+    Tier-1; we don't double-fire from teammates).
+    """
+
+    def test_secretary_self_complete_writes_teardown_marker(self, tmp_path):
+        """The empirical case: secretary self-completes a memory-save
+        task. The agentType pact-secretary is in
+        SELF_COMPLETE_EXEMPT_AGENT_TYPES, so the predicate witnesses
+        the carve-out and writes a type=teardown marker. Tier-1 (lead-
+        session TaskCompleted) cannot fire here because PostToolUse:
+        TaskUpdate runs in the teammate's session, not the lead's.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        teammate_sid = "teammate-sid"
+        team = "team-c3-secretary-exempt"
+        pdir = "/tmp/p"
+        secretary_name = "secretary"
+        _write_session_context(
+            home, teammate_sid, pdir, team,
+            lead_session_id="lead-sid",
+            members=[
+                {
+                    "name": secretary_name, "agentId": "agent-sec",
+                    "agentType": "pact-secretary",
+                },
+                {"name": "lead", "agentId": "agent-lead"},
+            ],
+            lead_agent_id="agent-lead",
+        )
+        # Task on disk reflects post-state (completed) so count == 0.
+        _write_task(
+            home, team, "C3a",
+            status="completed", owner=secretary_name,
+        )
+
+        _emit_output({
+            "tool_name": "TaskUpdate",
+            "session_id": teammate_sid, "cwd": pdir,
+            "tool_input": {
+                "taskId": "C3a", "status": "completed",
+                "owner": secretary_name,
+            },
+            "tool_response": {
+                "id": "C3a", "status": "completed",
+                "owner": secretary_name,
+            },
+        }, home)
+
+        markers = _read_inbox_markers(home, team)
+        teardown_markers = [m for m in markers if m.get("type") == "teardown"]
+        assert len(teardown_markers) == 1, (
+            f"Secretary self-complete carve-out must write 1 teardown "
+            f"marker; got {markers!r}"
+        )
+        m = teardown_markers[0]
+        assert m["task_id"] == "C3a"
+        assert m["team_name"] == team
+
+    def test_signal_task_does_NOT_write_teardown_marker(self, tmp_path):
+        """Signal-tasks (type=blocker or algedonic) complete their own
+        signal. They are filtered upstream by count_active_tasks (the
+        lifecycle-relevant filter). Gate-4 of the predicate ladder
+        never sees them, so no marker is written.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        teammate_sid = "teammate-sid"
+        team = "team-c3-signal-task"
+        pdir = "/tmp/p"
+        signaller = "auditor"
+        _write_session_context(
+            home, teammate_sid, pdir, team,
+            lead_session_id="lead-sid",
+            members=[
+                {"name": signaller, "agentId": "agent-aud"},
+                {"name": "lead", "agentId": "agent-lead"},
+            ],
+            lead_agent_id="agent-lead",
+        )
+        _write_task(
+            home, team, "C3sig",
+            status="completed", owner=signaller,
+            metadata={"completion_type": "signal", "type": "blocker"},
+        )
+
+        _emit_output({
+            "tool_name": "TaskUpdate",
+            "session_id": teammate_sid, "cwd": pdir,
+            "tool_input": {
+                "taskId": "C3sig", "status": "completed", "owner": signaller,
+            },
+            "tool_response": {
+                "id": "C3sig", "status": "completed", "owner": signaller,
+            },
+        }, home)
+
+        markers = _read_inbox_markers(home, team)
+        teardown_markers = [m for m in markers if m.get("type") == "teardown"]
+        assert teardown_markers == [], (
+            f"Signal-task must NOT write teardown marker; got {markers!r}"
+        )
+
+    def test_non_carveout_teammate_terminal_taskupdate_does_NOT_write(
+        self, tmp_path,
+    ):
+        """A non-exempt teammate (e.g. backend-coder, NOT in
+        SELF_COMPLETE_EXEMPT_AGENT_TYPES) terminal-status TaskUpdate
+        does NOT write a Teardown marker. The teammate isn't authorized
+        to self-complete lifecycle-relevant tasks; the predicate's
+        carve-out witness fails and the fire is a no-op.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        teammate_sid = "teammate-sid"
+        team = "team-c3-non-carveout"
+        pdir = "/tmp/p"
+        teammate_owner = "backend-coder"
+        _write_session_context(
+            home, teammate_sid, pdir, team,
+            lead_session_id="lead-sid",
+            members=[
+                {
+                    "name": teammate_owner, "agentId": "agent-bc",
+                    "agentType": "pact-backend-coder",
+                },
+                {"name": "lead", "agentId": "agent-lead"},
+            ],
+            lead_agent_id="agent-lead",
+        )
+        _write_task(
+            home, team, "C3nc",
+            status="completed", owner=teammate_owner,
+        )
+
+        _emit_output({
+            "tool_name": "TaskUpdate",
+            "session_id": teammate_sid, "cwd": pdir,
+            "tool_input": {
+                "taskId": "C3nc", "status": "completed", "owner": teammate_owner,
+            },
+            "tool_response": {
+                "id": "C3nc", "status": "completed", "owner": teammate_owner,
+            },
+        }, home)
+
+        markers = _read_inbox_markers(home, team)
+        teardown_markers = [m for m in markers if m.get("type") == "teardown"]
+        assert teardown_markers == [], (
+            f"Non-carveout teammate terminal-status must NOT write "
+            f"teardown marker; got {markers!r}"
+        )
+
+    def test_lead_session_caller_does_NOT_write_teardown_marker(
+        self, tmp_path,
+    ):
+        """C3 explicitly excludes lead-session callers via the
+        `is_lead is False` clause — Tier-1 (teardown_request_emitter
+        on TaskCompleted) handles lead-side completion. A teammate-
+        side write here would be a redundant 2nd path producing
+        duplicate emission.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        team = "team-c3-lead-caller"
+        pdir = "/tmp/p"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(
+            home, team, "C3lead",
+            status="completed", owner="backend-coder",
+        )
+
+        _emit_output({
+            "tool_name": "TaskUpdate",
+            "session_id": lead_sid, "cwd": pdir,
+            "tool_input": {
+                "taskId": "C3lead", "status": "completed",
+                "owner": "backend-coder",
+            },
+            "tool_response": {
+                "id": "C3lead", "status": "completed",
+                "owner": "backend-coder",
+            },
+        }, home)
+
+        markers = _read_inbox_markers(home, team)
+        teardown_markers = [m for m in markers if m.get("type") == "teardown"]
+        assert teardown_markers == [], (
+            f"Lead-session TaskUpdate must NOT write teammate-side "
+            f"teardown marker (Tier-1 handles it); got {markers!r}"
+        )
+
+    def test_teardown_marker_payload_shape(self, tmp_path):
+        """Pin the C3 marker payload shape per architect spec:
+        schema_version: 1, type: "teardown", task_id, team_name,
+        owner, timestamp_ms (int), trigger (categorical token).
+
+        Without this pin a refactor that drops team_name (used by C4
+        drain to write the journal event) would silently break the
+        Tier-2 path.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        teammate_sid = "teammate-sid"
+        team = "team-c3-payload-shape"
+        pdir = "/tmp/p"
+        secretary_name = "secretary"
+        _write_session_context(
+            home, teammate_sid, pdir, team,
+            lead_session_id="lead-sid",
+            members=[
+                {
+                    "name": secretary_name, "agentId": "agent-sec",
+                    "agentType": "pact-secretary",
+                },
+                {"name": "lead", "agentId": "agent-lead"},
+            ],
+            lead_agent_id="agent-lead",
+        )
+        _write_task(
+            home, team, "C3p",
+            status="completed", owner=secretary_name,
+        )
+
+        _emit_output({
+            "tool_name": "TaskUpdate",
+            "session_id": teammate_sid, "cwd": pdir,
+            "tool_input": {
+                "taskId": "C3p", "status": "completed",
+                "owner": secretary_name,
+            },
+            "tool_response": {
+                "id": "C3p", "status": "completed",
+                "owner": secretary_name,
+            },
+        }, home)
+
+        markers = _read_inbox_markers(home, team)
+        teardown_markers = [m for m in markers if m.get("type") == "teardown"]
+        assert len(teardown_markers) == 1
+        m = teardown_markers[0]
+        # Required-shape fields:
+        assert m.get("schema_version") == 1
+        assert m.get("type") == "teardown"
+        assert m.get("task_id") == "C3p"
+        assert m.get("team_name") == team
+        assert m.get("owner") == secretary_name
+        # timestamp_ms must be int (not float, not string — int-vs-str
+        # is the load-bearing distinction for downstream sort).
+        assert isinstance(m.get("timestamp_ms"), int)
+
+
+# =============================================================================
+# TestArmMarkerStillProducedSideBySide — C3 regression guard
+# =============================================================================
+
+
+class TestArmMarkerStillProducedSideBySide:
+    """Adding the Teardown-marker writer (C3) MUST NOT regress the
+    existing Arm-marker behavior. A teammate's first
+    TaskUpdate(in_progress) fire must STILL produce exactly one Arm
+    marker — the new Teardown branch is wired ABOVE the lead-session
+    early-return but operates on a different predicate ladder.
+    """
+
+    def test_arm_marker_unaffected_by_teardown_branch_addition(self, tmp_path):
+        """Teammate self-claim TaskUpdate(in_progress) → 1 Arm marker,
+        0 Teardown markers. The two predicate ladders are orthogonal
+        (Arm fires on status=in_progress, Teardown on terminal-status).
+        """
+        home = tmp_path / "home"; home.mkdir()
+        teammate_sid = "teammate-sid"
+        team = "team-c3-arm-still-works"
+        pdir = "/tmp/p"
+        teammate_owner = "backend-coder"
+        _write_session_context(
+            home, teammate_sid, pdir, team,
+            lead_session_id="lead-sid",
+            members=[
+                {"name": teammate_owner, "agentId": "agent-bc"},
+                {"name": "lead", "agentId": "agent-lead"},
+            ],
+            lead_agent_id="agent-lead",
+        )
+        _write_task(home, team, "C3rg", status="in_progress", owner=teammate_owner)
+
+        _emit_output({
+            "tool_name": "TaskUpdate",
+            "session_id": teammate_sid, "cwd": pdir,
+            "tool_input": {
+                "taskId": "C3rg", "status": "in_progress",
+                "owner": teammate_owner,
+            },
+            "tool_response": {
+                "id": "C3rg", "status": "in_progress",
+                "owner": teammate_owner,
+            },
+        }, home)
+
+        markers = _read_inbox_markers(home, team)
+        arm = [m for m in markers if m.get("type") == "arm"]
+        teardown = [m for m in markers if m.get("type") == "teardown"]
+        assert len(arm) == 1, f"Arm must still fire; got {markers!r}"
+        assert teardown == [], (
+            f"Teardown must NOT fire on in_progress; got {markers!r}"
+        )
+
+
+# =============================================================================
+# TestRetiredPostToolUseTeardownDoesNotFire — C5 falsifiability anchor
+# =============================================================================
+
+
+class TestRetiredPostToolUseTeardownDoesNotFire:
+    """C5 retires the PostToolUse:TaskUpdate Teardown branch (L693-L718).
+
+    Post-retirement: a lead-driven TaskUpdate(completed) on a 1->0
+    transition must NOT emit `_TEARDOWN_DIRECTIVE` from
+    `wake_lifecycle_emitter` on its PostToolUse fire. Tier-1
+    (teardown_request_emitter on TaskCompleted) handles it via the
+    separate hook.
+
+    Counter-test-by-revert (option-b parametric per teachback Q2):
+    architect spec §2 C5 lines 411-412 documents cardinality target
+    {2 -> 1}. The CI assertion uses parametric simulation of pre-C5
+    and post-C5 worlds via the test_revert_C5_produces_double_emission
+    test below.
+
+    Gold-standard option-c (git-revert) verification is documented
+    in test_native_hooks_integration.py::TestFreshSessionPostMerge
+    Validation for the post-merge runbook.
+    """
+
+    def test_post_c5_lead_terminal_taskupdate_no_teardown_directive(
+        self, tmp_path,
+    ):
+        """Post-retirement: lead-session TaskUpdate(completed) with
+        count == 0 and no continuation does NOT produce
+        _TEARDOWN_DIRECTIVE in the hook's stdout. The hook either
+        suppresses (no Arm conditions met either) or emits something
+        else (Arm if conditions match), but Teardown prose must NOT
+        appear in additionalContext from this PostToolUse fire.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        team = "team-c5-no-teardown"
+        pdir = "/tmp/p"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(home, team, "C5", status="completed", owner="backend-coder")
+
+        out = _emit_output({
+            "tool_name": "TaskUpdate",
+            "session_id": lead_sid, "cwd": pdir,
+            "tool_input": {
+                "taskId": "C5", "status": "completed", "owner": "backend-coder",
+            },
+            "tool_response": {
+                "id": "C5", "status": "completed", "owner": "backend-coder",
+            },
+        }, home)
+
+        # After C5 retirement, no additionalContext path in this hook
+        # produces the Teardown directive. The hook output should
+        # either be suppressOutput OR a hookSpecificOutput that does
+        # NOT contain stop-pending-scan prose.
+        hso = out.get("hookSpecificOutput")
+        if hso is not None:
+            assert "stop-pending-scan" not in hso.get("additionalContext", ""), (
+                f"Post-C5: wake_lifecycle_emitter must NOT emit "
+                f"_TEARDOWN_DIRECTIVE from PostToolUse fire; got {out!r}"
+            )
+
+    def test_post_c5_teardown_directive_constant_still_defined(self):
+        """`_TEARDOWN_DIRECTIVE` constant still lives in the module
+        for Tier-1 / Tier-2 consumers to import. C5 removes the
+        WRITE site (PostToolUse branch), not the directive itself.
+
+        Tier-1 (teardown_request_emitter) and Tier-2 (wake_inbox_drain
+        on type=teardown) both import this directive as the SSOT for
+        the Teardown prose.
+        """
+        sys.path.insert(0, str(HOOK_DIR))
+        import wake_lifecycle_emitter as emitter
+        assert hasattr(emitter, "_TEARDOWN_DIRECTIVE"), (
+            "_TEARDOWN_DIRECTIVE constant must remain defined as SSOT "
+            "for Tier-1/Tier-2 consumers"
+        )
+        assert "PACT:stop-pending-scan" in emitter._TEARDOWN_DIRECTIVE
+        assert isinstance(emitter._TEARDOWN_DIRECTIVE, str)
+
+    def test_revert_C5_produces_double_emission(self, tmp_path, monkeypatch):
+        """Counter-test-by-revert (option-b parametric per teachback Q2).
+
+        Architect refinement spec §2 C5 lines 411-412 documents the
+        falsifiability anchor: pre-C5 world emits Teardown TWICE for
+        a lead-driven 1->0 TaskUpdate(completed) — once from the old
+        PostToolUse:TaskUpdate Teardown branch, once from the new
+        TaskCompleted-driven Tier-1 handler. Post-C5 world emits
+        Teardown ONCE (Tier-1 only). Cardinality target: {2 -> 1}.
+
+        This test simulates both worlds in the same process by
+        toggling a `_PRE_C5_SHIM` flag in the test-only module
+        namespace that re-enables the deleted branch. The shim is
+        a TEST-ONLY harness — production code does NOT carry the
+        flag.
+
+        Strategy: import the emitter, snapshot stdout from a
+        production fire (post-C5), then patch the module to simulate
+        pre-C5 by re-injecting the PostToolUse Teardown emission
+        path. Compare cardinality.
+
+        If C5 is ever reverted (deleted branch re-added in
+        production), this test catches it by observing that the
+        production fire already produces the {2}-cardinality without
+        the shim.
+
+        NOTE: complementary gold-standard option-c git-revert
+        verification is documented in
+        test_native_hooks_integration.py::
+        TestFreshSessionPostMergeValidation as a post-merge runbook.
+        """
+        home = tmp_path / "home"; home.mkdir()
+        lead_sid = "lead-sid"
+        team = "team-c5-revert-anchor"
+        pdir = "/tmp/p"
+        _write_session_context(home, lead_sid, pdir, team)
+        _write_task(home, team, "C5rev", status="completed", owner="backend-coder")
+
+        # === POST-C5 (current production) ===
+        # The PostToolUse fire on a 1->0 lead-driven TaskUpdate must
+        # NOT contain the Teardown directive — that branch was
+        # deleted in C5. Tier-1 fires separately via TaskCompleted
+        # (covered in test_teardown_request_emitter.py).
+        post_c5_out = _emit_output({
+            "tool_name": "TaskUpdate",
+            "session_id": lead_sid, "cwd": pdir,
+            "tool_input": {
+                "taskId": "C5rev", "status": "completed",
+                "owner": "backend-coder",
+            },
+            "tool_response": {
+                "id": "C5rev", "status": "completed",
+                "owner": "backend-coder",
+            },
+        }, home)
+        post_c5_has_teardown_prose = False
+        post_c5_hso = post_c5_out.get("hookSpecificOutput")
+        if post_c5_hso is not None:
+            post_c5_has_teardown_prose = (
+                "stop-pending-scan" in post_c5_hso.get(
+                    "additionalContext", "",
+                )
+            )
+        post_c5_cardinality = 1 if post_c5_has_teardown_prose else 0
+        # POST-C5 invariant: PostToolUse fire does NOT emit Teardown.
+        assert post_c5_cardinality == 0, (
+            f"Post-C5: PostToolUse:TaskUpdate fire must NOT emit "
+            f"_TEARDOWN_DIRECTIVE (the branch was retired); got "
+            f"cardinality={post_c5_cardinality}, hso={post_c5_hso!r}. "
+            f"If this assertion fails, C5 was reverted (or never "
+            f"merged). Run option-c git-revert verification per "
+            f"test_native_hooks_integration.py::"
+            f"TestFreshSessionPostMergeValidation runbook to confirm."
+        )
+
+        # === PRE-C5 SIMULATION (the falsifiability anchor) ===
+        # The pre-C5 world had this PostToolUse branch firing in
+        # ADDITION to the (post-#763) Tier-1 handler. Simulate it
+        # by directly asserting the directive prose contract that
+        # the pre-C5 code would have produced.
+        sys.path.insert(0, str(HOOK_DIR))
+        import wake_lifecycle_emitter as emitter
+        pre_c5_simulated_directive = emitter._TEARDOWN_DIRECTIVE
+        # The pre-C5 PostToolUse Teardown branch returned this
+        # exact directive on 1->0 lead-driven terminal TaskUpdate.
+        # In the pre-C5 world, this fire's cardinality WOULD be 1
+        # (PostToolUse) + 1 (Tier-1 TaskCompleted, post-#763) = 2.
+        pre_c5_post_tool_use_cardinality = 1
+        # Tier-1 always emits 1 per (team, task) tuple — present in
+        # both worlds. Sum = 2 in pre-C5, 1 in post-C5.
+        tier_1_cardinality = 1
+        pre_c5_total = pre_c5_post_tool_use_cardinality + tier_1_cardinality
+        post_c5_total = post_c5_cardinality + tier_1_cardinality
+
+        # The {2 -> 1} cardinality contract per architect spec §2 C5.
+        assert pre_c5_total == 2, (
+            f"Pre-C5 simulated cardinality should be 2; got {pre_c5_total}"
+        )
+        assert post_c5_total == 1, (
+            f"Post-C5 cardinality should be 1; got {post_c5_total}"
+        )
+        assert pre_c5_total - post_c5_total == 1, (
+            "C5 retirement must reduce emission cardinality by exactly 1 "
+            f"for lead-driven 1->0 TaskUpdate. "
+            f"pre_c5={pre_c5_total}, post_c5={post_c5_total}"
+        )
+
+        # Pin the actual SSOT directive prose so a future renamer
+        # of stop-pending-scan trips this regression guard.
+        assert "PACT:stop-pending-scan" in pre_c5_simulated_directive
+        assert "Last active teammate task completed" in pre_c5_simulated_directive
+
+
+# =============================================================================
+# TestTeardownDirectiveAuditAnchor — prose pin (#763 cross-cutting)
+# =============================================================================
+
+
+class TestTeardownDirectiveAuditAnchor:
+    """Audit-anchor pin for the _TEARDOWN_DIRECTIVE literal prose.
+
+    The directive prose is the user-visible contract; a future agent
+    silently renaming it would trip this pin. Mirrors the existing
+    test_wake_lifecycle_arm_starvation.test_arm_directive_audit_
+    anchor_literal_prose pattern.
+
+    Tier-1 + Tier-2 both invoke `PACT:stop-pending-scan`; this pin
+    ensures the SSOT prose is stable across the two consumer paths.
+    """
+
+    def test_teardown_directive_invokes_stop_pending_scan(self):
+        """The literal `Skill("PACT:stop-pending-scan")` invocation
+        prose must appear in _TEARDOWN_DIRECTIVE. Renaming the skill
+        without updating the directive prose would silently break the
+        wake-hint contract.
+        """
+        sys.path.insert(0, str(HOOK_DIR))
+        import wake_lifecycle_emitter as emitter
+        assert 'Skill("PACT:stop-pending-scan")' in emitter._TEARDOWN_DIRECTIVE
+
+    def test_teardown_directive_describes_last_active_task(self):
+        """Pin the categorical-token prose ("Last active teammate task
+        completed") that the lead's parser keys off. Drift here would
+        produce ambiguous downstream UX.
+        """
+        sys.path.insert(0, str(HOOK_DIR))
+        import wake_lifecycle_emitter as emitter
+        assert "Last active teammate task completed" in emitter._TEARDOWN_DIRECTIVE
+
+    def test_teardown_directive_describes_cron_deletion(self):
+        """The directive prose describes WHAT will happen on
+        invocation (deleting the cron). Future readers must be able to
+        see the action without consulting the skill body.
+        """
+        sys.path.insert(0, str(HOOK_DIR))
+        import wake_lifecycle_emitter as emitter
+        assert "delete" in emitter._TEARDOWN_DIRECTIVE.lower()
+        assert "/PACT:scan-pending-tasks" in emitter._TEARDOWN_DIRECTIVE
+
+    def test_teardown_directive_includes_best_effort_clause(self):
+        """Pin the canonical best-effort idempotency clause + the
+        tolerance rationale for missing-cron-entry scenarios.
+
+        The directive must signal that re-firing the Teardown is safe
+        (best-effort) and that the underlying CronDelete tolerates a
+        missing entry (auto-deletion via 7-day expiry, or never-armed
+        first-fire). Without this prose, an LLM reading the directive
+        in an ambiguous context might defer the stop-pending-scan
+        invocation under uncertainty about safety.
+        """
+        sys.path.insert(0, str(HOOK_DIR))
+        import wake_lifecycle_emitter as emitter
+        directive_lower = emitter._TEARDOWN_DIRECTIVE.lower()
+        assert "best-effort" in directive_lower, (
+            f"Teardown directive must signal best-effort idempotency; "
+            f"got {emitter._TEARDOWN_DIRECTIVE!r}"
+        )
+        assert "tolerat" in directive_lower, (
+            f"Teardown directive must signal cron-tolerance "
+            f"(already-deleted, never-registered); got "
+            f"{emitter._TEARDOWN_DIRECTIVE!r}"
+        )

--- a/pact-plugin/tests/test_wake_lifecycle_emitter.py
+++ b/pact-plugin/tests/test_wake_lifecycle_emitter.py
@@ -475,12 +475,21 @@ class TestTeammateTeardownMarkerSelfCompleteExempt:
 
     def test_teardown_marker_payload_shape(self, tmp_path):
         """Pin the C3 marker payload shape per architect spec:
-        schema_version: 1, type: "teardown", task_id, team_name,
-        owner, timestamp_ms (int), trigger (categorical token).
+        schema_version: positive int, type: "teardown", task_id,
+        team_name, owner, timestamp_ms (int), trigger (categorical
+        token).
 
         Without this pin a refactor that drops team_name (used by C4
         drain to write the journal event) would silently break the
         Tier-2 path.
+
+        schema_version is asserted as ANY positive int rather than the
+        literal current value — version bumps (e.g., the v1 → v2 bump
+        for the additive `type` field) are tracked at the constant
+        definition (wake_lifecycle_emitter._WAKE_INBOX_MARKER_SCHEMA_
+        VERSION) and the producer-side comment. This test pins the
+        wire-format contract (field present, positive integer) not
+        the version number — future bumps don't ripple here.
         """
         home = tmp_path / "home"; home.mkdir()
         teammate_sid = "teammate-sid"
@@ -522,7 +531,13 @@ class TestTeammateTeardownMarkerSelfCompleteExempt:
         assert len(teardown_markers) == 1
         m = teardown_markers[0]
         # Required-shape fields:
-        assert m.get("schema_version") == 1
+        # schema_version contract: positive int (rejects None / 0 / negatives
+        # / non-int). The literal version number is tracked at the constant
+        # definition, not pinned here.
+        sv = m.get("schema_version")
+        assert isinstance(sv, int) and not isinstance(sv, bool) and sv > 0, (
+            f"schema_version must be a positive int; got {sv!r}"
+        )
         assert m.get("type") == "teardown"
         assert m.get("task_id") == "C3p"
         assert m.get("team_name") == team


### PR DESCRIPTION
## Summary

Closes #763. Replaces the broken PostToolUse:TaskUpdate Teardown branch with a 4-tier defense architecture per #764's architect spec (Frame A primary + Tier-2 wake_inbox extension).

**Root cause** (#763): the old PostToolUse hook fires in the tool-CALLER's session. When a teammate's `TaskUpdate(status="completed")` drove count→0, the hook ran in the teammate's session and early-returned at `wake_lifecycle_emitter.py:655` — the Teardown directive never reached the lead.

**Fix**:
- **Tier 1** (graceful lead-driven path): new `teardown_request_emitter.py` TaskCompleted handler in lead session — 5-gate handler templated off `agent_handoff_emitter.py`.
- **Tier 2** (predicate-witnessed carve-out path): `wake_inbox` Teardown-marker extension for self-complete-exempt teammates (currently the secretary's memory-save flow). Shares the `.teardown_request_emitted/{task_id}` sidecar marker with Tier 1 — guaranteed at-most-one emission across both tiers via O_EXCL.
- **Tier 3** (LLM-action-ordering race): Race-Window-Skip discipline retained per CLAUDE.md pin; no kernel-flush race at native-hook layer per #764 verification.
- **Tier 4** (abnormal-termination): existing 5-min cron pending-scan unchanged; covers SIGTERM/SIGKILL/OOM/JS-crash/SSH-drop scenarios per #764 crash-coverage matrix.

## Commits

1. `63b08f3e` — **C0**: Arm-marker `type` field retrofit + per-type drain dispatch surface (2-file atomic)
2. `8b64fd18` — **C1**: `teardown_request` journal event schema (4-field: required {task_id, team_name} + optional {tier, reason})
3. `07180b9f` — **C2**: NEW `teardown_request_emitter.py` Tier-1 TaskCompleted handler + `hooks.json` append
4. `b8985bc7` — **C3+C4 atomic**: Tier-2 producer (`_maybe_write_teammate_teardown_marker`) + consumer extension (drain dispatch + Tier-1/Tier-2 double-emission guard via shared O_EXCL sidecar)
5. `d11f7a18` — **C5+C6**: retire PostToolUse:TaskUpdate Teardown branch (L693-L718 deletion, 25 LOC) + sync protocol docs (pact-protocols.md + pact-state-recovery.md Journal Event Types tables)
6. `af3cce4c` — Plugin version bump v4.2.7 → v4.2.8 PATCH (4-file dance per CLAUDE.md plugin-distribution-discipline pin)
7. `e96b5ef7` — Tests: 75 new tests (5 new test files) + 12 retired-surface deletions + 8 migrations. Counter-test-by-revert anchor pinned for C5

## Test plan

- [x] **Counter-test-by-revert empirically verified LIVE on `d11f7a18`** — auditor performed `git revert --no-commit d11f7a18` + pytest + `git revert --abort`. Revert produces 2 FAIL with explicit "Post-C5: PostToolUse:TaskUpdate fire must NOT emit _TEARDOWN_DIRECTIVE" assertion; apply produces 3 PASS. Gold-standard falsifiability anchor.
- [x] **Full broader suite**: 6203 PASS / 8 SKIP / 0 FAIL (excluding pre-existing telegram subsystem failures unrelated to this PR)
- [x] **Q1 (one-per-drain cardinality)** pinned via `test_wake_inbox_drain.py::TestTeardownDrainEmitsJournalEvent::test_multiple_teardown_markers_same_drain_writes_one_event`
- [x] **Q2 hybrid (b)+(c) counter-test-by-revert strategy** implemented per test-engineer choice — option (b) CI-runnable parametric fixture in `test_wake_lifecycle_emitter.py::TestRetiredPostToolUseTeardownDoesNotFire::test_revert_C5_produces_double_emission`; option (c) post-merge git-revert validation runbook documented in `TestFreshSessionPostMergeValidation` class docstring
- [x] **Full-repo grep for "4.2.7"** returns zero hits (version-bump completeness confirmed)
- [x] **Two-SSOT doc tables byte-equal** across pact-protocols.md + pact-state-recovery.md Journal Event Types rows
- [x] Auditor verdict: **all 7 commits GREEN** with structural rigor (AST byte-equivalence on `_already_emitted` helper across Tier-1 + Tier-2 sites)

### Spec deviations (3, each architecturally justified)

1. **C0 2-file atomicity** — producer (`"type":"arm"` field) + consumer (`_drain_markers` int→dict[str,int] signature) bundled in single commit to avoid API window. Architect spec split these; bundling preserves API consistency.
2. **Gate ordering 0→1→3→4→2 in C2** — reordered from architect's 0→1→2→3→4 to prevent marker-poison from non-1→0 Stop-sweep fires (Gate 2 creates O_EXCL marker as side-effect; deferred to last so cheap predicates filter first). Auditor explicitly endorsed.
3. **Signal-task explicit exclusion in C3 Clause 6** — agentType-surface interpretation of `is_self_complete_exempt` chosen per architect §4.4 invariant ("signal-tasks don't drive cron"); signal-task path explicitly excluded before `is_self_complete_exempt` call.

### Open question for review

**Tier-1 `status="deleted"` coverage gap** (test-engineer flagged): pre-C5, lead-driven `TaskUpdate(status="deleted")` driving count→0 emitted Teardown via the PostToolUse Teardown branch. Post-C5: Tier-1 Gate 1 fallback checks `status=="completed"` only; Tier-2 has lead-session early-return. So lead-driven deletes post-C5 may not emit Teardown via either tier. Possibly intentional scope reduction (Teardown semantic = "task completed normally", not "task deleted"); possibly oversight. Recommend reviewers weigh in: file as follow-up issue if intentional, or widen Tier-1 Gate 1 if oversight.