### PR TITLE
fix(#917) + audit(#812): agent_handoff marker-poisoning fix + discriminator audit (v4.4.10)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.9",
+      "version": "4.4.10",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.9/      # Plugin version
+│               └── 4.4.10/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.9",
+  "version": "4.4.10",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.9
+> **Version**: 4.4.10
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/agent_handoff_emitter.py
+++ b/pact-plugin/hooks/agent_handoff_emitter.py
@@ -72,7 +72,7 @@ from shared.agent_handoff_marker import (
     sanitize_path_component,
 )
 from shared.pact_context import get_team_name
-from shared.session_journal import append_event, make_event
+from shared.session_journal import append_event, get_journal_path, make_event
 from shared.task_utils import read_task_json
 
 # Suppress false "hook error" display in Claude Code UI on bare exit paths.
@@ -192,6 +192,24 @@ def main() -> None:
         # the O_EXCL marker with empty content; the substantive completion
         # (with handoff populated) claims it instead.
         if not task_metadata.get("handoff"):
+            print(_SUPPRESS_OUTPUT)
+            sys.exit(0)
+
+        # #917: canonical-journal writability precondition. The O_EXCL marker
+        # below is an optimistic "we emitted it" promise claimed BEFORE
+        # append_event. b1 can resolve a team_name for the marker dir (a stdin
+        # team_name on a teammate TaskCompleted frame) while its OWN session
+        # context is unpersisted (teammate persist is is_lead-gated, #877) ->
+        # get_journal_path() == "" -> the append below would FAIL after the
+        # marker is claimed, poisoning it and permanently suppressing the
+        # lead-side b2 emit via already_emitted(). Gate the claim on writability
+        # so a non-writable fire DEFERS to a writable one (the lead's b2)
+        # instead of poisoning. This is a PURE read (get_journal_path does not
+        # create the marker); mark-then-write exactly-once below is unchanged —
+        # only the precondition is added. get_journal_path() and append_event()
+        # resolve from the same _journal_path()/get_session_dir() source, so the
+        # gate cannot false-negative a fire that append would have written.
+        if not get_journal_path():
             print(_SUPPRESS_OUTPUT)
             sys.exit(0)
 

--- a/pact-plugin/hooks/agent_handoff_emitter.py
+++ b/pact-plugin/hooks/agent_handoff_emitter.py
@@ -186,12 +186,19 @@ def main() -> None:
             print(_SUPPRESS_OUTPUT)
             sys.exit(0)
 
-        # Handoff-presence gate. Suppress emission AND skip marker creation
-        # when `metadata.handoff` is absent or empty. Required so that a
-        # fire arriving before the teammate has stored handoff cannot claim
-        # the O_EXCL marker with empty content; the substantive completion
-        # (with handoff populated) claims it instead.
-        if not task_metadata.get("handoff"):
+        # Handoff-presence + type gate. Suppress emission AND skip marker
+        # creation when `metadata.handoff` is absent, empty, or NOT A DICT.
+        # Required so that a fire arriving before the teammate has stored
+        # handoff cannot claim the O_EXCL marker with empty content; the
+        # substantive completion (with handoff populated) claims it instead.
+        # M1: the journal schema requires handoff to be a dict, so a
+        # truthy-but-non-dict handoff (str/list) would pass a bare presence
+        # check, claim the marker, then FAIL append_event's schema validation
+        # — an orphaned/poisoned marker (the same failure class the #917
+        # writability gate below closes for the unwritable case). isinstance
+        # makes a malformed handoff DEFER (claim nothing) too.
+        handoff = task_metadata.get("handoff")
+        if not isinstance(handoff, dict) or not handoff:
             print(_SUPPRESS_OUTPUT)
             sys.exit(0)
 
@@ -209,6 +216,9 @@ def main() -> None:
         # only the precondition is added. get_journal_path() and append_event()
         # resolve from the same _journal_path()/get_session_dir() source, so the
         # gate cannot false-negative a fire that append would have written.
+        # F3: this gate is the TWIN of task_lifecycle_gate._emit_lead_side_agent_handoff
+        # — keep both in parity. Mark-then-write / O_EXCL contract:
+        # shared/agent_handoff_marker.already_emitted.
         if not get_journal_path():
             print(_SUPPRESS_OUTPUT)
             sys.exit(0)
@@ -252,7 +262,7 @@ def main() -> None:
                 agent=teammate_name,
                 task_id=task_id,
                 task_subject=task_subject,
-                handoff=task_metadata.get("handoff"),
+                handoff=handoff,
             ),
         )
 

--- a/pact-plugin/hooks/bootstrap_marker_writer.py
+++ b/pact-plugin/hooks/bootstrap_marker_writer.py
@@ -217,10 +217,16 @@ def _try_write_marker(input_data: dict) -> None:
         return
 
     # Lead-role gate (#878): only the team-lead drives bootstrap (writes the
-    # marker). Migrated from the negative `resolve_agent_name(...) != ""`
-    # heuristic — which returned non-empty for BOTH lead spellings, so the lead
-    # itself took this bypass branch under tmux — to the positive is_lead
-    # predicate keyed on the harness-set agent_type.
+    # marker). This is NOT a teammate discriminator: an Agent-spawned team
+    # teammate has no UserPromptSubmit-fire path (it wakes via inbox/SendMessage,
+    # which is not hookable), so this event never carries a teammate frame
+    # (empirically confirmed by the discriminator audit). The guard ensures a
+    # plain / non-PACT primary frame (agent_type absent → is_lead False) does
+    # not write the marker. Migrated from the negative
+    # `resolve_agent_name(...) != ""` heuristic — which returned non-empty for
+    # BOTH lead spellings, so the lead itself took this non-lead bypass branch
+    # under tmux — to the positive is_lead predicate keyed on the harness-set
+    # agent_type.
     if not pact_context.is_lead(input_data):
         return
 

--- a/pact-plugin/hooks/bootstrap_prompt_gate.py
+++ b/pact-plugin/hooks/bootstrap_prompt_gate.py
@@ -10,7 +10,8 @@ message, checks for the session-scoped bootstrap-complete marker file:
   - Marker exists → suppressOutput (zero tokens, sub-ms)
   - No marker + PACT team-lead session (is_lead) → inject additionalContext instructing bootstrap
   - Non-PACT session (no context file) → no-op passthrough
