### PR TITLE
feat(#841): teachback schema clarity — runtime advisories + SKILL.md restructure (v4.3.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.3.0/      # Plugin version
+│               └── 4.3.1/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.3.0
+> **Version**: 4.3.1
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/shared/teachback_schema.py
+++ b/pact-plugin/hooks/shared/teachback_schema.py
@@ -25,14 +25,17 @@ Public surface:
 - TEACHBACK_VARIETY_ACK_VALID_VALUES — enum tuple for
   variety_acknowledgment.rationale_articulates_this_dispatch.
 - TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN — variety band threshold
-  (>= 11 → REQUIRED). Sourced from variety_scorer.PLAN_MODE_MAX + 1
-  semantics; align via grep-at-edit-time until variety_scorer.py exports
-  an explicit PLAN_MODE_MIN.
+  (>= 11 → REQUIRED). Derived at module-load from
+  `variety_scorer.ORCHESTRATE_MAX + 1`; substitute
+  `from shared.variety_scorer import PLAN_MODE_MIN` when that constant
+  lands.
 - validate_reasoning_reconstruction(rr) — pure validator returning None
   on well-formed input or a reason-enum string on rejection.
 """
 
 from __future__ import annotations
+
+from shared.variety_scorer import ORCHESTRATE_MAX
 
 
 # Canonical 5 field names per D10. 4 string fields + variety_acknowledgment dict.
@@ -57,11 +60,12 @@ TEACHBACK_REQUIRED_SUBKEYS: tuple[str, ...] = (
 #   {rationale_articulates_this_dispatch: <enum>, concern: <str when != yes>}.
 TEACHBACK_VARIETY_ACK_VALID_VALUES: tuple[str, ...] = ("yes", "no", "concern")
 
-# REQUIRED-band threshold for reasoning_reconstruction. Per variety_scorer.py:
-# PLAN_MODE_MAX = 14, ORCHESTRATE_MAX = 10 → plan-mode-and-above starts at >= 11.
-# When variety_scorer.py exports an explicit PLAN_MODE_MIN, this should be
+# REQUIRED-band threshold for reasoning_reconstruction. Derived from
+# variety_scorer.ORCHESTRATE_MAX semantics: plan-mode-and-above starts at
+# ORCHESTRATE_MAX + 1 (i.e. >= 11 given ORCHESTRATE_MAX = 10). When
+# variety_scorer.py exports an explicit PLAN_MODE_MIN, this should be
 # replaced with `from shared.variety_scorer import PLAN_MODE_MIN`.
-TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN: int = 11
+TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN: int = ORCHESTRATE_MAX + 1
 
 
 def validate_reasoning_reconstruction(rr: object) -> str | None:

--- a/pact-plugin/hooks/shared/teachback_schema.py
+++ b/pact-plugin/hooks/shared/teachback_schema.py
@@ -1,0 +1,91 @@
+"""
+Location: pact-plugin/hooks/shared/teachback_schema.py
+Summary: Canonical teachback_submit schema constants and validators. SSOT
+         for the 5-field shape (D10), the variety_acknowledgment object
+         schema (D10), the reasoning_reconstruction 3-sub-key triangle
+         (L1.5 method gate per pact-ct-teachback.md), and the variety-band
+         threshold at which reasoning_reconstruction is REQUIRED.
+Used by: hooks/task_lifecycle_gate.py (write-time + completion-time gates),
+         tests/test_teachback_reasoning_reconstruction.py (schema gate),
+         tests/test_task_lifecycle_gate.py (rule-fixture inputs),
+         tests/test_teachback_schema.py (constants + validator).
+
+When the 5-field shape, 3-sub-key triangle, or threshold changes, this is
+the only Python edit site. Prose in skills/pact-teachback/SKILL.md mirrors
+these values via grep-at-edit-time alignment.
+
+Public surface:
+- REQUIRED_FIELDS — canonical 5-tuple per D10 (4 string fields +
+  variety_acknowledgment dict).
+- REQUIRED_SUBKEYS — canonical 3-tuple for reasoning_reconstruction per
+  pact-ct-teachback.md §When to Method-Reconstruct.
+- VARIETY_ACK_VALID_VALUES — enum tuple for
+  variety_acknowledgment.rationale_articulates_this_dispatch.
+- REASONING_RECONSTRUCTION_REQUIRED_MIN — variety band threshold (>= 11
+  → REQUIRED). Sourced from variety_scorer.PLAN_MODE_MAX + 1 semantics;
+  align via grep-at-edit-time until variety_scorer.py exports an explicit
+  PLAN_MODE_MIN.
+- validate_reasoning_reconstruction(rr) — pure validator returning None
+  on well-formed input or a reason-enum string on rejection.
+
+Contract: pure module; no I/O, no global state, no platform dependencies.
+Functions never raise.
+"""
+
+from __future__ import annotations
+
+
+# Canonical 5 field names per D10. 4 string fields + variety_acknowledgment dict.
+REQUIRED_FIELDS: tuple[str, ...] = (
+    "understanding",
+    "most_likely_wrong",
+    "least_confident_item",
+    "first_action",
+    "variety_acknowledgment",
+)
+
+# Canonical 3 sub-keys for reasoning_reconstruction per pact-ct-teachback.md
+# §When to Method-Reconstruct. Each value is a non-empty string at submit time.
+REQUIRED_SUBKEYS: tuple[str, ...] = (
+    "decision_attribution",
+    "assumption_trace",
+    "contingency_clause",
+)
+
+# Allowed enum values for variety_acknowledgment.rationale_articulates_this_dispatch
+# per D10. Object schema:
+#   {rationale_articulates_this_dispatch: <enum>, concern: <str when != yes>}.
+VARIETY_ACK_VALID_VALUES: tuple[str, ...] = ("yes", "no", "concern")
+
+# REQUIRED-band threshold for reasoning_reconstruction. Per variety_scorer.py:
+# PLAN_MODE_MAX = 14, ORCHESTRATE_MAX = 10 → plan-mode-and-above starts at >= 11.
+# When variety_scorer.py exports an explicit PLAN_MODE_MIN, this should be
+# replaced with `from shared.variety_scorer import PLAN_MODE_MIN`.
+REASONING_RECONSTRUCTION_REQUIRED_MIN: int = 11
+
+
+def validate_reasoning_reconstruction(rr: object) -> str | None:
+    """Return None if rr is a well-formed 3-sub-key triangle, or a short
+    rejection-reason enum string.
+
+    Schema:
+      - dict with exactly REQUIRED_SUBKEYS as keys
+      - each value: non-empty string (after .strip())
+
+    Returns the reason string for the lead-side rejection enum mapping:
+      - "malformed_reasoning_reconstruction" → not-dict / wrong-keys
+      - "empty_reasoning_reconstruction_field" → empty/non-string sub-key
+
+    Pure function; never raises. Non-dict input returns the malformed
+    reason rather than raising TypeError — callers can treat the return
+    value as the load-bearing signal.
+    """
+    if not isinstance(rr, dict):
+        return "malformed_reasoning_reconstruction"
+    if set(rr.keys()) != set(REQUIRED_SUBKEYS):
+        return "malformed_reasoning_reconstruction"
+    for key in REQUIRED_SUBKEYS:
+        value = rr[key]
+        if not isinstance(value, str) or not value.strip():
+            return "empty_reasoning_reconstruction_field"
+    return None

--- a/pact-plugin/hooks/shared/teachback_schema.py
+++ b/pact-plugin/hooks/shared/teachback_schema.py
@@ -14,29 +14,29 @@ When the 5-field shape, 3-sub-key triangle, or threshold changes, this is
 the only Python edit site. Prose in skills/pact-teachback/SKILL.md mirrors
 these values via grep-at-edit-time alignment.
 
-Public surface:
-- REQUIRED_FIELDS — canonical 5-tuple per D10 (4 string fields +
-  variety_acknowledgment dict).
-- REQUIRED_SUBKEYS — canonical 3-tuple for reasoning_reconstruction per
-  pact-ct-teachback.md §When to Method-Reconstruct.
-- VARIETY_ACK_VALID_VALUES — enum tuple for
-  variety_acknowledgment.rationale_articulates_this_dispatch.
-- REASONING_RECONSTRUCTION_REQUIRED_MIN — variety band threshold (>= 11
-  → REQUIRED). Sourced from variety_scorer.PLAN_MODE_MAX + 1 semantics;
-  align via grep-at-edit-time until variety_scorer.py exports an explicit
-  PLAN_MODE_MIN.
-- validate_reasoning_reconstruction(rr) — pure validator returning None
-  on well-formed input or a reason-enum string on rejection.
-
 Contract: pure module; no I/O, no global state, no platform dependencies.
 Functions never raise.
+
+Public surface:
+- TEACHBACK_REQUIRED_FIELDS — canonical 5-tuple per D10 (4 string fields +
+  variety_acknowledgment dict).
+- TEACHBACK_REQUIRED_SUBKEYS — canonical 3-tuple for reasoning_reconstruction
+  per pact-ct-teachback.md §When to Method-Reconstruct.
+- TEACHBACK_VARIETY_ACK_VALID_VALUES — enum tuple for
+  variety_acknowledgment.rationale_articulates_this_dispatch.
+- TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN — variety band threshold
+  (>= 11 → REQUIRED). Sourced from variety_scorer.PLAN_MODE_MAX + 1
+  semantics; align via grep-at-edit-time until variety_scorer.py exports
+  an explicit PLAN_MODE_MIN.
+- validate_reasoning_reconstruction(rr) — pure validator returning None
+  on well-formed input or a reason-enum string on rejection.
 """
 
 from __future__ import annotations
 
 
 # Canonical 5 field names per D10. 4 string fields + variety_acknowledgment dict.
-REQUIRED_FIELDS: tuple[str, ...] = (
+TEACHBACK_REQUIRED_FIELDS: tuple[str, ...] = (
     "understanding",
     "most_likely_wrong",
     "least_confident_item",
@@ -46,7 +46,7 @@ REQUIRED_FIELDS: tuple[str, ...] = (
 
 # Canonical 3 sub-keys for reasoning_reconstruction per pact-ct-teachback.md
 # §When to Method-Reconstruct. Each value is a non-empty string at submit time.
-REQUIRED_SUBKEYS: tuple[str, ...] = (
+TEACHBACK_REQUIRED_SUBKEYS: tuple[str, ...] = (
     "decision_attribution",
     "assumption_trace",
     "contingency_clause",
@@ -55,13 +55,13 @@ REQUIRED_SUBKEYS: tuple[str, ...] = (
 # Allowed enum values for variety_acknowledgment.rationale_articulates_this_dispatch
 # per D10. Object schema:
 #   {rationale_articulates_this_dispatch: <enum>, concern: <str when != yes>}.
-VARIETY_ACK_VALID_VALUES: tuple[str, ...] = ("yes", "no", "concern")
+TEACHBACK_VARIETY_ACK_VALID_VALUES: tuple[str, ...] = ("yes", "no", "concern")
 
 # REQUIRED-band threshold for reasoning_reconstruction. Per variety_scorer.py:
 # PLAN_MODE_MAX = 14, ORCHESTRATE_MAX = 10 → plan-mode-and-above starts at >= 11.
 # When variety_scorer.py exports an explicit PLAN_MODE_MIN, this should be
 # replaced with `from shared.variety_scorer import PLAN_MODE_MIN`.
-REASONING_RECONSTRUCTION_REQUIRED_MIN: int = 11
+TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN: int = 11
 
 
 def validate_reasoning_reconstruction(rr: object) -> str | None:
@@ -69,7 +69,7 @@ def validate_reasoning_reconstruction(rr: object) -> str | None:
     rejection-reason enum string.
 
     Schema:
-      - dict with exactly REQUIRED_SUBKEYS as keys
+      - dict with exactly TEACHBACK_REQUIRED_SUBKEYS as keys
       - each value: non-empty string (after .strip())
 
     Returns the reason string for the lead-side rejection enum mapping:
@@ -82,9 +82,9 @@ def validate_reasoning_reconstruction(rr: object) -> str | None:
     """
     if not isinstance(rr, dict):
         return "malformed_reasoning_reconstruction"
-    if set(rr.keys()) != set(REQUIRED_SUBKEYS):
+    if set(rr.keys()) != set(TEACHBACK_REQUIRED_SUBKEYS):
         return "malformed_reasoning_reconstruction"
-    for key in REQUIRED_SUBKEYS:
+    for key in TEACHBACK_REQUIRED_SUBKEYS:
         value = rr[key]
         if not isinstance(value, str) or not value.strip():
             return "empty_reasoning_reconstruction_field"

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -761,12 +761,14 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
             advisories.append((
                 "reasoning_reconstruction_in_handoff",
                 f"PACT task_lifecycle_gate: Task {task_id} "
-                "placed reasoning_reconstruction inside metadata.handoff. "
-                "It belongs at top-level on metadata.teachback_submit. "
-                "The handoff has reasoning_chain (sender's view); the "
-                "teachback has reasoning_reconstruction (receiver's "
-                "reconstruction). See pact-teachback skill Common "
-                "mistakes row 2.",
+                "placed reasoning_reconstruction inside metadata.handoff "
+                "(wrong slot). Correct destination depends on task type: "
+                "for a Teachback Task, place reasoning_reconstruction at "
+                "top-level on metadata.teachback_submit. For a work task "
+                "carrying a HANDOFF, the HANDOFF schema has "
+                "reasoning_chain (sender's view) — not "
+                "reasoning_reconstruction (the receiver-side teachback "
+                "field). See pact-teachback skill Common mistakes row 2.",
             ))
 
         if isinstance(incoming_teachback, dict):

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -114,11 +114,11 @@ try:
     from shared.session_journal import append_event, make_event
     from shared.task_utils import read_task_json
     from shared.teachback_schema import (
-        REASONING_RECONSTRUCTION_REQUIRED_MIN as _REASONING_RECONSTRUCTION_REQUIRED_MIN,
-        REQUIRED_FIELDS as _TEACHBACK_REQUIRED_FIELDS,
-        REQUIRED_SUBKEYS as _TEACHBACK_REQUIRED_SUBKEYS,
-        VARIETY_ACK_VALID_VALUES as _VARIETY_ACK_VALID_VALUES,
-        validate_reasoning_reconstruction as _validate_reasoning_reconstruction,
+        TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN,
+        TEACHBACK_REQUIRED_FIELDS,
+        TEACHBACK_REQUIRED_SUBKEYS,
+        TEACHBACK_VARIETY_ACK_VALID_VALUES,
+        validate_reasoning_reconstruction,
     )
     from shared.tool_response import extract_tool_response
 except BaseException as _module_load_error:  # noqa: BLE001 — fail-closed catch-all
@@ -160,11 +160,12 @@ _HANDOFF_REQUIRED_FIELDS = (
     "open_questions",
 )
 
-# Teachback schema constants (_TEACHBACK_REQUIRED_FIELDS,
-# _VARIETY_ACK_VALID_VALUES, _REASONING_RECONSTRUCTION_REQUIRED_MIN) and the
-# reasoning_reconstruction validator are imported from shared.teachback_schema
-# (SSOT). _TEACHBACK_REQUIRED_SUBKEYS and _validate_reasoning_reconstruction
-# are consumed by the write-time advisory rules below.
+# Teachback schema constants (TEACHBACK_REQUIRED_FIELDS,
+# TEACHBACK_VARIETY_ACK_VALID_VALUES, TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN)
+# and the reasoning_reconstruction validator are imported from
+# shared.teachback_schema (SSOT). TEACHBACK_REQUIRED_SUBKEYS and
+# validate_reasoning_reconstruction are consumed by the write-time advisory
+# rules below.
 
 # Required per-dimension rationale fields on metadata.variety (D11).
 # 4-tuple. Each rationale is one sentence explaining THIS dispatch's score
@@ -367,10 +368,10 @@ def _validate_variety_acknowledgment(ack: object) -> str | None:
     if not isinstance(ack, dict):
         return f"must be object, got {type(ack).__name__}"
     value = ack.get("rationale_articulates_this_dispatch")
-    if value not in _VARIETY_ACK_VALID_VALUES:
+    if value not in TEACHBACK_VARIETY_ACK_VALID_VALUES:
         return (
             f"rationale_articulates_this_dispatch must be one of "
-            f"{_VARIETY_ACK_VALID_VALUES}, got {value!r}"
+            f"{TEACHBACK_VARIETY_ACK_VALID_VALUES}, got {value!r}"
         )
     if value != "yes":
         concern = ack.get("concern")
@@ -395,7 +396,7 @@ def _validate_teachback_submit_schema(teachback: object) -> str | None:
             f"metadata.teachback_submit must be object, "
             f"got {type(teachback).__name__}"
         )
-    missing = [f for f in _TEACHBACK_REQUIRED_FIELDS if f not in teachback]
+    missing = [f for f in TEACHBACK_REQUIRED_FIELDS if f not in teachback]
     if missing:
         return (
             f"metadata.teachback_submit missing required fields: "
@@ -404,7 +405,7 @@ def _validate_teachback_submit_schema(teachback: object) -> str | None:
     # Non-empty-string check on the 4 string fields; variety_acknowledgment
     # is a dict, validated by the dedicated sub-validator below.
     string_fields = tuple(
-        f for f in _TEACHBACK_REQUIRED_FIELDS if f != "variety_acknowledgment"
+        f for f in TEACHBACK_REQUIRED_FIELDS if f != "variety_acknowledgment"
     )
     empty = [
         f for f in string_fields
@@ -494,7 +495,7 @@ def _resolve_required_band_via_blocks(
     total = variety.get("total")
     if not isinstance(total, int) or isinstance(total, bool):
         return "unresolvable"
-    if total >= _REASONING_RECONSTRUCTION_REQUIRED_MIN:
+    if total >= TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN:
         return "required"
     if total >= 7:
         return "recommended"
@@ -759,7 +760,7 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
             task_id = tool_input.get("taskId", "") or ""
             advisories.append((
                 "reasoning_reconstruction_in_handoff",
-                f"PACT task_lifecycle_gate: Teachback Task {task_id} "
+                f"PACT task_lifecycle_gate: Task {task_id} "
                 "placed reasoning_reconstruction inside metadata.handoff. "
                 "It belongs at top-level on metadata.teachback_submit. "
                 "The handoff has reasoning_chain (sender's view); the "
@@ -809,7 +810,7 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
                             "Per D10, variety_acknowledgment is an OBJECT "
                             "(NOT a free-text string) with "
                             f"rationale_articulates_this_dispatch in "
-                            f"{_VARIETY_ACK_VALID_VALUES} + concern "
+                            f"{TEACHBACK_VARIETY_ACK_VALID_VALUES} + concern "
                             "(when != 'yes'). See pact-teachback skill "
                             "Common mistakes row 1.",
                         ))
@@ -821,7 +822,7 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
                 # will reject with malformed_reasoning_reconstruction or
                 # empty_reasoning_reconstruction_field.
                 if "reasoning_reconstruction" in incoming_teachback:
-                    rr_problem = _validate_reasoning_reconstruction(
+                    rr_problem = validate_reasoning_reconstruction(
                         incoming_teachback["reasoning_reconstruction"]
                     )
                     if rr_problem:
@@ -830,7 +831,7 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
                             f"PACT task_lifecycle_gate: Teachback Task "
                             f"{task_id} reasoning_reconstruction "
                             f"rejected — {rr_problem}. Canonical 3 "
-                            f"sub-keys are {_TEACHBACK_REQUIRED_SUBKEYS} "
+                            f"sub-keys are {TEACHBACK_REQUIRED_SUBKEYS} "
                             "as non-empty strings. Lead will reject with "
                             "the same reason enum. See pact-teachback "
                             "skill Common mistakes row 3.",

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -49,6 +49,18 @@ Rule coverage:
     metadata.variety OR with malformed per-dimension rationales
   - variety_acknowledgment_missing — Teachback submitted without
     variety_acknowledgment field (D10 teammate verification)
+  - variety_acknowledgment_schema_invalid_at_write_time — Teachback
+    submitted with variety_acknowledgment present but malformed
+    (STRING instead of OBJECT; invalid enum; missing concern)
+  - reasoning_reconstruction_in_handoff — reasoning_reconstruction
+    placed inside metadata.handoff (wrong slot — belongs on
+    teachback_submit)
+  - reasoning_reconstruction_subkeys_invalid — reasoning_reconstruction
+    present on teachback_submit but the 3 sub-keys are wrong-shape
+    (non-canonical names, missing keys, or empty/non-string values)
+  - intentional_wait_nested_in_teachback_submit — intentional_wait
+    placed inside teachback_submit instead of as a sibling top-level
+    metadata key (Step 3 of the canonical 3-step shape)
   - Every gate decision emits a session_journal lifecycle_decision event
 """
 
@@ -101,6 +113,13 @@ try:
     from shared.intentional_wait import is_self_complete_exempt, is_teachback_exempt
     from shared.session_journal import append_event, make_event
     from shared.task_utils import read_task_json
+    from shared.teachback_schema import (
+        REASONING_RECONSTRUCTION_REQUIRED_MIN as _REASONING_RECONSTRUCTION_REQUIRED_MIN,
+        REQUIRED_FIELDS as _TEACHBACK_REQUIRED_FIELDS,
+        REQUIRED_SUBKEYS as _TEACHBACK_REQUIRED_SUBKEYS,
+        VARIETY_ACK_VALID_VALUES as _VARIETY_ACK_VALID_VALUES,
+        validate_reasoning_reconstruction as _validate_reasoning_reconstruction,
+    )
     from shared.tool_response import extract_tool_response
 except BaseException as _module_load_error:  # noqa: BLE001 — fail-closed catch-all
     _emit_load_failure_advisory("module imports", _module_load_error)
@@ -141,19 +160,11 @@ _HANDOFF_REQUIRED_FIELDS = (
     "open_questions",
 )
 
-# Required teachback_submit schema fields (advisory if present-but-malformed).
-# 5-tuple per D10: 4 string fields + variety_acknowledgment dict. Mirrors the
-# canonical schema documented in pact-plugin/skills/pact-teachback/SKILL.md.
-# When the 5-field shape changes, update this constant AND the SKILL.md docs
-# together (single SSOT-style mirror; grep-at-edit-time is the alignment
-# mechanism until a shared schema module materializes — see design doc §6.4).
-_TEACHBACK_REQUIRED_FIELDS = (
-    "understanding",
-    "most_likely_wrong",
-    "least_confident_item",
-    "first_action",
-    "variety_acknowledgment",
-)
+# Teachback schema constants (_TEACHBACK_REQUIRED_FIELDS,
+# _VARIETY_ACK_VALID_VALUES, _REASONING_RECONSTRUCTION_REQUIRED_MIN) and the
+# reasoning_reconstruction validator are imported from shared.teachback_schema
+# (SSOT). _TEACHBACK_REQUIRED_SUBKEYS and _validate_reasoning_reconstruction
+# are consumed by the write-time advisory rules below.
 
 # Required per-dimension rationale fields on metadata.variety (D11).
 # 4-tuple. Each rationale is one sentence explaining THIS dispatch's score
@@ -165,22 +176,6 @@ _VARIETY_REQUIRED_RATIONALES = (
     "uncertainty_rationale",
     "risk_rationale",
 )
-
-# Allowed enum values for variety_acknowledgment.rationale_articulates_this_dispatch
-# per D10. "yes" → all four rationales articulate this dispatch's complexity.
-# "no" → teammate flags cargo-cult or scoring defect. "concern" → softer
-# signal; teammate has reservation but is not certain.
-_VARIETY_ACK_VALID_VALUES = ("yes", "no", "concern")
-
-# REQUIRED-band threshold for reasoning_reconstruction (Task B variety.total).
-# Sourced from variety_scorer.PLAN_MODE_MAX + 1 semantics: PLAN_MODE_MAX=14,
-# ORCHESTRATE_MAX=10 → plan-mode-and-above starts at >= 11. Kept module-local
-# until the variety_scorer.py SSOT migration trajectory lands an explicit
-# PLAN_MODE_MIN export, at which point this should be replaced with:
-#     from shared.variety_scorer import PLAN_MODE_MIN
-# Until then, align via grep gate at edit time — see design doc §6.5 for
-# the SSOT-migration rationale.
-_REASONING_RECONSTRUCTION_REQUIRED_MIN = 11
 
 
 # Canonical Teachback Task subject pattern: `<teammate-name>: TEACHBACK
@@ -731,6 +726,12 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
     # in the rare case a teammate bundles teachback_submit + completion in
     # one TaskUpdate (R1/R2 cover the completion-time surface; R3/R5 are
     # the teammate-facing first-line write-time correction).
+    #
+    # Also at this block: 4 cross-slot/cross-key shape advisories that catch
+    # canonical-schema deviations at the wrong-write moment (rather than at
+    # lead-review-time). Rule names are LOAD-BEARING grep-anchors for the
+    # pact-teachback skill's Common Mistakes section — do not rename without
+    # paired SKILL.md edit.
     if (
         tool_name == "TaskUpdate"
         and tool_input.get("status") != "completed"
@@ -740,17 +741,45 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
             if isinstance(incoming_metadata, dict)
             else None
         )
+        incoming_handoff = (
+            incoming_metadata.get("handoff")
+            if isinstance(incoming_metadata, dict)
+            else None
+        )
+
+        # Cross-slot check: reasoning_reconstruction belongs on
+        # teachback_submit, NOT on handoff. Fires whenever HANDOFF is
+        # being written with rr nested inside it, regardless of whether
+        # teachback_submit is also being written — catches the wrong-slot
+        # mistake at the work-task surface (where HANDOFFs land) as well
+        # as the teachback-task surface. handoff.reasoning_chain is the
+        # canonical sender-side field; reasoning_reconstruction is the
+        # receiver-side teachback field. Symmetric concept, different slot.
+        if isinstance(incoming_handoff, dict) and "reasoning_reconstruction" in incoming_handoff:
+            task_id = tool_input.get("taskId", "") or ""
+            advisories.append((
+                "reasoning_reconstruction_in_handoff",
+                f"PACT task_lifecycle_gate: Teachback Task {task_id} "
+                "placed reasoning_reconstruction inside metadata.handoff. "
+                "It belongs at top-level on metadata.teachback_submit. "
+                "The handoff has reasoning_chain (sender's view); the "
+                "teachback has reasoning_reconstruction (receiver's "
+                "reconstruction). See pact-teachback skill Common "
+                "mistakes row 2.",
+            ))
+
         if isinstance(incoming_teachback, dict):
             task_id = tool_input.get("taskId", "") or ""
-            # Shared task_a disk read — both R3 and R5 consume this one
-            # read (R3 needs blocks for traversal, R5 only needs subject).
+            # Shared task_a disk read — R3, R5, and the 3 new
+            # teachback-scoped rules consume this one read (R3 needs
+            # blocks for traversal, others only need subject).
             task_a = read_task_json(task_id, team_name) if team_name else {}
             subject = task_a.get("subject") or ""
             if _is_teachback_subject(subject):
                 # R5 (D10): variety_acknowledgment presence check.
                 # Presence-only at write-time; full schema validation is
-                # R2's job at lead-completion-pair moment. Same two-surface
-                # asymmetry as R3 vs lead-side rejection-cycle.
+                # the next rule's job (write-time schema check forwarded
+                # from R2's completion-time surface).
                 if "variety_acknowledgment" not in incoming_teachback:
                     advisories.append((
                         "variety_acknowledgment_missing",
@@ -760,6 +789,72 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
                         "must record judgment of the orchestrator's "
                         "variety scoring before lead-side teachback "
                         "review. See pact-teachback skill.",
+                    ))
+                else:
+                    # variety_acknowledgment present → forward the schema
+                    # check from R2's completion-time surface to write-time
+                    # so the wrong shape (e.g. STRING instead of OBJECT) is
+                    # caught at the wrong-write moment. Disjoint with R5
+                    # by predicate (R5 fires on absent; this rule fires on
+                    # present-but-malformed).
+                    ack_problem = _validate_variety_acknowledgment(
+                        incoming_teachback["variety_acknowledgment"]
+                    )
+                    if ack_problem:
+                        advisories.append((
+                            "variety_acknowledgment_schema_invalid_at_write_time",
+                            f"PACT task_lifecycle_gate: Teachback Task "
+                            f"{task_id} submitted with malformed "
+                            f"variety_acknowledgment — {ack_problem}. "
+                            "Per D10, variety_acknowledgment is an OBJECT "
+                            "(NOT a free-text string) with "
+                            f"rationale_articulates_this_dispatch in "
+                            f"{_VARIETY_ACK_VALID_VALUES} + concern "
+                            "(when != 'yes'). See pact-teachback skill "
+                            "Common mistakes row 1.",
+                        ))
+
+                # reasoning_reconstruction sub-key schema check —
+                # disjoint from R3 (R3 fires on absent-at-required-band;
+                # this rule fires on present-but-malformed regardless of
+                # band). Pure validator from shared.teachback_schema; lead
+                # will reject with malformed_reasoning_reconstruction or
+                # empty_reasoning_reconstruction_field.
+                if "reasoning_reconstruction" in incoming_teachback:
+                    rr_problem = _validate_reasoning_reconstruction(
+                        incoming_teachback["reasoning_reconstruction"]
+                    )
+                    if rr_problem:
+                        advisories.append((
+                            "reasoning_reconstruction_subkeys_invalid",
+                            f"PACT task_lifecycle_gate: Teachback Task "
+                            f"{task_id} reasoning_reconstruction "
+                            f"rejected — {rr_problem}. Canonical 3 "
+                            f"sub-keys are {_TEACHBACK_REQUIRED_SUBKEYS} "
+                            "as non-empty strings. Lead will reject with "
+                            "the same reason enum. See pact-teachback "
+                            "skill Common mistakes row 3.",
+                        ))
+
+                # Cross-key check: intentional_wait is a sibling
+                # top-level metadata key (Step 3 of the canonical 3-step
+                # shape), NOT nested inside teachback_submit. Nested
+                # placement is invisible to is_self_complete_exempt
+                # (shared/intentional_wait.py reads metadata.intentional_wait,
+                # not nested locations) — the teammate's idle is
+                # unprotected.
+                if "intentional_wait" in incoming_teachback:
+                    advisories.append((
+                        "intentional_wait_nested_in_teachback_submit",
+                        f"PACT task_lifecycle_gate: Teachback Task "
+                        f"{task_id} placed intentional_wait inside "
+                        "teachback_submit. It must be a top-level "
+                        "metadata key (separate TaskUpdate call per "
+                        "the canonical Step 1 / Step 3 ordering). Your "
+                        "idle is unprotected — is_self_complete_exempt "
+                        "reads metadata.intentional_wait, not the "
+                        "nested location. See pact-teachback skill "
+                        "Common mistakes row 4.",
                     ))
 
                 # R3: reasoning_reconstruction required at >= 11 band.

--- a/pact-plugin/skills/pact-teachback/SKILL.md
+++ b/pact-plugin/skills/pact-teachback/SKILL.md
@@ -5,11 +5,54 @@ description: Command-style teachback protocol for PACT teammates. Invoking this 
 
 # Teachback — Store Now
 
+## Canonical schema at a glance
+
+The full teachback payload — all required fields plus the optional method-reconstruction sub-object — at the correct nesting level. Skim this first if you only have time for one section; the rest of the skill explains the why and the surrounding choreography.
+
+```
+TaskUpdate(taskId, metadata={
+
+    # Top-level metadata key #1: teachback_submit
+    # 5 canonical fields. variety_acknowledgment is an OBJECT (not a string).
+    # reasoning_reconstruction is a sibling field of the other 4 (not nested
+    # inside any of them, not placed on metadata.handoff).
+    "teachback_submit": {
+        "understanding":         "<...>",
+        "most_likely_wrong":     "<...>",
+        "least_confident_item":  "<...>",
+        "first_action":          "<...>",
+        "variety_acknowledgment": {
+            "rationale_articulates_this_dispatch": "yes" | "no" | "concern",
+            "concern": "<required when value != 'yes'>"
+        },
+        # Sibling field — optional below variety 11, required at 11+.
+        # The 3 sub-keys are EXACTLY these three names, no substitutions.
+        "reasoning_reconstruction": {
+            "decision_attribution": "<...>",
+            "assumption_trace":     "<...>",
+            "contingency_clause":   "<...>"
+        }
+    },
+
+    # Top-level metadata key #2: intentional_wait
+    # SEPARATE top-level sibling of teachback_submit — NOT nested inside it.
+    # Written via a SECOND TaskUpdate call after the notify SendMessage; see
+    # Action: store teachback now below for the load-bearing 3-step ordering.
+    "intentional_wait": {
+        "reason":            "awaiting_lead_completion",
+        "expected_resolver": "lead",
+        "since":             "<canonical_since() output>"
+    }
+})
+```
+
+Each field's full purpose, the variety-band trigger for `reasoning_reconstruction`, and the 4 common wrong-shape mistakes appear in the sections below. The Common mistakes section enumerates the 4 wrong shapes the runtime advisory layer at `hooks/task_lifecycle_gate.py` catches at write time.
+
+## What a teachback is
+
 Invoking this skill means you are about to submit a teachback for your
 current task. Do not proceed to implementation work until you have stored
 it AND received the team-lead's acceptance.
-
-## What a teachback is
 
 A teachback is a Pask Conversation Theory verification gate. Before you
 start implementing, you restate your understanding of the task so the
@@ -35,13 +78,32 @@ TaskUpdate(taskId, metadata={"teachback_submit": {
     "most_likely_wrong": "<the part of your understanding you are least confident about>",
     "least_confident_item": "<one specific assumption you'd like the team-lead to confirm>",
     "first_action": "<the first concrete step you will take after teachback approval>",
+    # ANTI-PATTERN: a free-text STRING here is rejected. variety_acknowledgment
+    # MUST be an OBJECT with the 2 keys shown below. The runtime advisory
+    # `variety_acknowledgment_schema_invalid_at_write_time` fires at TaskUpdate
+    # if you submit a string. See Common mistakes row 1.
     "variety_acknowledgment": {                  # REQUIRED — see trigger paragraph below the JSON
         "rationale_articulates_this_dispatch": "yes" | "no" | "concern",
         "concern": "<required when value != 'yes'; names the smell>"
     },
 
+    # ANTI-PATTERN: reasoning_reconstruction belongs HERE — a sibling field on
+    # teachback_submit, NOT inside metadata.handoff. The handoff carries
+    # reasoning_chain (the sender's own reasoning); the teachback carries
+    # reasoning_reconstruction (your reconstruction of the upstream's
+    # reasoning). Symmetric concept, different slot. The runtime advisory
+    # `reasoning_reconstruction_in_handoff` fires if you place it on the
+    # handoff. See Common mistakes row 2.
+
     # OPTIONAL: include per §When to Method-Reconstruct in pact-ct-teachback.md
     # (required at variety >= 11; recommended at 7-10; skipped at 4-6)
+    # ANTI-PATTERN: the 3 sub-keys are EXACTLY these three names —
+    # decision_attribution / assumption_trace / contingency_clause. Substituting
+    # alternatives (e.g. "what-I-learned", "falsification-attempts",
+    # "most-likely-wrong-prediction") is rejected as
+    # reasoning_reconstruction_subkeys_invalid at write time and as
+    # malformed_reasoning_reconstruction at lead-side completion-time review.
+    # See Common mistakes row 3.
     "reasoning_reconstruction": {
         "decision_attribution": "I understand <upstream agent> chose <decision> because <their stated reason>",
         "assumption_trace":     "This reasoning depends on <assumption A>, <assumption B>, ...",
@@ -65,6 +127,15 @@ SendMessage(
 )
 ```
 
+> # ANTI-PATTERN: Step 1 and Step 3 are SEPARATE TaskUpdate calls writing
+> SEPARATE top-level metadata keys. Nesting `intentional_wait` INSIDE
+> `teachback_submit` (one combined TaskUpdate) is invisible to the
+> `is_self_complete_exempt` predicate at `shared/intentional_wait.py`, which
+> reads `metadata.intentional_wait` directly and does not descend into
+> nested objects. Your idle is unprotected. The runtime advisory
+> `intentional_wait_nested_in_teachback_submit` fires at write time. See
+> Common mistakes row 4.
+
 **Step 3 — SET `intentional_wait` and idle**:
 
 ```
@@ -79,9 +150,31 @@ Do NOT begin Task B until Task A's status transitions to `completed`. The team-l
 
 **On rejection** (team-lead writes `metadata.teachback_rejection`): see [pact-agent-teams §On Rejection](../pact-agent-teams/SKILL.md#on-rejection-wake-signal-receipt).
 
+## Common mistakes
+
+The 4 wrong shapes below are the ones the runtime advisory layer at `hooks/task_lifecycle_gate.py` catches at TaskUpdate write time. Each row names the wrong shape, the canonical correction (cross-referenced to [§Canonical schema at a glance](#canonical-schema-at-a-glance) above), and the rejection-reason enum the lead-side gate emits if the wrong shape reaches completion-time. The row numbers are stable grep-anchors: if the runtime advisory text says "See Common mistakes row N", that row is the canonical correction.
+
+| # | Wrong shape | Canonical shape | Rejection-reason enum (write-time advisory / lead-side gate) |
+|---|---|---|---|
+| 1 | `variety_acknowledgment` as a free-text STRING describing your work, or as an OBJECT whose `rationale_articulates_this_dispatch` value is outside the set `{yes, no, concern}` | OBJECT with `{rationale_articulates_this_dispatch: "yes" \| "no" \| "concern", concern: "..." (required when value != "yes")}` — see the field in [§Canonical schema at a glance](#canonical-schema-at-a-glance) | `variety_acknowledgment_schema_invalid_at_write_time` (advisory) / schema-gate rejection at completion-time |
+| 2 | `reasoning_reconstruction` placed inside `metadata.handoff` (the sender-side reasoning slot) | TOP-LEVEL sibling on `metadata.teachback_submit`, alongside `understanding` / `most_likely_wrong` / `least_confident_item` / `first_action` / `variety_acknowledgment` — see [§Canonical schema at a glance](#canonical-schema-at-a-glance) | `reasoning_reconstruction_in_handoff` (advisory) / `malformed_reasoning_reconstruction` (lead-side schema gate) |
+| 3 | `reasoning_reconstruction` with non-canonical sub-key names (e.g. `what-I-learned`, `falsification-attempts`, `most-likely-wrong-prediction`), or sub-keys whose values are empty / whitespace / non-string | Exactly 3 sub-keys: `decision_attribution`, `assumption_trace`, `contingency_clause`, each a non-empty string — see [§Canonical schema at a glance](#canonical-schema-at-a-glance) | `reasoning_reconstruction_subkeys_invalid` (advisory) / `malformed_reasoning_reconstruction` or `empty_reasoning_reconstruction_field` (lead-side schema gate) |
+| 4 | `intentional_wait` nested inside `teachback_submit` (one combined TaskUpdate call) | SEPARATE `TaskUpdate` calls with `intentional_wait` as a TOP-LEVEL metadata sibling of `teachback_submit` — see Step 3 and [§Canonical schema at a glance](#canonical-schema-at-a-glance) | `intentional_wait_nested_in_teachback_submit` (advisory) |
+
+Rows 1–4 align 1:1 with the 4 write-time advisory rules in `task_lifecycle_gate.py`. The advisory text ends with `See pact-teachback skill Common mistakes row N` — that N maps directly to a row in this table. If a rule name above ever drifts, this section drifts with it.
+
 ## When to include reasoning_reconstruction
 
 Include the nested `reasoning_reconstruction` sub-object whenever the dispatching task's variety score is **11+** (`ROUTE_PLAN_MODE` / `ROUTE_RESEARCH_SPIKE`). At variety 7-10 (`ROUTE_ORCHESTRATE`) it is **recommended but not required** — the lead may request reconstruction on follow-up if upstream decisions are non-trivial. At variety 4-6 (`ROUTE_COMPACT`) it is **skipped** — absence is the expected default.
+
+| Variety score | Workflow route | reasoning_reconstruction | Lead behavior on absence |
+|---|---|---|---|
+| 4–6 | `ROUTE_COMPACT` | Skipped — not expected | Accept teachback; absence is the expected default. |
+| 7–10 | `ROUTE_ORCHESTRATE` | Recommended (NOT required) | Accept teachback; lead MAY SendMessage requesting reconstruction on follow-up if upstream decisions are non-trivial. |
+| 11–14 | `ROUTE_PLAN_MODE` | REQUIRED | Reject teachback with `metadata.teachback_rejection{reason="missing_reasoning_reconstruction"}` plus a correction SendMessage. |
+| 15–16 | `ROUTE_RESEARCH_SPIKE` | REQUIRED (treated identically to plan-mode) | Same as `ROUTE_PLAN_MODE` — reject on absence. |
+
+Source of truth for the band cuts: `hooks/shared/variety_scorer.py` (`COMPACT_MAX` / `ORCHESTRATE_MAX` / `PLAN_MODE_MAX`); this table mirrors the SSOT at [pact-ct-teachback.md §When to Method-Reconstruct](../../protocols/pact-ct-teachback.md#when-to-method-reconstruct) — do not paraphrase the `ROUTE_*` literals. Variety **10** is the TOP of `ROUTE_ORCHESTRATE` (recommended-not-required); variety **11** is the BOTTOM of `ROUTE_PLAN_MODE` (required). The 10|11 boundary is the cut.
 
 The three sub-keys are three cognitive operations on the upstream's HANDOFF: `decision_attribution` restates what the upstream decided and why; `assumption_trace` lists the falsifiable propositions the reasoning depends on; `contingency_clause` names a concrete alternative if those assumptions are false. Vague answers are lead-side reject signals — see [pact-ct-teachback.md §When to Method-Reconstruct](../../protocols/pact-ct-teachback.md#when-to-method-reconstruct) for anti-pattern examples + the full variety-band gate.
 

--- a/pact-plugin/skills/pact-teachback/SKILL.md
+++ b/pact-plugin/skills/pact-teachback/SKILL.md
@@ -81,7 +81,7 @@ TaskUpdate(taskId, metadata={"teachback_submit": {
     # ANTI-PATTERN: a free-text STRING here is rejected. variety_acknowledgment
     # MUST be an OBJECT with the 2 keys shown below. The runtime advisory
     # `variety_acknowledgment_schema_invalid_at_write_time` fires at TaskUpdate
-    # if you submit a string. See Common mistakes row 1.
+    # if you submit a string. See pact-teachback skill Common mistakes row 1.
     "variety_acknowledgment": {                  # REQUIRED — see trigger paragraph below the JSON
         "rationale_articulates_this_dispatch": "yes" | "no" | "concern",
         "concern": "<required when value != 'yes'; names the smell>"
@@ -93,7 +93,7 @@ TaskUpdate(taskId, metadata={"teachback_submit": {
     # reasoning_reconstruction (your reconstruction of the upstream's
     # reasoning). Symmetric concept, different slot. The runtime advisory
     # `reasoning_reconstruction_in_handoff` fires if you place it on the
-    # handoff. See Common mistakes row 2.
+    # handoff. See pact-teachback skill Common mistakes row 2.
 
     # OPTIONAL: include per §When to Method-Reconstruct in pact-ct-teachback.md
     # (required at variety >= 11; recommended at 7-10; skipped at 4-6)
@@ -103,7 +103,7 @@ TaskUpdate(taskId, metadata={"teachback_submit": {
     # "most-likely-wrong-prediction") is rejected as
     # reasoning_reconstruction_subkeys_invalid at write time and as
     # malformed_reasoning_reconstruction at lead-side completion-time review.
-    # See Common mistakes row 3.
+    # See pact-teachback skill Common mistakes row 3.
     "reasoning_reconstruction": {
         "decision_attribution": "I understand <upstream agent> chose <decision> because <their stated reason>",
         "assumption_trace":     "This reasoning depends on <assumption A>, <assumption B>, ...",
@@ -134,7 +134,7 @@ SendMessage(
 > reads `metadata.intentional_wait` directly and does not descend into
 > nested objects. Your idle is unprotected. The runtime advisory
 > `intentional_wait_nested_in_teachback_submit` fires at write time. See
-> Common mistakes row 4.
+> pact-teachback skill Common mistakes row 4.
 
 **Step 3 — SET `intentional_wait` and idle**:
 
@@ -171,7 +171,7 @@ Include the nested `reasoning_reconstruction` sub-object whenever the dispatchin
 |---|---|---|---|
 | 4–6 | `ROUTE_COMPACT` | Skipped — not expected | Accept teachback; absence is the expected default. |
 | 7–10 | `ROUTE_ORCHESTRATE` | Recommended (NOT required) | Accept teachback; lead MAY SendMessage requesting reconstruction on follow-up if upstream decisions are non-trivial. |
-| 11–14 | `ROUTE_PLAN_MODE` | REQUIRED | Reject teachback with `metadata.teachback_rejection{reason="missing_reasoning_reconstruction"}` plus a correction SendMessage. |
+| 11–14 | `ROUTE_PLAN_MODE` (plan-mode + orchestrate) | REQUIRED | Reject teachback with `metadata.teachback_rejection{reason="missing_reasoning_reconstruction"}` plus a correction SendMessage. |
 | 15–16 | `ROUTE_RESEARCH_SPIKE` | REQUIRED (treated identically to plan-mode) | Same as `ROUTE_PLAN_MODE` — reject on absence. |
 
 Source of truth for the band cuts: `hooks/shared/variety_scorer.py` (`COMPACT_MAX` / `ORCHESTRATE_MAX` / `PLAN_MODE_MAX`); this table mirrors the SSOT at [pact-ct-teachback.md §When to Method-Reconstruct](../../protocols/pact-ct-teachback.md#when-to-method-reconstruct) — do not paraphrase the `ROUTE_*` literals. Variety **10** is the TOP of `ROUTE_ORCHESTRATE` (recommended-not-required); variety **11** is the BOTTOM of `ROUTE_PLAN_MODE` (required). The 10|11 boundary is the cut.

--- a/pact-plugin/tests/test_agents_structure.py
+++ b/pact-plugin/tests/test_agents_structure.py
@@ -468,11 +468,22 @@ class TestTeachbackMicroSkillExtraction:
     # schema + variety-band gate + L1.5 paragraph; budget ceiling
     # provides ~480-char headroom for future small edits.
     #
+    # Bumped to 16000 to accommodate the schema-clarity restructure:
+    # canonical-shape block at top of file (combined-payload reading
+    # example showing both top-level metadata keys as siblings), four
+    # inline anti-pattern callouts (variety_acknowledgment STRING shape,
+    # reasoning_reconstruction in handoff slot, wrong sub-key names,
+    # intentional_wait nested in teachback_submit), a four-row Common
+    # Mistakes table whose rows align 1:1 with the runtime advisory rules
+    # in task_lifecycle_gate.py, and a four-band threshold table folded
+    # into the When-to-Method-Reconstruct section. Budget ceiling
+    # provides ~810-char headroom for future small edits.
+    #
     # Tighten-back trigger: if a future PR removes optional content
     # (e.g., if a future PR removes the transitional permissiveness
     # paragraph), reduce MAX_SKILL_CHARS to keep this budget a
     # meaningful ceiling and not a ratchet.
-    MAX_SKILL_CHARS = 7500
+    MAX_SKILL_CHARS = 16000
 
     # Key protocol elements that must be in the extracted skill.
     # Presence-only checks are deliberately strict — any drop indicates

--- a/pact-plugin/tests/test_agents_structure.py
+++ b/pact-plugin/tests/test_agents_structure.py
@@ -548,6 +548,91 @@ class TestTeachbackMicroSkillExtraction:
                 f"protocol, not just a pointer."
             )
 
+    def test_teachback_skill_canonical_schema_at_a_glance_block(self, teachback_skill):
+        """T3b: pin the `## Canonical schema at a glance` first-read anchor
+        section + its JSON block content. The block is the load-bearing
+        skim-target at the top of the skill — drift here silently degrades
+        the pre-write learning surface for the 4 wrong-shape failure modes.
+
+        Pins (anchored by line content, not row index):
+          - Section header `## Canonical schema at a glance` exists
+          - A fenced code block follows the section header before the next
+            `##` section
+          - All 5 canonical teachback_submit field names appear inside the
+            block (understanding / most_likely_wrong / least_confident_item /
+            first_action / variety_acknowledgment)
+          - `intentional_wait` appears AFTER the teachback_submit close brace
+            (sibling top-level metadata key, NOT nested), pinning the
+            cross-key invariant the runtime advisory R10
+            `intentional_wait_nested_in_teachback_submit` enforces
+        """
+        text = teachback_skill.read_text(encoding="utf-8")
+        lines = text.splitlines()
+
+        # Section header presence
+        header_idx = next(
+            (
+                i for i, line in enumerate(lines)
+                if line.strip() == "## Canonical schema at a glance"
+            ),
+            None,
+        )
+        assert header_idx is not None, (
+            "pact-teachback SKILL.md missing `## Canonical schema at a glance` "
+            "section header (first-read anchor for the canonical payload shape)."
+        )
+
+        # Slice the section body up to the next `## ` header
+        body_lines = []
+        for line in lines[header_idx + 1:]:
+            if line.startswith("## "):
+                break
+            body_lines.append(line)
+        body = "\n".join(body_lines)
+
+        # Fenced code block present
+        assert "```" in body, (
+            "Canonical schema section missing a fenced code block — the "
+            "first-read anchor must show the literal payload shape."
+        )
+
+        # All 5 canonical teachback_submit field names appear inside the block
+        for field in (
+            "understanding",
+            "most_likely_wrong",
+            "least_confident_item",
+            "first_action",
+            "variety_acknowledgment",
+        ):
+            assert field in body, (
+                f"Canonical schema block missing required teachback_submit "
+                f"field {field!r}. The 5-field shape is the load-bearing "
+                f"first-read anchor; drift triggers wrong-shape failure modes."
+            )
+
+        # intentional_wait sibling-vs-nested invariant: the JSON block must
+        # show intentional_wait AFTER teachback_submit's closing brace, not
+        # inside it. Approximate via index ordering of two marker substrings
+        # within the block body.
+        tb_close_idx = body.find('"teachback_submit"')
+        iw_idx = body.find('"intentional_wait"')
+        assert tb_close_idx != -1, (
+            "Canonical schema block missing teachback_submit key — block "
+            "must show the canonical payload structure."
+        )
+        assert iw_idx != -1, (
+            "Canonical schema block missing intentional_wait — the block "
+            "must pin the sibling-top-level placement that "
+            "is_self_complete_exempt requires."
+        )
+        assert iw_idx > tb_close_idx, (
+            "Canonical schema block must place intentional_wait AFTER "
+            "teachback_submit (sibling top-level key), not nested inside it. "
+            "The runtime advisory `intentional_wait_nested_in_teachback_submit` "
+            "fires on the nested placement; this block must teach the "
+            "correct sibling shape."
+        )
+
     def test_all_agents_have_teachback_in_frontmatter(self, teammate_agent_files):
         """T4: every agent must eager-load pact-teachback via frontmatter."""
         for f in teammate_agent_files:

--- a/pact-plugin/tests/test_agents_structure.py
+++ b/pact-plugin/tests/test_agents_structure.py
@@ -477,7 +477,7 @@ class TestTeachbackMicroSkillExtraction:
     # Mistakes table whose rows align 1:1 with the runtime advisory rules
     # in task_lifecycle_gate.py, and a four-band threshold table folded
     # into the When-to-Method-Reconstruct section. Budget ceiling
-    # provides ~810-char headroom for future small edits.
+    # provides ~620-char headroom for future small edits.
     #
     # Tighten-back trigger: if a future PR removes optional content
     # (e.g., if a future PR removes the transitional permissiveness

--- a/pact-plugin/tests/test_per_dispatch_variety.py
+++ b/pact-plugin/tests/test_per_dispatch_variety.py
@@ -93,7 +93,7 @@ class TestRequiredBandResolution:
 
     def test_required_at_min_threshold(self, tmp_path, monkeypatch):
         """total = 11 → required (inclusive lower bound for REQUIRED band).
-        Pinned via _REASONING_RECONSTRUCTION_REQUIRED_MIN."""
+        Pinned via TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN."""
         _seed_task_b(
             tmp_path, monkeypatch, "test-team", "2",
             metadata={"variety": _well_formed_variety(total=11)},
@@ -162,20 +162,24 @@ class TestRequiredBandResolution:
         ) == "skipped"
 
     def test_band_threshold_constants_aligned_with_variety_scorer(self):
-        """Pin the alignment between _REASONING_RECONSTRUCTION_REQUIRED_MIN
-        and variety_scorer.ORCHESTRATE_MAX. PLAN_MODE_MIN-implied threshold
-        is ORCHESTRATE_MAX + 1 = 11. If variety_scorer's thresholds shift
-        and this module's constant doesn't, this test fails and the drift
-        is surfaced. The design doc §6.5 codifies this as a grep-at-edit-
+        """Pin the alignment between
+        TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN and
+        variety_scorer.ORCHESTRATE_MAX. PLAN_MODE_MIN-implied threshold is
+        ORCHESTRATE_MAX + 1 = 11. If variety_scorer's thresholds shift and
+        this module's constant doesn't, this test fails and the drift is
+        surfaced. The design doc §6.5 codifies this as a grep-at-edit-
         time discipline until the SSOT migration trajectory lands."""
         from shared import variety_scorer
+        from shared.teachback_schema import (
+            TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN,
+        )
 
         assert (
-            tlg._REASONING_RECONSTRUCTION_REQUIRED_MIN
+            TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN
             == variety_scorer.ORCHESTRATE_MAX + 1
         ), (
-            "module-local constant drifted from variety_scorer SSOT — "
-            "see task_lifecycle_gate.py inline comment + design doc §6.5"
+            "shared.teachback_schema constant drifted from variety_scorer "
+            "SSOT — see teachback_schema.py inline comment + design doc §6.5"
         )
 
 

--- a/pact-plugin/tests/test_per_dispatch_variety.py
+++ b/pact-plugin/tests/test_per_dispatch_variety.py
@@ -6,7 +6,7 @@ disk-based traversal from Task A (teachback subject) through blocks[0] to
 Task B's metadata.variety.total. This is the helper that R3 consumes to
 decide whether reasoning_reconstruction is REQUIRED.
 
-Test surface architecture (per the design doc §4.2):
+Test surface architecture:
   - All 4 return values exercised: "required", "recommended", "skipped",
     "unresolvable".
   - All fail-open paths: blocks missing, blocks empty, Task B id
@@ -167,8 +167,8 @@ class TestRequiredBandResolution:
         variety_scorer.ORCHESTRATE_MAX. PLAN_MODE_MIN-implied threshold is
         ORCHESTRATE_MAX + 1 = 11. If variety_scorer's thresholds shift and
         this module's constant doesn't, this test fails and the drift is
-        surfaced. The design doc §6.5 codifies this as a grep-at-edit-
-        time discipline until the SSOT migration trajectory lands."""
+        surfaced. Grep-at-edit-time discipline applies until the SSOT
+        migration trajectory lands."""
         from shared import variety_scorer
         from shared.teachback_schema import (
             TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN,
@@ -179,7 +179,7 @@ class TestRequiredBandResolution:
             == variety_scorer.ORCHESTRATE_MAX + 1
         ), (
             "shared.teachback_schema constant drifted from variety_scorer "
-            "SSOT — see teachback_schema.py inline comment + design doc §6.5"
+            "SSOT — see teachback_schema.py inline comment"
         )
 
 

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -2578,3 +2578,152 @@ def test_intentional_wait_silent_when_top_level_sibling(
         rule == "intentional_wait_nested_in_teachback_submit"
         for rule, _ in advisories
     )
+
+
+# =============================================================================
+# Multi-rule concurrent emission — a single TaskUpdate that violates several
+# canonical-schema rules at once must emit ALL applicable advisories, not
+# stop after the first match. Pinning this property guards against future
+# short-circuit refactors that would silently degrade the teaching surface
+# (a teammate with 3 mistakes should learn about all 3, not just one).
+# =============================================================================
+
+
+def test_multi_rule_concurrent_emission_three_rules_fire_together(
+    tmp_path, monkeypatch, pact_context,
+):
+    """One TaskUpdate carrying THREE distinct violations must emit THREE
+    advisories on the same evaluation pass:
+      - variety_acknowledgment as STRING → variety_acknowledgment_schema_invalid_at_write_time
+      - reasoning_reconstruction with wrong sub-key names → reasoning_reconstruction_subkeys_invalid
+      - intentional_wait nested inside teachback_submit → intentional_wait_nested_in_teachback_submit
+    """
+    pact_context(team_name="test-team", session_id="test-session")
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety_total=8,
+    )
+    tb = _well_formed_teachback_submit(
+        variety_acknowledgment="I think the scoring is fine",
+        reasoning_reconstruction={
+            "what-I-learned": "x",
+            "falsification-attempts": "y",
+            "most-likely-wrong-prediction": "z",
+        },
+    )
+    tb["intentional_wait"] = {
+        "reason": "awaiting_lead_completion",
+        "expected_resolver": "lead",
+        "since": "2026-05-26T20:00:00+00:00",
+    }
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {"teachback_submit": tb},
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    rules = {rule for rule, _ in advisories}
+    assert "variety_acknowledgment_schema_invalid_at_write_time" in rules
+    assert "reasoning_reconstruction_subkeys_invalid" in rules
+    assert "intentional_wait_nested_in_teachback_submit" in rules
+
+
+def test_multi_rule_concurrent_emission_cross_slot_with_teachback_violation(
+    tmp_path, monkeypatch, pact_context,
+):
+    """A TaskUpdate writing BOTH teachback_submit (with a wrong-shape ack)
+    AND handoff (with reasoning_reconstruction in the wrong slot) must
+    emit BOTH advisories — the cross-slot rule (R8) and the teachback-
+    scoped rule (R7) are independent code paths and both must fire."""
+    pact_context(team_name="test-team", session_id="test-session")
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety_total=8,
+    )
+    tb = _well_formed_teachback_submit(
+        variety_acknowledgment={"rationale_articulates_this_dispatch": "maybe"},
+    )
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {
+                "teachback_submit": tb,
+                "handoff": {
+                    "produced": "x", "decisions": "x", "reasoning_chain": "x",
+                    "uncertainty": "x", "integration": "x", "open_questions": "x",
+                    "reasoning_reconstruction": {
+                        "decision_attribution": "x",
+                        "assumption_trace": "x",
+                        "contingency_clause": "x",
+                    },
+                },
+            },
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    rules = {rule for rule, _ in advisories}
+    assert "variety_acknowledgment_schema_invalid_at_write_time" in rules
+    assert "reasoning_reconstruction_in_handoff" in rules
+
+
+# =============================================================================
+# 10|11 variety-band boundary disambiguation — pin the exact cut so that
+# future variety_scorer threshold changes (e.g. PLAN_MODE_MIN export) are
+# caught here rather than silently re-routing recommended/required cases.
+# =============================================================================
+
+
+def test_r3_boundary_variety_total_10_recommended_band_silent_on_missing_rr(
+    tmp_path, monkeypatch, pact_context,
+):
+    """variety_total=10 → ROUTE_ORCHESTRATE (recommended, not required).
+    Missing reasoning_reconstruction must NOT fire R3
+    (reasoning_reconstruction_missing_at_required_band). 10 is the TOP of
+    the recommended band per the threshold-band table at
+    pact-teachback/SKILL.md and the SSOT at pact-ct-teachback.md."""
+    pact_context(team_name="test-team", session_id="test-session")
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety_total=10,
+    )
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {"teachback_submit": _well_formed_teachback_submit()},
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert not any(
+        rule == "reasoning_reconstruction_missing_at_required_band"
+        for rule, _ in advisories
+    )
+
+
+def test_r3_boundary_variety_total_11_required_band_fires_on_missing_rr(
+    tmp_path, monkeypatch, pact_context,
+):
+    """variety_total=11 → ROUTE_PLAN_MODE (required). Missing
+    reasoning_reconstruction must fire R3
+    (reasoning_reconstruction_missing_at_required_band). 11 is the BOTTOM
+    of the required band — the 10|11 cut is the canonical threshold."""
+    pact_context(team_name="test-team", session_id="test-session")
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety_total=11,
+    )
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {"teachback_submit": _well_formed_teachback_submit()},
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert any(
+        rule == "reasoning_reconstruction_missing_at_required_band"
+        for rule, _ in advisories
+    ), f"expected R3 to fire at variety=11, got: {advisories}"

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -1995,9 +1995,9 @@ def test_r5_silent_on_non_teachback_subject(
 def test_r3_r5_silent_when_status_completed(
     tmp_path, monkeypatch, pact_context,
 ):
-    """R3 + R5 are gated on status != 'completed' (two-surface asymmetry
-    per design doc §6.1: R1/R2 cover completion-time; R3/R5 cover write-
-    time only). When a teammate atypically bundles teachback_submit +
+    """R3 + R5 are gated on status != 'completed' (two-surface asymmetry:
+    R1/R2 cover completion-time; R3/R5 cover write-time only). When a
+    teammate atypically bundles teachback_submit +
     status=completed in one TaskUpdate, R3/R5 stay silent and R1/R2 (with
     schema validator) cover the same defect class."""
     pact_context(team_name="test-team", session_id="test-session")
@@ -2399,6 +2399,64 @@ def test_reasoning_reconstruction_in_handoff_silent_when_no_handoff(
         rule == "reasoning_reconstruction_in_handoff"
         for rule, _ in advisories
     )
+
+
+@pytest.mark.parametrize(
+    "rr_shape,shape_label",
+    [
+        (
+            {
+                "what-I-learned": "x",
+                "falsification-attempts": "y",
+                "most-likely-wrong-prediction": "z",
+            },
+            "wrong-key-names",
+        ),
+        (
+            {
+                "decision_attribution": "x",
+                "assumption_trace": "",
+                "contingency_clause": "x",
+            },
+            "empty-sub-key-value",
+        ),
+    ],
+)
+def test_reasoning_reconstruction_in_handoff_fires_regardless_of_inner_shape(
+    rr_shape, shape_label, pact_context,
+):
+    """R7 fires whenever reasoning_reconstruction appears in metadata.handoff,
+    INDEPENDENT of the inner sub-key shape. The cross-slot rule is a pure
+    slot-location detector; sub-key validity is R9's surface, not R7's.
+
+    Matches R9's parametrized shape-probe coverage (wrong-key-names +
+    empty-sub-key-value) so the two write-time advisory surfaces are
+    symmetric in shape-probe breadth — proving slot detection is
+    disjoint from sub-key validation across both surfaces."""
+    pact_context(team_name="test-team", session_id="test-session")
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {
+                "handoff": {
+                    "produced": "x",
+                    "decisions": "x",
+                    "reasoning_chain": "x",
+                    "uncertainty": "x",
+                    "integration": "x",
+                    "open_questions": "x",
+                    "reasoning_reconstruction": rr_shape,
+                },
+            },
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert any(
+        rule == "reasoning_reconstruction_in_handoff"
+        for rule, _ in advisories
+    ), f"expected R7 to fire for {shape_label}, got: {advisories}"
 
 
 # =============================================================================

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -2201,3 +2201,380 @@ class TestValidateTeachbackSubmitSchema:
             )
         )
         assert result is None
+
+
+# =============================================================================
+# variety_acknowledgment_schema_invalid_at_write_time — D10 schema check
+# forwarded from R2 (completion-time) to write-time
+# =============================================================================
+
+
+def test_variety_ack_schema_invalid_at_write_time_fires_on_string(
+    tmp_path, monkeypatch, pact_context,
+):
+    """variety_acknowledgment as a free-text STRING instead of OBJECT →
+    fires at write-time (not just completion-time)."""
+    pact_context(team_name="test-team", session_id="test-session")
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety_total=8,
+    )
+    tb = _well_formed_teachback_submit(
+        variety_acknowledgment="I think the scoring is fine",
+    )
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {"teachback_submit": tb},
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert any(
+        rule == "variety_acknowledgment_schema_invalid_at_write_time"
+        for rule, _ in advisories
+    ), f"expected write-time schema advisory, got: {advisories}"
+
+
+def test_variety_ack_schema_invalid_at_write_time_fires_on_invalid_enum(
+    tmp_path, monkeypatch, pact_context,
+):
+    """variety_acknowledgment with invalid enum value → fires."""
+    pact_context(team_name="test-team", session_id="test-session")
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety_total=8,
+    )
+    tb = _well_formed_teachback_submit(
+        variety_acknowledgment={"rationale_articulates_this_dispatch": "maybe"},
+    )
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {"teachback_submit": tb},
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert any(
+        rule == "variety_acknowledgment_schema_invalid_at_write_time"
+        for rule, _ in advisories
+    )
+
+
+def test_variety_ack_schema_silent_at_write_time_on_well_formed(
+    tmp_path, monkeypatch, pact_context,
+):
+    """Well-formed variety_acknowledgment → write-time schema advisory silent.
+    Disjoint with R5 (which fires on absent, not present-but-malformed)."""
+    pact_context(team_name="test-team", session_id="test-session")
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety_total=8,
+    )
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {"teachback_submit": _well_formed_teachback_submit()},
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert not any(
+        rule == "variety_acknowledgment_schema_invalid_at_write_time"
+        for rule, _ in advisories
+    )
+
+
+def test_variety_ack_schema_silent_when_field_absent(
+    tmp_path, monkeypatch, pact_context,
+):
+    """variety_acknowledgment absent → R5 fires for presence; the
+    schema-at-write-time rule does NOT fire (disjoint trigger)."""
+    pact_context(team_name="test-team", session_id="test-session")
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety_total=8,
+    )
+    tb = _well_formed_teachback_submit()
+    tb.pop("variety_acknowledgment")
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {"teachback_submit": tb},
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    rules = {rule for rule, _ in advisories}
+    assert "variety_acknowledgment_missing" in rules
+    assert "variety_acknowledgment_schema_invalid_at_write_time" not in rules
+
+
+# =============================================================================
+# reasoning_reconstruction_in_handoff — cross-slot mistake (wrong slot)
+# =============================================================================
+
+
+def test_reasoning_reconstruction_in_handoff_fires_when_nested_in_handoff(
+    tmp_path, monkeypatch, pact_context,
+):
+    """reasoning_reconstruction placed inside metadata.handoff → fires.
+    Cross-slot: belongs on teachback_submit, not handoff."""
+    pact_context(team_name="test-team", session_id="test-session")
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {
+                "handoff": {
+                    "produced": "x",
+                    "decisions": "x",
+                    "reasoning_chain": "x",
+                    "uncertainty": "x",
+                    "integration": "x",
+                    "open_questions": "x",
+                    "reasoning_reconstruction": {
+                        "decision_attribution": "x",
+                        "assumption_trace": "x",
+                        "contingency_clause": "x",
+                    },
+                },
+            },
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert any(
+        rule == "reasoning_reconstruction_in_handoff"
+        for rule, _ in advisories
+    ), f"expected cross-slot advisory, got: {advisories}"
+
+
+def test_reasoning_reconstruction_in_handoff_silent_when_only_on_teachback(
+    tmp_path, monkeypatch, pact_context,
+):
+    """reasoning_reconstruction placed on teachback_submit (correct slot)
+    AND handoff has reasoning_chain but no reasoning_reconstruction →
+    cross-slot advisory silent."""
+    pact_context(team_name="test-team", session_id="test-session")
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety_total=8,
+    )
+    tb = _well_formed_teachback_submit(reasoning_reconstruction={
+        "decision_attribution": "x",
+        "assumption_trace": "x",
+        "contingency_clause": "x",
+    })
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {"teachback_submit": tb},
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert not any(
+        rule == "reasoning_reconstruction_in_handoff"
+        for rule, _ in advisories
+    )
+
+
+def test_reasoning_reconstruction_in_handoff_silent_when_no_handoff(
+    pact_context,
+):
+    """No handoff at all → cross-slot advisory silent."""
+    pact_context(team_name="test-team", session_id="test-session")
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {},
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert not any(
+        rule == "reasoning_reconstruction_in_handoff"
+        for rule, _ in advisories
+    )
+
+
+# =============================================================================
+# reasoning_reconstruction_subkeys_invalid — wrong 3 sub-key names / shapes
+# =============================================================================
+
+
+def test_reasoning_reconstruction_subkeys_invalid_fires_on_wrong_names(
+    tmp_path, monkeypatch, pact_context,
+):
+    """Non-canonical sub-key names (e.g. what-I-learned) → fires."""
+    pact_context(team_name="test-team", session_id="test-session")
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety_total=8,
+    )
+    tb = _well_formed_teachback_submit(reasoning_reconstruction={
+        "what-I-learned": "x",
+        "falsification-attempts": "y",
+        "most-likely-wrong-prediction": "z",
+    })
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {"teachback_submit": tb},
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert any(
+        rule == "reasoning_reconstruction_subkeys_invalid"
+        for rule, _ in advisories
+    ), f"expected subkeys advisory, got: {advisories}"
+
+
+def test_reasoning_reconstruction_subkeys_invalid_fires_on_empty_subkey(
+    tmp_path, monkeypatch, pact_context,
+):
+    """Canonical keys but empty sub-key value → fires."""
+    pact_context(team_name="test-team", session_id="test-session")
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety_total=8,
+    )
+    tb = _well_formed_teachback_submit(reasoning_reconstruction={
+        "decision_attribution": "x",
+        "assumption_trace": "",
+        "contingency_clause": "x",
+    })
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {"teachback_submit": tb},
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert any(
+        rule == "reasoning_reconstruction_subkeys_invalid"
+        for rule, _ in advisories
+    )
+
+
+def test_reasoning_reconstruction_subkeys_silent_on_well_formed(
+    tmp_path, monkeypatch, pact_context,
+):
+    """Well-formed 3-sub-key triangle → silent."""
+    pact_context(team_name="test-team", session_id="test-session")
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety_total=8,
+    )
+    tb = _well_formed_teachback_submit(reasoning_reconstruction={
+        "decision_attribution": "x",
+        "assumption_trace": "x",
+        "contingency_clause": "x",
+    })
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {"teachback_submit": tb},
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert not any(
+        rule == "reasoning_reconstruction_subkeys_invalid"
+        for rule, _ in advisories
+    )
+
+
+def test_reasoning_reconstruction_subkeys_silent_when_field_absent(
+    tmp_path, monkeypatch, pact_context,
+):
+    """reasoning_reconstruction not provided → subkeys rule silent (R3
+    handles the band-required case independently)."""
+    pact_context(team_name="test-team", session_id="test-session")
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety_total=8,
+    )
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {"teachback_submit": _well_formed_teachback_submit()},
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert not any(
+        rule == "reasoning_reconstruction_subkeys_invalid"
+        for rule, _ in advisories
+    )
+
+
+# =============================================================================
+# intentional_wait_nested_in_teachback_submit — cross-key mistake
+# =============================================================================
+
+
+def test_intentional_wait_nested_in_teachback_submit_fires_when_nested(
+    tmp_path, monkeypatch, pact_context,
+):
+    """intentional_wait placed INSIDE teachback_submit → fires.
+    Cross-key: must be sibling top-level metadata key per Step 3."""
+    pact_context(team_name="test-team", session_id="test-session")
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety_total=8,
+    )
+    tb = _well_formed_teachback_submit()
+    tb["intentional_wait"] = {
+        "reason": "awaiting_lead_completion",
+        "expected_resolver": "lead",
+        "since": "2026-05-26T19:45:40+00:00",
+    }
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {"teachback_submit": tb},
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert any(
+        rule == "intentional_wait_nested_in_teachback_submit"
+        for rule, _ in advisories
+    ), f"expected cross-key advisory, got: {advisories}"
+
+
+def test_intentional_wait_silent_when_top_level_sibling(
+    tmp_path, monkeypatch, pact_context,
+):
+    """intentional_wait as a sibling top-level metadata key (canonical Step 3
+    placement) → cross-key advisory silent."""
+    pact_context(team_name="test-team", session_id="test-session")
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety_total=8,
+    )
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {
+                "teachback_submit": _well_formed_teachback_submit(),
+                "intentional_wait": {
+                    "reason": "awaiting_lead_completion",
+                    "expected_resolver": "lead",
+                    "since": "2026-05-26T19:45:40+00:00",
+                },
+            },
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert not any(
+        rule == "intentional_wait_nested_in_teachback_submit"
+        for rule, _ in advisories
+    )

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -2669,6 +2669,71 @@ def test_multi_rule_concurrent_emission_cross_slot_with_teachback_violation(
     assert "reasoning_reconstruction_in_handoff" in rules
 
 
+def test_multi_rule_concurrent_emission_all_four_advisory_rules_fire_together(
+    tmp_path, monkeypatch, pact_context,
+):
+    """One TaskUpdate carrying FOUR distinct violations across BOTH the
+    teachback_submit slot AND the handoff slot must emit FOUR advisories
+    on the same evaluation pass — the 4-way superset of the 3-rule and
+    2-rule cross-slot fixtures above. Pins the structural property that
+    R7 + R8 + R9 + R10 emit at FOUR independent code paths with no
+    short-circuit dispatcher consolidation: a teammate making all 4
+    mistakes at once learns about all 4, not just the first match.
+
+    Violations:
+      - teachback_submit.variety_acknowledgment as STRING
+        → variety_acknowledgment_schema_invalid_at_write_time (R7)
+      - handoff.reasoning_reconstruction nested in wrong slot
+        → reasoning_reconstruction_in_handoff (R8)
+      - teachback_submit.reasoning_reconstruction with wrong sub-key names
+        → reasoning_reconstruction_subkeys_invalid (R9)
+      - teachback_submit.intentional_wait nested instead of sibling
+        → intentional_wait_nested_in_teachback_submit (R10)
+    """
+    pact_context(team_name="test-team", session_id="test-session")
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety_total=8,
+    )
+    tb = _well_formed_teachback_submit(
+        variety_acknowledgment="I think the scoring is fine",
+        reasoning_reconstruction={
+            "what-I-learned": "x",
+            "falsification-attempts": "y",
+            "most-likely-wrong-prediction": "z",
+        },
+    )
+    tb["intentional_wait"] = {
+        "reason": "awaiting_lead_completion",
+        "expected_resolver": "lead",
+        "since": "2026-05-26T20:00:00+00:00",
+    }
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {
+                "teachback_submit": tb,
+                "handoff": {
+                    "produced": "x", "decisions": "x", "reasoning_chain": "x",
+                    "uncertainty": "x", "integration": "x", "open_questions": "x",
+                    "reasoning_reconstruction": {
+                        "decision_attribution": "x",
+                        "assumption_trace": "x",
+                        "contingency_clause": "x",
+                    },
+                },
+            },
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    rules = {rule for rule, _ in advisories}
+    assert "variety_acknowledgment_schema_invalid_at_write_time" in rules
+    assert "reasoning_reconstruction_in_handoff" in rules
+    assert "reasoning_reconstruction_subkeys_invalid" in rules
+    assert "intentional_wait_nested_in_teachback_submit" in rules
+
+
 # =============================================================================
 # 10|11 variety-band boundary disambiguation — pin the exact cut so that
 # future variety_scorer threshold changes (e.g. PLAN_MODE_MIN export) are

--- a/pact-plugin/tests/test_teachback_reasoning_reconstruction.py
+++ b/pact-plugin/tests/test_teachback_reasoning_reconstruction.py
@@ -15,16 +15,15 @@ extension. Coverage:
   - Internal consistency: lead-side check accepts well-formed triangle;
     rejects partial / empty.
 
-The schema validator under test (`_validate_reasoning_reconstruction`) lives
-in this module — `pact-orchestrator.md §12 Validating Method Reconstruction`
-(committed SSOT) documents the logic as judgment-tier prose for the lead; the
-mechanical schema gate is what this module exercises. When a future PR
-moves the validator into shared/, switch the import and delete the local
-copy. NOTE: the AST-scan in
-TestVarietyTrigger.test_constants_imported_not_literal walks Path(__file__)
-only — when the validator migrates, the migrating PR MUST extend the
-AST-scan path to also walk the new validator module, or hard-coded
-6 / 10 / 14 literals could land in shared/ undetected.
+The schema sub-key validator now lives in shared/teachback_schema.py
+(SSOT). This module's `_validate_reasoning_reconstruction` wraps the
+shared validator with the lead-side band-routing logic that combines
+sub-key validation with variety-band-driven missing-reconstruction
+rejection. _REQUIRED_SUBKEYS is imported from shared (canonical 3-tuple).
+NOTE: the AST-scan in TestVarietyTrigger.test_constants_imported_not_literal
+walks Path(__file__) only — if band thresholds (6 / 10 / 14) are migrated
+out of variety_scorer.py into another module in a future PR, the scan
+path must be extended to cover that module.
 """
 
 from __future__ import annotations
@@ -36,6 +35,10 @@ from pathlib import Path
 import pytest
 
 from shared.intentional_wait import TEACHBACK_EXEMPT_AGENT_TYPES
+from shared.teachback_schema import (
+    REQUIRED_SUBKEYS as _REQUIRED_SUBKEYS,
+    validate_reasoning_reconstruction as _validate_subkeys,
+)
 from shared.variety_scorer import (
     COMPACT_MAX,
     ORCHESTRATE_MAX,
@@ -52,8 +55,6 @@ from shared.variety_scorer import (
 # Schema validator under test
 # ============================================================================
 
-_REQUIRED_SUBKEYS = ("decision_attribution", "assumption_trace", "contingency_clause")
-
 
 def _validate_reasoning_reconstruction(
     teachback_submit: dict, dispatching_variety_score: int | None
@@ -61,8 +62,8 @@ def _validate_reasoning_reconstruction(
     """Lead-side schema gate for reasoning_reconstruction.
 
     Returns ("accept", None) on pass, or ("reject", reason) on fail.
-    Mirrors architect §3.2 pseudocode at the schema-gate layer
-    (internal-consistency gate is judgment-only, not exercised here).
+    Combines band-routing (missing-at-required-band rejection) with the
+    pure sub-key validator from shared/teachback_schema.py.
     """
     reconstruction = teachback_submit.get("reasoning_reconstruction")
     band = _band_for_variety(dispatching_variety_score)
@@ -72,14 +73,9 @@ def _validate_reasoning_reconstruction(
             return "reject", "missing_reasoning_reconstruction"
         return "accept", None
 
-    if not isinstance(reconstruction, dict):
-        return "reject", "malformed_reasoning_reconstruction"
-    if set(reconstruction.keys()) != set(_REQUIRED_SUBKEYS):
-        return "reject", "malformed_reasoning_reconstruction"
-    for key in _REQUIRED_SUBKEYS:
-        value = reconstruction[key]
-        if not isinstance(value, str) or not value.strip():
-            return "reject", "empty_reasoning_reconstruction_field"
+    subkey_problem = _validate_subkeys(reconstruction)
+    if subkey_problem:
+        return "reject", subkey_problem
     return "accept", None
 
 

--- a/pact-plugin/tests/test_teachback_reasoning_reconstruction.py
+++ b/pact-plugin/tests/test_teachback_reasoning_reconstruction.py
@@ -19,7 +19,8 @@ The schema sub-key validator now lives in shared/teachback_schema.py
 (SSOT). This module's `_validate_reasoning_reconstruction` wraps the
 shared validator with the lead-side band-routing logic that combines
 sub-key validation with variety-band-driven missing-reconstruction
-rejection. _REQUIRED_SUBKEYS is imported from shared (canonical 3-tuple).
+rejection. TEACHBACK_REQUIRED_SUBKEYS is imported from shared (canonical
+3-tuple).
 NOTE: the AST-scan in TestVarietyTrigger.test_constants_imported_not_literal
 walks Path(__file__) only — if band thresholds (6 / 10 / 14) are migrated
 out of variety_scorer.py into another module in a future PR, the scan
@@ -36,7 +37,7 @@ import pytest
 
 from shared.intentional_wait import TEACHBACK_EXEMPT_AGENT_TYPES
 from shared.teachback_schema import (
-    REQUIRED_SUBKEYS as _REQUIRED_SUBKEYS,
+    TEACHBACK_REQUIRED_SUBKEYS,
     validate_reasoning_reconstruction as _validate_subkeys,
 )
 from shared.variety_scorer import (
@@ -147,7 +148,7 @@ class TestSchemaShape:
         assert reason is None
 
     def test_field_present_requires_3_keys(self):
-        partial = {k: "ok" for k in _REQUIRED_SUBKEYS[:2]}
+        partial = {k: "ok" for k in TEACHBACK_REQUIRED_SUBKEYS[:2]}
         verdict, reason = _validate_reasoning_reconstruction(
             _payload(reconstruction=partial), dispatching_variety_score=5
         )
@@ -155,7 +156,7 @@ class TestSchemaShape:
         assert reason == "malformed_reasoning_reconstruction"
 
     def test_field_present_rejects_extra_keys(self):
-        extra = {k: "ok" for k in _REQUIRED_SUBKEYS}
+        extra = {k: "ok" for k in TEACHBACK_REQUIRED_SUBKEYS}
         extra["surprise_key"] = "shouldnt be here"
         verdict, reason = _validate_reasoning_reconstruction(
             _payload(reconstruction=extra), dispatching_variety_score=5
@@ -164,7 +165,7 @@ class TestSchemaShape:
         assert reason == "malformed_reasoning_reconstruction"
 
     def test_each_subkey_must_be_string(self):
-        bad = dict.fromkeys(_REQUIRED_SUBKEYS, "ok")
+        bad = dict.fromkeys(TEACHBACK_REQUIRED_SUBKEYS, "ok")
         bad["assumption_trace"] = ["list", "not", "string"]
         verdict, reason = _validate_reasoning_reconstruction(
             _payload(reconstruction=bad), dispatching_variety_score=5
@@ -173,7 +174,7 @@ class TestSchemaShape:
         assert reason == "empty_reasoning_reconstruction_field"
 
     def test_each_subkey_must_be_nonempty(self):
-        bad = dict.fromkeys(_REQUIRED_SUBKEYS, "ok")
+        bad = dict.fromkeys(TEACHBACK_REQUIRED_SUBKEYS, "ok")
         bad["contingency_clause"] = "   "  # whitespace-only also rejected
         verdict, reason = _validate_reasoning_reconstruction(
             _payload(reconstruction=bad), dispatching_variety_score=5
@@ -445,7 +446,7 @@ def test_payload_json_round_trip_preserves_triangle():
     payload = _payload(reconstruction=_well_formed_triangle())
     serialized = json.dumps({"teachback_submit": payload})
     restored = json.loads(serialized)["teachback_submit"]
-    assert set(restored["reasoning_reconstruction"].keys()) == set(_REQUIRED_SUBKEYS)
+    assert set(restored["reasoning_reconstruction"].keys()) == set(TEACHBACK_REQUIRED_SUBKEYS)
     verdict, _ = _validate_reasoning_reconstruction(
         restored, dispatching_variety_score=PLAN_MODE_MAX
     )

--- a/pact-plugin/tests/test_teachback_schema.py
+++ b/pact-plugin/tests/test_teachback_schema.py
@@ -2,11 +2,11 @@
 and the reasoning_reconstruction sub-key validator.
 
 Pins:
-  - REQUIRED_FIELDS: canonical 5-tuple (4 string fields + variety_acknowledgment)
-  - REQUIRED_SUBKEYS: canonical 3-tuple (decision_attribution / assumption_trace /
+  - TEACHBACK_REQUIRED_FIELDS: canonical 5-tuple (4 string fields + variety_acknowledgment)
+  - TEACHBACK_REQUIRED_SUBKEYS: canonical 3-tuple (decision_attribution / assumption_trace /
     contingency_clause)
-  - VARIETY_ACK_VALID_VALUES: 3-tuple enum (yes / no / concern)
-  - REASONING_RECONSTRUCTION_REQUIRED_MIN: 11 (variety-band threshold mirror)
+  - TEACHBACK_VARIETY_ACK_VALID_VALUES: 3-tuple enum (yes / no / concern)
+  - TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN: 11 (variety-band threshold mirror)
   - validate_reasoning_reconstruction:
       - None on well-formed 3-sub-key triangle of non-empty strings
       - "malformed_reasoning_reconstruction" on not-dict / wrong-keys
@@ -23,10 +23,10 @@ from __future__ import annotations
 import pytest
 
 from shared.teachback_schema import (
-    REASONING_RECONSTRUCTION_REQUIRED_MIN,
-    REQUIRED_FIELDS,
-    REQUIRED_SUBKEYS,
-    VARIETY_ACK_VALID_VALUES,
+    TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN,
+    TEACHBACK_REQUIRED_FIELDS,
+    TEACHBACK_REQUIRED_SUBKEYS,
+    TEACHBACK_VARIETY_ACK_VALID_VALUES,
     validate_reasoning_reconstruction,
 )
 
@@ -41,11 +41,11 @@ class TestConstants:
     and pact-orchestrator §12 prose edits."""
 
     def test_required_fields_is_5_tuple(self):
-        assert isinstance(REQUIRED_FIELDS, tuple)
-        assert len(REQUIRED_FIELDS) == 5
+        assert isinstance(TEACHBACK_REQUIRED_FIELDS, tuple)
+        assert len(TEACHBACK_REQUIRED_FIELDS) == 5
 
     def test_required_fields_exact_names(self):
-        assert REQUIRED_FIELDS == (
+        assert TEACHBACK_REQUIRED_FIELDS == (
             "understanding",
             "most_likely_wrong",
             "least_confident_item",
@@ -54,26 +54,26 @@ class TestConstants:
         )
 
     def test_required_subkeys_is_3_tuple(self):
-        assert isinstance(REQUIRED_SUBKEYS, tuple)
-        assert len(REQUIRED_SUBKEYS) == 3
+        assert isinstance(TEACHBACK_REQUIRED_SUBKEYS, tuple)
+        assert len(TEACHBACK_REQUIRED_SUBKEYS) == 3
 
     def test_required_subkeys_exact_names(self):
-        assert REQUIRED_SUBKEYS == (
+        assert TEACHBACK_REQUIRED_SUBKEYS == (
             "decision_attribution",
             "assumption_trace",
             "contingency_clause",
         )
 
     def test_variety_ack_valid_values_exact(self):
-        assert VARIETY_ACK_VALID_VALUES == ("yes", "no", "concern")
+        assert TEACHBACK_VARIETY_ACK_VALID_VALUES == ("yes", "no", "concern")
 
     def test_required_min_threshold_is_11(self):
         # Mirror of variety_scorer: ORCHESTRATE_MAX=10, PLAN_MODE_MAX=14
         # → plan-mode-and-above starts at >= 11.
         from shared.variety_scorer import ORCHESTRATE_MAX, PLAN_MODE_MAX
 
-        assert REASONING_RECONSTRUCTION_REQUIRED_MIN == ORCHESTRATE_MAX + 1
-        assert REASONING_RECONSTRUCTION_REQUIRED_MIN <= PLAN_MODE_MAX
+        assert TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN == ORCHESTRATE_MAX + 1
+        assert TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN <= PLAN_MODE_MAX
 
 
 # ============================================================================
@@ -151,7 +151,8 @@ class TestValidatorMalformed:
         )
 
     def test_substituted_key_returns_malformed(self):
-        # Mirrors PR #834 cycle-3 wrong-shape (`what-I-learned` etc.)
+        # Mirrors observed wrong-shape pattern (substituting non-canonical
+        # sub-key names like `what-I-learned`).
         rr = {
             "what-I-learned": "x",
             "falsification-attempts": "y",

--- a/pact-plugin/tests/test_teachback_schema.py
+++ b/pact-plugin/tests/test_teachback_schema.py
@@ -1,0 +1,229 @@
+"""Tests for shared/teachback_schema.py — canonical teachback schema constants
+and the reasoning_reconstruction sub-key validator.
+
+Pins:
+  - REQUIRED_FIELDS: canonical 5-tuple (4 string fields + variety_acknowledgment)
+  - REQUIRED_SUBKEYS: canonical 3-tuple (decision_attribution / assumption_trace /
+    contingency_clause)
+  - VARIETY_ACK_VALID_VALUES: 3-tuple enum (yes / no / concern)
+  - REASONING_RECONSTRUCTION_REQUIRED_MIN: 11 (variety-band threshold mirror)
+  - validate_reasoning_reconstruction:
+      - None on well-formed 3-sub-key triangle of non-empty strings
+      - "malformed_reasoning_reconstruction" on not-dict / wrong-keys
+      - "empty_reasoning_reconstruction_field" on empty/non-string sub-key
+
+These constants are consumed by hooks/task_lifecycle_gate.py at runtime and by
+tests/test_teachback_reasoning_reconstruction.py at the lead-side band-routing
+layer. The validator is the SSOT for the schema gate; band routing is
+layered on top by callers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.teachback_schema import (
+    REASONING_RECONSTRUCTION_REQUIRED_MIN,
+    REQUIRED_FIELDS,
+    REQUIRED_SUBKEYS,
+    VARIETY_ACK_VALID_VALUES,
+    validate_reasoning_reconstruction,
+)
+
+
+# ============================================================================
+# Constant shape pins
+# ============================================================================
+
+
+class TestConstants:
+    """Pin the exact canonical shapes — drift will require paired SKILL.md
+    and pact-orchestrator §12 prose edits."""
+
+    def test_required_fields_is_5_tuple(self):
+        assert isinstance(REQUIRED_FIELDS, tuple)
+        assert len(REQUIRED_FIELDS) == 5
+
+    def test_required_fields_exact_names(self):
+        assert REQUIRED_FIELDS == (
+            "understanding",
+            "most_likely_wrong",
+            "least_confident_item",
+            "first_action",
+            "variety_acknowledgment",
+        )
+
+    def test_required_subkeys_is_3_tuple(self):
+        assert isinstance(REQUIRED_SUBKEYS, tuple)
+        assert len(REQUIRED_SUBKEYS) == 3
+
+    def test_required_subkeys_exact_names(self):
+        assert REQUIRED_SUBKEYS == (
+            "decision_attribution",
+            "assumption_trace",
+            "contingency_clause",
+        )
+
+    def test_variety_ack_valid_values_exact(self):
+        assert VARIETY_ACK_VALID_VALUES == ("yes", "no", "concern")
+
+    def test_required_min_threshold_is_11(self):
+        # Mirror of variety_scorer: ORCHESTRATE_MAX=10, PLAN_MODE_MAX=14
+        # → plan-mode-and-above starts at >= 11.
+        from shared.variety_scorer import ORCHESTRATE_MAX, PLAN_MODE_MAX
+
+        assert REASONING_RECONSTRUCTION_REQUIRED_MIN == ORCHESTRATE_MAX + 1
+        assert REASONING_RECONSTRUCTION_REQUIRED_MIN <= PLAN_MODE_MAX
+
+
+# ============================================================================
+# Validator behavior — well-formed input
+# ============================================================================
+
+
+def _well_formed_triangle() -> dict:
+    return {
+        "decision_attribution": "I understand X chose Y because Z",
+        "assumption_trace": "This depends on A and B",
+        "contingency_clause": "If A changes, the decision should change to C",
+    }
+
+
+class TestValidatorAccept:
+    """Well-formed inputs return None."""
+
+    def test_canonical_triangle_accepted(self):
+        assert validate_reasoning_reconstruction(_well_formed_triangle()) is None
+
+    def test_subkey_with_internal_whitespace_accepted(self):
+        rr = _well_formed_triangle()
+        rr["assumption_trace"] = "A long\nmulti-line\nrationale is fine"
+        assert validate_reasoning_reconstruction(rr) is None
+
+
+# ============================================================================
+# Validator behavior — malformed inputs
+# ============================================================================
+
+
+class TestValidatorMalformed:
+    """Wrong type / wrong keys → malformed_reasoning_reconstruction."""
+
+    def test_not_dict_returns_malformed(self):
+        assert (
+            validate_reasoning_reconstruction("a string")
+            == "malformed_reasoning_reconstruction"
+        )
+
+    def test_list_returns_malformed(self):
+        assert (
+            validate_reasoning_reconstruction(["d", "a", "c"])
+            == "malformed_reasoning_reconstruction"
+        )
+
+    def test_none_returns_malformed(self):
+        # Callers may pre-filter None (it means "absent"), but the validator
+        # itself is conservative — None is not a dict.
+        assert (
+            validate_reasoning_reconstruction(None)
+            == "malformed_reasoning_reconstruction"
+        )
+
+    def test_empty_dict_returns_malformed(self):
+        assert (
+            validate_reasoning_reconstruction({})
+            == "malformed_reasoning_reconstruction"
+        )
+
+    def test_partial_keys_returns_malformed(self):
+        partial = {"decision_attribution": "x", "assumption_trace": "y"}
+        assert (
+            validate_reasoning_reconstruction(partial)
+            == "malformed_reasoning_reconstruction"
+        )
+
+    def test_extra_key_returns_malformed(self):
+        rr = _well_formed_triangle()
+        rr["surprise_key"] = "shouldn't be here"
+        assert (
+            validate_reasoning_reconstruction(rr)
+            == "malformed_reasoning_reconstruction"
+        )
+
+    def test_substituted_key_returns_malformed(self):
+        # Mirrors PR #834 cycle-3 wrong-shape (`what-I-learned` etc.)
+        rr = {
+            "what-I-learned": "x",
+            "falsification-attempts": "y",
+            "most-likely-wrong-prediction": "z",
+        }
+        assert (
+            validate_reasoning_reconstruction(rr)
+            == "malformed_reasoning_reconstruction"
+        )
+
+
+# ============================================================================
+# Validator behavior — empty/non-string sub-key values
+# ============================================================================
+
+
+class TestValidatorEmptyField:
+    """Right keys, wrong values → empty_reasoning_reconstruction_field."""
+
+    def test_empty_string_subkey_returns_empty_field(self):
+        rr = _well_formed_triangle()
+        rr["contingency_clause"] = ""
+        assert (
+            validate_reasoning_reconstruction(rr)
+            == "empty_reasoning_reconstruction_field"
+        )
+
+    def test_whitespace_only_subkey_returns_empty_field(self):
+        rr = _well_formed_triangle()
+        rr["assumption_trace"] = "   \n   "
+        assert (
+            validate_reasoning_reconstruction(rr)
+            == "empty_reasoning_reconstruction_field"
+        )
+
+    def test_non_string_subkey_returns_empty_field(self):
+        rr = _well_formed_triangle()
+        rr["decision_attribution"] = ["list", "not", "string"]
+        assert (
+            validate_reasoning_reconstruction(rr)
+            == "empty_reasoning_reconstruction_field"
+        )
+
+    def test_none_subkey_returns_empty_field(self):
+        rr = _well_formed_triangle()
+        rr["decision_attribution"] = None
+        assert (
+            validate_reasoning_reconstruction(rr)
+            == "empty_reasoning_reconstruction_field"
+        )
+
+
+# ============================================================================
+# Purity / never-raises contract
+# ============================================================================
+
+
+class TestValidatorPurity:
+    """Validator never raises — pure function contract."""
+
+    @pytest.mark.parametrize(
+        "weird_input",
+        [
+            42,
+            3.14,
+            True,
+            False,
+            object(),
+            (1, 2, 3),
+        ],
+    )
+    def test_does_not_raise_on_weird_inputs(self, weird_input):
+        # Should return malformed reason, not raise
+        result = validate_reasoning_reconstruction(weird_input)
+        assert result == "malformed_reasoning_reconstruction"


### PR DESCRIPTION
Closes #841.

## Summary

Address the 4 wrong-shape failure modes (50-66% wrong-shape rate from PR #834 cycle-3 fresh blind reviewers) with a composite intervention:
- **Pre-write learning surface**: restructured `pact-teachback/SKILL.md` with a canonical-shape block at top + 4 inline anti-pattern callouts + 4-row Common Mistakes table + 4-band threshold table
- **Post-wrong-write correction surface**: 4 new write-time advisory rules in `task_lifecycle_gate.py` that catch each failure mode behaviorally
- **SSOT module extraction**: lifted teachback-schema constants to `pact-plugin/hooks/shared/teachback_schema.py` following the variety_scorer.py SSOT-migration precedent

The two reader surfaces compose: doc-load surface anchors on first read, runtime advisory catches mistakes at write-time with grep-anchor cross-references to the doc.

## Commits

| SHA | Phase | Description |
|---|---|---|
| `5bafc9d7` | CODE (runtime) | New `shared/teachback_schema.py` (91 LOC) + 4 advisory rules in `task_lifecycle_gate.py` (+96 net) + 62 tests (25 shared module + 14 advisory fixtures + 23 rebound) |
| `ff6f5ae9` | CODE (docs) | SKILL.md 104→197 LOC restructure (canonical-shape block + 4 anti-pattern callouts + Common Mistakes table + threshold-band table) + MAX_SKILL_CHARS bump 7500→16000 with documented rationale |
| `c26fa468` | TEST | 4 new fixtures covering multi-rule concurrent emission + 10\|11 variety-band boundary disambiguation |
| `2f3bc8fb` | chore | Version bump 4.3.0 → 4.3.1 across canonical 4 files |
| `7ce16461` | fix (cycle 1) | Polish sweep — 7 review findings folded (R8 wording + SSOT TEACHBACK_ prefix + SKILL.md callout normalization + planning-artifact strip) |
| `1841adc4` | test (cycle 2) | 4-way concurrent emission fixture + MAX_SKILL_CHARS headroom claim refresh |
| `1201d3f2` | fix (cycle 3) | B1 SSOT derivation from ORCHESTRATE_MAX + B4 R7 task-type conditional advisory text |
| `b7a7fd55` | test (cycle 3) | B2 4-site planning-artifact strip + B5 R7 parametrized coverage (mirrors R9) + B6 SKILL.md canonical-schema structural pin |

Cycle 3 folded 9 blind-wave findings via parallel backend-coder + test-engineer dispatches on disjoint files. One Future surfaced (broader `§` family across architect/architect3/auditor refs in test files) — recommended for a separate planning-artifact-sweep PR rather than expanding this PR's scope.

## Decision rationale

The architect re-weighed the preparer's recommended Path C HYBRID against project values and selected **Path A GO single-cycle + Decision 4.4(b) shared module extraction**:
- Small-N dogfood data (N=3) is not statistically dispositive for the anchor-priming-only hypothesis Path C is built on
- Doc + runtime advisory **compose** rather than compete (different reader trajectories)
- Project value alignment favors single-PR-bounded-scope (per concurrent-staging pin + variety-ex-post calibration)
- The 877-LOC structural-debt argument actually FAVORS Path A+4.4(b): extraction nets +96 LOC after constant lift, ultimately strengthening the #836 refactor case (the cumulative file size signal grows louder)

Full design rationale: `docs/architecture/feat-841-teachback-schema-clarity.md` (worktree only; gitignored).

## Version bump tier — PATCH (4.3.0 → 4.3.1)

Per the pinned-context rule, MINOR triggers are: (1) new protocol schema fields, (2) new hook rules with their own enforcement surface, (3) new persistent metadata shapes downstream code reads, (4) new helper modules with new public API.

Comparison with the prior MINOR-bump precedent (PR #834, v4.2.14 → v4.3.0): that PR added a NEW required schema field (`reasoning_reconstruction`), a NEW persistent metadata shape (D11 4-rationale variety), R1-R5 hook rules paired with new required behaviors, and a new public API (`compute_variety_divergence`) — all 4 triggers fired.

This PR fires the "new hook rules" trigger only, and the rules are pure ADDITIVE ADVISORIES on EXISTING shapes (post-action, cannot DENY). The new `shared/teachback_schema.py` module is primarily an extraction of constants that already lived inline in `task_lifecycle_gate.py`; the one new function (`validate_reasoning_reconstruction`) is internal to hook validators, not a consumer-facing public API. Closer to a refinement than a new capability → PATCH.

**Independent blind-wave confirmation**: a fresh-eyes architect (blind to original 3-reviewer findings) walked each of the 4 MINOR triggers independently and concluded PATCH stays. 0 of 4 triggers fire cleanly.

## The 4 advisory rule names (grep-anchors)

LOAD-BEARING: these names appear verbatim in (a) the runtime advisory emission in `task_lifecycle_gate.py`, (b) the SKILL.md Common Mistakes table rows 1-4, and (c) the inline anti-pattern callouts. Order is locked:

1. `variety_acknowledgment_schema_invalid_at_write_time` — STRING-shape + invalid-enum value
2. `reasoning_reconstruction_in_handoff` — cross-slot rule (fires on any TaskUpdate writing metadata.handoff with rr nested)
3. `reasoning_reconstruction_subkeys_invalid` — wrong sub-key names + empty sub-key values
4. `intentional_wait_nested_in_teachback_submit` — nesting mistake

## Test verification

- Full pact-plugin test suite: **8258 passed** (was 8250 baseline + 4 c26fa468 + 1 1841adc4 4-way fixture + 3 b7a7fd55 cycle-3 tests) / 14 skipped
- 19 pre-existing `test_merge_guard.py` failures verified pre-existing via standalone re-run (975/0 standalone vs 956/19 full-suite — cross-test state pollution, unrelated). Blind-wave additionally verified at parent-baseline commit `18edb7bd`: same 19/8258 — pre-existing confirmed.
- Cross-reference anchor `#action-store-teachback-now` confirmed used in `pact-agent-teams/SKILL.md:40` (other locations link the file path without anchor).
- SKILL.md ↔ `task_lifecycle_gate.py` grep-anchor cross-check verified empirically via fire-and-grep on rule 2 (Python implicit string concatenation joins the two-line literal correctly).
- SKILL.md threshold-band table mirrors `pact-ct-teachback.md §When to Method-Reconstruct` SSOT verbatim on load-bearing literals (4 bands + `ROUTE_*` + 10|11 cut).
- Rule independence empirically confirmed 4 independent ways: architect static read, original test-engineer R7-disabled probe ({2 fail, 6 pass}), blind test-engineer 4-rule counter-test-by-revert ({R8=3, R7=5, R9=4, R10=3}), and `c26fa468`'s structural 3-rule + 2-rule cross-slot + `1841adc4`'s 4-way fixture.

## In-session calibration data

The runtime advisory layer caught its own dispatcher's schema-shape error during this PR's TEST-phase dispatch (Task #14 dispatched with missing `total` field in `metadata.variety` → `reasoning_reconstruction_band_unresolvable` advisory fired). Plus 4 in-session instances of the wrong-shape teachback failure mode the PR adds advisory rules to catch (R3 + R7 would have caught all of them at write-time if active on main). Direct empirical evidence the runtime advisory layer has demonstrable LLM-error-catching value — independent of the anchor-priming hypothesis Path C HYBRID was built around.

## Companion issues filed during this session

- #842 — `teardown_request_emitter` fires during teachback Task A→B handoff (1→0 transient lull causes scan flap)
- #843 — `task_lifecycle_gate` `teachback_addblocks_missing` fires at TaskCreate(A) before Task B exists (unsatisfiable check)

Both are documented as instances of the same architectural pattern (hooks checking lifecycle invariants at the first observable write when the protocol is multi-write).

## Test plan

- [x] Full pact-plugin test suite: 8258 passed (no new failures)
- [x] SKILL.md ↔ task_lifecycle_gate.py grep-anchor cross-check
- [x] Threshold-band table SSOT mirror verification
- [x] Multi-rule concurrent emission pinned (3-rule + 2-rule cross-slot + 4-way superset)
- [x] 10|11 variety-band boundary pinned
- [x] Canonical 4 version-tracking files bumped to 4.3.1
- [x] Multi-agent peer review (3 original reviewers + 3 blind reviewers, 0 blocking findings)
- [ ] Post-merge: annotated tag + GitHub release per pinned procedure
