### PR TITLE
fix(hooks): Python 3.9 compatibility — defer annotation evaluation, add static regression guard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.17",
+      "version": "4.4.18",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.17/      # Plugin version
+│               └── 4.4.18/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.17",
+  "version": "4.4.18",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.17
+> **Version**: 4.4.18
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/agents/pact-auditor.md
+++ b/pact-plugin/agents/pact-auditor.md
@@ -189,7 +189,7 @@ Common triggers:
 Your task uses `completion_type: "signal"` (not standard HANDOFF). This places you in the **signal-task carve-out** to the team-lead-only-completion rule (see [pact-completion-authority.md](../protocols/pact-completion-authority.md)). You self-complete because:
 
 - The task IS the signal — there is no HANDOFF deliverable for the team-lead to inspect.
-- The canonical predicate is `metadata.completion_type == "signal"` AND `metadata.type ∈ {"blocker", "algedonic"}` (mirrored at `agent_handoff_emitter.py`, `task_utils.py:184`, `session_resume.py:525`).
+- The canonical predicate is `metadata.completion_type == "signal"` AND `metadata.type ∈ {"blocker", "algedonic"}` (mirrored at `agent_handoff_emitter.py`, `task_utils.py:276`, `session_resume.py:522`).
 
 1. Store your final signal as `metadata.audit_summary` via TaskUpdate:
    ```

--- a/pact-plugin/hooks/__init__.py
+++ b/pact-plugin/hooks/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/pact-plugin/hooks/agent_handoff_emitter.py
+++ b/pact-plugin/hooks/agent_handoff_emitter.py
@@ -61,6 +61,8 @@ Input: JSON from stdin with task_id, task_subject, task_description,
 Output: {"suppressOutput": true} on every path; exit 0.
 """
 
+from __future__ import annotations
+
 import json
 import sys
 

--- a/pact-plugin/hooks/bootstrap_gate.py
+++ b/pact-plugin/hooks/bootstrap_gate.py
@@ -56,6 +56,8 @@ Output: JSON with hookSpecificOutput.permissionDecision (deny case)
         or {"suppressOutput": true} (allow / passthrough)
 """
 
+from __future__ import annotations
+
 # ─── stdlib first (used by _emit_load_failure_deny BEFORE wrapped imports) ───
 import json
 import os

--- a/pact-plugin/hooks/bootstrap_gate.py
+++ b/pact-plugin/hooks/bootstrap_gate.py
@@ -174,7 +174,7 @@ def _is_canonical_secretary_spawn(input_data: dict) -> bool:
       3. tool_input.name == "secretary" (_SECRETARY_NAME, canonical literal)
       4. tool_input.team_name == pact_context.get_team_name()
          (note: get_team_name() returns the disk team_name lowercased per
-         pact_context.py:221; the binding is case-INsensitive against the
+         pact_context.py:256; the binding is case-INsensitive against the
          disk value. Current session-slug naming is lowercase-by-
          construction, so this normalization is unreachable in practice.)
       5. NOT _team_has_secretary(team_name) — one-shot semantic; flips to

--- a/pact-plugin/hooks/bootstrap_marker_writer.py
+++ b/pact-plugin/hooks/bootstrap_marker_writer.py
@@ -44,6 +44,8 @@ Output: JSON with hookSpecificOutput.additionalContext (load-failure case)
         or {"suppressOutput": true} (every other path)
 """
 
+from __future__ import annotations
+
 # ─── stdlib first (used by _emit_load_failure_advisory BEFORE wrapped imports) ─
 import json
 import sys

--- a/pact-plugin/hooks/bootstrap_prompt_gate.py
+++ b/pact-plugin/hooks/bootstrap_prompt_gate.py
@@ -27,6 +27,8 @@ Output: JSON with hookSpecificOutput.additionalContext (inject case)
         or {"suppressOutput": true} (fast path / passthrough)
 """
 
+from __future__ import annotations
+
 # ─── stdlib first (used by _emit_load_failure_advisory BEFORE wrapped imports) ─
 import json
 import sys

--- a/pact-plugin/hooks/dispatch_gate.py
+++ b/pact-plugin/hooks/dispatch_gate.py
@@ -49,6 +49,8 @@ Input: JSON from stdin (tool_name, tool_input, agent_id, etc.)
 Output: stdout JSON per harness contract.
 """
 
+from __future__ import annotations
+
 # ─── stdlib first (used by _emit_load_failure_deny BEFORE wrapped imports) ─
 import json
 import sys

--- a/pact-plugin/hooks/file_tracker.py
+++ b/pact-plugin/hooks/file_tracker.py
@@ -12,6 +12,8 @@ Input: JSON from stdin with tool_input.file_path
 Output: JSON with additionalContext warning if conflict detected
 """
 
+from __future__ import annotations
+
 import json
 import os
 import sys

--- a/pact-plugin/hooks/git_commit_check.py
+++ b/pact-plugin/hooks/git_commit_check.py
@@ -15,14 +15,49 @@ Output: Exit code 2 to block, 0 to allow; errors to stderr
 
 from __future__ import annotations
 
+# ─── stdlib first (used by _emit_load_failure_deny BEFORE wrapped imports) ─
 import sys
 import json
 import re
-
-from shared.error_output import hook_error_json
-from shared.git_helpers import run_git
+from typing import NoReturn
 
 _SUPPRESS_OUTPUT = json.dumps({"suppressOutput": True})
+
+
+def _emit_load_failure_deny(stage: str, error: BaseException) -> NoReturn:
+    """Stdlib-only fail-closed deny for module-load failure. Mirrors the
+    ``team_guard`` / ``dispatch_gate`` / ``bootstrap_gate`` analogue.
+
+    Without this, a raise from the cross-package imports below would crash the
+    hook (exit 1), which the platform treats as a NON-blocking PreToolUse hook
+    — the Bash tool would PROCEED and the commit-compliance gate (credential
+    scanning included) would silently FAIL-OPEN. Emitting a deny + exit 2
+    keeps the gate fail-CLOSED. hookEventName MUST be present.
+    """
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                f"PACT git_commit_check {stage} failure — blocking for safety. "
+                f"{type(error).__name__}: {error}. Check hook installation "
+                "and shared module availability."
+            ),
+        }
+    }))
+    print(
+        f"Hook load error (git_commit_check / {stage}): {error}",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+# ─── fail-closed wrapper on cross-package imports ──────────────────────────
+try:
+    from shared.error_output import hook_error_json
+    from shared.git_helpers import run_git
+except BaseException as _module_load_error:  # noqa: BLE001 — fail-closed catch-all
+    _emit_load_failure_deny("module imports", _module_load_error)
 
 
 def get_staged_files():

--- a/pact-plugin/hooks/git_commit_check.py
+++ b/pact-plugin/hooks/git_commit_check.py
@@ -13,6 +13,8 @@ Input: JSON from stdin with tool_input containing the command
 Output: Exit code 2 to block, 0 to allow; errors to stderr
 """
 
+from __future__ import annotations
+
 import sys
 import json
 import re

--- a/pact-plugin/hooks/merge_guard_post.py
+++ b/pact-plugin/hooks/merge_guard_post.py
@@ -26,6 +26,7 @@ Output: None (side effect: writes or retires token file).
 
 from __future__ import annotations
 
+# ─── stdlib first (used by _emit_load_failure_alert BEFORE wrapped imports) ─
 import glob
 import json
 import os
@@ -33,26 +34,68 @@ import re
 import sys
 import time
 from pathlib import Path
+from typing import NoReturn
 
-import shared.pact_context as pact_context
-from shared.pact_context import get_session_id
 
-# Shared constants and cleanup — single source of truth for both hooks
-sys.path.insert(0, str(Path(__file__).parent))
-from shared.error_output import hook_error_json
+def _emit_load_failure_alert(stage: str, error: BaseException) -> NoReturn:
+    """Stdlib-only fail-LOUD alert for module-load failure. PostToolUse cannot
+    DENY (the tool already ran), so this is the nearest fail-closed equivalent.
 
-from shared.merge_guard_common import (
-    TOKEN_TTL,
-    TOKEN_DIR,
-    TOKEN_PREFIX,
-    MAX_USES,
-    USE_MARKER_SUFFIX,
-    LAYER1_SUCCESS_STDOUT_PATTERNS,
-    cleanup_consumed_tokens as _cleanup_consumed_tokens,
-    cleanup_unused_tokens as _cleanup_unused_tokens,
-    detect_command_operation_type,
-)
-from shared.tool_response import extract_tool_response
+    Channel semantics: on a non-zero exit the platform does NOT parse stdout
+    JSON — for PostToolUse exit 2 the channel that reaches the model is
+    STDERR. The complete advisory therefore lives on stderr; the stdout JSON
+    below is forensic belt-and-braces only. Exit 2 (never 0) keeps the
+    failure rc-visible — an additionalContext advisory + exit 0 would be
+    rc-clean while bricked, the self-masking shape this gate family avoids.
+
+    Both branches of this hook are skipped on load failure, hence the two
+    consequences named in the message: the Bash branch cannot RETIRE a
+    consumed merge token, and the AskUserQuestion branch cannot WRITE new
+    authorization tokens.
+    """
+    message = (
+        f"PACT merge_guard_post {stage} failure — merge-token write/retirement "
+        f"SKIPPED this turn; a consumed token may remain live, and subsequent "
+        f"merge approvals will also fail to record — expect merge_guard_pre "
+        f"denials until fixed. {type(error).__name__}: {error}. Check hook "
+        "installation and shared module availability."
+    )
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": message,
+        }
+    }))
+    print(
+        f"Hook load error (merge_guard_post / {stage}): {message}",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+# ─── fail-loud wrapper on cross-package imports ─────────────────────────────
+try:
+    import shared.pact_context as pact_context
+    from shared.pact_context import get_session_id
+
+    # Shared constants and cleanup — single source of truth for both hooks
+    sys.path.insert(0, str(Path(__file__).parent))
+    from shared.error_output import hook_error_json
+
+    from shared.merge_guard_common import (
+        TOKEN_TTL,
+        TOKEN_DIR,
+        TOKEN_PREFIX,
+        MAX_USES,
+        USE_MARKER_SUFFIX,
+        LAYER1_SUCCESS_STDOUT_PATTERNS,
+        cleanup_consumed_tokens as _cleanup_consumed_tokens,
+        cleanup_unused_tokens as _cleanup_unused_tokens,
+        detect_command_operation_type,
+    )
+    from shared.tool_response import extract_tool_response
+except BaseException as _module_load_error:  # noqa: BLE001 — fail-loud catch-all
+    _emit_load_failure_alert("module imports", _module_load_error)
 
 
 # Regex for a quoted-command region inside question prose. Tries

--- a/pact-plugin/hooks/merge_guard_post.py
+++ b/pact-plugin/hooks/merge_guard_post.py
@@ -24,6 +24,8 @@ Input: JSON from stdin with tool_name (AskUserQuestion or Bash), tool_input,
 Output: None (side effect: writes or retires token file).
 """
 
+from __future__ import annotations
+
 import glob
 import json
 import os

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -21,6 +21,8 @@ Input: JSON from stdin with tool_input containing the command
 Output: JSON with hookSpecificOutput.permissionDecision if blocking
 """
 
+from __future__ import annotations
+
 import glob
 import json
 import os

--- a/pact-plugin/hooks/missed_wake_scan.py
+++ b/pact-plugin/hooks/missed_wake_scan.py
@@ -59,6 +59,8 @@ Output: hookSpecificOutput.additionalContext on the surface path; otherwise
         {"suppressOutput": true}. Exit 0 on every path.
 """
 
+from __future__ import annotations
+
 import json
 import sys
 from datetime import datetime, timezone

--- a/pact-plugin/hooks/peer_inject.py
+++ b/pact-plugin/hooks/peer_inject.py
@@ -17,6 +17,8 @@ Input: JSON from stdin with agent_id, agent_type
 Output: JSON with hookSpecificOutput.additionalContext
 """
 
+from __future__ import annotations
+
 import json
 import sys
 from pathlib import Path  # noqa: F401  # re-export: corpus patches peer_inject.Path.home

--- a/pact-plugin/hooks/pin_caps.py
+++ b/pact-plugin/hooks/pin_caps.py
@@ -226,7 +226,7 @@ def parse_pins(pinned_content: str) -> List[Pin]:
                 # (`test_gate_forbidden_chars_derived_from_parser_table`)
                 # has a stable parser-side counterpart. Not "mitigation"
                 # — prevention via upstream split. Mirrors
-                # `pin_caps_gate.py:148-180`.
+                # `pin_caps_gate.py:184-216`.
                 rationale = rationale.translate(_FORBIDDEN_TERMINATOR_TABLE)
                 # Strict parser: empty rationale or > max → treat as no-override.
                 if rationale and len(rationale) <= OVERRIDE_RATIONALE_MAX:
@@ -475,9 +475,9 @@ def _violation_for_kind(pins: List[Pin], kind: str) -> Optional[CapViolation]:
 
     Post-parse-derivable from candidate new_body (not from post_pins):
       - `"embedded_pin"` — constructed in `check_add_allowed`
-                      (`pin_caps.py:313`) when `parse_pins(new_body)`
+                      (`pin_caps.py:315`) when `parse_pins(new_body)`
                       returns non-empty. Also rendered via the
-                      `compute_deny_reason` shortcut at `pin_caps.py:666-668`
+                      `compute_deny_reason` shortcut at `pin_caps.py:686-687`
                       which returns `DENY_REASON_EMBEDDED_PIN` directly
                       (no CapViolation constructor; the shortcut
                       bypasses `_render_deny_reason`). Not derivable
@@ -489,10 +489,10 @@ def _violation_for_kind(pins: List[Pin], kind: str) -> Optional[CapViolation]:
       - `"empty"`            — reserved for a future empty-pin predicate.
       - `"invalid_override"` — intent was to represent an invalid
                       override rationale, but the actual emitter path at
-                      `pin_caps_gate.py:248-250` returns a bare formatted
+                      `pin_caps_gate.py:293-295` returns a bare formatted
                       string (`f"Pin cap violation (invalid override):
                       {reason}"`) without constructing a CapViolation.
