### PR TITLE
Resolve variety totals tolerantly in the lifecycle gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.14",
+      "version": "4.4.15",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.14/      # Plugin version
+│               └── 4.4.15/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.14",
+  "version": "4.4.15",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.14
+> **Version**: 4.4.15
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/precompact_state_reminder.py
+++ b/pact-plugin/hooks/precompact_state_reminder.py
@@ -34,6 +34,7 @@ from shared import pact_context
 from shared.error_output import hook_error_json
 from shared.session_state import summarize_session_state
 from shared.teachback_schema import resolve_variety_total
+from shared.variety_scorer import MAX_SCORE, MIN_SCORE
 
 
 # ---------------------------------------------------------------------------
@@ -47,22 +48,28 @@ def _extract_variety_total(variety: Any) -> int | None:
     journal) into a scalar suitable for f-string rendering.
 
     Render-scoped wrapper over the shared resolve_variety_total resolver.
-    Two render affordances stay local because the shared band-resolution
-    helper does not own them:
-      - A bare int passes through as-is (a legacy/test-fixture payload may
-        pass a bare int; render it rather than drop it). Bool is rejected
-        because it subclasses int — a True/False would surface as 1/0.
+    Both input shapes are range-gated to [MIN_SCORE, MAX_SCORE] (4..16) — the
+    resolver's no-clamp/no-fabricate policy: an out-of-range candidate is
+    dropped (line omitted), never clamped or rendered verbatim.
+      - A bare int is accepted only when it is a non-bool int IN range; an
+        out-of-range bare int (e.g. 99 or 0) drops the line rather than
+        rendering an impossible score. Bool is rejected because it
+        subclasses int — a True/False would surface as 1/0.
       - The dict path delegates to the shared resolver, so a non-canonical
         stamp (score / dimension-sum) now renders a total instead of
-        silently dropping the line. precompact calls the resolver with
-        only `variety` (no metadata) — the variety object IS the journal's
-        variety_score render context; there is no separate sibling key.
+        silently dropping the line, while an out-of-range dict `total`
+        (e.g. {"total": 99}) drops the line for the same reason. precompact
+        calls the resolver with only `variety` (no metadata) — the variety
+        object IS the journal's variety_score render context; there is no
+        separate sibling key.
 
