### PR TITLE
fix(#843): re-time teachback_addblocks_missing rule to TaskUpdate wiring boundary (v4.3.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.3.1",
+      "version": "4.3.2",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.3.1/      # Plugin version
+│               └── 4.3.2/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.3.1
+> **Version**: 4.3.2
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -28,6 +28,9 @@ Rule coverage:
     Task) rather than at TaskCreate — the historical TaskCreate-time
     check was structurally unsatisfiable because the work-task id did
     not exist yet at TaskCreate(A).
+    Fire condition (4-clause AND): subject is teachback-shaped AND
+    tool_input.owner is set AND tool_input.addBlocks is absent/empty
+    AND task_a.blocks is empty (benign late-wiring guard).
   - work_addblockedby_missing — pact-* work Task created without
     addBlockedBy=[<teachback_id>]
   - completion_no_paired_send — Teachback Task completed without paired
@@ -564,11 +567,27 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
         # 3rd clause and never hits disk. Failure path (missing
         # addBlockedBy) does hit disk via _iter_members, but this is
         # the rare misconfiguration path — amortized cost near zero.
+        #
+        # Cached short-circuit: `_teachback_exempt` is computed at most
+        # once per TaskCreate and reused by R4 below. Both rules share
+        # the same disk-touching predicate; the cache amortizes the
+        # `is_teachback_exempt(owner, team_name)` cost across rules.
+        # `None` sentinel means "not yet computed"; `False/True` is the
+        # cached result. The lazy fill preserves the cheap-first clause
+        # ordering (no eager disk read when cheap predicates fail).
+        _teachback_exempt: bool | None = None
+
+        def _exempt() -> bool:
+            nonlocal _teachback_exempt
+            if _teachback_exempt is None:
+                _teachback_exempt = is_teachback_exempt(owner, team_name)
+            return _teachback_exempt
+
         if (
             not is_teachback
             and owner.startswith("pact-")
             and not tool_input.get("addBlockedBy")
-            and not is_teachback_exempt(owner, team_name)
+            and not _exempt()
         ):
             advisories.append((
                 "work_addblockedby_missing",
@@ -584,11 +603,12 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
         # rationales); distinct message text per path, same rule name —
         # the lead-side correction is the same (re-stamp variety) in
         # either case. Clause order mirrors L575-580: cheap dict-lookups
-        # first, disk-touching exempt-check last.
+        # first, disk-touching exempt-check last (cached via `_exempt()`
+        # so the second invocation reuses the first call's result).
         if (
             not is_teachback
             and owner.startswith("pact-")
-            and not is_teachback_exempt(owner, team_name)
+            and not _exempt()
         ):
             incoming_variety = (
                 tool_input.get("metadata") or {}
@@ -806,6 +826,7 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
                 "the teachback gate unwired.",
             ))
 
+        # task_id, subject, task_a are hoisted to L776-780 (sibling-of-cross-slot-handoff-check); this branch consumes the hoisted values.
         if isinstance(incoming_teachback, dict):
             if _is_teachback_subject(subject):
                 # R5 (D10): variety_acknowledgment presence check.
@@ -918,7 +939,8 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
                         "missing OR Task B.metadata.variety absent. "
                         "Hook advisory skipped; lead should enforce "
                         "variety stamping via teachback_addblocks_missing "
-                        "+ variety_missing_on_dispatch_task upstream.",
+                        "wiring-time enforcement upstream + "
+                        "variety_missing_on_dispatch_task at TaskCreate.",
                     ))
 
     return advisories

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -22,8 +22,12 @@ hookSpecificOutput schema-rejection defense — missing hookEventName
 triggers silent platform-layer rejection).
 
 Rule coverage:
-  - teachback_addblocks_missing — Teachback Task created without
-    addBlocks=[<work_task_id>]
+  - teachback_addblocks_missing — Teachback Task owner-wiring
+    TaskUpdate landed without addBlocks=[<work_task_id>]. Fires at the
+    canonical Step-3 wiring boundary (lead sets owner on a teachback
+    Task) rather than at TaskCreate — the historical TaskCreate-time
+    check was structurally unsatisfiable because the work-task id did
+    not exist yet at TaskCreate(A).
   - work_addblockedby_missing — pact-* work Task created without
     addBlockedBy=[<teachback_id>]
   - completion_no_paired_send — Teachback Task completed without paired
@@ -552,14 +556,6 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
         if not isinstance(owner, str):
             owner = ""
 
-        if is_teachback and not tool_input.get("addBlocks"):
-            advisories.append((
-                "teachback_addblocks_missing",
-                "PACT task_lifecycle_gate: Teachback Task created without "
-                "addBlocks=[<work_task_id>]. The teachback gate must block "
-                "the work task (per pact-completion-authority).",
-            ))
-
         # Clause order is intentional: the cheap checks
         # (is_teachback dict-lookup, owner.startswith string-prefix,
         # tool_input.get dict-lookup) precede the disk-reading
@@ -771,13 +767,46 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
                 "field). See pact-teachback skill Common mistakes row 2.",
             ))
 