-                      A render branch at `pin_caps.py:802-806` remains
+                      A render branch at `pin_caps.py:821-825` remains
                       but is unreachable under the current emitter
                       graph. If a future refactor routes override
                       failures through a CapViolation, the render

--- a/pact-plugin/hooks/pin_caps.py
+++ b/pact-plugin/hooks/pin_caps.py
@@ -19,6 +19,8 @@ barrier); a drift-detection test in test_staleness.py guards against
 divergence.
 """
 
+from __future__ import annotations
+
 import re
 from typing import List, Literal, NamedTuple, Optional
 

--- a/pact-plugin/hooks/pin_caps_gate.py
+++ b/pact-plugin/hooks/pin_caps_gate.py
@@ -49,6 +49,8 @@ Output: JSON with hookSpecificOutput.permissionDecision (deny case)
         or {"suppressOutput": true} (allow / passthrough)
 """
 
+from __future__ import annotations
+
 import json
 import sys
 from pathlib import Path

--- a/pact-plugin/hooks/pin_caps_gate.py
+++ b/pact-plugin/hooks/pin_caps_gate.py
@@ -51,28 +51,62 @@ Output: JSON with hookSpecificOutput.permissionDecision (deny case)
 
 from __future__ import annotations
 
+# ─── stdlib first (used by _emit_load_failure_deny BEFORE wrapped imports) ─
 import json
 import sys
 from pathlib import Path
-from typing import Optional
-
-import shared.pact_context as pact_context
-from shared import (
-    file_lock,
-    match_project_claude_md,
-)
-from shared.failure_log import append_failure
-import pin_caps
-from pin_caps import (
-    OVERRIDE_COMMENT_RE,
-    OVERRIDE_RATIONALE_MAX,
-    apply_edit_and_parse,
-    compute_deny_reason,
-    evaluate_full_state,
-    parse_pins,
-)
+from typing import NoReturn, Optional
 
 _SUPPRESS_OUTPUT = json.dumps({"suppressOutput": True})
+
+
+def _emit_load_failure_deny(stage: str, error: BaseException) -> NoReturn:
+    """Stdlib-only fail-closed deny for module-load failure. Mirrors the
+    ``team_guard`` / ``dispatch_gate`` / ``bootstrap_gate`` analogue.
+
+    Without this, a raise from the cross-package imports below would crash the
+    hook (exit 1), which the platform treats as a NON-blocking PreToolUse hook
+    — the Edit/Write tool would PROCEED and the pin-caps gate would silently
+    FAIL-OPEN. Emitting a deny + exit 2 keeps the gate fail-CLOSED.
+    hookEventName MUST be present.
+    """
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                f"PACT pin_caps_gate {stage} failure — blocking for safety. "
+                f"{type(error).__name__}: {error}. Check hook installation "
+                "and shared module availability."
+            ),
+        }
+    }))
+    print(
+        f"Hook load error (pin_caps_gate / {stage}): {error}",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+# ─── fail-closed wrapper on cross-package imports ──────────────────────────
+try:
+    import shared.pact_context as pact_context
+    from shared import (
+        file_lock,
+        match_project_claude_md,
+    )
+    from shared.failure_log import append_failure
+    import pin_caps
+    from pin_caps import (
+        OVERRIDE_COMMENT_RE,
+        OVERRIDE_RATIONALE_MAX,
+        apply_edit_and_parse,
+        compute_deny_reason,
+        evaluate_full_state,
+        parse_pins,
+    )
+except BaseException as _module_load_error:  # noqa: BLE001 — fail-closed catch-all
+    _emit_load_failure_deny("module imports", _module_load_error)
 
 _GATED_TOOLS = frozenset({"Edit", "Write"})
 

--- a/pact-plugin/hooks/pin_caps_gate.py
+++ b/pact-plugin/hooks/pin_caps_gate.py
@@ -183,7 +183,7 @@ def _validate_override_rationale(rationale: Optional[str]) -> Optional[str]:
         )
     # Unreached at runtime under the current call graph: both the gate's
     # `_extract_override_rationale` AND the parser's `parse_pins` use
-    # str.splitlines() (pin_caps.py:166, post-#492-F1). splitlines()
+    # str.splitlines() (pin_caps.py:191, post-#492-F1). splitlines()
     # recognizes \n, \r, U+2028, U+2029, U+0085 (and VT, FF, FS, GS, RS)
     # as line boundaries, so any rationale containing one of those chars
     # is split before OVERRIDE_COMMENT_RE.fullmatch sees it — fullmatch