-    Returns `None` if no usable total is present (caller should omit
+    Returns `None` if no usable in-range total is present (caller should omit
     the variety line from its rendered output).
     """
     if isinstance(variety, int) and not isinstance(variety, bool):
-        return variety  # legacy/test bare-int passthrough (render-only)
+        # Bare-int render affordance, range-gated to match the resolver's
+        # [MIN_SCORE, MAX_SCORE] policy (an out-of-range bare int drops the line).
+        return variety if MIN_SCORE <= variety <= MAX_SCORE else None
     return resolve_variety_total(variety)  # dict path → canonical + fallbacks
 
 

--- a/pact-plugin/hooks/precompact_state_reminder.py
+++ b/pact-plugin/hooks/precompact_state_reminder.py
@@ -33,6 +33,7 @@ from typing import Any
 from shared import pact_context
 from shared.error_output import hook_error_json
 from shared.session_state import summarize_session_state
+from shared.teachback_schema import resolve_variety_total
 
 
 # ---------------------------------------------------------------------------
@@ -45,26 +46,24 @@ def _extract_variety_total(variety: Any) -> int | None:
     Normalize the `variety_score` field (opaque passthrough from the
     journal) into a scalar suitable for f-string rendering.
 
-    The journal writer stores variety as a dict
-    `{"novelty": N, "scope": N, "uncertainty": N, "risk": N,
-    "total": N}`. The module-boundary contract is "opaque dict";
-    consumers that want a clean scalar render call this helper. Bool
-    is rejected because it subclasses int — a `True`/`False` in the
-    dict would otherwise surface as a variety score of 1/0.
+    Render-scoped wrapper over the shared resolve_variety_total resolver.
+    Two render affordances stay local because the shared band-resolution
+    helper does not own them:
+      - A bare int passes through as-is (a legacy/test-fixture payload may
+        pass a bare int; render it rather than drop it). Bool is rejected
+        because it subclasses int — a True/False would surface as 1/0.
+      - The dict path delegates to the shared resolver, so a non-canonical
+        stamp (score / dimension-sum) now renders a total instead of
+        silently dropping the line. precompact calls the resolver with
+        only `variety` (no metadata) — the variety object IS the journal's
+        variety_score render context; there is no separate sibling key.
 
     Returns `None` if no usable total is present (caller should omit
     the variety line from its rendered output).
     """
-    if isinstance(variety, dict):
-        total = variety.get("total")
-        if isinstance(total, int) and not isinstance(total, bool):
-            return total
-        return None
     if isinstance(variety, int) and not isinstance(variety, bool):
-        # Defensive: a legacy or test-fixture payload may pass a bare
-        # int. Render it as-is rather than dropping it.
-        return variety
-    return None
+        return variety  # legacy/test bare-int passthrough (render-only)
+    return resolve_variety_total(variety)  # dict path → canonical + fallbacks
 
 
 def build_custom_instructions(state: dict) -> str:

--- a/pact-plugin/hooks/shared/session_state.py
+++ b/pact-plugin/hooks/shared/session_state.py
@@ -351,11 +351,13 @@ def _derive_variety_from_journal(
 ) -> Any:
     """
     Return the variety dict from the first variety_assessed event, or
-    None if no such event exists. Opaque passthrough — callers only
-    check `is not None` and/or read `.get("total")`. Keeping the full
-    dict preserves future flexibility (novelty/scope/uncertainty/risk
-    dimensions are rendered by consumers that want them; the default
-    compaction-hook render uses `.get("total")`).
+    None if no such event exists. Opaque passthrough — this helper does
+    not interpret the dict; consumers resolve the scalar total they need.
+    Keeping the full dict preserves future flexibility (the
+    novelty/scope/uncertainty/risk dimensions stay available to consumers
+    that want them; the compaction-hook render resolves a single total
+    via the shared `resolve_variety_total` helper, which prefers the
+    canonical `total` key — see its docstring for the fallback chain).
     """
     variety_events = sorted(
         [e for e in events if e.get("type") == "variety_assessed"],

--- a/pact-plugin/hooks/shared/teachback_schema.py
+++ b/pact-plugin/hooks/shared/teachback_schema.py
@@ -29,13 +29,29 @@ Public surface:
   `variety_scorer.ORCHESTRATE_MAX + 1`; substitute
   `from shared.variety_scorer import PLAN_MODE_MIN` when that constant
   lands.
+- TEACHBACK_RECOMMENDED_BAND_MIN — variety band threshold
+  (>= 7 → RECOMMENDED, below it → SKIPPED). Derived from
+  `variety_scorer.COMPACT_MAX + 1`.
 - validate_reasoning_reconstruction(rr) — pure validator returning None
   on well-formed input or a reason-enum string on rejection.
+- resolve_variety_total(variety, metadata=None) — pure resolver returning
+  the per-dispatch variety total as an in-range int, or None when no
+  candidate resolves. Ordered precedence: variety["total"] →
+  variety["score"] → metadata["variety_score"] → sum of the four
+  dimension scores. Shared SSOT for the lifecycle gate's read-time band
+  resolver and write-time validator (and precompact's render).
 """
 
 from __future__ import annotations
 
-from shared.variety_scorer import ORCHESTRATE_MAX
+from shared.variety_scorer import (
+    COMPACT_MAX,
+    MAX_DIMENSION,
+    MAX_SCORE,
+    MIN_DIMENSION,
+    MIN_SCORE,
+    ORCHESTRATE_MAX,
+)
 
 
 # Canonical 5 field names per D10. 4 string fields + variety_acknowledgment dict.
@@ -67,6 +83,14 @@ TEACHBACK_VARIETY_ACK_VALID_VALUES: tuple[str, ...] = ("yes", "no", "concern")
 # replaced with `from shared.variety_scorer import PLAN_MODE_MIN`.
 TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN: int = ORCHESTRATE_MAX + 1
 
+# RECOMMENDED-band floor for reasoning_reconstruction. Totals strictly above
+# COMPACT_MAX (i.e. >= COMPACT_MAX + 1 = 7) and below the REQUIRED threshold
+# are the recommended-not-required band; totals <= COMPACT_MAX are skipped.
+# Named here (symmetric with the REQUIRED threshold above) so the lifecycle
+# gate's band mapping references a constant instead of hard-coding 7, while
+# keeping the gate's reach to variety_scorer strictly 2-hop via this module.
+TEACHBACK_RECOMMENDED_BAND_MIN: int = COMPACT_MAX + 1
+
 
 def validate_reasoning_reconstruction(rr: object) -> str | None:
     """Return None if rr is a well-formed 3-sub-key triangle, or a short
@@ -93,3 +117,79 @@ def validate_reasoning_reconstruction(rr: object) -> str | None:
         if not isinstance(value, str) or not value.strip():
             return "empty_reasoning_reconstruction_field"
     return None
+
+
+# The four per-dimension keys whose sum is the definitional variety total
+# (see variety_scorer.score_variety). Used by the candidate-4 dimension-sum
+# fallback in resolve_variety_total.
+_VARIETY_DIMENSIONS: tuple[str, ...] = (
+    "novelty",
+    "scope",
+    "uncertainty",
+    "risk",
+)
+
+
+def _is_in_range_int(value: object, low: int, high: int) -> bool:
+    """True iff value is a non-bool int within the inclusive [low, high]
+    range. bool is rejected because it subclasses int (True→1, False→0)."""
+    return (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and low <= value <= high
+    )
+
+
+def resolve_variety_total(variety: object, metadata: object = None) -> int | None:
+    """Resolve the per-dispatch variety total from a (possibly non-canonical
+    or malformed) variety stamp.
+
+    Precedence (first valid in-range int wins):
+      1. variety["total"]          — canonical
+      2. variety["score"]          — non-canonical, field-evidenced
+      3. metadata["variety_score"] — non-canonical sibling, field-evidenced
+      4. sum(variety[d] for d in the 4 dimensions) when all four are valid
+         in-range dimension ints (1..4 each)
+
+    Returns an int in [MIN_SCORE, MAX_SCORE] (4..16), or None when no
+    candidate yields a resolvable in-range total.
+
+    Pure; NEVER raises. Non-dict / missing / malformed input → None.
+    bool is rejected at every key (bool subclasses int). A present-but-
+    out-of-range or wrong-typed candidate does NOT halt the chain — the
+    resolver falls through to the next candidate, so a junk canonical
+    total cannot shadow a recoverable fallback.
+    """
+    # Belt-and-suspenders: the body below is structurally non-raising, but
+    # the outermost guard ensures no exotic input can ever escape as an
+    # exception — this hook fires on every Task-tool use.
+    try:
+        if not isinstance(variety, dict):
+            return None
+
+        # Candidate 1: canonical total.
+        if _is_in_range_int(variety.get("total"), MIN_SCORE, MAX_SCORE):
+            return variety["total"]
+
+        # Candidate 2: non-canonical score (inside the variety dict).
+        if _is_in_range_int(variety.get("score"), MIN_SCORE, MAX_SCORE):
+            return variety["score"]
+
+        # Candidate 3: non-canonical top-level sibling (metadata.variety_score).
+        # Skipped when metadata is absent or not a dict.
+        if isinstance(metadata, dict) and _is_in_range_int(
+            metadata.get("variety_score"), MIN_SCORE, MAX_SCORE
+        ):
+            return metadata["variety_score"]
+
+        # Candidate 4: dimension-sum — only when ALL four dimensions are
+        # valid in-range ints. In-range by construction (4×1..4×4 = 4..16).
+        if all(
+            _is_in_range_int(variety.get(d), MIN_DIMENSION, MAX_DIMENSION)
+            for d in _VARIETY_DIMENSIONS
+        ):
+            return sum(variety[d] for d in _VARIETY_DIMENSIONS)
+
+        return None
+    except Exception:  # noqa: BLE001 — never raise out of an every-Task hook
+        return None

--- a/pact-plugin/hooks/shared/teachback_schema.py
+++ b/pact-plugin/hooks/shared/teachback_schema.py
@@ -6,6 +6,8 @@ Summary: Canonical teachback_submit schema constants and validators. SSOT
          (L1.5 method gate per pact-ct-teachback.md), and the variety-band
          threshold at which reasoning_reconstruction is REQUIRED.
 Used by: hooks/task_lifecycle_gate.py (write-time + completion-time gates),
+         hooks/precompact_state_reminder.py (resolve_variety_total for the
+         compaction-state render),
          tests/test_teachback_reasoning_reconstruction.py (schema gate),
          tests/test_task_lifecycle_gate.py (rule-fixture inputs),
          tests/test_teachback_schema.py (constants + validator).
@@ -25,10 +27,8 @@ Public surface:
 - TEACHBACK_VARIETY_ACK_VALID_VALUES — enum tuple for
   variety_acknowledgment.rationale_articulates_this_dispatch.
 - TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN — variety band threshold
-  (>= 11 → REQUIRED). Derived at module-load from
-  `variety_scorer.ORCHESTRATE_MAX + 1`; substitute
-  `from shared.variety_scorer import PLAN_MODE_MIN` when that constant
-  lands.
+  (>= 11 → REQUIRED). Bound at module-load to `variety_scorer.PLAN_MODE_MIN`
+  (the plan-mode band floor).
 - TEACHBACK_RECOMMENDED_BAND_MIN — variety band threshold
   (>= 7 → RECOMMENDED, below it → SKIPPED). Derived from
   `variety_scorer.COMPACT_MAX + 1`.
@@ -50,7 +50,7 @@ from shared.variety_scorer import (
     MAX_SCORE,
     MIN_DIMENSION,
     MIN_SCORE,
-    ORCHESTRATE_MAX,
+    PLAN_MODE_MIN,
 )
 
 
@@ -76,12 +76,11 @@ TEACHBACK_REQUIRED_SUBKEYS: tuple[str, ...] = (
 #   {rationale_articulates_this_dispatch: <enum>, concern: <str when != yes>}.
 TEACHBACK_VARIETY_ACK_VALID_VALUES: tuple[str, ...] = ("yes", "no", "concern")
 
-# REQUIRED-band threshold for reasoning_reconstruction. Derived from
-# variety_scorer.ORCHESTRATE_MAX semantics: plan-mode-and-above starts at
-# ORCHESTRATE_MAX + 1 (i.e. >= 11 given ORCHESTRATE_MAX = 10). When
-# variety_scorer.py exports an explicit PLAN_MODE_MIN, this should be
-# replaced with `from shared.variety_scorer import PLAN_MODE_MIN`.
-TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN: int = ORCHESTRATE_MAX + 1
+# REQUIRED-band threshold for reasoning_reconstruction: reasoning_reconstruction
+# is REQUIRED at plan-mode-and-above (>= 11). Bound to variety_scorer's
+# PLAN_MODE_MIN (the plan-mode band floor) so the threshold tracks the SSOT
+# band cuts directly instead of an off-by-one expression.
+TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN: int = PLAN_MODE_MIN
 
 # RECOMMENDED-band floor for reasoning_reconstruction. Totals strictly above
 # COMPACT_MAX (i.e. >= COMPACT_MAX + 1 = 7) and below the REQUIRED threshold

--- a/pact-plugin/hooks/shared/variety_scorer.py
+++ b/pact-plugin/hooks/shared/variety_scorer.py
@@ -33,6 +33,12 @@ ORCHESTRATE_MAX = 10  # 7-10 -> orchestrate
 PLAN_MODE_MAX = 14    # 11-14 -> plan-mode + orchestrate
 # 15-16 -> research spike
 
+# Inclusive LOWER bound of the plan-mode band: the first score above the
+# orchestrate band (= ORCHESTRATE_MAX + 1 = 11). Named so consumers that gate
+# on "plan-mode and above" reference a band-floor constant instead of the
+# off-by-one expression.
+PLAN_MODE_MIN = ORCHESTRATE_MAX + 1  # 11
+
 # ---------------------------------------------------------------------------
 # Workflow route names
 # ---------------------------------------------------------------------------

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -44,10 +44,12 @@ Rule coverage:
     submitted at REQUIRED band (Task B variety.total >= 11) without
     reasoning_reconstruction
   - reasoning_reconstruction_band_unresolvable — band traversal failed
-    (missing blocks, missing Task B, missing variety); fail-open advisory
-    documents the gap without blocking lifecycle
+    (missing blocks, missing Task B, missing variety, or variety present
+    but no resolvable total); fail-open advisory documents the gap without
+    blocking lifecycle
   - variety_missing_on_dispatch_task — pact-* work Task created without
-    metadata.variety OR with malformed per-dimension rationales
+    metadata.variety, with malformed per-dimension rationales, OR with no
+    resolvable variety total
   - variety_acknowledgment_missing — Teachback submitted without
     variety_acknowledgment field (D10 teammate verification)
   - variety_acknowledgment_schema_invalid_at_write_time — Teachback
@@ -121,10 +123,12 @@ try:
     from shared.session_journal import append_event, get_journal_path, make_event
     from shared.task_utils import read_task_json
     from shared.teachback_schema import (
+        TEACHBACK_RECOMMENDED_BAND_MIN,
         TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN,
         TEACHBACK_REQUIRED_FIELDS,
         TEACHBACK_REQUIRED_SUBKEYS,
         TEACHBACK_VARIETY_ACK_VALID_VALUES,
+        resolve_variety_total,
         validate_reasoning_reconstruction,
     )
     from shared.tool_response import extract_tool_response
@@ -176,6 +180,15 @@ _VARIETY_REQUIRED_RATIONALES = (
     "scope_rationale",
     "uncertainty_rationale",
     "risk_rationale",
+)
+
+# Sentinel problem string returned by _validate_variety_schema when the
+# rationales are well-formed but no resolvable variety total exists. The R4
+# rule keys on this exact value to select the distinct unresolvable-total
+# advisory message (vs. the rationale-malformed message).
+_NO_RESOLVABLE_TOTAL = (
+    "no resolvable total (need an integer 4-16 under key 'total', "
+    "or a recoverable fallback)"
 )
 
 
@@ -571,14 +584,27 @@ def _validate_teachback_submit_schema(teachback: object) -> str | None:
     return None
 
 
-def _validate_variety_schema(variety: object) -> str | None:
+def _validate_variety_schema(
+    variety: object, metadata: object = None
+) -> str | None:
     """Return None if metadata.variety is well-formed per D11, or a short
     reason string. Pure function; never raises.
 
     Validates the four per-dimension rationale fields (presence +
-    non-empty string). Dimension score range checks (1-4) are the
-    orchestrator's authority; this hook is defense-in-depth for the
-    cargo-cult-prevention property D11 codifies.
+    non-empty string) AND that the stamp carries a resolvable variety
+    total. The total check consults the same shared resolver the
+    read-time band resolver uses (resolve_variety_total) — this is the
+    cross-rule consistency property: any variety shape that passes
+    write-time validation MUST resolve at read-time. Dimension score
+    range checks (1-4) are the orchestrator's authority; this hook is
+    defense-in-depth for the cargo-cult-prevention property D11 codifies.
+
+    The optional `metadata` argument is forwarded to the resolver so the
+    non-canonical top-level `variety_score` sibling is reachable. Callers
+    that only have the variety dict may omit it (the resolver simply skips
+    that candidate). Rationale problems are checked first (cheap dict +
+    string checks), then the total (one resolver call); the first problem
+    found is returned, preserving the single-string-return contract.
     """
     if not isinstance(variety, dict):
         return f"must be object, got {type(variety).__name__}"
@@ -599,6 +625,8 @@ def _validate_variety_schema(variety: object) -> str | None:
             f"per-dimension rationales empty/non-string: "
             f"{', '.join(empty)}"
         )
+    if resolve_variety_total(variety, metadata) is None:
+        return _NO_RESOLVABLE_TOTAL
     return None
 
 
@@ -609,12 +637,17 @@ def _resolve_required_band_via_blocks(
     via blocks traversal to Task B.
 
     Returns one of:
-      - "required": Task B.metadata.variety.total >= 11
-      - "recommended": 7 <= total <= 10
-      - "skipped": total <= 6
+      - "required": resolved total >= TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN
+      - "recommended": TEACHBACK_RECOMMENDED_BAND_MIN <= total < required-min
+      - "skipped": total < TEACHBACK_RECOMMENDED_BAND_MIN
       - "unresolvable": blocks link missing, Task B file missing, or
-        variety absent/malformed on Task B (fail-open: caller emits a
-        separate band_unresolvable advisory documenting the gap)
+        variety absent/malformed/untotaled on Task B (fail-open: caller
+        emits a separate band_unresolvable advisory documenting the gap)
+
+    The total is resolved via the shared resolve_variety_total helper, so a
+    non-canonical stamp (score / top-level variety_score / dimension-sum)
+    resolves rather than reading as "unresolvable" — the same resolver the
+    write-time validator consults (the cross-rule consistency property).
     """
     blocks = task_a.get("blocks")
     if not isinstance(blocks, list) or not blocks:
@@ -636,12 +669,12 @@ def _resolve_required_band_via_blocks(
     variety = metadata.get("variety")
     if not isinstance(variety, dict):
         return "unresolvable"
-    total = variety.get("total")
-    if not isinstance(total, int) or isinstance(total, bool):
+    total = resolve_variety_total(variety, metadata)
+    if total is None:
         return "unresolvable"
     if total >= TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN:
         return "required"
-    if total >= 7:
+    if total >= TEACHBACK_RECOMMENDED_BAND_MIN:
         return "recommended"
     return "skipped"
 
@@ -808,20 +841,20 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
         # R4: variety_missing_on_dispatch_task (D11-refined).
         # Same discriminator pattern as work_addblockedby_missing
         # (not-teachback + pact-* owner + not exempt). Single rule with
-        # two trigger paths (absent variety OR malformed per-dimension
-        # rationales); distinct message text per path, same rule name —
-        # the lead-side correction is the same (re-stamp variety) in
-        # either case. Clause order mirrors L575-580: cheap dict-lookups
-        # first, disk-touching exempt-check last (cached via `_exempt()`
-        # so the second invocation reuses the first call's result).
+        # three trigger paths (absent variety OR malformed per-dimension
+        # rationales OR no resolvable total); distinct message text per
+        # path, same rule name — the lead-side correction is the same
+        # (re-stamp variety) in every case. Clause order mirrors L575-580:
+        # cheap dict-lookups first, disk-touching exempt-check last
+        # (cached via `_exempt()` so the second invocation reuses the
+        # first call's result).
         if (
             not is_teachback
             and owner.startswith("pact-")
             and not _exempt()
         ):
-            incoming_variety = (
-                tool_input.get("metadata") or {}
-            ).get("variety")
+            incoming_metadata = tool_input.get("metadata") or {}
+            incoming_variety = incoming_metadata.get("variety")
             if not incoming_variety:
                 advisories.append((
                     "variety_missing_on_dispatch_task",
@@ -832,8 +865,28 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
                     "peer-review dispatch surfaces.",
                 ))
             else:
-                schema_problem = _validate_variety_schema(incoming_variety)
-                if schema_problem:
+                # The validator forwards the surrounding metadata so the
+                # non-canonical top-level variety_score sibling is reachable
+                # by the shared resolver. It returns the rationale problem
+                # first (if any), then the total problem; the total problem
+                # carries the distinctive _NO_RESOLVABLE_TOTAL sentinel so
+                # the two paths emit distinct message text under one rule.
+                schema_problem = _validate_variety_schema(
+                    incoming_variety, incoming_metadata
+                )
+                if schema_problem == _NO_RESOLVABLE_TOTAL:
+                    advisories.append((
+                        "variety_missing_on_dispatch_task",
+                        f"PACT task_lifecycle_gate: pact-* Task created "
+                        f"(owner={owner!r}) with metadata.variety carrying "
+                        "no resolvable total (need an integer 4-16 under "
+                        "key 'total', or a recoverable fallback). Per "
+                        "pact-variety.md the canonical key is 'total'. The "
+                        "hook's read-time band resolver requires a "
+                        "resolvable total; stamping without one trips a "
+                        "band-unresolvable advisory at teachback-submit time.",
+                    ))
+                elif schema_problem:
                     advisories.append((
                         "variety_missing_on_dispatch_task",
                         f"PACT task_lifecycle_gate: pact-* Task created "
@@ -1148,13 +1201,16 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
                     advisories.append((
                         "reasoning_reconstruction_band_unresolvable",
                         f"PACT task_lifecycle_gate: Teachback Task "
-                        f"{task_id} cannot resolve variety band — "
-                        "Task A.blocks link missing OR Task B file "
-                        "missing OR Task B.metadata.variety absent. "
-                        "Hook advisory skipped; lead should enforce "
-                        "variety stamping via teachback_addblocks_missing "
-                        "wiring-time enforcement upstream + "
-                        "variety_missing_on_dispatch_task at TaskCreate.",
+                        f"{task_id} cannot resolve the variety band. One "
+                        "of: Task A.blocks is missing/empty; team context "
+                        "is unavailable; the Task B file is missing; or "
+                        "Task B.metadata.variety is absent OR present but "
+                        "carries no resolvable total (no integer 4-16 under "
+                        "'total' or a recoverable fallback). Advisory only "
+                        "— not blocking. If the variety stamp is the cause, "
+                        "re-stamp Task B with a canonical "
+                        "metadata.variety.total (see pact-variety.md "
+                        "Per-Dispatch Variety Stamping).",
                     ))
 
     return advisories

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -938,6 +938,8 @@ The feature-level CalibrationRecord above coexists with per-dispatch variety sta
 }
 ```
 
+> The canonical total key is `total`. The lifecycle hook's band resolver additionally tolerates non-canonical `score` / top-level `variety_score`, or the sum of the four dimension scores, as fallbacks for stamps seen in the field — but orchestrators MUST stamp `total`.
+
 **Why per-dimension rationales (not a single rationale)**: A single rationale field tolerates cargo-cult ("matches feature complexity" satisfies it). Four distinct rationale fields, one per dimension, force the orchestrator to articulate four independent judgments — cargo-culting all four with one phrase is mechanically incoherent (cannot coherently explain why novelty AND scope AND uncertainty AND risk are simultaneously "the same as feature" without exposing the copy-paste).
 
 #### variety_acknowledgment — Teammate Verification Workflow

--- a/pact-plugin/protocols/pact-variety.md
+++ b/pact-plugin/protocols/pact-variety.md
@@ -142,6 +142,8 @@ The feature-level CalibrationRecord above coexists with per-dispatch variety sta
 }
 ```
 
+> The canonical total key is `total`. The lifecycle hook's band resolver additionally tolerates non-canonical `score` / top-level `variety_score`, or the sum of the four dimension scores, as fallbacks for stamps seen in the field — but orchestrators MUST stamp `total`.
+
 **Why per-dimension rationales (not a single rationale)**: A single rationale field tolerates cargo-cult ("matches feature complexity" satisfies it). Four distinct rationale fields, one per dimension, force the orchestrator to articulate four independent judgments — cargo-culting all four with one phrase is mechanically incoherent (cannot coherently explain why novelty AND scope AND uncertainty AND risk are simultaneously "the same as feature" without exposing the copy-paste).
 
 #### variety_acknowledgment — Teammate Verification Workflow

--- a/pact-plugin/tests/test_per_dispatch_variety.py
+++ b/pact-plugin/tests/test_per_dispatch_variety.py
@@ -203,6 +203,101 @@ class TestRequiredBandResolution:
 
 
 # =============================================================================
+# Resolvable-via-fallback: non-canonical stamps that now resolve a band
+#
+# Before the shared-resolver fix, only a strict int `total` resolved; a stamp
+# carrying a non-canonical score / top-level variety_score / valid dimension
+# scores read as "unresolvable". These cases pin that such stamps now resolve
+# to the correct band — the false-positive the fix removes. They exercise the
+# caller's int→band mapping through each fallback candidate, so a regression
+# in either the resolver chain or the band cuts surfaces here.
+# =============================================================================
+
+
+class TestBandResolvableViaFallback:
+    """Non-canonical variety stamps resolve to a band via the shared
+    resolver's fallback chain, instead of reading as unresolvable."""
+
+    def test_score_fallback_resolves_band_for_field_report_shape(
+        self, tmp_path, monkeypatch,
+    ):
+        """The exact reported false-positive shape: rationales + a
+        non-canonical `score` int (no `total`), with a sibling top-level
+        `variety_score`. Must resolve to a band — NOT unresolvable."""
+        variety = _no_fallback_variety(score=12)
+        variety.pop("total")
+        _seed_task_b(
+            tmp_path, monkeypatch, "test-team", "2",
+            metadata={"variety": variety, "variety_score": 12},
+        )
+        assert tlg._resolve_required_band_via_blocks(
+            {"blocks": ["2"]}, "test-team"
+        ) == "required"
+
+    def test_score_fallback_maps_to_recommended_band(
+        self, tmp_path, monkeypatch,
+    ):
+        """score=8 (no total) → recommended band (7..10)."""
+        variety = _no_fallback_variety(score=8)
+        variety.pop("total")
+        _seed_task_b(
+            tmp_path, monkeypatch, "test-team", "2",
+            metadata={"variety": variety},
+        )
+        assert tlg._resolve_required_band_via_blocks(
+            {"blocks": ["2"]}, "test-team"
+        ) == "recommended"
+
+    def test_top_level_variety_score_fallback_resolves_band(
+        self, tmp_path, monkeypatch,
+    ):
+        """No `total`, no `score`, but a top-level metadata.variety_score
+        int → resolves via candidate 3 (reachable because the caller passes
+        Task B's full metadata to the resolver)."""
+        variety = _no_fallback_variety()
+        variety.pop("total")
+        _seed_task_b(
+            tmp_path, monkeypatch, "test-team", "2",
+            metadata={"variety": variety, "variety_score": 11},
+        )
+        assert tlg._resolve_required_band_via_blocks(
+            {"blocks": ["2"]}, "test-team"
+        ) == "required"
+
+    def test_dimension_sum_fallback_resolves_band(
+        self, tmp_path, monkeypatch,
+    ):
+        """No total/score/variety_score, but all four dimension scores
+        valid → resolves to the sum's band. _well_formed_variety carries
+        2/2/2/2 = 8, so popping `total` lands on recommended via the sum."""
+        variety = _well_formed_variety()
+        variety.pop("total")
+        _seed_task_b(
+            tmp_path, monkeypatch, "test-team", "2",
+            metadata={"variety": variety},
+        )
+        assert tlg._resolve_required_band_via_blocks(
+            {"blocks": ["2"]}, "test-team"
+        ) == "recommended"
+
+    def test_junk_total_falls_through_to_dimension_sum_band(
+        self, tmp_path, monkeypatch,
+    ):
+        """An out-of-range `total` does not shadow a recoverable dimension
+        sum: total=99 with dims 3/3/3/3=12 → required (the sum's band)."""
+        variety = _well_formed_variety(
+            total=99, novelty=3, scope=3, uncertainty=3, risk=3,
+        )
+        _seed_task_b(
+            tmp_path, monkeypatch, "test-team", "2",
+            metadata={"variety": variety},
+        )
+        assert tlg._resolve_required_band_via_blocks(
+            {"blocks": ["2"]}, "test-team"
+        ) == "required"
+
+
+# =============================================================================
 # Fail-open paths: every "unresolvable" return path
 # =============================================================================
 

--- a/pact-plugin/tests/test_per_dispatch_variety.py
+++ b/pact-plugin/tests/test_per_dispatch_variety.py
@@ -183,11 +183,10 @@ class TestRequiredBandResolution:
     def test_band_threshold_constants_aligned_with_variety_scorer(self):
         """Pin the alignment between
         TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN and
-        variety_scorer.ORCHESTRATE_MAX. PLAN_MODE_MIN-implied threshold is
+        variety_scorer. The threshold binds to PLAN_MODE_MIN, which is itself
         ORCHESTRATE_MAX + 1 = 11. If variety_scorer's thresholds shift and
         this module's constant doesn't, this test fails and the drift is
-        surfaced. Grep-at-edit-time discipline applies until the SSOT
-        migration trajectory lands."""
+        surfaced."""
         from shared import variety_scorer
         from shared.teachback_schema import (
             TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN,

--- a/pact-plugin/tests/test_per_dispatch_variety.py
+++ b/pact-plugin/tests/test_per_dispatch_variety.py
@@ -62,6 +62,25 @@ def _well_formed_variety(**overrides):
     return payload
 
 
+def _no_fallback_variety(**overrides):
+    """Return a variety dict whose `total` is the ONLY total candidate —
+    the four dimension scores are omitted so the dimension-sum fallback
+    cannot resolve, and there is no `score` key. Use this to exercise the
+    "every resolver candidate invalid → unresolvable" path: override `total`
+    with a bad value (or pop it) and no other candidate can recover it. The
+    rationales (not resolution candidates) are kept so the write-time schema
+    check still treats the shape as rationale-complete."""
+    payload = {
+        "novelty_rationale": "x",
+        "scope_rationale": "x",
+        "uncertainty_rationale": "x",
+        "risk_rationale": "x",
+        "total": 8,
+    }
+    payload.update(overrides)
+    return payload
+
+
 def _seed_task_b(
     tmp_path, monkeypatch, team_name, task_b_id,
     metadata=None,
@@ -283,9 +302,12 @@ class TestBandUnresolvableFailOpen:
             {"blocks": ["2"]}, "test-team"
         ) == "unresolvable"
 
-    def test_variety_total_missing(self, tmp_path, monkeypatch):
-        """Task B.metadata.variety has no `total` key → unresolvable."""
-        variety = _well_formed_variety()
+    def test_variety_total_missing_and_no_fallback(self, tmp_path, monkeypatch):
+        """Task B.metadata.variety has no `total` key AND no recoverable
+        fallback (dimensions stripped) → unresolvable. A missing total alone
+        now resolves via the dimension-sum fallback when the four dimensions
+        are valid; unresolvable requires every candidate to be invalid."""
+        variety = _no_fallback_variety()
         variety.pop("total")
         _seed_task_b(
             tmp_path, monkeypatch, "test-team", "2",
@@ -295,34 +317,36 @@ class TestBandUnresolvableFailOpen:
             {"blocks": ["2"]}, "test-team"
         ) == "unresolvable"
 
-    def test_variety_total_non_int_string(self, tmp_path, monkeypatch):
-        """Task B.metadata.variety.total = "twelve" → unresolvable."""
+    def test_variety_total_non_int_string_and_no_fallback(self, tmp_path, monkeypatch):
+        """Task B.metadata.variety.total = "twelve" with no recoverable
+        fallback → unresolvable."""
         _seed_task_b(
             tmp_path, monkeypatch, "test-team", "2",
-            metadata={"variety": _well_formed_variety(total="twelve")},
+            metadata={"variety": _no_fallback_variety(total="twelve")},
         )
         assert tlg._resolve_required_band_via_blocks(
             {"blocks": ["2"]}, "test-team"
         ) == "unresolvable"
 
-    def test_variety_total_bool_rejected(self, tmp_path, monkeypatch):
-        """Task B.metadata.variety.total = True → unresolvable.
-        Defensive: bool is a subclass of int in Python; reject explicitly.
-        """
+    def test_variety_total_bool_rejected_and_no_fallback(self, tmp_path, monkeypatch):
+        """Task B.metadata.variety.total = True with no recoverable fallback
+        → unresolvable. Defensive: bool is a subclass of int in Python;
+        reject explicitly."""
         _seed_task_b(
             tmp_path, monkeypatch, "test-team", "2",
-            metadata={"variety": _well_formed_variety(total=True)},
+            metadata={"variety": _no_fallback_variety(total=True)},
         )
         assert tlg._resolve_required_band_via_blocks(
             {"blocks": ["2"]}, "test-team"
         ) == "unresolvable"
 
-    def test_variety_total_float(self, tmp_path, monkeypatch):
-        """Task B.metadata.variety.total = 12.5 → unresolvable. The
-        traversal accepts ints only; floats indicate malformed data."""
+    def test_variety_total_float_and_no_fallback(self, tmp_path, monkeypatch):
+        """Task B.metadata.variety.total = 12.5 with no recoverable fallback
+        → unresolvable. The resolver accepts ints only; floats indicate
+        malformed data."""
         _seed_task_b(
             tmp_path, monkeypatch, "test-team", "2",
-            metadata={"variety": _well_formed_variety(total=12.5)},
+            metadata={"variety": _no_fallback_variety(total=12.5)},
         )
         assert tlg._resolve_required_band_via_blocks(
             {"blocks": ["2"]}, "test-team"

--- a/pact-plugin/tests/test_precompact_state_reminder.py
+++ b/pact-plugin/tests/test_precompact_state_reminder.py
@@ -135,7 +135,10 @@ class TestBuildCustomInstructions:
         result = build_custom_instructions(state)
         assert "Variety" not in result
 
-    def test_variety_zero_included(self):
+    def test_out_of_range_bare_int_omits_variety_line(self):
+        """A bare int below the valid score range (0 < MIN_SCORE=4) is an
+        impossible variety total — the line is omitted rather than rendering
+        "Variety score: 0", per the range-gate on the bare-int branch."""
         from precompact_state_reminder import build_custom_instructions
         state = {
             "feature_subject": "X", "feature_id": "1",
@@ -143,7 +146,7 @@ class TestBuildCustomInstructions:
             "teammates": [], "team_names": [],
         }
         result = build_custom_instructions(state)
-        assert "Variety score: 0" in result
+        assert "Variety" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -155,16 +158,12 @@ class TestExtractVarietyTotal:
     """Direct tests for the _extract_variety_total helper.
 
     Defensive code rejects bool because Python's bool is a subclass of
-    int — `isinstance(True, int) is True`. Without the explicit
-    `not isinstance(_, bool)` guards, a `variety_score: True` would
-    render as "Variety score: 1" in the compaction-model context, and
-    a dict `{"total": False}` would render as "Variety score: 0". Both
-    are misleading.
-
-    Round-2 review (PR #426 F4) found these guards silently removable.
-    Counter-test: removing `and not isinstance(_, bool)` from the two
-    type checks at precompact_state_reminder.py:56,59 makes these
-    fail with the assertion `is None` violated."""
+    int — `isinstance(True, int) is True`. The bare-int branch carries an
+    explicit `not isinstance(_, bool)` guard so a `variety_score: True`
+    cannot render as "Variety score: 1" in the compaction-model context;
+    the dict path delegates bool rejection to the shared resolver, which
+    rejects `{"total": False}` for the same reason. Removing the bare-int
+    guard makes the bool cases below fail the `is None` assertion."""
 
     def test_bool_true_at_top_level_rejected(self):
         from precompact_state_reminder import _extract_variety_total
@@ -201,19 +200,28 @@ class TestExtractVarietyTotal:
         from precompact_state_reminder import _extract_variety_total
         assert _extract_variety_total({"total": 99}) is None
 
-    # ----- bare-int passthrough (render affordance, kept local) ---------
+    # ----- bare-int render affordance, range-gated to [MIN_SCORE, MAX_SCORE] -
 
-    def test_bare_int_passes_through(self):
+    def test_bare_int_in_range_passes_through(self):
         from precompact_state_reminder import _extract_variety_total
         assert _extract_variety_total(8) == 8
 
-    def test_bare_int_passthrough_does_not_range_check(self):
-        """The bare-int passthrough is a render affordance and intentionally
-        does NOT range-check (unlike the dict path, which goes through the
-        range-enforcing shared resolver). A bare 99 renders as-is."""
+    def test_bare_int_at_range_bounds_passes_through(self):
+        """The inclusive [4, 16] bounds (MIN_SCORE/MAX_SCORE) both pass."""
         from precompact_state_reminder import _extract_variety_total
-        assert _extract_variety_total(99) == 99
-        assert _extract_variety_total(0) == 0
+        assert _extract_variety_total(4) == 4
+        assert _extract_variety_total(16) == 16
+
+    def test_out_of_range_bare_int_returns_none(self):
+        """The bare-int branch is range-gated to match the resolver's
+        no-clamp/no-fabricate [4, 16] policy: an out-of-range bare int is
+        dropped (line omitted), not rendered verbatim. Above the max (99)
+        and below the min (0, 3) both return None."""
+        from precompact_state_reminder import _extract_variety_total
+        assert _extract_variety_total(99) is None
+        assert _extract_variety_total(17) is None
+        assert _extract_variety_total(3) is None
+        assert _extract_variety_total(0) is None
 
     # ----- junk → None --------------------------------------------------
 

--- a/pact-plugin/tests/test_precompact_state_reminder.py
+++ b/pact-plugin/tests/test_precompact_state_reminder.py
@@ -179,6 +179,90 @@ class TestExtractVarietyTotal:
         assert _extract_variety_total({"total": True}) is None
         assert _extract_variety_total({"total": False}) is None
 
+    # ----- dict path delegates to the shared resolver -------------------
+
+    def test_dict_with_canonical_total(self):
+        from precompact_state_reminder import _extract_variety_total
+        assert _extract_variety_total({"total": 8}) == 8
+
+    def test_dict_with_score_only_resolves_via_shared_resolver(self):
+        """NEW behavior: a non-canonical `score`-only stamp now renders a
+        total instead of silently dropping the line. Before convergence on
+        the shared resolver, precompact only read `total` and dropped this."""
+        from precompact_state_reminder import _extract_variety_total
+        assert _extract_variety_total({"score": 8}) == 8
+
+    def test_dict_with_dimension_scores_resolves_via_shared_resolver(self):
+        from precompact_state_reminder import _extract_variety_total
+        v = {"novelty": 2, "scope": 3, "uncertainty": 1, "risk": 4}
+        assert _extract_variety_total(v) == 10
+
+    def test_dict_with_out_of_range_total_no_fallback_returns_none(self):
+        from precompact_state_reminder import _extract_variety_total
+        assert _extract_variety_total({"total": 99}) is None
+
+    # ----- bare-int passthrough (render affordance, kept local) ---------
+
+    def test_bare_int_passes_through(self):
+        from precompact_state_reminder import _extract_variety_total
+        assert _extract_variety_total(8) == 8
+
+    def test_bare_int_passthrough_does_not_range_check(self):
+        """The bare-int passthrough is a render affordance and intentionally
+        does NOT range-check (unlike the dict path, which goes through the
+        range-enforcing shared resolver). A bare 99 renders as-is."""
+        from precompact_state_reminder import _extract_variety_total
+        assert _extract_variety_total(99) == 99
+        assert _extract_variety_total(0) == 0
+
+    # ----- junk → None --------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "junk",
+        [None, 8.0, 8.5, "8", "high", [8], {"total": "twelve"}, {}],
+    )
+    def test_junk_returns_none(self, junk):
+        from precompact_state_reminder import _extract_variety_total
+        assert _extract_variety_total(junk) is None
+
+
+class TestExtractVarietyTotalRenders:
+    """build_custom_instructions renders or omits the variety line per the
+    resolver's verdict — the consumer-side of the precompact convergence."""
+
+    def _state(self, variety_score):
+        return {
+            "feature_subject": "X", "feature_id": "1",
+            "current_phase": "Phase: TEST", "variety_score": variety_score,
+            "teammates": ["a"], "team_names": ["t"],
+        }
+
+    def test_renders_line_for_score_only_dict(self):
+        from precompact_state_reminder import build_custom_instructions
+        result = build_custom_instructions(self._state({"score": 9}))
+        assert "Variety score: 9" in result
+
+    def test_renders_line_for_dimension_sum_dict(self):
+        from precompact_state_reminder import build_custom_instructions
+        v = {"novelty": 2, "scope": 3, "uncertainty": 1, "risk": 4}
+        result = build_custom_instructions(self._state(v))
+        assert "Variety score: 10" in result
+
+    def test_omits_line_for_unresolvable_dict(self):
+        from precompact_state_reminder import build_custom_instructions
+        result = build_custom_instructions(self._state({"total": 99}))
+        assert "Variety" not in result
+
+    def test_renders_line_for_bare_int(self):
+        from precompact_state_reminder import build_custom_instructions
+        result = build_custom_instructions(self._state(12))
+        assert "Variety score: 12" in result
+
+    def test_omits_line_for_junk(self):
+        from precompact_state_reminder import build_custom_instructions
+        result = build_custom_instructions(self._state("not-a-number"))
+        assert "Variety" not in result
+
 
 # ---------------------------------------------------------------------------
 # Unit tests: build_hook_output (full composition)

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -2161,13 +2161,21 @@ def test_r3_band_unresolvable_when_variety_absent_on_task_b(
     )
 
 
-def test_r3_band_unresolvable_when_variety_total_non_int(
+def test_r3_band_unresolvable_when_no_candidate_resolves(
     tmp_path, monkeypatch, pact_context,
 ):
-    """Task B.variety.total is a string → band_unresolvable."""
+    """Task B.variety has a non-int total AND no recoverable fallback
+    (no score, no top-level variety_score, dimensions stripped so the
+    dimension-sum cannot fire) → every resolver candidate is invalid →
+    band_unresolvable. A non-int total alone no longer yields unresolvable
+    when a valid dimension-sum or score fallback exists."""
     pact_context(team_name="test-team", session_id="test-session")
     variety = _well_formed_variety()
     variety["total"] = "twelve"
+    # Strip the four dimension scores so the dimension-sum fallback cannot
+    # resolve; the rationales (not resolution candidates) stay.
+    for dim in ("novelty", "scope", "uncertainty", "risk"):
+        variety.pop(dim, None)
     _setup_blocks_pair(
         tmp_path, monkeypatch, "test-team", "1", "2",
         variety=variety,

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -1158,6 +1158,110 @@ def test_main_no_op_on_malformed_stdin(capsys):
 
 
 # =============================================================================
+# Exception-safety (negative property) — hook level.
+#
+# The hook fires on every Task-tool use; no malformed variety shape may
+# raise out of it. The resolver-leg of this property lives in
+# test_teachback_schema.py; this is the full-hook leg: each malformed variety
+# is run through a complete main() invocation in BOTH a TaskCreate envelope
+# (write-time R4 path) and a TaskUpdate-to-completed-teachback envelope
+# (read-time band path). The hook must exit 0 with valid JSON in every case.
+# =============================================================================
+
+
+# Malformed variety values that flow into the resolver via both surfaces. The
+# hook receives its input as already-parsed JSON from stdin, so these values
+# are restricted to JSON-representable shapes (a real hook can never receive a
+# Python object() / NaN — those non-serializable inputs are covered at the
+# pure-helper leg in test_teachback_schema.py, which has no stdin round-trip).
+# The hook must absorb every one of these.
+_MALFORMED_VARIETIES = [
+    pytest.param(None, id="none"),
+    pytest.param([], id="empty_list"),
+    pytest.param("a string", id="string"),
+    pytest.param(42, id="bare_int"),
+    pytest.param(8.5, id="float"),
+    pytest.param(True, id="bool"),
+    pytest.param({"total": [1, 2, 3]}, id="total_list"),
+    pytest.param({"total": {"k": "v"}}, id="total_dict"),
+    pytest.param({"score": {"nested": "junk"}}, id="score_nested_dict"),
+    pytest.param({"novelty": "two", "scope": 1,
+                  "uncertainty": 1, "risk": 1}, id="dimension_wrong_type"),
+    pytest.param({"total": "twelve", "score": "eight"}, id="all_string_candidates"),
+    pytest.param({"deeply": {"nested": {"junk": [1, 2]}}}, id="unrelated_nested"),
+]
+
+
+def _assert_exits_zero_with_valid_json(payload, capsys):
+    """Run main() on the payload; assert it exits 0 and emits parseable JSON.
+    SystemExit(0) is the hook's normal termination; any OTHER exception is a
+    failure of the never-raise contract."""
+    code, out = _capture_main(payload, capsys)
+    assert code == 0
+    assert out is not None  # parseable JSON object (or None only if no output)
+
+
+@pytest.mark.parametrize("variety", _MALFORMED_VARIETIES)
+def test_hook_absorbs_malformed_variety_on_taskcreate(variety, capsys, pact_context):
+    """Write-time envelope: a pact-* work-task TaskCreate carrying a
+    malformed variety must not raise out of the hook."""
+    pact_context(team_name="test-team", session_id="test-session")
+    payload = {
+        "tool_name": "TaskCreate",
+        "tool_input": {
+            "subject": "implement foo",
+            "owner": "pact-backend-coder",
+            "addBlockedBy": ["41"],
+            "metadata": {"variety": variety},
+        },
+        "tool_response": {},
+    }
+    _assert_exits_zero_with_valid_json(payload, capsys)
+
+
+@pytest.mark.parametrize("variety", _MALFORMED_VARIETIES)
+def test_hook_absorbs_malformed_variety_on_teachback_submit(
+    variety, capsys, tmp_path, monkeypatch, pact_context,
+):
+    """Read-time envelope: a teachback-submit TaskUpdate whose blocked Task B
+    carries a malformed variety must not raise out of the hook (the band
+    resolver consults resolve_variety_total on the on-disk shape)."""
+    pact_context(team_name="test-team", session_id="test-session")
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety=variety,
+    )
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {"teachback_submit": _well_formed_teachback_submit()},
+        },
+        "tool_response": {},
+    }
+    _assert_exits_zero_with_valid_json(payload, capsys)
+
+
+def test_hook_absorbs_malformed_metadata_envelope_on_taskcreate(
+    capsys, pact_context,
+):
+    """The whole metadata object is malformed (a string, not a dict) → the
+    hook tolerates it and exits 0. Exercises the metadata-not-dict guard
+    above the variety lookup."""
+    pact_context(team_name="test-team", session_id="test-session")
+    payload = {
+        "tool_name": "TaskCreate",
+        "tool_input": {
+            "subject": "implement foo",
+            "owner": "pact-backend-coder",
+            "addBlockedBy": ["41"],
+            "metadata": "not-a-dict",
+        },
+        "tool_response": {},
+    }
+    _assert_exits_zero_with_valid_json(payload, capsys)
+
+
+# =============================================================================
 # Defensive fallback: `tool_response or tool_output or {}`
 # =============================================================================
 #
@@ -1894,6 +1998,354 @@ def test_advisory_r4_on_d4_legacy_single_rationale(pact_context):
     assert any(
         rule == "variety_missing_on_dispatch_task" for rule, _ in advisories
     )
+
+
+# =============================================================================
+# variety_missing_on_dispatch_task (R4) — the third (NEW) message path:
+# valid rationales present, but no resolvable variety total. Distinct from the
+# absent-variety and malformed-rationale paths; same rule name, distinct text.
+# =============================================================================
+
+
+def _r4_create_payload(variety, metadata_extra=None):
+    """A TaskCreate payload for a pact-* work task carrying the given variety
+    dict. metadata_extra merges into the task metadata alongside `variety`
+    (e.g. a top-level variety_score sibling)."""
+    metadata = {"variety": variety}
+    if metadata_extra:
+        metadata.update(metadata_extra)
+    return {
+        "tool_name": "TaskCreate",
+        "tool_input": {
+            "subject": "implement foo",
+            "owner": "pact-backend-coder",
+            "addBlockedBy": ["41"],
+            "metadata": metadata,
+        },
+        "tool_response": {},
+    }
+
+
+def _r4_message(advisories):
+    """Return the variety_missing_on_dispatch_task message text, or None if
+    the rule did not fire."""
+    for rule, message in advisories:
+        if rule == "variety_missing_on_dispatch_task":
+            return message
+    return None
+
+
+def _rationales_only_variety(**overrides):
+    """A variety dict with the four valid rationales but NO resolvable total
+    candidate (no total, no score, no dimension scores). Forces the
+    unresolvable-total path while staying rationale-complete. Overrides let a
+    test add back a single candidate (e.g. an out-of-range total)."""
+    variety = {
+        "novelty_rationale": "x",
+        "scope_rationale": "x",
+        "uncertainty_rationale": "x",
+        "risk_rationale": "x",
+    }
+    variety.update(overrides)
+    return variety
+
+
+def test_r4_unresolvable_total_path_fires_with_distinct_message(pact_context):
+    """Valid rationales + no resolvable total (out-of-range `total`, no
+    other candidate) → R4 fires on the NEW unresolvable-total path. The
+    message names the no-resolvable-total condition and does NOT name the
+    unrelated wiring rule that caused the original field misattribution."""
+    pact_context(team_name="test-team", session_id="test-session")
+    variety = _rationales_only_variety(total=99)
+    advisories = tlg.evaluate_lifecycle(_r4_create_payload(variety))
+    message = _r4_message(advisories)
+    assert message is not None, "expected R4 to fire on unresolvable total"
+    assert "no resolvable total" in message
+    assert "teachback_addblocks_missing" not in message
+
+
+def test_r4_unresolvable_total_message_distinct_from_rationale_path(pact_context):
+    """The unresolvable-total message text differs from the malformed-
+    rationale message text — the single rule emits path-specific detail."""
+    pact_context(team_name="test-team", session_id="test-session")
+    unresolvable = _r4_message(
+        tlg.evaluate_lifecycle(_r4_create_payload(_rationales_only_variety(total=99)))
+    )
+    missing_rationale_variety = _well_formed_variety()
+    missing_rationale_variety.pop("novelty_rationale")
+    malformed = _r4_message(
+        tlg.evaluate_lifecycle(_r4_create_payload(missing_rationale_variety))
+    )
+    assert unresolvable is not None and malformed is not None
+    assert unresolvable != malformed
+    assert "no resolvable total" in unresolvable
+    assert "no resolvable total" not in malformed
+
+
+def test_r4_unresolvable_total_message_distinct_from_absent_path(pact_context):
+    """The unresolvable-total message differs from the absent-variety
+    message — three distinct paths under one rule name."""
+    pact_context(team_name="test-team", session_id="test-session")
+    unresolvable = _r4_message(
+        tlg.evaluate_lifecycle(_r4_create_payload(_rationales_only_variety(total=99)))
+    )
+    absent_payload = {
+        "tool_name": "TaskCreate",
+        "tool_input": {
+            "subject": "implement foo",
+            "owner": "pact-backend-coder",
+            "addBlockedBy": ["41"],
+        },
+        "tool_response": {},
+    }
+    absent = _r4_message(tlg.evaluate_lifecycle(absent_payload))
+    assert unresolvable is not None and absent is not None
+    assert unresolvable != absent
+
+
+def test_r4_rationale_problem_reported_before_total_problem(pact_context):
+    """A stamp missing BOTH a rationale AND a total surfaces the rationale
+    problem first (return-the-first-problem contract). The unresolvable-total
+    detail appears only once rationales are complete."""
+    pact_context(team_name="test-team", session_id="test-session")
+    variety = _rationales_only_variety(total=99)
+    variety.pop("scope_rationale")  # now also rationale-incomplete
+    message = _r4_message(tlg.evaluate_lifecycle(_r4_create_payload(variety)))
+    assert message is not None
+    assert "no resolvable total" not in message
+    assert "scope_rationale" in message
+
+
+def test_r4_silent_when_score_fallback_resolves(pact_context):
+    """Valid rationales + a non-canonical `score` (no `total`) → R4 SILENT,
+    because the shared resolver resolves the total via the score fallback.
+    This is the write-time half of the consistency property for the exact
+    reported field shape."""
+    pact_context(team_name="test-team", session_id="test-session")
+    variety = _rationales_only_variety(score=12)
+    advisories = tlg.evaluate_lifecycle(_r4_create_payload(variety))
+    assert not any(
+        rule == "variety_missing_on_dispatch_task" for rule, _ in advisories
+    )
+
+
+def test_r4_silent_when_top_level_variety_score_resolves(pact_context):
+    """Valid rationales + no in-dict candidate but a top-level
+    metadata.variety_score → R4 SILENT. The validator forwards the
+    surrounding metadata so the sibling candidate is reachable."""
+    pact_context(team_name="test-team", session_id="test-session")
+    variety = _rationales_only_variety()
+    advisories = tlg.evaluate_lifecycle(
+        _r4_create_payload(variety, metadata_extra={"variety_score": 8})
+    )
+    assert not any(
+        rule == "variety_missing_on_dispatch_task" for rule, _ in advisories
+    )
+
+
+def test_r4_silent_when_dimension_sum_resolves(pact_context):
+    """Valid rationales + valid dimension scores (no explicit total) → R4
+    SILENT via the dimension-sum fallback."""
+    pact_context(team_name="test-team", session_id="test-session")
+    variety = _well_formed_variety()
+    variety.pop("total")
+    advisories = tlg.evaluate_lifecycle(_r4_create_payload(variety))
+    assert not any(
+        rule == "variety_missing_on_dispatch_task" for rule, _ in advisories
+    )
+
+
+# =============================================================================
+# Cross-rule consistency property (LOAD-BEARING) — the single test that pins
+# this bug closed. For a representative set of variety shapes (all
+# rationale-complete, so the rationale leg never confounds), the write-time
+# rule must NOT fire on its total leg if and only if the shared resolver
+# returns a non-None total. The two surfaces consult the same resolver, so
+# they cannot disagree. Includes the original reported field shape.
+# =============================================================================
+
+
+# (variety, metadata_extra, description). Every variety is rationale-complete
+# so the ONLY thing that can drive R4 is the total leg — isolating the
+# property under test. The metadata_extra carries any top-level sibling.
+_CONSISTENCY_SHAPES = [
+    pytest.param(
+        _rationales_only_variety(total=8), None,
+        id="canonical_total_in_range",
+    ),
+    pytest.param(
+        _rationales_only_variety(total=11), None,
+        id="canonical_total_required_band",
+    ),
+    pytest.param(
+        _rationales_only_variety(total=99), None,
+        id="total_out_of_range_no_fallback",
+    ),
+    pytest.param(
+        _rationales_only_variety(total="twelve"), None,
+        id="total_non_numeric_string_no_fallback",
+    ),
+    pytest.param(
+        _rationales_only_variety(total=True), None,
+        id="total_bool_no_fallback",
+    ),
+    pytest.param(
+        _rationales_only_variety(total=8.0), None,
+        id="total_float_no_fallback",
+    ),
+    pytest.param(
+        _rationales_only_variety(score=12), None,
+        id="field_report_shape_score_only",
+    ),
+    pytest.param(
+        _rationales_only_variety(score=99), None,
+        id="score_out_of_range_no_other",
+    ),
+    pytest.param(
+        _rationales_only_variety(total=99, score=8), None,
+        id="junk_total_recovered_by_score",
+    ),
+    pytest.param(
+        _rationales_only_variety(), {"variety_score": 8},
+        id="top_level_variety_score_only",
+    ),
+    pytest.param(
+        _rationales_only_variety(), {"variety_score": 99},
+        id="top_level_variety_score_out_of_range",
+    ),
+    pytest.param(
+        _well_formed_variety(),  # carries total=8 + valid dims
+        None,
+        id="full_well_formed",
+    ),
+    pytest.param(
+        {**_well_formed_variety(), "total": "bad"},  # dims still 2/2/2/2
+        None,
+        id="junk_total_recovered_by_dimension_sum",
+    ),
+    pytest.param(
+        _rationales_only_variety(), None,
+        id="no_candidate_at_all",
+    ),
+]
+
+
+@pytest.mark.parametrize("variety, metadata_extra", _CONSISTENCY_SHAPES)
+def test_write_time_silence_iff_resolver_resolves(
+    variety, metadata_extra, pact_context,
+):
+    """CONSISTENCY PROPERTY: variety_missing_on_dispatch_task does NOT fire
+    (rationales held valid, so only the total leg is in play) if and only if
+    resolve_variety_total returns a non-None total for the same (variety,
+    metadata). No stamp-time-accepted shape may read as unresolvable later."""
+    pact_context(team_name="test-team", session_id="test-session")
+    metadata = {"variety": variety}
+    if metadata_extra:
+        metadata.update(metadata_extra)
+
+    resolved = tlg.resolve_variety_total(variety, metadata)
+    advisories = tlg.evaluate_lifecycle(_r4_create_payload(variety, metadata_extra))
+    r4_fired = any(
+        rule == "variety_missing_on_dispatch_task" for rule, _ in advisories
+    )
+
+    # iff: silent (not fired) ⟺ resolver resolved.
+    assert (not r4_fired) == (resolved is not None), (
+        f"consistency violated: r4_fired={r4_fired}, "
+        f"resolved={resolved!r} for variety={variety!r} "
+        f"metadata_extra={metadata_extra!r}"
+    )
+
+
+def test_field_report_shape_agrees_across_both_surfaces(
+    tmp_path, monkeypatch, pact_context,
+):
+    """The exact reported false-positive shape — rationales + a non-canonical
+    `score` int with a sibling top-level `variety_score` — must AGREE across
+    both surfaces post-fix: write-time SILENT (TaskCreate) AND read-time
+    RESOLVABLE to a band (no band_unresolvable advisory at teachback submit).
+    This is the regression that the whole fix exists to close."""
+    pact_context(team_name="test-team", session_id="test-session")
+    field_variety = _rationales_only_variety(score=12)
+
+    # Write-time surface: TaskCreate is silent.
+    create_advisories = tlg.evaluate_lifecycle(
+        _r4_create_payload(field_variety, metadata_extra={"variety_score": 12})
+    )
+    assert not any(
+        rule == "variety_missing_on_dispatch_task"
+        for rule, _ in create_advisories
+    ), "write-time surface fired on a resolvable field shape"
+
+    # Read-time surface: teachback submit resolves the band, no unresolvable.
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2",
+        variety=field_variety,
+    )
+    # Add the top-level sibling onto the seeded Task B metadata.
+    tasks_dir = tmp_path / ".claude" / "tasks" / "test-team"
+    task_b = json.loads((tasks_dir / "2.json").read_text(encoding="utf-8"))
+    task_b["metadata"]["variety_score"] = 12
+    (tasks_dir / "2.json").write_text(json.dumps(task_b), encoding="utf-8")
+
+    submit_advisories = tlg.evaluate_lifecycle({
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {"teachback_submit": _well_formed_teachback_submit()},
+        },
+        "tool_response": {},
+    })
+    assert not any(
+        rule == "reasoning_reconstruction_band_unresolvable"
+        for rule, _ in submit_advisories
+    ), "read-time surface emitted unresolvable for a resolvable field shape"
+
+
+# =============================================================================
+# reasoning_reconstruction_band_unresolvable — rewritten advisory text.
+# The message must enumerate the no-resolvable-total cause and must NOT name
+# the unrelated wiring rule that caused the original field misattribution.
+# Text is asserted on normalized substrings (the prod text is word-identical
+# to the spec but reflowed as f-string continuations), never byte-equality.
+# =============================================================================
+
+
+def _band_unresolvable_message(advisories):
+    for rule, message in advisories:
+        if rule == "reasoning_reconstruction_band_unresolvable":
+            return message
+    return None
+
+
+def test_band_unresolvable_message_names_no_resolvable_total(
+    tmp_path, monkeypatch, pact_context,
+):
+    """When Task B variety is present but every resolver candidate is
+    invalid, the rewritten advisory enumerates the no-resolvable-total cause
+    and drops the misattributing cross-name."""
+    pact_context(team_name="test-team", session_id="test-session")
+    variety = _well_formed_variety()
+    variety["total"] = "twelve"
+    for dim in ("novelty", "scope", "uncertainty", "risk"):
+        variety.pop(dim, None)
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety=variety,
+    )
+    advisories = tlg.evaluate_lifecycle({
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {"teachback_submit": _well_formed_teachback_submit()},
+        },
+        "tool_response": {},
+    })
+    message = _band_unresolvable_message(advisories)
+    assert message is not None
+    normalized = " ".join(message.split())
+    assert "no resolvable total" in normalized
+    assert "cannot resolve the variety band" in normalized
+    assert "teachback_addblocks_missing" not in normalized
 
 
 # =============================================================================

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -3670,7 +3670,7 @@ def test_multi_rule_concurrent_emission_all_four_advisory_rules_fire_together(
 
 # =============================================================================
 # 10|11 variety-band boundary disambiguation — pin the exact cut so that
-# future variety_scorer threshold changes (e.g. PLAN_MODE_MIN export) are
+# variety_scorer threshold changes (e.g. a shift in PLAN_MODE_MIN) are
 # caught here rather than silently re-routing recommended/required cases.
 # =============================================================================
 

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -2349,6 +2349,115 @@ def test_band_unresolvable_message_names_no_resolvable_total(
 
 
 # =============================================================================
+# Read-time band MAPPING through the fallback candidates — advisory surface.
+#
+# The unit-layer counterpart in test_per_dispatch_variety.py asserts the band
+# STRING returned by _resolve_required_band_via_blocks for each fallback. These
+# tests assert the complementary observable: a fallback-only stamp seeded on
+# disk drives a full evaluate_lifecycle teachback-submit through to the
+# user-visible required-band advisory (reasoning_reconstruction_missing_at_
+# required_band) — and emits no band_unresolvable. Belt (advisory) + suspenders
+# (unit band string) cover different change classes: a regression that left the
+# band string correct but broke the advisory wiring, or vice versa, fails on
+# exactly one layer. Each stamp omits the canonical total so only the named
+# fallback can resolve, and lands at the required band (total >=
+# TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN) so R3 is observable.
+# =============================================================================
+
+
+def _assert_required_band_advisory(advisories):
+    """The read-time required-band advisory fired and no unresolvable
+    advisory was emitted alongside it."""
+    rules = [rule for rule, _ in advisories]
+    assert "reasoning_reconstruction_missing_at_required_band" in rules, (
+        f"expected the required-band advisory to fire, got: {rules}"
+    )
+    assert "reasoning_reconstruction_band_unresolvable" not in rules, (
+        f"a resolvable fallback stamp must not emit unresolvable, got: {rules}"
+    )
+
+
+def test_r3_fires_at_read_time_via_score_fallback(
+    tmp_path, monkeypatch, pact_context,
+):
+    """Task B carries a non-canonical `score` at the required band (no
+    `total`) → read-time resolves via the score fallback and the required-
+    band advisory fires. teachback_submit omits reasoning_reconstruction so
+    R3 is the expected miss."""
+    pact_context(team_name="test-team", session_id="test-session")
+    variety = _well_formed_variety(score=tlg.TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN)
+    variety.pop("total")
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety=variety,
+    )
+    advisories = tlg.evaluate_lifecycle({
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {"teachback_submit": _well_formed_teachback_submit()},
+        },
+        "tool_response": {},
+    })
+    _assert_required_band_advisory(advisories)
+
+
+def test_r3_fires_at_read_time_via_top_level_variety_score_fallback(
+    tmp_path, monkeypatch, pact_context,
+):
+    """Task B has no in-dict total/score but a top-level
+    metadata.variety_score at the required band → read-time resolves via the
+    sibling candidate (the caller forwards Task B's full metadata) and the
+    required-band advisory fires."""
+    pact_context(team_name="test-team", session_id="test-session")
+    variety = _well_formed_variety()
+    variety.pop("total")
+    for dim in ("novelty", "scope", "uncertainty", "risk"):
+        variety.pop(dim, None)
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety=variety,
+    )
+    # Add the top-level sibling onto the seeded Task B metadata.
+    tasks_dir = tmp_path / ".claude" / "tasks" / "test-team"
+    task_b = json.loads((tasks_dir / "2.json").read_text(encoding="utf-8"))
+    task_b["metadata"]["variety_score"] = (
+        tlg.TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN
+    )
+    (tasks_dir / "2.json").write_text(json.dumps(task_b), encoding="utf-8")
+    advisories = tlg.evaluate_lifecycle({
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {"teachback_submit": _well_formed_teachback_submit()},
+        },
+        "tool_response": {},
+    })
+    _assert_required_band_advisory(advisories)
+
+
+def test_r3_fires_at_read_time_via_dimension_sum_fallback(
+    tmp_path, monkeypatch, pact_context,
+):
+    """Task B has no total/score/variety_score but four valid dimension
+    scores summing into the required band (3+3+3+3=12) → read-time resolves
+    via the dimension-sum fallback and the required-band advisory fires."""
+    pact_context(team_name="test-team", session_id="test-session")
+    variety = _well_formed_variety(novelty=3, scope=3, uncertainty=3, risk=3)
+    variety.pop("total")
+    _setup_blocks_pair(
+        tmp_path, monkeypatch, "test-team", "1", "2", variety=variety,
+    )
+    advisories = tlg.evaluate_lifecycle({
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "1",
+            "metadata": {"teachback_submit": _well_formed_teachback_submit()},
+        },
+        "tool_response": {},
+    })
+    _assert_required_band_advisory(advisories)
+
+
+# =============================================================================
 # R3 + R5 write-time branch — TaskUpdate writing teachback_submit metadata
 # =============================================================================
 