-  - Teammate / non-lead frame (not is_lead) → no-op passthrough
+  - Non-lead / plain primary frame (not is_lead) → no-op passthrough
+    (NOT a teammate: teammates have no UserPromptSubmit-fire path)
 
 SACROSANCT (post-#662 module-load fail-closed retrofit): module-load
 failures emit an advisory `additionalContext` block at exit 0 —
@@ -94,7 +95,8 @@ def _check_bootstrap_needed(input_data: dict) -> str | None:
     """Determine whether a bootstrap instruction should be injected.
 
     Returns the additionalContext string to inject, or None if the gate
-    should be a no-op (marker exists, non-PACT session, or teammate).
+    should be a no-op (marker exists, non-PACT session, or a plain/non-lead
+    primary frame — NOT a teammate; teammates never fire UserPromptSubmit).
     """
     # Initialize context (sets session-scoped path from input_data)
     pact_context.init(input_data)
@@ -114,10 +116,15 @@ def _check_bootstrap_needed(input_data: dict) -> str | None:
         return None
 
     # Lead-role gate (#878): only the team-lead drives the bootstrap ritual.
-    # Migrated from the negative `resolve_agent_name(...) != ""` heuristic to
-    # the positive is_lead predicate — the old heuristic returned non-empty for
-    # BOTH lead spellings (Step-4 prefix-strip), so under tmux the lead itself
-    # took this teammate-bypass branch. is_lead keys on the harness-set
+    # This is NOT a teammate discriminator: an Agent-spawned team teammate has
+    # no UserPromptSubmit-fire path (it wakes via inbox/SendMessage, which is
+    # not hookable), so this event never carries a teammate frame (empirically
+    # confirmed by the discriminator audit). The guard ensures a plain /
+    # non-PACT primary frame (agent_type absent → is_lead False) does not drive
+    # bootstrap. Migrated from the negative `resolve_agent_name(...) != ""`
+    # heuristic — which returned non-empty for BOTH lead spellings (Step-4
+    # prefix-strip), so under tmux the lead itself took this non-lead bypass
+    # branch — to the positive is_lead predicate keyed on the harness-set
     # agent_type directly.
     if not pact_context.is_lead(input_data):
         return None

--- a/pact-plugin/hooks/shared/HOOK_STDIN_DISCRIMINATORS.md
+++ b/pact-plugin/hooks/shared/HOOK_STDIN_DISCRIMINATORS.md
@@ -52,7 +52,7 @@ empty.
 |---|---|---|---|---|---|---|
 | SessionStart | `agent_type` | lead spelling | `pact-<specialist>` | absent | no | lead: yes (persists context) · teammate: no |
 | UserPromptSubmit | `agent_type` | lead spelling | *(no teammate fire path — see note)* | absent | no | lead: yes |
-| PreToolUse `†` (incl. `TaskCreate` / `TaskUpdate`) | `agent_type` | lead spelling | `pact-<specialist>` | — | **no** | lead: yes · teammate: no |
+| PreToolUse `†` | `agent_type` | lead spelling | `pact-<specialist>` | — | **no** | lead: yes · teammate: no |
 | PostToolUse (incl. `TaskCreate` / `TaskUpdate`) | `agent_type` | lead spelling | `pact-<specialist>` | — | **no** | lead: yes · teammate: no |
 | TaskCompleted | `agent_type` | lead spelling | `pact-<specialist>` | — | lead: **no** · teammate: **yes** (also `teammate_name`) | lead: yes · teammate: no |
 | PostCompact `†` | `agent_type` | lead spelling | `pact-<specialist>` | — | no | lead: yes · teammate: no |
@@ -63,7 +63,11 @@ SessionStart / UserPromptSubmit / PostToolUse / TaskCompleted frames establish.
 `is_lead` is READ on PreToolUse and PostCompact (and SessionStart /
 UserPromptSubmit / PostToolUse) but is NOT read on TaskCompleted — that frame is
 captured for the #917 emit-path, which gates on `team_name` + journal
-writability rather than this predicate.
+writability rather than this predicate. On PreToolUse, `is_lead` is read via the
+match-all `bootstrap_gate` (matcher `''`, so it fires before every tool —
+including `TaskCreate` / `TaskUpdate`) and the `Edit` / `Write` pin gates; there
+is no `TaskCreate` / `TaskUpdate`-matched PreToolUse hook (that matcher is
+PostToolUse-only — `task_lifecycle_gate`, the row above).
 
 ### UserPromptSubmit has no teammate fire path
 

--- a/pact-plugin/hooks/shared/HOOK_STDIN_DISCRIMINATORS.md
+++ b/pact-plugin/hooks/shared/HOOK_STDIN_DISCRIMINATORS.md
@@ -37,19 +37,33 @@ spelling `pact-orchestrator` as a teammate.
 
 ## Per-event truth table
 
-Values below are from verbatim stdin captured under tmux (Claude Code 2.1.167).
-"journal-resolvable in this process?" = does `session_journal.get_journal_path()`
-return a non-empty path — i.e. can THIS process write the canonical session
-journal. It is **process-scoped**: a teammate process has no persisted
-session-context file, so its journal path is empty.
+Values below are grounded in verbatim stdin captured under tmux (Claude Code
+2.1.167) for **SessionStart, UserPromptSubmit, PostToolUse, and TaskCompleted**.
+The **PreToolUse** and **PostCompact** rows are NOT separately captured (marked
+`†`): their `agent_type` shape is inferred from the uniform harness-stamping the
+captured frames establish (PostCompact has only a synthesized-from-matrix
+builder; PreToolUse has no frame). "journal-resolvable in this process?" = does
+`session_journal.get_journal_path()` return a non-empty path — i.e. can THIS
+process write the canonical session journal. It is **process-scoped**: a
+teammate process has no persisted session-context file, so its journal path is
+empty.
 
 | Hook event | Role field | Lead value | Teammate value | Plain | `team_name` in stdin? | journal-resolvable here? |
 |---|---|---|---|---|---|---|
 | SessionStart | `agent_type` | lead spelling | `pact-<specialist>` | absent | no | lead: yes (persists context) · teammate: no |
 | UserPromptSubmit | `agent_type` | lead spelling | *(no teammate fire path — see note)* | absent | no | lead: yes |
-| PreToolUse / PostToolUse (incl. `TaskCreate` / `TaskUpdate`) | `agent_type` | lead spelling | `pact-<specialist>` | — | **no** | lead: yes · teammate: no |
+| PreToolUse `†` (incl. `TaskCreate` / `TaskUpdate`) | `agent_type` | lead spelling | `pact-<specialist>` | — | **no** | lead: yes · teammate: no |
+| PostToolUse (incl. `TaskCreate` / `TaskUpdate`) | `agent_type` | lead spelling | `pact-<specialist>` | — | **no** | lead: yes · teammate: no |
 | TaskCompleted | `agent_type` | lead spelling | `pact-<specialist>` | — | lead: **no** · teammate: **yes** (also `teammate_name`) | lead: yes · teammate: no |
-| PostCompact | `agent_type` | lead spelling | `pact-<specialist>` | — | no | lead: yes · teammate: no |
+| PostCompact `†` | `agent_type` | lead spelling | `pact-<specialist>` | — | no | lead: yes · teammate: no |
+
+`†` PreToolUse and PostCompact are NOT separately captured this campaign; their
+`agent_type` shape is inferred from the uniform harness-stamping the captured
+SessionStart / UserPromptSubmit / PostToolUse / TaskCompleted frames establish.
+`is_lead` is READ on PreToolUse and PostCompact (and SessionStart /
+UserPromptSubmit / PostToolUse) but is NOT read on TaskCompleted — that frame is
+captured for the #917 emit-path, which gates on `team_name` + journal
+writability rather than this predicate.
 
 ### UserPromptSubmit has no teammate fire path
 

--- a/pact-plugin/hooks/shared/HOOK_STDIN_DISCRIMINATORS.md
+++ b/pact-plugin/hooks/shared/HOOK_STDIN_DISCRIMINATORS.md
@@ -1,0 +1,107 @@
+# Hook-stdin role discriminators
+
+Which stdin field tells a hook whether it is running in the **team-lead**, a
+**teammate**, or a **plain / non-PACT** process — and which fields look usable
+but are not. Read this before writing any predicate that branches on session
+role.
+
+## The one rule
+
+**`agent_type` is the universal role discriminator.** It is the only field
+present and correct on every hook event, in every process, under the tmux
+(separate-process) teammate topology. The signal is **value-membership, not
+field-presence**:
+
+| Role | `agent_type` value |
+|------|--------------------|
+| team-lead | `PACT:pact-orchestrator` **or** `pact-orchestrator` (both spellings the harness can stamp) |
+| teammate | the specialist value, e.g. `pact-architect`, `pact-backend-coder` |
+| plain / non-PACT primary | **field absent** |
+
+`pact_context.is_lead()` / `classify_session_role()` are the single resolvers;
+both test exact membership of `agent_type` in `LEAD_AGENT_TYPES`. A
+`startswith("pact-")` test is WRONG — it misclassifies the unqualified lead
+spelling `pact-orchestrator` as a teammate.
+
+### Do NOT key a role decision on these
+
+- **`agent_id` / `agent_name`** — ABSENT on tmux hook stdin. (On some older
+  bundles a teammate `PostToolUse` frame carried `agent_id`; it is not
+  dependable across bundles. `is_lead` deliberately never reads it.)
+- **`team_name`** — absent on most events; present on stdin only for a
+  **teammate `TaskCompleted`** frame (see the table). It identifies the team,
+  not the role, and it is NOT a "this is a teammate" flag you can rely on for
+  any other event.
+- **`teammate_name`** — present only on `TaskCompleted` (and `TeammateIdle`),
+  and only for a teammate. Not a general role signal.
+
+## Per-event truth table
+
+Values below are from verbatim stdin captured under tmux (Claude Code 2.1.167).
+"journal-resolvable in this process?" = does `session_journal.get_journal_path()`
+return a non-empty path — i.e. can THIS process write the canonical session
+journal. It is **process-scoped**: a teammate process has no persisted
+session-context file, so its journal path is empty.
+
+| Hook event | Role field | Lead value | Teammate value | Plain | `team_name` in stdin? | journal-resolvable here? |
+|---|---|---|---|---|---|---|
+| SessionStart | `agent_type` | lead spelling | `pact-<specialist>` | absent | no | lead: yes (persists context) · teammate: no |
+| UserPromptSubmit | `agent_type` | lead spelling | *(no teammate fire path — see note)* | absent | no | lead: yes |
+| PreToolUse / PostToolUse (incl. `TaskCreate` / `TaskUpdate`) | `agent_type` | lead spelling | `pact-<specialist>` | — | **no** | lead: yes · teammate: no |
+| TaskCompleted | `agent_type` | lead spelling | `pact-<specialist>` | — | lead: **no** · teammate: **yes** (also `teammate_name`) | lead: yes · teammate: no |
+| PostCompact | `agent_type` | lead spelling | `pact-<specialist>` | — | no | lead: yes · teammate: no |
+
+### UserPromptSubmit has no teammate fire path
+
+An `Agent`-spawned team teammate never fires `UserPromptSubmit`: it wakes via
+inbox / `SendMessage` (a context injection, not a hookable tool). So the
+`if not is_lead: return` guard in the bootstrap hooks
+(`bootstrap_marker_writer.py`, `bootstrap_prompt_gate.py`) is a **plain /
+non-PACT primary-session** guard — it is NOT discriminating teammates. (A
+*headless* `--agent pact-<specialist> -p` launch is a primary process, not a
+team teammate, and CAN fire `UserPromptSubmit` — but that is a different launch
+mode, not the team topology.)
+
+### `UserPromptSubmit` carries no `source`
+
+`source` (e.g. `"startup"`) is a **SessionStart-only** field. A real
+`UserPromptSubmit` frame does not carry it. A fixture or test that asserts
+`source` on a `UserPromptSubmit` frame is modeling a shape the platform does
+not deliver.
+
+## Why marker-claim and journal-write must share a precondition
+
+The two facts a teammate `TaskCompleted` frame exposes together are the trap:
+its stdin **carries `team_name`** (enough to resolve a team-scoped path) while
+its process **cannot resolve the canonical journal** (no persisted
+session-context file → empty journal path). A side-effect that resolves the
+first precondition but not the second — for example, claiming a team-scoped
+dedup marker and then writing the journal — will **claim without writing**: the
+marker is taken, the write is lost, and a later writable process (the lead) is
+permanently suppressed by the now-poisoned marker.
+
+The rule that follows: **any optimistic "we did it" marker must be gated on the
+writability of the thing it promises.** Resolve the marker-claim precondition
+and the write precondition from the **same** process-scoped signal
+(`get_journal_path()` non-empty), so a process that cannot write defers to one
+that can rather than poisoning the shared marker. Do not substitute `is_lead`
+for this: the load-bearing question is "can THIS process write the journal," not
+"is this the lead" — they usually coincide but the writability test is the
+precise one.
+
+## See also
+
+- `HOOK_INPUT_CONVENTIONS.md` (sibling) — conventions for consuming
+  `hook_event_name` and pinning the verbatim platform stdin shape.
+- `pact-plugin/tests/fixtures/role_frames.py` — the committed real captured
+  frames substantiating this table (the `captured_*` accessors), each carrying
+  `_meta.capture_method` provenance.
+- `pact-plugin/hooks/shared/pact_context.py` — `is_lead` / `classify_session_role`
+  (the resolvers) and `get_journal_path` resolution via the session context.
+
+---
+
+*Background: the discriminator audit and the marker-poisoning failure it
+explains are tracked under #812 (audit) and #917 (the emit-path bug);
+teammate-context non-persistence under tmux is #877. These pointers are
+provenance only — the behavioral facts above stand on their own.*

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -410,18 +410,26 @@ def is_lead(input_data: dict) -> bool:
 
     EMPIRICAL PROVENANCE. ``agent_type`` is the UNIVERSAL role discriminator:
     it is the field that carries the lead/teammate signal on every hook event
-    where this predicate is read — SessionStart, UserPromptSubmit, PreToolUse /
+    where this predicate is READ — SessionStart, UserPromptSubmit, PreToolUse,
     PostToolUse (including the ``TaskCreate`` / ``TaskUpdate``-matched frames),
-    TaskCompleted, and PostCompact — confirmed by verbatim stdin captured under
-    tmux on Claude Code 2.1.167. The signal is VALUE-MEMBERSHIP, not field-
-    presence: a lead stamps one of the two ``LEAD_AGENT_TYPES`` spellings, a
-    teammate stamps its specialist value (e.g. ``pact-architect``), and a plain
-    / non-PACT primary frame omits the field entirely. ``agent_id`` /
-    ``agent_name`` / ``team_name`` are ABSENT on tmux frames — a predicate keyed
-    on any of those would mis-resolve, which is exactly why this one keys on
-    ``agent_type`` alone. The captured frames substantiating this live in
-    ``tests/fixtures/role_frames.py`` (the ``captured_*`` accessors); the per-
-    event truth table is in ``hooks/shared/HOOK_STDIN_DISCRIMINATORS.md``.
+    and PostCompact. The signal is VALUE-MEMBERSHIP, not field-presence: a lead
+    stamps one of the two ``LEAD_AGENT_TYPES`` spellings, a teammate stamps its
+    specialist value (e.g. ``pact-architect``), and a plain / non-PACT primary
+    frame omits the field entirely. ``agent_id`` / ``agent_name`` / ``team_name``
+    are ABSENT on tmux frames — a predicate keyed on any of those would mis-
+    resolve, which is exactly why this one keys on ``agent_type`` alone.
+
+    Capture scope (Claude Code 2.1.167). Verbatim tmux stdin was captured for
+    SessionStart, UserPromptSubmit, PostToolUse, and TaskCompleted — note
+    TaskCompleted was captured for the #917 emit-path, NOT because is_lead is
+    read there (it is not; the TaskCompleted hook gates on ``team_name`` +
+    journal writability, not this predicate). PreToolUse and PostCompact were
+    NOT separately captured: their ``agent_type`` shape is inferred from the
+    uniform harness-stamping the captured frames establish (PostCompact has only
+    a synthesized-from-matrix builder; PreToolUse has no frame). The captured
+    frames live in ``tests/fixtures/role_frames.py`` (the ``captured_*``
+    accessors); the per-event truth table — which rows are captured vs inferred
+    — is in ``hooks/shared/HOOK_STDIN_DISCRIMINATORS.md``.
 
     Args:
         input_data: Parsed stdin JSON from the hook.

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -408,6 +408,21 @@ def is_lead(input_data: dict) -> bool:
     file-under-review, tool arguments cannot forge it) — but a future
     author must NOT hang an access-control decision on this function.
 
+    EMPIRICAL PROVENANCE. ``agent_type`` is the UNIVERSAL role discriminator:
+    it is the field that carries the lead/teammate signal on every hook event
+    where this predicate is read — SessionStart, UserPromptSubmit, PreToolUse /
+    PostToolUse (including the ``TaskCreate`` / ``TaskUpdate``-matched frames),
+    TaskCompleted, and PostCompact — confirmed by verbatim stdin captured under
+    tmux on Claude Code 2.1.167. The signal is VALUE-MEMBERSHIP, not field-
+    presence: a lead stamps one of the two ``LEAD_AGENT_TYPES`` spellings, a
+    teammate stamps its specialist value (e.g. ``pact-architect``), and a plain
+    / non-PACT primary frame omits the field entirely. ``agent_id`` /
+    ``agent_name`` / ``team_name`` are ABSENT on tmux frames — a predicate keyed
+    on any of those would mis-resolve, which is exactly why this one keys on
+    ``agent_type`` alone. The captured frames substantiating this live in
+    ``tests/fixtures/role_frames.py`` (the ``captured_*`` accessors); the per-
+    event truth table is in ``hooks/shared/HOOK_STDIN_DISCRIMINATORS.md``.
+
     Args:
         input_data: Parsed stdin JSON from the hook.
 

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -115,7 +115,7 @@ try:
     )
     from shared.dispatch_helpers import trustworthy_actor_name
     from shared.intentional_wait import is_self_complete_exempt, is_teachback_exempt
