### PR TITLE
feat(#864): in-process teammateMode safeguard (Phase 1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.3.4",
+      "version": "4.3.5",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.3.4/      # Plugin version
+│               └── 4.3.5/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.3.4
+> **Version**: 4.3.5
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -6,6 +6,7 @@ Used by: Claude Code settings.json SessionStart hook
 
 Performs PACT environment initialization:
 0. Checks if ~/.claude/teams is in additionalDirectories (emits setup tip if not configured)
+0b. Emits a one-time in-process teammateMode notice recommending tmux for unattended runs (startup/resume only)
 1. Creates plugin symlinks for @reference resolution
 3. Ensures project CLAUDE.md exists with memory sections
 3b. One-time migration: wraps existing project CLAUDE.md in PACT_MANAGED boundary (#404)
@@ -100,6 +101,19 @@ from shared.session_resume import (
     restore_last_session,
     check_resumption_context,
     check_paused_state,
+)
+
+
+# #864 Phase 1: one-time startup notice recommending tmux for unattended runs
+# when the effective teammateMode is not positively "tmux". Emitted via
+# system_messages (user-facing) by main() step 0b. Lives HERE (presentation
+# layer) rather than in shared/teammate_mode.py (resolution layer) per SRP.
+# Pure literal (no interpolation) so tests can pin the exact substring.
+_INPROCESS_MODE_NOTICE = (
+    "PACT: unattended runs may stall in in-process teammate mode "
+    "(the lead can sit idle awaiting a wake that needs a manual nudge). "
+    "For hands-off runs, relaunch with `--teammate-mode tmux` for reliable "
+    "native delivery, or keep a heartbeat — see reference/unattended-runs.md."
 )
 
 
@@ -572,6 +586,7 @@ def main():
 
     Performs PACT environment initialization:
     0. Checks if ~/.claude/teams is in additionalDirectories (emits setup tip if not configured)
+    0b. Emits a one-time in-process teammateMode notice recommending tmux for unattended runs (startup/resume only)
     1. Creates plugin symlinks for @reference resolution
     3. Ensures project CLAUDE.md exists with memory sections
     3b. One-time migration: wraps existing project CLAUDE.md in PACT_MANAGED boundary (#404)
@@ -670,6 +685,33 @@ def main():
             dirs_tip = check_additional_directories()
             if dirs_tip:
                 system_messages.append(dirs_tip)
+
+        # 0b. One-time in-process teammateMode notice (#864 Phase 1, ADDITIVE).
+        # Warn that unattended runs may stall in in-process mode and recommend
+        # `--teammate-mode tmux`. User-facing recommendation (the model cannot
+        # relaunch itself) → system_messages channel, mirroring the step-0
+        # additionalDirectories tip.
+        #
+        # WHEN: emit only on session-LAUNCH events (startup + resume). A
+        # resumed session is the walk-away/unattended case worth re-warning,
+        # and each launch fires SessionStart exactly once for that source — so
+        # NO marker file is needed to stay once-per-launch. `compact` and
+        # `clear` are mid-launch context-reset events that CAN re-fire within a
+        # single launch; they are SUPPRESSED so the notice is never repeated.
+        # An unrecognized source (normalized to "unknown") is also suppressed.
+        #
+        # Fail-safe: should_emit_inprocess_notice() is total (never raises) and
+        # returns True on any read/parse uncertainty. The belt-and-suspenders
+        # try/except ALSO emits on any unexpected escape (e.g. an import
+        # failure) — "emit on uncertainty" is the protected direction — and it
+        # MUST NOT raise out of the SessionStart hot path.
+        if source in ("startup", "resume"):
+            try:
+                from shared.teammate_mode import should_emit_inprocess_notice
+                if should_emit_inprocess_notice():
+                    system_messages.append(_INPROCESS_MODE_NOTICE)
+            except Exception:  # noqa: BLE001 — fail-safe → emit; never block init
+                system_messages.append(_INPROCESS_MODE_NOTICE)
 
         # 1. Set up plugin symlinks (enables @~/.claude/protocols/pact-plugin/ references)
         # Context resets (compact/clear): symlinks are already set up from original session

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -705,6 +705,11 @@ def main():
         # try/except ALSO emits on any unexpected escape (e.g. an import
         # failure) — "emit on uncertainty" is the protected direction — and it
         # MUST NOT raise out of the SessionStart hot path.
+        #
+        # ALLOWLIST MAINTENANCE: a future Claude Code launch-like source not in
+        # this tuple normalizes to "unknown" (see source-normalization above)
+        # and is SUPPRESSED — update this allowlist if such a launch source is
+        # added upstream.
         if source in ("startup", "resume"):
             try:
                 from shared.teammate_mode import should_emit_inprocess_notice

--- a/pact-plugin/hooks/shared/teammate_mode.py
+++ b/pact-plugin/hooks/shared/teammate_mode.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Location: pact-plugin/hooks/shared/teammate_mode.py
+Summary: Resolve the effective Claude Code `teammateMode` setting from on-disk
+         settings sources, mirroring the runtime config getter's file-readable
+         precedence. Fail-open by construction — every public function is total
+         (never raises), because the sole consumer runs on the SessionStart hot
+         path where an uncaught exception would break bootstrap.
+Used by: session_init.py (in-process startup notice). Designed for reuse by a
+         future cron-auto-arm gate via resolve_effective_teammate_mode().
+
+Background (verified live, Claude Code 2.1.156):
+  `teammateMode` is a first-class Claude Code SETTING (one of {"auto","tmux",
+  "in-process"}), NOT a GrowthBook/Statsig flag. The runtime getter
+  g1("teammateMode","auto") scans settings sources highest-priority-first,
+  then a ~/.claude.json legacy fallback, then defaults to "auto". A per-launch
+  `--teammate-mode` CLI override lives only in the parent process's memory and
+  is invisible to a hook subprocess (absent from stdin, env, and every settings
+  file). This module therefore approximates the runtime value via the
+  FILE-READABLE precedence only; the caller fails SAFE toward emitting when the
+  resolved value is not positively "tmux".
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+# Full allowed value set (CLI .choices + settings-UI enum). A value outside
+# this set is treated as "not defined here" (fail-open → skip the source).
+VALID_TEAMMATE_MODES = frozenset({"auto", "tmux", "in-process"})
+
+# Runtime default when no source defines the key (mirrors g1's default arg).
+_DEFAULT_MODE = "auto"
+
+
+def _read_teammate_mode(path: Path) -> Optional[str]:
+    """Read top-level `teammateMode` from one JSON settings file.
+
+    Returns the value if it is a recognized mode string, else None.
+    Fail-open: ANY missing-file / unreadable / parse-error / wrong-type /
+    unrecognized-value condition returns None (caller treats None as "this
+    source does not define the key" and moves on). Never raises.
+    """
+    try:
+        if not path.exists():
+            return None
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return None
+        value = data.get("teammateMode")
+        if isinstance(value, str) and value in VALID_TEAMMATE_MODES:
+            return value
+        return None
+    except Exception:  # noqa: BLE001 — fail-open per module contract
+        return None
+
+
+def _settings_source_paths() -> list[Path]:
+    """Settings sources in runtime precedence order (highest first).
+
+    Mirrors the FILE-READABLE portion of Claude Code's settings precedence:
+      1. project  .claude/settings.local.json   (local — highest)
+      2. project  .claude/settings.json         (project)
+      3. user     ~/.claude/settings.json        (user)
+    The enterprise managed-settings layer (which sits ABOVE these in the
+    runtime) is intentionally NOT read here: it is absent on dev machines,
+    and omitting it only ever errs toward over-emitting the notice (the safe
+    direction). Adding that path later is a one-line prepend to this list.
+
+    Path-resolution conventions (test-seam compatible):
+      - project paths derive from CLAUDE_PROJECT_DIR (already consumed by
+        session_init.py); defaults to "." when unset.
+      - user path uses Path.home() (NOT os.path.expanduser) so tests that
+        monkeypatch Path.home resolve correctly.
+    """
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", ".")
+    project_claude = Path(project_dir) / ".claude"
+    return [
+        project_claude / "settings.local.json",
+        project_claude / "settings.json",
+        Path.home() / ".claude" / "settings.json",
+    ]
+
+
+def resolve_effective_teammate_mode() -> str:
+    """Return the effective teammateMode the runtime would resolve from disk.
+
+    Scans settings sources (local → project → user), then the ~/.claude.json
+    legacy global-config fallback, then defaults to "auto". Restricted to the
+    file-readable precedence: a live `--teammate-mode` CLI override cannot be
+    recovered from a hook and is NOT reflected here.
+
+    Returns one of {"tmux","in-process","auto"}. "auto" is returned both when
+    a source explicitly sets "auto" AND when nothing defines the key / every
+    source is unreadable (indistinguishable downstream; both fail SAFE to
+    emit). Total — never raises.
+    """
+    try:
+        for path in _settings_source_paths():
+            value = _read_teammate_mode(path)
+            if value is not None:
+                return value
+        legacy = _read_teammate_mode(Path.home() / ".claude.json")
+        if legacy is not None:
+            return legacy
+        return _DEFAULT_MODE
+    except Exception:  # noqa: BLE001 — total contract (defense in depth)
+        return _DEFAULT_MODE
+
+
+def should_emit_inprocess_notice() -> bool:
+    """True unless the effective teammateMode is positively "tmux".
+
+    Fail-safe direction (#864): EMIT on "in-process" / "auto" / anything not
+    confidently "tmux". The cost is asymmetric — a false suppress silently
+    reinstates the in-process idle-stall the notice exists to warn about,
+    while a false emit is one harmless extra startup line. Total — never
+    raises; any unexpected failure returns True (emit).
+    """
+    try:
+        return resolve_effective_teammate_mode() != "tmux"
+    except Exception:  # noqa: BLE001 — fail-safe → emit
+        return True

--- a/pact-plugin/hooks/shared/teammate_mode.py
+++ b/pact-plugin/hooks/shared/teammate_mode.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -57,26 +58,54 @@ def _read_teammate_mode(path: Path) -> Optional[str]:
         return None
 
 
+def _managed_settings_path() -> Path:
+    """Return the OS-specific enterprise managed-settings.json path.
+
+    Enterprise managed settings outrank every other source in Claude Code's
+    runtime getter (g1), so this is the highest-precedence entry in
+    _settings_source_paths(). The returned value is an absolute OS-specific
+    literal: it makes NO Path.home()/expanduser call and performs NO I/O here
+    (the file is read fail-open by _read_teammate_mode like any other source).
+    On a machine without a managed deployment the path simply does not exist
+    (exists()=False → skipped), so adding it is a no-op off managed fleets.
+
+    WSL's /mnt/c/... rewrite of the Windows path is deferred — not handled here.
+    Paths verified live against Claude Code 2.1.156.
+    """
+    if sys.platform == "darwin":
+        return Path("/Library/Application Support/ClaudeCode/managed-settings.json")
+    if sys.platform == "win32":
+        return Path(r"C:\Program Files\ClaudeCode\managed-settings.json")
+    return Path("/etc/claude-code/managed-settings.json")  # linux / default
+
+
 def _settings_source_paths() -> list[Path]:
     """Settings sources in runtime precedence order (highest first).
 
     Mirrors the FILE-READABLE portion of Claude Code's settings precedence:
-      1. project  .claude/settings.local.json   (local — highest)
-      2. project  .claude/settings.json         (project)
-      3. user     ~/.claude/settings.json        (user)
-    The enterprise managed-settings layer (which sits ABOVE these in the
-    runtime) is intentionally NOT read here (absent on dev machines; reading
-    it adds an OS-specific path matrix). This omission is an ACCEPTED
-    never-false-suppress breach: a managed `teammateMode` of "in-process" /
-    "auto" OVER a lower-layer "tmux" resolves non-tmux at runtime (managed
-    wins in g1), while this helper reads the lower "tmux" and SUPPRESSES — a
-    false-suppress (the #864-reinstating direction). Accepted for Phase 1
-    (narrow: a managed fleet forcing non-tmux beneath a lower-layer tmux); the
-    in-memory CLI `--teammate-mode` override is the OTHER accepted
-    false-suppress edge (see module docstring). Prepending the managed path
-    later is a one-line change that closes it (FUTURE, #868).
+      1. enterprise managed-settings (OS-specific; highest — managed wins in g1)
+      2. project  .claude/settings.local.json   (local)
+      3. project  .claude/settings.json         (project)
+      4. user     ~/.claude/settings.json        (user)
+    Reading the enterprise managed-settings layer at the TOP of the precedence
+    (it outranks all others in g1) CLOSES the former false-suppress edge: a
+    managed `teammateMode` of "in-process" / "auto" OVER a lower-layer "tmux"
+    now resolves correctly (managed read first → non-tmux → EMIT) instead of
+    this helper reading the lower "tmux" and wrongly SUPPRESSING. The managed
+    file is absent on dev machines (exists()=False → skipped), so this adds
+    zero behavior change off managed fleets.
+
+    The ONE remaining accepted never-false-suppress breach is the in-memory
+    `--teammate-mode` CLI override: it lives only in the parent process's
+    memory and is invisible to a hook subprocess (see module docstring), so a
+    live `--teammate-mode in-process` over a "tmux" config can still be missed.
+    That edge is irreducible from a hook; the managed-settings layer is now
+    handled (highest precedence).
 
     Path-resolution conventions (test-seam compatible):
+      - the managed path is an absolute OS-specific literal (see
+        _managed_settings_path); it makes no Path.home()/expanduser call, so it
+        does not perturb the home-monkeypatch test seam.
       - project paths derive from CLAUDE_PROJECT_DIR (already consumed by
         session_init.py); defaults to "." when unset.
       - user path uses Path.home() (NOT os.path.expanduser) so tests that
@@ -85,6 +114,7 @@ def _settings_source_paths() -> list[Path]:
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR", ".")
     project_claude = Path(project_dir) / ".claude"
     return [
+        _managed_settings_path(),
         project_claude / "settings.local.json",
         project_claude / "settings.json",
         Path.home() / ".claude" / "settings.json",
@@ -94,7 +124,7 @@ def _settings_source_paths() -> list[Path]:
 def resolve_effective_teammate_mode() -> str:
     """Return the effective teammateMode the runtime would resolve from disk.
 
-    Scans settings sources (local → project → user), then the ~/.claude.json
+    Scans settings sources (managed → local → project → user), then the ~/.claude.json
     legacy global-config fallback, then defaults to "auto". Restricted to the
     file-readable precedence: a live `--teammate-mode` CLI override cannot be
     recovered from a hook and is NOT reflected here.

--- a/pact-plugin/hooks/shared/teammate_mode.py
+++ b/pact-plugin/hooks/shared/teammate_mode.py
@@ -65,9 +65,16 @@ def _settings_source_paths() -> list[Path]:
       2. project  .claude/settings.json         (project)
       3. user     ~/.claude/settings.json        (user)
     The enterprise managed-settings layer (which sits ABOVE these in the
-    runtime) is intentionally NOT read here: it is absent on dev machines,
-    and omitting it only ever errs toward over-emitting the notice (the safe
-    direction). Adding that path later is a one-line prepend to this list.
+    runtime) is intentionally NOT read here (absent on dev machines; reading
+    it adds an OS-specific path matrix). This omission is an ACCEPTED
+    never-false-suppress breach: a managed `teammateMode` of "in-process" /
+    "auto" OVER a lower-layer "tmux" resolves non-tmux at runtime (managed
+    wins in g1), while this helper reads the lower "tmux" and SUPPRESSES — a
+    false-suppress (the #864-reinstating direction). Accepted for Phase 1
+    (narrow: a managed fleet forcing non-tmux beneath a lower-layer tmux); the
+    in-memory CLI `--teammate-mode` override is the OTHER accepted
+    false-suppress edge (see module docstring). Prepending the managed path
+    later is a one-line change that closes it (FUTURE, #868).
 
     Path-resolution conventions (test-seam compatible):
       - project paths derive from CLAUDE_PROJECT_DIR (already consumed by
@@ -96,6 +103,12 @@ def resolve_effective_teammate_mode() -> str:
     a source explicitly sets "auto" AND when nothing defines the key / every
     source is unreadable (indistinguishable downstream; both fail SAFE to
     emit). Total — never raises.
+
+    Reuse note: this "auto" conflation erases explicit-"auto" vs nothing-
+    defined/unreadable — correct for the Phase-1 emit-policy (both → emit), but
+    a future consumer (e.g. the Phase-2 cron-auto-arm gate) needing to
+    distinguish them must add a separate signal; it MUST NOT assume "auto"
+    means an explicit user choice.
     """
     try:
         for path in _settings_source_paths():

--- a/pact-plugin/reference/unattended-runs.md
+++ b/pact-plugin/reference/unattended-runs.md
@@ -1,0 +1,40 @@
+# Unattended PACT Runs
+
+> **Purpose**: Keep a hands-off (unattended) PACT session from stalling while the lead is idle.
+>
+> **Usage**: Read this when you saw the startup notice about in-process teammate mode, or before leaving a PACT run unattended.
+>
+> **Created**: 2026-05-29
+
+---
+
+## TL;DR — use tmux for unattended runs
+
+Relaunch Claude Code with tmux teammate delivery:
+
+```bash
+claude --teammate-mode tmux
+```
+
+In tmux mode, teammate wake signals are delivered natively and reliably even
+when the lead has been idle for a long time. In **in-process** mode, the lead
+can sit idle waiting for a wake that needs a manual nudge — fine when you are
+watching the session, a stall risk when you walk away.
+
+You can also set it permanently in `~/.claude/settings.json`:
+
+```json
+{ "teammateMode": "tmux" }
+```
+
+## If you must stay on in-process mode
+
+Keep a lightweight external heartbeat in another terminal so you periodically
+return to nudge the lead:
+
+```bash
+while sleep 300; do printf '\a'; done   # bell every 5 min as a "check the session" cue
+```
+
+This does not fix delivery — it just reminds you to glance at the run. For
+truly hands-off operation, prefer `--teammate-mode tmux`.

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -790,6 +790,146 @@ class TestCheckAdditionalDirectoriesMainIntegration:
         assert "PACT tip" not in system_msg
 
 
+class TestInprocessModeNoticeIntegration:
+    """#864 Phase 1 §9.2: the in-process teammateMode notice wired into main().
+
+    Drives session_init.main() end-to-end and asserts the notice appears in the
+    emitted systemMessage for launch events (startup/resume) when the effective
+    mode is not positively tmux, and is ABSENT for mid-launch context resets
+    (compact/clear) and when the mode is tmux.
+
+    The notice is detected by its stable doc-reference substring
+    'reference/unattended-runs.md' (the notice<->doc link contract). The
+    fixtures populate additionalDirectories so the step-0 dirs-tip is
+    suppressed, isolating systemMessage to the notice under test.
+    """
+
+    # Stable substrings the notice MUST contain (drift guards per §9.2).
+    _DOC_REF = "reference/unattended-runs.md"
+    _CLI_HINT = "--teammate-mode tmux"
+
+    def _run_main_capture_systemmessage(
+        self, monkeypatch, tmp_path, source, mode
+    ):
+        """Run main() with given source + effective teammateMode (mode=None ->
+        no teammateMode key -> resolves 'auto'). Returns the systemMessage str.
+
+        Filesystem-isolated: Path.home -> tmp_path, CLAUDE_PROJECT_DIR -> an
+        empty temp project dir (so project settings sources do not exist and the
+        mode resolves from the user settings.json we write here).
+        """
+        from session_init import main
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project_dir))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        # User settings.json: populate additionalDirectories (suppress the
+        # step-0 dirs-tip) and optionally pin teammateMode.
+        teams_abs = str(tmp_path / ".claude" / "teams")
+        sessions_abs = str(tmp_path / ".claude" / "pact-sessions")
+        settings = {"permissions": {"additionalDirectories": [teams_abs, sessions_abs]}}
+        if mode is not None:
+            settings["teammateMode"] = mode
+        settings_dir = tmp_path / ".claude"
+        settings_dir.mkdir(parents=True)
+        (settings_dir / "settings.json").write_text(
+            json.dumps(settings), encoding="utf-8"
+        )
+
+        # Team config so resume/compact/clear stay on the normal (non-anomalous)
+        # path; mirrors the existing context-reset integration tests.
+        team_dir = tmp_path / ".claude" / "teams" / "pact-aabb1122"
+        team_dir.mkdir(parents=True)
+        (team_dir / "config.json").write_text('{"members": []}')
+
+        stdin_data = json.dumps({
+            "session_id": "aabb1122-0000-0000-0000-000000000000",
+            "source": source,
+        })
+
+        with patch("session_init.setup_plugin_symlinks", return_value=None), \
+             patch("session_init.ensure_project_memory_md", return_value=None), \
+             patch("session_init.check_pinned_staleness", return_value=None), \
+             patch("session_init.update_session_info", return_value=None), \
+             patch("session_init.get_task_list", return_value=None), \
+             patch("session_init.restore_last_session", return_value=None), \
+             patch("session_init.check_paused_state", return_value=None), \
+             patch("sys.stdin", io.StringIO(stdin_data)), \
+             patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0
+        output = json.loads(mock_stdout.getvalue())
+        return output.get("systemMessage", "")
+
+    @pytest.mark.parametrize(
+        "source,mode,present",
+        [
+            ("startup", "in-process", True),
+            ("startup", "tmux", False),
+            ("resume", "in-process", True),     # D1: resume re-warns (walk-away case)
+            ("compact", "in-process", False),   # mid-launch reset -> suppressed
+            ("clear", "in-process", False),     # mid-launch reset -> suppressed
+            ("startup", None, True),            # no teammateMode -> auto -> emit (fail-safe)
+        ],
+    )
+    def test_notice_emit_matrix(self, monkeypatch, tmp_path, source, mode, present):
+        """§9.2 matrix: notice present iff launch-event AND mode not tmux."""
+        system_msg = self._run_main_capture_systemmessage(
+            monkeypatch, tmp_path, source=source, mode=mode
+        )
+        if present:
+            assert self._DOC_REF in system_msg, (
+                f"expected notice for source={source!r} mode={mode!r}"
+            )
+            # Drift guards: the notice pins both literal substrings (§9.2).
+            assert self._CLI_HINT in system_msg
+        else:
+            assert self._DOC_REF not in system_msg, (
+                f"expected NO notice for source={source!r} mode={mode!r}"
+            )
+
+    def test_notice_text_pins_literal_substrings(self, monkeypatch, tmp_path):
+        """The emitted notice contains BOTH the CLI hint and the doc link.
+
+        Standalone drift guard so a future edit to _INPROCESS_MODE_NOTICE that
+        drops either load-bearing substring fails loudly here.
+        """
+        system_msg = self._run_main_capture_systemmessage(
+            monkeypatch, tmp_path, source="startup", mode="in-process"
+        )
+        assert self._CLI_HINT in system_msg
+        assert self._DOC_REF in system_msg
+
+    def test_belt_and_suspenders_emits_when_helper_raises(self, monkeypatch, tmp_path):
+        """§9.3 fail-open: if should_emit_inprocess_notice() raises, the step-0b
+        except path STILL emits the notice and main() STILL exits 0.
+
+        The mode is pinned to 'tmux' so the happy path would SUPPRESS -- the
+        notice can therefore only appear via the belt-and-suspenders except,
+        proving that path emits (the protected #864 direction) rather than
+        crashing the SessionStart hot path.
+        """
+        import shared.teammate_mode as teammate_mode
+
+        def boom():
+            raise RuntimeError("helper exploded on the hot path")
+
+        # session_init imports the helper lazily at call time, so patching the
+        # module attribute is resolved by the in-block `from ... import ...`.
+        monkeypatch.setattr(teammate_mode, "should_emit_inprocess_notice", boom)
+
+        system_msg = self._run_main_capture_systemmessage(
+            monkeypatch, tmp_path, source="startup", mode="tmux"
+        )
+        # Notice emitted via the except path despite mode=tmux (would suppress).
+        assert self._DOC_REF in system_msg
+        assert self._CLI_HINT in system_msg
+
+
 class TestIsUnknownOrMissingSession:
     """Direct unit tests for _is_unknown_or_missing_session() predicate.
 

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -808,6 +808,11 @@ class TestInprocessModeNoticeIntegration:
     _DOC_REF = "reference/unattended-runs.md"
     _CLI_HINT = "--teammate-mode tmux"
 
+    # Sentinel: pass as `source` to OMIT the source key from stdin entirely
+    # (distinct from passing None, which sets {"source": null} -> normalizes to
+    # "unknown"). Drives main()'s missing-source default-to-"startup" path.
+    _OMIT_SOURCE = object()
+
     def _run_main_capture_systemmessage(
         self, monkeypatch, tmp_path, source, mode
     ):
@@ -824,6 +829,17 @@ class TestInprocessModeNoticeIntegration:
         project_dir.mkdir()
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project_dir))
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        # Determinism: neutralize the enterprise managed-settings source so the
+        # effective teammateMode resolves ONLY from the isolated tmp settings
+        # written below -- never the real OS managed path, which sits at
+        # precedence[0] and would otherwise confound mode resolution on a
+        # managed fleet. Sibling of the _ModeEnv fixture isolation in
+        # test_teammate_mode.py (same managed-path determinism class).
+        import shared.teammate_mode as teammate_mode
+        monkeypatch.setattr(
+            teammate_mode, "_managed_settings_path",
+            lambda: tmp_path / "absent-managed-settings.json",
+        )
 
         # User settings.json: populate additionalDirectories (suppress the
         # step-0 dirs-tip) and optionally pin teammateMode.
@@ -844,10 +860,12 @@ class TestInprocessModeNoticeIntegration:
         team_dir.mkdir(parents=True)
         (team_dir / "config.json").write_text('{"members": []}')
 
-        stdin_data = json.dumps({
-            "session_id": "aabb1122-0000-0000-0000-000000000000",
-            "source": source,
-        })
+        # Omit the source key entirely when _OMIT_SOURCE is passed (drives
+        # main()'s `.get("source","startup")` default); otherwise pin it.
+        payload = {"session_id": "aabb1122-0000-0000-0000-000000000000"}
+        if source is not self._OMIT_SOURCE:
+            payload["source"] = source
+        stdin_data = json.dumps(payload)
 
         with patch("session_init.setup_plugin_symlinks", return_value=None), \
              patch("session_init.ensure_project_memory_md", return_value=None), \
@@ -927,6 +945,44 @@ class TestInprocessModeNoticeIntegration:
         )
         # Notice emitted via the except path despite mode=tmux (would suppress).
         assert self._DOC_REF in system_msg
+        assert self._CLI_HINT in system_msg
+
+    def test_unrecognized_source_suppresses_notice(self, monkeypatch, tmp_path):
+        """Source-gate edge: an UNRECOGNIZED source ("banana") normalizes to
+        "unknown" (session_init source validation, not in _VALID_SOURCES) and is
+        NOT in the {startup,resume} notice allowlist -> the notice is SUPPRESSED.
+
+        The effective mode is forced 'in-process' (non-tmux) -- which WOULD emit
+        on a launch source -- so the suppression here is attributable to the
+        SOURCE gate alone. A regression that dropped or widened the source check
+        would EMIT and fail this test. (mode is deterministic: the helper
+        isolates all settings sources incl. the managed path, so this never
+        depends on the real machine's teammateMode.)
+        """
+        system_msg = self._run_main_capture_systemmessage(
+            monkeypatch, tmp_path, source="banana", mode="in-process"
+        )
+        assert self._DOC_REF not in system_msg, (
+            "an unrecognized source must SUPPRESS the in-process notice "
+            "(normalizes to 'unknown'; not in the startup/resume allowlist)"
+        )
+
+    def test_missing_source_defaults_to_startup_and_emits(self, monkeypatch, tmp_path):
+        """Source-gate edge: a stdin payload with NO source key defaults to
+        "startup" (main()'s `.get("source","startup")`) -> a launch source ->
+        the notice EMITS (mode 'in-process' is non-tmux). Pins the SAFE default:
+        a missing source must NOT silently suppress the notice on a real launch.
+
+        _OMIT_SOURCE omits the key entirely; passing None would instead set
+        {"source": null} -> None -> normalizes to "unknown" -> SUPPRESS, a
+        different path that is NOT what 'missing source' means here.
+        """
+        system_msg = self._run_main_capture_systemmessage(
+            monkeypatch, tmp_path, source=self._OMIT_SOURCE, mode="in-process"
+        )
+        assert self._DOC_REF in system_msg, (
+            "a missing source must default to 'startup' and EMIT the notice"
+        )
         assert self._CLI_HINT in system_msg
 
 

--- a/pact-plugin/tests/test_teammate_mode.py
+++ b/pact-plugin/tests/test_teammate_mode.py
@@ -1,0 +1,386 @@
+"""Tests for shared/teammate_mode.py -- effective teammateMode resolution and
+the in-process startup-notice emit decision.
+
+Background: the helper mirrors the FILE-READABLE portion of Claude Code's
+settings precedence to answer "what is the effective teammateMode?" from a hook
+subprocess (which cannot see the live `--teammate-mode` CLI override). It is
+fail-open by construction -- every public function is total (never raises),
+because the sole consumer runs on the SessionStart hot path where an uncaught
+exception would break bootstrap.
+
+Core invariant under test: NEVER FALSE-SUPPRESS. A false suppress silently
+reinstates the in-process idle-stall the notice exists to warn about; a false
+emit is one harmless extra startup line. Every fail-open / fail-safe decision
+resolves toward EMIT.
+
+Coverage:
+
+resolve_effective_teammate_mode() + should_emit_inprocess_notice() -- §9.1 matrix:
+1.  user settings.json {in-process}                 -> "in-process" / emit
+2.  user settings.json {tmux}                        -> "tmux"       / suppress
+3.  user settings.json {auto}                         -> "auto"       / emit
+4.  no settings files anywhere                        -> "auto"       / emit (default)
+5.  user settings.json malformed JSON                 -> "auto"       / emit (skip)
+6.  user settings.json {tmux} + ~/.claude.json {in-process}
+                                                       -> "tmux"       / suppress (settings>legacy)
+7.  only ~/.claude.json {in-process} (no settings)    -> "in-process" / emit (legacy fallback)
+8.  project settings.local.json {in-process} OVER user settings.json {tmux}
+                                                       -> "in-process" / emit (FALSE-SUPPRESS EDGE)
+9.  {teammateMode:"banana"} (unrecognized)            -> "auto"       / emit (value skipped)
+10. {teammateMode: 42} (non-string)                   -> "auto"       / emit (type guard skips)
+
+Precedence layering (defense-in-depth beyond the architect's 10):
+- project settings.json beats user settings.json
+- project settings.local.json beats project settings.json
+- empty-string teammateMode is skipped like any unrecognized value
+
+VALID_TEAMMATE_MODES contract:
+- exact membership + frozenset immutability
+
+Fail-open guarantee (§9.3) -- helper never raises under any read/parse error:
+- malformed JSON / non-dict JSON / unreadable (dir-in-place) / wrong-type value
+- Path.home() itself raising (outer-guard defense in depth)
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add hooks directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import shared.teammate_mode as teammate_mode
+from shared.teammate_mode import (
+    VALID_TEAMMATE_MODES,
+    _read_teammate_mode,
+    _settings_source_paths,
+    resolve_effective_teammate_mode,
+    should_emit_inprocess_notice,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+class _ModeEnv:
+    """Filesystem-isolated settings-source writer for teammate_mode tests.
+
+    Pins Path.home() -> tmp_path/home and CLAUDE_PROJECT_DIR -> tmp_path/project
+    so the helper reads ONLY the temp tree, never the real machine's settings
+    (devops flagged this determinism risk). Exposes one writer per settings
+    source so tests construct exactly the precedence they intend.
+    """
+
+    def __init__(self, tmp_path, monkeypatch):
+        self.home = tmp_path / "home"
+        self.project = tmp_path / "project"
+        self.home.mkdir()
+        self.project.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: self.home)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(self.project))
+
+    @staticmethod
+    def _write(path: Path, content):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # dict -> JSON; str written raw (for malformed-JSON / non-dict cases)
+        text = content if isinstance(content, str) else json.dumps(content)
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    # Settings sources, highest precedence first.
+    def write_project_local(self, content):
+        return self._write(self.project / ".claude" / "settings.local.json", content)
+
+    def write_project(self, content):
+        return self._write(self.project / ".claude" / "settings.json", content)
+
+    def write_user(self, content):
+        return self._write(self.home / ".claude" / "settings.json", content)
+
+    def write_legacy(self, content):
+        return self._write(self.home / ".claude.json", content)
+
+
+@pytest.fixture
+def mode_env(tmp_path, monkeypatch):
+    """Isolated settings tree for resolve/should_emit tests."""
+    return _ModeEnv(tmp_path, monkeypatch)
+
+
+# ---------------------------------------------------------------------------
+# §9.1 matrix: resolve_effective_teammate_mode + should_emit_inprocess_notice
+# ---------------------------------------------------------------------------
+
+class TestResolveAndEmitMatrix:
+    """The architect's §9.1 matrix: resolution value AND the emit decision.
+
+    should_emit is asserted alongside resolve in every row because the emit
+    decision is the load-bearing output (#864). Testing them together pins the
+    'never false-suppress' invariant at the boundary the safeguard defends.
+    """
+
+    def test_user_in_process_emits(self, mode_env):
+        """Row 1: user settings in-process -> resolve in-process, EMIT."""
+        mode_env.write_user({"teammateMode": "in-process"})
+        assert resolve_effective_teammate_mode() == "in-process"
+        assert should_emit_inprocess_notice() is True
+
+    def test_user_tmux_suppresses(self, mode_env):
+        """Row 2: user settings tmux -> resolve tmux, SUPPRESS (the only suppress case)."""
+        mode_env.write_user({"teammateMode": "tmux"})
+        assert resolve_effective_teammate_mode() == "tmux"
+        assert should_emit_inprocess_notice() is False
+
+    def test_user_auto_emits(self, mode_env):
+        """Row 3: user settings auto -> resolve auto, EMIT (may resolve to in-process at runtime)."""
+        mode_env.write_user({"teammateMode": "auto"})
+        assert resolve_effective_teammate_mode() == "auto"
+        assert should_emit_inprocess_notice() is True
+
+    def test_no_settings_anywhere_defaults_auto_emits(self, mode_env):
+        """Row 4: nothing defines the key -> default auto, EMIT (fail-safe default)."""
+        # mode_env writes nothing.
+        assert resolve_effective_teammate_mode() == "auto"
+        assert should_emit_inprocess_notice() is True
+
+    def test_user_malformed_json_skips_to_default_emits(self, mode_env):
+        """Row 5: malformed JSON -> source skipped -> default auto, EMIT (fail-open)."""
+        mode_env.write_user("{ this is not valid json ")
+        assert resolve_effective_teammate_mode() == "auto"
+        assert should_emit_inprocess_notice() is True
+
+    def test_settings_wins_over_legacy(self, mode_env):
+        """Row 6: settings tmux + legacy in-process -> tmux, SUPPRESS (live-machine case).
+
+        Settings sources outrank the ~/.claude.json legacy fallback. This is
+        the common live-machine shape and must SUPPRESS -- the legacy
+        in-process value must NOT leak through and force an emit.
+        """
+        mode_env.write_user({"teammateMode": "tmux"})
+        mode_env.write_legacy({"teammateMode": "in-process"})
+        assert resolve_effective_teammate_mode() == "tmux"
+        assert should_emit_inprocess_notice() is False
+
+    def test_legacy_only_fallback_used(self, mode_env):
+        """Row 7: only ~/.claude.json in-process (no settings file) -> in-process, EMIT.
+
+        The legacy fallback is consulted when no settings source defines the key.
+        """
+        mode_env.write_legacy({"teammateMode": "in-process"})
+        assert resolve_effective_teammate_mode() == "in-process"
+        assert should_emit_inprocess_notice() is True
+
+    def test_false_suppress_edge_project_local_over_user_tmux(self, mode_env):
+        """Row 8: THE FALSE-SUPPRESS EDGE -- project-local in-process OVER user tmux.
+
+        This is the exact #864-reinstating direction FULL precedence exists to
+        prevent. A two-file shortcut reader would see the user 'tmux' and
+        SUPPRESS, while the runtime actually resolves the project-local
+        'in-process' and the notice SHOULD fire. FULL precedence reads
+        project-local first -> 'in-process' -> EMIT.
+
+        If this test ever inverts (resolves tmux / suppresses), the precedence
+        assumption the whole design rests on has broken.
+        """
+        mode_env.write_project_local({"teammateMode": "in-process"})
+        mode_env.write_user({"teammateMode": "tmux"})
+        assert resolve_effective_teammate_mode() == "in-process"
+        assert should_emit_inprocess_notice() is True
+
+    def test_unrecognized_value_skipped_emits(self, mode_env):
+        """Row 9: {teammateMode:'banana'} -> value skipped -> default auto, EMIT."""
+        mode_env.write_user({"teammateMode": "banana"})
+        assert resolve_effective_teammate_mode() == "auto"
+        assert should_emit_inprocess_notice() is True
+
+    def test_non_string_value_skipped_emits(self, mode_env):
+        """Row 10: {teammateMode: 42} -> type guard skips -> default auto, EMIT."""
+        mode_env.write_user({"teammateMode": 42})
+        assert resolve_effective_teammate_mode() == "auto"
+        assert should_emit_inprocess_notice() is True
+
+
+# ---------------------------------------------------------------------------
+# Precedence layering -- defense-in-depth beyond the architect's 10 rows
+# ---------------------------------------------------------------------------
+
+class TestPrecedenceLayering:
+    """Each higher-priority source must shadow the lower one.
+
+    Row 8 pins layer-1 (project-local) over layer-3 (user). These pin the
+    intermediate edges so a future re-ordering of any single layer fails loudly.
+    """
+
+    def test_project_settings_beats_user_settings(self, mode_env):
+        """project settings.json (layer 2) outranks user settings.json (layer 3)."""
+        mode_env.write_project({"teammateMode": "in-process"})
+        mode_env.write_user({"teammateMode": "tmux"})
+        assert resolve_effective_teammate_mode() == "in-process"
+        assert should_emit_inprocess_notice() is True
+
+    def test_project_local_beats_project_settings(self, mode_env):
+        """project settings.local.json (layer 1) outranks project settings.json (layer 2)."""
+        mode_env.write_project_local({"teammateMode": "tmux"})
+        mode_env.write_project({"teammateMode": "in-process"})
+        assert resolve_effective_teammate_mode() == "tmux"
+        assert should_emit_inprocess_notice() is False
+
+    def test_full_chain_local_wins_over_all_lower(self, mode_env):
+        """All four sources set; the highest (project-local) wins outright."""
+        mode_env.write_project_local({"teammateMode": "in-process"})
+        mode_env.write_project({"teammateMode": "tmux"})
+        mode_env.write_user({"teammateMode": "tmux"})
+        mode_env.write_legacy({"teammateMode": "tmux"})
+        assert resolve_effective_teammate_mode() == "in-process"
+        assert should_emit_inprocess_notice() is True
+
+    def test_higher_source_without_key_falls_through(self, mode_env):
+        """A higher source that omits the key does NOT shadow a lower one.
+
+        project settings.local.json has no teammateMode (defines other keys);
+        resolution must fall through to the user 'tmux'.
+        """
+        mode_env.write_project_local({"permissions": {"additionalDirectories": []}})
+        mode_env.write_user({"teammateMode": "tmux"})
+        assert resolve_effective_teammate_mode() == "tmux"
+        assert should_emit_inprocess_notice() is False
+
+    def test_empty_string_value_skipped(self, mode_env):
+        """teammateMode:'' is not in VALID_TEAMMATE_MODES -> skipped like 'banana'."""
+        mode_env.write_user({"teammateMode": ""})
+        assert resolve_effective_teammate_mode() == "auto"
+        assert should_emit_inprocess_notice() is True
+
+
+# ---------------------------------------------------------------------------
+# VALID_TEAMMATE_MODES contract
+# ---------------------------------------------------------------------------
+
+class TestValidModesContract:
+    """Pin the allowed value set and its immutability.
+
+    If Claude Code adds/renames a teammateMode value, this test is the canary:
+    the helper resolves unknown values to 'auto' (safe / emit), so a schema
+    drift degrades gracefully, but the pinned set documents the known contract.
+    """
+
+    def test_valid_modes_exact_membership(self):
+        assert VALID_TEAMMATE_MODES == frozenset({"auto", "tmux", "in-process"})
+
+    def test_valid_modes_is_frozenset(self):
+        """Immutable so it cannot be mutated by an importer at runtime."""
+        assert isinstance(VALID_TEAMMATE_MODES, frozenset)
+        with pytest.raises(AttributeError):
+            VALID_TEAMMATE_MODES.add("new-mode")  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# §9.3 fail-open guarantee -- the helper is TOTAL (never raises)
+# ---------------------------------------------------------------------------
+
+class TestReadTeammateModeFailOpen:
+    """Per-file reader contract (§4.1 _read_teammate_mode): any missing /
+    unreadable / parse-error / wrong-type / unrecognized condition returns
+    None and NEVER raises.
+    """
+
+    def test_missing_file_returns_none(self, tmp_path):
+        assert _read_teammate_mode(tmp_path / "nope.json") is None
+
+    def test_malformed_json_returns_none(self, tmp_path):
+        p = tmp_path / "settings.json"
+        p.write_text("{ not json", encoding="utf-8")
+        assert _read_teammate_mode(p) is None
+
+    def test_non_dict_json_returns_none(self, tmp_path):
+        p = tmp_path / "settings.json"
+        p.write_text("[1, 2, 3]", encoding="utf-8")
+        assert _read_teammate_mode(p) is None
+
+    def test_unreadable_path_is_a_directory_returns_none(self, tmp_path):
+        """exists() is True but read_text raises (IsADirectoryError) -> None, no raise."""
+        p = tmp_path / "settings.json"
+        p.mkdir()
+        assert _read_teammate_mode(p) is None
+
+    def test_wrong_type_value_returns_none(self, tmp_path):
+        p = tmp_path / "settings.json"
+        p.write_text(json.dumps({"teammateMode": ["tmux"]}), encoding="utf-8")
+        assert _read_teammate_mode(p) is None
+
+    def test_unrecognized_value_returns_none(self, tmp_path):
+        p = tmp_path / "settings.json"
+        p.write_text(json.dumps({"teammateMode": "banana"}), encoding="utf-8")
+        assert _read_teammate_mode(p) is None
+
+    def test_recognized_value_returned(self, tmp_path):
+        p = tmp_path / "settings.json"
+        p.write_text(json.dumps({"teammateMode": "tmux"}), encoding="utf-8")
+        assert _read_teammate_mode(p) == "tmux"
+
+
+class TestResolveFailOpen:
+    """resolve_effective_teammate_mode + should_emit are TOTAL: any failure
+    degrades to 'auto' / EMIT, never an exception out of the hot path.
+    """
+
+    def test_unreadable_source_degrades_to_auto_emit(self, mode_env):
+        """A settings.json that is a directory (read raises) -> auto / EMIT."""
+        (mode_env.home / ".claude").mkdir(parents=True)
+        (mode_env.home / ".claude" / "settings.json").mkdir()
+        assert resolve_effective_teammate_mode() == "auto"
+        assert should_emit_inprocess_notice() is True
+
+    def test_path_home_raising_degrades_to_auto(self, mode_env, monkeypatch):
+        """If Path.home() itself raises, the outer guard returns the default.
+
+        _settings_source_paths() calls Path.home(); if that throws, the whole
+        source-list construction raises and resolve's outer try/except returns
+        _DEFAULT_MODE. Defense-in-depth beyond per-file fail-open.
+        """
+        def boom():
+            raise RuntimeError("home unavailable")
+
+        monkeypatch.setattr(Path, "home", boom)
+        assert resolve_effective_teammate_mode() == "auto"
+        assert should_emit_inprocess_notice() is True
+
+    def test_should_emit_isolated_from_resolve_failure(self, monkeypatch):
+        """should_emit's own try/except returns True (EMIT) if resolve raises.
+
+        Belt-and-suspenders: even if resolve_effective_teammate_mode were to
+        raise (it is total, but defense-in-depth matters on the hot path),
+        should_emit must fail-safe toward EMIT, never propagate.
+        """
+        def boom():
+            raise RuntimeError("resolve blew up")
+
+        monkeypatch.setattr(teammate_mode, "resolve_effective_teammate_mode", boom)
+        assert should_emit_inprocess_notice() is True
+
+
+# ---------------------------------------------------------------------------
+# _settings_source_paths -- precedence-order contract
+# ---------------------------------------------------------------------------
+
+class TestSettingsSourcePaths:
+    """Pin the file-readable precedence order and the CLAUDE_PROJECT_DIR seam."""
+
+    def test_paths_in_precedence_order(self, mode_env):
+        paths = _settings_source_paths()
+        assert paths == [
+            mode_env.project / ".claude" / "settings.local.json",
+            mode_env.project / ".claude" / "settings.json",
+            mode_env.home / ".claude" / "settings.json",
+        ]
+
+    def test_project_dir_defaults_to_cwd_when_unset(self, monkeypatch, tmp_path):
+        """Unset CLAUDE_PROJECT_DIR -> project paths derive from '.' (never raises)."""
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        paths = _settings_source_paths()
+        assert paths[0] == Path(".") / ".claude" / "settings.local.json"
+        assert paths[1] == Path(".") / ".claude" / "settings.json"
+        assert paths[2] == tmp_path / ".claude" / "settings.json"

--- a/pact-plugin/tests/test_teammate_mode.py
+++ b/pact-plugin/tests/test_teammate_mode.py
@@ -102,6 +102,22 @@ class _ModeEnv:
         self._monkeypatch = monkeypatch
         monkeypatch.setattr(Path, "home", lambda: self.home)
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(self.project))
+        # Default-neutralize the enterprise managed-settings source so a test
+        # that does NOT opt into write_managed() does not read the REAL OS
+        # managed path as the highest-precedence source[0]. Without this, every
+        # resolve/should_emit test silently reads
+        # /Library/Application Support/ClaudeCode/managed-settings.json (or the
+        # OS equivalent): green on a dev machine only because that file is
+        # absent, but non-deterministic on a managed fleet -- exactly the
+        # environment the managed-settings precedence targets. Mirrors the
+        # Path.home() / CLAUDE_PROJECT_DIR isolation above. Tests that WANT a
+        # managed file still opt in explicitly via write_managed(); the
+        # managed-absent case opts in via point_managed_at_absent().
+        self._default_absent_managed = tmp_path / "default-absent-managed-settings.json"
+        monkeypatch.setattr(
+            teammate_mode, "_managed_settings_path",
+            lambda: self._default_absent_managed,
+        )
 
     @staticmethod
     def _write(path: Path, content):
@@ -420,13 +436,21 @@ class TestSettingsSourcePaths:
     """
 
     def test_paths_in_precedence_order(self, mode_env):
-        """4 paths, managed highest. Asserts against _managed_settings_path()
-        itself (same-function compare) so it is platform-agnostic -- no
-        hardcoded OS literal in the order assertion.
+        """4 paths, managed highest. Asserts against the SAME managed-path
+        getter the resolver uses (same-function compare) so it is
+        platform-agnostic -- no hardcoded OS literal in the order assertion.
+
+        Reads teammate_mode._managed_settings_path (the MODULE attribute) rather
+        than the from-imported name: the mode_env fixture default-neutralizes
+        the module attribute (see _ModeEnv.__init__), and _settings_source_paths
+        resolves the getter through the module namespace at call time. Comparing
+        against the module attribute keeps both sides referring to the same
+        (neutralized) getter; the bare from-imported name would still point at
+        the original real-OS getter and spuriously mismatch.
         """
         paths = _settings_source_paths()
         assert paths == [
-            _managed_settings_path(),
+            teammate_mode._managed_settings_path(),
             mode_env.project / ".claude" / "settings.local.json",
             mode_env.project / ".claude" / "settings.json",
             mode_env.home / ".claude" / "settings.json",
@@ -503,6 +527,26 @@ class TestManagedPrecedence:
         mode_env.write_managed({"teammateMode": "in-process"})
         mode_env.write_user({"teammateMode": "tmux"})
         assert resolve_effective_teammate_mode() == "in-process"
+        assert should_emit_inprocess_notice() is True
+
+    def test_managed_auto_over_user_tmux_breach_closed(self, mode_env):
+        """** MANAGED 'auto' BREACH-CLOSURE (auto-flavor of the in-process case). **
+
+        managed-settings 'auto' layered OVER a user 'tmux' MUST resolve 'auto' /
+        EMIT. 'auto' is a non-tmux value, so the same false-suppress F1 closes
+        applies: before F1 the helper never read managed-settings, so a managed
+        fleet pinning 'auto' over a user 'tmux' was wrongly SUPPRESSED. Managed
+        sits at precedence [0], read first -> 'auto' -> EMIT (fail-safe: 'auto'
+        may resolve to in-process at runtime).
+
+        Symmetric companion to test_managed_in_process_over_user_tmux_breach_closed:
+        both pin that ANY non-tmux managed value over a lower 'tmux' EMITS. If
+        this inverts (resolve 'tmux' / suppress), the managed layer has stopped
+        being read at the top of the precedence and the breach is open again.
+        """
+        mode_env.write_managed({"teammateMode": "auto"})
+        mode_env.write_user({"teammateMode": "tmux"})
+        assert resolve_effective_teammate_mode() == "auto"
         assert should_emit_inprocess_notice() is True
 
     def test_managed_tmux_over_user_in_process_suppresses(self, mode_env):

--- a/pact-plugin/tests/test_teammate_mode.py
+++ b/pact-plugin/tests/test_teammate_mode.py
@@ -13,10 +13,13 @@ reinstates the in-process idle-stall the notice exists to warn about; a false
 emit is one harmless extra startup line. Every fail-open / fail-safe decision
 resolves toward EMIT.
 
-(Accepted breaches, NOT tested here because they are unreadable from a hook
-subprocess: the in-memory `--teammate-mode` CLI override and the enterprise
-managed-settings layer. Both are documented Phase-1 blind spots that only ever
-err toward over-emitting -- the safe direction.)
+(Accepted breach, NOT tested here because it is unreadable from a hook
+subprocess: the in-memory `--teammate-mode` CLI override. It only ever errs
+toward over-emitting -- the safe direction. The enterprise managed-settings
+layer USED to be an untested blind spot too, but F1 now reads it at the TOP of
+the precedence (see TestManagedSettingsPath / TestManagedPrecedence below), so
+it is no longer a blind spot: a managed "in-process"/"auto" over a lower-layer
+"tmux" now resolves correctly instead of false-suppressing.)
 
 Coverage:
 
@@ -39,6 +42,16 @@ Precedence layering (defense-in-depth beyond the architect's 10):
 - project settings.local.json beats project settings.json
 - empty-string teammateMode is skipped like any unrecognized value
 
+Enterprise managed-settings precedence (F1):
+- _managed_settings_path() returns the correct OS-specific absolute literal
+- managed-settings is the HIGHEST precedence source (paths[0])
+- ** breach-closure regression: managed "in-process" OVER user "tmux"
+  resolves "in-process" / EMIT (the false-suppress F1 closes)
+- symmetric: managed "tmux" OVER user "in-process" resolves "tmux" / SUPPRESS
+  (managed truly drives resolution both ways; closes the OQ1 over-emit)
+- managed-absent falls through to lower layers (dev-machine common case)
+- malformed managed file fails open (skip -> fall through -> never raises)
+
 VALID_TEAMMATE_MODES contract:
 - exact membership + frozenset immutability
 
@@ -58,6 +71,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 import shared.teammate_mode as teammate_mode
 from shared.teammate_mode import (
     VALID_TEAMMATE_MODES,
+    _managed_settings_path,
     _read_teammate_mode,
     _settings_source_paths,
     resolve_effective_teammate_mode,
@@ -79,10 +93,13 @@ class _ModeEnv:
     """
 
     def __init__(self, tmp_path, monkeypatch):
+        self.root = tmp_path
         self.home = tmp_path / "home"
         self.project = tmp_path / "project"
+        self.managed = tmp_path / "managed-settings.json"
         self.home.mkdir()
         self.project.mkdir()
+        self._monkeypatch = monkeypatch
         monkeypatch.setattr(Path, "home", lambda: self.home)
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(self.project))
 
@@ -106,6 +123,30 @@ class _ModeEnv:
 
     def write_legacy(self, content):
         return self._write(self.home / ".claude.json", content)
+
+    # Enterprise managed-settings (F1) -- highest precedence. Isolation seam:
+    # monkeypatch teammate_mode._managed_settings_path so the test owns the
+    # highest source WITHOUT touching a real OS managed-settings path.
+    def write_managed(self, content):
+        """Write a managed-settings.json under tmp and point the helper at it."""
+        self._write(self.managed, content)
+        self._monkeypatch.setattr(
+            teammate_mode, "_managed_settings_path", lambda: self.managed
+        )
+        return self.managed
+
+    def point_managed_at_absent(self):
+        """Point _managed_settings_path at an absent tmp file (managed-absent case).
+
+        Deterministic stand-in for the dev-machine common case where the real
+        OS managed path does not exist -- avoids depending on the host actually
+        lacking /Library/Application Support/ClaudeCode/managed-settings.json.
+        """
+        absent = self.root / "absent-managed-settings.json"
+        self._monkeypatch.setattr(
+            teammate_mode, "_managed_settings_path", lambda: absent
+        )
+        return absent
 
 
 @pytest.fixture
@@ -371,24 +412,149 @@ class TestResolveFailOpen:
 # ---------------------------------------------------------------------------
 
 class TestSettingsSourcePaths:
-    """Pin the file-readable precedence order and the CLAUDE_PROJECT_DIR seam."""
+    """Pin the file-readable precedence order and the CLAUDE_PROJECT_DIR seam.
+
+    F1: the enterprise managed-settings path is prepended as the HIGHEST
+    precedence source (paths[0]); the file-readable list is now 4 entries:
+    managed -> project-local -> project -> user.
+    """
 
     def test_paths_in_precedence_order(self, mode_env):
+        """4 paths, managed highest. Asserts against _managed_settings_path()
+        itself (same-function compare) so it is platform-agnostic -- no
+        hardcoded OS literal in the order assertion.
+        """
         paths = _settings_source_paths()
         assert paths == [
+            _managed_settings_path(),
             mode_env.project / ".claude" / "settings.local.json",
             mode_env.project / ".claude" / "settings.json",
             mode_env.home / ".claude" / "settings.json",
         ]
 
     def test_project_dir_defaults_to_cwd_when_unset(self, monkeypatch, tmp_path):
-        """Unset CLAUDE_PROJECT_DIR -> project paths derive from '.' (never raises)."""
+        """Unset CLAUDE_PROJECT_DIR -> project paths derive from '.' (never raises).
+
+        Managed stays at paths[0] (F1, highest); the cwd-default project-local
+        is now paths[1], project paths[2], user paths[3] (index +1 vs pre-F1).
+        """
         monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         paths = _settings_source_paths()
-        assert paths[0] == Path(".") / ".claude" / "settings.local.json"
-        assert paths[1] == Path(".") / ".claude" / "settings.json"
-        assert paths[2] == tmp_path / ".claude" / "settings.json"
+        assert paths[0] == _managed_settings_path()
+        assert paths[1] == Path(".") / ".claude" / "settings.local.json"
+        assert paths[2] == Path(".") / ".claude" / "settings.json"
+        assert paths[3] == tmp_path / ".claude" / "settings.json"
+
+
+# ---------------------------------------------------------------------------
+# Enterprise managed-settings (F1): OS-specific path + highest-precedence reads
+# ---------------------------------------------------------------------------
+
+class TestManagedSettingsPath:
+    """_managed_settings_path() returns the correct OS-specific absolute literal.
+
+    Pure path construction -- no I/O, no Path.home()/expanduser -- so it does
+    not perturb the home-monkeypatch seam. The literals are verified live
+    against Claude Code 2.1.156 (architect OQ1 / F1).
+    """
+
+    @pytest.mark.parametrize(
+        "platform,expected",
+        [
+            ("darwin", Path("/Library/Application Support/ClaudeCode/managed-settings.json")),
+            ("win32", Path(r"C:\Program Files\ClaudeCode\managed-settings.json")),
+            ("linux", Path("/etc/claude-code/managed-settings.json")),
+        ],
+    )
+    def test_managed_path_per_os(self, monkeypatch, platform, expected):
+        """Each platform maps to its documented absolute managed-settings path."""
+        monkeypatch.setattr(sys, "platform", platform)
+        assert _managed_settings_path() == expected
+
+    def test_unknown_platform_defaults_to_linux_path(self, monkeypatch):
+        """An unrecognized sys.platform falls to the linux/default literal."""
+        monkeypatch.setattr(sys, "platform", "freebsd13")
+        assert _managed_settings_path() == Path("/etc/claude-code/managed-settings.json")
+
+
+class TestManagedPrecedence:
+    """Managed-settings is the highest-precedence file source (F1).
+
+    Isolation: mode_env.write_managed()/point_managed_at_absent() monkeypatch
+    teammate_mode._managed_settings_path to a tmp file the test owns, so these
+    NEVER read or write a real OS managed-settings path.
+    """
+
+    def test_managed_in_process_over_user_tmux_breach_closed(self, mode_env):
+        """** MANAGED-SETTINGS BREACH-CLOSURE REGRESSION (F1). **
+
+        managed-settings 'in-process' layered OVER a user 'tmux' MUST resolve
+        'in-process' / EMIT. This is the exact false-suppress F1 closes: before
+        F1 the helper never read managed-settings, so a managed fleet pinning
+        'in-process' over a user 'tmux' was wrongly SUPPRESSED (the
+        #864-reinstating direction). Managed now sits at precedence [0], read
+        first -> 'in-process' -> EMIT.
+
+        If this ever inverts (resolve 'tmux' / suppress), the managed layer has
+        stopped being read at the top of the precedence and the breach is open
+        again.
+        """
+        mode_env.write_managed({"teammateMode": "in-process"})
+        mode_env.write_user({"teammateMode": "tmux"})
+        assert resolve_effective_teammate_mode() == "in-process"
+        assert should_emit_inprocess_notice() is True
+
+    def test_managed_tmux_over_user_in_process_suppresses(self, mode_env):
+        """Symmetric direction: managed 'tmux' OVER user 'in-process' -> tmux / SUPPRESS.
+
+        Proves managed genuinely DRIVES resolution both ways (not just that an
+        absent managed file falls through). Also closes architect OQ1: a
+        managed-tmux fleet that previously OVER-emitted the notice now correctly
+        suppresses -- because the fleet really is in tmux, this is a true
+        suppress, not a false one.
+        """
+        mode_env.write_managed({"teammateMode": "tmux"})
+        mode_env.write_user({"teammateMode": "in-process"})
+        assert resolve_effective_teammate_mode() == "tmux"
+        assert should_emit_inprocess_notice() is False
+
+    def test_managed_absent_falls_through_to_lower_layers(self, mode_env):
+        """managed path absent -> read lower layers normally (dev-machine case).
+
+        Zero behavior change off managed fleets: the user 'tmux' wins exactly as
+        it did pre-F1. Uses a controlled absent tmp path (not the real OS path)
+        for determinism.
+        """
+        mode_env.point_managed_at_absent()
+        mode_env.write_user({"teammateMode": "tmux"})
+        assert resolve_effective_teammate_mode() == "tmux"
+        assert should_emit_inprocess_notice() is False
+
+    def test_managed_malformed_fails_open_to_lower_layers(self, mode_env):
+        """Malformed managed file -> skipped (fail-open) -> fall through; never raises.
+
+        A corrupt highest-precedence source must NOT crash the hot path nor
+        wrongly suppress: it is skipped like any unreadable source and
+        resolution continues to the lower layers (here user 'in-process' -> EMIT).
+        """
+        mode_env.write_managed("{ this is not valid json ")
+        mode_env.write_user({"teammateMode": "in-process"})
+        assert resolve_effective_teammate_mode() == "in-process"
+        assert should_emit_inprocess_notice() is True
+
+    def test_managed_unreadable_dir_fails_open(self, mode_env, monkeypatch):
+        """Managed path is a directory (read raises) -> fail-open skip -> fall through.
+
+        Defense-in-depth alongside the malformed case: a non-OSError-free read
+        failure on the highest source still degrades safely to the lower layers.
+        """
+        managed_dir = mode_env.root / "managed-as-dir.json"
+        managed_dir.mkdir()
+        monkeypatch.setattr(teammate_mode, "_managed_settings_path", lambda: managed_dir)
+        mode_env.write_user({"teammateMode": "tmux"})
+        assert resolve_effective_teammate_mode() == "tmux"
+        assert should_emit_inprocess_notice() is False
 
 
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_teammate_mode.py
+++ b/pact-plugin/tests/test_teammate_mode.py
@@ -13,6 +13,11 @@ reinstates the in-process idle-stall the notice exists to warn about; a false
 emit is one harmless extra startup line. Every fail-open / fail-safe decision
 resolves toward EMIT.
 
+(Accepted breaches, NOT tested here because they are unreadable from a hook
+subprocess: the in-memory `--teammate-mode` CLI override and the enterprise
+managed-settings layer. Both are documented Phase-1 blind spots that only ever
+err toward over-emitting -- the safe direction.)
+
 Coverage:
 
 resolve_effective_teammate_mode() + should_emit_inprocess_notice() -- §9.1 matrix:
@@ -384,3 +389,110 @@ class TestSettingsSourcePaths:
         assert paths[0] == Path(".") / ".claude" / "settings.local.json"
         assert paths[1] == Path(".") / ".claude" / "settings.json"
         assert paths[2] == tmp_path / ".claude" / "settings.json"
+
+
+# ---------------------------------------------------------------------------
+# Anti-normalization regression guard (documentation-in-code)
+# ---------------------------------------------------------------------------
+
+class TestAntiNormalizationVariants:
+    """Pin case-variant and whitespace-padded values to EMIT -- on purpose.
+
+    The helper does an EXACT check: a value is recognized only if it is
+    byte-identical to a member of VALID_TEAMMATE_MODES, and should_emit
+    suppresses only on resolved == "tmux". So every case-variant ("Tmux",
+    "TMUX") and whitespace-padded (" tmux", "tmux ") value is NOT recognized
+    -> the source is skipped -> resolution falls through to "auto" -> the
+    notice EMITS. That EMIT is the fail-open-SAFE direction: a tmux user who
+    typed "Tmux" gets one harmless extra startup line.
+
+    These tests exist to FAIL LOUDLY if a future "be lenient" refactor adds
+    case/whitespace normalization (e.g. `value.strip().lower() in
+    VALID_TEAMMATE_MODES`) to _read_teammate_mode. Such a refactor would
+    silently flip these variants to the SUPPRESS direction -- a FALSE-SUPPRESS,
+    the exact #864-reinstating outcome the core invariant forbids -- while
+    passing every other test in this file. The test IS the guard: do NOT
+    "fix" these to suppress.
+    """
+
+    @pytest.mark.parametrize("variant", ["Tmux", "TMUX", "tMux"])
+    def test_case_variant_emits(self, mode_env, variant):
+        """A case-variant of 'tmux' is not byte-equal -> skipped -> auto -> EMIT.
+
+        Failure here (resolve 'tmux' / suppress) means someone added
+        case-normalization that introduced a false-suppress. See class docstring.
+        """
+        mode_env.write_user({"teammateMode": variant})
+        assert resolve_effective_teammate_mode() == "auto"
+        assert should_emit_inprocess_notice() is True
+
+    @pytest.mark.parametrize("variant", [" tmux", "tmux ", " tmux ", "\ttmux", "tmux\n"])
+    def test_whitespace_padded_emits(self, mode_env, variant):
+        """A whitespace-padded 'tmux' is not byte-equal -> skipped -> auto -> EMIT.
+
+        Failure here (resolve 'tmux' / suppress) means someone added
+        whitespace-stripping that introduced a false-suppress. See class docstring.
+        """
+        mode_env.write_user({"teammateMode": variant})
+        assert resolve_effective_teammate_mode() == "auto"
+        assert should_emit_inprocess_notice() is True
+
+
+# ---------------------------------------------------------------------------
+# Broad-except CONTRACT: the breadth of the per-file handler is load-bearing
+# ---------------------------------------------------------------------------
+
+class TestPerFileBroadExceptContract:
+    """Pin the BREADTH of _read_teammate_mode's `except Exception` -- not just
+    that it catches *something*.
+
+    The per-file reader wraps its body in a broad `except Exception` so ANY
+    read/parse failure degrades to None (fail-open). The existing fail-open
+    tests only exercise exceptions a NARROW tuple would STILL catch:
+    IsADirectoryError / PermissionError (OSError) and malformed JSON
+    (json.JSONDecodeError). None of them would fail if someone "tightened" the
+    handler to `except (OSError, json.JSONDecodeError)`.
+
+    This closes that gap with an input whose exception is OUTSIDE that narrow
+    tuple: a file whose bytes are not valid UTF-8. read_text(encoding="utf-8")
+    then raises UnicodeDecodeError -- a subclass of ValueError, and NOT a
+    subclass of OSError or json.JSONDecodeError (verified on CPython 3.14).
+    Only the broad `except Exception` catches it; a narrowed handler would let
+    it propagate and FAIL test_invalid_utf8_returns_none_via_broad_except --
+    which is exactly the regression signal we want.
+
+    NOTE: an embedded-NUL path is deliberately NOT used here. On CPython 3.12+
+    Path.exists() returns False for a NUL path (it does not raise), so
+    _read_teammate_mode short-circuits at its `if not path.exists()` guard
+    WITHOUT entering the try/except body -- a NUL test would be phantom-green
+    (it passes whether or not the except is narrowed). Invalid UTF-8 is the
+    live discriminator on this interpreter.
+    """
+
+    def test_invalid_utf8_returns_none_via_broad_except(self, tmp_path):
+        """Invalid-UTF-8 bytes -> UnicodeDecodeError (ValueError, not OSError /
+        JSONDecodeError) -> only the broad except returns None. THE discriminator.
+        """
+        p = tmp_path / "settings.json"
+        # Lone 0xFF/0xFE bytes inside an otherwise-JSON document: read_text
+        # with strict utf-8 raises UnicodeDecodeError before json.loads runs.
+        p.write_bytes(b'{"teammateMode": "\xff\xfetmux"}')
+        assert _read_teammate_mode(p) is None
+
+    def test_resolve_never_raises_on_invalid_utf8_source(self, mode_env):
+        """End-to-end public never-raises contract under a non-OSError parse
+        failure: an invalid-UTF-8 user settings.json -> resolve degrades to
+        'auto' / EMIT, never propagating onto the SessionStart hot path.
+
+        Defense-in-depth: resolve's OWN outer `except Exception` also backstops
+        a propagating UnicodeDecodeError, so this end-to-end assertion would
+        survive a per-file narrowing on its own. The per-file discriminator
+        above is the test that actually fails on a narrowed per-file handler;
+        this one pins the public contract that the hot path never sees a raise.
+        """
+        (mode_env.home / ".claude").mkdir(parents=True, exist_ok=True)
+        (mode_env.home / ".claude" / "settings.json").write_bytes(
+            b'{"teammateMode": "\xff\xfetmux"}'
+        )
+        assert resolve_effective_teammate_mode() == "auto"
+        assert should_emit_inprocess_notice() is True


### PR DESCRIPTION
## Summary

**Phase 1 of #864** — the phased removal of the cron wake machinery. This phase is **purely additive**: it lands the lightweight in-process safeguard **before** any deletion. No cron/wake machinery is touched (that is Phases 2–3).

The empirical conclusion from the #864 investigation: in-process `teammateMode` (the current default) stalls wake delivery when the lead is idle, while tmux mode delivers natively. Rather than keep patching the cron ecosystem, the plan steers users to tmux and covers the residual in-process sliver with a cheap startup notice.

## What landed

- **`pact-plugin/hooks/shared/teammate_mode.py`** (new) — fail-open resolver mirroring the Claude Code runtime getter's file precedence: project `.claude/settings.local.json` → project `.claude/settings.json` → `~/.claude/settings.json` → `~/.claude.json` (legacy) → `'auto'`. `should_emit_inprocess_notice()` returns `True` unless the resolved mode is exactly `'tmux'`. Both public functions are **total** (never raise).
- **`pact-plugin/hooks/session_init.py`** — emits a one-time startup notice (via `system_messages`) when the effective mode is non-tmux, gated on SessionStart `source in {startup, resume}` (suppressed on `compact`/`clear`). Lazy import + belt-and-suspenders guard so the bootstrap path never raises.
- **`pact-plugin/reference/unattended-runs.md`** (new) — recommends `--teammate-mode tmux` for unattended runs, the permanent `~/.claude/settings.json` option, and a one-line DIY heartbeat.
- **Tests** — `test_teammate_mode.py` (+29) and `test_session_init.py` (+8): the §9.1 precedence/should_emit matrix including the **false-suppress edge** (project-local `in-process` over user `tmux` must resolve `in-process` and EMIT), fail-open under malformed/unreadable/wrong-type input, the §9.2 emit-gate integration matrix, and a belt-and-suspenders test.

## Design invariant

**NEVER-FALSE-SUPPRESS.** A false suppress silently reinstates the #864 in-process idle-stall; a false emit is one harmless startup line. Every fail-open path resolves toward EMIT, and the FULL (not two-file) precedence is what closes the false-suppress edge. The tests pin this with counter-test-by-revert: reverting the notice fails the present-rows, reversing precedence fails the false-suppress edge, and inverting the emit polarity fails broadly.

## Key correction surfaced during PREPARE

The plan's open question framed `teammateMode` as a GrowthBook flag. It is **not** — it is a first-class Claude Code **setting** (`~/.claude/settings.json` authoritative, `~/.claude.json` a legacy fallback), and the CLI `--teammate-mode` override is **in-memory-only / hook-invisible**. The fail-safe absorbs the CLI blind spot (unreadable → unknown → emit).

## ⚠️ Pre-existing test baseline (NOT introduced by this PR)

`main` currently ships with **20 full-suite test failures**, unrelated to this change:
- 19 in `test_merge_guard.py` — order-dependent cross-test state pollution (passes in isolation). Tracked: **#845**.
- 1 in `test_inbox_wake_lifecycle_helper.py` — `fail_conservative` audit-anchor (`'Fail-CONSERVATIVE'` leaked outside the step-4 window at `wake_lifecycle.py:868`). Tracked: **#866** (filed during this work).

**This PR adds ZERO new failures** — proven via sorted node-id delta (baseline 20 == post-impl 20, identical sets). Full suite: 8402 passed / 20 failed / 14 skipped, +37 new tests all green. CI reds on these 20 are pre-existing; do not attribute them to this PR.

## Version

PATCH `4.3.4` → `4.3.5` (additive-only phase; no user-facing command-surface changes).

## Phasing

This is Phase 1 of 3. Phase 2 (disable cron auto-arm behind a sentinel, validation window) and Phase 3 (delete the ecosystem) are gated on this baking + cross-environment tmux validation. Plan: `docs/plans/remove-cron-machinery-plan-2026-05-28-v4.md`.

Closes (partial): #864 (Phase 1 only).