--- a/pact-plugin/tests/test_teachback_schema.py
+++ b/pact-plugin/tests/test_teachback_schema.py
@@ -375,6 +375,9 @@ class TestResolverCandidateDimensionSum:
         assert resolve_variety_total(_dimensions(2, 3, 1, 4)) == 10
 
     @pytest.mark.parametrize(
+        "position", ["novelty", "scope", "uncertainty", "risk"]
+    )
+    @pytest.mark.parametrize(
         "bad",
         [
             pytest.param(MIN_DIMENSION - 1, id="below_min_dim"),  # 0
@@ -385,16 +388,23 @@ class TestResolverCandidateDimensionSum:
             pytest.param(None, id="none"),
         ],
     )
-    def test_one_bad_dimension_invalidates_the_sum(self, bad):
+    def test_one_bad_dimension_invalidates_the_sum(self, bad, position):
         # A single out-of-range / wrong-typed dimension means the all-four
         # guard fails → the candidate does not fire → None (no other source).
+        # Parametrized across every dimension position so an asymmetric guard
+        # that skipped checking one dimension would surface here.
         v = _dimensions(2, 2, 2, 2)
-        v["uncertainty"] = bad
+        v[position] = bad
         assert resolve_variety_total(v) is None
 
-    def test_one_missing_dimension_invalidates_the_sum(self):
+    @pytest.mark.parametrize(
+        "position", ["novelty", "scope", "uncertainty", "risk"]
+    )
+    def test_one_missing_dimension_invalidates_the_sum(self, position):
+        # Every dimension position must be required by the all-four guard;
+        # dropping any one yields None.
         v = _dimensions(2, 2, 2, 2)
