### PR TITLE
fix(pact-memory): sync Working Memory to the worktree display CLAUDE.md and key project_id to the main repo

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.15",
+      "version": "4.4.16",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.15/      # Plugin version
+│               └── 4.4.16/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.15",
+  "version": "4.4.16",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.15
+> **Version**: 4.4.16
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/staleness.py
+++ b/pact-plugin/hooks/staleness.py
@@ -94,6 +94,9 @@ def get_project_claude_md_path() -> Optional[Path]:
     # returns the worktree path when run inside a worktree, which may not
     # contain CLAUDE.md. --git-common-dir always points to the shared .git
     # directory; its parent is the main repo root where CLAUDE.md lives.
+    # git returns this path relative to the invoking directory when run at a
+    # repo root (the bare ".git") and absolute elsewhere, so resolve a relative
+    # result against the cwd before taking its parent.
     # NOTE: Twin pattern in skills/pact-memory/scripts/memory_api.py
     #       (_detect_project_id) and working_memory.py (_get_claude_md_path)
     #       -- keep in sync.
@@ -105,8 +108,10 @@ def get_project_claude_md_path() -> Optional[Path]:
             timeout=5
         )
         if result.returncode == 0 and result.stdout.strip():
-            git_common_dir = result.stdout.strip()
-            repo_root = Path(git_common_dir).resolve().parent
+            common_dir = Path(result.stdout.strip())
+            if not common_dir.is_absolute():
+                common_dir = Path.cwd() / common_dir
+            repo_root = common_dir.resolve().parent
             found = _find_existing_claude_md(repo_root)
             if found is not None:
                 return found

--- a/pact-plugin/skills/pact-memory/scripts/memory_api.py
+++ b/pact-plugin/skills/pact-memory/scripts/memory_api.py
@@ -242,6 +242,36 @@ class PACTMemory:
         # Strategy 1: Environment variable (original behavior)
         project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
         if project_dir:
+            # When CLAUDE_PROJECT_DIR points below a repo's root (a worktree OR
+            # an in-repo subdirectory), its basename is not the project name and
+            # would fragment the project_id across sessions. Prefer the MAIN
+            # repo's basename so every session of a project shares one key,
+            # aligning this env branch (Strategy 1) with the git-root and
+            # cwd-marker branches (Strategies 2/3), which already resolve to the
+            # repo root. The rewrite fires when git resolves a main repo whose
+            # root differs from the env path; only a repo-root env path or a
+            # non-git path (where the main anchor equals, or cannot be resolved
+            # from, the env path) keeps the original basename.
+            try:
+                result = subprocess.run(
+                    ["git", "-C", project_dir, "rev-parse", "--git-common-dir"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    common_dir = Path(result.stdout.strip())
+                    if not common_dir.is_absolute():
+                        common_dir = Path(project_dir) / common_dir
+                    main_repo_root = common_dir.resolve().parent
+                    if main_repo_root != Path(project_dir).resolve():
+                        logger.debug(
+                            "project_id detected from CLAUDE_PROJECT_DIR worktree main repo: %s",
+                            main_repo_root.name,
+                        )
+                        return main_repo_root.name
+            except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+                pass
             logger.debug("project_id detected from CLAUDE_PROJECT_DIR: %s", Path(project_dir).name)
             return Path(project_dir).name
 

--- a/pact-plugin/skills/pact-memory/scripts/memory_api.py
+++ b/pact-plugin/skills/pact-memory/scripts/memory_api.py
@@ -76,7 +76,6 @@ from .working_memory import (
     RETRIEVED_CONTEXT_HEADER,
     RETRIEVED_CONTEXT_COMMENT,
     MAX_RETRIEVED_MEMORIES,
-    _get_claude_md_path,
     _format_memory_entry,
     _parse_working_memory_section,
 )
@@ -264,7 +263,12 @@ class PACTMemory:
                     if not common_dir.is_absolute():
                         common_dir = Path(project_dir) / common_dir
                     main_repo_root = common_dir.resolve().parent
-                    if main_repo_root != Path(project_dir).resolve():
+                    # Compare via normcase so a case-insensitive filesystem does
+                    # not fire the rewrite for paths that differ only in case
+                    # (a no-op on case-sensitive systems, where normcase is
+                    # identity).
+                    env_root = Path(project_dir).resolve()
+                    if os.path.normcase(str(main_repo_root)) != os.path.normcase(str(env_root)):
                         logger.debug(
                             "project_id detected from CLAUDE_PROJECT_DIR worktree main repo: %s",
                             main_repo_root.name,
@@ -280,6 +284,9 @@ class PACTMemory:
         # returns the worktree path when run inside a worktree, fragmenting
         # project_id across sessions. --git-common-dir always points to the
         # shared .git directory; its parent is the main repo root.
+        # git returns this path relative to the invoking directory when run at
+        # a repo root (the bare ".git") and absolute elsewhere, so resolve a
+        # relative result against the cwd before taking its parent.
         # NOTE: Twin pattern in working_memory.py (_get_claude_md_path) and
         #       hooks/staleness.py (get_project_claude_md_path) -- keep in sync.
         try:
@@ -290,8 +297,10 @@ class PACTMemory:
                 timeout=5,
             )
             if result.returncode == 0 and result.stdout.strip():
-                git_common_dir = result.stdout.strip()
-                repo_root = Path(git_common_dir).resolve().parent
+                common_dir = Path(result.stdout.strip())
+                if not common_dir.is_absolute():
+                    common_dir = Path.cwd() / common_dir
+                repo_root = common_dir.resolve().parent
                 project_name = repo_root.name
                 logger.debug("project_id detected from git root: %s", project_name)
                 return project_name

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -266,6 +266,60 @@ def _get_claude_md_path() -> Optional[Path]:
     return _find_existing_claude_md(Path.cwd())
 
 
+def _resolve_display_claude_md_path() -> Optional[Path]:
+    """
+    Resolve the CLAUDE.md the CURRENT SESSION displays, so Working Memory /
+    Retrieved Context syncs land in the file the session actually reads.
+
+    Resolution order:
+      1. CLAUDE_PROJECT_DIR env var, if set -> that dir's .claude/CLAUDE.md
+         (preferred) or ./CLAUDE.md (legacy).
+      2. Git worktree root via `git rev-parse --show-toplevel` -> the same
+         .claude/-then-legacy probe under the worktree root.
+      3. Current working directory -> the same probe.
+
+    Unlike _get_claude_md_path (which anchors to the MAIN repo via
+    --git-common-dir so it can find a single shared CLAUDE.md), this anchors
+    to the WORKTREE root via --show-toplevel so a worktree-rooted session
+    updates its OWN display file — the same file session_init/session_resume
+    create and read. In a non-worktree checkout the two anchors coincide, so
+    the resolved path is identical to _get_claude_md_path's.
+
+    This never CREATES a CLAUDE.md (the orchestrator manages the file's
+    lifecycle); it only probes for an existing one and returns its Path, or
+    None when none exists at the resolved base (callers skip the sync).
+
+    Returns:
+        Path to the existing display CLAUDE.md, or None if none exists.
+    """
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
+    if project_dir:
+        found = _find_existing_claude_md(Path(project_dir))
+        if found is not None:
+            return found
+
+    # Worktree root: --show-toplevel returns the worktree directory when run
+    # inside a worktree (and the main repo root otherwise), matching the
+    # directory session_init/session_resume target for the session's CLAUDE.md.
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            worktree_root = Path(result.stdout.strip())
+            found = _find_existing_claude_md(worktree_root)
+            if found is not None:
+                return found
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+
+    # Last resort: current working directory
+    return _find_existing_claude_md(Path.cwd())
+
+
 def _estimate_tokens(text: str) -> int:
     """
     Estimate token count for a text string.
@@ -618,7 +672,7 @@ def sync_to_claude_md(
     Returns:
         True if sync succeeded, False otherwise.
     """
-    claude_md_path = _get_claude_md_path()
+    claude_md_path = _resolve_display_claude_md_path()
 
     if claude_md_path is None:
         logger.debug("CLAUDE.md not found, skipping working memory sync")
@@ -825,7 +879,7 @@ def sync_retrieved_to_claude_md(
     if not memories:
         return False
 
-    claude_md_path = _get_claude_md_path()
+    claude_md_path = _resolve_display_claude_md_path()
 
     if claude_md_path is None:
         logger.debug("CLAUDE.md not found, skipping retrieved context sync")

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -244,6 +244,9 @@ def _get_claude_md_path() -> Optional[Path]:
     # returns the worktree path when run inside a worktree, which may not
     # contain CLAUDE.md. --git-common-dir always points to the shared .git
     # directory; its parent is the main repo root where CLAUDE.md lives.
+    # git returns this path relative to the invoking directory when run at a
+    # repo root (the bare ".git") and absolute elsewhere, so resolve a relative
+    # result against the cwd before taking its parent.
     # NOTE: Twin pattern in memory_api.py (_detect_project_id) and
     #       hooks/staleness.py (get_project_claude_md_path) -- keep in sync.
     try:
@@ -254,8 +257,10 @@ def _get_claude_md_path() -> Optional[Path]:
             timeout=5
         )
         if result.returncode == 0 and result.stdout.strip():
-            git_common_dir = result.stdout.strip()
-            repo_root = Path(git_common_dir).resolve().parent
+            common_dir = Path(result.stdout.strip())
+            if not common_dir.is_absolute():
+                common_dir = Path.cwd() / common_dir
+            repo_root = common_dir.resolve().parent
             found = _find_existing_claude_md(repo_root)
             if found is not None:
                 return found
@@ -292,32 +297,39 @@ def _resolve_display_claude_md_path() -> Optional[Path]:
     Returns:
         Path to the existing display CLAUDE.md, or None if none exists.
     """
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
-    if project_dir:
-        found = _find_existing_claude_md(Path(project_dir))
-        if found is not None:
-            return found
-
-    # Worktree root: --show-toplevel returns the worktree directory when run
-    # inside a worktree (and the main repo root otherwise), matching the
-    # directory session_init/session_resume target for the session's CLAUDE.md.
+    # Resolution must never raise into the sync path; on any failure (a bad
+    # CLAUDE_PROJECT_DIR value, an inaccessible probe target, or a deleted cwd)
+    # return None so the caller skips the sync and the save still succeeds.
     try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True,
-            text=True,
-            timeout=5
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            worktree_root = Path(result.stdout.strip())
-            found = _find_existing_claude_md(worktree_root)
+        project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
+        if project_dir:
+            found = _find_existing_claude_md(Path(project_dir))
             if found is not None:
                 return found
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        pass
 
-    # Last resort: current working directory
-    return _find_existing_claude_md(Path.cwd())
+        # Worktree root: --show-toplevel returns the worktree directory when run
+        # inside a worktree (and the main repo root otherwise), matching the
+        # directory session_init/session_resume target for the session's CLAUDE.md.
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                worktree_root = Path(result.stdout.strip())
+                found = _find_existing_claude_md(worktree_root)
+                if found is not None:
+                    return found
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            pass
+
+        # Last resort: current working directory
+        return _find_existing_claude_md(Path.cwd())
+    except Exception as e:
+        logger.debug("display CLAUDE.md resolution failed, skipping sync: %s", e)
+        return None
 
 
 def _estimate_tokens(text: str) -> int:

--- a/pact-plugin/tests/test_memory_ct_fields.py
+++ b/pact-plugin/tests/test_memory_ct_fields.py
@@ -708,8 +708,8 @@ class TestSyncToClaudeMdWithCTFields:
             "lessons_learned": ["Always validate refresh token rotation"],
         }
 
-        # Mock _get_claude_md_path to return our temp file
-        with patch("scripts.working_memory._get_claude_md_path", return_value=claude_md):
+        # Mock the display-target resolver to return our temp file
+        with patch("scripts.working_memory._resolve_display_claude_md_path", return_value=claude_md):
             result = sync_to_claude_md(memory, memory_id="test-ct-sync")
 
         assert result is True

--- a/pact-plugin/tests/test_project_id.py
+++ b/pact-plugin/tests/test_project_id.py
@@ -310,6 +310,67 @@ class TestDetectProjectId:
             result = _detect_project_id_under_test()
         assert result == "repo"
 
+    def test_env_var_in_repo_subdir_prefers_main_repo_basename(self):
+        """An env path inside a repo (a subdirectory) keys to the main basename.
+
+        The subdirectory's git common-dir resolves to the repo's shared .git,
+        whose parent differs from the subdirectory, so the env branch returns the
+        repo basename — aligning Strategy 1 with the repo-root semantics of
+        Strategies 2 and 3 and preventing per-subdirectory key fragmentation.
+        """
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "/home/user/myrepo/.git\n"
+
+        with patch.dict(os.environ, {"CLAUDE_PROJECT_DIR": "/home/user/myrepo/src/mod"}), \
+             patch("subprocess.run", return_value=mock_result):
+            result = _detect_project_id_under_test()
+        assert result == "myrepo"
+
+    def test_env_var_worktree_subdir_prefers_main_repo_basename(self):
+        """An env path inside a worktree (a subdirectory) keys to the main basename.
+
+        A worktree subdirectory's common-dir still points at the main repo's
+        shared .git, so it resolves to the main basename like the worktree root
+        and an in-repo subdirectory do.
+        """
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "/home/user/myrepo/.git\n"
+
+        with patch.dict(os.environ,
+                        {"CLAUDE_PROJECT_DIR": "/home/user/wt-feature/src/mod"}), \
+             patch("subprocess.run", return_value=mock_result):
+            result = _detect_project_id_under_test()
+        assert result == "myrepo"
+
+    def test_env_var_repo_root_keeps_env_basename(self):
+        """At a repo ROOT, --git-common-dir is the relative '.git', which resolves
+        back to the root itself, so the rewrite does not fire and the env
+        basename is kept.
+        """
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ".git\n"
+
+        with patch.dict(os.environ, {"CLAUDE_PROJECT_DIR": "/home/user/myrepo"}), \
+             patch("subprocess.run", return_value=mock_result):
+            result = _detect_project_id_under_test()
+        assert result == "myrepo"
+
+    def test_env_var_non_git_keeps_env_basename(self):
+        """A non-git env path cannot resolve a main repo (git returns non-zero),
+        so the original env basename is returned unchanged.
+        """
+        mock_result = MagicMock()
+        mock_result.returncode = 128
+        mock_result.stdout = ""
+
+        with patch.dict(os.environ, {"CLAUDE_PROJECT_DIR": "/tmp/loose-dir"}), \
+             patch("subprocess.run", return_value=mock_result):
+            result = _detect_project_id_under_test()
+        assert result == "loose-dir"
+
     # --- Strategy 2: Git repo root ---
 
     def test_uses_git_when_env_var_not_set(self, clean_env_no_claude_project_dir):

--- a/pact-plugin/tests/test_project_id.py
+++ b/pact-plugin/tests/test_project_id.py
@@ -127,6 +127,36 @@ def _detect_project_id_under_test():
     # Strategy 1: Environment variable (original behavior)
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
     if project_dir:
+        # When CLAUDE_PROJECT_DIR points below a repo's root (a worktree OR
+        # an in-repo subdirectory), its basename is not the project name and
+        # would fragment the project_id across sessions. Prefer the MAIN
+        # repo's basename so every session of a project shares one key,
+        # aligning this env branch (Strategy 1) with the git-root and
+        # cwd-marker branches (Strategies 2/3), which already resolve to the
+        # repo root. The rewrite fires when git resolves a main repo whose
+        # root differs from the env path; only a repo-root env path or a
+        # non-git path (where the main anchor equals, or cannot be resolved
+        # from, the env path) keeps the original basename.
+        try:
+            result = subprocess.run(
+                ["git", "-C", project_dir, "rev-parse", "--git-common-dir"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                common_dir = Path(result.stdout.strip())
+                if not common_dir.is_absolute():
+                    common_dir = Path(project_dir) / common_dir
+                main_repo_root = common_dir.resolve().parent
+                if main_repo_root != Path(project_dir).resolve():
+                    logger.debug(
+                        "project_id detected from CLAUDE_PROJECT_DIR worktree main repo: %s",
+                        main_repo_root.name,
+                    )
+                    return main_repo_root.name
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            pass
         logger.debug("project_id detected from CLAUDE_PROJECT_DIR: %s", Path(project_dir).name)
         return Path(project_dir).name
 
@@ -263,8 +293,14 @@ class TestDetectProjectId:
             result = _detect_project_id_under_test()
         assert result == "cool-repo"
 
-    def test_env_var_takes_priority_over_git(self):
-        """Env var should win even when git would return a different value."""
+    def test_env_var_worktree_prefers_main_repo_basename(self):
+        """When CLAUDE_PROJECT_DIR is a worktree, the MAIN repo basename wins.
+
+        A worktree env path resolves via git to a main repo whose root differs
+        from the env path; the project_id must be the main repo's basename so
+        all sessions of the project share one key, rather than the worktree's
+        own (fragmenting) basename.
+        """
         mock_result = MagicMock()
         mock_result.returncode = 0
         mock_result.stdout = "/some/git/repo/.git\n"
@@ -272,7 +308,7 @@ class TestDetectProjectId:
         with patch.dict(os.environ, {"CLAUDE_PROJECT_DIR": "/env/var/project"}), \
              patch("subprocess.run", return_value=mock_result):
             result = _detect_project_id_under_test()
-        assert result == "project"
+        assert result == "repo"
 
     # --- Strategy 2: Git repo root ---
 

--- a/pact-plugin/tests/test_project_id.py
+++ b/pact-plugin/tests/test_project_id.py
@@ -149,7 +149,12 @@ def _detect_project_id_under_test():
                 if not common_dir.is_absolute():
                     common_dir = Path(project_dir) / common_dir
                 main_repo_root = common_dir.resolve().parent
-                if main_repo_root != Path(project_dir).resolve():
+                # Compare via normcase so a case-insensitive filesystem does
+                # not fire the rewrite for paths that differ only in case
+                # (a no-op on case-sensitive systems, where normcase is
+                # identity).
+                env_root = Path(project_dir).resolve()
+                if os.path.normcase(str(main_repo_root)) != os.path.normcase(str(env_root)):
                     logger.debug(
                         "project_id detected from CLAUDE_PROJECT_DIR worktree main repo: %s",
                         main_repo_root.name,
@@ -165,6 +170,9 @@ def _detect_project_id_under_test():
     # returns the worktree path when run inside a worktree, fragmenting
     # project_id across sessions. --git-common-dir always points to the
     # shared .git directory; its parent is the main repo root.
+    # git returns this path relative to the invoking directory when run at a
+    # repo root (the bare ".git") and absolute elsewhere, so resolve a relative
+    # result against the cwd before taking its parent.
     # NOTE: Twin pattern in working_memory.py (_get_claude_md_path) and
     #       hooks/staleness.py (get_project_claude_md_path) -- keep in sync.
     try:
@@ -175,8 +183,10 @@ def _detect_project_id_under_test():
             timeout=5,
         )
         if result.returncode == 0 and result.stdout.strip():
-            git_common_dir = result.stdout.strip()
-            repo_root = Path(git_common_dir).resolve().parent
+            common_dir = Path(result.stdout.strip())
+            if not common_dir.is_absolute():
+                common_dir = Path.cwd() / common_dir
+            repo_root = common_dir.resolve().parent
             project_name = repo_root.name
             logger.debug("project_id detected from git root: %s", project_name)
             return project_name

--- a/pact-plugin/tests/test_token_budget.py
+++ b/pact-plugin/tests/test_token_budget.py
@@ -236,7 +236,7 @@ class TestSyncToClaudeMdBudgetEnforcement:
         )
         claude_md = self._create_claude_md(tmp_path, existing_content)
 
-        with patch("working_memory._get_claude_md_path", return_value=claude_md):
+        with patch("working_memory._resolve_display_claude_md_path", return_value=claude_md):
             result = sync_to_claude_md(
                 {"context": "New context entry", "goal": "New goal"},
                 memory_id="test123"
@@ -260,7 +260,7 @@ class TestSyncToClaudeMdBudgetEnforcement:
         )
         claude_md = self._create_claude_md(tmp_path, content)
 
-        with patch("working_memory._get_claude_md_path", return_value=claude_md):
+        with patch("working_memory._resolve_display_claude_md_path", return_value=claude_md):
             sync_to_claude_md({"context": "Test"}, memory_id="id1")
 
         new_content = claude_md.read_text(encoding="utf-8")
@@ -286,7 +286,7 @@ class TestSyncToClaudeMdBudgetEnforcement:
         )
         claude_md = self._create_claude_md(tmp_path, existing_content)
 
-        with patch("working_memory._get_claude_md_path", return_value=claude_md):
+        with patch("working_memory._resolve_display_claude_md_path", return_value=claude_md):
             result = sync_to_claude_md(
                 {"context": "Brand new entry"},
                 memory_id="new123"
@@ -347,7 +347,7 @@ class TestSyncRetrievedBudgetEnforcement:
         )
         claude_md = self._create_claude_md(tmp_path, existing_content)
 
-        with patch("working_memory._get_claude_md_path", return_value=claude_md):
+        with patch("working_memory._resolve_display_claude_md_path", return_value=claude_md):
             result = sync_retrieved_to_claude_md(
                 [{"context": "New retrieved", "goal": "test"}],
                 query="test search",

--- a/pact-plugin/tests/test_token_budget.py
+++ b/pact-plugin/tests/test_token_budget.py
@@ -261,9 +261,19 @@ class TestSyncToClaudeMdBudgetEnforcement:
         claude_md = self._create_claude_md(tmp_path, content)
 
         with patch("working_memory._resolve_display_claude_md_path", return_value=claude_md):
-            sync_to_claude_md({"context": "Test"}, memory_id="id1")
+            result = sync_to_claude_md({"context": "Test"}, memory_id="id1")
 
         new_content = claude_md.read_text(encoding="utf-8")
+        # The synced entry must actually be rendered into the Working Memory
+        # block. A no-op sync that left the file untouched would still satisfy
+        # the structural assertions below, so pin the entry content directly.
+        assert result is True
+        wm_block = re.search(
+            r"## Working Memory\n(.*?)(?=\n## |\Z)", new_content, re.DOTALL
+        ).group(1)
+        assert "**Context**: Test" in wm_block
+        assert "**Memory ID**: id1" in wm_block
+        # Surrounding structure is preserved.
         assert "## Pinned Context" in new_content
         assert "Some pinned stuff" in new_content
 

--- a/pact-plugin/tests/test_working_memory_worktree_sync.py
+++ b/pact-plugin/tests/test_working_memory_worktree_sync.py
@@ -1,0 +1,544 @@
+"""
+Tests for syncing Working Memory to the display CLAUDE.md a session actually reads.
+
+A session rooted in a git worktree reads and is shown the WORKTREE's
+.claude/CLAUDE.md (the file session_init/session_resume create), but the
+database that backs memory search is keyed to the MAIN repository so every
+worktree session of a project shares one history. These two targets must be
+resolved independently: the display write follows the worktree, the database
+key follows the main repo.
+
+This module exercises three surfaces with real, unmocked git repositories and
+worktrees wherever feasible:
+
+  * the display-target resolver, _resolve_display_claude_md_path
+  * the project-id detector's env branch, _detect_project_id
+  * the end-to-end save(), which must write the worktree display file AND store
+    the main-repo project_id on the database row
+
+The repository's own .claude/CLAUDE.md is the live file for the running
+session; every test here builds an isolated synthetic repo under tmp_path and
+never touches real session state.
+"""
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# scripts/ is a package; add skills/pact-memory so `scripts.*` imports resolve.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "skills", "pact-memory"))
+
+from scripts.working_memory import _resolve_display_claude_md_path, sync_to_claude_md
+from scripts import working_memory as wm
+from scripts.memory_api import PACTMemory
+
+
+WORKING_MEMORY_SCAFFOLD = (
+    "# {title}\n\n"
+    "## Working Memory\n"
+    "<!-- Auto-managed by pact-memory skill. Last 3 memories shown. "
+    "Full history searchable via pact-memory skill. -->\n"
+)
+RETRIEVED_CONTEXT_SCAFFOLD = (
+    "# {title}\n\n"
+    "## Retrieved Context\n"
+    "<!-- Auto-managed by pact-memory skill. -->\n"
+)
+
+
+def _git(*args, cwd):
+    """Run a git command, raising on failure, with output suppressed."""
+    subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_main_repo(root: Path, *, with_dot_claude=True, with_legacy=False):
+    """Create a committed git repository at `root` with a CLAUDE.md.
+
+    A worktree cannot be added until the main repo has at least one commit, so
+    every fixture seeds an initial commit. The CLAUDE.md is intentionally NOT
+    committed — it mirrors production, where CLAUDE.md is gitignored — so a
+    README is committed instead to anchor the initial commit.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    _git("init", cwd=root)
+    _git("config", "user.email", "test@example.com", cwd=root)
+    _git("config", "user.name", "Test", cwd=root)
+    if with_dot_claude:
+        dot = root / ".claude"
+        dot.mkdir(exist_ok=True)
+        (dot / "CLAUDE.md").write_text(
+            WORKING_MEMORY_SCAFFOLD.format(title="Main"), encoding="utf-8"
+        )
+    if with_legacy:
+        (root / "CLAUDE.md").write_text(
+            WORKING_MEMORY_SCAFFOLD.format(title="Main legacy"), encoding="utf-8"
+        )
+    (root / "README.md").write_text("anchor\n", encoding="utf-8")
+    _git("add", "README.md", cwd=root)
+    _git("commit", "-m", "initial", cwd=root)
+
+
+def _add_worktree(main: Path, worktree: Path, *, branch="feature",
+                  with_dot_claude=True, with_legacy=False):
+    """Attach a git worktree to `main` and optionally seed its CLAUDE.md."""
+    _git("worktree", "add", str(worktree), "-b", branch, cwd=main)
+    if with_dot_claude:
+        dot = worktree / ".claude"
+        dot.mkdir(parents=True, exist_ok=True)
+        (dot / "CLAUDE.md").write_text(
+            WORKING_MEMORY_SCAFFOLD.format(title="Worktree"), encoding="utf-8"
+        )
+    if with_legacy:
+        (worktree / "CLAUDE.md").write_text(
+            WORKING_MEMORY_SCAFFOLD.format(title="Worktree legacy"), encoding="utf-8"
+        )
+
+
+@pytest.fixture
+def worktree_repo(tmp_path):
+    """A real main repo plus an attached worktree, each with .claude/CLAUDE.md.
+
+    Yields (main_root, worktree_root). The current working directory is set to
+    the worktree for the duration of the test and restored afterwards, matching
+    a worktree-rooted session.
+    """
+    main = tmp_path / "mainproj"
+    worktree = tmp_path / "wt-feature"
+    _init_main_repo(main)
+    _add_worktree(main, worktree)
+    prev_cwd = Path.cwd()
+    os.chdir(str(worktree))
+    try:
+        yield main, worktree
+    finally:
+        os.chdir(str(prev_cwd))
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Ensure CLAUDE_PROJECT_DIR is unset for env-unset scenarios."""
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    return monkeypatch
+
+
+# ---------------------------------------------------------------------------
+# Display-target resolver — _resolve_display_claude_md_path
+# ---------------------------------------------------------------------------
+
+class TestDisplayTargetResolver:
+    """The resolver returns the CLAUDE.md the current session displays."""
+
+    def test_worktree_session_resolves_worktree_file_when_env_unset(
+        self, worktree_repo, clean_env
+    ):
+        """A worktree session with no env var resolves the worktree display file."""
+        _main, worktree = worktree_repo
+        resolved = _resolve_display_claude_md_path()
+        assert resolved == worktree / ".claude" / "CLAUDE.md"
+
+    def test_worktree_session_resolves_worktree_file_when_env_is_worktree(
+        self, worktree_repo, monkeypatch
+    ):
+        """With CLAUDE_PROJECT_DIR set to the worktree, the worktree file wins."""
+        _main, worktree = worktree_repo
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(worktree))
+        resolved = _resolve_display_claude_md_path()
+        assert resolved == worktree / ".claude" / "CLAUDE.md"
+
+    def test_main_checkout_resolves_main_file(self, tmp_path, clean_env):
+        """In a plain (non-worktree) checkout the display target is the main file.
+
+        Here the display target and the database target coincide, so the
+        resolver must return the same path a main-repo session would write.
+        """
+        main = tmp_path / "soloproj"
+        _init_main_repo(main)
+        prev = Path.cwd()
+        os.chdir(str(main))
+        try:
+            resolved = _resolve_display_claude_md_path()
+        finally:
+            os.chdir(str(prev))
+        assert resolved == main / ".claude" / "CLAUDE.md"
+
+    def test_resolves_legacy_root_file_when_no_dot_claude(self, tmp_path, clean_env):
+        """A worktree carrying only ./CLAUDE.md resolves that legacy location."""
+        main = tmp_path / "mainproj"
+        worktree = tmp_path / "wt-legacy"
+        _init_main_repo(main)
+        _add_worktree(main, worktree, with_dot_claude=False, with_legacy=True)
+        prev = Path.cwd()
+        os.chdir(str(worktree))
+        try:
+            resolved = _resolve_display_claude_md_path()
+        finally:
+            os.chdir(str(prev))
+        assert resolved == worktree / "CLAUDE.md"
+
+    def test_returns_none_when_no_display_file_exists(self, tmp_path, clean_env):
+        """When neither display location exists, the resolver returns None so the
+        caller skips the sync rather than creating a file."""
+        main = tmp_path / "mainproj"
+        worktree = tmp_path / "wt-bare"
+        _init_main_repo(main)
+        _add_worktree(main, worktree, with_dot_claude=False)
+        prev = Path.cwd()
+        os.chdir(str(worktree))
+        try:
+            resolved = _resolve_display_claude_md_path()
+        finally:
+            os.chdir(str(prev))
+        assert resolved is None
+
+    def test_non_git_directory_falls_through_to_cwd_without_crashing(
+        self, tmp_path, clean_env
+    ):
+        """Outside any git repo the resolver probes cwd and never raises."""
+        plain = tmp_path / "not-a-repo"
+        plain.mkdir()
+        prev = Path.cwd()
+        os.chdir(str(plain))
+        try:
+            # No CLAUDE.md anywhere under cwd -> None, and crucially no exception.
+            resolved = _resolve_display_claude_md_path()
+        finally:
+            os.chdir(str(prev))
+        assert resolved is None
+
+    def test_non_git_directory_resolves_cwd_file_when_present(
+        self, tmp_path, clean_env
+    ):
+        """Outside git, a CLAUDE.md under cwd is still resolved via the cwd probe."""
+        plain = tmp_path / "loose-dir"
+        (plain / ".claude").mkdir(parents=True)
+        (plain / ".claude" / "CLAUDE.md").write_text(
+            WORKING_MEMORY_SCAFFOLD.format(title="Loose"), encoding="utf-8"
+        )
+        prev = Path.cwd()
+        os.chdir(str(plain))
+        try:
+            resolved = _resolve_display_claude_md_path()
+        finally:
+            os.chdir(str(prev))
+        assert resolved == plain / ".claude" / "CLAUDE.md"
+
+    def test_unavailable_git_binary_falls_through_to_cwd(self, tmp_path, clean_env):
+        """If git cannot be invoked the resolver degrades to the cwd probe."""
+        plain = tmp_path / "loose"
+        (plain / ".claude").mkdir(parents=True)
+        (plain / ".claude" / "CLAUDE.md").write_text(
+            WORKING_MEMORY_SCAFFOLD.format(title="Loose"), encoding="utf-8"
+        )
+        prev = Path.cwd()
+        os.chdir(str(plain))
+        try:
+            with patch("scripts.working_memory.subprocess.run",
+                       side_effect=FileNotFoundError("git missing")):
+                resolved = _resolve_display_claude_md_path()
+        finally:
+            os.chdir(str(prev))
+        assert resolved == plain / ".claude" / "CLAUDE.md"
+
+    def test_env_outside_worktree_does_not_force_worktree_write(
+        self, worktree_repo, tmp_path, monkeypatch
+    ):
+        """When the env points at an unrelated directory that has no CLAUDE.md,
+        the resolver does not invent a worktree write; it falls through to the
+        git/cwd probe and resolves the worktree the session is actually in.
+
+        This guards the cwd-divergence degradation path: a stale or mismatched
+        CLAUDE_PROJECT_DIR must not silently redirect or suppress the sync.
+        """
+        _main, worktree = worktree_repo
+        stray = tmp_path / "stray-no-claude"
+        stray.mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(stray))
+        resolved = _resolve_display_claude_md_path()
+        # Env dir has no CLAUDE.md -> probe falls through to the worktree (cwd).
+        assert resolved == worktree / ".claude" / "CLAUDE.md"
+
+
+# ---------------------------------------------------------------------------
+# Database-key stability — _detect_project_id env branch
+# ---------------------------------------------------------------------------
+
+class TestProjectIdStability:
+    """The database key stays the main-repo slug across worktree sessions."""
+
+    def test_worktree_env_keys_to_main_repo_basename(self, worktree_repo, monkeypatch):
+        """CLAUDE_PROJECT_DIR set to a worktree resolves to the MAIN basename.
+
+        The worktree's own basename would fragment the project key across
+        sessions; the main repo's basename keeps one shared key.
+        """
+        main, worktree = worktree_repo
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(worktree))
+        assert PACTMemory._detect_project_id() == main.name
+
+    def test_worktree_subdir_env_keys_to_main_repo_basename(
+        self, worktree_repo, monkeypatch
+    ):
+        """CLAUDE_PROJECT_DIR at a subdirectory inside a worktree also keys to
+        the main basename.
+
+        A worktree subdirectory's git common-dir still resolves to the main
+        repo's shared .git, so it aligns to the main basename like the worktree
+        root and an in-repo subdirectory do. Exercised unmocked.
+        """
+        main, worktree = worktree_repo
+        subdir = worktree / "src" / "module"
+        subdir.mkdir(parents=True)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(subdir))
+        assert PACTMemory._detect_project_id() == main.name
+
+    def test_worktree_session_env_unset_keys_to_main_repo_basename(
+        self, worktree_repo, clean_env
+    ):
+        """A worktree session with no env var still keys to the main basename
+        via the git-root (Strategy 2) detection path."""
+        main, _worktree = worktree_repo
+        assert PACTMemory._detect_project_id() == main.name
+
+    def test_main_repo_env_keys_to_main_repo_basename(self, tmp_path, monkeypatch):
+        """CLAUDE_PROJECT_DIR at a plain repo root returns that repo's basename
+        unchanged — the worktree rewrite must not fire for the root itself."""
+        main = tmp_path / "soloproj"
+        _init_main_repo(main)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(main))
+        assert PACTMemory._detect_project_id() == "soloproj"
+
+    def test_non_git_env_keys_to_env_basename(self, tmp_path, monkeypatch):
+        """A non-git CLAUDE_PROJECT_DIR cannot resolve a main repo, so the env
+        basename is returned unchanged (graceful fall-through)."""
+        plain = tmp_path / "plain-target"
+        plain.mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(plain))
+        assert PACTMemory._detect_project_id() == "plain-target"
+
+    def test_in_repo_subdir_env_keys_to_main_repo_basename(self, tmp_path, monkeypatch):
+        """CLAUDE_PROJECT_DIR at a subdirectory inside a repo keys to the main
+        basename, not the subdirectory's own.
+
+        A subdirectory's basename is not the project name; returning it would
+        fragment the project key. The env branch aligns with the git-root and
+        cwd-marker branches, which already resolve any in-repo path to the repo
+        root. Exercised against a real git repository, unmocked.
+        """
+        main = tmp_path / "mainproj"
+        _init_main_repo(main)
+        subdir = main / "src" / "module"
+        subdir.mkdir(parents=True)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(subdir))
+        assert PACTMemory._detect_project_id() == "mainproj"
+
+    def test_in_repo_subdir_env_keys_to_main_repo_basename_mocked(self, monkeypatch):
+        """Fast mocked mirror of the in-repo-subdir alignment case.
+
+        A subdirectory's git common-dir resolves (absolutely) to the main repo's
+        .git, whose parent differs from the subdirectory, so the main basename
+        is returned. Kept alongside the unmocked pin as a quick regression check.
+        """
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "/home/user/mainproj/.git\n"
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/home/user/mainproj/src/module")
+        with patch("scripts.memory_api.subprocess.run", return_value=mock_result):
+            assert PACTMemory._detect_project_id() == "mainproj"
+
+    def test_git_timeout_in_env_branch_falls_back_to_env_basename(
+        self, tmp_path, monkeypatch
+    ):
+        """A git timeout while probing a worktree env path degrades to the env
+        basename rather than raising."""
+        worktree_like = tmp_path / "wt-like"
+        worktree_like.mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(worktree_like))
+        with patch("scripts.memory_api.subprocess.run",
+                   side_effect=subprocess.TimeoutExpired("git", 5)):
+            assert PACTMemory._detect_project_id() == "wt-like"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end parity — the acceptance criterion
+# ---------------------------------------------------------------------------
+
+def _working_memory_block(text: str) -> str:
+    """Return the text of the ## Working Memory section (up to the next ##)."""
+    match = re.search(r"## Working Memory\n(.*?)(?=\n## |\Z)", text, re.DOTALL)
+    return match.group(1) if match else ""
+
+
+def _retrieved_context_block(text: str) -> str:
+    match = re.search(r"## Retrieved Context\n(.*?)(?=\n## |\Z)", text, re.DOTALL)
+    return match.group(1) if match else ""
+
+
+class TestEndToEndParity:
+    """save() writes the worktree display file and keys the row to the main repo."""
+
+    def test_worktree_save_populates_worktree_block_and_keys_to_main(
+        self, worktree_repo, clean_env
+    ):
+        """A worktree-rooted save() writes the WORKTREE Working Memory block and
+        stores the main-repo slug on the database row.
+
+        This is the acceptance criterion: the display follows the worktree, the
+        database key follows the main repo. Driven through the real save() path
+        against a temporary database.
+        """
+        main, worktree = worktree_repo
+        db_path = worktree.parent / "memory.db"
+        mem = PACTMemory(db_path=db_path)
+
+        memory_id = mem.save({"context": "Worktree session entry"})
+
+        worktree_text = (worktree / ".claude" / "CLAUDE.md").read_text(encoding="utf-8")
+        main_text = (main / ".claude" / "CLAUDE.md").read_text(encoding="utf-8")
+
+        # Display write landed in the worktree, not the main repo.
+        assert "Worktree session entry" in _working_memory_block(worktree_text)
+        assert "Worktree session entry" not in main_text
+
+        # Database row keyed to the main-repo slug, not the worktree name.
+        stored = mem.get(memory_id)
+        assert stored is not None
+        assert stored.project_id == main.name
+
+    def test_main_session_save_populates_main_block(self, tmp_path, clean_env):
+        """A plain main-repo save() writes the main Working Memory block and
+        keys the row to the main slug."""
+        main = tmp_path / "soloproj"
+        _init_main_repo(main)
+        prev = Path.cwd()
+        os.chdir(str(main))
+        try:
+            db_path = tmp_path / "memory.db"
+            mem = PACTMemory(db_path=db_path)
+            memory_id = mem.save({"context": "Main session entry"})
+        finally:
+            os.chdir(str(prev))
+
+        main_text = (main / ".claude" / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "Main session entry" in _working_memory_block(main_text)
+
+        stored = mem.get(memory_id)
+        assert stored is not None
+        assert stored.project_id == "soloproj"
+
+    def test_worktree_and_main_saves_render_identical_entry(self, tmp_path, clean_env):
+        """Saving the same memory in a worktree session and a main session
+        produces the same rendered entry in each session's display block.
+
+        This is Option B's guarantee: a worktree session shows the same entries
+        a main-repo session would.
+        """
+        # Main-repo session.
+        main = tmp_path / "mainproj"
+        _init_main_repo(main)
+        worktree = tmp_path / "wt-feature"
+        _add_worktree(main, worktree)
+
+        memory = {"context": "Shared rendering check", "goal": "parity"}
+
+        # Render in the worktree session.
+        prev = Path.cwd()
+        os.chdir(str(worktree))
+        try:
+            with patch("scripts.working_memory._resolve_display_claude_md_path",
+                       return_value=worktree / ".claude" / "CLAUDE.md"):
+                sync_to_claude_md(dict(memory), memory_id="shared-id")
+        finally:
+            os.chdir(str(prev))
+
+        # Render in the main session.
+        with patch("scripts.working_memory._resolve_display_claude_md_path",
+                   return_value=main / ".claude" / "CLAUDE.md"):
+            sync_to_claude_md(dict(memory), memory_id="shared-id")
+
+        worktree_entry = _working_memory_block(
+            (worktree / ".claude" / "CLAUDE.md").read_text(encoding="utf-8")
+        )
+        main_entry = _working_memory_block(
+            (main / ".claude" / "CLAUDE.md").read_text(encoding="utf-8")
+        )
+        assert worktree_entry == main_entry
+        assert "Shared rendering check" in worktree_entry
+
+    def test_retrieved_context_sync_targets_worktree_display_file(
+        self, tmp_path, clean_env
+    ):
+        """The retrieved-context sibling syncs to the worktree display file too.
+
+        sync_retrieved_to_claude_md shares the same display-target resolver, so a
+        worktree session's Retrieved Context block lands in the worktree file.
+        """
+        from scripts.working_memory import sync_retrieved_to_claude_md
+
+        main = tmp_path / "mainproj"
+        worktree = tmp_path / "wt-feature"
+        _init_main_repo(main)
+        # Seed the worktree with a Retrieved Context scaffold instead of Working.
+        _add_worktree(main, worktree, with_dot_claude=False)
+        dot = worktree / ".claude"
+        dot.mkdir(parents=True, exist_ok=True)
+        (dot / "CLAUDE.md").write_text(
+            RETRIEVED_CONTEXT_SCAFFOLD.format(title="Worktree"), encoding="utf-8"
+        )
+
+        retrieved = [{"context": "Recalled worktree note", "memory_id": "r1"}]
+        prev = Path.cwd()
+        os.chdir(str(worktree))
+        try:
+            sync_retrieved_to_claude_md(retrieved, query="worktree note")
+        finally:
+            os.chdir(str(prev))
+
+        worktree_text = (dot / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "Recalled worktree note" in _retrieved_context_block(worktree_text)
+
+    def test_save_succeeds_when_display_file_missing(self, tmp_path, clean_env):
+        """A missing display file must never fail the save.
+
+        The resolver returns None when no CLAUDE.md exists; save() still returns
+        a memory_id and persists the database row.
+        """
+        main = tmp_path / "mainproj"
+        worktree = tmp_path / "wt-no-display"
+        _init_main_repo(main)
+        _add_worktree(main, worktree, with_dot_claude=False)
+        prev = Path.cwd()
+        os.chdir(str(worktree))
+        try:
+            db_path = tmp_path / "memory.db"
+            mem = PACTMemory(db_path=db_path)
+            memory_id = mem.save({"context": "No display file present"})
+        finally:
+            os.chdir(str(prev))
+
+        assert memory_id is not None
+        stored = mem.get(memory_id)
+        assert stored is not None
+        assert stored.context == "No display file present"
+
+    def test_save_succeeds_when_sync_raises(self, worktree_repo, clean_env):
+        """An exception inside the sync must be swallowed and never fail save()."""
+        main, worktree = worktree_repo
+        db_path = worktree.parent / "memory.db"
+        mem = PACTMemory(db_path=db_path)
+        with patch("scripts.memory_api.sync_to_claude_md",
+                   side_effect=RuntimeError("disk on fire")):
+            memory_id = mem.save({"context": "Sync blows up"})
+        assert memory_id is not None
+        stored = mem.get(memory_id)
+        assert stored is not None

--- a/pact-plugin/tests/test_working_memory_worktree_sync.py
+++ b/pact-plugin/tests/test_working_memory_worktree_sync.py
@@ -415,6 +415,44 @@ class TestEndToEndParity:
         assert stored is not None
         assert stored.project_id == main.name
 
+    def test_worktree_save_writes_worktree_block_not_main(
+        self, worktree_repo, clean_env
+    ):
+        """A worktree-rooted save() writes the display block to the WORKTREE file
+        and leaves the main repo untouched.
+
+        This isolates the display leg of the acceptance criterion. Unlike the
+        joint test above, it asserts only the display target, so it stays coupled
+        to the display-target resolver even if the database-key path regresses.
+        """
+        main, worktree = worktree_repo
+        db_path = worktree.parent / "memory.db"
+        mem = PACTMemory(db_path=db_path)
+
+        mem.save({"context": "Worktree display leg"})
+
+        worktree_text = (worktree / ".claude" / "CLAUDE.md").read_text(encoding="utf-8")
+        main_text = (main / ".claude" / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "Worktree display leg" in _working_memory_block(worktree_text)
+        assert "Worktree display leg" not in main_text
+
+    def test_worktree_save_keys_db_row_to_main_repo(self, worktree_repo, clean_env):
+        """A worktree-rooted save() keys the database row to the MAIN repo slug.
+
+        This isolates the database-key leg of the acceptance criterion. It
+        asserts only the stored project_id, so it stays coupled to the
+        project-id detector even if the display-write path regresses.
+        """
+        main, worktree = worktree_repo
+        db_path = worktree.parent / "memory.db"
+        mem = PACTMemory(db_path=db_path)
+
+        memory_id = mem.save({"context": "Worktree key leg"})
+
+        stored = mem.get(memory_id)
+        assert stored is not None
+        assert stored.project_id == main.name
+
     def test_main_session_save_populates_main_block(self, tmp_path, clean_env):
         """A plain main-repo save() writes the main Working Memory block and
         keys the row to the main slug."""


### PR DESCRIPTION
## Summary

Fixes #935 — in worktree-rooted sessions, the pact-memory `save()` Working Memory auto-sync wrote 0 entries to the display block the session actually reads.

**Root cause** (investigation falsified the issue's original hypothesis): not a project_id divergence — a CLAUDE.md **write-target vs read-target mismatch**. The sync wrote the main-repo CLAUDE.md (via `_get_claude_md_path`'s `--git-common-dir` fallback) while the session reads the worktree's `.claude/CLAUDE.md`.

## Changes

- **`working_memory.py`**: new `_resolve_display_claude_md_path()` — worktree-aware write-target resolver anchored on `git rev-parse --show-toplevel` (env → git → cwd, never creates the file, sync failure never fails a save). Both sync consumers (`sync_to_claude_md`, `sync_retrieved_to_claude_md`) now use it. Display resolution and DB-key resolution are decoupled: they read different git facts, so no single `CLAUDE_PROJECT_DIR` value is load-bearing for both.
- **`memory_api.py`**: `_detect_project_id`'s env branch hardened — when the env path resolves via git to a main repo whose root differs from itself (worktree root, worktree subdir, or in-repo subdir), the **main-repo basename** is returned, aligning Strategy 1 with Strategies 2/3 and preventing project_id fragmentation. Repo-root and non-git paths keep the env basename.
- **Tests**: new real-git-fixture integration suite (display-resolver D-matrix, DB-key K-matrix, end-to-end save() acceptance parity); strengthened a previously vacuous budget-sync assertion; replica-matrix pins for all env-branch directions; behavior pin reclassified to the new worktree semantics.
- **Version**: 4.4.16 (PATCH).

## Verification

- Full suite: 8627+ passed / 13 skipped / 0 failed / 0 errors (verified with errors-count check).
- End-to-end acceptance: real `save()` in a tmp worktree updates the worktree `.claude/CLAUDE.md` block while the DB row keys to the main-repo slug — same entries a main-repo session shows.
- RED-on-revert spot check: source-only revert of the env hardening fails the source-coupled integration pin.
- Concurrent auditor signal: GREEN (structural verification against diff ground truth).

## Out of scope (tracked)

- #936 — migrating existing worktree-named project_id DB rows (this PR is prevention-only)
- #937 — sync lock identity under env-unset subprocesses
- #938 — replica-based test pins don't couple to shipped source (functional gap closed by the new integration suite)