+        # Shared task_a disk read — lifted to sibling of the cross-slot
+        # handoff check above so the wiring-boundary
+        # teachback_addblocks_missing rule and the teachback_submit
+        # write-time rules below all consume one disk read per
+        # non-completed TaskUpdate. Single-pay disk cost across all
+        # write-time rules that need task_a's subject + blocks.
+        task_id = tool_input.get("taskId", "") or ""
+        task_a = read_task_json(task_id, team_name) if team_name else {}
+        if not isinstance(task_a, dict):
+            task_a = {}
+        subject = task_a.get("subject") or ""
+
+        # Wiring-boundary teachback_addblocks_missing — fires when the
+        # canonical Step-3 wiring TaskUpdate (lead sets owner on a
+        # teachback Task) lands WITHOUT addBlocks=[<work_task_id>].
+        # Predicates: subject is teachback-shaped AND incoming owner is
+        # being set AND addBlocks is absent on the wiring update AND the
+        # task_a already-on-disk record does not have blocks wired (benign
+        # late-wiring guard: if an earlier TaskUpdate already wired blocks,
+        # a later owner-only update is not a violation). Re-times the
+        # historical TaskCreate-time check (which was structurally
+        # unsatisfiable because the work-task id did not exist yet at
+        # TaskCreate(A)) to the moment the lead can satisfy both clauses
+        # in one TaskUpdate.
+        if (
+            _is_teachback_subject(subject)
+            and tool_input.get("owner")
+            and not tool_input.get("addBlocks")
+            and not task_a.get("blocks")
+        ):
+            advisories.append((
+                "teachback_addblocks_missing",
+                f"PACT task_lifecycle_gate: Teachback Task {task_id} "
+                "owner-wiring TaskUpdate landed without "
+                "addBlocks=[<work_task_id>]. Canonical sequence pairs "
+                "owner + addBlocks in one update; split-write leaves "
+                "the teachback gate unwired.",
+            ))
+
         if isinstance(incoming_teachback, dict):
-            task_id = tool_input.get("taskId", "") or ""
-            # Shared task_a disk read — R3, R5, and the 3 new
-            # teachback-scoped rules consume this one read (R3 needs
-            # blocks for traversal, others only need subject).
-            task_a = read_task_json(task_id, team_name) if team_name else {}
-            subject = task_a.get("subject") or ""
             if _is_teachback_subject(subject):
                 # R5 (D10): variety_acknowledgment presence check.
                 # Presence-only at write-time; full schema validation is

--- a/pact-plugin/tests/test_first_observable_write_misfire_invariant.py
+++ b/pact-plugin/tests/test_first_observable_write_misfire_invariant.py
@@ -54,12 +54,19 @@ MULTI_WRITE_PROTOCOL_RULES: tuple[str, ...] = (
 )
 
 
-def _find_taskcreate_branch(tree: ast.AST) -> ast.If | None:
-    """Return the `if tool_name == "TaskCreate":` AST node inside
-    evaluate_lifecycle, or None if not found. The lookup is structural —
-    matches an If whose test compares the Name `tool_name` against the
-    string constant `"TaskCreate"`.
+def _find_taskcreate_branches(tree: ast.AST) -> list[ast.If]:
+    """Return ALL `if tool_name == "TaskCreate":` AST nodes in the file,
+    not just the first one matched. The single-branch assumption from
+    the original implementation was a refactor-fragility hazard: if a
+    future refactor introduces a sibling dispatcher function with its
+    own TaskCreate branch and a denylisted rule moves into that second
+    branch, returning only the first branch would silently pass the
+    invariant.
+
+    The lookup is structural — matches an If whose test compares the
+    Name `tool_name` against the string constant `"TaskCreate"`.
     """
+    branches: list[ast.If] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.If):
             continue
@@ -76,65 +83,206 @@ def _find_taskcreate_branch(tree: ast.AST) -> ast.If | None:
             continue
         if not (len(test.ops) == 1 and isinstance(test.ops[0], ast.Eq)):
             continue
-        return node
-    return None
+        branches.append(node)
+    return branches
 
 
-def _collect_advisory_rule_names(branch: ast.AST) -> list[str]:
-    """Walk an AST subtree, collect the rule-name string literal from each
-    `advisories.append((<rule_name>, <message>))` call. Returns the list
-    of literal rule names found.
+def _find_advisory_wrap_helpers(tree: ast.AST) -> set[str]:
+    """Identify functions in the module whose body wraps
+    `advisories.append((<param_name>, ...))` — i.e., the rule name comes
+    from one of the function's own parameters. These are
+    "wrap helpers": calling them with a string literal as the first
+    argument is semantically equivalent to writing the literal directly
+    into an `advisories.append` tuple at the call site.
+
+    Returns the set of helper-function names. Phantom-green protection:
+    without this resolution step, a refactor introducing
+    `def _add(rule, msg): advisories.append((rule, msg))` and calling
+    `_add("teachback_addblocks_missing", ...)` from inside the
+    TaskCreate branch would silently pass the invariant — `ast.walk`
+    finds no direct `advisories.append` call inside the branch.
+
+    Only catches the one-hop direct-wrap pattern. Indirect chains
+    (helper-calls-helper-that-appends) are NOT resolved — this is
+    deliberately bounded to keep the AST analysis predictable.
+    """
+    helpers: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        param_names = {a.arg for a in node.args.args}
+        for body_node in ast.walk(node):
+            if not isinstance(body_node, ast.Call):
+                continue
+            func = body_node.func
+            if not (isinstance(func, ast.Attribute) and func.attr == "append"):
+                continue
+            receiver = func.value
+            if not (isinstance(receiver, ast.Name) and receiver.id == "advisories"):
+                continue
+            if not body_node.args:
+                continue
+            arg0 = body_node.args[0]
+            if not (isinstance(arg0, ast.Tuple) and arg0.elts):
+                continue
+            first = arg0.elts[0]
+            if isinstance(first, ast.Name) and first.id in param_names:
+                helpers.add(node.name)
+                break
+    return helpers
+
+
+def _collect_advisory_rule_names(branch: ast.AST, wrap_helpers: set[str]) -> list[str]:
+    """Walk an AST subtree, collect rule-name string literals from BOTH:
+    (1) direct `advisories.append((<rule_name>, <message>))` calls, and
+    (2) calls to a known wrap-helper (resolves the literal rule-name
+        passed at the call site).
+
+    `wrap_helpers` is the set of function names returned by
+    `_find_advisory_wrap_helpers`. Phantom-green protection: pass the
+    wrap-helper set so helper-wrapped calls inside the branch are
+    detected.
     """
     rule_names: list[str] = []
     for node in ast.walk(branch):
         if not isinstance(node, ast.Call):
             continue
         func = node.func