-    from shared.session_journal import append_event, make_event
+    from shared.session_journal import append_event, get_journal_path, make_event
     from shared.task_utils import read_task_json
     from shared.teachback_schema import (
         TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN,
@@ -315,6 +315,16 @@ def _emit_lead_side_agent_handoff(
             return
         handoff = task_metadata.get("handoff")
         if not handoff:
+            return
+        # #917 symmetry: same writability precondition as b1
+        # (agent_handoff_emitter). In the lead's gate process this is a no-op
+        # (the lead's context is persisted -> get_journal_path() resolves), but
+        # keeping both emit paths' marker-claim preconditions IDENTICAL prevents
+        # the b1/b2 divergence class (#887/#901): a future change that makes b2
+        # reachable from a non-lead / unresolvable context cannot silently
+        # claim-without-write and poison the shared marker. Pure read; the
+        # mark-then-write order below is unchanged.
+        if not get_journal_path():
             return
         occupant = occupant_hash(owner, subject)
         if already_emitted(team_name, task_id, occupant):

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -313,8 +313,13 @@ def _emit_lead_side_agent_handoff(
             return
         if is_signal_task(task_metadata):
             return
+        # M1: handoff must be a dict (the journal schema requires it). A
+        # truthy-but-non-dict handoff (str/list) would pass a bare presence
+        # check, claim the O_EXCL marker, then FAIL append_event's schema
+        # validation — an orphaned/poisoned marker. isinstance makes a
+        # malformed handoff DEFER (claim nothing). Mirrors b1's gate.
         handoff = task_metadata.get("handoff")
-        if not handoff:
+        if not isinstance(handoff, dict) or not handoff:
             return
         # #917 symmetry: same writability precondition as b1
         # (agent_handoff_emitter). In the lead's gate process this is a no-op
@@ -324,6 +329,9 @@ def _emit_lead_side_agent_handoff(
         # reachable from a non-lead / unresolvable context cannot silently
         # claim-without-write and poison the shared marker. Pure read; the
         # mark-then-write order below is unchanged.
+        # F3: this gate is the TWIN of agent_handoff_emitter.main — keep both
+        # in parity. Mark-then-write / O_EXCL contract:
+        # shared/agent_handoff_marker.already_emitted.
         if not get_journal_path():
             return
         occupant = occupant_hash(owner, subject)

--- a/pact-plugin/tests/fixtures/emitter.py
+++ b/pact-plugin/tests/fixtures/emitter.py
@@ -25,18 +25,20 @@ VALID_HANDOFF = {
     "open_questions": [],
 }
 
-# Non-empty sentinel for the in-hook get_journal_path() return. The path is
-# never written (append_event is spied), so any truthy value works — it only
-# needs to satisfy the #917 marker-claim writability gate
+# Shared non-empty sentinel for the in-hook get_journal_path() return (F2 —
+# the single source of truth, imported by every harness site + the
+# test-engineer regression test rather than re-literalled). The path is never
+# written (append_event is spied), so any truthy value works — it only needs to
+# satisfy the #917 marker-claim writability gate
 # (`if not get_journal_path(): defer`). Modelling a WRITABLE-journal b1 process
-# is the correct default for this helper: these tests assert b1's emit /
-# dedup / sanitization behaviour GIVEN that the canonical journal is writable
-# (the normal lead-or-resolvable-context fire). The journal-UNWRITABLE defer
-# path is exercised directly in test_handoff_writability_parity.py.
-_WRITABLE_JOURNAL_SENTINEL = "/pact-test-session/session-journal.jsonl"
+# is the correct default: these tests assert b1's emit / dedup / sanitization
+# behaviour GIVEN that the canonical journal is writable (the normal
+# lead-or-resolvable-context fire). The journal-UNWRITABLE defer path is
+# exercised directly in test_handoff_writability_parity.py.
+WRITABLE_TEST_JOURNAL = "/pact-test-session/session-journal.jsonl"
 
 
-def _run_main(stdin_payload, task_data, append_calls, journal_path=_WRITABLE_JOURNAL_SENTINEL):
+def _run_main(stdin_payload, task_data, append_calls, journal_path=WRITABLE_TEST_JOURNAL):
     """Invoke agent_handoff_emitter.main() with patched IO/deps.
 
     ``journal_path`` is the value the in-hook ``get_journal_path()`` returns

--- a/pact-plugin/tests/fixtures/emitter.py
+++ b/pact-plugin/tests/fixtures/emitter.py
@@ -25,9 +25,28 @@ VALID_HANDOFF = {
     "open_questions": [],
 }
 
+# Non-empty sentinel for the in-hook get_journal_path() return. The path is
+# never written (append_event is spied), so any truthy value works — it only
+# needs to satisfy the #917 marker-claim writability gate
+# (`if not get_journal_path(): defer`). Modelling a WRITABLE-journal b1 process
+# is the correct default for this helper: these tests assert b1's emit /
+# dedup / sanitization behaviour GIVEN that the canonical journal is writable
+# (the normal lead-or-resolvable-context fire). The journal-UNWRITABLE defer
+# path is exercised directly in test_handoff_writability_parity.py.
+_WRITABLE_JOURNAL_SENTINEL = "/pact-test-session/session-journal.jsonl"
 
-def _run_main(stdin_payload, task_data, append_calls):
-    """Invoke agent_handoff_emitter.main() with patched IO/deps."""
+
+def _run_main(stdin_payload, task_data, append_calls, journal_path=_WRITABLE_JOURNAL_SENTINEL):
+    """Invoke agent_handoff_emitter.main() with patched IO/deps.
+
+    ``journal_path`` is the value the in-hook ``get_journal_path()`` returns
+    inside ``main()``. Defaults to a non-empty sentinel so the helper models a
+    WRITABLE-journal b1 process (the #917 writability gate passes and emission
+    proceeds as before the gate). Pass ``""`` to exercise the journal-
+    UNWRITABLE defer path. The hook imports get_journal_path by value, so the
+    patch targets the symbol bound in ``agent_handoff_emitter`` — NOT
+    ``session_journal`` — or the gate would read the real resolution.
+    """
     # Lazy import: sys.path is configured in conftest.py before this module loads.
     # Do not hoist to module-level — sys.path coupling depends on conftest load order.
     from agent_handoff_emitter import main
@@ -38,6 +57,7 @@ def _run_main(stdin_payload, task_data, append_calls):
 
     with patch("agent_handoff_emitter.read_task_json", return_value=task_data), \
          patch("agent_handoff_emitter.append_event", side_effect=_append_spy), \
+         patch("agent_handoff_emitter.get_journal_path", return_value=journal_path), \
          patch("sys.stdin", io.StringIO(json.dumps(stdin_payload))):
         with pytest.raises(SystemExit) as exc_info:
             main()

--- a/pact-plugin/tests/fixtures/role_frames.py
+++ b/pact-plugin/tests/fixtures/role_frames.py
@@ -1,35 +1,43 @@
-"""Synthesized hook-stdin role frames for the lead/teammate discriminator.
+"""Hook-stdin role frames for the lead/teammate discriminator.
 
-PROVENANCE — these are SYNTHESIZED-from-matrix frames, NOT verbatim captured
-stdin: the raw platform frames were not persisted in this session. The shape
-matches the documented v4.4.0 / CC 2.1.158 capture matrix (teammate hook stdin
-carries ``agent_type`` on every event; ``agent_id`` / ``agent_name`` are ABSENT
-under tmux; ``teammate_name`` appears only on TeammateIdle). Every frame carries
-a ``_meta.capture_method`` stamp so no reader ever mistakes them for recovered
-captures.
+This module serves TWO frame sets, kept deliberately separate by provenance:
 
-RE-CAPTURE PROCEDURE (and why it is GATED on adopting tmux):
-  The actual real-frame re-capture CANNOT be done from the current in-process
-  teammateMode — in-process teammates do not fire their own separate hook
-  lifecycle with the tmux frame shape, so there is no genuine teammate stdin to
-  capture here. Re-capture therefore stays GATED on actually adopting tmux
-  teammateMode for an unattended run. When that happens, the procedure is:
-    1. On a scratch branch, add a passive additive hook (PostToolUse /
-       SubagentStart / PreToolUse-TaskUpdate) that appends raw ``sys.stdin`` to
-       a session-id-filtered capture file — over those 3 events, to settle the
-       per-event ``agent_name`` / ``agent_id`` presence under tmux.
-    2. Run a real tmux PACT session (lead + ≥1 specialist teammate) so each
-       process fires its own hook lifecycle and real frames land in the file.
-    3. Replace these synthesized builders with the captured frames, updating
-       ``_meta.capture_method`` to record the capture date + CC build.
-  Until tmux is adopted, the synthesized shape (matched to the documented
-  matrix) is the correct and only available source — re-capture is a follow-up,
-  not a gap in this PR. See the capture spec in
-  docs/plans/hook-lead-discriminator-fix-plan.md.
+1. SYNTHESIZED builders (``_frame`` / ``lead_frame_*`` / ``teammate_frame`` /
+   ``plain_frame`` / ``postcompact_frame``) - parametric frames matched to the
+   documented capture matrix (teammate hook stdin carries ``agent_type`` on
+   every event; ``agent_id`` / ``agent_name`` are ABSENT under tmux;
+   ``teammate_name`` appears only on TaskCompleted/TeammateIdle). Each carries
+   ``_meta.capture_method = "synthesized-from-matrix ..."`` so no reader ever
+   mistakes them for recovered captures. Use these when a test needs an
+   arbitrary event/role shape on demand.
 
-Consumed by test_is_lead.py (predicate truth-table) and the per-hook
-suppression tests (session_init / postcompact_archive gate behavior).
+2. CAPTURED (real) frames (``captured_frame`` + the ``captured_*`` accessors) -
+   verbatim platform stdin captured during the #812 empirical discriminator
+   audit on Claude Code 2.1.167 (2026-06-06), via two additive, plugin-unmodified
+   dumpers (a headless ``--settings`` dumper for SessionStart/UserPromptSubmit
+   per role, and a live ``settings.local.json`` dumper for the #917 PostToolUse /
+   TaskCompleted frames). Each frame carries its own ``_meta.capture_method``
+   provenance. Absolute paths (``cwd`` / ``transcript_path``) are sanitized to
+   ``<cwd>`` / ``<transcript_path>`` placeholders and the verbose
+   ``task_description`` / ``task_subject`` values are elided; the
+   role-discriminator shapes (``agent_type`` / ``session_id`` / ``team_name`` /
+   ``teammate_name``) are preserved verbatim because they are the point.
+
+These captured frames are the committed source of ground truth for the
+discriminator tests and the #917 marker-poisoning regression - the raw capture
+JSONL lives under the (gitignored) ``docs/`` tree, so promoting the frames here
+is what makes them available to the suite. See
+``pact-plugin/hooks/shared/HOOK_STDIN_DISCRIMINATORS.md`` for the per-event
+truth table these frames substantiate.
+
+Consumed by test_is_lead.py (predicate truth-table), the per-hook suppression
+tests (session_init / postcompact_archive gate behavior), and the agent_handoff
+emit-path regression tests.
 """
+
+import copy
+import json
+
 
 _CAPTURE_METHOD = "synthesized-from-matrix (v4.4.0 / CC 2.1.158); not a captured frame"
 
@@ -39,7 +47,7 @@ def _frame(agent_type, **extra):
 
     ``agent_type`` is the only field is_lead/classify_session_role read; the
     optional ``extra`` kwargs let a caller add event-specific fields
-    (``hook_event_name``, ``session_id``, ``compact_summary``, …) for the
+    (``hook_event_name``, ``session_id``, ``compact_summary``, ...) for the
     per-hook suppression tests without re-stamping provenance each time.
 
     Pass ``agent_type=None`` for the "unknown" / plain-frame role (the field
@@ -81,3 +89,253 @@ def postcompact_frame(agent_type, compact_summary="post-compaction summary text"
     """
     return _frame(agent_type, hook_event_name="PostCompact",
                   compact_summary=compact_summary)
+
+
+# =============================================================================
+# CAPTURED (real) frames - promoted from the #812 empirical discriminator audit
+# (Claude Code 2.1.167, 2026-06-06). Provenance in each frame's _meta.
+# Absolute paths sanitized to <cwd> / <transcript_path>; verbose task text
+# elided; role-discriminator shapes preserved verbatim. Parsed from a verbatim
+# JSON blob (not hand-transcribed Python literals) so each frame stays byte-
+# faithful to its capture and is trivially diffable.
+# =============================================================================
+
+_CAPTURED_FRAMES_JSON = r'''
+{
+  "lead_posttooluse_taskupdate_completed": {
+    "_meta": {
+      "capture_method": "live-session-additive-settings.local.json-dumper (Claude Code 2.1.167, 2026-06-06)",
+      "is_917_diagnostic": true,
+      "note": "#917 b2 side: lead PostToolUse(TaskUpdate,status=completed); tool_response has NO 'task' key so the gate disk-fallback is always taken; is_lead True",
+      "quick_summary": {
+        "AGENT_TYPE_top_level": "PACT:pact-orchestrator",
+        "agent_id_top_level": null,
+        "hook_event_name": "PostToolUse",
+        "taskupdate_status": "completed",
+        "team_name_top_level": null,
+        "teammate_name_top_level": null,
+        "tool_name": "TaskUpdate",
+        "tool_response_has_task": false
+      }
+    },
+    "agent_type": "PACT:pact-orchestrator",
+    "cwd": "<cwd>",
+    "duration_ms": 173,
+    "effort": {
+      "level": "xhigh"
+    },
+    "hook_event_name": "PostToolUse",
+    "permission_mode": "bypassPermissions",
+    "session_id": "e5e2be7d-84fb-4eb8-a932-1ca4557b4a43",
+    "tool_input": {
+      "status": "completed",
+      "taskId": "9"
+    },
+    "tool_name": "TaskUpdate",
+    "tool_response": {
+      "statusChange": {
+        "from": "pending",
+        "to": "completed"
+      },
+      "success": true,
+      "taskId": "9",
+      "updatedFields": [
+        "status"
+      ]
+    },
+    "tool_use_id": "toolu_012VtRb2bERWcUFzqdTX9KEA",
+    "transcript_path": "<transcript_path>"
+  },
+  "lead_sessionstart_qualified": {
+    "_meta": {
+      "capture_method": "headless-subprocess-additive-settings-dumper (Claude Code 2.1.167, 2026-06-06)",
+      "note": "--agent PACT:pact-orchestrator (qualified lead spelling) -> is_lead True"
+    },
+    "agent_type": "PACT:pact-orchestrator",
+    "cwd": "<cwd>",
+    "hook_event_name": "SessionStart",
+    "session_id": "fa92f1e3-756a-4c46-9704-26ae90fecda0",
+    "source": "startup",
+    "transcript_path": "<transcript_path>"
+  },
+  "lead_sessionstart_unqualified": {
+    "_meta": {
+      "capture_method": "headless-subprocess-additive-settings-dumper (Claude Code 2.1.167, 2026-06-06)",
+      "note": "--agent pact-orchestrator (unqualified lead spelling) -> is_lead True"
+    },
+    "agent_type": "pact-orchestrator",
+    "cwd": "<cwd>",
+    "hook_event_name": "SessionStart",
+    "session_id": "d09437a6-08e7-44df-9e69-5b3beb14c075",
+    "source": "startup",
+    "transcript_path": "<transcript_path>"
+  },
+  "lead_taskcompleted": {
+    "_meta": {
+      "capture_method": "live-session-additive-settings.local.json-dumper (Claude Code 2.1.167, 2026-06-06)",
+      "is_917_diagnostic": true,
+      "note": "#917 lead side: lead TaskCompleted has NO stdin team_name (cannot claim the marker from this frame; the lead's b2 PostToolUse path is the writable emitter)",
+      "quick_summary": {
+        "AGENT_TYPE_top_level": "PACT:pact-orchestrator",
+        "agent_id_top_level": null,
+        "hook_event_name": "TaskCompleted",
+        "taskupdate_status": null,
+        "team_name_top_level": null,
+        "teammate_name_top_level": null,
+        "tool_name": null,
+        "tool_response_has_task": false
+      }
+    },
+    "agent_type": "PACT:pact-orchestrator",
+    "cwd": "<cwd>",
+    "hook_event_name": "TaskCompleted",
+    "session_id": "e5e2be7d-84fb-4eb8-a932-1ca4557b4a43",
+    "task_description": "<elided for fixture - not read by the discriminator or emit paths>",
+    "task_id": "10",
+    "task_subject": "<elided for fixture>",
+    "transcript_path": "<transcript_path>"
+  },
+  "lead_userpromptsubmit_qualified": {
+    "_meta": {
+      "capture_method": "headless-subprocess-additive-settings-dumper (Claude Code 2.1.167, 2026-06-06)",
+      "note": "qualified lead UserPromptSubmit; no 'source' field on UserPromptSubmit"
+    },
+    "agent_type": "PACT:pact-orchestrator",
+    "cwd": "<cwd>",
+    "hook_event_name": "UserPromptSubmit",
+    "permission_mode": "acceptEdits",
+    "prompt": "Reply with the single word: ok",
+    "session_id": "fa92f1e3-756a-4c46-9704-26ae90fecda0",
+    "transcript_path": "<transcript_path>"
+  },
+  "plain_sessionstart": {
+    "_meta": {
+      "capture_method": "headless-subprocess-additive-settings-dumper (Claude Code 2.1.167, 2026-06-06)",
+      "note": "no --agent: agent_type ABSENT -> is_lead False / classify_session_role 'unknown'"
+    },
+    "cwd": "<cwd>",
+    "hook_event_name": "SessionStart",
+    "session_id": "b0f9c52e-8c38-44f0-a876-501ea3a27c7e",
+    "source": "startup",
+    "transcript_path": "<transcript_path>"
+  },
+  "plain_userpromptsubmit": {
+    "_meta": {
+      "capture_method": "headless-subprocess-additive-settings-dumper (Claude Code 2.1.167, 2026-06-06)",
+      "note": "no --agent: agent_type ABSENT. NOTE real UserPromptSubmit frames carry NO 'source' field (source is SessionStart-only)"
+    },
+    "cwd": "<cwd>",
+    "hook_event_name": "UserPromptSubmit",
+    "permission_mode": "acceptEdits",
+    "prompt": "Reply with the single word: ok",
+    "session_id": "b0f9c52e-8c38-44f0-a876-501ea3a27c7e",
+    "transcript_path": "<transcript_path>"
+  },
+  "teammate_sessionstart": {
+    "_meta": {
+      "capture_method": "headless-subprocess-additive-settings-dumper (Claude Code 2.1.167, 2026-06-06)",
+      "note": "--agent pact-preparer, a headless PRIMARY (NOT an Agent-spawned team teammate): agent_type present, not a lead spelling -> is_lead False"
+    },
+    "agent_type": "pact-preparer",
+    "cwd": "<cwd>",
+    "hook_event_name": "SessionStart",
+    "session_id": "6a0c8345-ff41-42da-941d-c0a2473177db",
+    "source": "startup",
+    "transcript_path": "<transcript_path>"
+  },
+  "teammate_taskcompleted": {
+    "_meta": {
+      "capture_method": "live-session-additive-settings.local.json-dumper (Claude Code 2.1.167, 2026-06-06)",
+      "is_917_diagnostic": true,
+      "note": "#917 poison side: teammate TaskCompleted carries a stdin team_name (b1 can claim the marker dir) but its session_id is foreign to the team (unpersisted teammate context) so the journal path is unwritable",
+      "quick_summary": {
+        "AGENT_TYPE_top_level": "pact-architect",
+        "agent_id_top_level": null,
+        "hook_event_name": "TaskCompleted",
+        "taskupdate_status": null,
+        "team_name_top_level": "pact-e5e2be7d",
+        "teammate_name_top_level": "architect",
+        "tool_name": null,
+        "tool_response_has_task": false
+      }
+    },
+    "agent_type": "pact-architect",
+    "cwd": "<cwd>",
+    "hook_event_name": "TaskCompleted",
+    "permission_mode": "bypassPermissions",
+    "session_id": "ce2de714-7b5c-48b5-a202-d6275bd5de47",
+    "task_description": "<elided for fixture - not read by the discriminator or emit paths>",
+    "task_id": "10",
+    "task_subject": "<elided for fixture>",
+    "team_name": "pact-e5e2be7d",
+    "teammate_name": "architect",
+    "transcript_path": "<transcript_path>"
+  }
+}
+'''
+
+_CAPTURED_FRAMES = json.loads(_CAPTURED_FRAMES_JSON)
+
+
+def captured_frame(label):
+    """Return a deep copy of the captured frame stored under ``label``.
+
+    Deep-copied so a caller mutating the returned dict cannot corrupt the
+    shared module-level capture. Raises ``KeyError`` on an unknown label
+    (fail-loud: a typo'd fixture name should not silently pass).
+    """
+    return copy.deepcopy(_CAPTURED_FRAMES[label])
+
+
+def captured_plain_sessionstart():
+    """Real plain SessionStart (no --agent; agent_type ABSENT)."""
+    return captured_frame("plain_sessionstart")
+
+
+def captured_plain_userpromptsubmit():
+    """Real plain UserPromptSubmit (agent_type ABSENT; carries no 'source')."""
+    return captured_frame("plain_userpromptsubmit")
+
+
+def captured_teammate_sessionstart():
+    """Real --agent pact-preparer SessionStart (headless primary, not a team teammate)."""
+    return captured_frame("teammate_sessionstart")
+
+
+def captured_lead_sessionstart_unqualified():
+    """Real --agent pact-orchestrator SessionStart (unqualified lead spelling)."""
+    return captured_frame("lead_sessionstart_unqualified")
+
+
+def captured_lead_sessionstart_qualified():
+    """Real --agent PACT:pact-orchestrator SessionStart (qualified lead spelling)."""
+    return captured_frame("lead_sessionstart_qualified")
+
+
+def captured_lead_userpromptsubmit_qualified():
+    """Real qualified-lead UserPromptSubmit frame."""
+    return captured_frame("lead_userpromptsubmit_qualified")
+
+
+def captured_lead_posttooluse_taskupdate_completed():
+    """#917 b2-side frame: lead PostToolUse(TaskUpdate, status=completed).
+
+    tool_response has NO 'task' key, so the gate's disk-fallback task read is
+    always taken; agent_type is the qualified lead spelling (is_lead True).
+    """
+    return captured_frame("lead_posttooluse_taskupdate_completed")
+
+
+def captured_teammate_taskcompleted():
+    """#917 poison-side frame: teammate TaskCompleted with team_name PRESENT.
+
+    Carries a stdin team_name (b1 can claim the marker dir) while its
+    session_id is foreign to the team (unpersisted teammate context) - the
+    exact asymmetry that lets a non-writable b1 fire poison the marker.
+    """
+    return captured_frame("teammate_taskcompleted")
+
+
+def captured_lead_taskcompleted():
+    """#917 lead-side frame: lead TaskCompleted with NO stdin team_name."""
+    return captured_frame("lead_taskcompleted")

--- a/pact-plugin/tests/fixtures/role_frames.py
+++ b/pact-plugin/tests/fixtures/role_frames.py
@@ -19,9 +19,11 @@ This module serves TWO frame sets, kept deliberately separate by provenance:
    TaskCompleted frames). Each frame carries its own ``_meta.capture_method``
    provenance. Absolute paths (``cwd`` / ``transcript_path``) are sanitized to
    ``<cwd>`` / ``<transcript_path>`` placeholders and the verbose
-   ``task_description`` / ``task_subject`` values are elided; the
-   role-discriminator shapes (``agent_type`` / ``session_id`` / ``team_name`` /
-   ``teammate_name``) are preserved verbatim because they are the point.
+   ``task_description`` value is elided (it is not read by the discriminator or
+   emit paths); ``task_subject`` is preserved verbatim (it is a load-bearing
+   input to the emit-path ``occupant_hash``). The role-discriminator shapes
+   (``agent_type`` / ``session_id`` / ``team_name`` / ``teammate_name``) are
+   preserved verbatim because they are the point.
 
 These captured frames are the committed source of ground truth for the
 discriminator tests and the #917 marker-poisoning regression - the raw capture
@@ -94,10 +96,11 @@ def postcompact_frame(agent_type, compact_summary="post-compaction summary text"
 # =============================================================================
 # CAPTURED (real) frames - promoted from the #812 empirical discriminator audit
 # (Claude Code 2.1.167, 2026-06-06). Provenance in each frame's _meta.
-# Absolute paths sanitized to <cwd> / <transcript_path>; verbose task text
-# elided; role-discriminator shapes preserved verbatim. Parsed from a verbatim
-# JSON blob (not hand-transcribed Python literals) so each frame stays byte-
-# faithful to its capture and is trivially diffable.
+# Absolute paths sanitized to <cwd> / <transcript_path>; task_description elided
+# (unread by the discriminator/emit paths); task_subject preserved (load-bearing
+# occupant_hash input); role-discriminator shapes preserved verbatim. Parsed
+# from a verbatim JSON blob (not hand-transcribed Python literals) so each frame
+# stays byte-faithful to its capture and is trivially diffable.
 # =============================================================================
 
 _CAPTURED_FRAMES_JSON = r'''
@@ -192,7 +195,7 @@ _CAPTURED_FRAMES_JSON = r'''
     "session_id": "e5e2be7d-84fb-4eb8-a932-1ca4557b4a43",
     "task_description": "<elided for fixture - not read by the discriminator or emit paths>",
     "task_id": "10",
-    "task_subject": "<elided for fixture>",
+    "task_subject": "architect: design #917 emit-path fix + #812 AC closures",
     "transcript_path": "<transcript_path>"
   },
   "lead_userpromptsubmit_qualified": {
@@ -266,7 +269,7 @@ _CAPTURED_FRAMES_JSON = r'''
     "session_id": "ce2de714-7b5c-48b5-a202-d6275bd5de47",
     "task_description": "<elided for fixture - not read by the discriminator or emit paths>",
     "task_id": "10",
-    "task_subject": "<elided for fixture>",
+    "task_subject": "architect: design #917 emit-path fix + #812 AC closures",
     "team_name": "pact-e5e2be7d",
     "teammate_name": "architect",
     "transcript_path": "<transcript_path>"

--- a/pact-plugin/tests/fixtures/userpromptsubmit_stdin_post_bootstrap.json
+++ b/pact-plugin/tests/fixtures/userpromptsubmit_stdin_post_bootstrap.json
@@ -1,8 +1,13 @@
 {
-  "_comment": "TODO(#672): replace this synthetic fixture with a captured-from-production UserPromptSubmit stdin per the capture procedure documented in #672. The procedure requires a separate scratch branch + fresh-startup PACT session and is incompatible with this PR's session. Synthetic shape below matches the platform schema documented in tests/test_bootstrap_prompt_gate.py (_make_input).",
+  "_meta": {
+    "capture_method": "headless-subprocess-additive-settings-dumper (Claude Code 2.1.167, 2026-06-06)",
+    "note": "Real captured UserPromptSubmit stdin, qualified lead spelling (--agent PACT:pact-orchestrator). Replaces the prior synthetic placeholder. NOTE: real UserPromptSubmit frames carry NO 'source' field (source is a SessionStart-only field) and NO agent_name/agent_id/team_name under tmux. Absolute paths sanitized to placeholders; the platform does not deliver the _meta key (tests strip it before feeding the hook)."
+  },
+  "agent_type": "PACT:pact-orchestrator",
+  "cwd": "<cwd>",
   "hook_event_name": "UserPromptSubmit",
-  "session_id": "fixture-session-id",
-  "prompt": "begin",
-  "source": "startup",
-  "transcript_path": "/tmp/fixture-transcript.jsonl"
+  "permission_mode": "acceptEdits",
+  "prompt": "Reply with the single word: ok",
+  "session_id": "fa92f1e3-756a-4c46-9704-26ae90fecda0",
+  "transcript_path": "<transcript_path>"
 }

--- a/pact-plugin/tests/test_bootstrap_marker_writer.py
+++ b/pact-plugin/tests/test_bootstrap_marker_writer.py
@@ -39,7 +39,7 @@ Fail-closed wrapper (P0 — architect §8.6):
     with hookEventName == "UserPromptSubmit"
 18. Runtime exception in _try_write_marker → suppressOutput at exit 0
 
-Captured fixture (P1 — architect §8.7, synthetic placeholder):
+Captured fixture (P1 — architect §8.7, real captured frame):
 19. Loading the fixture stdin and running main() produces clean exit 0
     with suppressOutput (verifies the platform-shape parser runs)
 
@@ -483,16 +483,17 @@ class TestFailClosedWrapper:
 
 
 # =============================================================================
-# Captured fixture (synthetic placeholder; TODO replace per architect §8.7)
+# Captured fixture round-trip — real captured-from-production UserPromptSubmit
+# stdin exercises the platform-shape parser end-to-end through main().
 # =============================================================================
 
 
 class TestCapturedFixtureRoundTrip:
-    """Architect §8.7. Placeholder synthetic fixture exercises the
-    platform-shape parser; replace with real captured-from-production
-    stdin per the follow-up issue. The hook should run cleanly on the
-    fixture even though the synthetic session_id has no team config in
-    the test environment (verify-and-refuse silent path)."""
+    """The fixture is a REAL captured UserPromptSubmit frame (qualified lead
+    spelling, Claude Code 2.1.167), carrying ``_meta.capture_method``
+    provenance. The hook should run cleanly on it: the captured session_id has
+    no team config in the test environment, so main() takes the silent
+    verify-and-refuse / no-session-dir path and exits 0."""
 
     FIXTURE = (
         Path(__file__).parent / "fixtures" /
@@ -501,24 +502,23 @@ class TestCapturedFixtureRoundTrip:
 
     def test_fixture_exists(self):
         assert self.FIXTURE.exists(), (
-            "synthetic fixture missing; placeholder is required even "
-            "before captured-from-production replacement"
+            "captured UserPromptSubmit fixture missing"
         )
 
     def test_main_runs_on_fixture(self, capsys):
         from bootstrap_marker_writer import main
 
         fixture_data = json.loads(self.FIXTURE.read_text(encoding="utf-8"))
-        # Strip the _comment field — the platform doesn't deliver it.
-        fixture_data.pop("_comment", None)
+        # Strip the _meta provenance key — the platform doesn't deliver it.
+        fixture_data.pop("_meta", None)
 
         with patch("sys.stdin", io.StringIO(json.dumps(fixture_data))):
             with pytest.raises(SystemExit) as exc_info:
                 main()
         captured = capsys.readouterr()
         assert exc_info.value.code == 0
-        # Synthetic session_id has no real team config; expect silent
-        # suppressOutput (verify-and-refuse path).
+        # Captured session_id has no real team config in the test env; expect
+        # silent suppressOutput (verify-and-refuse / no-session-dir path).
         assert json.loads(captured.out.strip()) == _SUPPRESS_EXPECTED
 
 
@@ -1213,18 +1213,23 @@ class TestConstantsRelocationRegression:
 
 
 # =============================================================================
-# Captured-fixture parity: synthetic shape contains documented platform fields
+# Captured-fixture parity: the real fixture carries the platform fields a
+# UserPromptSubmit frame actually delivers (and omits the ones it does not).
 # =============================================================================
 
 
 class TestFixtureShapeParity:
-    """The synthetic fixture is replaced post-merge with a real captured-
-    from-production stdin (architect §8.7). Until then, the synthetic
-    must include the documented platform fields so a partial regression
-    of the platform schema is visible at fixture-replacement time.
+    """The fixture is a real captured-from-production UserPromptSubmit frame.
+    Pin the platform fields it must carry so a partial regression of the
+    platform schema is visible.
 
-    Pinned shape: hook_event_name, session_id, prompt, source. These are
-    the fields the writer's main() and pact_context.init() actually read."""
+    Pinned shape: hook_event_name, session_id, prompt, permission_mode — the
+    fields a real UserPromptSubmit frame delivers (session_id is the one
+    pact_context.init() reads to resolve the session path). NOTE: the prior
+    synthetic placeholder asserted a ``source`` field here, but ``source`` is a
+    SessionStart-only field — a real UserPromptSubmit frame does NOT carry it.
+    That synthetic-vs-real discrepancy is exactly what this fixture promotion
+    corrects, so the negative is pinned below."""
 
     FIXTURE = (
         Path(__file__).parent / "fixtures" /
@@ -1233,29 +1238,18 @@ class TestFixtureShapeParity:
 
     def test_fixture_contains_documented_platform_fields(self):
         data = json.loads(self.FIXTURE.read_text(encoding="utf-8"))
-        # _comment is the synthetic-fixture marker; strip before checking.
-        data.pop("_comment", None)
-        for required in ("hook_event_name", "session_id", "prompt", "source"):
+        # _meta is our provenance annotation; the platform doesn't deliver it.
+        data.pop("_meta", None)
+        for required in ("hook_event_name", "session_id", "prompt",
+                         "permission_mode"):
             assert required in data, (
-                f"fixture missing platform field {required!r}; the "
-                f"synthetic placeholder must mirror the documented "
-                f"UserPromptSubmit stdin shape until the captured-from-"
-                f"production version replaces it (architect §8.7)."
+                f"fixture missing platform field {required!r}; the captured "
+                f"UserPromptSubmit fixture must mirror the real platform "
+                f"stdin shape."
             )
         assert data["hook_event_name"] == "UserPromptSubmit"
-
-    def test_fixture_synthetic_marker_present(self):
-        """The _comment field marks the fixture as synthetic. When the
-        captured-from-production version lands, this test should be
-        DELETED (not updated) — the synthetic-marker check is intentionally
-        scoped to the synthetic placeholder phase."""
-        data = json.loads(self.FIXTURE.read_text(encoding="utf-8"))
-        assert "_comment" in data, (
-            "synthetic-fixture _comment field absent; if you've replaced "
-            "with a real captured fixture, also delete this test "
-            "(per the test docstring)."
-        )
-        assert "TODO" in data["_comment"]
+        # `source` is SessionStart-only; a real UserPromptSubmit frame omits it.
+        assert "source" not in data
 
 
 # =============================================================================

--- a/pact-plugin/tests/test_dogfood_livelock_invariant.py
+++ b/pact-plugin/tests/test_dogfood_livelock_invariant.py
@@ -60,6 +60,10 @@ from unittest.mock import patch
 
 import pytest
 
+# F2: the single shared writable-journal sentinel (SSOT in fixtures.emitter),
+# imported rather than re-literalled. tests/ is on sys.path via conftest.
+from fixtures.emitter import WRITABLE_TEST_JOURNAL
+
 
 # ---------------------------------------------------------------------------
 # Path constants — resolved relative to this test file so refactors of the
@@ -298,7 +302,7 @@ def _run_emitter(stdin_payload, task_data, append_calls, tmp_home, monkeypatch):
     with patch("agent_handoff_emitter.read_task_json", return_value=task_data), \
          patch("agent_handoff_emitter.append_event", side_effect=_append_spy), \
          patch("agent_handoff_emitter.get_journal_path",
-               return_value="/pact-test-session/session-journal.jsonl"), \
+               return_value=WRITABLE_TEST_JOURNAL), \
          patch("sys.stdin", io.StringIO(json.dumps(stdin_payload))):
         with pytest.raises(SystemExit) as exc_info:
             main()
@@ -640,7 +644,7 @@ class TestLayer4_CounterTestByRevert:
              patch("agent_handoff_emitter.append_event",
                    side_effect=lambda e: (calls.append(e), True)[1]), \
              patch("agent_handoff_emitter.get_journal_path",
-                   return_value="/pact-test-session/session-journal.jsonl"), \
+                   return_value=WRITABLE_TEST_JOURNAL), \
              patch("sys.stdin", io.StringIO(json.dumps(payload))):
             with pytest.raises(SystemExit):
                 main()

--- a/pact-plugin/tests/test_dogfood_livelock_invariant.py
+++ b/pact-plugin/tests/test_dogfood_livelock_invariant.py
@@ -291,8 +291,14 @@ def _run_emitter(stdin_payload, task_data, append_calls, tmp_home, monkeypatch):
         append_calls.append(event)
         return True
 
+    # #917: model a WRITABLE-journal b1 process so the marker-claim
+    # writability gate passes (append_event is spied, so the path is never
+    # written — any truthy value satisfies the gate). The journal-unwritable
+    # defer path is covered in test_handoff_writability_parity.py.
     with patch("agent_handoff_emitter.read_task_json", return_value=task_data), \
          patch("agent_handoff_emitter.append_event", side_effect=_append_spy), \
+         patch("agent_handoff_emitter.get_journal_path",
+               return_value="/pact-test-session/session-journal.jsonl"), \
          patch("sys.stdin", io.StringIO(json.dumps(stdin_payload))):
         with pytest.raises(SystemExit) as exc_info:
             main()
@@ -628,9 +634,13 @@ class TestLayer4_CounterTestByRevert:
             "teammate_name": "test-agent",
             "team_name": "pact-counter",
         }
+        # #917: writable-journal b1 process (the gate is orthogonal to the
+        # status-gate this counter-test targets; append_event is spied).
         with patch("agent_handoff_emitter.read_task_json", return_value=completed_task), \
              patch("agent_handoff_emitter.append_event",
                    side_effect=lambda e: (calls.append(e), True)[1]), \
+             patch("agent_handoff_emitter.get_journal_path",
+                   return_value="/pact-test-session/session-journal.jsonl"), \
              patch("sys.stdin", io.StringIO(json.dumps(payload))):
             with pytest.raises(SystemExit):
                 main()

--- a/pact-plugin/tests/test_emitter_idempotency.py
+++ b/pact-plugin/tests/test_emitter_idempotency.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 
 import pytest
 
-from fixtures.emitter import VALID_HANDOFF, _run_main
+from fixtures.emitter import VALID_HANDOFF, WRITABLE_TEST_JOURNAL, _run_main
 
 
 class TestIdempotency:
@@ -237,7 +237,7 @@ class TestMarkerFailOpen:
         with patch("agent_handoff_emitter.read_task_json", return_value=task_data), \
              patch("agent_handoff_emitter.append_event", side_effect=_append_silent_fail), \
              patch("agent_handoff_emitter.get_journal_path",
-                   return_value="/pact-test-session/session-journal.jsonl"), \
+                   return_value=WRITABLE_TEST_JOURNAL), \
              patch("sys.stdin", io.StringIO(json.dumps(payload))):
             with pytest.raises(SystemExit) as exc1:
                 main()
@@ -268,7 +268,7 @@ class TestMarkerFailOpen:
         with patch("agent_handoff_emitter.read_task_json", return_value=task_data), \
              patch("agent_handoff_emitter.append_event", side_effect=_append_silent_fail), \
              patch("agent_handoff_emitter.get_journal_path",
-                   return_value="/pact-test-session/session-journal.jsonl"), \
+                   return_value=WRITABLE_TEST_JOURNAL), \
              patch("sys.stdin", io.StringIO(json.dumps(payload))):
             with pytest.raises(SystemExit) as exc2:
                 main()

--- a/pact-plugin/tests/test_emitter_idempotency.py
+++ b/pact-plugin/tests/test_emitter_idempotency.py
@@ -184,6 +184,17 @@ class TestMarkerFailOpen:
         #528 amplification class) is strictly more important than
         recovering a rare single-event loss on journal-write failure.
 
+        #917 NARROWING: the marker-claim is now gated on get_journal_path()
+        being non-empty (the canonical-journal writability precondition). So
+        the UNWRITABLE-journal cause of append failure (get_journal_path()=="")
+        now DEFERS before claiming the marker — no claim-without-write poison.
+        This test patches get_journal_path() to a writable value, isolating the
+        RESIDUAL scenario this asymmetry still covers: a WRITABLE journal whose
+        append_event nonetheless fails (e.g. a write error after path
+        resolution). The marker-persists trade-off remains intentional there.
+        The unwritable→defer behavior is pinned in
+        test_handoff_writability_parity.py.
+
         This test pins the CURRENT behavior so a future reviewer reading
         `_already_emitted` → `append_event` → `_mark_emitted` ordering
         does not mistake it for a bug. If the ordering is ever inverted
@@ -221,8 +232,12 @@ class TestMarkerFailOpen:
 
         # First invocation: marker gets created (by already_emitted),
         # append_event returns None (silent failure), event is lost.
+        # get_journal_path patched truthy → the #917 writability gate passes,
+        # isolating the residual writable-but-write-fails scenario (see docstring).
         with patch("agent_handoff_emitter.read_task_json", return_value=task_data), \
              patch("agent_handoff_emitter.append_event", side_effect=_append_silent_fail), \
+             patch("agent_handoff_emitter.get_journal_path",
+                   return_value="/pact-test-session/session-journal.jsonl"), \
              patch("sys.stdin", io.StringIO(json.dumps(payload))):
             with pytest.raises(SystemExit) as exc1:
                 main()
@@ -252,6 +267,8 @@ class TestMarkerFailOpen:
         # intact despite the lost event.
         with patch("agent_handoff_emitter.read_task_json", return_value=task_data), \
              patch("agent_handoff_emitter.append_event", side_effect=_append_silent_fail), \
+             patch("agent_handoff_emitter.get_journal_path",
+                   return_value="/pact-test-session/session-journal.jsonl"), \
              patch("sys.stdin", io.StringIO(json.dumps(payload))):
             with pytest.raises(SystemExit) as exc2:
                 main()

--- a/pact-plugin/tests/test_emitter_real_disk.py
+++ b/pact-plugin/tests/test_emitter_real_disk.py
@@ -14,7 +14,7 @@ from unittest.mock import patch
 
 import pytest
 
-from fixtures.emitter import VALID_HANDOFF, _run_main
+from fixtures.emitter import VALID_HANDOFF, WRITABLE_TEST_JOURNAL, _run_main
 
 
 # Verbatim 9-field stdin shape captured by 3 real-platform probes during #551
@@ -121,7 +121,7 @@ class TestRealDiskRead:
             # (read_task_json), not the journal write (spied). Model a writable
             # journal so the marker-claim writability gate passes.
             "agent_handoff_emitter.get_journal_path",
-            return_value="/pact-test-session/session-journal.jsonl",
+            return_value=WRITABLE_TEST_JOURNAL,
         ), patch("sys.stdin", io.StringIO(json.dumps({
             "session_id": "test-session-1",
             "hook_event_name": "TaskCompleted",
@@ -188,7 +188,7 @@ class TestRealDiskRead:
         ), patch(
             # #917: writable journal (real-disk fidelity is the task.json read).
             "agent_handoff_emitter.get_journal_path",
-            return_value="/pact-test-session/session-journal.jsonl",
+            return_value=WRITABLE_TEST_JOURNAL,
         ), patch("sys.stdin", io.StringIO(json.dumps({
             "session_id": "test-session-1",
             "hook_event_name": "TaskCompleted",

--- a/pact-plugin/tests/test_emitter_real_disk.py
+++ b/pact-plugin/tests/test_emitter_real_disk.py
@@ -116,6 +116,12 @@ class TestRealDiskRead:
         ), patch(
             "agent_handoff_emitter.append_event",
             side_effect=_append_spy,
+        ), patch(
+            # #917: the fidelity claim here is the real on-disk task.json READ
+            # (read_task_json), not the journal write (spied). Model a writable
+            # journal so the marker-claim writability gate passes.
+            "agent_handoff_emitter.get_journal_path",
+            return_value="/pact-test-session/session-journal.jsonl",
         ), patch("sys.stdin", io.StringIO(json.dumps({
             "session_id": "test-session-1",
             "hook_event_name": "TaskCompleted",
@@ -179,6 +185,10 @@ class TestRealDiskRead:
         ), patch(
             "agent_handoff_emitter.append_event",
             side_effect=lambda e: (calls.append(e), True)[1],
+        ), patch(
+            # #917: writable journal (real-disk fidelity is the task.json read).
+            "agent_handoff_emitter.get_journal_path",
+            return_value="/pact-test-session/session-journal.jsonl",
         ), patch("sys.stdin", io.StringIO(json.dumps({
             "session_id": "test-session-1",
             "hook_event_name": "TaskCompleted",

--- a/pact-plugin/tests/test_handoff_917_captured_regression.py
+++ b/pact-plugin/tests/test_handoff_917_captured_regression.py
@@ -1,0 +1,388 @@
+"""
+Location: pact-plugin/tests/test_handoff_917_captured_regression.py
+Summary: The #917 defer-then-emit SEQUENCE, grounded in REAL captured fixtures.
+Used by: the pact-plugin test suite (standing merge gate).
+
+WHAT THIS ADDS OVER THE EXISTING SUITE
+--------------------------------------
+test_handoff_writability_parity.py already pins, with INLINE SYNTHETIC frames
+and a MONKEYPATCHED get_journal_path(), the ISOLATED properties: an unwritable
+fire defers (no marker, no event), a writable fire emits exactly once, a re-fire
+dedups, and the source-ordering parity of the gate. test_handoff_b1_b2_dedup.py
+::TestDualModeMatrix pins the is_lead both-modes gate. This file does NOT
+re-assert those. It closes the two genuine gaps the dispatch named:
+
+1. THE SEQUENCE (the load-bearing #917 proof). The regression is not "a fire
+   defers" in isolation — it is that a NON-WRITABLE b1 poison-attempt must NOT
+   block the SUBSEQUENT writable b2, with BOTH contending for the SAME marker
+   (aligned team / task_id / occupant). A single-path defer test is
+   necessary-but-insufficient. Here a teammate-process b1 (captured frame,
+   team_name PRESENT but session unpersisted) DEFERS, then the lead's writable
+   b2 EMITS exactly one event for the same marker. Byte-faithful #917: pre-fix
+   b1 claims the marker + b2 is suppressed = 0 events; post-fix b1 defers + b2
+   emits = 1 event.
+
+2. REAL CAPTURED FIXTURES + NATURAL WRITABILITY (#880, masking-de-risking).
+   The frames are role_frames.captured_* (real stdin captured under tmux), and
+   writability resolves NATURALLY through pact_context (an unpersisted teammate
+   context yields get_journal_path() == "" with NO monkeypatch of the gate) —
+   precisely because the open masking question is whether a monkeypatched gate
+   faithfully models writability. The teammate fire's deferral is proved to be
+   for the RIGHT reason (get_journal_path() == "" asserted directly + a
+   same-frame writable POSITIVE CONTROL that emits), and the whole file's
+   non-vacuity is backstopped by a source-only-revert counter-test (documented
+   in the HANDOFF; reverting the C1/C2 gate flips the sequence to net 0).
+
+The marker mechanism (shared.agent_handoff_marker.already_emitted) runs for
+real against a tmp HOME, so marker-file assertions are against the actual
+O_EXCL side-effect, not a mock. append_event is spied (the path is never
+written) so "emits" means "the journal write was attempted exactly once".
+"""
+import copy
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import agent_handoff_emitter as b1  # noqa: E402
+import task_lifecycle_gate as tlg  # noqa: E402
+from shared.agent_handoff_marker import occupant_hash  # noqa: E402
+from shared.pact_context import is_lead  # noqa: E402
+from shared.session_journal import get_journal_path  # noqa: E402
+from fixtures.emitter import VALID_HANDOFF  # noqa: E402
+from fixtures.role_frames import (  # noqa: E402
+    captured_lead_posttooluse_taskupdate_completed,
+    captured_lead_taskcompleted,
+    captured_teammate_taskcompleted,
+)
+
+# Identity shared by b1 and b2 so they contend for the SAME marker.
+# team / task_id / owner come from the captured teammate frame (real values);
+# the subject is read from that frame so the occupant key aligns byte-for-byte.
+TEAM = "pact-e5e2be7d"          # captured_teammate_taskcompleted.team_name
+TASK_ID = "10"                  # captured_teammate_taskcompleted.task_id
+OWNER = "architect"            # captured_teammate_taskcompleted.teammate_name
+LEAD_SESSION = "e5e2be7d-84fb-4eb8-a932-1ca4557b4a43"  # lead/team session (writable)
+TEAMMATE_SESSION = "ce2de714-7b5c-48b5-a202-d6275bd5de47"  # foreign/unpersisted
+
+
+def _strip_meta(frame: dict) -> dict:
+    """Return a copy of a captured frame WITHOUT the ``_meta`` provenance key.
+
+    The platform never delivers ``_meta`` to a hook; the fixtures carry it for
+    auditability. Strip it before feeding stdin so the test exercises exactly
+    the bytes the hook would see in production.
+    """
+    f = copy.deepcopy(frame)
+    f.pop("_meta", None)
+    return f
+
+
+def _marker_files(home: Path) -> list[str]:
+    """Names of marker files the REAL O_EXCL test-and-set created under the
+    patched HOME, or [] if the marker dir was never created (the defer)."""
+    marker_dir = home / ".claude" / "teams" / TEAM / ".agent_handoff_emitted"
+    return sorted(p.name for p in marker_dir.iterdir()) if marker_dir.exists() else []
+
+
+def _task_data(subject: str) -> dict:
+    """Disk-shape task record both paths read (b1 via read_task_json, b2 via
+    its disk-fallback). owner + subject define the occupant; handoff present so
+    both paths reach the writability gate (not the handoff-presence gate)."""
+    return {
+        "id": TASK_ID,
+        "owner": OWNER,
+        "subject": subject,
+        "status": "completed",
+        "metadata": {"handoff": VALID_HANDOFF},
+    }
+
+
+def _count_agent_handoff_events() -> int:
+    """Count agent_handoff events in the CURRENTLY-resolved canonical journal.
+
+    Reads the file at get_journal_path() directly (rather than a spy) so the
+    headline SEQUENCE asserts the REAL end-to-end outcome: pre-fix the poisoned
+    marker yields 0 events; post-fix the lead's b2 write yields exactly 1.
+    """
+    path = get_journal_path()
+    if not path or not Path(path).exists():
+        return 0
+    n = 0
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if json.loads(line).get("type") == "agent_handoff":
+            n += 1
+    return n
+
+
+def _run_b1(frame: dict, task_data: dict, append_calls, monkeypatch) -> None:
+    """Fire b1 (agent_handoff_emitter.main) with a CAPTURED frame as stdin.
+
+    Does NOT patch get_journal_path — writability resolves NATURALLY via
+    pact_context (the masking-de-risking model). read_task_json supplies the
+    task. ``append_calls`` is a list to spy emissions, or None to use the REAL
+    append_event end-to-end (byte-faithful journal write/loss). The REAL marker
+    mechanism always runs.
+    """
+    monkeypatch.setattr(b1, "read_task_json", lambda tid, tn: task_data)
+    if append_calls is not None:
+        monkeypatch.setattr(b1, "append_event", lambda e: append_calls.append(e) or True)
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(_strip_meta(frame))))
+    with pytest.raises(SystemExit):
+        b1.main()
+
+
+def _run_b2(frame: dict, task_data: dict, append_calls, monkeypatch) -> None:
+    """Fire b2 (task_lifecycle_gate.evaluate_lifecycle) with a CAPTURED lead
+    PostToolUse(TaskUpdate, completed) frame whose tool_response carries NO
+    'task' (the #917 disk-fallback shape). get_journal_path is NOT patched
+    (natural resolution); read_task_json supplies the disk-fallback task.
+    ``append_calls`` is a spy list, or None to use the REAL append_event.
+    """
+    monkeypatch.setattr(tlg, "read_task_json", lambda tid, tn: task_data)
+    if append_calls is not None:
+        monkeypatch.setattr(tlg, "append_event", lambda e: append_calls.append(e) or True)
+    tlg.evaluate_lifecycle(_strip_meta(frame))
+
+
+class TestSequence917CapturedRegression:
+    """The defer-then-emit SEQUENCE on REAL captured fixtures — the #917 proof."""
+
+    def test_teammate_b1_unwritable_defers_then_lead_b2_emits_once(
+        self, tmp_path, monkeypatch, pact_context
+    ):
+        """THE #917 repro. A teammate b1 (unpersisted context → journal
+        unwritable) DEFERS (claims NO marker), then the lead's writable b2
+        EMITS exactly one event for the SAME marker. Net = 1.
+
+        Pre-fix this sequence netted 0 (b1 claimed the marker then lost the
+        append = poison; b2 hit already_emitted()==True and was suppressed).
+        Post-fix b1 defers and b2 emits → 1. Non-vacuity is proved by the
+        source-only-revert counter-test in the HANDOFF (gate removed → net 0).
+        """
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # A real teammate process HAS a project dir + session_id, but its
+        # session-context file was never persisted (persist is is_lead-gated,
+        # #877) → get_journal_path() resolves to "" with no monkeypatch.
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path / "proj"))
+
+        teammate = captured_teammate_taskcompleted()
+        lead = captured_lead_posttooluse_taskupdate_completed()
+        subject = teammate["task_subject"]
+        occupant = occupant_hash(OWNER, subject)
+        task_data = _task_data(subject)
+
+        # --- b1: teammate, UNWRITABLE → must DEFER (no pact_context set up) ---
+        # REAL append_event (append_calls=None): on an unwritable journal it
+        # writes nothing and returns False — byte-faithful to production, where
+        # pre-fix b1 claimed the marker and then LOST this append (the poison).
+        _run_b1(teammate, task_data, None, monkeypatch)
+        assert get_journal_path() == "", (
+            "model check: an unpersisted teammate context must make the "
+            "canonical journal UNWRITABLE (get_journal_path()=='') — natural "
+            "resolution, no monkeypatch."
+        )
+        assert _marker_files(tmp_path) == [], (
+            "b1 must DEFER on an unwritable journal — a claimed marker here is "
+            "the #917 claim-without-write poison."
+        )
+
+        # --- b2: lead, WRITABLE → must EMIT exactly once for the same marker ---
+        pact_context(team_name=TEAM, session_id=LEAD_SESSION)
+        lead["tool_input"]["taskId"] = TASK_ID  # align marker to the poisoned task
+        _run_b2(lead, task_data, None, monkeypatch)
+
+        assert _marker_files(tmp_path) == [f"{TASK_ID}-{occupant}"], (
+            "b2 must claim the now-free marker (b1 deferred, so it was never "
+            "poisoned)."
+        )
+        # THE load-bearing #917 assertion (byte-faithful): exactly ONE event in
+        # the canonical journal. Pre-fix this is 0 (b1 poisons the marker + its
+        # append fails → b2 hits already_emitted()==True and is suppressed);
+        # post-fix it is 1 (b1 defers → b2 emits).
+        assert _count_agent_handoff_events() == 1, (
+            "the canonical journal must hold EXACTLY ONE agent_handoff event "
+            "after the defer-then-emit sequence (#917 0/7 closed)."
+        )
+
+    def test_captured_teammate_b1_emits_when_writable_positive_control(
+        self, tmp_path, monkeypatch, pact_context
+    ):
+        """POSITIVE CONTROL for the deferral above: the SAME captured teammate
+        frame, given a WRITABLE context, claims its marker and emits once.
+
+        Proves the deferral in the sequence test is caused SOLELY by
+        unwritability — not by the teammate frame tripping some unrelated
+        earlier gate (handoff-presence, owner-empty, signal-task).
+        """
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # Persist a context for the teammate's own session → journal writable.
+        pact_context(team_name=TEAM, session_id=TEAMMATE_SESSION)
+
+        teammate = captured_teammate_taskcompleted()
+        subject = teammate["task_subject"]
+        occupant = occupant_hash(OWNER, subject)
+
+        calls: list = []
+        _run_b1(teammate, _task_data(subject), calls, monkeypatch)
+
+        assert get_journal_path() != "", "model check: this context is writable"
+        assert _marker_files(tmp_path) == [f"{TASK_ID}-{occupant}"], (
+            "a WRITABLE teammate b1 fire must claim its marker."
+        )
+        assert len(calls) == 1, "a writable b1 fire emits exactly once."
+
+    def test_lead_b2_emits_for_handoff_bearing_teammate_task(
+        self, tmp_path, monkeypatch, pact_context
+    ):
+        """AGREEMENT VERIFICATION (L2): the fix fulfils #917's ORIGINAL purpose.
+
+        Standalone (no prior b1): the lead completing a handoff-bearing teammate
+        task via TaskUpdate(status=completed) — the real captured b2 frame whose
+        tool_response has NO 'task' (disk-fallback always taken) — emits exactly
+        one agent_handoff event. This is the behaviour #917 reported as broken
+        (0/7); here it fires.
+        """
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        pact_context(team_name=TEAM, session_id=LEAD_SESSION)
+
+        lead = captured_lead_posttooluse_taskupdate_completed()
+        lead["tool_input"]["taskId"] = TASK_ID
+        subject = captured_teammate_taskcompleted()["task_subject"]
+
+        calls: list = []
+        _run_b2(lead, _task_data(subject), calls, monkeypatch)
+        assert len(calls) == 1, (
+            "the lead's b2 emit must fire for a lead completing a "
+            "handoff-bearing teammate task (the #917 original purpose)."
+        )
+
+
+class TestBothModesCaptured:
+    """Dual-mode pin grounded in the REAL captured frames (complements the
+    synthetic TestDualModeMatrix)."""
+
+    def test_is_lead_classifies_captured_frames(self):
+        """The real #917 frames classify correctly: the teammate TaskCompleted
+        is NOT lead (tmux teammate mode), both lead frames ARE lead. This is the
+        role-classification ground truth the SEQUENCE relies on."""
+        assert is_lead(captured_teammate_taskcompleted()) is False
+        assert is_lead(captured_lead_posttooluse_taskupdate_completed()) is True
+        assert is_lead(captured_lead_taskcompleted()) is True
+
+    def test_b2_gate_suppresses_captured_teammate_spelling(
+        self, tmp_path, monkeypatch, pact_context
+    ):
+        """The b2 emit is is_lead-gated: the REAL captured teammate agent_type
+        spelling ('pact-architect') applied to a b2-shaped frame is SUPPRESSED,
+        while the lead spelling on the same frame EMITS (positive control).
+
+        Frame STRUCTURE is the captured lead PostToolUse(TaskUpdate, completed);
+        only agent_type is varied — the captured-grounded analog of
+        TestDualModeMatrix's synthetic suppress test.
+        """
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        pact_context(team_name=TEAM, session_id=LEAD_SESSION)
+
+        teammate_spelling = captured_teammate_taskcompleted()["agent_type"]
+        subject = captured_teammate_taskcompleted()["task_subject"]
+
+        # teammate spelling → is_lead False → b2 suppressed
+        suppressed = captured_lead_posttooluse_taskupdate_completed()
+        suppressed["tool_input"]["taskId"] = TASK_ID
+        suppressed["agent_type"] = teammate_spelling
+        sup_calls: list = []
+        _run_b2(suppressed, _task_data(subject), sup_calls, monkeypatch)
+        assert sup_calls == [], (
+            "a teammate agent_type at the b2 call site must be suppressed by "
+            "the is_lead gate."
+        )
+
+        # positive control: lead spelling on the same frame → emits
+        lead = captured_lead_posttooluse_taskupdate_completed()
+        lead["tool_input"]["taskId"] = TASK_ID
+        lead_calls: list = []
+        _run_b2(lead, _task_data(subject), lead_calls, monkeypatch)
+        assert len(lead_calls) == 1, (
+            "same frame, lead spelling → emits (proves the suppression is the "
+            "is_lead gate, not a missing precondition)."
+        )
+
+
+class TestFixtureProvenance:
+    """T7 — the captured fixtures carry auditable provenance and the synthetic
+    placeholder has been retired (#880 no-synthetic-stdin)."""
+
+    def test_917_diagnostic_accessors_carry_capture_method(self):
+        """Every #917-diagnostic captured accessor returns a frame carrying a
+        non-empty _meta.capture_method (the provenance that makes the
+        no-synthetic-stdin discipline auditable)."""
+        for accessor in (
+            captured_teammate_taskcompleted,
+            captured_lead_posttooluse_taskupdate_completed,
+            captured_lead_taskcompleted,
+        ):
+            frame = accessor()
+            meta = frame.get("_meta", {})
+            method = meta.get("capture_method", "")
+            assert isinstance(method, str) and method, (
+                f"{accessor.__name__} must carry a non-empty "
+                f"_meta.capture_method; got {method!r}"
+            )
+            assert "synthetic" not in method.lower(), (
+                f"{accessor.__name__} must be a REAL capture, not synthetic "
+                f"(capture_method={method!r})"
+            )
+
+    def test_917_frames_encode_the_team_name_poisoning_asymmetry(self):
+        """The poisoning asymmetry is in the captured data: the teammate
+        TaskCompleted carries a stdin team_name (b1 can claim the marker dir),
+        the lead frames do NOT (their writable b2 path is the emitter). This is
+        the structural precondition for the #917 split."""
+        assert captured_teammate_taskcompleted().get("team_name") == TEAM, (
+            "the teammate frame must carry the stdin team_name that lets b1 "
+            "claim the marker."
+        )
+        assert "team_name" not in captured_lead_taskcompleted(), (
+            "the lead TaskCompleted must NOT carry a stdin team_name."
+        )
+        assert "team_name" not in captured_lead_posttooluse_taskupdate_completed(), (
+            "the lead PostToolUse frame must NOT carry a stdin team_name."
+        )
+
+    def test_retired_synthetic_userpromptsubmit_fixture_is_real_capture(self):
+        """The TODO #672 synthetic placeholder
+        (userpromptsubmit_stdin_post_bootstrap.json) is retired: the file now
+        holds a REAL captured lead UserPromptSubmit frame with provenance and
+        no synthetic markers."""
+        path = (
+            Path(__file__).parent
+            / "fixtures"
+            / "userpromptsubmit_stdin_post_bootstrap.json"
+        )
+        data = json.loads(path.read_text(encoding="utf-8"))
+        method = data.get("_meta", {}).get("capture_method", "")
+        assert isinstance(method, str) and method, (
+            "the retired fixture must carry _meta.capture_method provenance."
+        )
+        assert "synthetic" not in method.lower(), (
+            "the fixture must be a REAL capture (synthetic placeholder retired)."
+        )
+        assert data.get("agent_type") == "PACT:pact-orchestrator", (
+            "the captured UserPromptSubmit frame is a qualified-lead capture."
+        )
+        # Real UserPromptSubmit frames carry NO 'source' (SessionStart-only).
+        assert "source" not in data, (
+            "real UserPromptSubmit frames carry no 'source' field."
+        )

--- a/pact-plugin/tests/test_handoff_917_captured_regression.py
+++ b/pact-plugin/tests/test_handoff_917_captured_regression.py
@@ -320,6 +320,107 @@ class TestBothModesCaptured:
         )
 
 
+class TestReverseOrderingBenign:
+    """F1 completeness pins: the BENIGN reverse orderings — a LEGITIMATELY-claimed
+    marker (a writable fire that actually wrote) followed by an unwritable fire —
+    CANNOT poison.
+
+    These are deliberately NOT gate-coupled: already_emitted() would dedup the
+    second fire even without the writability gate, which is EXACTLY why the
+    reverse direction is safe. #917's poison requires the UNWRITABLE fire to come
+    FIRST and claim the marker before any successful write (the headline
+    SEQUENCE). Here the writable fire claims first, so the marker honestly
+    reflects a written event and the later unwritable fire (a) defers at its
+    writability gate and (b) could not corrupt the marker even if it reached
+    already_emitted(). These pin no-double-emit + marker-integrity for the two
+    orderings the headline SEQUENCE does not cover.
+
+    Writability is modeled NATURALLY (consistent with this file): a writable
+    process sets a resolvable pact_context; the unwritable process sets a context
+    whose team_name resolves (so the fire still reads the handoff and REACHES the
+    gate) but whose session_id is empty, so get_journal_path()=='' — the same
+    team-resolvable / journal-unresolvable split that defines the #917 hazard.
+    """
+
+    def test_writable_b1_then_unwritable_b2_cannot_poison(
+        self, tmp_path, monkeypatch, pact_context
+    ):
+        """(a) A writable b1 legitimately claims the marker + emits; a SUBSEQUENT
+        b2 in a journal-unwritable process DEFERS at the C2 gate without touching
+        the existing marker. Net: exactly ONE event, marker intact, no poison."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        teammate = captured_teammate_taskcompleted()
+        lead = captured_lead_posttooluse_taskupdate_completed()
+        subject = teammate["task_subject"]
+        occupant = occupant_hash(OWNER, subject)
+        task_data = _task_data(subject)
+        calls: list = []
+
+        # b1 WRITABLE → legitimate claim + emit
+        pact_context(team_name=TEAM, session_id=LEAD_SESSION)
+        _run_b1(teammate, task_data, calls, monkeypatch)
+        assert get_journal_path() != "", "b1 model check: writable"
+        assert _marker_files(tmp_path) == [f"{TASK_ID}-{occupant}"], "b1 claims the marker"
+        assert len(calls) == 1, "b1 emits once"
+
+        # b2 UNWRITABLE (team_name resolves so it reads the handoff + reaches the
+        # gate; session_id empty so the journal is unresolvable) → C2 defers
+        pact_context(team_name=TEAM, session_id="")
+        assert get_journal_path() == "", (
+            "b2 model check: journal unwritable while team still resolvable "
+            "(the #917 split)."
+        )
+        lead["tool_input"]["taskId"] = TASK_ID
+        _run_b2(lead, task_data, calls, monkeypatch)
+
+        assert len(calls) == 1, (
+            "the unwritable b2 must add NO event (C2 defer) — cannot poison a "
+            "legitimately-claimed marker."
+        )
+        assert _marker_files(tmp_path) == [f"{TASK_ID}-{occupant}"], (
+            "the legitimately-claimed marker is untouched by the deferred b2."
+        )
+
+    def test_writable_b2_then_unwritable_b1_cannot_poison(
+        self, tmp_path, monkeypatch, pact_context
+    ):
+        """(b) The realistic reverse of the #917 sequence: the lead's writable b2
+        emits + claims first (legitimate), THEN the platform Stop-sweep dispatches
+        an unwritable teammate b1 for the same task — it DEFERS at the C1 gate
+        (and already_emitted would dedup it anyway). Net: exactly ONE event,
+        marker intact, no poison."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        teammate = captured_teammate_taskcompleted()
+        lead = captured_lead_posttooluse_taskupdate_completed()
+        subject = teammate["task_subject"]
+        occupant = occupant_hash(OWNER, subject)
+        task_data = _task_data(subject)
+        calls: list = []
+
+        # b2 WRITABLE (lead) → legitimate claim + emit
+        pact_context(team_name=TEAM, session_id=LEAD_SESSION)
+        lead["tool_input"]["taskId"] = TASK_ID
+        _run_b2(lead, task_data, calls, monkeypatch)
+        assert _marker_files(tmp_path) == [f"{TASK_ID}-{occupant}"], "b2 claims the marker"
+        assert len(calls) == 1, "b2 emits once"
+
+        # b1 UNWRITABLE (teammate, unpersisted journal) for the SAME key → C1 defers
+        pact_context(team_name=TEAM, session_id="")
+        assert get_journal_path() == "", "b1 model check: journal unwritable"
+        _run_b1(teammate, task_data, calls, monkeypatch)
+
+        assert len(calls) == 1, (
+            "the unwritable b1 must add NO event (C1 defer) — a Stop-sweep "
+            "TaskCompleted arriving after the lead's legitimate emit cannot "
+            "poison."
+        )
+        assert _marker_files(tmp_path) == [f"{TASK_ID}-{occupant}"], (
+            "the legitimately-claimed marker is untouched by the deferred b1."
+        )
+
+
 class TestFixtureProvenance:
     """T7 — the captured fixtures carry auditable provenance and the synthetic
     placeholder has been retired (#880 no-synthetic-stdin)."""

--- a/pact-plugin/tests/test_handoff_writability_parity.py
+++ b/pact-plugin/tests/test_handoff_writability_parity.py
@@ -1,0 +1,223 @@
+"""
+Location: pact-plugin/tests/test_handoff_writability_parity.py
+Summary: C3a marker-claim WRITABILITY parity smoke test for the #917 fix.
+Used by: the pact-plugin test suite (standing merge gate).
+
+The #917 fix gates the OPTIMISTIC O_EXCL agent_handoff marker-claim on
+canonical-journal writability: get_journal_path() must be non-empty BEFORE
+already_emitted() (the marker test-and-set) runs, in BOTH emit paths —
+
+  b1 = agent_handoff_emitter.main()                       (TaskCompleted)
+  b2 = task_lifecycle_gate._emit_lead_side_agent_handoff  (lead TaskUpdate-completed)
+
+Without the gate, a fire that resolves a team_name for the marker dir but
+CANNOT write the canonical journal (a teammate process whose context is
+unpersisted, #877) claims the shared O_EXCL marker and then loses the
+append_event — a CLAIM-WITHOUT-WRITE that permanently suppresses the reliable
+lead-side b2 emit (the #917 0/7 symptom).
+
+LOAD-BEARING assertion (relational, mirroring the #898 eligibility-parity test):
+a journal-UNWRITABLE fire DEFERS — it claims NO marker (no file under
+.agent_handoff_emitted/) and writes NO event; a journal-WRITABLE fire still
+claims the marker + writes EXACTLY ONCE.
+
+WHY "no marker after an unwritable fire" PROVES the ordering: if a path lacked
+the get_journal_path() gate, or placed it AFTER already_emitted(), the O_EXCL
+marker file would be created before/without the writability check. Asserting
+the marker file is ABSENT after an unwritable fire is therefore the behavioral
+proof that the writability check runs BEFORE the marker claim on that path — and
+it fails the instant a future edit drops the gate from EITHER path (the
+#901/#887 divergence class this test guards). A source-ordering pin
+(test_writability_check_precedes_marker_claim_in_source) backstops it.
+
+SELF-CONTAINED: minimal frames + handoff are constructed inline; the REAL
+marker mechanism (shared.agent_handoff_marker.already_emitted) runs against a
+tmp HOME so the marker-file assertions are against the actual O_EXCL side-effect,
+not a mock. append_event is spied so "writes" means "the journal write was
+attempted exactly once" (the dedup semantic the marker exists for). This file
+imports NO captured-frame fixture promotion — it stands alone.
+"""
+import inspect
+import io
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import agent_handoff_emitter as b1  # noqa: E402
+import task_lifecycle_gate as tlg  # noqa: E402
+
+TEAM = "pact-test"
+LEAD = "PACT:pact-orchestrator"
+TASK_ID = "917"
+OWNER = "devops"
+SUBJECT = "devops: ship the gate"
+
+# Minimal valid handoff — inline (no fixtures import).
+HANDOFF = {
+    "produced": ["src/x"],
+    "decisions": ["d"],
+    "uncertainty": [],
+    "integration": ["i"],
+    "open_questions": [],
+}
+
+
+def _marker_files(home: Path) -> list[str]:
+    """Names of marker files the REAL O_EXCL test-and-set created under the
+    patched HOME, or [] if the marker dir was never created (the defer)."""
+    marker_dir = home / ".claude" / "teams" / TEAM / ".agent_handoff_emitted"
+    return sorted(p.name for p in marker_dir.iterdir()) if marker_dir.exists() else []
+
+
+def _drive_b1(*, writable: bool, tmp_path: Path, monkeypatch, append_calls: list) -> None:
+    """Fire b1 (agent_handoff_emitter.main) for one handoff-bearing completed
+    TaskCompleted frame. `writable` controls the in-hook get_journal_path()
+    return ('' = unwritable). The real already_emitted runs under the patched
+    HOME; append_event is spied."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    journal = str(tmp_path / "session-journal.jsonl") if writable else ""
+    task_data = {"status": "completed", "owner": OWNER, "metadata": {"handoff": HANDOFF}}
+    stdin = {
+        "task_id": TASK_ID,
+        "task_subject": SUBJECT,
+        "teammate_name": OWNER,
+        "team_name": TEAM,
+    }
+    # Patch the symbol bound in the HOOK module's namespace (b1 does
+    # `from shared.session_journal import ... get_journal_path`), NOT
+    # session_journal.get_journal_path — else the gate reads the real
+    # resolution while this stub is ignored (a vacuous pass).
+    with patch.object(b1, "get_journal_path", return_value=journal), \
+         patch.object(b1, "read_task_json", return_value=task_data), \
+         patch.object(b1, "append_event", side_effect=lambda e: append_calls.append(e) or True), \
+         patch("sys.stdin", io.StringIO(json.dumps(stdin))):
+        with pytest.raises(SystemExit):
+            b1.main()
+
+
+def _drive_b2(*, writable: bool, tmp_path: Path, monkeypatch, pact_context, append_calls: list) -> None:
+    """Fire b2 (_emit_lead_side_agent_handoff, reached via evaluate_lifecycle
+    with a LEAD frame so is_lead is True). Same writability control + append
+    spy; the real already_emitted runs under the patched HOME."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    pact_context(team_name=TEAM, session_id="s1")
+    journal = str(tmp_path / "session-journal.jsonl") if writable else ""
+    monkeypatch.setattr(tlg, "get_journal_path", lambda: journal)
+    monkeypatch.setattr(tlg, "append_event", lambda e: append_calls.append(e) or True)
+    task = {"id": TASK_ID, "subject": SUBJECT, "owner": OWNER, "metadata": {"handoff": HANDOFF}}
+    tlg.evaluate_lifecycle({
+        "agent_type": LEAD,
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": TASK_ID, "status": "completed"},
+        "tool_response": {"task": task},
+    })
+
+
+# Relational driver table: both emit paths exercised by the SAME assertions.
+# A param is (label, driver) where driver(writable, tmp_path, monkeypatch,
+# pact_context, append_calls) fires that path once.
+def _b1_driver(writable, tmp_path, monkeypatch, pact_context, append_calls):
+    _drive_b1(writable=writable, tmp_path=tmp_path, monkeypatch=monkeypatch, append_calls=append_calls)
+
+
+def _b2_driver(writable, tmp_path, monkeypatch, pact_context, append_calls):
+    _drive_b2(writable=writable, tmp_path=tmp_path, monkeypatch=monkeypatch,
+              pact_context=pact_context, append_calls=append_calls)
+
+
+_PATHS = [("b1", _b1_driver), ("b2", _b2_driver)]
+
+
+class TestWritabilityGateParity:
+    """Both emit paths must DEFER (claim no marker, write no event) on an
+    unwritable journal, and EMIT exactly once on a writable journal."""
+
+    @pytest.mark.parametrize("label,driver", _PATHS)
+    def test_unwritable_fire_defers_no_marker_no_event(
+        self, label, driver, tmp_path, monkeypatch, pact_context
+    ):
+        """get_journal_path()=='' → the fire DEFERS: NO marker file is claimed
+        (the gate runs BEFORE already_emitted) and NO event is written. This is
+        the #917 anti-poison property. NON-VACUOUS: reverting the gate makes the
+        marker get claimed (file appears) and this fails."""
+        calls: list = []
+        driver(False, tmp_path, monkeypatch, pact_context, calls)
+        assert _marker_files(tmp_path) == [], (
+            f"{label}: an UNWRITABLE fire must claim NO marker — a marker file "
+            "means the writability gate is missing or runs AFTER already_emitted "
+            "(claim-without-write poison, #917)."
+        )
+        assert calls == [], f"{label}: an unwritable fire must write no event."
+
+    @pytest.mark.parametrize("label,driver", _PATHS)
+    def test_writable_fire_claims_marker_and_emits_once(
+        self, label, driver, tmp_path, monkeypatch, pact_context
+    ):
+        """Positive control: get_journal_path() resolvable → the fire claims
+        exactly ONE marker and writes exactly ONE event. Proves the defer above
+        is the writability gate, not 'always suppress'."""
+        calls: list = []
+        driver(True, tmp_path, monkeypatch, pact_context, calls)
+        assert len(_marker_files(tmp_path)) == 1, (
+            f"{label}: a WRITABLE fire must claim exactly one marker."
+        )
+        assert len(calls) == 1, f"{label}: a writable fire must emit exactly once."
+
+    @pytest.mark.parametrize("label,driver", _PATHS)
+    def test_writable_refire_dedups_exactly_once(
+        self, label, driver, tmp_path, monkeypatch, pact_context
+    ):
+        """Exactly-once preserved: two writable fires for the same
+        (team, task_id, occupant) → still ONE marker + ONE event (the optimistic
+        O_EXCL test-and-set is unchanged; the gate only adds a precondition)."""
+        calls: list = []
+        driver(True, tmp_path, monkeypatch, pact_context, calls)
+        driver(True, tmp_path, monkeypatch, pact_context, calls)
+        assert len(_marker_files(tmp_path)) == 1, (
+            f"{label}: a re-fire must not create a second marker."
+        )
+        assert len(calls) == 1, (
+            f"{label}: a re-fire for the same occupant must dedup to one event "
+            "(exactly-once must survive the new writability precondition)."
+        )
+
+
+def test_writability_check_precedes_marker_claim_in_source():
+    """Source-ordering pin (relational): BOTH call sites must perform the
+    get_journal_path() writability check BEFORE the already_emitted() marker
+    claim in their source. Backstops the behavioral defer-test against a
+    refactor that keeps both symbols but reorders them. Fails if a future edit
+    drops the gate from either path.
+
+    Targets the executable CALL STATEMENTS (`if not get_journal_path():` and
+    `if already_emitted(`) rather than the bare symbol names — both functions
+    mention already_emitted in incidental earlier comments (e.g. the path-
+    sanitization note), so a bare `index("already_emitted")` would match the
+    comment, not the call. The two emit paths use the identical gate
+    statement, which is what makes this a true relational parity pin."""
+    GATE_CALL = "if not get_journal_path():"
+    MARKER_CALL = "if already_emitted("
+    for fn, name in (
+        (b1.main, "agent_handoff_emitter.main (b1)"),
+        (tlg._emit_lead_side_agent_handoff, "task_lifecycle_gate._emit_lead_side_agent_handoff (b2)"),
+    ):
+        src = inspect.getsource(fn)
+        assert GATE_CALL in src, (
+            f"{name} lost its `{GATE_CALL}` writability gate (#917)."
+        )
+        assert MARKER_CALL in src, (
+            f"{name} no longer calls already_emitted() — test may be stale."
+        )
+        assert src.index(GATE_CALL) < src.index(MARKER_CALL), (
+            f"{name}: the get_journal_path() writability check must precede the "
+            "already_emitted() marker claim — the gate must run BEFORE the "
+            "O_EXCL test-and-set so a non-writable fire defers without claiming "
+            "(#917)."
+        )

--- a/pact-plugin/tests/test_handoff_writability_parity.py
+++ b/pact-plugin/tests/test_handoff_writability_parity.py
@@ -74,15 +74,16 @@ def _marker_files(home: Path) -> list[str]:
     return sorted(p.name for p in marker_dir.iterdir()) if marker_dir.exists() else []
 
 
-def _drive_b1(*, writable: bool, tmp_path: Path, monkeypatch, append_calls: list) -> None:
+def _drive_b1(*, writable: bool, tmp_path: Path, monkeypatch, append_calls: list, handoff=HANDOFF) -> None:
     """Fire b1 (agent_handoff_emitter.main) for one handoff-bearing completed
     TaskCompleted frame. `writable` controls the in-hook get_journal_path()
-    return ('' = unwritable). The real already_emitted runs under the patched
-    HOME; append_event is spied."""
+    return ('' = unwritable). `handoff` is the metadata.handoff value (default
+    a valid dict; pass a non-dict to exercise the M1 type gate). The real
+    already_emitted runs under the patched HOME; append_event is spied."""
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setenv("HOME", str(tmp_path))
     journal = str(tmp_path / "session-journal.jsonl") if writable else ""
-    task_data = {"status": "completed", "owner": OWNER, "metadata": {"handoff": HANDOFF}}
+    task_data = {"status": "completed", "owner": OWNER, "metadata": {"handoff": handoff}}
     stdin = {
         "task_id": TASK_ID,
         "task_subject": SUBJECT,
@@ -101,17 +102,19 @@ def _drive_b1(*, writable: bool, tmp_path: Path, monkeypatch, append_calls: list
             b1.main()
 
 
-def _drive_b2(*, writable: bool, tmp_path: Path, monkeypatch, pact_context, append_calls: list) -> None:
+def _drive_b2(*, writable: bool, tmp_path: Path, monkeypatch, pact_context, append_calls: list, handoff=HANDOFF) -> None:
     """Fire b2 (_emit_lead_side_agent_handoff, reached via evaluate_lifecycle
     with a LEAD frame so is_lead is True). Same writability control + append
-    spy; the real already_emitted runs under the patched HOME."""
+    spy; `handoff` is the metadata.handoff value (default a valid dict; pass a
+    non-dict to exercise the M1 type gate). The real already_emitted runs under
+    the patched HOME."""
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setenv("HOME", str(tmp_path))
     pact_context(team_name=TEAM, session_id="s1")
     journal = str(tmp_path / "session-journal.jsonl") if writable else ""
     monkeypatch.setattr(tlg, "get_journal_path", lambda: journal)
     monkeypatch.setattr(tlg, "append_event", lambda e: append_calls.append(e) or True)
-    task = {"id": TASK_ID, "subject": SUBJECT, "owner": OWNER, "metadata": {"handoff": HANDOFF}}
+    task = {"id": TASK_ID, "subject": SUBJECT, "owner": OWNER, "metadata": {"handoff": handoff}}
     tlg.evaluate_lifecycle({
         "agent_type": LEAD,
         "tool_name": "TaskUpdate",
@@ -123,13 +126,14 @@ def _drive_b2(*, writable: bool, tmp_path: Path, monkeypatch, pact_context, appe
 # Relational driver table: both emit paths exercised by the SAME assertions.
 # A param is (label, driver) where driver(writable, tmp_path, monkeypatch,
 # pact_context, append_calls) fires that path once.
-def _b1_driver(writable, tmp_path, monkeypatch, pact_context, append_calls):
-    _drive_b1(writable=writable, tmp_path=tmp_path, monkeypatch=monkeypatch, append_calls=append_calls)
+def _b1_driver(writable, tmp_path, monkeypatch, pact_context, append_calls, handoff=HANDOFF):
+    _drive_b1(writable=writable, tmp_path=tmp_path, monkeypatch=monkeypatch,
+              append_calls=append_calls, handoff=handoff)
 
 
-def _b2_driver(writable, tmp_path, monkeypatch, pact_context, append_calls):
+def _b2_driver(writable, tmp_path, monkeypatch, pact_context, append_calls, handoff=HANDOFF):
     _drive_b2(writable=writable, tmp_path=tmp_path, monkeypatch=monkeypatch,
-              pact_context=pact_context, append_calls=append_calls)
+              pact_context=pact_context, append_calls=append_calls, handoff=handoff)
 
 
 _PATHS = [("b1", _b1_driver), ("b2", _b2_driver)]
@@ -186,6 +190,45 @@ class TestWritabilityGateParity:
         assert len(calls) == 1, (
             f"{label}: a re-fire for the same occupant must dedup to one event "
             "(exactly-once must survive the new writability precondition)."
+        )
+
+
+# M1: truthy-but-non-dict handoff values that must DEFER. The journal schema
+# requires handoff to be a dict; without the isinstance gate any of these would
+# pass a bare presence check, claim the O_EXCL marker, then fail append_event's
+# schema validation — an orphaned/poisoned marker.
+_NON_DICT_HANDOFFS = [
+    ("string", "a handoff string"),
+    ("list", ["produced", "decisions"]),
+    ("int", 42),
+    ("bool", True),
+]
+
+
+class TestHandoffTypeGateParity:
+    """M1: a truthy-but-NON-DICT metadata.handoff must DEFER on BOTH paths —
+    claim NO marker, write NO event — exactly like the unwritable case. The
+    journal is WRITABLE here, so the ONLY defer cause under test is the handoff
+    TYPE (isolated from the #917 writability gate). The valid-dict positive
+    control is TestWritabilityGateParity::test_writable_fire_claims_marker_and_
+    emits_once, so this is not 'always suppress'. NON-VACUOUS: dropping the
+    isinstance(dict) guard lets the marker get claimed (file appears) and these
+    fail."""
+
+    @pytest.mark.parametrize("label,driver", _PATHS)
+    @pytest.mark.parametrize("kind,handoff", _NON_DICT_HANDOFFS)
+    def test_non_dict_handoff_defers_no_marker_no_event(
+        self, label, driver, kind, handoff, tmp_path, monkeypatch, pact_context
+    ):
+        calls: list = []
+        driver(True, tmp_path, monkeypatch, pact_context, calls, handoff=handoff)
+        assert _marker_files(tmp_path) == [], (
+            f"{label}: a non-dict handoff ({kind}) must claim NO marker — a "
+            "marker means the isinstance(dict) type gate is missing or runs "
+            "AFTER already_emitted (orphaned-marker poison, M1)."
+        )
+        assert calls == [], (
+            f"{label}: a non-dict handoff ({kind}) must write no event."
         )
 
 


### PR DESCRIPTION
## Summary

Closes the #917 "0 agent_handoff events" bug and the #812 discriminator empirical-audit. Ships as **v4.4.10** (PATCH — internal-correctness fix + additive audit closures).

## What landed

**#917 — agent_handoff marker-poisoning fix** (`e8a1bd85`, `dfce22b8`, `57ba8116`)
- **Root cause** (confirmed live + byte-matched fixtures): *claim-without-write marker poisoning*. The b1 (`agent_handoff_emitter` / TaskCompleted) and b2 (`task_lifecycle_gate` / lead PostToolUse-TaskUpdate-completed) emit paths share one optimistic `O_EXCL` dedup marker created **before** `append_event`. A teammate-process b1 fire resolves a stdin `team_name` (claims the marker) but its unpersisted session context (#877) makes `get_journal_path()==''` → the append fails → the marker is poisoned → the lead's reliable b2 emit is suppressed at `already_emitted()` → **0 events**.
- **Fix**: gate the marker-claim on `get_journal_path()` writability in both emit paths; a non-writable fire **defers** instead of poisoning. The gate is a pure read placed before the sole `O_EXCL` test-and-set, so a writable fire behaves byte-identically to before and the exactly-once mark-then-write semantics are unchanged. Discriminator is **journal-writability, not `is_lead`** (`is_lead` is empirically confirmed correct and untouched).
- **Tests**: new writability-parity test (RED-on-revert proven non-vacuous) + a captured-fixture defer-then-emit **sequence** regression on real frames with naturally-resolved writability.

**#812 — discriminator empirical audit** (`62e71c9b`)
- **Verdict**: `is_lead()` is empirically correct on every event it gates; `agent_type` value-membership is the universal discriminator (the issue's original 4 named helpers were consolidated into one resolver). Closures: empirical-capture provenance on the `is_lead` docstring; bootstrap-gate docstrings corrected to "plain-session guard, not teammate discriminator" (no teammate UserPromptSubmit fire path exists); synthetic stdin fixtures replaced with **real captured frames** (retires the synthetic `userpromptsubmit_stdin_post_bootstrap.json`); new per-event discriminator reference doc (`hooks/shared/HOOK_STDIN_DISCRIMINATORS.md`).

## Why

The b2 lead-side emit (v4.4.4) was meant to make `agent_handoff` journal coverage deterministic, but a split-source dedup-marker race silently defeated it (0/7 handoffs emitted last session). This restores reliable emission. The bug was reproduced **live, in-session** (the orchestration's own machinery exhibited #917 on a real task completion), and the captured frames byte-match the test fixtures.

## Verification

- Full suite: **8064 passed / 13 skipped / 0 failed**.
- Fix non-vacuity proven by source-revert (isolated worktree); independent masking check confirms the keep-green test-harness modeling is faithful, not regression-masking.
- Concurrent auditor: **GREEN**.