-        del v["risk"]
+        del v[position]
         assert resolve_variety_total(v) is None
 
 

--- a/pact-plugin/tests/test_teachback_schema.py
+++ b/pact-plugin/tests/test_teachback_schema.py
@@ -75,11 +75,19 @@ class TestConstants:
         assert TEACHBACK_VARIETY_ACK_VALID_VALUES == ("yes", "no", "concern")
 
     def test_required_min_threshold_is_11(self):
-        # Mirror of variety_scorer: ORCHESTRATE_MAX=10, PLAN_MODE_MAX=14
-        # → plan-mode-and-above starts at >= 11.
-        from shared.variety_scorer import ORCHESTRATE_MAX, PLAN_MODE_MAX
+        # Mirror the source derivation: the threshold binds to the plan-mode
+        # floor PLAN_MODE_MIN, and PLAN_MODE_MIN itself is the SSOT relation
+        # ORCHESTRATE_MAX + 1. Asserting both links catches drift at either
+        # one — a change to PLAN_MODE_MIN's definition surfaces on the second
+        # assertion even though the threshold tracks it on the first.
+        from shared.variety_scorer import (
+            ORCHESTRATE_MAX,
+            PLAN_MODE_MAX,
+            PLAN_MODE_MIN,
+        )
 
-        assert TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN == ORCHESTRATE_MAX + 1
+        assert TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN == PLAN_MODE_MIN
+        assert PLAN_MODE_MIN == ORCHESTRATE_MAX + 1
         assert TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN <= PLAN_MODE_MAX
 
 