-        if not isinstance(func, ast.Attribute):
+        # Pattern (1): direct advisories.append((rule, msg)) call.
+        if isinstance(func, ast.Attribute) and func.attr == "append":
+            receiver = func.value
+            if isinstance(receiver, ast.Name) and receiver.id == "advisories":
+                if node.args:
+                    arg0 = node.args[0]
+                    if isinstance(arg0, ast.Tuple) and arg0.elts:
+                        first = arg0.elts[0]
+                        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                            rule_names.append(first.value)
             continue
-        if func.attr != "append":
-            continue
-        # advisories.append(...) — match the receiver name conservatively
-        receiver = func.value
-        if not (isinstance(receiver, ast.Name) and receiver.id == "advisories"):
+        # Pattern (2): wrap-helper call — resolve the literal first arg.
+        helper_name: str | None = None
+        if isinstance(func, ast.Name):
+            helper_name = func.id
+        elif isinstance(func, ast.Attribute):
+            helper_name = func.attr
+        if helper_name is None or helper_name not in wrap_helpers:
             continue
         if not node.args:
             continue
         arg0 = node.args[0]
-        # advisory tuples are 2-element (rule_name, message).
-        if not isinstance(arg0, ast.Tuple) or not arg0.elts:
-            continue
-        first = arg0.elts[0]
-        if isinstance(first, ast.Constant) and isinstance(first.value, str):
-            rule_names.append(first.value)
+        if isinstance(arg0, ast.Constant) and isinstance(arg0.value, str):
+            rule_names.append(arg0.value)
     return rule_names
 
 
 def test_no_multi_write_protocol_rule_in_taskcreate_branch():
