### PR TITLE
fix(#926): CLAUDE_CONFIG_DIR-aware hook path resolution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.12",
+      "version": "4.4.13",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.12/      # Plugin version
+│               └── 4.4.13/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.12",
+  "version": "4.4.13",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.12
+> **Version**: 4.4.13
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/dispatch_gate.py
+++ b/pact-plugin/hooks/dispatch_gate.py
@@ -95,6 +95,7 @@ try:
         has_task_assigned,
     )
     from shared.session_journal import append_event, make_event
+    from shared.paths import get_claude_config_dir
 except BaseException as _module_load_error:  # noqa: BLE001 — fail-closed catch-all
     _emit_load_failure_deny("module imports", _module_load_error)
 
@@ -258,7 +259,7 @@ def _team_member_names(team_name: str) -> set[str]:
     dispatch_helpers.py because task_lifecycle_gate has no need for the
     member roster.
     """
-    cfg_path = Path.home() / ".claude" / "teams" / team_name / "config.json"
+    cfg_path = get_claude_config_dir() / "teams" / team_name / "config.json"
     try:
         data = json.loads(cfg_path.read_text(encoding="utf-8"))
     except (OSError, ValueError):

--- a/pact-plugin/hooks/file_tracker.py
+++ b/pact-plugin/hooks/file_tracker.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import shared.pact_context as pact_context
 from shared.pact_context import get_session_id, get_team_name, resolve_agent_name
+from shared.paths import get_claude_config_dir
 
 try:
     import fcntl
@@ -229,7 +230,7 @@ def main():
     session_id = get_session_id()
 
     tracking_path = str(
-        Path.home() / ".claude" / "teams" / team_name / "file-edits.json"
+        get_claude_config_dir() / "teams" / team_name / "file-edits.json"
     )
 
     # Check for conflict BEFORE recording this edit. Pass the same

--- a/pact-plugin/hooks/postcompact_archive.py
+++ b/pact-plugin/hooks/postcompact_archive.py
@@ -11,7 +11,7 @@ Used by: hooks.json PostCompact hook
 
 After compaction completes:
 1. Reads compact_summary from stdin (PostCompact input field)
-2. Writes the compact_summary to the canonical COMPACT_SUMMARY_PATH
+2. Writes the compact_summary to the canonical get_compact_summary_path()
 3. Emits suppressOutput to avoid false "hook error" UI display on clean exits
 
 This is a non-blocking side effect (always exits 0), not a gate.
@@ -25,7 +25,7 @@ import os
 import sys
 from pathlib import Path
 
-from shared.constants import COMPACT_SUMMARY_PATH
+from shared.constants import get_compact_summary_path
 from shared.error_output import hook_error_json
 from shared.pact_context import is_lead
 
@@ -40,8 +40,8 @@ def _get_summary_path(
 ) -> Path:
     """Get the path for the compact summary file."""
     if sessions_base_dir is None:
-        return COMPACT_SUMMARY_PATH
-    return Path(sessions_base_dir) / COMPACT_SUMMARY_PATH.name
+        return get_compact_summary_path()
+    return Path(sessions_base_dir) / get_compact_summary_path().name
 
 
 def write_compact_summary(
@@ -86,7 +86,7 @@ def main():
         # "Post-compaction: critical context preserved" message was reassurance
         # that could suppress orchestrator self-check (see issue #444 root cause).
         #
-        # Lead-only (#881): COMPACT_SUMMARY_PATH is a GLOBAL SINGLETON the lead
+        # Lead-only (#881): the compact-summary path is a GLOBAL SINGLETON the lead
         # reads on resume; the write is O_TRUNC, so a teammate/plain frame's
         # PostCompact would CLOBBER the lead's summary (the 2nd acute clobber
         # after #877). Gate the write behind is_lead. is_lead is total and only

--- a/pact-plugin/hooks/refresh/checkpoint_builder.py
+++ b/pact-plugin/hooks/refresh/checkpoint_builder.py
@@ -20,6 +20,7 @@ if str(_hooks_dir) not in sys.path:
     sys.path.insert(0, str(_hooks_dir))
 
 from shared.pact_context import get_session_id as _pact_get_session_id
+from shared.paths import get_claude_config_dir
 
 from .workflow_detector import WorkflowInfo
 from .step_extractor import StepInfo
@@ -142,7 +143,7 @@ def get_checkpoint_path(encoded_path: str) -> Path:
     Returns:
         Path to the checkpoint file
     """
-    return Path.home() / ".claude" / "pact-refresh" / f"{encoded_path}.json"
+    return get_claude_config_dir() / "pact-refresh" / f"{encoded_path}.json"
 
 
 def get_session_id() -> str:

--- a/pact-plugin/hooks/session_end.py
+++ b/pact-plugin/hooks/session_end.py
@@ -43,6 +43,7 @@ from shared.session_journal import (
 
 from shared.session_state import is_safe_path_component
 from shared.session_registry import get_registry_path as _get_registry_path
+from shared.paths import get_claude_config_dir
 from shared.task_utils import get_task_list
 
 # Suppress false "hook error" display in Claude Code UI on bare exit paths
@@ -281,7 +282,7 @@ def cleanup_old_sessions(
         return
 
     if sessions_dir is None:
-        sessions_dir = str(Path.home() / ".claude" / "pact-sessions")
+        sessions_dir = str(get_claude_config_dir() / "pact-sessions")
 
     slug_dir = Path(sessions_dir) / project_slug
     if not slug_dir.exists():
@@ -457,7 +458,7 @@ def cleanup_old_teams(
         return 0, 0
 
     if teams_base_dir is None:
-        teams_base_dir = str(Path.home() / ".claude" / "teams")
+        teams_base_dir = str(get_claude_config_dir() / "teams")
     base = Path(teams_base_dir)
     if not base.exists():
         return 0, 0
@@ -546,7 +547,7 @@ def cleanup_old_tasks(
         return 0, 0
 
     if tasks_base_dir is None:
-        tasks_base_dir = str(Path.home() / ".claude" / "tasks")
+        tasks_base_dir = str(get_claude_config_dir() / "tasks")
     base = Path(tasks_base_dir)
     if not base.exists():
         return 0, 0
@@ -703,7 +704,7 @@ def _prune_registry_dead_teams(
     if registry_path is None:
         registry_path = _get_registry_path()
     if teams_dir is None:
-        teams_dir = Path.home() / ".claude" / "teams"
+        teams_dir = get_claude_config_dir() / "teams"
 
     try:
         if not registry_path.exists() or registry_path.is_symlink():
@@ -783,7 +784,7 @@ def _cleanup_old_checkpoints(
         Number of files cleaned up.
     """
     if checkpoint_dir is None:
-        checkpoint_dir = Path.home() / ".claude" / "pact-refresh"
+        checkpoint_dir = get_claude_config_dir() / "pact-refresh"
 
     if not checkpoint_dir.exists():
         return 0

--- a/pact-plugin/hooks/session_end.py
+++ b/pact-plugin/hooks/session_end.py
@@ -42,7 +42,7 @@ from shared.session_journal import (
 )
 
 from shared.session_state import is_safe_path_component
-from shared.session_registry import REGISTRY_PATH as _REGISTRY_PATH
+from shared.session_registry import get_registry_path as _get_registry_path
 from shared.task_utils import get_task_list
 
 # Suppress false "hook error" display in Claude Code UI on bare exit paths
@@ -694,14 +694,14 @@ def _prune_registry_dead_teams(
     cannot redirect the write.
 
     Args:
-        registry_path: the registry file. Defaults to the shared REGISTRY_PATH.
+        registry_path: the registry file. Defaults to the shared get_registry_path().
         teams_dir: the live-teams root. Defaults to ~/.claude/teams.
 
     Returns:
         Number of lines pruned (0 if the file is absent or nothing was stale).
     """
     if registry_path is None:
-        registry_path = _REGISTRY_PATH
+        registry_path = _get_registry_path()
     if teams_dir is None:
         teams_dir = Path.home() / ".claude" / "teams"
 

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -76,7 +76,7 @@ from pin_caps import (  # noqa: F401
 )
 
 from shared import BOOTSTRAP_MARKER_NAME, SESSION_ID_CONTROL_CHARS_RE, build_session_path
-from shared.constants import COMPACT_SUMMARY_PATH
+from shared.constants import get_compact_summary_path
 from shared.pact_context import (
     build_context_cache,
     classify_session_role,
@@ -789,7 +789,7 @@ def main():
         # Only "compact" source needs it (just written by postcompact_archive).
         if source != "compact":
             try:
-                COMPACT_SUMMARY_PATH.unlink(missing_ok=True)
+                get_compact_summary_path().unlink(missing_ok=True)
             except OSError:
                 pass  # Fail-open: don't block session init for cleanup
 
@@ -1267,7 +1267,7 @@ def main():
                 context_parts.insert(0, (
                     f'{_team_reuse} '
                     f'After bootstrap, recover session state: '
-                    f'(1) Read {COMPACT_SUMMARY_PATH} for prior context, '
+                    f'(1) Read {get_compact_summary_path()} for prior context, '
                     f'(2) Run TaskList to find in-progress work, '
                     f'(3) TaskGet on in-progress tasks for details. '
                     f"Re-engage secretary: SendMessage(to='secretary', "

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -91,6 +91,7 @@ from shared.failure_log import append_failure
 from shared.plugin_manifest import format_plugin_banner
 from shared.peer_context import get_peer_context
 from shared.session_registry import resolve as _registry_resolve
+from shared.paths import get_claude_config_dir
 
 # Import extracted modules (decomposed for maintainability per M5 audit finding).
 from shared.symlinks import setup_plugin_symlinks
@@ -430,7 +431,7 @@ def _validate_under_pact_sessions(path: str) -> str | None:
     fail-closed — callers already treat None as "no previous session").
     """
     try:
-        sessions_root = (Path.home() / ".claude" / "pact-sessions").resolve()
+        sessions_root = (get_claude_config_dir() / "pact-sessions").resolve()
         candidate = Path(path).resolve(strict=False)
         if candidate == sessions_root or sessions_root in candidate.parents:
             return path
@@ -528,7 +529,7 @@ def _extract_prev_session_dir(project_dir: str) -> str | None:
             # Use project root basename (not worktree) for slug
             slug = Path(project_dir).name
             derived = str(
-                Path.home() / ".claude" / "pact-sessions" / slug / session_id
+                get_claude_config_dir() / "pact-sessions" / slug / session_id
             )
             return _validate_under_pact_sessions(derived)
 

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -322,7 +322,7 @@ def check_additional_directories() -> str | None:
     Fail-open: returns None on any error (file missing, malformed JSON, etc.).
     """
     try:
-        settings_path = Path.home() / ".claude" / "settings.json"
+        settings_path = get_claude_config_dir() / "settings.json"
         if not settings_path.exists():
             return None  # No settings file — nothing to check
 
@@ -348,9 +348,9 @@ def check_additional_directories() -> str | None:
 
         # Check which required directories are missing
         required = {
-            "~/.claude/teams": (Path.home() / ".claude" / "teams").resolve(),
+            "~/.claude/teams": (get_claude_config_dir() / "teams").resolve(),
             "~/.claude/pact-sessions": (
-                Path.home() / ".claude" / "pact-sessions"
+                get_claude_config_dir() / "pact-sessions"
             ).resolve(),
         }
         missing = [
@@ -1133,7 +1133,7 @@ def main():
                 )
 
         try:
-            team_config = Path.home() / ".claude" / "teams" / team_name / "config.json"
+            team_config = get_claude_config_dir() / "teams" / team_name / "config.json"
             team_exists = team_config.exists()
         except OSError:
             # Fail-open: if filesystem check fails, assume fresh session

--- a/pact-plugin/hooks/shared/__init__.py
+++ b/pact-plugin/hooks/shared/__init__.py
@@ -42,7 +42,7 @@ from .claude_md_manager import (
 from .failure_log import (
     append_failure,
     read_failures,
-    LOG_PATH as FAILURE_LOG_PATH,
+    get_failure_log_path,
     MAX_ENTRIES as FAILURE_LOG_MAX_ENTRIES,
 )
 from .session_resume import (
@@ -139,7 +139,7 @@ __all__ = [
     "PACT_BOUNDARY_PREFIXES",
     "append_failure",
     "read_failures",
-    "FAILURE_LOG_PATH",
+    "get_failure_log_path",
     "FAILURE_LOG_MAX_ENTRIES",
     "update_session_info",
     "restore_last_session",

--- a/pact-plugin/hooks/shared/agent_handoff_marker.py
+++ b/pact-plugin/hooks/shared/agent_handoff_marker.py
@@ -42,6 +42,8 @@ import os
 import re
 from pathlib import Path
 
+from .paths import get_claude_config_dir
+
 # Hex chars of the SHA-256 digest retained for the occupant component of the
 # marker key. 16 hex chars = 64 bits — collision-negligible for the tiny
 # per-(team, task_id) occupant namespace (a handful of occupants per task at
@@ -132,7 +134,7 @@ def _marker_dir(team_name: str) -> Path:
     pause/resume: a secretary standing task that spans sessions must emit
     its agent_handoff event exactly once across the whole team lifespan.
     """
-    return Path.home() / ".claude" / "teams" / team_name / ".agent_handoff_emitted"
+    return get_claude_config_dir() / "teams" / team_name / ".agent_handoff_emitted"
 
 
 def _resolve_marker_target(
@@ -215,7 +217,7 @@ def _resolve_marker_target(
     # and is_relative_to is 3.9+. On breach OR any resolution error: fail-open
     # emit (return None) WITHOUT writing a marker at the escaped path —
     # consistent with the is_symlink() pre-check's fail-open posture.
-    team_base = Path.home() / ".claude" / "teams" / team_name
+    team_base = get_claude_config_dir() / "teams" / team_name
     try:
         real_marker = os.path.realpath(marker_dir)
         real_base = os.path.realpath(team_base)

--- a/pact-plugin/hooks/shared/claude_md_manager.py
+++ b/pact-plugin/hooks/shared/claude_md_manager.py
@@ -28,6 +28,8 @@ import time
 from contextlib import contextmanager
 from pathlib import Path
 
+from .paths import get_claude_config_dir
+
 # Project-level CLAUDE.md is preferred at .claude/CLAUDE.md (the new default)
 # but Claude Code also accepts ./CLAUDE.md for backwards compatibility.
 _DOT_CLAUDE_RELATIVE = Path(".claude") / "CLAUDE.md"
@@ -310,7 +312,7 @@ def strip_orphan_kernel_block() -> str | None:
         on defensive no-op (malformed marker state; session_init.py
         routes these to systemMessages via the "failed"/"skipped" check).
     """
-    target_file = Path.home() / ".claude" / "CLAUDE.md"
+    target_file = get_claude_config_dir() / "CLAUDE.md"
     if not target_file.exists():
         return None
 

--- a/pact-plugin/hooks/shared/constants.py
+++ b/pact-plugin/hooks/shared/constants.py
@@ -3,10 +3,12 @@ Location: pact-plugin/hooks/shared/constants.py
 Summary: Canonical constants shared across PACT hooks and tests.
 Used by: test_patterns.py (cross-list consistency checks),
          verify-scope-integrity.sh (baseline checks),
-         postcompact_archive.py (COMPACT_SUMMARY_PATH),
-         session_init.py (COMPACT_SUMMARY_PATH).
+         postcompact_archive.py (get_compact_summary_path),
+         session_init.py (get_compact_summary_path).
 """
 from pathlib import Path
+
+from .paths import get_claude_config_dir
 
 # Canonical list of all PACT specialist agents in lifecycle order.
 # This is the single source of truth for agent enumeration.
@@ -31,7 +33,9 @@ PACT_AGENTS = [
 # and read by session_init (post-compaction recovery) and pact-secretary
 # (session briefing). Single-use: secretary deletes after processing.
 # Also referenced in: pact-plugin/agents/pact-secretary.md (documentation only).
-COMPACT_SUMMARY_PATH = Path.home() / ".claude" / "pact-sessions" / "compact-summary.txt"
+# Accessor (B1) — resolves $CLAUDE_CONFIG_DIR at CALL time (no import-time freeze).
+def get_compact_summary_path() -> Path:
+    return get_claude_config_dir() / "pact-sessions" / "compact-summary.txt"
 
 
 # Subject prefixes that indicate synthetic / system-level tasks (phase

--- a/pact-plugin/hooks/shared/failure_log.py
+++ b/pact-plugin/hooks/shared/failure_log.py
@@ -48,14 +48,18 @@ from pathlib import Path
 from typing import Any
 
 from .claude_md_manager import file_lock
+from .paths import get_claude_config_dir
 
 
 # Locked decision: global log at the pact-sessions root. Underscore prefix
 # prevents cleanup_old_sessions from reaping it (that reaper filters on
 # _UUID_PATTERN, which "_session_init_failures.log" never matches).
-LOG_PATH = (
-    Path.home() / ".claude" / "pact-sessions" / "_session_init_failures.log"
-)
+# Accessor (B1) — resolves $CLAUDE_CONFIG_DIR at CALL time (avoids the
+# import-time freeze; consumers call get_failure_log_path()).
+def get_failure_log_path() -> Path:
+    return (
+        get_claude_config_dir() / "pact-sessions" / "_session_init_failures.log"
+    )
 
 # Bounded ring buffer cap: large enough to see a multi-day failure pattern,
 # small enough that read-truncate-write stays fast (~10KB file at steady state).
@@ -123,29 +127,30 @@ def append_failure(
             "source": source[:_ERROR_MAX_CHARS] if source is not None else None,
         }
 
+        log_path = get_failure_log_path()
         # Ensure parent dir exists. 0o700 matches the rest of PACT's
         # secure-by-default permission scheme.
-        LOG_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        log_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
 
         # file_lock serializes the read-mutate-write critical section.
         # Timeout fails open via the outer try/except below.
-        with file_lock(LOG_PATH):
+        with file_lock(log_path):
             # Symlink guard (TOCTOU defense): inside the lock so no concurrent
             # writer can swap the file between check and write. is_symlink()
             # is lstat-based and does not follow the link, so an attacker who
-            # replaces LOG_PATH with a symlink to /etc/passwd cannot trick us
+            # replaces log_path with a symlink to /etc/passwd cannot trick us
             # into clobbering the target. Silent fail-open preserves the
             # SACROSANCT invariant.
-            if LOG_PATH.is_symlink():
+            if log_path.is_symlink():
                 return
 
             existing_lines: list[str] = []
-            if LOG_PATH.exists():
+            if log_path.exists():
                 try:
                     # errors="replace" matches session_journal read conventions:
                     # a single bad byte substitutes U+FFFD instead of raising,
                     # so a corrupt byte in one line cannot poison the whole read.
-                    existing_lines = LOG_PATH.read_text(
+                    existing_lines = log_path.read_text(
                         encoding="utf-8", errors="replace"
                     ).splitlines()
                 except OSError:
@@ -176,11 +181,11 @@ def append_failure(
             # Single write under the lock — read-truncate-write is correct
             # for a bounded ring buffer and avoids O_APPEND's "lose oldest"
             # impossibility.
-            LOG_PATH.write_text(
+            log_path.write_text(
                 "\n".join(kept) + "\n", encoding="utf-8"
             )
             try:
-                LOG_PATH.chmod(0o600)
+                log_path.chmod(0o600)
             except OSError:
                 # Permission bump is best-effort; the write already succeeded.
                 pass
@@ -210,13 +215,14 @@ def read_failures() -> list[dict[str, Any]]:
         or when the log does not exist.
     """
     try:
-        if not LOG_PATH.exists():
+        log_path = get_failure_log_path()
+        if not log_path.exists():
             return []
-        with file_lock(LOG_PATH):
+        with file_lock(log_path):
             # errors="replace" prevents one bad byte from poisoning the scan.
             # A single stray byte substitutes U+FFFD rather than raising,
             # so a corrupt byte cannot block reads of the surviving entries.
-            content = LOG_PATH.read_text(encoding="utf-8", errors="replace")
+            content = log_path.read_text(encoding="utf-8", errors="replace")
         entries: list[dict[str, Any]] = []
         for line in content.splitlines():
             stripped = line.strip()

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -53,11 +53,20 @@ import re
 import time
 from pathlib import Path
 
+from .paths import get_claude_config_dir
+
 # Token TTL in seconds (5 minutes)
 TOKEN_TTL = 300
 
-# Directory for token files
-TOKEN_DIR = Path.home() / ".claude"
+# Directory for token files. B2 (import-time binding): CLAUDE_CONFIG_DIR is
+# fixed per-process before this module is imported, so an eager SSOT-derived
+# read is production-correct here; the merge-guard tests patch THIS attribute
+# (not the env), so they stay valid and non-vacuous. Derive from the SSOT
+# resolver eagerly — do NOT re-hardcode Path.home()/".claude" (that breaks the
+# single-source-of-truth). Convert to a call-time accessor only if call-time
+# env-following is ever needed (TOKEN_DIR's write+read are both PACT-side, so it
+# never needs to follow a post-import env change).
+TOKEN_DIR = get_claude_config_dir()
 
 # Token file prefix
 TOKEN_PREFIX = "merge-authorized-"

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -23,6 +23,7 @@ from .session_state import SESSION_ID_CONTROL_CHARS_RE
 # nothing from shared.*), so this introduces NO circular import. Used by
 # resolve_agent_name Step 3.5 to recover a tmux teammate's friendly name.
 from .session_registry import resolve as _registry_resolve
+from .paths import get_claude_config_dir
 
 # Slug sanitizer: collapse any character outside the safe-path-component
 # allowlist into "_". The slug derives from CLAUDE_PROJECT_DIR's basename
@@ -110,7 +111,7 @@ def _build_session_path(slug: str, session_id: str) -> Path:
     so sessions with unusual project-dir names still proceed.
     """
     safe_slug = _UNSAFE_SLUG_CHARS_RE.sub("_", slug) if slug else slug
-    sessions_root = Path.home() / ".claude" / "pact-sessions"
+    sessions_root = get_claude_config_dir() / "pact-sessions"
     candidate = sessions_root / safe_slug / session_id
     try:
         sessions_root_resolved = sessions_root.resolve()
@@ -513,7 +514,7 @@ def _iter_members(
         config_path = Path(teams_dir) / team_name / "config.json"
     else:
         config_path = (
-            Path.home() / ".claude" / "teams" / team_name / "config.json"
+            get_claude_config_dir() / "teams" / team_name / "config.json"
         )
     try:
         data = json.loads(config_path.read_text(encoding="utf-8"))

--- a/pact-plugin/hooks/shared/paths.py
+++ b/pact-plugin/hooks/shared/paths.py
@@ -1,0 +1,45 @@
+"""
+Location: pact-plugin/hooks/shared/paths.py
+Summary: Single source of truth for the Claude Code config/state root.
+         Resolves $CLAUDE_CONFIG_DIR (fail-loud, monkeypatch-safe, single-path),
+         falling back to ~/.claude. Every PACT hook that reads/writes state
+         under the config dir derives its base from get_claude_config_dir().
+Used by: shared/{constants,session_registry,failure_log,merge_guard_common,
+         task_utils,pact_context,...}.py and the hook entrypoints
+         (dispatch_gate, session_init, session_end, ...).
+"""
+import os
+from pathlib import Path
+
+
+def get_claude_config_dir(env=None, home=None) -> Path:
+    """Resolve the Claude Code config/state root.
+
+    Pure resolver of (env, home) with both defaulting to the live process
+    globals, so L2/resolution-consumer tests drive it via monkeypatch.setenv +
+    Path.home redirect (NO DI — injecting there is a vacuous green), while L1
+    resolver-unit tests MAY pass env=/home= to assert the contract directly.
+
+    Precedence (fail-loud — NEVER a silent wrong-root fallback):
+      1. $CLAUDE_CONFIG_DIR, honored EVEN IF the dir does not yet exist (the
+         platform creates it; only CONSUMERS fail-open on a missing dir).
+         set-but-empty / whitespace == UNSET.
+           "~"      -> home
+           "~/x"    -> home / "x"     (exact-prefix slice; monkeypatch-safe)
+           "/abs"   -> Path("/abs")
+           "rel"    -> Path("rel")    (honored as-is; surfaced via observability)
+      2. fallback (unset): home / ".claude"
+
+    Returns an UNRESOLVED path — the single .resolve() stays at the call sites
+    that perform containment checks. NO expanduser/lstrip/removeprefix.
+    """
+    env = os.environ if env is None else env
+    home = Path.home() if home is None else home
+    raw = (env.get("CLAUDE_CONFIG_DIR") or "").strip()
+    if not raw:
+        return home / ".claude"
+    if raw == "~":
+        return home
+    if raw.startswith("~/"):
+        return home / raw[2:]          # exact 2-char prefix — NOT lstrip, NOT removeprefix
+    return Path(raw)

--- a/pact-plugin/hooks/shared/peer_context.py
+++ b/pact-plugin/hooks/shared/peer_context.py
@@ -23,6 +23,7 @@ import re
 from pathlib import Path
 
 from shared.plugin_manifest import format_plugin_banner
+from shared.paths import get_claude_config_dir
 
 
 _TEACHBACK_REMINDER = (
@@ -144,7 +145,7 @@ def get_peer_context(
         return None
 
     if teams_dir is None:
-        teams_dir = str(Path.home() / ".claude" / "teams")
+        teams_dir = str(get_claude_config_dir() / "teams")
 
     config_path = Path(teams_dir) / team_name / "config.json"
     if not config_path.exists():

--- a/pact-plugin/hooks/shared/session_registry.py
+++ b/pact-plugin/hooks/shared/session_registry.py
@@ -83,13 +83,14 @@ def _config_root() -> Path:
     through this one copy, or ``register()``'s ``_is_under_pact_sessions`` gate
     fail-closes under a non-default CLAUDE_CONFIG_DIR (silent name-recovery loss).
     """
+    home = Path.home()
     raw = (os.environ.get("CLAUDE_CONFIG_DIR") or "").strip()
     if not raw:
-        return Path.home() / ".claude"
+        return home / ".claude"
     if raw == "~":
-        return Path.home()
+        return home
     if raw.startswith("~/"):
-        return Path.home() / raw[2:]
+        return home / raw[2:]
     return Path(raw)
 
 

--- a/pact-plugin/hooks/shared/session_registry.py
+++ b/pact-plugin/hooks/shared/session_registry.py
@@ -59,7 +59,43 @@ from pathlib import Path
 # the value's @team carries the team. Team-scoping would re-open the bootstrap
 # paradox a tmux teammate cannot compute its lead's team to locate a team-scoped
 # file).
-REGISTRY_PATH = Path.home() / ".claude" / "pact-sessions" / ".teammate-registry.jsonl"
+
+
+def _config_root() -> Path:
+    """Claude Code config/state root — INLINE copy of the canonical
+    ``shared.paths.get_claude_config_dir()``.
+
+    session_registry is a standalone-SCRIPT leaf (the team-registration CLI runs
+    it as ``python session_registry.py``), so it MUST NOT import ``shared.*`` — a
+    relative or ``shared.X`` import raises ImportError in __main__ script mode
+    (module docstring + test_cli_runs_from_foreign_cwd_no_shared_import_error
+    enforce this). This inline copy mirrors the established ``_is_safe_team_segment``
+    dual-copy precedent in this same file.
+
+    DRIFT-ANCHOR: keep byte-equivalent to ``shared.paths.get_claude_config_dir()``;
+    a behavioral parity test enforces they never diverge. A1: sources
+    CLAUDE_CONFIG_DIR from ``os.environ`` ONLY (never a teammate-writable
+    artifact). Returns an UNRESOLVED path — the single ``.resolve()`` stays at the
+    containment call site (``_is_under_pact_sessions``).
+
+    ALL THREE config-root derivations in this module (the registry path, the
+    ``_is_under_pact_sessions`` anchor, and the team-config path) MUST route
+    through this one copy, or ``register()``'s ``_is_under_pact_sessions`` gate
+    fail-closes under a non-default CLAUDE_CONFIG_DIR (silent name-recovery loss).
+    """
+    raw = (os.environ.get("CLAUDE_CONFIG_DIR") or "").strip()
+    if not raw:
+        return Path.home() / ".claude"
+    if raw == "~":
+        return Path.home()
+    if raw.startswith("~/"):
+        return Path.home() / raw[2:]
+    return Path(raw)
+
+
+def get_registry_path() -> Path:
+    """The global teammate-registry path (config-dir-aware; resolved at call time)."""
+    return _config_root() / "pact-sessions" / ".teammate-registry.jsonl"
 
 # Portable single-write atomicity bound. POSIX guarantees os.write atomicity
 # up to PIPE_BUF (512 bytes on macOS); a registry line is realistically
@@ -104,7 +140,7 @@ def _is_under_pact_sessions(path: Path) -> bool:
     Never raises — returns False on any error.
     """
     try:
-        sessions_root = (Path.home() / ".claude" / "pact-sessions").resolve()
+        sessions_root = (_config_root() / "pact-sessions").resolve()
         candidate = path.resolve(strict=False)
         return candidate == sessions_root or sessions_root in candidate.parents
     except (TypeError, ValueError, OSError):
@@ -141,7 +177,8 @@ def register(name_at_team: str) -> None:
             return
         value = _sanitize_agent_name(name) + "@" + team
 
-        if not _is_under_pact_sessions(REGISTRY_PATH):
+        registry_path = get_registry_path()
+        if not _is_under_pact_sessions(registry_path):
             return  # defense-in-depth: refuse to write outside the tree
 
         line = json.dumps(
@@ -153,12 +190,12 @@ def register(name_at_team: str) -> None:
         if len(encoded) > _MAX_LINE_BYTES:
             return  # over the portable single-write atomicity bound → skip
 
-        REGISTRY_PATH.parent.mkdir(parents=True, exist_ok=True)
+        registry_path.parent.mkdir(parents=True, exist_ok=True)
         # O_NOFOLLOW (POSIX) so a planted symlink at the registry path cannot
         # redirect the write; getattr fallback for platforms that lack it.
         nofollow = getattr(os, "O_NOFOLLOW", 0)
         flags = os.O_WRONLY | os.O_APPEND | os.O_CREAT | nofollow
-        fd = os.open(str(REGISTRY_PATH), flags, 0o600)
+        fd = os.open(str(registry_path), flags, 0o600)
         try:
             os.write(fd, encoded)  # single <=PIPE_BUF write → atomic, no lock
         finally:
@@ -188,13 +225,14 @@ def resolve(session_id: str) -> str | None:
     try:
         if not session_id:
             return None
-        if not _is_under_pact_sessions(REGISTRY_PATH):
+        registry_path = get_registry_path()
+        if not _is_under_pact_sessions(registry_path):
             return None
 
         # O_NOFOLLOW open for read so a planted symlink can't redirect us.
         nofollow = getattr(os, "O_NOFOLLOW", 0)
         try:
-            fd = os.open(str(REGISTRY_PATH), os.O_RDONLY | nofollow)
+            fd = os.open(str(registry_path), os.O_RDONLY | nofollow)
         except OSError:
             return None  # missing / symlink (ELOOP) / unreadable → miss
         try:
@@ -274,7 +312,7 @@ def _name_is_team_member(name: str, team: str) -> bool:
     if not _is_safe_team_segment(team):
         return False
     try:
-        config_path = Path.home() / ".claude" / "teams" / team / "config.json"
+        config_path = _config_root() / "teams" / team / "config.json"
         config = json.loads(config_path.read_text(encoding="utf-8"))
         if not isinstance(config, dict):
             return False

--- a/pact-plugin/hooks/shared/session_state.py
+++ b/pact-plugin/hooks/shared/session_state.py
@@ -396,12 +396,23 @@ def _read_team_members(
         return []
 
     try:
-        if teams_base_dir:
-            config_path = Path(teams_base_dir) / team_name / "config.json"
-        else:
-            config_path = (
-                get_claude_config_dir() / "teams" / team_name / "config.json"
-            )
+        teams_base = (
+            Path(teams_base_dir) if teams_base_dir
+            else get_claude_config_dir() / "teams"
+        )
+        team_dir = teams_base / team_name
+        # Bounded containment parity (mirror iter_team_task_jsons / read_task_json
+        # C3): reject a safe-NAMED team_dir that resolves OUTSIDE the teams base
+        # (a SYMLINK escaping it); fail-open (return []) on the escape or an
+        # unreadable path. SINGLE-named-file reader (reads ONE config.json, never
+        # globs) -> only the 2-of-5 guards apply: is_safe_path_component (above) +
+        # this resolve()/relative_to. The glob-result hygiene guards (per-file
+        # is_symlink / dotfile skip) are correctly ABSENT.
+        try:
+            team_dir.resolve().relative_to(teams_base.resolve())
+        except (ValueError, OSError):
+            return []
+        config_path = team_dir / "config.json"
 
         if not config_path.exists():
             return []
@@ -451,15 +462,37 @@ def _read_task_counts(
         return counts
 
     try:
-        if tasks_base_dir:
-            team_dir = Path(tasks_base_dir) / team_name
-        else:
-            team_dir = get_claude_config_dir() / "tasks" / team_name
+        tasks_base = (
+            Path(tasks_base_dir) if tasks_base_dir
+            else get_claude_config_dir() / "tasks"
+        )
+        team_dir = tasks_base / team_name
+        # Bounded containment parity: reject a team_dir SYMLINK escaping the base
+        # (fail-open). This is the GLOB reader, so it ALSO gets the per-file
+        # is_symlink skip below (a *.json symlink could resolve outside the base
+        # even when team_dir is contained) — mirroring iter_team_task_jsons.
+        try:
+            team_dir.resolve().relative_to(tasks_base.resolve())
+        except (ValueError, OSError):
+            return counts
 
         if not team_dir.exists():
             return counts
 
         for task_file in team_dir.glob("*.json"):
+            # Dotfile skip (glob-result hygiene): glob('*.json') DOES match
+            # dotfile-prefixed names; this is a COUNT reader, so a planted
+            # `.evil.json` would inflate the tally. Mirror iter_team_task_jsons's
+            # dotfile exclusion. (Security #37 5-mirror guard #4.)
+            if task_file.name.startswith("."):
+                continue
+            # Per-file symlink skip (glob-result hygiene): glob returns symlink
+            # entries; one could resolve outside the base. Skip silently.
+            try:
+                if task_file.is_symlink():
+                    continue
+            except OSError:
+                continue
             try:
                 data = json.loads(
                     task_file.read_text(encoding="utf-8", errors="replace")
@@ -504,17 +537,21 @@ def _read_feature_subject_from_disk(
         return None
 
     try:
-        if tasks_base_dir:
-            task_path = (
-                Path(tasks_base_dir) / team_name / f"{feature_id}.json"
-            )
-        else:
-            task_path = (
-                get_claude_config_dir()
-                / "tasks"
-                / team_name
-                / f"{feature_id}.json"
-            )
+        tasks_base = (
+            Path(tasks_base_dir) if tasks_base_dir
+            else get_claude_config_dir() / "tasks"
+        )
+        team_dir = tasks_base / team_name
+        # Bounded containment parity (single-named-file reader -> 2-of-5 guards:
+        # is_safe_path_component on team_name+feature_id above + this
+        # resolve()/relative_to; glob-result hygiene guards correctly ABSENT —
+        # reads ONE {feature_id}.json, never globs). Fail-open (return None) on a
+        # team_dir symlink escaping the base or an unreadable path.
+        try:
+            team_dir.resolve().relative_to(tasks_base.resolve())
+        except (ValueError, OSError):
+            return None
+        task_path = team_dir / f"{feature_id}.json"
 
         if not task_path.exists():
             return None

--- a/pact-plugin/hooks/shared/session_state.py
+++ b/pact-plugin/hooks/shared/session_state.py
@@ -34,6 +34,7 @@ from typing import Any
 
 from shared import pact_context
 from shared.constants import SYSTEM_TASK_PREFIXES
+from shared.paths import get_claude_config_dir
 from shared.session_journal import read_events_from
 
 
@@ -399,7 +400,7 @@ def _read_team_members(
             config_path = Path(teams_base_dir) / team_name / "config.json"
         else:
             config_path = (
-                Path.home() / ".claude" / "teams" / team_name / "config.json"
+                get_claude_config_dir() / "teams" / team_name / "config.json"
             )
 
         if not config_path.exists():
@@ -453,7 +454,7 @@ def _read_task_counts(
         if tasks_base_dir:
             team_dir = Path(tasks_base_dir) / team_name
         else:
-            team_dir = Path.home() / ".claude" / "tasks" / team_name
+            team_dir = get_claude_config_dir() / "tasks" / team_name
 
         if not team_dir.exists():
             return counts
@@ -509,8 +510,7 @@ def _read_feature_subject_from_disk(
             )
         else:
             task_path = (
-                Path.home()
-                / ".claude"
+                get_claude_config_dir()
                 / "tasks"
                 / team_name
                 / f"{feature_id}.json"

--- a/pact-plugin/hooks/shared/symlinks.py
+++ b/pact-plugin/hooks/shared/symlinks.py
@@ -55,10 +55,13 @@ def setup_plugin_symlinks() -> str | None:
             protocols_roots.append(config_root)
         for root in protocols_roots:
             protocols_dst = root / "protocols" / "pact-plugin"
-            # mode=0o700 applies to the leaf directory only; parent dirs use umask
-            protocols_dst.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-
             try:
+                # mkdir INSIDE the try (#926): a pathological config_root
+                # (relative / unwritable / file-in-path) must fail-open per this
+                # function's "returns None/status, never raises" contract, not
+                # propagate to the caller. mode=0o700 applies to the leaf dir
+                # only; parent dirs use umask.
+                protocols_dst.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
                 if protocols_dst.is_symlink():
                     if protocols_dst.resolve() != protocols_src.resolve():
                         protocols_dst.unlink()

--- a/pact-plugin/hooks/shared/symlinks.py
+++ b/pact-plugin/hooks/shared/symlinks.py
@@ -14,6 +14,8 @@ Creates two types of symlinks:
 import os
 from pathlib import Path
 
+from .paths import get_claude_config_dir
+
 
 def setup_plugin_symlinks() -> str | None:
     """
@@ -36,32 +38,44 @@ def setup_plugin_symlinks() -> str | None:
     if not plugin_root.exists():
         return None
 
-    claude_dir = Path.home() / ".claude"
+    home_claude = Path.home() / ".claude"
+    config_root = get_claude_config_dir()
     messages = []
 
-    # 1. Symlink protocols/ directory
+    # 1. Symlink protocols/ directory.
+    # DUAL-LOCATION (#926): the protocols symlink is consumed by a CLAUDE.md
+    # `@~/.claude/protocols/...` import. Whether Claude expands the literal `~`
+    # to $HOME or rewrites it to $CLAUDE_CONFIG_DIR is not knowable here, so we
+    # create the link in BOTH roots when they differ (answer-immune). With the
+    # env unset the two roots are equal and we create exactly once.
     protocols_src = plugin_root / "protocols"
     if protocols_src.exists():
-        protocols_dst = claude_dir / "protocols" / "pact-plugin"
-        # mode=0o700 applies to the leaf directory only; parent dirs use umask
-        protocols_dst.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        protocols_roots = [home_claude]
+        if config_root.resolve() != home_claude.resolve():
+            protocols_roots.append(config_root)
+        for root in protocols_roots:
+            protocols_dst = root / "protocols" / "pact-plugin"
+            # mode=0o700 applies to the leaf directory only; parent dirs use umask
+            protocols_dst.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
 
-        try:
-            if protocols_dst.is_symlink():
-                if protocols_dst.resolve() != protocols_src.resolve():
-                    protocols_dst.unlink()
+            try:
+                if protocols_dst.is_symlink():
+                    if protocols_dst.resolve() != protocols_src.resolve():
+                        protocols_dst.unlink()
+                        protocols_dst.symlink_to(protocols_src)
+                        messages.append("protocols updated")
+                elif not protocols_dst.exists():
                     protocols_dst.symlink_to(protocols_src)
-                    messages.append("protocols updated")
-            elif not protocols_dst.exists():
-                protocols_dst.symlink_to(protocols_src)
-                messages.append("protocols linked")
-        except OSError as e:
-            messages.append(f"protocols failed: {str(e)[:20]}")
+                    messages.append("protocols linked")
+            except OSError as e:
+                messages.append(f"protocols failed: {str(e)[:20]}")
 
-    # 2. Symlink individual agent files (enables non-prefixed agent names)
+    # 2. Symlink individual agent files (enables non-prefixed agent names).
+    # Agents FOLLOW the config dir — Claude discovers subagents from
+    # $CLAUDE_CONFIG_DIR/agents/.
     agents_src = plugin_root / "agents"
     if agents_src.exists():
-        agents_dst = claude_dir / "agents"
+        agents_dst = config_root / "agents"
         # mode=0o700 applies to the leaf directory only; parent dirs use umask
         agents_dst.mkdir(parents=True, exist_ok=True, mode=0o700)
 

--- a/pact-plugin/hooks/shared/task_utils.py
+++ b/pact-plugin/hooks/shared/task_utils.py
@@ -31,6 +31,7 @@ from typing import Any, Iterator
 
 from shared.pact_context import get_session_id, get_team_name
 from shared.session_state import is_safe_path_component
+from shared.paths import get_claude_config_dir
 
 
 def get_task_list(tasks_base_dir: str | None = None) -> list[dict[str, Any]] | None:
@@ -98,7 +99,7 @@ def get_task_list(tasks_base_dir: str | None = None) -> list[dict[str, Any]] | N
     if not is_safe_path_component(task_list_id):
         return None
 
-    base = Path(tasks_base_dir) if tasks_base_dir else (Path.home() / ".claude" / "tasks")
+    base = Path(tasks_base_dir) if tasks_base_dir else (get_claude_config_dir() / "tasks")
     tasks_dir = base / task_list_id
 
     # R3 (security): the {task_list_id} dir could itself be a SYMLINK that
@@ -387,7 +388,7 @@ def iter_team_task_jsons(
     if not is_safe_path_component(team_name):
         return
     try:
-        base = Path(tasks_base_dir) if tasks_base_dir else (Path.home() / ".claude" / "tasks")
+        base = Path(tasks_base_dir) if tasks_base_dir else (get_claude_config_dir() / "tasks")
         tasks_root = base.resolve()
     except OSError:
         return

--- a/pact-plugin/hooks/shared/task_utils.py
+++ b/pact-plugin/hooks/shared/task_utils.py
@@ -459,16 +459,32 @@ def read_task_json(
         return {}
 
     if tasks_base_dir is None:
-        tasks_base_dir = str(Path.home() / ".claude" / "tasks")
+        tasks_base_dir = str(get_claude_config_dir() / "tasks")
 
     base = Path(tasks_base_dir)
 
     task_dirs = []
-    if team_name:
+    # Bounded containment parity, guard (1): reject a traversal team_name
+    # (mirror iter_team_task_jsons's is_safe_path_component return-on-invalid).
+    # An unsafe team_name skips the team dir and falls through to the bare-base
+    # read, preserving the fail-open {} contract. Legit pact-<slug>/UUID names
+    # are single [A-Za-z0-9_-] components and pass unchanged.
+    if team_name and is_safe_path_component(team_name):
         task_dirs.append(base / team_name)
     task_dirs.append(base)
 
     for task_dir in task_dirs:
+        # Bounded containment parity, guard (2): skip a task_dir that resolves
+        # OUTSIDE base — e.g. a safe-named team dir that is a SYMLINK escaping
+        # the tasks base. Mirror the sibling readers' resolve()+relative_to;
+        # fail-open (continue to the bare-base fallback), preserving {}. Only
+        # guards (1)+(2) apply to this single-named-file reader; the glob-result
+        # hygiene guards (per-file is_symlink / dotfile skip / isinstance(dict))
+        # are correctly absent — read_task_json reads ONE named file, never globs.
+        try:
+            task_dir.resolve().relative_to(base.resolve())
+        except (ValueError, OSError):
+            continue
         task_file = task_dir / f"{task_id}.json"
         # M2 (security): exists() is INSIDE the try and ValueError is caught.
         # A NUL byte in task_id that slips past the sanitizer raises

--- a/pact-plugin/hooks/shared/teammate_mode.py
+++ b/pact-plugin/hooks/shared/teammate_mode.py
@@ -28,6 +28,8 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+from .paths import get_claude_config_dir
+
 # Full allowed value set (CLI .choices + settings-UI enum). A value outside
 # this set is treated as "not defined here" (fail-open → skip the source).
 VALID_TEAMMATE_MODES = frozenset({"auto", "tmux", "in-process"})
@@ -117,7 +119,7 @@ def _settings_source_paths() -> list[Path]:
         _managed_settings_path(),
         project_claude / "settings.local.json",
         project_claude / "settings.json",
-        Path.home() / ".claude" / "settings.json",
+        get_claude_config_dir() / "settings.json",
     ]
 
 
@@ -144,7 +146,16 @@ def resolve_effective_teammate_mode() -> str:
             value = _read_teammate_mode(path)
             if value is not None:
                 return value
-        legacy = _read_teammate_mode(Path.home() / ".claude.json")
+        # Legacy ~/.claude.json (F*, #926): SIBLING-file asymmetry — the default
+        # lives at $HOME/.claude.json (a sibling of .claude/), but under a
+        # non-default CLAUDE_CONFIG_DIR it relocates to $CONFIG_DIR/.claude.json.
+        # NOT get_claude_config_dir()/".claude.json" blindly — when unset that
+        # would yield $HOME/.claude/.claude.json (wrong). Explicit env branch:
+        if (os.environ.get("CLAUDE_CONFIG_DIR") or "").strip():
+            legacy_path = get_claude_config_dir() / ".claude.json"
+        else:
+            legacy_path = Path.home() / ".claude.json"  # preserve $HOME sibling default
+        legacy = _read_teammate_mode(legacy_path)
         if legacy is not None:
             return legacy
         return _DEFAULT_MODE

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -108,6 +108,7 @@ try:
     from pathlib import Path
 
     import shared.pact_context as pact_context
+    from shared.paths import get_claude_config_dir
     from shared.agent_handoff_marker import (
         already_emitted,
         is_signal_task,
@@ -259,7 +260,7 @@ def _writeback_dispute(task_id: str) -> bool:
     metadata["completion_disputed"] = True
     metadata["gate_writeback"] = True
 
-    tasks_root = Path.home() / ".claude" / "tasks" / team_name
+    tasks_root = get_claude_config_dir() / "tasks" / team_name
     target = tasks_root / f"{sanitized_id}.json"
     tmp = tasks_root / f".{sanitized_id}.json.tmp"
     try:
@@ -360,7 +361,7 @@ def _writeback_audit_recovery(task_id: str, updates: dict) -> bool:
         metadata[key] = value
     metadata["gate_writeback"] = True
 
-    tasks_root = Path.home() / ".claude" / "tasks" / team_name
+    tasks_root = get_claude_config_dir() / "tasks" / team_name
     target = tasks_root / f"{sanitized_id}.json"
     tmp = tasks_root / f".{sanitized_id}.json.tmp"
     try:

--- a/pact-plugin/hooks/team_guard.py
+++ b/pact-plugin/hooks/team_guard.py
@@ -16,6 +16,15 @@ import json
 import sys
 from pathlib import Path
 
+# Add hooks/ to sys.path for the shared import below (mirrors the sibling
+# PreToolUse hooks). Needed now that the team-existence check derives the teams
+# dir from the shared CLAUDE_CONFIG_DIR resolver instead of a hardcoded ~/.claude.
+_hooks_dir = Path(__file__).parent
+if str(_hooks_dir) not in sys.path:
+    sys.path.insert(0, str(_hooks_dir))
+
+from shared.paths import get_claude_config_dir
+
 _SUPPRESS_OUTPUT = json.dumps({"suppressOutput": True})
 
 
@@ -36,7 +45,7 @@ def check_team_exists(tool_input: dict, teams_dir: str | None = None) -> str | N
     team_name = team_name.lower()
 
     if teams_dir is None:
-        teams_dir = str(Path.home() / ".claude" / "teams")
+        teams_dir = str(get_claude_config_dir() / "teams")
 
     team_config = Path(teams_dir) / team_name / "config.json"
     if not team_config.exists():

--- a/pact-plugin/hooks/team_guard.py
+++ b/pact-plugin/hooks/team_guard.py
@@ -12,20 +12,57 @@ Input: JSON from stdin with tool_input containing Task parameters
 Output: JSON with hookSpecificOutput.permissionDecision if blocking
 """
 
+# ─── stdlib first (used by _emit_load_failure_deny BEFORE wrapped imports) ─
 import json
 import sys
 from pathlib import Path
+from typing import NoReturn
 
-# Add hooks/ to sys.path for the shared import below (mirrors the sibling
-# PreToolUse hooks). Needed now that the team-existence check derives the teams
-# dir from the shared CLAUDE_CONFIG_DIR resolver instead of a hardcoded ~/.claude.
-_hooks_dir = Path(__file__).parent
-if str(_hooks_dir) not in sys.path:
-    sys.path.insert(0, str(_hooks_dir))
-
-from shared.paths import get_claude_config_dir
 
 _SUPPRESS_OUTPUT = json.dumps({"suppressOutput": True})
+
+
+def _emit_load_failure_deny(stage: str, error: BaseException) -> NoReturn:
+    """Stdlib-only fail-closed deny for module-load failure. Mirrors PR #660
+    ``merge_guard_pre._emit_load_failure_deny`` / ``dispatch_gate`` analogue.
+
+    Without this, a raise from the cross-package import below would crash the
+    hook (exit 1), which the platform treats as a NON-blocking PreToolUse hook
+    — the Task tool would PROCEED and the team-existence gate would silently
+    FAIL-OPEN. Emitting a deny + exit 2 keeps the gate fail-CLOSED. hookEventName
+    MUST be present.
+    """
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                f"PACT team_guard {stage} failure — blocking for safety. "
+                f"{type(error).__name__}: {error}. Check hook installation "
+                "and shared module availability."
+            ),
+        }
+    }))
+    print(
+        f"Hook load error (team_guard / {stage}): {error}",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+# ─── fail-closed wrapper on cross-package imports ──────────────────────────
+# The team-existence check derives the teams dir from the shared
+# CLAUDE_CONFIG_DIR resolver. Add hooks/ to sys.path (mirrors the sibling
+# PreToolUse hooks), then import under the fail-closed wrapper so a load failure
+# DENIES rather than crash-and-fail-open.
+try:
+    _hooks_dir = Path(__file__).parent
+    if str(_hooks_dir) not in sys.path:
+        sys.path.insert(0, str(_hooks_dir))
+
+    from shared.paths import get_claude_config_dir
+except BaseException as _module_load_error:  # noqa: BLE001 — fail-closed catch-all
+    _emit_load_failure_deny("module imports", _module_load_error)
 
 
 def check_team_exists(tool_input: dict, teams_dir: str | None = None) -> str | None:

--- a/pact-plugin/hooks/teammate_idle.py
+++ b/pact-plugin/hooks/teammate_idle.py
@@ -41,6 +41,7 @@ if str(_hooks_dir) not in sys.path:
 from shared.error_output import hook_error_json
 import shared.pact_context as pact_context
 from shared.pact_context import get_team_name
+from shared.paths import get_claude_config_dir
 from shared.task_utils import get_task_list
 
 
@@ -319,7 +320,7 @@ def main():
             sys.exit(0)
 
         idle_counts_path = str(
-            Path.home() / ".claude" / "teams" / team_name / "idle_counts.json"
+            get_claude_config_dir() / "teams" / team_name / "idle_counts.json"
         )
 
         messages = []

--- a/pact-plugin/hooks/track_files.py
+++ b/pact-plugin/hooks/track_files.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from shared.error_output import hook_error_json
 import shared.pact_context as pact_context
 from shared.pact_context import get_session_id
+from shared.paths import get_claude_config_dir
 
 # Suppress false "hook error" display in Claude Code UI on bare exit paths
 _SUPPRESS_OUTPUT = json.dumps({"suppressOutput": True})
@@ -30,13 +31,16 @@ except ImportError:
     HAS_FLOCK = False
 
 
-# Directory for tracking data
-TRACKING_DIR = Path.home() / ".claude" / "pact-memory" / "session-tracking"
+# Directory for tracking data. Accessor (B1) — resolves $CLAUDE_CONFIG_DIR at
+# CALL time via the shared resolver, so a non-default config dir is honored and
+# the import-time freeze (a #924-class inert trap) is avoided.
+def get_tracking_dir() -> Path:
+    return get_claude_config_dir() / "pact-memory" / "session-tracking"
 
 
 def ensure_tracking_dir():
     """Ensure the tracking directory exists."""
-    TRACKING_DIR.mkdir(parents=True, exist_ok=True)
+    get_tracking_dir().mkdir(parents=True, exist_ok=True)
 
 
 def get_session_tracking_file() -> Path:
@@ -46,7 +50,7 @@ def get_session_tracking_file() -> Path:
     reads from the correct session-scoped context file.
     """
     session_id = get_session_id() or "unknown"
-    return TRACKING_DIR / f"{session_id}.json"
+    return get_tracking_dir() / f"{session_id}.json"
 
 
 def load_tracked_files() -> dict:

--- a/pact-plugin/tests/runbooks/926-config-dir-live-probe.md
+++ b/pact-plugin/tests/runbooks/926-config-dir-live-probe.md
@@ -1,0 +1,78 @@
+# Runbook: CLAUDE_CONFIG_DIR Path-Resolution Live-Probe Acceptance Gate
+
+**Purpose:** the post-merge runtime-confirmation gate for the config-dir-aware
+path resolution (`shared/paths.py::get_claude_config_dir`). The comprehensive
+L1 (resolver contract) + L2 (non-mocked integration: dispatch-flip,
+two-idiom containment, both-modes, classification-stay-fixed) layers ship IN the
+PR and run in CI. L3 — that a REAL Claude Code session launched under a
+non-default `CLAUDE_CONFIG_DIR` actually resolves state, agents, and `@`-ref
+imports from the relocated root — CANNOT be driven by pytest (platform `@`-ref
+resolution + agent discovery + state writes happen at real session bootstrap).
+This runbook is that gate.
+
+This mirrors the #923 / #861 pattern: a fix is "merged-but-not-runtime-confirmed"
+until a live session under the real env demonstrates the behavior end-to-end.
+
+## §1 — Acceptance criterion (NOT closed on green tests alone)
+
+The fix is runtime-confirmed only when ALL hold under a real session whose
+`CLAUDE_CONFIG_DIR` is set to a non-default dir (e.g. `~/.claude-kimi`):
+
+- (a) **Dispatch unblocks** — a teammate with an assigned task is NOT blocked by
+  `dispatch_gate` rule ⑧ (`has_task_assigned` resolves the task under
+  `$CLAUDE_CONFIG_DIR/tasks`, not `~/.claude/tasks`). This is the original bug.
+- (b) **Agents resolve** — specialist agents are discovered/loaded from
+  `$CLAUDE_CONFIG_DIR/agents` (or the dual-location install), i.e. the team
+  spawns specialists at all.
+- (c) **`@`-ref imports resolve** — at least one `@~/.claude/protocols/...`
+  import inside a loaded `CLAUDE.md` / agent body resolves to readable content
+  under the active config (the C6 dual-location protocols symlink makes this
+  answer-immune by construction; verify it live anyway).
+- (d) **No silent state loss** — the session's `pact-sessions/<slug>/<id>` dir is
+  created under `$CLAUDE_CONFIG_DIR/pact-sessions` and the Resume line points
+  there (validates the migrated `session_init:433` `_validate_under_pact_sessions`
+  anchor — a home-lagged anchor would reject the correctly-stored path → None →
+  session-dir silently lost).
+
+## §2 — Live-probe procedure (per teammateMode)
+
+Run once per mode the operator uses (tmux mandatory; in-process if used). The
+resolver is mode-independent (keys on the env var, not session topology — proven
+by the L2 both-modes pair), so a divergence between modes here is itself a finding.
+
+**Setup.** In a fresh shell:
+```bash
+export CLAUDE_CONFIG_DIR="$HOME/.claude-kimi"     # any non-default, pre-created or platform-created
+mkdir -p "$CLAUDE_CONFIG_DIR"
+# launch Claude Code / the PACT session in the target mode under this env
+```
+
+- **Step 1 — bootstrap a team.** Start a PACT session; let it create a team +
+  spawn the secretary. **OBSERVE:** the team config and tasks appear under
+  `$CLAUDE_CONFIG_DIR/teams/<team>/` and `$CLAUDE_CONFIG_DIR/tasks/<team>/`
+  (NOT under `~/.claude/...`). → criterion (a) substrate + (b) spawn.
+- **Step 2 — dispatch a teammate with a task.** Create a Task A/B dispatch to any
+  specialist. **OBSERVE:** the teammate is NOT blocked at dispatch (no
+  "no task assigned" deny); it proceeds to teachback. → criterion (a).
+- **Step 3 — confirm agent + `@`-ref resolution.** The spawned specialist loads
+  its agent body and `CLAUDE.md`. **OBSERVE:** the agent runs (agents resolved
+  from the config-dir install) and at least one `@~/.claude/protocols/...`
+  import renders non-empty content. → criteria (b)+(c).
+- **Step 4 — confirm session-dir placement.** **OBSERVE:** the Resume line / session
+  dir is `$CLAUDE_CONFIG_DIR/pact-sessions/<slug>/<id>` and is readable. → (d).
+- **Step 5 — settings tip sanity (optional).** If `additionalDirectories` is
+  unset, the setup tip should reference the config-dir paths (validates the
+  `session_init:350` membership anchor). → corroborates (a)/(d).
+
+**PASS** = (a)+(b)+(c)+(d) all hold in the mode under test (Step 5 corroborating).
+On any FAIL, capture the resolved path observed vs expected and file a follow-up
+with the session-journal evidence; a home-anchored resolution in any criterion is
+a re-anchoring regression (cross-check against the L2 counter-test cardinality
+`{4 failed, 7 passed}` documented in `test_config_dir_comprehensive.py`).
+
+## §3 — Sections-passed denominator
+
+Denominator is **4** (criteria a/b/c/d) per mode. Record per-mode in
+`RUNBOOK_RUN_DATES.md`. The live run is expected to occur under the user's
+non-default-config environment (e.g. a kimi-cli session) or a deliberate
+`CLAUDE_CONFIG_DIR` export in a tmux session post-merge.

--- a/pact-plugin/tests/runbooks/RUNBOOK_RUN_DATES.md
+++ b/pact-plugin/tests/runbooks/RUNBOOK_RUN_DATES.md
@@ -50,6 +50,14 @@ Sections-passed denominator is 3 per runbook (standard-teammate first-action; se
 
 Sections-passed denominator is 2 per runbook §4 (tmux live-probe; in-process live-probe), each gated on all of §2 (a)+(b)+(c)+(d)+Step 5 with the Step 6 tripwire clear. The inline-mission mode column does not apply (`n/a`). Unlike a pre-merge overlay smoke, this is the **POST-merge acceptance gate** — a green suite does NOT close #923; the tmux live-probe is mandatory. If tmux is RED, re-open and route back to the resolver. If the Step 6 tripwire finds `CLAUDE_CODE_TASK_LIST_ID` SET in a team session, HALT + architect escalation (Design A/B divergence, devops contingency C).
 
+## 926-config-dir-live-probe.md
+
+| Run date (UTC) | Operator | Plugin version | Sections passed | inline-mission mode | Notes / per-mode observations |
+| -------------- | -------- | -------------- | --------------- | ------------------- | -------------------------------- |
+| _pending — execute POST-merge under a real non-default CLAUDE_CONFIG_DIR session (e.g. kimi-cli, or `export CLAUDE_CONFIG_DIR=~/.claude-kimi` in tmux)_ | | 4.4.13 | /4 per mode | n/a | (a) dispatch unblocks — `has_task_assigned` resolves task under `$CONFIG/tasks` (the original bug) PASS/FAIL · (b) agents resolve from `$CONFIG/agents` (team spawns specialists) PASS/FAIL · (c) ≥1 `@~/.claude/protocols/...` import resolves non-empty PASS/FAIL · (d) session-dir under `$CONFIG/pact-sessions` + Resume line correct (validates `session_init:433` anchor) PASS/FAIL. Cross-check the L2 counter-test cardinality `{4 failed, 7 passed}` from `test_config_dir_comprehensive.py` if any criterion shows a home-anchored resolution. |
+
+Sections-passed denominator is 4 per mode per runbook §3 (criteria a/b/c/d). This is the **POST-merge runtime-confirmation gate** (#861 class) — a green CI suite (L1+L2, 8246 passed) does NOT close #926; the live run under a non-default `CLAUDE_CONFIG_DIR` is mandatory. The resolver is mode-independent (keys on the env var, not session topology — proven by the L2 both-modes pair), so a divergence between in-process and tmux is itself a finding. On any FAIL, capture resolved-vs-expected path and route back to the resolver / call-site.
+
 ## v4.0.0-launch-and-isolation.md
 
 | Run date (UTC) | Operator | Plugin version | Sections passed | Notes / fallback-ladder signals |

--- a/pact-plugin/tests/test_config_dir_comprehensive.py
+++ b/pact-plugin/tests/test_config_dir_comprehensive.py
@@ -1,0 +1,236 @@
+"""
+Comprehensive TEST-phase coverage for #926 (CLAUDE_CONFIG_DIR-aware path
+resolution), BEYOND the per-commit verification tests devops shipped in CODE.
+
+What is ALREADY covered (do not duplicate):
+  - L1 resolver contract (all precedence branches, ~/x exact-slice, FOLLOWS
+    accessors) ........................................ test_paths.py (21 tests)
+  - L2 dispatch-flip happy path + relative_to escape (task_utils idiom) under a
+    relocated config ................. test_config_dir_dispatch_integration.py
+  - parents-based idiom POSITIVE under relocated config + sibling-prefix under
+    the DEFAULT root .......... test_session_registry.py (C4b: L245 / L289 / L304)
+
+What THIS file adds (the genuine comprehensive gaps):
+  1. The INTERSECTION devops's tests miss: the parents-based sibling-prefix
+     collision (`<config>/pact-sessions-evil`) under a RELOCATED config dir, for
+     BOTH parents-based anchors (session_init:433 + session_registry:107), plus a
+     traversal-escape negative. The default-root sibling test and the
+     relocated-positive test each cover one axis; neither covers their product.
+  2. session_init:350 required-dir membership config-awareness (deferred from
+     C5 as a tip-check, per #13 metadata.test_phase_items).
+  3. dispatch_gate both-modes confirmatory pair (in-process vs tmux) — devops's
+     L2 file explicitly deferred this to the TEST phase.
+  4. Classification STAY-FIXED (section C): install/cache (CLAUDE_PLUGIN_ROOT)
+     do NOT follow CLAUDE_CONFIG_DIR — the backstop against over-application.
+
+ANTI-VACUITY (the whole point — a mocked/DI-bypassed seam is a vacuous green):
+every test drives the REAL resolver via monkeypatch.setenv("CLAUDE_CONFIG_DIR")
++ Path.home redirect, NEVER the tasks_base_dir DI seam. The redirected home is a
+SEPARATE EMPTY dir, so a source-revert of any re-anchoring (back to
+Path.home()/".claude") flips the assertion — these tests FAIL BEHAVIORALLY, and
+reference only pre-existing production entrypoints (no post-fix-only symbol), so a
+revert fails on the assertion, not on an ImportError artifact.
+
+Counter-test cardinality (source-only revert of the re-anchoring, leaving these
+tests in place) — documented per class below.
+
+L3 (live @-ref + real-session dispatch) is RUNBOOK-deferred (lead-confirmed):
+see tests/runbooks/926-config-dir-live-probe.md — platform @-ref resolution
+happens at real session bootstrap, which pytest cannot drive.
+"""
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from shared.dispatch_helpers import has_task_assigned
+import shared.session_registry as sr
+from shared.plugin_manifest import _resolve_plugin_root
+
+
+@pytest.fixture
+def relocated(tmp_path, monkeypatch):
+    """Non-default CLAUDE_CONFIG_DIR + a SEPARATE empty redirected home.
+
+    Returns (config_dir, fake_home). The empty fake_home is the anti-vacuity
+    lever: any anchor that lags on Path.home() resolves into this empty tree and
+    the corresponding assertion flips.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+    return config_dir, fake_home
+
+
+class TestParentsBasedContainmentUnderRelocatedConfig:
+    """Section-B teeth: the parents-based containment idiom
+    (`candidate == root or root in candidate.parents`) must re-anchor to the
+    relocated root AND keep rejecting the sibling-prefix-collision class.
+
+    Counter-test cardinality (source-only revert of the :433 / :107 root
+    re-anchoring back to Path.home()): the legit-accept tests flip to None
+    (reject) and the silent-bail surfaces -> {2 accept-tests fail}. The reject
+    tests stay green under that revert (a home-anchored root still rejects a
+    $CONFIG sibling) but flip under a str-prefix regression of the idiom.
+    """
+
+    def test_session_init_validate_accepts_legit_path_under_relocated_config(self, relocated):
+        config_dir, _ = relocated
+        from session_init import _validate_under_pact_sessions
+
+        legit = str(config_dir / "pact-sessions" / "myproject" / "abc12345")
+        # Non-vacuous: if sessions_root lagged on Path.home()/.claude, this
+        # $CONFIG-rooted candidate would NOT be under it -> None.
+        assert _validate_under_pact_sessions(legit) == legit
+
+    def test_session_init_validate_rejects_sibling_prefix_under_relocated_config(self, relocated):
+        config_dir, _ = relocated
+        from session_init import _validate_under_pact_sessions
+
+        # THE GAP: sibling-prefix collision under the RELOCATED root. A naive
+        # str-prefix check ("<config>/pact-sessions-evil".startswith(
+        # "<config>/pact-sessions")) would WRONGLY accept; the parents-based
+        # idiom rejects.
+        sibling = str(config_dir / "pact-sessions-evil" / "stolen" / "x")
+        assert _validate_under_pact_sessions(sibling) is None
+
+    def test_session_init_validate_rejects_traversal_escape_under_relocated_config(self, relocated):
+        config_dir, _ = relocated
+        from session_init import _validate_under_pact_sessions
+
+        escape = str(config_dir / "pact-sessions" / ".." / ".." / "etc" / "passwd")
+        assert _validate_under_pact_sessions(escape) is None
+
+    def test_session_registry_rejects_sibling_prefix_under_relocated_config(self, relocated):
+        config_dir, _ = relocated
+        # Complements C4b: L245 covers the sibling under the DEFAULT root and
+        # L304 covers a legit path under a relocated root; THIS covers their
+        # product — sibling-prefix under the RELOCATED root.
+        sibling = config_dir / "pact-sessions-evil" / "x.jsonl"
+        assert sr._is_under_pact_sessions(sibling) is False
+
+    def test_session_registry_accepts_legit_under_relocated_config(self, relocated):
+        config_dir, _ = relocated
+        legit = config_dir / "pact-sessions" / "team" / "reg.jsonl"
+        # Non-vacuous: a home-lagged anchor rejects this $CONFIG path.
+        assert sr._is_under_pact_sessions(legit) is True
+
+
+class TestSessionInit350RequiredDirConfigAwareness:
+    """session_init:350 required-dir membership check must anchor the required
+    {teams, pact-sessions} set on get_claude_config_dir(), so the setup tip
+    reflects the relocated config dir.
+
+    Counter-test cardinality (source-only revert of the :350/:351-354 anchor
+    back to Path.home()/.claude): the non-vacuity test below flips
+    (old-home paths would then satisfy `required`, so no tip) -> {1 fail}.
+    """
+
+    def _write_settings(self, config_dir, additional_dirs):
+        (config_dir / "settings.json").write_text(
+            json.dumps({"permissions": {"additionalDirectories": additional_dirs}}),
+            encoding="utf-8",
+        )
+
+    def test_no_tip_when_config_dir_paths_are_configured(self, relocated):
+        config_dir, _ = relocated
+        from session_init import check_additional_directories
+
+        self._write_settings(
+            config_dir,
+            [str(config_dir / "teams"), str(config_dir / "pact-sessions")],
+        )
+        assert check_additional_directories() is None
+
+    def test_tip_fires_when_only_old_home_paths_configured(self, relocated):
+        config_dir, fake_home = relocated
+        from session_init import check_additional_directories
+
+        # NON-VACUITY: configure the PRE-#926 home-based paths. Because the
+        # required set now anchors on $CONFIG, these stale paths no longer
+        # satisfy it -> a tip MUST fire. If :350 had stayed on Path.home(),
+        # required would equal these paths -> no tip -> this assertion fails.
+        self._write_settings(
+            config_dir,
+            [
+                str(fake_home / ".claude" / "teams"),
+                str(fake_home / ".claude" / "pact-sessions"),
+            ],
+        )
+        tip = check_additional_directories()
+        assert tip is not None
+        assert "additionalDirectories" in tip
+
+
+class TestDispatchGateBothModesUnderRelocatedConfig:
+    """Both-modes confirmatory pair (deferred from devops's L2 file).
+
+    The #926 resolver keys on $CLAUDE_CONFIG_DIR (process env) and the dispatch
+    gate keys on team_name (arg) — NEITHER consults session topology — so
+    has_task_assigned resolves IDENTICALLY under the in-process
+    (session_id == leadSessionId) and tmux (session_id != leadSessionId)
+    teammateModes. This pair asserts that invariance, satisfying the standing
+    dual-mode merge-gate convention WITHOUT implying a mode branch exists (there
+    is none; a divergence here would itself be the finding).
+    """
+
+    def _write_task(self, config_dir, team, owner):
+        team_dir = config_dir / "tasks" / team
+        team_dir.mkdir(parents=True, exist_ok=True)
+        (team_dir / "5.json").write_text(
+            json.dumps({"id": "5", "owner": owner, "status": "in_progress"}),
+            encoding="utf-8",
+        )
+
+    @pytest.mark.parametrize(
+        "mode,session_id,lead_session_id",
+        [
+            ("in_process", "sess-AAAA", "sess-AAAA"),   # session_id == leadSessionId
+            ("tmux", "sess-BBBB", "sess-AAAA"),         # session_id != leadSessionId
+        ],
+    )
+    def test_dispatch_resolves_identically_across_modes(
+        self, relocated, monkeypatch, mode, session_id, lead_session_id
+    ):
+        config_dir, _ = relocated
+        team = "pact-relocated-team"
+        owner = "test-engineer"
+        self._write_task(config_dir, team, owner)
+        # Set the mode-discriminating signals as ambient env; the resolution
+        # path does not read them, which is exactly the invariance under test.
+        monkeypatch.setenv("CLAUDE_SESSION_ID", session_id)
+        monkeypatch.setenv("PACT_LEAD_SESSION_ID", lead_session_id)
+        assert has_task_assigned(team, owner) is True, (
+            f"dispatch resolution diverged under teammateMode={mode}"
+        )
+
+
+class TestClassificationStayFixed:
+    """Section C: install/cache paths key on CLAUDE_PLUGIN_ROOT and MUST NOT
+    follow CLAUDE_CONFIG_DIR (architect spec: 0 Path.home() sites for
+    install/cache). Guards against R3 over-application — a future change routing
+    plugin-root through the config resolver.
+    """
+
+    def test_plugin_root_does_not_follow_config_dir(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", "/opt/plugin/root")
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "cfgA"))
+        assert _resolve_plugin_root() == "/opt/plugin/root"
+        # Relocate the CONFIG dir; plugin root MUST be unchanged.
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "cfgB-different"))
+        assert _resolve_plugin_root() == "/opt/plugin/root"
+
+    def test_plugin_root_reader_does_not_route_through_config_resolver(self):
+        # Negative source backstop: the plugin-root reader must not derive from
+        # the config-dir resolver (over-application would couple install paths to
+        # CLAUDE_CONFIG_DIR). Asserts the anti-pattern is absent at the source.
+        import inspect
+        import shared.plugin_manifest as pm
+
+        src = inspect.getsource(pm._resolve_plugin_root)
+        assert "get_claude_config_dir" not in src
+        assert "CLAUDE_CONFIG_DIR" not in src

--- a/pact-plugin/tests/test_config_dir_dispatch_integration.py
+++ b/pact-plugin/tests/test_config_dir_dispatch_integration.py
@@ -1,0 +1,96 @@
+"""
+L2 non-mocked integration test for the #926 dispatch-unblock keystone (C2).
+
+Proves the dispatch gate resolves an owned task under a NON-DEFAULT
+CLAUDE_CONFIG_DIR, and that the re-anchored symlink-escape defense still
+rejects a safe-named team dir that escapes the relocated tasks base.
+
+NON-MOCKED at the resolver seam (the whole point — a mocked seam is a
+vacuous green): drives get_claude_config_dir() via the live process globals
+(monkeypatch.setenv + Path.home redirect), never via DI injection.
+
+ANTI-VACUITY: the task is written ONLY under $CLAUDE_CONFIG_DIR/tasks, and
+Path.home() is redirected to a SEPARATE empty temp dir. So a source-revert of
+the resolver call (back to Path.home()/".claude"/"tasks") reads the empty home
+-> has_task_assigned returns False -> these tests FAIL BEHAVIORALLY (not
+ImportError — no post-fix-only symbol is referenced here, only the production
+has_task_assigned entrypoint).
+
+Mode-independence: the resolver keys on $CLAUDE_CONFIG_DIR (env), NOT on
+session topology, so the in-process and tmux teammateModes resolve identically;
+one env-driven pair covers both. The comprehensive both-modes 3-layer suite is
+the TEST phase's work — this is the keystone's self-proof.
+"""
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from shared.dispatch_helpers import has_task_assigned
+
+
+def _write_task(tasks_dir: Path, team: str, task_id: str, owner: str, status: str) -> None:
+    team_dir = tasks_dir / team
+    team_dir.mkdir(parents=True, exist_ok=True)
+    (team_dir / f"{task_id}.json").write_text(
+        json.dumps({"id": task_id, "owner": owner, "status": status}),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def relocated_config(tmp_path, monkeypatch):
+    """A non-default CLAUDE_CONFIG_DIR + an empty redirected home.
+
+    The redirected (empty) home is the anti-vacuity lever: if the resolver
+    call is reverted, the production code reads home/".claude"/"tasks" — which
+    is empty here — and the positive assertion flips to False.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+    return config_dir
+
+
+def test_has_task_assigned_resolves_under_relocated_config(relocated_config):
+    # The bug: under a non-default CLAUDE_CONFIG_DIR the platform writes the
+    # task here, but pre-fix hooks read ~/.claude and miss it (rule 8 -> False).
+    team = "pact-relocated-team"
+    owner = "devops-engineer"
+    _write_task(relocated_config / "tasks", team, "5", owner, "in_progress")
+    assert has_task_assigned(team, owner) is True
+
+
+def test_pending_status_also_resolves(relocated_config):
+    team = "pact-relocated-team"
+    owner = "devops-engineer"
+    _write_task(relocated_config / "tasks", team, "7", owner, "pending")
+    assert has_task_assigned(team, owner) is True
+
+
+def test_unowned_task_under_relocated_config_not_assigned(relocated_config):
+    team = "pact-relocated-team"
+    _write_task(relocated_config / "tasks", team, "5", "someone-else", "in_progress")
+    assert has_task_assigned(team, "devops-engineer") is False
+
+
+def test_symlink_escape_rejected_under_relocated_base(relocated_config, tmp_path):
+    # A safe-NAMED team dir that is a symlink escaping the relocated tasks base
+    # must be rejected by the re-anchored relative_to containment defense — the
+    # ROOT moved, but the guard's resolve()+relative_to logic is byte-identical.
+    team = "pact-escape-team"
+    owner = "devops-engineer"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "9.json").write_text(
+        json.dumps({"id": "9", "owner": owner, "status": "pending"}),
+        encoding="utf-8",
+    )
+    tasks_dir = relocated_config / "tasks"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    os.symlink(outside, tasks_dir / team)  # team dir escapes the base
+    assert has_task_assigned(team, owner) is False

--- a/pact-plugin/tests/test_config_dir_migration_completeness.py
+++ b/pact-plugin/tests/test_config_dir_migration_completeness.py
@@ -1,0 +1,137 @@
+"""
+Standing AST guard against hardcoded-state-path drift (#926).
+
+#926 migrated ~40 hardcoded `Path.home() / ".claude" / <state-subdir>` sites to
+the central `shared.paths.get_claude_config_dir()` resolver. The behavioral
+suites (test_paths.py L1, test_config_dir_dispatch_integration.py +
+test_config_dir_comprehensive.py L2) prove the MIGRATED sites resolve correctly.
+This file guards the COMPLETENESS claim itself: that no `Path.home()/".claude"`
+state-path construction reappears (a future re-add or a regressed migration would
+silently re-introduce the exact fail-silent/drift class #926 exists to kill).
+
+The guarantee otherwise rests only on AttributeError-fail-loud (for the removed
+constants) + a green suite + the manual sweep — none of which catches a NEW
+hardcoded site. This standing guard does.
+
+NON-VACUITY (mirrors the test_session_registry_trust_partition AST-guard
+discipline): the detector is exercised against synthetic source that DOES and
+does NOT contain the construction, so the negative leg cannot be a vacuous
+always-pass. A guard that can't fail is the inert class we are fighting.
+
+Allowlist — exactly the two legitimate residual `Path.home()/".claude"` roots
+(verified by hand + by the detector run at authoring time):
+  - shared/symlinks.py   — the C6 dual-location protocols-symlink HOME-side root
+                           (the link is created in BOTH ~/.claude and $CONFIG when
+                           they differ; the home-side is intentional + answer-immune).
+  - shared/session_registry.py — the inline `_config_root()` env-UNSET fallback
+                           (`return Path.home() / ".claude"`), which mirrors the
+                           canonical resolver's own fallback.
+(shared/paths.py's fallback is `home / ".claude"` on a param, NOT the literal
+`Path.home() / ".claude"`, so it does not match the detector and needs no entry.)
+"""
+import ast
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent / "hooks"
+
+# (basename, exact unparsed construction) pairs that are legitimate residuals.
+ALLOWLIST = {
+    ("symlinks.py", "Path.home() / '.claude'"),
+    ("session_registry.py", "Path.home() / '.claude'"),
+}
+
+
+def _hardcoded_home_claude(tree: ast.AST, basename: str) -> list[tuple[str, int, str]]:
+    """Return (basename, lineno, unparsed) for every `Path.home() / ".claude" ...`
+    division construction in `tree`.
+
+    Walks Div BinOps and matches on the normalized unparse prefix
+    `Path.home() / '.claude'`, so it catches BOTH the bare 2-segment root AND any
+    3+-segment state path (`.../"tasks"`, etc.), and is multi-line-robust (the AST
+    normalizes a line-wrapped construction into one expression — a same-line grep
+    would miss the `session_state.py:511-517`-style multi-line form). Nested
+    BinOps at one site are deduped to the outermost (longest) per (file, lineno).
+    """
+    found: dict[tuple[str, int], str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+            unparsed = ast.unparse(node).replace('"', "'")
+            if unparsed.startswith("Path.home() / '.claude'"):
+                key = (basename, node.lineno)
+                if key not in found or len(unparsed) > len(found[key]):
+                    found[key] = unparsed
+    return [(b, ln, u) for (b, ln), u in found.items()]
+
+
+def _scan_hooks() -> list[tuple[str, int, str]]:
+    violations: list[tuple[str, int, str]] = []
+    for path in sorted(HOOKS_DIR.rglob("*.py")):
+        if "__pycache__" in str(path):
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        rel = str(path.relative_to(HOOKS_DIR))
+        violations += [(rel, ln, u) for (_, ln, u) in _hardcoded_home_claude(tree, path.name)]
+    return violations
+
+
+def _unallowlisted(violations: list[tuple[str, int, str]]) -> list[tuple[str, int, str]]:
+    out = []
+    for rel, ln, unparsed in violations:
+        basename = Path(rel).name
+        if (basename, unparsed) not in ALLOWLIST:
+            out.append((rel, ln, unparsed))
+    return out
+
+
+class TestNoHardcodedStatePathDrift:
+    def test_no_unallowlisted_home_claude_sites(self):
+        """Every `Path.home()/".claude"` construction in hooks/**/*.py must be one
+        of the two known-legitimate residuals. A future re-added/regressed
+        hardcoded state path is NOT in the allowlist -> this FAILS loudly."""
+        offenders = _unallowlisted(_scan_hooks())
+        assert offenders == [], (
+            "Hardcoded Path.home()/'.claude' state-path site(s) outside the "
+            "allowlist — route through shared.paths.get_claude_config_dir() "
+            f"instead:\n" + "\n".join(f"  {f}:{ln}: {u}" for f, ln, u in offenders)
+        )
+
+    def test_both_allowlisted_residuals_still_present(self):
+        """Guard the allowlist against rot: if a residual is itself migrated away,
+        prune the allowlist (so it cannot mask a future real offender at that
+        basename). Keeps the allowlist honest."""
+        scanned = {(Path(f).name, u) for f, _, u in _scan_hooks()}
+        missing = ALLOWLIST - scanned
+        assert missing == set(), (
+            f"Allowlisted residual(s) no longer present (prune the allowlist): {missing}"
+        )
+
+
+class TestDetectorNonVacuity:
+    """The detector + allowlist gate must be able to FAIL. Mirror the
+    trust_partition synthetic-source non-vacuity discipline."""
+
+    @pytest.mark.parametrize("src", [
+        'x = Path.home() / ".claude" / "tasks" / team\n',
+        'p = Path.home() / ".claude" / "pact-sessions"\n',
+        # multi-line form a same-line grep would miss:
+        'q = (\n    Path.home()\n    / ".claude"\n    / "teams"\n    / name\n)\n',
+    ])
+    def test_detector_fires_on_synthetic_hardcoded_state_path(self, src):
+        hits = _hardcoded_home_claude(ast.parse(src), "synthetic_offender.py")
+        assert hits, f"detector FAILED to flag a hardcoded state path: {src!r}"
+        # And the full gate would reject it (not in allowlist):
+        assert _unallowlisted([(h[0], h[1], h[2]) for h in
+                               [("synthetic_offender.py", ln, u) for _, ln, u in hits]]), \
+            "gate FAILED to reject an unallowlisted synthetic offender"
+
+    @pytest.mark.parametrize("src", [
+        'x = get_claude_config_dir() / "tasks" / team\n',   # the CORRECT post-#926 idiom
+        'y = Path.home() / ".ssh" / "config"\n',            # unrelated home path
+        'z = base / ".claude" / "tasks"\n',                 # not rooted at Path.home()
+    ])
+    def test_detector_ignores_non_offending_constructions(self, src):
+        assert _hardcoded_home_claude(ast.parse(src), "ok.py") == [], (
+            f"detector wrongly flagged a non-offending construction: {src!r}"
+        )

--- a/pact-plugin/tests/test_config_dir_migration_completeness.py
+++ b/pact-plugin/tests/test_config_dir_migration_completeness.py
@@ -18,16 +18,17 @@ discipline): the detector is exercised against synthetic source that DOES and
 does NOT contain the construction, so the negative leg cannot be a vacuous
 always-pass. A guard that can't fail is the inert class we are fighting.
 
-Allowlist — exactly the two legitimate residual `Path.home()/".claude"` roots
+Allowlist — the ONE legitimate residual `Path.home() / ".claude"` LITERAL
 (verified by hand + by the detector run at authoring time):
   - shared/symlinks.py   — the C6 dual-location protocols-symlink HOME-side root
                            (the link is created in BOTH ~/.claude and $CONFIG when
                            they differ; the home-side is intentional + answer-immune).
-  - shared/session_registry.py — the inline `_config_root()` env-UNSET fallback
-                           (`return Path.home() / ".claude"`), which mirrors the
-                           canonical resolver's own fallback.
-(shared/paths.py's fallback is `home / ".claude"` on a param, NOT the literal
-`Path.home() / ".claude"`, so it does not match the detector and needs no entry.)
+(shared/session_registry.py's inline `_config_root()` env-UNSET fallback and
+shared/paths.py's fallback are BOTH param-style `home / ".claude"` — NOT the
+literal `Path.home() / ".claude"` — so they do NOT match the detector and need
+no allowlist entry. session_registry was a literal until the home-once refactor
+aligned it with paths.py's canonical structure; the allowlist-rot test below
+prunes-by-failing if a residual ever vanishes, which is what dropped it here.)
 """
 import ast
 from pathlib import Path
@@ -39,7 +40,6 @@ HOOKS_DIR = Path(__file__).resolve().parent.parent / "hooks"
 # (basename, exact unparsed construction) pairs that are legitimate residuals.
 ALLOWLIST = {
     ("symlinks.py", "Path.home() / '.claude'"),
-    ("session_registry.py", "Path.home() / '.claude'"),
 }
 
 

--- a/pact-plugin/tests/test_failure_log.py
+++ b/pact-plugin/tests/test_failure_log.py
@@ -37,7 +37,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared import failure_log
 from shared.failure_log import (
-    LOG_PATH,
     MAX_ENTRIES,
     append_failure,
     read_failures,
@@ -50,15 +49,16 @@ from shared.failure_log import (
 
 @pytest.fixture
 def failure_log_home(tmp_path, monkeypatch):
-    """Redirect Path.home() and the module-level LOG_PATH to tmp_path.
+    """Redirect Path.home() into tmp_path; the accessor follows it.
 
-    The module caches LOG_PATH at import time, so monkeypatching Path.home()
-    alone is not enough — we also override failure_log.LOG_PATH to the tmp
-    location. Symmetric with how test_session_journal pins its paths.
+    get_failure_log_path() resolves $CLAUDE_CONFIG_DIR at CALL time (B1), so
+    with the env unset it derives the log path from the monkeypatched
+    Path.home() — no module-level constant override needed (the import-time
+    freeze is gone). delenv guarantees the fallback branch deterministically.
     """
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     tmp_log = tmp_path / ".claude" / "pact-sessions" / "_session_init_failures.log"
-    monkeypatch.setattr(failure_log, "LOG_PATH", tmp_log)
     return tmp_log
 
 

--- a/pact-plugin/tests/test_paths.py
+++ b/pact-plugin/tests/test_paths.py
@@ -1,0 +1,144 @@
+"""
+L1 resolver-unit tests for shared/paths.py::get_claude_config_dir().
+
+Asserts the resolution contract directly (§A.2 of the architecture spec):
+fail-loud env honoring, empty/whitespace==unset, exact-prefix ~ slicing with
+NO expanduser (monkeypatch-safe), unresolved return, single-path.
+
+Two drive modes are exercised:
+  - DI mode (env=/home=): direct contract assertions (allowed at L1).
+  - live-globals mode (monkeypatch.setenv + Path.home redirect): proves the
+    real seam consumers depend on works without DI.
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+from shared.paths import get_claude_config_dir
+
+
+FAKE_HOME = Path("/fake/home")
+
+
+# --- DI mode: env unset --------------------------------------------------
+
+def test_unset_falls_back_to_home_dotclaude():
+    assert get_claude_config_dir(env={}, home=FAKE_HOME) == FAKE_HOME / ".claude"
+
+
+def test_empty_string_is_unset():
+    assert get_claude_config_dir(env={"CLAUDE_CONFIG_DIR": ""}, home=FAKE_HOME) == FAKE_HOME / ".claude"
+
+
+def test_whitespace_only_is_unset():
+    assert get_claude_config_dir(env={"CLAUDE_CONFIG_DIR": "   "}, home=FAKE_HOME) == FAKE_HOME / ".claude"
+
+
+def test_whitespace_trimmed_then_honored():
+    # leading/trailing whitespace stripped, the remainder honored
+    assert get_claude_config_dir(env={"CLAUDE_CONFIG_DIR": "  /abs  "}, home=FAKE_HOME) == Path("/abs")
+
+
+# --- DI mode: env set ----------------------------------------------------
+
+def test_absolute_path_honored():
+    assert get_claude_config_dir(env={"CLAUDE_CONFIG_DIR": "/opt/cfg"}, home=FAKE_HOME) == Path("/opt/cfg")
+
+
+def test_tilde_alone_maps_to_home():
+    assert get_claude_config_dir(env={"CLAUDE_CONFIG_DIR": "~"}, home=FAKE_HOME) == FAKE_HOME
+
+
+def test_tilde_slash_prefix_exact_slice():
+    assert get_claude_config_dir(env={"CLAUDE_CONFIG_DIR": "~/x"}, home=FAKE_HOME) == FAKE_HOME / "x"
+
+
+def test_tilde_slash_nested():
+    assert get_claude_config_dir(
+        env={"CLAUDE_CONFIG_DIR": "~/.claude-kimi"}, home=FAKE_HOME
+    ) == FAKE_HOME / ".claude-kimi"
+
+
+def test_relative_path_honored_as_is():
+    # honored as-is (surfaced via observability at the consumer); NOT joined to home
+    assert get_claude_config_dir(env={"CLAUDE_CONFIG_DIR": "rel/dir"}, home=FAKE_HOME) == Path("rel/dir")
+
+
+def test_trailing_slash_normalizes_via_path():
+    # Path() collapses a trailing slash; behavior is "honored as-is" then Path-normalized
+    assert get_claude_config_dir(env={"CLAUDE_CONFIG_DIR": "/abs/"}, home=FAKE_HOME) == Path("/abs")
+
+
+def test_exact_prefix_slice_not_lstrip():
+    # A path like "~/~backup" must slice the EXACT 2-char "~/" prefix → home/"~backup".
+    # str.lstrip("~/") would mangle this to home/"backup" (char-set strip). Guards A-no-expanduser.
+    assert get_claude_config_dir(
+        env={"CLAUDE_CONFIG_DIR": "~/~backup"}, home=FAKE_HOME
+    ) == FAKE_HOME / "~backup"
+
+
+def test_returns_unresolved_path():
+    # The resolver must NOT call .resolve() (the single resolve stays at containment sites).
+    # A symlink-bearing value comes back byte-identical, not dereferenced.
+    result = get_claude_config_dir(env={"CLAUDE_CONFIG_DIR": "/a/../b"}, home=FAKE_HOME)
+    assert result == Path("/a/../b")  # unresolved; ".." NOT collapsed by resolve()
+
+
+# --- live-globals mode: the no-DI seam consumers use ---------------------
+
+def test_live_globals_unset(monkeypatch):
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: FAKE_HOME))
+    assert get_claude_config_dir() == FAKE_HOME / ".claude"
+
+
+def test_live_globals_env_set(monkeypatch):
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/run/cfg")
+    assert get_claude_config_dir() == Path("/run/cfg")
+
+
+def test_no_expanduser_uses_resolved_home(monkeypatch):
+    # Critical seam test: with CLAUDE_CONFIG_DIR="~/sub", the resolver MUST expand
+    # via the monkeypatched Path.home() (→ FAKE_HOME/"sub"), NOT via expanduser()
+    # which reads $HOME directly and would bypass the monkeypatch seam.
+    monkeypatch.setenv("HOME", "/real/home/should/not/be/used")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "~/sub")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: FAKE_HOME))
+    assert get_claude_config_dir() == FAKE_HOME / "sub"
+
+
+def _code_tokens(py_path: Path) -> str:
+    """Return source CODE only (docstrings + comments stripped via tokenize).
+
+    Lets the verbatim contract docstring legitimately MENTION the forbidden
+    idioms ("NO expanduser/lstrip/removeprefix") while still catching any
+    real CODE use of them.
+    """
+    import io
+    import tokenize
+
+    text = py_path.read_text(encoding="utf-8")
+    pieces = []
+    for tok in tokenize.generate_tokens(io.StringIO(text).readline):
+        if tok.type in (tokenize.STRING, tokenize.COMMENT):
+            continue
+        pieces.append(tok.string)
+    return " ".join(pieces)
+
+
+def test_no_expanduser_idiom_in_code():
+    # Structural guard (A-no-expanduser): forbid expanduser/lstrip/removeprefix
+    # in executable CODE (docstring mentions of the contract are allowed).
+    src = Path(__file__).parent.parent / "hooks" / "shared" / "paths.py"
+    code = _code_tokens(src)
+    for forbidden in ("expanduser", "lstrip", "removeprefix"):
+        assert forbidden not in code, f"{forbidden} must not appear in paths.py code (A-no-expanduser)"
+
+
+def test_resolver_has_no_logging_or_print_in_code():
+    # DATA-G1: the pure resolver must not log/print the resolved root.
+    src = Path(__file__).parent.parent / "hooks" / "shared" / "paths.py"
+    code = _code_tokens(src)
+    for forbidden in ("print", "logging", "logger", "stderr"):
+        assert forbidden not in code, f"{forbidden!r} must not appear in the pure resolver code (DATA-G1)"

--- a/pact-plugin/tests/test_paths.py
+++ b/pact-plugin/tests/test_paths.py
@@ -142,3 +142,46 @@ def test_resolver_has_no_logging_or_print_in_code():
     code = _code_tokens(src)
     for forbidden in ("print", "logging", "logger", "stderr"):
         assert forbidden not in code, f"{forbidden!r} must not appear in the pure resolver code (DATA-G1)"
+
+
+# ---------------------------------------------------------------------------
+# C4 — the B1 accessors FOLLOW $CLAUDE_CONFIG_DIR at call time (proves the
+# import-time freeze is gone). env-set → config root; env-unset → home/.claude.
+# ---------------------------------------------------------------------------
+
+def test_get_tracking_dir_follows_config_dir(tmp_path, monkeypatch):
+    from track_files import get_tracking_dir
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    assert get_tracking_dir() == tmp_path / "pact-memory" / "session-tracking"
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    assert get_tracking_dir() == tmp_path / ".claude" / "pact-memory" / "session-tracking"
+
+
+def test_get_failure_log_path_follows_config_dir(tmp_path, monkeypatch):
+    from shared.failure_log import get_failure_log_path
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    assert get_failure_log_path() == tmp_path / "pact-sessions" / "_session_init_failures.log"
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    assert get_failure_log_path() == tmp_path / ".claude" / "pact-sessions" / "_session_init_failures.log"
+
+
+def test_get_compact_summary_path_follows_config_dir(tmp_path, monkeypatch):
+    from shared.constants import get_compact_summary_path
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    assert get_compact_summary_path() == tmp_path / "pact-sessions" / "compact-summary.txt"
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    assert get_compact_summary_path() == tmp_path / ".claude" / "pact-sessions" / "compact-summary.txt"
+
+
+def test_token_dir_b2_is_ssot_derived_not_rehardcoded():
+    # B2 contract: TOKEN_DIR is an eager import-time constant, but it MUST derive
+    # from the SSOT resolver (get_claude_config_dir()), NOT a re-hardcoded
+    # Path.home()/".claude" (re-hardcode would re-open the drift the SSOT closes).
+    # Structural check — runtime equality can't distinguish the two when the env
+    # is unset (both yield home/.claude), so we assert on the source idiom.
+    src = (Path(__file__).parent.parent / "hooks" / "shared" / "merge_guard_common.py").read_text(encoding="utf-8")
+    assert "TOKEN_DIR = get_claude_config_dir()" in src
+    assert 'TOKEN_DIR = Path.home()' not in src

--- a/pact-plugin/tests/test_postcompact_archive.py
+++ b/pact-plugin/tests/test_postcompact_archive.py
@@ -177,16 +177,17 @@ class TestConstants:
     """Verify module-level constants."""
 
     def test_compact_summary_path_from_shared_constants(self):
-        from shared.constants import COMPACT_SUMMARY_PATH
-        assert COMPACT_SUMMARY_PATH.name == "compact-summary.txt"
-        assert "pact-sessions" in str(COMPACT_SUMMARY_PATH)
+        from shared.constants import get_compact_summary_path
+        p = get_compact_summary_path()
+        assert p.name == "compact-summary.txt"
+        assert "pact-sessions" in str(p)
 
     def test_postcompact_uses_shared_path(self):
-        """Verify postcompact_archive imports COMPACT_SUMMARY_PATH from shared."""
+        """Verify postcompact_archive derives the default path from the shared accessor."""
         from postcompact_archive import _get_summary_path
-        from shared.constants import COMPACT_SUMMARY_PATH
-        # Default path (no override) should match the shared constant
-        assert _get_summary_path() == COMPACT_SUMMARY_PATH
+        from shared.constants import get_compact_summary_path
+        # Default path (no override) should match the shared accessor's result
+        assert _get_summary_path() == get_compact_summary_path()
 
 
 # ---------------------------------------------------------------------------
@@ -324,12 +325,11 @@ class TestPostcompactLeadGateRealDisk:
     against a REAL file on disk: a teammate/plain frame through main() must NOT
     truncate the global-singleton compact-summary file (#881's O_TRUNC clobber).
 
-    COMPACT_SUMMARY_PATH is computed at IMPORT in shared.constants
-    (Path.home()/...), so a post-import Path.home monkeypatch does NOT redirect
-    it; we monkeypatch the name postcompact_archive binds (it does
-    `from shared.constants import COMPACT_SUMMARY_PATH`) to a tmp file. main()
-    calls write_compact_summary(summary) with no base-dir → _get_summary_path()
-    returns this redirected path.
+    The compact-summary path is now a call-time accessor
+    (get_compact_summary_path, B1). postcompact_archive binds it via
+    `from shared.constants import get_compact_summary_path`; we monkeypatch that
+    name to return a tmp file. main() calls write_compact_summary(summary) with
+    no base-dir → _get_summary_path() returns this redirected path.
     """
 
     _SENTINEL = "PRIOR LEAD SUMMARY — must survive a teammate PostCompact"
@@ -339,9 +339,9 @@ class TestPostcompactLeadGateRealDisk:
 
         summary_path = tmp_path / "compact-summary.txt"
         summary_path.write_text(self._SENTINEL, encoding="utf-8")
-        # Redirect the global-singleton path (import-frozen constant) to tmp.
+        # Redirect the global-singleton path by patching the call-time accessor.
         monkeypatch.setattr(
-            "postcompact_archive.COMPACT_SUMMARY_PATH", summary_path
+            "postcompact_archive.get_compact_summary_path", lambda: summary_path
         )
 
         with patch("sys.stdin", StringIO(json.dumps(frame))):

--- a/pact-plugin/tests/test_session_end_registry_prune.py
+++ b/pact-plugin/tests/test_session_end_registry_prune.py
@@ -161,9 +161,9 @@ def test_defaults_resolve_without_args(monkeypatch, tmp_path):
     default registry is a clean 0 (no raise)."""
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
     import session_end
-    # patch the module-bound REGISTRY_PATH default to the isolated home
+    # patch the module-bound registry-path accessor to the isolated home
     monkeypatch.setattr(
-        session_end, "_REGISTRY_PATH",
-        tmp_path / ".claude" / "pact-sessions" / ".teammate-registry.jsonl",
+        session_end, "_get_registry_path",
+        lambda: tmp_path / ".claude" / "pact-sessions" / ".teammate-registry.jsonl",
     )
     assert session_end._prune_registry_dead_teams() == 0

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -425,7 +425,7 @@ class TestCompactSummaryCleanup:
         summary_file = sessions_dir / "compact-summary.txt"
         summary_file.write_text("Prior compaction context")
 
-        # Patch COMPACT_SUMMARY_PATH to point to our tmp_path version
+        # Patch get_compact_summary_path() to return our tmp_path version
         patched_path = summary_file
 
         stdin_data = json.dumps({
@@ -433,7 +433,7 @@ class TestCompactSummaryCleanup:
             "source": source,
         })
 
-        with patch("session_init.COMPACT_SUMMARY_PATH", patched_path), \
+        with patch("session_init.get_compact_summary_path", lambda: patched_path), \
              patch("session_init.setup_plugin_symlinks", return_value=None), \
              patch("session_init.ensure_project_memory_md", return_value=None), \
              patch("session_init.check_pinned_staleness", return_value=None), \

--- a/pact-plugin/tests/test_session_registry.py
+++ b/pact-plugin/tests/test_session_registry.py
@@ -31,7 +31,7 @@ def registry_env(tmp_path, monkeypatch):
     fake_home = tmp_path
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
     reg_path = fake_home / ".claude" / "pact-sessions" / ".teammate-registry.jsonl"
-    monkeypatch.setattr(session_registry, "REGISTRY_PATH", reg_path)
+    monkeypatch.setattr(session_registry, "get_registry_path", lambda: reg_path)
     monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
 
     class _Env:
@@ -227,7 +227,7 @@ def test_register_never_raises_on_bad_input(registry_env):
 def test_registry_path_is_under_pact_sessions_not_teams():
     """The path is under pact-sessions/ (PACT-owned), NOT under teams/
     (shared, not PACT-owned). LOCKED team-agnostic global fixed path."""
-    p = session_registry.REGISTRY_PATH
+    p = session_registry.get_registry_path()
     parts = p.parts
     assert "pact-sessions" in parts
     assert "teams" not in parts
@@ -265,3 +265,54 @@ def test_path_containment_rejects_sibling_prefix_of_root(registry_env):
     child = root / "sub" / "x.jsonl"
     assert session_registry._is_under_pact_sessions(root) is True
     assert session_registry._is_under_pact_sessions(child) is True
+
+
+# ---------------------------------------------------------------------------
+# C4b — inline config-root resolver parity (session_registry is a standalone-
+# script leaf that can't import shared.paths, so it inlines the resolver). These
+# parity tests enforce the inline copy never drifts from the canonical resolver,
+# and guard the silent-bail trap. Mirrors the _is_safe_team_segment dual-copy
+# parity precedent (test_session_registry_trust_partition.py).
+# ---------------------------------------------------------------------------
+
+class TestConfigRootInlineParity:
+
+    @pytest.mark.parametrize("env_value", [
+        None,                 # unset -> home/.claude
+        "",                   # empty == unset
+        "   ",                # whitespace == unset
+        "/abs/config",        # absolute
+        "~",                  # home
+        "~/.claude-kimi",     # ~/x exact-prefix slice
+        "rel/dir",            # relative, honored as-is
+    ])
+    def test_inline_config_root_matches_canonical_resolver(self, env_value, monkeypatch, tmp_path):
+        # (a) the inline _config_root() MUST be byte-equivalent to the canonical
+        # shared.paths.get_claude_config_dir() across every env scenario.
+        import shared.session_registry as sr
+        from shared.paths import get_claude_config_dir
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        if env_value is None:
+            monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        else:
+            monkeypatch.setenv("CLAUDE_CONFIG_DIR", env_value)
+        assert sr._config_root() == get_claude_config_dir(), (
+            f"inline _config_root drifted from get_claude_config_dir for "
+            f"CLAUDE_CONFIG_DIR={env_value!r}"
+        )
+
+    def test_is_under_pact_sessions_holds_under_nondefault_config_dir(self, monkeypatch, tmp_path):
+        # (b) THE SILENT-BAIL TRAP GUARD: under a non-default CLAUDE_CONFIG_DIR,
+        # the registry path AND the _is_under_pact_sessions anchor must resolve
+        # through the SAME inline root, or register()/resolve() fail-closed at the
+        # containment gate (teammate-name recovery silently dies). NON-VACUOUS:
+        # if the anchor lagged on Path.home() the candidate (under $CONFIG) would
+        # not be under sessions_root (under ~/.claude) -> False -> this FAILS.
+        import shared.session_registry as sr
+        config_dir = tmp_path / "kimi-config"
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+        assert sr._is_under_pact_sessions(sr.get_registry_path()) is True, (
+            "_is_under_pact_sessions rejected the registry path under a non-default "
+            "CLAUDE_CONFIG_DIR — the containment anchor is not co-routed through the "
+            "inline _config_root() (register() would silently bail)"
+        )

--- a/pact-plugin/tests/test_session_registry_concurrency.py
+++ b/pact-plugin/tests/test_session_registry_concurrency.py
@@ -99,7 +99,7 @@ def _prepare_child(home: str):
     # Redirect Path.home so _is_under_pact_sessions resolves the tmp tree.
     Path.home = classmethod(lambda cls: fake_home)  # type: ignore[assignment]
     import shared.session_registry as sr
-    sr.REGISTRY_PATH = fake_home / ".claude" / "pact-sessions" / ".teammate-registry.jsonl"
+    sr.get_registry_path = lambda: fake_home / ".claude" / "pact-sessions" / ".teammate-registry.jsonl"
     return sr
 
 
@@ -171,7 +171,7 @@ def concurrency_env(tmp_path, monkeypatch):
     fake_home = tmp_path
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
     reg_path = fake_home / ".claude" / "pact-sessions" / ".teammate-registry.jsonl"
-    monkeypatch.setattr(session_registry, "REGISTRY_PATH", reg_path)
+    monkeypatch.setattr(session_registry, "get_registry_path", lambda: reg_path)
     monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
 
     class _Env:

--- a/pact-plugin/tests/test_session_registry_integrity.py
+++ b/pact-plugin/tests/test_session_registry_integrity.py
@@ -47,7 +47,7 @@ def registry_env(tmp_path, monkeypatch):
     fake_home = tmp_path
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
     reg_path = fake_home / ".claude" / "pact-sessions" / ".teammate-registry.jsonl"
-    monkeypatch.setattr(session_registry, "REGISTRY_PATH", reg_path)
+    monkeypatch.setattr(session_registry, "get_registry_path", lambda: reg_path)
     monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
 
     class _Env:

--- a/pact-plugin/tests/test_session_registry_trust_partition.py
+++ b/pact-plugin/tests/test_session_registry_trust_partition.py
@@ -179,7 +179,7 @@ class TestTrustPartitionNoRegistryImport:
         "from shared.session_registry import resolve as _registry_resolve\n",
         "import shared.session_registry\n",
         "from shared import session_registry\n",          # aliased module-as-name
-        "from shared.session_registry import REGISTRY_PATH\n",
+        "from shared.session_registry import get_registry_path\n",
     ])
     def test_detector_fires_on_synthetic_import(self, src):
         """Phantom-green guard: the no-import detector FIRES on EVERY import shape
@@ -456,22 +456,22 @@ class TestTeamSegmentValidatorParity:
 
 class TestPathNotTeamScoped:
     def test_registry_path_under_pact_sessions_not_teams(self):
-        from shared.session_registry import REGISTRY_PATH
-        parts = REGISTRY_PATH.parts
+        from shared.session_registry import get_registry_path
+        p = get_registry_path()
+        parts = p.parts
         assert "pact-sessions" in parts, (
-            f"REGISTRY_PATH {REGISTRY_PATH} must live under pact-sessions/ "
-            f"(PACT-owned)."
+            f"registry path {p} must live under pact-sessions/ (PACT-owned)."
         )
         assert "teams" not in parts, (
-            f"REGISTRY_PATH {REGISTRY_PATH} is team-scoped (under teams/). It "
-            f"MUST be global + team-agnostic — a team-scoped path re-opens the "
-            f"bootstrap paradox (a tmux teammate cannot compute its lead's team "
-            f"to locate a team-scoped file)."
+            f"registry path {p} is team-scoped (under teams/). It MUST be global "
+            f"+ team-agnostic — a team-scoped path re-opens the bootstrap paradox "
+            f"(a tmux teammate cannot compute its lead's team to locate a "
+            f"team-scoped file)."
         )
 
     def test_registry_path_filename_is_the_locked_constant(self):
-        from shared.session_registry import REGISTRY_PATH
-        assert REGISTRY_PATH.name == ".teammate-registry.jsonl"
+        from shared.session_registry import get_registry_path
+        assert get_registry_path().name == ".teammate-registry.jsonl"
 
 
 # ===========================================================================
@@ -494,9 +494,10 @@ class TestBothModesMatrix:
     @pytest.fixture
     def registry(self, tmp_path, monkeypatch):
         import shared.session_registry as sr
+        # get_registry_path() follows the patched Path.home() via the inline
+        # _config_root() (C4b's accessor refactor removed the module-level
+        # REGISTRY_PATH constant, so there is nothing to override here).
         monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
-        reg = tmp_path / ".claude" / "pact-sessions" / ".teammate-registry.jsonl"
-        monkeypatch.setattr(sr, "REGISTRY_PATH", reg)
         monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
 
         def write_team(team, members):

--- a/pact-plugin/tests/test_session_state.py
+++ b/pact-plugin/tests/test_session_state.py
@@ -1486,3 +1486,112 @@ class TestIsSafePathComponent_Public:
         assert hasattr(shared, "SAFE_PATH_COMPONENT_RE")
         assert shared.is_safe_path_component("pact-0001639f") is True
         assert shared.is_safe_path_component("../etc") is False
+
+
+class TestSessionStateTaskReaderContainmentParity:
+    """#926 remediation: session_state's 3 task/team readers gained bounded
+    containment parity (mirror iter_team_task_jsons / read_task_json). The
+    CONTAINMENT tests drive the DI seam (teams_base_dir / tasks_base_dir) -- the
+    correct use: they exercise the resolve()/relative_to anchor under an injected
+    base, NOT the resolver (resolver-derivation is covered by the env-SET sibling
+    tests + the central resolver L1). Per-reader guard asymmetry:
+      - GLOB reader _read_task_counts: full hygiene set -- containment +
+        per-file is_symlink skip + dotfile skip (it COUNTS, so plants inflate).
+      - SINGLE-FILE readers _read_team_members / _read_feature_subject_from_disk:
+        only is_safe_path_component + containment; dotfile/symlink-file guards
+        are CORRECTLY ABSENT (they read ONE named file, never glob) -- so this
+        suite does NOT assert those guards on them (an absent-guard test would be
+        a wrong-expectation test).
+
+    NON-VACUITY (per guard, surgical-neuter against 5080ae2b, verified):
+      - neuter the relative_to anchor in a reader -> that reader's escape-reject FAILS.
+      - neuter _read_task_counts dotfile-skip -> dotfile-not-inflated FAILS.
+      - neuter _read_task_counts per-file is_symlink skip -> symlink-skip FAILS.
+    """
+
+    # --- _read_team_members (single-file: config.json) ---
+    def test_team_members_legit_accepted(self, tmp_path):
+        from shared.session_state import _read_team_members
+        base = tmp_path / "teams"
+        td = base / "pact-legit"
+        td.mkdir(parents=True)
+        (td / "config.json").write_text(
+            json.dumps({"members": [{"name": "alice"}]}), encoding="utf-8")
+        assert _read_team_members("pact-legit", teams_base_dir=str(base)) == ["alice"]
+
+    def test_team_members_symlink_team_dir_escape_rejected(self, tmp_path):
+        from shared.session_state import _read_team_members
+        base = tmp_path / "teams"
+        base.mkdir(parents=True)
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "config.json").write_text(
+            json.dumps({"members": [{"name": "evil"}]}), encoding="utf-8")
+        (base / "pact-escape").symlink_to(outside)  # safe-named team dir escaping base
+        assert _read_team_members("pact-escape", teams_base_dir=str(base)) == []
+
+    # --- _read_feature_subject_from_disk (single-file: {feature_id}.json) ---
+    def test_feature_subject_legit_accepted(self, tmp_path):
+        from shared.session_state import _read_feature_subject_from_disk
+        base = tmp_path / "tasks"
+        td = base / "pact-legit"
+        td.mkdir(parents=True)
+        (td / "F1.json").write_text(json.dumps({"subject": "the feature"}), encoding="utf-8")
+        assert _read_feature_subject_from_disk(
+            "pact-legit", "F1", tasks_base_dir=str(base)) == "the feature"
+
+    def test_feature_subject_symlink_team_dir_escape_rejected(self, tmp_path):
+        from shared.session_state import _read_feature_subject_from_disk
+        base = tmp_path / "tasks"
+        base.mkdir(parents=True)
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "F1.json").write_text(json.dumps({"subject": "evil"}), encoding="utf-8")
+        (base / "pact-escape").symlink_to(outside)
+        assert _read_feature_subject_from_disk(
+            "pact-escape", "F1", tasks_base_dir=str(base)) is None
+
+    # --- _read_task_counts (GLOB reader: full hygiene set) ---
+    def test_task_counts_legit_counted(self, tmp_path):
+        from shared.session_state import _read_task_counts
+        base = tmp_path / "tasks"
+        td = base / "pact-legit"
+        td.mkdir(parents=True)
+        (td / "1.json").write_text(json.dumps({"status": "pending"}), encoding="utf-8")
+        (td / "2.json").write_text(json.dumps({"status": "completed"}), encoding="utf-8")
+        c = _read_task_counts("pact-legit", tasks_base_dir=str(base))
+        assert c["total"] == 2 and c["pending"] == 1 and c["completed"] == 1
+
+    def test_task_counts_symlink_team_dir_escape_rejected(self, tmp_path):
+        from shared.session_state import _read_task_counts
+        base = tmp_path / "tasks"
+        base.mkdir(parents=True)
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "1.json").write_text(json.dumps({"status": "pending"}), encoding="utf-8")
+        (base / "pact-escape").symlink_to(outside)
+        assert _read_task_counts("pact-escape", tasks_base_dir=str(base))["total"] == 0
+
+    def test_task_counts_per_file_symlink_skipped(self, tmp_path):
+        from shared.session_state import _read_task_counts
+        base = tmp_path / "tasks"
+        td = base / "pact-legit"
+        td.mkdir(parents=True)
+        (td / "1.json").write_text(json.dumps({"status": "pending"}), encoding="utf-8")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "evil.json").write_text(json.dumps({"status": "completed"}), encoding="utf-8")
+        (td / "2.json").symlink_to(outside / "evil.json")  # *.json symlink -> skipped
+        assert _read_task_counts("pact-legit", tasks_base_dir=str(base))["total"] == 1
+
+    def test_task_counts_dotfile_not_inflated(self, tmp_path):
+        from shared.session_state import _read_task_counts
+        base = tmp_path / "tasks"
+        td = base / "pact-legit"
+        td.mkdir(parents=True)
+        (td / "1.json").write_text(json.dumps({"status": "pending"}), encoding="utf-8")
+        (td / ".evil.json").write_text(json.dumps({"status": "completed"}), encoding="utf-8")
+        # glob('*.json') DOES match dotfiles; the dotfile-skip guard prevents the
+        # planted .evil.json from inflating the count. (Verified non-vacuous: neuter
+        # the dotfile-skip -> total becomes 2.)
+        assert _read_task_counts("pact-legit", tasks_base_dir=str(base))["total"] == 1

--- a/pact-plugin/tests/test_symlinks.py
+++ b/pact-plugin/tests/test_symlinks.py
@@ -214,3 +214,60 @@ class TestSetupPluginSymlinks:
 
         assert result is not None
         assert "protocols failed" in result
+
+
+class TestConfigDirSymlinks:
+    """C6 (#926): under a non-default CLAUDE_CONFIG_DIR, agents follow the config
+    dir and the protocols symlink is created in BOTH roots (dual-location,
+    answer-immune to the @-import ~ resolution question)."""
+
+    @staticmethod
+    def _plugin(tmp_path):
+        plugin_root = tmp_path / "plugin"
+        (plugin_root / "protocols").mkdir(parents=True)
+        (plugin_root / "agents").mkdir(parents=True)
+        (plugin_root / "agents" / "pact-secretary.md").write_text("x", encoding="utf-8")
+        return plugin_root
+
+    def test_protocols_dual_location_when_config_dir_differs(self, tmp_path, monkeypatch):
+        from shared.symlinks import setup_plugin_symlinks
+        plugin_root = self._plugin(tmp_path)
+        home = tmp_path / "home"
+        (home / ".claude").mkdir(parents=True)
+        config_dir = tmp_path / "config-kimi"
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+        monkeypatch.setattr(Path, "home", lambda: home)
+        setup_plugin_symlinks()
+        src = (plugin_root / "protocols").resolve()
+        home_link = home / ".claude" / "protocols" / "pact-plugin"
+        config_link = config_dir / "protocols" / "pact-plugin"
+        assert home_link.is_symlink() and home_link.resolve() == src
+        assert config_link.is_symlink() and config_link.resolve() == src
+
+    def test_agents_follow_config_dir(self, tmp_path, monkeypatch):
+        from shared.symlinks import setup_plugin_symlinks
+        plugin_root = self._plugin(tmp_path)
+        home = tmp_path / "home"
+        (home / ".claude").mkdir(parents=True)
+        config_dir = tmp_path / "config-kimi"
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+        monkeypatch.setattr(Path, "home", lambda: home)
+        setup_plugin_symlinks()
+        # agents discovered from $CONFIG/agents — NOT $HOME/.claude/agents
+        assert (config_dir / "agents" / "pact-secretary.md").is_symlink()
+        assert not (home / ".claude" / "agents" / "pact-secretary.md").exists()
+
+    def test_protocols_single_location_when_env_unset(self, tmp_path, monkeypatch):
+        from shared.symlinks import setup_plugin_symlinks
+        plugin_root = self._plugin(tmp_path)
+        home = tmp_path / "home"
+        (home / ".claude").mkdir(parents=True)
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        monkeypatch.setattr(Path, "home", lambda: home)
+        setup_plugin_symlinks()
+        # env unset → config root == $HOME/.claude → single create there
+        assert (home / ".claude" / "protocols" / "pact-plugin").is_symlink()
+        assert (home / ".claude" / "agents" / "pact-secretary.md").is_symlink()

--- a/pact-plugin/tests/test_symlinks.py
+++ b/pact-plugin/tests/test_symlinks.py
@@ -271,3 +271,34 @@ class TestConfigDirSymlinks:
         # env unset → config root == $HOME/.claude → single create there
         assert (home / ".claude" / "protocols" / "pact-plugin").is_symlink()
         assert (home / ".claude" / "agents" / "pact-secretary.md").is_symlink()
+
+
+class TestProtocolsMkdirFailOpen:
+    """#926 (ea74cd0d): the protocols-symlink parent mkdir moved INSIDE the
+    per-root try, so a pathological config_root whose mkdir raises must fail-open
+    (a 'protocols failed' status), honoring setup_plugin_symlinks's
+    'returns None/status, never raises' contract.
+
+    NON-VACUITY: with the mkdir OUTSIDE the try (the pre-ea74cd0d shape) the
+    OSError would PROPAGATE and setup_plugin_symlinks would RAISE -> this test
+    (asserting no-raise + 'protocols failed') would ERROR. Verified: moving the
+    mkdir above the try -> this test raises. Complements
+    test_protocols_oserror_reports_failure, which covers the symlink_to (not
+    mkdir) failure path.
+    """
+
+    def test_mkdir_failure_is_caught_and_reported(self, tmp_path, monkeypatch):
+        from shared.symlinks import setup_plugin_symlinks
+
+        plugin_root = tmp_path / "plugin"
+        (plugin_root / "protocols").mkdir(parents=True)
+        # No agents/ dir -> the (un-tried) agents mkdir block is skipped, so the
+        # patched mkdir below only hits the protocols parent mkdir (in-try).
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+
+        with patch.object(Path, "mkdir", side_effect=OSError("Read-only file system")):
+            result = setup_plugin_symlinks()  # must NOT raise
+
+        assert result is not None
+        assert "protocols failed" in result

--- a/pact-plugin/tests/test_task_utils.py
+++ b/pact-plugin/tests/test_task_utils.py
@@ -703,3 +703,45 @@ class TestReadTaskJsonContainmentParity:
             "an unsafe (multi-segment) team_name must be rejected by "
             "is_safe_path_component and skip the team dir -> bare-base fall-through"
         )
+
+
+class TestReadTaskJsonResolverEnvSet:
+    """#926 remediation (was F2/Future, folded in): read_task_json's
+    tasks_base_dir=None resolver-derivation must resolve under a non-default
+    CLAUDE_CONFIG_DIR (get_claude_config_dir()/"tasks"). The containment-parity
+    tests inject tasks_base_dir= (correct -- they test the defense); the existing
+    no-base tests run env-UNSET. This covers the env-SET resolver path.
+
+    NON-VACUITY: Path.home is redirected to a SEPARATE EMPTY dir, so a revert of
+    the resolver call (back to Path.home()/".claude"/"tasks") reads the empty home
+    -> file absent -> {} -> the positive assertion FAILS behaviorally.
+    """
+
+    def test_resolves_task_under_relocated_config(self, tmp_path, monkeypatch):
+        from task_utils import read_task_json
+
+        config_dir = tmp_path / "config"
+        team_dir = config_dir / "tasks" / "pact-relocated"
+        team_dir.mkdir(parents=True)
+        (team_dir / "7.json").write_text(
+            json.dumps({"id": "7", "subject": "relocated task"}), encoding="utf-8")
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+
+        # tasks_base_dir=None -> exercises get_claude_config_dir()/"tasks".
+        assert read_task_json("7", "pact-relocated").get("subject") == "relocated task"
+
+    def test_absent_task_under_relocated_config_returns_empty(self, tmp_path, monkeypatch):
+        # Complement so the positive isn't trivially always-truthy.
+        from task_utils import read_task_json
+
+        config_dir = tmp_path / "config"
+        (config_dir / "tasks" / "pact-relocated").mkdir(parents=True)
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+
+        assert read_task_json("999", "pact-relocated") == {}

--- a/pact-plugin/tests/test_task_utils.py
+++ b/pact-plugin/tests/test_task_utils.py
@@ -637,3 +637,69 @@ class TestReadTaskJsonNulByteSafety:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         assert read_task_json("12\x00bad", "test-team") == {}
         assert read_task_json("\x00", "team", tasks_base_dir=str(tmp_path)) == {}
+
+
+# ---------------------------------------------------------------------------
+# read_task_json — bounded containment parity (team_name guards 1+2)
+# ---------------------------------------------------------------------------
+
+class TestReadTaskJsonContainmentParity:
+    """read_task_json gains the 2-of-5 sibling-reader guards that apply to a
+    single-named-file reader: (1) is_safe_path_component(team_name) and (2)
+    resolve()+relative_to(base) containment. The glob-result hygiene guards
+    (per-file is_symlink / dotfile skip / isinstance(dict)) are correctly
+    ABSENT — read_task_json reads ONE named file, it never globs.
+    """
+
+    def test_legit_team_dir_still_read(self, tmp_path):
+        # Happy path preserved: a legit team_name + real dir is read unchanged.
+        from task_utils import read_task_json
+        base = tmp_path / "tasks"
+        tdir = base / "pact-legit-team"
+        tdir.mkdir(parents=True)
+        (tdir / "5.json").write_text(
+            json.dumps({"id": "5", "subject": "Real"}), encoding="utf-8"
+        )
+        result = read_task_json("5", "pact-legit-team", tasks_base_dir=str(base))
+        assert result.get("subject") == "Real"
+
+    def test_symlink_team_dir_escaping_base_rejected(self, tmp_path):
+        # Guard (2): a safe-NAMED team dir that is a SYMLINK escaping the base
+        # must be rejected by resolve()/relative_to -> falls through to bare
+        # base -> {}. NON-VACUOUS: without the guard, exists() follows the
+        # symlink and reads the planted out-of-base secret.
+        from task_utils import read_task_json
+        base = tmp_path / "tasks"
+        base.mkdir(parents=True)
+        outside = tmp_path / "escapedir"
+        outside.mkdir()
+        (outside / "7.json").write_text(
+            json.dumps({"id": "7", "subject": "LEAKED"}), encoding="utf-8"
+        )
+        (base / "evil-team").symlink_to(outside, target_is_directory=True)
+        result = read_task_json("7", "evil-team", tasks_base_dir=str(base))
+        assert result == {}, (
+            "a team dir that is a symlink escaping the base must be rejected by "
+            "the resolve()/relative_to containment (without it, exists() follows "
+            "the symlink and reads the out-of-base secret -> LEAKED)"
+        )
+
+    def test_unsafe_team_name_falls_through_to_bare_base(self, tmp_path):
+        # Guard (1): an is_safe_path_component-failing team_name (here a slash
+        # name that stays UNDER base, so guard (2) alone would NOT catch it)
+        # must skip the team dir and fall through to the bare-base read.
+        # NON-VACUOUS for guard (1) specifically: without it, base/"sub/evil" is
+        # under base (guard 2 passes) and read_task_json reads NESTED.
+        from task_utils import read_task_json
+        base = tmp_path / "tasks"
+        nested = base / "sub" / "evil"
+        nested.mkdir(parents=True)
+        (nested / "3.json").write_text(
+            json.dumps({"id": "3", "subject": "NESTED"}), encoding="utf-8"
+        )
+        # bare base has no 3.json -> guard (1) skip -> fall-through yields {}
+        result = read_task_json("3", "sub/evil", tasks_base_dir=str(base))
+        assert result == {}, (
+            "an unsafe (multi-segment) team_name must be rejected by "
+            "is_safe_path_component and skip the team dir -> bare-base fall-through"
+        )

--- a/pact-plugin/tests/test_team_guard.py
+++ b/pact-plugin/tests/test_team_guard.py
@@ -152,3 +152,63 @@ class TestMainEntryPoint:
                 main()
 
         assert exc_info.value.code == 0
+
+
+class TestFailClosedModuleLoad:
+    """C5b (#926 / PR #660 discipline): a raise from team_guard's cross-package
+    import must DENY (exit 2 + permissionDecision='deny'), NOT crash-and-fail-open.
+    A crashed PreToolUse hook (exit 1) is treated by the platform as non-blocking,
+    so the Task would PROCEED and the team-existence gate would silently fail-open.
+    Mirrors test_dispatch_gate_smoke.test_fail_closed_module_load: subprocess
+    isolation, a sabotaged copy of shared/ (never pop shared.* from sys.modules in
+    the test process)."""
+
+    def test_fail_closed_module_load(self, tmp_path):
+        import os
+        import shutil
+        import subprocess
+
+        repo_hooks = Path(__file__).parent.parent / "hooks"
+        sabotage_root = tmp_path / "sabotage"
+        sabotage_shared = sabotage_root / "shared"
+        # Copy the real shared/ tree so every OTHER submodule imports normally.
+        shutil.copytree(repo_hooks / "shared", sabotage_shared)
+        # Overwrite ONLY paths.py — team_guard's sole shared import — with a raise
+        # so the wrapped `from shared.paths import ...` fires the except branch.
+        (sabotage_shared / "paths.py").write_text(
+            "raise ImportError('sabotage: forced module-load failure')\n",
+            encoding="utf-8",
+        )
+
+        env = os.environ.copy()
+        # Sabotage dir FIRST so its `shared` package wins. team_guard's
+        # conditional `if str(_hooks_dir) not in sys.path` insert is skipped here
+        # (repo_hooks is already on PYTHONPATH), preserving this ordering.
+        env["PYTHONPATH"] = os.pathsep.join([str(sabotage_root), str(repo_hooks)])
+        env["PYTHONSAFEPATH"] = "1"  # disable script-dir auto-insert → PYTHONPATH wins
+
+        proc = subprocess.run(
+            [sys.executable, str(repo_hooks / "team_guard.py")],
+            input=json.dumps({
+                "hook_event_name": "PreToolUse",
+                "session_id": "test",
+                "tool_name": "Task",
+                "tool_input": {"team_name": "pact-x"},
+            }),
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=10,
+        )
+        assert proc.returncode == 2, (
+            f"expected exit 2 (fail-closed deny), got {proc.returncode}. "
+            f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+        )
+        out = json.loads(proc.stdout.strip())
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "deny"
+        assert (
+            "load failure" in hso["permissionDecisionReason"].lower()
+            or "module imports" in hso["permissionDecisionReason"].lower()
+        )

--- a/pact-plugin/tests/test_team_guard.py
+++ b/pact-plugin/tests/test_team_guard.py
@@ -212,3 +212,47 @@ class TestFailClosedModuleLoad:
             "load failure" in hso["permissionDecisionReason"].lower()
             or "module imports" in hso["permissionDecisionReason"].lower()
         )
+
+
+class TestTeamsDirResolverDerivationUnderConfigDir:
+    """F1 (#926 review): the teams_dir=None resolver path
+    (get_claude_config_dir() / "teams") must resolve under a non-default
+    CLAUDE_CONFIG_DIR. Every other team_guard test injects teams_dir= (DI seam,
+    bypasses the resolver) or mocks check_team_exists, so this DISPATCH-CRITICAL
+    path -- a wrong teams dir -> 'team does not exist' -> deny -> blocks Task
+    dispatch (the #926 symptom for team_guard) -- is otherwise unexercised in-CI.
+
+    NON-VACUITY: Path.home is redirected to a SEPARATE EMPTY dir. If the resolver
+    call were reverted to Path.home()/".claude"/"teams", it would read the empty
+    home -> team 'missing' -> deny-reason -> the allow assertion FAILS
+    behaviorally (verified: source-neuter of team_guard's resolver line -> {1 failed}).
+    """
+
+    def test_allows_existing_team_under_relocated_config(self, tmp_path, monkeypatch):
+        from team_guard import check_team_exists
+
+        config_dir = tmp_path / "config"
+        team_dir = config_dir / "teams" / "pact-relocated"
+        team_dir.mkdir(parents=True)
+        (team_dir / "config.json").write_text('{"members": []}')
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+
+        # teams_dir=None -> exercises the get_claude_config_dir()/"teams" path.
+        assert check_team_exists({"team_name": "pact-relocated"}) is None
+
+    def test_blocks_absent_team_under_relocated_config(self, tmp_path, monkeypatch):
+        # Complement so the allow-assertion above is not trivially always-None:
+        # a genuinely absent team under $CONFIG/teams -> deny-reason (not None).
+        from team_guard import check_team_exists
+
+        config_dir = tmp_path / "config"
+        (config_dir / "teams").mkdir(parents=True)
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+
+        assert check_team_exists({"team_name": "pact-missing"}) is not None

--- a/pact-plugin/tests/test_teammate_mode.py
+++ b/pact-plugin/tests/test_teammate_mode.py
@@ -706,3 +706,42 @@ class TestPerFileBroadExceptContract:
         )
         assert resolve_effective_teammate_mode() == "auto"
         assert should_emit_inprocess_notice() is True
+
+
+class TestConfigDirSettingsAndLegacy:
+    """C6 (#926): the user settings.json source (:120) and the legacy
+    ~/.claude.json fallback (:147) follow CLAUDE_CONFIG_DIR. The legacy file is
+    a SIBLING-asymmetry special case: $HOME/.claude.json when unset (NOT
+    $HOME/.claude/.claude.json), $CONFIG_DIR/.claude.json when set."""
+
+    def test_user_settings_follows_config_dir(self, mode_env, monkeypatch):
+        # :120 — env-set: the user settings source is $CONFIG/settings.json.
+        # NON-VACUOUS: if it still read $HOME/.claude/settings.json, the file
+        # below wouldn't be found and resolution would fall through to "auto".
+        config_dir = mode_env.root / "config-kimi"
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+        mode_env._write(config_dir / "settings.json", {"teammateMode": "tmux"})
+        assert resolve_effective_teammate_mode() == "tmux"
+
+    def test_old_home_settings_not_read_when_config_dir_set(self, mode_env, monkeypatch):
+        # env-set: the OLD $HOME/.claude/settings.json is NOT in the source list.
+        config_dir = mode_env.root / "config-kimi"
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+        mode_env.write_user({"teammateMode": "tmux"})  # $HOME/.claude/settings.json
+        # $CONFIG has no settings + no legacy → default
+        assert resolve_effective_teammate_mode() == "auto"
+
+    def test_legacy_claude_json_follows_config_dir_when_set(self, mode_env, monkeypatch):
+        # :147 — env-set: legacy reads $CONFIG/.claude.json.
+        config_dir = mode_env.root / "config-kimi"
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+        mode_env._write(config_dir / ".claude.json", {"teammateMode": "in-process"})
+        assert resolve_effective_teammate_mode() == "in-process"
+
+    def test_legacy_claude_json_preserves_home_sibling_when_unset(self, mode_env, monkeypatch):
+        # :147 — env-UNSET: legacy reads $HOME/.claude.json (sibling). NON-VACUOUS:
+        # a blind get_claude_config_dir()/".claude.json" would yield
+        # $HOME/.claude/.claude.json and miss the file below → "auto".
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        mode_env.write_legacy({"teammateMode": "in-process"})  # $HOME/.claude.json
+        assert resolve_effective_teammate_mode() == "in-process"


### PR DESCRIPTION
## Summary

PACT hooks hardcoded `Path.home() / ".claude"` at every filesystem path-construction site. When an operator set `CLAUDE_CONFIG_DIR` to a non-default location (e.g. `~/.claude-kimi`), the platform relocated its state tree (teams/, tasks/, pact-sessions/, settings, …) under that dir — but the hooks kept reading `~/.claude`, producing a **split-brain** that left `dispatch_gate` rule ⑧ (`has_task_assigned`) searching the wrong root and **blocking ALL specialist agent dispatch**. (Observed at runtime under `~/.claude-kimi`, then traced to code.)

This centralizes path resolution behind a single fail-loud resolver and migrates every state-path site to honor `CLAUDE_CONFIG_DIR`.

Fixes #926.

## What changed

- **New `shared/paths.py::get_claude_config_dir()`** — a function (not a module constant), fail-loud (honors the env var regardless of existence; never silently falls back when set), monkeypatch-safe (exact-prefix `~` expansion via `Path.home()`, **no `expanduser`** — preserves the test seam), returns an unresolved path (single `.resolve()` stays at the call sites that perform containment checks).
- **40 state-path sites across 21 hook files** migrated. The plugin install/cache path is *not* among them (always `CLAUDE_PLUGIN_ROOT`), so there is no "discriminate state vs install" risk — the semantic is "relocate everything PACT reads/writes under the config dir."
- **Containment defenses re-anchored in lockstep** — wherever a path is both joined *and* a `relative_to`/parents-based containment anchor, both re-anchor through the same root in the same commit (else the gate silently fail-closes). Defenses kept byte-identical.
- **Two special cases**: legacy `~/.claude.json` sibling-file asymmetry (env-set → `$CONFIG/.claude.json`; unset → `$HOME/.claude.json` preserved); protocols symlink created in **both** `$HOME/.claude` and `$CONFIG` when they differ (answer-immune to the `@`-import `~` resolution question; agents follow `$CONFIG/agents`).
- **Two hardenings surfaced during the work**: `read_task_json` gains the `is_safe_path_component` + `relative_to` containment its sibling readers had; `team_guard` (a fail-closed PreToolUse gate) gains the sibling gates' `_emit_load_failure_deny` wrap so its new cross-package import can't crash → fail-open.

## Why these design calls

- **TOKEN_DIR stays an eager constant (B2)** but REGISTRY_PATH becomes a call-time accessor (B1). The discriminator: a value that is a *candidate in a containment check against a separately-derived anchor* must resolve at call-time, or it desyncs from the anchor. (A frozen candidate is an anchor that lags in *time*.)
- **REGISTRY_PATH uses an inline resolver, not an import** — `session_registry.py` runs in `__main__` script mode where `shared.*` imports raise; it inlines `_config_root()` + a behavioral parity test, matching the established `_is_safe_team_segment` precedent. All three config-root derivations in that file route through the one inline copy.

## Testing

- Suite: **8254 passed / 0 errors** (verified via `rtk proxy python -m pytest` — note rtk's normal summary omits the errors count).
- 3-layer gate: L1 mocked-unit, L2 **non-mocked integration** (real temp `CLAUDE_CONFIG_DIR` flips `has_task_assigned`; escape defenses reject under the relocated root across both idioms incl. the sibling-prefix-collision negative), L3 live-probe **runbook** (post-merge runtime-confirmation, per the #923/#924 pattern).
- Non-vacuity proven throughout (surgical anchor-neuter counter-tests; the completeness AST guard proven by real-file `_DRIFT_PROBE` injection).
- A **standing AST guard** fails if any future edit re-introduces a hardcoded `Path.home()/".claude"/<state-subdir>` outside the 2 legitimate residuals — locks the completeness claim against drift.

## Post-merge follow-ups

- Run the L3 live-probe runbook under a real non-default `CLAUDE_CONFIG_DIR` session (`tests/runbooks/926-config-dir-live-probe.md`).
- Update the `session_init.py` docstring-parity pin's verification window `692,713 → 695,716` (the convention itself holds; only the line numbers shifted).
- **Version note**: bumped to **4.4.13**. In-flight #924 also claims 4.4.13 — whichever merges second should take the next patch.

## Commits (11)

`feat: resolver` → `fix: dispatch state paths (keystone)` → `harden: read_task_json parity` → `refactor: 5 import-time constants` → `fix: session_registry 3-derivation re-anchor` → `fix: remaining sweep + session_init anchor` → `fix: special cases (symlink + .claude.json)` → `harden: team_guard fail-closed` → `chore: v4.4.13` → `test: comprehensive 3-layer coverage + L3 runbook` → `test: standing AST drift guard`.
