### PR TITLE
feat(#864): Phase 2 — disable cron auto-arm behind CRON_AUTOARM_ENABLED sentinel (v4.3.8)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.3.7",
+      "version": "4.3.8",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.3.7/      # Plugin version
+│               └── 4.3.8/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.3.7",
+  "version": "4.3.8",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.3.7
+> **Version**: 4.3.8
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -81,7 +81,7 @@ from shared.pact_context import get_session_dir, write_context
 from shared.session_journal import append_event, make_event
 from shared.failure_log import append_failure
 from shared.plugin_manifest import format_plugin_banner
-from shared.wake_lifecycle import count_active_tasks, is_lead_context
+from shared.wake_lifecycle import count_active_tasks, is_lead_context, CRON_AUTOARM_ENABLED
 
 # Import extracted modules (decomposed for maintainability per M5 audit finding).
 from shared.symlinks import setup_plugin_symlinks
@@ -827,7 +827,7 @@ def main():
         # (shared.wake_lifecycle module-wide pin); call it directly,
         # no try/except wrapper required.
         active_count = count_active_tasks(team_name)
-        if active_count > 0 and is_lead_context(input_data, team_name):
+        if CRON_AUTOARM_ENABLED and active_count > 0 and is_lead_context(input_data, team_name):
             # Audit anchor (editing-LLM warning): the directive prose
             # below is UNCONDITIONAL by design. Do not introduce
             # LLM-self-diagnosis here ("only emit if X"). Diagnostic

--- a/pact-plugin/hooks/shared/wake_lifecycle.py
+++ b/pact-plugin/hooks/shared/wake_lifecycle.py
@@ -51,6 +51,15 @@ Public surface:
     AND re-exported through tests/fixtures/disk_shapes.py for the
     OPERATIONAL-LULL regression fixture surface. Adding a new
     umbrella-creating workflow requires updating ONLY this constant.
+- CRON_AUTOARM_ENABLED: bool
+    Master switch for the cron auto-arm directive. When False (the
+    default), the three auto-arm producers (wake_lifecycle_emitter.py,
+    session_init.py, wake_inbox_drain.py) each suppress their arm emit at
+    its source; the manual /PACT:start-pending-scan path and all teardown
+    machinery are unaffected. Flipping to True re-enables every auto-arm
+    path in one line. Homed in this module so the sentinel outlives the
+    eventual deletion of the two emitter hooks (this module is retained
+    while they are removed).
 - is_lead_context(stdin, team_name="") -> bool
     Predicate. True iff this hook fire originated in the lead context
     (not an in-process teammate frame). Single consolidated discriminator
@@ -180,6 +189,21 @@ UMBRELLA_SUBJECT_PREFIXES = (
     "TEST: ",
     "Review: ",
 )
+
+# Cron auto-arm master switch (single source of truth). When False, every
+# hook-emitted auto-arm directive — the hint that tells the lead to invoke
+# Skill("PACT:start-pending-scan") — is suppressed at its emit site. The
+# three auto-arm producers (wake_lifecycle_emitter._arm_or_none +
+# _maybe_write_teammate_arm_marker, session_init's resume/startup arm block,
+# wake_inbox_drain._emit_arm) each guard on this token. The manual
+# /PACT:start-pending-scan command, all teardown machinery, and every
+# non-arm hook behavior are deliberately left intact — this disables ONLY
+# the automatic arming. Reversal is a one-line flip to True. Homed in this
+# (retained) shared module rather than an emitter so the surviving
+# session_init guard keeps a valid reference after the emitter hooks are
+# removed. A bare bool is side-effect-free and respects this module's
+# pure/never-raises contract.
+CRON_AUTOARM_ENABLED = False
 
 
 @dataclass(frozen=True)

--- a/pact-plugin/hooks/wake_inbox_drain.py
+++ b/pact-plugin/hooks/wake_inbox_drain.py
@@ -155,7 +155,11 @@ try:
     from shared.pact_context import get_team_name
     from shared.session_journal import append_event, make_event, read_last_event
     from shared.session_state import is_safe_path_component
-    from shared.wake_lifecycle import count_active_tasks, is_lead_context
+    from shared.wake_lifecycle import (
+        count_active_tasks,
+        is_lead_context,
+        CRON_AUTOARM_ENABLED,
+    )
     # Reuse the canonical _ARM_DIRECTIVE / _TEARDOWN_DIRECTIVE literals
     # from the emitter so the directive prose has a single source of
     # truth. The audit-anchor literal-prose pins on the emitter side
@@ -372,6 +376,9 @@ def _emit_arm() -> None:
     """Print the _ARM_DIRECTIVE additionalContext payload with the
     required hookEventName field. Caller is responsible for sys.exit(0).
     """
+    if not CRON_AUTOARM_ENABLED:
+        print(_SUPPRESS_OUTPUT)
+        return
     output = {
         "hookSpecificOutput": {
             "hookEventName": "UserPromptSubmit",

--- a/pact-plugin/hooks/wake_inbox_drain.py
+++ b/pact-plugin/hooks/wake_inbox_drain.py
@@ -375,6 +375,8 @@ def _drain_markers(inbox_dir: Path) -> dict[str, Any]:
 def _emit_arm() -> None:
     """Print the _ARM_DIRECTIVE additionalContext payload with the
     required hookEventName field. Caller is responsible for sys.exit(0).
+    When CRON_AUTOARM_ENABLED is False (the auto-arm master switch),
+    prints _SUPPRESS_OUTPUT and returns without emitting the directive.
     """
     if not CRON_AUTOARM_ENABLED:
         print(_SUPPRESS_OUTPUT)

--- a/pact-plugin/hooks/wake_lifecycle_emitter.py
+++ b/pact-plugin/hooks/wake_lifecycle_emitter.py
@@ -397,7 +397,9 @@ def _arm_or_none(team_name: str) -> str | None:
     """
     Return _ARM_DIRECTIVE iff the conditions for emitting Arm are met:
     at least one lifecycle-relevant active teammate task. Otherwise
-    return None.
+    return None. Precondition: returns None unconditionally when
+    CRON_AUTOARM_ENABLED is False (the auto-arm master switch); the
+    active-task check is reached only when auto-arm is enabled.
 
     Shared between the TaskCreate Arm branch and the pending->in_progress
     re-Arm branch in `_decide_directive` — both branches share identical

--- a/pact-plugin/hooks/wake_lifecycle_emitter.py
+++ b/pact-plugin/hooks/wake_lifecycle_emitter.py
@@ -159,6 +159,7 @@ from shared.session_state import is_safe_path_component
 from shared.task_utils import read_task_json
 from shared.tool_response import extract_tool_response
 from shared.wake_lifecycle import (
+    CRON_AUTOARM_ENABLED,
     count_active_tasks,
     has_in_progress_umbrella_orchestration,
     is_lead_context,
@@ -404,6 +405,8 @@ def _arm_or_none(team_name: str) -> str | None:
     filters carve-outs (signal-tasks, wake-excluded agentTypes), so
     `>= 1` is the lifecycle-relevant positive count.
     """
+    if not CRON_AUTOARM_ENABLED:
+        return None
     if count_active_tasks(team_name) < 1:
         return None
     return _ARM_DIRECTIVE
@@ -505,6 +508,8 @@ def _maybe_write_teammate_arm_marker(
     OSError + Exception class). Returns None unconditionally — caller
     must NOT branch on a return value.
     """
+    if not CRON_AUTOARM_ENABLED:
+        return
     try:
         # Clause 1: team_name path-safety.
         if not isinstance(team_name, str) or not team_name:

--- a/pact-plugin/tests/test_inbox_wake_lifecycle_emitter.py
+++ b/pact-plugin/tests/test_inbox_wake_lifecycle_emitter.py
@@ -30,14 +30,28 @@ EMITTER = HOOK_DIR / "wake_lifecycle_emitter.py"
 HOOKS_JSON = HOOK_DIR / "hooks.json"
 
 
-def _run_emitter(stdin_payload: str | bytes, env_extra: dict | None = None) -> tuple[int, str, str]:
+def _run_emitter(stdin_payload: str | bytes, env_extra: dict | None = None, autoarm_enabled: bool = True) -> tuple[int, str, str]:
     # Start from a clean env so the harness's CLAUDE_PROJECT_DIR doesn't
     # leak into the synthesized context resolution.
     env = {k: v for k, v in os.environ.items() if not k.startswith("CLAUDE_")}
     if env_extra:
         env.update(env_extra)
+    # Production default is CRON_AUTOARM_ENABLED=False (auto-arm disabled).
+    # These tests exercise the arm MACHINERY (still reachable via the manual
+    # /PACT:start-pending-scan path), so re-enable the gate in the subprocess
+    # by importing the hook, setting the CONSUMER-module binding, and calling
+    # main(). Patching shared.wake_lifecycle would NOT reach the already-bound
+    # wake_lifecycle_emitter.CRON_AUTOARM_ENABLED name (name-import snapshot).
+    # Pass autoarm_enabled=False to exercise production-default suppression.
+    runner_src = (
+        "import sys\n"
+        f"sys.path.insert(0, {str(HOOK_DIR)!r})\n"
+        "import wake_lifecycle_emitter\n"
+        f"wake_lifecycle_emitter.CRON_AUTOARM_ENABLED = {autoarm_enabled!r}\n"
+        "wake_lifecycle_emitter.main()\n"
+    )
     proc = subprocess.run(
-        [sys.executable, str(EMITTER)],
+        [sys.executable, "-c", runner_src],
         input=stdin_payload if isinstance(stdin_payload, bytes) else stdin_payload.encode("utf-8"),
         capture_output=True,
         env=env,
@@ -682,7 +696,10 @@ def test_count_active_tasks_called_on_taskcreate():
     import wake_lifecycle_emitter as emitter
 
     from unittest.mock import patch
-    with patch.object(emitter, "is_lead_context", return_value=True), \
+    # G1 (_arm_or_none) early-returns before count_active_tasks under the
+    # production default; re-enable the gate to exercise the count-call path.
+    with patch.object(emitter, "CRON_AUTOARM_ENABLED", True), \
+         patch.object(emitter, "is_lead_context", return_value=True), \
          patch.object(emitter, "_extract_task_id", return_value="1"), \
          patch.object(emitter, "count_active_tasks", return_value=1) as mock_count:
         emitter._decide_directive({

--- a/pact-plugin/tests/test_pending_scan_session_init.py
+++ b/pact-plugin/tests/test_pending_scan_session_init.py
@@ -72,8 +72,12 @@ def test_directive_emitted_only_when_count_positive(src):
     `active_count > 0` predicate participating in the if-test."""
     assert "active_count > 0" in src
     # And the gate must use an `if` statement (not a ternary/while/etc.).
+    # Per this test's own contract, the gate expression may carry additional
+    # conjuncts; one such conjunct (the auto-arm sentinel
+    # `CRON_AUTOARM_ENABLED and ...`) precedes `active_count > 0`, so allow
+    # any same-line prefix between `if` and the load-bearing predicate.
     import re as _re
-    assert _re.search(r"\bif\s+active_count\s*>\s*0", src) is not None
+    assert _re.search(r"\bif\b[^\n]*\bactive_count\s*>\s*0", src) is not None
 
 
 def test_directive_appended_to_context_parts(src):
@@ -133,6 +137,7 @@ def _run_session_init(
     agent_type: str | None = None,
     agent_id: str | None = None,
     teammate_name: str | None = None,
+    autoarm_enabled: bool = True,
 ) -> dict:
     """Run session_init.py with synthesized SessionStart stdin.
 
@@ -154,8 +159,23 @@ def _run_session_init(
     payload = json.dumps(payload_dict)
     env = {k: v for k, v in os.environ.items() if not k.startswith("CLAUDE_")}
     env.update({"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir})
+    # Production default is CRON_AUTOARM_ENABLED=False (auto-arm disabled).
+    # G3 gates the session-start arm directive on it; these tests exercise
+    # the arm MACHINERY (still reachable via the manual
+    # /PACT:start-pending-scan path), so re-enable the gate in the subprocess
+    # by importing the hook, setting the CONSUMER-module binding, and calling
+    # main(). Patching shared.wake_lifecycle would NOT reach the already-bound
+    # session_init.CRON_AUTOARM_ENABLED name (name-import snapshot). Pass
+    # autoarm_enabled=False to exercise production-default suppression.
+    runner_src = (
+        "import sys\n"
+        f"sys.path.insert(0, {str(SESSION_INIT_HOOK.parent)!r})\n"
+        "import session_init\n"
+        f"session_init.CRON_AUTOARM_ENABLED = {autoarm_enabled!r}\n"
+        "session_init.main()\n"
+    )
     proc = subprocess.run(
-        [sys.executable, str(SESSION_INIT_HOOK)],
+        [sys.executable, "-c", runner_src],
         input=payload.encode("utf-8"),
         capture_output=True,
         env=env,

--- a/pact-plugin/tests/test_pending_scan_session_init.py
+++ b/pact-plugin/tests/test_pending_scan_session_init.py
@@ -338,3 +338,79 @@ def test_session_init_does_not_emit_arm_directive_from_in_process_teammate_frame
         "session_init emitted start-pending-scan slug from in-process "
         "teammate frame."
     )
+
+
+# ===========================================================================
+# Cron auto-arm DISABLE contract (Phase 2) — G3 (session_init resume/startup
+# arm block) + the step-0b in-process teammateMode notice regression guard.
+#
+# G3 extended the SAME main() arm `if` that sits just below the step-0b notice
+# append. Under the PRODUCTION default CRON_AUTOARM_ENABLED=False the arm
+# directive is suppressed; the True-recovery anchor is the existing
+# test_session_init_emits_arm_directive_when_active_tasks_present. The step-0b
+# tests pin that the G3 edit caused NO collateral damage: the notice still
+# fires when arm is suppressed (regression), and both surface together when
+# arm is enabled (coexistence — the gate toggles ARM only).
+#
+# _INPROCESS_NOTICE_FRAGMENT is a distinctive substring of the step-0b notice,
+# taken verbatim from the hook's emitted systemMessage and confirmed
+# empirically to fire under BOTH gate states in the subprocess harness.
+# ===========================================================================
+
+_INPROCESS_NOTICE_FRAGMENT = "unattended runs may stall in in-process teammate mode"
+
+
+def test_session_init_suppresses_arm_when_autoarm_disabled(tmp_path):
+    """G3: with >=1 active task on disk and a lead-context SessionStart, the
+    arm directive is SUPPRESSED under CRON_AUTOARM_ENABLED=False. Recovery
+    anchor: test_session_init_emits_arm_directive_when_active_tasks_present
+    (which runs the same shape at the default autoarm_enabled=True)."""
+    home = tmp_path / "home"; home.mkdir()
+    sid = "abcdef01-autoarm-off"
+    pdir = "/tmp/pi-autoarm-g3"
+    team = "pact-abcdef01"
+    _stage_pact_session(home, team, sid, pdir)
+    _stage_active_task(home, team)
+    result = _run_session_init(home, sid, pdir, source="resume", autoarm_enabled=False)
+    ctx = result.get("hookSpecificOutput", {}).get("additionalContext", "")
+    assert _ARM_DIRECTIVE_PHRASE not in ctx, (
+        f"G3 must suppress the session-start arm directive under "
+        f"autoarm-disabled; got additionalContext={ctx!r}"
+    )
+
+
+def test_step0b_notice_still_fires_when_autoarm_disabled(tmp_path):
+    """Regression guard: the step-0b in-process teammateMode notice MUST
+    still fire under CRON_AUTOARM_ENABLED=False, while the adjacent G3 arm
+    directive is suppressed. Pins that the G3 edit to the shared main() arm
+    block did not collaterally break the Phase-1 step-0b notice."""
+    home = tmp_path / "home"; home.mkdir()
+    sid = "abcdef01-step0b-off"
+    pdir = "/tmp/pi-step0b-off"
+    team = "pact-abcdef01"
+    _stage_pact_session(home, team, sid, pdir)
+    _stage_active_task(home, team)
+    result = _run_session_init(home, sid, pdir, source="startup", autoarm_enabled=False)
+    assert _INPROCESS_NOTICE_FRAGMENT in result.get("systemMessage", ""), (
+        "step-0b in-process notice must still fire under autoarm-disabled"
+    )
+    ctx = result.get("hookSpecificOutput", {}).get("additionalContext", "")
+    assert _ARM_DIRECTIVE_PHRASE not in ctx, (
+        "G3 arm directive must be suppressed under autoarm-disabled"
+    )
+
+
+def test_step0b_notice_and_arm_coexist_when_autoarm_enabled(tmp_path):
+    """Coexistence/recovery: with the gate True, BOTH the step-0b notice and
+    the G3 arm directive fire — confirming the gate toggles the ARM path
+    ONLY; the step-0b notice is independent."""
+    home = tmp_path / "home"; home.mkdir()
+    sid = "abcdef01-step0b-on"
+    pdir = "/tmp/pi-step0b-on"
+    team = "pact-abcdef01"
+    _stage_pact_session(home, team, sid, pdir)
+    _stage_active_task(home, team)
+    result = _run_session_init(home, sid, pdir, source="startup", autoarm_enabled=True)
+    assert _INPROCESS_NOTICE_FRAGMENT in result.get("systemMessage", "")
+    ctx = result.get("hookSpecificOutput", {}).get("additionalContext", "")
+    assert _ARM_DIRECTIVE_PHRASE in ctx

--- a/pact-plugin/tests/test_pending_scan_session_init.py
+++ b/pact-plugin/tests/test_pending_scan_session_init.py
@@ -138,6 +138,7 @@ def _run_session_init(
     agent_id: str | None = None,
     teammate_name: str | None = None,
     autoarm_enabled: bool = True,
+    managed_teammate_mode: str | None = None,
 ) -> dict:
     """Run session_init.py with synthesized SessionStart stdin.
 
@@ -148,6 +149,13 @@ def _run_session_init(
     auxiliary platform-frame schema bits (it does not influence the
     actor-discriminator under the compound check). Lead-frame fires
     omit all three (default None).
+
+    `managed_teammate_mode` controls the (otherwise OS-absolute, #867)
+    enterprise managed-settings source that the step-0b in-process notice
+    consults at top precedence: None neutralizes it to an ABSENT path under
+    the isolated HOME (source[0] inert; behavior-neutral where the real file
+    is absent); a value (e.g. "tmux") writes a managed-settings.json carrying
+    that teammateMode so a test can exercise the managed-precedence direction.
     """
     payload_dict: dict = {"session_id": sid, "cwd": pdir, "source": source}
     if agent_type is not None:
@@ -159,6 +167,25 @@ def _run_session_init(
     payload = json.dumps(payload_dict)
     env = {k: v for k, v in os.environ.items() if not k.startswith("CLAUDE_")}
     env.update({"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir})
+    # Hermeticity (#867): the effective-teammateMode resolver consulted by the
+    # step-0b in-process notice reads an OS-ABSOLUTE enterprise managed-settings
+    # path as its HIGHEST-precedence source (shared.teammate_mode.
+    # _managed_settings_path() -> /Library/.../managed-settings.json etc.).
+    # HOME/CLAUDE_PROJECT_DIR env isolation does NOT cover it, so without
+    # neutralization the notice's firing would be contingent on the real
+    # machine's managed settings (green-by-luck on a dev box; false-RED on a
+    # managed fleet that sets teammateMode=tmux). monkeypatch cannot cross the
+    # subprocess boundary, so rebind _managed_settings_path INSIDE runner_src to
+    # a path UNDER the isolated HOME. Default (managed_teammate_mode=None) points
+    # at an ABSENT path -> source[0] inert. A value writes a managed-settings.json
+    # carrying that teammateMode so a test can exercise managed precedence.
+    managed_dir = Path(home) / ".claude" / "_managed_test"
+    managed_path = managed_dir / "managed-settings.json"
+    if managed_teammate_mode is not None:
+        managed_dir.mkdir(parents=True, exist_ok=True)
+        managed_path.write_text(
+            json.dumps({"teammateMode": managed_teammate_mode}), encoding="utf-8",
+        )
     # Production default is CRON_AUTOARM_ENABLED=False (auto-arm disabled).
     # G3 gates the session-start arm directive on it; these tests exercise
     # the arm MACHINERY (still reachable via the manual
@@ -167,11 +194,19 @@ def _run_session_init(
     # main(). Patching shared.wake_lifecycle would NOT reach the already-bound
     # session_init.CRON_AUTOARM_ENABLED name (name-import snapshot). Pass
     # autoarm_enabled=False to exercise production-default suppression.
+    #
+    # The _managed_settings_path rebind lands BEFORE main(): session_init imports
+    # should_emit_inprocess_notice lazily inside main()'s step-0b block, and that
+    # function reaches _managed_settings_path() by module-bare-name at call time,
+    # so the rebind on the shared.teammate_mode module is honored.
     runner_src = (
         "import sys\n"
         f"sys.path.insert(0, {str(SESSION_INIT_HOOK.parent)!r})\n"
         "import session_init\n"
         f"session_init.CRON_AUTOARM_ENABLED = {autoarm_enabled!r}\n"
+        "import shared.teammate_mode as _tm\n"
+        "import pathlib as _pl\n"
+        f"_tm._managed_settings_path = lambda: _pl.Path({str(managed_path)!r})\n"
         "session_init.main()\n"
     )
     proc = subprocess.run(
@@ -414,3 +449,29 @@ def test_step0b_notice_and_arm_coexist_when_autoarm_enabled(tmp_path):
     assert _INPROCESS_NOTICE_FRAGMENT in result.get("systemMessage", "")
     ctx = result.get("hookSpecificOutput", {}).get("additionalContext", "")
     assert _ARM_DIRECTIVE_PHRASE in ctx
+
+
+def test_step0b_notice_suppressed_when_managed_teammate_mode_tmux(tmp_path):
+    """Managed-precedence pin (suppression direction): the enterprise
+    managed-settings source — source[0], the HIGHEST-precedence layer — setting
+    teammateMode="tmux" SUPPRESSES the step-0b in-process notice, even though no
+    lower source defines the key. The rest of the step-0b suite only asserts the
+    notice FIRES (the absence/auto direction); this pins the opposite direction
+    AND that _managed_settings_path is actually read at top precedence.
+
+    Hermetic by construction: the managed source is fixture-controlled under the
+    isolated HOME via the runner_src override (#867) — the assertion depends ONLY
+    on the injected teammateMode, never on the host's real managed-settings."""
+    home = tmp_path / "home"; home.mkdir()
+    sid = "abcdef01-managed-tmux"
+    pdir = "/tmp/pi-managed-tmux"
+    team = "pact-abcdef01"
+    _stage_pact_session(home, team, sid, pdir)
+    _stage_active_task(home, team)
+    result = _run_session_init(
+        home, sid, pdir, source="startup", managed_teammate_mode="tmux",
+    )
+    assert _INPROCESS_NOTICE_FRAGMENT not in result.get("systemMessage", ""), (
+        "managed teammateMode=tmux (top-precedence source) must suppress the "
+        "step-0b in-process notice"
+    )

--- a/pact-plugin/tests/test_start_pending_scan_command_structure.py
+++ b/pact-plugin/tests/test_start_pending_scan_command_structure.py
@@ -694,3 +694,26 @@ def test_references_section_links_to_companion_commands(cmd_text):
     assert "stop-pending-scan.md" in refs_section
     # Relative-path discipline.
     assert "@~/" not in refs_section
+
+
+# ===========================================================================
+# Cron auto-arm DISABLE contract (Phase 2) — manual arm-path independence.
+#
+# Disabling AUTO-arm (the hooks) must leave the user-invocable MANUAL arm path
+# (/PACT:start-pending-scan) fully functional. The manual command does NOT
+# route through the CRON_AUTOARM_ENABLED gate (the sentinel is consulted only
+# by the auto-arm hooks) and still carries its CronCreate arm machinery.
+# ===========================================================================
+
+
+def test_manual_arm_path_independent_of_autoarm_sentinel(cmd_text):
+    """The /PACT:start-pending-scan command bypasses the CRON_AUTOARM_ENABLED
+    gate entirely: the command file does not reference the sentinel, and it
+    still contains its CronCreate arm machinery. Proves Phase-2's disable of
+    AUTO-arm leaves the MANUAL arm path intact."""
+    assert "CRON_AUTOARM_ENABLED" not in cmd_text, (
+        "manual arm command must not route through the auto-arm gate"
+    )
+    assert "CronCreate" in cmd_text, (
+        "manual arm machinery (CronCreate) must remain intact"
+    )

--- a/pact-plugin/tests/test_wake_arm_in_process_teammate_field_presence.py
+++ b/pact-plugin/tests/test_wake_arm_in_process_teammate_field_presence.py
@@ -79,7 +79,7 @@ FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "wake_lifecycle"
 # ─── Helpers (mirror existing wake_lifecycle test pattern) ──────────────
 
 
-def _run_hook(hook_path, stdin_payload, env_extra=None, timeout=10):
+def _run_hook(hook_path, stdin_payload, env_extra=None, timeout=10, autoarm_enabled=True):
     env = {k: v for k, v in os.environ.items() if not k.startswith("CLAUDE_")}
     if env_extra:
         env.update(env_extra)
@@ -87,8 +87,23 @@ def _run_hook(hook_path, stdin_payload, env_extra=None, timeout=10):
         stdin_payload if isinstance(stdin_payload, bytes)
         else stdin_payload.encode("utf-8")
     )
+    # Production default is CRON_AUTOARM_ENABLED=False (auto-arm disabled).
+    # These tests exercise the arm MACHINERY (still reachable via the manual
+    # /PACT:start-pending-scan path), so re-enable the gate in the subprocess
+    # by importing the hook module, setting the CONSUMER-module binding, and
+    # calling main(). Patching shared.wake_lifecycle would NOT reach the
+    # already-bound consumer-module name (name-import snapshot). Pass
+    # autoarm_enabled=False to exercise production-default suppression.
+    module_name = Path(hook_path).stem
+    runner_src = (
+        "import sys\n"
+        f"sys.path.insert(0, {str(HOOK_DIR)!r})\n"
+        f"import {module_name} as _hook\n"
+        f"_hook.CRON_AUTOARM_ENABLED = {autoarm_enabled!r}\n"
+        "_hook.main()\n"
+    )
     proc = subprocess.run(
-        [sys.executable, str(hook_path)],
+        [sys.executable, "-c", runner_src],
         input=payload_bytes,
         capture_output=True,
         env=env,

--- a/pact-plugin/tests/test_wake_inbox_drain.py
+++ b/pact-plugin/tests/test_wake_inbox_drain.py
@@ -40,7 +40,7 @@ def _iso_ts(epoch_seconds: int) -> str:
     ).strftime(ISO_FORMAT_LITERAL)
 
 
-def _run_drain(stdin_payload, env_extra=None):
+def _run_drain(stdin_payload, env_extra=None, autoarm_enabled=True):
     env = {k: v for k, v in os.environ.items() if not k.startswith("CLAUDE_")}
     if env_extra:
         env.update(env_extra)
@@ -48,8 +48,24 @@ def _run_drain(stdin_payload, env_extra=None):
         stdin_payload if isinstance(stdin_payload, bytes)
         else stdin_payload.encode("utf-8")
     )
+    # Production default is CRON_AUTOARM_ENABLED=False (auto-arm disabled).
+    # These tests exercise the arm MACHINERY, which is still present and
+    # reachable via the manual /PACT:start-pending-scan path, so the runner
+    # re-enables the gate inside the subprocess by importing the hook,
+    # setting the CONSUMER-module binding, and calling main(). The
+    # name-import snapshot means patching shared.wake_lifecycle would not
+    # reach the already-bound `wake_inbox_drain.CRON_AUTOARM_ENABLED` name.
+    # Pass autoarm_enabled=False to exercise the production-default
+    # suppression behavior.
+    runner_src = (
+        "import sys\n"
+        f"sys.path.insert(0, {str(HOOK_DIR)!r})\n"
+        "import wake_inbox_drain\n"
+        f"wake_inbox_drain.CRON_AUTOARM_ENABLED = {autoarm_enabled!r}\n"
+        "wake_inbox_drain.main()\n"
+    )
     proc = subprocess.run(
-        [sys.executable, str(DRAIN)],
+        [sys.executable, "-c", runner_src],
         input=payload_bytes,
         capture_output=True,
         env=env,
@@ -548,6 +564,9 @@ def test_outer_guard_catches_unexpected_exception(tmp_path):
         "def _raise(*_a, **_k):\n"
         "    raise ImportError('simulated lazy-import failure')\n"
         "wake_inbox_drain.read_last_event = _raise\n"
+        # Re-enable the gate: this test exercises the arm machinery's
+        # fail-conservative path (production default is disabled).
+        "wake_inbox_drain.CRON_AUTOARM_ENABLED = True\n"
         "wake_inbox_drain.main()\n",
         encoding="utf-8",
     )
@@ -1440,6 +1459,9 @@ def test_outer_guard_catches_arbitrary_exception(tmp_path, exception_class):
         "def _raise(*_a, **_k):\n"
         "    raise _exc_class('simulated widened-except contract probe')\n"
         "wake_inbox_drain.read_last_event = _raise\n"
+        # Re-enable the gate: this test exercises the arm machinery's
+        # fail-conservative path (production default is disabled).
+        "wake_inbox_drain.CRON_AUTOARM_ENABLED = True\n"
         "wake_inbox_drain.main()\n",
         encoding="utf-8",
     )

--- a/pact-plugin/tests/test_wake_inbox_drain.py
+++ b/pact-plugin/tests/test_wake_inbox_drain.py
@@ -2220,3 +2220,228 @@ class TestMalformedTeardownMarkerDemotedToArm:
                     f"{child!r}; drain-side guard failed"
                 )
 
+
+
+# ===========================================================================
+# Cron auto-arm DISABLE contract (Phase 2) — G4 (_emit_arm), all 3 drain
+# call sites, plus the no-over-suppression guard on the ungated teardown path.
+#
+# Under the PRODUCTION default CRON_AUTOARM_ENABLED=False, every arm emit
+# through _emit_arm suppresses; each suppression is PAIRED with a True-recovery
+# on the SAME fixture (recovery firing proves count/marker drives an arm under
+# this fixture, so the False suppression is gate-driven, not phantom-green).
+# The teardown path (_emit_teardown) is a SEPARATE, ungated function and MUST
+# still fire under autoarm-disabled — the final test pins that G4 suppresses
+# ARM only and does not over-suppress TEARDOWN.
+# ===========================================================================
+
+
+def _g4_user_prompt(sid, pdir):
+    return {
+        "session_id": sid, "cwd": pdir,
+        "hook_event_name": "UserPromptSubmit", "prompt": "go",
+    }
+
+
+def _g4_member_fixture(home, lead_sid, pdir, team, owner="backend-coder"):
+    _write_session_context(
+        home, lead_sid, pdir, team,
+        members=[
+            {"name": owner, "agentId": "agent-bc"},
+            {"name": "lead", "agentId": "agent-lead"},
+        ],
+        lead_agent_id="agent-lead",
+    )
+
+
+def test_autoarm_disabled_count_fallback_suppresses(tmp_path):
+    """G4 site 3 — the marker-INDEPENDENT B-1 count fallback (the path that
+    re-fires on every lead prompt with active work). Empty inbox + count>=1,
+    CRON_AUTOARM_ENABLED=False -> _emit_arm suppresses. Paired recovery:
+    test_autoarm_recovery_count_fallback_emits."""
+    home = tmp_path / "home"; home.mkdir()
+    lead_sid = "lead-sid"; pdir = "/tmp/p"; team = "team-g4-fallback"
+    _g4_member_fixture(home, lead_sid, pdir, team)
+    _write_task(home, team, "Q", status="in_progress", owner="backend-coder")
+    rc, out, err = _run_drain(
+        json.dumps(_g4_user_prompt(lead_sid, pdir)),
+        env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        autoarm_enabled=False,
+    )
+    assert rc == 0, f"stderr={err}"
+    assert json.loads(out).get("suppressOutput") is True
+    assert "PACT:start-pending-scan" not in out
+
+
+def test_autoarm_recovery_count_fallback_emits(tmp_path):
+    """G4 site 3 recovery: SAME fixture, gate True -> count fallback emits
+    Arm. Proves count>=1 here, so the False suppression is gate-driven."""
+    home = tmp_path / "home"; home.mkdir()
+    lead_sid = "lead-sid"; pdir = "/tmp/p"; team = "team-g4-fallback"
+    _g4_member_fixture(home, lead_sid, pdir, team)
+    _write_task(home, team, "Q", status="in_progress", owner="backend-coder")
+    rc, out, err = _run_drain(
+        json.dumps(_g4_user_prompt(lead_sid, pdir)),
+        env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        autoarm_enabled=True,
+    )
+    assert rc == 0, f"stderr={err}"
+    hso = json.loads(out)["hookSpecificOutput"]
+    assert "PACT:start-pending-scan" in hso["additionalContext"]
+
+
+def test_autoarm_disabled_drained_arm_marker_suppresses(tmp_path):
+    """G4 site 2 — arm-only drain. An arm marker drains (and is consumed)
+    but _emit_arm suppresses under CRON_AUTOARM_ENABLED=False. Paired
+    recovery: test_autoarm_recovery_drained_arm_marker_emits."""
+    home = tmp_path / "home"; home.mkdir()
+    lead_sid = "lead-sid"; pdir = "/tmp/p"; team = "team-g4-arm-drain"
+    _write_session_context(home, lead_sid, pdir, team)
+    _write_marker(
+        home, team, "20260516T160200Z-x-T3.json",
+        {
+            "schema_version": 1, "type": "arm",
+            "trigger": "teammate_self_claim_in_progress",
+            "tool_name": "TaskUpdate", "task_id": "T3", "owner": "backend-coder",
+        },
+    )
+    rc, out, err = _run_drain(
+        json.dumps(_g4_user_prompt(lead_sid, pdir)),
+        env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        autoarm_enabled=False,
+    )
+    assert rc == 0, f"stderr={err}"
+    assert json.loads(out).get("suppressOutput") is True
+    assert "PACT:start-pending-scan" not in out
+
+
+def test_autoarm_recovery_drained_arm_marker_emits(tmp_path):
+    """G4 site 2 recovery: SAME fixture, gate True -> drained arm marker
+    emits Arm."""
+    home = tmp_path / "home"; home.mkdir()
+    lead_sid = "lead-sid"; pdir = "/tmp/p"; team = "team-g4-arm-drain"
+    _write_session_context(home, lead_sid, pdir, team)
+    _write_marker(
+        home, team, "20260516T160200Z-x-T3.json",
+        {
+            "schema_version": 1, "type": "arm",
+            "trigger": "teammate_self_claim_in_progress",
+            "tool_name": "TaskUpdate", "task_id": "T3", "owner": "backend-coder",
+        },
+    )
+    rc, out, err = _run_drain(
+        json.dumps(_g4_user_prompt(lead_sid, pdir)),
+        env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        autoarm_enabled=True,
+    )
+    assert rc == 0, f"stderr={err}"
+    hso = json.loads(out)["hookSpecificOutput"]
+    assert "PACT:start-pending-scan" in hso["additionalContext"]
+
+
+def test_autoarm_disabled_arm_teardown_disambiguation_suppresses(tmp_path):
+    """G4 site 1 — arm+teardown same-prompt disambiguation. With count>0 the
+    drain normally DEMOTES the mixed drain to an arm emit; under
+    CRON_AUTOARM_ENABLED=False the demoted arm emit suppresses (and the stale
+    teardown still must NOT win). Paired recovery:
+    test_autoarm_recovery_arm_teardown_disambiguation_emits."""
+    home = tmp_path / "home"; home.mkdir()
+    lead_sid = "lead-sid"; pdir = "/tmp/p"; team = "team-g4-disambig"
+    _g4_member_fixture(home, lead_sid, pdir, team)
+    _write_task(home, team, "A_active", status="in_progress", owner="backend-coder")
+    _write_marker(
+        home, team, "20260516T160600Z-x-Z_stale.json",
+        {
+            "schema_version": 1, "type": "teardown", "task_id": "Z_stale",
+            "team_name": team, "owner": "secretary",
+            "timestamp_ms": 1715792300000,
+            "trigger": "self_complete_exempt_or_stop_sweep",
+        },
+    )
+    _write_marker(
+        home, team, "20260516T160700Z-x-A_active.json",
+        {
+            "schema_version": 1, "type": "arm",
+            "trigger": "teammate_self_claim_in_progress",
+            "tool_name": "TaskUpdate", "task_id": "A_active",
+            "owner": "backend-coder",
+        },
+    )
+    rc, out, err = _run_drain(
+        json.dumps(_g4_user_prompt(lead_sid, pdir)),
+        env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        autoarm_enabled=False,
+    )
+    assert rc == 0, f"stderr={err}"
+    assert json.loads(out).get("suppressOutput") is True
+    assert "PACT:start-pending-scan" not in out
+    # The stale teardown must NOT win either — the demoted-arm branch was
+    # taken (count>0) and that branch is what G4 suppresses.
+    assert "PACT:stop-pending-scan" not in out
+
+
+def test_autoarm_recovery_arm_teardown_disambiguation_emits(tmp_path):
+    """G4 site 1 recovery: SAME fixture, gate True -> the demoted-arm branch
+    emits Arm (cron stays armed; stale teardown yields)."""
+    home = tmp_path / "home"; home.mkdir()
+    lead_sid = "lead-sid"; pdir = "/tmp/p"; team = "team-g4-disambig"
+    _g4_member_fixture(home, lead_sid, pdir, team)
+    _write_task(home, team, "A_active", status="in_progress", owner="backend-coder")
+    _write_marker(
+        home, team, "20260516T160600Z-x-Z_stale.json",
+        {
+            "schema_version": 1, "type": "teardown", "task_id": "Z_stale",
+            "team_name": team, "owner": "secretary",
+            "timestamp_ms": 1715792300000,
+            "trigger": "self_complete_exempt_or_stop_sweep",
+        },
+    )
+    _write_marker(
+        home, team, "20260516T160700Z-x-A_active.json",
+        {
+            "schema_version": 1, "type": "arm",
+            "trigger": "teammate_self_claim_in_progress",
+            "tool_name": "TaskUpdate", "task_id": "A_active",
+            "owner": "backend-coder",
+        },
+    )
+    rc, out, err = _run_drain(
+        json.dumps(_g4_user_prompt(lead_sid, pdir)),
+        env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        autoarm_enabled=True,
+    )
+    assert rc == 0, f"stderr={err}"
+    ac = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert "PACT:start-pending-scan" in ac
+    assert "PACT:stop-pending-scan" not in ac
+
+
+def test_autoarm_disabled_teardown_marker_still_emits(tmp_path):
+    """NO OVER-SUPPRESSION: G4 gates _emit_arm ONLY. A drained teardown
+    marker MUST still emit the Teardown directive under
+    CRON_AUTOARM_ENABLED=False (teardown is a separate, ungated path).
+    Pins the surgical placement of G4 — disabling auto-ARM must not
+    collaterally disable auto-TEARDOWN."""
+    home = tmp_path / "home"; home.mkdir()
+    lead_sid = "lead-sid"; pdir = "/tmp/p"; team = "team-g4-teardown-survives"
+    _write_session_context(home, lead_sid, pdir, team)
+    _write_marker(
+        home, team, "20260516T160300Z-x-T4.json",
+        {
+            "schema_version": 1, "type": "teardown", "task_id": "T4",
+            "team_name": team, "owner": "secretary",
+            "timestamp_ms": 1715792180000,
+            "trigger": "self_complete_exempt_or_stop_sweep",
+        },
+    )
+    rc, out, err = _run_drain(
+        json.dumps(_g4_user_prompt(lead_sid, pdir)),
+        env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        autoarm_enabled=False,
+    )
+    assert rc == 0, f"stderr={err}"
+    hso = json.loads(out)["hookSpecificOutput"]
+    assert "PACT:stop-pending-scan" in hso["additionalContext"], (
+        "teardown must still fire under autoarm-disabled (no over-suppression)"
+    )
+    assert "PACT:start-pending-scan" not in hso["additionalContext"]

--- a/pact-plugin/tests/test_wake_lifecycle_arm_starvation.py
+++ b/pact-plugin/tests/test_wake_lifecycle_arm_starvation.py
@@ -32,7 +32,7 @@ EMITTER = HOOK_DIR / "wake_lifecycle_emitter.py"
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "wake_lifecycle"
 
 
-def _run_emitter(stdin_payload, env_extra=None):
+def _run_emitter(stdin_payload, env_extra=None, autoarm_enabled=True):
     env = {k: v for k, v in os.environ.items() if not k.startswith("CLAUDE_")}
     if env_extra:
         env.update(env_extra)
@@ -40,8 +40,22 @@ def _run_emitter(stdin_payload, env_extra=None):
         stdin_payload if isinstance(stdin_payload, bytes)
         else stdin_payload.encode("utf-8")
     )
+    # Production default is CRON_AUTOARM_ENABLED=False (auto-arm disabled).
+    # These tests exercise the arm MACHINERY (still reachable via the manual
+    # /PACT:start-pending-scan path), so re-enable the gate in the subprocess
+    # by importing the hook, setting the CONSUMER-module binding, and calling
+    # main(). Patching shared.wake_lifecycle would NOT reach the already-bound
+    # wake_lifecycle_emitter.CRON_AUTOARM_ENABLED name (name-import snapshot).
+    # Pass autoarm_enabled=False to exercise production-default suppression.
+    runner_src = (
+        "import sys\n"
+        f"sys.path.insert(0, {str(HOOK_DIR)!r})\n"
+        "import wake_lifecycle_emitter\n"
+        f"wake_lifecycle_emitter.CRON_AUTOARM_ENABLED = {autoarm_enabled!r}\n"
+        "wake_lifecycle_emitter.main()\n"
+    )
     proc = subprocess.run(
-        [sys.executable, str(EMITTER)],
+        [sys.executable, "-c", runner_src],
         input=payload_bytes,
         capture_output=True,
         env=env,
@@ -470,7 +484,11 @@ def test_marker_o_excl_collision_silent(tmp_path):
             return fixed
 
     original_dt = emitter.datetime
+    original_autoarm = emitter.CRON_AUTOARM_ENABLED
     emitter.datetime = _FixedDateTime
+    # Re-enable the gate: G2 (_maybe_write_teammate_arm_marker) early-returns
+    # under the production default; this test exercises the marker machinery.
+    emitter.CRON_AUTOARM_ENABLED = True
     try:
         os.environ["HOME"] = str(home)
         payload = {
@@ -502,6 +520,7 @@ def test_marker_o_excl_collision_silent(tmp_path):
         )
     finally:
         emitter.datetime = original_dt
+        emitter.CRON_AUTOARM_ENABLED = original_autoarm
 
 
 # ─── Audit-anchor regression guards ────────────────────────────────────

--- a/pact-plugin/tests/test_wake_lifecycle_bug_b_rearm.py
+++ b/pact-plugin/tests/test_wake_lifecycle_bug_b_rearm.py
@@ -43,7 +43,7 @@ EMITTER = HOOK_DIR / "wake_lifecycle_emitter.py"
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "wake_lifecycle"
 
 
-def _run_emitter(stdin_payload: str | bytes, env_extra: dict | None = None) -> tuple[int, str, str]:
+def _run_emitter(stdin_payload: str | bytes, env_extra: dict | None = None, autoarm_enabled: bool = True) -> tuple[int, str, str]:
     env = {k: v for k, v in os.environ.items() if not k.startswith("CLAUDE_")}
     if env_extra:
         env.update(env_extra)
@@ -51,8 +51,22 @@ def _run_emitter(stdin_payload: str | bytes, env_extra: dict | None = None) -> t
         stdin_payload if isinstance(stdin_payload, bytes)
         else stdin_payload.encode("utf-8")
     )
+    # Production default is CRON_AUTOARM_ENABLED=False (auto-arm disabled).
+    # These tests exercise the arm MACHINERY (still reachable via the manual
+    # /PACT:start-pending-scan path), so re-enable the gate in the subprocess
+    # by importing the hook, setting the CONSUMER-module binding, and calling
+    # main(). Patching shared.wake_lifecycle would NOT reach the already-bound
+    # wake_lifecycle_emitter.CRON_AUTOARM_ENABLED name (name-import snapshot).
+    # Pass autoarm_enabled=False to exercise production-default suppression.
+    runner_src = (
+        "import sys\n"
+        f"sys.path.insert(0, {str(HOOK_DIR)!r})\n"
+        "import wake_lifecycle_emitter\n"
+        f"wake_lifecycle_emitter.CRON_AUTOARM_ENABLED = {autoarm_enabled!r}\n"
+        "wake_lifecycle_emitter.main()\n"
+    )
     proc = subprocess.run(
-        [sys.executable, str(EMITTER)],
+        [sys.executable, "-c", runner_src],
         input=payload_bytes,
         capture_output=True,
         env=env,

--- a/pact-plugin/tests/test_wake_lifecycle_emitter.py
+++ b/pact-plugin/tests/test_wake_lifecycle_emitter.py
@@ -962,3 +962,166 @@ class TestDirectiveAntiSofteningGuard:
             f"task completed` (#738: provably-false on re-fire); got "
             f"{emitter._TEARDOWN_DIRECTIVE!r}"
         )
+
+
+# ===========================================================================
+# Cron auto-arm DISABLE contract (Phase 2) — G1 (_arm_or_none) + G2
+# (_maybe_write_teammate_arm_marker), production-default suppression.
+#
+# Under the PRODUCTION default CRON_AUTOARM_ENABLED=False, NO arm directive
+# (G1) and NO teammate arm marker (G2) is produced even with active teammate
+# work present. Each suppression test is PAIRED with a True-recovery on the
+# SAME fixture: the True case firing proves count_active_tasks > 0 for that
+# fixture, so the False suppression cannot be a count==0 phantom-green — it is
+# gate-driven. The pairing is a contract-level counter-test-by-revert with the
+# sentinel flip standing in for the revert; the gate is proven the SOLE
+# suppressor. (A source-level guard-removal counter-test was run out-of-band;
+# see the TEST-phase HANDOFF.)
+# ===========================================================================
+
+
+def _g1_taskcreate_payload(sid, pdir, task_id="task-1"):
+    return {
+        "tool_name": "TaskCreate",
+        "session_id": sid,
+        "cwd": pdir,
+        "tool_input": {"taskId": task_id},
+        "tool_response": {"task": {"id": task_id}},
+    }
+
+
+def _g1_rearm_payload(sid, pdir, task_id="B", owner="backend-coder"):
+    return {
+        "tool_name": "TaskUpdate",
+        "session_id": sid,
+        "cwd": pdir,
+        "tool_input": {"taskId": task_id, "status": "in_progress"},
+        "tool_response": {"id": task_id, "status": "in_progress", "owner": owner},
+    }
+
+
+def test_autoarm_disabled_taskcreate_suppresses_arm(tmp_path):
+    """G1 (TaskCreate branch): one active task on disk, production default
+    CRON_AUTOARM_ENABLED=False -> _arm_or_none returns None -> suppressOutput.
+    Paired recovery: test_autoarm_recovery_taskcreate_emits_arm."""
+    home = tmp_path / "home"; home.mkdir()
+    sid = "session-1"; pdir = "/tmp/proj"; team = "team-a"
+    _write_session_context(home, sid, pdir, team)
+    _write_task(home, team, "task-1", status="in_progress", owner="backend-coder")
+    rc, out, err = _run_emitter(
+        json.dumps(_g1_taskcreate_payload(sid, pdir)),
+        env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        autoarm_enabled=False,
+    )
+    assert rc == 0, f"stderr={err}"
+    assert json.loads(out) == {"suppressOutput": True}
+
+
+def test_autoarm_recovery_taskcreate_emits_arm(tmp_path):
+    """G1 recovery: SAME fixture, gate flipped True -> arm fires again.
+    Proves count_active_tasks > 0 for this fixture, so the False
+    suppression above is gate-driven, not a count==0 phantom-green."""
+    home = tmp_path / "home"; home.mkdir()
+    sid = "session-1"; pdir = "/tmp/proj"; team = "team-a"
+    _write_session_context(home, sid, pdir, team)
+    _write_task(home, team, "task-1", status="in_progress", owner="backend-coder")
+    rc, out, err = _run_emitter(
+        json.dumps(_g1_taskcreate_payload(sid, pdir)),
+        env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        autoarm_enabled=True,
+    )
+    assert rc == 0, f"stderr={err}"
+    hso = json.loads(out)["hookSpecificOutput"]
+    assert 'Skill("PACT:start-pending-scan")' in hso["additionalContext"]
+
+
+def test_autoarm_disabled_rearm_suppresses_arm(tmp_path):
+    """G1 (TaskUpdate pending->in_progress re-arm branch — the SECOND
+    _arm_or_none funnel): active task on disk, CRON_AUTOARM_ENABLED=False ->
+    suppressOutput. Paired recovery: test_autoarm_recovery_rearm_emits_arm."""
+    home = tmp_path / "home"; home.mkdir()
+    sid = "s"; pdir = "/tmp/p"; team = "team-rearm"
+    _write_session_context(home, sid, pdir, team)
+    _write_task(home, team, "B", status="in_progress", owner="backend-coder")
+    rc, out, err = _run_emitter(
+        json.dumps(_g1_rearm_payload(sid, pdir)),
+        env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        autoarm_enabled=False,
+    )
+    assert rc == 0, f"stderr={err}"
+    assert json.loads(out) == {"suppressOutput": True}
+
+
+def test_autoarm_recovery_rearm_emits_arm(tmp_path):
+    """G1 re-arm recovery: SAME fixture, gate True -> arm fires again."""
+    home = tmp_path / "home"; home.mkdir()
+    sid = "s"; pdir = "/tmp/p"; team = "team-rearm"
+    _write_session_context(home, sid, pdir, team)
+    _write_task(home, team, "B", status="in_progress", owner="backend-coder")
+    rc, out, err = _run_emitter(
+        json.dumps(_g1_rearm_payload(sid, pdir)),
+        env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        autoarm_enabled=True,
+    )
+    assert rc == 0, f"stderr={err}"
+    hso = json.loads(out)["hookSpecificOutput"]
+    assert 'Skill("PACT:start-pending-scan")' in hso["additionalContext"]
+
+
+def _g2_teammate_fixture(home, team, teammate_sid, pdir, owner):
+    _write_session_context(
+        home, teammate_sid, pdir, team,
+        lead_session_id="lead-sid",
+        members=[
+            {"name": owner, "agentId": "agent-bc"},
+            {"name": "lead", "agentId": "agent-lead"},
+        ],
+        lead_agent_id="agent-lead",
+    )
+    _write_task(home, team, "G2a", status="in_progress", owner=owner)
+    return {
+        "tool_name": "TaskUpdate",
+        "session_id": teammate_sid, "agent_id": "agent-bc", "cwd": pdir,
+        "tool_input": {"taskId": "G2a", "status": "in_progress", "owner": owner},
+        "tool_response": {"id": "G2a", "status": "in_progress", "owner": owner},
+    }
+
+
+def test_autoarm_disabled_teammate_arm_marker_not_written(tmp_path):
+    """G2 (_maybe_write_teammate_arm_marker): an in-process teammate-frame
+    self-claim that WOULD write an arm marker writes NOTHING under
+    CRON_AUTOARM_ENABLED=False (producer early-returns before any I/O).
+    Paired recovery: test_autoarm_recovery_teammate_arm_marker_written."""
+    home = tmp_path / "home"; home.mkdir()
+    team = "team-g2"; pdir = "/tmp/p"; owner = "backend-coder"
+    payload = _g2_teammate_fixture(home, team, "teammate-sid", pdir, owner)
+    rc, out, err = _run_emitter(
+        json.dumps(payload),
+        env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        autoarm_enabled=False,
+    )
+    assert rc == 0, f"stderr={err}"
+    assert _read_inbox_markers(home, team) == [], (
+        "no teammate arm marker may be written under autoarm-disabled"
+    )
+
+
+def test_autoarm_recovery_teammate_arm_marker_written(tmp_path):
+    """G2 recovery: SAME fixture, gate True -> exactly one arm marker is
+    written. Proves the producer's clause ladder reaches the write under
+    this fixture, so the False no-write above is gate-driven."""
+    home = tmp_path / "home"; home.mkdir()
+    team = "team-g2"; pdir = "/tmp/p"; owner = "backend-coder"
+    payload = _g2_teammate_fixture(home, team, "teammate-sid", pdir, owner)
+    rc, out, err = _run_emitter(
+        json.dumps(payload),
+        env_extra={"HOME": str(home), "CLAUDE_PROJECT_DIR": pdir},
+        autoarm_enabled=True,
+    )
+    assert rc == 0, f"stderr={err}"
+    markers = _read_inbox_markers(home, team)
+    arm_markers = [m for m in markers if m.get("type") == "arm"]
+    assert len(arm_markers) == 1, (
+        f"exactly one teammate arm marker expected under autoarm-enabled; "
+        f"got {markers!r}"
+    )

--- a/pact-plugin/tests/test_wake_lifecycle_emitter.py
+++ b/pact-plugin/tests/test_wake_lifecycle_emitter.py
@@ -44,7 +44,7 @@ EMITTER = HOOK_DIR / "wake_lifecycle_emitter.py"
 # =============================================================================
 
 
-def _run_emitter(stdin_payload, env_extra=None):
+def _run_emitter(stdin_payload, env_extra=None, autoarm_enabled=True):
     env = {k: v for k, v in os.environ.items() if not k.startswith("CLAUDE_")}
     if env_extra:
         env.update(env_extra)
@@ -52,8 +52,22 @@ def _run_emitter(stdin_payload, env_extra=None):
         stdin_payload if isinstance(stdin_payload, bytes)
         else stdin_payload.encode("utf-8")
     )