-    """AST gate: the TaskCreate branch of evaluate_lifecycle must not
-    fire any rule that enforces a multi-write-protocol invariant. Such
-    rules belong at a write-time TaskUpdate (or completion-time) boundary
-    where the downstream writes have happened and the invariant can be
-    satisfied or falsified.
+    """AST gate: NO `if tool_name == "TaskCreate":` branch in the file
+    may fire a rule that enforces a multi-write-protocol invariant.
+    Such rules belong at a write-time TaskUpdate (or completion-time)
+    boundary where the downstream writes have happened and the
+    invariant can be satisfied or falsified.
+
+    Robust against two refactor-fragility hazards:
+    (1) multiple TaskCreate branches in the file — all are enumerated;
+    (2) helper-wrapped `advisories.append` calls — rule names passed
+        through a one-hop wrap helper are still resolved at call sites.
     """
     source = HOOK_FILE.read_text(encoding="utf-8")
     tree = ast.parse(source, filename=str(HOOK_FILE))
-    branch = _find_taskcreate_branch(tree)
-    assert branch is not None, (
-        f"Could not locate `if tool_name == \"TaskCreate\":` branch in "
-        f"{HOOK_FILE}. The AST invariant cannot evaluate without this "
+    branches = _find_taskcreate_branches(tree)
+    assert branches, (
+        f"Could not locate any `if tool_name == \"TaskCreate\":` branch "
+        f"in {HOOK_FILE}. The AST invariant cannot evaluate without this "
         "structural landmark — has evaluate_lifecycle been restructured?"
     )
-    rule_names = _collect_advisory_rule_names(branch)
-    offending = [r for r in rule_names if r in MULTI_WRITE_PROTOCOL_RULES]
+    wrap_helpers = _find_advisory_wrap_helpers(tree)
+    offending: list[str] = []
+    for branch in branches:
+        for rule in _collect_advisory_rule_names(branch, wrap_helpers):
+            if rule in MULTI_WRITE_PROTOCOL_RULES and rule not in offending:
+                offending.append(rule)
     assert offending == [], (
-        f"Multi-write-protocol rule(s) found inside the TaskCreate branch "
+        f"Multi-write-protocol rule(s) found inside a TaskCreate branch "
         f"of {HOOK_FILE.name}: {offending}. These rules enforce invariants "
         f"that span multiple writes; firing them at TaskCreate is either "
         f"spurious (the downstream writes have not happened) or "
         f"structurally unsatisfiable (the work-task id has not yet been "
         f"assigned). Move the rule to a TaskUpdate (or completion-time) "
         f"boundary where the invariant can be honestly evaluated."
+    )
+
+
+def test_helper_wrapped_appends_are_resolved_through_one_hop():
+    """Phantom-green protection: synthetic source where the TaskCreate
+    branch invokes a wrap helper with the denylisted rule name as a
+    string-literal argument. The wrap helper's body forwards the
+    parameter to advisories.append. Without one-hop resolution, the
+    direct-append walker would find no advisories.append call inside
+    the branch and the invariant would silently pass. With resolution,
+    the offending rule is detected at the call site.
+    """
+    src = (
+        "def _add_advisory(rule, msg):\n"
+        "    advisories.append((rule, msg))\n"
+        "\n"
+        "def evaluate_lifecycle(input_data):\n"
+        "    advisories = []\n"
+        "    tool_name = input_data.get('tool_name')\n"
+        "    if tool_name == 'TaskCreate':\n"
+        "        _add_advisory('teachback_addblocks_missing', 'fake')\n"
+        "    return advisories\n"
+    )
+    tree = ast.parse(src)
+    wrap_helpers = _find_advisory_wrap_helpers(tree)
+    assert "_add_advisory" in wrap_helpers, (
+        f"Wrap helper detector failed to identify _add_advisory; "
+        f"detected helpers: {wrap_helpers}"
+    )
+    branches = _find_taskcreate_branches(tree)
+    assert len(branches) == 1
+    rule_names = _collect_advisory_rule_names(branches[0], wrap_helpers)
+    assert "teachback_addblocks_missing" in rule_names, (
+        f"One-hop wrap-helper resolution failed to surface the rule "
+        f"passed via the helper. Detected rules: {rule_names}"
+    )
+
+
+def test_multiple_taskcreate_branches_are_all_inspected():
+    """Phantom-green protection: synthetic source with TWO sibling
+    `if tool_name == "TaskCreate":` branches in different functions.
+    A denylisted rule moved into the second branch must be caught.
+    Without multi-branch enumeration, the original single-branch walker
+    would return only the first branch and the offending second-branch
+    rule would silently pass.
+    """
+    src = (
+        "def evaluate_lifecycle(input_data):\n"
+        "    advisories = []\n"
+        "    tool_name = input_data.get('tool_name')\n"
+        "    if tool_name == 'TaskCreate':\n"
+        "        advisories.append(('work_addblockedby_missing', 'ok'))\n"
+        "    return advisories\n"
+        "\n"
+        "def evaluate_lifecycle_sibling_dispatch(input_data):\n"
+        "    advisories = []\n"
+        "    tool_name = input_data.get('tool_name')\n"
+        "    if tool_name == 'TaskCreate':\n"
+        "        advisories.append(('teachback_addblocks_missing', 'fake'))\n"
+        "    return advisories\n"
+    )
+    tree = ast.parse(src)
+    branches = _find_taskcreate_branches(tree)
+    assert len(branches) == 2, (
+        f"Multi-branch enumerator returned {len(branches)} branches; "
+        f"expected 2 (one per evaluate_lifecycle*)."
+    )
+    wrap_helpers = _find_advisory_wrap_helpers(tree)
+    all_rules: list[str] = []
+    for branch in branches:
+        all_rules.extend(_collect_advisory_rule_names(branch, wrap_helpers))
+    assert "teachback_addblocks_missing" in all_rules, (
+        f"Multi-branch walker failed to surface the rule from the "
+        f"second branch. Detected rules across all branches: {all_rules}"
     )
 
 

--- a/pact-plugin/tests/test_first_observable_write_misfire_invariant.py
+++ b/pact-plugin/tests/test_first_observable_write_misfire_invariant.py
@@ -1,0 +1,154 @@
+"""
+Cross-file AST invariant for the FIRST-OBSERVABLE-WRITE class.
+
+This invariant pins one architectural shape — once empirically observed and
+mitigated — into executable form so a future regression that re-introduces it
+fails loudly at CI time rather than during a live session.
+
+The shape: a hook checks a multi-write-protocol invariant at the FIRST
+observable write of the protocol, when the invariant cannot yet hold
+(downstream writes have not happened). The hook either (a) fires
+spuriously on every canonical-shape dispatch or (b) is structurally
+unsatisfiable by construction. Either way the advisory becomes noise that
+trains the editing LLM to dismiss legitimate signal.
+
+Worked example (the one this invariant directly protects):
+`teachback_addblocks_missing` was previously fired inside
+`task_lifecycle_gate.py`'s TaskCreate branch, but `addBlocks=[<work_task_id>]`
+cannot be set at TaskCreate(A) time because the work-task id does not yet
+exist. The rule was re-timed to the wiring TaskUpdate boundary (where the
+lead can satisfy both clauses in one update). This test asserts the rule
+never returns to the TaskCreate branch.
+
+Scope: this invariant currently denylists a single rule (the one above).
+The hypothesized parent class COUNT-BASED-LIFECYCLE-INVARIANT-MISFIRE has
+only two known instances at the time of writing; broadening this AST gate
+to enforce the parent class would over-constrain hook design while the
+class taxonomy is still under-specified. If a third instance crystallizes,
+re-shape this test from a denylist lookup into a walk-and-assert that
+flags any rule named `*_addblocks_missing` / `*_blockedby_missing` / etc.
+sitting inside a TaskCreate branch.
+
+The invariant is intentionally narrow: it does NOT enumerate hook files
+generally. It scopes to `task_lifecycle_gate.py` because that's where the
+FIRST-OBSERVABLE-WRITE instance lived. Generalization to other hooks (e.g.,
+`wake_lifecycle_emitter.py`) is deliberately deferred to a future
+architectural-class consolidation pass.
+"""
+
+import ast
+from pathlib import Path
+
+
+HOOK_FILE = (
+    Path(__file__).parent.parent / "hooks" / "task_lifecycle_gate.py"
+)
+
+
+# Rules that enforce a multi-write-protocol invariant — they CANNOT live
+# inside the TaskCreate branch because the protocol they enforce has not
+# yet completed at TaskCreate time. Adding a rule to this tuple is a
+# deliberate architectural-class assertion; do not append casually.
+MULTI_WRITE_PROTOCOL_RULES: tuple[str, ...] = (
+    "teachback_addblocks_missing",
+)
+
+
+def _find_taskcreate_branch(tree: ast.AST) -> ast.If | None:
+    """Return the `if tool_name == "TaskCreate":` AST node inside
+    evaluate_lifecycle, or None if not found. The lookup is structural —
+    matches an If whose test compares the Name `tool_name` against the
+    string constant `"TaskCreate"`.
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        test = node.test
+        if not isinstance(test, ast.Compare):
+            continue
+        left = test.left
+        if not (isinstance(left, ast.Name) and left.id == "tool_name"):
+            continue
+        if len(test.comparators) != 1:
+            continue
+        comparator = test.comparators[0]
+        if not (isinstance(comparator, ast.Constant) and comparator.value == "TaskCreate"):
+            continue
+        if not (len(test.ops) == 1 and isinstance(test.ops[0], ast.Eq)):
+            continue
+        return node
+    return None
+
+
+def _collect_advisory_rule_names(branch: ast.AST) -> list[str]:
+    """Walk an AST subtree, collect the rule-name string literal from each
+    `advisories.append((<rule_name>, <message>))` call. Returns the list
+    of literal rule names found.
+    """
+    rule_names: list[str] = []
+    for node in ast.walk(branch):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            continue
+        if func.attr != "append":
+            continue
+        # advisories.append(...) — match the receiver name conservatively
+        receiver = func.value
+        if not (isinstance(receiver, ast.Name) and receiver.id == "advisories"):
+            continue
+        if not node.args:
+            continue
+        arg0 = node.args[0]
+        # advisory tuples are 2-element (rule_name, message).
+        if not isinstance(arg0, ast.Tuple) or not arg0.elts:
+            continue
+        first = arg0.elts[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            rule_names.append(first.value)
+    return rule_names
+
+
+def test_no_multi_write_protocol_rule_in_taskcreate_branch():
+    """AST gate: the TaskCreate branch of evaluate_lifecycle must not
+    fire any rule that enforces a multi-write-protocol invariant. Such
+    rules belong at a write-time TaskUpdate (or completion-time) boundary
+    where the downstream writes have happened and the invariant can be
+    satisfied or falsified.
+    """
+    source = HOOK_FILE.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(HOOK_FILE))
+    branch = _find_taskcreate_branch(tree)
+    assert branch is not None, (
+        f"Could not locate `if tool_name == \"TaskCreate\":` branch in "
+        f"{HOOK_FILE}. The AST invariant cannot evaluate without this "
+        "structural landmark — has evaluate_lifecycle been restructured?"
+    )
+    rule_names = _collect_advisory_rule_names(branch)
+    offending = [r for r in rule_names if r in MULTI_WRITE_PROTOCOL_RULES]
+    assert offending == [], (
+        f"Multi-write-protocol rule(s) found inside the TaskCreate branch "
+        f"of {HOOK_FILE.name}: {offending}. These rules enforce invariants "
+        f"that span multiple writes; firing them at TaskCreate is either "
+        f"spurious (the downstream writes have not happened) or "
+        f"structurally unsatisfiable (the work-task id has not yet been "
+        f"assigned). Move the rule to a TaskUpdate (or completion-time) "
+        f"boundary where the invariant can be honestly evaluated."
+    )
+
+
+def test_denylist_is_non_empty():
+    """Documentation-in-code: the denylist MUST carry at least one rule
+    name. An empty denylist would make the invariant test trivially
+    vacuous (it would assert the absence of nothing). If a future cleanup
+    proposes emptying this tuple, the architectural-class taxonomy
+    should be re-evaluated first — an empty denylist with no replacement
+    invariant is a signal that the class has stopped being load-bearing,
+    which deserves explicit consideration rather than a silent drop.
+    """
+    assert MULTI_WRITE_PROTOCOL_RULES, (
+        "MULTI_WRITE_PROTOCOL_RULES must carry at least one rule name. "
+        "If the FIRST-OBSERVABLE-WRITE class is no longer load-bearing, "
+        "delete this test file rather than leaving an empty denylist."
+    )

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -71,16 +71,53 @@ def _capture_main(payload: dict, capsys) -> tuple[int, dict | None]:
 
 
 # =============================================================================
