### PR TITLE
fix(#880): journal coverage — #869 lead-side emit + #887 occupant-identity marker (v4.4.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.3",
+      "version": "4.4.4",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.3/      # Plugin version
+│               └── 4.4.4/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.3",
+  "version": "4.4.4",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.3
+> **Version**: 4.4.4
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/agent_handoff_emitter.py
+++ b/pact-plugin/hooks/agent_handoff_emitter.py
@@ -6,7 +6,10 @@ Used by: hooks.json TaskCompleted registration.
 
 Responsibilities:
 - On TaskCompleted, write a single agent_handoff event to the session
-  journal, keyed by (team_name, task_id) for idempotent emission.
+  journal, keyed by (team_name, task_id, occupant) for idempotent
+  emission, where occupant = hash(agent + subject) (see
+  shared/agent_handoff_marker.py — the SSOT shared with the #869 lead-side
+  emit in task_lifecycle_gate.py).
 - Bypass non-agent completions (no owner + no platform teammate_name) and
   signal-type tasks (metadata.type in ("blocker", "algedonic")).
 
@@ -22,7 +25,7 @@ Emission invariant: write exactly once iff
 AND
 (2)  task_metadata.get("handoff") is truthy
 AND
-(3)  the per-(team, task_id) sidecar marker does not yet exist.
+(3)  the per-(team, task_id, occupant) sidecar marker does not yet exist.
 
 The transition signal is `hook_event_name`. The disk-status read is a
 fallback only — used when stdin lacks `hook_event_name`. The disk-state
@@ -37,162 +40,43 @@ creation; only the fire with `metadata.handoff` populated claims the
 marker and writes the journal entry.
 
 Idempotency: sidecar O_EXCL marker at
-~/.claude/teams/{team}/.agent_handoff_emitted/{task_id}. The platform's
-Stop flow dispatches TaskCompleted on every matching owner; the marker
-deduplicates these so the journal records exactly one entry per
-(team, task_id).
+~/.claude/teams/{team}/.agent_handoff_emitted/{task_id}-{occupant_hash}.
+The platform's Stop flow dispatches TaskCompleted on every matching owner;
+the marker deduplicates these so the journal records exactly one entry per
+(team, task_id, occupant). Occupant-identity keying (vs. the prior bare
+{task_id}) fixes the #887 stale-marker collision on team-name reuse while
+preserving the standing-task fire-once-across-lifespan dedup. The marker
+machinery lives in shared/agent_handoff_marker.py (SSOT shared with
+task_lifecycle_gate.py's #869 lead-side emit).
 
 # livelock-safe: pure journal-writer; zero emission sinks. Writes at most
-# one agent_handoff event per (team, task_id) via an O_EXCL sidecar marker
-# gated on (a) hook_event_name OR disk-status, (b) handoff-presence in
-# task_metadata, and exits 0 suppressOutput on every code path. Does NOT
-# consume intentional_wait, does NOT emit systemMessage or stderr prompts,
-# and does NOT block completion.
+# one agent_handoff event per (team, task_id, occupant) via an O_EXCL
+# sidecar marker gated on (a) hook_event_name OR disk-status, (b)
+# handoff-presence in task_metadata, and exits 0 suppressOutput on every
+# code path. Does NOT consume intentional_wait, does NOT emit systemMessage
+# or stderr prompts, and does NOT block completion.
 
 Input: JSON from stdin with task_id, task_subject, task_description,
        teammate_name, team_name (TaskCompleted schema).
 Output: {"suppressOutput": true} on every path; exit 0.
 """
 
-import errno
 import json
-import os
-import re
 import sys
-from pathlib import Path
 
 import shared.pact_context as pact_context
+from shared.agent_handoff_marker import (
+    already_emitted,
+    is_signal_task,
+    occupant_hash,
+    sanitize_path_component,
+)
 from shared.pact_context import get_team_name
 from shared.session_journal import append_event, make_event
 from shared.task_utils import read_task_json
 
 # Suppress false "hook error" display in Claude Code UI on bare exit paths.
 _SUPPRESS_OUTPUT = json.dumps({"suppressOutput": True})
-
-# Signal-task types — inline literal, matches the
-# `task_type in ("blocker", "algedonic")` check inside task_utils.find_blockers
-# and the session_resume convention. Do NOT import is_signal_task: no
-# such helper exists.
-# Forward-anchor: extract to a shared `is_signal_task` predicate when a
-# 2nd consumer of this tuple appears.
-_SIGNAL_TASK_TYPES = ("blocker", "algedonic")
-
-
-def _sanitize_path_component(value: str) -> str:
-    """
-    Strip path-traversal fragments from a value destined for filesystem joins.
-
-    Mirrors the regex used inside task_utils.read_task_json so the gate
-    site (status read) and the write site (O_EXCL marker create) apply
-    symmetric sanitization. Without this, an attacker-crafted task_id or
-    team_name that happens to sanitize (in read_task_json) into a matching
-    existing completed-task file could still carry raw "../" fragments into
-    the marker-path join and cause zero-byte file creation outside the team's
-    marker directory.
-
-    Strips path-traversal primitives (`/`, `\\`, `..`) and C0 control
-    characters (NUL, CR/LF, and 0x00-0x1f range) at the producer
-    boundary. Control-char stripping defends against log-injection and
-    embedded-newline attacks on values that flow into filesystem paths.
-    """
-    return re.sub(r"[/\\\x00-\x1f]|\.\.", "", value)
-
-
-def _marker_dir(team_name: str) -> Path:
-    """
-    Return the per-team marker directory path.
-
-    Lives under ~/.claude/teams/{team}/.agent_handoff_emitted/ — a sibling
-    to the team's inboxes/ and config.json. session_end.py's team reaper
-    removes the whole team directory (shutil.rmtree), so the marker dir is
-    cleaned up automatically when the team ages out.
-
-    Kept task-scoped (not session-scoped) so fire-once semantics survive
-    pause/resume: a secretary standing task that spans sessions must emit
-    its agent_handoff event exactly once across the whole team lifespan.
-    """
-    return Path.home() / ".claude" / "teams" / team_name / ".agent_handoff_emitted"
-
-
-def _already_emitted(team_name: str, task_id: str) -> bool:
-    """
-    Test-and-set the per-(team, task_id) marker.
-
-    Returns True iff a prior fire for the same (team, task_id) already
-    created the marker (caller should suppress the journal write).
-    Returns False on fresh fires — the marker is created as a side-effect
-    of this call, making the test-and-set atomic at the kernel level.
-
-    Fail-open: on any OSError other than EEXIST (permission denied,
-    ENOSPC, filesystem race), returns False so the caller emits the
-    event anyway. Data-integrity (preserving the HANDOFF in the journal)
-    outweighs duplication-prevention when the marker subsystem itself
-    breaks; worst case the caller falls back to per-fire emission for
-    this one task (up to 37× per task, empirically measured).
-
-    Graceful-degrade caveat: a pre-existing non-symlink file at the
-    marker path (e.g., from a manually-created file or stale state
-    surviving an unclean cleanup) also returns True via EEXIST and
-    suppresses emission permanently for that (team, task_id) — the
-    O_EXCL test cannot distinguish "prior fire owns it" from "external
-    file was placed here." Acceptable trade-off versus the alternative
-    (read-the-file-to-verify, which races and complicates the atomic
-    test-and-set).
-    """
-    # Degenerate post-sanitization values collapse the marker path onto an
-    # existing directory:
-    #   `Path(marker_dir) / "."`  → marker_dir itself
-    #   `Path(marker_dir) / ".."` → marker_dir's parent
-    # In either case `os.open(..., O_CREAT | O_EXCL)` on that existing
-    # directory returns EEXIST, which the catch below interprets as "prior
-    # fire owns the marker" and PERMANENTLY SUPPRESSES every future emit for
-    # the degenerate key. The regex in _sanitize_path_component strips `/`,
-    # `\`, and `..` substrings but leaves single `.` segments untouched — so
-    # inputs like `"."`, `"..."`, `"/./"` and the two-segment form `"/./."`
-    # (which sanitizes to `".."`) all reach this site as `.` or `..`. Guard
-    # both task_id and team_name: emit the event, accept the rare-degenerate
-    # duplication risk over silent event loss.
-    if (
-        not team_name
-        or team_name in (".", "..")
-        or not task_id
-        or task_id in (".", "..")
-    ):
-        # No valid marker key → cannot dedupe. Emit rather than suppress.
-        return False
-
-    marker_dir = _marker_dir(team_name)
-    # Symlink-containment pre-check: if marker_dir already exists as a
-    # symlink, refuse to use it (a pre-planted symlink could redirect
-    # marker creation outside the team directory). Fail-open emit rather
-    # than risk writing to an attacker-controlled location.
-    if marker_dir.is_symlink():
-        return False
-    try:
-        marker_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
-    except OSError:
-        # Directory creation failed; fall back to fail-open (emit).
-        return False
-
-    marker_path = marker_dir / task_id
-    # O_NOFOLLOW defends against a pre-planted symlink at the marker path —
-    # mirrors the Sec-M1 pattern in session_init's symlink-defense path. POSIX O_CREAT|O_EXCL
-    # already refuses to follow a trailing symlink; O_NOFOLLOW is defense-in-depth
-    # against any future flag-combination divergence and against intermediate-symlink
-    # variants. getattr graceful-degrades on platforms that lack the flag.
-    nofollow = getattr(os, "O_NOFOLLOW", 0)
-    try:
-        fd = os.open(
-            str(marker_path),
-            os.O_WRONLY | os.O_CREAT | os.O_EXCL | nofollow,
-            0o600,
-        )
-        os.close(fd)
-        return False  # we created it; proceed with emit
-    except OSError as e:
-        if e.errno == errno.EEXIST:
-            return True  # prior fire owns the marker; suppress
-        return False  # any other error (incl. ELOOP) → fail-open, emit anyway
 
 
 def main() -> None:
@@ -245,12 +129,12 @@ def main() -> None:
 
         # Sanitize path-joining components symmetrically with
         # task_utils.read_task_json. task_id and team_name both flow into
-        # filesystem paths (read_task_json for the status read, _marker_dir /
-        # marker_path for the O_EXCL dedup marker). A helper applied at a
-        # single producer-side site ensures the two sink paths can never
-        # diverge.
-        task_id = _sanitize_path_component(str(task_id))
-        team_name = _sanitize_path_component(
+        # filesystem paths (read_task_json for the status read; the marker
+        # join inside shared.agent_handoff_marker.already_emitted for the
+        # O_EXCL dedup marker). A helper applied at a single producer-side
+        # site ensures the sink paths can never diverge.
+        task_id = sanitize_path_component(str(task_id))
+        team_name = sanitize_path_component(
             str(input_data.get("team_name") or get_team_name()).lower()
         )
 
@@ -296,8 +180,9 @@ def main() -> None:
 
         # Signal-task bypass: blocker/algedonic tasks MUST NOT emit a phantom
         # agent_handoff event (would pollute read_events("agent_handoff") +
-        # mis-route secretary harvest).
-        if task_metadata.get("type") in _SIGNAL_TASK_TYPES:
+        # mis-route secretary harvest). Shared predicate (SSOT) — the #869
+        # lead-side emit in task_lifecycle_gate.py applies the same exclusion.
+        if is_signal_task(task_metadata):
             print(_SUPPRESS_OUTPUT)
             sys.exit(0)
 
@@ -311,12 +196,16 @@ def main() -> None:
             sys.exit(0)
 
         # Idempotency guard — suppress duplicate fires for the same
-        # (team, task_id). The marker is created ONLY when handoff-presence
-        # is verified above; the optimistic ordering (marker created before
-        # append_event completes) trades one rare write-failure event loss
-        # against repeated duplicate emission (see `_already_emitted` for
-        # empirical basis).
-        if _already_emitted(team_name, task_id):
+        # (team, task_id, occupant). The marker is created ONLY when
+        # handoff-presence is verified above; the optimistic ordering (marker
+        # created before append_event completes) trades one rare write-failure
+        # event loss against repeated duplicate emission (see
+        # shared.agent_handoff_marker.already_emitted for empirical basis).
+        #
+        # Fix B (#887): occupant-identity marker key. A re-scoped subject →
+        # one extra emit (biases to HANDOFF preservation, never loss).
+        occupant = occupant_hash(teammate_name, task_subject)
+        if already_emitted(team_name, task_id, occupant):
             print(_SUPPRESS_OUTPUT)
             sys.exit(0)
 

--- a/pact-plugin/hooks/shared/agent_handoff_marker.py
+++ b/pact-plugin/hooks/shared/agent_handoff_marker.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""
+Location: pact-plugin/hooks/shared/agent_handoff_marker.py
+Summary: SSOT for agent_handoff emission — the shape-agnostic emit-eligibility
+         atom (is_signal_task) + occupant-identity marker key derivation +
+         the O_EXCL test-and-set. Imported by BOTH agent_handoff emit paths
+         so they derive the SAME emit decision and the SAME marker key and
+         dedup to exactly one agent_handoff event per (team, task_id,
+         occupant):
+           - agent_handoff_emitter.py (TaskCompleted; the platform Stop-sweep
+             dispatches this on every matching owner — "b1")
+           - task_lifecycle_gate.py   (the lead's TaskUpdate(completed)
+             acceptance-commit; closes the #869 never-fires gap — "b2")
+Used by: agent_handoff_emitter.py, task_lifecycle_gate.py, and the emitter
+         idempotency / path-sanitization test suites.
+
+Coupling rationale: this module is the SSOT for the marker key + test-and-set.
+The two emit paths MUST import the same occupant_hash() + already_emitted()
+so their marker filenames align byte-for-byte. Divergent key derivation
+across two paths is EXACTLY the #887 stale-marker bug class — a single
+source of truth makes alignment structural rather than a convention two
+files must each remember to honor.
+
+Occupant identity: the marker filename is f"{task_id}-{occupant_hash}" where
+occupant_hash = a STABLE hash of (teammate_name + task_subject). "Stable"
+means hashlib — NOT the builtin hash(): CPython salts str hashing with
+PYTHONHASHSEED, so builtin hash() differs across processes/fires and would
+defeat the cross-process O_EXCL dedup the marker exists to provide.
+
+Re-scoped subject → one extra emit: because the subject is part of the key,
+a task whose subject changes mid-lifespan emits one additional agent_handoff
+event. This biases to HANDOFF preservation, never loss — the intended
+trade-off (see occupant_hash).
+"""
+
+import errno
+import hashlib
+import os
+import re
+from pathlib import Path
+
+# Hex chars of the SHA-256 digest retained for the occupant component of the
+# marker key. 16 hex chars = 64 bits — collision-negligible for the tiny
+# per-(team, task_id) occupant namespace (a handful of occupants per task at
+# most), while keeping the marker filename short.
+_OCCUPANT_HASH_LEN = 16
+
+# Signal-task types — tasks that MUST NOT emit a phantom agent_handoff event
+# (a blocker/algedonic completion is a control signal, not a HANDOFF; emitting
+# would pollute read_events("agent_handoff") + mis-route secretary harvest).
+# Matches the `task_type in ("blocker", "algedonic")` check inside
+# task_utils.find_blockers and the session_resume convention. Extracted here
+# (per the agent_handoff_emitter forward-anchor) now that there is a 2nd
+# consumer: the #869 lead-side emit in task_lifecycle_gate.py shares this
+# exact emit-eligibility atom. (A future cleanup could promote this to
+# task_utils to also dedup find_blockers' inline literal — out of scope here.)
+SIGNAL_TASK_TYPES = ("blocker", "algedonic")
+
+
+def is_signal_task(task_metadata: object) -> bool:
+    """Return True iff the task is a signal task (blocker/algedonic) that must
+    be excluded from agent_handoff emission.
+
+    Pure; never raises. A non-dict metadata (None, missing, malformed) is
+    not a signal task → returns False (the emit-eligibility default; the
+    handoff-presence gate independently suppresses no-handoff tasks).
+    """
+    if not isinstance(task_metadata, dict):
+        return False
+    return task_metadata.get("type") in SIGNAL_TASK_TYPES
+
+
+def sanitize_path_component(value: str) -> str:
+    """
+    Strip path-traversal fragments + C0 control chars from a value destined
+    for filesystem joins.
+
+    Mirrors the regex used inside task_utils.read_task_json so the status-read
+    site and the marker-write site apply symmetric sanitization. Without this,
+    an attacker-crafted task_id / team_name that happens to sanitize (in
+    read_task_json) into a matching existing completed-task file could still
+    carry raw "../" fragments into the marker-path join.
+
+    Strips path-traversal primitives (`/`, `\\`, `..`) and C0 control
+    characters (NUL, CR/LF, and the 0x00-0x1f range) at the producer
+    boundary. Control-char stripping defends against log-injection and
+    embedded-newline attacks on values that flow into filesystem paths.
+    """
+    return re.sub(r"[/\\\x00-\x1f]|\.\.", "", value)
+
+
+def occupant_hash(teammate_name: str, task_subject: str) -> str:
+    """
+    Return a stable occupant-identity hash for the marker key.
+
+    The "occupant" of a task is (teammate_name, task_subject). Keying the
+    marker on the occupant — rather than on task_id alone — is the #887 fix:
+
+    - A reused task_id under a DIFFERENT occupant → different key → the new
+      occupant's HANDOFF is NOT falsely suppressed by a stale marker left by
+      a prior occupant of the same task_id (the team-name-reuse collision).
+    - The SAME occupant across re-fires / sessions → same key → the deliberate
+      standing-task fire-once-across-lifespan dedup is preserved (see the
+      _marker_dir docstring): a secretary standing task that spans sessions
+      still emits its agent_handoff exactly once.
+
+    A subject that is re-scoped mid-lifespan changes the key → one extra emit.
+    This biases to HANDOFF preservation, never loss — the intended trade-off.
+
+    Stable across processes: hashlib, NOT the builtin hash(). CPython salts
+    str hashing with PYTHONHASHSEED, so builtin hash() would differ across
+    processes/fires and break the cross-process O_EXCL dedup. The hex digest
+    is path-safe by construction (no separators / traversal fragments).
+    """
+    payload = f"{teammate_name}\x00{task_subject}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:_OCCUPANT_HASH_LEN]
+
+
+def _marker_dir(team_name: str) -> Path:
+    """
+    Return the per-team marker directory path.
+
+    Lives under ~/.claude/teams/{team}/.agent_handoff_emitted/ — a sibling
+    to the team's inboxes/ and config.json. session_end.py's team reaper
+    removes the whole team directory (shutil.rmtree), so the marker dir is
+    cleaned up automatically when the team ages out.
+
+    Kept task-scoped (not session-scoped) so fire-once semantics survive
+    pause/resume: a secretary standing task that spans sessions must emit
+    its agent_handoff event exactly once across the whole team lifespan.
+    """
+    return Path.home() / ".claude" / "teams" / team_name / ".agent_handoff_emitted"
+
+
+def already_emitted(team_name: str, task_id: str, occupant: str) -> bool:
+    """
+    Test-and-set the per-(team, task_id, occupant) marker.
+
+    Returns True iff a prior fire for the same key already created the marker
+    (caller should suppress the journal write). Returns False on fresh fires —
+    the marker is created as a side-effect of this call, making the
+    test-and-set atomic at the kernel level (O_CREAT | O_EXCL).
+
+    Marker filename: f"{task_id}-{occupant}" (occupant-identity keyed, #887).
+
+    Inputs are sanitized internally (idempotent for already-clean callers like
+    the emitter, which pre-sanitizes task_id/team_name for its read_task_json
+    path) so a caller that has NOT pre-sanitized (the #869 lead-side gate)
+    cannot drive raw traversal fragments into the marker join.
+
+    Fail-open: on any OSError other than EEXIST (permission denied, ENOSPC,
+    filesystem race), returns False so the caller emits the event anyway.
+    Data-integrity (preserving the HANDOFF in the journal) outweighs
+    duplication-prevention when the marker subsystem itself breaks; worst case
+    the caller falls back to per-fire emission for this one task.
+
+    Graceful-degrade caveat: a pre-existing non-symlink file at the marker
+    path (manually created, or stale state surviving an unclean cleanup) also
+    returns True via EEXIST and suppresses emission permanently for that key —
+    the O_EXCL test cannot distinguish "prior fire owns it" from "external
+    file was placed here." Acceptable trade-off versus read-the-file-to-verify
+    (which races and complicates the atomic test-and-set).
+    """
+    team_name = sanitize_path_component(team_name)
+    task_id = sanitize_path_component(task_id)
+    occupant = sanitize_path_component(occupant)
+
+    # Degenerate post-sanitization values collapse the marker path onto an
+    # existing directory:
+    #   _marker_dir(".")  → .../teams/./.agent_handoff_emitted
+    #   _marker_dir("..") → .../teams/../.agent_handoff_emitted
+    # For the filename, the composite key f"{task_id}-{occupant}" no longer
+    # collapses on a degenerate task_id alone ("." → ".-<hash>", a normal
+    # file) — but the task_id guard is retained for defense + behavioral
+    # parity with the pre-occupant key, and a missing occupant (only possible
+    # if a caller bypasses occupant_hash()) is treated as "no valid key".
+    # In every degenerate case: emit rather than suppress (accept the rare
+    # duplication risk over silent event loss).
+    if (
+        not team_name
+        or team_name in (".", "..")
+        or not task_id
+        or task_id in (".", "..")
+        or not occupant
+    ):
+        return False
+
+    marker_dir = _marker_dir(team_name)
+    # Symlink-containment pre-check: if marker_dir already exists as a
+    # symlink, refuse to use it (a pre-planted symlink could redirect marker
+    # creation outside the team directory). Fail-open emit rather than risk
+    # writing to an attacker-controlled location.
+    if marker_dir.is_symlink():
+        return False
+    try:
+        marker_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    except OSError:
+        # Directory creation failed; fall back to fail-open (emit).
+        return False
+
+    # TOCTOU containment re-check (closes the window between the is_symlink()
+    # pre-check above and this mkdir): a symlink race could swap marker_dir
+    # to a directory OUTSIDE the team base between the two operations, and
+    # mkdir(exist_ok=True) silently follows an existing symlink. Re-resolve
+    # both paths and verify marker_dir is still contained within the team
+    # base. commonpath (not str.startswith — defeats the /teams/foo vs
+    # /teams/foobar prefix-collision) is the robust containment test; chosen
+    # over Path.is_relative_to because pyproject pins requires-python >=3.7
+    # and is_relative_to is 3.9+. On breach OR any resolution error: fail-open
+    # emit (return False) WITHOUT writing a marker at the escaped path —
+    # consistent with the is_symlink() pre-check's fail-open posture.
+    team_base = Path.home() / ".claude" / "teams" / team_name
+    try:
+        real_marker = os.path.realpath(marker_dir)
+        real_base = os.path.realpath(team_base)
+        if os.path.commonpath([real_marker, real_base]) != real_base:
+            return False
+    except (OSError, ValueError):
+        return False
+
+    marker_path = marker_dir / f"{task_id}-{occupant}"
+    # O_NOFOLLOW defends against a pre-planted symlink at the marker path.
+    # POSIX O_CREAT|O_EXCL already refuses to follow a trailing symlink;
+    # O_NOFOLLOW is defense-in-depth against any future flag-combination
+    # divergence and against intermediate-symlink variants. getattr
+    # graceful-degrades on platforms that lack the flag.
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(
+            str(marker_path),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | nofollow,
+            0o600,
+        )
+        os.close(fd)
+        return False  # we created it; proceed with emit
+    except OSError as e:
+        if e.errno == errno.EEXIST:
+            return True  # prior fire owns the marker; suppress
+        return False  # any other error (incl. ELOOP) → fail-open, emit anyway

--- a/pact-plugin/hooks/shared/agent_handoff_marker.py
+++ b/pact-plugin/hooks/shared/agent_handoff_marker.py
@@ -161,7 +161,15 @@ def already_emitted(team_name: str, task_id: str, occupant: str) -> bool:
     file was placed here." Acceptable trade-off versus read-the-file-to-verify
     (which races and complicates the atomic test-and-set).
     """
-    team_name = sanitize_path_component(team_name)
+    # Centralized normalization (SSOT): case-fold + sanitize team_name HERE so
+    # every caller derives a BYTE-IDENTICAL marker dir regardless of what it
+    # passed in — b1 (agent_handoff_emitter) pre-lowercases for its
+    # read_task_json path, b2 (task_lifecycle_gate) does not; folding .lower()
+    # in here makes the two structurally identical and closes the dormant
+    # case-drift (the #887 divergence shape one level up). Idempotent w.r.t.
+    # b1's external .lower(). The normalized value flows into BOTH _marker_dir()
+    # and the TOCTOU team_base below, keeping the containment check consistent.
+    team_name = sanitize_path_component(team_name.lower())
     task_id = sanitize_path_component(task_id)
     occupant = sanitize_path_component(occupant)
 

--- a/pact-plugin/hooks/shared/agent_handoff_marker.py
+++ b/pact-plugin/hooks/shared/agent_handoff_marker.py
@@ -226,18 +226,32 @@ def already_emitted(team_name: str, task_id: str, occupant: str) -> bool:
     except (OSError, ValueError):
         return False
 
-    marker_path = marker_dir / f"{task_id}-{occupant}"
-    # O_NOFOLLOW defends against a pre-planted symlink at the marker path.
-    # POSIX O_CREAT|O_EXCL already refuses to follow a trailing symlink;
-    # O_NOFOLLOW is defense-in-depth against any future flag-combination
-    # divergence and against intermediate-symlink variants. getattr
-    # graceful-degrades on platforms that lack the flag.
     nofollow = getattr(os, "O_NOFOLLOW", 0)
+    # Intermediate-dir TOCTOU close-out. O_NOFOLLOW on the marker FILE guards
+    # only the FINAL path component — between the containment re-check above
+    # and the create, marker_dir itself could be swapped to a symlink, and a
+    # full-path os.open would then write THROUGH the symlinked DIRECTORY.
+    # Defense: pin marker_dir as a dir_fd opened with O_DIRECTORY|O_NOFOLLOW
+    # (a symlinked marker_dir makes THIS open fail → fail-open), then create
+    # the marker RELATIVE to that pinned fd so the directory identity is held
+    # by the descriptor, not re-resolved by path. The file open keeps
+    # O_CREAT|O_EXCL|O_NOFOLLOW for the final-component guard + atomic
+    # test-and-set. getattr fallbacks to 0 graceful-degrade where the dir
+    # flags are absent (the relative-to-dir_fd create still pins the dir);
+    # assumes POSIX openat (os.open dir_fd=), consistent with the existing
+    # O_NOFOLLOW reliance.
+    dir_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | nofollow
+    try:
+        dir_fd = os.open(str(marker_dir), dir_flags)
+    except OSError:
+        # Symlinked / vanished marker_dir → fail-open emit, no marker write.
+        return False
     try:
         fd = os.open(
-            str(marker_path),
+            f"{task_id}-{occupant}",
             os.O_WRONLY | os.O_CREAT | os.O_EXCL | nofollow,
             0o600,
+            dir_fd=dir_fd,
         )
         os.close(fd)
         return False  # we created it; proceed with emit
@@ -245,3 +259,5 @@ def already_emitted(team_name: str, task_id: str, occupant: str) -> bool:
         if e.errno == errno.EEXIST:
             return True  # prior fire owns the marker; suppress
         return False  # any other error (incl. ELOOP) → fail-open, emit anyway
+    finally:
+        os.close(dir_fd)

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -116,6 +116,11 @@ try:
     from pathlib import Path
 
     import shared.pact_context as pact_context
+    from shared.agent_handoff_marker import (
+        already_emitted,
+        is_signal_task,
+        occupant_hash,
+    )
     from shared.dispatch_helpers import trustworthy_actor_name
     from shared.intentional_wait import is_self_complete_exempt, is_teachback_exempt
     from shared.session_journal import append_event, make_event
@@ -346,6 +351,69 @@ def _writeback_dispute(task_id: str) -> bool:
         except OSError:
             pass
         return False
+
+
+def _emit_lead_side_agent_handoff(
+    team_name: str,
+    task_id: str,
+    owner: str,
+    subject: str,
+    task_metadata: dict,
+) -> None:
+    """Fix A (#869): emit a single agent_handoff event at the lead's
+    acceptance-commit — the lead's TaskUpdate(status="completed") on a work
+    task carrying a populated metadata.handoff.
+
+    WHY HERE (the b2 emit point): agent_handoff is TaskCompleted-keyed; a
+    stage-ready task completes mid-turn, so it is already "completed" at the
+    lead's Stop-sweep and swept over → the TaskCompleted-keyed
+    agent_handoff_emitter (b1) never fires for it. The lead's process has a
+    populated context, so append_event writes the canonical journal via
+    get_session_dir() with no resolver.
+
+    EMIT-ELIGIBILITY MIRRORS agent_handoff_emitter (b1) — that hook is the
+    CANONICAL source for the emit-shape (owner non-empty, not a teachback
+    task, not a signal task, handoff present). The divergence-critical atoms
+    (is_signal_task, occupant_hash, already_emitted) are SHARED via
+    shared.agent_handoff_marker so the two paths cannot drift on signal-task
+    exclusion or the dedup key (#887 class). The b2-specific topology gate
+    (is_lead) is applied by the caller. Deliberately NOT gated on the gate's
+    is_work_task `pact-` prefix, which no-ops for bare owner names — an
+    orthogonal pre-existing matter, out of scope here.
+
+    Shares the occupant-keyed marker with b1: if a mid-turn TaskUpdate ALSO
+    dispatches TaskCompleted (R2 — open until the real-tmux smoke), b1 and b2
+    test-and-set the SAME marker and dedup to exactly one event.
+
+    Best-effort: fail-open on any error (matches append_event's policy and
+    this hook's livelock-safe exit-0 posture; never raises to the caller).
+    """
+    try:
+        # Emit-eligibility (mirrors b1). owner-empty / teachback / signal-task
+        # / handoff-absent all suppress, same as the emitter's bypass gates.
+        if not owner or _is_teachback_subject(subject):
+            return
+        if is_signal_task(task_metadata):
+            return
+        handoff = task_metadata.get("handoff")
+        if not handoff:
+            return
+        occupant = occupant_hash(owner, subject)
+        if already_emitted(team_name, task_id, occupant):
+            return
+        append_event(
+            make_event(
+                "agent_handoff",
+                agent=owner,
+                task_id=task_id,
+                task_subject=subject,
+                handoff=handoff,
+            )
+        )
+    except Exception:
+        # Fail-open: a journal-emit failure must never break the gate's
+        # advisory evaluation or its exit-0 contract.
+        pass
 
 
 # ─── core evaluation ─────────────────────────────────────────────────────────
@@ -679,6 +747,20 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
                         f"PACT task_lifecycle_gate: Task {task_id} "
                         f"metadata.handoff schema is invalid — {schema_problem}.",
                     ))
+
+        # Fix A (#869): lead-side agent_handoff emission at acceptance-commit.
+        # Independent of the is_work_task `pact-` discriminator above (which
+        # no-ops for bare owner names) — _emit_lead_side_agent_handoff applies
+        # the b1-mirrored emit-eligibility (owner / not-teachback / not-signal
+        # / handoff-present) + the shared occupant-keyed dedup. Gated on
+        # is_lead so the emit only runs in the lead's process, where
+        # get_session_dir() resolves the canonical journal; a teammate
+        # self-completion (carve-out / disputed) has no populated context and
+        # is correctly skipped (it would no-op AND must not be double-counted).
+        if pact_context.is_lead(input_data):
+            _emit_lead_side_agent_handoff(
+                team_name, task_id, owner, subject, metadata
+            )
 
         # Teachback-subject completion-time checks: teachback_submit presence
         # + schema, then paired wake-SendMessage. R1/R2 are disjoint by the

--- a/pact-plugin/tests/test_agent_handoff_marker.py
+++ b/pact-plugin/tests/test_agent_handoff_marker.py
@@ -1,0 +1,367 @@
+"""
+Direct unit coverage for shared/agent_handoff_marker.py — the SSOT shared by
+BOTH agent_handoff emit paths (agent_handoff_emitter "b1" + the lead-side
+task_lifecycle_gate emit "b2"). #880 Fix B (#887 occupant-identity marker key).
+
+This file is the HOME for module-level coverage of the SSOT primitives. It
+focuses on the surface NOT already exercised through the emitter's main()
+in the sibling files:
+
+  - occupant_hash(): cross-process determinism (the hashlib-not-builtin-hash
+    property #887 rests on), distinctness, path-safety, separator-collision
+    resistance.
+  - is_signal_task(): the shared emit-eligibility atom.
+  - already_emitted(): the occupant-keyed test-and-set — specifically the
+    #887 HEART (same team + same task_id + DIFFERENT occupant → BOTH emit)
+    and the within-session ~37x re-fire dedup, with same-fixture positive
+    controls.
+  - the NEW post-mkdir TOCTOU containment re-check (realpath + commonpath
+    after mkdir) — distinct from the is_symlink() PRE-check that the
+    TestMarkerDirSymlinkGuard family in test_emitter_idempotency.py already
+    covers. O_NOFOLLOW guards only the FINAL path component, so a symlinked
+    marker_dir appearing in the race window would still let os.open write
+    THROUGH it — the re-check is the only thing stopping the escaped write.
+
+Already covered ELSEWHERE (not duplicated here):
+  - sanitize_path_component() + degenerate-value guards → test_emitter_path_sanitization.py
+  - is_symlink() PRE-check + fail-open (PermissionError/ENOSPC) → test_emitter_idempotency.py
+  - 8-thread concurrent O_EXCL race → test_emitter_idempotency.py::TestConcurrentFireRace
+
+Non-vacuity (#887): the same-task_id-different-occupant rows below FAIL if the
+marker key is reverted to the bare {task_id} (pre-#887) shape — they are the
+delete-the-fix counter-tests. See the docstring on TestOccupantKeyedDedup.
+"""
+import hashlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from shared.agent_handoff_marker import (
+    already_emitted,
+    is_signal_task,
+    occupant_hash,
+    sanitize_path_component,
+)
+
+HOOKS_DIR = Path(__file__).parent.parent / "hooks"
+
+
+# =============================================================================
+# occupant_hash — the #887 key-derivation primitive
+# =============================================================================
+class TestOccupantHash:
+    def test_pins_hashlib_sha256_algorithm(self):
+        """occupant_hash MUST be hashlib SHA-256 of f'{agent}\\x00{subject}',
+        first 16 hex chars. Pinning the exact algorithm (not just 'some
+        stable hash') guards against a refactor silently swapping in the
+        builtin hash() — which PYTHONHASHSEED salts per process and would
+        break the cross-process O_EXCL dedup."""
+        agent, subject = "backend-coder", "implement feature X"
+        expected = hashlib.sha256(
+            f"{agent}\x00{subject}".encode("utf-8")
+        ).hexdigest()[:16]
+        assert occupant_hash(agent, subject) == expected
+
+    def test_digest_is_path_safe_hex_of_fixed_length(self):
+        occ = occupant_hash("a/../b", "subject\x00with/controls")
+        assert len(occ) == 16
+        assert all(c in "0123456789abcdef" for c in occ), (
+            "hex digest must carry no path separators / traversal / control "
+            f"chars; got {occ!r}"
+        )
+
+    def test_in_process_determinism(self):
+        assert occupant_hash("x", "y") == occupant_hash("x", "y")
+
+    def test_distinct_agent_distinct_hash(self):
+        assert occupant_hash("agent-a", "same subject") != occupant_hash(
+            "agent-b", "same subject"
+        )
+
+    def test_distinct_subject_distinct_hash(self):
+        assert occupant_hash("same agent", "subject 1") != occupant_hash(
+            "same agent", "subject 2"
+        )
+
+    def test_nul_separator_resists_boundary_collision(self):
+        """The \\x00 join means (agent='a', subject='bc') and
+        (agent='ab', subject='c') do NOT collide — without the separator,
+        naive concatenation 'abc' would alias them and let one occupant's
+        marker suppress a genuinely different occupant."""
+        assert occupant_hash("a", "bc") != occupant_hash("ab", "c")
+
+    def test_cross_process_determinism_under_varying_hashseed(self):
+        """THE #887-load-bearing property: the digest is identical across
+        processes with DIFFERENT PYTHONHASHSEED values, and equals the
+        in-process value. b1 (teammate process) and b2 (lead process) must
+        derive the same marker key for the cross-process O_EXCL dedup to
+        work; a PYTHONHASHSEED-salted builtin hash() would diverge."""
+        agent, subject = "occupant-agent", "a representative task subject"
+        in_proc = occupant_hash(agent, subject)
+        seen = {in_proc}
+        for seed in ("0", "1", "12345"):
+            out = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    (
+                        "import sys; sys.path.insert(0, sys.argv[1]); "
+                        "from shared.agent_handoff_marker import occupant_hash; "
+                        "print(occupant_hash(sys.argv[2], sys.argv[3]))"
+                    ),
+                    str(HOOKS_DIR),
+                    agent,
+                    subject,
+                ],
+                capture_output=True,
+                text=True,
+                env={**os.environ, "PYTHONHASHSEED": seed},
+                check=True,
+            )
+            seen.add(out.stdout.strip())
+        assert seen == {in_proc}, (
+            "occupant_hash diverged across PYTHONHASHSEED values "
+            f"{sorted(seen)} — the digest is NOT cross-process stable. "
+            "This breaks the b1/b2 shared-marker dedup (#887)."
+        )
+
+    def test_builtin_hash_would_diverge_contrast(self):
+        """Contrast / rationale guard: demonstrate that the builtin hash()
+        of the SAME payload is NOT stable across PYTHONHASHSEED values — the
+        exact failure occupant_hash() avoids by using hashlib. Robust against
+        a rare seed-collision by sampling 5 seeds and asserting they are not
+        ALL identical."""
+        # Reconstruct the NUL-joined payload INSIDE the child — an embedded
+        # NUL cannot be passed through argv.
+        digests = set()
+        for seed in ("1", "2", "3", "4", "5"):
+            out = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    'print(hash("occupant-agent\\x00a representative task subject"))',
+                ],
+                capture_output=True,
+                text=True,
+                env={**os.environ, "PYTHONHASHSEED": seed},
+                check=True,
+            )
+            digests.add(out.stdout.strip())
+        assert len(digests) > 1, (
+            "builtin hash() was identical across 5 PYTHONHASHSEED values — "
+            "extraordinarily unlikely; the contrast that motivates hashlib "
+            "may no longer hold."
+        )
+
+
+# =============================================================================
+# is_signal_task — the shared emit-eligibility atom
+# =============================================================================
+class TestIsSignalTask:
+    @pytest.mark.parametrize("ttype", ["blocker", "algedonic"])
+    def test_signal_types_are_excluded(self, ttype):
+        assert is_signal_task({"type": ttype}) is True
+
+    @pytest.mark.parametrize(
+        "metadata",
+        [
+            {"type": "work"},
+            {"type": "teachback"},
+            {},
+            {"type": None},
+            None,
+            "not-a-dict",
+            ["type", "blocker"],
+        ],
+    )
+    def test_non_signal_or_malformed_is_false(self, metadata):
+        assert is_signal_task(metadata) is False
+
+
+# =============================================================================
+# already_emitted — occupant-keyed test-and-set (#887 heart)
+# =============================================================================
+class TestOccupantKeyedDedup:
+    """The #887 fix: keying the marker on (team, task_id, occupant) rather
+    than the bare (team, task_id).
+
+    NON-VACUITY: test_same_task_id_different_occupant_both_emit is the
+    delete-the-fix counter-test — if occupant_hash is collapsed to a constant
+    (reverting to the bare-{task_id} key), the two DIFFERENT occupants share
+    a marker and the second is suppressed (1 winner, not 2), failing the
+    assertion. Documented expected cardinality: {2 winners}; pre-#887: {1}.
+    """
+
+    def test_same_task_id_different_occupant_both_emit(self, tmp_path, monkeypatch):
+        """HEART OF #887: a reused (team, task_id) under two DIFFERENT
+        occupants must produce TWO winners — the new occupant's HANDOFF is
+        not falsely suppressed by the prior occupant's stale marker."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        team, task_id = "pact-test", "5"
+        occ_a = occupant_hash("agent-alpha", "alpha's task")
+        occ_b = occupant_hash("agent-beta", "beta's task")
+        assert occ_a != occ_b  # precondition: genuinely different occupants
+
+        first = already_emitted(team, task_id, occ_a)
+        second = already_emitted(team, task_id, occ_b)
+        assert first is False, "first occupant must win (emit)"
+        assert second is False, (
+            "DIFFERENT occupant on the same task_id must ALSO win (emit) — "
+            "this is the #887 collision fix. If this is True, the marker key "
+            "has regressed to the bare {task_id} shape."
+        )
+        # Two distinct marker files exist.
+        marker_dir = tmp_path / ".claude" / "teams" / team / ".agent_handoff_emitted"
+        assert (marker_dir / f"{task_id}-{occ_a}").exists()
+        assert (marker_dir / f"{task_id}-{occ_b}").exists()
+
+    def test_same_occupant_dedups_positive_control(self, tmp_path, monkeypatch):
+        """POSITIVE CONTROL for the row above: the SAME occupant on the same
+        task_id is deduped (fire-once preserved) — proving the row above
+        emits twice because the occupants DIFFER, not because dedup is
+        globally broken."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        team, task_id, occ = "pact-test", "5", occupant_hash("agent", "subj")
+        assert already_emitted(team, task_id, occ) is False, "first fire wins"
+        assert already_emitted(team, task_id, occ) is True, (
+            "same occupant re-fire must be suppressed (standing-task "
+            "fire-once-across-lifespan preserved)"
+        )
+
+    def test_cross_session_same_occupant_fire_once(self, tmp_path, monkeypatch):
+        """A standing task spanning sessions (same occupant, separate
+        already_emitted calls simulating separate session fires) must emit
+        exactly once across the team lifespan — the marker dir is
+        task-scoped, not session-scoped."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        team, task_id, occ = "pact-team", "standing-7", occupant_hash("secretary", "harvest")
+        winners = sum(
+            1 for _ in range(3) if already_emitted(team, task_id, occ) is False
+        )
+        assert winners == 1, f"expected fire-once across sessions, got {winners}"
+
+    def test_within_session_37x_stop_sweep_refire_dedups(self, tmp_path, monkeypatch):
+        """The platform's Stop flow dispatches TaskCompleted on every matching
+        owner — empirically ~37x in the #528 amplification class. The
+        occupant marker must collapse all of them to exactly ONE winner."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        team, task_id, occ = "pact-test", "amp", occupant_hash("coder", "amplified task")
+        winners = sum(
+            1 for _ in range(37) if already_emitted(team, task_id, occ) is False
+        )
+        assert winners == 1, (
+            f"expected exactly 1 winner across 37 re-fires, got {winners} — "
+            "the #528 amplification dedup has regressed."
+        )
+
+    def test_marker_filename_is_occupant_keyed(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        team, task_id = "pact-test", "probe"
+        occ = occupant_hash("probe-agent", "probe subject")
+        already_emitted(team, task_id, occ)
+        expected = (
+            tmp_path / ".claude" / "teams" / team / ".agent_handoff_emitted"
+            / f"{task_id}-{occ}"
+        )
+        assert expected.exists(), "marker must be written at {task_id}-{occupant}"
+
+
+# =============================================================================
+# TOCTOU containment re-check (NEW in #880 — post-mkdir realpath/commonpath)
+# =============================================================================
+class TestTocTouContainmentRecheck:
+    """The post-mkdir re-check (realpath(marker_dir) must stay inside
+    realpath(team_base)) closes the race window between the is_symlink()
+    PRE-check and mkdir(exist_ok=True): a symlink swapped in AFTER the
+    pre-check would be silently followed by mkdir, and O_NOFOLLOW only
+    protects the FINAL path component — so os.open would write THROUGH a
+    symlinked marker_dir to an escaped location. This family pins that the
+    re-check fail-open emits (returns False) WITHOUT an escaped marker write.
+
+    Distinct from TestMarkerDirSymlinkGuard (test_emitter_idempotency.py),
+    which covers the is_symlink() PRE-check only.
+    """
+
+    def test_symlink_appearing_after_precheck_is_contained(self, tmp_path, monkeypatch):
+        """Simulate the TOCTOU race: marker_dir IS a symlink escaping the
+        team base, but is_symlink() reports False (as it would have at
+        pre-check time). The re-check must catch it via realpath/commonpath,
+        return False (fail-open emit), and write NO marker at the escape
+        target.
+
+        NON-VACUITY: deleting the re-check lets os.open create
+        `<escape>/{task_id}-{occ}` (O_NOFOLLOW does not stop traversal
+        through a symlinked DIRECTORY) — the final assertion would then fail.
+        """
+        team = "pact-test"
+        team_base = tmp_path / ".claude" / "teams" / team
+        team_base.mkdir(parents=True)
+        escape_target = tmp_path / "escape_target"
+        escape_target.mkdir()
+        marker_dir = team_base / ".agent_handoff_emitted"
+        marker_dir.symlink_to(escape_target, target_is_directory=True)
+
+        # Patch is_symlink → False AFTER constructing the symlink: models the
+        # pre-check passing (path was not a symlink at check time) while the
+        # path is a symlink by the time mkdir/realpath run.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(Path, "is_symlink", lambda self: False)
+
+        result = already_emitted(team, "5", "occ")
+
+        assert result is False, (
+            "TOCTOU breach must fail-open emit (return False)"
+        )
+        assert not (escape_target / "5-occ").exists(), (
+            "no marker may be written at the escaped (symlink) target — the "
+            "post-mkdir containment re-check must short-circuit before "
+            "os.open. If this file exists, the re-check was removed/bypassed."
+        )
+
+    def test_realpath_resolution_error_fails_open(self, tmp_path, monkeypatch):
+        """Any resolution error during the containment re-check (OSError /
+        ValueError from realpath/commonpath) is treated as fail-open emit."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        def _boom(_path):
+            raise OSError("simulated resolution failure")
+
+        monkeypatch.setattr(os.path, "realpath", _boom)
+        assert already_emitted("pact-test", "5", "occ") is False
+
+    def test_contained_marker_dir_proceeds_positive_control(self, tmp_path, monkeypatch):
+        """POSITIVE CONTROL: an ordinary contained marker_dir passes the
+        re-check — first call wins (False + marker created), second observes
+        EEXIST (True). Proves the re-check discriminates breach from the
+        normal path rather than rejecting everything."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        team, task_id, occ = "pact-test", "5", "occ"
+        assert already_emitted(team, task_id, occ) is False
+        assert already_emitted(team, task_id, occ) is True
+        marker = (
+            tmp_path / ".claude" / "teams" / team / ".agent_handoff_emitted"
+            / f"{task_id}-{occ}"
+        )
+        assert marker.exists()
+
+
+# =============================================================================
+# Degenerate-value guard (smoke — full matrix in test_emitter_path_sanitization)
+# =============================================================================
+class TestDegenerateGuardSmoke:
+    @pytest.mark.parametrize("bad", ["", ".", ".."])
+    def test_degenerate_task_id_emits_without_marker(self, tmp_path, monkeypatch, bad):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        # bad task_id sanitizes to a degenerate value → fail-open emit, no marker
+        assert already_emitted("pact-test", bad, "occ") is False
+
+    def test_missing_occupant_emits_without_marker(self, tmp_path, monkeypatch):
+        """An empty occupant (only reachable if a caller bypasses
+        occupant_hash) is treated as 'no valid key' → fail-open emit."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert already_emitted("pact-test", "5", "") is False
+        # sanitize_path_component is the SSOT used internally; sanity-pin it
+        assert sanitize_path_component("..") == ""

--- a/pact-plugin/tests/test_agent_handoff_marker.py
+++ b/pact-plugin/tests/test_agent_handoff_marker.py
@@ -349,6 +349,102 @@ class TestTocTouContainmentRecheck:
 
 
 # =============================================================================
+# dir_fd intermediate-dir TOCTOU race (remediation cycle 2)
+# =============================================================================
+@pytest.mark.skipif(
+    os.open not in os.supports_dir_fd,
+    reason="platform lacks openat/dir_fd support",
+)
+class TestDirFdIntermediateDirRace:
+    """The marker create opens marker_dir as a dir_fd (O_DIRECTORY|O_NOFOLLOW)
+    and creates the marker RELATIVE to that fd. This closes the residual
+    INTERMEDIATE-DIR TOCTOU window: between the realpath/commonpath containment
+    re-check and the create, marker_dir itself could be swapped to a symlink,
+    and a full-path os.open would then write THROUGH the symlinked DIRECTORY
+    (O_NOFOLLOW on the marker FILE guards only the final component).
+
+    DISTINCT from TestTocTouContainmentRecheck: that family covers PRE-PLANTED
+    symlinks (caught by the is_symlink() pre-check OR the realpath/commonpath
+    re-check). The dir_fd fix is load-bearing ONLY for the RACE — marker_dir is
+    a REAL contained dir at pre-check AND containment-check time, THEN swapped to
+    an escaping symlink BEFORE the dir_fd open. So this test injects the swap in
+    exactly that window (as a side effect of the containment check's realpath
+    call), which a pre-planted symlink cannot exercise.
+
+    NON-VACUITY: reverting the create to the plain full-path
+    `os.open(str(marker_path), ...)` (pre-cycle-2 shape) makes the symlinked
+    marker_dir get followed and the marker written THROUGH to the escape target
+    — the no-write-through assertion then fails. Verified by isolated-worktree
+    revert.
+    """
+
+    def test_marker_dir_swapped_to_symlink_after_containment_is_contained(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        team, task_id, occ = "pact-test", "race", "occ"
+
+        team_base = tmp_path / ".claude" / "teams" / team
+        team_base.mkdir(parents=True)
+        escape_target = tmp_path / "escape_target"
+        escape_target.mkdir()
+        marker_dir = team_base / ".agent_handoff_emitted"
+
+        # Inject the TOCTOU swap as a side effect of the containment check's
+        # realpath(marker_dir) call: marker_dir is a REAL empty dir when
+        # resolved (so commonpath passes with the real contained path), then
+        # is swapped to an escaping symlink BEFORE the dir_fd open runs.
+        orig_realpath = os.path.realpath
+        state = {"swapped": False}
+
+        def _realpath_then_swap(path, *args, **kwargs):
+            resolved = orig_realpath(path, *args, **kwargs)
+            if not state["swapped"] and str(path).endswith(".agent_handoff_emitted"):
+                # marker_dir was just mkdir'd (real, empty) — swap it now.
+                Path(marker_dir).rmdir()
+                Path(marker_dir).symlink_to(escape_target, target_is_directory=True)
+                state["swapped"] = True
+            return resolved
+
+        monkeypatch.setattr(os.path, "realpath", _realpath_then_swap)
+
+        result = already_emitted(team, task_id, occ)
+
+        assert state["swapped"] is True, (
+            "vacuity guard: the race-swap must have fired (else the test "
+            "passes trivially via normal creation)"
+        )
+        assert marker_dir.is_symlink(), "marker_dir must be the escaping symlink at open time"
+        assert result is False, (
+            "a marker_dir swapped to a symlink in the race window must "
+            "fail-open EMIT (return False) — the dir_fd O_DIRECTORY|O_NOFOLLOW "
+            "open fails on the symlink"
+        )
+        assert not (escape_target / f"{task_id}-{occ}").exists(), (
+            "NO write-through: the marker must NOT be created at the escape "
+            "target. If this file exists, the dir_fd pinning was removed and a "
+            "full-path open followed the symlinked directory."
+        )
+
+    def test_real_contained_marker_dir_still_creates_positive_control(
+        self, tmp_path, monkeypatch
+    ):
+        """POSITIVE CONTROL: with NO swap, an ordinary contained marker_dir
+        creates the marker via the dir_fd path (first call → False + marker;
+        second → EEXIST → True). Proves the dir_fd open succeeds on the normal
+        path and the race assertion above isn't 'dir_fd always fails'."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        team, task_id, occ = "pact-test", "ok", "occ"
+        assert already_emitted(team, task_id, occ) is False
+        assert already_emitted(team, task_id, occ) is True
+        marker = (
+            tmp_path / ".claude" / "teams" / team / ".agent_handoff_emitted"
+            / f"{task_id}-{occ}"
+        )
+        assert marker.exists()
+
+
+# =============================================================================
 # Degenerate-value guard (smoke — full matrix in test_emitter_path_sanitization)
 # =============================================================================
 class TestDegenerateGuardSmoke:

--- a/pact-plugin/tests/test_emitter_idempotency.py
+++ b/pact-plugin/tests/test_emitter_idempotency.py
@@ -62,6 +62,8 @@ class TestIdempotency:
 
     def test_marker_file_created_at_expected_path(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
+        from shared.agent_handoff_marker import occupant_hash
+
         calls = []
         _run_main(
             stdin_payload={
@@ -77,7 +79,14 @@ class TestIdempotency:
             },
             append_calls=calls,
         )
-        marker = tmp_path / ".claude" / "teams" / "pact-test" / ".agent_handoff_emitted" / "marker-probe"
+        # #887: marker is occupant-keyed — {task_id}-{occupant_hash}. The
+        # emitter derives the occupant from owner ("probe-agent") + subject
+        # ("probe"); recompute via the SSOT to assert the exact path.
+        occ = occupant_hash("probe-agent", "probe")
+        marker = (
+            tmp_path / ".claude" / "teams" / "pact-test" / ".agent_handoff_emitted"
+            / f"marker-probe-{occ}"
+        )
         assert marker.exists(), "fire-once marker must be created at team-scoped path"
 
 class TestMarkerFailOpen:
@@ -88,8 +97,9 @@ class TestMarkerFailOpen:
     when the marker layer breaks. Worst case: fall back to pre-#538
     duplication on THIS task only.
 
-    These tests target `_already_emitted`'s OSError branches directly,
-    which are otherwise hard to exercise without filesystem manipulation.
+    These tests exercise the marker layer's OSError branches (now in
+    shared.agent_handoff_marker.already_emitted) via main(), which are
+    otherwise hard to exercise without filesystem manipulation.
     """
 
     def test_marker_dir_mkdir_permission_denied_still_emits(self, tmp_path, monkeypatch):
@@ -127,9 +137,9 @@ class TestMarkerFailOpen:
 
     def test_marker_open_enospc_still_emits(self, tmp_path, monkeypatch):
         """ENOSPC during O_EXCL marker creation must not suppress the
-        journal write. `os.open` raises OSError(errno=ENOSPC); the
-        emitter's _already_emitted returns False on any non-EEXIST
-        OSError, allowing the fire-OPEN path."""
+        journal write. `os.open` raises OSError(errno=ENOSPC); the marker
+        layer's already_emitted (shared.agent_handoff_marker) returns False
+        on any non-EEXIST OSError, allowing the fire-OPEN path."""
         monkeypatch.setenv("HOME", str(tmp_path))
         calls: list[dict] = []
 
@@ -140,7 +150,7 @@ class TestMarkerFailOpen:
                 raise OSError(errno.ENOSPC, "No space left on device", str(path))
             return original_os_open(path, flags, mode)
 
-        with patch("agent_handoff_emitter.os.open", side_effect=_os_open_enospc):
+        with patch("shared.agent_handoff_marker.os.open", side_effect=_os_open_enospc):
             _run_main(
                 stdin_payload={
                     "task_id": "enospc-probe",
@@ -189,6 +199,7 @@ class TestMarkerFailOpen:
         """
         monkeypatch.setenv("HOME", str(tmp_path))
         from agent_handoff_emitter import main
+        from shared.agent_handoff_marker import occupant_hash
 
         append_call_count = {"n": 0}
 
@@ -208,7 +219,7 @@ class TestMarkerFailOpen:
             "team_name": "pact-test",
         }
 
-        # First invocation: marker gets created (by _already_emitted),
+        # First invocation: marker gets created (by already_emitted),
         # append_event returns None (silent failure), event is lost.
         with patch("agent_handoff_emitter.read_task_json", return_value=task_data), \
              patch("agent_handoff_emitter.append_event", side_effect=_append_silent_fail), \
@@ -222,13 +233,14 @@ class TestMarkerFailOpen:
             "append_event must be called exactly once on first invocation — "
             "the journal-write path IS attempted, not skipped"
         )
+        occ = occupant_hash("probe-agent", "journal write fails silently")
         marker = (
             tmp_path / ".claude" / "teams" / "pact-test"
-            / ".agent_handoff_emitted" / "journal-fail-probe"
+            / ".agent_handoff_emitted" / f"journal-fail-probe-{occ}"
         )
         assert marker.exists(), (
             "marker persists despite journal-write failure — this is the "
-            "intentional asymmetry. `_already_emitted` creates the marker "
+            "intentional asymmetry. `already_emitted` creates the marker "
             "BEFORE `append_event` is called; a silent fail in append_event "
             "does NOT unwind the marker. Trade-off: prevents 37× duplicate "
             "emission at the cost of rare single-event loss."
@@ -253,7 +265,7 @@ class TestMarkerFailOpen:
 class TestMarkerDirSymlinkGuard:
     """Pin the symlink-containment pre-check at the marker_dir creation
     site. If `~/.claude/teams/{team}/.agent_handoff_emitted` already
-    exists as a symlink, `_already_emitted` MUST return False (fail-open
+    exists as a symlink, `already_emitted` MUST return False (fail-open
     emit) without following the symlink — refusing to create the marker
     file at an attacker-controlled location.
 
@@ -270,7 +282,7 @@ class TestMarkerDirSymlinkGuard:
         and short-circuited. The function returns False (fail-open emit)
         and creates no file at the symlink target."""
         monkeypatch.setenv("HOME", str(tmp_path))
-        from agent_handoff_emitter import _already_emitted
+        from shared.agent_handoff_marker import already_emitted
 
         team = "pact-test"
         task_id = "t1"
@@ -283,14 +295,14 @@ class TestMarkerDirSymlinkGuard:
         marker_dir_path = team_dir / ".agent_handoff_emitted"
         marker_dir_path.symlink_to(attacker_target, target_is_directory=True)
 
-        result = _already_emitted(team, task_id)
+        result = already_emitted(team, task_id, "occ")
 
         assert result is False, (
             "symlink at marker_dir must fail-open emit (return False); "
             "removing the is_symlink() guard would let the marker create "
             "via the symlink and return False/True based on EEXIST race."
         )
-        assert not (attacker_target / task_id).exists(), (
+        assert not (attacker_target / f"{task_id}-occ").exists(), (
             "no file may be created at the symlink target — the guard "
             "must short-circuit BEFORE any os.open call follows the link."
         )
@@ -305,7 +317,7 @@ class TestMarkerDirSymlinkGuard:
         True). Confirms the guard discriminates symlink vs ordinary
         dir rather than treating any pre-existing dir as hostile."""
         monkeypatch.setenv("HOME", str(tmp_path))
-        from agent_handoff_emitter import _already_emitted
+        from shared.agent_handoff_marker import already_emitted
 
         team = "pact-test"
         task_id = "t1"
@@ -315,8 +327,8 @@ class TestMarkerDirSymlinkGuard:
         )
         marker_dir_path.mkdir(parents=True)
 
-        first = _already_emitted(team, task_id)
-        second = _already_emitted(team, task_id)
+        first = already_emitted(team, task_id, "occ")
+        second = already_emitted(team, task_id, "occ")
 
         assert first is False, (
             "first call against an ordinary marker_dir must create the "
@@ -326,28 +338,29 @@ class TestMarkerDirSymlinkGuard:
             "second call must observe EEXIST on the existing marker and "
             "return True (suppress duplicate emission)."
         )
-        assert (marker_dir_path / task_id).exists(), (
+        assert (marker_dir_path / f"{task_id}-occ").exists(), (
             "winner must have created a real marker file inside the "
             "ordinary marker_dir."
         )
 
 class TestConcurrentFireRace:
     """O_EXCL marker must deterministically deduplicate concurrent
-    `_already_emitted` calls for the same (team, task_id). One caller
-    wins marker creation (returns False → emit); the other observes
+    `already_emitted` calls for the same (team, task_id, occupant). One
+    caller wins marker creation (returns False → emit); the other observes
     FileExistsError (returns True → suppress).
 
     We target the atomic test-and-set primitive directly rather than
     invoking `main()` in threads — `sys.stdin` and unittest.mock patches
     are process-global state that thread-based invocation of main()
     cannot safely share. The atomicity invariant lives in
-    `_already_emitted`, which is what #538 C1 added to defend against
-    stopHooks.ts duplication.
+    `shared.agent_handoff_marker.already_emitted` (#538 C1 added it to
+    defend against stopHooks.ts duplication; #880 moved it to the shared
+    SSOT and occupant-keyed it for #887).
     """
 
     def test_concurrent_already_emitted_exactly_one_false(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
-        from agent_handoff_emitter import _already_emitted
+        from shared.agent_handoff_marker import already_emitted
 
         team = "pact-race"
         task_id = "race-probe"
@@ -357,7 +370,7 @@ class TestConcurrentFireRace:
 
         def _fire():
             barrier.wait()
-            r = _already_emitted(team, task_id)
+            r = already_emitted(team, task_id, "occ")
             with results_lock:
                 results.append(r)
 
@@ -381,6 +394,9 @@ class TestConcurrentFireRace:
             f"expected {len(results) - 1} losers returning True; got {true_count}"
         )
         # The marker file exists on disk after the race.
-        marker = tmp_path / ".claude" / "teams" / team / ".agent_handoff_emitted" / task_id
+        marker = (
+            tmp_path / ".claude" / "teams" / team / ".agent_handoff_emitted"
+            / f"{task_id}-occ"
+        )
         assert marker.exists(), "race winner must have created the marker file"
 

--- a/pact-plugin/tests/test_emitter_path_sanitization.py
+++ b/pact-plugin/tests/test_emitter_path_sanitization.py
@@ -7,7 +7,7 @@ from fixtures.emitter import VALID_HANDOFF, _run_main
 
 
 class TestPathSanitization:
-    """Direct coverage for `_sanitize_path_component` helper + integration
+    """Direct coverage for `sanitize_path_component` helper + integration
     coverage for degenerate post-sanitize values.
 
     The helper uses `re.sub(r"[/\\\\]|\\.\\.", "", v)` which strips `/`,
@@ -23,7 +23,7 @@ class TestPathSanitization:
     """
 
     class TestSanitizeHelper:
-        """Direct unit tests against _sanitize_path_component. Independent
+        """Direct unit tests against sanitize_path_component. Independent
         of task #24 guard — these exercise the regex behavior alone."""
 
         @pytest.mark.parametrize(
@@ -31,19 +31,19 @@ class TestPathSanitization:
             ["42", "12345", "feature-task-5", "task_5", "abc-def"],
         )
         def test_sanitize_preserves_legitimate_task_ids(self, legitimate):
-            from agent_handoff_emitter import _sanitize_path_component
-            assert _sanitize_path_component(legitimate) == legitimate, (
+            from shared.agent_handoff_marker import sanitize_path_component
+            assert sanitize_path_component(legitimate) == legitimate, (
                 f"legitimate task_id {legitimate!r} was altered by sanitizer; "
                 f"the regex must only strip `/`, `\\\\`, and `..` substrings."
             )
 
         def test_sanitize_strips_forward_slash(self):
-            from agent_handoff_emitter import _sanitize_path_component
-            assert _sanitize_path_component("foo/bar") == "foobar"
+            from shared.agent_handoff_marker import sanitize_path_component
+            assert sanitize_path_component("foo/bar") == "foobar"
 
         def test_sanitize_strips_backslash(self):
-            from agent_handoff_emitter import _sanitize_path_component
-            assert _sanitize_path_component("foo\\bar") == "foobar"
+            from shared.agent_handoff_marker import sanitize_path_component
+            assert sanitize_path_component("foo\\bar") == "foobar"
 
         @pytest.mark.parametrize(
             "input_value,expected",
@@ -57,8 +57,8 @@ class TestPathSanitization:
             ],
         )
         def test_sanitize_strips_dotdot_sequences(self, input_value, expected):
-            from agent_handoff_emitter import _sanitize_path_component
-            assert _sanitize_path_component(input_value) == expected, (
+            from shared.agent_handoff_marker import sanitize_path_component
+            assert sanitize_path_component(input_value) == expected, (
                 f"sanitize({input_value!r}) expected {expected!r}; "
                 f"regex may have drifted."
             )
@@ -77,8 +77,8 @@ class TestPathSanitization:
             """Compound attack inputs — the output must contain no `/`,
             no `\\`, and no `..` substring. Exact value is less
             important than the absence of traversal primitives."""
-            from agent_handoff_emitter import _sanitize_path_component
-            out = _sanitize_path_component(traversal_attempt)
+            from shared.agent_handoff_marker import sanitize_path_component
+            out = sanitize_path_component(traversal_attempt)
             assert "/" not in out, f"forward slash survived in {out!r}"
             assert "\\" not in out, f"backslash survived in {out!r}"
             assert ".." not in out, f"parent-dir sequence survived in {out!r}"
@@ -88,23 +88,23 @@ class TestPathSanitization:
             matches `..`). Caller guards against this degenerate shape
             separately (#24 guard). This test pins the current contract
             so a future regex tightening is a deliberate decision."""
-            from agent_handoff_emitter import _sanitize_path_component
-            assert _sanitize_path_component(".") == "."
+            from shared.agent_handoff_marker import sanitize_path_component
+            assert sanitize_path_component(".") == "."
 
         def test_sanitize_preserves_whitespace(self):
             """Whitespace is not a path-traversal primitive — regex doesn't
             strip it. Whitespace-only values create filesystem-valid
             (if unusual) filenames, so the guard does NOT need to treat
             them as degenerate."""
-            from agent_handoff_emitter import _sanitize_path_component
-            assert _sanitize_path_component(" ") == " "
-            assert _sanitize_path_component("  ") == "  "
+            from shared.agent_handoff_marker import sanitize_path_component
+            assert sanitize_path_component(" ") == " "
+            assert sanitize_path_component("  ") == "  "
 
         def test_sanitize_empty_string_unchanged(self):
             """Empty input returns empty — pinned for guard-paired tests
             that rely on the empty sentinel reaching _already_emitted."""
-            from agent_handoff_emitter import _sanitize_path_component
-            assert _sanitize_path_component("") == ""
+            from shared.agent_handoff_marker import sanitize_path_component
+            assert sanitize_path_component("") == ""
 
         @pytest.mark.parametrize(
             "control_input",
@@ -127,8 +127,8 @@ class TestPathSanitization:
             would survive into filesystem path joins, enabling
             log-injection (CR/LF) and path-truncation (NUL on some
             filesystems) attacks."""
-            from agent_handoff_emitter import _sanitize_path_component
-            out = _sanitize_path_component(control_input)
+            from shared.agent_handoff_marker import sanitize_path_component
+            out = sanitize_path_component(control_input)
             for ch in out:
                 assert ord(ch) >= 0x20 or ch == "\x7f", (
                     f"control char {ord(ch):#x} survived in {out!r}"
@@ -157,8 +157,8 @@ class TestPathSanitization:
             `..`). Either branch preserves the fail-open data-integrity
             contract; neither branch can leak path-traversal primitives
             to the marker write."""
-            from agent_handoff_emitter import _sanitize_path_component
-            sanitized = _sanitize_path_component(raw_input)
+            from shared.agent_handoff_marker import sanitize_path_component
+            sanitized = sanitize_path_component(raw_input)
 
             if sanitized in ("", ".", ".."):
                 # Caught by the degenerate guard in _already_emitted —
@@ -521,6 +521,8 @@ class TestPathSanitization:
             self, attack_task_id, expected_sanitized, tmp_path, monkeypatch
         ):
             monkeypatch.setenv("HOME", str(tmp_path))
+            from shared.agent_handoff_marker import occupant_hash
+
             calls: list[dict] = []
             _run_main(
                 stdin_payload={
@@ -537,12 +539,15 @@ class TestPathSanitization:
                 append_calls=calls,
             )
             assert len(calls) == 1
-            # Marker file (if created) lives at the sanitized basename
-            # INSIDE the team's .agent_handoff_emitted dir — never at
-            # an escape path.
+            # Marker file (if created) lives at the sanitized basename —
+            # now occupant-keyed ({sanitized}-{occupant_hash}, #887) —
+            # INSIDE the team's .agent_handoff_emitted dir, never at an
+            # escape path. occupant = hash(owner + subject), fixed across
+            # the parametrized cases.
+            occ = occupant_hash("probe-agent", "path-traversal probe")
             expected_marker = (
                 tmp_path / ".claude" / "teams" / "pact-test"
-                / ".agent_handoff_emitted" / expected_sanitized
+                / ".agent_handoff_emitted" / f"{expected_sanitized}-{occ}"
             )
             assert expected_marker.exists(), (
                 f"path-traversal attempt {attack_task_id!r} sanitized to "

--- a/pact-plugin/tests/test_emitter_race_regression.py
+++ b/pact-plugin/tests/test_emitter_race_regression.py
@@ -120,6 +120,8 @@ class TestRaceShapeRegression:
                     handoff content lands in journal.
         """
         monkeypatch.setenv("HOME", str(tmp_path))
+        from shared.agent_handoff_marker import occupant_hash
+
         calls: list[dict] = []
         payload = {
             "hook_event_name": "TaskCompleted",
@@ -148,9 +150,11 @@ class TestRaceShapeRegression:
             "(review-architect, PR #563) would resurface — empty-content "
             "marker would suppress the later genuine completion."
         )
+        # #887: marker is occupant-keyed — {task_id}-{occupant_hash}.
+        occ = occupant_hash("probe-agent", "two-fire revert sequence probe")
         marker = (
             tmp_path / ".claude" / "teams" / "pact-test"
-            / ".agent_handoff_emitted" / "two-fire-revert"
+            / ".agent_handoff_emitted" / f"two-fire-revert-{occ}"
         )
         assert not marker.exists(), (
             "Fire 1: marker MUST NOT be created when handoff is absent. "

--- a/pact-plugin/tests/test_handoff_b1_b2_dedup.py
+++ b/pact-plugin/tests/test_handoff_b1_b2_dedup.py
@@ -1,0 +1,257 @@
+"""
+Cross-path coverage for the two agent_handoff emit paths sharing ONE marker:
+  - b1: agent_handoff_emitter.py  (TaskCompleted Stop-sweep)
+  - b2: task_lifecycle_gate.py    (lead's TaskUpdate(completed) acceptance-commit, Fix A #869)
+
+Both import occupant_hash + already_emitted from shared/agent_handoff_marker.py
+(the SSOT), so for one logical completion they derive the SAME marker key and
+the shared O_EXCL marker dedups them to EXACTLY ONE journal event. This file
+proves that, plus:
+
+  - ASSERTION A (the b1/b2 occupant-alignment crux flagged in TEST teachback):
+    b1 derives occupant from (owner OR teammate_name); b2 from owner alone.
+    They align iff owner is populated. When owner is empty, b2 early-returns
+    no-emit, so the derivation difference never manifests as a double-emit.
+  - #887 integration through the emitter: same team + same task_id + DIFFERENT
+    occupant → BOTH emit (with a same-occupant positive control).
+  - DUAL-MODE matrix: in the shipped DEFER scope there is NO
+    session_id==leadSessionId code branch (that was the deferred redirect, D5).
+    The topology discriminator that IS shipped is is_lead — which under real
+    multi-process tmux corresponds to "this process's session == the lead's
+    session" (lead) vs "!=" (teammate). The matrix below exercises both modes
+    of the b2 gate with same-fixture positive controls, and pins that b1 is
+    agent_type-AGNOSTIC (it writes to its own session journal in either mode;
+    WHERE that lands under tmux is what the E1 real-tmux smoke resolves).
+
+Shared-marker mechanics: both paths resolve the marker dir via Path.home();
+patching Path.home (+ HOME) to one tmp_path and using one team_name/task_id/
+owner/subject makes b1 and b2 contend for the identical marker file.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import task_lifecycle_gate as tlg  # noqa: E402
+from fixtures.emitter import VALID_HANDOFF, _run_main  # noqa: E402
+from shared.agent_handoff_marker import occupant_hash  # noqa: E402
+
+TEAM = "pact-test"
+LEAD = "PACT:pact-orchestrator"
+TASK_ID = "55"
+OWNER = "devops"
+SUBJECT = "devops: ship it"
+
+
+def _gate_payload(*, agent_type=LEAD, owner=OWNER, subject=SUBJECT, task_id=TASK_ID, handoff=VALID_HANDOFF):
+    metadata = {"handoff": handoff} if handoff is not None else {}
+    task = {"id": task_id, "subject": subject, "owner": owner, "metadata": metadata}
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": task_id, "status": "completed"},
+        "tool_response": {"task": task},
+    }
+    if agent_type is not None:
+        payload["agent_type"] = agent_type
+    return payload
+
+
+def _emitter_stdin(*, teammate_name=OWNER, subject=SUBJECT, task_id=TASK_ID, team=TEAM):
+    return {
+        "task_id": task_id,
+        "task_subject": subject,
+        "teammate_name": teammate_name,
+        "team_name": team,
+    }
+
+
+def _emitter_task_data(*, owner=OWNER, handoff=VALID_HANDOFF):
+    metadata = {"handoff": handoff} if handoff is not None else {}
+    return {"status": "completed", "owner": owner, "metadata": metadata}
+
+
+@pytest.fixture
+def shared_home(tmp_path, monkeypatch):
+    """Make BOTH emit paths resolve the SAME marker dir under tmp_path."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+# =============================================================================
+# Cross-path shared-marker dedup → exactly ONE event
+# =============================================================================
+class TestCrossPathDedup:
+    def test_b2_then_b1_dedups_to_one(self, shared_home, monkeypatch, pact_context):
+        """Lead acceptance-commit (b2) fires first and claims the marker; the
+        later Stop-sweep TaskCompleted (b1) sees the shared marker and is
+        suppressed. Net: exactly ONE journal event."""
+        pact_context(team_name=TEAM, session_id="s1")
+        gate_events: list[dict] = []
+        monkeypatch.setattr(tlg, "append_event", lambda e: gate_events.append(e) or True)
+
+        tlg.evaluate_lifecycle(_gate_payload())
+        assert len(gate_events) == 1, "b2 must emit first"
+
+        emitter_events: list[dict] = []
+        _run_main(_emitter_stdin(), _emitter_task_data(), emitter_events)
+        assert len(emitter_events) == 0, "b1 must be suppressed by the shared marker"
+        assert len(gate_events) + len(emitter_events) == 1, "exactly ONE net event"
+
+    def test_b1_then_b2_dedups_to_one(self, shared_home, monkeypatch, pact_context):
+        """Reverse order: the Stop-sweep (b1) fires first; the lead's
+        acceptance-commit (b2) then sees the shared marker and suppresses."""
+        pact_context(team_name=TEAM, session_id="s1")
+        emitter_events: list[dict] = []
+        _run_main(_emitter_stdin(), _emitter_task_data(), emitter_events)
+        assert len(emitter_events) == 1, "b1 must emit first"
+
+        gate_events: list[dict] = []
+        monkeypatch.setattr(tlg, "append_event", lambda e: gate_events.append(e) or True)
+        tlg.evaluate_lifecycle(_gate_payload())
+        assert len(gate_events) == 0, "b2 must be suppressed by the shared marker"
+        assert len(gate_events) + len(emitter_events) == 1, "exactly ONE net event"
+
+    def test_b1_b2_compute_identical_marker_key(self):
+        """Structural pin: with owner populated, both paths' occupant is
+        identical (the marker filenames align byte-for-byte)."""
+        # b1: teammate_name = owner or stdin-teammate_name → owner when populated
+        b1_occ = occupant_hash(OWNER or "stdin-teammate", SUBJECT)
+        # b2: occupant from owner directly
+        b2_occ = occupant_hash(OWNER, SUBJECT)
+        assert b1_occ == b2_occ
+
+
+# =============================================================================
+# ASSERTION A — the owner/teammate_name occupant-alignment crux
+# =============================================================================
+class TestAssertionA:
+    def test_owner_populated_aligns_and_dedups(self, shared_home, monkeypatch, pact_context):
+        """owner populated → b1 and b2 share the key → one event (covered by
+        TestCrossPathDedup; re-pinned here as the assertion-A positive)."""
+        pact_context(team_name=TEAM, session_id="s1")
+        gate_events: list[dict] = []
+        monkeypatch.setattr(tlg, "append_event", lambda e: gate_events.append(e) or True)
+        tlg.evaluate_lifecycle(_gate_payload(owner=OWNER))
+        emitter_events: list[dict] = []
+        _run_main(
+            _emitter_stdin(teammate_name=OWNER), _emitter_task_data(owner=OWNER), emitter_events
+        )
+        assert len(gate_events) + len(emitter_events) == 1
+
+    def test_owner_empty_b2_silent_no_divergence(self, shared_home, monkeypatch, pact_context):
+        """owner EMPTY → b2 early-returns no-emit, so the derivation
+        difference (b1 uses teammate_name, b2 uses owner) cannot produce a
+        double-emit. b1 still emits once via its teammate_name fallback.
+
+        This is the crux: a divergent key only matters if BOTH paths emit; b2's
+        owner-empty early-return guarantees they don't both fire here."""
+        pact_context(team_name=TEAM, session_id="s1")
+        gate_events: list[dict] = []
+        monkeypatch.setattr(tlg, "append_event", lambda e: gate_events.append(e) or True)
+
+        # b2 with empty owner → silent
+        tlg.evaluate_lifecycle(_gate_payload(owner=""))
+        assert len(gate_events) == 0, "b2 must be silent when owner is empty"
+
+        # b1 (emitter) with owner empty falls back to stdin teammate_name → emits once
+        emitter_events: list[dict] = []
+        _run_main(
+            _emitter_stdin(teammate_name="devops-teammate"),
+            _emitter_task_data(owner=""),
+            emitter_events,
+        )
+        assert len(emitter_events) == 1, (
+            "b1 falls back to teammate_name and emits once; total stays at one"
+        )
+        assert len(gate_events) + len(emitter_events) == 1
+
+
+# =============================================================================
+# #887 integration through the emitter — different occupant → both emit
+# =============================================================================
+class TestEmitterOccupantCollision:
+    def test_same_task_id_different_subject_both_emit(self, shared_home):
+        """A reused (team, task_id) under two DIFFERENT subjects (→ different
+        occupant) must produce TWO emitter events — the #887 collision fix
+        seen end-to-end through main(). NON-VACUITY: reverting to the bare
+        {task_id} key collapses this to 1."""
+        events: list[dict] = []
+        _run_main(
+            _emitter_stdin(subject="alpha phase handoff"),
+            _emitter_task_data(),
+            events,
+        )
+        _run_main(
+            _emitter_stdin(subject="beta phase handoff"),
+            _emitter_task_data(),
+            events,
+        )
+        assert len(events) == 2, (
+            "different occupants on the same task_id must both emit (#887); "
+            f"got {len(events)} — marker key may have regressed to bare task_id"
+        )
+
+    def test_same_task_id_different_owner_both_emit(self, shared_home):
+        events: list[dict] = []
+        _run_main(_emitter_stdin(teammate_name="agent-a"), _emitter_task_data(owner="agent-a"), events)
+        _run_main(_emitter_stdin(teammate_name="agent-b"), _emitter_task_data(owner="agent-b"), events)
+        assert len(events) == 2
+
+    def test_same_occupant_dedups_positive_control(self, shared_home):
+        """POSITIVE CONTROL: identical occupant on the same task_id → ONE
+        event. Proves the two rows above emit twice because occupants DIFFER,
+        not because dedup is globally broken."""
+        events: list[dict] = []
+        _run_main(_emitter_stdin(), _emitter_task_data(), events)
+        _run_main(_emitter_stdin(), _emitter_task_data(), events)
+        assert len(events) == 1
+
+
+# =============================================================================
+# DUAL-MODE matrix (is_lead topology ≙ session==leadSessionId vs !=)
+# =============================================================================
+class TestDualModeMatrix:
+    """The shipped DEFER scope has NO session_id==leadSessionId branch; the
+    topology discriminator that IS shipped is is_lead. Under real tmux,
+    is_lead==True ≙ this process's session == the lead's session.
+
+    b2 (gate): KEEP under lead mode, SUPPRESS under teammate mode, with a
+    same-fixture positive control. b1 (emitter): agent_type-agnostic — emits in
+    either mode (the WHERE-it-lands question is the E1 smoke's, not a code
+    branch here)."""
+
+    def test_b2_lead_mode_keeps(self, shared_home, monkeypatch, pact_context):
+        pact_context(team_name=TEAM, session_id="s1")
+        events: list[dict] = []
+        monkeypatch.setattr(tlg, "append_event", lambda e: events.append(e) or True)
+        tlg.evaluate_lifecycle(_gate_payload(agent_type=LEAD))
+        assert len(events) == 1, "lead mode (session==leadSessionId) → KEEP"
+
+    def test_b2_teammate_mode_suppresses(self, shared_home, monkeypatch, pact_context):
+        pact_context(team_name=TEAM, session_id="s2")
+        events: list[dict] = []
+        monkeypatch.setattr(tlg, "append_event", lambda e: events.append(e) or True)
+        tlg.evaluate_lifecycle(_gate_payload(agent_type="pact-devops-engineer"))
+        assert len(events) == 0, "teammate mode (session!=leadSessionId) → SUPPRESS"
+
+    def test_b2_teammate_mode_positive_control(self, shared_home, monkeypatch, pact_context):
+        """Same fixture, lead frame → emits. Proves the suppression above is
+        the topology gate, not a missing precondition."""
+        pact_context(team_name=TEAM, session_id="s2")
+        events: list[dict] = []
+        monkeypatch.setattr(tlg, "append_event", lambda e: events.append(e) or True)
+        tlg.evaluate_lifecycle(_gate_payload(agent_type=LEAD))
+        assert len(events) == 1
+
+    def test_b1_emitter_is_agent_type_agnostic(self, shared_home):
+        """b1 does not read agent_type — it emits regardless of mode (an
+        agent_type field in stdin is simply ignored). The marker, not a
+        topology gate, is what dedups it against b2."""
+        events: list[dict] = []
+        stdin = _emitter_stdin()
+        stdin["agent_type"] = "pact-devops-engineer"  # ignored by the emitter
+        _run_main(stdin, _emitter_task_data(), events)
+        assert len(events) == 1

--- a/pact-plugin/tests/test_handoff_eligibility_parity.py
+++ b/pact-plugin/tests/test_handoff_eligibility_parity.py
@@ -1,0 +1,228 @@
+"""
+#880 remediation (PR #898 review cycle 1) — closes two convergent test gaps:
+
+1. ELIGIBILITY-PARITY (devops Future-minor + architect drift-path): b1 (the
+   agent_handoff_emitter) and b2 (task_lifecycle_gate._emit_lead_side_agent_handoff)
+   are supposed to fire on the SAME emit-eligibility set. This regression-pins
+   that mirrored eligibility — the "#887 divergence shape one level up" — by
+   DRIVING THE ACTUAL CODE PATHS over the (owner, handoff, signal, teachback)
+   matrix and asserting b1 and b2 agree on emit-vs-suppress. A future edit to
+   one path's bypass gates that desyncs the other fails this test.
+
+   NOTE — one DOCUMENTED, BENIGN asymmetry the parity scan surfaces: b2 carries
+   an explicit `_is_teachback_subject` exclusion that b1 LACKS. b1 instead
+   relies on its handoff-presence gate to suppress teachback tasks (which carry
+   metadata.teachback_submit, NOT metadata.handoff). So they CONVERGE on every
+   realistic input; they diverge only on the unreachable cell
+   (teachback-subject AND handoff-present AND owner AND not-signal), where b1
+   would emit and b2 suppresses. That cell is pinned explicitly below so a
+   future change in EITHER direction is a deliberate, test-visible decision.
+
+2. FAIL-OPEN (test-engineer M3): _emit_lead_side_agent_handoff wraps its body in
+   `except Exception: pass`. Pin that a raising append_event does NOT propagate
+   out of evaluate_lifecycle (the gate's advisory eval + exit-0 contract stay
+   intact). Non-vacuous: removing the except makes the exception propagate and
+   this test fails.
+
+Test-only; no source dependency on devops's concurrent .lower() centralization
+(team names here are already lowercase, so .lower() is a no-op either way).
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import task_lifecycle_gate as tlg  # noqa: E402
+from fixtures.emitter import VALID_HANDOFF, _run_main  # noqa: E402
+
+TEAM = "pact-test"
+LEAD = "PACT:pact-orchestrator"
+
+
+def _subject(teachback: bool) -> str:
+    # Matches _TEACHBACK_SUBJECT_PATTERN ^[a-z0-9-]+: TEACHBACK for
+    return "agent: TEACHBACK for the mission" if teachback else "agent: do the work"
+
+
+def _metadata(handoff: bool, signal: bool) -> dict:
+    md: dict = {}
+    if handoff:
+        md["handoff"] = VALID_HANDOFF
+    if signal:
+        md["type"] = "blocker"  # is_signal_task reads metadata.type
+    return md
+
+
+def _b1_emits(tmp_path, owner: str, handoff: bool, signal: bool, teachback: bool) -> bool:
+    """Run the ACTUAL emitter (b1) and report whether it emitted. Fresh marker
+    via the dedicated task_id 'e-b1' under tmp_path's HOME."""
+    calls: list[dict] = []
+    # b1's actor = owner OR stdin teammate_name; mirror owner into teammate_name
+    # so the 'owner' dimension drives b1 the same way it drives b2.
+    _run_main(
+        stdin_payload={
+            "task_id": "e-b1",
+            "task_subject": _subject(teachback),
+            "teammate_name": owner,
+            "team_name": TEAM,
+        },
+        task_data={
+            "status": "completed",
+            "owner": owner,
+            "metadata": _metadata(handoff, signal),
+        },
+        append_calls=calls,
+    )
+    return len(calls) == 1
+
+
+def _b2_emits(monkeypatch, owner: str, handoff: bool, signal: bool, teachback: bool) -> bool:
+    """Run the ACTUAL gate emit path (b2) and report whether it emitted. Fresh
+    marker via task_id 'e-b2'. is_lead gate satisfied via agent_type=LEAD."""
+    events: list[dict] = []
+    monkeypatch.setattr(tlg, "append_event", lambda e: events.append(e) or True)
+    task = {
+        "id": "e-b2",
+        "subject": _subject(teachback),
+        "owner": owner,
+        "metadata": _metadata(handoff, signal),
+    }
+    tlg.evaluate_lifecycle({
+        "agent_type": LEAD,
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": "e-b2", "status": "completed"},
+        "tool_response": {"task": task},
+    })
+    return len(events) == 1
+
+
+# Full (owner, handoff, signal, teachback) matrix — 16 cells.
+_MATRIX = [
+    (owner, handoff, signal, teachback)
+    for owner in ("devops", "")
+    for handoff in (True, False)
+    for signal in (True, False)
+    for teachback in (True, False)
+]
+
+
+class TestEligibilityParity:
+    """b1 and b2 must agree on emit-vs-suppress across the eligibility matrix,
+    with ONE documented benign asymmetry (teachback-subject + handoff-present).
+    Driven off the actual code paths (relational assertion), so any desync of
+    the mirrored gates fails this test."""
+
+    @pytest.mark.parametrize("owner,handoff,signal,teachback", _MATRIX)
+    def test_b1_b2_eligibility_agree(
+        self, tmp_path, monkeypatch, pact_context, owner, handoff, signal, teachback
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s")
+
+        b1 = _b1_emits(tmp_path, owner, handoff, signal, teachback)
+        b2 = _b2_emits(monkeypatch, owner, handoff, signal, teachback)
+
+        # The ONLY licensed divergence: b2 has an explicit teachback-subject
+        # exclusion that b1 lacks (b1 relies on handoff-absence for realistic
+        # teachback tasks). It manifests only when a teachback-subject task ALSO
+        # carries a handoff AND has an owner AND is not a signal task — an
+        # unreachable shape in practice (teachback tasks carry teachback_submit).
+        divergence_cell = bool(owner) and handoff and (not signal) and teachback
+
+        if divergence_cell:
+            assert b1 is True and b2 is False, (
+                "documented asymmetry changed: b2 has a teachback-subject "
+                "exclusion that b1 lacks. If a path changed, update deliberately. "
+                f"got b1={b1}, b2={b2}"
+            )
+        else:
+            assert b1 == b2, (
+                f"b1/b2 eligibility DESYNCED at "
+                f"(owner={owner!r}, handoff={handoff}, signal={signal}, "
+                f"teachback={teachback}): b1={b1}, b2={b2}. The mirrored "
+                "emit-eligibility (the #887 divergence shape one level up) "
+                "has drifted."
+            )
+
+    def test_fully_eligible_both_emit_positive_control(self, tmp_path, monkeypatch, pact_context):
+        """Vacuity guard: the all-eligible cell (owner + handoff + not-signal +
+        not-teachback) makes BOTH paths emit — so the agreement above isn't
+        'both always suppress'."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s")
+        assert _b1_emits(tmp_path, "devops", True, False, False) is True
+        assert _b2_emits(monkeypatch, "devops", True, False, False) is True
+
+    def test_documented_teachback_asymmetry_explicit(self, tmp_path, monkeypatch, pact_context):
+        """Pin the one asymmetry on its own so it is unmistakable: a
+        teachback-subject task that (unrealistically) carries a handoff →
+        b1 EMITS (no teachback check), b2 SUPPRESSES (explicit teachback
+        exclusion). Benign because teachback tasks carry teachback_submit, not
+        handoff — but the mechanisms differ, and that is pinned here."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s")
+        assert _b1_emits(tmp_path, "devops", True, False, True) is True
+        assert _b2_emits(monkeypatch, "devops", True, False, True) is False
+
+
+class TestGateEmitFailOpen:
+    """M3: _emit_lead_side_agent_handoff's `except Exception: pass` must fail
+    open — a raising append_event MUST NOT propagate out of evaluate_lifecycle.
+    Non-vacuous: removing the except makes evaluate_lifecycle raise and this
+    test fails."""
+
+    def test_append_event_raise_does_not_propagate(self, tmp_path, monkeypatch, pact_context):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s")
+
+        def _boom(_event):
+            raise RuntimeError("simulated journal-write failure")
+
+        monkeypatch.setattr(tlg, "append_event", _boom)
+
+        task = {
+            "id": "fo",
+            "subject": "devops: do the work",
+            "owner": "devops",
+            "metadata": {"handoff": VALID_HANDOFF},
+        }
+        payload = {
+            "agent_type": LEAD,  # is_lead True → reaches the emit (which raises)
+            "tool_name": "TaskUpdate",
+            "tool_input": {"taskId": "fo", "status": "completed"},
+            "tool_response": {"task": task},
+        }
+
+        # Must return normally (a list of advisories), NOT raise. If the
+        # except: pass is removed, RuntimeError propagates and this fails.
+        advisories = tlg.evaluate_lifecycle(payload)
+        assert isinstance(advisories, list), (
+            "evaluate_lifecycle must return its advisory list even when the "
+            "lead-side emit's append_event raises — the fail-open except must "
+            "absorb it (exit-0 / advisory-eval contract intact)."
+        )
+
+    def test_fail_open_does_not_suppress_unrelated_advisories(self, tmp_path, monkeypatch, pact_context):
+        """The emit failure must not swallow the gate's normal advisory
+        evaluation. A teammate self-completion (no is_lead → emit not reached,
+        but an unrelated advisory path) still evaluates — sanity that the emit
+        try/except is scoped to the emit, not the whole gate."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s")
+
+        def _boom(_event):
+            raise RuntimeError("simulated journal-write failure")
+
+        monkeypatch.setattr(tlg, "append_event", _boom)
+        # Lead frame, work task with handoff → emit path is hit and raises;
+        # evaluate still completes and returns a list.
+        task = {"id": "fo2", "subject": "devops: work", "owner": "devops",
+                "metadata": {"handoff": VALID_HANDOFF}}
+        result = tlg.evaluate_lifecycle({
+            "agent_type": LEAD, "tool_name": "TaskUpdate",
+            "tool_input": {"taskId": "fo2", "status": "completed"},
+            "tool_response": {"task": task},
+        })
+        assert isinstance(result, list)

--- a/pact-plugin/tests/test_lead_side_handoff_emit.py
+++ b/pact-plugin/tests/test_lead_side_handoff_emit.py
@@ -1,0 +1,245 @@
+"""
+Fix A (#869) — lead-side agent_handoff emission at the lead's acceptance-commit
+(task_lifecycle_gate.py block ③, _emit_lead_side_agent_handoff).
+
+#869 gap: agent_handoff is TaskCompleted-keyed; a stage-ready task completes
+mid-turn so it is already "completed" at the lead's Stop-sweep → swept over →
+the TaskCompleted-keyed agent_handoff_emitter never fires → the HANDOFF never
+lands in the lead's canonical journal. Fix A re-emits it from the lead's
+TaskUpdate(status="completed") acceptance-commit, where the lead's process has
+a populated context.
+
+This file drives tlg.evaluate_lifecycle(payload) with tlg.append_event spied to
+capture emitted events, exercising the b2 emit-eligibility discriminator (which
+MIRRORS agent_handoff_emitter's b1 gates) + the is_lead topology gate. Every
+SUPPRESS row carries a same-fixture POSITIVE CONTROL proving the suppression is
+the intended discriminator firing, not an unrelated missing precondition.
+
+is_lead reads input_data["agent_type"] DIRECTLY against
+{"PACT:pact-orchestrator", "pact-orchestrator"} (pact_context.LEAD_AGENT_TYPES).
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import task_lifecycle_gate as tlg  # noqa: E402
+from fixtures.emitter import VALID_HANDOFF  # noqa: E402
+
+TEAM = "pact-test"
+LEAD = "PACT:pact-orchestrator"
+
+
+@pytest.fixture
+def emit_events(monkeypatch):
+    """Spy on the gate's append_event so emitted agent_handoff events are
+    captured instead of written to a journal."""
+    events: list[dict] = []
+
+    def _spy(event):
+        events.append(event)
+        return True
+
+    monkeypatch.setattr(tlg, "append_event", _spy)
+    return events
+
+
+def _payload(
+    *,
+    agent_type=LEAD,
+    task_id="42",
+    subject="devops: implement Fix A",
+    owner="devops",
+    handoff=VALID_HANDOFF,
+    task_type=None,
+):
+    """Build a TaskUpdate(status=completed) PostToolUse payload. Post-state is
+    supplied via tool_response.task (the gate's preferred source)."""
+    metadata: dict = {}
+    if handoff is not None:
+        metadata["handoff"] = handoff
+    if task_type is not None:
+        metadata["type"] = task_type
+    task = {"id": task_id, "subject": subject, "owner": owner, "metadata": metadata}
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": task_id, "status": "completed"},
+        "tool_response": {"task": task},
+    }
+    if agent_type is not None:
+        payload["agent_type"] = agent_type
+    return payload
+
+
+# =============================================================================
+# Positive: lead + work + handoff → emit
+# =============================================================================
+class TestLeadEmits:
+    def test_lead_with_handoff_emits_one(self, tmp_path, monkeypatch, pact_context, emit_events):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(_payload())
+        assert len(emit_events) == 1, "lead acceptance-commit on a work task with handoff must emit"
+
+    def test_emitted_event_payload_shape(self, tmp_path, monkeypatch, pact_context, emit_events):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(
+            _payload(task_id="77", subject="devops: ship it", owner="devops")
+        )
+        assert len(emit_events) == 1
+        ev = emit_events[0]
+        assert ev["type"] == "agent_handoff"
+        assert ev["agent"] == "devops"
+        assert ev["task_id"] == "77"
+        assert ev["task_subject"] == "devops: ship it"
+        assert ev["handoff"] == VALID_HANDOFF
+
+    @pytest.mark.parametrize("spelling", ["PACT:pact-orchestrator", "pact-orchestrator"])
+    def test_both_qualified_lead_spellings_emit(
+        self, tmp_path, monkeypatch, pact_context, emit_events, spelling
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(_payload(agent_type=spelling))
+        assert len(emit_events) == 1, f"lead spelling {spelling!r} must emit"
+
+
+# =============================================================================
+# Topology gate (is_lead) — SUPPRESS rows + same-fixture positive controls
+# =============================================================================
+class TestIsLeadTopologyGate:
+    def test_teammate_frame_no_emit(self, tmp_path, monkeypatch, pact_context, emit_events):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(_payload(agent_type="pact-devops-engineer"))
+        assert len(emit_events) == 0, (
+            "a teammate process (is_lead False) must NOT emit — its context "
+            "has no canonical journal; only the lead's process emits"
+        )
+
+    def test_teammate_frame_positive_control_lead_same_fixture_emits(
+        self, tmp_path, monkeypatch, pact_context, emit_events
+    ):
+        """Positive control: the identical fixture under the LEAD frame DOES
+        emit — proving the suppression above is the is_lead gate, not a
+        missing handoff/owner."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(_payload(agent_type=LEAD))
+        assert len(emit_events) == 1
+
+    def test_empty_agent_type_no_emit(self, tmp_path, monkeypatch, pact_context, emit_events):
+        """is_lead('') is False (empty agent_type fail-safe)."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(_payload(agent_type=""))
+        assert len(emit_events) == 0
+
+    def test_missing_agent_type_no_emit(self, tmp_path, monkeypatch, pact_context, emit_events):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(_payload(agent_type=None))
+        assert len(emit_events) == 0
+
+    def test_is_lead_empty_string_predicate(self):
+        """Direct predicate pin: is_lead('') and the non-lead spellings."""
+        import shared.pact_context as ctx
+
+        assert ctx.is_lead({"agent_type": ""}) is False
+        assert ctx.is_lead({}) is False
+        assert ctx.is_lead({"agent_type": "pact-devops-engineer"}) is False
+        assert ctx.is_lead({"agent_type": "PACT:pact-orchestrator"}) is True
+        assert ctx.is_lead({"agent_type": "pact-orchestrator"}) is True
+
+
+# =============================================================================
+# Emit-eligibility discriminator (mirrors b1) — SUPPRESS rows + positive controls
+# =============================================================================
+class TestEmitEligibilityMirrorsB1:
+    @pytest.mark.parametrize("signal_type", ["blocker", "algedonic"])
+    def test_signal_task_no_emit(
+        self, tmp_path, monkeypatch, pact_context, emit_events, signal_type
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(_payload(task_type=signal_type))
+        assert len(emit_events) == 0, (
+            f"signal task ({signal_type}) must not emit a phantom agent_handoff"
+        )
+
+    def test_signal_task_positive_control(self, tmp_path, monkeypatch, pact_context, emit_events):
+        """Same fixture WITHOUT the signal type → emits (proves the
+        suppression is the signal-task gate, not something else)."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(_payload(task_type=None))
+        assert len(emit_events) == 1
+
+    def test_teachback_subject_no_emit(self, tmp_path, monkeypatch, pact_context, emit_events):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(
+            _payload(subject="test-engineer: TEACHBACK for #880 TEST", owner="test-engineer")
+        )
+        assert len(emit_events) == 0, "a teachback task is not a HANDOFF-bearing work task"
+
+    def test_teachback_subject_positive_control(
+        self, tmp_path, monkeypatch, pact_context, emit_events
+    ):
+        """Same owner, NON-teachback subject → emits."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(
+            _payload(subject="test-engineer: write the tests", owner="test-engineer")
+        )
+        assert len(emit_events) == 1
+
+    def test_no_handoff_no_emit(self, tmp_path, monkeypatch, pact_context, emit_events):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(_payload(handoff=None))
+        assert len(emit_events) == 0, "no metadata.handoff → nothing to preserve"
+
+    def test_empty_handoff_no_emit(self, tmp_path, monkeypatch, pact_context, emit_events):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(_payload(handoff={}))
+        assert len(emit_events) == 0, "empty (falsy) handoff → suppress"
+
+    def test_no_handoff_positive_control(self, tmp_path, monkeypatch, pact_context, emit_events):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(_payload(handoff=VALID_HANDOFF))
+        assert len(emit_events) == 1
+
+    def test_owner_empty_no_emit(self, tmp_path, monkeypatch, pact_context, emit_events):
+        """owner-empty → b2 early-returns no-emit. (This is the owner half of
+        the b1/b2 occupant-alignment crux — see test_handoff_b1_b2_dedup.py.)"""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(_payload(owner=""))
+        assert len(emit_events) == 0
+
+
+# =============================================================================
+# Re-completion dedup (shared occupant marker)
+# =============================================================================
+class TestReCompletionDedup:
+    def test_lead_recompletion_dedups_to_one(
+        self, tmp_path, monkeypatch, pact_context, emit_events
+    ):
+        """The lead may TaskUpdate(completed) the same task more than once
+        (e.g. a metadata correction). The shared occupant marker must collapse
+        re-emits to exactly ONE journal event."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        p = _payload(task_id="99", subject="devops: dedup probe", owner="devops")
+        tlg.evaluate_lifecycle(p)
+        tlg.evaluate_lifecycle(p)
+        tlg.evaluate_lifecycle(p)
+        assert len(emit_events) == 1, (
+            f"re-completion must dedup to 1 via the occupant marker; got {len(emit_events)}"
+        )


### PR DESCRIPTION
## Summary

Closes #869 and #887 — the two concrete bugs from the #880 umbrella (journal / session-dir audit under N:1 tmux teammateMode). Scope: **DEFER-REDIRECT** (user-approved) — ship the two named fixes as a small PATCH; the speculative teammate→canonical journal redirect is deferred to a follow-up. **#880 stays OPEN** as the umbrella (redirect + the Cluster-G doc cleanup remain tracked there).

## What landed

- **fix(#887)** — Occupant-identity marker key. The `agent_handoff` idempotency marker is keyed on `(team, task_id, hash(agent+subject))` instead of `(team, task_id)`, so a reused `task_id` with a **different** occupant no longer silently suppresses the HANDOFF on team-name reuse — while the deliberate standing-task fire-once dedup (same occupant → same key) is preserved. Marker logic is extracted into `shared/agent_handoff_marker.py` (occupant_hash, the O_EXCL test-and-set, `is_signal_task`, path sanitizer) so the emitter and the lead-side gate derive one byte-identical key. Includes a realpath / `commonpath` containment re-check closing the `is_symlink`→`mkdir(exist_ok=True)` TOCTOU window.
- **fix(#869)** — Lead-side `agent_handoff` emission. Stage-ready→lead-commit HANDOFFs complete mid-turn, so they are already `completed` at the lead's Stop-sweep and get swept over — the `TaskCompleted`-keyed emitter never fires and the HANDOFF goes un-journaled. A lead-side emit in `task_lifecycle_gate`'s TaskUpdate-to-completed path (is_lead-gated, mirroring the emitter's eligibility discriminator — deliberately NOT the `is_work_task` `pact-` prefix, which no-ops for bare owner names) closes the gap.
- **test(#880)** — +60 tests (full hook suite 8071 green), non-vacuous (counter-test-by-revert on both fixes).
- **chore** — PATCH bump to 4.4.4 (4 canonical files; `pyproject.toml` untouched).

## Why occupant-identity (not session-id)

`team_name = "pact-" + session_id[:8]`, so team-name reuse implies the same `session_id` → `leadSessionId` is stable across the #887 boundary. Session-id namespacing therefore cannot fix #887 — occupant identity can.

## Scope note (beyond the plan's "~2 files localized" framing)

Implementation extracted `shared/agent_handoff_marker.py` + `is_signal_task` so b1 (emitter) and b2 (gate) derive a **byte-identical** occupant key. This is a justified DRY extraction — divergent derivation IS the #887 bug class — not a resolver (the deferred redirect stays deferred). `marker_schema.py` was rejected as the home (bootstrap-marker-specific); a new sibling module was added instead.

## E1 real-tmux merge gate (resolved without live-cache mutation)

R2 — does a mid-turn `TaskUpdate(completed)` *reliably* dispatch `TaskCompleted`, co-firing the emitter? — was resolved from **this session's own real-tmux journals** at zero risk. Of the handoff-bearing mid-turn completions, **#8 / #9 / #11 produced 0 `agent_handoff` events** while a later one (#13) produced exactly 1 — so **b1 fires *unreliably* for mid-turn completions** (Stop-timing-dependent: the Stop-sweep skips tasks already in `completed` state), which is precisely the non-determinism Fix A's deterministic lead-side emit eliminates. (Load-bearing R2 evidence is **n=3** — #7/#12 are teachback tasks with no handoff, suppressed by b1's handoff-presence gate regardless.) A different team's journal carries 50 `agent_handoff` events, proving b1 works generally. "b2 lands in the canonical journal" is the additive composition of three independently real-tmux-observed components (the gate runs in the lead process — 68 `lifecycle_decision` events; `is_lead` is deployed & load-bearing — validated in PreToolUse/`bootstrap_gate`, with PostToolUse-`agent_type` resting on PreToolUse↔PostToolUse envelope parity; `append_event` writes the canonical journal), with Fix A reading only fields the existing gate already consumes from real stdin. User-approved acceptance of observational evidence over a live-cache overlay (isolation was unworkable under the HMAC-version constraint; in-place overlay carries whole-team blast radius). The b1+b2 co-fire case (if platform semantics ever change) dedups to one event via the shared occupant-keyed marker.

## Test plan

- Full hook suite: **8071 passed / 0 failed / 13 skipped**.
- Non-vacuity: #887 bare-key revert → exactly the occupant-discriminating assertions fail; #869 emit-neuter → exactly the lead-emit rows fail.
- Dual-mode (`is_lead` topology) matrix with same-fixture positive controls on every suppress/keep row.

## Peer review (4 reviewers) + cycle-1 hardening

Four independent reviewers (architect, security-engineer, devops, test-engineer): **0 Blocking**. Security **RATIFIES** the fail-open posture (`return False` = emit, skip marker — data-integrity over dedup); the trust-partition is empirically *and* exhaustively verified — no journal consumer across the whole plugin tree elevates `agent_handoff` content to a control decision (the control reader consumes a disjoint event-type set).

Three reviewers independently converged on the b1/b2 marker-key parity invariant (the #887 divergence class, one level up), so it was hardened in-PR:

- **`27e7a15e`** — centralize `team_name` normalization in the SSOT (`already_emitted`) so b1 and b2 derive a byte-identical marker dir *structurally*, rather than relying on team names being lowercase-by-construction. Verified by architect (mixed-case drift probe converges to one marker) and security (lower-before-sanitize, no traversal residue).
- **`61f3ac7b`** — a relational b1/b2 eligibility-parity test (full owner/handoff/signal/teachback matrix, driven off the actual code paths so a future desync fails) + gate fail-open coverage. The parity test pins one **benign, unreachable** asymmetry: b2 carries an explicit teachback-subject guard that b1 satisfies implicitly via its handoff-presence gate (the divergence cell — a teachback task that also has a handoff — cannot occur).

The security-flagged TOCTOU was also fully closed in-PR (cycle 2):

- **`64a6bf19`** — pin the marker dir by file descriptor (`O_DIRECTORY|O_NOFOLLOW` open + `dir_fd=` relative create) so a `marker_dir` symlink swapped in *after* the containment re-check can't redirect the create. Security verified the automated MEDIUM is now closed by construction.
- **`ea539237`** — race-coverage test (swap `marker_dir` to an escaping symlink inside the containment check → dir-open fails → fail-open, no write-through), non-vacuous.

Remaining findings are pre-existing/dormant and tracked as post-merge follow-ups under #880: `session_resume` C0/Unicode stripping, the auditor placeholder-handoff (`completion_type=signal`), the team_name case-drift sweep, and an intermediate-*path* symlink (openat-walk, same-user-benign).

Full suite after all hardening: **8093 passed / 0 failed / 13 skipped**.
