### PR TITLE
fix(#878): hook lead/teammate discriminator — is_lead predicate + gate migration (v4.4.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.0",
+      "version": "4.4.1",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.0/      # Plugin version
+│               └── 4.4.1/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.0
+> **Version**: 4.4.1
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/bootstrap_gate.py
+++ b/pact-plugin/hooks/bootstrap_gate.py
@@ -357,9 +357,15 @@ def _check_tool_allowed(input_data: dict) -> str | None:
     if is_marker_set(Path(session_dir)):
         return None
 
-    # Teammate detection
-    agent_name = pact_context.resolve_agent_name(input_data)
-    if agent_name:
+    # Lead-role gate (#878, DENY-gate enforcement RESTORATION): only the
+    # team-lead's pre-bootstrap tool calls are gated. Migrated from the
+    # negative `resolve_agent_name(...) != ""` heuristic — which returned
+    # non-empty for BOTH lead spellings (Step-4 prefix-strip), so at v4.4.0 the
+    # lead itself took this teammate-bypass branch and the DENY gate was
+    # silently DEAD for the lead. is_lead keys on the harness-set agent_type
+    # directly, re-enabling lead-side enforcement. is_lead is total (never
+    # raises), so the caller's exception-fail-CLOSED path is preserved.
+    if not pact_context.is_lead(input_data):
         return None
 
     # Lead session, no marker — check tool classification

--- a/pact-plugin/hooks/bootstrap_marker_writer.py
+++ b/pact-plugin/hooks/bootstrap_marker_writer.py
@@ -216,8 +216,12 @@ def _try_write_marker(input_data: dict) -> None:
     if is_marker_set(session_dir):
         return
 
-    # Teammate sessions don't drive bootstrap (their lead does). Skip.
-    if pact_context.resolve_agent_name(input_data):
+    # Lead-role gate (#878): only the team-lead drives bootstrap (writes the
+    # marker). Migrated from the negative `resolve_agent_name(...) != ""`
+    # heuristic — which returned non-empty for BOTH lead spellings, so the lead
+    # itself took this bypass branch under tmux — to the positive is_lead
+    # predicate keyed on the harness-set agent_type.
+    if not pact_context.is_lead(input_data):
         return
 
     # Pre-condition: team config + secretary member exist on disk.

--- a/pact-plugin/hooks/bootstrap_prompt_gate.py
+++ b/pact-plugin/hooks/bootstrap_prompt_gate.py
@@ -8,9 +8,9 @@ Used by: hooks.json UserPromptSubmit hook (no matcher — fires on every prompt)
 Layer 2 of the four-layer bootstrap gate enforcement (#401). On each user
 message, checks for the session-scoped bootstrap-complete marker file:
   - Marker exists → suppressOutput (zero tokens, sub-ms)
-  - No marker + PACT team-lead session → inject additionalContext instructing bootstrap
+  - No marker + PACT team-lead session (is_lead) → inject additionalContext instructing bootstrap
   - Non-PACT session (no context file) → no-op passthrough
-  - Teammate (resolve_agent_name non-empty) → no-op passthrough
+  - Teammate / non-lead frame (not is_lead) → no-op passthrough
 
 SACROSANCT (post-#662 module-load fail-closed retrofit): module-load
 failures emit an advisory `additionalContext` block at exit 0 —
@@ -113,9 +113,13 @@ def _check_bootstrap_needed(input_data: dict) -> str | None:
         # Bootstrap already done → suppress (zero tokens)
         return None
 
-    # Teammate detection: teammates don't need the team-lead's bootstrap gate
-    agent_name = pact_context.resolve_agent_name(input_data)
-    if agent_name:
+    # Lead-role gate (#878): only the team-lead drives the bootstrap ritual.
+    # Migrated from the negative `resolve_agent_name(...) != ""` heuristic to
+    # the positive is_lead predicate — the old heuristic returned non-empty for
+    # BOTH lead spellings (Step-4 prefix-strip), so under tmux the lead itself
+    # took this teammate-bypass branch. is_lead keys on the harness-set
+    # agent_type directly.
+    if not pact_context.is_lead(input_data):
         return None
 
     # Lead session, no marker → inject bootstrap instruction with session dir

--- a/pact-plugin/hooks/file_tracker.py
+++ b/pact-plugin/hooks/file_tracker.py
@@ -19,7 +19,7 @@ import time
 from pathlib import Path
 
 import shared.pact_context as pact_context
-from shared.pact_context import get_team_name, resolve_agent_name
+from shared.pact_context import get_session_id, get_team_name, resolve_agent_name
 
 try:
     import fcntl
@@ -46,8 +46,20 @@ def track_edit(
     agent_name: str,
     tool_name: str,
     tracking_path: str,
+    session_id: str = "",
 ) -> None:
-    """Append a file edit record to the tracking file."""
+    """Append a file edit record to the tracking file.
+
+    NEW-1 (#878): the editor is identified by the COMPOSITE key
+    ``(agent_name, session_id)``, not by ``agent_name`` alone. Under tmux,
+    same-``agent_type`` siblings (e.g. two ``backend-coder`` instances)
+    collapse to the same ``resolve_agent_name`` value, so an agent-name-only
+    key cannot tell them apart and conflict detection false-negatives. The
+    ``session_id`` (already in stdin via ``pact_context.init``) supplies the
+    per-instance uniqueness in BOTH modes. ``agent_name`` is retained as the
+    human-readable LABEL (the friendly-name recovery for the label under tmux
+    is a deferred follow-up; detection-uniqueness is what this fix restores).
+    """
     file_path = _normalize_path(file_path)
     tracking_file = Path(tracking_path)
     tracking_file.parent.mkdir(parents=True, exist_ok=True)
@@ -55,6 +67,7 @@ def track_edit(
     new_entry = {
         "file": file_path,
         "agent": agent_name,
+        "session_id": session_id,
         "tool": tool_name,
         "ts": int(time.time()),
     }
@@ -91,8 +104,23 @@ def check_conflict(
     file_path: str,
     agent_name: str,
     tracking_path: str,
+    session_id: str = "",
 ) -> str | None:
-    """Check if another agent has edited this file."""
+    """Check if another EDITOR INSTANCE has edited this file.
+
+    NEW-1 (#878): an editor is the COMPOSITE ``(agent_name, session_id)`` — so
+    a different *instance* of the same ``agent_type`` (same ``agent_name``,
+    different ``session_id``) is correctly counted as a separate editor and a
+    real cross-instance conflict is DETECTED under tmux (the prior
+    agent-name-only key false-negatived here). The SAME instance editing twice
+    (same composite) is NOT a conflict.
+
+    The conflict message lists the human-readable ``agent`` LABEL of each other
+    editor. When two other editors share an ``agent`` label but differ by
+    ``session_id`` (same-type siblings under tmux), the label is disambiguated
+    with a short session_id suffix so the message names two distinct editors
+    rather than a confusing repeated name.
+    """
     file_path = _normalize_path(file_path)
     if not agent_name:
         return None
@@ -106,19 +134,39 @@ def check_conflict(
     except (json.JSONDecodeError, IOError):
         return None
 
-    other_agents = set()
+    self_key = (agent_name, session_id)
+    # Collect the distinct OTHER editor instances (composite key) and, per
+    # agent label, the set of session_ids seen — so the label can be
+    # disambiguated only when a name is genuinely shared across instances.
+    other_keys: set[tuple[str, str]] = set()
+    sessions_by_agent: dict[str, set[str]] = {}
     for entry in entries:
-        if entry.get("file") == file_path and entry.get("agent") != agent_name:
-            other_agents.add(entry["agent"])
+        if entry.get("file") != file_path:
+            continue
+        entry_agent = entry.get("agent", "")
+        entry_session = entry.get("session_id", "")
+        if (entry_agent, entry_session) == self_key:
+            continue
+        other_keys.add((entry_agent, entry_session))
+        sessions_by_agent.setdefault(entry_agent, set()).add(entry_session)
 
-    if other_agents:
-        others = ", ".join(sorted(other_agents))
-        return (
-            f"File conflict: {file_path} was also edited by {others}. "
-            f"Consider coordinating via SendMessage to avoid merge conflicts."
-        )
+    if not other_keys:
+        return None
 
-    return None
+    labels = []
+    for entry_agent, entry_session in other_keys:
+        # Disambiguate with a short session_id suffix only when this agent
+        # name is shared by more than one instance (otherwise the bare name
+        # is unambiguous and cleaner).
+        if entry_session and len(sessions_by_agent.get(entry_agent, set())) > 1:
+            labels.append(f"{entry_agent} (session {entry_session[:8]})")
+        else:
+            labels.append(entry_agent)
+    others = ", ".join(sorted(labels))
+    return (
+        f"File conflict: {file_path} was also edited by {others}. "
+        f"Consider coordinating via SendMessage to avoid merge conflicts."
+    )
 
 
 def get_environment_delta(
@@ -175,16 +223,25 @@ def main():
 
     agent_name = resolve_agent_name(input_data)
     tool_name = input_data.get("tool_name", "")
+    # NEW-1 (#878): session_id is the per-instance uniqueness component of the
+    # composite editor key. Available via pact_context after init() above.
+    # resolve_agent_name is KEPT for the human-readable label.
+    session_id = get_session_id()
 
     tracking_path = str(
         Path.home() / ".claude" / "teams" / team_name / "file-edits.json"
     )
 
-    # Check for conflict BEFORE recording this edit
-    conflict = check_conflict(file_path, agent_name, tracking_path)
+    # Check for conflict BEFORE recording this edit. Pass the same
+    # (agent_name, session_id) composite so this instance's own prior edits are
+    # excluded but a different instance's are detected.
+    conflict = check_conflict(file_path, agent_name, tracking_path, session_id)
 
     # Record this edit
-    track_edit(file_path, agent_name or "orchestrator", tool_name, tracking_path)
+    track_edit(
+        file_path, agent_name or "orchestrator", tool_name, tracking_path,
+        session_id,
+    )
 
     # Warn if conflict
     if conflict:

--- a/pact-plugin/hooks/pin_caps_gate.py
+++ b/pact-plugin/hooks/pin_caps_gate.py
@@ -233,7 +233,10 @@ def _check_tool_allowed(input_data: dict) -> Optional[str]:
     # (resolve_agent_name returned non-empty for both lead spellings, so the
     # lead took this bypass branch and the DENY gate was silently DEAD for it).
     # is_lead keys on the harness-set agent_type directly; it is total (never
-    # raises), preserving the caller's exception-fail-CLOSED path.
+    # raises), preserving the caller's existing exception posture — which for
+    # this gate is fail-OPEN (the SACROSANCT default at main()'s except), with
+    # the narrow asymmetric Write-baseline-over-cap fail-CLOSED exception
+    # (Sec N7). A raising predicate would have perturbed that posture.
     if not pact_context.is_lead(input_data):
         return None
 

--- a/pact-plugin/hooks/pin_caps_gate.py
+++ b/pact-plugin/hooks/pin_caps_gate.py
@@ -225,10 +225,16 @@ def _check_tool_allowed(input_data: dict) -> Optional[str]:
 
     pact_context.init(input_data)
 
-    # Teammate bypass — mirror pin_staleness_gate. Teammates do not edit
-    # the project CLAUDE.md; only the team-lead (empty agent_name) is gated.
-    agent_name = pact_context.resolve_agent_name(input_data)
-    if agent_name:
+    # Lead-role gate (#878, DENY-gate enforcement RESTORATION) — mirror
+    # pin_staleness_gate. Teammates do not edit the project CLAUDE.md; only the
+    # team-lead is gated. The team-lead carries a POSITIVE lead agent_type
+    # (`PACT:pact-orchestrator` / `pact-orchestrator`) — NOT an empty
+    # agent_name; the prior "empty agent_name" assumption was the bug
+    # (resolve_agent_name returned non-empty for both lead spellings, so the
+    # lead took this bypass branch and the DENY gate was silently DEAD for it).
+    # is_lead keys on the harness-set agent_type directly; it is total (never
+    # raises), preserving the caller's exception-fail-CLOSED path.
+    if not pact_context.is_lead(input_data):
         return None
 
     tool_input = input_data.get("tool_input", {})

--- a/pact-plugin/hooks/pin_staleness_gate.py
+++ b/pact-plugin/hooks/pin_staleness_gate.py
@@ -170,7 +170,9 @@ def _check_tool_allowed(input_data: dict) -> str | None:
     # heuristic — which returned non-empty for BOTH lead spellings, so the lead
     # itself took this bypass branch and the DENY gate was silently DEAD for
     # the lead. is_lead keys on the harness-set agent_type directly; it is total
-    # (never raises), preserving the caller's exception-fail-CLOSED path.
+    # (never raises), preserving the caller's existing exception posture — which
+    # for this gate is fail-OPEN (the SACROSANCT default: any exception in gate
+    # logic allows the edit). A raising predicate would have perturbed that.
     if not pact_context.is_lead(input_data):
         return None
 

--- a/pact-plugin/hooks/pin_staleness_gate.py
+++ b/pact-plugin/hooks/pin_staleness_gate.py
@@ -164,10 +164,14 @@ def _check_tool_allowed(input_data: dict) -> str | None:
 
     pact_context.init(input_data)
 
-    # Teammate bypass — teammates don't edit project CLAUDE.md
-    # (worktree scope rule), so this gate is team-lead-only.
-    agent_name = pact_context.resolve_agent_name(input_data)
-    if agent_name:
+    # Lead-role gate (#878, DENY-gate enforcement RESTORATION) — teammates
+    # don't edit project CLAUDE.md (worktree scope rule), so this gate is
+    # team-lead-only. Migrated from the negative `resolve_agent_name(...) != ""`
+    # heuristic — which returned non-empty for BOTH lead spellings, so the lead
+    # itself took this bypass branch and the DENY gate was silently DEAD for
+    # the lead. is_lead keys on the harness-set agent_type directly; it is total
+    # (never raises), preserving the caller's exception-fail-CLOSED path.
+    if not pact_context.is_lead(input_data):
         return None
 
     session_dir = pact_context.get_session_dir()

--- a/pact-plugin/hooks/postcompact_archive.py
+++ b/pact-plugin/hooks/postcompact_archive.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 from shared.constants import COMPACT_SUMMARY_PATH
 from shared.error_output import hook_error_json
+from shared.pact_context import is_lead
 
 
 # ---------------------------------------------------------------------------
@@ -84,7 +85,15 @@ def main():
         # Per #444 Tertiary: no systemMessage emission. The previously-emitted
         # "Post-compaction: critical context preserved" message was reassurance
         # that could suppress orchestrator self-check (see issue #444 root cause).
-        if compact_summary:
+        #
+        # Lead-only (#881): COMPACT_SUMMARY_PATH is a GLOBAL SINGLETON the lead
+        # reads on resume; the write is O_TRUNC, so a teammate/plain frame's
+        # PostCompact would CLOBBER the lead's summary (the 2nd acute clobber
+        # after #877). Gate the write behind is_lead. is_lead is total and only
+        # reaches stdin_data here when compact_summary is truthy, which the
+        # isinstance(dict) guard above already established — so stdin_data is a
+        # dict and the .get inside is_lead cannot raise.
+        if compact_summary and is_lead(stdin_data):
             write_compact_summary(compact_summary)
 
         # Suppress output to avoid false "hook error" UI display on clean exits.

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -78,10 +78,11 @@ from pin_caps import (  # noqa: F401
 from shared import BOOTSTRAP_MARKER_NAME, SESSION_ID_CONTROL_CHARS_RE, build_session_path
 from shared.constants import COMPACT_SUMMARY_PATH
 from shared.pact_context import (
+    build_context_cache,
     classify_session_role,
     get_session_dir,
     is_lead,
-    write_context,
+    persist_context,
 )
 from shared.session_journal import append_event, make_event
 from shared.failure_log import append_failure
@@ -969,16 +970,20 @@ def main():
         frame_is_lead = is_lead(input_data)
         if not session_id_was_missing:
             try:
-                # SPLIT (#877): always populate the in-process cache/path so
+                # SEAM (#877): compose the two halves directly. ALWAYS build +
+                # cache (every frame gets the in-process context so
                 # get_session_dir() and append_event's path-resolution behave
-                # identically for every frame; gate ONLY the disk write on
-                # is_lead so a teammate/plain frame never clobbers the lead's
-                # on-disk session-context file (or creates a phantom session
-                # dir). See write_context's DISK-WRITE / CACHE SPLIT docstring.
-                write_context(
+                # identically), then persist to disk ONLY for a lead frame so a
+                # teammate/plain frame never clobbers the lead's on-disk
+                # session-context file (or creates a phantom session dir).
+                # build_context_cache is the sole owner of _cache; persist_context
+                # is the is_lead-gated best-effort disk side-effect. See the
+                # build_context_cache / persist_context docstrings.
+                _ctx_result = build_context_cache(
                     team_name, session_id, project_dir, plugin_root,
-                    write_disk=frame_is_lead,
                 )
+                if frame_is_lead and _ctx_result is not None:
+                    persist_context(*_ctx_result)
             except Exception as e:
                 # Fail-open: context file is best-effort; hooks fall back to empty strings
                 print(f"session_init: could not write context file: {e}", file=sys.stderr)

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -552,13 +552,15 @@ def _is_unknown_or_missing_session(raw_id: object) -> bool:
     """Return True if the session_id is missing, blank, a sentinel, or contains control chars.
 
     Single canonical predicate for the malformed-stdin gate. Both the
-    persistence call sites at the top of main() (write_context + append_event)
-    and the CLAUDE.md write at step 5b consult this helper so the two gates
-    can never drift. Drift previously allowed three corruption classes:
+    persistence call sites at the top of main() (build_context_cache +
+    persist_context + append_event) and the CLAUDE.md write at step 5b consult
+    this helper so the two gates can never drift. Drift previously allowed
+    three corruption classes:
 
     * Whitespace-only ids (e.g. `"   "`) were truthy and bypassed
-      `not raw_id`, leaking through to write_context as a literal directory
-      name.
+      `not raw_id`, leaking through to the context-persist path
+      (build_context_cache resolves it, persist_context mkdir's it) as a
+      literal directory name.
     * An attacker-supplied `"unknown-foo"` value passed `not raw_id` because
       the string is non-empty, then later passed `startswith("unknown")`
       and was written into CLAUDE.md anyway via a different code path.
@@ -737,7 +739,7 @@ def main():
         # Clear bootstrap-complete marker on user-initiated clear only (#414).
         #
         # Cannot use get_session_dir() here because the context module
-        # hasn't been initialized yet (write_context() runs at step 5a
+        # hasn't been initialized yet (build_context_cache() runs at step 5a
         # below). Uses build_session_path() directly — it has its own
         # path traversal guard (Path.parents containment check).
         #
@@ -896,9 +898,10 @@ def main():
         # 5. Remind orchestrator to create session-unique PACT team (or reuse on resume)
         team_name = generate_team_name(input_data)
 
-        # 5a. Write session context file FIRST so get_session_dir() works for
-        # subsequent journal writes. write_context() populates the _cache
-        # immediately, enabling append_event() to derive the journal path.
+        # 5a. Build the session context FIRST so get_session_dir() works for
+        # subsequent journal writes. build_context_cache() populates the _cache
+        # immediately (for every frame), enabling append_event() to derive the
+        # journal path; persist_context() then writes the file (lead frames only).
         # Defensive substitution: the RA1+RG2 schema validator (commit 2d6448c)
         # rejects empty strings for str-typed required fields, so an empty
         # session_id would cause append_event() to silently drop the
@@ -915,8 +918,9 @@ def main():
         # `~/.claude/pact-sessions/{slug}/unknown-a3f9b2c4/`. session_end's
         # cleanup_old_sessions filters by strict _UUID_PATTERN, which
         # "unknown-*" never matches — so these directories accumulate
-        # indefinitely. Gate BOTH persistence call sites (write_context and
-        # append_event) on session_id_was_missing to prevent the leak. The
+        # indefinitely. Gate BOTH persistence call sites (the
+        # build_context_cache/persist_context pair and append_event) on
+        # session_id_was_missing to prevent the leak. The
         # existing CLAUDE.md guard at step 5b handles its own persistence.
         # The session_start journal anchor event is intentionally dropped on
         # the malformed-stdin path: without a valid session_id, we cannot
@@ -1041,8 +1045,8 @@ def main():
                 # Fail-open: context file is best-effort; hooks fall back to empty strings
                 print(f"session_init: could not write context file: {e}", file=sys.stderr)
 
-            # Write session_start event to journal (after write_context so path is
-            # available). Lead-only (#877): the journal session_start anchor is a
+            # Write session_start event to journal (after build_context_cache so
+            # path is available). Lead-only (#877): the journal session_start anchor is a
             # lead-only write — a teammate/plain frame would append a phantom
             # anchor to (or create) a session journal it does not own.
             # `source` is the already-normalized value from the `_VALID_SOURCES`
@@ -1070,7 +1074,7 @@ def main():
             team_exists = False
 
         # Resolve session_dir early so substitution instructions can include it.
-        # get_session_dir() works here because write_context() populated _cache above.
+        # get_session_dir() works here because build_context_cache() populated _cache above.
         # Suppress session_dir for the unknown-* sentinel so the literal
         # `.../unknown-xxxx/` path never leaks into the substitution instructions
         # block — otherwise the orchestrator would obediently mkdir that path

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -84,6 +84,7 @@ from shared.pact_context import (
     is_lead,
     persist_context,
 )
+from shared.dispatch_helpers import is_registered_pact_specialist
 from shared.session_journal import append_event, make_event
 from shared.failure_log import append_failure
 from shared.plugin_manifest import format_plugin_banner
@@ -137,6 +138,55 @@ _UNKNOWN_ROLE_NOTICE = (
     "meant to drive PACT as the orchestrator, relaunch with "
     "`--agent PACT:pact-orchestrator`."
 )
+
+
+def _should_warn_unknown_role(input_data: dict) -> bool:
+    """Decide whether the #878 unknown-role startup notice should fire.
+
+    Fires when the frame has NO recognized PACT role:
+      classify_session_role == "unknown"  (agent_type absent)
+        OR
+      agent_type is present AND NOT is_lead AND NOT a recognized specialist.
+
+    The "present-but-unrecognized" arm catches a mis-launched / typo'd
+    agent_type (e.g. ``--agent pact-architct``) that the absent-only check
+    misses. Recognized = the live ``agents/pact-*.md`` registry (SSOT), tested
+    via ``is_registered_pact_specialist``.
+
+    ORDERING IS LOAD-BEARING — do NOT reorder (security-engineer ruling):
+    ``is_lead`` is checked BEFORE the registry. ``pact-orchestrator.md`` IS in
+    the glob set, so the registry would recognize the unqualified lead spelling
+    as a "specialist" — but is_lead short-circuits first, so a genuine lead is
+    never mis-bucketed and a registered-lead-spelling edge can't suppress the
+    notice for a frame that should get it.
+
+    plugin_root is read from the ENV (``CLAUDE_PLUGIN_ROOT``), NOT the cache:
+    this notice fires BEFORE build_context_cache populates the pact_context
+    cache, so a cache-backed registry lookup would see an empty plugin_root →
+    empty registry → every teammate would false-fire the notice. The env is the
+    authoritative pre-cache source (it is the same value the cache later copies).
+
+    SPELLING-SYMMETRY: strip a leading ``PACT:`` before the membership test, so
+    a qualified specialist spelling (``PACT:pact-backend-coder``) is recognized
+    just as is_lead accepts both qualified and unqualified lead spellings.
+
+    FAIL-OPEN residual: when even the env plugin_root is empty/unresolvable, the
+    registry is empty and a present-but-non-lead frame fires the notice. That is
+    correct — an install with no resolvable plugin_root is broken, and a
+    spurious advisory notice is harmless (the notice never DENIES).
+    """
+    if classify_session_role(input_data) == "unknown":
+        return True
+    if is_lead(input_data):
+        return False
+    agent_type = input_data.get("agent_type")
+    if not isinstance(agent_type, str):
+        # Present-but-non-string (unhashable/odd) agent_type: not lead, not a
+        # resolvable specialist spelling → treat as unrecognized → fire.
+        return True
+    stripped = agent_type.removeprefix("PACT:")
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT", "")
+    return not is_registered_pact_specialist(stripped, plugin_root=plugin_root)
 
 
 def check_pinned_staleness():
@@ -741,15 +791,18 @@ def main():
                 system_messages.append(_INPROCESS_MODE_NOTICE)
 
         # 0c. Unknown-role startup warning (#878). The lead-only writes in
-        # steps 5a/5b/8 are gated behind is_lead below; an "unknown" role
-        # (no `--agent` flag) silently performs none of them. Surface that so a
+        # steps 5a/5b/8 are gated behind is_lead below; a frame with NO
+        # recognized role (no `--agent` flag, OR a present-but-unrecognized /
+        # typo'd agent_type) silently performs none of them. Surface that so a
         # mis-launched orchestrator is observable. Conditional emission mirroring
         # the 0b notice shape (NOT a new numbered init step — keeps clear of the
         # module/main() docstring-parity convention). Launch events only
         # (startup/resume): a mid-launch compact/clear context-reset must not
-        # re-fire it. classify_session_role is total (never raises); no
-        # try/except needed at the call site.
-        if source in ("startup", "resume") and classify_session_role(input_data) == "unknown":
+        # re-fire it. The unknown-role decision (incl. the is_lead-first ordering,
+        # the live specialist-registry check against env plugin_root, and the
+        # PACT:-strip) lives in _should_warn_unknown_role — total (never raises),
+        # so no try/except is needed at the call site.
+        if source in ("startup", "resume") and _should_warn_unknown_role(input_data):
             system_messages.append(_UNKNOWN_ROLE_NOTICE)
 
         # 1. Set up plugin symlinks (enables @~/.claude/protocols/pact-plugin/ references)

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -77,7 +77,12 @@ from pin_caps import (  # noqa: F401
 
 from shared import BOOTSTRAP_MARKER_NAME, SESSION_ID_CONTROL_CHARS_RE, build_session_path
 from shared.constants import COMPACT_SUMMARY_PATH
-from shared.pact_context import get_session_dir, write_context
+from shared.pact_context import (
+    classify_session_role,
+    get_session_dir,
+    is_lead,
+    write_context,
+)
 from shared.session_journal import append_event, make_event
 from shared.failure_log import append_failure
 from shared.plugin_manifest import format_plugin_banner
@@ -113,6 +118,23 @@ _INPROCESS_MODE_NOTICE = (
     "(the lead can sit idle awaiting a wake that needs a manual nudge). "
     "For hands-off runs, relaunch with `--teammate-mode tmux` for reliable "
     "native delivery, or keep a heartbeat — see reference/unattended-runs.md."
+)
+
+# Unknown-role startup warning (#878). The lead-only writes below are gated
+# behind is_lead, which keys on the harness-set agent_type field. A session
+# launched WITHOUT `--agent` (or with a non-PACT agent_type) carries no
+# recognizable role — classify_session_role() returns "unknown" — so its
+# session_init silently performs none of the lead-only writes. That is the
+# intended fail-toward-teammate direction, but it is invisible to an operator
+# who MEANT to launch the orchestrator and forgot the flag. This notice makes
+# that case observable. Emitted via system_messages (user-facing) only for the
+# "unknown" role; lead and teammate frames never see it. Pure literal so tests
+# can pin the exact substring.
+_UNKNOWN_ROLE_NOTICE = (
+    "PACT: this session has no recognized agent role (no `--agent` flag, or an "
+    "unrecognized agent_type), so lead-only session setup was skipped. If you "
+    "meant to drive PACT as the orchestrator, relaunch with "
+    "`--agent PACT:pact-orchestrator`."
 )
 
 
@@ -717,6 +739,18 @@ def main():
             except Exception:  # noqa: BLE001 — fail-safe → emit; never block init
                 system_messages.append(_INPROCESS_MODE_NOTICE)
 
+        # 0c. Unknown-role startup warning (#878). The lead-only writes in
+        # steps 5a/5b/8 are gated behind is_lead below; an "unknown" role
+        # (no `--agent` flag) silently performs none of them. Surface that so a
+        # mis-launched orchestrator is observable. Conditional emission mirroring
+        # the 0b notice shape (NOT a new numbered init step — keeps clear of the
+        # module/main() docstring-parity convention). Launch events only
+        # (startup/resume): a mid-launch compact/clear context-reset must not
+        # re-fire it. classify_session_role is total (never raises); no
+        # try/except needed at the call site.
+        if source in ("startup", "resume") and classify_session_role(input_data) == "unknown":
+            system_messages.append(_UNKNOWN_ROLE_NOTICE)
+
         # 1. Set up plugin symlinks (enables @~/.claude/protocols/pact-plugin/ references)
         # Context resets (compact/clear): symlinks are already set up from original session
         if not is_context_reset:
@@ -928,29 +962,47 @@ def main():
                 file=sys.stderr,
             )
         plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT", "")
+        # Lead-role gate (#877). is_lead is total (never raises) and reads only
+        # the harness-set agent_type. Computed once and reused for both Class-A
+        # writes below so the disk-write split and the journal-anchor gate share
+        # one verdict.
+        frame_is_lead = is_lead(input_data)
         if not session_id_was_missing:
             try:
-                write_context(team_name, session_id, project_dir, plugin_root)
+                # SPLIT (#877): always populate the in-process cache/path so
+                # get_session_dir() and append_event's path-resolution behave
+                # identically for every frame; gate ONLY the disk write on
+                # is_lead so a teammate/plain frame never clobbers the lead's
+                # on-disk session-context file (or creates a phantom session
+                # dir). See write_context's DISK-WRITE / CACHE SPLIT docstring.
+                write_context(
+                    team_name, session_id, project_dir, plugin_root,
+                    write_disk=frame_is_lead,
+                )
             except Exception as e:
                 # Fail-open: context file is best-effort; hooks fall back to empty strings
                 print(f"session_init: could not write context file: {e}", file=sys.stderr)
 
-            # Write session_start event to journal (after write_context so path is available).
+            # Write session_start event to journal (after write_context so path is
+            # available). Lead-only (#877): the journal session_start anchor is a
+            # lead-only write — a teammate/plain frame would append a phantom
+            # anchor to (or create) a session journal it does not own.
             # `source` is the already-normalized value from the `_VALID_SOURCES`
             # check above — one of {startup, resume, compact, clear, unknown}.
             # Persisting it here gives downstream triage direct attribution for
             # marker-wipe and other source-conditioned behavior, instead of
             # forcing triangulation from timing clusters (#414 R2).
-            append_event(
-                make_event(
-                    "session_start",
-                    team=team_name,
-                    session_id=session_id,
-                    project_dir=project_dir,
-                    worktree="",  # Not yet created at this point
-                    source=source,
-                ),
-            )
+            if frame_is_lead:
+                append_event(
+                    make_event(
+                        "session_start",
+                        team=team_name,
+                        session_id=session_id,
+                        project_dir=project_dir,
+                        worktree="",  # Not yet created at this point
+                        source=source,
+                    ),
+                )
 
         try:
             team_config = Path.home() / ".claude" / "teams" / team_name / "config.json"
@@ -1136,7 +1188,11 @@ def main():
         # _extract_prev_session_dir, and session_end.py:cleanup_old_sessions
         # filters by _UUID_PATTERN (which "unknown-*" never matches), so the
         # directory would accumulate indefinitely.
-        if not _is_unknown_or_missing_session(session_id):
+        # Lead-only (#877): the CLAUDE.md "## Current Session" block is the true
+        # CROSS-PROCESS CLOBBER — a teammate/plain frame writing it overwrites
+        # the lead's session block in the shared project file. Gate on is_lead
+        # in addition to the existing sentinel guard.
+        if frame_is_lead and not _is_unknown_or_missing_session(session_id):
             session_msg = update_session_info(session_id, team_name, session_dir, plugin_root)
             if session_msg:
                 if "failed" in session_msg.lower() or "skipped" in session_msg.lower():
@@ -1163,10 +1219,16 @@ def main():
         if session_snapshot:
             context_parts.append(session_snapshot)
 
-        # 8. Check for paused work from previous session's /PACT:pause
-        paused_msg = check_paused_state(prev_session_dir=prev_session_dir)
-        if paused_msg:
-            context_parts.append(paused_msg)
+        # 8. Check for paused work from previous session's /PACT:pause.
+        # Lead-only (#877): mechanically this is a READ (it surfaces a
+        # resume/paused-work prompt, not a write), but surfacing the lead's
+        # paused-work is a lead-only operation — a teammate/plain frame must not
+        # receive the lead's resume prompt. Gate the check itself so a non-lead
+        # frame does no journal read either.
+        if frame_is_lead:
+            paused_msg = check_paused_state(prev_session_dir=prev_session_dir)
+            if paused_msg:
+                context_parts.append(paused_msg)
 
         # Build output
         output = {}

--- a/pact-plugin/hooks/shared/__init__.py
+++ b/pact-plugin/hooks/shared/__init__.py
@@ -113,6 +113,8 @@ from .pact_context import (
     is_lead,
     classify_session_role,
     LEAD_AGENT_TYPES,
+    build_context_cache,
+    persist_context,
     write_context,
 )
 
@@ -175,5 +177,7 @@ __all__ = [
     "is_lead",
     "classify_session_role",
     "LEAD_AGENT_TYPES",
+    "build_context_cache",
+    "persist_context",
     "write_context",
 ]

--- a/pact-plugin/hooks/shared/__init__.py
+++ b/pact-plugin/hooks/shared/__init__.py
@@ -110,6 +110,9 @@ from .pact_context import (
     get_session_id,
     get_project_dir,
     resolve_agent_name,
+    is_lead,
+    classify_session_role,
+    LEAD_AGENT_TYPES,
     write_context,
 )
 
@@ -169,5 +172,8 @@ __all__ = [
     "get_session_id",
     "get_project_dir",
     "resolve_agent_name",
+    "is_lead",
+    "classify_session_role",
+    "LEAD_AGENT_TYPES",
     "write_context",
 ]

--- a/pact-plugin/hooks/shared/dispatch_helpers.py
+++ b/pact-plugin/hooks/shared/dispatch_helpers.py
@@ -76,19 +76,21 @@ SOLO_EXEMPT = frozenset({"general-purpose", "Explore", "Plan"})
 
 # ─── specialist registry ───────────────────────────────────────────────────
 
-@functools.lru_cache(maxsize=1)
-def _specialist_registry() -> frozenset[str]:
-    """Glob agents/pact-*.md once per hook subprocess.
+def _glob_specialists(plugin_root: str) -> frozenset[str]:
+    """Glob the specialist stems at ``{plugin_root}/agents/pact-*.md``.
 
-    Hook subprocesses are short-lived (per-tool-call); the cache is rebuilt
-    on every dispatch evaluation. Empty plugin_root or missing agents/
-    directory → empty registry → every pact-* dispatch is DENIED
-    (registry fail-closed). pact-orchestrator.md IS in the glob set;
-    the "orchestrator is the persona, not a dispatchable specialist"
-    semantic is enforced at a different layer (system-prompt --agent
-    flag at session start), not at the registry.
+    Uncached, pure-of-cache: the caller supplies plugin_root explicitly. Empty
+    plugin_root or missing agents/ directory → empty frozenset (registry
+    fail-closed); OSError → empty frozenset. ``pact-orchestrator.md`` IS in the
+    glob set; the "orchestrator is the persona, not a dispatchable specialist"
+    semantic is enforced at a different layer (system-prompt --agent flag at
+    session start), not at the registry.
+
+    Extracted from ``_specialist_registry`` (#878) so the cached registry and
+    an explicit-root caller (the session_init startup notice, which runs BEFORE
+    the pact_context cache is populated and so must pass an env-resolved root)
+    share ONE glob implementation without parameterizing the lru_cache.
     """
-    plugin_root = pact_context.get_plugin_root()
     if not plugin_root:
         return frozenset()
     agents_dir = Path(plugin_root) / "agents"
@@ -98,11 +100,42 @@ def _specialist_registry() -> frozenset[str]:
         return frozenset()
 
 
-def is_registered_pact_specialist(subagent_type: str) -> bool:
-    """True iff subagent_type matches a file at ``agents/pact-*.md``."""
+@functools.lru_cache(maxsize=1)
+def _specialist_registry() -> frozenset[str]:
+    """Glob agents/pact-*.md once per hook subprocess (cached, arg-less).
+
+    Hook subprocesses are short-lived (per-tool-call); the cache is rebuilt
+    on every dispatch evaluation. Resolves plugin_root from the pact_context
+    cache and delegates the glob to ``_glob_specialists``. Deliberately
+    ARG-LESS so the lru_cache holds exactly one entry per subprocess (the hot
+    dispatch path); the explicit-root path the startup notice needs pre-cache
+    goes through ``_glob_specialists`` directly, never through this cache.
+    Empty plugin_root / missing agents/ → empty registry (fail-closed).
+    """
+    return _glob_specialists(pact_context.get_plugin_root())
+
+
+def is_registered_pact_specialist(
+    subagent_type: str, plugin_root: str = ""
+) -> bool:
+    """True iff subagent_type matches a file at ``agents/pact-*.md``.
+
+    ``plugin_root`` (#878, additive + backward-compatible): when a non-empty
+    plugin_root is passed, resolve the registry against it directly via
+    ``_glob_specialists`` (the uncached path) — required by the session_init
+    startup notice, which runs BEFORE the pact_context cache is populated, so
+    the cached ``_specialist_registry()`` would see an empty plugin_root and
+    wrongly report every type as unregistered there. When omitted/empty (every
+    existing caller, e.g. the dispatch self-completion gate), fall back to the
+    cached ``_specialist_registry()`` — identical behavior to before this param
+    existed.
+    """
     if not isinstance(subagent_type, str) or not subagent_type:
         return False
-    return subagent_type in _specialist_registry()
+    registry = (
+        _glob_specialists(plugin_root) if plugin_root else _specialist_registry()
+    )
+    return subagent_type in registry
 
 
 # ─── task-assigned check ───────────────────────────────────────────────────

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -506,6 +506,7 @@ def write_context(
     session_id: str,
     project_dir: str,
     plugin_root: str = "",
+    write_disk: bool = True,
 ) -> None:
     """
     Write the session context file. Called ONLY by session_init.py.
@@ -521,11 +522,27 @@ def write_context(
     Also sets _context_path so subsequent reads in the same process use the
     correct path (relevant for session_init.py which may read context after writing).
 
+    DISK-WRITE / CACHE SPLIT (#877 — the one non-mechanical lead-gate site):
+    this function COUPLES two responsibilities — (1) the on-disk session-context
+    file and (2) the in-process ``_cache`` / ``_context_path`` population that
+    ``get_session_dir()`` and ``append_event()``'s implicit path-resolution read.
+    The on-disk file is the lead-only artifact a teammate frame must NOT clobber
+    (#877); but ``session_init`` does NOT call ``pact_context.init()`` — it relies
+    on this function to populate the cache, so blanket-gating the whole call
+    would also starve same-process readers of the cache. ``write_disk``
+    decouples the two: gate ONLY the disk side-effect on ``is_lead`` while
+    populating the cache UNCONDITIONALLY. Non-lead frames thus get identical
+    in-memory cache behavior (no behavior change for ``get_session_dir()``) but
+    perform NO disk write. ``write_disk=True`` preserves the historical
+    lead-path behavior byte-for-byte.
+
     Args:
         team_name: The generated team name (e.g., "pact-0001639f")
         session_id: Session ID from stdin JSON or env var
         project_dir: CLAUDE_PROJECT_DIR value
         plugin_root: CLAUDE_PLUGIN_ROOT value (path to installed plugin directory)
+        write_disk: When False, populate the in-process cache/path but skip the
+            on-disk write (non-lead frames — #877). Defaults to True (lead path).
     """
     global _context_path, _cache
 
@@ -553,6 +570,16 @@ def write_context(
             "pact_context: skipping write — session_id or project_dir unavailable",
             file=sys.stderr,
         )
+        return
+
+    # Non-lead frame (#877): populate the in-process cache/path so same-process
+    # readers (get_session_dir, append_event path-resolution) behave exactly as
+    # on the lead path, but do NOT touch disk — the on-disk session-context file
+    # is a lead-only artifact and a teammate write would create a phantom
+    # session dir. No mkdir, no temp file, no rename.
+    if not write_disk:
+        _context_path = target
+        _cache = context
         return
 
     context_dir = target.parent

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -371,11 +371,12 @@ def is_lead(input_data: dict) -> bool:
     definitionally not a lead spelling anyway, so it short-circuits to False.
     ``dict.get`` on a non-dict input would still raise, so callers that may pass
     a non-dict must guard upstream; in practice every hook parses stdin into a
-    dict before calling. Totality preserves each gate's existing exception-fail-
-    CLOSED path — a raising predicate would change that fail semantics. (We
-    deliberately do NOT add an ``isinstance(input_data, dict)`` guard: it would
-    change the gates' fail-CLOSED contract, which relies on a non-dict stdin
-    raising through to each gate's own try/except.)
+    dict before calling. Totality preserves each gate's existing exception
+    posture (``bootstrap_gate`` fail-CLOSED; the pin gates fail-OPEN) — a raising
+    predicate would change that per-gate fail semantics. (We deliberately do NOT
+    add an ``isinstance(input_data, dict)`` guard: it would change those per-gate
+    postures, which rely on a non-dict stdin raising through to each gate's own
+    try/except.)
 
     COORDINATION CONTROL, NOT A SECURITY BOUNDARY. This predicate decides
     *coordination* (which frame performs lead-only writes / drives the

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -364,15 +364,18 @@ def is_lead(input_data: dict) -> bool:
     ``agent_id``, environment variables, or team config — purity is a
     tested assertion (a future author must not smuggle other signals in).
 
-    TOTAL: never raises on a dict input. The membership test is guarded by
-    an ``isinstance(..., str)`` check because ``x in frozenset`` raises
-    ``TypeError`` for an unhashable ``x`` (a malformed ``agent_type`` that is
-    a list/dict) — and a non-string ``agent_type`` is definitionally not a
-    lead spelling anyway, so it short-circuits to False. ``dict.get`` on a
-    non-dict input would still raise, so callers that may pass a non-dict
-    must guard upstream; in practice every hook parses stdin into a dict
-    before calling. Totality preserves each gate's existing exception-fail-
-    CLOSED path — a raising predicate would change that fail semantics.
+    TOTAL (given a dict): never raises when ``input_data`` is a dict. The
+    membership test is guarded by an ``isinstance(..., str)`` check because
+    ``x in frozenset`` raises ``TypeError`` for an unhashable ``x`` (a malformed
+    ``agent_type`` that is a list/dict) — and a non-string ``agent_type`` is
+    definitionally not a lead spelling anyway, so it short-circuits to False.
+    ``dict.get`` on a non-dict input would still raise, so callers that may pass
+    a non-dict must guard upstream; in practice every hook parses stdin into a
+    dict before calling. Totality preserves each gate's existing exception-fail-
+    CLOSED path — a raising predicate would change that fail semantics. (We
+    deliberately do NOT add an ``isinstance(input_data, dict)`` guard: it would
+    change the gates' fail-CLOSED contract, which relies on a non-dict stdin
+    raising through to each gate's own try/except.)
 
     COORDINATION CONTROL, NOT A SECURITY BOUNDARY. This predicate decides
     *coordination* (which frame performs lead-only writes / drives the
@@ -418,12 +421,13 @@ def classify_session_role(input_data: dict) -> str:
     Returns:
         One of ``"lead"``, ``"teammate"``, ``"unknown"``.
     """
-    agent_type = input_data.get("agent_type")
-    # Mirror is_lead's isinstance guard so the membership test stays TOTAL
-    # for an unhashable (list/dict) agent_type.
-    if isinstance(agent_type, str) and agent_type in LEAD_AGENT_TYPES:
+    # Delegate the lead test to is_lead so there is a SINGLE expression of
+    # "what lead means" (DRY) — a future change to the lead predicate (e.g.
+    # normalization) then lands in one place. is_lead carries the isinstance
+    # guard that keeps the membership test TOTAL for an unhashable agent_type.
+    if is_lead(input_data):
         return "lead"
-    if agent_type:
+    if input_data.get("agent_type"):
         return "teammate"
     return "unknown"
 

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -339,6 +339,95 @@ def resolve_agent_name(
     return ""
 
 
+# Lead agent_type spellings — the single source of truth for is_lead /
+# classify_session_role. Both forms the harness can stamp when the
+# orchestrator is launched: the qualified `--agent PACT:pact-orchestrator`
+# and the unqualified `--agent pact-orchestrator`. Case-SENSITIVE exact
+# match (a mixed-case spelling is NOT a lead). Deliberately a 2-element
+# literal, NOT derived from _specialist_registry(): pact-orchestrator.md
+# lives in agents/, so a registry-derived set would both conflate the
+# orchestrator with a specialist AND miss the qualified `PACT:` spelling.
+LEAD_AGENT_TYPES = frozenset({"PACT:pact-orchestrator", "pact-orchestrator"})
+
+
+def is_lead(input_data: dict) -> bool:
+    """Return True iff this hook frame belongs to the PACT team-lead.
+
+    Reads the TOP-LEVEL ``agent_type`` field DIRECTLY (not via
+    ``resolve_agent_name``) and tests membership in ``LEAD_AGENT_TYPES``.
+    Reading ``agent_type`` directly drops ``resolve_agent_name``'s Step-4
+    prefix-strip ambiguity and the ``agent_id`` resolution surface entirely
+    out of the role decision: the lead/teammate question reduces to one
+    dict lookup on one harness-set field.
+
+    PURE: reads ONLY ``agent_type``. Never reads ``tool_input``,
+    ``agent_id``, environment variables, or team config — purity is a
+    tested assertion (a future author must not smuggle other signals in).
+
+    TOTAL: never raises on a dict input. The membership test is guarded by
+    an ``isinstance(..., str)`` check because ``x in frozenset`` raises
+    ``TypeError`` for an unhashable ``x`` (a malformed ``agent_type`` that is
+    a list/dict) — and a non-string ``agent_type`` is definitionally not a
+    lead spelling anyway, so it short-circuits to False. ``dict.get`` on a
+    non-dict input would still raise, so callers that may pass a non-dict
+    must guard upstream; in practice every hook parses stdin into a dict
+    before calling. Totality preserves each gate's existing exception-fail-
+    CLOSED path — a raising predicate would change that fail semantics.
+
+    COORDINATION CONTROL, NOT A SECURITY BOUNDARY. This predicate decides
+    *coordination* (which frame performs lead-only writes / drives the
+    bootstrap gate), not *authorization*. Lead, teammate, and plain frames
+    all run as the same OS user, so there is no privilege boundary to
+    breach here. ``agent_type`` is harness-spawn-set from process context
+    and is NOT reflectable from untrusted request content (prompt text,
+    file-under-review, tool arguments cannot forge it) — but a future
+    author must NOT hang an access-control decision on this function.
+
+    Args:
+        input_data: Parsed stdin JSON from the hook.
+
+    Returns:
+        True iff ``input_data["agent_type"]`` is one of LEAD_AGENT_TYPES.
+    """
+    agent_type = input_data.get("agent_type")
+    # isinstance guard keeps the predicate TOTAL: `x in frozenset` raises
+    # TypeError for an unhashable x (list/dict). A non-string agent_type is
+    # not a lead spelling, so short-circuit to False.
+    return isinstance(agent_type, str) and agent_type in LEAD_AGENT_TYPES
+
+
+def classify_session_role(input_data: dict) -> str:
+    """Classify the hook frame's session role as a 3-way value.
+
+    A bare ``is_lead`` boolean cannot separate "teammate" from "neither"
+    (a non-PACT / no-``--agent`` primary frame). The startup warning in
+    session_init needs that distinction — it fires ONLY for the "unknown"
+    role — so this companion classifier reads the same ``agent_type`` field
+    and the same ``LEAD_AGENT_TYPES`` SSOT as ``is_lead``.
+
+        lead     := agent_type in LEAD_AGENT_TYPES
+        teammate := agent_type present (truthy) and not in LEAD_AGENT_TYPES
+        unknown  := agent_type absent (None / missing / empty)
+
+    PURE / TOTAL on the same contract as ``is_lead``. Same coordination-not-
+    security caveat applies.
+
+    Args:
+        input_data: Parsed stdin JSON from the hook.
+
+    Returns:
+        One of ``"lead"``, ``"teammate"``, ``"unknown"``.
+    """
+    agent_type = input_data.get("agent_type")
+    # Mirror is_lead's isinstance guard so the membership test stays TOTAL
+    # for an unhashable (list/dict) agent_type.
+    if isinstance(agent_type, str) and agent_type in LEAD_AGENT_TYPES:
+        return "lead"
+    if agent_type:
+        return "teammate"
+    return "unknown"
+
+
 def _iter_members(
     team_name: str,
     teams_dir: str | None = None,

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -501,48 +501,43 @@ def _lookup_agent_in_team_config(
     return ""
 
 
-def write_context(
+def build_context_cache(
     team_name: str,
     session_id: str,
     project_dir: str,
     plugin_root: str = "",
-    write_disk: bool = True,
-) -> None:
-    """
-    Write the session context file. Called ONLY by session_init.py.
+) -> tuple[Path, dict] | None:
+    """Build the session context dict + path and populate the in-process cache.
 
-    Computes the session-scoped path from session_id and project_dir:
-        ~/.claude/pact-sessions/{project-slug}/{session-id}/pact-session-context.json
-    Requires session_id and project_dir — returns without writing if either
-    is missing (the fail-open read behavior handles the no-file case).
+    PURE of disk I/O: this is the cache-half of the session-context write. It
+    builds the ``context`` dict, resolves the session-scoped ``target`` path,
+    and populates the module-level ``_cache`` / ``_context_path`` so same-process
+    readers (``get_session_dir()`` and ``append_event()``'s implicit
+    path-resolution) work immediately — but it NEVER touches disk.
 
-    Uses atomic write (write to temp file, then os.rename) for crash safety.
-    File permissions: 0o600 (user-only read/write).
+    Returns ``(target, context)`` so a caller can pass them straight to
+    ``persist_context()``; returns ``None`` when the session-scoped path cannot
+    be computed (missing ``session_id`` / ``project_dir``), preserving the
+    historical skip-write behavior (readers fall back to ``_EMPTY_CONTEXT``).
 
-    Also sets _context_path so subsequent reads in the same process use the
-    correct path (relevant for session_init.py which may read context after writing).
-
-    DISK-WRITE / CACHE SPLIT (#877 — the one non-mechanical lead-gate site):
-    this function COUPLES two responsibilities — (1) the on-disk session-context
-    file and (2) the in-process ``_cache`` / ``_context_path`` population that
-    ``get_session_dir()`` and ``append_event()``'s implicit path-resolution read.
-    The on-disk file is the lead-only artifact a teammate frame must NOT clobber
-    (#877); but ``session_init`` does NOT call ``pact_context.init()`` — it relies
-    on this function to populate the cache, so blanket-gating the whole call
-    would also starve same-process readers of the cache. ``write_disk``
-    decouples the two: gate ONLY the disk side-effect on ``is_lead`` while
-    populating the cache UNCONDITIONALLY. Non-lead frames thus get identical
-    in-memory cache behavior (no behavior change for ``get_session_dir()``) but
-    perform NO disk write. ``write_disk=True`` preserves the historical
-    lead-path behavior byte-for-byte.
+    CACHE OWNERSHIP (#877, the disk/cache seam): this function is the SOLE owner
+    of ``_cache`` / ``_context_path``. The cache is the PROCESS'S OWN working
+    context — populated UNCONDITIONALLY for every frame (lead, teammate, plain),
+    independent of whether the disk file is ever persisted. Disk persistence is
+    a separate, ``is_lead``-gated best-effort side-effect (``persist_context``)
+    for OTHER processes to read; a non-lead frame builds+caches and never
+    persists, and a lead frame whose ``persist_context`` later raises STILL has
+    its correct in-memory context (it is NOT unset on persist failure). This
+    uniform rule replaced the old ``write_disk`` flag — see ``persist_context``.
 
     Args:
         team_name: The generated team name (e.g., "pact-0001639f")
         session_id: Session ID from stdin JSON or env var
         project_dir: CLAUDE_PROJECT_DIR value
         plugin_root: CLAUDE_PLUGIN_ROOT value (path to installed plugin directory)
-        write_disk: When False, populate the in-process cache/path but skip the
-            on-disk write (non-lead frames — #877). Defaults to True (lead path).
+
+    Returns:
+        ``(target, context)`` on success, or ``None`` if the path is uncomputable.
     """
     global _context_path, _cache
 
@@ -564,24 +559,39 @@ def write_context(
             _build_session_path(slug, session_id) / "pact-session-context.json"
         )
     else:
-        # Cannot compute session-scoped path — skip writing.
+        # Cannot compute session-scoped path — skip.
         # Readers fall back to empty context via _EMPTY_CONTEXT.
         print(
             "pact_context: skipping write — session_id or project_dir unavailable",
             file=sys.stderr,
         )
-        return
+        return None
 
-    # Non-lead frame (#877): populate the in-process cache/path so same-process
-    # readers (get_session_dir, append_event path-resolution) behave exactly as
-    # on the lead path, but do NOT touch disk — the on-disk session-context file
-    # is a lead-only artifact and a teammate write would create a phantom
-    # session dir. No mkdir, no temp file, no rename.
-    if not write_disk:
-        _context_path = target
-        _cache = context
-        return
+    # Populate the in-process cache UNCONDITIONALLY (Option A). The cache is the
+    # process's own working truth; disk persistence is an independent side-effect.
+    _context_path = target
+    _cache = context
+    return target, context
 
+
+def persist_context(target: Path, context: dict) -> None:
+    """Atomically write the session context to disk. The impure half of the seam.
+
+    Writes ``context`` to ``target`` via a temp file + ``os.rename`` (crash-safe
+    atomic write), 0o600 permissions. Called ONLY for a lead frame (the on-disk
+    session-context file is a lead-only artifact a teammate/plain frame must NOT
+    clobber — #877). Fail-open: any error is logged and swallowed.
+
+    DOES NOT touch ``_cache`` / ``_context_path`` — ``build_context_cache`` is the
+    sole owner of cache state (Option A). A persist failure therefore leaves the
+    process's in-memory context intact (correct values), rather than unsetting it
+    and degrading the lead to empty strings. ``target`` / ``context`` are exactly
+    the pair returned by ``build_context_cache``.
+
+    Args:
+        target: The resolved session-context file path (from build_context_cache).
+        context: The context dict to serialize (from build_context_cache).
+    """
     context_dir = target.parent
     try:
         context_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -604,16 +614,48 @@ def write_context(
             except OSError:
                 pass
             raise
-
-        # Only after successful rename: update module state so reads in the
-        # same process find the file. Populate _cache so get_session_dir()
-        # works right after write_context() within the same process (e.g.,
-        # session_init.py). On rename failure, the cache stays unset and the
-        # in-memory state matches the on-disk state (no file).
-        _context_path = target
-        _cache = context
     except Exception as e:
         print(
             f"pact_context: could not write context file: {e}",
             file=sys.stderr,
         )
+
+
+def write_context(
+    team_name: str,
+    session_id: str,
+    project_dir: str,
+    plugin_root: str = "",
+) -> None:
+    """
+    Write the session context file (full op: build + cache + persist to disk).
+
+    Computes the session-scoped path from session_id and project_dir:
+        ~/.claude/pact-sessions/{project-slug}/{session-id}/pact-session-context.json
+    Requires session_id and project_dir — returns without writing if either
+    is missing (the fail-open read behavior handles the no-file case).
+
+    Uses atomic write (write to temp file, then os.rename) for crash safety.
+    File permissions: 0o600 (user-only read/write).
+
+    Also populates ``_cache`` / ``_context_path`` so subsequent reads in the same
+    process use the correct path (relevant for callers that read context after
+    writing).
+
+    SEAM (#877): this is the thin composition of the two halves —
+    ``build_context_cache`` (pure: build dict + path + populate cache) followed by
+    ``persist_context`` (impure: disk write). ``session_init`` does NOT call this
+    full op; it composes the two halves directly so it can populate the cache for
+    EVERY frame while gating the disk persist on ``is_lead`` (a teammate/plain
+    frame must not clobber the lead's on-disk file). Every OTHER caller wants the
+    full build+cache+persist and keeps this unchanged public contract.
+
+    Args:
+        team_name: The generated team name (e.g., "pact-0001639f")
+        session_id: Session ID from stdin JSON or env var
+        project_dir: CLAUDE_PROJECT_DIR value
+        plugin_root: CLAUDE_PLUGIN_ROOT value (path to installed plugin directory)
+    """
+    result = build_context_cache(team_name, session_id, project_dir, plugin_root)
+    if result is not None:
+        persist_context(*result)

--- a/pact-plugin/hooks/validate_handoff.py
+++ b/pact-plugin/hooks/validate_handoff.py
@@ -14,7 +14,7 @@ status under Agent Teams, and the team-lead may process output after this hook
 fires), so Task state cannot be reliably checked here.
 
 Input: JSON from stdin with `last_assistant_message` (preferred, SDK v2.1.47+),
-       `transcript` (fallback), and `agent_id`
+       `transcript` (fallback), and `agent_type` (the role-class gate field, #812)
 Output: JSON with `systemMessage` if handoff format is incomplete
 """
 
@@ -180,21 +180,25 @@ def validate_handoff(transcript: str) -> tuple:
     return is_valid, missing, []
 
 
-def is_pact_agent(agent_id: str) -> bool:
+def is_pact_agent(agent_identifier: str) -> bool:
     """
-    Check if the agent is a PACT framework agent.
+    Check if the agent is a PACT framework agent (role-class gate).
 
     Args:
-        agent_id: The identifier of the agent
+        agent_identifier: The agent's role identifier — under #812 this is the
+            harness-set ``agent_type`` (e.g. ``"pact-preparer"``). The ``pact-``
+            prefix family below matches ``agent_type`` values directly, so the
+            same prefix-check answers the role-class question against the field
+            that is actually present at SubagentStop.
 
     Returns:
         True if this is a PACT agent that should be validated
     """
-    if not agent_id:
+    if not agent_identifier:
         return False
 
     pact_prefixes = ["pact-", "PACT-", "pact_", "PACT_"]
-    return any(agent_id.startswith(prefix) for prefix in pact_prefixes)
+    return any(agent_identifier.startswith(prefix) for prefix in pact_prefixes)
 
 
 def main():
@@ -216,10 +220,18 @@ def main():
 
         # Prefer last_assistant_message (SDK v2.1.47+), fall back to transcript
         transcript = input_data.get("last_assistant_message", "") or input_data.get("transcript", "")
-        agent_id = input_data.get("agent_id", "")
+        # #812 role-class gate: key on the harness-set ``agent_type``, NOT
+        # ``agent_id``. agent_id is ABSENT under the separate-process teammate
+        # model (v4.4.0), so the prior agent_id-keyed check was DORMANT for all
+        # teammates — this hook fires on SubagentStop (teammate-only) and the
+        # teammate's agent_type (e.g. "pact-preparer") matches the pact- prefix.
+        # The lead's "PACT:"-prefixed agent_type never reaches this hook
+        # (SubagentStop is teammate-only). Fail-safe: advisory systemMessage, no
+        # DENY — re-enabling it can only ADD a missing-HANDOFF warning.
+        agent_type = input_data.get("agent_type", "")
 
         # Only validate PACT agents
-        if not is_pact_agent(agent_id):
+        if not is_pact_agent(agent_type):
             print(_SUPPRESS_OUTPUT)
             sys.exit(0)
 
@@ -231,14 +243,14 @@ def main():
 
             if not is_valid and missing:
                 warnings.append(
-                    f"PACT Handoff Warning: Agent '{agent_id}' completed without "
+                    f"PACT Handoff Warning: Agent '{agent_type}' completed without "
                     f"proper handoff. Missing: {', '.join(missing)}. "
                     "Consider including: what was produced, key decisions, and next steps."
                 )
 
             if lossless_missing:
                 warnings.append(
-                    f"PACT Lossless Field Warning: Agent '{agent_id}' HANDOFF "
+                    f"PACT Lossless Field Warning: Agent '{agent_type}' HANDOFF "
                     f"section is missing: {', '.join(lossless_missing)}. "
                     "These fields preserve information that would otherwise be lost."
                 )

--- a/pact-plugin/tests/conftest.py
+++ b/pact-plugin/tests/conftest.py
@@ -131,3 +131,32 @@ def _reset_pact_context_state():
     ctx_module.reset_for_tests()
     yield
     ctx_module.reset_for_tests()
+
+
+@pytest.fixture(autouse=True)
+def _reset_specialist_registry_cache():
+    """Unconditional cross-test isolation for ``dispatch_helpers``'s
+    ``_specialist_registry`` ``@lru_cache``. Runs for EVERY test (autouse).
+
+    F1 (#883 fold-in). ``_specialist_registry`` memoizes the globbed
+    ``agents/pact-*.md`` registry (keyed on the pact_context-resolved
+    ``plugin_root``) for the life of the process. Like ``pact_context``'s
+    ``_cache`` / ``_context_path`` (reset by the sibling fixture above), an
+    uncleared lru_cache leaks a stale — or empty — registry across tests: the
+    same #845-class order-dependent pollution vector, now more exposed since the
+    suite exercises the registry more (the is_lead startup-notice path + the
+    dispatch tests). Cleared before AND after every test (symmetric), mirroring
+    the pact_context reset.
+
+    DELIBERATELY A SEPARATE FIXTURE (SRP): the sibling
+    ``_reset_pact_context_state`` is the documented single-source-of-truth for
+    ``pact_context``'s module-globals; folding a second module's cache-clear into
+    it would muddy that scope. Each autouse reset owns exactly one module's
+    state. (``cache_clear`` is the lru_cache-provided reset; a future removal of
+    the ``@lru_cache`` decorator on ``_specialist_registry`` must update this.)
+    """
+    import shared.dispatch_helpers as dispatch_helpers
+
+    dispatch_helpers._specialist_registry.cache_clear()
+    yield
+    dispatch_helpers._specialist_registry.cache_clear()

--- a/pact-plugin/tests/fixtures/role_frames.py
+++ b/pact-plugin/tests/fixtures/role_frames.py
@@ -1,0 +1,54 @@
+"""Synthesized hook-stdin role frames for the lead/teammate discriminator.
+
+These are SYNTHESIZED-from-matrix frames, NOT verbatim captured stdin: the
+raw platform frames were not persisted in this session. The shape matches the
+documented v4.4.0 / CC 2.1.158 capture matrix (teammate hook stdin carries
+``agent_type`` on every event; ``agent_id`` / ``agent_name`` are ABSENT under
+tmux; ``teammate_name`` appears only on TeammateIdle). Every frame carries a
+``_meta.capture_method`` stamp so no reader mistakes them for recovered
+captures. If byte-exact frames are ever needed, re-capture freshly per the
+capture spec in docs/plans/hook-lead-discriminator-fix-plan.md.
+
+Consumed by test_is_lead.py (predicate truth-table) and the per-hook
+suppression tests (session_init / postcompact_archive gate behavior).
+"""
+
+_CAPTURE_METHOD = "synthesized-from-matrix (v4.4.0 / CC 2.1.158); not a captured frame"
+
+
+def _frame(agent_type, **extra):
+    """Build a synthesized hook-stdin frame with the role-discriminator field.
+
+    ``agent_type`` is the only field is_lead/classify_session_role read; the
+    optional ``extra`` kwargs let a caller add event-specific fields
+    (``hook_event_name``, ``session_id``, ``compact_summary``, …) for the
+    per-hook suppression tests without re-stamping provenance each time.
+
+    Pass ``agent_type=None`` for the "unknown" / plain-frame role (the field
+    is omitted entirely, matching a no-``--agent`` primary frame).
+    """
+    frame = {"_meta": {"capture_method": _CAPTURE_METHOD}}
+    if agent_type is not None:
+        frame["agent_type"] = agent_type
+    frame.update(extra)
+    return frame
+
+
+def lead_frame_qualified(**extra):
+    """Lead launched as ``--agent PACT:pact-orchestrator`` (qualified)."""
+    return _frame("PACT:pact-orchestrator", **extra)
+
+
+def lead_frame_unqualified(**extra):
+    """Lead launched as ``--agent pact-orchestrator`` (unqualified)."""
+    return _frame("pact-orchestrator", **extra)
+
+
+def teammate_frame(agent_type="pact-backend-coder", **extra):
+    """A PACT specialist teammate frame (agent_type present, not a lead)."""
+    return _frame(agent_type, **extra)
+
+
+def plain_frame(**extra):
+    """A non-PACT / no-``--agent`` primary frame (agent_type absent)."""
+    return _frame(None, **extra)

--- a/pact-plugin/tests/fixtures/role_frames.py
+++ b/pact-plugin/tests/fixtures/role_frames.py
@@ -52,3 +52,14 @@ def teammate_frame(agent_type="pact-backend-coder", **extra):
 def plain_frame(**extra):
     """A non-PACT / no-``--agent`` primary frame (agent_type absent)."""
     return _frame(None, **extra)
+
+
+def postcompact_frame(agent_type, compact_summary="post-compaction summary text"):
+    """A synthesized PostCompact hook-stdin frame for the #881 gate tests.
+
+    PostCompact frames carry ``compact_summary``; ``agent_type`` carries the
+    role discriminator the is_lead gate keys on. Pass ``agent_type=None`` for a
+    plain frame (the field is omitted).
+    """
+    return _frame(agent_type, hook_event_name="PostCompact",
+                  compact_summary=compact_summary)

--- a/pact-plugin/tests/fixtures/role_frames.py
+++ b/pact-plugin/tests/fixtures/role_frames.py
@@ -1,13 +1,31 @@
 """Synthesized hook-stdin role frames for the lead/teammate discriminator.
 
-These are SYNTHESIZED-from-matrix frames, NOT verbatim captured stdin: the
-raw platform frames were not persisted in this session. The shape matches the
-documented v4.4.0 / CC 2.1.158 capture matrix (teammate hook stdin carries
-``agent_type`` on every event; ``agent_id`` / ``agent_name`` are ABSENT under
-tmux; ``teammate_name`` appears only on TeammateIdle). Every frame carries a
-``_meta.capture_method`` stamp so no reader mistakes them for recovered
-captures. If byte-exact frames are ever needed, re-capture freshly per the
-capture spec in docs/plans/hook-lead-discriminator-fix-plan.md.
+PROVENANCE — these are SYNTHESIZED-from-matrix frames, NOT verbatim captured
+stdin: the raw platform frames were not persisted in this session. The shape
+matches the documented v4.4.0 / CC 2.1.158 capture matrix (teammate hook stdin
+carries ``agent_type`` on every event; ``agent_id`` / ``agent_name`` are ABSENT
+under tmux; ``teammate_name`` appears only on TeammateIdle). Every frame carries
+a ``_meta.capture_method`` stamp so no reader ever mistakes them for recovered
+captures.
+
+RE-CAPTURE PROCEDURE (and why it is GATED on adopting tmux):
+  The actual real-frame re-capture CANNOT be done from the current in-process
+  teammateMode — in-process teammates do not fire their own separate hook
+  lifecycle with the tmux frame shape, so there is no genuine teammate stdin to
+  capture here. Re-capture therefore stays GATED on actually adopting tmux
+  teammateMode for an unattended run. When that happens, the procedure is:
+    1. On a scratch branch, add a passive additive hook (PostToolUse /
+       SubagentStart / PreToolUse-TaskUpdate) that appends raw ``sys.stdin`` to
+       a session-id-filtered capture file — over those 3 events, to settle the
+       per-event ``agent_name`` / ``agent_id`` presence under tmux.
+    2. Run a real tmux PACT session (lead + ≥1 specialist teammate) so each
+       process fires its own hook lifecycle and real frames land in the file.
+    3. Replace these synthesized builders with the captured frames, updating
+       ``_meta.capture_method`` to record the capture date + CC build.
+  Until tmux is adopted, the synthesized shape (matched to the documented
+  matrix) is the correct and only available source — re-capture is a follow-up,
+  not a gap in this PR. See the capture spec in
+  docs/plans/hook-lead-discriminator-fix-plan.md.
 
 Consumed by test_is_lead.py (predicate truth-table) and the per-hook
 suppression tests (session_init / postcompact_archive gate behavior).

--- a/pact-plugin/tests/test_bootstrap_gate.py
+++ b/pact-plugin/tests/test_bootstrap_gate.py
@@ -106,14 +106,24 @@ _CANONICAL_DENY_REASON_LITERAL = (
 # =============================================================================
 
 
-def _make_input(tool_name="Edit", session_id=_SESSION_ID):
-    """Build a minimal PreToolUse hook input dict."""
-    return {
+def _make_input(tool_name="Edit", session_id=_SESSION_ID,
+                agent_type="pact-orchestrator"):
+    """Build a minimal PreToolUse hook input dict.
+
+    #878: the gate now keys lead-detection on the harness-set agent_type via
+    is_lead. The default is a LEAD frame (the unmarked case these DENY tests
+    historically assumed via empty resolve_agent_name). Teammate/non-lead tests
+    pass agent_type=<teammate> or agent_type=None to exercise the bypass branch.
+    """
+    data = {
         "hook_event_name": "PreToolUse",
         "session_id": session_id,
         "tool_name": tool_name,
         "tool_input": {},
     }
+    if agent_type is not None:
+        data["agent_type"] = agent_type
+    return data
 
 
 def _run_main(input_data, capsys):
@@ -288,38 +298,32 @@ class TestCheckToolAllowed:
         assert result is None
 
     def test_teammate_allows_all(self, monkeypatch, tmp_path):
-        """Teammate → None even for blocked tools."""
+        """Teammate (non-lead agent_type) → None even for blocked tools.
+
+        #878: lead-detection migrated to is_lead, which reads agent_type. A
+        specialist agent_type is not a lead spelling, so the gate bypasses.
+        """
         from bootstrap_gate import _check_tool_allowed
 
         _setup_pact_session(monkeypatch, tmp_path, with_marker=False)
 
-        input_data = _make_input("Edit")
-        input_data["agent_name"] = "backend-coder"
+        input_data = _make_input("Edit", agent_type="pact-backend-coder")
 
         result = _check_tool_allowed(input_data)
         assert result is None
 
-    def test_teammate_via_agent_id(self, monkeypatch, tmp_path):
-        """Teammate via agent_id format → None."""
+    def test_teammate_via_qualified_agent_type(self, monkeypatch, tmp_path):
+        """Teammate carrying a qualified non-lead agent_type → None.
+
+        #878: the gate no longer resolves agent_id/agent_name — it reads
+        agent_type directly. A `PACT:`-qualified specialist type is not a lead
+        spelling, so the gate bypasses.
+        """
         from bootstrap_gate import _check_tool_allowed
-        import shared.pact_context as ctx_module
 
-        session_dir = _setup_pact_session(monkeypatch, tmp_path, with_marker=False)
+        _setup_pact_session(monkeypatch, tmp_path, with_marker=False)
 
-        # Override context to have a team_name
-        plugin_root = tmp_path / "plugin"
-        context_file = session_dir / "pact-session-context.json"
-        context_file.write_text(json.dumps({
-            "team_name": "pact-test1234",
-            "session_id": _SESSION_ID,
-            "project_dir": _PROJECT_DIR,
-            "plugin_root": str(plugin_root),
-            "started_at": "2026-01-01T00:00:00Z",
-        }), encoding="utf-8")
-        ctx_module._cache = None
-
-        input_data = _make_input("Write")
-        input_data["agent_id"] = "backend-coder@pact-test1234"
+        input_data = _make_input("Write", agent_type="PACT:pact-backend-coder")
 
         result = _check_tool_allowed(input_data)
         assert result is None
@@ -409,11 +413,10 @@ class TestMainEntryPoint:
         assert output == _SUPPRESS_EXPECTED
 
     def test_teammate_exits_0(self, monkeypatch, tmp_path, capsys):
-        """Teammate → exit 0."""
+        """Teammate (non-lead agent_type) → exit 0 (bypass, no DENY)."""
         _setup_pact_session(monkeypatch, tmp_path, with_marker=False)
 
-        input_data = _make_input("Edit")
-        input_data["agent_name"] = "backend-coder"
+        input_data = _make_input("Edit", agent_type="pact-backend-coder")
 
         exit_code, output = _run_main(input_data, capsys)
         assert exit_code == 0
@@ -655,11 +658,16 @@ def _setup_pact_session_with_team(monkeypatch, tmp_path, team_name="t1",
     return session_dir
 
 
-def _canonical_secretary_input(team_name="t1", overrides=None):
+def _canonical_secretary_input(team_name="t1", overrides=None,
+                               agent_type="pact-orchestrator"):
     """Build the canonical Agent(secretary) PreToolUse input.
 
     overrides: dict merged into tool_input to forge mismatched bindings
     in negative tests.
+
+    #878: the gate keys lead-detection on is_lead (the harness-set agent_type).
+    The secretary-spawn carve-out only applies on the LEAD path (the lead's
+    pre-bootstrap secretary dispatch), so the default is a lead agent_type.
     """
     tool_input = {
         "subagent_type": "pact-secretary",
@@ -668,12 +676,15 @@ def _canonical_secretary_input(team_name="t1", overrides=None):
     }
     if overrides:
         tool_input.update(overrides)
-    return {
+    data = {
         "hook_event_name": "PreToolUse",
         "session_id": _SESSION_ID,
         "tool_name": "Agent",
         "tool_input": tool_input,
     }
+    if agent_type is not None:
+        data["agent_type"] = agent_type
+    return data
 
 
 class TestCanonicalSecretarySpawnCarveOut:
@@ -1472,6 +1483,7 @@ class TestCanonicalSecretarySpawnAdversarial:
             "hook_event_name": "PreToolUse",
             "session_id": _SESSION_ID,
             "tool_name": "Agent",
+            "agent_type": "pact-orchestrator",  # #878: lead frame reaches the gate body
             "tool_input": tool_input_value,
         }
         result = _check_tool_allowed(input_data)
@@ -1510,6 +1522,7 @@ class TestCanonicalSecretarySpawnAdversarial:
             "hook_event_name": "PreToolUse",
             "session_id": _SESSION_ID,
             "tool_name": "Agent",
+            "agent_type": "pact-orchestrator",  # #878: lead frame reaches the gate body
             "tool_input": canonical,
         }
         result = _check_tool_allowed(input_data)
@@ -1565,6 +1578,7 @@ class TestCanonicalSecretarySpawnAdversarial:
         input_data = {
             "hook_event_name": "PreToolUse",
             "session_id": _SESSION_ID,
+            "agent_type": "pact-orchestrator",  # #878: lead frame reaches the gate body
             "tool_input": {
                 "subagent_type": "pact-secretary",
                 "name": "secretary",
@@ -2051,6 +2065,7 @@ class TestCanonicalSecretarySpawnAdversarial:
                 "hook_event_name": "PreToolUse",
                 "session_id": _SESSION_ID,
                 "tool_name": "Agent",
+                "agent_type": "pact-orchestrator",  # #878: lead frame reaches the gate body
                 "tool_input": {"name": "secretary", "team_name": "t1"},
             }
         else:

--- a/pact-plugin/tests/test_bootstrap_marker_writer.py
+++ b/pact-plugin/tests/test_bootstrap_marker_writer.py
@@ -82,14 +82,24 @@ _PLUGIN_VERSION = "9.9.9"
 # =============================================================================
 
 
-def _make_input(session_id=_SESSION_ID, source="startup"):
-    """Build a minimal UserPromptSubmit hook input dict."""
-    return {
+def _make_input(session_id=_SESSION_ID, source="startup",
+                agent_type="pact-orchestrator"):
+    """Build a minimal UserPromptSubmit hook input dict.
+
+    #878: the writer now keys lead-detection on the harness-set agent_type via
+    is_lead. The default is a LEAD frame (the unmarked case these tests
+    historically assumed). Teammate/non-lead tests pass agent_type=<teammate>
+    or agent_type=None to exercise the bypass branch.
+    """
+    data = {
         "hook_event_name": "UserPromptSubmit",
         "session_id": session_id,
         "prompt": "Hello world",
         "source": source,
     }
+    if agent_type is not None:
+        data["agent_type"] = agent_type
+    return data
 
 
 def _setup_session(monkeypatch, tmp_path, *, with_team_config=False,
@@ -359,17 +369,20 @@ class TestVerifyAndRefuse:
         assert marker.read_bytes() == before
 
     def test_teammate_session_skips_writer(self, monkeypatch, tmp_path, capsys):
-        """Teammate session (resolve_agent_name returns non-empty) → no
-        marker write. Teammates don't drive bootstrap."""
+        """Teammate session (non-lead agent_type) → no marker write.
+        Teammates don't drive bootstrap.
+
+        #878: lead-detection migrated to is_lead, which reads agent_type. A
+        specialist agent_type is not a lead spelling, so the writer bypasses.
+        """
         members = [
             {"id": "agent-uuid-xyz", "name": "secretary"},
             {"id": "agent-uuid-tm", "name": "backend-coder"},
         ]
         session_dir, _ = _setup_session(monkeypatch, tmp_path,
                                         with_team_config=True, members=members)
-        # Teammate input shape: agent_id matching a member entry.
-        input_data = _make_input()
-        input_data["agent_id"] = "agent-uuid-tm"
+        # Teammate input shape: a non-lead agent_type.
+        input_data = _make_input(agent_type="pact-backend-coder")
         code, out = _run_main(input_data, capsys)
         assert code == 0
         assert out == _SUPPRESS_EXPECTED
@@ -1085,11 +1098,13 @@ class TestSubprocessIntegration:
         )
         assert hook_path.exists(), f"writer hook missing at {hook_path}"
 
+        # #878: lead frame (agent_type) so the is_lead-gated writer runs.
         stdin_payload = json.dumps({
             "hook_event_name": "UserPromptSubmit",
             "session_id": session_id,
             "prompt": "first real prompt",
             "source": "startup",
+            "agent_type": "pact-orchestrator",
         })
 
         env = os.environ.copy()

--- a/pact-plugin/tests/test_bootstrap_prompt_gate.py
+++ b/pact-plugin/tests/test_bootstrap_prompt_gate.py
@@ -6,7 +6,7 @@ Tests cover:
 1. Marker exists → suppressOutput (fast path, zero tokens)
 2. No marker + PACT team-lead session → inject additionalContext with bootstrap instruction
 3. Non-PACT session (no session dir) → suppressOutput (no-op passthrough)
-4. Teammate (agent_name non-empty) → suppressOutput (no-op passthrough)
+4. Teammate / non-lead frame (non-lead agent_type) → suppressOutput (no-op passthrough)
 5. Malformed stdin JSON → fail-open (suppressOutput, exit 0)
 6. Exception in _check_bootstrap_needed → fail-open (suppressOutput, exit 0)
 7. main() entry point: exit codes, output format, JSON structure
@@ -43,14 +43,24 @@ _SLUG = "project"
 # =============================================================================
 
 
-def _make_input(session_id=_SESSION_ID, source="startup"):
-    """Build a minimal UserPromptSubmit hook input dict."""
-    return {
+def _make_input(session_id=_SESSION_ID, source="startup",
+                agent_type="pact-orchestrator"):
+    """Build a minimal UserPromptSubmit hook input dict.
+
+    #878: the gate now keys lead-detection on the harness-set agent_type via
+    is_lead. The default is a LEAD frame (the unmarked case these tests
+    historically assumed). Teammate/non-lead tests pass agent_type=<teammate>
+    or agent_type=None to exercise the bypass branch.
+    """
+    data = {
         "hook_event_name": "UserPromptSubmit",
         "session_id": session_id,
         "prompt": "Hello world",
         "source": source,
     }
+    if agent_type is not None:
+        data["agent_type"] = agent_type
+    return data
 
 
 def _run_main(input_data, capsys):
@@ -157,37 +167,32 @@ class TestCheckBootstrapNeeded:
         assert result is None
 
     def test_returns_none_for_teammate(self, monkeypatch, tmp_path):
-        """Teammate (agent_name resolved) → None (passthrough)."""
+        """Teammate (non-lead agent_type) → None (passthrough).
+
+        #878: lead-detection migrated to is_lead, which keys on agent_type. A
+        specialist agent_type is not a lead spelling, so the gate bypasses.
+        """
         from bootstrap_prompt_gate import _check_bootstrap_needed
 
         _setup_pact_session(monkeypatch, tmp_path, with_marker=False)
 
-        input_data = _make_input()
-        input_data["agent_name"] = "backend-coder"
+        input_data = _make_input(agent_type="pact-backend-coder")
 
         result = _check_bootstrap_needed(input_data)
         assert result is None
 
-    def test_teammate_with_agent_id_format(self, monkeypatch, tmp_path):
-        """Teammate identified via agent_id 'name@team' format → None."""
+    def test_teammate_with_qualified_agent_type(self, monkeypatch, tmp_path):
+        """Teammate carrying a qualified non-lead agent_type → None.
+
+        #878: the gate no longer resolves agent_id/agent_name — it reads
+        agent_type directly. A `PACT:`-qualified specialist type is still not a
+        lead spelling, so the gate bypasses.
+        """
         from bootstrap_prompt_gate import _check_bootstrap_needed
-        import shared.pact_context as ctx_module
 
-        session_dir = _setup_pact_session(monkeypatch, tmp_path, with_marker=False)
+        _setup_pact_session(monkeypatch, tmp_path, with_marker=False)
 
-        # Override context to have a team_name (needed for agent_id resolution)
-        context_file = session_dir / "pact-session-context.json"
-        context_file.write_text(json.dumps({
-            "team_name": "pact-test1234",
-            "session_id": _SESSION_ID,
-            "project_dir": _PROJECT_DIR,
-            "plugin_root": "",
-            "started_at": "2026-01-01T00:00:00Z",
-        }), encoding="utf-8")
-        ctx_module._cache = None
-
-        input_data = _make_input()
-        input_data["agent_id"] = "backend-coder@pact-test1234"
+        input_data = _make_input(agent_type="PACT:pact-backend-coder")
 
         result = _check_bootstrap_needed(input_data)
         assert result is None
@@ -257,11 +262,10 @@ class TestMainEntryPoint:
         assert output == _SUPPRESS_EXPECTED
 
     def test_suppress_for_teammate(self, monkeypatch, tmp_path, capsys):
-        """Teammate → suppressOutput."""
+        """Teammate (non-lead agent_type) → suppressOutput."""
         _setup_pact_session(monkeypatch, tmp_path, with_marker=False)
 
-        input_data = _make_input()
-        input_data["agent_name"] = "backend-coder"
+        input_data = _make_input(agent_type="pact-backend-coder")
 
         _, output = _run_main(input_data, capsys)
         assert output == _SUPPRESS_EXPECTED

--- a/pact-plugin/tests/test_dispatch_gate.py
+++ b/pact-plugin/tests/test_dispatch_gate.py
@@ -1027,3 +1027,77 @@ def test_mixed_case_team_name_normalizes_consistently(tmp_path, monkeypatch, cap
         f"Mixed-case team_name should normalize and ALLOW (canonical "
         f"lowercase form passes all rules); got code={code} out={out}"
     )
+
+
+# ===========================================================================
+# #878 #1: is_registered_pact_specialist additive plugin_root param
+# (Option X seam: cached registry untouched; uncached _glob_specialists shared)
+# ===========================================================================
+
+class TestIsRegisteredSpecialistPluginRootParam:
+    """The additive ``plugin_root`` param is backward-compatible: existing
+    callers passing NOTHING resolve via the cached registry exactly as before;
+    the new explicit-root path (the session_init startup notice) globs directly.
+    """
+
+    def test_existing_caller_no_plugin_root_arg_resolves_via_cache(
+        self, monkeypatch, tmp_path
+    ):
+        """(f) BACKWARD-COMPAT PIN: a caller passing NO plugin_root (the existing
+        self-completion-gate / dispatch path) still resolves via the cached
+        _specialist_registry() reading the pact_context cache — identical to
+        before the param existed."""
+        import shared.dispatch_helpers as dh
+
+        plugin_root = tmp_path / "plugin"
+        _seed_plugin(plugin_root, agents=("pact-architect", "pact-backend-coder"))
+        _setup_session(monkeypatch, tmp_path, plugin_root)  # wires cache + cache_clear
+
+        # No plugin_root arg → cached cache-read path.
+        assert dh.is_registered_pact_specialist("pact-architect") is True
+        assert dh.is_registered_pact_specialist("pact-backend-coder") is True
+        assert dh.is_registered_pact_specialist("pact-not-a-real-agent") is False
+        # Empty/non-str guard unchanged.
+        assert dh.is_registered_pact_specialist("") is False
+        assert dh.is_registered_pact_specialist(None) is False  # type: ignore[arg-type]
+
+    def test_explicit_plugin_root_globs_directly_uncached(self, monkeypatch, tmp_path):
+        """The explicit-root path resolves against the PASSED plugin_root via the
+        uncached _glob_specialists — independent of the pact_context cache (which
+        is empty at the 0c notice site)."""
+        import shared.dispatch_helpers as dh
+        import shared.pact_context as ctx_module
+
+        plugin_root = tmp_path / "plugin"
+        _seed_plugin(plugin_root, agents=("pact-architect",))
+        # Deliberately leave the pact_context cache EMPTY (the 0c condition):
+        monkeypatch.setattr(ctx_module, "_context_path", None)
+        monkeypatch.setattr(ctx_module, "_cache", None)
+        dh._specialist_registry.cache_clear()
+
+        # No-arg path sees the empty cache → empty registry → not registered.
+        assert dh.is_registered_pact_specialist("pact-architect") is False, (
+            "with an empty cache the cached path must NOT resolve — this is the "
+            "exact 0c timing trap the explicit-root param fixes"
+        )
+        # Explicit plugin_root path globs the real dir → registered.
+        assert dh.is_registered_pact_specialist(
+            "pact-architect", plugin_root=str(plugin_root)
+        ) is True
+        assert dh.is_registered_pact_specialist(
+            "pact-not-real", plugin_root=str(plugin_root)
+        ) is False
+
+    def test_explicit_empty_plugin_root_falls_back_to_cache(self, monkeypatch, tmp_path):
+        """An explicitly-passed EMPTY plugin_root ("") is treated as 'not
+        provided' → cache fallback (so the param default and an explicit ""
+        behave identically)."""
+        import shared.dispatch_helpers as dh
+
+        plugin_root = tmp_path / "plugin"
+        _seed_plugin(plugin_root, agents=("pact-architect",))
+        _setup_session(monkeypatch, tmp_path, plugin_root)
+
+        assert dh.is_registered_pact_specialist(
+            "pact-architect", plugin_root=""
+        ) is True  # "" → cache fallback, which resolves to the seeded root

--- a/pact-plugin/tests/test_error_output.py
+++ b/pact-plugin/tests/test_error_output.py
@@ -650,8 +650,11 @@ class TestPostcompactArchiveErrorOutput:
     def test_exception_outputs_json_with_system_message(self, capsys):
         from postcompact_archive import main
 
+        # #881: the compact-summary write is gated behind is_lead, so a LEAD
+        # frame (agent_type) is required for the patched side-effect to fire.
         input_data = json.dumps({
             "compact_summary": "test summary",
+            "agent_type": "pact-orchestrator",
         })
 
         with patch("sys.stdin", io.StringIO(input_data)), \
@@ -668,8 +671,10 @@ class TestPostcompactArchiveErrorOutput:
         """stderr should contain the hook name and the specific error message."""
         from postcompact_archive import main
 
+        # #881: lead frame so the gated write (and its side-effect) executes.
         input_data = json.dumps({
             "compact_summary": "test summary",
+            "agent_type": "pact-orchestrator",
         })
 
         with patch("sys.stdin", io.StringIO(input_data)), \

--- a/pact-plugin/tests/test_file_tracker.py
+++ b/pact-plugin/tests/test_file_tracker.py
@@ -279,3 +279,99 @@ class TestMainEntryPoint:
         # Issue #658: hookEventName is required by the harness schema; missing
         # it causes the harness to silently fail open (additionalContext dropped).
         assert output["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
+
+
+class TestFileTrackerCompositeKey:
+    """NEW-1 (#878): the editor key is the composite (agent_name, session_id),
+    so same-agent_type instances are distinguished under tmux.
+
+    Smoke tests for the functional fix; comprehensive matrix is the TEST phase.
+    """
+
+    def test_same_agent_type_distinct_sessions_conflict_detected(self, tmp_path):
+        """Two backend-coder instances (same agent_name, DIFFERENT session_id)
+        editing one file → conflict DETECTED. The prior agent-name-only key
+        false-negatived this under tmux. Only ONE other instance exists here,
+        so the label is the bare name (no session suffix — disambiguation only
+        kicks in when a name is shared across multiple OTHER editors)."""
+        from file_tracker import track_edit, check_conflict
+
+        tracking_file = str(tmp_path / "file-edits.json")
+        abs_path = str(tmp_path / "src" / "auth.ts")
+
+        # Instance A edits.
+        track_edit(abs_path, "backend-coder", "Edit", tracking_file, session_id="sess-aaaa")
+        # Instance B (same agent_name, different session) checks before editing.
+        conflict = check_conflict(abs_path, "backend-coder", tracking_file, session_id="sess-bbbb")
+        assert conflict is not None
+        assert "auth.ts" in conflict
+        assert "backend-coder" in conflict
+
+    def test_two_same_name_other_instances_label_disambiguated(self, tmp_path):
+        """When TWO other editors share an agent_name (different sessions), the
+        labels are disambiguated with a session suffix so the message names two
+        distinct editors rather than a confusing repeated bare name."""
+        from file_tracker import track_edit, check_conflict
+
+        tracking_file = str(tmp_path / "file-edits.json")
+        abs_path = str(tmp_path / "src" / "auth.ts")
+
+        track_edit(abs_path, "backend-coder", "Edit", tracking_file, session_id="sess-aaaa")
+        track_edit(abs_path, "backend-coder", "Edit", tracking_file, session_id="sess-bbbb")
+        # A third instance checks.
+        conflict = check_conflict(abs_path, "backend-coder", tracking_file, session_id="sess-cccc")
+        assert conflict is not None
+        assert "session sess-aaa" in conflict
+        assert "session sess-bbb" in conflict
+
+    def test_same_instance_twice_no_false_positive(self, tmp_path):
+        """The SAME instance (same agent_name AND session_id) editing twice is
+        NOT a conflict."""
+        from file_tracker import track_edit, check_conflict
+
+        tracking_file = str(tmp_path / "file-edits.json")
+        abs_path = str(tmp_path / "src" / "auth.ts")
+
+        track_edit(abs_path, "backend-coder", "Edit", tracking_file, session_id="sess-aaaa")
+        conflict = check_conflict(abs_path, "backend-coder", tracking_file, session_id="sess-aaaa")
+        assert conflict is None
+
+    def test_in_process_distinct_agent_names_shared_session_detected(self, tmp_path):
+        """In-process model (one process → one shared session_id, distinct
+        agent_names) → conflict still DETECTED via the agent_name half of the
+        composite."""
+        from file_tracker import track_edit, check_conflict
+
+        tracking_file = str(tmp_path / "file-edits.json")
+        abs_path = str(tmp_path / "src" / "auth.ts")
+
+        track_edit(abs_path, "backend-coder", "Edit", tracking_file, session_id="sess-shared")
+        conflict = check_conflict(abs_path, "frontend-coder", tracking_file, session_id="sess-shared")
+        assert conflict is not None
+        assert "backend-coder" in conflict
+
+    def test_track_edit_records_session_id(self, tmp_path):
+        """The composite-key session_id component is persisted in the entry."""
+        from file_tracker import track_edit
+
+        tracking_file = tmp_path / "file-edits.json"
+        abs_path = str(tmp_path / "src" / "auth.ts")
+        track_edit(abs_path, "backend-coder", "Edit", str(tracking_file), session_id="sess-xyz")
+
+        entries = json.loads(tracking_file.read_text())
+        assert entries[0]["session_id"] == "sess-xyz"
+        assert entries[0]["agent"] == "backend-coder"  # label retained
+
+    def test_single_other_editor_label_not_disambiguated(self, tmp_path):
+        """When only ONE other editor instance exists for a name, the label is
+        the bare agent_name (no noisy session suffix)."""
+        from file_tracker import track_edit, check_conflict
+
+        tracking_file = str(tmp_path / "file-edits.json")
+        abs_path = str(tmp_path / "src" / "auth.ts")
+
+        track_edit(abs_path, "frontend-coder", "Edit", tracking_file, session_id="sess-aaaa")
+        conflict = check_conflict(abs_path, "backend-coder", tracking_file, session_id="sess-bbbb")
+        assert conflict is not None
+        assert "frontend-coder" in conflict
+        assert "session" not in conflict  # unambiguous single editor → no suffix

--- a/pact-plugin/tests/test_file_tracker_composite_key_edges.py
+++ b/pact-plugin/tests/test_file_tracker_composite_key_edges.py
@@ -1,0 +1,96 @@
+"""file_tracker composite-key — adversarial / backward-compat edges (#878 NEW-1).
+
+The coder's test_file_tracker.py::TestFileTrackerCompositeKey covers the plan's
+P1 matrix (same-type distinct-session detection, label disambiguation,
+same-instance no-false-positive, in-process shared-session detection, session_id
+persistence, single-editor-no-disambiguation). This file is the adversarial
+supplement: the edges that matrix does not exercise —
+
+  * backward-compat: a LEGACY entry written before the composite key existed
+    (no ``session_id`` field) behaves as session_id="" and does not corrupt
+    detection,
+  * the empty-``agent_name`` early-return (a frame whose resolve_agent_name
+    yielded "" must short-circuit to no-conflict),
+  * a mixed legacy/new shape where the same name appears once WITH and once
+    WITHOUT a session_id (two distinct composite keys → a real conflict).
+"""
+
+import json
+
+import pytest
+
+
+class TestCompositeKeyBackwardCompat:
+    """Entries predating the session_id field default to session_id="" and
+    must not break detection."""
+
+    def test_legacy_entry_no_session_field_treated_as_empty_session(self, tmp_path):
+        """A tracking entry written WITHOUT a session_id key (legacy shape) is
+        read as session_id="" — a new instance of the SAME name with a real
+        session is a DIFFERENT composite → conflict detected."""
+        from file_tracker import check_conflict
+
+        tracking_file = tmp_path / "file-edits.json"
+        abs_path = str(tmp_path / "src" / "auth.ts")
+        # Hand-write a legacy entry: no "session_id" key at all.
+        legacy = [{"file": __import__("os").path.realpath(abs_path),
+                   "agent": "backend-coder", "tool": "Edit", "ts": 1}]
+        tracking_file.write_text(json.dumps(legacy))
+
+        conflict = check_conflict(
+            abs_path, "backend-coder", str(tracking_file), session_id="sess-new"
+        )
+        assert conflict is not None, (
+            "a legacy (session-less) entry must still count as a distinct "
+            "editor instance vs a new session — conflict detected"
+        )
+        assert "backend-coder" in conflict
+
+    def test_same_name_legacy_and_self_session_less_is_self(self, tmp_path):
+        """A legacy entry (session-less) and a current frame that ALSO has no
+        session_id share the SAME composite ('backend-coder', '') → it is the
+        SAME instance → NO false-positive conflict."""
+        from file_tracker import track_edit, check_conflict
+
+        tracking_file = str(tmp_path / "file-edits.json")
+        abs_path = str(tmp_path / "src" / "auth.ts")
+        # track_edit with the default empty session_id (legacy-equivalent).
+        track_edit(abs_path, "backend-coder", "Edit", tracking_file)
+        conflict = check_conflict(abs_path, "backend-coder", tracking_file)
+        assert conflict is None, (
+            "same name + same (empty) session = same instance → no conflict"
+        )
+
+    def test_same_name_one_with_one_without_session_conflicts(self, tmp_path):
+        """The same agent_name appearing once WITH a session and once WITHOUT
+        are two distinct composite keys → a real cross-instance conflict."""
+        from file_tracker import track_edit, check_conflict
+
+        tracking_file = str(tmp_path / "file-edits.json")
+        abs_path = str(tmp_path / "src" / "auth.ts")
+        # Instance A: legacy (no session).
+        track_edit(abs_path, "backend-coder", "Edit", tracking_file)
+        # Instance B: same name, real session → distinct composite → checks.
+        conflict = check_conflict(
+            abs_path, "backend-coder", tracking_file, session_id="sess-bbbb"
+        )
+        assert conflict is not None
+        assert "backend-coder" in conflict
+
+
+class TestEmptyAgentNameShortCircuit:
+    """An empty agent_name (resolve_agent_name yielded "") short-circuits
+    check_conflict to None — no attribution is possible without a name."""
+
+    def test_empty_agent_name_returns_none(self, tmp_path):
+        from file_tracker import track_edit, check_conflict
+
+        tracking_file = str(tmp_path / "file-edits.json")
+        abs_path = str(tmp_path / "src" / "auth.ts")
+        # Another instance has edited the file.
+        track_edit(abs_path, "backend-coder", "Edit", tracking_file, session_id="s1")
+        # The checking frame has no resolvable name.
+        conflict = check_conflict(abs_path, "", tracking_file, session_id="s2")
+        assert conflict is None, (
+            "empty agent_name must short-circuit to None (cannot attribute)"
+        )

--- a/pact-plugin/tests/test_is_lead.py
+++ b/pact-plugin/tests/test_is_lead.py
@@ -1,0 +1,179 @@
+"""Tests for is_lead / classify_session_role — the lead/teammate role predicate.
+
+The predicate reads the TOP-LEVEL ``agent_type`` field directly (NOT via
+resolve_agent_name) and tests membership in LEAD_AGENT_TYPES. It is PURE
+(agent_type only), TOTAL (never raises on a dict input), case-SENSITIVE, and
+a COORDINATION control — not a security boundary.
+
+Coverage:
+
+is_lead() truth-table:
+1.  Both lead spellings → True (qualified PACT:pact-orchestrator, unqualified)
+2.  Teammate agent_type → False
+3.  Plain frame (agent_type absent) → False
+4.  Empty-string / None / non-string agent_type → False
+5.  Mixed-case lead spelling → False (case-sensitive exact match)
+6.  agent_id present but agent_type not a lead → False (#812 guard)
+
+is_lead() purity:
+7.  Does NOT read tool_input (a forged tool_input.agent_type cannot flip it)
+
+classify_session_role() 3-way:
+8.  lead / teammate / unknown across the same frame matrix
+
+LEAD_AGENT_TYPES SSOT:
+9.  Exactly the two sanctioned spellings; is_lead agrees with membership
+"""
+
+import pytest
+
+from shared.pact_context import (
+    LEAD_AGENT_TYPES,
+    classify_session_role,
+    is_lead,
+)
+from fixtures.role_frames import (
+    lead_frame_qualified,
+    lead_frame_unqualified,
+    plain_frame,
+    teammate_frame,
+)
+
+
+class TestIsLead:
+    """is_lead() truth-table — both lead spellings True, everything else False."""
+
+    def test_qualified_lead_spelling_is_lead(self):
+        """`--agent PACT:pact-orchestrator` → True."""
+        assert is_lead({"agent_type": "PACT:pact-orchestrator"}) is True
+
+    def test_unqualified_lead_spelling_is_lead(self):
+        """`--agent pact-orchestrator` → True."""
+        assert is_lead({"agent_type": "pact-orchestrator"}) is True
+
+    @pytest.mark.parametrize("agent_type", [
+        "pact-backend-coder",
+        "pact-test-engineer",
+        "pact-secretary",
+        "pact-orchestrator-helper",   # superstring of a lead spelling, not equal
+        "orchestrator",               # the Step-4-stripped form is NOT a lead spelling
+        "PACT:pact-backend-coder",
+    ])
+    def test_teammate_agent_types_are_not_lead(self, agent_type):
+        """Any non-lead agent_type → False."""
+        assert is_lead({"agent_type": agent_type}) is False
+
+    def test_plain_frame_is_not_lead(self):
+        """agent_type absent (no --agent / non-PACT primary) → False."""
+        assert is_lead({}) is False
+        assert is_lead({"session_id": "abc", "hook_event_name": "SessionStart"}) is False
+
+    @pytest.mark.parametrize("agent_type", [
+        "",        # empty string (falsy, not in set)
+        None,      # explicit None
+        123,       # non-string int
+        ["pact-orchestrator"],  # unhashable list — isinstance(str) guard keeps it total
+        {"x": 1},  # unhashable dict — isinstance(str) guard keeps it total
+    ])
+    def test_non_lead_agent_type_values_are_not_lead(self, agent_type):
+        """Empty / None / non-string agent_type → False, never raises.
+
+        The unhashable (list / dict) cases specifically pin TOTALITY: a bare
+        ``x in frozenset`` would raise TypeError for them; the isinstance(str)
+        guard short-circuits to False instead.
+        """
+        assert is_lead({"agent_type": agent_type}) is False
+
+    @pytest.mark.parametrize("agent_type", [
+        "PACT:PACT-ORCHESTRATOR",
+        "Pact-Orchestrator",
+        "PACT:Pact-Orchestrator",
+        "pact-Orchestrator",
+    ])
+    def test_mixed_case_lead_spelling_is_not_lead(self, agent_type):
+        """Case-SENSITIVE exact match — a mixed-case spelling is NOT a lead."""
+        assert is_lead({"agent_type": agent_type}) is False
+
+    def test_agent_id_present_but_not_orchestrator_is_not_lead(self):
+        """#812 guard: an agent_id field never promotes a non-lead to lead.
+
+        is_lead ignores agent_id entirely — only agent_type decides. A frame
+        carrying an agent_id (e.g. a future CC build re-adds it) with a
+        non-lead agent_type stays False.
+        """
+        frame = {"agent_type": "pact-backend-coder", "agent_id": "backend-coder@team"}
+        assert is_lead(frame) is False
+
+    def test_synthesized_role_frames(self):
+        """The shared role-frame fixtures classify as expected."""
+        assert is_lead(lead_frame_qualified()) is True
+        assert is_lead(lead_frame_unqualified()) is True
+        assert is_lead(teammate_frame()) is False
+        assert is_lead(plain_frame()) is False
+
+
+class TestIsLeadPurity:
+    """is_lead must read ONLY agent_type — never tool_input, agent_id, env, config."""
+
+    def test_does_not_read_tool_input(self):
+        """A forged tool_input.agent_type cannot flip the verdict.
+
+        agent_type at top level is harness-set; tool_input is request-shaped
+        content. If is_lead ever consulted tool_input, an untrusted tool
+        argument could forge lead status. This pins it shut.
+        """
+        forged = {
+            "agent_type": "pact-backend-coder",  # genuine: a teammate
+            "tool_input": {"agent_type": "PACT:pact-orchestrator"},  # forged
+        }
+        assert is_lead(forged) is False
+
+    def test_no_agent_type_with_forged_tool_input_still_not_lead(self):
+        """Plain frame stays False even if tool_input claims lead."""
+        forged = {"tool_input": {"agent_type": "pact-orchestrator"}}
+        assert is_lead(forged) is False
+
+
+class TestClassifySessionRole:
+    """classify_session_role() — the 3-way lead/teammate/unknown classifier."""
+
+    @pytest.mark.parametrize("frame, expected", [
+        ({"agent_type": "PACT:pact-orchestrator"}, "lead"),
+        ({"agent_type": "pact-orchestrator"}, "lead"),
+        ({"agent_type": "pact-backend-coder"}, "teammate"),
+        ({"agent_type": "orchestrator"}, "teammate"),   # stripped form is a teammate, NOT lead
+        ({"agent_type": "some-non-pact-type"}, "teammate"),
+        ({}, "unknown"),                                 # absent
+        ({"agent_type": ""}, "unknown"),                 # empty == falsy == unknown
+        ({"agent_type": None}, "unknown"),               # explicit None
+    ])
+    def test_classify_matrix(self, frame, expected):
+        assert classify_session_role(frame) == expected
+
+    def test_classify_agrees_with_is_lead(self):
+        """classify==lead iff is_lead is True, across the role-frame fixtures."""
+        for builder in (lead_frame_qualified, lead_frame_unqualified):
+            frame = builder()
+            assert (classify_session_role(frame) == "lead") is is_lead(frame)
+        for frame in (teammate_frame(), plain_frame()):
+            assert classify_session_role(frame) != "lead"
+            assert is_lead(frame) is False
+
+
+class TestLeadAgentTypesSSOT:
+    """LEAD_AGENT_TYPES is the single source of truth for both helpers."""
+
+    def test_exactly_two_sanctioned_spellings(self):
+        assert LEAD_AGENT_TYPES == frozenset({"PACT:pact-orchestrator", "pact-orchestrator"})
+
+    def test_is_lead_agrees_with_membership(self):
+        """For every member, is_lead is True; for a clear non-member, False."""
+        for spelling in LEAD_AGENT_TYPES:
+            assert is_lead({"agent_type": spelling}) is True
+        assert is_lead({"agent_type": "pact-backend-coder"}) is False
+
+    def test_frozenset_is_immutable(self):
+        """A frozenset cannot be mutated in place — guards the SSOT."""
+        assert isinstance(LEAD_AGENT_TYPES, frozenset)
+        with pytest.raises(AttributeError):
+            LEAD_AGENT_TYPES.add("pact-rogue")  # type: ignore[attr-defined]

--- a/pact-plugin/tests/test_lead_discriminator_invariant.py
+++ b/pact-plugin/tests/test_lead_discriminator_invariant.py
@@ -1,0 +1,587 @@
+"""HYBRID structural invariant for the lead/teammate role discriminator.
+
+This is the drift backstop for the is_lead migration. It pins TWO
+complementary shapes into executable form so a future regression fails at
+CI time rather than silently under a live tmux session.
+
+THE MIGRATION (context):
+    The role decision used to be a NEGATIVE heuristic — ``resolve_agent_name(
+    input_data) == ""`` meant "lead". Under tmux that is wrong in BOTH
+    directions: resolve_agent_name's Step-4 strips the ``pact-`` prefix and
+    returns a NON-empty string for both lead spellings, so the v4.4.0 lead
+    took the teammate-bypass branch in every Class-B gate (the three DENY
+    gates were silently dead for the lead). The fix is a single POSITIVE
+    predicate ``is_lead(input_data)`` keyed on the harness-set top-level
+    ``agent_type`` field.
+
+THE TWO LEGS:
+
+  POSITIVE leg (``test_migrated_hooks_route_role_decision_through_is_lead``):
+    every hook that makes a lead/teammate role decision routes it through
+    ``pact_context.is_lead`` — proven by asserting each migrated hook's
+    source contains an ``is_lead(...)`` call. This leg DEPENDS on the
+    enumerated migrated-set being complete; it catches a migrated hook that
+    REGRESSES away from is_lead.
+
+  NEGATIVE leg (``test_no_hook_reintroduces_a_banned_role_signal``):
+    an AST denylist that scans ALL top-level hook files and flags any hook
+    that reintroduces a banned role signal —
+      (a) an env-var read used as a role discriminator,
+      (b) an ``agent_id``-presence role branch, or
+      (c) ``resolve_agent_name()`` used as a lead proxy
+          (``if resolve_agent_name(...)`` / ``... == "" `` / ``!= ""``).
+    This leg does NOT depend on the migrated-set being complete — it is the
+    future-drift + incomplete-migration backstop (a brand-new hook that
+    keys role off a banned signal is caught even though it is not in any
+    enumerated list).
+
+  NAMED-SITE ALLOWLIST (``_SANCTIONED_RESOLVE_AGENT_NAME_SITES``):
+    ``resolve_agent_name`` has THREE sanctioned non-role uses (human-readable
+    edit attribution / labels), which the negative leg must NOT flag. The
+    allowlist is keyed by (file, enclosing-function) and is deliberately
+    EXPLICIT rather than a structural discriminator: distinguishing
+    "resolve_agent_name as a lead proxy" from "resolve_agent_name for a
+    label" is genuinely hard to express structurally, and an auditable named
+    list makes every sanctioned site a deliberate, documented decision.
+    Adding a new sanctioned site MUST require a deliberate allowlist + test
+    update — that maintenance cost is a FEATURE (same philosophy as the
+    "new field must update this test" phantom-green guard in
+    test_first_observable_write_misfire_invariant.py).
+
+PHANTOM-GREEN PROTECTION:
+    The negative leg's value is only real if the detector actually FIRES on
+    a banned signal. ``test_negative_leg_detector_fires_on_*`` feed synthetic
+    source containing each banned shape and assert the detector flags it —
+    proving the leg is coupled to the regression, not a vacuous pass. A
+    non-vacuity guard (``test_negative_leg_scans_a_nonempty_hook_set`` +
+    ``test_allowlist_sites_are_all_real``) ensures the scan never silently
+    degrades to "found nothing because it looked at nothing".
+
+Modeled on tests/test_first_observable_write_misfire_invariant.py.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+HOOKS_DIR = Path(__file__).parent.parent / "hooks"
+
+
+# ---------------------------------------------------------------------------
+# POSITIVE leg: the migrated hooks and the role-decision symbol they route to.
+# ---------------------------------------------------------------------------
+
+# Hooks that make a lead/teammate role decision and MUST route it through
+# is_lead. Each entry is a top-level hook filename relative to hooks/. This
+# set IS the migrated Class-A (session_init, postcompact_archive) + Class-B
+# (the 5 teammate-bypass gates) surface. A migrated hook dropping its is_lead
+# call (regressing to the old heuristic) is caught here.
+MIGRATED_HOOKS: tuple[str, ...] = (
+    "session_init.py",          # Class-A: 4 lead-only writes
+    "postcompact_archive.py",   # Class-A2 (#881): compact-summary write
+    "bootstrap_gate.py",        # Class-B DENY
+    "pin_staleness_gate.py",    # Class-B DENY
+    "pin_caps_gate.py",         # Class-B DENY
+    "bootstrap_prompt_gate.py", # Class-B inject
+    "bootstrap_marker_writer.py",  # Class-B marker write
+)
+
+
+# ---------------------------------------------------------------------------
+# NEGATIVE leg: named-site allowlist for sanctioned resolve_agent_name uses.
+# ---------------------------------------------------------------------------
+
+# resolve_agent_name's sanctioned non-role uses, keyed (file, function). These
+# are human-readable edit-attribution / label uses — NOT lead-proxy role
+# decisions — so the negative leg must NOT flag them. EXPLICIT by design: a
+# new sanctioned site requires a deliberate edit here + a documented reason.
+#
+# Why each site is sanctioned:
+#   file_tracker.py / main:
+#       resolve_agent_name supplies the human-readable LABEL for the editor in
+#       the file-edit tracking record. The ROLE/uniqueness decision in
+#       file_tracker uses the composite (agent_name, session_id) editor KEY,
+#       NOT a lead/teammate verdict — resolve_agent_name here is attribution,
+#       never a lead proxy. (#878 NEW-1 KEPT-for-label.)
+#   file_tracker.py / get_environment_delta:
+#       reads the stored ``agent`` LABEL off tracking entries to attribute
+#       drift to a named editor — attribution, not a role gate. (Listed for
+#       auditability even though it reads a stored label rather than calling
+#       resolve_agent_name directly, so a future refactor that switches it to
+#       a live resolve_agent_name call stays pre-sanctioned and documented.)
+#   shared/pact_context.py / resolve_agent_name:
+#       the function's OWN definition + its internal agent_id name-resolution
+#       (Step 1-3) — this is the name-resolver itself, not a consumer keying
+#       role off it.
+_SANCTIONED_RESOLVE_AGENT_NAME_SITES: frozenset[tuple[str, str]] = frozenset({
+    ("file_tracker.py", "main"),
+    ("file_tracker.py", "get_environment_delta"),
+    ("shared/pact_context.py", "resolve_agent_name"),
+})
+
+
+def _hook_files() -> list[Path]:
+    """All top-level hook .py files (excludes __init__, shared/, tests)."""
+    return sorted(
+        p for p in HOOKS_DIR.glob("*.py")
+        if p.name != "__init__.py"
+    )
+
+
+def _enclosing_function(tree: ast.AST, target: ast.AST) -> str:
+    """Return the name of the FunctionDef enclosing ``target``, or "" if the
+    node sits at module scope. Walks the tree once building a child->name map.
+    """
+    enclosing = ""
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for child in ast.walk(node):
+                if child is target:
+                    enclosing = node.name
+                    # keep the INNERMOST function: a later (nested) match
+                    # overwrites an outer one because ast.walk yields the
+                    # outer FunctionDef first.
+    return enclosing
+
+
+# ---------------------------------------------------------------------------
+# Banned-signal detectors (operate on an AST tree + a file label).
+# ---------------------------------------------------------------------------
+
+def _find_resolve_agent_name_role_uses(
+    tree: ast.AST, file_label: str
+) -> list[tuple[str, int]]:
+    """Flag resolve_agent_name() calls used as a LEAD PROXY (banned), skipping
+    the named-site allowlist.
+
+    A "lead proxy" is any resolve_agent_name() call whose result feeds a role
+    branch. We treat EVERY call site as a candidate and rely on the named-site
+    allowlist to exempt the sanctioned attribution/label uses — this is
+    deliberately conservative (a new resolve_agent_name call in a non-
+    allowlisted site is flagged regardless of whether it textually looks like
+    a role branch), so that drift toward "resolve_agent_name == lead" cannot
+    sneak in through a site the structural matcher fails to recognize.
+
+    Returns (function_name, lineno) for each NON-allowlisted call.
+    """
+    offending: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else (
+            func.attr if isinstance(func, ast.Attribute) else None
+        )
+        if name != "resolve_agent_name":
+            continue
+        fn = _enclosing_function(tree, node)
+        if (file_label, fn) in _SANCTIONED_RESOLVE_AGENT_NAME_SITES:
+            continue
+        offending.append((fn, node.lineno))
+    return offending
+
+
+def _find_agent_id_role_uses(
+    tree: ast.AST, file_label: str
+) -> list[tuple[str, int]]:
+    """Flag reads of the ``agent_id`` stdin field used as a role discriminator.
+
+    Detects ``input_data.get("agent_id")`` / ``input_data["agent_id"]`` style
+    reads. The role decision must key on ``agent_type`` (via is_lead), never on
+    ``agent_id``-presence — agent_id is absent under tmux and its presence/
+    absence is exactly the #812 drift hazard.
+
+    validate_handoff.py is EXEMPT: its agent_id read is a role-CLASS check
+    (``is_pact_agent``), explicitly deferred to the #812 follow-up per the
+    plan's scope decision — NOT a lead/teammate discriminator. Listed by file
+    so the exemption is auditable.
+    """
+    if file_label == "validate_handoff.py":
+        return []
+    offending: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        # input_data.get("agent_id", ...)
+        if isinstance(node, ast.Call):
+            func = node.func
+            if (isinstance(func, ast.Attribute) and func.attr == "get"
+                    and node.args):
+                arg0 = node.args[0]
+                if isinstance(arg0, ast.Constant) and arg0.value == "agent_id":
+                    offending.append((_enclosing_function(tree, node), node.lineno))
+        # input_data["agent_id"]
+        if isinstance(node, ast.Subscript):
+            sl = node.slice
+            if isinstance(sl, ast.Constant) and sl.value == "agent_id":
+                offending.append((_enclosing_function(tree, node), node.lineno))
+    return offending
+
+
+def _find_env_var_role_reads(
+    tree: ast.AST, file_label: str
+) -> list[tuple[str, int]]:
+    """Flag os.environ reads of a ROLE-bearing env var.
+
+    The role decision must derive from the harness-set ``agent_type`` stdin
+    field, never from an environment variable (the old in-process model used
+    env vars; under tmux they are unreliable role signals). Matches
+    os.environ.get("...") / os.getenv("...") / os.environ["..."] whose key
+    name contains a role token (AGENT / TEAMMATE / LEAD / ORCHESTRAT / ROLE),
+    EXCLUDING the benign infra vars (CLAUDE_PROJECT_DIR, CLAUDE_PLUGIN_ROOT,
+    CLAUDE_ENV_FILE — paths, not roles).
+    """
+    role_tokens = ("AGENT", "TEAMMATE", "LEAD", "ORCHESTRAT", "ROLE")
+    benign = ("CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT", "CLAUDE_ENV_FILE")
+    offending: list[tuple[str, int]] = []
+
+    def _key_is_role(key: str) -> bool:
+        up = key.upper()
+        if up in benign:
+            return False
+        return any(tok in up for tok in role_tokens)
+
+    def _receiver_is_environ(attr_node: ast.Attribute) -> bool:
+        """True iff ``attr_node`` is ``<...>.environ.<attr>`` — so we only
+        match an os.environ ``.get`` and never ``input_data.get(...)`` /
+        ``tool_input.get(...)`` (those carry stdin role FIELDS, not env vars,
+        and are handled by the dedicated agent_id / is_lead detectors)."""
+        recv = attr_node.value
+        return isinstance(recv, ast.Attribute) and recv.attr == "environ"
+
+    for node in ast.walk(tree):
+        # os.environ.get("KEY") / os.getenv("KEY")
+        if isinstance(node, ast.Call):
+            func = node.func
+            if not (isinstance(func, ast.Attribute) and node.args):
+                continue
+            # `.get` must be on an os.environ receiver; `getenv` is always env.
+            is_env_get = (
+                (func.attr == "get" and _receiver_is_environ(func))
+                or func.attr == "getenv"
+            )
+            if is_env_get:
+                arg0 = node.args[0]
+                if isinstance(arg0, ast.Constant) and isinstance(arg0.value, str):
+                    if _key_is_role(arg0.value):
+                        offending.append((_enclosing_function(tree, node), node.lineno))
+        # os.environ["KEY"]
+        if isinstance(node, ast.Subscript):
+            value = node.value
+            is_environ = (
+                isinstance(value, ast.Attribute) and value.attr == "environ"
+            )
+            sl = node.slice
+            if is_environ and isinstance(sl, ast.Constant) and isinstance(sl.value, str):
+                if _key_is_role(sl.value):
+                    offending.append((_enclosing_function(tree, node), node.lineno))
+    return offending
+
+
+def _parse(path: Path) -> ast.AST:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+# ===========================================================================
+# POSITIVE leg
+# ===========================================================================
+
+class TestPositiveLeg:
+    """Every migrated hook routes its role decision through is_lead."""
+
+    @pytest.mark.parametrize("hook_name", MIGRATED_HOOKS)
+    def test_migrated_hook_calls_is_lead(self, hook_name):
+        """Each migrated hook's source contains an is_lead(...) call.
+
+        A migrated hook that REGRESSES away from is_lead (back to the old
+        resolve_agent_name heuristic, or to any other discriminator) drops
+        the call and fails here. Pinned by AST so a mention of ``is_lead`` in
+        a comment/docstring does NOT satisfy it — only a real Call node.
+        """
+        path = HOOKS_DIR / hook_name
+        assert path.exists(), f"Migrated hook {hook_name} not found at {path}"
+        tree = _parse(path)
+        calls_is_lead = any(
+            isinstance(n, ast.Call)
+            and (
+                (isinstance(n.func, ast.Name) and n.func.id == "is_lead")
+                or (isinstance(n.func, ast.Attribute) and n.func.attr == "is_lead")
+            )
+            for n in ast.walk(tree)
+        )
+        assert calls_is_lead, (
+            f"{hook_name} makes a lead/teammate role decision but does NOT "
+            f"call is_lead(). If this hook regressed to the old "
+            f"resolve_agent_name heuristic (or any non-is_lead discriminator), "
+            f"restore the is_lead routing. If the hook legitimately no longer "
+            f"makes a role decision, remove it from MIGRATED_HOOKS with a "
+            f"documented reason."
+        )
+
+    def test_migrated_set_is_the_full_class_a_and_class_b_surface(self):
+        """Documentation-in-code: the migrated set is exactly the 7 hooks the
+        plan enumerates (2 Class-A + 5 Class-B). Pinning the cardinality means
+        a future edit that drops a hook from the positive leg is a deliberate,
+        reviewed change — not a silent omission that would weaken the leg.
+        """
+        assert len(MIGRATED_HOOKS) == 7, (
+            f"MIGRATED_HOOKS has {len(MIGRATED_HOOKS)} entries; expected 7 "
+            f"(session_init + postcompact_archive + 5 Class-B gates). If the "
+            f"migrated surface genuinely changed, update this count with a "
+            f"documented reason."
+        )
+
+
+# ===========================================================================
+# NEGATIVE leg
+# ===========================================================================
+
+class TestNegativeLeg:
+    """No hook reintroduces a banned role signal (the drift backstop)."""
+
+    def test_no_hook_uses_resolve_agent_name_as_lead_proxy(self):
+        """AST denylist across ALL hooks: no non-allowlisted resolve_agent_name
+        call. Independent of the migrated-set — a brand-new hook keying role
+        off resolve_agent_name is caught even though it is in no enumerated
+        list.
+        """
+        offending: list[str] = []
+        for path in _hook_files():
+            label = path.name
+            for fn, lineno in _find_resolve_agent_name_role_uses(_parse(path), label):
+                offending.append(f"{label}:{lineno} (in {fn or '<module>'})")
+        assert offending == [], (
+            f"resolve_agent_name() called outside the sanctioned named-site "
+            f"allowlist: {offending}. resolve_agent_name as a role/lead proxy "
+            f"is the migrated-away-from anti-pattern. If this is a NEW "
+            f"sanctioned attribution/label use, add (file, function) to "
+            f"_SANCTIONED_RESOLVE_AGENT_NAME_SITES with a documented reason."
+        )
+
+    def test_no_hook_branches_role_on_agent_id_presence(self):
+        """AST denylist: no hook reads the agent_id stdin field for a role
+        decision (validate_handoff exempt — #812 role-class, deferred).
+        agent_id-presence is the #812 drift hazard — absent under tmux.
+        """
+        offending: list[str] = []
+        for path in _hook_files():
+            label = path.name
+            for fn, lineno in _find_agent_id_role_uses(_parse(path), label):
+                offending.append(f"{label}:{lineno} (in {fn or '<module>'})")
+        assert offending == [], (
+            f"agent_id read for a role decision: {offending}. The role "
+            f"discriminator must key on agent_type (via is_lead), never on "
+            f"agent_id-presence (absent under tmux; the #812 drift hazard). "
+            f"If this is a sanctioned non-role agent_id use, exempt the file "
+            f"in _find_agent_id_role_uses with a documented reason."
+        )
+
+    def test_no_hook_reads_a_role_env_var(self):
+        """AST denylist: no hook derives role from a role-bearing env var.
+        The role signal is harness-set agent_type stdin, not the environment.
+        """
+        offending: list[str] = []
+        for path in _hook_files():
+            label = path.name
+            for fn, lineno in _find_env_var_role_reads(_parse(path), label):
+                offending.append(f"{label}:{lineno} (in {fn or '<module>'})")
+        assert offending == [], (
+            f"role-bearing env-var read: {offending}. Role must derive from "
+            f"the harness-set agent_type stdin field, never an env var (the "
+            f"old in-process model's unreliable-under-tmux signal)."
+        )
+
+
+# ===========================================================================
+# PHANTOM-GREEN PROTECTION — prove each detector actually fires
+# ===========================================================================
+
+class TestNegativeLegDetectorsFire:
+    """Synthetic-source proofs: each banned-signal detector FIRES on the
+    shape it is meant to catch. Without these, a detector that silently
+    matches nothing would make the negative leg a vacuous always-pass.
+    """
+
+    def test_resolve_agent_name_detector_fires_on_non_allowlisted_call(self):
+        src = (
+            "def some_gate(input_data):\n"
+            "    if resolve_agent_name(input_data):\n"
+            "        return None  # teammate bypass — the banned old heuristic\n"
+        )
+        tree = ast.parse(src)
+        hits = _find_resolve_agent_name_role_uses(tree, "some_new_gate.py")
+        assert hits, (
+            "resolve_agent_name detector did NOT fire on a non-allowlisted "
+            "call — the negative leg would be vacuous."
+        )
+
+    def test_resolve_agent_name_detector_respects_allowlist(self):
+        """The same call shape inside an ALLOWLISTED (file, function) is NOT
+        flagged — proving the allowlist actually exempts, so the detector
+        isn't trivially flagging everything.
+        """
+        src = (
+            "def main(input_data):\n"
+            "    agent_name = resolve_agent_name(input_data)  # label use\n"
+            "    return agent_name\n"
+        )
+        tree = ast.parse(src)
+        hits = _find_resolve_agent_name_role_uses(tree, "file_tracker.py")
+        assert hits == [], (
+            "Allowlisted (file_tracker.py, main) resolve_agent_name use was "
+            "flagged — the named-site allowlist is not being honored."
+        )
+
+    def test_agent_id_detector_fires_on_get(self):
+        src = (
+            "def gate(input_data):\n"
+            "    if input_data.get('agent_id'):\n"
+            "        return None\n"
+        )
+        tree = ast.parse(src)
+        hits = _find_agent_id_role_uses(tree, "some_new_gate.py")
+        assert hits, "agent_id .get detector did NOT fire."
+
+    def test_agent_id_detector_fires_on_subscript(self):
+        src = (
+            "def gate(input_data):\n"
+            "    aid = input_data['agent_id']\n"
+            "    return aid\n"
+        )
+        tree = ast.parse(src)
+        hits = _find_agent_id_role_uses(tree, "some_new_gate.py")
+        assert hits, "agent_id subscript detector did NOT fire."
+
+    def test_agent_id_detector_exempts_validate_handoff(self):
+        """validate_handoff's agent_id read is the deferred #812 role-class
+        check — must NOT be flagged.
+        """
+        src = (
+            "def main(input_data):\n"
+            "    agent_id = input_data.get('agent_id', '')\n"
+            "    return is_pact_agent(agent_id)\n"
+        )
+        tree = ast.parse(src)
+        hits = _find_agent_id_role_uses(tree, "validate_handoff.py")
+        assert hits == [], (
+            "validate_handoff.py agent_id read was flagged — the #812 "
+            "role-class exemption is not being honored."
+        )
+
+    def test_env_var_detector_fires_on_role_token(self):
+        src = (
+            "import os\n"
+            "def gate(input_data):\n"
+            "    if os.environ.get('CLAUDE_AGENT_TYPE') == 'lead':\n"
+            "        return None\n"
+        )
+        tree = ast.parse(src)
+        hits = _find_env_var_role_reads(tree, "some_new_gate.py")
+        assert hits, "env-var role detector did NOT fire on a role token."
+
+    def test_env_var_detector_ignores_benign_infra_vars(self):
+        """CLAUDE_PROJECT_DIR / CLAUDE_PLUGIN_ROOT are paths, not roles — must
+        NOT be flagged (else the detector would scream on every hook).
+        """
+        src = (
+            "import os\n"
+            "def main():\n"
+            "    pd = os.environ.get('CLAUDE_PROJECT_DIR', '.')\n"
+            "    pr = os.environ.get('CLAUDE_PLUGIN_ROOT', '')\n"
+            "    return pd, pr\n"
+        )
+        tree = ast.parse(src)
+        hits = _find_env_var_role_reads(tree, "session_init.py")
+        assert hits == [], (
+            f"Benign infra env vars were flagged as role reads: {hits}."
+        )
+
+    def test_env_var_detector_ignores_stdin_field_gets(self):
+        """A ``.get("agent_type")`` on a STDIN dict (input_data / tool_input)
+        is NOT an env-var read — it is a legitimate stdin role-field access
+        (is_lead / classify_session_role do exactly this). The env-var
+        detector must require an ``os.environ`` receiver, else it would
+        false-positive on every is_lead call site. This pins the receiver
+        check that the first pass got wrong.
+        """
+        src = (
+            "def is_lead(input_data):\n"
+            "    return input_data.get('agent_type') in LEAD_AGENT_TYPES\n"
+            "def gate(input_data):\n"
+            "    aid = input_data.get('agent_id', '')\n"
+            "    role = input_data['tool_input'].get('agent_role')\n"
+            "    return aid, role\n"
+        )
+        tree = ast.parse(src)
+        hits = _find_env_var_role_reads(tree, "session_init.py")
+        assert hits == [], (
+            f"Stdin-field .get() calls were misflagged as env-var reads: "
+            f"{hits}. The detector must require an os.environ receiver."
+        )
+
+
+# ===========================================================================
+# NON-VACUITY GUARDS — the scan never silently degrades to "looked at nothing"
+# ===========================================================================
+
+class TestNonVacuity:
+    """Guards so a false-clean from an empty scan is impossible."""
+
+    def test_negative_leg_scans_a_nonempty_hook_set(self):
+        """The hook-file glob resolves to a substantial set. If this ever
+        returns near-empty (wrong cwd, moved dir), every negative-leg
+        assertion would vacuously pass — this canary fails first instead.
+        """
+        files = _hook_files()
+        assert len(files) >= 20, (
+            f"Hook-file scan found only {len(files)} files (expected >= 20). "
+            f"The negative-leg AST denylist would be near-vacuous. Is "
+            f"HOOKS_DIR ({HOOKS_DIR}) resolving correctly?"
+        )
+
+    def test_canary_a_known_hook_is_in_the_scan_set(self):
+        """Positive canary: a hook KNOWN to call resolve_agent_name
+        (file_tracker.py) is actually in the scanned set, so the scan is
+        exercising real files — not an empty/false-clean list.
+        """
+        names = {p.name for p in _hook_files()}
+        assert "file_tracker.py" in names, (
+            "file_tracker.py (a known resolve_agent_name caller) is NOT in "
+            "the scanned hook set — the scan is not seeing real files."
+        )
+
+    def test_allowlist_sites_are_all_real(self):
+        """Every allowlisted (file, function) actually EXISTS in the source.
+        A stale allowlist entry (renamed/removed function) would silently
+        exempt nothing — or worse, mask a future real-site collision. Pinning
+        existence keeps the allowlist honest.
+        """
+        missing: list[str] = []
+        for rel_file, fn_name in _SANCTIONED_RESOLVE_AGENT_NAME_SITES:
+            path = HOOKS_DIR / rel_file
+            if not path.exists():
+                missing.append(f"{rel_file} (file missing)")
+                continue
+            tree = _parse(path)
+            fn_names = {
+                n.name for n in ast.walk(tree)
+                if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+            }
+            if fn_name not in fn_names:
+                missing.append(f"{rel_file}::{fn_name} (function missing)")
+        assert missing == [], (
+            f"Stale allowlist entries (no longer in source): {missing}. "
+            f"Remove or correct them so the allowlist stays auditable."
+        )
+
+    def test_allowlist_is_nonempty(self):
+        """Documentation-in-code: the allowlist MUST carry at least one site
+        (resolve_agent_name has genuine sanctioned label uses). An empty
+        allowlist would mean either the detector is flagging everything or
+        the label uses were removed — both warrant explicit review.
+        """
+        assert _SANCTIONED_RESOLVE_AGENT_NAME_SITES, (
+            "_SANCTIONED_RESOLVE_AGENT_NAME_SITES is empty. resolve_agent_name "
+            "has sanctioned label uses (file_tracker); an empty allowlist is "
+            "a signal the negative-leg semantics changed — review explicitly."
+        )

--- a/pact-plugin/tests/test_lead_discriminator_invariant.py
+++ b/pact-plugin/tests/test_lead_discriminator_invariant.py
@@ -230,6 +230,14 @@ def _find_env_var_role_reads(
     name contains a role token (AGENT / TEAMMATE / LEAD / ORCHESTRAT / ROLE),
     EXCLUDING the benign infra vars (CLAUDE_PROJECT_DIR, CLAUDE_PLUGIN_ROOT,
     CLAUDE_ENV_FILE — paths, not roles).
+
+    Catches BOTH the attribute form (``import os`` → ``os.environ`` /
+    ``os.getenv``, where the receiver is an ``ast.Attribute``) AND the aliased
+    form (``from os import environ`` → ``environ.get(...)`` / ``environ[...]``;
+    ``from os import getenv`` → ``getenv(...)``, where the receiver/callee is a
+    bare ``ast.Name``). Both spell the same env read; a drift author reaching
+    for an env role signal must not be able to dodge the denylist by importing
+    the name directly.
     """
     role_tokens = ("AGENT", "TEAMMATE", "LEAD", "ORCHESTRAT", "ROLE")
     benign = ("CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT", "CLAUDE_ENV_FILE")
@@ -241,38 +249,48 @@ def _find_env_var_role_reads(
             return False
         return any(tok in up for tok in role_tokens)
 
-    def _receiver_is_environ(attr_node: ast.Attribute) -> bool:
-        """True iff ``attr_node`` is ``<...>.environ.<attr>`` — so we only
-        match an os.environ ``.get`` and never ``input_data.get(...)`` /
-        ``tool_input.get(...)`` (those carry stdin role FIELDS, not env vars,
-        and are handled by the dedicated agent_id / is_lead detectors)."""
-        recv = attr_node.value
-        return isinstance(recv, ast.Attribute) and recv.attr == "environ"
+    def _is_environ_ref(node: ast.AST) -> bool:
+        """True iff ``node`` refers to ``os.environ`` in EITHER form:
+        - attribute: ``os.environ`` → ``ast.Attribute(attr="environ")``
+        - aliased:   ``from os import environ`` → ``ast.Name(id="environ")``
+        Matching only these never matches ``input_data.get(...)`` /
+        ``tool_input.get(...)`` (stdin role FIELDS, handled by the dedicated
+        agent_id / is_lead detectors)."""
+        return (
+            (isinstance(node, ast.Attribute) and node.attr == "environ")
+            or (isinstance(node, ast.Name) and node.id == "environ")
+        )
+
+    def _is_getenv_callee(func: ast.AST) -> bool:
+        """True iff ``func`` is a ``getenv`` callee in EITHER form:
+        - attribute: ``os.getenv`` → ``ast.Attribute(attr="getenv")``
+        - aliased:   ``from os import getenv`` → ``ast.Name(id="getenv")``."""
+        return (
+            (isinstance(func, ast.Attribute) and func.attr == "getenv")
+            or (isinstance(func, ast.Name) and func.id == "getenv")
+        )
 
     for node in ast.walk(tree):
-        # os.environ.get("KEY") / os.getenv("KEY")
-        if isinstance(node, ast.Call):
+        # os.environ.get("KEY") / environ.get("KEY") / os.getenv("KEY") / getenv("KEY")
+        if isinstance(node, ast.Call) and node.args:
             func = node.func
-            if not (isinstance(func, ast.Attribute) and node.args):
-                continue
-            # `.get` must be on an os.environ receiver; `getenv` is always env.
-            is_env_get = (
-                (func.attr == "get" and _receiver_is_environ(func))
-                or func.attr == "getenv"
+            # `.get` must be on an os.environ receiver (attr OR aliased Name);
+            # `getenv` (attr OR aliased bare Name) is always an env read.
+            is_environ_get = (
+                isinstance(func, ast.Attribute)
+                and func.attr == "get"
+                and _is_environ_ref(func.value)
             )
+            is_env_get = is_environ_get or _is_getenv_callee(func)
             if is_env_get:
                 arg0 = node.args[0]
                 if isinstance(arg0, ast.Constant) and isinstance(arg0.value, str):
                     if _key_is_role(arg0.value):
                         offending.append((_enclosing_function(tree, node), node.lineno))
-        # os.environ["KEY"]
+        # os.environ["KEY"] / environ["KEY"]
         if isinstance(node, ast.Subscript):
-            value = node.value
-            is_environ = (
-                isinstance(value, ast.Attribute) and value.attr == "environ"
-            )
             sl = node.slice
-            if is_environ and isinstance(sl, ast.Constant) and isinstance(sl.value, str):
+            if _is_environ_ref(node.value) and isinstance(sl, ast.Constant) and isinstance(sl.value, str):
                 if _key_is_role(sl.value):
                     offending.append((_enclosing_function(tree, node), node.lineno))
     return offending
@@ -517,6 +535,77 @@ class TestNegativeLegDetectorsFire:
         assert hits == [], (
             f"Stdin-field .get() calls were misflagged as env-var reads: "
             f"{hits}. The detector must require an os.environ receiver."
+        )
+
+    # ---- #5: aliased `from os import ...` forms must ALSO be detected ----
+    # The first pass matched only the ATTRIBUTE form (os.environ / os.getenv,
+    # receiver = ast.Attribute). A drift author could dodge the denylist by
+    # importing the name directly (`from os import environ` / `from os import
+    # getenv`), where the receiver/callee is a bare ast.Name. These phantom-green
+    # proofs pin that the aliased forms are now caught.
+
+    def test_env_var_detector_fires_on_aliased_environ_get(self):
+        """`from os import environ` → `environ.get('CLAUDE_AGENT_TYPE')` (Name
+        receiver, not os.environ Attribute) MUST be detected."""
+        src = (
+            "from os import environ\n"
+            "def gate(input_data):\n"
+            "    if environ.get('CLAUDE_AGENT_TYPE') == 'lead':\n"
+            "        return None\n"
+        )
+        tree = ast.parse(src)
+        hits = _find_env_var_role_reads(tree, "some_new_gate.py")
+        assert hits, (
+            "aliased environ.get role read was NOT detected — a drift author "
+            "could dodge the denylist via `from os import environ`."
+        )
+
+    def test_env_var_detector_fires_on_aliased_getenv(self):
+        """`from os import getenv` → `getenv('CLAUDE_LEAD')` (bare Name callee,
+        not os.getenv Attribute) MUST be detected."""
+        src = (
+            "from os import getenv\n"
+            "def gate(input_data):\n"
+            "    return getenv('CLAUDE_LEAD')\n"
+        )
+        tree = ast.parse(src)
+        hits = _find_env_var_role_reads(tree, "some_new_gate.py")
+        assert hits, (
+            "aliased getenv role read was NOT detected — a drift author could "
+            "dodge the denylist via `from os import getenv`."
+        )
+
+    def test_env_var_detector_fires_on_aliased_environ_subscript(self):
+        """`from os import environ` → `environ['CLAUDE_ORCHESTRATOR']` (Name
+        subscript value, not os.environ Attribute) MUST be detected."""
+        src = (
+            "from os import environ\n"
+            "def gate(input_data):\n"
+            "    return environ['CLAUDE_ORCHESTRATOR']\n"
+        )
+        tree = ast.parse(src)
+        hits = _find_env_var_role_reads(tree, "some_new_gate.py")
+        assert hits, (
+            "aliased environ[...] role read was NOT detected — a drift author "
+            "could dodge the denylist via `from os import environ` subscript."
+        )
+
+    def test_env_var_detector_aliased_form_still_ignores_benign(self):
+        """The receiver-form fix must NOT relax the benign-infra allowlist:
+        aliased reads of CLAUDE_PLUGIN_ROOT / CLAUDE_PROJECT_DIR still pass."""
+        src = (
+            "from os import environ, getenv\n"
+            "def main():\n"
+            "    pr = environ.get('CLAUDE_PLUGIN_ROOT', '')\n"
+            "    pd = getenv('CLAUDE_PROJECT_DIR')\n"
+            "    ef = environ['CLAUDE_ENV_FILE']\n"
+            "    return pr, pd, ef\n"
+        )
+        tree = ast.parse(src)
+        hits = _find_env_var_role_reads(tree, "session_init.py")
+        assert hits == [], (
+            f"Aliased benign infra env reads were misflagged: {hits}. The "
+            f"aliased-form fix must keep the benign allowlist intact."
         )
 
 

--- a/pact-plugin/tests/test_pin_caps_adversarial.py
+++ b/pact-plugin/tests/test_pin_caps_adversarial.py
@@ -107,8 +107,10 @@ class TestPinCapsAdversarial_PathResolution:
         import staleness
         monkeypatch.setattr(staleness, "get_project_claude_md_path", lambda: claude_md)
         # ADD-shape Write: new content has 1 pin comment; current file has 0.
+        # #878: lead frame (agent_type) so the is_lead-gated DENY path fires.
         result = _check_tool_allowed({
             "tool_name": "Write",
+            "agent_type": "pact-orchestrator",
             "tool_input": {
                 "file_path": str(symlink),
                 "content": "# Project\n<!-- pinned: 2026-04-20 -->\n### New\nbody\n",

--- a/pact-plugin/tests/test_pin_caps_gate.py
+++ b/pact-plugin/tests/test_pin_caps_gate.py
@@ -67,7 +67,13 @@ def caps_gate_env(tmp_path, monkeypatch, pact_context):
 
 
 def _call_gate(input_data):
+    # #878: the gate now keys lead-detection on is_lead (the harness-set
+    # agent_type), not the old empty-resolve_agent_name heuristic. Default to a
+    # LEAD frame (the unmarked case these DENY tests assume) unless the caller
+    # supplies an explicit agent_type (teammate/plain bypass tests).
     from pin_caps_gate import _check_tool_allowed
+    if "agent_type" not in input_data:
+        input_data = {**input_data, "agent_type": "pact-orchestrator"}
     return _check_tool_allowed(input_data)
 
 
@@ -282,24 +288,25 @@ class TestPinCapsGate_Smoke:
         assert result is None
 
     def test_teammate_bypass(self, caps_gate_env):
-        """Teammate sessions (agent_name non-empty) bypass the gate."""
+        """Teammate sessions (non-lead agent_type) bypass the gate.
+
+        #878: lead-detection migrated to is_lead, which reads agent_type
+        directly (no longer resolve_agent_name). A specialist agent_type is not
+        a lead spelling, so the gate bypasses.
+        """
         env = caps_gate_env(pin_count=3)
-        # Patch resolve_agent_name to return a non-empty name.
-        import shared.pact_context as ctx_module
-        with patch.object(
-            ctx_module, "resolve_agent_name", return_value="backend-coder-x"
-        ):
-            entries = [
-                make_pin_entry(title=f"Pin{i}", body_chars=4) for i in range(13)
-            ]
-            new_content = make_claude_md_with_pins(entries)
-            result = _call_gate({
-                "tool_name": "Write",
-                "tool_input": {
-                    "file_path": str(env["claude_md"]),
-                    "content": new_content,
-                },
-            })
+        entries = [
+            make_pin_entry(title=f"Pin{i}", body_chars=4) for i in range(13)
+        ]
+        new_content = make_claude_md_with_pins(entries)
+        result = _call_gate({
+            "tool_name": "Write",
+            "agent_type": "pact-backend-coder",
+            "tool_input": {
+                "file_path": str(env["claude_md"]),
+                "content": new_content,
+            },
+        })
         assert result is None
 
     def test_edit_legitimate_new_pin_with_date_comment_allows(

--- a/pact-plugin/tests/test_pin_caps_gate_counter_test.py
+++ b/pact-plugin/tests/test_pin_caps_gate_counter_test.py
@@ -64,7 +64,13 @@ def gate_env(tmp_path, monkeypatch, pact_context):
 
 
 def _call_gate(input_data):
+    # #878: the gate now keys lead-detection on is_lead (the harness-set
+    # agent_type), not the old empty-resolve_agent_name heuristic. Default to a
+    # LEAD frame (the unmarked case these DENY tests assume) unless the caller
+    # supplies an explicit agent_type.
     from pin_caps_gate import _check_tool_allowed
+    if "agent_type" not in input_data:
+        input_data = {**input_data, "agent_type": "pact-orchestrator"}
     return _check_tool_allowed(input_data)
 
 

--- a/pact-plugin/tests/test_pin_caps_gate_low_priority.py
+++ b/pact-plugin/tests/test_pin_caps_gate_low_priority.py
@@ -74,7 +74,13 @@ def gate_with_captured_failures(tmp_path, monkeypatch, pact_context):
 
 
 def _call_gate(input_data):
+    # #878: the gate now keys lead-detection on is_lead (the harness-set
+    # agent_type), not the old empty-resolve_agent_name heuristic. Default to a
+    # LEAD frame (the unmarked case these DENY tests assume) unless the caller
+    # supplies an explicit agent_type.
     from pin_caps_gate import _check_tool_allowed
+    if "agent_type" not in input_data:
+        input_data = {**input_data, "agent_type": "pact-orchestrator"}
     return _check_tool_allowed(input_data)
 
 

--- a/pact-plugin/tests/test_pin_caps_gate_matrix.py
+++ b/pact-plugin/tests/test_pin_caps_gate_matrix.py
@@ -115,7 +115,13 @@ def gate_env(tmp_path, monkeypatch, pact_context):
 
 
 def _call_gate(input_data):
+    # #878: the gate now keys lead-detection on is_lead (the harness-set
+    # agent_type), not the old empty-resolve_agent_name heuristic. Default to a
+    # LEAD frame (the unmarked case these DENY tests assume) unless the caller
+    # supplies an explicit agent_type (teammate/plain bypass tests).
     from pin_caps_gate import _check_tool_allowed
+    if "agent_type" not in input_data:
+        input_data = {**input_data, "agent_type": "pact-orchestrator"}
     return _check_tool_allowed(input_data)
 
 
@@ -534,21 +540,21 @@ class TestPinCapsGate_Matrix_Edit:
 
     @pytest.mark.parametrize("baseline", ["fresh", "missing", "corrupt"])
     def test_edit_teammate_bypass(self, gate_env, baseline):
-        """Teammate session bypasses the gate regardless of baseline state."""
+        """Teammate session bypasses the gate regardless of baseline state.
+
+        #878: a non-lead agent_type bypasses (the gate keys on is_lead, not
+        resolve_agent_name)."""
         env = gate_env(pin_count=3, baseline=baseline)
-        import shared.pact_context as ctx_module
-        with patch.object(
-            ctx_module, "resolve_agent_name", return_value="backend-coder-x"
-        ):
-            result = _call_gate({
-                "tool_name": "Edit",
-                "tool_input": {
-                    "file_path": str(env["claude_md"]),
-                    "old_string": "anything",
-                    "new_string": _build_claude_md(99),  # Wildly over-cap
-                    "replace_all": False,
-                },
-            })
+        result = _call_gate({
+            "tool_name": "Edit",
+            "agent_type": "pact-backend-coder",
+            "tool_input": {
+                "file_path": str(env["claude_md"]),
+                "old_string": "anything",
+                "new_string": _build_claude_md(99),  # Wildly over-cap
+                "replace_all": False,
+            },
+        })
         assert result is None, (
             f"teammate should bypass regardless of baseline={baseline}, got {result!r}"
         )
@@ -764,18 +770,16 @@ class TestPinCapsGate_Matrix_Write:
 
     @pytest.mark.parametrize("baseline", ["fresh", "missing", "corrupt"])
     def test_write_teammate_bypass(self, gate_env, baseline):
+        """#878: a non-lead agent_type bypasses (gate keys on is_lead)."""
         env = gate_env(pin_count=3, baseline=baseline)
-        import shared.pact_context as ctx_module
-        with patch.object(
-            ctx_module, "resolve_agent_name", return_value="backend-coder-x"
-        ):
-            result = _call_gate({
-                "tool_name": "Write",
-                "tool_input": {
-                    "file_path": str(env["claude_md"]),
-                    "content": _build_claude_md(99),
-                },
-            })
+        result = _call_gate({
+            "tool_name": "Write",
+            "agent_type": "pact-backend-coder",
+            "tool_input": {
+                "file_path": str(env["claude_md"]),
+                "content": _build_claude_md(99),
+            },
+        })
         assert result is None
 
 
@@ -878,8 +882,10 @@ class TestPinCapsGate_Matrix_Main:
     ):
         env = gate_env(pin_count=3)
         new_content = _build_claude_md(13)
+        # #878: lead frame (agent_type) so the is_lead-gated DENY path fires.
         stdin_payload = json.dumps({
             "tool_name": "Write",
+            "agent_type": "pact-orchestrator",
             "tool_input": {
                 "file_path": str(env["claude_md"]),
                 "content": new_content,

--- a/pact-plugin/tests/test_pin_caps_phantom_green.py
+++ b/pact-plugin/tests/test_pin_caps_phantom_green.py
@@ -55,7 +55,17 @@ def _build_over_cap_payload():
 
 
 def _call_gate(input_data):
+    # #878: the gate now keys lead-detection on is_lead (the harness-set
+    # top-level agent_type), not the old empty-resolve_agent_name heuristic.
+    # Default to a LEAD frame (the unmarked case these enforcement tests assume)
+    # unless the caller supplies an explicit TOP-LEVEL agent_type. NOTE: the
+    # adversarial tests below deliberately smuggle agent_type/subagent_type into
+    # tool_input or as subagent_type — those are NOT top-level agent_type, so
+    # this default-inject does not clobber them and is_lead correctly ignores
+    # the smuggled fields (the purity property under test).
     from pin_caps_gate import _check_tool_allowed
+    if "agent_type" not in input_data:
+        input_data = {**input_data, "agent_type": "pact-orchestrator"}
     return _check_tool_allowed(input_data)
 
 
@@ -219,17 +229,25 @@ class TestPhantomGreen_CliBypass:
 
 
 class TestPhantomGreen_TeammateNameProbe:
-    """The teammate bypass IS intentional (`agent_name` non-empty →
-    allow), but probe that it's keyed ONLY on the pact_context resolution
-    — not on a string in file_path, tool_input, or stdin payload."""
+    """The teammate bypass IS intentional (a non-lead frame → allow), but
+    probe that lead/teammate detection is keyed ONLY on the top-level
+    harness-set agent_type (is_lead) — NOT on a string in file_path,
+    tool_input, or a smuggled non-top-level field.
+
+    #878: detection migrated from resolve_agent_name to is_lead. is_lead reads
+    ONLY top-level agent_type, so smuggling teammate-identity fields into
+    tool_input (user-controlled) cannot flip the lead verdict — these probes
+    pin that purity at the gate level."""
 
     def test_fake_agent_name_in_file_path_does_not_bypass(
         self, loaded_gate_env
     ):
         """A file path containing 'backend-coder' doesn't trigger bypass."""
-        # The gate checks `resolve_agent_name(input_data)` — not file_path.
-        # So a phantom file_path like /tmp/backend-coder/CLAUDE.md should
-        # NOT trigger teammate bypass.
+        # The gate checks is_lead(input_data) on top-level agent_type — not
+        # file_path. So a phantom file_path like /tmp/backend-coder/CLAUDE.md
+        # (or a phantom tool_input field) must NOT flip lead→teammate. The lead
+        # frame here (top-level agent_type) enforces; the phantom field is
+        # ignored.
         result = _call_gate({
             "tool_name": "Write",
             "tool_input": {
@@ -246,14 +264,14 @@ class TestPhantomGreen_TeammateNameProbe:
         """Teammate-identity fields injected into `tool_input` (not the
         top-level input_data) MUST NOT bypass the gate.
 
-        Rationale: `resolve_agent_name` legitimately reads top-level
-        `agent_name` / `agent_id` / `agent_type` fields — these are
-        populated by Claude Code's platform for real teammate dispatch,
-        not by user-controlled tool_input. The attack surface is
-        whether a curator can smuggle teammate identity through the
-        Edit/Write tool_input payload (user-controlled). This test
-        confirms the gate reads agent identity ONLY from top-level
-        input_data, not from tool_input.
+        Rationale: is_lead reads the top-level `agent_type` field — set by
+        Claude Code's platform from process context, not by user-controlled
+        tool_input. The attack surface is whether a curator can smuggle
+        teammate identity through the Edit/Write tool_input payload
+        (user-controlled) to flip the gate's lead verdict to teammate (which
+        would bypass enforcement). This test confirms is_lead reads role
+        identity ONLY from top-level input_data, never from tool_input — so the
+        injected fields are ignored and the (top-level) lead frame enforces.
         """
         result = _call_gate({
             "tool_name": "Write",
@@ -261,7 +279,7 @@ class TestPhantomGreen_TeammateNameProbe:
                 "file_path": str(loaded_gate_env),
                 "content": _build_over_cap_payload(),
                 # Attempts to smuggle teammate identity via user-controlled
-                # tool_input — these MUST be ignored by resolve_agent_name.
+                # tool_input — these MUST be ignored by is_lead (purity).
                 "agent_name": "backend-coder-x",
                 "agent_id": "backend-coder-x@pact-fake",
                 "agent_type": "pact-backend-coder",
@@ -271,20 +289,21 @@ class TestPhantomGreen_TeammateNameProbe:
         })
         assert result is not None, (
             "Phantom teammate bypass via tool_input fields — "
-            "resolve_agent_name must only read top-level input_data identity"
+            "is_lead must only read top-level input_data agent_type"
         )
         assert "Pin count cap" in result
 
     def test_subagent_type_at_top_level_is_not_accepted(
         self, loaded_gate_env
     ):
-        """`subagent_type` is NOT in resolve_agent_name's resolution
-        chain (only agent_name / agent_id / agent_type are). Top-level
-        `subagent_type` alone must not bypass the gate.
+        """`subagent_type` is NOT the field is_lead reads (is_lead keys ONLY
+        on top-level `agent_type`). A top-level `subagent_type` must not flip
+        the lead verdict to teammate, so it cannot bypass the gate.
 
-        Documents the resolution-chain surface: adding a new identity
-        field to resolve_agent_name implicitly adds a bypass vector;
-        this test pins that `subagent_type` is currently out-of-chain.
+        Documents the role-discriminator surface: is_lead reads exactly one
+        field (agent_type). This test pins that `subagent_type` is NOT that
+        field — adding any new field to the role decision would be a new bypass
+        vector and must update this test.
         """
         result = _call_gate({
             "tool_name": "Write",
@@ -295,8 +314,8 @@ class TestPhantomGreen_TeammateNameProbe:
             "subagent_type": "pact-backend-coder",
         })
         assert result is not None, (
-            "subagent_type at top-level bypassed gate — resolve_agent_name "
-            "resolution chain has changed; update this test to reflect the "
-            "new surface"
+            "subagent_type at top-level bypassed gate — is_lead's "
+            "role-discriminator field has changed; update this test to reflect "
+            "the new surface"
         )
         assert "Pin count cap" in result

--- a/pact-plugin/tests/test_pin_staleness_gate.py
+++ b/pact-plugin/tests/test_pin_staleness_gate.py
@@ -76,8 +76,16 @@ def gate_env(tmp_path, monkeypatch, pact_context):
 
 
 def _call_gate(input_data):
-    """Invoke _check_tool_allowed directly with a synthesized input_data."""
+    """Invoke _check_tool_allowed directly with a synthesized input_data.
+
+    #878: the gate now keys lead-detection on is_lead (the harness-set
+    agent_type), not the old empty-resolve_agent_name heuristic. Default to a
+    LEAD frame (the unmarked case these DENY tests assume) unless the caller
+    supplies an explicit agent_type (teammate/plain bypass tests).
+    """
     from pin_staleness_gate import _check_tool_allowed
+    if "agent_type" not in input_data:
+        input_data = {**input_data, "agent_type": "pact-orchestrator"}
     return _check_tool_allowed(input_data)
 
 
@@ -252,14 +260,12 @@ class TestPinStalenessGate_TeammateBypass:
     """Teammates bypass the gate (worktree scope — no CLAUDE.md in worktrees)."""
 
     def test_teammate_edit_on_claude_md_allowed(self, gate_env, monkeypatch):
+        """#878: a non-lead agent_type bypasses the gate. The gate keys on
+        is_lead (agent_type), not resolve_agent_name."""
         env = gate_env(marker_present=True)
-        import shared.pact_context as ctx_module
-        monkeypatch.setattr(
-            ctx_module, "resolve_agent_name",
-            lambda _input_data: "backend-coder",
-        )
         result = _call_gate({
             "tool_name": "Edit",
+            "agent_type": "pact-backend-coder",
             "tool_input": {
                 "file_path": str(env["claude_md"]),
                 "old_string": "## Pinned Context",
@@ -359,8 +365,10 @@ class TestPinStalenessGate_MainDenyPath:
             f"{new_pin}## Working Memory\n",
         )
         assert replacement != current
+        # #878: lead frame (agent_type) so the is_lead-gated DENY path fires.
         monkeypatch.setattr(sys, "stdin", StringIO(json.dumps({
             "tool_name": "Write",
+            "agent_type": "pact-orchestrator",
             "tool_input": {
                 "file_path": str(env["claude_md"]),
                 "content": replacement,

--- a/pact-plugin/tests/test_postcompact_archive.py
+++ b/pact-plugin/tests/test_postcompact_archive.py
@@ -203,11 +203,16 @@ class TestPostcompactOuterExceptionHandler:
     (the only external call remaining in main()'s happy path).
     """
 
+    # #881: the compact-summary write is now gated behind is_lead, so these
+    # outer-exception-handler tests must present a LEAD frame (agent_type) for
+    # the patched write_compact_summary side-effect to actually fire.
     def test_exits_zero_on_unexpected_error(self):
         """main() must exit 0 even when write_compact_summary raises."""
         from postcompact_archive import main
 
-        stdin_data = json.dumps({"compact_summary": "test"})
+        stdin_data = json.dumps(
+            {"compact_summary": "test", "agent_type": "pact-orchestrator"}
+        )
         with patch("sys.stdin", StringIO(stdin_data)), \
              patch("postcompact_archive.write_compact_summary",
                    side_effect=RuntimeError("test error")):
@@ -219,7 +224,9 @@ class TestPostcompactOuterExceptionHandler:
         """Error details must appear on stderr for logging."""
         from postcompact_archive import main
 
-        stdin_data = json.dumps({"compact_summary": "test"})
+        stdin_data = json.dumps(
+            {"compact_summary": "test", "agent_type": "pact-orchestrator"}
+        )
         with patch("sys.stdin", StringIO(stdin_data)), \
              patch("postcompact_archive.write_compact_summary",
                    side_effect=RuntimeError("test error")):
@@ -234,7 +241,9 @@ class TestPostcompactOuterExceptionHandler:
         """Stdout must contain structured JSON from hook_error_json."""
         from postcompact_archive import main
 
-        stdin_data = json.dumps({"compact_summary": "test"})
+        stdin_data = json.dumps(
+            {"compact_summary": "test", "agent_type": "pact-orchestrator"}
+        )
         with patch("sys.stdin", StringIO(stdin_data)), \
              patch("postcompact_archive.write_compact_summary",
                    side_effect=RuntimeError("test error")):
@@ -247,3 +256,58 @@ class TestPostcompactOuterExceptionHandler:
         assert "PACT hook warning" in output["systemMessage"]
         assert "postcompact_archive" in output["systemMessage"]
         assert "test error" in output["systemMessage"]
+
+
+# ---------------------------------------------------------------------------
+# #881: lead-only gate on the global-singleton compact-summary write
+# ---------------------------------------------------------------------------
+
+
+class TestPostcompactLeadGate:
+    """The compact-summary write is gated behind is_lead (#881).
+
+    COMPACT_SUMMARY_PATH is a GLOBAL SINGLETON the lead reads on resume, and
+    the write is O_TRUNC. A teammate/plain frame's PostCompact must NOT clobber
+    it. These are smoke tests (call / no-call of write_compact_summary by
+    role); comprehensive per-role suppression coverage is the TEST phase.
+    """
+
+    def _run_main_with(self, frame):
+        from postcompact_archive import main
+
+        stdin_data = json.dumps(frame)
+        with patch("sys.stdin", StringIO(stdin_data)), \
+             patch("postcompact_archive.write_compact_summary") as mock_write:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 0
+            return mock_write
+
+    def test_lead_qualified_writes(self):
+        from fixtures.role_frames import postcompact_frame
+        mock_write = self._run_main_with(
+            postcompact_frame("PACT:pact-orchestrator", compact_summary="x")
+        )
+        mock_write.assert_called_once_with("x")
+
+    def test_lead_unqualified_writes(self):
+        from fixtures.role_frames import postcompact_frame
+        mock_write = self._run_main_with(
+            postcompact_frame("pact-orchestrator", compact_summary="x")
+        )
+        mock_write.assert_called_once_with("x")
+
+    def test_teammate_suppressed(self):
+        from fixtures.role_frames import postcompact_frame
+        mock_write = self._run_main_with(
+            postcompact_frame("pact-backend-coder", compact_summary="x")
+        )
+        mock_write.assert_not_called()
+
+    def test_plain_frame_suppressed(self):
+        """No agent_type (no --agent) → not lead → write suppressed."""
+        from fixtures.role_frames import postcompact_frame
+        mock_write = self._run_main_with(
+            postcompact_frame(None, compact_summary="x")
+        )
+        mock_write.assert_not_called()

--- a/pact-plugin/tests/test_postcompact_archive.py
+++ b/pact-plugin/tests/test_postcompact_archive.py
@@ -311,3 +311,75 @@ class TestPostcompactLeadGate:
             postcompact_frame(None, compact_summary="x")
         )
         mock_write.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# #4 (#883 fold-in): real-disk defense-in-depth for the #881 lead-gate.
+# ---------------------------------------------------------------------------
+
+
+class TestPostcompactLeadGateRealDisk:
+    """Defense-in-depth complement to TestPostcompactLeadGate (which mocks
+    write_compact_summary and asserts call/no-call). Here the REAL function runs
+    against a REAL file on disk: a teammate/plain frame through main() must NOT
+    truncate the global-singleton compact-summary file (#881's O_TRUNC clobber).
+
+    COMPACT_SUMMARY_PATH is computed at IMPORT in shared.constants
+    (Path.home()/...), so a post-import Path.home monkeypatch does NOT redirect
+    it; we monkeypatch the name postcompact_archive binds (it does
+    `from shared.constants import COMPACT_SUMMARY_PATH`) to a tmp file. main()
+    calls write_compact_summary(summary) with no base-dir → _get_summary_path()
+    returns this redirected path.
+    """
+
+    _SENTINEL = "PRIOR LEAD SUMMARY — must survive a teammate PostCompact"
+
+    def _run_main_realdisk(self, frame, monkeypatch, tmp_path):
+        from postcompact_archive import main
+
+        summary_path = tmp_path / "compact-summary.txt"
+        summary_path.write_text(self._SENTINEL, encoding="utf-8")
+        # Redirect the global-singleton path (import-frozen constant) to tmp.
+        monkeypatch.setattr(
+            "postcompact_archive.COMPACT_SUMMARY_PATH", summary_path
+        )
+
+        with patch("sys.stdin", StringIO(json.dumps(frame))):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 0
+        return summary_path
+
+    def test_teammate_frame_does_not_truncate_real_file(self, monkeypatch, tmp_path):
+        """A teammate PostCompact must leave the lead's on-disk compact-summary
+        UNTOUCHED — the #881 is_lead gate suppresses the real O_TRUNC write."""
+        from fixtures.role_frames import postcompact_frame
+        summary_path = self._run_main_realdisk(
+            postcompact_frame("pact-backend-coder", compact_summary="TEAMMATE CLOBBER"),
+            monkeypatch, tmp_path,
+        )
+        assert summary_path.read_text(encoding="utf-8") == self._SENTINEL, (
+            "a teammate PostCompact truncated the global compact-summary file — "
+            "the #881 lead-gate failed to suppress the real O_TRUNC write"
+        )
+
+    def test_plain_frame_does_not_truncate_real_file(self, monkeypatch, tmp_path):
+        """A plain (no-agent_type) PostCompact must also leave the file intact."""
+        from fixtures.role_frames import postcompact_frame
+        summary_path = self._run_main_realdisk(
+            postcompact_frame(None, compact_summary="PLAIN CLOBBER"),
+            monkeypatch, tmp_path,
+        )
+        assert summary_path.read_text(encoding="utf-8") == self._SENTINEL
+
+    def test_lead_frame_does_overwrite_real_file(self, monkeypatch, tmp_path):
+        """Positive symmetry: a LEAD PostCompact DOES write the file (the gate
+        suppresses only NON-lead frames; the lead's archival must still work)."""
+        from fixtures.role_frames import postcompact_frame
+        summary_path = self._run_main_realdisk(
+            postcompact_frame("PACT:pact-orchestrator", compact_summary="NEW LEAD SUMMARY"),
+            monkeypatch, tmp_path,
+        )
+        assert summary_path.read_text(encoding="utf-8") == "NEW LEAD SUMMARY", (
+            "a lead PostCompact must still archive the compact summary"
+        )

--- a/pact-plugin/tests/test_prune_memory_integration.py
+++ b/pact-plugin/tests/test_prune_memory_integration.py
@@ -76,9 +76,12 @@ def curator_env(tmp_path, monkeypatch, pact_context):
         )
 
     def _call_gate(tool_name, tool_input):
+        # #878: the gate keys lead-detection on is_lead (top-level agent_type).
+        # These integration assertions exercise the lead CLAUDE.md-edit path.
         from pin_caps_gate import _check_tool_allowed
         return _check_tool_allowed({
             "tool_name": tool_name,
+            "agent_type": "pact-orchestrator",
             "tool_input": tool_input,
         })
 

--- a/pact-plugin/tests/test_role_gate_flip_and_postcompact.py
+++ b/pact-plugin/tests/test_role_gate_flip_and_postcompact.py
@@ -1,0 +1,353 @@
+"""Role-gate flip regression + postcompact suppression + #812 drift fixture.
+
+Three comprehensive groups complementing the coder's gate-specific smoke
+tests:
+
+  1. POSTCOMPACT suppression (#881) — postcompact_archive's global-singleton
+     compact-summary O_TRUNC write × {lead writes / teammate suppressed /
+     plain suppressed}, end-to-end via stdin.
+
+  2. CLASS-B GATE FLIP regression — each of the 5 migrated teammate-bypass
+     gates: a non-lead frame (teammate both spellings + plain) takes the
+     bypass branch (no-op), while a lead frame ENGAGES the gate. Parameterized
+     across the gate seams so a single gate regressing to the old heuristic
+     (or dropping the is_lead routing) is caught with a tight, gate-specific
+     assertion. (bootstrap_gate's full DENY matrix is the coder's existing
+     coverage; this file adds the consolidated cross-gate flip contract +
+     the plain-frame row.)
+
+  3. #812 DRIFT fixture — pins the CURRENT identity-signal facts so a future
+     regression (agent_id re-appearing as a role signal, or an agent_type
+     role-mapping change) surfaces loudly: agent_id is absent from the
+     synthesized frames; agent_type maps to role per the SSOT.
+"""
+
+import io
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from fixtures.role_frames import (
+    lead_frame_qualified,
+    lead_frame_unqualified,
+    plain_frame,
+    postcompact_frame,
+    teammate_frame,
+)
+
+import shared.pact_context as pact_context
+
+
+_SESSION_ID = "aabb1122-0000-0000-0000-000000000000"
+
+
+# ===========================================================================
+# GROUP 3a — postcompact_archive #881 suppression
+# ===========================================================================
+
+class TestPostcompactSuppression:
+    """The compact-summary write is a GLOBAL SINGLETON (#881) — a teammate or
+    plain frame's PostCompact must NOT clobber the lead's summary. Gated behind
+    is_lead. Drives postcompact_archive.main() end-to-end via stdin.
+    """
+
+    def _run_postcompact(self, frame, monkeypatch, tmp_path):
+        from postcompact_archive import main
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        stdin_data = json.dumps(frame)
+
+        with patch("postcompact_archive.write_compact_summary") as mock_write, \
+             patch("sys.stdin", io.StringIO(stdin_data)), \
+             patch("sys.stdout", new_callable=io.StringIO):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 0
+        return mock_write
+
+    @pytest.mark.parametrize("frame_builder", [
+        lead_frame_qualified, lead_frame_unqualified,
+    ], ids=["qualified", "unqualified"])
+    def test_lead_writes_compact_summary(self, frame_builder, monkeypatch, tmp_path):
+        """A lead frame with a compact_summary writes the summary."""
+        frame = frame_builder(hook_event_name="PostCompact",
+                              compact_summary="lead summary text")
+        mock_write = self._run_postcompact(frame, monkeypatch, tmp_path)
+        mock_write.assert_called_once()
+        assert mock_write.call_args.args[0] == "lead summary text"
+
+    @pytest.mark.parametrize("frame, role", [
+        (postcompact_frame(agent_type="pact-backend-coder"), "teammate"),
+        (postcompact_frame(agent_type=None), "plain"),
+    ])
+    def test_non_lead_suppresses_compact_summary(self, frame, role, monkeypatch, tmp_path):
+        """A teammate/plain frame must NOT write the compact-summary (it would
+        clobber the lead's global singleton)."""
+        mock_write = self._run_postcompact(frame, monkeypatch, tmp_path)
+        mock_write.assert_not_called()
+
+    def test_lead_with_empty_summary_does_not_write(self, monkeypatch, tmp_path):
+        """Even a lead frame with an empty compact_summary skips the write
+        (the `compact_summary and is_lead(...)` short-circuit). Confirms the
+        gate is `summary AND lead`, not `lead alone`."""
+        frame = lead_frame_qualified(hook_event_name="PostCompact",
+                                     compact_summary="")
+        mock_write = self._run_postcompact(frame, monkeypatch, tmp_path)
+        mock_write.assert_not_called()
+
+
+# ===========================================================================
+# GROUP 3b — Class-B gate flip regression (the 5 migrated teammate-bypass gates)
+# ===========================================================================
+
+class TestBootstrapGateFlip:
+    """bootstrap_gate (DENY): lead(both spellings)-no-marker → ENFORCE;
+    teammate/plain → PASSTHROUGH. Consolidated flip matrix (the coder's file
+    has the full DENY-reason matrix; this adds the explicit plain-frame row +
+    the both-spellings contrast in one place).
+    """
+
+    def _setup_session_no_marker(self, monkeypatch, tmp_path):
+        """Minimal: a session_dir that exists with NO bootstrap marker, so the
+        gate reaches the is_lead branch. Patches the two pre-is_lead guards."""
+        import bootstrap_gate
+        monkeypatch.setattr(
+            bootstrap_gate.pact_context, "init", lambda _d: None
+        )
+        monkeypatch.setattr(
+            bootstrap_gate.pact_context, "get_session_dir",
+            lambda: str(tmp_path / "sess")
+        )
+        monkeypatch.setattr(bootstrap_gate, "is_marker_set", lambda _p: False)
+
+    def _input(self, frame, tool_name="Edit"):
+        return {
+            "hook_event_name": "PreToolUse",
+            "session_id": _SESSION_ID,
+            "tool_name": tool_name,
+            "tool_input": {},
+            **frame,
+        }
+
+    @pytest.mark.parametrize("frame_builder", [
+        lead_frame_qualified, lead_frame_unqualified,
+    ], ids=["qualified", "unqualified"])
+    def test_lead_no_marker_enforces(self, frame_builder, monkeypatch, tmp_path):
+        from bootstrap_gate import _check_tool_allowed, _DENY_REASON
+        self._setup_session_no_marker(monkeypatch, tmp_path)
+        result = _check_tool_allowed(self._input(frame_builder()))
+        assert result == _DENY_REASON, (
+            "lead frame, no marker, blocked tool → must ENFORCE (deny)"
+        )
+
+    @pytest.mark.parametrize("frame, role", [
+        (teammate_frame(), "teammate"),
+        (teammate_frame(agent_type="PACT:pact-backend-coder"), "teammate-qualified"),
+        (plain_frame(), "plain"),
+    ])
+    def test_non_lead_passes_through(self, frame, role, monkeypatch, tmp_path):
+        from bootstrap_gate import _check_tool_allowed
+        self._setup_session_no_marker(monkeypatch, tmp_path)
+        result = _check_tool_allowed(self._input(frame))
+        assert result is None, (
+            f"{role} frame must PASS THROUGH the bootstrap DENY gate (no-op)"
+        )
+
+
+class TestClassBGateBypassFlip:
+    """The 4 OTHER migrated Class-B gates: a non-lead frame takes the bypass
+    branch (no-op), a lead frame engages. Each gate is reached by patching its
+    pre-is_lead guards so only the is_lead verdict decides.
+
+    Asserting the FLIP (bypass for non-lead, engagement for lead) on each gate
+    is the per-migrated-hook regression: a gate that regresses to the old
+    `if resolve_agent_name(...)` heuristic would invert under tmux (lead
+    bypasses, teammate engages) and fail here.
+    """
+
+    # --- bootstrap_prompt_gate._check_bootstrap_needed ---
+
+    def _setup_prompt_gate(self, monkeypatch, tmp_path):
+        import bootstrap_prompt_gate as g
+        monkeypatch.setattr(g.pact_context, "init", lambda _d: None)
+        monkeypatch.setattr(g.pact_context, "get_session_dir",
+                            lambda: str(tmp_path / "sess"))
+        monkeypatch.setattr(g, "is_marker_set", lambda _p: False)
+        return g
+
+    @pytest.mark.parametrize("frame, expect_bypass", [
+        (lead_frame_qualified(), False),
+        (lead_frame_unqualified(), False),
+        (teammate_frame(), True),
+        (plain_frame(), True),
+    ], ids=["lead-q", "lead-u", "teammate", "plain"])
+    def test_prompt_gate_flip(self, frame, expect_bypass, monkeypatch, tmp_path):
+        g = self._setup_prompt_gate(monkeypatch, tmp_path)
+        result = g._check_bootstrap_needed({"session_id": _SESSION_ID, **frame})
+        if expect_bypass:
+            assert result is None, "non-lead must bypass (no injection)"
+        else:
+            assert result is not None, "lead must engage (inject bootstrap instruction)"
+
+    # --- bootstrap_marker_writer._try_write_marker ---
+
+    @pytest.mark.parametrize("frame, expect_write", [
+        (lead_frame_qualified(), True),
+        (lead_frame_unqualified(), True),
+        (teammate_frame(), False),
+        (plain_frame(), False),
+    ], ids=["lead-q", "lead-u", "teammate", "plain"])
+    def test_marker_writer_flip(self, frame, expect_write, monkeypatch, tmp_path):
+        """_try_write_marker(input_data) reads session_dir internally; is_lead
+        gates BEFORE the team-has-secretary / plugin-version pre-conditions.
+        Stub the whole post-is_lead chain so a lead frame reaches _write_marker
+        and a non-lead frame bypasses before any of it. The write function is
+        _write_marker (underscore)."""
+        import bootstrap_marker_writer as g
+        sess = tmp_path / "sess"
+        sess.mkdir()
+        monkeypatch.setattr(g.pact_context, "init", lambda _d: None)
+        monkeypatch.setattr(g.pact_context, "get_session_dir", lambda: str(sess))
+        monkeypatch.setattr(g, "is_marker_set", lambda _p: False)
+        # Post-is_lead pre-conditions — stub so a lead frame reaches _write_marker.
+        monkeypatch.setattr(g, "_team_has_secretary", lambda _t: True)
+        monkeypatch.setattr(g.pact_context, "get_team_name", lambda: "t1")
+        monkeypatch.setattr(g.pact_context, "get_plugin_root", lambda: str(tmp_path))
+        monkeypatch.setattr(g, "_read_plugin_version", lambda _r: "9.9.9")
+        with patch.object(g, "_write_marker") as mock_write:
+            g._try_write_marker({"session_id": _SESSION_ID, **frame})
+        if expect_write:
+            assert mock_write.called, "lead must proceed to write the marker"
+        else:
+            assert not mock_write.called, "non-lead must bypass (no marker write)"
+
+    # --- pin_caps_gate._check_tool_allowed ---
+
+    @pytest.mark.parametrize("frame, expect_bypass", [
+        (lead_frame_qualified(), False),
+        (teammate_frame(), True),
+        (plain_frame(), True),
+    ], ids=["lead", "teammate", "plain"])
+    def test_pin_caps_gate_bypass(self, frame, expect_bypass, monkeypatch, tmp_path):
+        """A non-lead frame returns None at the is_lead bypass BEFORE reading
+        tool_input / calling match_project_claude_md. Make the post-is_lead
+        path observable via a sentinel on match_project_claude_md: non-lead must
+        return None without hitting it; lead must hit it."""
+        import pin_caps_gate as g
+
+        monkeypatch.setattr(g.pact_context, "init", lambda _d: None)
+        reached = {"hit": False}
+        def _sentinel(_path):
+            reached["hit"] = True
+            return None  # no claude_md match → gate ultimately returns None
+        monkeypatch.setattr(g, "match_project_claude_md", _sentinel)
+
+        # tool_name must be a _GATED_TOOLS member ({Edit, Write}) to pass the
+        # gate's first guard and reach the is_lead branch.
+        inp = {"session_id": _SESSION_ID, "tool_name": "Edit",
+               "tool_input": {"file_path": "/x/CLAUDE.md"}, **frame}
+        result = g._check_tool_allowed(inp)
+        assert result is None  # empty match → no deny regardless of role
+        assert reached["hit"] is (not expect_bypass), (
+            "non-lead must bypass before match_project_claude_md; "
+            "lead must reach it"
+        )
+
+    # --- pin_staleness_gate._check_tool_allowed ---
+
+    @pytest.mark.parametrize("frame, expect_bypass", [
+        (lead_frame_qualified(), False),
+        (teammate_frame(), True),
+        (plain_frame(), True),
+    ], ids=["lead", "teammate", "plain"])
+    def test_pin_staleness_gate_bypass(self, frame, expect_bypass, monkeypatch, tmp_path):
+        """For a non-lead frame the gate returns None at the is_lead bypass —
+        BEFORE it would read session_dir. We assert the bypass by making the
+        post-is_lead path (get_session_dir) raise: a non-lead frame must return
+        None WITHOUT hitting it, a lead frame must hit it (and we catch the
+        sentinel)."""
+        import pin_staleness_gate as g
+
+        _SENTINEL = RuntimeError("reached post-is_lead path")
+        monkeypatch.setattr(g.pact_context, "init", lambda _d: None)
+        def _boom():
+            raise _SENTINEL
+        monkeypatch.setattr(g.pact_context, "get_session_dir", _boom)
+
+        # tool_name must be a _GATED_TOOLS member ({Edit, Write}) to pass the
+        # gate's first guard and reach the is_lead branch.
+        inp = {"session_id": _SESSION_ID, "tool_name": "Edit",
+               "tool_input": {}, **frame}
+        if expect_bypass:
+            # Non-lead → returns None at is_lead, never calls get_session_dir.
+            assert g._check_tool_allowed(inp) is None
+        else:
+            # Lead → proceeds past is_lead and hits the sentinel.
+            with pytest.raises(RuntimeError, match="reached post-is_lead path"):
+                g._check_tool_allowed(inp)
+
+
+# ===========================================================================
+# GROUP 3c — #812 drift-detection fixture
+# ===========================================================================
+
+class TestAgentIdDriftFixture:
+    """Pin the CURRENT identity-signal facts. A future regression that
+    re-introduces agent_id as a role signal, or remaps agent_type→role, breaks
+    these — surfacing the #812 drift class loudly at CI rather than silently
+    under tmux.
+    """
+
+    def test_synthesized_frames_carry_no_agent_id(self):
+        """The synthesized role frames model the tmux reality: agent_id is
+        ABSENT on every hook event. If a future capture/fixture re-adds it,
+        this fails — prompting a deliberate review of whether the role
+        discriminator still (correctly) ignores it."""
+        for builder in (lead_frame_qualified, lead_frame_unqualified,
+                        teammate_frame, plain_frame):
+            frame = builder()
+            assert "agent_id" not in frame, (
+                f"{builder.__name__} unexpectedly carries agent_id — the tmux "
+                f"capture matrix says agent_id is absent. If this changed, "
+                f"re-verify the role discriminator still ignores agent_id."
+            )
+
+    def test_agent_type_maps_to_role_per_ssot(self):
+        """Pin the agent_type→role mapping against the SSOT. A change to
+        LEAD_AGENT_TYPES or the classifier that silently remaps a role surfaces
+        here."""
+        from shared.pact_context import classify_session_role, is_lead
+
+        cases = [
+            ("PACT:pact-orchestrator", "lead", True),
+            ("pact-orchestrator", "lead", True),
+            ("pact-backend-coder", "teammate", False),
+            ("pact-secretary", "teammate", False),
+            (None, "unknown", False),
+        ]
+        for agent_type, expected_role, expected_is_lead in cases:
+            frame = {} if agent_type is None else {"agent_type": agent_type}
+            assert classify_session_role(frame) == expected_role, (
+                f"agent_type={agent_type!r} role drift"
+            )
+            assert is_lead(frame) is expected_is_lead
+
+    def test_agent_id_presence_never_promotes_role(self):
+        """The #812 guard, pinned at the discriminator level: adding an
+        agent_id to a NON-lead frame must never flip it to lead — agent_type is
+        the sole role signal."""
+        from shared.pact_context import is_lead, classify_session_role
+
+        # A teammate frame with an agent_id re-added (simulating a future CC
+        # build) stays a teammate.
+        frame = {"agent_type": "pact-backend-coder", "agent_id": "backend@team"}
+        assert is_lead(frame) is False
+        assert classify_session_role(frame) == "teammate"
+
+        # A plain frame with an agent_id stays unknown (agent_id alone is not
+        # a role).
+        frame2 = {"agent_id": "someone@team"}
+        assert is_lead(frame2) is False
+        assert classify_session_role(frame2) == "unknown"

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -1112,7 +1112,8 @@ class TestWriteContextIntegration:
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
-        # #877: lead frame → write_disk=True (the on-disk write happens).
+        # #878 SHAPE-2 seam: lead frame → session_init builds the cache then
+        # persists. build_context_cache carries the 4 positional args (no flag).
         stdin_data = json.dumps(_with_lead_role({
             "session_id": "aabb1122-0000-0000-0000-000000000000",
         }))
@@ -1124,20 +1125,23 @@ class TestWriteContextIntegration:
              patch("session_init.get_task_list", return_value=None), \
              patch("session_init.restore_last_session", return_value=None), \
              patch("session_init.check_paused_state", return_value=None), \
-             patch("session_init.write_context") as mock_write_ctx, \
+             patch("session_init.build_context_cache",
+                   return_value=(Path("/tmp/ctx.json"), {})) as mock_build_ctx, \
+             patch("session_init.persist_context", return_value=None), \
              patch("sys.stdin", io.StringIO(stdin_data)), \
              patch("sys.stdout", new_callable=io.StringIO):
             with pytest.raises(SystemExit) as exc_info:
                 main()
 
         assert exc_info.value.code == 0
-        # #877: the disk-write split adds write_disk=is_lead (True on the lead path).
-        mock_write_ctx.assert_called_once_with(
+        # #878 SHAPE-2: build_context_cache takes the 4 positional args; the
+        # lead/teammate disk gate moved OUT of this call (it's now persist_context,
+        # invoked only when frame_is_lead) — so no write_disk kwarg here.
+        mock_build_ctx.assert_called_once_with(
             "pact-aabb1122",
             "aabb1122-0000-0000-0000-000000000000",
             "/Users/example/Sites/test-project",
             "",  # plugin_root: CLAUDE_PLUGIN_ROOT not set in this test
-            write_disk=True,
         )
 
     def test_missing_session_id_falls_back_to_unknown_and_warns(self, monkeypatch, tmp_path, capsys):
@@ -1169,17 +1173,21 @@ class TestWriteContextIntegration:
              patch("session_init.get_task_list", return_value=None), \
              patch("session_init.restore_last_session", return_value=None), \
              patch("session_init.check_paused_state", return_value=None), \
-             patch("session_init.write_context") as mock_write_ctx, \
+             patch("session_init.build_context_cache") as mock_build_ctx, \
+             patch("session_init.persist_context") as mock_persist, \
              patch("session_init.append_event") as mock_append, \
              patch("sys.stdin", io.StringIO(stdin_data)), \
              patch("sys.stdout", new_callable=io.StringIO):
             with pytest.raises(SystemExit):
                 main()
 
-        # R3: write_context and append_event must NOT be called on the
-        # malformed-stdin path — they would create an unreapable
-        # `pact-sessions/.../unknown-xxxx/` directory.
-        mock_write_ctx.assert_not_called()
+        # R3: the context build/persist and append_event must NOT be called on
+        # the malformed-stdin path — they would create an unreapable
+        # `pact-sessions/.../unknown-xxxx/` directory. The whole
+        # `if not session_id_was_missing` block is skipped, so neither half of
+        # the build_context_cache/persist_context seam runs.
+        mock_build_ctx.assert_not_called()
+        mock_persist.assert_not_called()
         session_start_calls = [
             call for call in mock_append.call_args_list
             if call.args and call.args[0].get("type") == "session_start"
@@ -1232,7 +1240,7 @@ class TestWriteContextIntegration:
              patch("session_init.get_task_list", return_value=None), \
              patch("session_init.restore_last_session", return_value=None), \
              patch("session_init.check_paused_state", return_value=None), \
-             patch("session_init.write_context", return_value=None), \
+             patch("session_init.persist_context", return_value=None), \
              patch("session_init.append_event") as mock_append, \
              patch("sys.stdin", io.StringIO(stdin_data)), \
              patch("sys.stdout", new_callable=io.StringIO), \
@@ -1349,7 +1357,7 @@ class TestWriteContextIntegration:
              patch("session_init.get_task_list", return_value=None), \
              patch("session_init.restore_last_session", return_value=None), \
              patch("session_init.check_paused_state", return_value=None), \
-             patch("session_init.write_context", return_value=None), \
+             patch("session_init.persist_context", return_value=None), \
              patch("session_init.append_event", return_value=True), \
              patch("sys.stdin", io.StringIO(stdin_data)), \
              patch("sys.stdout", new_callable=io.StringIO), \
@@ -1387,7 +1395,7 @@ class TestWriteContextIntegration:
              patch("session_init.get_task_list", return_value=None), \
              patch("session_init.restore_last_session", return_value=None), \
              patch("session_init.check_paused_state", return_value=None), \
-             patch("session_init.write_context", return_value=None), \
+             patch("session_init.persist_context", return_value=None), \
              patch("session_init.append_event", return_value=True), \
              patch("sys.stdin", io.StringIO(stdin_data)), \
              patch("sys.stdout", new_callable=io.StringIO), \
@@ -1447,7 +1455,7 @@ class TestFailureLogIntegration:
              patch("session_init.get_task_list", return_value=None), \
              patch("session_init.restore_last_session", return_value=None), \
              patch("session_init.check_paused_state", return_value=None), \
-             patch("session_init.write_context", return_value=None), \
+             patch("session_init.persist_context", return_value=None), \
              patch("session_init.append_event", return_value=None), \
              patch("session_init.append_failure") as mock_append_failure, \
              patch("sys.stdin", io.StringIO(stdin_data)), \
@@ -1494,7 +1502,7 @@ class TestFailureLogIntegration:
              patch("session_init.get_task_list", return_value=None), \
              patch("session_init.restore_last_session", return_value=None), \
              patch("session_init.check_paused_state", return_value=None), \
-             patch("session_init.write_context", return_value=None), \
+             patch("session_init.persist_context", return_value=None), \
              patch("session_init.append_event", return_value=None), \
              patch("session_init.append_failure") as mock_append_failure, \
              patch("sys.stdin", io.StringIO(stdin_data)), \
@@ -1532,7 +1540,7 @@ class TestFailureLogIntegration:
              patch("session_init.get_task_list", return_value=None), \
              patch("session_init.restore_last_session", return_value=None), \
              patch("session_init.check_paused_state", return_value=None), \
-             patch("session_init.write_context", return_value=None), \
+             patch("session_init.persist_context", return_value=None), \
              patch("session_init.append_event", return_value=None), \
              patch("session_init.append_failure") as mock_append_failure, \
              patch("sys.stdin", io.StringIO(stdin_data)), \
@@ -1571,7 +1579,7 @@ class TestFailureLogIntegration:
              patch("session_init.get_task_list", return_value=None), \
              patch("session_init.restore_last_session", return_value=None), \
              patch("session_init.check_paused_state", return_value=None), \
-             patch("session_init.write_context", return_value=None), \
+             patch("session_init.persist_context", return_value=None), \
              patch("session_init.append_event", return_value=None), \
              patch("session_init.append_failure") as mock_append_failure, \
              patch("sys.stdin", io.StringIO(stdin_data)), \
@@ -1610,7 +1618,7 @@ class TestFailureLogIntegration:
              patch("session_init.get_task_list", return_value=None), \
              patch("session_init.restore_last_session", return_value=None), \
              patch("session_init.check_paused_state", return_value=None), \
-             patch("session_init.write_context", return_value=None), \
+             patch("session_init.persist_context", return_value=None), \
              patch("session_init.append_event", return_value=None), \
              patch("session_init.append_failure") as mock_append_failure, \
              patch("sys.stdin", io.StringIO(stdin_data)), \
@@ -1654,7 +1662,7 @@ class TestFailureLogIntegration:
              patch("session_init.get_task_list", return_value=None), \
              patch("session_init.restore_last_session", return_value=None), \
              patch("session_init.check_paused_state", return_value=None), \
-             patch("session_init.write_context", return_value=None), \
+             patch("session_init.persist_context", return_value=None), \
              patch("session_init.append_event", return_value=None), \
              patch("session_init.append_failure", side_effect=raising_append_failure), \
              patch("sys.stdin", io.StringIO(stdin_data)), \
@@ -1729,7 +1737,8 @@ class TestFailureLogIntegration:
              patch("session_init.get_task_list", return_value=None), \
              patch("session_init.restore_last_session", return_value=None), \
              patch("session_init.check_paused_state", return_value=None), \
-             patch("session_init.write_context") as mock_write_context, \
+             patch("session_init.build_context_cache") as mock_build_context, \
+             patch("session_init.persist_context") as mock_persist_context, \
              patch("session_init.append_event", return_value=None), \
              patch("session_init.append_failure") as mock_append_failure, \
              patch("sys.stdin", io.StringIO(stdin_data)), \
@@ -1758,10 +1767,12 @@ class TestFailureLogIntegration:
         # write entirely. If this assertion fails the tainted id could be
         # interpolated into the Resume line verbatim.
         mock_update_session_info.assert_not_called()
-        # write_context is also gated by session_id_was_missing — the
-        # pact-session-context.json write must not happen either, since
-        # the tainted id would otherwise land on disk as a dir segment.
-        mock_write_context.assert_not_called()
+        # The context build/persist seam is also gated by session_id_was_missing
+        # — the pact-session-context.json write must not happen either, since the
+        # tainted id would otherwise land on disk as a dir segment. Neither half
+        # of build_context_cache/persist_context runs.
+        mock_build_context.assert_not_called()
+        mock_persist_context.assert_not_called()
 
     def test_other_classification_catchall_via_mock(
         self, monkeypatch, tmp_path
@@ -1792,7 +1803,7 @@ class TestFailureLogIntegration:
              patch("session_init.get_task_list", return_value=None), \
              patch("session_init.restore_last_session", return_value=None), \
              patch("session_init.check_paused_state", return_value=None), \
-             patch("session_init.write_context", return_value=None), \
+             patch("session_init.persist_context", return_value=None), \
              patch("session_init.append_event", return_value=None), \
              patch("session_init.append_failure") as mock_append_failure, \
              patch("session_init._is_unknown_or_missing_session", return_value=True), \
@@ -2494,21 +2505,22 @@ class TestPluginRootEnvWiring:
              patch("session_init.update_session_info", return_value=None), \
              patch("session_init.get_task_list", return_value=None), \
              patch("session_init.restore_last_session", return_value=None), \
-             patch("session_init.check_paused_state", return_value=None), \
-             patch("session_init.write_context") as mock_write_ctx, \
+             patch("session_init.build_context_cache",
+                   return_value=(Path("/tmp/ctx.json"), {})) as mock_build_ctx, \
+             patch("session_init.persist_context", return_value=None), \
              patch("sys.stdin", io.StringIO(stdin_data)), \
              patch("sys.stdout", new_callable=io.StringIO):
             with pytest.raises(SystemExit) as exc_info:
                 main()
 
         assert exc_info.value.code == 0
-        # 4th positional arg of write_context is plugin_root; #877 adds write_disk.
-        mock_write_ctx.assert_called_once_with(
+        # 4th positional arg is plugin_root; #878 SHAPE-2 moved the disk gate out
+        # of this call into persist_context, so no write_disk kwarg here.
+        mock_build_ctx.assert_called_once_with(
             "pact-aabb1122",
             "aabb1122-0000-0000-0000-000000000000",
             str(tmp_path / "proj"),
             plugin_root_value,
-            write_disk=True,
         )
 
     def test_plugin_root_env_flows_to_update_session_info(
@@ -2593,7 +2605,8 @@ class TestPluginRootEnvWiring:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         session_id = "ccdd3344-0000-0000-0000-000000000000"
-        # #877: lead frame so write_disk=True and the JSON lands on disk.
+        # #878 SHAPE-2: lead frame so session_init persists (build + persist) and
+        # the JSON lands on disk.
         stdin_data = json.dumps(_with_lead_role({"session_id": session_id}))
 
         # pact_context._cache / _context_path reset handled by the class's
@@ -2793,7 +2806,7 @@ class TestSessionStartSourceField:
              patch("session_init.get_task_list", return_value=None), \
              patch("session_init.restore_last_session", return_value=None), \
              patch("session_init.check_paused_state", return_value=None), \
-             patch("session_init.write_context", return_value=None), \
+             patch("session_init.persist_context", return_value=None), \
              patch("session_init.append_event") as mock_append, \
              patch("sys.stdin", io.StringIO(stdin_data)), \
              patch("sys.stdout", new_callable=io.StringIO):

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -53,6 +53,25 @@ import pytest
 # Add hooks directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
+
+# #877: session_init's Class-A writes (write_context disk-write, session_start
+# journal anchor, CLAUDE.md Current Session block, paused-state surface) are now
+# gated behind is_lead, which keys on the harness-set agent_type. These tests
+# exercise the LEAD path, so their stdin payloads must carry a lead agent_type.
+# _with_lead_role injects it without disturbing any payload that already sets
+# agent_type (e.g. a teammate/plain-frame suppression test sets it explicitly).
+_LEAD_AGENT_TYPE = "pact-orchestrator"
+
+
+def _with_lead_role(payload: dict) -> dict:
+    """Return a copy of ``payload`` with a lead ``agent_type`` unless one is
+    already present. Lets the lead-path tests opt in to is_lead==True with a
+    single shared edit instead of stamping every inline stdin literal."""
+    if "agent_type" in payload:
+        return payload
+    return {**payload, "agent_type": _LEAD_AGENT_TYPE}
+
+
 class TestGenerateTeamName:
     """Tests for generate_team_name() -- session-unique team name generation."""
 
@@ -186,8 +205,11 @@ class TestMainPausedStateIntegration:
 
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
 
-        # Provide valid JSON on stdin with a session_id
-        stdin_data = json.dumps({"session_id": "aabb1122-0000-0000-0000-000000000000"})
+        # Provide valid JSON on stdin with a session_id (#877: lead frame so the
+        # is_lead-gated check_paused_state actually runs).
+        stdin_data = json.dumps(_with_lead_role(
+            {"session_id": "aabb1122-0000-0000-0000-000000000000"}
+        ))
 
         with patch("session_init.setup_plugin_symlinks", return_value=None), \
              patch("session_init.ensure_project_memory_md", return_value=None), \
@@ -307,8 +329,9 @@ class TestMainPrevSessionDirOrdering:
         )
 
         # --- Arrange: current session id (different from the prior one) ---
+        # #877: lead frame so the is_lead-gated check_paused_state runs.
         current_session_id = "aabb1122-0000-0000-0000-000000000000"
-        stdin_data = json.dumps({"session_id": current_session_id})
+        stdin_data = json.dumps(_with_lead_role({"session_id": current_session_id}))
 
         # Spies so we can assert exactly which prev_session_dir the downstream
         # calls received. We wrap rather than replace so the real implementations
@@ -1089,9 +1112,10 @@ class TestWriteContextIntegration:
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
-        stdin_data = json.dumps({
+        # #877: lead frame → write_disk=True (the on-disk write happens).
+        stdin_data = json.dumps(_with_lead_role({
             "session_id": "aabb1122-0000-0000-0000-000000000000",
-        })
+        }))
 
         with patch("session_init.setup_plugin_symlinks", return_value=None), \
              patch("session_init.ensure_project_memory_md", return_value=None), \
@@ -1107,11 +1131,13 @@ class TestWriteContextIntegration:
                 main()
 
         assert exc_info.value.code == 0
+        # #877: the disk-write split adds write_disk=is_lead (True on the lead path).
         mock_write_ctx.assert_called_once_with(
             "pact-aabb1122",
             "aabb1122-0000-0000-0000-000000000000",
             "/Users/example/Sites/test-project",
             "",  # plugin_root: CLAUDE_PLUGIN_ROOT not set in this test
+            write_disk=True,
         )
 
     def test_missing_session_id_falls_back_to_unknown_and_warns(self, monkeypatch, tmp_path, capsys):
@@ -1351,7 +1377,8 @@ class TestWriteContextIntegration:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         real_session_id = "aabb1122-0000-0000-0000-000000000000"
-        stdin_data = json.dumps({"session_id": real_session_id})
+        # #877: lead frame so the is_lead-gated update_session_info runs.
+        stdin_data = json.dumps(_with_lead_role({"session_id": real_session_id}))
 
         with patch("session_init.setup_plugin_symlinks", return_value=None), \
              patch("session_init.ensure_project_memory_md", return_value=None), \
@@ -2457,9 +2484,9 @@ class TestPluginRootEnvWiring:
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", plugin_root_value)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
-        stdin_data = json.dumps({
+        stdin_data = json.dumps(_with_lead_role({
             "session_id": "aabb1122-0000-0000-0000-000000000000",
-        })
+        }))
 
         with patch("session_init.setup_plugin_symlinks", return_value=None), \
              patch("session_init.ensure_project_memory_md", return_value=None), \
@@ -2475,12 +2502,13 @@ class TestPluginRootEnvWiring:
                 main()
 
         assert exc_info.value.code == 0
-        # 4th positional arg of write_context is plugin_root
+        # 4th positional arg of write_context is plugin_root; #877 adds write_disk.
         mock_write_ctx.assert_called_once_with(
             "pact-aabb1122",
             "aabb1122-0000-0000-0000-000000000000",
             str(tmp_path / "proj"),
             plugin_root_value,
+            write_disk=True,
         )
 
     def test_plugin_root_env_flows_to_update_session_info(
@@ -2504,9 +2532,10 @@ class TestPluginRootEnvWiring:
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", plugin_root_value)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
-        stdin_data = json.dumps({
+        # #877: lead frame so the is_lead-gated update_session_info runs.
+        stdin_data = json.dumps(_with_lead_role({
             "session_id": "aabb1122-0000-0000-0000-000000000000",
-        })
+        }))
 
         # Intentionally NOT mocking update_session_info — we want it to run
         # for real against the tmp_path project dir. Everything else that
@@ -2564,7 +2593,8 @@ class TestPluginRootEnvWiring:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         session_id = "ccdd3344-0000-0000-0000-000000000000"
-        stdin_data = json.dumps({"session_id": session_id})
+        # #877: lead frame so write_disk=True and the JSON lands on disk.
+        stdin_data = json.dumps(_with_lead_role({"session_id": session_id}))
 
         # pact_context._cache / _context_path reset handled by the class's
         # autouse _reset_pact_context_cache fixture (T2) — no inline reset
@@ -2754,7 +2784,7 @@ class TestSessionStartSourceField:
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
-        stdin_data = json.dumps(stdin_payload)
+        stdin_data = json.dumps(_with_lead_role(stdin_payload))
 
         with patch("session_init.setup_plugin_symlinks", return_value=None), \
              patch("session_init.ensure_project_memory_md", return_value=None), \
@@ -4111,9 +4141,11 @@ class TestMainExceptionSafetyNet:
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
-        stdin_data = json.dumps({
+        # #877: lead frame so the is_lead-gated update_session_info runs and the
+        # injected late failure actually fires.
+        stdin_data = json.dumps(_with_lead_role({
             "session_id": "aabb1122-0000-0000-0000-000000000000",
-        })
+        }))
 
         def raise_late(*args, **kwargs):
             raise RuntimeError("simulated late failure after team name captured")

--- a/pact-plugin/tests/test_session_init_role_suppression.py
+++ b/pact-plugin/tests/test_session_init_role_suppression.py
@@ -133,6 +133,32 @@ class TestLeadRowsAllWritesRun:
         # paused-state surface checked.
         mocks["check_paused_state"].assert_called_once()
 
+    def test_lead_with_missing_session_id_suppresses_all_writes(
+        self, monkeypatch, tmp_path
+    ):
+        """#9: a LEAD frame with NO session_id suppresses ALL Class-A writes —
+        including update_session_info. The is_lead gate is necessary but not
+        sufficient: the `session_id_was_missing` guard (R3) independently skips
+        every persistence call so a malformed-stdin lead can't leak an
+        unreapable `pact-sessions/.../unknown-xxxx/` dir or interpolate a junk
+        session_id into the CLAUDE.md Current Session block. This pins that the
+        two gates compose (lead AND valid-session_id), not lead alone."""
+        # Lead frame (qualified) but OMIT session_id → session_id_was_missing.
+        stdin = json.dumps({**lead_frame_qualified()})  # no session_id key
+        mocks = _run_main_with(stdin, monkeypatch, tmp_path)
+
+        # The whole `if not session_id_was_missing` block is skipped: neither
+        # half of the build/persist seam, nor the journal anchor, runs.
+        mocks["build_context_cache"].assert_not_called()
+        mocks["persist_context"].assert_not_called()
+        assert _session_start_calls(mocks["append_event"]) == [], (
+            "missing-session_id lead must NOT append the session_start anchor"
+        )
+        # update_session_info is gated by `frame_is_lead AND not
+        # _is_unknown_or_missing_session` — the missing-session_id arm suppresses
+        # it even though the frame IS the lead.
+        mocks["update_session_info"].assert_not_called()
+
 
 # ===========================================================================
 # TEAMMATE + PLAIN rows — every write is SUPPRESSED.

--- a/pact-plugin/tests/test_session_init_role_suppression.py
+++ b/pact-plugin/tests/test_session_init_role_suppression.py
@@ -1,0 +1,314 @@
+"""session_init per-write role-suppression matrix (#877) — end-to-end.
+
+The comprehensive complement to the coder's function-level verification in
+test_session_init.py. Drives the REAL session_init.main() end-to-end via
+synthetic stdin (under the established Path.home/tmp_path isolation) so the
+actual ``frame_is_lead = is_lead(input_data)`` computation and the gating
+branches execute — not a mock of them.
+
+THE MATRIX: each of session_init's 4 Class-A lead-only writes ×
+{lead / teammate / plain}:
+
+    write                         | lead | teammate | plain
+    ------------------------------|------|----------|------
+    write_context disk-write      | runs | SUPPRESS | SUPPRESS
+    append_event(session_start)   | runs | SUPPRESS | SUPPRESS
+    update_session_info           | runs | SUPPRESS | SUPPRESS
+    check_paused_state            | runs | SUPPRESS | SUPPRESS
+
+CRUCIAL split-correctness property (the one non-mechanical site, #877):
+``write_context`` populates the in-process ``_cache`` / ``_context_path``
+UNCONDITIONALLY (every frame) so ``get_session_dir()`` / append_event's
+path-resolution keep working — but gates ONLY the on-disk write on is_lead.
+A teammate/plain frame must get the cache populated AND no disk file written.
+``TestWriteContextSplit`` exercises the REAL write_context (not a mock) to pin
+this.
+
+Lead path is the coder's existing coverage (test_session_init.py
+TestWriteContextIntegration etc.); this file is the SUPPRESSION-side
+comprehensiveness add: teammate + plain rows for every write, plus the split.
+"""
+
+import io
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from fixtures.role_frames import (
+    lead_frame_qualified,
+    lead_frame_unqualified,
+    plain_frame,
+    teammate_frame,
+)
+
+
+_SESSION_ID = "aabb1122-0000-0000-0000-000000000000"
+_PROJECT_DIR = "/Users/example/Sites/test-project"
+
+
+def _stdin_for(frame: dict) -> str:
+    """Build a SessionStart stdin payload carrying ``frame``'s role
+    discriminator + a valid session_id (so the writes are reached and only
+    the is_lead gate decides suppression)."""
+    payload = {"session_id": _SESSION_ID, **frame}
+    return json.dumps(payload)
+
+
+def _run_main_with(stdin_data: str, monkeypatch, tmp_path):
+    """Run session_init.main() end-to-end with the heavy collaborators
+    patched out, returning the four gated-write mocks for assertion.
+
+    Patches the SAME collaborator set the coder's integration tests use so we
+    isolate the is_lead gating decision. Returns a dict of the 4 write mocks.
+    """
+    from session_init import main
+
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", _PROJECT_DIR)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    with patch("session_init.setup_plugin_symlinks", return_value=None), \
+         patch("session_init.ensure_project_memory_md", return_value=None), \
+         patch("session_init.check_pinned_staleness", return_value=None), \
+         patch("session_init.get_task_list", return_value=None), \
+         patch("session_init.restore_last_session", return_value=None), \
+         patch("session_init.write_context") as mock_write_ctx, \
+         patch("session_init.append_event") as mock_append, \
+         patch("session_init.update_session_info", return_value=None) as mock_update, \
+         patch("session_init.check_paused_state", return_value=None) as mock_paused, \
+         patch("sys.stdin", io.StringIO(stdin_data)), \
+         patch("sys.stdout", new_callable=io.StringIO):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    assert exc_info.value.code == 0
+    return {
+        "write_context": mock_write_ctx,
+        "append_event": mock_append,
+        "update_session_info": mock_update,
+        "check_paused_state": mock_paused,
+    }
+
+
+def _session_start_calls(mock_append):
+    """The session_start append_event calls (filtering out any other event
+    types the hook may append)."""
+    return [
+        c for c in mock_append.call_args_list
+        if c.args and c.args[0].get("type") == "session_start"
+    ]
+
+
+# ===========================================================================
+# LEAD rows — every write RUNS (both spellings).
+# ===========================================================================
+
+class TestLeadRowsAllWritesRun:
+    """For a lead frame (both spellings), all 4 Class-A writes fire."""
+
+    @pytest.mark.parametrize("frame_builder", [
+        lead_frame_qualified,
+        lead_frame_unqualified,
+    ], ids=["qualified", "unqualified"])
+    def test_lead_runs_all_four_writes(self, frame_builder, monkeypatch, tmp_path):
+        mocks = _run_main_with(_stdin_for(frame_builder()), monkeypatch, tmp_path)
+
+        # write_context invoked with write_disk=True (the disk write happens).
+        mocks["write_context"].assert_called_once()
+        assert mocks["write_context"].call_args.kwargs.get("write_disk") is True, (
+            "lead frame must call write_context with write_disk=True"
+        )
+        # session_start journal anchor appended.
+        assert _session_start_calls(mocks["append_event"]), (
+            "lead frame must append the session_start journal anchor"
+        )
+        # CLAUDE.md Current Session block written.
+        mocks["update_session_info"].assert_called_once()
+        # paused-state surface checked.
+        mocks["check_paused_state"].assert_called_once()
+
+
+# ===========================================================================
+# TEAMMATE + PLAIN rows — every write is SUPPRESSED.
+# ===========================================================================
+
+class TestNonLeadRowsAllWritesSuppressed:
+    """For a teammate or plain frame, all 4 Class-A writes are suppressed.
+
+    write_context is still CALLED (the cache must be populated — see
+    TestWriteContextSplit) but with write_disk=False so no disk write occurs;
+    the other 3 writes are not called at all.
+    """
+
+    @pytest.mark.parametrize("frame_builder, role", [
+        (teammate_frame, "teammate"),
+        (plain_frame, "plain"),
+    ])
+    def test_non_lead_suppresses_disk_write_and_other_writes(
+        self, frame_builder, role, monkeypatch, tmp_path
+    ):
+        mocks = _run_main_with(_stdin_for(frame_builder()), monkeypatch, tmp_path)
+
+        # write_context IS called (cache population is unconditional) but the
+        # disk write is gated OFF (write_disk=False).
+        mocks["write_context"].assert_called_once()
+        assert mocks["write_context"].call_args.kwargs.get("write_disk") is False, (
+            f"{role} frame must call write_context with write_disk=False "
+            f"(disk write suppressed, cache still populated)"
+        )
+        # The other 3 lead-only writes are NOT called at all.
+        assert _session_start_calls(mocks["append_event"]) == [], (
+            f"{role} frame must NOT append the session_start journal anchor"
+        )
+        mocks["update_session_info"].assert_not_called()
+        mocks["check_paused_state"].assert_not_called()
+
+    def test_teammate_specific_agent_types_all_suppress(self, monkeypatch, tmp_path):
+        """A range of specialist agent_types all suppress (not just the
+        default). Guards against a literal-coupling bug where only one
+        teammate spelling is treated as non-lead."""
+        for at in ("pact-backend-coder", "pact-secretary", "pact-test-engineer"):
+            mocks = _run_main_with(
+                _stdin_for(teammate_frame(agent_type=at)), monkeypatch, tmp_path
+            )
+            assert mocks["write_context"].call_args.kwargs.get("write_disk") is False
+            mocks["update_session_info"].assert_not_called()
+
+
+# ===========================================================================
+# write_context SPLIT — the load-bearing correctness property (REAL function).
+# ===========================================================================
+
+class TestWriteContextSplit:
+    """write_context populates _cache/_context_path UNCONDITIONALLY but gates
+    the on-disk write on write_disk. Exercises the REAL write_context (not a
+    mock) — this is the #877 split's correctness property. The autouse
+    _reset_pact_context_state fixture (conftest.py) gives each test a clean
+    cache.
+    """
+
+    def test_non_lead_populates_cache_but_writes_no_disk_file(self, monkeypatch, tmp_path):
+        """write_disk=False: _cache + _context_path are set (get_session_dir
+        works) and NO on-disk pact-session-context.json is created."""
+        import shared.pact_context as ctx
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        # Pre-state: autouse reset leaves both None.
+        assert ctx._cache is None and ctx._context_path is None
+
+        ctx.write_context(
+            "pact-aabb1122", _SESSION_ID, str(tmp_path / "proj"),
+            "", write_disk=False,
+        )
+
+        # Cache + path populated unconditionally.
+        assert ctx._cache is not None, "non-lead frame must still populate _cache"
+        assert ctx._cache["session_id"] == _SESSION_ID
+        assert ctx._context_path is not None, "non-lead frame must set _context_path"
+        # get_session_dir() (the downstream consumer) resolves off the cache.
+        assert ctx.get_session_dir(), "get_session_dir must work for a non-lead frame"
+        # But NO disk file was written.
+        assert not ctx._context_path.exists(), (
+            "write_disk=False must NOT create the on-disk session-context file "
+            "(the lead-only artifact a teammate frame must not clobber)"
+        )
+
+    def test_lead_populates_cache_and_writes_disk_file(self, monkeypatch, tmp_path):
+        """write_disk=True (lead): _cache populated AND the on-disk file
+        exists with the expected content — byte-for-byte historical behavior."""
+        import shared.pact_context as ctx
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert ctx._cache is None and ctx._context_path is None
+
+        ctx.write_context(
+            "pact-aabb1122", _SESSION_ID, str(tmp_path / "proj"),
+            "", write_disk=True,
+        )
+
+        assert ctx._cache is not None
+        assert ctx._context_path is not None
+        assert ctx._context_path.exists(), (
+            "write_disk=True (lead) must create the on-disk session-context file"
+        )
+        written = json.loads(ctx._context_path.read_text(encoding="utf-8"))
+        assert written["session_id"] == _SESSION_ID
+        assert written["team_name"] == "pact-aabb1122"
+
+    def test_cache_identical_between_disk_and_no_disk(self, monkeypatch, tmp_path):
+        """The in-memory cache content is IDENTICAL whether or not the disk
+        write happens — the split changes only the disk side-effect, never the
+        cache the downstream consumers read. (started_at differs by clock, so
+        compare the stable fields.)"""
+        import shared.pact_context as ctx
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        ctx.write_context("pact-x", _SESSION_ID, "/p", "plug", write_disk=False)
+        no_disk = {k: ctx._cache[k] for k in
+                   ("team_name", "session_id", "project_dir", "plugin_root")}
+
+        ctx.reset_for_tests()
+        ctx.write_context("pact-x", _SESSION_ID, "/p", "plug", write_disk=True)
+        with_disk = {k: ctx._cache[k] for k in
+                     ("team_name", "session_id", "project_dir", "plugin_root")}
+
+        assert no_disk == with_disk, (
+            "the in-memory cache must be identical regardless of write_disk — "
+            "the split gates ONLY the disk side-effect"
+        )
+
+
+# ===========================================================================
+# UNKNOWN-ROLE STARTUP WARNING — fires for unknown role ONLY.
+# ===========================================================================
+
+class TestUnknownRoleStartupWarning:
+    """The unknown-role notice fires for a plain (agent_type-absent) frame on
+    startup/resume, and NOT for lead or teammate frames."""
+
+    def _run_capture_systemmessage(self, stdin_data, monkeypatch, tmp_path):
+        from session_init import main
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", _PROJECT_DIR)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        with patch("session_init.setup_plugin_symlinks", return_value=None), \
+             patch("session_init.ensure_project_memory_md", return_value=None), \
+             patch("session_init.check_pinned_staleness", return_value=None), \
+             patch("session_init.get_task_list", return_value=None), \
+             patch("session_init.restore_last_session", return_value=None), \
+             patch("session_init.write_context", return_value=None), \
+             patch("session_init.append_event", return_value=None), \
+             patch("session_init.update_session_info", return_value=None), \
+             patch("session_init.check_paused_state", return_value=None), \
+             patch("sys.stdin", io.StringIO(stdin_data)), \
+             patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            with pytest.raises(SystemExit):
+                main()
+        out = json.loads(mock_stdout.getvalue())
+        return json.dumps(out)  # whole output blob; notice may be systemMessage
+
+    def _notice_text(self):
+        import session_init
+        return session_init._UNKNOWN_ROLE_NOTICE
+
+    def test_plain_frame_startup_fires_warning(self, monkeypatch, tmp_path):
+        stdin = json.dumps({"session_id": _SESSION_ID, "source": "startup",
+                            **plain_frame()})
+        blob = self._run_capture_systemmessage(stdin, monkeypatch, tmp_path)
+        assert self._notice_text() in blob, (
+            "unknown-role (plain) frame on startup must emit the notice"
+        )
+
+    @pytest.mark.parametrize("frame_builder", [
+        lead_frame_qualified, lead_frame_unqualified, teammate_frame,
+    ], ids=["lead-qualified", "lead-unqualified", "teammate"])
+    def test_known_role_does_not_fire_warning(self, frame_builder, monkeypatch, tmp_path):
+        stdin = json.dumps({"session_id": _SESSION_ID, "source": "startup",
+                            **frame_builder()})
+        blob = self._run_capture_systemmessage(stdin, monkeypatch, tmp_path)
+        assert self._notice_text() not in blob, (
+            "a recognized (lead/teammate) role must NOT emit the unknown-role notice"
+        )

--- a/pact-plugin/tests/test_session_init_role_suppression.py
+++ b/pact-plugin/tests/test_session_init_role_suppression.py
@@ -73,7 +73,9 @@ def _run_main_with(stdin_data: str, monkeypatch, tmp_path):
          patch("session_init.check_pinned_staleness", return_value=None), \
          patch("session_init.get_task_list", return_value=None), \
          patch("session_init.restore_last_session", return_value=None), \
-         patch("session_init.write_context") as mock_write_ctx, \
+         patch("session_init.build_context_cache",
+               return_value=(Path("/tmp/ctx.json"), {})) as mock_build_ctx, \
+         patch("session_init.persist_context", return_value=None) as mock_persist, \
          patch("session_init.append_event") as mock_append, \
          patch("session_init.update_session_info", return_value=None) as mock_update, \
          patch("session_init.check_paused_state", return_value=None) as mock_paused, \
@@ -84,7 +86,11 @@ def _run_main_with(stdin_data: str, monkeypatch, tmp_path):
 
     assert exc_info.value.code == 0
     return {
-        "write_context": mock_write_ctx,
+        # #878 SHAPE-2: the disk/cache seam is two functions. build_context_cache
+        # runs for EVERY frame (cache always populated); persist_context (the disk
+        # side-effect) runs ONLY for a lead frame.
+        "build_context_cache": mock_build_ctx,
+        "persist_context": mock_persist,
         "append_event": mock_append,
         "update_session_info": mock_update,
         "check_paused_state": mock_paused,
@@ -114,11 +120,10 @@ class TestLeadRowsAllWritesRun:
     def test_lead_runs_all_four_writes(self, frame_builder, monkeypatch, tmp_path):
         mocks = _run_main_with(_stdin_for(frame_builder()), monkeypatch, tmp_path)
 
-        # write_context invoked with write_disk=True (the disk write happens).
-        mocks["write_context"].assert_called_once()
-        assert mocks["write_context"].call_args.kwargs.get("write_disk") is True, (
-            "lead frame must call write_context with write_disk=True"
-        )
+        # #878 SHAPE-2: cache is built for every frame; the lead ALSO persists to
+        # disk (persist_context fires).
+        mocks["build_context_cache"].assert_called_once()
+        mocks["persist_context"].assert_called_once()
         # session_start journal anchor appended.
         assert _session_start_calls(mocks["append_event"]), (
             "lead frame must append the session_start journal anchor"
@@ -136,8 +141,8 @@ class TestLeadRowsAllWritesRun:
 class TestNonLeadRowsAllWritesSuppressed:
     """For a teammate or plain frame, all 4 Class-A writes are suppressed.
 
-    write_context is still CALLED (the cache must be populated — see
-    TestWriteContextSplit) but with write_disk=False so no disk write occurs;
+    build_context_cache is still CALLED (the cache must be populated — see
+    TestWriteContextSplit) but persist_context (the disk write) is NOT called;
     the other 3 writes are not called at all.
     """
 
@@ -150,13 +155,11 @@ class TestNonLeadRowsAllWritesSuppressed:
     ):
         mocks = _run_main_with(_stdin_for(frame_builder()), monkeypatch, tmp_path)
 
-        # write_context IS called (cache population is unconditional) but the
-        # disk write is gated OFF (write_disk=False).
-        mocks["write_context"].assert_called_once()
-        assert mocks["write_context"].call_args.kwargs.get("write_disk") is False, (
-            f"{role} frame must call write_context with write_disk=False "
-            f"(disk write suppressed, cache still populated)"
-        )
+        # #878 SHAPE-2: build_context_cache IS called (cache population is
+        # unconditional) but persist_context (the disk write) is NOT — the disk
+        # side-effect is gated on is_lead.
+        mocks["build_context_cache"].assert_called_once()
+        mocks["persist_context"].assert_not_called()
         # The other 3 lead-only writes are NOT called at all.
         assert _session_start_calls(mocks["append_event"]) == [], (
             f"{role} frame must NOT append the session_start journal anchor"
@@ -172,7 +175,9 @@ class TestNonLeadRowsAllWritesSuppressed:
             mocks = _run_main_with(
                 _stdin_for(teammate_frame(agent_type=at)), monkeypatch, tmp_path
             )
-            assert mocks["write_context"].call_args.kwargs.get("write_disk") is False
+            # #878 SHAPE-2: cache built, but the disk persist is suppressed.
+            mocks["build_context_cache"].assert_called_once()
+            mocks["persist_context"].assert_not_called()
             mocks["update_session_info"].assert_not_called()
 
 
@@ -181,82 +186,87 @@ class TestNonLeadRowsAllWritesSuppressed:
 # ===========================================================================
 
 class TestWriteContextSplit:
-    """write_context populates _cache/_context_path UNCONDITIONALLY but gates
-    the on-disk write on write_disk. Exercises the REAL write_context (not a
-    mock) — this is the #877 split's correctness property. The autouse
-    _reset_pact_context_state fixture (conftest.py) gives each test a clean
-    cache.
+    """#878 SHAPE-2 seam: build_context_cache populates _cache/_context_path
+    UNCONDITIONALLY (NO disk I/O); persist_context is the separate is_lead-gated
+    disk write. The #877 split's correctness property. Exercises the REAL
+    functions (not mocks). The autouse _reset_pact_context_state fixture
+    (conftest.py) gives each test a clean cache.
     """
 
     def test_non_lead_populates_cache_but_writes_no_disk_file(self, monkeypatch, tmp_path):
-        """write_disk=False: _cache + _context_path are set (get_session_dir
-        works) and NO on-disk pact-session-context.json is created."""
+        """Non-lead = build_context_cache ONLY (no persist): _cache +
+        _context_path are set (get_session_dir works) and NO on-disk
+        pact-session-context.json is created."""
         import shared.pact_context as ctx
 
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         # Pre-state: autouse reset leaves both None.
         assert ctx._cache is None and ctx._context_path is None
 
-        ctx.write_context(
-            "pact-aabb1122", _SESSION_ID, str(tmp_path / "proj"),
-            "", write_disk=False,
+        result = ctx.build_context_cache(
+            "pact-aabb1122", _SESSION_ID, str(tmp_path / "proj"), "",
         )
+        # (no persist_context call — this is the non-lead path)
 
-        # Cache + path populated unconditionally.
+        assert result is not None
+        # Cache + path populated unconditionally by the builder.
         assert ctx._cache is not None, "non-lead frame must still populate _cache"
         assert ctx._cache["session_id"] == _SESSION_ID
         assert ctx._context_path is not None, "non-lead frame must set _context_path"
         # get_session_dir() (the downstream consumer) resolves off the cache.
         assert ctx.get_session_dir(), "get_session_dir must work for a non-lead frame"
-        # But NO disk file was written.
+        # But NO disk file was written (persist_context was never called).
         assert not ctx._context_path.exists(), (
-            "write_disk=False must NOT create the on-disk session-context file "
+            "skipping persist must NOT create the on-disk session-context file "
             "(the lead-only artifact a teammate frame must not clobber)"
         )
 
     def test_lead_populates_cache_and_writes_disk_file(self, monkeypatch, tmp_path):
-        """write_disk=True (lead): _cache populated AND the on-disk file
-        exists with the expected content — byte-for-byte historical behavior."""
+        """Lead = build_context_cache THEN persist_context: _cache populated AND
+        the on-disk file exists with the expected content — byte-for-byte
+        historical behavior."""
         import shared.pact_context as ctx
 
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         assert ctx._cache is None and ctx._context_path is None
 
-        ctx.write_context(
-            "pact-aabb1122", _SESSION_ID, str(tmp_path / "proj"),
-            "", write_disk=True,
+        result = ctx.build_context_cache(
+            "pact-aabb1122", _SESSION_ID, str(tmp_path / "proj"), "",
         )
+        assert result is not None
+        ctx.persist_context(*result)
 
         assert ctx._cache is not None
         assert ctx._context_path is not None
         assert ctx._context_path.exists(), (
-            "write_disk=True (lead) must create the on-disk session-context file"
+            "lead path (build + persist) must create the on-disk session-context file"
         )
         written = json.loads(ctx._context_path.read_text(encoding="utf-8"))
         assert written["session_id"] == _SESSION_ID
         assert written["team_name"] == "pact-aabb1122"
 
     def test_cache_identical_between_disk_and_no_disk(self, monkeypatch, tmp_path):
-        """The in-memory cache content is IDENTICAL whether or not the disk
-        write happens — the split changes only the disk side-effect, never the
-        cache the downstream consumers read. (started_at differs by clock, so
-        compare the stable fields.)"""
+        """The in-memory cache content is IDENTICAL whether or not persist runs
+        — the seam changes only the disk side-effect, never the cache the
+        downstream consumers read. (started_at differs by clock, so compare the
+        stable fields.)"""
         import shared.pact_context as ctx
 
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
-        ctx.write_context("pact-x", _SESSION_ID, "/p", "plug", write_disk=False)
+        ctx.build_context_cache("pact-x", _SESSION_ID, "/p", "plug")  # no persist
         no_disk = {k: ctx._cache[k] for k in
                    ("team_name", "session_id", "project_dir", "plugin_root")}
 
         ctx.reset_for_tests()
-        ctx.write_context("pact-x", _SESSION_ID, "/p", "plug", write_disk=True)
+        result = ctx.build_context_cache("pact-x", _SESSION_ID, "/p", "plug")
+        ctx.persist_context(*result)
         with_disk = {k: ctx._cache[k] for k in
                      ("team_name", "session_id", "project_dir", "plugin_root")}
 
         assert no_disk == with_disk, (
-            "the in-memory cache must be identical regardless of write_disk — "
-            "the split gates ONLY the disk side-effect"
+            "the in-memory cache must be identical regardless of whether persist "
+            "runs — the seam gates ONLY the disk side-effect"
         )
 
 
@@ -279,7 +289,7 @@ class TestUnknownRoleStartupWarning:
              patch("session_init.check_pinned_staleness", return_value=None), \
              patch("session_init.get_task_list", return_value=None), \
              patch("session_init.restore_last_session", return_value=None), \
-             patch("session_init.write_context", return_value=None), \
+             patch("session_init.persist_context", return_value=None), \
              patch("session_init.append_event", return_value=None), \
              patch("session_init.update_session_info", return_value=None), \
              patch("session_init.check_paused_state", return_value=None), \

--- a/pact-plugin/tests/test_session_init_role_suppression.py
+++ b/pact-plugin/tests/test_session_init_role_suppression.py
@@ -31,6 +31,7 @@ comprehensiveness add: teammate + plain rows for every write, plus the split.
 
 import io
 import json
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -300,14 +301,36 @@ class TestWriteContextSplit:
 # UNKNOWN-ROLE STARTUP WARNING — fires for unknown role ONLY.
 # ===========================================================================
 
-class TestUnknownRoleStartupWarning:
-    """The unknown-role notice fires for a plain (agent_type-absent) frame on
-    startup/resume, and NOT for lead or teammate frames."""
+# The live plugin root (this file is tests/…, parent.parent is pact-plugin/,
+# which carries the real agents/pact-*.md registry). #1 resolves the recognized-
+# specialist set from CLAUDE_PLUGIN_ROOT at the 0c site, so the notice tests
+# point that env at the live root — exercising the REAL specialist registry
+# (the SSOT), not a hand-seeded fixture.
+_REAL_PLUGIN_ROOT = str(Path(__file__).resolve().parent.parent)
 
-    def _run_capture_systemmessage(self, stdin_data, monkeypatch, tmp_path):
+
+class TestUnknownRoleStartupWarning:
+    """#1 (#878): the unknown-role notice fires when a frame has NO recognized
+    role — agent_type ABSENT, OR present-but-unrecognized (typo'd) — and NOT for
+    a lead frame or a RECOGNIZED specialist. Recognized = the live
+    agents/pact-*.md registry, resolved at 0c from CLAUDE_PLUGIN_ROOT (env), with
+    a PACT:-strip for spelling-symmetry and is_lead checked FIRST.
+    """
+
+    def _run_capture_systemmessage(
+        self, stdin_data, monkeypatch, tmp_path, plugin_root=_REAL_PLUGIN_ROOT,
+    ):
         from session_init import main
 
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", _PROJECT_DIR)
+        # #1: the specialist-registry resolution at 0c reads CLAUDE_PLUGIN_ROOT
+        # from env. Default to the live plugin root so a recognized specialist
+        # type actually resolves; pass "" to exercise the unresolvable-registry
+        # fail-OPEN residual.
+        if plugin_root:
+            monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", plugin_root)
+        else:
+            monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         with patch("session_init.setup_plugin_symlinks", return_value=None), \
@@ -330,21 +353,77 @@ class TestUnknownRoleStartupWarning:
         import session_init
         return session_init._UNKNOWN_ROLE_NOTICE
 
-    def test_plain_frame_startup_fires_warning(self, monkeypatch, tmp_path):
+    # ---- FIRES: no recognized role ----
+
+    def test_absent_agent_type_fires(self, monkeypatch, tmp_path):
+        """(d) plain frame — agent_type ABSENT → notice fires."""
         stdin = json.dumps({"session_id": _SESSION_ID, "source": "startup",
                             **plain_frame()})
         blob = self._run_capture_systemmessage(stdin, monkeypatch, tmp_path)
         assert self._notice_text() in blob, (
-            "unknown-role (plain) frame on startup must emit the notice"
+            "absent agent_type on startup must emit the unknown-role notice"
         )
 
+    def test_present_but_unrecognized_agent_type_fires(self, monkeypatch, tmp_path):
+        """(c) a present-but-unrecognized / typo'd agent_type (not in the live
+        registry) → notice fires. This is the #1 broadening over the prior
+        absent-only check."""
+        stdin = json.dumps({"session_id": _SESSION_ID, "source": "startup",
+                            "agent_type": "pact-architct"})  # typo: not in registry
+        blob = self._run_capture_systemmessage(stdin, monkeypatch, tmp_path)
+        assert self._notice_text() in blob, (
+            "a present-but-unrecognized agent_type must emit the notice "
+            "(the typo'd-orchestrator case #1 exists to catch)"
+        )
+
+    def test_unresolvable_registry_present_unrecognized_fires(self, monkeypatch, tmp_path):
+        """(e) fail-OPEN residual: env CLAUDE_PLUGIN_ROOT empty → registry
+        unresolvable → a present-but-(unverifiable) agent_type fires. An install
+        with no resolvable plugin_root is broken; a spurious advisory is harmless."""
+        stdin = json.dumps({"session_id": _SESSION_ID, "source": "startup",
+                            "agent_type": "pact-backend-coder"})
+        blob = self._run_capture_systemmessage(
+            stdin, monkeypatch, tmp_path, plugin_root="",
+        )
+        assert self._notice_text() in blob, (
+            "unresolvable registry (empty env plugin_root) must FAIL-OPEN — "
+            "the notice fires rather than being suppressed"
+        )
+
+    # ---- DOES NOT FIRE: recognized role ----
+
     @pytest.mark.parametrize("frame_builder", [
-        lead_frame_qualified, lead_frame_unqualified, teammate_frame,
-    ], ids=["lead-qualified", "lead-unqualified", "teammate"])
-    def test_known_role_does_not_fire_warning(self, frame_builder, monkeypatch, tmp_path):
+        lead_frame_qualified, lead_frame_unqualified,
+    ], ids=["lead-qualified", "lead-unqualified"])
+    def test_lead_does_not_fire(self, frame_builder, monkeypatch, tmp_path):
         stdin = json.dumps({"session_id": _SESSION_ID, "source": "startup",
                             **frame_builder()})
         blob = self._run_capture_systemmessage(stdin, monkeypatch, tmp_path)
         assert self._notice_text() not in blob, (
-            "a recognized (lead/teammate) role must NOT emit the unknown-role notice"
+            "a lead frame must NOT emit the unknown-role notice"
+        )
+
+    def test_recognized_teammate_does_not_fire(self, monkeypatch, tmp_path):
+        """(a) THE REGRESSION PIN: a recognized specialist teammate at 0c (with
+        env plugin_root set) must NOT fire. The timing-blocker fix exists so the
+        registry resolves at 0c — without it, the empty pre-cache registry would
+        false-fire for every teammate."""
+        stdin = json.dumps({"session_id": _SESSION_ID, "source": "startup",
+                            **teammate_frame()})  # agent_type=pact-backend-coder
+        blob = self._run_capture_systemmessage(stdin, monkeypatch, tmp_path)
+        assert self._notice_text() not in blob, (
+            "a RECOGNIZED specialist teammate must NOT fire the unknown-role "
+            "notice — this is the false-fire regression the #1 timing fix prevents"
+        )
+
+    def test_qualified_specialist_does_not_fire(self, monkeypatch, tmp_path):
+        """(b) the PACT:-strip pin: a qualified specialist spelling
+        (PACT:pact-backend-coder) is recognized just like is_lead accepts both
+        lead spellings → NO notice."""
+        stdin = json.dumps({"session_id": _SESSION_ID, "source": "startup",
+                            "agent_type": "PACT:pact-backend-coder"})
+        blob = self._run_capture_systemmessage(stdin, monkeypatch, tmp_path)
+        assert self._notice_text() not in blob, (
+            "a qualified specialist spelling must be recognized (PACT:-strip) "
+            "and NOT fire the unknown-role notice"
         )

--- a/pact-plugin/tests/test_session_journal.py
+++ b/pact-plugin/tests/test_session_journal.py
@@ -2604,7 +2604,7 @@ class TestSessionInitJournalWrite:
              patch("session_init.ensure_project_memory_md", return_value=None), \
              patch("session_init.check_pinned_staleness", return_value=None), \
              patch("session_init.get_task_list", return_value=[]), \
-             patch("session_init.write_context"), \
+             patch("session_init.persist_context"), \
              patch("session_init.check_resumption_context", return_value=None), \
              patch("session_init.restore_last_session", return_value=None), \
              patch("session_init.check_paused_state", return_value=None):

--- a/pact-plugin/tests/test_session_journal.py
+++ b/pact-plugin/tests/test_session_journal.py
@@ -2591,9 +2591,12 @@ class TestSessionInitJournalWrite:
         (journal_home / "project").mkdir()
         (journal_home / "project" / "CLAUDE.md").write_text("# Project\n## Retrieved Context\n")
 
+        # #877: the session_start journal anchor is a lead-only write (gated
+        # behind is_lead), so a lead agent_type is required for it to be written.
         input_data = {
             "session_id": "abc12345-test",
             "source": stdin_source,
+            "agent_type": "pact-orchestrator",
         }
 
         with patch("sys.stdin", io.StringIO(json.dumps(input_data))), \

--- a/pact-plugin/tests/test_validate_handoff.py
+++ b/pact-plugin/tests/test_validate_handoff.py
@@ -140,7 +140,7 @@ class TestMainLastAssistantMessage:
         from validate_handoff import main
 
         input_data = json.dumps({
-            "agent_id": "pact-backend-coder",
+            "agent_type": "pact-backend-coder",
             "last_assistant_message": GOOD_HANDOFF,
             "transcript": MISSING_HANDOFF,  # Would fail if used
         })
@@ -160,7 +160,7 @@ class TestMainLastAssistantMessage:
         from validate_handoff import main
 
         input_data = json.dumps({
-            "agent_id": "pact-backend-coder",
+            "agent_type": "pact-backend-coder",
             "transcript": GOOD_HANDOFF,
         })
 
@@ -178,7 +178,7 @@ class TestMainLastAssistantMessage:
         from validate_handoff import main
 
         input_data = json.dumps({
-            "agent_id": "pact-backend-coder",
+            "agent_type": "pact-backend-coder",
             "last_assistant_message": "",
             "transcript": GOOD_HANDOFF,
         })
@@ -196,7 +196,7 @@ class TestMainLastAssistantMessage:
         from validate_handoff import main
 
         input_data = json.dumps({
-            "agent_id": "pact-backend-coder",
+            "agent_type": "pact-backend-coder",
             "last_assistant_message": "x" * 100 + " " + MISSING_HANDOFF,
         })
 
@@ -223,7 +223,7 @@ class TestMainEntryPoint:
         from validate_handoff import main
 
         input_data = json.dumps({
-            "agent_id": "custom-agent",
+            "agent_type": "custom-agent",
             "transcript": MISSING_HANDOFF,
         })
 
@@ -248,7 +248,7 @@ class TestMainEntryPoint:
         from validate_handoff import main
 
         input_data = json.dumps({
-            "agent_id": "pact-backend-coder",
+            "agent_type": "pact-backend-coder",
             "last_assistant_message": "short",
         })
 
@@ -290,7 +290,7 @@ class TestLastAssistantMessagePreference:
         from validate_handoff import main
 
         input_data = json.dumps({
-            "agent_id": "pact-backend-coder",
+            "agent_type": "pact-backend-coder",
             "last_assistant_message": GOOD_HANDOFF,
             "transcript": "x" * 200,  # Long enough to trigger validation, but no handoff
         })
@@ -308,7 +308,7 @@ class TestLastAssistantMessagePreference:
         from validate_handoff import main
 
         input_data = json.dumps({
-            "agent_id": "pact-backend-coder",
+            "agent_type": "pact-backend-coder",
             "last_assistant_message": None,
             "transcript": GOOD_HANDOFF,
         })
@@ -326,7 +326,7 @@ class TestLastAssistantMessagePreference:
         from validate_handoff import main
 
         input_data = json.dumps({
-            "agent_id": "pact-backend-coder",
+            "agent_type": "pact-backend-coder",
         })
 
         with patch("sys.stdin", io.StringIO(input_data)):
@@ -668,7 +668,7 @@ class TestMainLosslessWarnings:
         # Pad to exceed 100 char minimum + has HANDOFF section but missing Produced
         transcript = HANDOFF_MISSING_PRODUCED + " " * max(0, 100 - len(HANDOFF_MISSING_PRODUCED))
         input_data = json.dumps({
-            "agent_id": "pact-backend-coder",
+            "agent_type": "pact-backend-coder",
             "last_assistant_message": transcript,
         })
 
@@ -688,7 +688,7 @@ class TestMainLosslessWarnings:
 
         transcript = HANDOFF_MISSING_BOTH_LOSSLESS + " " * max(0, 100 - len(HANDOFF_MISSING_BOTH_LOSSLESS))
         input_data = json.dumps({
-            "agent_id": "pact-backend-coder",
+            "agent_type": "pact-backend-coder",
             "last_assistant_message": transcript,
         })
 
@@ -708,7 +708,7 @@ class TestMainLosslessWarnings:
         from validate_handoff import main
 
         input_data = json.dumps({
-            "agent_id": "pact-backend-coder",
+            "agent_type": "pact-backend-coder",
             "last_assistant_message": HANDOFF_BOTH_LOSSLESS,
         })
 
@@ -725,7 +725,7 @@ class TestMainLosslessWarnings:
         from validate_handoff import main
 
         input_data = json.dumps({
-            "agent_id": "pact-auditor",
+            "agent_type": "pact-auditor",
             "last_assistant_message": SIGNAL_COMPLETION_TRANSCRIPT,
         })
 
@@ -736,3 +736,86 @@ class TestMainLosslessWarnings:
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
         assert json.loads(captured.out.strip()) == {"suppressOutput": True}
+
+
+# =============================================================================
+# #812 role-class gate: keyed on agent_type (was agent_id, dormant at v4.4.0)
+# =============================================================================
+
+class TestRoleClassGateOnAgentType:
+    """The role-class gate ("is this a PACT agent?") reads ``agent_type``, not
+    ``agent_id`` (#812). agent_id is absent under the separate-process teammate
+    model, so the prior agent_id-keyed check was DORMANT for all teammates;
+    keying on agent_type re-enables teammate HANDOFF validation. Fail-safe:
+    advisory systemMessage, never DENY.
+    """
+
+    def test_teammate_agent_type_fires_handoff_warning(self, capsys):
+        """A teammate's agent_type (e.g. "pact-preparer") matches the pact-
+        prefix → the gate fires → a missing-HANDOFF transcript warns. This is
+        the validation that was dormant before the #812 swap."""
+        from validate_handoff import main
+
+        input_data = json.dumps({
+            "agent_type": "pact-preparer",
+            "last_assistant_message": "x" * 100 + " " + MISSING_HANDOFF,
+        })
+
+        with patch("sys.stdin", io.StringIO(input_data)):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        output = json.loads(captured.out.strip())
+        assert "systemMessage" in output, (
+            "teammate agent_type 'pact-preparer' must engage the role-class gate "
+            "(re-enabled #812 validation) and warn on a missing HANDOFF"
+        )
+        # The warning labels the agent by its agent_type (no longer the absent agent_id).
+        assert "pact-preparer" in output["systemMessage"]
+
+    def test_agent_id_only_no_agent_type_is_dormant(self, capsys):
+        """DOCUMENTS THE v4.4.0 STATE THE SWAP FIXES: a frame carrying ONLY
+        agent_id (no agent_type) does NOT engage the gate — the role-class check
+        reads agent_type, which is absent → suppressOutput. Pins that agent_id
+        is no longer consulted (so the check is no longer dormant-via-agent_id-
+        absence in the normal teammate case, which DOES carry agent_type)."""
+        from validate_handoff import main
+
+        input_data = json.dumps({
+            "agent_id": "pact-backend-coder",  # present, but NOT the gate field
+            "last_assistant_message": "x" * 100 + " " + MISSING_HANDOFF,
+        })
+
+        with patch("sys.stdin", io.StringIO(input_data)):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert json.loads(captured.out.strip()) == {"suppressOutput": True}, (
+            "agent_id is no longer the gate field — an agent_id-only frame "
+            "(no agent_type) must suppress, proving the gate reads agent_type"
+        )
+
+    def test_non_pact_agent_type_suppresses(self, capsys):
+        """A non-PACT agent_type ("custom-agent") does not match the pact-
+        prefix → suppress (no false-positive HANDOFF warning for non-PACT
+        agents)."""
+        from validate_handoff import main
+
+        input_data = json.dumps({
+            "agent_type": "custom-agent",
+            "last_assistant_message": "x" * 100 + " " + MISSING_HANDOFF,
+        })
+
+        with patch("sys.stdin", io.StringIO(input_data)):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert json.loads(captured.out.strip()) == {"suppressOutput": True}, (
+            "a non-PACT agent_type must not engage the role-class gate"
+        )


### PR DESCRIPTION
## Summary

Under tmux `teammateMode`, every PACT teammate is a **separate `claude` process** firing its own hook lifecycle. PACT's hooks discriminated "lead vs teammate" with a **negative heuristic** — `resolve_agent_name(input_data) == "" ⇒ lead` — whose Step-4 `pact-` prefix-strip returns a **non-empty** string for *both* lead spellings. So the v4.4.0 lead took the teammate-bypass branch in all five Class-B gates: the three DENY gates were **silently dead for the lead**, and `session_init` / `postcompact_archive` had no role gate at all on their lead-only writes.

This PR introduces a single **positive role predicate** keyed on the only reliable signal (`agent_type`, harness-set from process context, not request-reflectable), gates the lead-only writes behind it, migrates the five Class-B gates to it, and distinguishes same-type instances in `file_tracker`. **Net enforcement *restoration*, not a relaxation** — and mode-independent (the lead misfire is present in in-process mode too).

## What landed (8 commits, never-broken-intermediate — full suite green after each)

| | Commit | |
|---|---|---|
| A | `aca12b8c` | `is_lead` / `classify_session_role` predicates in `pact_context` (reads top-level `agent_type` directly; pure, total via isinstance guard, coordination-not-security) |
| B | `d5d41a8c` | **#877/#881** — gate `session_init`'s 4 lead-only writes (incl. the `write_context` disk/cache **split**) + `postcompact_archive`'s compact-summary write behind `is_lead`; unknown-role startup warning |
| C | `491dfcbd` | **#878** — migrate the 2 non-DENY gates (`bootstrap_prompt_gate`, `bootstrap_marker_writer`) |
| D | `958d3b82` | **#878** — migrate the 3 DENY gates (`bootstrap_gate`, `pin_staleness_gate`, `pin_caps_gate`) — the enforcement restoration; fix the stale `pin_caps_gate` false-assumption comment |
| E | `a32c0764` | **#878 / NEW-1** — `file_tracker` composite `(agent_name, session_id)` editor key (distinguish same-`agent_type` instances; keep `resolve_agent_name` for the label; no self-registration) |
| F | `9c81fb21` | version bump 4.4.0 → 4.4.1 (PATCH) |
| G1 | `357b7f90` | tests — HYBRID structural invariant (positive routing + negative AST denylist drift backstop, named-site allowlist, phantom-green + non-vacuity guards) |
| G2-3 | `059b89d7` | tests — per-write suppression matrix (end-to-end via stdin), postcompact suppression, 5-gate flip regression, #812 drift fixture, file_tracker edges |

## Why it's safe (verified at source)

- **Trust-root**: `agent_type` is harness-spawn-set, NOT reflectable from untrusted request content (prompt / file-under-review / tool args). `is_lead` reads top-level `agent_type` only — the adversarial phantom-green probes confirm smuggling identity into `tool_input`/`file_path`/`subagent_type` cannot flip the verdict.
- **`write_context` split** (the one non-mechanical site): the disk write is gated on `is_lead`, but `_cache`/`_context_path` population stays **unconditional**, so `get_session_dir`/`append_event` path-resolution are unchanged for non-lead frames.
- **Total predicate** preserves each gate's exception-fail-CLOSED path.

## Testing

- Full suite: **7841 passed / 0 failed / 12 skipped** (baseline 7775 + 66 new tests).
- Concurrent auditor: **GREEN** on all 6 commits (every structural AC verified against `git show`, scope discipline confirmed).
- Counter-test-by-revert: breaking `is_lead→always-True` fails exactly the non-lead suppression/flip + #812-drift rows while the AST structural invariant stays green (proving behavioral coupling + a distinct defense layer).

## Scope

Closes **#877**, **#881**; substantially closes **#878** (the `is_lead` discriminator family). Deferred to follow-ups (out of scope, by design): the `validate_handoff` `agent_id→agent_type` swap and `trustworthy_actor_name` re-anchor (#812 siblings), and the `file_tracker` friendly-name *label* recovery (instance-identity-under-tmux via SessionStart self-registration).