-# teachback_addblocks_missing — TEACHBACK Task without addBlocks=[<work_task_id>]
+# teachback_addblocks_missing — TaskUpdate-wiring-time rule
+#
+# The rule fires at the canonical Step-3 wiring TaskUpdate (lead sets owner
+# on a teachback Task) when the update lands without paired
+# addBlocks=[<work_task_id>] AND the on-disk task_a record does not already
+# carry blocks (benign late-wiring guard). Re-times the historical
+# TaskCreate-time check, which was structurally unsatisfiable because the
+# work-task id did not exist yet at TaskCreate(A) time.
+#
+# Fixture discipline: the wiring-boundary check calls
+# read_task_json(task_id, team_name) at the top of the write-time branch
+# (fires on EVERY non-completed TaskUpdate, not only those carrying
+# teachback_submit metadata). Tests must seed ~/.claude/tasks/{team}/{id}.json
+# under tmp_path via monkeypatch.setattr(Path, "home", lambda: tmp_path) so
+# that the disk read resolves the teachback subject + blocks fields.
 # =============================================================================
 
 
-def test_silent_when_teachback_carries_addblocks(pact_context):
+def _seed_task_a(tmp_path: Path, team_name: str, task_id: str, **fields) -> None:
+    """Write a task .json under the test-scoped HOME so the lifted
+    `read_task_json(task_id, team_name)` call inside the write-time
+    TaskUpdate branch resolves to a real on-disk record.
+    """
+    tasks_dir = tmp_path / ".claude" / "tasks" / team_name
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    payload = {"id": task_id, **fields}
+    (tasks_dir / f"{task_id}.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+def test_silent_when_owner_wiring_carries_addblocks(tmp_path, monkeypatch, pact_context):
+    """Canonical Step-3 wiring TaskUpdate pairs owner + addBlocks in one
+    update — no advisory at the wiring boundary."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
     pact_context(team_name="test-team", session_id="test-session")
+    _seed_task_a(
+        tmp_path,
+        "test-team",
+        "A",
+        subject="preparer: TEACHBACK for foo",
+        status="pending",
+    )
     payload = {
-        "tool_name": "TaskCreate",
+        "tool_name": "TaskUpdate",
         "tool_input": {
-            "subject": "preparer: TEACHBACK for foo",
+            "taskId": "A",
             "owner": "pact-preparer",
             "addBlocks": ["42"],
         },
@@ -88,7 +125,91 @@ def test_silent_when_teachback_carries_addblocks(pact_context):
     }
     advisories = tlg.evaluate_lifecycle(payload)
     assert not any(rule == "teachback_addblocks_missing" for rule, _ in advisories), (
-        f"expected silent (teachback_addblocks_missing satisfied), got: {advisories}"
+        f"expected silent (owner+addBlocks paired in wiring update), got: {advisories}"
+    )
+
+
+def test_fires_on_wiring_update_without_addblocks(tmp_path, monkeypatch, pact_context):
+    """Positive: the canonical owner-wiring TaskUpdate lands without paired
+    addBlocks AND task_a has no pre-existing blocks → advisory fires.
+    """
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    pact_context(team_name="test-team", session_id="test-session")
+    _seed_task_a(
+        tmp_path,
+        "test-team",
+        "A",
+        subject="preparer: TEACHBACK for foo",
+        status="pending",
+        blocks=[],
+    )
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "A",
+            "owner": "pact-preparer",
+            # no addBlocks
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert any(rule == "teachback_addblocks_missing" for rule, _ in advisories), (
+        f"expected teachback_addblocks_missing on owner-only wiring, got: {advisories}"
+    )
+
+
+def test_silent_when_task_a_already_has_blocks(tmp_path, monkeypatch, pact_context):
+    """Benign late-wiring guard: an earlier TaskUpdate already wired
+    blocks; a later owner-only update is not a violation."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    pact_context(team_name="test-team", session_id="test-session")
+    _seed_task_a(
+        tmp_path,
+        "test-team",
+        "A",
+        subject="preparer: TEACHBACK for foo",
+        status="pending",
+        blocks=["42"],
+    )
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "A",
+            "owner": "pact-preparer",
+            # no addBlocks — but task_a.blocks already populated
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert not any(rule == "teachback_addblocks_missing" for rule, _ in advisories), (
+        f"expected silent (task_a.blocks already wired), got: {advisories}"
+    )
+
+
+def test_silent_when_subject_is_not_teachback(tmp_path, monkeypatch, pact_context):
+    """Subject gate: a work-task subject (non-teachback) carrying owner
+    without addBlocks does not trip the teachback-specific rule."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    pact_context(team_name="test-team", session_id="test-session")
+    _seed_task_a(
+        tmp_path,
+        "test-team",
+        "B",
+        subject="preparer: implement feature X",
+        status="pending",
+    )
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "B",
+            "owner": "pact-preparer",
+            # no addBlocks — but subject is not a teachback subject
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert not any(rule == "teachback_addblocks_missing" for rule, _ in advisories), (
+        f"expected silent on non-teachback subject, got: {advisories}"
     )
 
 
@@ -223,9 +344,9 @@ def test_teachback_addblocks_missing_still_fires_for_stray_secretary_teachback(
     tmp_path, monkeypatch, pact_context
 ):
     """Defensive: the teachback_addblocks_missing rule is independent of the
-    new exemption. A stray teachback-subject task for the secretary still
-    triggers the addBlocks advisory — exemption applies only to the
-    work_addblockedby_missing rule."""
+    secretary exemption. A stray teachback-subject task whose owner-wiring
+    TaskUpdate lands without paired addBlocks still triggers the advisory —
+    the agentType exemption applies only to work_addblockedby_missing."""
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     pact_context(team_name="test-team", session_id="test-session")
     team_dir = tmp_path / ".claude" / "teams" / "test-team"
@@ -239,10 +360,18 @@ def test_teachback_addblocks_missing_still_fires_for_stray_secretary_teachback(
         }),
         encoding="utf-8",
     )