--- a/pact-plugin/hooks/pin_staleness_gate.py
+++ b/pact-plugin/hooks/pin_staleness_gate.py
@@ -29,6 +29,8 @@ Output: JSON with hookSpecificOutput.permissionDecision (deny case)
         or {\"suppressOutput\": true} (allow / passthrough)
 """
 
+from __future__ import annotations
+
 import json
 import sys
 from pathlib import Path

--- a/pact-plugin/hooks/pin_staleness_gate.py
+++ b/pact-plugin/hooks/pin_staleness_gate.py
@@ -19,10 +19,13 @@ Gate triggers only when ALL hold:
   4. Stale-pins-pending marker exists in session_dir
   5. Not a teammate session (teammates bypass; CLAUDE.md edits are scoped to the team-lead session)
 
-SACROSANCT: every raisable path is wrapped in try/except that defaults
-to allow (exit 0 with suppressOutput). A gate bug must never block a
-tool call. Fail-open: missing session_dir, unparseable CLAUDE.md,
-unresolvable marker → allow.
+SACROSANCT (post-load runtime): every raisable path after module load is
+wrapped in try/except that defaults to allow (exit 0 with suppressOutput).
+A gate-logic bug must never block a tool call. Fail-open: missing
+session_dir, unparseable CLAUDE.md, unresolvable marker → allow.
+Module LOAD failure is the deliberate exception: a failed import would
+otherwise crash the hook (exit 1 = platform-non-blocking = silent
+fail-open), so it denies via _emit_load_failure_deny instead.
 
 Input: JSON from stdin with tool_name, tool_input, session_id, etc.
 Output: JSON with hookSpecificOutput.permissionDecision (deny case)
@@ -31,15 +34,50 @@ Output: JSON with hookSpecificOutput.permissionDecision (deny case)
 
 from __future__ import annotations
 
+# ─── stdlib first (used by _emit_load_failure_deny BEFORE wrapped imports) ─
 import json
 import sys
 from pathlib import Path
-
-import shared.pact_context as pact_context
-from shared import match_project_claude_md
-from pin_caps import parse_pins
+from typing import NoReturn
 
 _SUPPRESS_OUTPUT = json.dumps({"suppressOutput": True})
+
+
+def _emit_load_failure_deny(stage: str, error: BaseException) -> NoReturn:
+    """Stdlib-only fail-closed deny for module-load failure. Mirrors the
+    ``team_guard`` / ``dispatch_gate`` / ``bootstrap_gate`` analogue.
+
+    Without this, a raise from the cross-package imports below would crash the
+    hook (exit 1), which the platform treats as a NON-blocking PreToolUse hook
+    — the Edit/Write tool would PROCEED and the staleness gate would silently
+    FAIL-OPEN. Emitting a deny + exit 2 keeps the gate fail-CLOSED.
+    hookEventName MUST be present.
+    """
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                f"PACT pin_staleness_gate {stage} failure — blocking for safety. "
+                f"{type(error).__name__}: {error}. Check hook installation "
+                "and shared module availability."
+            ),
+        }
+    }))
+    print(
+        f"Hook load error (pin_staleness_gate / {stage}): {error}",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+# ─── fail-closed wrapper on cross-package imports ──────────────────────────
+try:
+    import shared.pact_context as pact_context
+    from shared import match_project_claude_md
+    from pin_caps import parse_pins
+except BaseException as _module_load_error:  # noqa: BLE001 — fail-closed catch-all
+    _emit_load_failure_deny("module imports", _module_load_error)
 
 # Marker file name written when stale-pins-pending state is detected.
 # Placed in session_dir so it is per-session scoped — clears on new

--- a/pact-plugin/hooks/postcompact_archive.py
+++ b/pact-plugin/hooks/postcompact_archive.py
@@ -20,6 +20,8 @@ Input: JSON from stdin with compact_summary field
 Output: JSON suppressOutput on stdout (clean path) or hook_error_json (failure)
 """
 
+from __future__ import annotations
+
 import json
 import os
 import sys

--- a/pact-plugin/hooks/precompact_state_reminder.py
+++ b/pact-plugin/hooks/precompact_state_reminder.py
@@ -26,6 +26,8 @@ Input: JSON from stdin (PreCompact event data)
 Output: JSON with custom_instructions on stdout
 """
 
+from __future__ import annotations
+
 import json
 import sys
 from typing import Any

--- a/pact-plugin/hooks/refresh/__init__.py
+++ b/pact-plugin/hooks/refresh/__init__.py
@@ -8,6 +8,8 @@ for the compaction refresh system. The main entry point is
 `extract_workflow_state()` which returns a checkpoint-ready dict.
 """
 
+from __future__ import annotations
+
 from .transcript_parser import parse_transcript, Turn
 from .workflow_detector import detect_active_workflow, WorkflowInfo
 from .step_extractor import extract_current_step, StepInfo, PendingAction

--- a/pact-plugin/hooks/refresh/checkpoint_builder.py
+++ b/pact-plugin/hooks/refresh/checkpoint_builder.py
@@ -8,6 +8,8 @@ refresh plan, suitable for writing to disk and later refresh.
 Also provides shared utilities for checkpoint path resolution.
 """
 
+from __future__ import annotations
+
 import os
 import sys
 from datetime import datetime, timezone

--- a/pact-plugin/hooks/refresh/constants.py
+++ b/pact-plugin/hooks/refresh/constants.py
@@ -11,6 +11,8 @@ STEP_DESCRIPTIONS and PROSE_CONTEXT_TEMPLATES are imported from
 shared_constants.py to centralize constants shared by refresh consumers.
 """
 
+from __future__ import annotations
+
 # Import shared constants for re-export
 from .shared_constants import STEP_DESCRIPTIONS, PROSE_CONTEXT_TEMPLATES
 

--- a/pact-plugin/hooks/refresh/patterns.py
+++ b/pact-plugin/hooks/refresh/patterns.py
@@ -19,6 +19,8 @@ parseable. Dispatch code (bootstrap_gate, hooks.json matchers, persona,
 commands, skills, protocols) is clean Agent only — no dual-naming.
 """
 
+from __future__ import annotations
+
 import re
 from dataclasses import dataclass
 

--- a/pact-plugin/hooks/refresh/shared_constants.py
+++ b/pact-plugin/hooks/refresh/shared_constants.py
@@ -9,6 +9,8 @@ test_checkpoint_builder.py). Extracting these to a shared module eliminates
 code duplication (DRY principle).
 """
 
+from __future__ import annotations
+
 # === STEP DESCRIPTIONS ===
 # Human-readable descriptions for workflow steps, used in refresh messages
 # to help the AI understand what each state means when resuming after compaction

--- a/pact-plugin/hooks/refresh/step_extractor.py
+++ b/pact-plugin/hooks/refresh/step_extractor.py
@@ -7,6 +7,8 @@ Analyzes transcript turns after a workflow trigger to determine
 the current step/phase and any pending user action.
 """
 
+from __future__ import annotations
+
 import re
 from dataclasses import dataclass, field
 from typing import Any

--- a/pact-plugin/hooks/refresh/transcript_parser.py
+++ b/pact-plugin/hooks/refresh/transcript_parser.py
@@ -12,6 +12,8 @@ Supports both dispatch models for agent detection:
 - Agent Teams teammate: name and team_name fields in Task input
 """
 
+from __future__ import annotations
+
 import json
 import sys
 from dataclasses import dataclass, field

--- a/pact-plugin/hooks/refresh/workflow_detector.py
+++ b/pact-plugin/hooks/refresh/workflow_detector.py
@@ -8,6 +8,8 @@ checking for trigger commands, agent invocations, and termination
 signals.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 from .transcript_parser import Turn, find_trigger_turn_index

--- a/pact-plugin/hooks/session_end.py
+++ b/pact-plugin/hooks/session_end.py
@@ -17,6 +17,8 @@ Input: JSON from stdin with session context
 Output: None (SessionEnd hooks cannot inject context)
 """
 
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -1200,7 +1200,7 @@ def main():
         #
         # Fail-open layering (defense in depth):
         #   1. Primary: get_task_list() has its own internal try/except
-        #      (shared/task_utils.py:50-59) that returns None on any
+        #      (shared/task_utils.py:52-61) that returns None on any
         #      filesystem or JSON parse error. Callers never see a raise
         #      from a corrupted tasks dir.
         #   2. Belt-and-suspenders: main()'s outer try/except catches

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -31,6 +31,8 @@ Input: JSON from stdin with session context
 Output: JSON with `hookSpecificOutput.additionalContext` for status
 """
 
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/pact-plugin/hooks/shared/__init__.py
+++ b/pact-plugin/hooks/shared/__init__.py
@@ -17,6 +17,8 @@ This package provides shared utilities for hooks:
 - gh_helpers: Shared gh CLI wrappers (fail-open by construction)
 """
 
+from __future__ import annotations
+
 from .task_utils import (
     get_task_list,
     find_feature_task,

--- a/pact-plugin/hooks/shared/agent_handoff_marker.py
+++ b/pact-plugin/hooks/shared/agent_handoff_marker.py
@@ -36,6 +36,8 @@ event. This biases to HANDOFF preservation, never loss — the intended
 trade-off (see occupant_hash).
 """
 
+from __future__ import annotations
+
 import errno
 import hashlib
 import os

--- a/pact-plugin/hooks/shared/claude_md_manager.py
+++ b/pact-plugin/hooks/shared/claude_md_manager.py
@@ -20,6 +20,8 @@ The resolve_project_claude_md_path() helper picks whichever exists, with
 default path so creators land at the preferred location.
 """
 
+from __future__ import annotations
+
 import fcntl  # Unix-only; PACT supports macOS/Linux. No Windows compat shim.
 import os
 import re

--- a/pact-plugin/hooks/shared/constants.py
+++ b/pact-plugin/hooks/shared/constants.py
@@ -6,6 +6,9 @@ Used by: test_patterns.py (cross-list consistency checks),
          postcompact_archive.py (get_compact_summary_path),
          session_init.py (get_compact_summary_path).
 """
+
+from __future__ import annotations
+
 from pathlib import Path
 
 from .paths import get_claude_config_dir

--- a/pact-plugin/hooks/shared/dispatch_helpers.py
+++ b/pact-plugin/hooks/shared/dispatch_helpers.py
@@ -23,6 +23,8 @@ Module-load discipline (architect §5.6):
   re-raised BaseException.
 """
 
+from __future__ import annotations
+
 import json
 import sys
 import os

--- a/pact-plugin/hooks/shared/error_output.py
+++ b/pact-plugin/hooks/shared/error_output.py
@@ -9,6 +9,8 @@ Claude Code's UI can display hook errors to the user instead of showing
 "hook error (No output)" or silently suppressing the error.
 """
 
+from __future__ import annotations
+
 import json
 
 

--- a/pact-plugin/hooks/shared/failure_log.py
+++ b/pact-plugin/hooks/shared/failure_log.py
@@ -42,6 +42,8 @@ File location: ~/.claude/pact-sessions/_session_init_failures.log
 Permissions: 0o600 (owner read/write only); parent directory 0o700.
 """
 
+from __future__ import annotations
+
 import json
 from datetime import datetime, timezone
 from pathlib import Path

--- a/pact-plugin/hooks/shared/intentional_wait.py
+++ b/pact-plugin/hooks/shared/intentional_wait.py
@@ -92,8 +92,8 @@ DEFAULT_THRESHOLD_MINUTES = 30
 #
 # Auditor signal-tasks are NOT in this set — they self-complete via
 # `metadata.completion_type == "signal"` + `metadata.type in {"blocker",
-# "algedonic"}` (the inline-literal pattern at task_utils.py:184 /
-# session_resume.py:525). Two distinct exemption surfaces:
+# "algedonic"}` (the inline-literal pattern at task_utils.py:276 /
+# session_resume.py:522). Two distinct exemption surfaces:
 # - SELF_COMPLETE_EXEMPT_AGENT_TYPES: by team-config agentType lookup.
 # - signal-task pattern: by task metadata, applies to any agent.
 SELF_COMPLETE_EXEMPT_AGENT_TYPES: frozenset = frozenset({
@@ -352,8 +352,8 @@ def is_self_complete_exempt(
        surface short-circuits to False (fail-closed).
     2. By signal-task metadata: task.metadata.completion_type == "signal" AND
        task.metadata.type in {"blocker", "algedonic"}. Mirrors the inline
-       literal at agent_handoff_emitter.py / task_utils.py:184 /
-       session_resume.py:525. Independent of `team_name`.
+       literal at agent_handoff_emitter.py / task_utils.py:276 /
+       session_resume.py:522. Independent of `team_name`.
 
     Pure function; never raises on plain dicts (PACT task representation
     via json.loads); defaults to False on missing or malformed fields

--- a/pact-plugin/hooks/shared/intentional_wait.py
+++ b/pact-plugin/hooks/shared/intentional_wait.py
@@ -47,6 +47,8 @@ Public surface:
   Consumed by task_lifecycle_gate.work_addblockedby_missing.
 """
 
+from __future__ import annotations
+
 from datetime import datetime, timezone
 from typing import Any
 

--- a/pact-plugin/hooks/shared/marker_schema.py
+++ b/pact-plugin/hooks/shared/marker_schema.py
@@ -24,6 +24,8 @@ signature is a fingerprint that closes the trivial Bash-touch bypass
 (#662) and creates a detection surface for forgery; it is not a MAC.
 """
 
+from __future__ import annotations
+
 import hashlib
 
 # Marker schema version. Bump if marker JSON shape changes; verifier

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -47,6 +47,8 @@ eager-cleanup at session start). Disk-hygiene defense — not a primary
 security check; the primary check is I-3 TTL expiry at 5 minutes.
 """
 
+from __future__ import annotations
+
 import glob
 import os
 import re

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -10,6 +10,8 @@ by session_init.py and read by subsequent hooks via init() + accessors.
 See: docs/architecture/pact-context-module.md for full design rationale.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/pact-plugin/hooks/shared/paths.py
+++ b/pact-plugin/hooks/shared/paths.py
@@ -8,6 +8,9 @@ Used by: shared/{constants,session_registry,failure_log,merge_guard_common,
          task_utils,pact_context,...}.py and the hook entrypoints
          (dispatch_gate, session_init, session_end, ...).
 """
+
+from __future__ import annotations
+
 import os
 from pathlib import Path
 

--- a/pact-plugin/hooks/shared/peer_context.py
+++ b/pact-plugin/hooks/shared/peer_context.py
@@ -18,6 +18,8 @@ agent_name under tmux, so re-claiming a role would reintroduce the mis-roling
 this relocation fixes).
 """
 
+from __future__ import annotations
+
 import json
 import re
 from pathlib import Path

--- a/pact-plugin/hooks/shared/session_journal.py
+++ b/pact-plugin/hooks/shared/session_journal.py
@@ -44,6 +44,8 @@ Permissions: 0o600 (owner read/write only)
 Directory permissions: 0o700 (owner only)
 """
 
+from __future__ import annotations
+
 import fcntl
 import json
 import os

--- a/pact-plugin/hooks/shared/session_registry.py
+++ b/pact-plugin/hooks/shared/session_registry.py
@@ -49,6 +49,8 @@ Fail-safe everywhere: register() is a no-op and never raises; resolve()
     no-op as "use current behavior".
 """
 
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/pact-plugin/hooks/shared/session_resume.py
+++ b/pact-plugin/hooks/shared/session_resume.py
@@ -12,6 +12,8 @@ Manages:
 4. Detecting paused state from session journal
 """
 
+from __future__ import annotations
+
 import os
 import re
 import sys

--- a/pact-plugin/hooks/shared/session_state.py
+++ b/pact-plugin/hooks/shared/session_state.py
@@ -51,7 +51,7 @@ _NAME_MAX_CHARS = 200
 # input containing anything outside [A-Za-z0-9_-] is rejected. This
 # matches the shape of legitimate values:
 #   - team_name: "pact-" + hex-with-hyphens (per generate_team_name
-#     at session_init.py:173, which uses `re.sub(r"[^a-f0-9-]", "",
+#     at session_init.py:376, which uses `re.sub(r"[^a-f0-9-]", "",
 #     session_id[:8])`).
 #   - feature_id: numeric task IDs or UUIDs (hex + hyphens).
 # Rejects ".", "..", "../etc", path separators, control chars, null,
@@ -142,7 +142,7 @@ def is_safe_path_component(value: str) -> bool:
 
     Defense-in-depth against path-traversal via tampered session
     context (see security review Finding 2). The upstream allowlist
-    lives at `session_init.py:173` — `re.sub(r"[^a-f0-9-]", "",
+    lives at `session_init.py:401` — `re.sub(r"[^a-f0-9-]", "",
     session_id[:8])` — which already filters path separators, `..`,
     nulls, and controls at team-name generation time. This guard is a
     second line of defense at the I/O boundary.

--- a/pact-plugin/hooks/shared/session_state.py
+++ b/pact-plugin/hooks/shared/session_state.py
@@ -27,6 +27,8 @@ Architecture reference: docs/architecture/journal-based-task-scanner.md
 in the fix/journal-based-task-scanner worktree.
 """
 
+from __future__ import annotations
+
 import json
 import re
 from pathlib import Path

--- a/pact-plugin/hooks/shared/symlinks.py
+++ b/pact-plugin/hooks/shared/symlinks.py
@@ -11,6 +11,8 @@ Creates two types of symlinks:
    (enables non-prefixed agent names like "pact-secretary")
 """
 
+from __future__ import annotations
+
 import os
 from pathlib import Path
 

--- a/pact-plugin/hooks/shared/task_utils.py
+++ b/pact-plugin/hooks/shared/task_utils.py
@@ -23,6 +23,8 @@ Functions:
     read_task_json: Read the raw task JSON by id + team_name (path-traversal safe)
 """
 
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/pact-plugin/hooks/shared/tool_response.py
+++ b/pact-plugin/hooks/shared/tool_response.py
@@ -19,6 +19,8 @@ a SECURITY warning to stderr identifying it as a possible
 envelope-confusion attack, and returns the canonical `tool_response` value.
 """
 
+from __future__ import annotations
+
 import sys
 
 

--- a/pact-plugin/hooks/staleness.py
+++ b/pact-plugin/hooks/staleness.py
@@ -15,6 +15,8 @@ Extracted from session_init.py to keep that file focused on hook orchestration
 and under the 500-line maintainability limit.
 """
 
+from __future__ import annotations
+
 import os
 import re
 import subprocess

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -67,6 +67,8 @@ Rule coverage:
   - Every gate decision emits a session_journal lifecycle_decision event
 """
 
+from __future__ import annotations
+
 # ─── stdlib first (used by _emit_load_failure_advisory BEFORE wrapped imports) ─
 import json
 import os

--- a/pact-plugin/hooks/team_guard.py
+++ b/pact-plugin/hooks/team_guard.py
@@ -12,6 +12,8 @@ Input: JSON from stdin with tool_input containing Task parameters
 Output: JSON with hookSpecificOutput.permissionDecision if blocking
 """
 
+from __future__ import annotations
+
 # ─── stdlib first (used by _emit_load_failure_deny BEFORE wrapped imports) ─
 import json
 import sys

--- a/pact-plugin/hooks/teammate_idle.py
+++ b/pact-plugin/hooks/teammate_idle.py
@@ -22,6 +22,8 @@ Input: JSON from stdin with teammate_name, team_name
 Output: JSON with systemMessage (shutdown suggestion / force request)
 """
 
+from __future__ import annotations
+
 import json
 import sys
 from collections.abc import Callable

--- a/pact-plugin/hooks/track_files.py
+++ b/pact-plugin/hooks/track_files.py
@@ -11,6 +11,8 @@ Input: JSON from stdin with tool_name, tool_input, tool_response
 Output: None (writes to tracking file for later memory association)
 """
 
+from __future__ import annotations
+
 import json
 import sys
 from datetime import datetime, timezone

--- a/pact-plugin/hooks/validate_handoff.py
+++ b/pact-plugin/hooks/validate_handoff.py
@@ -35,6 +35,8 @@ Input: JSON from stdin with `last_assistant_message` (preferred, SDK v2.1.47+),
 Output: JSON with `systemMessage` if handoff format is incomplete
 """
 
+from __future__ import annotations
+
 import json
 import sys
 import re

--- a/pact-plugin/hooks/worktree_guard.py
+++ b/pact-plugin/hooks/worktree_guard.py
@@ -12,6 +12,8 @@ Input: JSON from stdin with tool_input.file_path
 Output: JSON with hookSpecificOutput.permissionDecision if blocking
 """
 
+from __future__ import annotations
+
 import json
 import sys
 import os

--- a/pact-plugin/hooks/worktree_guard.py
+++ b/pact-plugin/hooks/worktree_guard.py
@@ -18,8 +18,46 @@ import json
 import sys
 import os
 from pathlib import Path
+from typing import NoReturn
 
 _SUPPRESS_OUTPUT = json.dumps({"suppressOutput": True})
+
+
+def _emit_load_failure_deny(stage: str, error: BaseException) -> NoReturn:
+    """Stdlib-only fail-closed deny. Mirrors the ``team_guard`` /
+    ``dispatch_gate`` / ``bootstrap_gate`` analogue.
+
+    This module imports only stdlib, so there is no cross-package import to
+    wrap (an import wrapper here would be vacuous). The live fail-open
+    exposure is RUNTIME: an uncaught gate-logic exception crashes the hook
+    (exit 1), which the platform treats as a NON-blocking PreToolUse hook —
+    the Edit/Write would PROCEED outside the worktree boundary. main() wraps
+    everything after stdin parsing in ``except Exception`` routing here
+    (stdin-parse failure stays fail-open: input-side failure is the
+    harness's domain and cannot be evaluated, mirroring bootstrap_gate).
+
+    Residual not covered here: an in-file SyntaxError / parse-time crash
+    still exits 1 → fail-open; no in-file code can close that (a file cannot
+    wrap its own parse). That class is held closed by the static
+    annotation-compat guard in tests/ (Python 3.9 importability rules).
+    hookEventName MUST be present.
+    """
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                f"PACT worktree_guard {stage} failure — blocking for safety. "
+                f"{type(error).__name__}: {error}. Check hook installation "
+                "and shared module availability."
+            ),
+        }
+    }))
+    print(
+        f"Hook load error (worktree_guard / {stage}): {error}",
+        file=sys.stderr,
+    )
+    sys.exit(2)
 
 # Paths always allowed regardless of worktree
 ALLOW_PATTERNS = [
@@ -206,12 +244,22 @@ def main():
         print(_SUPPRESS_OUTPUT)
         sys.exit(0)
 
-    file_path = input_data.get("tool_input", {}).get("file_path", "")
-    if not file_path:
-        print(_SUPPRESS_OUTPUT)
-        sys.exit(0)
+    try:
+        file_path = input_data.get("tool_input", {}).get("file_path", "")
+        if not file_path:
+            print(_SUPPRESS_OUTPUT)
+            sys.exit(0)
 
-    error = check_worktree_boundary(file_path, worktree_path)
+        error = check_worktree_boundary(file_path, worktree_path)
+    except Exception as e:
+        # Runtime fail-CLOSED — a gate-logic exception must DENY. Uncaught it
+        # would exit 1, which PreToolUse treats as NON-blocking, and the
+        # Edit/Write would proceed outside the worktree boundary. The wrap
+        # starts at tool_input extraction: a valid-JSON-but-non-dict
+        # tool_input raises AttributeError right here. except Exception (not
+        # BaseException) so SystemExit from the legitimate decision paths
+        # above passes through.
+        _emit_load_failure_deny("runtime", e)
 
     if error:
         # hookEventName is required by the harness; missing it silently fails open

--- a/pact-plugin/tests/runbooks/923-missed-wake-live-probe.md
+++ b/pact-plugin/tests/runbooks/923-missed-wake-live-probe.md
@@ -102,10 +102,10 @@ edits. Recommended non-mocked test coverage, **priority by blast radius**:
 
 | # | Caller | Severity under Agent Teams (pre-fix) | Own non-mocked test? | Test shape |
 |---|--------|--------------------------------------|----------------------|------------|
-| 1 | `missed_wake_scan.py:274` | **INERT** — alarm never fires (the #923 subject) | **DONE** — `test_missed_wake_scan_integration.py` IT-1/IT-2 | `run_surface` e2e via `Path.home` redirect + real team dir → surfaces + 1 journal event |
-| 2 | `teammate_idle.py:316` | **INERT** — idle-cleanup + auto-shutdown nudge dead (2nd live bug) | **SMOKE DONE** (IT-6); fuller e2e RECOMMENDED | arg-less `get_task_list()` resolves the team dir → `check_idle_cleanup` escalation path runs |
-| 3 | `session_init.py:1211` | **PARTIAL** — post-compaction checkpoint degrades to the bootstrap safety-net | RECOMMENDED (medium) | build the post-compaction checkpoint from a real team dir → `find_feature_task`/`current_phase`/`active_agents` non-empty |
-| 4 | `session_end.py:837` | **MINOR** — only the secondary untracked-PR scan lost (primary PR-unpause path still fires via journal) | OPTIONAL (low) | `check_unpaused_pr` reads a real team dir for the secondary scan |
+| 1 | `missed_wake_scan.py:276` | **INERT** — alarm never fires (the #923 subject) | **DONE** — `test_missed_wake_scan_integration.py` IT-1/IT-2 | `run_surface` e2e via `Path.home` redirect + real team dir → surfaces + 1 journal event |
+| 2 | `teammate_idle.py:319` | **INERT** — idle-cleanup + auto-shutdown nudge dead (2nd live bug) | **SMOKE DONE** (IT-6); fuller e2e RECOMMENDED | arg-less `get_task_list()` resolves the team dir → `check_idle_cleanup` escalation path runs |
+| 3 | `session_init.py:1214` | **PARTIAL** — post-compaction checkpoint degrades to the bootstrap safety-net | RECOMMENDED (medium) | build the post-compaction checkpoint from a real team dir → `find_feature_task`/`current_phase`/`active_agents` non-empty |
+| 4 | `session_end.py:840` | **MINOR** — only the secondary untracked-PR scan lost (primary PR-unpause path still fires via journal) | OPTIONAL (low) | `check_unpaused_pr` reads a real team dir for the secondary scan |
 
 **Key framing:** callers 3 & 4 are already REPAIRED by the GLOBAL fix — their
 own non-mocked tests would be **regression-pinning** coverage (prevent a future

--- a/pact-plugin/tests/test_claude_md_resolver_parity.py
+++ b/pact-plugin/tests/test_claude_md_resolver_parity.py
@@ -119,11 +119,11 @@ def resolver_memory_api(tmp: Path, monkeypatch) -> str:
 def resolver_worktree_guard(tmp: Path, monkeypatch) -> str:
     """
     worktree_guard has no importable helper -- its probe is inline at
-    worktree_guard.py:139-144. This wrapper mirrors that exact expression.
+    worktree_guard.py:141-146. This wrapper mirrors that exact expression.
     Because the inline probe is a bool, drift here is especially easy to
     miss without this parity test.
     """
-    # Mirror worktree_guard.py lines 139-144 exactly
+    # Mirror worktree_guard.py lines 141-146 exactly
     is_project_dir = (
         (tmp / "CLAUDE.md").exists()
         or (tmp / ".claude" / "CLAUDE.md").exists()

--- a/pact-plugin/tests/test_claude_md_resolver_parity.py
+++ b/pact-plugin/tests/test_claude_md_resolver_parity.py
@@ -119,11 +119,11 @@ def resolver_memory_api(tmp: Path, monkeypatch) -> str:
 def resolver_worktree_guard(tmp: Path, monkeypatch) -> str:
     """
     worktree_guard has no importable helper -- its probe is inline at
-    worktree_guard.py:141-146. This wrapper mirrors that exact expression.
+    worktree_guard.py:179-184. This wrapper mirrors that exact expression.
     Because the inline probe is a bool, drift here is especially easy to
     miss without this parity test.
     """
-    # Mirror worktree_guard.py lines 141-146 exactly
+    # Mirror worktree_guard.py lines 179-184 exactly
     is_project_dir = (
         (tmp / "CLAUDE.md").exists()
         or (tmp / ".claude" / "CLAUDE.md").exists()

--- a/pact-plugin/tests/test_config_dir_migration_completeness.py
+++ b/pact-plugin/tests/test_config_dir_migration_completeness.py
@@ -51,7 +51,7 @@ def _hardcoded_home_claude(tree: ast.AST, basename: str) -> list[tuple[str, int,
     `Path.home() / '.claude'`, so it catches BOTH the bare 2-segment root AND any
     3+-segment state path (`.../"tasks"`, etc.), and is multi-line-robust (the AST
     normalizes a line-wrapped construction into one expression — a same-line grep
-    would miss the `session_state.py:511-517`-style multi-line form). Nested
+    would miss the `session_state.py:513-519`-style multi-line form). Nested
     BinOps at one site are deduped to the outermost (longest) per (file, lineno).
     """
     found: dict[tuple[str, int], str] = {}

--- a/pact-plugin/tests/test_emitter_robustness.py
+++ b/pact-plugin/tests/test_emitter_robustness.py
@@ -22,7 +22,7 @@ class TestMalformedStdin:
     """#10 remediation (per task #16): closes the header promise-drift at
     lines 6-8 — "Comprehensive coverage (malformed stdin, ...) lands in
     the TEST phase." Marker-OSError and fallback-field landed in initial
-    TEST; JSONDecodeError path at agent_handoff_emitter.py:134-138 did
+    TEST; JSONDecodeError path at agent_handoff_emitter.py:99-102 did
     not. These tests pin that path directly.
 
     AC #8 invariant under test: no matter what stdin carries, the

--- a/pact-plugin/tests/test_gh_helpers.py
+++ b/pact-plugin/tests/test_gh_helpers.py
@@ -73,7 +73,7 @@ class TestCheckPrStateGhHelpersHappyPath:
 
         Pins the `.upper()` in the return path. Old gh releases and some
         JSON clients can return canonical states in lowercase; the
-        detector's string comparison at session_end.py:157 is
+        detector's string comparison at session_end.py:160 is
         uppercase-sensitive, so the wrapper MUST normalize.
         """
         from shared.gh_helpers import check_pr_state

--- a/pact-plugin/tests/test_handoff_unclaim_twin_917.py
+++ b/pact-plugin/tests/test_handoff_unclaim_twin_917.py
@@ -108,7 +108,7 @@ class TestB2R2WhitespaceTwin:
     """M4: #917/#901 R2 (validate-before-claim) F3 TWIN for b2. b1's R2 whitespace
     handling is pinned by test_emitter_resolution.py::test_owner_whitespace_only_
     is_treated_as_falsy; b2 (_emit_lead_side_agent_handoff) implements the SAME
-    guards (task_lifecycle_gate.py:413 `not owner.strip()`, :431-432 `not
+    guards (task_lifecycle_gate.py:440 `not owner.strip()`, :458-459 `not
     subject.strip()`→"(no subject)") but had NO twin coverage (the gap the
     coverage review surfaced). R2 guards the claim-without-write poison on the
     LEAD path: a whitespace-only owner would pass a bare `not owner` check, claim

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -5091,7 +5091,7 @@ class TestSessionScoping:
         the AND-short-circuit on `not token_session` left tokens with empty
         session_id through — the bypass surface SEC-S1 closes.
 
-        Cycle-2 revised asymmetric predicate at merge_guard_pre.py:633:
+        Cycle-2 revised asymmetric predicate at merge_guard_pre.py:635:
         `if current_session: if not token_session or current_session != token_session: continue`
         — when current_session IS populated, both an empty token_session AND
         a foreign token_session reject. Graceful-degradation preserved at
@@ -5102,7 +5102,7 @@ class TestSessionScoping:
         for the design rationale.
 
         # counter-test: remove the inner `if not token_session` half of the
-        #               predicate at merge_guard_pre.py:643 → empty token_
+        #               predicate at merge_guard_pre.py:645 → empty token_
         #               session falls through to acceptance (the cycle-1
         #               attack surface re-opens); assertion `result is None`
         #               FAILS because result is a valid token dict.
@@ -5135,7 +5135,7 @@ class TestSessionScoping:
         Both are bypass-surface attacker shapes under the cycle-1 predicate;
         both reject under cycle-2.
 
-        # counter-test: revert merge_guard_pre.py:633-644 to the cycle-1
+        # counter-test: revert merge_guard_pre.py:635-646 to the cycle-1
         #               short-circuit predicate
         #                   `if current_session and token_session and
         #                    current_session != token_session: continue`
@@ -5174,12 +5174,12 @@ class TestSessionScoping:
         This is the cycle-1 behavior preserved verbatim (foreign session
         always rejected) but anchored under the new asymmetric predicate
         framing. Documents that the AND-tightening at
-        merge_guard_pre.py:643 (`if not token_session OR current_session
+        merge_guard_pre.py:645 (`if not token_session OR current_session
         != token_session`) preserves the foreign-session rejection half
         exactly while ADDING the empty-token_session rejection half.
 
         # counter-test: remove the inner `current_session != token_session`
-        #               half of the predicate at merge_guard_pre.py:643 →
+        #               half of the predicate at merge_guard_pre.py:645 →
         #               foreign-session token would fall through to
         #               acceptance; assertion FAILS.
         # expected RED cardinality: {1}

--- a/pact-plugin/tests/test_pin_caps_gate.py
+++ b/pact-plugin/tests/test_pin_caps_gate.py
@@ -129,7 +129,7 @@ class TestPinCapsGate_Smoke:
         parsed as an extra pin on reload and defeat the count cap.
 
         Pre-fix: `_extract_new_body` returned "" for Write, so
-        compute_deny_reason's embedded-pin check at pin_caps.py:557 never
+        compute_deny_reason's embedded-pin check at pin_caps.py:686-687 never
         ran on Write. Only the count cap caught pin inflation, and a
         smuggled heading inside a body wouldn't register in the count
         cap because the smuggle becomes visible only AFTER a reload.

--- a/pact-plugin/tests/test_pin_caps_gate_matrix.py
+++ b/pact-plugin/tests/test_pin_caps_gate_matrix.py
@@ -425,7 +425,7 @@ class TestPinCapsGate_Matrix_Edit:
         """Upstream-split invariant (per auditor-2 recommendation,
         2026-04-21 consultant mode): Python's str.splitlines() recognizes
         every char in `_FORBIDDEN_RATIONALE_CHARS` as a line boundary,
-        which is WHY the char check at `pin_caps_gate.py:148` is not
+        which is WHY the char check at `pin_caps_gate.py:184` is not
         runtime-reachable in the current call graph.
 
         `_extract_override_rationale` applies `splitlines()` and then
@@ -440,7 +440,7 @@ class TestPinCapsGate_Matrix_Edit:
         future refactor of `_extract_override_rationale` stops calling
         splitlines (e.g., moves to a regex that scans the whole fragment
         in one pass), this test fails loudly and the char-check block at
-        `pin_caps_gate.py:148` becomes the load-bearing defense. Converts
+        `pin_caps_gate.py:184` becomes the load-bearing defense. Converts
         the latent dead-code tradeoff into a loud one.
         """
         # The canonical override-comment fragment, with a forbidden char
@@ -453,7 +453,7 @@ class TestPinCapsGate_Matrix_Edit:
         # At least two parts — splitlines recognized the terminator.
         assert len(parts) >= 2, (
             f"splitlines() did NOT split on {ord_hex} ({terminator!r}) — "
-            f"if this fails, the forbidden-char check at pin_caps_gate.py:148 "
+            f"if this fails, the forbidden-char check at pin_caps_gate.py:184 "
             f"has become runtime-reachable. Update the inline comment in "
             f"that file and re-verify the char-check block is exercised."
         )
@@ -534,7 +534,7 @@ class TestPinCapsGate_Matrix_Edit:
         )
         assert parser_rationale is None, (
             f"Parser still captured a rationale on {ord_hex} despite "
-            f"splitlines-based parsing (pin_caps.py:166 fix regressed). "
+            f"splitlines-based parsing (pin_caps.py:191 fix regressed). "
             f"Size cap bypass is live again."
         )
 

--- a/pact-plugin/tests/test_pin_staleness_gate.py
+++ b/pact-plugin/tests/test_pin_staleness_gate.py
@@ -564,7 +564,7 @@ class TestPinStalenessGate_DecoyBypass:
     """Arch-M3 managed-region bounding of `_count_pin_comments`.
 
     Load-bearing coverage for the bounded-count defense at
-    `pin_staleness_gate.py:120-127` (extract_managed_region import
+    `pin_staleness_gate.py:128-138` (extract_managed_region import
     block). Before this defense, a `<!-- pinned:` token appearing in
     user-authored prose or a fenced code block OUTSIDE the managed
     region would inflate the gate's count and either:
@@ -574,7 +574,7 @@ class TestPinStalenessGate_DecoyBypass:
         structural reality).
 
     Counter-test-by-revert: commenting out the try-block at
-    `pin_staleness_gate.py:120-127` (so `_count_pin_comments` always
+    `pin_staleness_gate.py:128-138` (so `_count_pin_comments` always
     falls through to `text.count(...)`) MUST cause at least one test
     here to fail. Without that proof, the defense is phantom-green.
     """
@@ -678,7 +678,7 @@ class TestPinStalenessGate_DecoyBypass:
         assert result is not None, (
             "In-region ADD masked by outside decoy removal — Arch-M3 bounding "
             "bypassed. If you see this failure after reverting "
-            "pin_staleness_gate.py lines 120-127, that is the counter-test "
+            "pin_staleness_gate.py lines 128-138, that is the counter-test "
             "proof the defense is load-bearing."
         )
         assert "stale pins" in result

--- a/pact-plugin/tests/test_plugin_manifest.py
+++ b/pact-plugin/tests/test_plugin_manifest.py
@@ -532,7 +532,7 @@ class TestBannerContractInvariants:
 
     # --- Project-wide sanitization regex contract (mirrors session_state._RENDER_STRIP_RE) ---
     # plugin_manifest.py exposes `_sanitize()` with the same
-    # regex `[\x00-\x1f\x7f\u0085\u2028\u2029]` used by session_state.py:83
+    # regex `[\x00-\x1f\x7f\u0085\u2028\u2029]` used by session_state.py:89
     # Replacement is space (not empty).
     # Tests below assert the output-level contract (characters absent from banner,
     # banner remains single-line) — robust to whether the fix ships as an

--- a/pact-plugin/tests/test_py39_annotation_compat.py
+++ b/pact-plugin/tests/test_py39_annotation_compat.py
@@ -1,0 +1,470 @@
+"""
+Location: pact-plugin/tests/test_py39_annotation_compat.py
+Summary: Static AST guard keeping pact-plugin/hooks/ importable under
+         Python 3.9 (GUI-launched macOS sessions run hooks on
+         /usr/bin/python3 = 3.9.x). Three rules:
+         R1 every scanned .py carries `from __future__ import annotations`;
+         R2 no runtime-position type unions (the future import cannot
+            defer those);
+         R3 no typing.get_type_hints / typing.cast anywhere in scanned
+            roots — their absence is what makes universal annotation
+            stringification safe on 3.9.
+         Pure static analysis: runs identically under any CI interpreter.
+Used by: pact-plugin test suite (standing merge gate).
+"""
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, List, Optional, Tuple
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+
+# Extension point: add adjacent bare-python3 surfaces here (one line each),
+# e.g. PLUGIN_ROOT / "skills" / "pact-memory" / "scripts",
+#      PLUGIN_ROOT / "scripts".
+SCANNED_ROOTS: tuple[Path, ...] = (PLUGIN_ROOT / "hooks",)
+
+# Integer-flag namespaces: `a.X | a.Y` rooted here is bitwise-OR on int
+# constants, valid on every Python 3.x — never a type union.
+FLAG_MODULES = frozenset({"os", "re", "fcntl", "stat", "mmap", "socket", "errno", "signal", "select"})
+
+# Names that mark a BitOr operand as type-like in runtime position.
+TYPE_NAMES = frozenset({
+    "str", "int", "float", "bool", "bytes", "bytearray", "complex",
+    "dict", "list", "tuple", "set", "frozenset", "type", "object",
+    "Path", "Optional", "Union", "Any", "Callable", "Iterable",
+    "Iterator", "Sequence", "Mapping", "MutableMapping",
+})
+
+_CLASS_LIKE = re.compile(r"^[A-Z][A-Za-z0-9]*[a-z][A-Za-z0-9]*$")  # CamelCase, NOT ALL_CAPS
+
+ANNOTATION_EVAL_NAMES = frozenset({"cast", "get_type_hints"})
+
+FUTURE_IMPORT_LINE = "from __future__ import annotations"
+
+
+@dataclass(frozen=True)
+class Violation:
+    relpath: str
+    lineno: int
+    rule: str      # "missing_future_import" | "runtime_type_union" | "annotation_eval_api"
+    detail: str
+
+
+# ---------------------------------------------------------------------------
+# File discovery
+# ---------------------------------------------------------------------------
+
+def iter_python_files(roots: Iterable[Path] = SCANNED_ROOTS) -> Iterator[Path]:
+    """Yield every .py file under the given roots, sorted for stable ids."""
+    for root in roots:
+        for path in sorted(root.rglob("*.py")):
+            yield path
+
+
+def _relpath(path: Path) -> str:
+    try:
+        return path.relative_to(PLUGIN_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+# ---------------------------------------------------------------------------
+# Shared AST helpers
+# ---------------------------------------------------------------------------
+
+def _is_docstring_stmt(node: ast.stmt) -> bool:
+    return (
+        isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    )
+
+
+def _annotation_nodes(tree: ast.AST) -> Iterator[ast.expr]:
+    """Yield every annotation expression in the module.
+
+    Carriers: FunctionDef/AsyncFunctionDef argument annotations (positional-only,
+    positional, keyword-only, *args, **kwargs), return annotations, and
+    AnnAssign annotations. Lambdas cannot carry annotations.
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            args = node.args
+            every_arg = list(args.posonlyargs) + list(args.args) + list(args.kwonlyargs)
+            every_arg.append(args.vararg)
+            every_arg.append(args.kwarg)
+            for arg in every_arg:
+                if arg is not None and arg.annotation is not None:
+                    yield arg.annotation
+            if node.returns is not None:
+                yield node.returns
+        elif isinstance(node, ast.AnnAssign):
+            yield node.annotation
+
+
+def _annotation_subtree_ids(tree: ast.AST) -> set:
+    """Object ids of every AST node living inside an annotation expression."""
+    ids = set()
+    for annotation in _annotation_nodes(tree):
+        for sub in ast.walk(annotation):
+            ids.add(id(sub))
+    return ids
+
+
+def _annotation_union_lines(tree: ast.AST) -> List[int]:
+    """Line numbers of annotation-position `X | Y` unions (3.9 crash sites
+    when the future import is absent)."""
+    lines = []
+    for annotation in _annotation_nodes(tree):
+        for sub in ast.walk(annotation):
+            if isinstance(sub, ast.BinOp) and isinstance(sub.op, ast.BitOr):
+                lines.append(sub.lineno)
+    return sorted(set(lines))
+
+
+def _flatten_bitor(node: ast.BinOp) -> List[ast.expr]:
+    """Flatten a (possibly nested) `a | b | c` chain into its operand list."""
+    operands: List[ast.expr] = []
+    stack = [node.left, node.right]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, ast.BinOp) and isinstance(current.op, ast.BitOr):
+            stack.append(current.left)
+            stack.append(current.right)
+        else:
+            operands.append(current)
+    return operands
+
+
+def _root_and_terminal(node: ast.expr) -> Tuple[Optional[str], Optional[str]]:
+    """For Name/Attribute operands, return (root identifier, terminal identifier).
+
+    `os.O_CREAT` -> ("os", "O_CREAT"); `Path` -> ("Path", "Path");
+    `pkg.mod.Cls` -> ("pkg", "Cls"). Anything else -> (None, None).
+    """
+    if isinstance(node, ast.Name):
+        return node.id, node.id
+    if isinstance(node, ast.Attribute):
+        terminal = node.attr
+        current: ast.expr = node.value
+        while isinstance(current, ast.Attribute):
+            current = current.value
+        if isinstance(current, ast.Name):
+            return current.id, terminal
+        return None, terminal
+    return None, None
+
+
+def _operand_type_likeness(node: ast.expr) -> Optional[str]:
+    """Return a human-readable reason if the operand marks a type union,
+    else None. Whitelist-first: FLAG_MODULES-rooted operands never flag."""
+    if isinstance(node, ast.Constant) and node.value is None:
+        return "operand is the None constant"
+    root, terminal = _root_and_terminal(node)
+    if terminal is None:
+        return None
+    if root in FLAG_MODULES:
+        return None
+    if terminal in TYPE_NAMES:
+        return "operand {!r} is in TYPE_NAMES".format(terminal)
+    if _CLASS_LIKE.match(terminal):
+        return "operand {!r} is class-like (CamelCase)".format(terminal)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Detectors — pure (source -> list[Violation]) so the non-vacuity tests can
+# drive them with synthetic strings.
+# ---------------------------------------------------------------------------
+
+def check_future_import(source: str, relpath: str) -> List[Violation]:
+    """R1: the first non-docstring statement must be the annotations future
+    import. Position is checked, not just presence — a future import buried
+    below other imports is a 3.9 SyntaxError. On failure the detail cites
+    every annotation-position union in the file (the lines that would crash
+    Python 3.9)."""
+    tree = ast.parse(source)
+    body = tree.body
+
+    if not body:
+        return [Violation(
+            relpath=relpath, lineno=1, rule="missing_future_import",
+            detail="empty module: add the import as the sole line",
+        )]
+
+    first_index = 1 if _is_docstring_stmt(body[0]) else 0
+    if first_index < len(body):
+        first_stmt = body[first_index]
+        if (
+            isinstance(first_stmt, ast.ImportFrom)
+            and first_stmt.module == "__future__"
+            and any(alias.name == "annotations" for alias in first_stmt.names)
+        ):
+            return []
+
+    union_lines = _annotation_union_lines(tree)
+    enrichment = (
+        "; annotation-position unions that would crash 3.9 at lines: {}".format(
+            ", ".join(str(line) for line in union_lines)
+        )
+        if union_lines else ""
+    )
+    return [Violation(
+        relpath=relpath, lineno=1, rule="missing_future_import",
+        detail=(
+            "`{}` must be the first statement after the module docstring{}"
+            .format(FUTURE_IMPORT_LINE, enrichment)
+        ),
+    )]
+
+
+def check_runtime_type_unions(source: str, relpath: str) -> List[Violation]:
+    """R2: flag `X | Y` outside annotation positions when an operand is the
+    None constant or a type-like name — the future import cannot defer those,
+    so they crash Python 3.9 at runtime. Integer-flag ORs (os.O_CREAT |
+    os.O_WRONLY, re.IGNORECASE | re.DOTALL, ...) pass via FLAG_MODULES and
+    the ALL-CAPS exclusion in _CLASS_LIKE."""
+    tree = ast.parse(source)
+    annotation_ids = _annotation_subtree_ids(tree)
+    runtime_bitors = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.BinOp)
+        and isinstance(node.op, ast.BitOr)
+        and id(node) not in annotation_ids
+    ]
+
+    # Report each chain once: skip BitOr nodes that are operands of another
+    # runtime BitOr (the outermost node sees the flattened chain).
+    inner_ids = set()
+    for node in runtime_bitors:
+        for side in (node.left, node.right):
+            if isinstance(side, ast.BinOp) and isinstance(side.op, ast.BitOr):
+                inner_ids.add(id(side))
+
+    violations = []
+    for node in runtime_bitors:
+        if id(node) in inner_ids:
+            continue
+        for operand in _flatten_bitor(node):
+            reason = _operand_type_likeness(operand)
+            if reason is not None:
+                violations.append(Violation(
+                    relpath=relpath, lineno=node.lineno, rule="runtime_type_union",
+                    detail=(
+                        "runtime `|` looks like a type union ({}); use "
+                        "typing.Union/typing.Optional or a tuple of types here, "
+                        "or extend FLAG_MODULES if this is an integer-flag "
+                        "namespace".format(reason)
+                    ),
+                ))
+                break
+    return violations
+
+
+def check_annotation_eval_apis(source: str, relpath: str) -> List[Violation]:
+    """R3: typing.cast / typing.get_type_hints re-evaluate stringified
+    annotations at runtime and would silently re-introduce the 3.9 crash
+    class. Their count in the scanned roots is zero and must stay zero.
+    Detects both `from typing import cast` (any alias) and attribute access
+    through `import typing` / `import typing as T` bindings."""
+    tree = ast.parse(source)
+    typing_aliases = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "typing":
+                    typing_aliases.add(alias.asname or "typing")
+
+    violations = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "typing":
+            for alias in node.names:
+                if alias.name in ANNOTATION_EVAL_NAMES:
+                    violations.append(Violation(
+                        relpath=relpath, lineno=node.lineno, rule="annotation_eval_api",
+                        detail="`from typing import {}` re-evaluates stringified "
+                               "annotations at runtime".format(alias.name),
+                    ))
+        elif isinstance(node, ast.Attribute) and node.attr in ANNOTATION_EVAL_NAMES:
+            if isinstance(node.value, ast.Name) and node.value.id in typing_aliases:
+                violations.append(Violation(
+                    relpath=relpath, lineno=node.lineno, rule="annotation_eval_api",
+                    detail="`{}.{}` re-evaluates stringified annotations at "
+                           "runtime".format(node.value.id, node.attr),
+                ))
+    return violations
+
+
+def _format_violations(violations: List[Violation]) -> str:
+    return "\n".join(
+        "{}:{} [{}] {}".format(v.relpath, v.lineno, v.rule, v.detail)
+        for v in violations
+    )
+
+
+_SCANNED_FILES = list(iter_python_files())
+
+
+# ---------------------------------------------------------------------------
+# Live-tree rules
+# ---------------------------------------------------------------------------
+
+class TestFutureImportPresence:
+    """R1 over every scanned file, one test per file."""
+
+    @pytest.mark.parametrize(
+        "path", _SCANNED_FILES, ids=[_relpath(p) for p in _SCANNED_FILES]
+    )
+    def test_future_import_is_first_statement(self, path):
+        source = path.read_text(encoding="utf-8")
+        violations = check_future_import(source, _relpath(path))
+        assert not violations, _format_violations(violations)
+
+
+class TestNoRuntimeTypeUnions:
+    """R2 aggregate: zero runtime-position type unions across scanned roots."""
+
+    def test_no_runtime_type_unions(self):
+        violations = []
+        for path in _SCANNED_FILES:
+            source = path.read_text(encoding="utf-8")
+            violations.extend(check_runtime_type_unions(source, _relpath(path)))
+        assert not violations, _format_violations(violations)
+
+
+class TestNoAnnotationEvalAPIs:
+    """R3 aggregate: zero typing.cast / typing.get_type_hints uses."""
+
+    def test_no_annotation_eval_apis(self):
+        violations = []
+        for path in _SCANNED_FILES:
+            source = path.read_text(encoding="utf-8")
+            violations.extend(check_annotation_eval_apis(source, _relpath(path)))
+        assert not violations, _format_violations(violations)
+
+
+# ---------------------------------------------------------------------------
+# Detector non-vacuity — synthetic sources prove each rule actually fires
+# (and stays silent where it must). A detector that flags everything or
+# nothing fails the silent cases.
+# ---------------------------------------------------------------------------
+
+class TestDetectorNonVacuity:
+
+    def test_union_annotation_without_future_import_fires(self):
+        source = "def f(x: str | None): ...\n"
+        violations = check_future_import(source, "synthetic.py")
+        assert len(violations) == 1
+        assert violations[0].rule == "missing_future_import"
+        # Enrichment cites the line of the annotation union.
+        assert "lines: 1" in violations[0].detail
+
+    def test_future_import_first_passes(self):
+        source = (
+            "from __future__ import annotations\n"
+            "\n"
+            "def f(x: str | None): ...\n"
+        )
+        assert check_future_import(source, "synthetic.py") == []
+
+    def test_future_import_below_other_imports_fires(self):
+        source = (
+            "import json\n"
+            "from __future__ import annotations\n"
+        )
+        violations = check_future_import(source, "synthetic.py")
+        assert len(violations) == 1
+        assert violations[0].rule == "missing_future_import"
+
+    def test_docstring_then_future_import_passes(self):
+        source = (
+            '"""Docstring."""\n'
+            "\n"
+            "from __future__ import annotations\n"
+        )
+        assert check_future_import(source, "synthetic.py") == []
+
+    def test_runtime_union_with_none_operand_fires(self):
+        source = (
+            "from __future__ import annotations\n"
+            "\n"
+            "def g(x):\n"
+            "    return isinstance(x, str | None)\n"
+        )
+        violations = check_runtime_type_unions(source, "synthetic.py")
+        assert len(violations) == 1
+        assert violations[0].rule == "runtime_type_union"
+        assert violations[0].lineno == 4
+
+    def test_module_level_type_alias_union_fires(self):
+        source = "Alias = str | int\n"
+        violations = check_runtime_type_unions(source, "synthetic.py")
+        assert len(violations) == 1
+        assert violations[0].rule == "runtime_type_union"
+
+    def test_camelcase_exception_union_fires(self):
+        source = (
+            "def g(x):\n"
+            "    return isinstance(x, MyError | ValueError)\n"
+        )
+        violations = check_runtime_type_unions(source, "synthetic.py")
+        assert len(violations) == 1
+        assert violations[0].rule == "runtime_type_union"
+
+    def test_integer_flag_ors_stay_silent(self):
+        source = (
+            "import os\n"
+            "import re\n"
+            "\n"
+            "flags = os.O_CREAT | os.O_WRONLY\n"
+            "pattern = re.compile('p', re.IGNORECASE | re.DOTALL)\n"
+            "lock = fcntl.LOCK_EX | fcntl.LOCK_NB\n"
+        )
+        assert check_runtime_type_unions(source, "synthetic.py") == []
+
+    def test_annotation_position_union_not_flagged_by_r2(self):
+        source = (
+            "from __future__ import annotations\n"
+            "\n"
+            "def f(x: str | None) -> int | None: ...\n"
+            "value: dict | None = None\n"
+        )
+        assert check_runtime_type_unions(source, "synthetic.py") == []
+
+    def test_typing_cast_import_fires(self):
+        source = "from typing import cast\n"
+        violations = check_annotation_eval_apis(source, "synthetic.py")
+        assert len(violations) == 1
+        assert violations[0].rule == "annotation_eval_api"
+
+    def test_typing_module_alias_attribute_fires(self):
+        source = (
+            "import typing as t\n"
+            "\n"
+            "def f(): ...\n"
+            "hints = t.get_type_hints(f)\n"
+        )
+        violations = check_annotation_eval_apis(source, "synthetic.py")
+        assert len(violations) == 1
+        assert violations[0].rule == "annotation_eval_api"
+        assert violations[0].lineno == 4
+
+    def test_unrelated_attribute_named_cast_stays_silent(self):
+        source = (
+            "import numpy\n"
+            "\n"
+            "value = numpy.cast('f8')\n"
+        )
+        assert check_annotation_eval_apis(source, "synthetic.py") == []
+
+    def test_empty_module_fires_with_sole_line_remediation(self):
+        violations = check_future_import("", "synthetic.py")
+        assert len(violations) == 1
+        assert violations[0].rule == "missing_future_import"
+        assert "sole line" in violations[0].detail

--- a/pact-plugin/tests/test_py39_annotation_compat.py
+++ b/pact-plugin/tests/test_py39_annotation_compat.py
@@ -2,14 +2,28 @@
 Location: pact-plugin/tests/test_py39_annotation_compat.py
 Summary: Static AST guard keeping pact-plugin/hooks/ importable under
          Python 3.9 (GUI-launched macOS sessions run hooks on
-         /usr/bin/python3 = 3.9.x). Three rules:
-         R1 every scanned .py carries `from __future__ import annotations`;
+         /usr/bin/python3 = 3.9.x). Four rules:
+         R0 every scanned .py parses at ast feature_version=(3, 9) — a
+            best-effort syntax floor per CPython policy: it rejects
+            match/case but accepts some newer forms (notably
+            parenthesized multi-item `with`), so it narrows, rather
+            than replaces, live 3.9 import verification at fix time;
+         R1 every scanned .py defers annotation evaluation via
+            `from __future__ import annotations` in its leading
+            __future__-import block;
          R2 no runtime-position type unions (the future import cannot
             defer those);
-         R3 no typing.get_type_hints / typing.cast anywhere in scanned
-            roots — their absence is what makes universal annotation
-            stringification safe on 3.9.
-         Pure static analysis: runs identically under any CI interpreter.
+         R3 no runtime annotation evaluators (typing.cast,
+            typing.get_type_hints, inspect.get_annotations,
+            functools.singledispatch/singledispatchmethod) anywhere in
+            scanned roots — their absence is what makes universal
+            annotation stringification safe on 3.9.
+         Pure static analysis: nothing scanned is imported or executed.
+         Because R0 pins feature_version statically, the suite needs no
+         Python 3.9 CI interpreter — any modern interpreter enforces
+         the same floor. (Under an actual 3.9 interpreter, py310+
+         syntax would surface as parse ERRORS in R1-R3 instead of clean
+         R0 violations — the gate goes red either way.)
 Used by: pact-plugin test suite (standing merge gate).
 """
 from __future__ import annotations
@@ -43,7 +57,17 @@ TYPE_NAMES = frozenset({
 
 _CLASS_LIKE = re.compile(r"^[A-Z][A-Za-z0-9]*[a-z][A-Za-z0-9]*$")  # CamelCase, NOT ALL_CAPS
 
-ANNOTATION_EVAL_NAMES = frozenset({"cast", "get_type_hints"})
+# Per-module runtime annotation evaluators. typing.cast/get_type_hints and
+# inspect.get_annotations re-evaluate stringified annotations directly;
+# functools.singledispatch/singledispatchmethod evaluate them via an internal
+# typing.get_type_hints call on the annotation-inference @register path.
+# Any of them silently re-introduces the 3.9 crash class that universal
+# stringification avoids, so their count in scanned roots must stay zero.
+ANNOTATION_EVAL_NAMES = {
+    "typing": frozenset({"cast", "get_type_hints"}),
+    "inspect": frozenset({"get_annotations"}),
+    "functools": frozenset({"singledispatch", "singledispatchmethod"}),
+}
 
 FUTURE_IMPORT_LINE = "from __future__ import annotations"
 
@@ -52,7 +76,7 @@ FUTURE_IMPORT_LINE = "from __future__ import annotations"
 class Violation:
     relpath: str
     lineno: int
-    rule: str      # "missing_future_import" | "runtime_type_union" | "annotation_eval_api"
+    rule: str      # "py310_syntax" | "missing_future_import" | "runtime_type_union" | "annotation_eval_api"
     detail: str
 
 
@@ -183,12 +207,33 @@ def _operand_type_likeness(node: ast.expr) -> Optional[str]:
 # drive them with synthetic strings.
 # ---------------------------------------------------------------------------
 
+def check_py39_syntax_floor(source: str, relpath: str) -> List[Violation]:
+    """R0: the file must parse at feature_version=(3, 9). Catches py310+
+    statement syntax (e.g. match/case) that R1's deferred annotations cannot
+    fix and that would otherwise pass R1-R3 silently under a modern
+    interpreter. Best-effort per CPython policy: some newer forms
+    (parenthesized multi-item `with`) parse anyway, so a clean R0 is
+    necessary, not sufficient — live 3.9 import verification at fix time
+    remains the ground truth for what feature_version misses."""
+    try:
+        ast.parse(source, feature_version=(3, 9))
+    except SyntaxError as exc:
+        return [Violation(
+            relpath=relpath, lineno=exc.lineno or 1, rule="py310_syntax",
+            detail="not parseable at feature_version=(3, 9): {}".format(exc.msg),
+        )]
+    return []
+
+
 def check_future_import(source: str, relpath: str) -> List[Violation]:
-    """R1: the first non-docstring statement must be the annotations future
-    import. Position is checked, not just presence — a future import buried
-    below other imports is a 3.9 SyntaxError. On failure the detail cites
-    every annotation-position union in the file (the lines that would crash
-    Python 3.9)."""
+    """R1: `from __future__ import annotations` must appear in the module's
+    leading __future__-import block — after the docstring, before the first
+    statement that is not itself a __future__ import. That is exactly the
+    placement Python permits for future imports, so every layout this rule
+    accepts is valid 3.9 source with annotation evaluation fully deferred;
+    a future import buried below other imports is a 3.9 SyntaxError. On
+    failure the detail cites every annotation-position union in the file
+    (the lines that would crash Python 3.9)."""
     tree = ast.parse(source)
     body = tree.body
 
@@ -199,14 +244,12 @@ def check_future_import(source: str, relpath: str) -> List[Violation]:
         )]
 
     first_index = 1 if _is_docstring_stmt(body[0]) else 0
-    if first_index < len(body):
-        first_stmt = body[first_index]
-        if (
-            isinstance(first_stmt, ast.ImportFrom)
-            and first_stmt.module == "__future__"
-            and any(alias.name == "annotations" for alias in first_stmt.names)
-        ):
-            return []
+    for stmt in body[first_index:]:
+        if isinstance(stmt, ast.ImportFrom) and stmt.module == "__future__":
+            if any(alias.name == "annotations" for alias in stmt.names):
+                return []
+            continue   # another __future__ import; keep scanning the block
+        break          # first non-future statement ends the leading block
 
     union_lines = _annotation_union_lines(tree)
     enrichment = (
@@ -218,8 +261,8 @@ def check_future_import(source: str, relpath: str) -> List[Violation]:
     return [Violation(
         relpath=relpath, lineno=1, rule="missing_future_import",
         detail=(
-            "`{}` must be the first statement after the module docstring{}"
-            .format(FUTURE_IMPORT_LINE, enrichment)
+            "`{}` must appear in the leading __future__-import block after "
+            "the module docstring{}".format(FUTURE_IMPORT_LINE, enrichment)
         ),
     )]
 
@@ -268,35 +311,46 @@ def check_runtime_type_unions(source: str, relpath: str) -> List[Violation]:
 
 
 def check_annotation_eval_apis(source: str, relpath: str) -> List[Violation]:
-    """R3: typing.cast / typing.get_type_hints re-evaluate stringified
-    annotations at runtime and would silently re-introduce the 3.9 crash
-    class. Their count in the scanned roots is zero and must stay zero.
-    Detects both `from typing import cast` (any alias) and attribute access
-    through `import typing` / `import typing as T` bindings."""
+    """R3: runtime annotation evaluators (see ANNOTATION_EVAL_NAMES) would
+    silently re-introduce the 3.9 crash class. Their count in the scanned
+    roots is zero and must stay zero. Detects both `from <module> import
+    <name>` (under any asname) and attribute access through
+    `import <module>` / `import <module> as M` bindings.
+    functools.singledispatch is banned at presence level: only its
+    annotation-inference @register path evaluates annotations, but no
+    legitimate use exists in scanned roots — if one ever does, narrow this
+    rule deliberately rather than working around it."""
     tree = ast.parse(source)
-    typing_aliases = set()
+    module_bindings = {}
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
-                if alias.name == "typing":
-                    typing_aliases.add(alias.asname or "typing")
+                if alias.name in ANNOTATION_EVAL_NAMES:
+                    module_bindings[alias.asname or alias.name] = alias.name
 
     violations = []
     for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and node.module == "typing":
+        if isinstance(node, ast.ImportFrom) and node.module in ANNOTATION_EVAL_NAMES:
             for alias in node.names:
-                if alias.name in ANNOTATION_EVAL_NAMES:
+                if alias.name in ANNOTATION_EVAL_NAMES[node.module]:
                     violations.append(Violation(
                         relpath=relpath, lineno=node.lineno, rule="annotation_eval_api",
-                        detail="`from typing import {}` re-evaluates stringified "
-                               "annotations at runtime".format(alias.name),
+                        detail="`from {} import {}` re-evaluates stringified "
+                               "annotations at runtime (directly or via an "
+                               "internal typing.get_type_hints)"
+                               .format(node.module, alias.name),
                     ))
-        elif isinstance(node, ast.Attribute) and node.attr in ANNOTATION_EVAL_NAMES:
-            if isinstance(node.value, ast.Name) and node.value.id in typing_aliases:
+        elif isinstance(node, ast.Attribute):
+            if (
+                isinstance(node.value, ast.Name)
+                and node.value.id in module_bindings
+                and node.attr in ANNOTATION_EVAL_NAMES[module_bindings[node.value.id]]
+            ):
                 violations.append(Violation(
                     relpath=relpath, lineno=node.lineno, rule="annotation_eval_api",
                     detail="`{}.{}` re-evaluates stringified annotations at "
-                           "runtime".format(node.value.id, node.attr),
+                           "runtime (directly or via an internal "
+                           "typing.get_type_hints)".format(node.value.id, node.attr),
                 ))
     return violations
 
@@ -314,6 +368,31 @@ _SCANNED_FILES = list(iter_python_files())
 # ---------------------------------------------------------------------------
 # Live-tree rules
 # ---------------------------------------------------------------------------
+
+class TestDiscoveryFloor:
+    """Discovery must never silently collapse to an empty scan."""
+
+    def test_scanned_file_count_floor(self):
+        # If SCANNED_ROOTS resolves empty (directory rename, anchor break),
+        # the per-file parameter sets degrade to a single skip each and the
+        # aggregate rules pass vacuously over zero files — silently green.
+        # Floor rather than exact count so adding hooks never breaks it;
+        # bump the floor as hooks/ grows, never lower it without a
+        # deliberate scope decision.
+        assert len(_SCANNED_FILES) >= 63
+
+
+class TestPy39SyntaxFloor:
+    """R0 over every scanned file, one test per file."""
+
+    @pytest.mark.parametrize(
+        "path", _SCANNED_FILES, ids=[_relpath(p) for p in _SCANNED_FILES]
+    )
+    def test_parses_at_py39_feature_version(self, path):
+        source = path.read_text(encoding="utf-8")
+        violations = check_py39_syntax_floor(source, _relpath(path))
+        assert not violations, _format_violations(violations)
+
 
 class TestFutureImportPresence:
     """R1 over every scanned file, one test per file."""
@@ -357,6 +436,26 @@ class TestNoAnnotationEvalAPIs:
 
 class TestDetectorNonVacuity:
 
+    def test_match_statement_fires_syntax_floor(self):
+        source = (
+            "def f(x):\n"
+            "    match x:\n"
+            "        case 1:\n"
+            "            return 'one'\n"
+            "    return 'other'\n"
+        )
+        violations = check_py39_syntax_floor(source, "synthetic.py")
+        assert len(violations) == 1
+        assert violations[0].rule == "py310_syntax"
+
+    def test_py39_clean_source_passes_syntax_floor(self):
+        source = (
+            "from __future__ import annotations\n"
+            "\n"
+            "def f(x: str | None) -> int | None: ...\n"
+        )
+        assert check_py39_syntax_floor(source, "synthetic.py") == []
+
     def test_union_annotation_without_future_import_fires(self):
         source = "def f(x: str | None): ...\n"
         violations = check_future_import(source, "synthetic.py")
@@ -386,6 +485,16 @@ class TestDetectorNonVacuity:
         source = (
             '"""Docstring."""\n'
             "\n"
+            "from __future__ import annotations\n"
+        )
+        assert check_future_import(source, "synthetic.py") == []
+
+    def test_annotations_after_other_future_import_passes(self):
+        # Multiple __future__ imports may share the leading block in any
+        # order — valid Python with annotations fully deferred, so R1's
+        # position rule is relative to non-future statements only.
+        source = (
+            "from __future__ import generators\n"
             "from __future__ import annotations\n"
         )
         assert check_future_import(source, "synthetic.py") == []
@@ -428,6 +537,27 @@ class TestDetectorNonVacuity:
         )
         assert check_runtime_type_unions(source, "synthetic.py") == []
 
+    def test_all_caps_bare_name_or_stays_silent(self):
+        # ALL_CAPS names fail _CLASS_LIKE (no lowercase char) — integer-flag
+        # constants outside FLAG_MODULES must not flag.
+        source = "flags = DEFAULT_FLAGS | EXTRA_FLAGS\n"
+        assert check_runtime_type_unions(source, "synthetic.py") == []
+
+    def test_all_caps_attr_outside_flag_modules_stays_silent(self):
+        source = (
+            "import customflags\n"
+            "\n"
+            "flags = customflags.FLAG_A | customflags.FLAG_B\n"
+        )
+        assert check_runtime_type_unions(source, "synthetic.py") == []
+
+    def test_three_operand_runtime_chain_fires_once(self):
+        # The chain-flattening dedup must report `a | b | c` as ONE
+        # violation on the outermost node, not one per nested BinOp.
+        source = "x = isinstance(y, str | int | None)\n"
+        violations = check_runtime_type_unions(source, "synthetic.py")
+        assert len(violations) == 1
+
     def test_annotation_position_union_not_flagged_by_r2(self):
         source = (
             "from __future__ import annotations\n"
@@ -454,6 +584,61 @@ class TestDetectorNonVacuity:
         assert len(violations) == 1
         assert violations[0].rule == "annotation_eval_api"
         assert violations[0].lineno == 4
+
+    @pytest.mark.parametrize("name", sorted(ANNOTATION_EVAL_NAMES["typing"]))
+    @pytest.mark.parametrize(
+        "form", ["from_import", "module_attr", "aliased_module_attr"]
+    )
+    def test_typing_eval_api_name_form_matrix_fires(self, name, form):
+        source = {
+            "from_import": "from typing import {}\n".format(name),
+            "module_attr": (
+                "import typing\n"
+                "\n"
+                "result = typing.{}(object)\n".format(name)
+            ),
+            "aliased_module_attr": (
+                "import typing as t\n"
+                "\n"
+                "result = t.{}(object)\n".format(name)
+            ),
+        }[form]
+        violations = check_annotation_eval_apis(source, "synthetic.py")
+        assert len(violations) == 1
+        assert violations[0].rule == "annotation_eval_api"
+
+    def test_inspect_get_annotations_fires(self):
+        source = (
+            "import inspect\n"
+            "\n"
+            "def f(): ...\n"
+            "hints = inspect.get_annotations(f)\n"
+        )
+        violations = check_annotation_eval_apis(source, "synthetic.py")
+        assert len(violations) == 1
+        assert violations[0].rule == "annotation_eval_api"
+
+    def test_functools_singledispatch_fires(self):
+        source = (
+            "from functools import singledispatch\n"
+            "\n"
+            "@singledispatch\n"
+            "def f(x): ...\n"
+        )
+        violations = check_annotation_eval_apis(source, "synthetic.py")
+        assert len(violations) == 1
+        assert violations[0].rule == "annotation_eval_api"
+
+    def test_functools_non_banned_names_stay_silent(self):
+        source = (
+            "import functools\n"
+            "from functools import lru_cache\n"
+            "\n"
+            "@lru_cache(maxsize=None)\n"
+            "def f(): ...\n"
+            "g = functools.partial(f)\n"
+        )
+        assert check_annotation_eval_apis(source, "synthetic.py") == []
 
     def test_unrelated_attribute_named_cast_stays_silent(self):
         source = (

--- a/pact-plugin/tests/test_session_end.py
+++ b/pact-plugin/tests/test_session_end.py
@@ -3190,7 +3190,7 @@ class TestReaperBehaviorPins:
 
 
 class TestTaskListIdAllowlistRejection:
-    """Pins `re.fullmatch(r"[A-Za-z0-9_-]+", ...)` guard at session_end.py:615.
+    """Pins `re.fullmatch(r"[A-Za-z0-9_-]+", ...)` guard at session_end.py:642-644.
 
     The cycle-1 happy-path test (`test_main_assembles_union_skip_set`)
     covers a well-formed `task-C` passing through to skip_names. But it
@@ -3273,7 +3273,7 @@ class TestTaskListIdAllowlistRejection:
         assert hostile_value not in skip_names, (
             f"Hostile CLAUDE_CODE_TASK_LIST_ID={hostile_value!r} leaked into "
             f"skip_names={skip_names!r}. Regex allowlist at "
-            f"session_end.py:615 must be filtering it."
+            f"session_end.py:642-644 must be filtering it."
         )
         # Sanity: the other two skip members still pass through.
         assert "team-A" in skip_names
@@ -3374,7 +3374,7 @@ class TestTaskListIdAllowlistRejection:
 
 
 class TestTaskDirMtimeInnerSymlink:
-    """Pins `child.stat(follow_symlinks=False)` at session_end.py:358.
+    """Pins `child.stat(follow_symlinks=False)` at session_end.py:384.
 
     `_task_dir_mtime` iterates each `*.json` child to compute the tight
     max-mtime used as the dir's reap decision. If `stat()` FOLLOWED
@@ -3432,7 +3432,7 @@ class TestTaskDirMtimeInnerSymlink:
             "Old-link-with-fresh-target scenario must reap — link lstat "
             "mtime (40d) should win over target stat mtime (fresh). "
             "If this fails, `follow_symlinks=False` was likely removed "
-            "from session_end.py:358."
+            "from session_end.py:384."
         )
         assert not d.exists()
         # Target must survive (rmtree on the parent dir unlinks the
@@ -3480,7 +3480,7 @@ class TestTaskDirMtimeInnerSymlink:
             "Fresh-link-with-old-target scenario must preserve — link "
             "lstat mtime (fresh) should win over target stat mtime (60d). "
             "If this fails, `follow_symlinks=False` was likely removed "
-            "from session_end.py:358."
+            "from session_end.py:384."
         )
         assert d.exists()
         assert target.exists()
@@ -4523,7 +4523,7 @@ class TestTeamNameAllowlist:
         """Each hostile current_team_name is filtered from skip_names.
 
         COUNTER-TEST BY REVERT target: removing the `safe_team_name`
-        allowlist at session_end.py:769-773 (restoring the direct
+        allowlist at session_end.py:641-646 (restoring the direct
         `{current_team_name, task_list_id, safe_session_id}` shape)
         flips this test — hostile team_names leak into skip_names.
         """
@@ -4564,7 +4564,7 @@ class TestTeamNameAllowlist:
         assert hostile_value not in skip_names, (
             f"Hostile current_team_name={hostile_value!r} leaked into "
             f"skip_names={skip_names!r}. Cycle-7 allowlist on team_name "
-            f"(session_end.py:769-773) must filter it — mirroring the "
+            f"(session_end.py:641-646) must filter it — mirroring the "
             f"task_list_id and session_id channels."
         )
         # Sanity: the other two skip members still pass through.
@@ -4698,7 +4698,7 @@ class TestSentinelFalseReapHardening:
         Mirrors `test_caller_skips_on_sentinel_no_false_reap` but via
         `cleanup_old_teams` rather than `cleanup_old_tasks`. The
         sentinel-handling guard exists in BOTH reapers (cleanup_old_teams
-        at session_end.py:527-529 and cleanup_old_tasks at 600-602). Test
+        at session_end.py:502-504 and cleanup_old_tasks at 576-578). Test
         4's original caller-integration pin only probes the tasks path —
         a regression that removes ONLY the teams-side guard would not be
         caught. This pin closes that coverage gap.
@@ -4740,7 +4740,7 @@ class TestSentinelFalseReapHardening:
         assert reaped == 0, (
             "teams caller must NOT reap on sentinel. If reaped == 1, the "
             "teams-side `if mtime is None: skipped += 1; continue` guard "
-            "(session_end.py:527-529) was removed or short-circuited."
+            "(session_end.py:502-504) was removed or short-circuited."
         )
         assert skipped == 1
         assert d.exists()

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -1954,7 +1954,7 @@ class TestExtractPrevSessionDirDualLocation:
         """M3: derives session dir from Resume line + project basename when
         the `- Session dir:` line is absent.
 
-        Targets the fallback branch at session_init.py:207-218. Backward-compat
+        Targets the fallback branch at session_init.py:524-536. Backward-compat
         path for sessions written before the Session dir line existed: when only
         the `- Resume:` line is present, the function reconstructs the path as
         ~/.claude/pact-sessions/<project-basename>/<session-id>.
@@ -2452,7 +2452,7 @@ class TestPluginRootEnvWiring:
     The happy-path tests (TestWriteContextIntegration) cover the case where
     CLAUDE_PLUGIN_ROOT is unset (empty string is passed through). These tests
     cover the complementary case where the Claude Code plugin loader sets
-    CLAUDE_PLUGIN_ROOT BEFORE session_init runs. session_init.py:317 reads
+    CLAUDE_PLUGIN_ROOT BEFORE session_init runs. session_init.py:319 reads
     the env var directly:
 
         plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT", "")

--- a/pact-plugin/tests/test_session_journal.py
+++ b/pact-plugin/tests/test_session_journal.py
@@ -2219,7 +2219,7 @@ class TestCheckJournalPausedState:
     def test_unparseable_ts_does_not_crash(self, journal_home, session_dir, journal_file):
         """M5: corrupted `ts` field is swallowed, function falls through to PR check.
 
-        The TTL gate at session_resume.py:358-369 catches
+        The TTL gate at session_resume.py:605-618 catches
         (ValueError, TypeError, OverflowError) from datetime.fromisoformat(...)
         and pass-throughs to the active-PR check. With PR state mocked to OPEN,
         the standard 'Paused work detected' message must be returned -- the
@@ -2278,7 +2278,7 @@ class TestCheckJournalPausedState:
         """M5: missing `ts` field is treated as fail-open (skips TTL gate).
 
         When the `ts` field is absent (empty string from .get default), the
-        `if ts_str:` guard at session_resume.py:358 short-circuits past the
+        `if ts_str:` guard at session_resume.py:607 short-circuits past the
         TTL block entirely and falls through to the PR check. With PR mocked
         to OPEN, the standard paused message is returned.
         """
@@ -4031,7 +4031,7 @@ class TestValidateOptionalFieldTypes:
 
         Note: value=None is NOT tested as a reject case because the
         validator's optional-field path explicitly treats None as
-        "field absent" (session_journal.py:324) — consistent with the
+        "field absent" (session_journal.py:394) — consistent with the
         `continue` semantics for missing optional fields. This is
         intentional and correct for OPTIONAL fields.
         """
@@ -4090,7 +4090,7 @@ class TestValidateOptionalFieldTypes:
         session_end in `_REQUIRED_FIELDS_BY_TYPE` combined with the
         `{"warning": str}` entry here IS the activation mechanism.
 
-        session_end.py:687-688 writes `make_event("session_end",
+        session_end.py:850-851 writes `make_event("session_end",
         warning=<str>)` when check_unpaused_pr detects an open-but-
         unpaused PR. Without the schema entry, a future writer could
         pass a non-string warning (e.g. a dict of findings) and no

--- a/pact-plugin/tests/test_session_state.py
+++ b/pact-plugin/tests/test_session_state.py
@@ -401,7 +401,7 @@ class TestTeamMembers:
         could inject a fake role-marker line into the compaction-model
         context — same vector as `\\n`, just via a different code point.
 
-        Counter-test: revert `_RENDER_STRIP_RE` at session_state.py:77 to
+        Counter-test: revert `_RENDER_STRIP_RE` at session_state.py:93 to
         the pre-A1 set `[\\x00-\\x1f\\x7f]` (drop the `\\u0085\\u2028\\u2029`
         suffix) — this test fails because the U+2028 survives the read
         path.
@@ -687,7 +687,7 @@ class TestSummarize:
         unexpected-exception path.
 
         Counter-test: changing the outer `except Exception: return
-        _default_state(...)` at session_state.py:596-601 to bare
+        _default_state(...)` at session_state.py:707-712 to bare
         `raise` makes this test fail with the RuntimeError propagating.
 
         Round-2 review (PR #426 F5) found this handler is claimed
@@ -1094,7 +1094,7 @@ class TestDeriveFeatureFromJournal:
         secretary's briefing dispatch — typically chronologically first —
         would be mis-identified as the feature task.
 
-        Counter-test: removing the filter at session_state.py:286-290
+        Counter-test: removing the filter at session_state.py:288-292
         makes this fail with feature_id == "1" instead of "2".
 
         Round-2 review (PR #426 F1) found the journal-side filter was


### PR DESCRIPTION
## Summary

Fixes Synaptic-Labs-AI/PACT-Plugin#941.

When Claude Code is GUI-launched on macOS, hooks execute under the system `python3` (3.9.6, via launchd's minimal PATH). PEP 604 unions (`X | None`) in annotation positions are evaluated at import time on 3.9 and raise `TypeError`; the eager imports in `hooks/shared/__init__.py` propagate a single failure to **every** hook, bricking the session fail-closed — while three entry points self-mask the crash behind `rc=0`.

## Changes

- **`from __future__ import annotations`** added to the 54 hook files lacking it (uniform coverage of `hooks/**`; defers all annotation evaluation, eliminating the entire incident class)
- **Static AST regression guard** (`tests/test_py39_annotation_compat.py`): fails CI on any hook file missing/misplacing the future import, on runtime-position type unions (integer-flag whitelist), and on any `typing.cast`/`get_type_hints` usage in `hooks/` — the premise that makes universal annotation stringification sound. Scanned roots are a single constant for future surface extension. Synthetic negative tests prove each detector fires.
- Two-line comment citation update in `tests/test_claude_md_resolver_parity.py` (line numbers shifted by the insertion)
- Version bump → 4.4.18 (rebased onto v4.4.17 main)

## Verification

| Gate | Result |
|---|---|
| Full pytest suite (3.12.7, raw output) | 8668 passed / 0 failed / 0 errors |
| Per-module import sweep, all 63 hook files, `/usr/bin/python3` 3.9.6 | 63/63 clean |
| CLI smoke, 6 text predicates (incl. the three `sys.exit(0)` self-maskers: `bootstrap_marker_writer`, `bootstrap_prompt_gate`, `task_lifecycle_gate`) | all healthy, no advisory tokens |
| Guard non-vacuity on a real mutilated file (control + mutation) | fires exactly once |
| **Pre-fix falsification** (detached checkout of `b695e5c4`) | import sweep detects 57/63 failures; self-masker advisory token present at `rc=0` — predicates proven against the masked-brick state |

## Reviewer notes

- ~15 narrative line-number citations in other test files drift by +2 for the swept files; deliberate — they are prose, not executable, and rewriting them was judged churn.
- ~~Residual: future 3.10+ syntax classes pass CI~~ **Closed by post-review remediation**: the guard now carries a per-file 3.9 syntax floor (R0, `ast.parse(feature_version=(3,9))` — best-effort per CPython policy, rejects `match`/`case`), so no 3.9 CI interpreter is needed.



## Post-review remediation (multi-agent panel: 4× approve, 0 blocking; minors folded in at author's direction)

- `375c9e57` — **fail closed when gate hooks cannot load**: five gates previously crashed rc=1 on import failure (platform-non-blocking → gated tool proceeded). Three get the established load-failure deny; `worktree_guard` (stdlib-only imports) gets a runtime-stage deny instead; `merge_guard_post` (PostToolUse — cannot deny) now fails loud on stderr with exit 2 rather than rc-clean. Healthy paths verified byte-identical under 3.9.6; broken states proven RED.
- `a8ead4ad` — **guard hardening**: R0 syntax floor; discovery-floor assertion (empty scan root can no longer pass silently); banned-evaluator set extended (`inspect.get_annotations`, `functools.singledispatch(method)`); future-import position rule corrected to accept any ordering within the leading `__future__` block (both legs pinned); chain-dedup cardinality, ALL-CAPS silence branch, and the evaluator name×form matrix pinned. Guard: 157 tests.
- `45d6b50e` — **citation re-anchoring**: 60 prose line-citations into hook files construct-verified against current code (~20 were stale before this branch). Three sites left flagged where the cited construct no longer exists or prose needs an author rewrite: `session_resume.py:199` (×2, prose describes a regex not present), `dispatch_helpers.py` historical reference.

Full suite at final HEAD: 8747 passed / 0 failed / 0 errors.

