### PR TITLE
feat: add model: inherit to teammate agent frontmatter (v4.4.17)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.16",
+      "version": "4.4.17",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.16/      # Plugin version
+│               └── 4.4.17/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.16",
+  "version": "4.4.17",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.16
+> **Version**: 4.4.17
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/agents/pact-architect.md
+++ b/pact-plugin/agents/pact-architect.md
@@ -4,6 +4,7 @@ description: |
   Use this agent to design system architectures: component diagrams, API contracts,
   data flows, and implementation guidelines. Use after preparation/research is complete.
 color: "#6A0DAD"
+model: inherit
 permissionMode: acceptEdits
 memory: user
 skills:

--- a/pact-plugin/agents/pact-auditor.md
+++ b/pact-plugin/agents/pact-auditor.md
@@ -5,6 +5,7 @@ description: |
   comparing against architecture specs, and emitting GREEN/YELLOW/RED signals. Does not write
   code — observes while others build.
 color: "#4169E1"
+model: inherit
 permissionMode: byDefault
 memory: user
 skills:

--- a/pact-plugin/agents/pact-backend-coder.md
+++ b/pact-plugin/agents/pact-backend-coder.md
@@ -4,6 +4,7 @@ description: |
   Use this agent to implement backend code: server-side components, APIs, business logic,
   and data processing. Use after architectural specifications are ready.
 color: "#1E90FF"
+model: inherit
 permissionMode: acceptEdits
 memory: user
 skills:

--- a/pact-plugin/agents/pact-database-engineer.md
+++ b/pact-plugin/agents/pact-database-engineer.md
@@ -4,6 +4,7 @@ description: |
   Use this agent to implement database solutions: schemas, optimized queries, data models,
   indexes, and data integrity. Use after architectural specifications are ready.
 color: "#FFBF00"
+model: inherit
 permissionMode: acceptEdits
 memory: user
 skills:

--- a/pact-plugin/agents/pact-devops-engineer.md
+++ b/pact-plugin/agents/pact-devops-engineer.md
@@ -4,6 +4,7 @@ description: |
   Use this agent to implement infrastructure and build systems: CI/CD pipelines, Dockerfiles,
   shell scripts, Makefiles, and infrastructure as code. Use after architectural specifications are ready.
 color: "#FF6600"
+model: inherit
 permissionMode: acceptEdits
 memory: user
 skills:

--- a/pact-plugin/agents/pact-frontend-coder.md
+++ b/pact-plugin/agents/pact-frontend-coder.md
@@ -4,6 +4,7 @@ description: |
   Use this agent to implement frontend code: responsive, accessible user interfaces with
   proper state management. Use after architectural specifications are ready.
 color: "#32CD32"
+model: inherit
 permissionMode: acceptEdits
 memory: user
 skills:

--- a/pact-plugin/agents/pact-n8n.md
+++ b/pact-plugin/agents/pact-n8n.md
@@ -4,6 +4,7 @@ description: |
   Use this agent to build, validate, or troubleshoot n8n workflows: webhooks, HTTP integrations,
   database workflows, AI agent workflows, and scheduled tasks. Requires n8n-mcp MCP server.
 color: "#FF7F50"
+model: inherit
 permissionMode: acceptEdits
 memory: user
 skills:

--- a/pact-plugin/agents/pact-preparer.md
+++ b/pact-plugin/agents/pact-preparer.md
@@ -4,6 +4,7 @@ description: |
   Use this agent to research and gather documentation: API docs, best practices,
   code examples, and technical information for development. First phase of PACT.
 color: "#008080"
+model: inherit
 permissionMode: acceptEdits
 memory: user
 skills:

--- a/pact-plugin/agents/pact-qa-engineer.md
+++ b/pact-plugin/agents/pact-qa-engineer.md
@@ -4,6 +4,7 @@ description: |
   Use this agent for runtime verification: starting the app, navigating pages, testing interactions,
   and catching regressions invisible to static analysis. Requires a runnable dev server.
 color: "#FF69B4"
+model: inherit
 permissionMode: acceptEdits
 memory: user
 skills:

--- a/pact-plugin/agents/pact-secretary.md
+++ b/pact-plugin/agents/pact-secretary.md
@@ -28,6 +28,7 @@ description: |
   <commentary>The secretary proactively searches pact-memory at spawn, cleans stale Working Memory entries, and delivers a session briefing — no explicit query needed.</commentary>
   </example>
 color: "#708090"
+model: inherit
 permissionMode: acceptEdits
 memory: user
 skills:

--- a/pact-plugin/agents/pact-security-engineer.md
+++ b/pact-plugin/agents/pact-security-engineer.md
@@ -4,6 +4,7 @@ description: |
   Use this agent for adversarial security code review: finding vulnerabilities, auth flaws,
   injection risks, and data exposure. Does not fix issues — reports findings for coders to address.
 color: "#8B0000"
+model: inherit
 permissionMode: acceptEdits
 memory: user
 skills:

--- a/pact-plugin/agents/pact-test-engineer.md
+++ b/pact-plugin/agents/pact-test-engineer.md
@@ -4,6 +4,7 @@ description: |
   Use this agent to create and run tests: unit tests, integration tests, E2E tests,
   performance tests, and security tests. Use after code implementation is complete.
 color: "#DC143C"
+model: inherit
 permissionMode: acceptEdits
 memory: user
 skills:

--- a/pact-plugin/tests/helpers.py
+++ b/pact-plugin/tests/helpers.py
@@ -19,16 +19,31 @@ from typing import Any
 # Shared Utilities: Frontmatter Parser
 # =============================================================================
 
+def frontmatter_block(text):
+    """Return the unstripped frontmatter text between the opening and
+    closing --- delimiters, or None if text does not start with ---.
+
+    Single source of the delimiter logic, shared by parse_frontmatter and
+    structure tests that need the raw block (e.g. line-level key counting).
+    Raises ValueError (via str.index) when an opening delimiter has no
+    closing delimiter, preserving parse_frontmatter's historical behavior.
+    """
+    if not text.startswith("---"):
+        return None
+    end = text.index("---", 3)
+    return text[3:end]
+
+
 def parse_frontmatter(text):
     """Parse YAML frontmatter from markdown text.
 
     Handles simple key: value pairs and multiline values using the | block
     scalar indicator. Used by agent, command, and skill structure tests.
     """
-    if not text.startswith("---"):
+    block = frontmatter_block(text)
+    if block is None:
         return None
-    end = text.index("---", 3)
-    fm_text = text[3:end].strip()
+    fm_text = block.strip()
     result = {}
     current_key = None
     for line in fm_text.split("\n"):

--- a/pact-plugin/tests/test_agents_structure.py
+++ b/pact-plugin/tests/test_agents_structure.py
@@ -107,6 +107,41 @@ class TestAgentFrontmatter:
             assert len(desc) > 0, f"{name} has empty description"
 
 
+class TestTeammateModelInheritance:
+    """Every teammate agent def must pin `model: inherit` in frontmatter.
+
+    Teammates are spawned via Agent() from the lead's session; without an
+    explicit `model:` key the harness falls back to its own default model
+    instead of the lead's, silently splitting the team across models.
+    `inherit` resolves the lead's full model ID at spawn time.
+
+    This is the positive half of a deliberate frontmatter asymmetry: the
+    orchestrator is launched via `claude --agent` with no parent to inherit
+    from, so pact-orchestrator.md must NOT carry the key — that negative
+    half is enforced by test_pact_orchestrator_agent.py::
+    test_pact_orchestrator_omits_model_permissionmode_tools.
+    """
+
+    def test_all_teammates_declare_model_inherit(self, teammate_agent_files):
+        # Cardinality pin: guards THIS test's iteration surface against a
+        # vacuous pass if the fixture glob silently yields fewer files
+        # (test_no_unexpected_agents guards the on-disk closed set, not
+        # this loop's coverage).
+        names = {f.stem for f in teammate_agent_files}
+        assert names == TEAMMATE_AGENT_NAMES and len(names) == 12, (
+            f"Expected exactly the 12 teammate agent defs, got {len(names)}: "
+            f"{sorted(names)}"
+        )
+        for f in teammate_agent_files:
+            fm = parse_frontmatter(f.read_text(encoding="utf-8"))
+            assert fm is not None, f"{f.name}: frontmatter failed to parse"
+            assert fm.get("model") == "inherit", (
+                f"{f.name}: frontmatter `model` must be 'inherit' so the "
+                f"spawned teammate inherits the lead session's model "
+                f"(got {fm.get('model')!r})"
+            )
+
+
 class TestAgentBody:
     def test_has_system_prompt_content(self, agent_files):
         for f in agent_files:

--- a/pact-plugin/tests/test_agents_structure.py
+++ b/pact-plugin/tests/test_agents_structure.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import pytest
 
-from helpers import parse_frontmatter
+from helpers import frontmatter_block, parse_frontmatter
 
 AGENTS_DIR = Path(__file__).parent.parent / "agents"
 
@@ -146,7 +146,7 @@ class TestTeammateModelInheritance:
             text = f.read_text(encoding="utf-8")
             fm = parse_frontmatter(text)
             assert fm is not None, f"{f.name}: frontmatter failed to parse"
-            fm_block = text[3:text.index("---", 3)]
+            fm_block = frontmatter_block(text)
             model_lines = [
                 ln for ln in fm_block.splitlines()
                 if ln.startswith("model:")

--- a/pact-plugin/tests/test_agents_structure.py
+++ b/pact-plugin/tests/test_agents_structure.py
@@ -5,7 +5,7 @@ Tests cover:
 1. All agent files exist and are readable
 2. YAML frontmatter is valid and contains required fields
 3. Agent names follow pact-{role} convention
-4. Required frontmatter keys: name, description, color, permissionMode
+4. Required frontmatter keys: name, description
 5. Skills reference exists
 6. Agent body contains expected sections
 """
@@ -120,21 +120,43 @@ class TestTeammateModelInheritance:
     from, so pact-orchestrator.md must NOT carry the key — that negative
     half is enforced by test_pact_orchestrator_agent.py::
     test_pact_orchestrator_omits_model_permissionmode_tools.
+
+    The value check is deliberately byte-form-strict: YAML-equivalent
+    spellings such as a quoted "inherit" or a trailing comment fail by
+    design (false-fail direction), enforcing one uniform authoring shape
+    across all teammate defs.
     """
 
     def test_all_teammates_declare_model_inherit(self, teammate_agent_files):
-        # Cardinality pin: guards THIS test's iteration surface against a
-        # vacuous pass if the fixture glob silently yields fewer files
-        # (test_no_unexpected_agents guards the on-disk closed set, not
-        # this loop's coverage).
+        # Addition-ratchet: the set-equality leg alone already fails on a
+        # missing/unexpected def and on a vacuous fixture glob. The `== 12`
+        # literal is therefore not a vacuity guard — it exists to force a
+        # conscious edit HERE when a teammate def is added, because
+        # set-equality would silently auto-track an EXPECTED_AGENTS
+        # addition.
         names = {f.stem for f in teammate_agent_files}
         assert names == TEAMMATE_AGENT_NAMES and len(names) == 12, (
             f"Expected exactly the 12 teammate agent defs, got {len(names)}: "
-            f"{sorted(names)}"
+            f"{sorted(names)}. If a teammate def was deliberately added or "
+            f"removed, update the count literal (and EXPECTED_AGENTS) with a "
+            f"comment naming which def changed and why — this failure is the "
+            f"ratchet prompting that conscious update, not a defect."
         )
         for f in teammate_agent_files:
-            fm = parse_frontmatter(f.read_text(encoding="utf-8"))
+            text = f.read_text(encoding="utf-8")
+            fm = parse_frontmatter(text)
             assert fm is not None, f"{f.name}: frontmatter failed to parse"
+            fm_block = text[3:text.index("---", 3)]
+            model_lines = [
+                ln for ln in fm_block.splitlines()
+                if ln.startswith("model:")
+            ]
+            assert len(model_lines) == 1, (
+                f"{f.name}: expected exactly one `model:` line in "
+                f"frontmatter, got {len(model_lines)} — duplicate keys "
+                f"resolve last-wins and can silently shadow the intended "
+                f"value"
+            )
             assert fm.get("model") == "inherit", (
                 f"{f.name}: frontmatter `model` must be 'inherit' so the "
                 f"spawned teammate inherits the lead session's model "

--- a/pact-plugin/tests/test_agents_structure.py
+++ b/pact-plugin/tests/test_agents_structure.py
@@ -241,13 +241,12 @@ class TestNoSkillInvocationOnFirstAction:
         This is scoped to this test class rather than extended in helpers.py
         to avoid destabilizing other tests that rely on the flattened form.
         """
-        if not text.startswith("---"):
-            return []
         try:
-            end = text.index("---", 3)
+            fm_text = frontmatter_block(text)
         except ValueError:
             return []
-        fm_text = text[3:end]
+        if fm_text is None:
+            return []
         lines = fm_text.split("\n")
         skills = []
         in_skills = False

--- a/pact-plugin/tests/test_pact_orchestrator_agent.py
+++ b/pact-plugin/tests/test_pact_orchestrator_agent.py
@@ -70,7 +70,12 @@ def test_pact_orchestrator_color_is_gold():
 
 
 def test_pact_orchestrator_omits_model_permissionmode_tools():
-    """Frontmatter asymmetry: orchestrator inherits defaults; teammate files keep them."""
+    """Frontmatter asymmetry: orchestrator inherits defaults; teammate files keep them.
+
+    Negative half of the contract; the positive half (every teammate def
+    must pin `model: inherit`) is enforced by test_agents_structure.py::
+    TestTeammateModelInheritance.
+    """
     text = ORCHESTRATOR_PATH.read_text()
     fm = parse_frontmatter(text)
     forbidden = {"model", "permissionMode", "tools"}


### PR DESCRIPTION
## Summary

Teammates spawned via `Agent(name=..., team_name=..., subagent_type=...)` without an explicit `model=` param do not inherit the lead's model — they silently fall back to a harness-internal default (`claude-opus-4-8` observed), in both teammate modes and across all agent types. This PR adds `model: inherit` to the frontmatter of the 12 teammate-spawned specialist agent definitions so spawned teammates resolve the lead session's full model ID (including context-window variants like `[1m]`).

Closes #940.

## What landed

| Commit | Content |
|---|---|
| `4d194c3a` | `model: inherit` added to all 12 teammate agent defs (uniform slot, after `color:`); `pact-orchestrator.md` untouched |
| `e7305d03` | PATCH version bump 4.4.16 → 4.4.17 (canonical 4 files) |
| `d4785b38` | Positive guard test `TestTeammateModelInheritance` (per-file `model == inherit` + cardinality pin) |

## Why

- Evidence base: three-condition resolution matrix in #940 — no-param spawns fall back to the harness default regardless of lead model/settings; explicit param alias pins but cannot express variants; frontmatter `inherit` resolves the lead's full model ID.
- **Orchestrator exemption** (resolved in issue body): empirical A/B under `--agent` launch shows `model: inherit` is a no-op with no parent; the existing forbid-test (`test_pact_orchestrator_agent.py`) codifies the asymmetry. The new guard test is the positive half of that contract.
- Zero plugin code parses agent frontmatter at runtime (PREPARE-verified), so the change surface is exactly: 12 defs + tests.

## Reviewer notes

- The `== 12` cardinality literal in the new guard is a **deliberate review-forcing ratchet** (same pattern as `EXPECTED_AGENTS`/`EXPECTED_SKILLS`): adding a future teammate def must touch this test consciously. A failure there is a prompt, not a defect.
- Test gate: 8587 passed / 13 skipped / 0 failed / 0 errors (`rtk proxy`, errors token explicitly checked). Non-vacuity proven per assertion leg via isolated-worktree mutations.

## Post-merge checklist

- [x] Re-run the resolution matrix — **tmux leg** (2026-06-12, plugin v4.4.18): Conditions A+B PASS, `[1m]` preserved — see [verification comment](https://github.com/Synaptic-Labs-AI/PACT-Plugin/pull/944#issuecomment-4692621218)
- [x] Re-run the resolution matrix — **in-process leg** (2026-06-12, plugin v4.4.18): Conditions A+B PASS, `[1m]` preserved at config layer — see [verification comment](https://github.com/Synaptic-Labs-AI/PACT-Plugin/pull/944#issuecomment-4692905454). **Dual-mode gate CLOSED.**
- [x] Annotated tag `v4.4.17` at merge commit + push + GitHub release (published 2026-06-11T22:14Z)