+    _seed_task_a(
+        tmp_path,
+        "test-team",
+        "A",
+        subject="secretary: TEACHBACK for some task",
+        status="pending",
+        blocks=[],
+    )
     payload = {
-        "tool_name": "TaskCreate",
+        "tool_name": "TaskUpdate",
         "tool_input": {
-            "subject": "secretary: TEACHBACK for some task",
+            "taskId": "A",
             "owner": "pact-secretary",
             # no addBlocks
         },

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -213,6 +213,143 @@ def test_silent_when_subject_is_not_teachback(tmp_path, monkeypatch, pact_contex
     )
 
 
+def test_silent_when_owner_not_provided_on_teachback_subject(tmp_path, monkeypatch, pact_context):
+    """Clause-2 coverage: the rule requires `tool_input.get('owner')` as
+    one of the four AND clauses. A TaskUpdate that touches a teachback
+    subject WITHOUT setting owner (e.g., a status-change update or an
+    addBlocks-only update) must NOT trip the rule — the rule fires
+    specifically on the canonical Step-3 owner-wiring update, not on
+    arbitrary mutations to teachback-subject tasks.
+
+    Phantom-green protection: if a future refactor drops the owner check
+    (simplifying to `is_teachback AND NOT addBlocks AND NOT blocks_on_disk`),
+    this test catches the regression."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    pact_context(team_name="test-team", session_id="test-session")
+    _seed_task_a(
+        tmp_path,
+        "test-team",
+        "A",
+        subject="preparer: TEACHBACK for foo",
+        status="pending",
+        blocks=[],
+    )
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "A",
+            "addBlocks": ["42"],
+            # owner deliberately omitted — exercises the clause-2 short-circuit
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert not any(rule == "teachback_addblocks_missing" for rule, _ in advisories), (
+        f"expected silent on owner-less TaskUpdate, got: {advisories}"
+    )
+
+
+def test_silent_when_status_completed_on_teachback_subject(tmp_path, monkeypatch, pact_context):
+    """Defense-in-depth: the write-time TaskUpdate branch carrying the
+    teachback_addblocks_missing rule is gated by `status != 'completed'`.
+    A completion-time TaskUpdate (status=completed) must NOT trip the
+    wiring-boundary rule — completion-time rules (teachback_submit checks,
+    paired-send window, etc.) handle that branch in the sibling
+    `if tool_name == 'TaskUpdate' and tool_input.get('status') == 'completed':`
+    block. A regression that moves the new rule outside the status guard
+    would fire on every completion of a teachback-subject task."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    pact_context(team_name="test-team", session_id="test-session")
+    _seed_task_a(
+        tmp_path,
+        "test-team",
+        "A",
+        subject="preparer: TEACHBACK for foo",
+        status="pending",
+        blocks=[],
+    )
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "A",
+            "owner": "pact-preparer",
+            "status": "completed",
+            # no addBlocks — but the status-completed guard suppresses
+        },
+        "tool_response": {
+            "task": {
+                "id": "A",
+                "subject": "preparer: TEACHBACK for foo",
+                "owner": "pact-preparer",
+            }
+        },
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert not any(rule == "teachback_addblocks_missing" for rule, _ in advisories), (
+        f"expected silent on status=completed TaskUpdate, got: {advisories}"
+    )
+
+
+def test_silent_when_team_name_empty(tmp_path, monkeypatch, pact_context):
+    """Defense-in-depth: empty team_name short-circuits the
+    `read_task_json(task_id, team_name) if team_name else {}` disk read
+    at the top of the write-time branch. With task_a = {}, subject = ""
+    → `_is_teachback_subject("")` is False → clause 1 fails → rule silent.
+    A regression dropping the `if team_name` guard would route through
+    read_task_json with an empty team and potentially misbehave depending
+    on the function's empty-team-name semantics."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    pact_context(team_name="", session_id="test-session")
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "A",
+            "owner": "pact-preparer",
+            # owner set, no addBlocks — would fire if subject resolved
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert not any(rule == "teachback_addblocks_missing" for rule, _ in advisories), (
+        f"expected silent on empty team_name, got: {advisories}"
+    )
+
+
+def test_silent_when_gate_writeback_recursion_marker_present(tmp_path, monkeypatch, pact_context):
+    """Defense-in-depth: the recursion guard at evaluate_lifecycle's top
+    short-circuits when `tool_input.metadata.gate_writeback is True`. This
+    is the gate's own writeback re-entry path; the new wiring-boundary
+    rule must never fire on it (and no other rule fires either — the
+    guard returns [] immediately). A regression that moves the recursion
+    guard below the new rule would emit a spurious advisory on every
+    gate-writeback re-entry."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    pact_context(team_name="test-team", session_id="test-session")
+    _seed_task_a(
+        tmp_path,
+        "test-team",
+        "A",
+        subject="preparer: TEACHBACK for foo",
+        status="pending",
+        blocks=[],
+    )
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "A",
+            "owner": "pact-preparer",
+            "metadata": {"gate_writeback": True},
+            # no addBlocks — would otherwise fire, but recursion guard preempts
+        },
+        "tool_response": {},
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    assert advisories == [], (
+        f"expected empty advisory list (recursion guard short-circuits), "
+        f"got: {advisories}"
+    )
+
+
 # =============================================================================
 # work_addblockedby_missing — pact-* non-TEACHBACK Task without addBlockedBy=[<teachback_id>]
 # =============================================================================

