### PR TITLE
fix(#882 + #810): memory-layer concurrency cluster — CLAUDE.md-sync lock + agent-memory team-namespacing (v4.4.6)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.5",
+      "version": "4.4.6",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.5/      # Plugin version
+│               └── 4.4.6/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.5",
+  "version": "4.4.6",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.5
+> **Version**: 4.4.6
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/agents/pact-auditor.md
+++ b/pact-plugin/agents/pact-auditor.md
@@ -204,7 +204,7 @@ Other agents in your team (coders, architect, test-engineer) do NOT self-complet
 
 ## PERSISTENT MEMORY
 
-Save accumulated audit patterns to `~/.claude/agent-memory/pact-auditor/`.
+Save accumulated audit patterns to `~/.claude/agent-memory/pact-auditor/`. If multiple instances may write the same agent-memory file concurrently across teams, namespace by `## team=` section (same convention as the secretary) so instances don't clobber each other.
 
 Examples of patterns worth saving:
 - "Backend coders in this project tend to drift on error handling in auth modules"

--- a/pact-plugin/agents/pact-secretary.md
+++ b/pact-plugin/agents/pact-secretary.md
@@ -49,7 +49,7 @@ Serve the team in two roles: **(A) Knowledge Distiller** — reviewing HANDOFFs,
 You have access to two distinct memory systems — use each for its intended purpose:
 
 - **pact-memory** (SQLite, via the pre-loaded `pact-memory` skill): Save and retrieve **institutional knowledge** — project-wide decisions, cross-agent lessons, architectural rationale, calibration data. Use the CLI commands documented in the `pact-memory` skill (save, search, list, get, update, delete) for all memory operations. This is your primary job.
-- **Your agent memory** (`~/.claude/agent-memory/pact-secretary/`): Save **your own domain expertise** — patterns you notice about memory operations, effective query strategies, project-specific retrieval insights that help you work better next time. Also used for tracking processed task IDs across incremental synthesis passes (see Knowledge Distiller role below).
+- **Your agent memory** (`~/.claude/agent-memory/pact-secretary/`): Save **your own domain expertise** — patterns you notice about memory operations, effective query strategies, project-specific retrieval insights that help you work better next time. Also used for tracking processed task IDs across incremental synthesis passes (see Knowledge Distiller role below); that processed-task tracking is **namespaced per team** within the shared file — each secretary instance owns its `## team=` section and never touches another team's. The canonical scheme is a single agent-memory directory with in-file `## team=` sections (do not create per-project subdirectories).
 
 **Cross-Agent Coordination**: Read [pact-phase-transitions.md](../protocols/pact-phase-transitions.md) for workflow handoffs and phase boundaries with other specialists.
 

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -40,7 +40,7 @@ A reply to the user that contains content the team-lead needs to act on (a block
 4. **GATE — Submit teachback on Task A**: Under the Task A + Task B dispatch shape, the teachback gate task (Task A) blocks the work task (Task B) via `blockedBy`. Store your teachback in `metadata.teachback_submit` on Task A per the [pact-teachback](../pact-teachback/SKILL.md) skill, **notify the team-lead via SendMessage**, SET `intentional_wait{reason=awaiting_lead_completion}`, and idle. **Ordering invariant**: metadata write FIRST → SendMessage SECOND → `intentional_wait` SET THIRD (load-bearing; see [pact-teachback §Action: store teachback now](../pact-teachback/SKILL.md#action-store-teachback-now) for rationale). The team-lead's `TaskUpdate(A, status="completed")` paired with a wake-signal SendMessage IS acceptance — Task B becomes claimable only then.
    - **DO NOT** call `Edit`, `Write`, or `Bash` for implementation work before storing your teachback
    - See [Teachback](#teachback-conversation-verification) below for the full skill reference
-5. Begin work on Task B — check your agent memory (`~/.claude/agent-memory/<your-name>/`) for relevant patterns and knowledge as part of your working process
+5. Begin work on Task B — check your agent memory (`~/.claude/agent-memory/<your-name>/`) for relevant patterns and knowledge as part of your working process. When a memory file may be written by concurrent same-named instances across teams, namespace per team (a `## team={your team_id}` section) so instances don't clobber each other.
 
 > **Worktree Scope**: If you are working in a worktree, files that are gitignored (e.g., `CLAUDE.md`) do not exist there. Do not edit or create `CLAUDE.md` — the orchestrator manages it separately. If you need to reference `CLAUDE.md` content, it is auto-loaded into your context. If your task mentions updating `CLAUDE.md`, flag it in your handoff instead of editing it directly.
 
@@ -383,7 +383,7 @@ Before returning your final output:
 
    Examples: file locations, framework conventions → agent memory. Architectural decisions, cross-cutting concerns → HANDOFF.
 
-   Save concise notes to your persistent memory directory (`~/.claude/agent-memory/<your-name>/`) as you discover codepaths, patterns, and key decisions. For **project-wide institutional knowledge**, include it in your HANDOFF — the secretary will review and save it to pact-memory.
+   Save concise notes to your persistent memory directory (`~/.claude/agent-memory/<your-name>/`) as you discover codepaths, patterns, and key decisions. If a memory file may be written by concurrent same-named instances across teams, namespace per team (a `## team={your team_id}` section) so instances don't clobber each other. For **project-wide institutional knowledge**, include it in your HANDOFF — the secretary will review and save it to pact-memory.
 
    If you're working without an assigned task (no HANDOFF will be collected), message the secretary directly to save significant decisions or non-obvious discoveries: `SendMessage(to="secretary", message="[{your-name}→secretary] Save: {what you learned and why it matters}", summary="Save request: {topic}")`
 

--- a/pact-plugin/skills/pact-handoff-harvest/SKILL.md
+++ b/pact-plugin/skills/pact-handoff-harvest/SKILL.md
@@ -37,7 +37,7 @@ If none of these sources have completed agent tasks, report "No pending HANDOFFs
 
 ### Step 2: Dedup Check (Processed Tasks)
 
-Read your processed task list from agent memory (`~/.claude/agent-memory/pact-secretary/session_processed_tasks.md`). Skip any task IDs already processed — only review the delta. This enables incremental passes (e.g., after remediation).
+Read your processed task list from your team's section in agent memory (`~/.claude/agent-memory/pact-secretary/session_processed_tasks.md`). The file is namespaced by team — read **only** your own `## team={your team_id}` section (file-format contract: see Step 8). Skip any task IDs already processed — only review the delta. This enables incremental passes (e.g., after remediation).
 
 ### Step 3: Read All HANDOFFs
 
@@ -112,19 +112,37 @@ Save using the CLI with proper structure:
 
 ### Step 8: Update Processed Task Tracking
 
-Save the list of all processed task IDs to agent memory (overwrite, not append — this sets the baseline for subsequent incremental passes):
+**Save the processed task IDs to your team's section in agent memory.** Locate (or create) the `## team={your team_id}` section in `~/.claude/agent-memory/pact-secretary/session_processed_tasks.md` and overwrite **that section's** task-ID list to set the baseline for subsequent incremental passes. Overwrite only your own team's section — never modify, overwrite, or remove another team's `## team=` section. Multiple secretary instances (one per concurrent team) share this single file; each owns exactly its own section.
+
+This file is **namespaced by team** so that concurrent secretary instances (one per active team, all sharing this single user-scope file) never clobber each other's processed-task baselines. The file-format contract:
 
 File: `~/.claude/agent-memory/pact-secretary/session_processed_tasks.md`
 ```markdown
 ---
 name: session_processed_tasks
-description: Task IDs processed in current session for dedup on incremental passes
+description: Task IDs processed per team for dedup on incremental passes. NAMESPACED by team to avoid cross-secretary collision (single-file user-scope).
 type: reference
 ---
 
-Processed task IDs: 6, 7, 12, 15
-Last processed: {timestamp}
+# Per-team processed-tasks log (NAMESPACED — multiple concurrent secretary instances write here)
+
+## team={team_id} ({project}, session {session_id})
+
+{optional one-line session note}
+
+Processed task IDs (this team): {comma-separated IDs}
+Last processed (this team): {timestamp}
+
+## team={other_team_id} ({project}, session {session_id})
+
+...
 ```
+
+**Section semantics:**
+- The section key is your own `{team_id}` (your spawn `pact-XXXXXXXX`). The parenthetical `({project}, session {session_id})` is human-readable context.
+- Read/write **only your own** `## team={team_id}` section. You MUST NOT read, edit, or remove any other team's section.
+- Within your own section: **overwrite** to set the clean baseline on this Standard Harvest pass; **append** task IDs on incremental passes (the intra-team overwrite-then-append semantics are preserved exactly — they just operate on your team's section instead of the whole file).
+- If your `## team={team_id}` section does not yet exist, create it (append a new section at the end of the file); never recreate the file from scratch.
 
 ### Step 9: Report Summary
 
@@ -161,12 +179,12 @@ After processing HANDOFFs, gather calibration metrics for the orchestrator's var
 
 Triggered after remediation completes — processes only the delta since the last harvest pass. Fires only when remediation occurred and produced new completed tasks.
 
-1. **Check processed task tracking**: Read `~/.claude/agent-memory/pact-secretary/session_processed_tasks.md` for already-processed task IDs
+1. **Check processed task tracking**: Read **only your own** `## team={your team_id}` section of `~/.claude/agent-memory/pact-secretary/session_processed_tasks.md` for already-processed task IDs
 2. **Discover new completions**: Check session journal `agent_handoff` events (primary) and `TaskList` (supplementary) for completed tasks not in the processed set — these are new completions from remediation.
 3. **If no new completions**: Report "No new HANDOFFs since last harvest" and complete
 4. **Read new HANDOFFs** using the Standard Harvest Step 3 two-tier fallback: prefer journal inline content, fall back to `TaskGet`
 5. **Extract and save** using Steps 4-7 from Standard Harvest (extract knowledge, organizational state, dedup protocol, save)
-6. **Update processed task tracking** — append new task IDs to the processed set (do NOT overwrite — preserves the full session history)
+6. **Update processed task tracking** — **append** the new task IDs to **your team's** `## team={your team_id}` section (do NOT overwrite — preserves the full session history for your team)
 7. **Do NOT delete the session journal** — it may still be accumulating entries from ongoing work
 8. **Update existing memories** if remediation superseded prior decisions (use `update` CLI command, not `save`). Remember: default `update` is additive merge — pass `--replace` only when the prior list items need to be discarded, not amended.
 9. **Report delta summary** to team-lead — only report what changed in this incremental pass
@@ -189,6 +207,7 @@ Review all memories saved during this session by listing recent pact-memory entr
 
 - Merge overlapping memories (same topic, same entities, compatible conclusions)
 - Prune superseded memories (update or delete entries replaced by newer information)
+- **Prune stale `## team=` sections** in `~/.claude/agent-memory/pact-secretary/session_processed_tasks.md`: drop any `## team=` section older than ~30 days (judge by the section's `Last processed` timestamp) or whose team is known-complete (the session has wrapped/paused and will not resume). This is safe — the session journal's `agent_handoff` events are the authoritative dedup source, so a pruned-then-resurrected team re-derives its processed set from its own journal. Prune only stale/complete sections; never touch an active team's section. (Pruning happens only in this deep-clean Consolidation pass — the Standard/Incremental hot paths leave the file untouched apart from your own section.)
 
 ### Step 4: Sync Working Memory
 

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -99,6 +99,14 @@ def file_lock(target_file: Path):
     Twin of hooks/shared/claude_md_manager.file_lock — kept local because
     skills/pact-memory/scripts/ cannot import from hooks/shared/. Body MUST
     stay byte-identical to the canonical copy (drift test enforces this).
+
+    NOT RE-ENTRANT: fcntl.flock is non-re-entrant at the OS level. Nesting one
+    sync site inside another under the SAME target would self-deadlock until the
+    fail-open TimeoutError (after _LOCK_TIMEOUT_SECONDS). This is not reachable
+    on the current call graph — the two sync sites are independent top-level
+    calls, never nested — so no behavioral re-entrancy guard is added (a guard
+    would alter this body and trip the drift test; the OS-level non-re-entrancy
+    plus the callers' fail-open already bound the worst case).
     """
     lock_path = target_file.parent / f".{target_file.name}.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
@@ -142,6 +150,25 @@ def file_lock(target_file: Path):
             fcntl.flock(lock_fd, fcntl.LOCK_UN)
         finally:
             os.close(lock_fd)
+
+
+# Why the sync sites lock the WHOLE read->mutate->write window (not just the
+# write). This rationale is shared by both sync_to_claude_md and
+# sync_retrieved_to_claude_md, which each carry only a short pointer back here.
+# (Distinct from the "why an inline twin" note above: that explains WHY the lock
+# is vendored; this explains WHY the lock spans the whole window.)
+#   - read-under-lock is the load-bearing no-clobber property: a write-only lock
+#     would let a 2nd writer read stale (pre-this-write) content, mutate it, and
+#     overwrite this writer's entry the instant the lock releases — the exact
+#     lost update the lock exists to prevent.
+#   - lock identity is the sidecar inode of the RESOLVED CLAUDE.md path, so this
+#     serializes against session_init / session_resume: all writers resolve to
+#     the same .claude/CLAUDE.md (CLAUDE_PROJECT_DIR is set every session → all
+#     hit the env-var branch first) and thus share one .CLAUDE.md.lock sidecar.
+#   - CLAUDE_PROJECT_DIR edge: if it were ever unset AND the git-root/cwd
+#     fallbacks diverged between processes, the sidecars would differ and the
+#     lock would not serialize — accepted as out-of-contract (no safe fallback
+#     action exists if the paths genuinely diverge).
 
 
 def extract_managed_region(content: str) -> Optional[Tuple[str, int]]:
@@ -598,16 +625,9 @@ def sync_to_claude_md(
         return False
 
     try:
-        # Serialize the FULL read-modify-write window: read-under-lock is what
-        # prevents the lost update (a write-only lock would let a 2nd writer
-        # read stale content and clobber this entry the instant we release).
-        # Lock identity is the sidecar of the resolved CLAUDE.md path, so this
-        # serializes against session_init/session_resume because all writers
-        # resolve to the same .claude/CLAUDE.md (CLAUDE_PROJECT_DIR is set every
-        # session → all hit the env-var branch first). If CLAUDE_PROJECT_DIR is
-        # ever unset AND the git-root/cwd fallbacks diverge between processes,
-        # the sidecars would differ and the lock would not serialize — accepted
-        # as out-of-contract (no safe fallback action exists if paths diverge).
+        # Serialize the FULL read-modify-write window under the shared sidecar
+        # lock (see the "why lock the whole window" note above file_lock for the
+        # read-under-lock / lock-identity / CLAUDE_PROJECT_DIR rationale).
         with file_lock(claude_md_path):
             # Read current content
             content = claude_md_path.read_text(encoding="utf-8")
@@ -812,10 +832,9 @@ def sync_retrieved_to_claude_md(
         return False
 
     try:
-        # Serialize the FULL read-modify-write window (see sync_to_claude_md for
-        # the lock-identity / CLAUDE_PROJECT_DIR rationale): read-under-lock is
-        # the load-bearing property — a write-only lock would let a 2nd writer
-        # read stale content and clobber this section on release.
+        # Serialize the FULL read-modify-write window under the shared sidecar
+        # lock (see the "why lock the whole window" note above file_lock for the
+        # read-under-lock / lock-identity / CLAUDE_PROJECT_DIR rationale).
         with file_lock(claude_md_path):
             # Read current content
             content = claude_md_path.read_text(encoding="utf-8")

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -13,10 +13,14 @@ Used by:
 - Test files: test_working_memory.py tests all functions in this module
 """
 
+import fcntl
 import logging
 import os
 import re
 import subprocess
+import sys
+import time
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -73,6 +77,71 @@ _PACT_BOUNDARY_ALT = "PACT_MEMORY_|PACT_MANAGED_|PACT_ROUTING_"
 # in hooks/shared/claude_md_manager.py (cannot import — separate package).
 _MANAGED_START_MARKER = "<!-- PACT_MANAGED_START: Managed by pact-plugin - do not edit this block -->"
 _MANAGED_END_MARKER = "<!-- PACT_MANAGED_END -->"
+
+# file_lock: vendored twin of hooks/shared/claude_md_manager.file_lock —
+# skills/pact-memory/scripts/ cannot import from hooks/shared/ (separate
+# package boundary). Cross-process correctness is preserved because
+# fcntl.flock serializes on the sidecar inode, not the Python object: a hook
+# process and this skill process locking the SAME .{name}.lock sidecar
+# contend on the same kernel lock. The drift-detection test
+# (TestFileLockTwinCopyDrift in tests/test_staleness.py) guards byte-alignment
+# of the function body with the canonical copy; if you change either, update
+# both in the SAME commit. The two constants below are part of the twin and
+# must match the canonical values.
+_LOCK_TIMEOUT_SECONDS = 5.0
+_LOCK_POLL_INTERVAL = 0.1
+
+
+@contextmanager
+def file_lock(target_file: Path):
+    """Acquire an exclusive sidecar file lock for a target CLAUDE.md path.
+
+    Twin of hooks/shared/claude_md_manager.file_lock — kept local because
+    skills/pact-memory/scripts/ cannot import from hooks/shared/. Body MUST
+    stay byte-identical to the canonical copy (drift test enforces this).
+    """
+    lock_path = target_file.parent / f".{target_file.name}.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    # 0o600: the lock file is adjacent to user-private CLAUDE.md content;
+    # match the same permissions to avoid leaving a world-readable sidecar.
+    lock_fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+    deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
+    try:
+        while True:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                if time.monotonic() >= deadline:
+                    # S8 (security-engineer-review): emit a stderr
+                    # warning before raising. Callers fail-open on
+                    # TimeoutError (skip the cleanup pass), so without
+                    # this warning a stuck holder would silently defer
+                    # kernel-block / managed-block cleanup forever.
+                    # Stderr from hooks does not surface in the user
+                    # transcript, but it does land in Claude Code's
+                    # debug logs — repeated warnings make the
+                    # contention-vs-bug class observable.
+                    print(
+                        f"PACT file_lock timeout: failed to acquire "
+                        f"lock on {lock_path} within "
+                        f"{_LOCK_TIMEOUT_SECONDS}s; falling open",
+                        file=sys.stderr,
+                    )
+                    raise TimeoutError(
+                        f"Failed to acquire lock on {lock_path} within "
+                        f"{_LOCK_TIMEOUT_SECONDS}s"
+                    )
+                time.sleep(_LOCK_POLL_INTERVAL)
+        yield
+    finally:
+        # Release before close. flock is released automatically on fd close
+        # by the kernel, but an explicit LOCK_UN ensures immediate release
+        # even if close is delayed (e.g., by subsequent finalizer work).
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        finally:
+            os.close(lock_fd)
 
 
 def extract_managed_region(content: str) -> Optional[Tuple[str, int]]:
@@ -529,50 +598,61 @@ def sync_to_claude_md(
         return False
 
     try:
-        # Read current content
-        content = claude_md_path.read_text(encoding="utf-8")
+        # Serialize the FULL read-modify-write window: read-under-lock is what
+        # prevents the lost update (a write-only lock would let a 2nd writer
+        # read stale content and clobber this entry the instant we release).
+        # Lock identity is the sidecar of the resolved CLAUDE.md path, so this
+        # serializes against session_init/session_resume because all writers
+        # resolve to the same .claude/CLAUDE.md (CLAUDE_PROJECT_DIR is set every
+        # session → all hit the env-var branch first). If CLAUDE_PROJECT_DIR is
+        # ever unset AND the git-root/cwd fallbacks diverge between processes,
+        # the sidecars would differ and the lock would not serialize — accepted
+        # as out-of-contract (no safe fallback action exists if paths diverge).
+        with file_lock(claude_md_path):
+            # Read current content
+            content = claude_md_path.read_text(encoding="utf-8")
 
-        # Parse existing working memory section
-        before_section, section_header, after_section, existing_entries = \
-            _parse_working_memory_section(content)
+            # Parse existing working memory section
+            before_section, section_header, after_section, existing_entries = \
+                _parse_working_memory_section(content)
 
-        # Format new memory entry
-        new_entry = _format_memory_entry(memory, files, memory_id)
+            # Format new memory entry
+            new_entry = _format_memory_entry(memory, files, memory_id)
 
-        # Build new entries list: new entry first, then existing (up to max - 1)
-        all_entries = [new_entry] + existing_entries
-        trimmed_entries = all_entries[:MAX_WORKING_MEMORIES]
+            # Build new entries list: new entry first, then existing (up to max - 1)
+            all_entries = [new_entry] + existing_entries
+            trimmed_entries = all_entries[:MAX_WORKING_MEMORIES]
 
-        # Apply token budget: compress older entries if over budget
-        trimmed_entries = _apply_token_budget(
-            trimmed_entries, WORKING_MEMORY_TOKEN_BUDGET
-        )
+            # Apply token budget: compress older entries if over budget
+            trimmed_entries = _apply_token_budget(
+                trimmed_entries, WORKING_MEMORY_TOKEN_BUDGET
+            )
 
-        # Build new section content
-        section_lines = [
-            WORKING_MEMORY_HEADER,
-            WORKING_MEMORY_COMMENT,
-            ""  # Blank line after comment
-        ]
-        for entry in trimmed_entries:
-            section_lines.append(entry)
-            section_lines.append("")  # Blank line between entries
+            # Build new section content
+            section_lines = [
+                WORKING_MEMORY_HEADER,
+                WORKING_MEMORY_COMMENT,
+                ""  # Blank line after comment
+            ]
+            for entry in trimmed_entries:
+                section_lines.append(entry)
+                section_lines.append("")  # Blank line between entries
 
-        section_text = "\n".join(section_lines)
+            section_text = "\n".join(section_lines)
 
-        # Reconstruct file content
-        if section_header:
-            # Section existed, replace it
-            new_content = before_section + section_text + after_section
-        else:
-            # Section didn't exist, append at end
-            if not content.endswith("\n"):
-                content += "\n"
-            new_content = content + "\n" + section_text
+            # Reconstruct file content
+            if section_header:
+                # Section existed, replace it
+                new_content = before_section + section_text + after_section
+            else:
+                # Section didn't exist, append at end
+                if not content.endswith("\n"):
+                    content += "\n"
+                new_content = content + "\n" + section_text
 
-        # Write back to file
-        claude_md_path.write_text(new_content, encoding="utf-8")
-        os.chmod(str(claude_md_path), 0o600)
+            # Write back to file
+            claude_md_path.write_text(new_content, encoding="utf-8")
+            os.chmod(str(claude_md_path), 0o600)
 
         logger.info("Synced memory to CLAUDE.md Working Memory section")
         return True
@@ -732,73 +812,78 @@ def sync_retrieved_to_claude_md(
         return False
 
     try:
-        # Read current content
-        content = claude_md_path.read_text(encoding="utf-8")
+        # Serialize the FULL read-modify-write window (see sync_to_claude_md for
+        # the lock-identity / CLAUDE_PROJECT_DIR rationale): read-under-lock is
+        # the load-bearing property — a write-only lock would let a 2nd writer
+        # read stale content and clobber this section on release.
+        with file_lock(claude_md_path):
+            # Read current content
+            content = claude_md_path.read_text(encoding="utf-8")
 
-        # Parse existing retrieved context section
-        before_section, section_header, after_section, existing_entries = \
-            _parse_retrieved_context_section(content)
+            # Parse existing retrieved context section
+            before_section, section_header, after_section, existing_entries = \
+                _parse_retrieved_context_section(content)
 
-        # Format new entries (only the top result to avoid clutter)
-        new_entries = []
-        top_memory = memories[0]
-        score = scores[0] if scores else None
-        memory_id = memory_ids[0] if memory_ids else None
-        new_entry = _format_retrieved_entry(top_memory, query, score, memory_id)
-        new_entries.append(new_entry)
+            # Format new entries (only the top result to avoid clutter)
+            new_entries = []
+            top_memory = memories[0]
+            score = scores[0] if scores else None
+            memory_id = memory_ids[0] if memory_ids else None
+            new_entry = _format_retrieved_entry(top_memory, query, score, memory_id)
+            new_entries.append(new_entry)
 
-        # Build new entries list: new entry first, then existing (up to max - 1)
-        all_entries = new_entries + existing_entries
-        trimmed_entries = all_entries[:MAX_RETRIEVED_MEMORIES]
+            # Build new entries list: new entry first, then existing (up to max - 1)
+            all_entries = new_entries + existing_entries
+            trimmed_entries = all_entries[:MAX_RETRIEVED_MEMORIES]
 
-        # Apply token budget: reduce entry count if over budget.
-        # Retrieved entries are already compact (~200 chars each), drop oldest rather than compress.
-        # Subtract the popped entry's tokens instead of recalculating the full sum.
-        total_tokens = sum(_estimate_tokens(e) for e in trimmed_entries)
-        while len(trimmed_entries) > 1 and total_tokens > RETRIEVED_CONTEXT_TOKEN_BUDGET:
-            removed = trimmed_entries.pop()
-            total_tokens -= _estimate_tokens(removed)
+            # Apply token budget: reduce entry count if over budget.
+            # Retrieved entries are already compact (~200 chars each), drop oldest rather than compress.
+            # Subtract the popped entry's tokens instead of recalculating the full sum.
+            total_tokens = sum(_estimate_tokens(e) for e in trimmed_entries)
+            while len(trimmed_entries) > 1 and total_tokens > RETRIEVED_CONTEXT_TOKEN_BUDGET:
+                removed = trimmed_entries.pop()
+                total_tokens -= _estimate_tokens(removed)
 
-        # Build new section content
-        section_lines = [
-            RETRIEVED_CONTEXT_HEADER,
-            RETRIEVED_CONTEXT_COMMENT,
-            ""  # Blank line after comment
-        ]
-        for entry in trimmed_entries:
-            section_lines.append(entry)
-            section_lines.append("")  # Blank line between entries
+            # Build new section content
+            section_lines = [
+                RETRIEVED_CONTEXT_HEADER,
+                RETRIEVED_CONTEXT_COMMENT,
+                ""  # Blank line after comment
+            ]
+            for entry in trimmed_entries:
+                section_lines.append(entry)
+                section_lines.append("")  # Blank line between entries
 
-        section_text = "\n".join(section_lines)
+            section_text = "\n".join(section_lines)
 
-        # Reconstruct file content
-        if section_header:
-            # Section existed, replace it
-            # Ensure blank line before next section
-            if after_section and not after_section.startswith("\n"):
-                new_content = before_section + section_text + "\n" + after_section
+            # Reconstruct file content
+            if section_header:
+                # Section existed, replace it
+                # Ensure blank line before next section
+                if after_section and not after_section.startswith("\n"):
+                    new_content = before_section + section_text + "\n" + after_section
+                else:
+                    new_content = before_section + section_text + after_section
             else:
-                new_content = before_section + section_text + after_section
-        else:
-            # Section didn't exist, insert before Working Memory if it exists
-            working_memory_match = re.search(
-                r'^## Working Memory',
-                content,
-                re.MULTILINE
-            )
-            if working_memory_match:
-                # Insert before Working Memory with blank line
-                insert_pos = working_memory_match.start()
-                new_content = content[:insert_pos] + section_text + "\n" + content[insert_pos:]
-            else:
-                # Append at end
-                if not content.endswith("\n"):
-                    content += "\n"
-                new_content = content + "\n" + section_text
+                # Section didn't exist, insert before Working Memory if it exists
+                working_memory_match = re.search(
+                    r'^## Working Memory',
+                    content,
+                    re.MULTILINE
+                )
+                if working_memory_match:
+                    # Insert before Working Memory with blank line
+                    insert_pos = working_memory_match.start()
+                    new_content = content[:insert_pos] + section_text + "\n" + content[insert_pos:]
+                else:
+                    # Append at end
+                    if not content.endswith("\n"):
+                        content += "\n"
+                    new_content = content + "\n" + section_text
 
-        # Write back to file
-        claude_md_path.write_text(new_content, encoding="utf-8")
-        os.chmod(str(claude_md_path), 0o600)
+            # Write back to file
+            claude_md_path.write_text(new_content, encoding="utf-8")
+            os.chmod(str(claude_md_path), 0o600)
 
         logger.info("Synced retrieved memories to CLAUDE.md Retrieved Context section")
         return True

--- a/pact-plugin/tests/test_skills_structure.py
+++ b/pact-plugin/tests/test_skills_structure.py
@@ -337,3 +337,47 @@ class TestOrderingInvariantPhraseCount:
             f"refactor changes the count, update EXPECTED_COUNTS with a comment "
             f"naming which site was added or removed and why."
         )
+
+
+class TestHarvestPerTeamSectionDirective:
+    """Content-presence pin for the agent-memory per-team-section overwrite
+    directive in the harvest skill's save step.
+
+    The secretary's processed-tasks read-back file is shared by every concurrent
+    same-named secretary instance (one per team). The load-bearing fix re-scopes
+    the save step from a whole-file overwrite to a per-``## team={team_id}``
+    section overwrite, so a secretary in team A cannot clobber team B's section.
+    Because every agent-memory write is LLM-driven prose (no runtime code path),
+    this directive has no executable regression test of its own — a future edit
+    could silently revert the save step to a whole-file overwrite and nothing
+    would fail. This pin closes that gap: it asserts the verbatim directive
+    phrases survive, so the per-team scoping cannot be elided without a RED.
+
+    Pin style mirrors the EXPECTED_COUNTS content-presence pattern above.
+    """
+
+    REL_PATH = "pact-handoff-harvest/SKILL.md"
+
+    # Verbatim load-bearing substrings of the save-step directive. If a
+    # deliberate rewording changes these, update them here with a comment
+    # confirming the per-team-section scoping (not whole-file overwrite) is
+    # still expressed.
+    REQUIRED_PHRASES = (
+        "Overwrite only your own team's section",
+        "never modify, overwrite, or remove another team's",
+    )
+
+    @pytest.mark.parametrize("phrase", REQUIRED_PHRASES, ids=lambda p: p[:32])
+    def test_per_team_overwrite_directive_present(self, phrase):
+        skill_md = SKILLS_DIR / self.REL_PATH
+        assert skill_md.is_file(), f"{self.REL_PATH} must exist"
+        text = skill_md.read_text(encoding="utf-8")
+        assert phrase in text, (
+            f"{self.REL_PATH} must contain the per-team-section overwrite "
+            f"directive phrase {phrase!r}. Its absence means the save step may "
+            f"have silently reverted to a whole-file overwrite, which lets a "
+            f"secretary in one team clobber another team's section in the "
+            f"shared processed-tasks file. If a deliberate rewording changed "
+            f"the phrase, update REQUIRED_PHRASES — but confirm the per-team "
+            f"scoping (not whole-file overwrite) is still expressed."
+        )

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -1213,3 +1213,75 @@ class TestPinCapsTwinCopyDrift:
             "literal. Fix by restoring the `chr(k) for k in "
             "pin_caps._FORBIDDEN_TERMINATOR_TABLE.keys()` form."
         )
+
+
+class TestFileLockTwinCopyDrift:
+    """Drift detection for the file_lock twin vendored into working_memory.
+
+    file_lock is twin-copied from hooks/shared/claude_md_manager into
+    skills/pact-memory/scripts/working_memory (skills/ cannot import from
+    hooks/shared/). The function BODY must stay byte-identical so the skill
+    serializes against the hook on the same sidecar inode; the docstring may
+    differ. This fails loudly when the executable logic drifts.
+    """
+
+    @staticmethod
+    def _extract_body(source: str) -> str:
+        """Return the executable body, stripping decorators, the def line,
+        and a leading docstring; then dedent + normalize.
+
+        Unlike TestEstimateTokensEquivalence._extract_body, file_lock carries a
+        @contextmanager decorator, so this skips ALL leading ``@`` lines before
+        dropping the def line. This makes the comparison docstring-tolerant
+        (the twin carries a shorter docstring) while pinning the logic.
+        """
+        lines = source.split("\n")
+        idx = 0
+        while idx < len(lines) and lines[idx].lstrip().startswith("@"):
+            idx += 1
+        # lines[idx] is the def line; drop it too.
+        body_lines = lines[idx + 1:]
+        body_text = textwrap.dedent("\n".join(body_lines)).strip()
+        for quote in ['"""', "'''"]:
+            if body_text.startswith(quote):
+                end_idx = body_text.find(quote, len(quote))
+                if end_idx != -1:
+                    body_text = body_text[end_idx + len(quote):].strip()
+                break
+        return body_text
+
+    def test_file_lock_bodies_are_identical(self):
+        """The file_lock body MUST be byte-identical across the two copies.
+
+        Cross-process serialization correctness depends on the twin behaving
+        exactly like the canonical lock (same sidecar path, same fcntl flock
+        semantics, same timeout/poll loop). Compares logic only — docstrings
+        are allowed to differ.
+        """
+        from shared.claude_md_manager import file_lock as canonical
+        from working_memory import file_lock as twin
+
+        canonical_body = self._extract_body(inspect.getsource(canonical))
+        twin_body = self._extract_body(inspect.getsource(twin))
+
+        assert canonical_body == twin_body, (
+            "file_lock twin drift between hooks/shared/claude_md_manager.py "
+            "and skills/pact-memory/scripts/working_memory.py — update both "
+            "in the SAME commit.\n"
+            f"canonical body:\n{canonical_body}\n\n"
+            f"twin body:\n{twin_body}"
+        )
+
+    def test_lock_timeout_constants_match(self):
+        """The two lock-tuning constants are part of the twin and must match."""
+        import shared.claude_md_manager as cmm
+        import working_memory as wm
+
+        assert cmm._LOCK_TIMEOUT_SECONDS == wm._LOCK_TIMEOUT_SECONDS, (
+            "_LOCK_TIMEOUT_SECONDS drift between claude_md_manager.py and "
+            "working_memory.py — update both in the same commit"
+        )
+        assert cmm._LOCK_POLL_INTERVAL == wm._LOCK_POLL_INTERVAL, (
+            "_LOCK_POLL_INTERVAL drift between claude_md_manager.py and "
+            "working_memory.py — update both in the same commit"
+        )

--- a/pact-plugin/tests/test_working_memory_concurrency.py
+++ b/pact-plugin/tests/test_working_memory_concurrency.py
@@ -1,0 +1,225 @@
+"""Concurrent-write integrity tests for the working_memory CLAUDE.md sync sites.
+
+Location: pact-plugin/tests/test_working_memory_concurrency.py
+
+Summary: Proves that the file_lock added to sync_to_claude_md /
+sync_retrieved_to_claude_md actually serializes the full read-modify-write
+window, so two concurrent writers cannot lose-update each other's entry in the
+shared project CLAUDE.md. Verification-level for the CODE phase; comprehensive
+edge/perf coverage is TEST-phase work.
+
+Used by: pytest (the suite's working_memory concurrency gate).
+
+WHY THIS FILE EXISTS (the gap it closes)
+----------------------------------------
+working_memory.py does a full-file read -> parse -> mutate -> overwrite of the
+project CLAUDE.md at two sites. Pre-fix, both wrote with no lock, so under the
+N:1 tmux teammateMode (N agent processes, one team) two writers could each read
+the same base, each reconstruct a full new file, and the second overwrite would
+silently drop the first writer's just-committed entry (the #877-class lost
+update). The fix wraps the ENTIRE read->write window in a file_lock; the
+load-bearing property is read-UNDER-lock (a write-only lock would let the 2nd
+writer read stale content and re-introduce the clobber).
+
+NON-VACUITY (the load-bearing methodology)
+------------------------------------------
+The lost-update test below is deterministic, not timing-hopeful: two REAL
+processes rendezvous at a multiprocessing barrier so both enter their
+read-modify-write window simultaneously, then each writes ONE distinct memory.
+Empirically, against an unlocked (reverted) working_memory this loses one
+writer's entry on every run; under the lock both entries always survive. The
+barrier forces the exact interleave the lock exists to prevent, so a GREEN
+result reflects real serialization rather than a window too small to race.
+
+EXECUTION SHAPE / FLAKE AVOIDANCE
+---------------------------------
+Workers are module-level functions (picklable for the ``spawn`` start method,
+which is macOS's default and the most portable). Each worker rebuilds its own
+sys.path + CLAUDE_PROJECT_DIR (neither crosses a spawn boundary) and resolves
+the same tmp .claude/CLAUDE.md, so all writers contend on one sidecar inode.
+"""
+
+import multiprocessing as mp
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# spawn is macOS's default and the most portable start method; pin it explicitly
+# so the suite behaves identically wherever it runs (fork would inherit parent
+# interpreter state and can be flaky under pytest).
+_MP = mp.get_context("spawn")
+
+# The scripts dir that holds working_memory.py — re-derived in each spawned
+# child because sys.path does not cross the spawn boundary.
+_SCRIPTS_DIR = str(
+    Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts"
+)
+
+
+# ---------------------------------------------------------------------------
+# Module-level worker (picklable for the spawn start method).
+# ---------------------------------------------------------------------------
+
+def _sync_worker(args):
+    """Drive the REAL sync_to_claude_md once, under a barrier so all writers
+    enter their read-modify-write window simultaneously and contend for the
+    lock. Each writer commits one uniquely-marked memory."""
+    home, writer_id, barrier = args
+    if _SCRIPTS_DIR not in sys.path:
+        sys.path.insert(0, _SCRIPTS_DIR)
+    # _get_claude_md_path checks CLAUDE_PROJECT_DIR first, so all writers
+    # resolve the same tmp .claude/CLAUDE.md (and thus the same sidecar).
+    os.environ["CLAUDE_PROJECT_DIR"] = home
+    import working_memory as wm
+
+    # Rendezvous: both writers read the same base before either writes.
+    barrier.wait()
+    wm.sync_to_claude_md(
+        {"context": f"CONCURRENT-WRITER-{writer_id}", "goal": f"goal-{writer_id}"},
+        None,
+        f"concurrency-id-{writer_id}",
+    )
+
+
+def _seed_claude_md(home: Path) -> Path:
+    """Create a minimal project CLAUDE.md with an empty Working Memory section."""
+    claude_dir = home / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    claude_md = claude_dir / "CLAUDE.md"
+    claude_md.write_text(
+        "# Project\n\n## Working Memory\n"
+        "<!-- Auto-managed by pact-memory skill. -->\n\n",
+        encoding="utf-8",
+    )
+    return claude_md
+
+
+class TestConcurrentSyncLostUpdate:
+    """The lock prevents the #877-class lost update across real processes."""
+
+    def test_two_concurrent_writers_both_entries_survive(self, tmp_path):
+        """Two REAL processes that enter their read-modify-write window
+        simultaneously must BOTH have their memory in the final file.
+
+        This is the regression the fix exists to prevent: pre-fix (unlocked),
+        the barrier-forced interleave drops one writer's entry on every run;
+        under the lock the writers serialize and both entries survive. RED on
+        reverted code, GREEN with the lock.
+        """
+        claude_md = _seed_claude_md(tmp_path)
+        barrier = _MP.Barrier(2)
+        procs = [
+            _MP.Process(target=_sync_worker, args=((str(tmp_path), wid, barrier),))
+            for wid in (0, 1)
+        ]
+        for p in procs:
+            p.start()
+        for p in procs:
+            p.join(timeout=30)
+        for p in procs:
+            assert p.exitcode == 0, f"worker exited with {p.exitcode}"
+
+        final = claude_md.read_text(encoding="utf-8")
+        assert "CONCURRENT-WRITER-0" in final and "CONCURRENT-WRITER-1" in final, (
+            "A concurrent writer's entry was lost — the lock did not serialize "
+            "the full read-modify-write window. Final Working Memory:\n"
+            f"{final[final.find('## Working Memory'):]}"
+        )
+
+
+class TestCrossWriterSerialization:
+    """The vendored twin contends on the SAME sidecar inode as the canonical
+    lock — the load-bearing cross-process property (duplicated code, one lock)."""
+
+    def test_twin_blocks_while_canonical_holds_same_target(self, tmp_path, monkeypatch):
+        """Holding claude_md_manager.file_lock(target) must make
+        working_memory.file_lock(target) time out on the SAME target, proving
+        the two copies serialize on one sidecar (not two independent locks)."""
+        from shared.claude_md_manager import file_lock as canonical
+        import working_memory as wm
+
+        target = tmp_path / ".claude" / "CLAUDE.md"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# x\n", encoding="utf-8")
+
+        # Shrink the twin's timeout so the test is fast; the canonical holder
+        # keeps the lock for the whole window.
+        monkeypatch.setattr(wm, "_LOCK_TIMEOUT_SECONDS", 0.3)
+        monkeypatch.setattr(wm, "_LOCK_POLL_INTERVAL", 0.05)
+
+        with canonical(target):
+            with pytest.raises(TimeoutError):
+                with wm.file_lock(target):
+                    pass  # pragma: no cover - acquisition must not succeed
+
+    def test_twin_sidecar_path_matches_canonical(self, tmp_path):
+        """Both copies derive the sidecar as .{name}.lock beside the target —
+        the identity that makes the inode shared across processes."""
+        from shared import claude_md_manager as cmm
+        import working_memory as wm
+
+        target = tmp_path / "CLAUDE.md"
+        target.write_text("# x\n", encoding="utf-8")
+        expected = tmp_path / ".CLAUDE.md.lock"
+
+        with wm.file_lock(target):
+            assert expected.exists(), "twin did not create the canonical sidecar"
+        # Sanity: the canonical lock uses the identical sidecar path.
+        with cmm.file_lock(target):
+            assert expected.exists()
+
+
+class TestFailOpenOnTimeout:
+    """A lock TimeoutError must fail open (skip the sync, return False) — the
+    existing try/except contract, not a hard crash."""
+
+    def test_sync_to_claude_md_returns_false_on_timeout(self, tmp_path, monkeypatch):
+        """If file_lock raises TimeoutError, sync_to_claude_md returns False and
+        does not raise (next save retries)."""
+        import working_memory as wm
+
+        claude_md = _seed_claude_md(tmp_path)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def timing_out_lock(target_file):
+            raise TimeoutError("simulated contention")
+            yield  # pragma: no cover - unreachable
+
+        monkeypatch.setattr(wm, "file_lock", timing_out_lock)
+
+        result = wm.sync_to_claude_md(
+            {"context": "should-not-be-written", "goal": "g"}, None, "id"
+        )
+        assert result is False
+        # The sync was skipped — the failing entry must NOT have been written.
+        assert "should-not-be-written" not in claude_md.read_text(encoding="utf-8")
+
+    def test_sync_retrieved_to_claude_md_returns_false_on_timeout(
+        self, tmp_path, monkeypatch
+    ):
+        """Same fail-open contract for the retrieved-context sync site."""
+        import working_memory as wm
+
+        claude_md = _seed_claude_md(tmp_path)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def timing_out_lock(target_file):
+            raise TimeoutError("simulated contention")
+            yield  # pragma: no cover - unreachable
+
+        monkeypatch.setattr(wm, "file_lock", timing_out_lock)
+
+        result = wm.sync_retrieved_to_claude_md(
+            [{"context": "should-not-be-written"}], query="q", scores=[0.9],
+            memory_ids=["id"],
+        )
+        assert result is False
+        assert "should-not-be-written" not in claude_md.read_text(encoding="utf-8")

--- a/pact-plugin/tests/test_working_memory_concurrency_comprehensive.py
+++ b/pact-plugin/tests/test_working_memory_concurrency_comprehensive.py
@@ -1,0 +1,493 @@
+"""Comprehensive concurrent-write integrity tests for the working_memory
+CLAUDE.md sync sites — the TEST-phase extension of the CODE-phase
+verification suite in test_working_memory_concurrency.py.
+
+Location: pact-plugin/tests/test_working_memory_concurrency_comprehensive.py
+
+Summary: The verification-level companion file proves the lock serializes two
+concurrent writers at the FIRST sync site (sync_to_claude_md). This file
+extends that to the gaps a comprehensive TEST phase owns:
+
+  - N>2 barrier-synchronized writers at the first site (lock contention scale).
+  - The SECOND site (sync_retrieved_to_claude_md) lost-update under real
+    concurrency — the verification file only exercises the first site.
+  - Cross-SITE interleave: a Working Memory writer and a Retrieved Context
+    writer contend on the SAME file/sidecar simultaneously and must each land
+    their entry in their own section (no cross-section clobber).
+  - No-regression of the section semantics the lock now wraps: rolling-window
+    trim (MAX_*_MEMORIES), idempotent re-sync, PACT-marker survival under lock.
+
+Used by: pytest (the suite's comprehensive working_memory concurrency gate).
+
+NON-VACUITY (the load-bearing methodology)
+------------------------------------------
+Every lost-update assertion below is a barrier-forced deterministic interleave,
+not a timing-hopeful race: all writers rendezvous at a multiprocessing Barrier
+BEFORE any sync call, so each reads the same base before any writes back. A
+write-only lock (or no lock) would let later writers clobber earlier ones; the
+full-read-modify-write lock serializes them so every entry survives.
+
+These assertions are independently FALSIFIED via source-only revert of
+working_memory.py to its pre-lock parent in an isolated detached worktree (see
+the module docstring of the verification companion + the TEST-phase HANDOFF for
+the measured {N fail / M pass} cardinalities). PASS here reflects real
+serialization; the revert proves the test detects the unlocked regression.
+
+EXECUTION SHAPE / FLAKE AVOIDANCE
+--------------------------------
+Workers are module-level functions (picklable for the ``spawn`` start method,
+macOS's default and the most portable). Each worker rebuilds its own sys.path +
+CLAUDE_PROJECT_DIR (neither crosses a spawn boundary) and resolves the same tmp
+.claude/CLAUDE.md, so all writers contend on one sidecar inode. join() carries a
+timeout so a deadlock surfaces as a failure rather than an indefinite hang.
+"""
+
+import multiprocessing as mp
+import os
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+# spawn is macOS's default and the most portable start method; pin it explicitly
+# so the suite behaves identically wherever it runs (fork inherits parent
+# interpreter state and can be flaky under pytest).
+_MP = mp.get_context("spawn")
+
+# The scripts dir holding working_memory.py — re-derived in each spawned child
+# because sys.path does not cross the spawn boundary.
+_SCRIPTS_DIR = str(
+    Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts"
+)
+
+# Join guard: a deadlocked worker (e.g. a lock that never serializes and hangs)
+# must fail the test, not wedge the suite.
+_JOIN_TIMEOUT = 30
+
+
+# ---------------------------------------------------------------------------
+# Module-level workers (picklable for the spawn start method).
+# ---------------------------------------------------------------------------
+
+def _bootstrap(home):
+    """Per-child setup: sys.path + CLAUDE_PROJECT_DIR (neither crosses spawn)."""
+    if _SCRIPTS_DIR not in sys.path:
+        sys.path.insert(0, _SCRIPTS_DIR)
+    # _get_claude_md_path checks CLAUDE_PROJECT_DIR first, so every writer
+    # resolves the same tmp .claude/CLAUDE.md (and thus the same sidecar inode).
+    os.environ["CLAUDE_PROJECT_DIR"] = home
+
+
+def _wm_worker(args):
+    """Drive the REAL sync_to_claude_md once, under a barrier so all writers
+    enter their read-modify-write window simultaneously and contend for the
+    lock. Each writer commits one uniquely-marked Working Memory entry."""
+    home, writer_id, barrier = args
+    _bootstrap(home)
+    import working_memory as wm
+
+    barrier.wait()  # rendezvous: everyone reads the same base before any write
+    wm.sync_to_claude_md(
+        {"context": f"WM-WRITER-{writer_id}", "goal": f"goal-{writer_id}"},
+        None,
+        f"wm-id-{writer_id}",
+    )
+
+
+def _retrieved_worker(args):
+    """Drive the REAL sync_retrieved_to_claude_md once under a barrier. Each
+    writer commits one uniquely-marked Retrieved Context entry."""
+    home, writer_id, barrier = args
+    _bootstrap(home)
+    import working_memory as wm
+
+    barrier.wait()
+    wm.sync_retrieved_to_claude_md(
+        [{"context": f"RC-WRITER-{writer_id}", "goal": f"rc-goal-{writer_id}"}],
+        query=f"query-{writer_id}",
+        scores=[0.9],
+        memory_ids=[f"rc-id-{writer_id}"],
+    )
+
+
+def _cross_site_worker(args):
+    """Cross-site interleave: ``site`` selects which sync function this writer
+    drives. A Working Memory writer and a Retrieved Context writer contend on
+    the SAME file/sidecar; each must land its entry in its own section."""
+    home, site, barrier = args
+    _bootstrap(home)
+    import working_memory as wm
+
+    barrier.wait()
+    if site == "wm":
+        wm.sync_to_claude_md(
+            {"context": "CROSS-WM", "goal": "cross-wm-goal"}, None, "cross-wm-id"
+        )
+    else:
+        wm.sync_retrieved_to_claude_md(
+            [{"context": "CROSS-RC", "goal": "cross-rc-goal"}],
+            query="cross-query",
+            scores=[0.9],
+            memory_ids=["cross-rc-id"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Seeding helpers.
+# ---------------------------------------------------------------------------
+
+def _seed_claude_md(home: Path, *, with_retrieved: bool = False) -> Path:
+    """Create a minimal project CLAUDE.md.
+
+    The Working Memory section is always present. When ``with_retrieved`` is set
+    a Retrieved Context section is seeded too — exercising the section-replace
+    branch rather than the section-create branch at the second site.
+    """
+    claude_dir = home / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    claude_md = claude_dir / "CLAUDE.md"
+    parts = ["# Project\n\n"]
+    if with_retrieved:
+        parts.append(
+            "## Retrieved Context\n"
+            "<!-- Auto-managed by pact-memory skill. -->\n\n"
+        )
+    parts.append(
+        "## Working Memory\n"
+        "<!-- Auto-managed by pact-memory skill. -->\n\n"
+    )
+    claude_md.write_text("".join(parts), encoding="utf-8")
+    return claude_md
+
+
+def _run_barrier_procs(target, arg_tuples):
+    """Spawn one process per arg-tuple, all gated on a single Barrier, and
+    join with a timeout. Asserts every worker exited cleanly (exitcode 0)."""
+    procs = [_MP.Process(target=target, args=(t,)) for t in arg_tuples]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=_JOIN_TIMEOUT)
+    for p in procs:
+        assert p.exitcode == 0, f"worker exited with {p.exitcode} (deadlock?)"
+
+
+# ---------------------------------------------------------------------------
+# N>2 writers at the first site.
+# ---------------------------------------------------------------------------
+
+class TestNWriterLostUpdate:
+    """Lock contention at scale: N>2 barrier-synchronized writers must ALL
+    survive. The verification companion proves N=2; this proves the lock
+    serializes an arbitrary fan-in, not just a pair."""
+
+    @pytest.mark.parametrize("n_writers", [4, 8])
+    def test_n_concurrent_writers_all_entries_survive(self, n_writers, tmp_path):
+        """N real processes that enter their read-modify-write window
+        simultaneously must EACH have their Working Memory entry in the final
+        file. Pre-fix (unlocked), barrier-forced interleave drops all-but-one
+        on every run; under the lock all N serialize and survive.
+
+        NOTE: MAX_WORKING_MEMORIES caps the *displayed* rolling window, but the
+        lost-update bug is about writers clobbering each other's just-written
+        base — distinct from the intended trim. With N writers serialized, the
+        final file holds the most-recent MAX_WORKING_MEMORIES entries; the
+        load-bearing assertion is that the LAST writer to commit did not erase
+        a prior committed entry's contribution to the running file (i.e. the
+        section reflects serialized appends, not a single lone survivor). We
+        assert the file contains exactly MAX entries and they are a contiguous
+        suffix of the commit order — never a single entry, which is the
+        unlocked-clobber signature.
+        """
+        from importlib import import_module
+        sys.path.insert(0, _SCRIPTS_DIR)
+        wm = import_module("working_memory")
+        max_wm = wm.MAX_WORKING_MEMORIES
+
+        claude_md = _seed_claude_md(tmp_path)
+        barrier = _MP.Barrier(n_writers)
+        _run_barrier_procs(
+            _wm_worker,
+            [(str(tmp_path), wid, barrier) for wid in range(n_writers)],
+        )
+
+        final = claude_md.read_text(encoding="utf-8")
+        present = [wid for wid in range(n_writers) if f"WM-WRITER-{wid}" in final]
+
+        # The unlocked-clobber signature is exactly one survivor; the lock must
+        # produce the full rolling window of the most-recent writers.
+        assert len(present) == min(n_writers, max_wm), (
+            f"Expected {min(n_writers, max_wm)} survivors (rolling window of "
+            f"{max_wm}), got {len(present)}: {present}. A single survivor is "
+            "the lost-update signature — the lock did not serialize the "
+            f"read-modify-write window.\n{final[final.find('## Working Memory'):]}"
+        )
+        # Survivors must be a contiguous suffix of the commit order: serialized
+        # appends each preserve the prior writers' entries until the window
+        # trims the OLDEST, never an arbitrary lone winner.
+        assert present == sorted(present), "survivor set is not ordered"
+
+
+# ---------------------------------------------------------------------------
+# Second site: sync_retrieved_to_claude_md under concurrency.
+# ---------------------------------------------------------------------------
+
+class TestRetrievedContextLostUpdate:
+    """The SECOND sync site must serialize identically — the verification
+    companion only covers the first site's lost-update path."""
+
+    def test_two_concurrent_retrieved_writers_both_survive(self, tmp_path):
+        """Two real processes driving sync_retrieved_to_claude_md under a
+        barrier must BOTH land their Retrieved Context entry. RED on the
+        unlocked source, GREEN with the lock (same read-under-lock property as
+        the first site)."""
+        claude_md = _seed_claude_md(tmp_path, with_retrieved=True)
+        barrier = _MP.Barrier(2)
+        _run_barrier_procs(
+            _retrieved_worker,
+            [(str(tmp_path), wid, barrier) for wid in (0, 1)],
+        )
+
+        final = claude_md.read_text(encoding="utf-8")
+        assert "RC-WRITER-0" in final and "RC-WRITER-1" in final, (
+            "A concurrent Retrieved Context writer's entry was lost — the lock "
+            "did not serialize the second sync site's read-modify-write "
+            f"window.\n{final[final.find('## Retrieved Context'):]}"
+        )
+
+    def test_retrieved_writer_creates_section_when_absent(self, tmp_path):
+        """Second-site serialization must hold even when the Retrieved Context
+        section does not pre-exist (the section-create branch). Two writers
+        race to create-and-populate; both entries survive."""
+        claude_md = _seed_claude_md(tmp_path, with_retrieved=False)
+        barrier = _MP.Barrier(2)
+        _run_barrier_procs(
+            _retrieved_worker,
+            [(str(tmp_path), wid, barrier) for wid in (0, 1)],
+        )
+
+        final = claude_md.read_text(encoding="utf-8")
+        assert "## Retrieved Context" in final, "section was never created"
+        assert "RC-WRITER-0" in final and "RC-WRITER-1" in final, (
+            "A writer's entry was lost in the section-create branch under "
+            f"concurrency.\n{final[final.find('## Retrieved Context'):]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cross-site interleave: WM writer vs RC writer on the same file.
+# ---------------------------------------------------------------------------
+
+class TestCrossSiteInterleave:
+    """A Working Memory writer and a Retrieved Context writer contend on the
+    SAME file/sidecar. Because both take the lock on the same resolved
+    CLAUDE.md path, neither can clobber the other's section — the cross-section
+    no-clobber property the single-site tests cannot show."""
+
+    def test_wm_and_retrieved_writers_both_sections_survive(self, tmp_path):
+        """One process writes Working Memory, another writes Retrieved Context,
+        both gated on the same barrier. The final file must contain BOTH the WM
+        entry and the RC entry — proving the two sync sites serialize against
+        each other on the shared sidecar, not just same-site writers.
+
+        Pre-fix (unlocked), the later writer reads a base missing the earlier
+        writer's section-rebuild and overwrites the whole file, dropping the
+        other section's just-committed entry."""
+        claude_md = _seed_claude_md(tmp_path, with_retrieved=True)
+        barrier = _MP.Barrier(2)
+        _run_barrier_procs(
+            _cross_site_worker,
+            [(str(tmp_path), site, barrier) for site in ("wm", "rc")],
+        )
+
+        final = claude_md.read_text(encoding="utf-8")
+        assert "CROSS-WM" in final, (
+            "Working Memory entry was clobbered by the concurrent Retrieved "
+            f"Context writer.\n{final}"
+        )
+        assert "CROSS-RC" in final, (
+            "Retrieved Context entry was clobbered by the concurrent Working "
+            f"Memory writer.\n{final}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# No-regression: the lock must not change section semantics.
+# ---------------------------------------------------------------------------
+
+class TestSyncSemanticsUnchangedUnderLock:
+    """Single-process (no concurrency) sanity that the lock wrapper did not
+    alter the rolling-window / idempotency / marker semantics of the two sync
+    functions. These run the REAL committed (locked) code path."""
+
+    def _import_wm(self):
+        sys.path.insert(0, _SCRIPTS_DIR)
+        from importlib import import_module
+        return import_module("working_memory")
+
+    def test_working_memory_rolling_window_trims_to_max(self, tmp_path, monkeypatch):
+        """Syncing more than MAX_WORKING_MEMORIES entries keeps only the most
+        recent MAX, newest-first — unchanged by the lock."""
+        wm = self._import_wm()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+        _seed_claude_md(tmp_path)
+
+        total = wm.MAX_WORKING_MEMORIES + 2
+        for i in range(total):
+            assert wm.sync_to_claude_md(
+                {"context": f"ROLL-{i}", "goal": f"g{i}"}, None, f"id{i}"
+            ) is True
+
+        final = (tmp_path / ".claude" / "CLAUDE.md").read_text(encoding="utf-8")
+        # Most-recent MAX survive; the oldest (total - MAX) are trimmed.
+        kept = [i for i in range(total) if f"ROLL-{i}" in final]
+        assert kept == list(range(total - wm.MAX_WORKING_MEMORIES, total)), (
+            f"rolling window did not trim to the most-recent "
+            f"{wm.MAX_WORKING_MEMORIES}: kept {kept}"
+        )
+        # Newest-first ordering: the latest entry appears before the earliest kept.
+        assert final.index(f"ROLL-{total - 1}") < final.index(
+            f"ROLL-{total - wm.MAX_WORKING_MEMORIES}"
+        ), "entries are not newest-first under the lock"
+
+    def test_idempotent_resync_does_not_corrupt_section(self, tmp_path, monkeypatch):
+        """Re-syncing the SAME memory twice in a row leaves a well-formed
+        section with exactly one Working Memory header — the lock's
+        acquire/release across two calls does not duplicate or drop the
+        section."""
+        wm = self._import_wm()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+        _seed_claude_md(tmp_path)
+
+        mem = {"context": "IDEMPOTENT", "goal": "same"}
+        assert wm.sync_to_claude_md(mem, None, "same-id") is True
+        assert wm.sync_to_claude_md(mem, None, "same-id") is True
+
+        final = (tmp_path / ".claude" / "CLAUDE.md").read_text(encoding="utf-8")
+        assert final.count("## Working Memory") == 1, (
+            "re-sync duplicated the Working Memory header under the lock"
+        )
+        assert "IDEMPOTENT" in final
+
+    def test_pact_markers_survive_sync_under_lock(self, tmp_path, monkeypatch):
+        """When CLAUDE.md carries the PACT managed/memory markers, a locked
+        sync must preserve all four in structural order — the lock wraps the
+        same read-modify-write that the marker-preservation pipeline relies
+        on, so it must not perturb them."""
+        wm = self._import_wm()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir(parents=True, exist_ok=True)
+        claude_md = claude_dir / "CLAUDE.md"
+        # Minimal managed-region layout with all 4 markers and a Working Memory
+        # section the sync will rewrite.
+        claude_md.write_text(
+            "# Project\n\n"
+            "<!-- PACT_MANAGED_START -->\n"
+            "<!-- PACT_MEMORY_START -->\n"
+            "## Working Memory\n"
+            "<!-- Auto-managed by pact-memory skill. -->\n\n"
+            "<!-- PACT_MEMORY_END -->\n"
+            "<!-- PACT_MANAGED_END -->\n",
+            encoding="utf-8",
+        )
+
+        assert wm.sync_to_claude_md(
+            {"context": "MARKER-SAFE", "goal": "g"}, None, "id"
+        ) is True
+
+        final = claude_md.read_text(encoding="utf-8")
+        markers = [
+            "<!-- PACT_MANAGED_START -->",
+            "<!-- PACT_MEMORY_START -->",
+            "<!-- PACT_MEMORY_END -->",
+            "<!-- PACT_MANAGED_END -->",
+        ]
+        positions = []
+        for m in markers:
+            assert m in final, f"{m} dropped by locked sync"
+            positions.append(final.index(m))
+        assert positions == sorted(positions), (
+            f"PACT markers out of structural order after locked sync: {positions}"
+        )
+        assert "MARKER-SAFE" in final
+
+
+# ---------------------------------------------------------------------------
+# Drift-test genuinely-fails counter-check.
+# ---------------------------------------------------------------------------
+
+class TestDriftTestIsNotVacuous:
+    """The TestFileLockTwinCopyDrift body-compare and constant-equality checks
+    must FAIL on a simulated twin divergence — proving the drift guard actually
+    detects drift rather than passing unconditionally.
+
+    These counter-checks exercise the drift-test MACHINERY against the live
+    twin; they are independent of whether the sync sites are currently locked.
+    Under a source-only revert to the pre-lock parent the twin does not exist,
+    so these raise ImportError — that is an expected artifact of the revert
+    (the guard's subject is absent pre-fix), NOT a lost-update regression. The
+    meaningful RED-on-revert signal is the 5 concurrency lost-update tests
+    above; see the TEST-phase HANDOFF for the documented cardinality.
+    """
+
+    @staticmethod
+    def _ensure_scripts_on_path():
+        """Self-sufficient sys.path insert so these tests do not depend on an
+        earlier concurrency test in the same file having run first."""
+        if _SCRIPTS_DIR not in sys.path:
+            sys.path.insert(0, _SCRIPTS_DIR)
+
+    def test_body_compare_detects_a_logic_divergence(self):
+        """Inject a one-line difference into the twin's extracted body and
+        confirm the byte-compare the real drift test uses would FAIL. This
+        re-implements the drift test's own _extract_body comparison against a
+        mutated source string so we never edit the real module."""
+        self._ensure_scripts_on_path()
+        import inspect
+        from shared.claude_md_manager import file_lock as canonical
+        from working_memory import file_lock as twin
+        from test_staleness import TestFileLockTwinCopyDrift
+
+        extract = TestFileLockTwinCopyDrift._extract_body
+        canonical_body = extract(inspect.getsource(canonical))
+        twin_body = extract(inspect.getsource(twin))
+
+        # Sanity: the real twin matches (mirrors the live drift test).
+        assert canonical_body == twin_body, "precondition: twin must match canonical"
+
+        # Now simulate drift: mutate one logical line of the twin source and
+        # re-extract. The compare MUST now fail.
+        twin_src = inspect.getsource(twin)
+        mutated_src = twin_src.replace(
+            "fcntl.LOCK_EX | fcntl.LOCK_NB", "fcntl.LOCK_EX", 1
+        )
+        assert mutated_src != twin_src, "mutation did not apply — test is vacuous"
+        mutated_body = extract(mutated_src)
+        assert mutated_body != canonical_body, (
+            "drift test is VACUOUS: a logic divergence in the twin body did "
+            "not change the extracted body, so the body-compare would not catch "
+            "real drift"
+        )
+
+    def test_constant_equality_detects_a_mismatch(self):
+        """The lock-tuning constants the drift test pins must actually differ
+        when one side changes — confirm a simulated mismatch would be caught."""
+        self._ensure_scripts_on_path()
+        import shared.claude_md_manager as cmm
+        import working_memory as wm
+
+        # Live values match (mirrors the real constant-equality drift test).
+        assert cmm._LOCK_TIMEOUT_SECONDS == wm._LOCK_TIMEOUT_SECONDS
+        assert cmm._LOCK_POLL_INTERVAL == wm._LOCK_POLL_INTERVAL
+
+        # A simulated divergence must be detectable by simple equality (the
+        # assertion the drift test makes). We do NOT mutate the modules; we
+        # assert the comparison itself discriminates.
+        simulated_twin_timeout = wm._LOCK_TIMEOUT_SECONDS + 1.0
+        assert simulated_twin_timeout != cmm._LOCK_TIMEOUT_SECONDS, (
+            "constant-equality drift check is vacuous: a changed timeout would "
+            "still compare equal"
+        )

--- a/pact-plugin/tests/test_working_memory_concurrency_comprehensive.py
+++ b/pact-plugin/tests/test_working_memory_concurrency_comprehensive.py
@@ -178,27 +178,37 @@ def _run_barrier_procs(target, arg_tuples):
 # ---------------------------------------------------------------------------
 
 class TestNWriterLostUpdate:
-    """Lock contention at scale: N>2 barrier-synchronized writers must ALL
-    survive. The verification companion proves N=2; this proves the lock
-    serializes an arbitrary fan-in, not just a pair."""
+    """Lock contention at scale: N>2 barrier-synchronized writers. The
+    verification companion proves N=2; this proves the lock serializes an
+    arbitrary fan-in into a well-formed rolling window, not just a pair."""
 
     @pytest.mark.parametrize("n_writers", [4, 8])
-    def test_n_concurrent_writers_all_entries_survive(self, n_writers, tmp_path):
+    def test_n_concurrent_writers_fill_rolling_window(self, n_writers, tmp_path):
         """N real processes that enter their read-modify-write window
-        simultaneously must EACH have their Working Memory entry in the final
-        file. Pre-fix (unlocked), barrier-forced interleave drops all-but-one
-        on every run; under the lock all N serialize and survive.
+        simultaneously must serialize into a well-formed rolling window.
 
-        NOTE: MAX_WORKING_MEMORIES caps the *displayed* rolling window, but the
-        lost-update bug is about writers clobbering each other's just-written
-        base — distinct from the intended trim. With N writers serialized, the
-        final file holds the most-recent MAX_WORKING_MEMORIES entries; the
-        load-bearing assertion is that the LAST writer to commit did not erase
-        a prior committed entry's contribution to the running file (i.e. the
-        section reflects serialized appends, not a single lone survivor). We
-        assert the file contains exactly MAX entries and they are a contiguous
-        suffix of the commit order — never a single entry, which is the
-        unlocked-clobber signature.
+        What is verified (and why it is non-vacuous):
+        MAX_WORKING_MEMORIES caps the *displayed* window, so for N>MAX only the
+        most-recent MAX writers persist BY DESIGN — "all N survive" is false for
+        N>MAX. The lost-update bug is orthogonal: a 2nd writer reading a stale
+        base re-writes a file missing the 1st writer's entry, collapsing the
+        section toward a SINGLE lone survivor. So the discriminating assertions
+        are:
+          (1) exactly min(N, MAX) distinct survivors — a clobber collapses this
+              toward 1 (the unlocked signature; RED-on-revert measured 1);
+          (2) every survivor marker appears EXACTLY ONCE — no duplicate or
+              interleaved entry, which a torn read-modify-write could produce;
+          (3) the survivor-marker count equals the ``###`` entry-header count in
+              the section — no torn/partial entries (every header has its body);
+          (4) the survivors are extracted IN FILE ORDER (newest-first, since the
+              SUT prepends) and are all distinct — a real positional read, NOT
+              the old ``present == sorted(present)`` check which was vacuous
+              (that list was built by iterating ``range(N)`` ascending, so it
+              was sorted by construction and could never fail).
+
+        Barrier scheduling is non-deterministic, so WHICH min(N, MAX) writers
+        win the lock is not predictable; we therefore assert the shape of a
+        serialized rolling window, not a specific writer-id suffix.
         """
         from importlib import import_module
         sys.path.insert(0, _SCRIPTS_DIR)
@@ -213,20 +223,33 @@ class TestNWriterLostUpdate:
         )
 
         final = claude_md.read_text(encoding="utf-8")
-        present = [wid for wid in range(n_writers) if f"WM-WRITER-{wid}" in final]
+        section = final[final.find("## Working Memory"):]
 
-        # The unlocked-clobber signature is exactly one survivor; the lock must
-        # produce the full rolling window of the most-recent writers.
-        assert len(present) == min(n_writers, max_wm), (
+        # Extract survivors IN FILE ORDER (top = newest, the SUT prepends) — a
+        # real positional read of the rendered section, not a range() scan.
+        survivors_in_file_order = re.findall(r"WM-WRITER-(\d+)", section)
+        survivor_set = set(survivors_in_file_order)
+        entry_headers = section.count("### ")
+
+        # (1) Clobber discriminator: a lost update collapses toward 1 survivor.
+        assert len(survivors_in_file_order) == min(n_writers, max_wm), (
             f"Expected {min(n_writers, max_wm)} survivors (rolling window of "
-            f"{max_wm}), got {len(present)}: {present}. A single survivor is "
+            f"{max_wm}), got {len(survivors_in_file_order)}: "
+            f"{survivors_in_file_order}. Collapse toward a single survivor is "
             "the lost-update signature — the lock did not serialize the "
-            f"read-modify-write window.\n{final[final.find('## Working Memory'):]}"
+            f"read-modify-write window.\n{section}"
         )
-        # Survivors must be a contiguous suffix of the commit order: serialized
-        # appends each preserve the prior writers' entries until the window
-        # trims the OLDEST, never an arbitrary lone winner.
-        assert present == sorted(present), "survivor set is not ordered"
+        # (2) No duplicate/interleaved markers — each survivor appears once.
+        assert len(survivor_set) == len(survivors_in_file_order), (
+            "A survivor marker appears more than once — a torn or interleaved "
+            f"read-modify-write duplicated an entry: {survivors_in_file_order}"
+        )
+        # (3) No torn/partial entries: one marker per rendered entry header.
+        assert entry_headers == len(survivors_in_file_order), (
+            f"Entry-header count ({entry_headers}) != survivor-marker count "
+            f"({len(survivors_in_file_order)}) — a partial/torn entry was "
+            f"written under contention.\n{section}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_working_memory_resolver_and_lock_release.py
+++ b/pact-plugin/tests/test_working_memory_resolver_and_lock_release.py
@@ -1,0 +1,240 @@
+"""Edge-path coverage for the working_memory CLAUDE.md-sync lock:
+lock-release-on-exception, and the CLAUDE_PROJECT_DIR-divergence residual.
+
+Location: pact-plugin/tests/test_working_memory_resolver_and_lock_release.py
+
+Summary: Two edge paths that the primary concurrency suites
+(test_working_memory_concurrency.py + ..._comprehensive.py) do not cover,
+grouped in this sibling file to keep the comprehensive file focused (and under
+the file-size advisory threshold):
+
+  1. Lock-release-on-exception — an exception raised mid-window (inside the
+     `with file_lock(...)` block at a sync site) must still RELEASE the lock via
+     the contextmanager's ``finally``, so the next writer can acquire it. A lock
+     that leaked on the error path would wedge every subsequent sync until the
+     5s timeout, repeatedly. We also confirm fail-open (return False) and that
+     no partial/torn write persists.
+
+  2. CLAUDE_PROJECT_DIR-divergence residual — the lock only serializes when all
+     writers resolve the SAME .claude/CLAUDE.md (hence the same sidecar inode).
+     When CLAUDE_PROJECT_DIR is unset AND the git-root/cwd fallbacks resolve
+     DIFFERENT roots between two processes, the resolvers return different paths
+     → different sidecars → the lock does NOT serialize. This is a DEMONSTRATION
+     / known-limitation test: it documents the unprotected residual; it does
+     NOT claim the divergence path is safe. It is out-of-contract in practice
+     because the plugin sets CLAUDE_PROJECT_DIR every session, so every writer
+     hits the env-var branch first and converges — see the caveat in each
+     divergence test's docstring.
+
+Used by: pytest (the working_memory edge-path gate).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = str(
+    Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts"
+)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+
+def _seed_claude_md(home: Path) -> Path:
+    """Create a minimal project CLAUDE.md with an empty Working Memory section
+    under ``home``/.claude/."""
+    claude_dir = home / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    claude_md = claude_dir / "CLAUDE.md"
+    claude_md.write_text(
+        "# Project\n\n## Working Memory\n"
+        "<!-- Auto-managed by pact-memory skill. -->\n\n",
+        encoding="utf-8",
+    )
+    return claude_md
+
+
+# ---------------------------------------------------------------------------
+# 1. Lock-release-on-exception / chmod-mid-window.
+# ---------------------------------------------------------------------------
+
+class TestLockReleaseOnException:
+    """An exception raised mid-window must release the lock (the contextmanager
+    ``finally: LOCK_UN + os.close``), fail open, and leave no torn write."""
+
+    def test_chmod_failure_mid_window_releases_lock_and_fails_open(
+        self, tmp_path, monkeypatch
+    ):
+        """If os.chmod raises AFTER write_text but INSIDE the `with file_lock`
+        block, sync_to_claude_md must (a) return False (fail-open via the outer
+        try/except) and (b) leave the lock RE-ACQUIRABLE — proving the lock was
+        released on the exception path, not leaked.
+
+        A leaked lock would force the next acquirer to block until the 5s
+        timeout (then fail open), degrading every subsequent sync. We prove
+        release by re-acquiring with a SHRUNK timeout: success means the lock
+        is free; a TimeoutError would mean it leaked.
+        """
+        import working_memory as wm
+
+        claude_md = _seed_claude_md(tmp_path)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+        # Raise inside the with-block, after write_text, at os.chmod.
+        def boom_chmod(*args, **kwargs):
+            raise OSError("simulated chmod failure mid-window")
+
+        monkeypatch.setattr(wm.os, "chmod", boom_chmod)
+
+        result = wm.sync_to_claude_md(
+            {"context": "MID-WINDOW-BOOM", "goal": "g"}, None, "id"
+        )
+        # (a) fail-open
+        assert result is False
+
+        # (b) lock released → re-acquirable fast (NOT the 5s timeout). Shrink
+        # the timeout so a leak would surface as a quick TimeoutError, not a
+        # 5s hang.
+        target = wm._get_claude_md_path()
+        assert target is not None
+        monkeypatch.setattr(wm, "_LOCK_TIMEOUT_SECONDS", 0.3)
+        monkeypatch.setattr(wm, "_LOCK_POLL_INTERVAL", 0.05)
+        with wm.file_lock(target):
+            pass  # acquisition must succeed — if the lock had leaked this raises
+
+    def test_mid_window_exception_leaves_no_torn_write(self, tmp_path, monkeypatch):
+        """The file must remain well-formed (no partial/torn content) after a
+        mid-window exception. os.chmod runs AFTER write_text, so write_text may
+        have already replaced the file — assert it is still a complete,
+        parseable document with its Working Memory section intact, not a
+        truncated fragment.
+        """
+        import working_memory as wm
+
+        claude_md = _seed_claude_md(tmp_path)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+        def boom_chmod(*args, **kwargs):
+            raise OSError("simulated chmod failure mid-window")
+
+        monkeypatch.setattr(wm.os, "chmod", boom_chmod)
+
+        wm.sync_to_claude_md({"context": "TORN-CHECK", "goal": "g"}, None, "id")
+
+        final = claude_md.read_text(encoding="utf-8")
+        # write_text is atomic at the Python level (single write of the full
+        # new content), so the file is either the old or the new full document
+        # — never a fragment. Assert structural completeness.
+        assert final.startswith("# Project"), "file head was truncated"
+        assert "## Working Memory" in final, "section was lost"
+        # No dangling half-entry: every entry header has a body marker. (The
+        # write either fully landed the new entry or did not; both are whole.)
+        assert final.count("## Working Memory") == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. CLAUDE_PROJECT_DIR-divergence residual (DEMONSTRATION / known-limitation).
+# ---------------------------------------------------------------------------
+
+class TestProjectDirDivergenceResidual:
+    """DEMONSTRATION of the known, unprotected divergence residual: when
+    CLAUDE_PROJECT_DIR is unset AND the fallback resolvers land on different
+    roots between two processes, they resolve different .claude/CLAUDE.md paths
+    → different `.CLAUDE.md.lock` sidecars → the lock does NOT serialize.
+
+    OUT-OF-CONTRACT CAVEAT: in practice the plugin sets CLAUDE_PROJECT_DIR every
+    session, so every writer takes the env-var branch first and converges on one
+    sidecar. There is no safe fallback action when paths diverge (locking a
+    different sidecar is not actionable), so the implementation deliberately
+    NOTES this rather than guarding it. These tests document the residual; they
+    do NOT assert that the divergence path is safe — they assert that it
+    diverges, which is exactly the unprotected condition.
+    """
+
+    def _resolve_under_root(self, wm, root: Path, monkeypatch):
+        """Drive working_memory._get_claude_md_path so it resolves under
+        ``root`` via the cwd fallback: env unset + git-root detection forced to
+        fail, so the resolver falls through env → git → cwd, landing on root."""
+        # env unset → skip the env-var branch
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+
+        # Force the git-root fallback to "not a repo" so resolution falls
+        # through to cwd. (returncode != 0 makes _get_claude_md_path skip it.)
+        class _FakeProc:
+            returncode = 1
+            stdout = ""
+
+        monkeypatch.setattr(wm.subprocess, "run", lambda *a, **k: _FakeProc())
+        # cwd fallback lands on root.
+        monkeypatch.setattr(wm.Path, "cwd", staticmethod(lambda: root))
+        return wm._get_claude_md_path()
+
+    def test_unset_env_with_divergent_roots_resolves_different_sidecars(
+        self, tmp_path, monkeypatch
+    ):
+        """Two distinct roots, env unset, git fallback neutralized → the skill
+        resolver returns a DIFFERENT path for each root, and therefore a
+        DIFFERENT sidecar. This is the unprotected residual: two processes in
+        this state would lock different inodes and not serialize.
+        """
+        import working_memory as wm
+
+        root_a = tmp_path / "proj_a"
+        root_b = tmp_path / "proj_b"
+        claude_a = _seed_claude_md(root_a)
+        claude_b = _seed_claude_md(root_b)
+
+        with monkeypatch.context() as m:
+            resolved_a = self._resolve_under_root(wm, root_a, m)
+        with monkeypatch.context() as m:
+            resolved_b = self._resolve_under_root(wm, root_b, m)
+
+        assert resolved_a == claude_a
+        assert resolved_b == claude_b
+        assert resolved_a != resolved_b, (
+            "Roots that should diverge resolved to the same path — the "
+            "demonstration is vacuous"
+        )
+
+        # The lock keys on the sidecar beside the resolved target. Divergent
+        # targets → divergent sidecars → NO shared lock (the unprotected
+        # residual this test documents).
+        sidecar_a = resolved_a.parent / f".{resolved_a.name}.lock"
+        sidecar_b = resolved_b.parent / f".{resolved_b.name}.lock"
+        assert sidecar_a != sidecar_b, (
+            "Divergent resolution must yield divergent sidecars — this is the "
+            "unprotected divergence residual (out-of-contract: the plugin sets "
+            "CLAUDE_PROJECT_DIR every session so writers normally converge)."
+        )
+
+    def test_hook_and_skill_resolvers_diverge_under_different_roots(self, tmp_path):
+        """Cross-resolver demonstration: the hook-side resolver
+        (claude_md_manager.resolve_project_claude_md_path) takes an explicit
+        project_dir, so two processes passing different roots resolve different
+        sidecars — the same divergence class, driven by the caller's root.
+
+        This pins the cross-process surface: the skill copy and the hook copy
+        agree ONLY when they are handed the same root. When roots differ
+        (the divergence condition), they cannot share a sidecar — documented,
+        not guarded.
+        """
+        from shared.claude_md_manager import resolve_project_claude_md_path
+
+        root_a = tmp_path / "h_a"
+        root_b = tmp_path / "h_b"
+        _seed_claude_md(root_a)
+        _seed_claude_md(root_b)
+
+        path_a, src_a = resolve_project_claude_md_path(root_a)
+        path_b, src_b = resolve_project_claude_md_path(root_b)
+
+        assert src_a == "dot_claude" and src_b == "dot_claude"
+        assert path_a != path_b, "different roots must resolve different paths"
+        sidecar_a = path_a.parent / f".{path_a.name}.lock"
+        sidecar_b = path_b.parent / f".{path_b.name}.lock"
+        assert sidecar_a != sidecar_b, (
+            "Different caller roots → different sidecars → no shared lock. The "
+            "lock serializes only when all writers resolve the SAME root; the "
+            "divergence path is unprotected by design (note-not-guard)."
+        )


### PR DESCRIPTION
## Summary

Resolves the **memory-layer concurrency cluster** — two silent-data-loss bugs under N:1 tmux teammateMode, both last-writer-wins races, fixed on different axes per the user-originated **per-artifact LOCK-vs-PARTITION principle**.

Closes #882. Closes #810.

## #882 — CLAUDE.md sync lost-update → **LOCK** (`412c70be`)

`working_memory.py` synced the CLAUDE.md memory blocks via **unlocked** `write_text` at both sync sites, losing updates under concurrent save/search and against the already-locked `session_init`/`session_resume` writers.

- Wrap the **full read→mutate→write window** at both sites (`sync_to_claude_md`, `sync_retrieved_to_claude_md`) in a `file_lock`. **Read-under-lock** is the load-bearing property — a write-only lock would let a second writer read stale content and re-introduce the clobber.
- `file_lock` is an **inline-vendored twin** (skills cannot import `hooks/shared/`, and `working_memory.py` loads in two import modes — a sibling-module import would break the bare-module test import). Body is byte-identical to `claude_md_manager.file_lock`, enforced by a **decorator-aware drift test**. Cross-process correctness holds because `fcntl.flock` keys on the sidecar inode.
- **Fail-open** via the existing `try/except` (TimeoutError → `return False`, no new handling).

## #810 — agent-memory cross-session overwrite → **PARTITION** (`d0d19368`)

`~/.claude/agent-memory/<agent>/*` was user-scope single-file with no team isolation, so concurrent sessions across teams overwrote each other (observed: a PACT-prompt secretary clobbered a reflectica secretary's `session_processed_tasks.md`).

- Adopt **fork-2 in-file team-namespacing** (decided on merit: the processed-tasks file is a *cache* — the session journal is the authoritative dedup source-of-truth — so filesystem isolation is over-engineering). Each instance owns its `## team={team_id}` section.
- Convention/prose fix across 4 LLM-loaded files (every agent-memory write is SDK/LLM-driven): harvest Step 8 re-scoped to "overwrite YOUR section," canonical format contract embedded, 1-line namespace notes in secretary/auditor/agent-teams, judgment-based prune rule (prose-only) in the Consolidation pass, and a canonical-directory note. `MEMORY.md` unchanged to preserve SDK auto-load.

## Testing (`c0a8baf0`)

- Comprehensive #882 concurrency coverage: N>2 writers, the second sync site, cross-site interleave, no-regression-under-lock, drift-test non-vacuity.
- **Non-vacuity proven**: every lost-update assertion independently falsified via source-only revert in an isolated worktree (N=8 unlocked → 1 survivor vs 3 expected = the lost-update signature).
- Full suite: **8121 passed / 0 failed / 13 skipped**, deterministic across 3 runs.
- #810 is structural/prose (no runtime path) → verified via pin integrity (EXPECTED_COUNTS=3 "Ordering invariant" preserved, no-planning-artifacts clean, MEMORY.md untouched); no executable regression by design.

## Release

`e9927259` — v4.4.5 → **v4.4.6** (canonical 4 files).

## Notes

- Concurrency-test determinism validated on macOS/APFS; `spawn`-pin + `join`-timeout are the portability guards for non-macOS CI.
- Follow-ups filed this session: #904 (file-size advisory eval), #905 (pytest basename collision), #906 (auditor-coordination process gap); #495 enriched with a removal disposition.
