### PR TITLE
fix(#923): resolve get_task_list by team_name — kill the inert hook bug class (v4.4.12)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.11",
+      "version": "4.4.12",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.11/      # Plugin version
+│               └── 4.4.12/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.11",
+  "version": "4.4.12",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.11
+> **Version**: 4.4.12
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/shared/task_utils.py
+++ b/pact-plugin/hooks/shared/task_utils.py
@@ -4,9 +4,11 @@ Summary: Shared Task system integration utilities for PACT hooks.
 Used by: session_init.py, agent_handoff_emitter.py
 
 This module provides common functions for reading and analyzing Tasks from
-the Claude Task system. Tasks are stored at ~/.claude/tasks/{sessionId}/*.json
-and survive context compaction, making them the primary state source for
-workflow recovery.
+the Claude Task system. Tasks live under one of two storage topologies, keyed
+on a structural signal (team_name): a TEAM session stores tasks at
+~/.claude/tasks/{team_name}/*.json, a SOLO/no-team session at
+~/.claude/tasks/{session_id}/*.json. They survive context compaction, making
+them the primary state source for workflow recovery.
 
 Functions:
     get_task_list: Read all tasks from the Task system
@@ -25,20 +27,47 @@ import re
 from pathlib import Path
 from typing import Any, Iterator
 
-from shared.pact_context import get_session_id
+from shared.pact_context import get_session_id, get_team_name
 from shared.session_state import is_safe_path_component
 
 
-def get_task_list() -> list[dict[str, Any]] | None:
+def get_task_list(tasks_base_dir: str | None = None) -> list[dict[str, Any]] | None:
     """
     Read TaskList from the Claude Task system.
 
-    Tasks are stored at ~/.claude/tasks/{sessionId}/*.json and survive compaction.
-    This function reads directly from the filesystem since hooks cannot call Task tools.
+    Two live storage topologies, keyed on a structural signal (team_name):
+      - TEAM session -> tasks under ~/.claude/tasks/{team_name}/   (Agent Teams)
+      - SOLO session -> tasks under ~/.claude/tasks/{session_id}/  (no team)
+    team_name is mode-independent (resolves identically under in-process and
+    tmux), so the team branch needs no teammateMode detection. This function
+    reads directly from the filesystem since hooks cannot call Task tools.
+
+    Args:
+        tasks_base_dir: Override for the ~/.claude/tasks base dir (testing only;
+            production default None resolves the real home path). Mirrors the
+            institutional test seam in _read_task_counts / read_task_json.
 
     Returns:
         List of task dicts, or None if tasks unavailable
     """
+    # TEAM branch (the team-dir resolution fix): a team session stores tasks
+    # under {team_name}, NOT the bare session_id. Reuse the path-traversal-safe
+    # SSOT reader. An empty/absent team dir returns None and MUST NOT fall
+    # through to the solo session_id dir: a team session with no tasks yet is
+    # still a team session (branch key = "is this a team session?", not "did the
+    # team dir have tasks?"). The return lives INSIDE the `if` to guarantee that
+    # invariant — control never reaches the solo branch when team_name is truthy.
+    team_name = get_team_name()
+    if team_name:
+        tasks = list(iter_team_task_jsons(team_name, tasks_base_dir=tasks_base_dir))
+        return tasks if tasks else None
+
+    # SOLO / no-team branch: the existing resolution, preserved. The
+    # CLAUDE_CODE_TASK_LIST_ID-or-session_id key choice and the raw glob are kept
+    # verbatim — the env var is user-controlled and may hold a value the
+    # validated team reader would reject, so the solo path is deliberately NOT
+    # routed through iter_team_task_jsons. Only the base root is parameterized
+    # (for the test seam); resolution semantics are unchanged from before.
     session_id = get_session_id()
     # Also check for multi-session task list ID
     task_list_id = os.environ.get("CLAUDE_CODE_TASK_LIST_ID", session_id)
@@ -46,7 +75,8 @@ def get_task_list() -> list[dict[str, Any]] | None:
     if not task_list_id:
         return None
 
-    tasks_dir = Path.home() / ".claude" / "tasks" / task_list_id
+    base = Path(tasks_base_dir) if tasks_base_dir else (Path.home() / ".claude" / "tasks")
+    tasks_dir = base / task_list_id
     if not tasks_dir.exists():
         return None
 
@@ -267,7 +297,10 @@ def build_post_compaction_checkpoint(
     return "\n".join(lines)
 
 
-def iter_team_task_jsons(team_name: str) -> Iterator[dict]:
+def iter_team_task_jsons(
+    team_name: str,
+    tasks_base_dir: str | None = None,
+) -> Iterator[dict]:
     """
     Yield parsed task JSON dicts from ~/.claude/tasks/{team_name}/*.json.
 
@@ -278,6 +311,14 @@ def iter_team_task_jsons(team_name: str) -> Iterator[dict]:
         separators, controls, whitespace).
       - tasks_root resolved once; team_dir resolved and asserted under
         tasks_root via relative_to (symlink-escape defense).
+
+    Args:
+        team_name: Team identifier; the {team_name} path component.
+        tasks_base_dir: Override for the ~/.claude/tasks base dir (testing
+            only; production default None resolves the real home path). The
+            symlink-escape relative_to assertion still anchors to this base,
+            so the path-traversal defense holds for any base. Mirrors the
+            institutional test seam in _read_task_counts / read_task_json.
 
     Pure generator; never raises. Yields nothing on any error
     (unsafe team_name, missing dir, symlink escape, IO error). Individual
@@ -291,7 +332,8 @@ def iter_team_task_jsons(team_name: str) -> Iterator[dict]:
     if not is_safe_path_component(team_name):
         return
     try:
-        tasks_root = (Path.home() / ".claude" / "tasks").resolve()
+        base = Path(tasks_base_dir) if tasks_base_dir else (Path.home() / ".claude" / "tasks")
+        tasks_root = base.resolve()
     except OSError:
         return
     team_dir = tasks_root / team_name

--- a/pact-plugin/hooks/shared/task_utils.py
+++ b/pact-plugin/hooks/shared/task_utils.py
@@ -66,14 +66,16 @@ def get_task_list(tasks_base_dir: str | None = None) -> list[dict[str, Any]] | N
 
     # SOLO / no-team branch: the CLAUDE_CODE_TASK_LIST_ID-or-session_id key
     # choice is preserved, and the dir is read by this branch's own direct glob
-    # (NOT routed through iter_team_task_jsons) — but with the SAME path-safety
-    # defenses applied INLINE: is_safe_path_component on the name (F2 guard
-    # below), a resolve/relative_to base-anchor on the dir, and a per-file
-    # is_symlink skip (R3). The solo branch is therefore NOT raw/unvalidated: it
-    # has defense PARITY with the team branch (component-validation + anchor +
-    # symlink-skip), just implemented inline. Surgical-inline duplication (NOT a
-    # shared-helper refactor) is the accepted trade-off to avoid touching the
-    # working/tested team path. Only the base root is parameterized (test seam).
+    # (NOT routed through iter_team_task_jsons) — but with the SAME FIVE
+    # path-safety + content-hygiene defenses applied INLINE, in FULL PARITY with
+    # the team branch (iter_team_task_jsons): (1) is_safe_path_component on the
+    # name (F2 guard below), (2) a resolve/relative_to base-anchor on the dir,
+    # (3) a per-file is_symlink skip, (4) a dotfile-prefixed-file skip, and
+    # (5) an isinstance(dict) parse guard. The solo branch is therefore NOT
+    # raw/unvalidated: it has FULL 5/5 defense parity with the team branch, just
+    # implemented inline. Surgical-inline duplication (NOT a shared-helper
+    # refactor) is the accepted trade-off to avoid touching the working/tested
+    # team path. Only the base root is parameterized (test seam).
     session_id = get_session_id()
     # Also check for multi-session task list ID
     task_list_id = os.environ.get("CLAUDE_CODE_TASK_LIST_ID", session_id)
@@ -116,6 +118,12 @@ def get_task_list(tasks_base_dir: str | None = None) -> list[dict[str, Any]] | N
     tasks = []
     try:
         for task_file in tasks_dir.glob("*.json"):
+            # R4 (hygiene parity): skip dotfile-prefixed JSON. pathlib glob
+            # INCLUDES them, but the platform task system never writes them; an
+            # attacker dropping one into the user's own tasks dir could otherwise
+            # inflate the task count. Mirrors the team branch's dotfile skip.
+            if task_file.name.startswith("."):
+                continue
             # R3 (security): skip a *.json that is a SYMLINK — it could point
             # outside the tasks base. Mirrors the team branch's per-file
             # is_symlink skip; real task files are regular files, unaffected.
@@ -127,6 +135,12 @@ def get_task_list(tasks_base_dir: str | None = None) -> list[dict[str, Any]] | N
             try:
                 content = task_file.read_text(encoding='utf-8')
                 task = json.loads(content)
+                # R4 (hygiene parity): skip a parse that is not a dict (e.g.
+                # [1,2,3]/42/"x" from a malformed-but-valid JSON). Mirrors the
+                # team branch's isinstance(dict) yield-guard; downstream readers
+                # (find_feature_task etc.) call .get() and need a dict.
+                if not isinstance(task, dict):
+                    continue
                 tasks.append(task)
             except (IOError, json.JSONDecodeError):
                 continue

--- a/pact-plugin/hooks/shared/task_utils.py
+++ b/pact-plugin/hooks/shared/task_utils.py
@@ -1,7 +1,9 @@
 """
 Location: pact-plugin/hooks/shared/task_utils.py
 Summary: Shared Task system integration utilities for PACT hooks.
-Used by: session_init.py, agent_handoff_emitter.py
+Used by: PACT lifecycle/wake hooks (via get_task_list), the lifecycle gate
+and handoff machinery (via read_task_json), and dispatch helpers (via
+iter_team_task_jsons).
 
 This module provides common functions for reading and analyzing Tasks from
 the Claude Task system. Tasks live under one of two storage topologies, keyed
@@ -62,17 +64,33 @@ def get_task_list(tasks_base_dir: str | None = None) -> list[dict[str, Any]] | N
         tasks = list(iter_team_task_jsons(team_name, tasks_base_dir=tasks_base_dir))
         return tasks if tasks else None
 
-    # SOLO / no-team branch: the existing resolution, preserved. The
-    # CLAUDE_CODE_TASK_LIST_ID-or-session_id key choice and the raw glob are kept
-    # verbatim — the env var is user-controlled and may hold a value the
-    # validated team reader would reject, so the solo path is deliberately NOT
-    # routed through iter_team_task_jsons. Only the base root is parameterized
-    # (for the test seam); resolution semantics are unchanged from before.
+    # SOLO / no-team branch: the CLAUDE_CODE_TASK_LIST_ID-or-session_id key
+    # choice and the raw glob are preserved — the solo path keeps its own glob
+    # rather than being routed through iter_team_task_jsons (it does NOT adopt
+    # that reader's resolve/relative_to/symlink pipeline). Only the base root is
+    # parameterized (test seam); the user-controlled task_list_id is now
+    # validated via is_safe_path_component before use — symmetric with the team
+    # branch (see the F2 guard below) — so a traversal value is rejected.
     session_id = get_session_id()
     # Also check for multi-session task list ID
     task_list_id = os.environ.get("CLAUDE_CODE_TASK_LIST_ID", session_id)
 
     if not task_list_id:
+        return None
+
+    # F2 (security): task_list_id is USER-CONTROLLED via the
+    # CLAUDE_CODE_TASK_LIST_ID env var, then used as a path component. Validate
+    # it with the same positive allowlist the team branch already applies to
+    # team_name (is_safe_path_component, inside iter_team_task_jsons) so a
+    # traversal value ("../secret") cannot escape the tasks base and read *.json
+    # outside it. Legitimate task-list IDs (pact-<slug>, UUIDs, multi-session
+    # pointers) are single [A-Za-z0-9_-] components and pass unchanged — no solo
+    # behavior change for real inputs (the env var must name a ~/.claude/tasks/
+    # dir, which the platform generates within that alphabet). Validating BEFORE
+    # the path-join also rejects an embedded-NUL value before the .exists() call
+    # (which could otherwise raise ValueError on some Python versions). Fail
+    # CLOSED (return None) to preserve the None-on-unavailable contract.
+    if not is_safe_path_component(task_list_id):
         return None
 
     base = Path(tasks_base_dir) if tasks_base_dir else (Path.home() / ".claude" / "tasks")

--- a/pact-plugin/hooks/shared/task_utils.py
+++ b/pact-plugin/hooks/shared/task_utils.py
@@ -65,12 +65,15 @@ def get_task_list(tasks_base_dir: str | None = None) -> list[dict[str, Any]] | N
         return tasks if tasks else None
 
     # SOLO / no-team branch: the CLAUDE_CODE_TASK_LIST_ID-or-session_id key
-    # choice and the raw glob are preserved — the solo path keeps its own glob
-    # rather than being routed through iter_team_task_jsons (it does NOT adopt
-    # that reader's resolve/relative_to/symlink pipeline). Only the base root is
-    # parameterized (test seam); the user-controlled task_list_id is now
-    # validated via is_safe_path_component before use — symmetric with the team
-    # branch (see the F2 guard below) — so a traversal value is rejected.
+    # choice is preserved, and the dir is read by this branch's own direct glob
+    # (NOT routed through iter_team_task_jsons) — but with the SAME path-safety
+    # defenses applied INLINE: is_safe_path_component on the name (F2 guard
+    # below), a resolve/relative_to base-anchor on the dir, and a per-file
+    # is_symlink skip (R3). The solo branch is therefore NOT raw/unvalidated: it
+    # has defense PARITY with the team branch (component-validation + anchor +
+    # symlink-skip), just implemented inline. Surgical-inline duplication (NOT a
+    # shared-helper refactor) is the accepted trade-off to avoid touching the
+    # working/tested team path. Only the base root is parameterized (test seam).
     session_id = get_session_id()
     # Also check for multi-session task list ID
     task_list_id = os.environ.get("CLAUDE_CODE_TASK_LIST_ID", session_id)
@@ -95,12 +98,32 @@ def get_task_list(tasks_base_dir: str | None = None) -> list[dict[str, Any]] | N
 
     base = Path(tasks_base_dir) if tasks_base_dir else (Path.home() / ".claude" / "tasks")
     tasks_dir = base / task_list_id
+
+    # R3 (security): the {task_list_id} dir could itself be a SYMLINK that
+    # escapes the tasks base. is_safe_path_component (above) rejects '../' in the
+    # NAME, but not a safe-NAME dir that resolves out-of-base via a symlink.
+    # Mirror the team branch's anchor (iter_team_task_jsons): resolve the dir and
+    # assert it stays under the resolved base. A legit (non-symlink) dir resolves
+    # to itself and passes unchanged; only an escaping symlink-dir is rejected.
+    try:
+        tasks_dir.resolve().relative_to(base.resolve())
+    except (OSError, ValueError):
+        return None
+
     if not tasks_dir.exists():
         return None
 
     tasks = []
     try:
         for task_file in tasks_dir.glob("*.json"):
+            # R3 (security): skip a *.json that is a SYMLINK — it could point
+            # outside the tasks base. Mirrors the team branch's per-file
+            # is_symlink skip; real task files are regular files, unaffected.
+            try:
+                if task_file.is_symlink():
+                    continue
+            except OSError:
+                continue
             try:
                 content = task_file.read_text(encoding='utf-8')
                 task = json.loads(content)

--- a/pact-plugin/tests/runbooks/923-missed-wake-live-probe.md
+++ b/pact-plugin/tests/runbooks/923-missed-wake-live-probe.md
@@ -1,0 +1,126 @@
+# Runbook: Missed-Wake Surfacer Live-Probe Acceptance Gate (#923)
+
+**Purpose:** the post-merge acceptance gate for the `get_task_list` team-dir
+resolution fix. The fix repairs two hooks that shipped INERT under Agent Teams
+(`missed_wake_scan` and `teammate_idle`). A green test suite is **necessary but
+NOT sufficient** to close #923 — the v4.4.11 cycle proved that a fully-mocked
+suite (and review, and an architect design-verify) can all be green over a
+feature that never fires in live operation, because they operate on
+mocked/stubbed task input. **Only a live probe confirms the hook actually FIRES
+in a real Agent-Teams session.** This runbook defines that probe.
+
+> Why static verification structurally cannot replace this: the broken seam was
+> `get_team_name() → ~/.claude/tasks/{team_name}/ → glob`. Every prior unit test
+> stubbed `get_task_list` or fed tasks straight to the predicate, so the one
+> broken seam was the one every test bypassed. The non-mocked integration suite
+> (`tests/test_missed_wake_scan_integration.py`) closes the static gap; this
+> live probe closes the residual "does it fire in a real process?" gap.
+
+---
+
+## §1 — Acceptance criterion (NOT closed on green tests alone)
+
+#923 is closed only when BOTH hold:
+
+1. The non-mocked integration suite is green AND its non-vacuity gate FAILS on a
+   source-revert of the resolver fix (see `test_missed_wake_scan_integration.py`
+   module docstring — expected cardinality `{3 failed, 15 deselected}` on
+   `-k non_vacuity_gate` against pre-fix `task_utils.py`).
+2. This live probe passes in **both** teammateModes:
+   - **tmux = MANDATORY real live-probe** (the dominant mode + where the bug
+     bit hardest; N separate processes, N:1 session→team).
+   - **in-process = real preferred; faithful-synthetic fallback acceptable** (1
+     process per team). The synthetic fallback drives a real team-dir on disk +
+     a real `is_lead` UserPromptSubmit frame in a live session — equivalent to
+     the integration test but executed in a running process rather than pytest.
+
+---
+
+## §2 — Live-probe procedure (per mode)
+
+Run once per mode. Record the results in `RUNBOOK_RUN_DATES.md`.
+
+**Setup.** Start a real PACT session in the target mode; let it create a team
+(`team_name = pact-<uuid8>`). Confirm tasks persist at
+`~/.claude/tasks/{team_name}/*.json` (NOT `~/.claude/tasks/{bare-session_id}/`).
+
+**Step 1 — induce a stranded wait.** Have a teammate set
+`metadata.intentional_wait = {reason:"awaiting_lead_completion",
+expected_resolver:"lead", since:<now>}` on its in-progress task and idle (the
+canonical missed-wake: the teammate is waiting for the lead's completion + paired
+wake-SendMessage).
+
+**Step 2 — cross the staleness threshold.** Back-date the task JSON's
+`intentional_wait.since` to **> 30 min** ago (edit the file directly), or wait
+out the real 30-min `wait_stale()` window.
+
+**Step 3 — trigger the lead surface.** Take a lead turn (any
+`UserPromptSubmit`) — or start a new session (`SessionStart`). The
+`missed_wake_scan` hook fires on the lead's process.
+
+**Step 4 — OBSERVE (the gate):**
+- **(a) SURFACE:** the lead's turn-start `additionalContext` carries the
+  `PACT missed-wake alarm:` notice naming the stranded teammate + task id +
+  subject + age + the corrective action.
+- **(b) FORENSIC:** **exactly one** `missed_wake` event lands in the real
+  `~/.claude/pact-sessions/{slug}/{session_id}/session-journal.jsonl`
+  (`grep '"type":"missed_wake"'`).
+- **(c) PERSISTENT + DEDUP:** a second lead turn while still stale RE-SHOWS the
+  surface (no surface dedup) but writes **NO 2nd** journal event
+  (once-per-`(task_id, since)`).
+- **(d) AUTO-CLEAR:** resolve the wait (lead sends the wake / completes or
+  re-sets the task) → next lead turn → the surface is GONE (`suppressOutput`),
+  no new event.
+
+**Step 5 — teammate_idle companion probe (the 2nd live bug).** Let a teammate
+idle past the idle threshold. Confirm `teammate_idle` now FIRES: the
+idle-count escalation → shutdown suggestion → `shutdown_request` path runs
+(pre-fix it no-op'd because arg-less `get_task_list()` returned `None`). Observe
+the idle-cleanup message reaches the lead.
+
+**Step 6 — CONTINGENCY tripwire (defense-in-depth).** While probing, confirm
+`CLAUDE_CODE_TASK_LIST_ID` is **unset** in the team-session hook env
+(`env | grep CLAUDE_CODE_TASK_LIST_ID` from the hook context, or inspect the
+captured stdin). devops's CODE-phase grep confirmed it is never platform-set in
+a team context; under Design A (team-first) that env var is consulted ONLY in
+the solo branch. **If it is empirically SET to anything in a team session,
+HALT and escalate to the architect** — Design A and the rejected Design B
+(strict-honor) would diverge for real sessions (devops contingency C), and the
+`team × TASK_LIST_ID=SID` matrix cell would need re-derivation.
+
+**PASS** = (a)+(b)+(c)+(d)+Step 5 all hold in the mode under test, and Step 6
+finds `CLAUDE_CODE_TASK_LIST_ID` unset. tmux PASS is mandatory; in-process PASS
+may use the faithful-synthetic fallback.
+
+---
+
+## §3 — Per-caller audit (#551 inert-class candidates)
+
+`get_task_list` has **4 production callers**, all previously resolving by the
+broken `session_id` key. The GLOBAL fix repairs all four with zero call-site
+edits. Recommended non-mocked test coverage, **priority by blast radius**:
+
+| # | Caller | Severity under Agent Teams (pre-fix) | Own non-mocked test? | Test shape |
+|---|--------|--------------------------------------|----------------------|------------|
+| 1 | `missed_wake_scan.py:274` | **INERT** — alarm never fires (the #923 subject) | **DONE** — `test_missed_wake_scan_integration.py` IT-1/IT-2 | `run_surface` e2e via `Path.home` redirect + real team dir → surfaces + 1 journal event |
+| 2 | `teammate_idle.py:316` | **INERT** — idle-cleanup + auto-shutdown nudge dead (2nd live bug) | **SMOKE DONE** (IT-6); fuller e2e RECOMMENDED | arg-less `get_task_list()` resolves the team dir → `check_idle_cleanup` escalation path runs |
+| 3 | `session_init.py:1211` | **PARTIAL** — post-compaction checkpoint degrades to the bootstrap safety-net | RECOMMENDED (medium) | build the post-compaction checkpoint from a real team dir → `find_feature_task`/`current_phase`/`active_agents` non-empty |
+| 4 | `session_end.py:837` | **MINOR** — only the secondary untracked-PR scan lost (primary PR-unpause path still fires via journal) | OPTIONAL (low) | `check_unpaused_pr` reads a real team dir for the secondary scan |
+
+**Key framing:** callers 3 & 4 are already REPAIRED by the GLOBAL fix — their
+own non-mocked tests would be **regression-pinning** coverage (prevent a future
+re-break), not bug-discovery. The two INERT *alarms* (1 & 2) are the
+mandatory live-probe targets above. `dispatch_helpers.has_task_assigned` uses
+the CORRECT `iter_team_task_jsons(team_name)` already — it is the reference
+pattern, NOT a candidate. Staging the caller-3/4 regression tests as a fast
+follow-up after this PR is acceptable.
+
+---
+
+## §4 — Sections-passed denominator
+
+Denominator = **2** (tmux live-probe; in-process live-probe). Each must satisfy
+all of §2 (a)+(b)+(c)+(d)+Step 5 with the Step 6 tripwire clear. Record per-mode
+PASS/FAIL in `RUNBOOK_RUN_DATES.md`. If tmux is RED, do **not** declare #923
+closed — re-open and route back to the resolver. If only in-process is feasible
+this cycle, record tmux as `pending` and close only after the tmux probe lands.

--- a/pact-plugin/tests/runbooks/RUNBOOK_RUN_DATES.md
+++ b/pact-plugin/tests/runbooks/RUNBOOK_RUN_DATES.md
@@ -41,6 +41,14 @@ Sections-passed denominator is 4 per runbook §5 (§1, §2, §3, §4). The inlin
 
 Sections-passed denominator is 3 per runbook (standard-teammate first-action; secretary register-before-briefing; registry-non-empty assertion). The inline-mission mode column does not apply (`n/a`). Unlike the post-merge runbooks above, this is a **PRE-merge overlay smoke** — the empirical gate the LEG-4 NO-GO requires before this PR merges. If any section is RED, apply an architecture-doc §8.6 contingency and do **not** merge. The overlay revert (§Step 5) is mandatory regardless of outcome.
 
+## 923-missed-wake-live-probe.md
+
+| Run date (UTC) | Operator | Plugin version | Sections passed | inline-mission mode | Notes / per-mode observations |
+| -------------- | -------- | -------------- | --------------- | ------------------- | -------------------------------- |
+| _pending — execute POST-merge in fresh sessions (tmux mandatory; in-process real-or-synthetic)_ | | | /2 | n/a | tmux live-probe: SURFACE (§2a) PASS/FAIL · FORENSIC exactly-one (§2b) PASS/FAIL · PERSISTENT+DEDUP (§2c) PASS/FAIL · AUTO-CLEAR (§2d) PASS/FAIL · teammate_idle 2nd-bug fires (§2 Step 5) PASS/FAIL · CONTINGENCY tripwire CLAUDE_CODE_TASK_LIST_ID unset (§2 Step 6) PASS/FAIL. in-process live-probe: same six (real preferred / faithful-synthetic fallback). |
+
+Sections-passed denominator is 2 per runbook §4 (tmux live-probe; in-process live-probe), each gated on all of §2 (a)+(b)+(c)+(d)+Step 5 with the Step 6 tripwire clear. The inline-mission mode column does not apply (`n/a`). Unlike a pre-merge overlay smoke, this is the **POST-merge acceptance gate** — a green suite does NOT close #923; the tmux live-probe is mandatory. If tmux is RED, re-open and route back to the resolver. If the Step 6 tripwire finds `CLAUDE_CODE_TASK_LIST_ID` SET in a team session, HALT + architect escalation (Design A/B divergence, devops contingency C).
+
 ## v4.0.0-launch-and-isolation.md
 
 | Run date (UTC) | Operator | Plugin version | Sections passed | Notes / fallback-ladder signals |

--- a/pact-plugin/tests/test_missed_wake_scan_integration.py
+++ b/pact-plugin/tests/test_missed_wake_scan_integration.py
@@ -1,0 +1,380 @@
+"""
+Location: pact-plugin/tests/test_missed_wake_scan_integration.py
+Summary: NON-MOCKED integration coverage for the get_task_list team-dir
+         resolution fix — the one seam EVERY prior test stubbed, which let the
+         missed-wake surfacer ship INERT through a fully-green unit suite. The
+         sibling unit file (test_missed_wake_scan.py) pins the pure predicate /
+         build / emit behavior with a mocked journal + synthetic task lists;
+         THIS file drives the REAL get_team_name -> team-dir -> glob resolution
+         end-to-end so a re-inert resolver can never again pass green.
+
+Used by: the pact-plugin test suite (standing both-modes / inert-class merge gate).
+
+================================ ANTI-MOCK INVARIANT ===========================
+The tests here MUST NOT monkeypatch get_task_list / iter_team_task_jsons /
+find_stale_missed_wakes. The real get_team_name -> team-dir -> glob resolution
+IS the seam under test — mocking it reproduces the exact gap that shipped the
+surfacer inert (a green suite over a dead feature). The ONLY test doubles
+permitted are filesystem redirection (Path.home + the additive tasks_base_dir
+seam) and the deterministic `since` offset. If a future edit stubs the
+resolver here, it has re-opened the bug.
+
+============================ NON-VACUITY (un-mock-then-revert) =================
+The two disciplines are SEQUENTIAL, not redundant:
+  1. UN-MOCK the seam (these tests already do) -> closes the integration-seam
+     gap. (A revert on a still-MOCKED test catches NOTHING — that is the exact
+     trap that shipped the surfacer inert through ~50 mocked tests.)
+  2. THEN source-only revert the resolver fix and confirm the gate tests FAIL.
+
+Procedure (run from the worktree pact-plugin/ dir):
+    git checkout <fix-sha>^ -- hooks/shared/task_utils.py   # restore pre-fix resolver
+    python -m pytest tests/test_missed_wake_scan_integration.py -k non_vacuity_gate
+    #   EXPECTED: FAIL — pre-fix arg-less get_task_list() reads
+    #   ~/.claude/tasks/{session_id}/ (absent under Agent Teams) -> None ->
+    #   run_surface returns None / no journal event.
+    git checkout <fix-sha> -- hooks/shared/task_utils.py     # restore the fix
+    python -m pytest tests/test_missed_wake_scan_integration.py # all green again
+
+Expected cardinality on the source-revert: the NON-VACUITY GATE SET
+(TestRunSurfaceEndToEnd + TestForensicEmitRealJournal + the teammate_idle
+smoke) FAILS; they drive the ARG-LESS get_task_list() via a Path.home redirect
+and reference NO post-fix-only symbol, so the revert is a clean behavioral
+failure (None), not a TypeError artifact. The tasks_base_dir-seam tests
+(TestResolverMatrix, TestEmptyTeamDirInvariant, TestSoloBranchResolver) are
+post-fix-coupled BY CONSTRUCTION (the param did not exist pre-fix) and are NOT
+part of the revert set — the arg-less gate tests carry the non-vacuity proof.
+
+assertion-vacuity = "right path, toothless check" -> caught by revert/mutation.
+integration-seam gap (this case) = "real check, WRONG path — the mock bypassed
+the broken wiring" -> caught by UN-MOCKING the seam, not by revert alone.
+================================================================================
+"""
+import io
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import missed_wake_scan as mw  # noqa: E402
+import teammate_idle  # noqa: E402
+from shared import task_utils  # noqa: E402
+from shared.session_journal import read_events  # noqa: E402
+from fixtures.role_frames import (  # noqa: E402
+    captured_lead_userpromptsubmit_qualified,
+    captured_plain_userpromptsubmit,
+    captured_teammate_sessionstart,
+)
+
+# A valid Agent-Teams team name (pact-<slug>; lowercased by get_team_name,
+# hyphen-safe per is_safe_path_component — mirrors the real pact-<uuid8> shape).
+TEAM = "pact-testteam"
+# Models the in-process topology: the lead's own session_id (== leadSessionId).
+LEAD_SID = "aaaaaaaa-1111-2222-3333-444444444444"
+# Models the tmux topology: a teammate session_id that != leadSessionId.
+OTHER_SID = "bbbbbbbb-5555-6666-7777-888888888888"
+PROJECT_DIR = "/test/project"
+
+STALE = 60   # minutes past -> beyond the 30-min staleness threshold
+FRESH = 5    # minutes past -> below the threshold
+
+
+def _since(minutes_ago: int) -> str:
+    """ISO-8601 UTC `since` at a fixed offset from real now (positive = past)."""
+    return (datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)).isoformat()
+
+
+def _write_task(
+    tasks_dir: Path,
+    task_id: str = "42",
+    owner: str = "test-engineer",
+    subject: str = "do the thing",
+    status: str = "in_progress",
+    reason: str = "awaiting_lead_completion",
+    minutes_ago: int = STALE,
+    with_wait: bool = True,
+) -> dict:
+    """Write a REAL task JSON file into `tasks_dir` (created if absent). Mirrors
+    the platform's task-file shape so the real resolver parses it verbatim."""
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    meta: dict = {}
+    if with_wait:
+        meta["intentional_wait"] = {
+            "reason": reason,
+            "expected_resolver": "lead",
+            "since": _since(minutes_ago),
+        }
+    task = {
+        "id": task_id,
+        "owner": owner,
+        "subject": subject,
+        "status": status,
+        "metadata": meta,
+    }
+    (tasks_dir / f"{task_id}.json").write_text(json.dumps(task), encoding="utf-8")
+    return task
+
+
+class _LiveEnv:
+    """Handle returned by the live_task_env fixture. Exposes the redirected
+    tasks root + a `configure` to (re)point the pact_context, with NO resolver
+    mocked."""
+
+    def __init__(self, home: Path, pact_context_factory):
+        self.home = home
+        self.tasks_root = home / ".claude" / "tasks"
+        self._pact_context = pact_context_factory
+
+    def configure(self, team_name: str = TEAM, session_id: str = LEAD_SID,
+                  project_dir: str = PROJECT_DIR) -> None:
+        """Point the real pact_context at this team/session. get_team_name() /
+        get_session_id() resolve from here; the autouse reset clears the cache
+        so a re-configure mid-test re-reads."""
+        self._pact_context(team_name=team_name, session_id=session_id,
+                           project_dir=project_dir)
+
+    def dir_for(self, name: str) -> Path:
+        return self.tasks_root / name
+
+
+@pytest.fixture
+def live_task_env(tmp_path, monkeypatch, pact_context):
+    """Redirect Path.home -> a tmp home and expose a real-resolver task env.
+
+    Path.home is the ONLY task-storage indirection production has (the arg-less
+    get_task_list() / iter_team_task_jsons() resolve ~/.claude/tasks via
+    Path.home, and the journal resolves ~/.claude/pact-sessions via Path.home),
+    so redirecting it lets run_surface exercise the REAL resolver end-to-end
+    with no stub. The conftest `pact_context` factory configures team_name /
+    session_id / project_dir (patches _context_path directly, independent of
+    Path.home). Defaults to a TEAM session; call .configure(...) to vary it.
+    """
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    env = _LiveEnv(tmp_path, pact_context)
+    env.configure()  # default team session
+    return env
+
+
+# ===========================================================================
+# IT-1 — run_surface END-TO-END through the REAL team-dir resolver
+#   NON-VACUITY GATE. Path.home redirect; arg-less get_task_list(); NO stub.
+# ===========================================================================
+class TestRunSurfaceEndToEnd:
+    """The test that would have caught the inert surfacer: a real team-dir on
+    disk -> run_surface drives the real get_team_name -> team-dir -> glob
+    resolution and surfaces. FAILS against the pre-fix resolver (source-revert)
+    because the arg-less get_task_list() reads the absent {session_id} dir."""
+
+    def test_non_vacuity_gate_lead_stale_team_task_surfaces(self, live_task_env):
+        _write_task(live_task_env.dir_for(TEAM), task_id="7", owner="architect",
+                    subject="design X", minutes_ago=STALE)
+        out = mw.run_surface(captured_lead_userpromptsubmit_qualified())
+        assert out is not None, (
+            "run_surface MUST surface a stale awaiting_lead_completion task that "
+            "lives in the REAL team dir — None here is the inert-surfacer bug"
+        )
+        assert "missed-wake" in out.lower()
+        assert "wake-SendMessage" in out, "must name the corrective action"
+        assert "#7" in out and "architect" in out and "design X" in out
+
+    def test_non_lead_frame_no_surface_even_with_stale_team_task(self, live_task_env):
+        # is_lead gate holds end-to-end: a plain frame no-ops regardless of a
+        # real stale team task (the resolver is reached only past the gate).
+        _write_task(live_task_env.dir_for(TEAM), task_id="7")
+        assert mw.run_surface(captured_plain_userpromptsubmit()) is None
+        assert mw.run_surface(captured_teammate_sessionstart()) is None
+
+    def test_fresh_team_task_below_threshold_no_surface(self, live_task_env):
+        # Real resolver returns the task, but it is not yet stale -> no surface.
+        _write_task(live_task_env.dir_for(TEAM), task_id="7", minutes_ago=FRESH)
+        assert mw.run_surface(captured_lead_userpromptsubmit_qualified()) is None
+
+    def test_no_team_tasks_no_surface(self, live_task_env):
+        # Team dir exists but empty -> get_task_list None -> run_surface None.
+        live_task_env.dir_for(TEAM).mkdir(parents=True, exist_ok=True)
+        assert mw.run_surface(captured_lead_userpromptsubmit_qualified()) is None
+
+
+# ===========================================================================
+# IT-2 — forensic emit against the REAL session journal
+#   NON-VACUITY GATE. Real append_event -> real read_events (no mock).
+# ===========================================================================
+class TestForensicEmitRealJournal:
+    """run_surface writes a real `missed_wake` event to the real
+    session-journal.jsonl (append_event mkdir -p's the session dir under the
+    redirected home). Asserts exactly one event, with the real schema, read
+    back via the real read_events. Pre-fix -> 0 events (resolver None)."""
+
+    def test_non_vacuity_gate_emits_exactly_one_missed_wake_event(self, live_task_env):
+        _write_task(live_task_env.dir_for(TEAM), task_id="7", owner="architect",
+                    subject="design X", minutes_ago=STALE)
+        out = mw.run_surface(captured_lead_userpromptsubmit_qualified())
+        assert out is not None, "precondition: the surface fired"
+        events = read_events("missed_wake")
+        assert len(events) == 1, (
+            "exactly one forensic missed_wake event must land in the REAL "
+            "journal; got %d" % len(events)
+        )
+        ev = events[0]
+        assert ev["type"] == "missed_wake"
+        assert ev["task_id"] == "7" and ev["agent"] == "architect"
+        assert ev["reason"] == "awaiting_lead_completion"
+        assert ev["task_subject"] == "design X"
+
+    def test_re_fire_while_stale_re_shows_but_no_second_event(self, live_task_env):
+        # PERSISTENT-while-stale surface + once-per-(task,since) forensic dedup,
+        # both driven through the REAL journal across two fires.
+        _write_task(live_task_env.dir_for(TEAM), task_id="7", minutes_ago=STALE)
+        out1 = mw.run_surface(captured_lead_userpromptsubmit_qualified())
+        out2 = mw.run_surface(captured_lead_userpromptsubmit_qualified())
+        assert out1 is not None and out2 is not None, "surface re-shows every fire while stale"
+        assert len(read_events("missed_wake")) == 1, (
+            "the forensic emit is once-per-(task_id,since) — the 2nd fire's "
+            "journal-read dedup suppresses a 2nd event"
+        )
+
+    def test_auto_clears_when_task_resolved(self, live_task_env):
+        # Stale -> surfaces + 1 event; then resolve (status flips) -> re-scan of
+        # the REAL dir finds nothing -> None, no new event. THE auto-clear.
+        team_dir = live_task_env.dir_for(TEAM)
+        _write_task(team_dir, task_id="7", minutes_ago=STALE)
+        assert mw.run_surface(captured_lead_userpromptsubmit_qualified()) is not None
+        # Resolve the task in the real dir (overwrite the file, status completed).
+        _write_task(team_dir, task_id="7", status="completed", with_wait=False)
+        assert mw.run_surface(captured_lead_userpromptsubmit_qualified()) is None
+        assert len(read_events("missed_wake")) == 1, "no new event after resolve"
+
+
+# ===========================================================================
+# IT-3 — 3-axis resolver matrix {mode} x {CLAUDE_CODE_TASK_LIST_ID}
+#   Uses the additive tasks_base_dir seam at the RESOLVER level (§5.3).
+# ===========================================================================
+class TestResolverMatrix:
+    """Design A (team-first additive): in a TEAM session team_name ALWAYS wins,
+    so get_task_list returns the team dir's tasks regardless of session_id
+    (mode-independence) AND regardless of CLAUDE_CODE_TASK_LIST_ID (it is
+    consulted ONLY in the solo branch).
+
+    Mask/unmask map (documented; the broken-code column is NOT executed — the
+    tasks_base_dir param did not exist pre-fix):
+        broken code fired ONLY at (CLAUDE_CODE_TASK_LIST_ID == TEAM) — every
+        other cell read the absent {session_id} dir and returned None (inert).
+        the FIX fires in ALL six team cells (team-first); TASK_LIST_ID is a
+        no-op in a team session.
+    """
+
+    @pytest.mark.parametrize("session_id", [LEAD_SID, OTHER_SID],
+                             ids=["in_process", "tmux"])
+    @pytest.mark.parametrize("task_list_id", [None, TEAM, LEAD_SID],
+                             ids=["TASK_LIST_ID_unset", "TASK_LIST_ID_eq_TEAM",
+                                  "TASK_LIST_ID_eq_SID"])
+    def test_team_session_always_resolves_team_dir(
+        self, live_task_env, monkeypatch, session_id, task_list_id,
+    ):
+        live_task_env.configure(team_name=TEAM, session_id=session_id)
+        # Real team task on disk.
+        _write_task(live_task_env.dir_for(TEAM), task_id="7", minutes_ago=STALE)
+        # A DECOY populated session_id dir — team-first must ignore it.
+        _write_task(live_task_env.dir_for(session_id), task_id="999",
+                    owner="decoy", minutes_ago=STALE)
+        if task_list_id is None:
+            monkeypatch.delenv("CLAUDE_CODE_TASK_LIST_ID", raising=False)
+        else:
+            monkeypatch.setenv("CLAUDE_CODE_TASK_LIST_ID", task_list_id)
+        tasks = task_utils.get_task_list(tasks_base_dir=str(live_task_env.tasks_root))
+        assert tasks is not None, "team session must resolve the team dir in every cell"
+        ids = {t["id"] for t in tasks}
+        assert ids == {"7"}, (
+            "team-first wins: only the team dir's task; the decoy session_id "
+            "task (#999) and TASK_LIST_ID=%r must NOT leak in. got %r"
+            % (task_list_id, ids)
+        )
+
+
+# ===========================================================================
+# IT-4 — empty-team-dir invariant (R4 correctness): NO fall-through
+#   Uses the tasks_base_dir seam at the RESOLVER level.
+# ===========================================================================
+class TestEmptyTeamDirInvariant:
+    """A team session (team_name truthy) with an empty/absent team dir returns
+    None — it MUST NOT fall through to a populated foreign session_id /
+    TASK_LIST_ID dir. The branch key is 'is this a team session?', not 'did the
+    team dir have tasks?'. (Structurally guaranteed by the return INSIDE the
+    `if team_name:` block; this formalizes it as a committed test.)"""
+
+    def test_empty_team_dir_returns_none_not_foreign_session(self, live_task_env):
+        # Team dir EXISTS but empty.
+        live_task_env.dir_for(TEAM).mkdir(parents=True, exist_ok=True)
+        # POPULATED foreign session_id dir that a fall-through would wrongly read.
+        _write_task(live_task_env.dir_for(LEAD_SID), task_id="999", owner="foreign")
+        tasks = task_utils.get_task_list(tasks_base_dir=str(live_task_env.tasks_root))
+        assert tasks is None, (
+            "empty team dir -> None; MUST NOT fall through to the populated "
+            "foreign session_id dir (got %r)" % (tasks,)
+        )
+
+    def test_absent_team_dir_returns_none_not_foreign_session(self, live_task_env, monkeypatch):
+        # Team dir ABSENT entirely; foreign session_id dir AND a TASK_LIST_ID
+        # dir both populated -> still None (no fall-through on either tier).
+        _write_task(live_task_env.dir_for(LEAD_SID), task_id="999", owner="foreign")
+        _write_task(live_task_env.dir_for("env-pointer-dir"), task_id="888", owner="envdecoy")
+        monkeypatch.setenv("CLAUDE_CODE_TASK_LIST_ID", "env-pointer-dir")
+        tasks = task_utils.get_task_list(tasks_base_dir=str(live_task_env.tasks_root))
+        assert tasks is None, (
+            "absent team dir -> None; neither the foreign session_id dir nor the "
+            "CLAUDE_CODE_TASK_LIST_ID dir may be read in a team session"
+        )
+
+
+# ===========================================================================
+# IT-5 — solo branch (team_name == "") resolver-tier behavior
+#   Asserts ONLY resolver behavior; does NOT assert any caller consumes solo
+#   tasks (per §5.3 — the invariant means no caller does; that would be dead).
+# ===========================================================================
+class TestSoloBranchResolver:
+    """When team_name=='' the existing solo body is preserved verbatim:
+    CLAUDE_CODE_TASK_LIST_ID-or-session_id keys the dir. TASK_LIST_ID matters
+    ONLY here. Resolver-tier assertions only."""
+
+    def test_solo_resolves_by_session_id_when_no_env(self, live_task_env, monkeypatch):
+        live_task_env.configure(team_name="", session_id=LEAD_SID)
+        monkeypatch.delenv("CLAUDE_CODE_TASK_LIST_ID", raising=False)
+        _write_task(live_task_env.dir_for(LEAD_SID), task_id="5", owner="solo")
+        tasks = task_utils.get_task_list(tasks_base_dir=str(live_task_env.tasks_root))
+        assert tasks is not None and {t["id"] for t in tasks} == {"5"}
+
+    def test_solo_task_list_id_overrides_session_id(self, live_task_env, monkeypatch):
+        live_task_env.configure(team_name="", session_id=LEAD_SID)
+        monkeypatch.setenv("CLAUDE_CODE_TASK_LIST_ID", "multi-session-pointer")
+        _write_task(live_task_env.dir_for("multi-session-pointer"), task_id="9", owner="ptr")
+        _write_task(live_task_env.dir_for(LEAD_SID), task_id="5", owner="solo")
+        tasks = task_utils.get_task_list(tasks_base_dir=str(live_task_env.tasks_root))
+        assert tasks is not None and {t["id"] for t in tasks} == {"9"}, (
+            "in a SOLO session CLAUDE_CODE_TASK_LIST_ID takes precedence over session_id"
+        )
+
+
+# ===========================================================================
+# IT-6 — teammate_idle 2nd-bug smoke (the GLOBAL fix repairs it for free)
+#   NON-VACUITY GATE (arg-less get_task_list via the shared resolver).
+# ===========================================================================
+class TestTeammateIdleResolvesTeamTasks:
+    """teammate_idle.main() guards `if not tasks: exit` at the arg-less
+    get_task_list() call (:316). Pre-fix that returned None under Agent Teams,
+    so the whole hook no-op'd (zombie-cleanup + auto-shutdown nudge dead).
+    Post-fix the arg-less call resolves the team dir, so the guard is passed.
+    This is a SMOKE on the shared resolver as teammate_idle invokes it."""
+
+    def test_non_vacuity_gate_teammate_idle_arg_less_resolves_team_tasks(self, live_task_env):
+        _write_task(live_task_env.dir_for(TEAM), task_id="3", owner="backend",
+                    status="in_progress", with_wait=False)
+        # teammate_idle calls the shared get_task_list() arg-less (:316).
+        tasks = teammate_idle.get_task_list()
+        assert tasks is not None, (
+            "teammate_idle's arg-less get_task_list() must resolve the team dir "
+            "post-fix — None here is the 2nd inert bug (idle-cleanup never runs)"
+        )
+        assert {t["id"] for t in tasks} == {"3"}

--- a/pact-plugin/tests/test_pact_context.py
+++ b/pact-plugin/tests/test_pact_context.py
@@ -1817,14 +1817,17 @@ class TestLibraryModuleInitContract:
     """
 
     def test_task_utils_get_task_list_after_init(self, pact_context, monkeypatch, tmp_path):
-        """task_utils.get_task_list() should read session_id via get_session_id() after init()."""
+        """task_utils.get_task_list() should resolve team_name via get_team_name()
+        after init() (a team session reads ~/.claude/tasks/{team_name}/)."""
         from shared.task_utils import get_task_list
 
         session_id = "contract-test-session"
-        pact_context(session_id=session_id)
+        team_name = "test-team"
+        pact_context(session_id=session_id, team_name=team_name)
 
-        # Create a task file at the expected path so get_task_list finds it
-        tasks_dir = tmp_path / ".claude" / "tasks" / session_id
+        # Create a task file under the TEAM dir so get_task_list's team branch
+        # finds it (the fixture defaults team_name="test-team").
+        tasks_dir = tmp_path / ".claude" / "tasks" / team_name
         tasks_dir.mkdir(parents=True)
         task_file = tasks_dir / "1.json"
         task_file.write_text(json.dumps({

--- a/pact-plugin/tests/test_session_end_integration.py
+++ b/pact-plugin/tests/test_session_end_integration.py
@@ -1,0 +1,136 @@
+"""
+Location: pact-plugin/tests/test_session_end_integration.py
+Summary: NON-MOCKED regression-pin for session_end's get_task_list consumption
+         (caller 4 of the team-dir resolution fix). check_unpaused_pr's
+         secondary task-scan fallback is the ONLY session_end consumer of
+         get_task_list, and test_session_end.py exercises it ONLY against a
+         MOCKED get_task_list (patched at ~20 sites) — so session_end's
+         consumption of real team-dir-resolved tasks was never gated through
+         the real seam. This file closes that gap (the sole remaining
+         e2e-coverage hole identified in the coverage review; runbook §3
+         session_end item). The existing mocked session_end tests are KEPT —
+         they pin the cleanup-reaper / pause-vs-review / PR-state behavior;
+         this file adds the one missing real-resolver consumption pin.
+
+Used by: the pact-plugin test suite (caller-4 inert-class regression guard).
+
+================================ ANTI-MOCK INVARIANT ===========================
+get_task_list / iter_team_task_jsons are NOT stubbed — the real
+get_team_name -> team-dir -> glob resolution IS the seam under test (driven via
+a Path.home redirect + a real team-named task dir, the same pattern as the
+missed-wake integration centerpiece). The ONLY test double is check_pr_state —
+an EXTERNAL `gh` CLI call, NOT the resolver — stubbed for determinism so a
+found PR yields the warning without a network round-trip. Stubbing the external
+gh dependency does not undermine the seam guarantee; stubbing get_task_list
+would (and is forbidden here).
+
+============================ NON-VACUITY (source-revert) =======================
+Method: in-place `git checkout <fix-sha>^ -- hooks/shared/task_utils.py` on a
+clean tree, OR — when task_utils.py has concurrent uncommitted WIP (e.g. a
+parallel remediation) — an ISOLATED throwaway worktree
+(`git worktree add --detach /tmp/v <fix-sha>^`; cp this file in; run; then
+`git worktree remove --force`) so the shared tree is never mutated.
+
+Pre-fix behavior: the arg-less session_end.get_task_list() reads
+~/.claude/tasks/{session_id}/ (absent in a team session) -> None -> EVERY test
+here breaks on its `assert tasks is not None` precondition (and the two
+*_non_vacuity_gate tests additionally lose their warning assertion, since
+check_unpaused_pr's `if not pr_number and tasks:` task-scan is skipped on
+None). No TypeError artifact — get_task_list is arg-less and exists pre-fix.
+
+Expected cardinality: FULL FILE pre-fix -> {3 failed} (all three are coupled to
+the resolver via the `assert tasks is not None` precondition); restore the fix
+-> {3 passed}. `pytest -k non_vacuity_gate` -> {2 failed} pre-fix / {2 passed}
+post-fix (the 2 named gate tests). The discrimination control
+(test_team_task_without_pr_indicator_no_warning) is ALSO coupled to the resolver
+(so it too fails pre-fix), but it is NOT named a *gate* because its load-bearing
+assertion is a POST-fix property — "a resolved team task carrying no PR
+indicator yields no warning" — which only has meaning once the resolver returns
+the task. Empirically confirmed via isolated worktree @ <fix-sha>^: {3 failed}.
+================================================================================
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import session_end  # noqa: E402
+
+TEAM = "pact-testteam"
+SID = "aaaaaaaa-1111-2222-3333-444444444444"
+PROJECT_DIR = "/test/project"
+
+
+@pytest.fixture
+def session_end_live_env(tmp_path, monkeypatch, pact_context):
+    """Path.home -> tmp + a real PACT team context, NO resolver stub. Returns
+    the real team-named task dir; tests drop task JSON there to drive the real
+    get_team_name -> team-dir resolver that session_end.get_task_list() reads.
+    No journal is written, so read_events('session_consolidated' / 'session_paused'
+    / 'review_dispatch') all return [] -> the review-event pr_number path yields
+    nothing -> check_unpaused_pr's task-scan fallback runs (the path under test)."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    pact_context(team_name=TEAM, session_id=SID, project_dir=PROJECT_DIR)
+    team_dir = tmp_path / ".claude" / "tasks" / TEAM
+    team_dir.mkdir(parents=True)
+    return team_dir
+
+
+def _write_task(team_dir: Path, task_id: str, metadata: dict) -> None:
+    (team_dir / f"{task_id}.json").write_text(json.dumps({
+        "id": task_id, "owner": "x", "subject": "s",
+        "status": "in_progress", "metadata": metadata,
+    }), encoding="utf-8")
+
+
+class TestSessionEndUnpausedPrRealResolver:
+    """check_unpaused_pr's task-scan fallback driven through the REAL
+    get_task_list resolver. The warning is produced ONLY when the scan finds a
+    PR indicator in a task that the real team-dir resolver returned."""
+
+    def test_non_vacuity_gate_pr_number_in_task_metadata(self, session_end_live_env, monkeypatch):
+        # Real team task carrying metadata.pr_number -> the task-scan fallback
+        # must find it THROUGH the real resolver and warn. Pre-fix: get_task_list
+        # -> None -> no scan -> no warning -> FAIL.
+        _write_task(session_end_live_env, "1", {"pr_number": 4242})
+        monkeypatch.setattr(session_end, "check_pr_state", lambda pr: "")  # external gh stub
+        tasks = session_end.get_task_list()  # REAL resolver, arg-less, NO stub
+        assert tasks is not None, "real resolver must return the team task (the seam under test)"
+        warning = session_end.check_unpaused_pr(tasks=tasks, project_slug="proj")
+        assert warning is not None and "4242" in warning, (
+            "the task-scan fallback must resolve the pr_number through the real "
+            "team-dir resolver and emit the unpaused-PR warning"
+        )
+
+    def test_non_vacuity_gate_pr_url_in_handoff(self, session_end_live_env, monkeypatch):
+        # The OTHER task-scan sub-path: a github PR URL embedded in a handoff
+        # string value (regex scan). Also driven through the real resolver.
+        _write_task(session_end_live_env, "1", {
+            "handoff": {"produced": "landed via https://github.com/org/repo/pull/777 today"},
+        })
+        monkeypatch.setattr(session_end, "check_pr_state", lambda pr: "")
+        tasks = session_end.get_task_list()
+        assert tasks is not None
+        warning = session_end.check_unpaused_pr(tasks=tasks, project_slug="proj")
+        assert warning is not None and "777" in warning, (
+            "the handoff-URL scan sub-path must resolve the PR through the real resolver"
+        )
+
+    def test_team_task_without_pr_indicator_no_warning(self, session_end_live_env, monkeypatch):
+        # Discrimination control: a real team task with NO pr indicator -> the
+        # scan finds nothing -> None. Proves the warnings above come SPECIFICALLY
+        # from the PR in the task metadata, not from the mere fact that the
+        # resolver returned tasks. NOT named a *gate* because its load-bearing
+        # assertion (no-PR-task -> no-warning) is a POST-fix property; but it is
+        # still resolver-coupled via the `assert tasks is not None` precondition,
+        # so it too FAILS on a source-revert (full-file pre-fix = {3 failed}).
+        _write_task(session_end_live_env, "1", {"intentional_wait": {"reason": "x"}})
+        monkeypatch.setattr(session_end, "check_pr_state", lambda pr: "")
+        tasks = session_end.get_task_list()
+        assert tasks is not None, "resolver returns the task; the scan just finds no PR in it"
+        assert session_end.check_unpaused_pr(tasks=tasks, project_slug="proj") is None, (
+            "a team task with no PR indicator must NOT produce a warning"
+        )

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -2942,15 +2942,20 @@ class TestSessionStartSourceField:
 
 @pytest.fixture
 def _compact_tasks_dir(tmp_path, monkeypatch, pact_context):
-    """Create a real ~/.claude/tasks/{session_id}/ under tmp_path and
+    """Create a real ~/.claude/tasks/{team_name}/ under tmp_path and
     route session_init's Path.home() to tmp_path. Yields the tasks dir
-    so each test can drop task JSON files into it. The session_id
-    matches the stdin session_id used by the migrated tests below.
+    so each test can drop task JSON files into it.
+
+    Post team-dir-resolution fix: session_init runs in a team context, so
+    get_task_list resolves tasks under {team_name} (pact-aabb1122 — matching
+    the team config the compact-branch tests create). The session_id still
+    matches the stdin session_id used by the tests below.
     """
     session_id = "aabb1122-0000-0000-0000-000000000000"
-    tasks_dir = tmp_path / ".claude" / "tasks" / session_id
+    team_name = "pact-aabb1122"
+    tasks_dir = tmp_path / ".claude" / "tasks" / team_name
     tasks_dir.mkdir(parents=True)
-    pact_context(session_id=session_id)
+    pact_context(session_id=session_id, team_name=team_name)
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     return tasks_dir
@@ -4837,7 +4842,8 @@ class TestSessionInitCompactBranchExceptions:
         from session_init import main
 
         session_id = "aabb1122-0000-0000-0000-000000000000"
-        pact_context(session_id=session_id)
+        team_name = "pact-aabb1122"
+        pact_context(session_id=session_id, team_name=team_name)
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
@@ -4848,8 +4854,9 @@ class TestSessionInitCompactBranchExceptions:
         # Put an in_progress task on disk so the 5 downstream helpers are
         # actually reached — without it, the `if _in_progress` gate short-
         # circuits and find_feature_task / find_current_phase / etc. never
-        # fire, making their parametrize cases vacuously pass.
-        tasks_dir = tmp_path / ".claude" / "tasks" / session_id
+        # fire, making their parametrize cases vacuously pass. Team session →
+        # tasks resolve under {team_name} (the team-dir resolution fix).
+        tasks_dir = tmp_path / ".claude" / "tasks" / team_name
         tasks_dir.mkdir(parents=True)
         (tasks_dir / "f-1.json").write_text(json.dumps({
             "id": "f-1",
@@ -5044,7 +5051,8 @@ class TestSessionInitDirectiveAcrossAllSources:
         from session_init import main
 
         session_id = "aabb1122-0000-0000-0000-000000000000"
-        pact_context(session_id=session_id)
+        team_name = "pact-aabb1122"
+        pact_context(session_id=session_id, team_name=team_name)
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/Users/example/Sites/test-project")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
@@ -5052,7 +5060,8 @@ class TestSessionInitDirectiveAcrossAllSources:
         team_dir.mkdir(parents=True, exist_ok=True)
         (team_dir / "config.json").write_text('{"members": []}')
 
-        tasks_dir = tmp_path / ".claude" / "tasks" / session_id
+        # Team session → tasks resolve under {team_name} (team-dir fix).
+        tasks_dir = tmp_path / ".claude" / "tasks" / team_name
         tasks_dir.mkdir(parents=True)
         feature = {
             "id": "f-order",

--- a/pact-plugin/tests/test_task_integration.py
+++ b/pact-plugin/tests/test_task_integration.py
@@ -31,15 +31,21 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 @pytest.fixture
 def mock_tasks_dir(tmp_path: Path, monkeypatch, pact_context):
     """
-    Create mock ~/.claude/tasks/{sessionId}/ structure.
+    Create mock ~/.claude/tasks/{team_name}/ structure.
+
+    Post team-dir-resolution fix: a team session (team_name truthy) resolves
+    tasks under {team_name}, so the fixture builds the team-named dir and sets
+    a matching team_name on the context. Tests writing JSON into the returned
+    dir exercise the real team branch of get_task_list.
 
     Returns:
-        Path to the tasks directory for the test session
+        Path to the tasks directory for the test team
     """
     session_id = "test-session-123"
-    tasks_dir = tmp_path / ".claude" / "tasks" / session_id
+    team_name = "test-team"
+    tasks_dir = tmp_path / ".claude" / "tasks" / team_name
     tasks_dir.mkdir(parents=True)
-    pact_context(session_id=session_id)
+    pact_context(session_id=session_id, team_name=team_name)
     monkeypatch.setenv("HOME", str(tmp_path))
 
     # Patch Path.home() to return our temp directory
@@ -182,11 +188,16 @@ class TestGetTaskList:
         assert result[0]["subject"] == "Valid task"
 
     def test_returns_none_when_session_id_not_set(self, tmp_path, monkeypatch, pact_context):
-        """Test returns None when session ID is not available."""
+        """Test returns None when session ID is not available.
+
+        Solo context (team_name="") so this exercises the REAL solo branch's
+        no-id guard rather than passing vacuously via the team-branch
+        short-circuit. Real-resolver coverage of the preserved solo path.
+        """
         from shared.task_utils import get_task_list
 
-        # Set up pact_context with empty session_id
-        pact_context(session_id="")
+        # Set up pact_context with empty session_id AND empty team_name (solo)
+        pact_context(session_id="", team_name="")
         monkeypatch.delenv("CLAUDE_CODE_TASK_LIST_ID", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
@@ -195,14 +206,21 @@ class TestGetTaskList:
         assert result is None
 
     def test_uses_task_list_id_when_provided(self, tmp_path, monkeypatch, make_task, pact_context):
-        """Test uses CLAUDE_CODE_TASK_LIST_ID when available."""
+        """Test uses CLAUDE_CODE_TASK_LIST_ID when available.
+
+        CLAUDE_CODE_TASK_LIST_ID is honored in the SOLO branch (the team
+        branch ignores it — team sessions resolve by team_name). So this test
+        runs in a solo context (team_name="") to exercise the preserved
+        env-var precedence. Doubles as real-resolver coverage of the solo
+        branch (the path the team-dir fix must NOT regress).
+        """
         from shared.task_utils import get_task_list
 
         # Setup with different session_id and task_list_id
         session_id = "session-abc"
         task_list_id = "shared-task-list-xyz"
 
-        pact_context(session_id=session_id)
+        pact_context(session_id=session_id, team_name="")
         monkeypatch.setenv("CLAUDE_CODE_TASK_LIST_ID", task_list_id)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 

--- a/pact-plugin/tests/test_task_utils.py
+++ b/pact-plugin/tests/test_task_utils.py
@@ -249,6 +249,80 @@ class TestGetTaskList:
             "exists() follows the symlink and the glob reads the out-of-base secret)"
         )
 
+    def test_solo_skips_dotfile_json(self, tmp_path, monkeypatch, pact_context):
+        # R4 (content-hygiene parity): a dotfile-prefixed *.json in the solo
+        # tasks dir must be SKIPPED, mirroring the team branch. NON-VACUOUS:
+        # pathlib glob('*.json') INCLUDES '.evil.json', so WITHOUT the
+        # dotfile-skip get_task_list reads it (count inflation). (Revert the
+        # dotfile-skip -> DOTFILE-INJECTED appears -> this FAILS.)
+        from task_utils import get_task_list
+        pact_context(session_id="session-id", team_name="")
+        base = tmp_path / "tasks"
+        tdir = base / "solo-x"
+        tdir.mkdir(parents=True)
+        write_task(tdir, "1", {"subject": "Real", "status": "in_progress"})
+        (tdir / ".evil.json").write_text(
+            json.dumps({"id": "e", "subject": "DOTFILE-INJECTED"}), encoding="utf-8"
+        )
+        monkeypatch.setenv("CLAUDE_CODE_TASK_LIST_ID", "solo-x")
+        result = get_task_list(tasks_base_dir=str(base))
+        subjects = {t["subject"] for t in (result or [])}
+        assert "DOTFILE-INJECTED" not in subjects, (
+            "a dotfile-prefixed *.json must be skipped (pathlib glob includes "
+            "it; without the dotfile-skip it is read)"
+        )
+        assert subjects == {"Real"}
+
+    def test_solo_skips_non_dict_json(self, tmp_path, monkeypatch, pact_context):
+        # R4 (content-hygiene parity): a malformed-but-valid JSON that parses to
+        # a NON-dict (list/int/str) must be SKIPPED, not appended, mirroring the
+        # team branch's isinstance(dict) guard. NON-VACUOUS: without the guard
+        # the non-dict is appended AND a downstream reader (find_feature_task)
+        # calls .get() on it -> AttributeError. (Revert the guard -> this FAILS,
+        # either the all-dict assert or the find_feature_task crash.)
+        from task_utils import get_task_list, find_feature_task
+        pact_context(session_id="session-id", team_name="")
+        base = tmp_path / "tasks"
+        tdir = base / "solo-x"
+        tdir.mkdir(parents=True)
+        write_task(tdir, "1", {"subject": "Real", "status": "in_progress"})
+        (tdir / "bad.json").write_text(json.dumps([1, 2, 3]), encoding="utf-8")  # valid JSON, non-dict
+        monkeypatch.setenv("CLAUDE_CODE_TASK_LIST_ID", "solo-x")
+        result = get_task_list(tasks_base_dir=str(base))
+        assert result is not None
+        assert all(isinstance(t, dict) for t in result), (
+            "a non-dict parse ([1,2,3]) must be skipped, not appended"
+        )
+        assert {t["subject"] for t in result} == {"Real"}
+        # Downstream consumer must not crash on the returned list.
+        find_feature_task(result)  # raises AttributeError if a non-dict leaked through
+
+    def test_solo_r1_unique_nonallowlisted_in_base_name(self, tmp_path, monkeypatch, pact_context):
+        # R2-F3 (R1-UNIQUENESS pin, spec'd by test-engineer): a non-allowlisted
+        # but IN-BASE task_list_id must be rejected by is_safe_path_component
+        # (R1) BEFORE the path-join. "a b" (space ∉ [A-Za-z0-9_-]) is rejected by
+        # R1, but base/"a b" resolves UNDER base so R3's resolve/relative_to
+        # anchor PASSES it — only R1 catches it. NON-VACUOUS vs R1 ALONE: revert
+        # ONLY the is_safe_path_component guard (R3 intact) -> base/"a b" passes
+        # the anchor + exists -> the planted task is read -> non-None -> this
+        # FAILS. (NUL / "../escape" would NOT prove this — R3 masks them:
+        # resolve() raises ValueError / escapes base, so both R1+R3 catch them.)
+        from task_utils import get_task_list
+        pact_context(session_id="session-id", team_name="")
+        base = tmp_path / "tasks"
+        d = base / "a b"
+        d.mkdir(parents=True)
+        (d / "1.json").write_text(
+            json.dumps({"id": "1", "subject": "NONALLOWLISTED"}), encoding="utf-8"
+        )
+        monkeypatch.setenv("CLAUDE_CODE_TASK_LIST_ID", "a b")
+        assert get_task_list(tasks_base_dir=str(base)) is None, (
+            "a non-allowlisted in-base task_list_id must be rejected by "
+            "is_safe_path_component (R1) BEFORE the path-join — R3's anchor "
+            "passes it (in-base), so this is the R1-UNIQUE case proving the "
+            "guard is load-bearing"
+        )
+
 
 # ---------------------------------------------------------------------------
 # find_feature_task

--- a/pact-plugin/tests/test_task_utils.py
+++ b/pact-plugin/tests/test_task_utils.py
@@ -39,8 +39,10 @@ class TestGetTaskList:
     """Tests for get_task_list() — filesystem-based task reading."""
 
     def test_returns_none_when_no_session_id(self, monkeypatch, pact_context):
+        # SOLO context (team_name="") so this exercises the REAL solo no-id
+        # guard, not a vacuous pass via the team-branch short-circuit.
         from task_utils import get_task_list
-        pact_context(session_id="")  # No session ID available
+        pact_context(session_id="", team_name="")  # No session ID, no team
         monkeypatch.delenv("CLAUDE_CODE_TASK_LIST_ID", raising=False)
         result = get_task_list()
         assert result is None
@@ -54,12 +56,14 @@ class TestGetTaskList:
         assert result is None
 
     def test_reads_tasks_from_filesystem(self, tmp_path, monkeypatch, pact_context):
+        # TEAM branch: the pact_context fixture defaults team_name="test-team",
+        # so a team session resolves tasks under {team_name}, not {session_id}.
         from task_utils import get_task_list
         pact_context(session_id="test-session")
         monkeypatch.delenv("CLAUDE_CODE_TASK_LIST_ID", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
-        tasks_dir = tmp_path / ".claude" / "tasks" / "test-session"
+        tasks_dir = tmp_path / ".claude" / "tasks" / "test-team"
         tasks_dir.mkdir(parents=True)
         write_task(tasks_dir, "1", {"subject": "Test task", "status": "pending"})
         write_task(tasks_dir, "2", {"subject": "Another task", "status": "in_progress"})
@@ -69,8 +73,12 @@ class TestGetTaskList:
         assert len(result) == 2
 
     def test_prefers_task_list_id_over_session_id(self, tmp_path, monkeypatch, pact_context):
+        # SOLO context (team_name=""): CLAUDE_CODE_TASK_LIST_ID is honored only
+        # in the solo branch (the team branch resolves by team_name and ignores
+        # the env var). Verifies the preserved solo env-var precedence + gives
+        # the solo branch positive real-resolver coverage.
         from task_utils import get_task_list
-        pact_context(session_id="session-id")
+        pact_context(session_id="session-id", team_name="")
         monkeypatch.setenv("CLAUDE_CODE_TASK_LIST_ID", "task-list-id")
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
@@ -84,8 +92,11 @@ class TestGetTaskList:
         assert len(result) == 1
 
     def test_returns_none_for_empty_dir(self, tmp_path, monkeypatch, pact_context):
+        # SOLO context (team_name="") so the empty-dir->None path is exercised
+        # through the REAL solo resolver (session_id dir), not vacuously via the
+        # team-branch short-circuit.
         from task_utils import get_task_list
-        pact_context(session_id="test-session")
+        pact_context(session_id="test-session", team_name="")
         monkeypatch.delenv("CLAUDE_CODE_TASK_LIST_ID", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
@@ -96,12 +107,14 @@ class TestGetTaskList:
         assert result is None
 
     def test_skips_invalid_json_files(self, tmp_path, monkeypatch, pact_context):
+        # TEAM branch (default team_name="test-team"). iter_team_task_jsons
+        # skips the unparseable file the same way the solo glob did.
         from task_utils import get_task_list
         pact_context(session_id="test-session")
         monkeypatch.delenv("CLAUDE_CODE_TASK_LIST_ID", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
-        tasks_dir = tmp_path / ".claude" / "tasks" / "test-session"
+        tasks_dir = tmp_path / ".claude" / "tasks" / "test-team"
         tasks_dir.mkdir(parents=True)
         (tasks_dir / "bad.json").write_text("not json", encoding="utf-8")
         write_task(tasks_dir, "1", {"subject": "Good task", "status": "pending"})
@@ -111,8 +124,12 @@ class TestGetTaskList:
         assert len(result) == 1
 
     def test_returns_none_on_exception(self, tmp_path, monkeypatch, pact_context):
+        # SOLO context (team_name="") so the glob raises inside the solo
+        # branch's own try/except — the path this test targets. Under a team
+        # context the team branch would short-circuit before the patched glob,
+        # making the assertion vacuous.
         from task_utils import get_task_list
-        pact_context(session_id="test-session")
+        pact_context(session_id="test-session", team_name="")
         monkeypatch.delenv("CLAUDE_CODE_TASK_LIST_ID", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
@@ -122,6 +139,26 @@ class TestGetTaskList:
         with patch.object(Path, "glob", side_effect=PermissionError("denied")):
             result = get_task_list()
         assert result is None
+
+    def test_solo_resolves_tasks_by_session_id(self, tmp_path, monkeypatch, pact_context):
+        # Positive real-resolver coverage of the SOLO branch's bare-session_id
+        # path (no CLAUDE_CODE_TASK_LIST_ID): team_name="" routes to the solo
+        # branch, which must resolve ~/.claude/tasks/{session_id}/ and read it.
+        # Guards the preserved solo path the team-dir fix must NOT regress, and
+        # is non-vacuous (a team context would short-circuit before this path).
+        from task_utils import get_task_list
+        pact_context(session_id="solo-session", team_name="")
+        monkeypatch.delenv("CLAUDE_CODE_TASK_LIST_ID", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        tasks_dir = tmp_path / ".claude" / "tasks" / "solo-session"
+        tasks_dir.mkdir(parents=True)
+        write_task(tasks_dir, "1", {"subject": "Solo task", "status": "in_progress"})
+
+        result = get_task_list()
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["subject"] == "Solo task"
 
 
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_task_utils.py
+++ b/pact-plugin/tests/test_task_utils.py
@@ -160,6 +160,47 @@ class TestGetTaskList:
         assert len(result) == 1
         assert result[0]["subject"] == "Solo task"
 
+    def test_solo_rejects_traversal_task_list_id(self, tmp_path, monkeypatch, pact_context):
+        # F2 (security): a user-controlled CLAUDE_CODE_TASK_LIST_ID that is not a
+        # safe single path component must be rejected (-> None) BEFORE the
+        # path-join, so it cannot escape the tasks base and read *.json outside.
+        # Solo context (team_name="") — the env var is consulted only there.
+        # NON-VACUOUS: a *.json is planted at the traversal target, so WITHOUT
+        # the is_safe_path_component guard get_task_list would resolve
+        # base/"../escape" -> the planted dir and return the LEAKED task
+        # (non-None). The guard makes it None. (Revert the guard -> this FAILS.)
+        from task_utils import get_task_list
+        pact_context(session_id="session-id", team_name="")
+        base = tmp_path / "tasks"
+        base.mkdir(parents=True)
+        escape = tmp_path / "escape"
+        escape.mkdir()
+        (escape / "secret.json").write_text(
+            json.dumps({"id": "x", "subject": "LEAKED"}), encoding="utf-8"
+        )
+        for hostile in ("../escape", "../../etc", "..", "a/b", "foo/../bar"):
+            monkeypatch.setenv("CLAUDE_CODE_TASK_LIST_ID", hostile)
+            assert get_task_list(tasks_base_dir=str(base)) is None, (
+                f"unsafe task_list_id {hostile!r} must be rejected before the "
+                f"path-join — must NOT resolve out-of-base and read the planted "
+                f"secret (that is the F2 traversal-read vector)"
+            )
+
+    def test_solo_accepts_legit_task_list_id(self, tmp_path, monkeypatch, pact_context):
+        # Guardrail: a legitimate single-component task-list id (pact-<slug> /
+        # UUID / multi-session pointer) still passes is_safe_path_component and
+        # resolves — proves the F2 validation adds NO solo regression.
+        from task_utils import get_task_list
+        pact_context(session_id="session-id", team_name="")
+        monkeypatch.setenv("CLAUDE_CODE_TASK_LIST_ID", "pact-abcd1234")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        tasks_dir = tmp_path / ".claude" / "tasks" / "pact-abcd1234"
+        tasks_dir.mkdir(parents=True)
+        write_task(tasks_dir, "1", {"subject": "Legit", "status": "in_progress"})
+        result = get_task_list()
+        assert result is not None and len(result) == 1
+        assert result[0]["subject"] == "Legit"
+
 
 # ---------------------------------------------------------------------------
 # find_feature_task

--- a/pact-plugin/tests/test_task_utils.py
+++ b/pact-plugin/tests/test_task_utils.py
@@ -201,6 +201,54 @@ class TestGetTaskList:
         assert result is not None and len(result) == 1
         assert result[0]["subject"] == "Legit"
 
+    def test_solo_skips_symlinked_json_file(self, tmp_path, monkeypatch, pact_context):
+        # R3 (security): a *.json INSIDE the (legit) tasks dir that is a SYMLINK
+        # to a file OUTSIDE the base must be SKIPPED, not followed-and-read.
+        # NON-VACUOUS: the symlink targets a planted out-of-base secret; WITHOUT
+        # the per-file is_symlink skip the glob follows it and reads LEAKED. The
+        # defense skips it; only the real (regular-file) task is returned.
+        from task_utils import get_task_list
+        pact_context(session_id="session-id", team_name="")
+        base = tmp_path / "tasks"
+        tdir = base / "solo-x"
+        tdir.mkdir(parents=True)
+        secret = tmp_path / "secret.json"  # OUTSIDE base
+        secret.write_text(json.dumps({"id": "leak", "subject": "LEAKED"}), encoding="utf-8")
+        write_task(tdir, "1", {"subject": "Real", "status": "in_progress"})
+        (tdir / "leak.json").symlink_to(secret)
+        monkeypatch.setenv("CLAUDE_CODE_TASK_LIST_ID", "solo-x")
+        result = get_task_list(tasks_base_dir=str(base))
+        subjects = {t["subject"] for t in (result or [])}
+        assert "LEAKED" not in subjects, (
+            "a symlinked *.json pointing outside the base must be SKIPPED, not "
+            "read — without the is_symlink skip the glob follows it -> LEAKED"
+        )
+        assert subjects == {"Real"}
+
+    def test_solo_rejects_symlink_dir_escaping_base(self, tmp_path, monkeypatch, pact_context):
+        # R3 (security): a {task_list_id} dir that is itself a SYMLINK escaping
+        # the base must yield None — the resolve/relative_to anchor rejects it.
+        # The NAME passes is_safe_path_component (safe component); the escape is
+        # via the symlink TARGET. NON-VACUOUS: without the anchor, exists()
+        # follows the symlink and the glob reads the planted out-of-base secret.
+        from task_utils import get_task_list
+        pact_context(session_id="session-id", team_name="")
+        base = tmp_path / "tasks"
+        base.mkdir(parents=True)
+        outside = tmp_path / "escapedir"  # OUTSIDE base
+        outside.mkdir()
+        (outside / "secret.json").write_text(
+            json.dumps({"id": "leak", "subject": "LEAKED"}), encoding="utf-8"
+        )
+        (base / "evil-link").symlink_to(outside, target_is_directory=True)
+        monkeypatch.setenv("CLAUDE_CODE_TASK_LIST_ID", "evil-link")
+        result = get_task_list(tasks_base_dir=str(base))
+        assert result is None, (
+            "a {task_list_id} dir that is a symlink escaping the base must be "
+            "rejected by the resolve/relative_to anchor -> None (without it, "
+            "exists() follows the symlink and the glob reads the out-of-base secret)"
+        )
+
 
 # ---------------------------------------------------------------------------
 # find_feature_task


### PR DESCRIPTION
## Summary
The #903 missed-wake surfacer shipped in v4.4.11 was **inert in live operation** — it never fired. Root cause: `get_task_list` resolved the task dir by `session_id`/`CLAUDE_CODE_TASK_LIST_ID`, but Agent-Teams tasks persist under `{team_name}`, so it returned `None` and every caller short-circuited. This is a bug **class**: 4 hooks were silently degraded.

## What landed
- **Resolver fix** (`ef4dd66f`): `get_task_list` is now a strictly-additive **team-first 2-tier** resolver — team session → `~/.claude/tasks/{team_name}/` via the path-safe `iter_team_task_jsons` SSOT (returns `None`, **no fall-through**, on an empty team dir); else the prior `session_id`/`CLAUDE_CODE_TASK_LIST_ID` body verbatim as the solo fallback. `team_name` is mode-invariant — no teammateMode detection. All 4 callers fixed with **zero call-site edits**:
  - `missed_wake_scan` (INERT → fires) — the #903 subject
  - `teammate_idle` (INERT → fires) — a **2nd live bug** found this cycle (zombie-teammate cleanup never ran)
  - `session_init` (partial post-compaction degrade → fixed)
  - `session_end` (minor secondary-scan loss → fixed)
- **Test gate** (`d2a577ad`): `test_missed_wake_scan_integration.py` (18 **non-mocked** tests) drives `run_surface` end-to-end through the *real* resolver (no stub; a docstring invariant forbids monkeypatching the seam under test). Non-vacuity proven by source-revert. 3-axis matrix, empty-team-dir invariant, solo branch, `teammate_idle` smoke. Plus `runbooks/923-missed-wake-live-probe.md` — the **mandatory post-merge multi-mode live-probe gate**.
- **Version** (`8ad9a16d`): v4.4.12 (PATCH).

## Why
v4.4.11 shipped inert despite 2 review rounds + 50 unit tests + an architect design-verify — all of which **mocked the broken seam**. The non-mocked integration test + the live-probe gate are the structural fix for that class of miss. Static green is now seam-exercising; the tmux live-probe is the load-bearing runtime confirmation before the cycle closes.

## Coverage boundary (honest scope)
Callers 1&2 are e2e/smoke-proven to the static limit; callers 3&4 are repaired-by-construction (same resolver, resolver-level proven via IT-3) + suite-green but **not e2e-pinned** — their non-mocked regression-pins are a tracked follow-up (runbook §3).

**Suite: 8181 passed / 0 failed.**