--- a/pact-plugin/tests/test_task_lifecycle_gate_smoke.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate_smoke.py
@@ -5,7 +5,8 @@ PACT lifecycle rules (#662 Commit 3).
 NOT comprehensive coverage — that is TEST-phase scope. These cases lock
 the load-bearing decisions in place so a future regression surfaces fast:
 
-  S1. teachback_addblocks_missing advisory: TEACHBACK Task created without addBlocks
+  S1. teachback_addblocks_missing advisory: TEACHBACK Task owner-wiring TaskUpdate
+      lands without paired addBlocks and task_a has no pre-existing blocks
   S2. work_addblockedby_missing advisory: pact-* Task created without addBlockedBy
   S3. handoff_missing advisory: pact-* work-Task completed with empty metadata.handoff
   S4. self_completion advisory + writeback: teammate self-completes; assert
@@ -51,15 +52,27 @@ def _capture_main(payload: dict, capsys) -> tuple[int, dict | None]:
     return code, parsed
 
 
-# ─── S1: teachback_addblocks_missing — TEACHBACK Task created without addBlocks ─
+# ─── S1: teachback_addblocks_missing — owner-wiring TaskUpdate without addBlocks ─
 
 
-def test_teachback_create_without_addblocks(pact_context, capsys):
+def test_teachback_wiring_update_without_addblocks(tmp_path, monkeypatch, pact_context, capsys):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
     pact_context(team_name="test-team", session_id="test-session")
-    payload = {
-        "tool_name": "TaskCreate",
-        "tool_input": {
+    tasks_dir = tmp_path / ".claude" / "tasks" / "test-team"
+    tasks_dir.mkdir(parents=True)
+    (tasks_dir / "A.json").write_text(
+        json.dumps({
+            "id": "A",
             "subject": "preparer: TEACHBACK for foo",
+            "status": "pending",
+            "blocks": [],
+        }),
+        encoding="utf-8",
+    )
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "A",
             "owner": "pact-preparer",
             # addBlocks deliberately omitted
         },


### PR DESCRIPTION
## Summary

Re-time the `teachback_addblocks_missing` advisory rule from the TaskCreate boundary (where the predicate was structurally unsatisfiable — work-task id does not exist yet at TaskCreate(A)) to the canonical Step-3 wiring TaskUpdate boundary (where the lead sets owner+addBlocks on the teachback Task in one update).

**Class**: FIRST-OBSERVABLE-WRITE-LIFECYCLE-INVARIANT-MISFIRE. The rule was firing 13× per session at the wrong boundary because the multi-write protocol invariant cannot hold at the first observable write. This PR moves the check to the terminal write where the invariant can be satisfied.

Sibling fix #842 (OPERATIONAL-LULL-AT-PHASE-BOUNDARY) ships separately under a MINOR bump because it introduces new public-API surface; PR-A is a tight boundary move under PATCH (4.3.1 → 4.3.2).

## What landed

| Commit | Subject | Scope |
|--------|---------|-------|
| `ed4d4d9f` | `fix(#843): re-time teachback_addblocks_missing to TaskUpdate wiring boundary` | `pact-plugin/hooks/task_lifecycle_gate.py` (+45/-16). New rule lives as sibling of the cross-slot `reasoning_reconstruction_in_handoff` check at the outer write-time-branch scope. Lifted `task_a = read_task_json(...)` disk read out of the inner `incoming_teachback` block to the top of the write-time branch — single read, multiple consumers (the new rule + the existing R5/R2/R3 cluster). Defensive `if not isinstance(task_a, dict): task_a = {}` guard added. Module docstring `Rule coverage` block refreshed to describe new boundary semantics. |
| `b39b72ba` | `test(#843): migrate teachback_addblocks_missing tests to wiring boundary` | 3 test files (+311/-15). Migrated 2 anchored tests in `test_task_lifecycle_gate.py` + 1 in `test_task_lifecycle_gate_smoke.py`; added 4 new boundary tests covering all 4 clauses of the AND predicate; new `_seed_task_a` fixture helper for the lifted disk-read constraint. New `test_first_observable_write_misfire_invariant.py` (+154) pins the class constraint via cross-file AST walk with denylist of multi-write-protocol rule names. |
| `775b80f5` | `chore: bump plugin version to 4.3.2` | Canonical 4 files (`plugin.json` + `marketplace.json` + `README.md` + `pact-plugin/README.md`). PATCH bump. |

## Why

The historical TaskCreate-time check was structurally unsatisfiable: `addBlocks=[<work_task_id>]` cannot be set at `TaskCreate(A)` because `B.id` doesn't yet exist. The rule fired on every canonical dispatch, training the editing LLM to dismiss legitimate signal. Moving the check to the wiring TaskUpdate boundary makes the predicate satisfiable in one update.

## Counter-test-by-revert verification

Per plan PR-A line 184-187 + the phantom-green discipline:

Source-only revert of `pact-plugin/hooks/task_lifecycle_gate.py` to `ed4d4d9f~1` (tests unchanged) → exactly **4 RED** at parent across the 3 affected test files:
- `test_fires_on_wiring_update_without_addblocks` (positive boundary)
- `test_teachback_addblocks_missing_still_fires_for_stray_secretary_teachback` (migrated stray-secretary)
- `test_no_multi_write_protocol_rule_in_taskcreate_branch` (AST invariant)
- `test_teachback_wiring_update_without_addblocks` (migrated smoke S1)

The 3 silent-negative migrated tests stay GREEN at parent (they assert absence; rule is absent from the TaskUpdate branch at parent).

HEAD verifies 136 PASS across the 3 affected test files. Byte-identical restore verified via `git diff --quiet HEAD -- pact-plugin/hooks/task_lifecycle_gate.py` exit 0.

## Observability note

`lifecycle_decision` journal-event distribution for `teachback_addblocks_missing` shifts from `tool_name=TaskCreate` to `tool_name=TaskUpdate`. Downstream tooling filtering events by tool_name should be aware of the boundary change. Rule name preserved as grep-anchor; the L920 cross-rule reference from `reasoning_reconstruction_band_unresolvable` remains valid (rule still enforces upstream wiring discipline, just at the wiring-update boundary).

**Affected TaskUpdate paths** (per peer-review devops-engineer M3): The lifted `task_a = read_task_json(task_id, team_name)` disk read at the top of the write-time TaskUpdate branch now fires on **every non-completed TaskUpdate**, not only those carrying `teachback_submit` metadata. The high-frequency paths affected are:

- **Status-only updates** — teammate self-claim (`status=in_progress`), lead-side status flips on signal tasks
- **Owner-assignment updates** — lead's canonical Step-3 wiring (`owner+addBlocks` in one call)
- **Metadata patches** — HANDOFF writes, intentional_wait SET/CLEAR, teachback_submit writes

**Cost analysis** (per architect peer-review): single-stat + read_text + JSON parse on a typically <10KB file (~50-200µs locally). Empirical 197 TaskUpdate fires/session × 50-200µs = ~10-40ms cumulative — negligible vs LLM-inference latency. The lift **amortizes** the disk read across the new rule + existing R3/R5/teachback_submit cluster rather than adding a new disk read; the cost was previously paid per-rule and is now paid once per write-time TaskUpdate.

## Out of scope

- PR-B (#842 OPERATIONAL-LULL HYBRID defense) — ships separately under MINOR bump per `docs/plans/fix-first-observable-write-hook-misfires-plan-2026-05-27.md` PR-B section.
- Pre-existing test pollution in `tests/test_merge_guard.py` (19 cross-test failures full-suite; 975/0 PASS standalone) — orthogonal, flagged as wrap-up-retrospective follow-up.
- Follow-up issue #846 (teachback_rejection_unaddressed write-time advisory) — surfaced during this session's empirical signal.

## Post-merge steps (mandatory per pinned `plugin-version-merge-ritual`)

1. Annotated tag at merge commit: `git tag -a v4.3.2 <merge-sha> -m "v4.3.2 — #843 FIRST-OBSERVABLE-WRITE rule re-time"`
2. Push tag: `git push origin v4.3.2`
3. `gh release create v4.3.2 --title "v4.3.2 — #843 FIRST-OBSERVABLE-WRITE rule re-time" --notes-file <notes>.md --latest`
4. Verification: `gh release list --limit 5` must show v4.3.2 at top.

## Test plan

- [x] `pytest pact-plugin/tests/test_task_lifecycle_gate.py pact-plugin/tests/test_first_observable_write_misfire_invariant.py pact-plugin/tests/test_task_lifecycle_gate_smoke.py` → 136 PASS at HEAD
- [x] Counter-test-by-revert verified (4 RED at parent → 0 RED at HEAD; byte-identical restore)
- [x] `py_compile` clean on `pact-plugin/hooks/task_lifecycle_gate.py`
- [x] No SKILL.md edit needed (verified no rule-name reference)
- [x] Version bump correct across canonical 4 files
