### PR TITLE
fix(hooks): bootstrap failure-path hardening — degraded-mode read-only allowlist + session-context recovery (#942, #943)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.18",
+      "version": "4.4.19",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.18/      # Plugin version
+│               └── 4.4.19/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.18",
+  "version": "4.4.19",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.18
+> **Version**: 4.4.19
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/bootstrap_gate.py
+++ b/pact-plugin/hooks/bootstrap_gate.py
@@ -56,11 +56,14 @@ Tool classification rationale:
 SACROSANCT (post-#662, amended #942): module-load failures and runtime
 gate-logic exceptions are fail-CLOSED (deny) per #658 defect class —
 EXCEPT for verified read-only tools (_READ_ONLY_TOOLS), which are
-allowed WITH an explicit degraded-mode warning at exit 0 so the failure
-can be diagnosed (#942). Malformed stdin in the HEALTHY path remains
-fail-OPEN (input-side failure → harness's domain); malformed stdin in
-the DEGRADED path is fail-CLOSED — an unparseable frame means the tool
-name cannot be verified read-only.
+routed onward WITH an explicit degraded-mode warning at exit 0 so the
+failure can be diagnosed (#942): permissionDecision "defer" (normal
+permission flow) for local tools, "ask" (explicit user approval) for
+outbound WebFetch/WebSearch — degraded mode never emits "allow", so it
+is a permission-layer subset by construction. Malformed stdin in the
+HEALTHY path remains fail-OPEN (input-side failure → harness's domain);
+malformed stdin in the DEGRADED path is fail-CLOSED — an unparseable
+frame means the tool name cannot be verified read-only.
 
 Input: JSON from stdin with tool_name, tool_input, session_id, etc.
 Output: JSON with hookSpecificOutput.permissionDecision (deny case)
@@ -102,10 +105,13 @@ def _emit_load_failure_deny(stage: str, error: BaseException) -> NoReturn:
     sys.exit(2)
 
 
-# Verified read-only tools allowed in DEGRADED mode (gate cannot evaluate).
-# Membership ⇒ allow-with-warning; EVERYTHING else ⇒ deny (unknown/future
-# tool names fail safe automatically — do NOT enumerate "the hookable set";
-# entries for tools that never fire PreToolUse are harmless dead entries).
+# Verified read-only tools recognized in DEGRADED mode (gate cannot
+# evaluate). Membership ⇒ warn-without-granting: permissionDecision
+# "defer" (normal permission flow) for local tools, "ask" (explicit user
+# approval) for outbound _DEGRADED_ASK_TOOLS — NEVER "allow". EVERYTHING
+# else ⇒ deny (unknown/future tool names fail safe automatically — do NOT
+# enumerate "the hookable set"; entries for tools that never fire
+# PreToolUse are harmless dead entries).
 # INVARIANT (pinned by test): this set must be disjoint from _BLOCKED_TOOLS
 # and every member must be allowed on every healthy-path branch — degraded
 # mode can never grant something the healthy gate would deny.
@@ -141,18 +147,58 @@ def _read_stdin_tool_name() -> "str | None":
         return None
 
 
-def _emit_degraded_allow(stage: str, error: BaseException, tool_name: str) -> NoReturn:
-    """Allow-with-warning for a verified read-only tool while the gate is
-    degraded. MUST exit 0 — stdout JSON is only honored on exit 0 (official
-    hooks docs, re-verified 2026-06-12: 'JSON output is only processed on
-    exit 0'; on exit 2 stdout is ignored and stderr is fed to Claude).
-    permissionDecisionReason and additionalContext carry the same warning
-    (docs are ambiguous on which is surfaced for `allow`; both costs
-    nothing); systemMessage is the user-visible banner."""
+# Outbound-network members of _READ_ONLY_TOOLS: under a degraded gate these
+# escalate to the user permission prompt ("ask") instead of deferring —
+# network traffic under a broken governance gate warrants explicit user
+# approval. INVARIANT (pinned by test): subset of _READ_ONLY_TOOLS.
+_DEGRADED_ASK_TOOLS = frozenset({"WebFetch", "WebSearch"})
+
+# Cap on exception text interpolated into context-bound output (warning
+# strings reaching Claude's context and the user banner). Exception
+# messages can embed attacker-influencable content (file contents, paths,
+# crafted payloads in tracebacks) — bound + sanitize before interpolation.
+# The stderr diagnostic line keeps the full text (debug channel).
+_ERROR_TEXT_MAX = 200
+
+
+def _bounded_error_text(error: BaseException) -> str:
+    """Sanitized, length-bounded rendering of an exception for embedding in
+    context-bound warning text: control/non-printable characters become
+    spaces, and the result is truncated to _ERROR_TEXT_MAX chars with an
+    explicit marker. Full text still goes to stderr at the call site."""
+    text = f"{type(error).__name__}: {error}"
+    text = "".join(ch if ch.isprintable() else " " for ch in text)
+    if len(text) > _ERROR_TEXT_MAX:
+        text = text[:_ERROR_TEXT_MAX] + "...[truncated]"
+    return text
+
+
+def _emit_degraded_warning(stage: str, error: BaseException, tool_name: str) -> NoReturn:
+    """Warn-WITHOUT-granting for a verified read-only tool while the gate is
+    degraded. Local read-only tools emit permissionDecision="defer" — a
+    documented PreToolUse decision value (official hooks docs enum
+    allow/deny/ask/defer, re-verified 2026-06-12) that routes the call
+    through the NORMAL permission flow; outbound tools
+    (_DEGRADED_ASK_TOOLS) emit "ask" so the user explicitly approves
+    network traffic under a broken gate. Degraded mode therefore never
+    emits "allow" at all — it is a permission-layer SUBSET by
+    construction and cannot grant anything the permission system
+    wouldn't. MUST exit 0 — stdout JSON is only honored on exit 0
+    ('JSON output is only processed on exit 0'; on exit 2 stdout is
+    ignored and stderr is fed to Claude). permissionDecisionReason and
+    additionalContext carry the same warning; systemMessage is the
+    user-visible banner."""
+    decision = "ask" if tool_name in _DEGRADED_ASK_TOOLS else "defer"
+    routed = (
+        "escalated to your explicit approval"
+        if decision == "ask"
+        else "deferred to the normal permission flow"
+    )
     warning = (
         f"PACT bootstrap_gate is DEGRADED ({stage} failure — "
-        f"{type(error).__name__}: {error}). Read-only tool '{tool_name}' "
-        "allowed so the failure can be diagnosed. Mutating tools (Edit, "
+        f"{_bounded_error_text(error)}). Read-only tool '{tool_name}' is "
+        f"{routed} so the failure can be diagnosed; nothing is "
+        "auto-allowed while the gate is degraded. Mutating tools (Edit, "
         "Write, Agent, NotebookEdit), Bash, and MCP tools remain blocked "
         "fail-closed. Surface this to the user: PACT hooks are failing — "
         "check Python version compatibility and the plugin install under "
@@ -162,17 +208,18 @@ def _emit_degraded_allow(stage: str, error: BaseException, tool_name: str) -> No
     print(json.dumps({
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
-            "permissionDecision": "allow",
+            "permissionDecision": decision,
             "permissionDecisionReason": warning,
             "additionalContext": warning,
         },
         "systemMessage": (
             f"PACT bootstrap_gate degraded ({stage} failure): read-only "
-            "tools allowed with warning; mutating tools blocked."
+            "tools routed to the normal permission flow with a warning; "
+            "mutating tools blocked."
         ),
     }))
     print(
-        f"Hook degraded-allow (bootstrap_gate / {stage}): {tool_name} — {error}",
+        f"Hook degraded-{decision} (bootstrap_gate / {stage}): {tool_name} — {error}",
         file=sys.stderr,
     )
     sys.exit(0)
@@ -180,10 +227,11 @@ def _emit_degraded_allow(stage: str, error: BaseException, tool_name: str) -> No
 
 def _degraded_decision(stage: str, error: BaseException, tool_name: "str | None") -> NoReturn:
     """Single decision point for BOTH degraded stages (import + runtime).
-    Membership ⇒ allow-with-warning; everything else (incl. tool_name=None
-    from unparseable stdin — fail-CLOSED) ⇒ the unchanged deny emitter."""
+    Membership ⇒ warn-without-granting (defer / ask, never allow);
+    everything else (incl. tool_name=None from unparseable stdin —
+    fail-CLOSED) ⇒ the unchanged deny emitter."""
     if tool_name is not None and tool_name in _READ_ONLY_TOOLS:
-        _emit_degraded_allow(stage, error, tool_name)
+        _emit_degraded_warning(stage, error, tool_name)
     _emit_load_failure_deny(stage, error)
 
 
@@ -201,10 +249,11 @@ try:
         expected_marker_signature,
     )
 except BaseException as _module_load_error:  # noqa: BLE001 — fail-closed catch-all
-    # Degraded mode (#942): verified read-only tools allow-with-warning so
-    # the failure can be diagnosed; everything else takes the unchanged
-    # fail-closed deny. Stdin is parsed here by stdlib-only code (the
-    # healthy path's json.load in main() is never reached on this branch).
+    # Degraded mode (#942): verified read-only tools defer/ask with a
+    # warning so the failure can be diagnosed; everything else takes the
+    # unchanged fail-closed deny. Stdin is parsed here by stdlib-only code
+    # (the healthy path's json.load in main() is never reached on this
+    # branch).
     _degraded_decision("module imports", _module_load_error, _read_stdin_tool_name())
 
 

--- a/pact-plugin/hooks/bootstrap_gate.py
+++ b/pact-plugin/hooks/bootstrap_gate.py
@@ -42,14 +42,25 @@ Tool classification rationale:
     compaction.
   - MCP tools are always allowed — they're external integrations that may
     be needed for context gathering.
-  - Non-hookable tools (Skill, ToolSearch, TaskList/TaskGet/TaskUpdate,
-    SendMessage) never reach this hook because they don't fire PreToolUse
-    events. Note: TaskList/TaskGet/TaskUpdate are PACT plugin task-system
+  - Hookability: only `SendMessage` is verified-unhookable (#897 audit).
+    Skill, ToolSearch, and the Task tools HAVE been observed reaching
+    PreToolUse (incident evidence #942; HOOK_STDIN_DISCRIMINATORS.md) —
+    assume ANY tool name can reach this hook. The degraded-mode
+    allowlist (_READ_ONLY_TOOLS) is membership-based precisely so the
+    "which tools are hookable" question is moot: an entry for a tool
+    that never fires PreToolUse is a harmless dead entry, and
+    unknown/future tool names fail safe (deny) automatically.
+    Note: TaskList/TaskGet/TaskUpdate are PACT plugin task-system
     tools, distinct from the agent-dispatch `Agent` tool that IS blocked.
 
-SACROSANCT (post-#662): module-load failures and runtime gate-logic
-exceptions are fail-CLOSED (deny) per #658 defect class. Only malformed
-stdin remains fail-OPEN (input-side failure → harness's domain).
+SACROSANCT (post-#662, amended #942): module-load failures and runtime
+gate-logic exceptions are fail-CLOSED (deny) per #658 defect class —
+EXCEPT for verified read-only tools (_READ_ONLY_TOOLS), which are
+allowed WITH an explicit degraded-mode warning at exit 0 so the failure
+can be diagnosed (#942). Malformed stdin in the HEALTHY path remains
+fail-OPEN (input-side failure → harness's domain); malformed stdin in
+the DEGRADED path is fail-CLOSED — an unparseable frame means the tool
+name cannot be verified read-only.
 
 Input: JSON from stdin with tool_name, tool_input, session_id, etc.
 Output: JSON with hookSpecificOutput.permissionDecision (deny case)
@@ -91,6 +102,91 @@ def _emit_load_failure_deny(stage: str, error: BaseException) -> NoReturn:
     sys.exit(2)
 
 
+# Verified read-only tools allowed in DEGRADED mode (gate cannot evaluate).
+# Membership ⇒ allow-with-warning; EVERYTHING else ⇒ deny (unknown/future
+# tool names fail safe automatically — do NOT enumerate "the hookable set";
+# entries for tools that never fire PreToolUse are harmless dead entries).
+# INVARIANT (pinned by test): this set must be disjoint from _BLOCKED_TOOLS
+# and every member must be allowed on every healthy-path branch — degraded
+# mode can never grant something the healthy gate would deny.
+# Deliberate asymmetry (degraded STRICTER than healthy pre-marker mode):
+# Bash and mcp__* are allowed on the healthy pre-marker path but DENIED
+# here. A healthy gate allows Bash because the rest of the governance
+# stack is verifiable and the marker verifier defends bypass; a degraded
+# gate cannot distinguish diagnostic Bash from mutating Bash and has no
+# operative verifier behind it. The mcp__ prefix carries zero information
+# about mutation capability (e.g. computer-use), so no MCP name can be a
+# VERIFIED read-only tool.
+_READ_ONLY_TOOLS = frozenset({
+    "Read", "Glob", "Grep",          # pure file read/search
+    "ToolSearch", "Skill",           # context loading only (incident-proven denied)
+    "TaskList", "TaskGet",           # read-only task views (TaskCreate/TaskUpdate excluded)
+    "WebFetch", "WebSearch",         # outbound read (healthy path already allows)
+    "AskUserQuestion", "ExitPlanMode",  # user-interaction channel for diagnosis
+})
+
+
+def _read_stdin_tool_name() -> "str | None":
+    """stdlib-only stdin parse for the DEGRADED import-stage path. None on
+    ANY failure (unparseable JSON, non-dict frame, missing/non-string/empty
+    tool_name) — caller treats None as deny (fail-CLOSED: an unverifiable
+    frame means the tool name cannot be verified read-only; behavior-
+    preserving, since a module-load failure denied before stdin was ever
+    read pre-#942)."""
+    try:
+        data = json.load(sys.stdin)
+        name = data.get("tool_name")
+        return name if isinstance(name, str) and name else None
+    except Exception:
+        return None
+
+
+def _emit_degraded_allow(stage: str, error: BaseException, tool_name: str) -> NoReturn:
+    """Allow-with-warning for a verified read-only tool while the gate is
+    degraded. MUST exit 0 — stdout JSON is only honored on exit 0 (official
+    hooks docs, re-verified 2026-06-12: 'JSON output is only processed on
+    exit 0'; on exit 2 stdout is ignored and stderr is fed to Claude).
+    permissionDecisionReason and additionalContext carry the same warning
+    (docs are ambiguous on which is surfaced for `allow`; both costs
+    nothing); systemMessage is the user-visible banner."""
+    warning = (
+        f"PACT bootstrap_gate is DEGRADED ({stage} failure — "
+        f"{type(error).__name__}: {error}). Read-only tool '{tool_name}' "
+        "allowed so the failure can be diagnosed. Mutating tools (Edit, "
+        "Write, Agent, NotebookEdit), Bash, and MCP tools remain blocked "
+        "fail-closed. Surface this to the user: PACT hooks are failing — "
+        "check Python version compatibility and the plugin install under "
+        "~/.claude/plugins/cache/. Bootstrap cannot complete until the "
+        "hook loads cleanly."
+    )
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "permissionDecisionReason": warning,
+            "additionalContext": warning,
+        },
+        "systemMessage": (
+            f"PACT bootstrap_gate degraded ({stage} failure): read-only "
+            "tools allowed with warning; mutating tools blocked."
+        ),
+    }))
+    print(
+        f"Hook degraded-allow (bootstrap_gate / {stage}): {tool_name} — {error}",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+
+
+def _degraded_decision(stage: str, error: BaseException, tool_name: "str | None") -> NoReturn:
+    """Single decision point for BOTH degraded stages (import + runtime).
+    Membership ⇒ allow-with-warning; everything else (incl. tool_name=None
+    from unparseable stdin — fail-CLOSED) ⇒ the unchanged deny emitter."""
+    if tool_name is not None and tool_name in _READ_ONLY_TOOLS:
+        _emit_degraded_allow(stage, error, tool_name)
+    _emit_load_failure_deny(stage, error)
+
+
 # ─── fail-closed wrapper around cross-package imports + risky module work ─────
 try:
     import hmac
@@ -105,7 +201,11 @@ try:
         expected_marker_signature,
     )
 except BaseException as _module_load_error:  # noqa: BLE001 — fail-closed catch-all
-    _emit_load_failure_deny("module imports", _module_load_error)
+    # Degraded mode (#942): verified read-only tools allow-with-warning so
+    # the failure can be diagnosed; everything else takes the unchanged
+    # fail-closed deny. Stdin is parsed here by stdlib-only code (the
+    # healthy path's json.load in main() is never reached on this branch).
+    _degraded_decision("module imports", _module_load_error, _read_stdin_tool_name())
 
 
 _SUPPRESS_OUTPUT = json.dumps({
@@ -410,8 +510,18 @@ def main():
         deny_reason = _check_tool_allowed(input_data)
     except Exception as e:
         # Runtime fail-CLOSED — gate-logic exception must DENY (#658
-        # sibling defect class). Pre-#662 this path was fail-OPEN.
-        _emit_load_failure_deny("runtime", e)
+        # sibling defect class; pre-#662 this path was fail-OPEN) — with
+        # the #942 degraded-mode carve-out: a runtime gate-logic bug
+        # bricks diagnosis identically to an import failure, so it routes
+        # through the same _degraded_decision. stdin was already consumed
+        # by the json.load above — pass the already-parsed tool_name,
+        # never re-read stdin. input_data may be a non-dict JSON value
+        # (itself a plausible cause of the exception), so guard the .get;
+        # a missing/non-string tool_name denies, same as the import stage.
+        _tool = input_data.get("tool_name") if isinstance(input_data, dict) else None
+        _degraded_decision(
+            "runtime", e, _tool if isinstance(_tool, str) and _tool else None
+        )
 
     if deny_reason:
         # hookEventName is required by the harness; missing it silently fails open

--- a/pact-plugin/hooks/bootstrap_marker_writer.py
+++ b/pact-plugin/hooks/bootstrap_marker_writer.py
@@ -201,6 +201,13 @@ def _try_write_marker(input_data: dict) -> None:
     """
     pact_context.init(input_data)
 
+    # Self-heal: re-create a MISSING context file (session_init crashed at
+    # SessionStart) before reading session_dir. Total/never-raises; no-op
+    # unless lead frame + valid session_id + file absent. The verify-and-
+    # refuse pre-conditions below still gate the marker write — a healed
+    # context never forges bootstrap completion.
+    pact_context.heal_context_if_missing(input_data)
+
     # Trust boundary: session_dir comes from pact_context.get_session_dir(),
     # which derives it via shared.build_session_path's path-traversal guard
     # (Path.parents containment check). The writer trusts that upstream

--- a/pact-plugin/hooks/bootstrap_prompt_gate.py
+++ b/pact-plugin/hooks/bootstrap_prompt_gate.py
@@ -31,6 +31,8 @@ from __future__ import annotations
 
 # ─── stdlib first (used by _emit_load_failure_advisory BEFORE wrapped imports) ─
 import json
+import os
+import re
 import sys
 from typing import NoReturn
 
@@ -92,6 +94,79 @@ _SESSION_DIR_HINT = (
     "\n\nPACT_SESSION_DIR={session_dir}"
 )
 
+# Mirrors the Resume-line fallback regex in session_init's
+# _extract_prev_session_dir — the established defensive parse for the
+# session_resume.update_session_info managed block. Parity with
+# claude_md_manager.resolve_project_claude_md_path's existing-file
+# precedence is pinned by test (NOT by a runtime import — every new
+# top-level import here widens the import-failure blast radius the
+# bootstrap-resilience work exists to shrink).
+_RESUME_LINE_RE = re.compile(r"- Resume:\s*`claude --resume\s+([0-9a-f-]+)`")
+
+_STALENESS_WARNING_TEMPLATE = (
+    "\n\nWARNING — stale session block: the project CLAUDE.md 'Current "
+    "Session' block records session {recorded} but this session is "
+    "{actual}. session_init likely failed at SessionStart this session "
+    "(or the CLAUDE.md write failed). Do NOT trust the recorded Team/"
+    "Session dir/Resume lines for THIS session; completing bootstrap "
+    "will rewrite them."
+)
+
+
+def _detect_stale_session_block(input_data: dict) -> str | None:
+    """Detect a stale 'Current Session' block in the project CLAUDE.md.
+
+    When session_init crashes at SessionStart, the previous session's
+    Resume/Team/Session-dir lines survive in CLAUDE.md and misdirect
+    recovery. Compare the recorded Resume-line session_id against this
+    frame's raw stdin session_id; on mismatch, return an advisory warning
+    string for additionalContext composition. Returns None (no warning)
+    when:
+
+      1. stdin session_id is missing/empty (nothing to compare)
+      2. CLAUDE_PROJECT_DIR is unset (cannot locate CLAUDE.md)
+      3. neither CLAUDE.md location exists, or reading raises OSError
+         (worktrees: CLAUDE.md is gitignored/absent → silent skip)
+      4. no Resume line matches the regex (tampered/garbage → no claim)
+      5. recorded session_id equals this session's (healthy resume)
+
+    Stdlib-only two-path read: .claude/CLAUDE.md preferred, legacy
+    ./CLAUDE.md fallback — same existing-file precedence as
+    resolve_project_claude_md_path (parity pinned by test). False
+    positives: none in healthy flows — session_init rewrites the block
+    before the first prompt on startup/clear, and resume keeps the same
+    session_id.
+    """
+    raw_id = input_data.get("session_id")
+    if not raw_id:
+        return None
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
+    if not project_dir:
+        return None
+    try:
+        content = None
+        for candidate in (
+            Path(project_dir) / ".claude" / "CLAUDE.md",
+            Path(project_dir) / "CLAUDE.md",
+        ):
+            if candidate.exists():
+                content = candidate.read_text(encoding="utf-8")
+                break
+        if content is None:
+            return None
+    except OSError:
+        return None
+    match = _RESUME_LINE_RE.search(content)
+    if not match:
+        return None
+    recorded = match.group(1)
+    actual = str(raw_id)
+    if recorded != actual:
+        return _STALENESS_WARNING_TEMPLATE.format(
+            recorded=recorded, actual=actual
+        )
+    return None
+
 
 def _check_bootstrap_needed(input_data: dict) -> str | None:
     """Determine whether a bootstrap instruction should be injected.
@@ -138,10 +213,14 @@ def _check_bootstrap_needed(input_data: dict) -> str | None:
     if not pact_context.is_lead(input_data):
         return None
 
-    # Lead session, no marker → inject bootstrap instruction with session dir
+    # Lead session, no marker → inject bootstrap instruction with session
+    # dir, composed with the staleness advisory (or "") by concatenation.
+    # Staleness runs ONLY here (lead + no-marker): the marker-set fast path
+    # above keeps its zero-tokens/sub-ms contract (no per-prompt file read),
+    # and a marker-set session has by definition completed bootstrap.
     return _BOOTSTRAP_INSTRUCTION_TEMPLATE.format(
         session_dir_hint=_SESSION_DIR_HINT.format(session_dir=session_dir)
-    )
+    ) + (_detect_stale_session_block(input_data) or "")
 
 
 def main():

--- a/pact-plugin/hooks/bootstrap_prompt_gate.py
+++ b/pact-plugin/hooks/bootstrap_prompt_gate.py
@@ -123,10 +123,19 @@ def _detect_stale_session_block(input_data: dict) -> str | None:
     string for additionalContext composition. Returns None (no warning)
     when:
 
-      1. stdin session_id is missing/empty (nothing to compare)
+      1. stdin session_id is missing or invalid per the canonical
+         _is_unknown_or_missing_session predicate (None/non-string/empty/
+         whitespace-only/`unknown-*` sentinel/C0-control chars) — nothing
+         trustworthy to compare, and an unvalidated stdin id must never be
+         interpolated into the warning text
       2. CLAUDE_PROJECT_DIR is unset (cannot locate CLAUDE.md)
-      3. neither CLAUDE.md location exists, or reading raises OSError
-         (worktrees: CLAUDE.md is gitignored/absent → silent skip)
+      3. neither CLAUDE.md location exists, or reading raises OSError or
+         UnicodeDecodeError (worktrees: CLAUDE.md is gitignored/absent →
+         silent skip; a non-UTF-8/corrupted CLAUDE.md → silent skip — this
+         helper is ADVISORY, so its failure budget is "no warning", never
+         "no bootstrap instruction": an uncaught raise here would propagate
+         to main()'s fail-open and suppress the ENTIRE injection, primary
+         instruction included)
       4. no Resume line matches the regex (tampered/garbage → no claim)
       5. recorded session_id equals this session's (healthy resume)
 
@@ -138,7 +147,13 @@ def _detect_stale_session_block(input_data: dict) -> str | None:
     session_id.
     """
     raw_id = input_data.get("session_id")
-    if not raw_id:
+    # Canonical validity predicate (shared with the heal gate and
+    # session_init's persist/CLAUDE.md-write gates) — subsumes the plain
+    # truthiness check and additionally rejects non-string, whitespace-only,
+    # `unknown-*` sentinel, and C0-control-char ids, so `actual` below is
+    # never an attacker-shaped or sentinel value interpolated into the
+    # warning. The predicate is total for any input.
+    if pact_context._is_unknown_or_missing_session(raw_id):
         return None
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
     if not project_dir:
@@ -154,7 +169,13 @@ def _detect_stale_session_block(input_data: dict) -> str | None:
                 break
         if content is None:
             return None
-    except OSError:
+    except (OSError, UnicodeDecodeError):
+        # UnicodeDecodeError (a ValueError, NOT an OSError) from read_text
+        # on a non-UTF-8 CLAUDE.md — e.g. a latin-1 byte from a wrong-editor
+        # save, or the partial/corrupted session_init write this detector
+        # exists to flag. Must be swallowed HERE: this helper composes into
+        # the load-bearing bootstrap instruction by concatenation, and an
+        # escape to main()'s fail-open suppresses the whole injection.
         return None
     match = _RESUME_LINE_RE.search(content)
     if not match:

--- a/pact-plugin/hooks/bootstrap_prompt_gate.py
+++ b/pact-plugin/hooks/bootstrap_prompt_gate.py
@@ -103,6 +103,13 @@ def _check_bootstrap_needed(input_data: dict) -> str | None:
     # Initialize context (sets session-scoped path from input_data)
     pact_context.init(input_data)
 
+    # Self-heal: re-create a MISSING context file (session_init crashed at
+    # SessionStart) so this gate and downstream consumers can resolve the
+    # session again. Total/never-raises; no-op unless lead frame + valid
+    # session_id + file absent. Does NOT forge bootstrap completion — a
+    # healed session still flows into the no-marker inject branch below.
+    pact_context.heal_context_if_missing(input_data)
+
     # Fast path: check marker first (cheapest check, most common case)
     session_dir = pact_context.get_session_dir()
     if not session_dir:

--- a/pact-plugin/hooks/dispatch_gate.py
+++ b/pact-plugin/hooks/dispatch_gate.py
@@ -356,11 +356,25 @@ def evaluate_dispatch(tool_input: dict) -> tuple[str, str | None, str | None]:
                 "role-descriptive name.",
                 "name_reserved_token")
 
-    # ⑤ Plugin agents/ presence (cheap stat). Caught BEFORE the registry
+    # ⑤a Context/plugin_root resolution. With the env fallback in
+    # get_plugin_root() and the UserPromptSubmit self-heal, an empty
+    # plugin_root requires context-file-missing AND env-missing — when it
+    # does happen, name the REAL cause (the derived context path and the
+    # session_init root cause) instead of misdirecting recovery at the
+    # plugin install. Caught BEFORE the agents/ stat so the two causes
+    # (context unresolvable vs plugin install broken) stay separable.
+    plugin_root = pact_context.get_plugin_root()
+    if not plugin_root:
+        return ("DENY",
+                "PACT dispatch_gate: plugin_root is unavailable. "
+                + (pact_context.describe_context_failure()
+                   or "pact-session-context.json has an empty plugin_root "
+                      "and CLAUDE_PLUGIN_ROOT is not exported."),
+                "plugin_root_unavailable")
+    # ⑤b Plugin agents/ presence (cheap stat). Caught BEFORE the registry
     # check so a missing plugin install gets the more actionable
     # "plugin broken" message rather than "specialist not registered".
-    plugin_root = pact_context.get_plugin_root()
-    if not plugin_root or not (Path(plugin_root) / "agents").is_dir():
+    if not (Path(plugin_root) / "agents").is_dir():
         return ("DENY",
                 "PACT dispatch_gate: plugin agents/ directory is "
                 "unavailable. Plugin install may be broken; check "
@@ -383,11 +397,16 @@ def evaluate_dispatch(tool_input: dict) -> tuple[str, str | None, str | None]:
     # spawn-input side.
     session_team = pact_context.get_team_name()
     if not session_team:
-        return ("DENY",
-                "PACT dispatch_gate: session team_name is unavailable "
-                "(pact-session-context.json missing or unreadable). "
-                "Re-run /PACT:bootstrap to restore session context.",
-                "team_name_unavailable")
+        message = ("PACT dispatch_gate: session team_name is unavailable "
+                   "(pact-session-context.json missing or unreadable). "
+                   "Re-run /PACT:bootstrap to restore session context.")
+        # Append the shared context diagnosis (non-empty only when the
+        # context file is underivable/absent) so the deny names the real
+        # root cause instead of leaving recovery to guesswork.
+        diagnosis = pact_context.describe_context_failure()
+        if diagnosis:
+            message += " " + diagnosis
+        return ("DENY", message, "team_name_unavailable")
     if team_name != session_team:
         return ("DENY",
                 f"PACT dispatch_gate: team_name {team_name!r} does not "

--- a/pact-plugin/hooks/session_end.py
+++ b/pact-plugin/hooks/session_end.py
@@ -178,7 +178,7 @@ _UUID_PATTERN = re.compile(
 )
 
 # Regex for validating PACT team directory names. Intentionally LOOSER
-# than what `generate_team_name` in session_init.py actually emits —
+# than what `generate_team_name` in shared/pact_context.py actually emits —
 # the producer emits `pact-` + `secrets.token_hex(4)` (8 lowercase hex
 # chars, no internal hyphens) or the session-id-prefix fallback
 # (`pact-` + 8 hex chars). This regex accepts any `pact-`-prefixed
@@ -422,7 +422,7 @@ def cleanup_old_teams(
     Three defense layers:
     1. Name-pattern gate — only directories matching `_TEAM_NAME_PATTERN`
        (`^pact-[a-f0-9-]+$`) are candidates. This mirrors the INVARIANT
-       documented on `generate_team_name` in session_init.py. Non-PACT
+       documented on `generate_team_name` in shared/pact_context.py. Non-PACT
        writers that create `~/.claude/teams/foo-bar/` are out of scope:
        `~/.claude/teams/` is shared space, not PACT-owned space.
     2. Current-team skip — exact-match skip of `current_team_name`.
@@ -478,7 +478,7 @@ def cleanup_old_teams(
             if not entry.is_dir():
                 continue
             # Name-shape gate: only touch PACT-shaped team dirs. Mirrors
-            # the generate_team_name INVARIANT in session_init.py. Non-
+            # the generate_team_name INVARIANT in shared/pact_context.py. Non-
             # matching entries belong to other tooling and are out of
             # scope for this reaper.
             if not _TEAM_NAME_PATTERN.match(entry.name):

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -39,7 +39,7 @@ import re
 import secrets
 import sys
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 # Add hooks directory to path for shared package imports
 _hooks_dir = Path(__file__).parent
@@ -80,8 +80,10 @@ from pin_caps import (  # noqa: F401
 from shared import BOOTSTRAP_MARKER_NAME, SESSION_ID_CONTROL_CHARS_RE, build_session_path
 from shared.constants import get_compact_summary_path
 from shared.pact_context import (
+    _is_unknown_or_missing_session,
     build_context_cache,
     classify_session_role,
+    generate_team_name,
     get_session_dir,
     get_session_id,
     is_lead,
@@ -373,37 +375,6 @@ def check_additional_directories() -> str | None:
         return None  # Fail-open: never block session start
 
 
-def generate_team_name(input_data: dict[str, Any]) -> str:
-    """
-    Generate a session-unique PACT team name.
-
-    Uses the first 8 characters of the session_id from the SessionStart hook
-    stdin JSON to create a unique team name like "pact-0001639f". Falls back
-    to a random 8-character hex suffix if session_id is not in stdin.
-
-    Args:
-        input_data: Parsed JSON from stdin (SessionStart hook input)
-
-    Returns:
-        Team name string like "pact-0001639f"
-    """
-    # INVARIANT: all team directory names MUST be produced by this
-    # function. Output is lowercase ASCII hex ([a-f0-9-]) prefixed with
-    # "pact-" — the session_end reaper's exact-match skip predicate
-    # (cleanup_old_teams) and the union skip-set for cleanup_old_tasks
-    # rely on this shape. A writer that creates ~/.claude/teams/ dirs
-    # with characters outside this charset (uppercase, unicode,
-    # separators) could bypass the skip predicate and be reaped on the
-    # NEXT session_end.
-    raw_id = input_data.get("session_id")
-    session_id = str(raw_id) if raw_id else ""
-    if session_id:
-        suffix = re.sub(r"[^a-f0-9-]", "", session_id[:8]) or secrets.token_hex(4)
-    else:
-        suffix = secrets.token_hex(4)
-    return f"pact-{suffix}"
-
-
 def _validate_under_pact_sessions(path: str) -> str | None:
     """Reject extracted session paths that escape the pact-sessions root.
 
@@ -553,45 +524,11 @@ def _extract_prev_session_dir(project_dir: str) -> str | None:
 # strip sets across interpolation sinks become the attacker's entry point.
 _SESSION_ID_CONTROL_CHARS_RE = SESSION_ID_CONTROL_CHARS_RE
 
-
-def _is_unknown_or_missing_session(raw_id: object) -> bool:
-    """Return True if the session_id is missing, blank, a sentinel, or contains control chars.
-
-    Single canonical predicate for the malformed-stdin gate. Both the
-    persistence call sites at the top of main() (build_context_cache +
-    persist_context + append_event) and the CLAUDE.md write at step 5b consult
-    this helper so the two gates can never drift. Drift previously allowed
-    three corruption classes:
-
-    * Whitespace-only ids (e.g. `"   "`) were truthy and bypassed
-      `not raw_id`, leaking through to the context-persist path
-      (build_context_cache resolves it, persist_context mkdir's it) as a
-      literal directory name.
-    * An attacker-supplied `"unknown-foo"` value passed `not raw_id` because
-      the string is non-empty, then later passed `startswith("unknown")`
-      and was written into CLAUDE.md anyway via a different code path.
-    * A session_id containing C0 control characters (newline, CR, NUL,
-      etc.) passed all existing non-empty/non-sentinel checks but, when
-      interpolated into ``f"- Resume: `claude --resume {session_id}`"``
-      by update_session_info, could inject a fake CLAUDE.md line via
-      embedded newlines. The unified helper strips C0 controls to close
-      this injection path at the session_id entry point.
-
-    The unified helper rejects all of: None, non-strings, empty strings,
-    whitespace-only strings, any string already shaped like the
-    `unknown-*` sentinel, and any string containing C0 control characters
-    or DEL.
-    """
-    if not raw_id:
-        return True
-    if not isinstance(raw_id, str):
-        return True
-    stripped = raw_id.strip()
-    if not stripped:
-        return True
-    if _SESSION_ID_CONTROL_CHARS_RE.search(raw_id):
-        return True
-    return stripped.startswith("unknown-")
+# _is_unknown_or_missing_session — the single canonical session-id validity
+# predicate — now lives in shared.pact_context (imported above), where the
+# context self-heal gate consumes it alongside this module's persistence and
+# CLAUDE.md-write gates. One definition, three call sites: the gates can
+# never drift.
 
 
 def _build_safety_net_context(

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import secrets
 import sys
 import tempfile
 from datetime import datetime, timezone
@@ -300,6 +301,80 @@ def get_plugin_root() -> str:
     return get_pact_context().get("plugin_root", "") or os.environ.get(
         "CLAUDE_PLUGIN_ROOT", ""
     )
+
+
+def generate_team_name(input_data: dict) -> str:
+    """
+    Generate a session-unique PACT team name.
+
+    Uses the first 8 characters of the session_id from the SessionStart hook
+    stdin JSON to create a unique team name like "pact-0001639f". Falls back
+    to a random 8-character hex suffix if session_id is not in stdin.
+
+    Args:
+        input_data: Parsed JSON from stdin (SessionStart hook input)
+
+    Returns:
+        Team name string like "pact-0001639f"
+    """
+    # INVARIANT: all team directory names MUST be produced by this
+    # function. Output is lowercase ASCII hex ([a-f0-9-]) prefixed with
+    # "pact-" — the session_end reaper's exact-match skip predicate
+    # (cleanup_old_teams) and the union skip-set for cleanup_old_tasks
+    # rely on this shape. A writer that creates ~/.claude/teams/ dirs
+    # with characters outside this charset (uppercase, unicode,
+    # separators) could bypass the skip predicate and be reaped on the
+    # NEXT session_end.
+    raw_id = input_data.get("session_id")
+    session_id = str(raw_id) if raw_id else ""
+    if session_id:
+        suffix = re.sub(r"[^a-f0-9-]", "", session_id[:8]) or secrets.token_hex(4)
+    else:
+        suffix = secrets.token_hex(4)
+    return f"pact-{suffix}"
+
+
+def _is_unknown_or_missing_session(raw_id: object) -> bool:
+    """Return True if the session_id is missing, blank, a sentinel, or contains control chars.
+
+    Single canonical predicate for the malformed-stdin gate. Three call
+    sites consult this helper so the gates can never drift: the persistence
+    call sites at the top of session_init's main() (build_context_cache +
+    persist_context + append_event), the CLAUDE.md write at session_init
+    step 5b, and the self-heal gate in heal_context_if_missing() below
+    (a missing/sentinel id would make generate_team_name go RANDOM and
+    create an unreapable session dir). Drift previously allowed
+    three corruption classes:
+
+    * Whitespace-only ids (e.g. `"   "`) were truthy and bypassed
+      `not raw_id`, leaking through to the context-persist path
+      (build_context_cache resolves it, persist_context mkdir's it) as a
+      literal directory name.
+    * An attacker-supplied `"unknown-foo"` value passed `not raw_id` because
+      the string is non-empty, then later passed `startswith("unknown")`
+      and was written into CLAUDE.md anyway via a different code path.
+    * A session_id containing C0 control characters (newline, CR, NUL,
+      etc.) passed all existing non-empty/non-sentinel checks but, when
+      interpolated into ``f"- Resume: `claude --resume {session_id}`"``
+      by update_session_info, could inject a fake CLAUDE.md line via
+      embedded newlines. The unified helper strips C0 controls to close
+      this injection path at the session_id entry point.
+
+    The unified helper rejects all of: None, non-strings, empty strings,
+    whitespace-only strings, any string already shaped like the
+    `unknown-*` sentinel, and any string containing C0 control characters
+    or DEL.
+    """
+    if not raw_id:
+        return True
+    if not isinstance(raw_id, str):
+        return True
+    stripped = raw_id.strip()
+    if not stripped:
+        return True
+    if SESSION_ID_CONTROL_CHARS_RE.search(raw_id):
+        return True
+    return stripped.startswith("unknown-")
 
 
 def resolve_agent_name(

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -800,6 +800,42 @@ def write_context(
         persist_context(*result)
 
 
+def describe_context_failure() -> str:
+    """One-line diagnosis of WHY session context is empty, for embedding in
+    consumer deny messages (e.g. dispatch_gate). Returns '' when context is
+    healthy (file present and readable). Cases:
+
+      - _context_path is None → 'session context underivable (no session_id
+        in hook stdin or CLAUDE_PROJECT_DIR unset)'
+      - path set, file absent → 'context file not found: {path} — ...'
+        naming the derived path, the likely session_init root cause, and
+        the two recovery actions (self-heal on next prompt / /PACT:bootstrap)
+      - path set, file present (readable or not) → '' (not a missing-context
+        failure; read errors are already stderr-logged by get_pact_context)
+
+    Deliberately NOT auto-injected into get_pact_context(), which must stay
+    silent on file-absent (normal for pre-session_init hooks and non-PACT
+    sessions). TOTAL: no exceptions escape — an OSError from exists() maps
+    to the file-absent arm (an unstattable path is not a healthy context).
+    """
+    if _context_path is None:
+        return (
+            "session context underivable (no session_id in hook stdin or "
+            "CLAUDE_PROJECT_DIR unset)"
+        )
+    try:
+        file_present = _context_path.exists()
+    except OSError:
+        file_present = False
+    if not file_present:
+        return (
+            f"context file not found: {_context_path} — session_init may "
+            "have failed at SessionStart; submit any message to trigger "
+            "self-heal, or run /PACT:bootstrap"
+        )
+    return ""
+
+
 def heal_context_if_missing(input_data: dict) -> bool:
     """Re-create a missing pact-session-context.json from the same inputs
     session_init would use (stdin session_id, CLAUDE_PROJECT_DIR,

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -298,6 +298,16 @@ def get_plugin_root() -> str:
     rather than introducing a new failure mode. Empty string when both
     sources are unavailable.
     """
+    # Provenance / defense-in-depth (security review): in the empty-context
+    # case the env value flows into is_marker_set's signature computation
+    # (sha256(sid|plugin_root|version|1)), i.e. the fallback root PARTICIPATES
+    # in bootstrap-marker verification. CLAUDE_PLUGIN_ROOT is operator/
+    # harness-owned — exported by the platform into every hook process, the
+    # same trust domain as this hook itself — and is not reflectable from
+    # untrusted request content. No new privilege boundary: a wrong or
+    # tampered env value makes the marker's compare_digest FAIL → marker
+    # False → fail-closed, and the context-file value always wins when
+    # non-empty.
     return get_pact_context().get("plugin_root", "") or os.environ.get(
         "CLAUDE_PLUGIN_ROOT", ""
     )

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -286,8 +286,20 @@ def get_session_dir() -> str:
 
 
 def get_plugin_root() -> str:
-    """Convenience: return plugin_root from context. Empty string on error."""
-    return get_pact_context().get("plugin_root", "")
+    """Convenience: return plugin_root from context. Falls back to the
+    CLAUDE_PLUGIN_ROOT env var (exported into every hook process by the
+    harness) when the context-file value is empty or the file is missing.
+
+    Fallback-AFTER-file-read, never a replacement: the file value wins
+    whenever it is non-empty, and the uniform ``or`` covers both the
+    file-missing and field-empty cases. If the platform ever regresses
+    the env export, behavior degrades to the historical file-only read
+    rather than introducing a new failure mode. Empty string when both
+    sources are unavailable.
+    """
+    return get_pact_context().get("plugin_root", "") or os.environ.get(
+        "CLAUDE_PLUGIN_ROOT", ""
+    )
 
 
 def resolve_agent_name(

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -798,3 +798,74 @@ def write_context(
     result = build_context_cache(team_name, session_id, project_dir, plugin_root)
     if result is not None:
         persist_context(*result)
+
+
+def heal_context_if_missing(input_data: dict) -> bool:
+    """Re-create a missing pact-session-context.json from the same inputs
+    session_init would use (stdin session_id, CLAUDE_PROJECT_DIR,
+    CLAUDE_PLUGIN_ROOT). Lead frames only (#877). Returns True iff healed.
+
+    Fires ONLY when ALL hold:
+      1. init(input_data) derived a path (_context_path is not None)
+      2. the file is ABSENT on disk — a present-but-malformed file is NOT
+         clobbered (different failure class, preserve the evidence; read
+         errors are already stderr-logged by get_pact_context)
+      3. is_lead(input_data) — a teammate/plain frame must never create
+         or clobber the lead's on-disk file (#877). UserPromptSubmit has
+         no teammate fire path; the residual non-lead frame is a plain
+         session (agent_type absent) → no heal, exactly as intended
+      4. NOT _is_unknown_or_missing_session(input_data.get("session_id"))
+         — a missing/sentinel id would make generate_team_name go RANDOM
+         (fabricated team name) and create an unreapable session dir;
+         mirrors session_init's session_id_was_missing persist gate
+
+    Heal = write_context(generate_team_name(input_data), str(raw_id),
+    CLAUDE_PROJECT_DIR, CLAUDE_PLUGIN_ROOT) — the existing
+    build+cache+persist seam: atomic write (mkstemp+rename), 0o600, and
+    build_context_cache resets _cache so THIS process's subsequent
+    get_team_name()/get_session_dir() calls see the healed values.
+
+    Content parity with session_init: session_id is persisted as
+    str(raw_id) — RAW, exactly as session_init's main() persists it
+    (init() sanitizes only the PATH segment, not the stored value).
+    started_at is heal time, not session start — its consumers are
+    journal-naming/display only (cosmetic), documented trade-off.
+
+    Two-healer race (bootstrap_marker_writer + bootstrap_prompt_gate fire
+    on the same prompt; the platform runs same-event hooks in parallel):
+    persist_context is atomic (mkstemp + rename), and both healers compute
+    IDENTICAL content except started_at → last-writer-wins with equivalent
+    content. Benign.
+
+    TOTAL: never raises — any internal exception is swallowed to a stderr
+    line and False (both callers are fail-open hooks; the heal must not
+    convert a degraded session into a crashed hook).
+
+    Args:
+        input_data: Parsed stdin JSON from the hook (UserPromptSubmit frame).
+
+    Returns:
+        True iff the context file was absent and is now healed on disk.
+    """
+    try:
+        if _context_path is None:
+            return False
+        if _context_path.exists():
+            return False
+        if not is_lead(input_data):
+            return False
+        raw_id = input_data.get("session_id")
+        if _is_unknown_or_missing_session(raw_id):
+            return False
+        write_context(
+            generate_team_name(input_data),
+            str(raw_id),
+            os.environ.get("CLAUDE_PROJECT_DIR", ""),
+            os.environ.get("CLAUDE_PLUGIN_ROOT", ""),
+        )
+        # write_context's persist half is fail-open (errors swallowed to
+        # stderr) — verify on disk so the contract "True iff healed" holds.
+        return _context_path.exists()
+    except Exception as e:
+        print(f"pact_context: self-heal failed: {e}", file=sys.stderr)
+        return False

--- a/pact-plugin/hooks/shared/session_state.py
+++ b/pact-plugin/hooks/shared/session_state.py
@@ -51,7 +51,7 @@ _NAME_MAX_CHARS = 200
 # input containing anything outside [A-Za-z0-9_-] is rejected. This
 # matches the shape of legitimate values:
 #   - team_name: "pact-" + hex-with-hyphens (per generate_team_name
-#     at session_init.py:376, which uses `re.sub(r"[^a-f0-9-]", "",
+#     in shared/pact_context.py, which uses `re.sub(r"[^a-f0-9-]", "",
 #     session_id[:8])`).
 #   - feature_id: numeric task IDs or UUIDs (hex + hyphens).
 # Rejects ".", "..", "../etc", path separators, control chars, null,

--- a/pact-plugin/tests/conftest.py
+++ b/pact-plugin/tests/conftest.py
@@ -246,3 +246,35 @@ def _restore_claude_project_dir_env():
         os.environ.pop("CLAUDE_PROJECT_DIR", None)
     else:
         os.environ["CLAUDE_PROJECT_DIR"] = original
+
+
+@pytest.fixture(autouse=True)
+def _scrub_claude_plugin_root_env():
+    """Pop + restore ``os.environ['CLAUDE_PLUGIN_ROOT']`` around every test.
+    Runs for EVERY test (autouse).
+
+    ``shared.pact_context.get_plugin_root()`` falls back to the
+    CLAUDE_PLUGIN_ROOT env var when the context-file value is empty or the
+    file is missing. That fallback makes ambient process env VISIBLE to
+    production code under test: running the suite inside an environment
+    that exports CLAUDE_PLUGIN_ROOT (e.g. a Claude Code hook process, or a
+    developer shell that sourced one) would silently flip the
+    empty-plugin_root pins (test_pact_context.py
+    ``test_returns_empty_when_plugin_root_missing``, test_bootstrap_gate.py
+    ``test_rejects_when_plugin_root_missing``) from deterministic to
+    environment-sensitive.
+
+    Unlike the CLAUDE_PROJECT_DIR sibling above (snapshot/restore only —
+    guarding cross-test LEAKS), this fixture POPS the var at setup so every
+    test starts from a guaranteed-unset baseline, then restores the original
+    value at teardown. Tests that exercise the fallback set the var
+    explicitly via monkeypatch.setenv. This is the generalization the
+    sibling fixture's closing comment anticipated for CLAUDE_PLUGIN_ROOT.
+    """
+    _UNSET = object()
+    original = os.environ.pop("CLAUDE_PLUGIN_ROOT", _UNSET)
+    yield
+    if original is _UNSET:
+        os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+    else:
+        os.environ["CLAUDE_PLUGIN_ROOT"] = original

--- a/pact-plugin/tests/test_bootstrap_gate.py
+++ b/pact-plugin/tests/test_bootstrap_gate.py
@@ -497,7 +497,9 @@ class TestFailClosedGateLogic:
 
 class TestErrorSuppressMutualExclusivity:
     """P0: input-side fail-open uses suppressOutput; deny path (block + runtime fail-closed
-    fail-closed) uses hookSpecificOutput. systemMessage is never emitted.
+    fail-closed) uses hookSpecificOutput. systemMessage is never emitted on
+    suppress/deny paths; the degraded-allow path (#942) is the single
+    deliberate systemMessage emitter (see TestDegradedMode).
     """
 
     def test_malformed_stdin_no_system_message(self, capsys):
@@ -1139,19 +1141,29 @@ class TestAuditAnchorParity:
     """Every JSON output path bootstrap_gate produces MUST carry
     hookSpecificOutput.hookEventName == "PreToolUse". Missing the field
     silently fails open at the platform layer (per pinned context). The
-    invariant is parametrized over the three distinct emit shapes:
+    invariant is parametrized over the five distinct emit shapes:
 
     - "deny-load-failure": _emit_load_failure_deny advisory
     - "deny-runtime": runtime-exception deny via _emit_load_failure_deny
     - "suppress": every other exit path via the _SUPPRESS_OUTPUT constant
+    - "degraded-allow-import": #942 allow-with-warning, import stage
+      (direct _emit_degraded_allow invocation)
+    - "degraded-allow-runtime": #942 allow-with-warning, runtime stage
+      (gate-logic exception + allowlisted tool through main())
 
-    All three MUST carry the audit anchor — parametrizing pins the
+    All five MUST carry the audit anchor — parametrizing pins the
     invariant so no future emit path can be added without it. Mirrors
     bootstrap_marker_writer's test_every_emit_shape_carries_hook_event_name
     so all three bootstrap-related hooks share one parity contract.
     """
 
-    @pytest.mark.parametrize("shape", ["deny-load-failure", "deny-runtime", "suppress"])
+    @pytest.mark.parametrize("shape", [
+        "deny-load-failure",
+        "deny-runtime",
+        "suppress",
+        "degraded-allow-import",
+        "degraded-allow-runtime",
+    ])
     def test_every_emit_shape_carries_hook_event_name(self, shape, capsys):
         if shape == "deny-load-failure":
             from bootstrap_gate import _emit_load_failure_deny
@@ -1166,6 +1178,26 @@ class TestAuditAnchorParity:
                 side_effect=RuntimeError("boom"),
             ):
                 with patch("sys.stdin", io.StringIO(json.dumps(_make_input()))):
+                    with pytest.raises(SystemExit):
+                        main()
+            captured = capsys.readouterr()
+            out = json.loads(captured.out.strip())
+        elif shape == "degraded-allow-import":
+            from bootstrap_gate import _emit_degraded_allow
+            with pytest.raises(SystemExit):
+                _emit_degraded_allow("module imports", RuntimeError("x"), "Read")
+            captured = capsys.readouterr()
+            out = json.loads(captured.out.strip())
+        elif shape == "degraded-allow-runtime":
+            from bootstrap_gate import main
+            with patch(
+                "bootstrap_gate._check_tool_allowed",
+                side_effect=RuntimeError("boom"),
+            ):
+                with patch(
+                    "sys.stdin",
+                    io.StringIO(json.dumps(_make_input(tool_name="Read"))),
+                ):
                     with pytest.raises(SystemExit):
                         main()
             captured = capsys.readouterr()
@@ -1185,6 +1217,216 @@ class TestAuditAnchorParity:
             f"shape={shape} emit MUST carry hookEventName=='PreToolUse'; "
             f"got {hso!r}"
         )
+
+
+# =============================================================================
+# Degraded mode (#942) — verification slice (CODE phase)
+# =============================================================================
+
+
+def _run_degraded_subprocess(tmp_path, stdin_text):
+    """Run bootstrap_gate.py as a subprocess inside a scaffold whose
+    `shared` package is deliberately syntax-broken, forcing the import-stage
+    degraded path. Returns the CompletedProcess.
+
+    Minimal smoke scaffold (CODE-phase verification); the comprehensive
+    broken-import behavior matrix (full allowlist/deny parametrization)
+    is TEST-phase scope.
+    """
+    import subprocess
+
+    hook_src = Path(__file__).parent.parent / "hooks" / "bootstrap_gate.py"
+    scaffold = tmp_path / "scaffold"
+    (scaffold / "shared").mkdir(parents=True)
+    (scaffold / "bootstrap_gate.py").write_text(
+        hook_src.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    # Syntax error → ImportError class failure at module load.
+    (scaffold / "shared" / "__init__.py").write_text(
+        "this is not valid python (", encoding="utf-8"
+    )
+    return subprocess.run(
+        [sys.executable, str(scaffold / "bootstrap_gate.py")],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        cwd=str(scaffold),
+        timeout=10,
+    )
+
+
+class TestDegradedMode:
+    """#942 degraded-mode handler: while the gate cannot evaluate (import
+    or runtime failure), verified read-only tools are allowed WITH a
+    warning at exit 0; everything else keeps the unchanged fail-closed
+    deny at exit 2. Malformed/unverifiable stdin in the degraded path is
+    fail-CLOSED (deny) — the opposite of the healthy path's input-side
+    fail-open, because in degraded mode this module IS the broken layer.
+
+    CODE-phase verification slice only: structural allowlist pins, the
+    runtime-stage branch in-process, and an import-stage subprocess smoke.
+    The comprehensive subprocess matrix is TEST-phase scope.
+    """
+
+    # --- structural invariant pins (master safety property) ---
+
+    def test_allowlist_disjoint_from_blocked_tools(self):
+        """Degraded-allow ⊆ healthy-allow, part 1: no allowlist member is
+        ever in the blocked set."""
+        from bootstrap_gate import _BLOCKED_TOOLS, _READ_ONLY_TOOLS
+
+        assert _READ_ONLY_TOOLS & _BLOCKED_TOOLS == frozenset()
+
+    def test_allowlist_excludes_bash_and_mcp(self):
+        """Deliberate strictness asymmetry: Bash and MCP tools are allowed
+        on the healthy pre-marker path but must NOT be degraded-allowable."""
+        from bootstrap_gate import _READ_ONLY_TOOLS
+
+        assert "Bash" not in _READ_ONLY_TOOLS
+        assert not any(t.startswith("mcp__") for t in _READ_ONLY_TOOLS)
+
+    def test_every_allowlist_member_allowed_on_healthy_gated_branch(
+        self, monkeypatch, tmp_path
+    ):
+        """Degraded-allow ⊆ healthy-allow, part 2: on the strictest healthy
+        branch (lead, no marker), every allowlist member is allowed."""
+        from bootstrap_gate import _READ_ONLY_TOOLS, _check_tool_allowed
+
+        _setup_pact_session(monkeypatch, tmp_path, with_marker=False)
+        for tool in sorted(_READ_ONLY_TOOLS):
+            assert _check_tool_allowed(_make_input(tool)) is None, (
+                f"allowlist member {tool!r} must be allowed on the healthy "
+                f"lead+no-marker branch — degraded mode may never grant "
+                f"something the healthy gate denies"
+            )
+
+    # --- runtime stage (in-process, symmetric with import stage) ---
+
+    def test_runtime_exception_with_readonly_tool_allows_with_warning(self, capsys):
+        """Gate-logic exception + allowlisted tool → exit 0, allow JSON with
+        warning text and systemMessage (the single deliberate emitter)."""
+        from bootstrap_gate import main
+
+        with patch(
+            "bootstrap_gate._check_tool_allowed",
+            side_effect=RuntimeError("boom"),
+        ):
+            with patch(
+                "sys.stdin", io.StringIO(json.dumps(_make_input(tool_name="Read")))
+            ):
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+
+        assert exc_info.value.code == 0
+        out = json.loads(capsys.readouterr().out.strip())
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "allow"
+        for field in ("permissionDecisionReason", "additionalContext"):
+            assert "runtime" in hso[field]
+            assert "RuntimeError" in hso[field]
+            assert "DEGRADED" in hso[field]
+        assert "systemMessage" in out
+
+    def test_runtime_exception_with_mutating_tool_still_denies(self, capsys):
+        """Symmetry must not weaken the deny arm: Edit under a gate-logic
+        exception keeps today's fail-closed deny (exit 2)."""
+        from bootstrap_gate import main
+
+        with patch(
+            "bootstrap_gate._check_tool_allowed",
+            side_effect=RuntimeError("boom"),
+        ):
+            with patch(
+                "sys.stdin", io.StringIO(json.dumps(_make_input(tool_name="Edit")))
+            ):
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+
+        assert exc_info.value.code == 2
+        out = json.loads(capsys.readouterr().out.strip())
+        assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert "systemMessage" not in out
+
+    def test_runtime_exception_with_missing_tool_name_denies(self, capsys):
+        """Unverifiable tool name in the degraded runtime path → fail-CLOSED
+        deny, same as the import stage."""
+        from bootstrap_gate import main
+
+        frame = _make_input()
+        del frame["tool_name"]
+        with patch(
+            "bootstrap_gate._check_tool_allowed",
+            side_effect=RuntimeError("boom"),
+        ):
+            with patch("sys.stdin", io.StringIO(json.dumps(frame))):
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+
+        assert exc_info.value.code == 2
+        out = json.loads(capsys.readouterr().out.strip())
+        assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_runtime_exception_with_non_dict_frame_denies(self, capsys):
+        """Valid-JSON non-dict stdin (e.g. a list) raises inside the gate
+        logic; the degraded handler must not crash on the .get and must
+        deny fail-closed (rc 2 with structured JSON, never a traceback)."""
+        from bootstrap_gate import main
+
+        with patch("sys.stdin", io.StringIO(json.dumps([1, 2, 3]))):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 2
+        out = json.loads(capsys.readouterr().out.strip())
+        assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    # --- import stage (subprocess smoke; full matrix is TEST phase) ---
+
+    def test_subprocess_broken_import_readonly_tool_allows(self, tmp_path):
+        """Broken `shared` import + tool_name=Read → allow-with-warning,
+        rc 0 (rc IS the emit contract: JSON only honored on exit 0 — pair
+        with content asserts, never rc alone)."""
+        result = _run_degraded_subprocess(
+            tmp_path, json.dumps(_make_input(tool_name="Read"))
+        )
+        assert result.returncode == 0, (
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        out = json.loads(result.stdout.strip().splitlines()[0])
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "allow"
+        assert "module imports" in hso["permissionDecisionReason"]
+        assert "systemMessage" in out
+        assert result.stderr.strip(), "stderr diagnostic line expected"
+
+    def test_subprocess_broken_import_mutating_tool_denies(self, tmp_path):
+        """Broken import + tool_name=Edit → byte-shape of today's
+        _emit_load_failure_deny, rc 2, stderr non-empty."""
+        result = _run_degraded_subprocess(
+            tmp_path, json.dumps(_make_input(tool_name="Edit"))
+        )
+        assert result.returncode == 2, (
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        out = json.loads(result.stdout.strip().splitlines()[0])
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "deny"
+        assert "module imports failure" in hso["permissionDecisionReason"]
+        assert "systemMessage" not in out
+        assert result.stderr.strip()
+
+    def test_subprocess_broken_import_malformed_stdin_denies(self, tmp_path):
+        """Broken import + unparseable stdin → fail-CLOSED deny (decision
+        (b)): the degraded path inverts the healthy input-side fail-open."""
+        result = _run_degraded_subprocess(tmp_path, "not valid json {")
+        assert result.returncode == 2, (
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        out = json.loads(result.stdout.strip().splitlines()[0])
+        assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
 
 
 # =============================================================================

--- a/pact-plugin/tests/test_bootstrap_gate.py
+++ b/pact-plugin/tests/test_bootstrap_gate.py
@@ -1224,10 +1224,55 @@ class TestAuditAnchorParity:
 # =============================================================================
 
 
-def _run_degraded_subprocess(tmp_path, stdin_text, interpreter=None):
+def _break_shared_syntax(scaffold):
+    """Canonical vector: shared/ exists but its __init__.py is syntax-broken."""
+    (scaffold / "shared").mkdir(parents=True)
+    (scaffold / "shared" / "__init__.py").write_text(
+        "this is not valid python (", encoding="utf-8"
+    )
+
+
+def _break_shared_absent(scaffold):
+    """shared/ package absent entirely (deleted / never installed)."""
+    # Deliberately create nothing — `import shared.pact_context` raises
+    # ModuleNotFoundError at module load.
+
+
+def _break_shared_missing_transitive(scaffold):
+    """shared/__init__.py parses fine but its body fails a from-import of a
+    name that does not exist (the missing-transitive-dependency shape) —
+    raises ImportError (NOT its ModuleNotFoundError subclass)."""
+    (scaffold / "shared").mkdir(parents=True)
+    (scaffold / "shared" / "__init__.py").write_text(
+        "from json import name_that_does_not_exist_in_json\n",
+        encoding="utf-8",
+    )
+
+
+# Breakage-vector table for the degraded-import scaffold: vector name →
+# (scaffold-breaker, exception type name the warning must carry). The
+# production degraded region is `except BaseException`, so the defer/deny
+# split must be IDENTICAL no matter HOW shared/ broke; the distinct
+# exception type names make each vector's diagnosability assertable. The
+# 2026-06-11 incident vector (py3.9 TypeError from annotation evaluation)
+# is exercised separately by test_degraded_path_runs_on_python39_floor on
+# a real 3.9 interpreter.
+_BREAKAGE_VECTORS = {
+    "syntax-broken-init": (_break_shared_syntax, "SyntaxError"),
+    "shared-package-absent": (_break_shared_absent, "ModuleNotFoundError"),
+    "missing-transitive-import": (
+        _break_shared_missing_transitive, "ImportError",
+    ),
+}
+
+
+def _run_degraded_subprocess(tmp_path, stdin_text, interpreter=None,
+                             vector="syntax-broken-init"):
     """Run bootstrap_gate.py as a subprocess inside a scaffold whose
-    `shared` package is deliberately syntax-broken, forcing the import-stage
-    degraded path. Returns the CompletedProcess.
+    `shared` package is deliberately broken per ``vector`` (a
+    _BREAKAGE_VECTORS key; default = the canonical syntax-broken
+    __init__.py), forcing the import-stage degraded path. Returns the
+    CompletedProcess.
 
     ``interpreter`` defaults to the dev interpreter (sys.executable); the
     py3.9-floor test passes a discovered 3.9 binary to exercise the
@@ -1238,14 +1283,11 @@ def _run_degraded_subprocess(tmp_path, stdin_text, interpreter=None):
 
     hook_src = Path(__file__).parent.parent / "hooks" / "bootstrap_gate.py"
     scaffold = tmp_path / "scaffold"
-    (scaffold / "shared").mkdir(parents=True)
+    scaffold.mkdir(parents=True)
     (scaffold / "bootstrap_gate.py").write_text(
         hook_src.read_text(encoding="utf-8"), encoding="utf-8"
     )
-    # Syntax error → ImportError class failure at module load.
-    (scaffold / "shared" / "__init__.py").write_text(
-        "this is not valid python (", encoding="utf-8"
-    )
+    _BREAKAGE_VECTORS[vector][0](scaffold)
     return subprocess.run(
         [interpreter or sys.executable, str(scaffold / "bootstrap_gate.py")],
         input=stdin_text,
@@ -1717,6 +1759,65 @@ class TestDegradedMode:
             f"{label}: stderr={result.stderr!r} stdout={result.stdout!r}"
         )
 
+    # --- breakage-vector agnosticism (beyond the canonical SyntaxError) ---
+
+    @pytest.mark.parametrize("vector", sorted(_BREAKAGE_VECTORS))
+    def test_subprocess_breakage_vectors_readonly_defers(self, tmp_path, vector):
+        """The degraded region catches BaseException, so the warn arm must
+        behave IDENTICALLY no matter HOW shared/ broke: syntax-broken
+        __init__.py (SyntaxError), package absent (ModuleNotFoundError),
+        or a failing from-import inside an otherwise-parseable __init__.py
+        (ImportError — the missing-transitive-dependency shape). Read
+        defers with the vector's exception type named in the warning
+        (diagnosability), rc 0 alongside content."""
+        result = _run_degraded_subprocess(
+            tmp_path, json.dumps(_make_input(tool_name="Read")), vector=vector
+        )
+
+        out = json.loads(result.stdout.strip().splitlines()[0])
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "defer", (
+            f"vector {vector!r} must take the same defer arm as the "
+            f"canonical syntax vector"
+        )
+        expected_exc = _BREAKAGE_VECTORS[vector][1]
+        for field in ("permissionDecisionReason", "additionalContext"):
+            assert "DEGRADED" in hso[field]
+            assert "module imports" in hso[field], "stage must be named"
+            assert expected_exc in hso[field], (
+                f"vector {vector!r} must name its exception type "
+                f"({expected_exc}) so the warning is diagnosable"
+            )
+        assert "systemMessage" in out
+        assert result.returncode == 0, (
+            f"{vector}: stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        assert result.stderr.strip(), "stderr diagnostic line expected"
+
+    @pytest.mark.parametrize("vector", sorted(_BREAKAGE_VECTORS))
+    def test_subprocess_breakage_vectors_mutating_denies(self, tmp_path, vector):
+        """Deny-arm twin of the vector matrix: Edit takes the unchanged
+        fail-closed deny at rc 2 under EVERY breakage vector, with the
+        vector's exception type named in the deny reason."""
+        result = _run_degraded_subprocess(
+            tmp_path, json.dumps(_make_input(tool_name="Edit")), vector=vector
+        )
+
+        out = json.loads(result.stdout.strip().splitlines()[0])
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "deny", (
+            f"vector {vector!r} must keep the fail-closed deny arm"
+        )
+        assert "module imports failure" in hso["permissionDecisionReason"]
+        assert _BREAKAGE_VECTORS[vector][1] in hso["permissionDecisionReason"]
+        assert "systemMessage" not in out
+        assert result.returncode == 2, (
+            f"{vector}: stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        assert result.stderr.strip()
+
     # --- py3.9 floor exercise (conditional on an available interpreter) ---
 
     def test_degraded_path_runs_on_python39_floor(self, tmp_path):
@@ -1760,6 +1861,123 @@ class TestDegradedMode:
         out = json.loads(malformed.stdout.strip().splitlines()[0])
         assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
         assert malformed.returncode == 2
+
+
+# =============================================================================
+# Marker verification × CLAUDE_PLUGIN_ROOT env fallback — healthy path
+# =============================================================================
+
+
+class TestMarkerVerifyEnvFallback:
+    """is_marker_set derives plugin_root via pact_context.get_plugin_root(),
+    which falls back to the CLAUDE_PLUGIN_ROOT env var when the context-file
+    value is empty or the file is missing. These tests pin that the
+    fallback participates in MARKER VERIFICATION on the healthy path — the
+    realistic shape being a context file healed (or written) while
+    CLAUDE_PLUGIN_ROOT was absent, leaving plugin_root='' on disk while the
+    env var is exported into every subsequent hook process.
+
+    Three arms: (1) env rescues verification — a validly-signed marker
+    verifies with the context plugin_root unavailable; (2) both sources
+    absent fails closed (the conftest autouse scrub guarantees the env
+    baseline); (3) a WRONG env root fails the SIGNATURE — proving the env
+    value participates in the HMAC input, not merely the non-empty check.
+    """
+
+    def _scaffold(self, monkeypatch, tmp_path, context_state):
+        """Session dir + plugin root (plugin.json v9.9.9) + validly-signed
+        marker; the context file is per ``context_state``: 'absent' (never
+        written) or 'empty-plugin-root' (present, plugin_root='')."""
+        import shared.pact_context as ctx_module
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        session_dir = tmp_path / ".claude" / "pact-sessions" / _SLUG / _SESSION_ID
+        session_dir.mkdir(parents=True)
+
+        plugin_root = tmp_path / "plugin"
+        (plugin_root / ".claude-plugin").mkdir(parents=True)
+        (plugin_root / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"version": "9.9.9"}), encoding="utf-8"
+        )
+        _write_f24_marker(session_dir, plugin_root)
+
+        context_file = session_dir / "pact-session-context.json"
+        if context_state == "empty-plugin-root":
+            context_file.write_text(json.dumps({
+                "team_name": "",
+                "session_id": _SESSION_ID,
+                "project_dir": _PROJECT_DIR,
+                "plugin_root": "",
+                "started_at": "2026-01-01T00:00:00Z",
+            }), encoding="utf-8")
+        # 'absent': deliberately not written.
+
+        monkeypatch.setattr(ctx_module, "_context_path", context_file)
+        monkeypatch.setattr(ctx_module, "_cache", None)
+        return session_dir, plugin_root
+
+    @pytest.mark.parametrize("context_state", ["absent", "empty-plugin-root"])
+    def test_env_fallback_rescues_marker_verification(
+            self, monkeypatch, tmp_path, context_state):
+        """Context plugin_root unavailable + CLAUDE_PLUGIN_ROOT exported →
+        the validly-signed marker verifies via the env-derived root."""
+        from bootstrap_gate import is_marker_set
+
+        session_dir, plugin_root = self._scaffold(
+            monkeypatch, tmp_path, context_state)
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+
+        assert is_marker_set(session_dir) is True
+
+    @pytest.mark.parametrize("context_state", ["absent", "empty-plugin-root"])
+    def test_both_sources_absent_fails_closed(
+            self, monkeypatch, tmp_path, context_state):
+        """Same scaffold, env NOT set (conftest scrub guarantees the unset
+        baseline) → plugin_root resolves '' → marker verification fails
+        closed, single-variable counterpart of the rescue arm above."""
+        from bootstrap_gate import is_marker_set
+
+        session_dir, _ = self._scaffold(monkeypatch, tmp_path, context_state)
+
+        assert is_marker_set(session_dir) is False
+
+    def test_wrong_env_root_fails_signature(self, monkeypatch, tmp_path):
+        """Env pointing at a DIFFERENT root (own valid plugin.json, SAME
+        version, so only the root path differs in the HMAC input) → the
+        signature mismatch rejects the marker — the env value participates
+        in verification, it does not merely satisfy the non-empty check."""
+        from bootstrap_gate import is_marker_set
+
+        session_dir, _ = self._scaffold(monkeypatch, tmp_path, "absent")
+        other_root = tmp_path / "other-plugin"
+        (other_root / ".claude-plugin").mkdir(parents=True)
+        (other_root / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"version": "9.9.9"}), encoding="utf-8"
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(other_root))
+
+        assert is_marker_set(session_dir) is False
+
+    def test_empty_plugin_root_context_marker_fast_path_via_env(
+            self, monkeypatch, tmp_path):
+        """Integration through the real gate: context file PRESENT with
+        plugin_root='' (the heal-without-env shape) + env exported → the
+        marker fast path allows a normally-blocked tool; with the env
+        absent the SAME scaffold denies — the discriminating pair pins
+        that the env fallback is what carries the fast path."""
+        from bootstrap_gate import _check_tool_allowed
+
+        session_dir, plugin_root = self._scaffold(
+            monkeypatch, tmp_path, "empty-plugin-root")
+
+        # Without the env var (scrubbed baseline): marker unverifiable →
+        # lead+no-marker branch → Edit denied.
+        assert _check_tool_allowed(_make_input("Edit")) is not None
+
+        # With the env var: marker verifies → fast path allows Edit.
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        assert _check_tool_allowed(_make_input("Edit")) is None
 
 
 # =============================================================================

--- a/pact-plugin/tests/test_bootstrap_gate.py
+++ b/pact-plugin/tests/test_bootstrap_gate.py
@@ -1224,14 +1224,15 @@ class TestAuditAnchorParity:
 # =============================================================================
 
 
-def _run_degraded_subprocess(tmp_path, stdin_text):
+def _run_degraded_subprocess(tmp_path, stdin_text, interpreter=None):
     """Run bootstrap_gate.py as a subprocess inside a scaffold whose
     `shared` package is deliberately syntax-broken, forcing the import-stage
     degraded path. Returns the CompletedProcess.
 
-    Minimal smoke scaffold (CODE-phase verification); the comprehensive
-    broken-import behavior matrix (full allowlist/deny parametrization)
-    is TEST-phase scope.
+    ``interpreter`` defaults to the dev interpreter (sys.executable); the
+    py3.9-floor test passes a discovered 3.9 binary to exercise the
+    stdlib-only degraded region on the production system interpreter
+    (GUI-launched macOS sessions run hooks on /usr/bin/python3 = 3.9.x).
     """
     import subprocess
 
@@ -1246,13 +1247,80 @@ def _run_degraded_subprocess(tmp_path, stdin_text):
         "this is not valid python (", encoding="utf-8"
     )
     return subprocess.run(
-        [sys.executable, str(scaffold / "bootstrap_gate.py")],
+        [interpreter or sys.executable, str(scaffold / "bootstrap_gate.py")],
         input=stdin_text,
         capture_output=True,
         text=True,
         cwd=str(scaffold),
         timeout=10,
     )
+
+
+def _find_python39():
+    """Best-effort discovery of a Python 3.9 interpreter for the floor
+    exercise: an explicit ``python3.9`` on PATH, else the macOS system
+    ``/usr/bin/python3`` when it reports 3.9.x (the actual interpreter
+    GUI-launched sessions run hooks on). Returns None when unavailable —
+    callers skip; the static AST floor guard
+    (test_py39_annotation_compat.py) remains the unconditional gate.
+    """
+    import shutil
+    import subprocess
+
+    candidates = [shutil.which("python3.9"), "/usr/bin/python3"]
+    for candidate in candidates:
+        if not candidate or not Path(candidate).exists():
+            continue
+        try:
+            probe = subprocess.run(
+                [candidate, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if (probe.stdout + probe.stderr).strip().startswith("Python 3.9"):
+            return candidate
+    return None
+
+
+# Canonical degraded-allowlist literal — deliberately independent of
+# bootstrap_gate._READ_ONLY_TOOLS (same convention as
+# _CANONICAL_DENY_REASON_LITERAL above): the parametrized subprocess matrix
+# anchors on this literal so a member silently dropped from (or added to)
+# the production set cannot shrink the matrix unnoticed. The set-equality +
+# cardinality pin in TestDegradedMode is the two-site edit surface: any
+# intentional allowlist change must update BOTH the production frozenset
+# AND this literal, forcing the matrix to follow.
+_DEGRADED_ALLOWLIST_LITERAL = (
+    "AskUserQuestion",
+    "ExitPlanMode",
+    "Glob",
+    "Grep",
+    "Read",
+    "Skill",
+    "TaskGet",
+    "TaskList",
+    "ToolSearch",
+    "WebFetch",
+    "WebSearch",
+)
+
+# Deny matrix: representatives of every non-member class — blocked mutating
+# tools, the deliberate healthy/degraded asymmetry (Bash, mcp__*), task-
+# mutation tools excluded from the read-only views, and an unknown/future
+# name proving deny-by-default needs no enumeration.
+_DEGRADED_DENY_MATRIX = (
+    "Write",
+    "Agent",
+    "NotebookEdit",
+    "Bash",
+    "mcp__computer-use__key",
+    "TaskCreate",
+    "TaskUpdate",
+    "SomeFutureTool",
+)
 
 
 class TestDegradedMode:
@@ -1427,6 +1495,184 @@ class TestDegradedMode:
         )
         out = json.loads(result.stdout.strip().splitlines()[0])
         assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    # --- comprehensive subprocess matrix (TEST phase) ---
+
+    def test_allowlist_literal_matches_production_set(self):
+        """Two-site edit pin: the parametrization literal and the production
+        frozenset must stay in lockstep, at the architecturally-settled
+        cardinality of 11. A drop OR an addition on either side fails here,
+        so the subprocess matrix below can never silently under-cover the
+        live allowlist (per-member parametrization, not per-container)."""
+        from bootstrap_gate import _READ_ONLY_TOOLS
+
+        assert len(_DEGRADED_ALLOWLIST_LITERAL) == 11
+        assert len(set(_DEGRADED_ALLOWLIST_LITERAL)) == 11, (
+            "literal must not contain duplicates — each matrix row must be "
+            "a distinct member"
+        )
+        assert set(_DEGRADED_ALLOWLIST_LITERAL) == set(_READ_ONLY_TOOLS), (
+            "allowlist literal drifted from bootstrap_gate._READ_ONLY_TOOLS "
+            "— update BOTH sites (intentional change) or revert the "
+            "production edit (accidental)"
+        )
+
+    @pytest.mark.parametrize("tool", _DEGRADED_ALLOWLIST_LITERAL)
+    def test_subprocess_broken_import_full_allowlist_allows(self, tmp_path, tool):
+        """T1 full matrix: EVERY allowlist member gets allow-with-warning
+        from a real broken-import process — rc 0 (the emit contract: stdout
+        JSON is only honored on exit 0), full emit shape pinned key-by-key,
+        warning carries stage + exception type + the tool name, systemMessage
+        present, stderr diagnostic non-empty."""
+        result = _run_degraded_subprocess(
+            tmp_path, json.dumps(_make_input(tool_name=tool))
+        )
+
+        # Content asserts first; rc is asserted WITH content, never alone.
+        out = json.loads(result.stdout.strip().splitlines()[0])
+        assert set(out.keys()) == {"hookSpecificOutput", "systemMessage"}, (
+            f"degraded-allow emit shape drifted for {tool!r}: {out.keys()!r}"
+        )
+        hso = out["hookSpecificOutput"]
+        assert set(hso.keys()) == {
+            "hookEventName",
+            "permissionDecision",
+            "permissionDecisionReason",
+            "additionalContext",
+        }
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "allow"
+        for field in ("permissionDecisionReason", "additionalContext"):
+            assert "DEGRADED" in hso[field]
+            assert "module imports" in hso[field], "stage must be named"
+            assert "SyntaxError" in hso[field], (
+                "exception type from the broken shared/__init__.py must be "
+                "named so the warning is diagnosable"
+            )
+            assert f"'{tool}'" in hso[field], "allowed tool must be named"
+        assert hso["permissionDecisionReason"] == hso["additionalContext"], (
+            "both fields carry the SAME warning (docs ambiguity hedge)"
+        )
+        assert "degraded" in out["systemMessage"]
+        assert result.returncode == 0, (
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        assert result.stderr.strip(), "stderr diagnostic line expected"
+
+    @pytest.mark.parametrize("tool", _DEGRADED_DENY_MATRIX)
+    def test_subprocess_broken_import_full_deny_matrix_denies(self, tmp_path, tool):
+        """T2 full matrix: every non-member class — mutating tools, the
+        Bash/mcp__ healthy-vs-degraded asymmetry, task-mutation tools, and
+        an unknown/future name — takes the byte-shape of today's
+        _emit_load_failure_deny at rc 2 with non-empty stderr. Deny is the
+        default: nothing here requires enumerating 'the hookable set'."""
+        result = _run_degraded_subprocess(
+            tmp_path, json.dumps(_make_input(tool_name=tool))
+        )
+
+        out = json.loads(result.stdout.strip().splitlines()[0])
+        # Byte-shape pin of the unchanged deny emitter: exactly one
+        # top-level key, exactly three hookSpecificOutput keys.
+        assert set(out.keys()) == {"hookSpecificOutput"}, (
+            f"deny emit shape drifted for {tool!r}: {out.keys()!r}"
+        )
+        hso = out["hookSpecificOutput"]
+        assert set(hso.keys()) == {
+            "hookEventName",
+            "permissionDecision",
+            "permissionDecisionReason",
+        }
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "deny"
+        assert "module imports failure" in hso["permissionDecisionReason"]
+        assert "blocking for safety" in hso["permissionDecisionReason"]
+        assert "systemMessage" not in out, (
+            "error/suppress-style exclusivity: the deny arm never carries "
+            "the degraded-allow banner"
+        )
+        assert result.returncode == 2, (
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        assert result.stderr.strip()
+
+    @pytest.mark.parametrize("label,stdin_text", [
+        ("missing-tool-name", json.dumps({
+            k: v for k, v in _make_input().items() if k != "tool_name"
+        })),
+        ("null-tool-name", json.dumps(dict(_make_input(), tool_name=None))),
+        ("int-tool-name", json.dumps(dict(_make_input(), tool_name=123))),
+        ("list-tool-name", json.dumps(dict(_make_input(), tool_name=["Read"]))),
+        ("empty-string-tool-name", json.dumps(dict(_make_input(), tool_name=""))),
+        ("empty-stdin", ""),
+        ("non-dict-frame-list", json.dumps([1, 2, 3])),
+        ("non-dict-frame-bare-string", json.dumps("Read")),
+    ])
+    def test_subprocess_broken_import_unverifiable_stdin_denies(
+        self, tmp_path, label, stdin_text
+    ):
+        """T3 full matrix: every unverifiable-stdin class — absent, null,
+        non-string, empty tool_name; empty stdin; valid-JSON non-dict
+        frames (including a bare string "Read", which must NOT be read as
+        a tool name) — is fail-CLOSED deny at rc 2. The degraded path
+        inverts the healthy input-side fail-open because in degraded mode
+        this module IS the broken layer."""
+        result = _run_degraded_subprocess(tmp_path, stdin_text)
+
+        out = json.loads(result.stdout.strip().splitlines()[0])
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "deny", (
+            f"stdin class {label!r} must deny fail-closed"
+        )
+        assert "module imports failure" in hso["permissionDecisionReason"]
+        assert "systemMessage" not in out
+        assert result.returncode == 2, (
+            f"{label}: stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+
+    # --- py3.9 floor exercise (conditional on an available interpreter) ---
+
+    def test_degraded_path_runs_on_python39_floor(self, tmp_path):
+        """The degraded region is stdlib-only and must execute on the
+        production system interpreter (GUI-launched macOS sessions run
+        hooks on /usr/bin/python3 = 3.9.x). Exercise the three behavior
+        classes — allow, deny, fail-closed-stdin — under a REAL 3.9
+        interpreter when one is discoverable; the static AST floor guard
+        (test_py39_annotation_compat.py R0–R3) remains the unconditional
+        merge gate when none is."""
+        py39 = _find_python39()
+        if py39 is None:
+            pytest.skip(
+                "no Python 3.9 interpreter discoverable (python3.9 on PATH "
+                "or /usr/bin/python3 reporting 3.9.x); static floor guard "
+                "test_py39_annotation_compat.py covers the syntax floor"
+            )
+
+        allow = _run_degraded_subprocess(
+            tmp_path / "allow", json.dumps(_make_input(tool_name="Read")),
+            interpreter=py39,
+        )
+        out = json.loads(allow.stdout.strip().splitlines()[0])
+        assert out["hookSpecificOutput"]["permissionDecision"] == "allow"
+        assert "DEGRADED" in out["hookSpecificOutput"]["permissionDecisionReason"]
+        assert allow.returncode == 0, (
+            f"stderr={allow.stderr!r} stdout={allow.stdout!r}"
+        )
+
+        deny = _run_degraded_subprocess(
+            tmp_path / "deny", json.dumps(_make_input(tool_name="Edit")),
+            interpreter=py39,
+        )
+        out = json.loads(deny.stdout.strip().splitlines()[0])
+        assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert deny.returncode == 2
+
+        malformed = _run_degraded_subprocess(
+            tmp_path / "malformed", "not valid json {", interpreter=py39,
+        )
+        out = json.loads(malformed.stdout.strip().splitlines()[0])
+        assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert malformed.returncode == 2
 
 
 # =============================================================================

--- a/pact-plugin/tests/test_bootstrap_gate.py
+++ b/pact-plugin/tests/test_bootstrap_gate.py
@@ -498,8 +498,8 @@ class TestFailClosedGateLogic:
 class TestErrorSuppressMutualExclusivity:
     """P0: input-side fail-open uses suppressOutput; deny path (block + runtime fail-closed
     fail-closed) uses hookSpecificOutput. systemMessage is never emitted on
-    suppress/deny paths; the degraded-allow path (#942) is the single
-    deliberate systemMessage emitter (see TestDegradedMode).
+    suppress/deny paths; the degraded warn path (#942, defer/ask) is the
+    single deliberate systemMessage emitter (see TestDegradedMode).
     """
 
     def test_malformed_stdin_no_system_message(self, capsys):
@@ -1146,10 +1146,10 @@ class TestAuditAnchorParity:
     - "deny-load-failure": _emit_load_failure_deny advisory
     - "deny-runtime": runtime-exception deny via _emit_load_failure_deny
     - "suppress": every other exit path via the _SUPPRESS_OUTPUT constant
-    - "degraded-allow-import": #942 allow-with-warning, import stage
-      (direct _emit_degraded_allow invocation)
-    - "degraded-allow-runtime": #942 allow-with-warning, runtime stage
-      (gate-logic exception + allowlisted tool through main())
+    - "degraded-warn-import": #942 warn-without-granting (defer/ask),
+      import stage (direct _emit_degraded_warning invocation)
+    - "degraded-warn-runtime": #942 warn-without-granting (defer/ask),
+      runtime stage (gate-logic exception + allowlisted tool through main())
 
     All five MUST carry the audit anchor — parametrizing pins the
     invariant so no future emit path can be added without it. Mirrors
@@ -1161,8 +1161,8 @@ class TestAuditAnchorParity:
         "deny-load-failure",
         "deny-runtime",
         "suppress",
-        "degraded-allow-import",
-        "degraded-allow-runtime",
+        "degraded-warn-import",
+        "degraded-warn-runtime",
     ])
     def test_every_emit_shape_carries_hook_event_name(self, shape, capsys):
         if shape == "deny-load-failure":
@@ -1182,13 +1182,13 @@ class TestAuditAnchorParity:
                         main()
             captured = capsys.readouterr()
             out = json.loads(captured.out.strip())
-        elif shape == "degraded-allow-import":
-            from bootstrap_gate import _emit_degraded_allow
+        elif shape == "degraded-warn-import":
+            from bootstrap_gate import _emit_degraded_warning
             with pytest.raises(SystemExit):
-                _emit_degraded_allow("module imports", RuntimeError("x"), "Read")
+                _emit_degraded_warning("module imports", RuntimeError("x"), "Read")
             captured = capsys.readouterr()
             out = json.loads(captured.out.strip())
-        elif shape == "degraded-allow-runtime":
+        elif shape == "degraded-warn-runtime":
             from bootstrap_gate import main
             with patch(
                 "bootstrap_gate._check_tool_allowed",
@@ -1325,29 +1325,50 @@ _DEGRADED_DENY_MATRIX = (
 
 class TestDegradedMode:
     """#942 degraded-mode handler: while the gate cannot evaluate (import
-    or runtime failure), verified read-only tools are allowed WITH a
-    warning at exit 0; everything else keeps the unchanged fail-closed
-    deny at exit 2. Malformed/unverifiable stdin in the degraded path is
-    fail-CLOSED (deny) — the opposite of the healthy path's input-side
-    fail-open, because in degraded mode this module IS the broken layer.
-
-    CODE-phase verification slice only: structural allowlist pins, the
-    runtime-stage branch in-process, and an import-stage subprocess smoke.
-    The comprehensive subprocess matrix is TEST-phase scope.
+    or runtime failure), verified read-only tools are routed onward WITH a
+    warning at exit 0 — permissionDecision "defer" (normal permission
+    flow) for local tools, "ask" (explicit user approval) for outbound
+    WebFetch/WebSearch, NEVER "allow" — so degraded mode is a
+    permission-layer subset by construction. Everything else keeps the
+    unchanged fail-closed deny at exit 2. Malformed/unverifiable stdin in
+    the degraded path is fail-CLOSED (deny) — the opposite of the healthy
+    path's input-side fail-open, because in degraded mode this module IS
+    the broken layer.
     """
 
-    # --- structural invariant pins (master safety property) ---
+    # --- structural invariant pins (master safety property) -------------
+    # MEMBERSHIP-CHANGE INVARIANT GUARD: the three tests below re-derive
+    # the degraded⊆healthy safety property from the PRODUCTION sets
+    # (_READ_ONLY_TOOLS, _DEGRADED_ASK_TOOLS, _BLOCKED_TOOLS) on every
+    # run. They exist to catch FUTURE membership edits: any tool added to
+    # the degraded allowlist that the healthy gate would deny — or any
+    # ask-tool that is not an allowlist member — fails here before it can
+    # ship. Do not weaken these to literal snapshots.
 
     def test_allowlist_disjoint_from_blocked_tools(self):
-        """Degraded-allow ⊆ healthy-allow, part 1: no allowlist member is
-        ever in the blocked set."""
-        from bootstrap_gate import _BLOCKED_TOOLS, _READ_ONLY_TOOLS
+        """Membership invariant, part 1: no allowlist member is ever in
+        the blocked set, and every ask-escalation tool is itself an
+        allowlist member (ask is a refinement of membership, not a
+        side-channel). Re-derived from production sets — guards future
+        membership edits."""
+        from bootstrap_gate import (
+            _BLOCKED_TOOLS,
+            _DEGRADED_ASK_TOOLS,
+            _READ_ONLY_TOOLS,
+        )
 
         assert _READ_ONLY_TOOLS & _BLOCKED_TOOLS == frozenset()
+        assert _DEGRADED_ASK_TOOLS <= _READ_ONLY_TOOLS, (
+            "_DEGRADED_ASK_TOOLS must be a subset of _READ_ONLY_TOOLS — an "
+            "ask-tool outside the allowlist would never reach the ask arm "
+            "(denied first), masking a dead or drifted entry"
+        )
 
     def test_allowlist_excludes_bash_and_mcp(self):
-        """Deliberate strictness asymmetry: Bash and MCP tools are allowed
-        on the healthy pre-marker path but must NOT be degraded-allowable."""
+        """Membership invariant, part 2 (deliberate strictness asymmetry):
+        Bash and MCP tools are allowed on the healthy pre-marker path but
+        must NOT be degraded-recognized. Re-derived from the production
+        set — guards future membership edits."""
         from bootstrap_gate import _READ_ONLY_TOOLS
 
         assert "Bash" not in _READ_ONLY_TOOLS
@@ -1356,22 +1377,53 @@ class TestDegradedMode:
     def test_every_allowlist_member_allowed_on_healthy_gated_branch(
         self, monkeypatch, tmp_path
     ):
-        """Degraded-allow ⊆ healthy-allow, part 2: on the strictest healthy
-        branch (lead, no marker), every allowlist member is allowed."""
+        """Membership invariant, part 3 (degraded ⊆ healthy, empirical):
+        on the strictest healthy branch (lead, no marker), every allowlist
+        member is allowed by the REAL production gate. A future membership
+        edit that adds a healthy-denied tool fails here — degraded mode
+        must never route a tool the healthy gate denies onward to the
+        permission flow."""
         from bootstrap_gate import _READ_ONLY_TOOLS, _check_tool_allowed
 
         _setup_pact_session(monkeypatch, tmp_path, with_marker=False)
         for tool in sorted(_READ_ONLY_TOOLS):
             assert _check_tool_allowed(_make_input(tool)) is None, (
                 f"allowlist member {tool!r} must be allowed on the healthy "
-                f"lead+no-marker branch — degraded mode may never grant "
-                f"something the healthy gate denies"
+                f"lead+no-marker branch — degraded mode may never route "
+                f"onward something the healthy gate denies"
             )
+
+    # --- M1: bounded error interpolation ---------------------------------
+
+    def test_degraded_warning_bounds_error_text(self, capsys):
+        """Exception text interpolated into the context-bound warning is
+        sanitized (control chars stripped) and truncated with an explicit
+        marker; the stderr diagnostic channel keeps the full text."""
+        from bootstrap_gate import _ERROR_TEXT_MAX, _emit_degraded_warning
+
+        payload = "X" * 1000 + "\x07\x1b[31m\ninjected"
+        with pytest.raises(SystemExit) as exc_info:
+            _emit_degraded_warning("runtime", RuntimeError(payload), "Read")
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        out = json.loads(captured.out.strip())
+        reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "...[truncated]" in reason
+        # The embedded exception rendering is bounded: the 1000-char payload
+        # must not appear in full in any context-bound field.
+        assert "X" * (_ERROR_TEXT_MAX + 1) not in reason
+        assert "X" * (_ERROR_TEXT_MAX + 1) not in out["hookSpecificOutput"]["additionalContext"]
+        # Control / escape characters never reach the context-bound warning.
+        assert "\x07" not in reason and "\x1b" not in reason
+        # Full text still goes to stderr (debug channel).
+        assert "X" * 999 in captured.err
 
     # --- runtime stage (in-process, symmetric with import stage) ---
 
-    def test_runtime_exception_with_readonly_tool_allows_with_warning(self, capsys):
-        """Gate-logic exception + allowlisted tool → exit 0, allow JSON with
+    def test_runtime_exception_with_readonly_tool_defers_with_warning(self, capsys):
+        """Gate-logic exception + local allowlisted tool → exit 0, JSON with
+        permissionDecision="defer" (normal permission flow — never "allow"),
         warning text and systemMessage (the single deliberate emitter)."""
         from bootstrap_gate import main
 
@@ -1389,11 +1441,35 @@ class TestDegradedMode:
         out = json.loads(capsys.readouterr().out.strip())
         hso = out["hookSpecificOutput"]
         assert hso["hookEventName"] == "PreToolUse"
-        assert hso["permissionDecision"] == "allow"
+        assert hso["permissionDecision"] == "defer"
         for field in ("permissionDecisionReason", "additionalContext"):
             assert "runtime" in hso[field]
             assert "RuntimeError" in hso[field]
             assert "DEGRADED" in hso[field]
+        assert "systemMessage" in out
+
+    def test_runtime_exception_with_outbound_tool_asks(self, capsys):
+        """Gate-logic exception + outbound tool (WebFetch) → exit 0,
+        permissionDecision="ask": network traffic under a broken gate
+        escalates to explicit user approval rather than deferring."""
+        from bootstrap_gate import main
+
+        with patch(
+            "bootstrap_gate._check_tool_allowed",
+            side_effect=RuntimeError("boom"),
+        ):
+            with patch(
+                "sys.stdin",
+                io.StringIO(json.dumps(_make_input(tool_name="WebFetch"))),
+            ):
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+
+        assert exc_info.value.code == 0
+        out = json.loads(capsys.readouterr().out.strip())
+        hso = out["hookSpecificOutput"]
+        assert hso["permissionDecision"] == "ask"
+        assert "DEGRADED" in hso["permissionDecisionReason"]
         assert "systemMessage" in out
 
     def test_runtime_exception_with_mutating_tool_still_denies(self, capsys):
@@ -1451,8 +1527,8 @@ class TestDegradedMode:
 
     # --- import stage (subprocess smoke; full matrix is TEST phase) ---
 
-    def test_subprocess_broken_import_readonly_tool_allows(self, tmp_path):
-        """Broken `shared` import + tool_name=Read → allow-with-warning,
+    def test_subprocess_broken_import_readonly_tool_defers(self, tmp_path):
+        """Broken `shared` import + tool_name=Read → defer-with-warning,
         rc 0 (rc IS the emit contract: JSON only honored on exit 0 — pair
         with content asserts, never rc alone)."""
         result = _run_degraded_subprocess(
@@ -1464,7 +1540,7 @@ class TestDegradedMode:
         out = json.loads(result.stdout.strip().splitlines()[0])
         hso = out["hookSpecificOutput"]
         assert hso["hookEventName"] == "PreToolUse"
-        assert hso["permissionDecision"] == "allow"
+        assert hso["permissionDecision"] == "defer"
         assert "module imports" in hso["permissionDecisionReason"]
         assert "systemMessage" in out
         assert result.stderr.strip(), "stderr diagnostic line expected"
@@ -1518,12 +1594,17 @@ class TestDegradedMode:
         )
 
     @pytest.mark.parametrize("tool", _DEGRADED_ALLOWLIST_LITERAL)
-    def test_subprocess_broken_import_full_allowlist_allows(self, tmp_path, tool):
-        """T1 full matrix: EVERY allowlist member gets allow-with-warning
-        from a real broken-import process — rc 0 (the emit contract: stdout
-        JSON is only honored on exit 0), full emit shape pinned key-by-key,
-        warning carries stage + exception type + the tool name, systemMessage
-        present, stderr diagnostic non-empty."""
+    def test_subprocess_broken_import_full_allowlist_warns(self, tmp_path, tool):
+        """T1 full matrix: EVERY allowlist member gets warn-without-granting
+        from a real broken-import process — permissionDecision "defer" for
+        local tools, "ask" for outbound WebFetch/WebSearch, NEVER "allow" —
+        rc 0 (the emit contract: stdout JSON is only honored on exit 0),
+        full emit shape pinned key-by-key, warning carries stage + exception
+        type + the tool name, systemMessage present, stderr diagnostic
+        non-empty. Expected decision is re-derived from the production
+        _DEGRADED_ASK_TOOLS set so a membership edit moves this pin with it."""
+        from bootstrap_gate import _DEGRADED_ASK_TOOLS
+
         result = _run_degraded_subprocess(
             tmp_path, json.dumps(_make_input(tool_name=tool))
         )
@@ -1531,7 +1612,7 @@ class TestDegradedMode:
         # Content asserts first; rc is asserted WITH content, never alone.
         out = json.loads(result.stdout.strip().splitlines()[0])
         assert set(out.keys()) == {"hookSpecificOutput", "systemMessage"}, (
-            f"degraded-allow emit shape drifted for {tool!r}: {out.keys()!r}"
+            f"degraded-warn emit shape drifted for {tool!r}: {out.keys()!r}"
         )
         hso = out["hookSpecificOutput"]
         assert set(hso.keys()) == {
@@ -1541,7 +1622,13 @@ class TestDegradedMode:
             "additionalContext",
         }
         assert hso["hookEventName"] == "PreToolUse"
-        assert hso["permissionDecision"] == "allow"
+        expected_decision = "ask" if tool in _DEGRADED_ASK_TOOLS else "defer"
+        assert hso["permissionDecision"] == expected_decision, (
+            f"{tool!r} must {expected_decision} under a degraded gate — and "
+            f"never 'allow' (degraded mode is a permission-layer subset by "
+            f"construction)"
+        )
+        assert hso["permissionDecision"] != "allow"
         for field in ("permissionDecisionReason", "additionalContext"):
             assert "DEGRADED" in hso[field]
             assert "module imports" in hso[field], "stage must be named"
@@ -1588,7 +1675,7 @@ class TestDegradedMode:
         assert "blocking for safety" in hso["permissionDecisionReason"]
         assert "systemMessage" not in out, (
             "error/suppress-style exclusivity: the deny arm never carries "
-            "the degraded-allow banner"
+            "the degraded-warn banner"
         )
         assert result.returncode == 2, (
             f"stderr={result.stderr!r} stdout={result.stdout!r}"
@@ -1636,7 +1723,7 @@ class TestDegradedMode:
         """The degraded region is stdlib-only and must execute on the
         production system interpreter (GUI-launched macOS sessions run
         hooks on /usr/bin/python3 = 3.9.x). Exercise the three behavior
-        classes — allow, deny, fail-closed-stdin — under a REAL 3.9
+        classes — warn(defer), deny, fail-closed-stdin — under a REAL 3.9
         interpreter when one is discoverable; the static AST floor guard
         (test_py39_annotation_compat.py R0–R3) remains the unconditional
         merge gate when none is."""
@@ -1648,15 +1735,15 @@ class TestDegradedMode:
                 "test_py39_annotation_compat.py covers the syntax floor"
             )
 
-        allow = _run_degraded_subprocess(
-            tmp_path / "allow", json.dumps(_make_input(tool_name="Read")),
+        warn = _run_degraded_subprocess(
+            tmp_path / "warn", json.dumps(_make_input(tool_name="Read")),
             interpreter=py39,
         )
-        out = json.loads(allow.stdout.strip().splitlines()[0])
-        assert out["hookSpecificOutput"]["permissionDecision"] == "allow"
+        out = json.loads(warn.stdout.strip().splitlines()[0])
+        assert out["hookSpecificOutput"]["permissionDecision"] == "defer"
         assert "DEGRADED" in out["hookSpecificOutput"]["permissionDecisionReason"]
-        assert allow.returncode == 0, (
-            f"stderr={allow.stderr!r} stdout={allow.stdout!r}"
+        assert warn.returncode == 0, (
+            f"stderr={warn.stderr!r} stdout={warn.stdout!r}"
         )
 
         deny = _run_degraded_subprocess(

--- a/pact-plugin/tests/test_bootstrap_marker_writer.py
+++ b/pact-plugin/tests/test_bootstrap_marker_writer.py
@@ -1342,3 +1342,131 @@ class TestAtomicityTempFileLocation:
         assert captured["dir"] == str(session_dir)
         assert captured["prefix"] == ".bootstrap-complete-"
         assert captured["suffix"] == ".tmp"
+
+
+class TestSubprocessSelfHeal:
+    """Subprocess integration for the UserPromptSubmit self-heal: the
+    TestSubprocessIntegration scaffold MINUS the context file. A lead-frame
+    run must HEAL the missing pact-session-context.json (assert exists +
+    content) while STILL refusing the marker when the team-config
+    pre-conditions are unmet — heal never forges bootstrap completion.
+
+    Self-masker rule: marker_writer exits 0 on every path, so health is
+    asserted via stdout envelope + on-disk effects, never via returncode
+    alone.
+    """
+
+    def test_lead_run_heals_missing_context_but_refuses_marker(self, tmp_path):
+        import subprocess
+
+        home = tmp_path
+        slug = "healproj"
+        # Hex prefix → deterministic generated team name "pact-deadbeef".
+        session_id = "deadbeef-4242-4242-4242-deadbeef4242"
+
+        plugin_root = home / "plugin"
+        plugin_root.mkdir(parents=True)
+
+        # Session dir intentionally NOT created; context file ABSENT;
+        # team config for "pact-deadbeef" intentionally NOT created.
+        session_dir = home / ".claude" / "pact-sessions" / slug / session_id
+        ctx = session_dir / "pact-session-context.json"
+
+        hook_path = (
+            Path(__file__).parent.parent / "hooks" /
+            "bootstrap_marker_writer.py"
+        )
+        assert hook_path.exists(), f"writer hook missing at {hook_path}"
+
+        stdin_payload = json.dumps({
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": session_id,
+            "prompt": "first prompt after session_init crashed",
+            "source": "startup",
+            "agent_type": "pact-orchestrator",
+        })
+
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        env.pop("CLAUDE_CONFIG_DIR", None)  # force the HOME/.claude fallback
+        env["CLAUDE_PROJECT_DIR"] = f"/tmp/{slug}"
+        env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
+
+        result = subprocess.run(
+            [sys.executable, str(hook_path)],
+            input=stdin_payload,
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(home),
+            timeout=10,
+        )
+
+        # Content assertion FIRST (self-masker rule), rc second.
+        out = json.loads(result.stdout.strip())
+        assert out["suppressOutput"] is True
+        assert out["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+        assert result.returncode == 0, (
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+
+        # Healed: context file re-created with session_init-parity content.
+        assert ctx.exists(), "self-heal should re-create the context file"
+        content = json.loads(ctx.read_text(encoding="utf-8"))
+        assert content["team_name"] == "pact-deadbeef"
+        assert content["session_id"] == session_id
+        assert content["project_dir"] == f"/tmp/{slug}"
+        assert content["plugin_root"] == str(plugin_root)
+        assert content["started_at"]
+
+        # Heal != forged bootstrap: the team-config pre-condition is unmet
+        # (no ~/.claude/teams/pact-deadbeef/config.json with a secretary),
+        # so the marker MUST NOT be written.
+        marker = session_dir / BOOTSTRAP_MARKER_NAME
+        assert not marker.exists(), (
+            "heal must not forge bootstrap completion — marker pre-conditions "
+            "are unmet"
+        )
+
+    def test_teammate_run_does_not_heal(self, tmp_path):
+        """Same scaffold, teammate frame → no heal (is_lead gate, #877)."""
+        import subprocess
+
+        home = tmp_path
+        slug = "healproj"
+        session_id = "deadbeef-4242-4242-4242-deadbeef4242"
+        session_dir = home / ".claude" / "pact-sessions" / slug / session_id
+        ctx = session_dir / "pact-session-context.json"
+
+        hook_path = (
+            Path(__file__).parent.parent / "hooks" /
+            "bootstrap_marker_writer.py"
+        )
+
+        stdin_payload = json.dumps({
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": session_id,
+            "prompt": "teammate frame",
+            "source": "startup",
+            "agent_type": "pact-backend-coder",
+        })
+
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        env.pop("CLAUDE_CONFIG_DIR", None)
+        env["CLAUDE_PROJECT_DIR"] = f"/tmp/{slug}"
+
+        result = subprocess.run(
+            [sys.executable, str(hook_path)],
+            input=stdin_payload,
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(home),
+            timeout=10,
+        )
+
+        out = json.loads(result.stdout.strip())
+        assert out["suppressOutput"] is True
+        assert result.returncode == 0
+        assert not ctx.exists(), "teammate frame must never heal (#877)"

--- a/pact-plugin/tests/test_bootstrap_marker_writer.py
+++ b/pact-plugin/tests/test_bootstrap_marker_writer.py
@@ -1429,12 +1429,22 @@ class TestSubprocessSelfHeal:
         )
 
     def test_teammate_run_does_not_heal(self, tmp_path):
-        """Same scaffold, teammate frame → no heal (is_lead gate, #877)."""
+        """Same scaffold, teammate frame → no heal (is_lead gate, #877).
+
+        Single-variable discipline: the env (including CLAUDE_PLUGIN_ROOT
+        and the plugin_root dir on disk) mirrors the lead positive control
+        above EXACTLY, so agent_type is the ONLY input that differs — the
+        no-heal outcome is attributable to the is_lead gate alone, not to
+        an incidentally missing env var."""
         import subprocess
 
         home = tmp_path
         slug = "healproj"
         session_id = "deadbeef-4242-4242-4242-deadbeef4242"
+
+        plugin_root = home / "plugin"
+        plugin_root.mkdir(parents=True)
+
         session_dir = home / ".claude" / "pact-sessions" / slug / session_id
         ctx = session_dir / "pact-session-context.json"
 
@@ -1455,6 +1465,7 @@ class TestSubprocessSelfHeal:
         env["HOME"] = str(home)
         env.pop("CLAUDE_CONFIG_DIR", None)
         env["CLAUDE_PROJECT_DIR"] = f"/tmp/{slug}"
+        env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
 
         result = subprocess.run(
             [sys.executable, str(hook_path)],

--- a/pact-plugin/tests/test_bootstrap_marker_writer.py
+++ b/pact-plugin/tests/test_bootstrap_marker_writer.py
@@ -1470,3 +1470,131 @@ class TestSubprocessSelfHeal:
         assert out["suppressOutput"] is True
         assert result.returncode == 0
         assert not ctx.exists(), "teammate frame must never heal (#877)"
+
+
+class TestConcurrentTwoHealerRace:
+    """TRUE parallel-process model of the two-healer race: on the SAME
+    UserPromptSubmit, the platform runs bootstrap_marker_writer and
+    bootstrap_prompt_gate in parallel; with the context file ABSENT, BOTH
+    are eligible to heal. persist_context is atomic (mkstemp + rename) and
+    both healers compute identical content except started_at, so NO
+    interleaving may produce a torn/malformed file, a crashed hook, or a
+    forged marker — and the assertions below are winner-agnostic.
+
+    Scope honesty: a single run cannot force a specific interleaving (the
+    OS schedules the two processes); what this pins is that the REAL
+    parallel composition holds the invariants on every observed schedule.
+    Content parity across healers is pinned deterministically by the
+    sequential-equivalence unit test
+    (test_pact_context.py::TestHealContextIfMissing::
+    test_sequential_heals_equivalent_content).
+
+    Self-masker rule: both hooks exit 0 on every path — health asserted on
+    stdout envelopes + on-disk effects, never returncode alone.
+    """
+
+    def test_parallel_healers_yield_one_wellformed_context_no_marker(
+            self, tmp_path):
+        import subprocess
+
+        home = tmp_path
+        slug = "raceproj"
+        # Hex prefix → deterministic generated team name "pact-deadbeef".
+        session_id = "deadbeef-5555-6666-7777-deadbeef8888"
+
+        plugin_root = home / "plugin"
+        plugin_root.mkdir(parents=True)
+
+        # Context ABSENT; no team config (marker pre-conditions unmet, so
+        # the writer must refuse the marker on every schedule).
+        session_dir = home / ".claude" / "pact-sessions" / slug / session_id
+        ctx = session_dir / "pact-session-context.json"
+
+        hooks_dir = Path(__file__).parent.parent / "hooks"
+        writer_path = hooks_dir / "bootstrap_marker_writer.py"
+        gate_path = hooks_dir / "bootstrap_prompt_gate.py"
+        assert writer_path.exists() and gate_path.exists()
+
+        stdin_payload = json.dumps({
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": session_id,
+            "prompt": "first prompt after session_init crashed",
+            "agent_type": "pact-orchestrator",
+        }).encode("utf-8")
+
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        env.pop("CLAUDE_CONFIG_DIR", None)
+        env["CLAUDE_PROJECT_DIR"] = f"/tmp/{slug}"
+        env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
+
+        # Start BOTH processes, feed both stdins, THEN reap — the payload
+        # is far below the pipe buffer, so the writes don't block and the
+        # two hooks genuinely execute concurrently (a communicate() on the
+        # first process before spawning work on the second would serialize
+        # them and silently test the sequential case instead).
+        procs = [
+            subprocess.Popen(
+                [sys.executable, str(path)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+                cwd=str(home),
+            )
+            for path in (writer_path, gate_path)
+        ]
+        for proc in procs:
+            proc.stdin.write(stdin_payload)
+            proc.stdin.close()
+        outs = []
+        for proc in procs:
+            out = proc.stdout.read().decode("utf-8")
+            err = proc.stderr.read().decode("utf-8")
+            rc = proc.wait(timeout=15)
+            outs.append((rc, out, err))
+
+        writer_rc, writer_out, writer_err = outs[0]
+        gate_rc, gate_out, gate_err = outs[1]
+
+        # Both hooks emitted their healthy envelopes (no crash on any
+        # schedule); content first, rc alongside.
+        writer_json = json.loads(writer_out.strip())
+        assert writer_json["suppressOutput"] is True
+        assert (writer_json["hookSpecificOutput"]["hookEventName"]
+                == "UserPromptSubmit")
+        assert writer_rc == 0, f"writer stderr={writer_err!r}"
+
+        gate_json = json.loads(gate_out.strip())
+        gate_hso = gate_json["hookSpecificOutput"]
+        assert gate_hso["hookEventName"] == "UserPromptSubmit"
+        assert "PACT:bootstrap" in gate_hso["additionalContext"], (
+            "healed lead session without marker must inject, not suppress"
+        )
+        assert gate_rc == 0, f"gate stderr={gate_err!r}"
+
+        # Exactly one well-formed context file with the expected content,
+        # whichever healer won the rename race.
+        assert ctx.exists(), "at least one healer must land the file"
+        content = json.loads(ctx.read_text(encoding="utf-8"))
+        assert set(content.keys()) == {
+            "team_name", "session_id", "project_dir", "plugin_root",
+            "started_at",
+        }
+        assert content["team_name"] == "pact-deadbeef"
+        assert content["session_id"] == session_id
+        assert content["project_dir"] == f"/tmp/{slug}"
+        assert content["plugin_root"] == str(plugin_root)
+        assert content["started_at"]
+
+        # No leftover mkstemp temp files (atomic-rename hygiene).
+        stray = [p for p in session_dir.iterdir()
+                 if p.name != "pact-session-context.json"]
+        assert stray == [], f"unexpected files after race: {stray}"
+
+        # Heal != forged bootstrap on EVERY schedule: marker pre-conditions
+        # are unmet (no team config), so the marker must not exist.
+        marker = session_dir / BOOTSTRAP_MARKER_NAME
+        assert not marker.exists(), (
+            "two-healer race must never forge bootstrap completion"
+        )

--- a/pact-plugin/tests/test_bootstrap_prompt_gate.py
+++ b/pact-plugin/tests/test_bootstrap_prompt_gate.py
@@ -649,6 +649,29 @@ class TestStalenessDetection:
         assert _detect_stale_session_block(
             {"session_id": self._ACTUAL}) is None
 
+    def test_non_utf8_claude_md_returns_none(self, monkeypatch, tmp_path):
+        """Non-UTF-8 CLAUDE.md (e.g. a latin-1 byte from a wrong-editor
+        save, or a partial/corrupted session_init write — the very failure
+        neighborhood this detector exists to flag) → silent skip, NOT a
+        raise. UnicodeDecodeError is a ValueError, not an OSError; an
+        OSError-only catch lets it escape (RED on reverting the widened
+        catch tuple)."""
+        from bootstrap_prompt_gate import _detect_stale_session_block
+
+        project = tmp_path / "proj"
+        target = project / ".claude" / "CLAUDE.md"
+        target.parent.mkdir(parents=True)
+        # Valid stale Resume line followed by one invalid UTF-8
+        # continuation byte (0xE9 = latin-1 'é').
+        target.write_bytes(
+            f"- Resume: `claude --resume {self._STALE}`\n".encode("utf-8")
+            + b"caf\xe9\n"
+        )
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+
+        assert _detect_stale_session_block(
+            {"session_id": self._ACTUAL}) is None
+
     @pytest.mark.parametrize("layout", ["both", "preferred_only",
                                         "legacy_only", "neither"])
     def test_precedence_parity_with_resolver(self, monkeypatch, tmp_path,
@@ -757,6 +780,70 @@ class TestStalenessComposition:
         assert result is not None
         assert "PACT:bootstrap" in result
         assert "stale session block" not in result
+
+    def test_non_utf8_claude_md_keeps_instruction(
+            self, monkeypatch, tmp_path, capsys):
+        """Blast-radius pin: a non-UTF-8 CLAUDE.md must degrade to
+        instruction-only — NEVER suppress the bootstrap instruction.
+
+        The advisory detector composes onto the load-bearing instruction by
+        concatenation inside _check_bootstrap_needed; before the catch was
+        widened to UnicodeDecodeError, the raise escaped to main()'s
+        fail-open and the ENTIRE injection (primary instruction included)
+        was silently suppressed on every prompt. End-to-end arm through
+        main() so the pin covers the real escape path, not just the helper.
+        (RED on reverting the widened catch tuple.)"""
+        _setup_pact_session(monkeypatch, tmp_path, with_marker=False)
+        project = tmp_path / "proj"
+        target = project / ".claude" / "CLAUDE.md"
+        target.parent.mkdir(parents=True)
+        target.write_bytes(
+            f"- Resume: `claude --resume {self._STALE}`\n".encode("utf-8")
+            + b"caf\xe9\n"  # one invalid UTF-8 continuation byte
+        )
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+
+        exit_code, output = _run_main(
+            _make_input(session_id=self._ACTUAL_HEX), capsys)
+
+        assert exit_code == 0
+        injected = output.get("hookSpecificOutput", {}).get(
+            "additionalContext", "")
+        assert "PACT:bootstrap" in injected, (
+            "non-UTF-8 CLAUDE.md must not suppress the bootstrap "
+            "instruction — the advisory's failure budget is 'no warning', "
+            "never 'no bootstrap'"
+        )
+        assert "stale session block" not in injected, (
+            "unreadable CLAUDE.md → no staleness claim"
+        )
+
+    @pytest.mark.parametrize("invalid_id", [
+        "   ",                                    # whitespace-only (truthy)
+        "unknown-deadbeef",                       # sentinel shape
+        "deadbeef-0000\nINJECTED LINE",           # C0 control char (newline)
+    ], ids=["whitespace_only", "unknown_sentinel", "control_char"])
+    def test_invalid_stdin_id_suppresses_warning_keeps_instruction(
+            self, monkeypatch, tmp_path, invalid_id):
+        """An invalid-but-truthy stdin session_id (whitespace-only,
+        `unknown-*` sentinel, or control-char-bearing) must suppress the
+        staleness warning — the unvalidated id is never interpolated into
+        the warning's {actual} slot — while the bootstrap instruction
+        stays intact. Gated by the canonical
+        _is_unknown_or_missing_session predicate, shared with the heal
+        gate; a plain truthiness check passes all three of these shapes."""
+        from bootstrap_prompt_gate import _check_bootstrap_needed
+
+        _setup_pact_session(monkeypatch, tmp_path, with_marker=False)
+        self._stale_project(monkeypatch, tmp_path)
+
+        result = _check_bootstrap_needed(_make_input(
+            session_id=invalid_id))
+
+        assert result is not None
+        assert "PACT:bootstrap" in result            # instruction intact
+        assert "stale session block" not in result   # no warning
+        assert "INJECTED LINE" not in result         # id never interpolated
 
     def test_no_claude_md_returns_instruction_only(
             self, monkeypatch, tmp_path):

--- a/pact-plugin/tests/test_bootstrap_prompt_gate.py
+++ b/pact-plugin/tests/test_bootstrap_prompt_gate.py
@@ -17,6 +17,7 @@ Tests cover:
 
 import io
 import json
+import os
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -816,3 +817,167 @@ class TestStalenessComposition:
 
         assert result is None
         assert calls == []
+
+    @pytest.mark.parametrize("frame_kind", [
+        "teammate-in-process",
+        "teammate-captured-tmux",
+    ])
+    def test_teammate_frames_both_modes_never_run_staleness(
+            self, monkeypatch, tmp_path, frame_kind):
+        """Both-modes gate: the lead/non-lead split keys ONLY on the
+        structural agent_type signal via is_lead — never a mode flag. A
+        synthesized in-process teammate frame AND a real captured tmux
+        teammate frame must both suppress without ever invoking the
+        staleness check (the plain-frame sibling above covers the third
+        non-lead shape)."""
+        import bootstrap_prompt_gate as gate_module
+        from fixtures.role_frames import (
+            captured_teammate_sessionstart,
+            teammate_frame,
+        )
+
+        _setup_pact_session(monkeypatch, tmp_path, with_marker=False)
+        self._stale_project(monkeypatch, tmp_path)
+
+        if frame_kind == "teammate-in-process":
+            frame = teammate_frame(session_id=self._ACTUAL_HEX)
+        else:
+            frame = captured_teammate_sessionstart()  # real tmux capture
+
+        calls = []
+        monkeypatch.setattr(
+            gate_module, "_detect_stale_session_block",
+            lambda input_data: calls.append(1) or None,
+        )
+
+        result = gate_module._check_bootstrap_needed(frame)
+
+        assert result is None, f"{frame_kind} must suppress (is_lead False)"
+        assert calls == [], (
+            f"{frame_kind} must never reach the staleness check"
+        )
+
+
+class TestSubprocessStalenessE2E:
+    """Full-process E2E for the #943 incident chain: session_init crashed
+    at SessionStart → pact-session-context.json ABSENT → the prompt gate's
+    self-heal re-creates it in the SAME invocation → the lead+no-marker
+    inject branch is reached → the staleness check reads the project
+    CLAUDE.md and (on a recorded-vs-actual session mismatch) appends the
+    advisory warning to the bootstrap instruction. In-process tests mock
+    pieces of this chain; a fresh subprocess proves the chain end-to-end
+    with real module loading, real env reads, and real disk I/O.
+
+    Self-masker rule: bootstrap_prompt_gate exits 0 on EVERY path, so
+    health is asserted on stdout content + on-disk effects; returncode is
+    asserted only alongside content.
+    """
+
+    # Hex-only ids (the production _RESUME_LINE_RE matches [0-9a-f-]).
+    _SID = "deadbeef-4242-4242-4242-deadbeef4242"
+    _STALE_SID = "0badcafe-9999-8888-7777-666655554444"
+
+    def _run_gate_subprocess(self, tmp_path, recorded_sid):
+        """Scaffold: HOME under tmp_path, real project dir whose
+        .claude/CLAUDE.md records ``recorded_sid``, context file ABSENT,
+        lead UserPromptSubmit frame for ``_SID``. Returns
+        (CompletedProcess, healed_context_path)."""
+        import subprocess
+
+        home = tmp_path
+        project = home / "staleproj"
+        claude_md = project / ".claude" / "CLAUDE.md"
+        claude_md.parent.mkdir(parents=True)
+        claude_md.write_text(
+            "# Project\n\n## Current Session\n"
+            f"- Resume: `claude --resume {recorded_sid}`\n"
+            "- Team: `pact-old`\n",
+            encoding="utf-8",
+        )
+
+        plugin_root = home / "plugin"
+        plugin_root.mkdir(parents=True)
+
+        # Session dir intentionally NOT created; context file ABSENT.
+        ctx = (home / ".claude" / "pact-sessions" / "staleproj" /
+               self._SID / "pact-session-context.json")
+
+        hook_path = (
+            Path(__file__).parent.parent / "hooks" /
+            "bootstrap_prompt_gate.py"
+        )
+        assert hook_path.exists(), f"gate hook missing at {hook_path}"
+
+        stdin_payload = json.dumps({
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": self._SID,
+            "prompt": "first prompt after session_init crashed",
+            "agent_type": "pact-orchestrator",
+        })
+
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        env.pop("CLAUDE_CONFIG_DIR", None)  # force the HOME/.claude fallback
+        env["CLAUDE_PROJECT_DIR"] = str(project)
+        env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
+
+        result = subprocess.run(
+            [sys.executable, str(hook_path)],
+            input=stdin_payload,
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(home),
+            timeout=10,
+        )
+        return result, ctx
+
+    def test_heal_chain_with_stale_block_injects_instruction_and_warning(
+            self, tmp_path):
+        """Mismatch (CLAUDE.md records the PREVIOUS session) → ONE
+        additionalContext string carrying the bootstrap instruction with
+        the staleness warning APPENDED, both ids named; the context file
+        is healed on disk with session_init-parity content."""
+        result, ctx = self._run_gate_subprocess(
+            tmp_path, recorded_sid=self._STALE_SID
+        )
+
+        # Content first (self-masker rule), rc alongside.
+        out = json.loads(result.stdout.strip())
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "UserPromptSubmit"
+        context = hso["additionalContext"]
+        assert "PACT:bootstrap" in context
+        assert "PACT_SESSION_DIR=" in context
+        assert "stale session block" in context
+        assert self._STALE_SID in context, "recorded (stale) id named"
+        assert self._SID in context, "actual id named"
+        assert context.index("PACT:bootstrap") < context.index(
+            "stale session block"), "warning is APPENDED, not prepended"
+        assert "suppressOutput" not in out
+        assert result.returncode == 0, (
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+
+        # Heal landed on disk (the chain's enabling step).
+        assert ctx.exists(), "self-heal should re-create the context file"
+        content = json.loads(ctx.read_text(encoding="utf-8"))
+        assert content["team_name"] == "pact-deadbeef"
+        assert content["session_id"] == self._SID
+
+    def test_heal_chain_with_matching_block_injects_instruction_only(
+            self, tmp_path):
+        """Match (healthy resume shape) → instruction WITHOUT the warning;
+        the heal still lands (it is independent of staleness)."""
+        result, ctx = self._run_gate_subprocess(
+            tmp_path, recorded_sid=self._SID
+        )
+
+        out = json.loads(result.stdout.strip())
+        context = out["hookSpecificOutput"]["additionalContext"]
+        assert "PACT:bootstrap" in context
+        assert "stale session block" not in context
+        assert result.returncode == 0, (
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        assert ctx.exists()

--- a/pact-plugin/tests/test_bootstrap_prompt_gate.py
+++ b/pact-plugin/tests/test_bootstrap_prompt_gate.py
@@ -554,3 +554,265 @@ class TestSelfHealWiring:
 
         assert not target.exists()
         assert result is None
+
+
+class TestStalenessDetection:
+    """Unit tests for _detect_stale_session_block() — the stdlib-only
+    Resume-line session_id compare that flags a stale CLAUDE.md 'Current
+    Session' block after a session_init crash."""
+
+    _ACTUAL = "deadbeef-0000-1111-2222-333344445555"
+    _STALE = "01dcafe0-9999-8888-7777-666655554444"
+
+    def _project_with_claude_md(self, tmp_path, recorded_sid,
+                                location=".claude"):
+        """Create a project dir whose CLAUDE.md records ``recorded_sid``."""
+        project = tmp_path / "proj"
+        if location == ".claude":
+            target = project / ".claude" / "CLAUDE.md"
+        else:
+            target = project / "CLAUDE.md"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(
+            "# Project\n\n## Current Session\n"
+            f"- Resume: `claude --resume {recorded_sid}`\n"
+            "- Team: `pact-old`\n",
+            encoding="utf-8",
+        )
+        return project
+
+    def test_mismatch_returns_warning(self, monkeypatch, tmp_path):
+        from bootstrap_prompt_gate import _detect_stale_session_block
+
+        project = self._project_with_claude_md(tmp_path, self._STALE)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+
+        result = _detect_stale_session_block({"session_id": self._ACTUAL})
+
+        assert result is not None
+        assert "stale session block" in result
+        assert self._STALE in result
+        assert self._ACTUAL in result
+
+    def test_match_returns_none(self, monkeypatch, tmp_path):
+        """Recorded == actual (healthy resume) → no warning."""
+        from bootstrap_prompt_gate import _detect_stale_session_block
+
+        project = self._project_with_claude_md(tmp_path, self._ACTUAL)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+
+        assert _detect_stale_session_block(
+            {"session_id": self._ACTUAL}) is None
+
+    def test_no_claude_md_returns_none(self, monkeypatch, tmp_path):
+        """Worktree case: CLAUDE.md absent at both locations → silent skip."""
+        from bootstrap_prompt_gate import _detect_stale_session_block
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+
+        assert _detect_stale_session_block(
+            {"session_id": self._ACTUAL}) is None
+
+    def test_garbage_resume_line_returns_none(self, monkeypatch, tmp_path):
+        """Tampered/garbage Resume line that misses the regex → no claim."""
+        from bootstrap_prompt_gate import _detect_stale_session_block
+
+        project = tmp_path / "proj"
+        target = project / ".claude" / "CLAUDE.md"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            "## Current Session\n- Resume: claude --resume NOT_HEX_$(rm -rf)\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+
+        assert _detect_stale_session_block(
+            {"session_id": self._ACTUAL}) is None
+
+    def test_missing_session_id_returns_none(self, monkeypatch, tmp_path):
+        from bootstrap_prompt_gate import _detect_stale_session_block
+
+        project = self._project_with_claude_md(tmp_path, self._STALE)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+
+        assert _detect_stale_session_block({}) is None
+        assert _detect_stale_session_block({"session_id": ""}) is None
+
+    def test_missing_project_dir_returns_none(self, monkeypatch):
+        from bootstrap_prompt_gate import _detect_stale_session_block
+
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+
+        assert _detect_stale_session_block(
+            {"session_id": self._ACTUAL}) is None
+
+    @pytest.mark.parametrize("layout", ["both", "preferred_only",
+                                        "legacy_only", "neither"])
+    def test_precedence_parity_with_resolver(self, monkeypatch, tmp_path,
+                                             layout):
+        """Precedence parity pin (the drift guard for the no-runtime-import
+        decision): for every file-existence layout, the staleness reader's
+        CHOSEN file must equal resolve_project_claude_md_path's result
+        whenever source != 'new_default'. Distinct recorded ids per file
+        reveal which one was read. (Tests MAY import claude_md_manager —
+        tests are not hooks.)"""
+        from bootstrap_prompt_gate import _detect_stale_session_block
+        from shared.claude_md_manager import resolve_project_claude_md_path
+
+        sid_by_location = {
+            ".claude": "aaaa1111-aaaa-1111-aaaa-111111111111",
+            "legacy": "bbbb2222-bbbb-2222-bbbb-222222222222",
+        }
+        project = tmp_path / "proj"
+        project.mkdir()
+        if layout in ("both", "preferred_only"):
+            self._project_with_claude_md(
+                tmp_path, sid_by_location[".claude"], location=".claude")
+        if layout in ("both", "legacy_only"):
+            self._project_with_claude_md(
+                tmp_path, sid_by_location["legacy"], location="legacy")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+
+        result = _detect_stale_session_block({"session_id": self._ACTUAL})
+
+        resolved_path, source = resolve_project_claude_md_path(str(project))
+        if source == "new_default":
+            assert result is None, "neither file exists → silent skip"
+        else:
+            resolver_recorded = _RE_RESUME_TEST.search(
+                resolved_path.read_text(encoding="utf-8")
+            ).group(1)
+            assert result is not None
+            assert resolver_recorded in result, (
+                f"staleness reader and resolver disagree on which CLAUDE.md "
+                f"to read for layout={layout}"
+            )
+
+
+# Test-local mirror of the production regex, used ONLY to extract the
+# resolver-chosen file's recorded id in the parity test above.
+import re as _re_for_parity  # noqa: E402
+_RE_RESUME_TEST = _re_for_parity.compile(
+    r"- Resume:\s*`claude --resume\s+([0-9a-f-]+)`"
+)
+
+
+class TestStalenessComposition:
+    """Placement tests: staleness composes onto the bootstrap instruction
+    ONLY on the lead+no-marker inject branch; the marker-set fast path
+    never reads CLAUDE.md (perf contract pin)."""
+
+    _ACTUAL_HEX = "deadbeef-0000-1111-2222-333344445555"
+    _STALE = "01dcafe0-9999-8888-7777-666655554444"
+
+    def _stale_project(self, monkeypatch, tmp_path):
+        project = tmp_path / "proj"
+        target = project / ".claude" / "CLAUDE.md"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            f"- Resume: `claude --resume {self._STALE}`\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+        return project
+
+    def test_mismatch_composes_instruction_and_warning(
+            self, monkeypatch, tmp_path):
+        """Lead + no marker + stale block → BOTH the bootstrap instruction
+        AND the staleness warning in one additionalContext string."""
+        from bootstrap_prompt_gate import _check_bootstrap_needed
+
+        _setup_pact_session(monkeypatch, tmp_path, with_marker=False)
+        self._stale_project(monkeypatch, tmp_path)
+
+        result = _check_bootstrap_needed(_make_input(
+            session_id=self._ACTUAL_HEX))
+
+        # NOTE: _setup_pact_session pre-writes the context file keyed on
+        # _SESSION_ID; the heal is a no-op here (file present).
+        assert result is not None
+        assert "PACT:bootstrap" in result            # instruction present
+        assert "stale session block" in result       # warning appended
+        assert result.index("PACT:bootstrap") < result.index(
+            "stale session block"), "warning is APPENDED, not prepended"
+
+    def test_match_returns_instruction_only(self, monkeypatch, tmp_path):
+        from bootstrap_prompt_gate import _check_bootstrap_needed
+
+        _setup_pact_session(monkeypatch, tmp_path, with_marker=False)
+        project = tmp_path / "proj"
+        target = project / ".claude" / "CLAUDE.md"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            f"- Resume: `claude --resume {self._ACTUAL_HEX}`\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+
+        result = _check_bootstrap_needed(_make_input(
+            session_id=self._ACTUAL_HEX))
+
+        assert result is not None
+        assert "PACT:bootstrap" in result
+        assert "stale session block" not in result
+
+    def test_no_claude_md_returns_instruction_only(
+            self, monkeypatch, tmp_path):
+        """Worktree case: no CLAUDE.md → instruction only, no warning."""
+        from bootstrap_prompt_gate import _check_bootstrap_needed
+
+        _setup_pact_session(monkeypatch, tmp_path, with_marker=False)
+        project = tmp_path / "proj"
+        project.mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+
+        result = _check_bootstrap_needed(_make_input())
+
+        assert result is not None
+        assert "PACT:bootstrap" in result
+        assert "stale session block" not in result
+
+    def test_marker_set_fast_path_never_runs_staleness(
+            self, monkeypatch, tmp_path):
+        """Perf contract pin: the marker-set fast path suppresses WITHOUT
+        any CLAUDE.md read — _detect_stale_session_block must not be
+        called at all."""
+        import bootstrap_prompt_gate as gate_module
+
+        _setup_pact_session(monkeypatch, tmp_path, with_marker=True)
+        self._stale_project(monkeypatch, tmp_path)
+
+        calls = []
+        monkeypatch.setattr(
+            gate_module, "_detect_stale_session_block",
+            lambda input_data: calls.append(1) or None,
+        )
+
+        result = gate_module._check_bootstrap_needed(_make_input(
+            session_id=self._ACTUAL_HEX))
+
+        assert result is None, "marker set → suppress"
+        assert calls == [], (
+            "fast path must not invoke the staleness check (zero-read "
+            "perf contract)"
+        )
+
+    def test_non_lead_path_never_runs_staleness(self, monkeypatch, tmp_path):
+        """Plain frame (non-lead) → suppress without staleness check."""
+        import bootstrap_prompt_gate as gate_module
+
+        _setup_pact_session(monkeypatch, tmp_path, with_marker=False)
+        self._stale_project(monkeypatch, tmp_path)
+
+        calls = []
+        monkeypatch.setattr(
+            gate_module, "_detect_stale_session_block",
+            lambda input_data: calls.append(1) or None,
+        )
+
+        result = gate_module._check_bootstrap_needed(_make_input(
+            session_id=self._ACTUAL_HEX, agent_type=None))
+
+        assert result is None
+        assert calls == []

--- a/pact-plugin/tests/test_bootstrap_prompt_gate.py
+++ b/pact-plugin/tests/test_bootstrap_prompt_gate.py
@@ -493,3 +493,64 @@ class TestAuditAnchorParity:
             f"shape={shape} emit MUST carry hookEventName=='UserPromptSubmit'; "
             f"got {hso!r}"
         )
+
+
+class TestSelfHealWiring:
+    """Wiring tests for the heal_context_if_missing call in
+    _check_bootstrap_needed: a missing context file is healed in-line
+    (lead frame + valid session_id), after which the SAME invocation
+    resolves the session dir and flows into the normal no-marker inject
+    branch — the heal unbricks the gate without forging bootstrap.
+    """
+
+    _SID = "deadbeef-7777-8888-9999-aaaabbbbcccc"
+
+    def test_missing_context_healed_then_instruction_injected(
+            self, monkeypatch, tmp_path):
+        """Context file ABSENT + lead frame → healed + bootstrap
+        instruction returned (chain effect; heal does NOT suppress)."""
+        import shared.pact_context as ctx_module
+        from bootstrap_prompt_gate import _check_bootstrap_needed
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/test/project")
+
+        # init() is a no-op when _context_path is pre-set: derive the path
+        # exactly as a fresh hook process would, but pointed under tmp_path.
+        target = (tmp_path / ".claude" / "pact-sessions" / "project" /
+                  self._SID / "pact-session-context.json")
+        monkeypatch.setattr(ctx_module, "_context_path", target)
+        monkeypatch.setattr(ctx_module, "_cache", None)
+        assert not target.exists()
+
+        result = _check_bootstrap_needed(_make_input(session_id=self._SID))
+
+        assert target.exists(), "gate should heal the missing context file"
+        assert result is not None, (
+            "healed lead session without marker must flow into the inject "
+            "branch, not suppress"
+        )
+        assert "PACT:bootstrap" in result
+        assert "PACT_SESSION_DIR=" in result
+
+    def test_missing_context_plain_frame_no_heal_no_inject(
+            self, monkeypatch, tmp_path):
+        """Context file ABSENT + plain frame (agent_type absent) → no heal,
+        no instruction (existing non-PACT passthrough preserved)."""
+        import shared.pact_context as ctx_module
+        from bootstrap_prompt_gate import _check_bootstrap_needed
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/test/project")
+
+        target = (tmp_path / ".claude" / "pact-sessions" / "project" /
+                  self._SID / "pact-session-context.json")
+        monkeypatch.setattr(ctx_module, "_context_path", target)
+        monkeypatch.setattr(ctx_module, "_cache", None)
+
+        result = _check_bootstrap_needed(
+            _make_input(session_id=self._SID, agent_type=None)
+        )
+
+        assert not target.exists()
+        assert result is None

--- a/pact-plugin/tests/test_dispatch_gate.py
+++ b/pact-plugin/tests/test_dispatch_gate.py
@@ -17,6 +17,9 @@ Rule coverage:
     disposition controlled by PACT_DISPATCH_INLINE_MISSION_MODE
     (warn|deny|shadow) → WARN | DENY | ALLOW(shadow)
   - name_not_unique — name already in team config members → DENY
+  - plugin_root_unavailable — plugin_root unresolvable (context file
+    missing/underivable AND no CLAUDE_PLUGIN_ROOT env) → DENY with the
+    context diagnosis from describe_context_failure()
   - plugin_agents_missing — plugin_root agents/ directory missing → DENY
   - Runtime gate-logic exception → fail-closed DENY (covered via
     subprocess in smoke)
@@ -1101,3 +1104,85 @@ class TestIsRegisteredSpecialistPluginRootParam:
         assert dh.is_registered_pact_specialist(
             "pact-architect", plugin_root=""
         ) is True  # "" → cache fallback, which resolves to the seeded root
+
+
+# =============================================================================
+# plugin_root_unavailable — context/plugin_root resolution (rule 5a split)
+# =============================================================================
+
+
+def test_deny_when_plugin_root_unavailable_context_file_absent(
+    tmp_path, monkeypatch, capsys
+):
+    """Context file ABSENT + no CLAUDE_PLUGIN_ROOT (conftest scrub) →
+    plugin_root_unavailable DENY whose message names the derived context
+    path and the session_init root cause — not the misleading
+    'plugin install may be broken'."""
+    import shared.pact_context as ctx_module
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    ctx_path = tmp_path / "pact-session-context.json"  # never written
+    monkeypatch.setattr(ctx_module, "_context_path", ctx_path)
+    monkeypatch.setattr(ctx_module, "_cache", None)
+    monkeypatch.setattr(ctx_module, "init", lambda input_data: None)
+    _seed_team(tmp_path, members=(), tasks=((_NAME, "pending"),))
+
+    code, out = _run_main(_make_input(), capsys)
+
+    assert code == 2
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "plugin_root is unavailable" in reason
+    assert str(ctx_path) in reason
+    assert "session_init may have failed" in reason
+    assert "plugin install may be broken" not in reason.lower()
+
+
+def test_deny_when_plugin_root_unavailable_context_underivable(
+    tmp_path, monkeypatch, capsys
+):
+    """Context path underivable (init() could not derive) → the underivable
+    arm of describe_context_failure() is embedded in the deny."""
+    import shared.pact_context as ctx_module
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(ctx_module, "_context_path", None)
+    monkeypatch.setattr(ctx_module, "_cache", None)
+    monkeypatch.setattr(ctx_module, "init", lambda input_data: None)
+    _seed_team(tmp_path, members=(), tasks=((_NAME, "pending"),))
+
+    code, out = _run_main(_make_input(), capsys)
+
+    assert code == 2
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "plugin_root is unavailable" in reason
+    assert "session context underivable" in reason
+
+
+def test_env_fallback_rescues_plugin_root_and_team_deny_names_cause(
+    tmp_path, monkeypatch, capsys
+):
+    """Context file ABSENT but CLAUDE_PLUGIN_ROOT exported → rule 5a is
+    rescued by the env fallback (plugin checks pass); the gate then denies
+    at rule 6 (empty session team) with the context diagnosis APPENDED, so
+    the deny names the real root cause."""
+    import shared.pact_context as ctx_module
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    plugin_root = tmp_path / "plugin"
+    _seed_plugin(plugin_root)
+    ctx_path = tmp_path / "pact-session-context.json"  # never written
+    monkeypatch.setattr(ctx_module, "_context_path", ctx_path)
+    monkeypatch.setattr(ctx_module, "_cache", None)
+    monkeypatch.setattr(ctx_module, "init", lambda input_data: None)
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+    _seed_team(tmp_path, members=(), tasks=((_NAME, "pending"),))
+
+    code, out = _run_main(_make_input(), capsys)
+
+    assert code == 2
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+    # Existing first sentence preserved (no-touch pin on rule 6)...
+    assert "session team_name is unavailable" in reason
+    # ...with the shared diagnosis appended naming the missing file.
+    assert str(ctx_path) in reason
+    assert "session_init may have failed" in reason

--- a/pact-plugin/tests/test_pact_context.py
+++ b/pact-plugin/tests/test_pact_context.py
@@ -2540,6 +2540,47 @@ class TestHealContextIfMissing:
         assert not target.exists()
         assert "self-heal failed" in capsys.readouterr().err
 
+    def test_unwritable_session_dir_real_oserror_returns_false(
+            self, monkeypatch, tmp_path, capsys):
+        """TOTAL under a REAL permission failure (no mocked seam): the
+        session dir exists but is unwritable (mode 0o500), so the atomic
+        write's mkstemp raises a genuine PermissionError inside
+        persist_context. The heal must return False (its disk-verified
+        'True iff healed' contract — persist_context swallows the error,
+        so only the exists() re-check keeps the return honest), must not
+        raise, must leave no file and no stray temp, and the swallowed
+        error must be named on stderr. Complements the mocked-seam
+        sibling above: that row pins the never-raises property at the
+        write_context boundary; this row drives the REAL OSError path
+        through persist_context's mkdir/mkstemp sequence."""
+        import shared.pact_context as ctx_module
+        from fixtures.role_frames import lead_frame_qualified
+
+        if hasattr(os, "geteuid") and os.geteuid() == 0:
+            pytest.skip("running as root — mode bits are not enforced, "
+                        "the PermissionError cannot be provoked")
+
+        target = self._absent_context(monkeypatch, tmp_path)
+        session_dir = target.parent
+        session_dir.mkdir(parents=True)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/test/heal-project")
+
+        frame = lead_frame_qualified(session_id=self._VALID_SID)
+        session_dir.chmod(0o500)  # r-x: traversable+listable, NOT writable
+        try:
+            assert ctx_module.heal_context_if_missing(frame) is False
+            err = capsys.readouterr().err
+            assert "could not write context file" in err, (
+                "persist_context must name the swallowed write failure "
+                "on stderr"
+            )
+            assert not target.exists()
+            assert list(session_dir.iterdir()) == [], (
+                "no stray mkstemp temp file may survive the failure"
+            )
+        finally:
+            session_dir.chmod(0o700)  # restore so tmp_path cleanup works
+
 
 class TestDescribeContextFailure:
     """Three-arm unit tests for describe_context_failure() — the shared

--- a/pact-plugin/tests/test_pact_context.py
+++ b/pact-plugin/tests/test_pact_context.py
@@ -307,6 +307,59 @@ class TestGetPluginRoot:
         assert get_plugin_root() == ""
 
 
+class TestGetPluginRootEnvFallback:
+    """Fallback matrix for get_plugin_root()'s CLAUDE_PLUGIN_ROOT env
+    fallback. File value wins when non-empty; env covers file-missing AND
+    field-empty; both absent → "". The autouse conftest scrub pops
+    CLAUDE_PLUGIN_ROOT before every test, so the env var is only present
+    when a test sets it explicitly.
+    """
+
+    def test_file_value_wins_over_env(self, pact_context, monkeypatch):
+        """A non-empty context-file plugin_root beats a differing env value."""
+        from shared.pact_context import get_plugin_root
+
+        pact_context(plugin_root="/from/context/file")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", "/from/env/var")
+
+        assert get_plugin_root() == "/from/context/file"
+
+    def test_env_fallback_when_file_missing(self, monkeypatch, tmp_path):
+        """File missing entirely → env value is returned."""
+        import shared.pact_context as ctx_module
+
+        monkeypatch.setattr(ctx_module, "_context_path", tmp_path / "missing.json")
+        monkeypatch.setattr(ctx_module, "_cache", None)
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", "/from/env/var")
+
+        assert ctx_module.get_plugin_root() == "/from/env/var"
+
+    def test_env_fallback_when_field_empty(self, pact_context, monkeypatch):
+        """File present but plugin_root empty → env value is returned."""
+        from shared.pact_context import get_plugin_root
+
+        pact_context()  # plugin_root defaults to ""
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", "/from/env/var")
+
+        assert get_plugin_root() == "/from/env/var"
+
+    def test_empty_when_both_absent(self, monkeypatch, tmp_path):
+        """File missing and env unset (conftest scrub guarantees) → ''."""
+        import shared.pact_context as ctx_module
+
+        monkeypatch.setattr(ctx_module, "_context_path", tmp_path / "missing.json")
+        monkeypatch.setattr(ctx_module, "_cache", None)
+
+        assert ctx_module.get_plugin_root() == ""
+
+    def test_conftest_scrub_pops_ambient_env(self):
+        """The autouse scrub guarantees CLAUDE_PLUGIN_ROOT is absent at test
+        start — this is the isolation contract the empty-plugin_root pins
+        (here and in test_bootstrap_gate.py) rely on under the fallback."""
+        assert "CLAUDE_PLUGIN_ROOT" not in os.environ
+
+
+
 class TestGetSessionDir:
     """Tests for get_session_dir() — session-scoped directory path."""
 

--- a/pact-plugin/tests/test_pact_context.py
+++ b/pact-plugin/tests/test_pact_context.py
@@ -359,7 +359,6 @@ class TestGetPluginRootEnvFallback:
         assert "CLAUDE_PLUGIN_ROOT" not in os.environ
 
 
-
 class TestGetSessionDir:
     """Tests for get_session_dir() — session-scoped directory path."""
 
@@ -2540,3 +2539,68 @@ class TestHealContextIfMissing:
         assert ctx_module.heal_context_if_missing(frame) is False
         assert not target.exists()
         assert "self-heal failed" in capsys.readouterr().err
+
+
+class TestDescribeContextFailure:
+    """Three-arm unit tests for describe_context_failure() — the shared
+    diagnosis helper consumer deny messages embed. '' means healthy
+    (present file), regardless of readability (read errors are logged
+    elsewhere)."""
+
+    def test_underivable_path_arm(self, monkeypatch):
+        """_context_path is None → 'session context underivable' naming the
+        two possible causes."""
+        import shared.pact_context as ctx_module
+
+        monkeypatch.setattr(ctx_module, "_context_path", None)
+
+        result = ctx_module.describe_context_failure()
+        assert "session context underivable" in result
+        assert "session_id" in result
+        assert "CLAUDE_PROJECT_DIR" in result
+
+    def test_file_absent_arm(self, monkeypatch, tmp_path):
+        """Path derived but file absent → diagnosis names the DERIVED path,
+        the session_init root cause, and both recovery actions."""
+        import shared.pact_context as ctx_module
+
+        target = tmp_path / "pact-session-context.json"
+        monkeypatch.setattr(ctx_module, "_context_path", target)
+
+        result = ctx_module.describe_context_failure()
+        assert str(target) in result
+        assert "session_init may have failed" in result
+        assert "self-heal" in result
+        assert "/PACT:bootstrap" in result
+
+    def test_file_present_arm_returns_empty(self, monkeypatch, tmp_path):
+        """File present (even malformed) → '' — not a missing-context
+        failure; read errors are already stderr-logged by get_pact_context."""
+        import shared.pact_context as ctx_module
+
+        for content in ('{"team_name": "t"}', "{malformed!!"):
+            target = tmp_path / "ctx.json"
+            target.write_text(content, encoding="utf-8")
+            monkeypatch.setattr(ctx_module, "_context_path", target)
+
+            assert ctx_module.describe_context_failure() == ""
+
+    def test_oserror_maps_to_file_absent_arm(self, monkeypatch, tmp_path):
+        """An OSError from exists() maps to the file-absent arm (total
+        function — an unstattable path is not a healthy context)."""
+        import shared.pact_context as ctx_module
+
+        target = tmp_path / "ctx.json"
+        monkeypatch.setattr(ctx_module, "_context_path", target)
+
+        original_exists = Path.exists
+
+        def _raising_exists(self, *args, **kwargs):
+            if self == target:
+                raise OSError("simulated stat failure")
+            return original_exists(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "exists", _raising_exists)
+
+        result = ctx_module.describe_context_failure()
+        assert "context file not found" in result

--- a/pact-plugin/tests/test_pact_context.py
+++ b/pact-plugin/tests/test_pact_context.py
@@ -2308,3 +2308,235 @@ class TestParallelSessionIsolation:
         assert dir_a != dir_b
         assert "project-a" in dir_a
         assert "project-b" in dir_b
+
+
+class TestHealContextIfMissing:
+    """Tests for heal_context_if_missing() — UserPromptSubmit self-heal that
+    re-creates a MISSING pact-session-context.json for a lead frame with a
+    valid session_id. Four guards: path derivable, file absent, is_lead,
+    session-id validity (the same canonical predicate session_init's
+    persistence gates use). Total: never raises.
+    """
+
+    _VALID_SID = "deadbeef-1111-2222-3333-444455556666"
+
+    def _absent_context(self, monkeypatch, tmp_path):
+        """Point _context_path at an ABSENT file under tmp_path."""
+        import shared.pact_context as ctx_module
+
+        target = tmp_path / "session" / "pact-session-context.json"
+        monkeypatch.setattr(ctx_module, "_context_path", target)
+        monkeypatch.setattr(ctx_module, "_cache", None)
+        return target
+
+    @pytest.mark.parametrize("lead_frame_builder", ["qualified", "unqualified"])
+    def test_lead_frame_absent_file_heals(self, monkeypatch, tmp_path,
+                                          lead_frame_builder):
+        """Lead frame + derivable path + absent file → healed with expected
+        content, and same-process accessors immediately resolve (cache reset
+        proof)."""
+        import shared.pact_context as ctx_module
+        from fixtures.role_frames import lead_frame_qualified, lead_frame_unqualified
+
+        builder = (lead_frame_qualified if lead_frame_builder == "qualified"
+                   else lead_frame_unqualified)
+        frame = builder(session_id=self._VALID_SID)
+        target = self._absent_context(monkeypatch, tmp_path)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/test/heal-project")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", "/test/plugin-root")
+
+        assert ctx_module.heal_context_if_missing(frame) is True
+
+        assert target.exists()
+        content = json.loads(target.read_text(encoding="utf-8"))
+        assert content["team_name"] == ctx_module.generate_team_name(frame)
+        assert content["session_id"] == self._VALID_SID
+        assert content["project_dir"] == "/test/heal-project"
+        assert content["plugin_root"] == "/test/plugin-root"
+        assert content["started_at"]  # ISO timestamp, non-empty
+
+        # In-process chain effect: accessors resolve WITHOUT re-reading disk
+        # (build_context_cache reset _cache as part of the heal).
+        assert ctx_module.get_team_name() == content["team_name"]
+        assert ctx_module.get_session_id() == self._VALID_SID
+
+    def test_team_name_matches_generate_team_name_deterministically(
+            self, monkeypatch, tmp_path):
+        """Hex session_id prefix → deterministic generated team name."""
+        import shared.pact_context as ctx_module
+        from fixtures.role_frames import lead_frame_qualified
+
+        frame = lead_frame_qualified(session_id=self._VALID_SID)
+        target = self._absent_context(monkeypatch, tmp_path)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/test/heal-project")
+
+        assert ctx_module.heal_context_if_missing(frame) is True
+        content = json.loads(target.read_text(encoding="utf-8"))
+        assert content["team_name"] == "pact-deadbeef"
+
+    def test_teammate_frames_never_heal(self, monkeypatch, tmp_path):
+        """Teammate frames (synthesized AND captured-tmux) must not heal —
+        the gate keys ONLY on agent_type via is_lead, never a mode flag
+        (both-modes rule)."""
+        import shared.pact_context as ctx_module
+        from fixtures.role_frames import (
+            captured_teammate_sessionstart,
+            teammate_frame,
+        )
+
+        frames = [
+            teammate_frame(session_id=self._VALID_SID),  # in-process shape
+            captured_teammate_sessionstart(),            # real tmux capture
+        ]
+        for frame in frames:
+            target = self._absent_context(monkeypatch, tmp_path)
+            monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/test/heal-project")
+
+            assert ctx_module.heal_context_if_missing(frame) is False
+            assert not target.exists()
+
+    def test_plain_frame_never_heals(self, monkeypatch, tmp_path):
+        """Plain frame (agent_type absent → is_lead False) must not heal."""
+        import shared.pact_context as ctx_module
+        from fixtures.role_frames import plain_frame
+
+        frame = plain_frame(session_id=self._VALID_SID)
+        target = self._absent_context(monkeypatch, tmp_path)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/test/heal-project")
+
+        assert ctx_module.heal_context_if_missing(frame) is False
+        assert not target.exists()
+
+    @pytest.mark.parametrize("bad_sid", [
+        None,            # missing
+        "",              # empty
+        "   ",           # whitespace-only
+        "\t\n",          # whitespace-only (tabs/newlines)
+        "unknown-abc123",  # sentinel
+        "unknown-",        # sentinel edge
+        "abc\ndef",        # C0 control char (newline injection)
+        True,              # non-string truthy
+        0,                 # non-string falsy
+    ])
+    def test_invalid_session_id_never_heals(self, monkeypatch, tmp_path, bad_sid):
+        """Predicate parity with session_init's persistence gate: the same
+        value classes TestIsUnknownOrMissingSession pins as rejected must
+        also block the heal (a sentinel id would fabricate a RANDOM team
+        name and an unreapable session dir)."""
+        import shared.pact_context as ctx_module
+        from fixtures.role_frames import lead_frame_qualified
+
+        frame = lead_frame_qualified()
+        if bad_sid is not None:
+            frame["session_id"] = bad_sid
+        target = self._absent_context(monkeypatch, tmp_path)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/test/heal-project")
+
+        assert ctx_module.heal_context_if_missing(frame) is False
+        assert not target.exists()
+
+    def test_underived_path_never_heals(self, monkeypatch):
+        """Guard 1: _context_path is None (init() could not derive) → no heal."""
+        import shared.pact_context as ctx_module
+        from fixtures.role_frames import lead_frame_qualified
+
+        monkeypatch.setattr(ctx_module, "_context_path", None)
+        monkeypatch.setattr(ctx_module, "_cache", None)
+
+        assert ctx_module.heal_context_if_missing(
+            lead_frame_qualified(session_id=self._VALID_SID)
+        ) is False
+
+    def test_present_valid_file_untouched(self, monkeypatch, tmp_path, pact_context):
+        """File PRESENT and valid → no heal, byte-unchanged."""
+        import shared.pact_context as ctx_module
+        from fixtures.role_frames import lead_frame_qualified
+
+        ctx_file = pact_context(team_name="pact-original")
+        original_bytes = ctx_file.read_bytes()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/test/heal-project")
+
+        frame = lead_frame_qualified(session_id=self._VALID_SID)
+        assert ctx_module.heal_context_if_missing(frame) is False
+        assert ctx_file.read_bytes() == original_bytes
+
+    def test_present_malformed_file_not_clobbered(self, monkeypatch, tmp_path):
+        """File PRESENT but malformed → NOT clobbered (different failure
+        class; preserve the evidence)."""
+        import shared.pact_context as ctx_module
+        from fixtures.role_frames import lead_frame_qualified
+
+        target = tmp_path / "pact-session-context.json"
+        target.write_text("{not valid json — evidence!!", encoding="utf-8")
+        original_bytes = target.read_bytes()
+        monkeypatch.setattr(ctx_module, "_context_path", target)
+        monkeypatch.setattr(ctx_module, "_cache", None)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/test/heal-project")
+
+        frame = lead_frame_qualified(session_id=self._VALID_SID)
+        assert ctx_module.heal_context_if_missing(frame) is False
+        assert target.read_bytes() == original_bytes
+
+    def test_second_heal_is_noop(self, monkeypatch, tmp_path):
+        """Idempotency: a second call observes the healed file and no-ops
+        (returns False, content unchanged)."""
+        import shared.pact_context as ctx_module
+        from fixtures.role_frames import lead_frame_qualified
+
+        frame = lead_frame_qualified(session_id=self._VALID_SID)
+        target = self._absent_context(monkeypatch, tmp_path)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/test/heal-project")
+
+        assert ctx_module.heal_context_if_missing(frame) is True
+        first_bytes = target.read_bytes()
+
+        assert ctx_module.heal_context_if_missing(frame) is False
+        assert target.read_bytes() == first_bytes
+
+    def test_sequential_heals_equivalent_content(self, monkeypatch, tmp_path):
+        """Two-healer race model: sequential heals from identical input
+        produce equivalent content (started_at aside) — last-writer-wins
+        is benign."""
+        import shared.pact_context as ctx_module
+        from fixtures.role_frames import lead_frame_qualified
+
+        frame = lead_frame_qualified(session_id=self._VALID_SID)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/test/heal-project")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", "/test/plugin-root")
+
+        target = self._absent_context(monkeypatch, tmp_path)
+        assert ctx_module.heal_context_if_missing(frame) is True
+        content_a = json.loads(target.read_text(encoding="utf-8"))
+
+        # Simulate the second healer: fresh process state, file gone again.
+        target.unlink()
+        ctx_module.reset_for_tests()
+        import shared.pact_context as ctx2
+        monkeypatch.setattr(ctx2, "_context_path", target)
+        monkeypatch.setattr(ctx2, "_cache", None)
+        assert ctx2.heal_context_if_missing(frame) is True
+        content_b = json.loads(target.read_text(encoding="utf-8"))
+
+        content_a.pop("started_at")
+        content_b.pop("started_at")
+        assert content_a == content_b
+
+    def test_total_never_raises(self, monkeypatch, tmp_path, capsys):
+        """Internal exception (write seam raising) → swallowed to stderr +
+        False; the heal must not convert a degraded session into a crashed
+        hook."""
+        import shared.pact_context as ctx_module
+        from fixtures.role_frames import lead_frame_qualified
+
+        target = self._absent_context(monkeypatch, tmp_path)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/test/heal-project")
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("simulated write failure")
+
+        monkeypatch.setattr(ctx_module, "write_context", _boom)
+
+        frame = lead_frame_qualified(session_id=self._VALID_SID)
+        assert ctx_module.heal_context_if_missing(frame) is False
+        assert not target.exists()
+        assert "self-heal failed" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Hardens the two bootstrap failure paths exposed by the 2026-06-11 py3.9 incident, closing #942 and #943.

- **#942 — degraded-mode read-only allowlist in `bootstrap_gate`**: when the gate cannot verify itself (import or runtime failure), an 11-member read-only allowlist (Read, Glob, Grep, ToolSearch, Skill, TaskList, TaskGet, WebFetch, WebSearch, AskUserQuestion, ExitPlanMode) routes through the NORMAL permission flow with an explicit degraded-mode warning — `permissionDecision="defer"` for the 9 local tools, `"ask"` for WebFetch/WebSearch, never `"allow"` (post-review hardening: degraded mode is a permission-layer strict subset by construction); everything else — including Bash and all `mcp__*` tools — stays denied via the byte-unchanged existing deny path. Malformed stdin fails CLOSED. Master safety invariant: degraded-allow ⊆ healthy-allow, pinned structurally AND empirically (mutation-proven non-vacuous).
- **#943 — session-context recovery + diagnosis** (4 independently shippable fixes):
  1. `get_plugin_root()` falls back to the `CLAUDE_PLUGIN_ROOT` env var (verified exported into hook processes) when the context file is missing/empty — fallback after file read, never replacement.
  2. Both UserPromptSubmit hooks self-heal a missing `pact-session-context.json` (is_lead-gated, file-ABSENT-only, session-id validity predicate shared with `session_init` via a pure refactor to `shared/pact_context`).
  3. `dispatch_gate` names the real cause: new `plugin_root_unavailable` reason code carries the derived context-file path + "session_init may have failed at SessionStart" instead of the incident's misleading message.
  4. `bootstrap_prompt_gate` warns when the CLAUDE.md Current Session block belongs to a different session (Resume-line compare; lead+no-marker injection path only; marker-set fast path keeps its zero-read contract).

## Verification

- Suite: **8841 passed, 13 skipped, 0 errors** (rtk-proxy errors-token explicitly confirmed 0)
- Full broken-import subprocess matrix: 11-member allow arm, 8-class deny arm, 8-class unverifiable-stdin arm — plus a **live Python 3.9.6 floor run**
- 6 RED-on-revert non-vacuity legs (isolated detached worktree, source-only reverts): every protection demonstrated load-bearing with exact failing-test cardinalities
- True parallel two-process two-healer race harness (5/5 stable) + sequential content-parity pin
- T7 byte-unchanged audit: pre-existing test deltas limited to the two disclosed edits
- Concurrent CODE-phase audit: **GREEN** (deny path byte-identical base-vs-HEAD via AST extraction; containment + boundaries diff-verified)
- L2 agreement verification: incident replay against this branch passes both issue intents

## Why

During the incident, `bootstrap_gate`'s fail-closed import handler denied every tool (including Read/Grep needed for diagnosis), and the missing context file + stale CLAUDE.md block forced manual state reconstruction with a wrong-team detour. Fail-closed stays correct for mutating tools; this PR makes the failure diagnosable and the state self-healing.

## Notes

- Version bump: 4.4.19 (PATCH — hook-internal hardening; degraded-mode behavior only observable during failures)
- `session_init` docstring-parity sed anchors shift 695,716 → 634,655 (pure-move refactor; content parity unchanged) — pinned-convention update is a post-merge lead task

## Review remediation (4-reviewer panel: architect / test / security / backend)

All findings resolved and cross-verified (verify-only re-reviews: 0 new issues):

- **Blocking** — staleness reader now survives non-UTF-8 `CLAUDE.md` (`except (OSError, UnicodeDecodeError)`); previously a decode error suppressed the entire bootstrap instruction every prompt (`32b98d58`)
- Degraded mode emits documented `defer`/`ask` tokens, never `allow` — permission-prompt bypass closed (`baeb5c22`)
- Degraded warning's raw exception text bounded (200 chars + control-strip; full text stderr-only) (`baeb5c22`)
- Staleness warning's stdin id gated by the canonical session-id validity predicate (`32b98d58`)
- Env-fallback provenance documented at the marker-signature participation site (`79baef2a`)
- Test strengthenings: 3-vector broken-import matrix, env-fallback×marker pins (incl. HMAC-input proof), real-OSError heal totality row, single-variable teammate negative (`ebd2e0a9`)

Final gate: **8861 passed / 13 skipped / 0 failed / 0 errors**. Follow-up filed: #951 (task_lifecycle_gate self-masking). Post-merge live-probe item: empirical confirmation of `defer` normal-flow routing (documented enum token; prose semantics unstated — fallback is `ask` for all 11).

Closes #942
Closes #943