--- a/pact-plugin/tests/test_teachback_schema.py
+++ b/pact-plugin/tests/test_teachback_schema.py
@@ -27,7 +27,14 @@ from shared.teachback_schema import (
     TEACHBACK_REQUIRED_FIELDS,
     TEACHBACK_REQUIRED_SUBKEYS,
     TEACHBACK_VARIETY_ACK_VALID_VALUES,
+    resolve_variety_total,
     validate_reasoning_reconstruction,
+)
+from shared.variety_scorer import (
+    MAX_DIMENSION,
+    MAX_SCORE,
+    MIN_DIMENSION,
+    MIN_SCORE,
 )
 
 
@@ -228,3 +235,270 @@ class TestValidatorPurity:
         # Should return malformed reason, not raise
         result = validate_reasoning_reconstruction(weird_input)
         assert result == "malformed_reasoning_reconstruction"
+
+
+# ============================================================================
+# resolve_variety_total — per-candidate type matrix
+#
+# The resolver walks an ordered candidate chain (total → score →
+# metadata.variety_score → dimension-sum) and returns the first valid
+# in-range int, or None when nothing resolves. These tests isolate each
+# candidate so the value-type acceptance/rejection contract is pinned for
+# every candidate independently; precedence interactions are covered in the
+# precedence section below.
+#
+# In-range means MIN_SCORE..MAX_SCORE (4..16) for the total/score/
+# variety_score candidates, and MIN_DIMENSION..MAX_DIMENSION (1..4) per
+# dimension for the dimension-sum candidate — referenced via the
+# variety_scorer constants, never hard-coded.
+# ============================================================================
+
+
+# A set of values that are NOT a valid in-range int under any candidate.
+# `id`s double as readable parametrize labels.
+_REJECTED_VALUES = [
+    pytest.param(True, id="bool_true"),
+    pytest.param(False, id="bool_false"),
+    pytest.param(8.0, id="float_whole"),
+    pytest.param(8.5, id="float_fractional"),
+    pytest.param("8", id="numeric_string"),
+    pytest.param("high", id="non_numeric_string"),
+    pytest.param(None, id="none"),
+    pytest.param([8], id="list"),
+    pytest.param({"x": 8}, id="dict"),
+]
+
+# Out-of-range ints for the [4, 16] total/score candidates: below MIN_SCORE
+# and above MAX_SCORE. These are well-typed ints that still must NOT resolve.
+_OUT_OF_RANGE_SCORE_INTS = [
+    pytest.param(0, id="zero"),
+    pytest.param(MIN_SCORE - 1, id="below_min"),  # 3
+    pytest.param(MAX_SCORE + 1, id="above_max"),  # 17
+    pytest.param(99, id="far_above_max"),
+]
+
+# Boundary + interior in-range ints. The 6/7 and 10/11 pairs straddle the
+# band cuts the CALLER applies; the resolver itself returns the int unchanged
+# for any of them (band mapping is the caller's job, asserted separately).
+_IN_RANGE_SCORE_INTS = [4, 6, 7, 8, 10, 11, 16]
+
+
+class TestResolverCandidateTotal:
+    """Candidate 1: variety['total'] in isolation (no other candidate
+    present, so a fall-through lands on None)."""
+
+    @pytest.mark.parametrize("value", _IN_RANGE_SCORE_INTS)
+    def test_in_range_total_resolves_to_itself(self, value):
+        assert resolve_variety_total({"total": value}) == value
+
+    @pytest.mark.parametrize("value", _OUT_OF_RANGE_SCORE_INTS)
+    def test_out_of_range_total_does_not_resolve(self, value):
+        assert resolve_variety_total({"total": value}) is None
+
+    @pytest.mark.parametrize("value", _REJECTED_VALUES)
+    def test_wrong_typed_total_does_not_resolve(self, value):
+        assert resolve_variety_total({"total": value}) is None
+
+    def test_absent_total_does_not_resolve(self):
+        assert resolve_variety_total({}) is None
+
+
+class TestResolverCandidateScore:
+    """Candidate 2: variety['score'] in isolation (no 'total' key, so the
+    canonical candidate is absent and the chain reaches 'score')."""
+
+    @pytest.mark.parametrize("value", _IN_RANGE_SCORE_INTS)
+    def test_in_range_score_resolves_to_itself(self, value):
+        assert resolve_variety_total({"score": value}) == value
+
+    @pytest.mark.parametrize("value", _OUT_OF_RANGE_SCORE_INTS)
+    def test_out_of_range_score_does_not_resolve(self, value):
+        assert resolve_variety_total({"score": value}) is None
+
+    @pytest.mark.parametrize("value", _REJECTED_VALUES)
+    def test_wrong_typed_score_does_not_resolve(self, value):
+        assert resolve_variety_total({"score": value}) is None
+
+
+class TestResolverCandidateVarietyScore:
+    """Candidate 3: metadata['variety_score'] in isolation — a top-level
+    sibling reached only when the `metadata` argument is supplied. The
+    variety dict carries no resolvable candidate of its own."""
+
+    @pytest.mark.parametrize("value", _IN_RANGE_SCORE_INTS)
+    def test_in_range_variety_score_resolves_to_itself(self, value):
+        assert resolve_variety_total({}, {"variety_score": value}) == value
+
+    @pytest.mark.parametrize("value", _OUT_OF_RANGE_SCORE_INTS)
+    def test_out_of_range_variety_score_does_not_resolve(self, value):
+        assert resolve_variety_total({}, {"variety_score": value}) is None
+
+    @pytest.mark.parametrize("value", _REJECTED_VALUES)
+    def test_wrong_typed_variety_score_does_not_resolve(self, value):
+        assert resolve_variety_total({}, {"variety_score": value}) is None
+
+    def test_variety_score_skipped_when_metadata_absent(self):
+        # The sibling lives on metadata, never inside the variety dict. With
+        # no metadata argument it must NOT be consulted, even if a same-named
+        # key sits inside the variety dict.
+        assert resolve_variety_total({"variety_score": 8}) is None
+
+    def test_variety_score_skipped_when_metadata_not_dict(self):
+        assert resolve_variety_total({}, "not-a-dict") is None
+
+
+def _dimensions(novelty, scope, uncertainty, risk):
+    """A variety dict carrying ONLY the four per-dimension scores (no total,
+    no score), so the dimension-sum candidate is the only one that can fire."""
+    return {
+        "novelty": novelty,
+        "scope": scope,
+        "uncertainty": uncertainty,
+        "risk": risk,
+    }
+
+
+class TestResolverCandidateDimensionSum:
+    """Candidate 4: sum of the four dimension scores, valid only when ALL
+    four are in-range dimension ints (1..4 each). The sum is in [4, 16] by
+    construction."""
+
+    def test_all_min_dimensions_sums_to_min_score(self):
+        v = _dimensions(MIN_DIMENSION, MIN_DIMENSION, MIN_DIMENSION, MIN_DIMENSION)
+        assert resolve_variety_total(v) == MIN_SCORE  # 4
+
+    def test_all_max_dimensions_sums_to_max_score(self):
+        v = _dimensions(MAX_DIMENSION, MAX_DIMENSION, MAX_DIMENSION, MAX_DIMENSION)
+        assert resolve_variety_total(v) == MAX_SCORE  # 16
+
+    def test_mixed_in_range_dimensions_sum(self):
+        assert resolve_variety_total(_dimensions(2, 3, 1, 4)) == 10
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            pytest.param(MIN_DIMENSION - 1, id="below_min_dim"),  # 0
+            pytest.param(MAX_DIMENSION + 1, id="above_max_dim"),  # 5
+            pytest.param(True, id="bool"),
+            pytest.param(2.0, id="float"),
+            pytest.param("2", id="numeric_string"),
+            pytest.param(None, id="none"),
+        ],
+    )
+    def test_one_bad_dimension_invalidates_the_sum(self, bad):
+        # A single out-of-range / wrong-typed dimension means the all-four
+        # guard fails → the candidate does not fire → None (no other source).
+        v = _dimensions(2, 2, 2, 2)
+        v["uncertainty"] = bad
+        assert resolve_variety_total(v) is None
+
+    def test_one_missing_dimension_invalidates_the_sum(self):
+        v = _dimensions(2, 2, 2, 2)
+        del v["risk"]
+        assert resolve_variety_total(v) is None
+
+
+# ============================================================================
+# resolve_variety_total — precedence & conflict combinations
+# ============================================================================
+
+
+class TestResolverPrecedence:
+    """Ordered first-valid-match precedence and the fall-through-on-invalid
+    robustness property: a junk higher-precedence candidate never shadows a
+    recoverable lower-precedence one."""
+
+    def test_canonical_total_wins_over_all_other_candidates(self):
+        v = {"total": 12, "score": 8, "novelty": 1, "scope": 1,
+             "uncertainty": 1, "risk": 1}
+        assert resolve_variety_total(v, {"variety_score": 8}) == 12
+
+    def test_invalid_total_falls_through_to_valid_score(self):
+        # Out-of-range canonical total must not halt the chain.
+        assert resolve_variety_total({"total": 99, "score": 8}) == 8
+
+    @pytest.mark.parametrize(
+        "junk_total",
+        [99, 0, True, 8.0, "8", "high", None, [8]],
+    )
+    def test_any_invalid_total_falls_through_to_score(self, junk_total):
+        v = {"total": junk_total, "score": 9}
+        assert resolve_variety_total(v) == 9
+
+    def test_falls_through_total_and_score_to_variety_score(self):
+        v = {"total": 99, "score": 0}
+        assert resolve_variety_total(v, {"variety_score": 11}) == 11
+
+    def test_score_absent_total_absent_resolves_variety_score(self):
+        assert resolve_variety_total({}, {"variety_score": 7}) == 7
+
+    def test_falls_through_to_dimension_sum_when_higher_candidates_invalid(self):
+        # total junk, score junk, no variety_score, but all four dims valid.
+        v = {"total": 99, "score": "bad", "novelty": 3, "scope": 3,
+             "uncertainty": 2, "risk": 2}
+        assert resolve_variety_total(v, {"variety_score": "bad"}) == 10
+
+    def test_divergent_total_and_score_returns_total_silently(self):
+        # Canonical wins; the resolver returns a single deterministic answer
+        # and emits no divergence signal (it is a pure int-or-None function).
+        result = resolve_variety_total({"total": 12, "score": 8})
+        assert result == 12
+
+    def test_all_candidates_absent_returns_none(self):
+        assert resolve_variety_total({}, {}) is None
+
+    def test_all_candidates_invalid_returns_none(self):
+        v = {"total": 99, "score": 0, "novelty": 5, "scope": 0,
+             "uncertainty": 2, "risk": 2}
+        assert resolve_variety_total(v, {"variety_score": 99}) is None
+
+
+# ============================================================================
+# resolve_variety_total — exception-safety negative property
+#
+# The hook fires on every Task-tool use; the resolver must be total (defined
+# for every input) and never raise. This is the helper-leg of the negative
+# property; the hook-level leg (full evaluate_lifecycle envelopes) lives in
+# test_task_lifecycle_gate.py.
+# ============================================================================
+
+
+class TestResolverNeverRaises:
+    """No input — well-formed, malformed, or exotic — escapes as an
+    exception; the resolver always returns an int or None."""
+
+    @pytest.mark.parametrize(
+        "variety",
+        [
+            None,
+            [],
+            "string",
+            42,
+            8.5,
+            True,
+            (1, 2),
+            object(),
+            {"total": object()},
+            {"total": float("nan")},
+            {"score": [1, 2, 3]},
+            {"novelty": {"nested": "junk"}},
+            {"total": {"deeply": {"nested": "junk"}}},
+        ],
+    )
+    def test_malformed_variety_returns_int_or_none_never_raises(self, variety):
+        result = resolve_variety_total(variety)
+        assert result is None or isinstance(result, int)
+
+    @pytest.mark.parametrize(
+        "metadata",
+        [None, [], "string", 42, object(), {"variety_score": object()}],
+    )
+    def test_malformed_metadata_returns_int_or_none_never_raises(self, metadata):
+        result = resolve_variety_total({}, metadata)
+        assert result is None or isinstance(result, int)
+
+    def test_resolved_value_is_never_a_bool(self):
+        # bool subclasses int; a True total must not surface as 1.
+        for v in ({"total": True}, {"score": False}):
+            result = resolve_variety_total(v)
+            assert result is None or not isinstance(result, bool)