+    # Production default is CRON_AUTOARM_ENABLED=False (auto-arm disabled).
+    # These tests exercise the arm MACHINERY (still reachable via the manual
+    # /PACT:start-pending-scan path), so re-enable the gate in the subprocess
+    # by importing the hook, setting the CONSUMER-module binding, and calling
+    # main(). Patching shared.wake_lifecycle would NOT reach the already-bound
+    # wake_lifecycle_emitter.CRON_AUTOARM_ENABLED name (name-import snapshot).
+    # Pass autoarm_enabled=False to exercise production-default suppression.
+    runner_src = (
+        "import sys\n"
+        f"sys.path.insert(0, {str(HOOK_DIR)!r})\n"
+        "import wake_lifecycle_emitter\n"
+        f"wake_lifecycle_emitter.CRON_AUTOARM_ENABLED = {autoarm_enabled!r}\n"
+        "wake_lifecycle_emitter.main()\n"
+    )
     proc = subprocess.run(
-        [sys.executable, str(EMITTER)],
+        [sys.executable, "-c", runner_src],
         input=payload_bytes,
         capture_output=True,
         env=env,


### PR DESCRIPTION
## Summary

Phase 2 of #864 (remove cron machinery, steer to tmux): disable the cron auto-arm directive behind a single sentinel `CRON_AUTOARM_ENABLED = False`, so **no auto-arm emission fires** — while the manual `/PACT:start-pending-scan` path, all teardown machinery, and every other hook behavior stay intact. Cron code stays on disk and manually invocable. Reversal is a one-line flip. This is the second reversibility gate before the irreversible Phase-3 deletion.

## What landed

- **Sentinel** `CRON_AUTOARM_ENABLED = False` in `shared/wake_lifecycle.py` (the module Phase 3 retains; all three consumers already import from it → zero new import statements).
- **4 guards** funnel all **7 auto-arm emit paths** to zero, each placed INSIDE the arm-only function (never at the `_decide_*` choke points that also host teardown):
  - **G1** `_arm_or_none` — covers the TaskCreate path AND the TaskUpdate pending→in_progress re-arm path
  - **G2** `_maybe_write_teammate_arm_marker` — hygiene (G4 already neutralizes any marker that reaches the drain)
  - **G3** `session_init` resume/startup arm if-block
  - **G4** `_emit_arm` (wake_inbox_drain) — the single choke point for all 3 drain sites, **including the marker-independent step-6 `count_active_tasks>=1` fallback** (the load-bearing 3rd site the original "two-sites" framing missed)
- **17 new tests**: per-guard suppression + paired True-recovery (proving the gate is the sole suppressor, not a count==0 phantom-green), manual-path-still-arms, step-0b startup-notice regression, and no-over-suppression anchors (teardown still fires). Counter-tested by source-guard removal: G1→2, G2→1, G4→3, G3→2 FAIL on removal.
- **Version bump 4.3.7 → 4.3.8** (PATCH; canonical 4 files).

## Why

The stalls the cron exists to prevent are an in-process teammateMode pathology that tmux eliminates natively. Phase 2 disables auto-arm behind a flippable sentinel and runs a validation window before Phase 3 deletes the ecosystem. PATCH per the phased-release criterion — MINOR (4.4.0) is reserved for the arc-completing Phase 3 (the user-visible cron + slash-command removal).

## Test evidence

Full suite GREEN: **8461 passed / 14 skipped / 0 failed**. No-half-state proof: `_emit_arm` is pure output; `scan_armed`/`scan_disarmed` are written only by the skill body, so gating the hook directive cannot desync the journal.