### PR DESCRIPTION
## Problem

The lifecycle gate's teachback band resolver required `variety["total"]` as a strict int, while the dispatch-task validator checked only the four per-dimension rationales. A variety stamp carrying a non-canonical `score` key (with or without a sibling `variety_score`) passed task creation but read as unresolvable at teachback submit, firing a band-unresolvable advisory whose text enumerated the wrong causes and pointed at an unrelated wiring rule — observed three times in one session on correctly-wired task pairs.

## Fix

- **One shared resolver** — `resolve_variety_total(variety, metadata=None)` in `teachback_schema.py`: precedence `total` → `score` → `metadata.variety_score` → sum of the four dimension scores; int-only (bool rejected), range 4–16 from `variety_scorer` constants; invalid candidates fall through; never raises.
- **Both surfaces consult it** — the read-time band resolver and the write-time variety validator now share the same resolution logic, so no stamp accepted at task creation can read as unresolvable at teachback submit (the cross-rule consistency property).
- **Accurate advisory** — the band-unresolvable message now enumerates the true causes (including "variety present but no resolvable total") and drops the misattributing cross-reference; a distinct no-resolvable-total advisory path fires at task creation.
- **Render convergence** — precompact's variety render adopts the shared resolver via a thin wrapper (bare-int passthrough preserved).
- **Docs** — canonical `total` plus tolerated fallbacks documented in `pact-variety.md` and the `pact-protocols.md` SSOT.

## Testing

- +181 adversarial tests: per-candidate type/range/boundary matrix, precedence/conflict combinations, traversal fail-open paths, write-time three-path discrimination, hook-level exception safety (no input raises; hook exits 0 with valid JSON), precompact wrapper cases.
- Load-bearing 14-shape parametrized biconditional pinning the consistency property (verified non-vacuous: 7 resolve/7 fire).
- Regression reconstructing the exact in-the-wild stamp shape, resolving at both surfaces.
- Classifier structure meta-test passes unchanged (2-hop import invariant preserved via a re-exported band constant).
- Full suite: 8532 passed, 13 skipped, 0 failed, 0 errors.

Version bumped to 4.4.15 (PATCH).