### PR TITLE
fix(hooks): add content-assertable pactGateHealth crash-path marker to task_lifecycle_gate (#951)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.19",
+      "version": "4.4.20",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.19/      # Plugin version
+│               └── 4.4.20/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.19",
+  "version": "4.4.20",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.19
+> **Version**: 4.4.20
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/bootstrap_gate.py
+++ b/pact-plugin/hooks/bootstrap_gate.py
@@ -182,13 +182,20 @@ def _bounded_error_text(error: BaseException) -> str:
     spaces, and the result is truncated to _ERROR_TEXT_MAX chars with an
     explicit marker. Full text still goes to stderr at the call site.
 
-    Total over hostile exceptions: rendering the message runs the
-    exception's own __str__ (arbitrary code that can itself raise) — fall
-    back to the type name, which renders for any exception class."""
+    Total over hostile exceptions: BOTH renderings that run exception-owned
+    code are guarded. The type name is captured first — a metaclass can make
+    __name__ a property that raises — falling back to a literal; the message
+    runs the exception's own __str__ (arbitrary code that can itself raise),
+    falling back to a marker. Neither fallback touches the exception again,
+    so the function returns a string for any exception object."""
     try:
-        text = f"{type(error).__name__}: {error}"
+        type_name = type(error).__name__
+    except BaseException:  # noqa: BLE001 — hostile metaclass __name__ must not escape
+        type_name = "exception"
+    try:
+        text = f"{type_name}: {error}"
     except BaseException:  # noqa: BLE001 — hostile __str__ must not escape the renderer
-        text = f"{type(error).__name__}: <exception str() raised>"
+        text = f"{type_name}: <exception str() raised>"
     text = "".join(ch if ch.isprintable() else " " for ch in text)
     if len(text) > _ERROR_TEXT_MAX:
         text = text[:_ERROR_TEXT_MAX] + "...[truncated]"

--- a/pact-plugin/hooks/bootstrap_gate.py
+++ b/pact-plugin/hooks/bootstrap_gate.py
@@ -87,19 +87,34 @@ def _emit_load_failure_deny(stage: str, error: BaseException) -> NoReturn:
     import below fails. Audit anchor: hookEventName must be present in any
     deny output.
     """
+    # Guarded rendering BEFORE the deny print: an unguarded hostile/raising
+    # __str__ here would suppress the deny output and exit nonzero-non-2 —
+    # for PreToolUse that is a non-blocking error and the tool call
+    # PROCEEDS (fail-open). The deny must print for any exception; the
+    # fallback is a raise-proof constant.
+    try:
+        error_render = f"{type(error).__name__}: {error}"
+    except BaseException:  # noqa: BLE001 — hostile __str__ must not suppress the deny
+        error_render = "<error text unavailable>"
     print(json.dumps({
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
             "permissionDecision": "deny",
             "permissionDecisionReason": (
                 f"PACT bootstrap_gate {stage} failure — blocking for safety. "
-                f"{type(error).__name__}: {error}. Check hook installation "
+                f"{error_render}. Check hook installation "
                 "and shared module availability."
             ),
         }
     }))
+    # Guarded full-text rendering: a raise here would replace the deliberate
+    # exit 2 (blocking) with a traceback exit 1 (non-blocking → fail-open).
+    try:
+        error_full = f"{error}"
+    except BaseException:  # noqa: BLE001 — hostile __str__; keep the exit-2 path
+        error_full = "<exception str() raised>"
     print(
-        f"Hook load error (bootstrap_gate / {stage}): {error}",
+        f"Hook load error (bootstrap_gate / {stage}): {error_full}",
         file=sys.stderr,
     )
     sys.exit(2)
@@ -225,8 +240,15 @@ def _emit_degraded_warning(stage: str, error: BaseException, tool_name: str) -> 
             "mutating tools blocked."
         ),
     }))
+    # Guarded full-text rendering: this line runs AFTER the decision JSON
+    # printed, but a raise here would exit nonzero — and stdout JSON is only
+    # honored on exit 0, voiding the defer/ask decision retroactively.
+    try:
+        error_full = f"{error}"
+    except BaseException:  # noqa: BLE001 — hostile __str__; keep the exit-0 path
+        error_full = "<exception str() raised>"
     print(
-        f"Hook degraded-{decision} (bootstrap_gate / {stage}): {tool_name} — {error}",
+        f"Hook degraded-{decision} (bootstrap_gate / {stage}): {tool_name} — {error_full}",
         file=sys.stderr,
     )
     sys.exit(0)

--- a/pact-plugin/hooks/bootstrap_gate.py
+++ b/pact-plugin/hooks/bootstrap_gate.py
@@ -182,24 +182,28 @@ def _bounded_error_text(error: BaseException) -> str:
     spaces, and the result is truncated to _ERROR_TEXT_MAX chars with an
     explicit marker. Full text still goes to stderr at the call site.
 
-    Total over hostile exceptions: BOTH renderings that run exception-owned
-    code are guarded. The type name is captured first — a metaclass can make
-    __name__ a property that raises (caught; falls back to a literal) or
-    return a non-str object whose own __str__/__format__ raises (coerced to a
-    literal by the isinstance guard below, so type_name is provably a str
-    before interpolation); the message then runs the exception's own __str__
-    (arbitrary code that can itself raise), falling back to a marker. After
-    the coercion neither branch can raise on type_name, so the function
-    returns a string for any exception object."""
+    Total over hostile exceptions, structurally: the type name is captured
+    first — a metaclass can make __name__ a property that raises (caught;
+    falls back to a literal) or return any non-str value, INCLUDING a str
+    subclass whose own __str__/__format__ raises. The exact-type check below
+    (type(...) is str, which rejects str subclasses too) reduces type_name to
+    an EXACT str, whose __format__/__str__ are str's own built-ins and cannot
+    be overridden — so neither f-string branch below can raise on type_name
+    regardless of the original __name__ value. The only exception-owned code
+    left is the message render (error's own __str__), isolated to the main
+    branch and guarded by the fallback. The function therefore returns a
+    string for ANY exception object."""
     try:
         type_name = type(error).__name__
     except BaseException:  # noqa: BLE001 — hostile metaclass __name__ must not escape
         type_name = "exception"
-    # __name__ can also RETURN (not raise) a non-str object whose own
-    # __str__/__format__ raises; that poisoned value would defeat BOTH
-    # f-string branches below (the fallback re-interpolates type_name too).
-    # Coerce to a guaranteed str so the renderer is total for any exception.
-    if not isinstance(type_name, str):
+    # __name__ can also RETURN (not raise) a non-str value — including a str
+    # SUBCLASS whose own __str__/__format__ raises, which an isinstance check
+    # would wave through. An EXACT-type check (type(...) is str) rejects
+    # subclasses too, so type_name is provably an exact str whose formatting
+    # uses str's own unpatchable built-ins → both f-string branches below
+    # (incl. the fallback, which re-interpolates type_name) cannot raise on it.
+    if type(type_name) is not str:
         type_name = "exception"
     try:
         text = f"{type_name}: {error}"

--- a/pact-plugin/hooks/bootstrap_gate.py
+++ b/pact-plugin/hooks/bootstrap_gate.py
@@ -184,13 +184,22 @@ def _bounded_error_text(error: BaseException) -> str:
 
     Total over hostile exceptions: BOTH renderings that run exception-owned
     code are guarded. The type name is captured first — a metaclass can make
-    __name__ a property that raises — falling back to a literal; the message
-    runs the exception's own __str__ (arbitrary code that can itself raise),
-    falling back to a marker. Neither fallback touches the exception again,
-    so the function returns a string for any exception object."""
+    __name__ a property that raises (caught; falls back to a literal) or
+    return a non-str object whose own __str__/__format__ raises (coerced to a
+    literal by the isinstance guard below, so type_name is provably a str
+    before interpolation); the message then runs the exception's own __str__
+    (arbitrary code that can itself raise), falling back to a marker. After
+    the coercion neither branch can raise on type_name, so the function
+    returns a string for any exception object."""
     try:
         type_name = type(error).__name__
     except BaseException:  # noqa: BLE001 — hostile metaclass __name__ must not escape
+        type_name = "exception"
+    # __name__ can also RETURN (not raise) a non-str object whose own
+    # __str__/__format__ raises; that poisoned value would defeat BOTH
+    # f-string branches below (the fallback re-interpolates type_name too).
+    # Coerce to a guaranteed str so the renderer is total for any exception.
+    if not isinstance(type_name, str):
         type_name = "exception"
     try:
         text = f"{type_name}: {error}"

--- a/pact-plugin/hooks/bootstrap_gate.py
+++ b/pact-plugin/hooks/bootstrap_gate.py
@@ -165,8 +165,15 @@ def _bounded_error_text(error: BaseException) -> str:
     """Sanitized, length-bounded rendering of an exception for embedding in
     context-bound warning text: control/non-printable characters become
     spaces, and the result is truncated to _ERROR_TEXT_MAX chars with an
-    explicit marker. Full text still goes to stderr at the call site."""
-    text = f"{type(error).__name__}: {error}"
+    explicit marker. Full text still goes to stderr at the call site.
+
+    Total over hostile exceptions: rendering the message runs the
+    exception's own __str__ (arbitrary code that can itself raise) — fall
+    back to the type name, which renders for any exception class."""
+    try:
+        text = f"{type(error).__name__}: {error}"
+    except BaseException:  # noqa: BLE001 — hostile __str__ must not escape the renderer
+        text = f"{type(error).__name__}: <exception str() raised>"
     text = "".join(ch if ch.isprintable() else " " for ch in text)
     if len(text) > _ERROR_TEXT_MAX:
         text = text[:_ERROR_TEXT_MAX] + "...[truncated]"

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -192,12 +192,14 @@ def _emit_load_failure_advisory(
     context-bound output; the stderr diagnostic keeps the full text.
     """
     # Thin call-site fallback (defense-in-depth over the now-total helper):
-    # the FLOOR below must print no matter what the renderer does. The type
-    # name alone is renderable for any exception class.
+    # the FLOOR below must print no matter what the renderer does. The
+    # fallback is a raise-proof CONSTANT — type(error).__name__ would
+    # re-invoke the same attribute access (hostile metaclass __name__) that
+    # is the helper's one remaining fall-through path.
     try:
         error_text = _bounded_error_text(error)
     except BaseException:  # noqa: BLE001 — floor must survive any renderer defect
-        error_text = type(error).__name__
+        error_text = "<error text unavailable>"
     advisory = (
         f"PACT task_lifecycle_gate {stage} failure — lifecycle "
         f"rule enforcement skipped this turn. "

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -86,13 +86,28 @@ _SUPPRESS_OUTPUT = json.dumps({"suppressOutput": True})
 # The stderr diagnostic line keeps the full text (debug channel).
 _ERROR_TEXT_MAX = 200
 
+# Cap on the crash-path stdin read in _emit_gate_health_event. Generous:
+# real PostToolUse frames embed tool_response payloads (file contents,
+# command output) and stay well under this; anything larger is not a
+# realistic hook frame and must not be slurped unbounded by a best-effort
+# emitter. An over-cap frame truncates mid-JSON → JSONDecodeError → the
+# guard's stderr disposition (marker-only outcome, never a raise).
+_STDIN_READ_MAX = 8 * 1024 * 1024  # 8 MB
+
 
 def _bounded_error_text(error: BaseException) -> str:
     """Sanitized, length-bounded rendering of an exception for embedding in
     context-bound warning text: control/non-printable characters become
     spaces, and the result is truncated to _ERROR_TEXT_MAX chars with an
-    explicit marker. Full text still goes to stderr at the call site."""
-    text = f"{type(error).__name__}: {error}"
+    explicit marker. Full text still goes to stderr at the call site.
+
+    Total over hostile exceptions: rendering the message runs the
+    exception's own __str__ (arbitrary code that can itself raise) — fall
+    back to the type name, which renders for any exception class."""
+    try:
+        text = f"{type(error).__name__}: {error}"
+    except BaseException:  # noqa: BLE001 — hostile __str__ must not escape the renderer
+        text = f"{type(error).__name__}: <exception str() raised>"
     text = "".join(ch if ch.isprintable() else " " for ch in text)
     if len(text) > _ERROR_TEXT_MAX:
         text = text[:_ERROR_TEXT_MAX] + "...[truncated]"
@@ -108,7 +123,8 @@ def _emit_gate_health_event(
     the import-stage crash path (works unless the breakage hits those very
     modules or shared/__init__ — then the lazy import raises into the guard
     below and the stdout marker remains the only record; prep §2.1 table).
-    On the import-stage path stdin is still unconsumed: read + init here.
+    On the import-stage path stdin is still unconsumed: read (capped at
+    _STDIN_READ_MAX) + init here.
     Never raises; never load-bearing (tmux teammate fires self-drop, #877).
     """
     try:
@@ -116,18 +132,28 @@ def _emit_gate_health_event(
         import shared.session_journal as _lazy_session_journal
 
         if input_data is None:
-            input_data = json.load(sys.stdin)
+            input_data = json.loads(sys.stdin.read(_STDIN_READ_MAX))
         if not isinstance(input_data, dict):
             return
         if not _lazy_pact_context.is_initialized():
             _lazy_pact_context.init(input_data)
+        # tool_name is attacker-set stdin on the import-stage path (main()'s
+        # TaskCreate/TaskUpdate allowlist short-circuit never ran) — apply
+        # the same sanitize+bound discipline as the error text before it
+        # reaches the durable journal.
+        tool_name = input_data.get("tool_name", "")
+        if not isinstance(tool_name, str):
+            tool_name = f"<non-str {type(tool_name).__name__}>"
+        tool_name = "".join(ch if ch.isprintable() else " " for ch in tool_name)
+        if len(tool_name) > _ERROR_TEXT_MAX:
+            tool_name = tool_name[:_ERROR_TEXT_MAX] + "...[truncated]"
         event = _lazy_session_journal.make_event(
             "gate_health",
             hook="task_lifecycle_gate",
             status="failed",
             stage=stage,
             error=error_text,
-            tool_name=input_data.get("tool_name", ""),
+            tool_name=tool_name,
         )
         written = _lazy_session_journal.append_event(event)
         if not written:
@@ -136,7 +162,12 @@ def _emit_gate_health_event(
                 "(append_event returned False)",
                 file=sys.stderr,
             )
-    except Exception:  # noqa: BLE001 — the crash handler must not crash
+    except BaseException:  # noqa: BLE001 — the crash handler must not crash:
+        # mirror the import gauntlet's breadth (except BaseException at the
+        # wrapped-import block). The lazy imports execute arbitrary module
+        # bodies — a module-level sys.exit or KeyboardInterrupt surfacing
+        # here would exit nonzero AFTER the floor marker printed, and stdout
+        # JSON is only honored on exit 0.
         print(
             "task_lifecycle_gate: gate_health journal emit unavailable "
             "(late import or init failed)",
@@ -160,7 +191,13 @@ def _emit_load_failure_advisory(
     gate_health journal event. Error text is bounded/sanitized for all
     context-bound output; the stderr diagnostic keeps the full text.
     """
-    error_text = _bounded_error_text(error)
+    # Thin call-site fallback (defense-in-depth over the now-total helper):
+    # the FLOOR below must print no matter what the renderer does. The type
+    # name alone is renderable for any exception class.
+    try:
+        error_text = _bounded_error_text(error)
+    except BaseException:  # noqa: BLE001 — floor must survive any renderer defect
+        error_text = type(error).__name__
     advisory = (
         f"PACT task_lifecycle_gate {stage} failure — lifecycle "
         f"rule enforcement skipped this turn. "
@@ -182,8 +219,15 @@ def _emit_load_failure_advisory(
         },
     }
     print(json.dumps(output))                                   # floor FIRST
+    # Guarded full-text rendering: this line runs AFTER the floor printed,
+    # but an unguarded str(error) raising here would exit nonzero — and
+    # stdout JSON is only honored on exit 0, voiding the floor retroactively.
+    try:
+        error_full = f"{error}"
+    except BaseException:  # noqa: BLE001 — hostile __str__; keep the exit-0 path
+        error_full = "<exception str() raised>"
     print(
-        f"Hook load error (task_lifecycle_gate / {stage}): {error}",  # full text
+        f"Hook load error (task_lifecycle_gate / {stage}): {error_full}",  # full text
         file=sys.stderr,
     )
     _emit_gate_health_event(stage, error_text, input_data)      # bonus LAST

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -79,28 +79,66 @@ from typing import NoReturn
 _SUPPRESS_OUTPUT = json.dumps({"suppressOutput": True})
 
 
-def _emit_load_failure_advisory(stage: str, error: BaseException) -> NoReturn:
+# Cap on exception text interpolated into context-bound output (warning
+# strings reaching Claude's context and the user banner). Exception
+# messages can embed attacker-influencable content (file contents, paths,
+# crafted payloads in tracebacks) — bound + sanitize before interpolation.
+# The stderr diagnostic line keeps the full text (debug channel).
+_ERROR_TEXT_MAX = 200
+
+
+def _bounded_error_text(error: BaseException) -> str:
+    """Sanitized, length-bounded rendering of an exception for embedding in
+    context-bound warning text: control/non-printable characters become
+    spaces, and the result is truncated to _ERROR_TEXT_MAX chars with an
+    explicit marker. Full text still goes to stderr at the call site."""
+    text = f"{type(error).__name__}: {error}"
+    text = "".join(ch if ch.isprintable() else " " for ch in text)
+    if len(text) > _ERROR_TEXT_MAX:
+        text = text[:_ERROR_TEXT_MAX] + "...[truncated]"
+    return text
+
+
+def _emit_load_failure_advisory(
+    stage: str, error: BaseException, input_data: dict | None = None
+) -> NoReturn:
     """Stdlib-only fail-advisory (PostToolUse cannot DENY).
 
     Mirrors bootstrap_gate._emit_load_failure_deny but for PostToolUse —
     advisory output + exit 0 since deny is not a valid PostToolUse verdict.
     Uses ONLY stdlib (json, sys) so it remains functional even when every
     wrapped import below fails.
+
+    Crash-path health surfacing: a top-level pactGateHealth key (stripped by
+    the platform's non-strict output schema; assertable on RAW stdout only)
+    plus a systemMessage mirror of the advisory, plus a best-effort
+    gate_health journal event. Error text is bounded/sanitized for all
+    context-bound output; the stderr diagnostic keeps the full text.
     """
+    error_text = _bounded_error_text(error)
+    advisory = (
+        f"PACT task_lifecycle_gate {stage} failure — lifecycle "
+        f"rule enforcement skipped this turn. "
+        f"{error_text}. Investigate hook "
+        "installation and shared module availability."
+    )
     output = {
         "hookSpecificOutput": {
             "hookEventName": "PostToolUse",
-            "additionalContext": (
-                f"PACT task_lifecycle_gate {stage} failure — lifecycle "
-                f"rule enforcement skipped this turn. "
-                f"{type(error).__name__}: {error}. Investigate hook "
-                "installation and shared module availability."
-            ),
-        }
+            "additionalContext": advisory,
+        },
+        "systemMessage": advisory,
+        "pactGateHealth": {
+            "v": 1,
+            "hook": "task_lifecycle_gate",
+            "status": "failed",
+            "stage": stage,
+            "error": error_text,
+        },
     }
-    print(json.dumps(output))
+    print(json.dumps(output))                                   # floor FIRST
     print(
-        f"Hook load error (task_lifecycle_gate / {stage}): {error}",
+        f"Hook load error (task_lifecycle_gate / {stage}): {error}",  # full text
         file=sys.stderr,
     )
     sys.exit(0)
@@ -1275,7 +1313,7 @@ def main() -> None:
     try:
         advisories = evaluate_lifecycle(input_data)
     except Exception as e:  # noqa: BLE001 — runtime catch-all → advisory
-        _emit_load_failure_advisory("runtime", e)
+        _emit_load_failure_advisory("runtime", e, input_data)
         return  # unreachable; helper exits
 
     _journal_lifecycle_decision(input_data, advisories)

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -1354,9 +1354,8 @@ def main() -> None:
         print(_SUPPRESS_OUTPUT)
         sys.exit(0)
 
-    pact_context.init(input_data)
-
     try:
+        pact_context.init(input_data)
         advisories = evaluate_lifecycle(input_data)
     except Exception as e:  # noqa: BLE001 — runtime catch-all → advisory
         _emit_load_failure_advisory("runtime", e, input_data)

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -99,6 +99,51 @@ def _bounded_error_text(error: BaseException) -> str:
     return text
 
 
+def _emit_gate_health_event(
+    stage: str, error_text: str, input_data: dict | None
+) -> None:
+    """Best-effort durable journal emit for a crash-path gate_health event.
+
+    Lazy-imports pact_context + session_journal so it stays functional on
+    the import-stage crash path (works unless the breakage hits those very
+    modules or shared/__init__ — then the lazy import raises into the guard
+    below and the stdout marker remains the only record; prep §2.1 table).
+    On the import-stage path stdin is still unconsumed: read + init here.
+    Never raises; never load-bearing (tmux teammate fires self-drop, #877).
+    """
+    try:
+        import shared.pact_context as _lazy_pact_context
+        import shared.session_journal as _lazy_session_journal
+
+        if input_data is None:
+            input_data = json.load(sys.stdin)
+        if not isinstance(input_data, dict):
+            return
+        if not _lazy_pact_context.is_initialized():
+            _lazy_pact_context.init(input_data)
+        event = _lazy_session_journal.make_event(
+            "gate_health",
+            hook="task_lifecycle_gate",
+            status="failed",
+            stage=stage,
+            error=error_text,
+            tool_name=input_data.get("tool_name", ""),
+        )
+        written = _lazy_session_journal.append_event(event)
+        if not written:
+            print(
+                "task_lifecycle_gate: gate_health journal emit skipped "
+                "(append_event returned False)",
+                file=sys.stderr,
+            )
+    except Exception:  # noqa: BLE001 — the crash handler must not crash
+        print(
+            "task_lifecycle_gate: gate_health journal emit unavailable "
+            "(late import or init failed)",
+            file=sys.stderr,
+        )
+
+
 def _emit_load_failure_advisory(
     stage: str, error: BaseException, input_data: dict | None = None
 ) -> NoReturn:
@@ -141,6 +186,7 @@ def _emit_load_failure_advisory(
         f"Hook load error (task_lifecycle_gate / {stage}): {error}",  # full text
         file=sys.stderr,
     )
+    _emit_gate_health_event(stage, error_text, input_data)      # bonus LAST
     sys.exit(0)
 
 

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -101,24 +101,28 @@ def _bounded_error_text(error: BaseException) -> str:
     spaces, and the result is truncated to _ERROR_TEXT_MAX chars with an
     explicit marker. Full text still goes to stderr at the call site.
 
-    Total over hostile exceptions: BOTH renderings that run exception-owned
-    code are guarded. The type name is captured first — a metaclass can make
-    __name__ a property that raises (caught; falls back to a literal) or
-    return a non-str object whose own __str__/__format__ raises (coerced to a
-    literal by the isinstance guard below, so type_name is provably a str
-    before interpolation); the message then runs the exception's own __str__
-    (arbitrary code that can itself raise), falling back to a marker. After
-    the coercion neither branch can raise on type_name, so the function
-    returns a string for any exception object."""
+    Total over hostile exceptions, structurally: the type name is captured
+    first — a metaclass can make __name__ a property that raises (caught;
+    falls back to a literal) or return any non-str value, INCLUDING a str
+    subclass whose own __str__/__format__ raises. The exact-type check below
+    (type(...) is str, which rejects str subclasses too) reduces type_name to
+    an EXACT str, whose __format__/__str__ are str's own built-ins and cannot
+    be overridden — so neither f-string branch below can raise on type_name
+    regardless of the original __name__ value. The only exception-owned code
+    left is the message render (error's own __str__), isolated to the main
+    branch and guarded by the fallback. The function therefore returns a
+    string for ANY exception object."""
     try:
         type_name = type(error).__name__
     except BaseException:  # noqa: BLE001 — hostile metaclass __name__ must not escape
         type_name = "exception"
-    # __name__ can also RETURN (not raise) a non-str object whose own
-    # __str__/__format__ raises; that poisoned value would defeat BOTH
-    # f-string branches below (the fallback re-interpolates type_name too).
-    # Coerce to a guaranteed str so the renderer is total for any exception.
-    if not isinstance(type_name, str):
+    # __name__ can also RETURN (not raise) a non-str value — including a str
+    # SUBCLASS whose own __str__/__format__ raises, which an isinstance check
+    # would wave through. An EXACT-type check (type(...) is str) rejects
+    # subclasses too, so type_name is provably an exact str whose formatting
+    # uses str's own unpatchable built-ins → both f-string branches below
+    # (incl. the fallback, which re-interpolates type_name) cannot raise on it.
+    if type(type_name) is not str:
         type_name = "exception"
     try:
         text = f"{type_name}: {error}"

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -101,13 +101,20 @@ def _bounded_error_text(error: BaseException) -> str:
     spaces, and the result is truncated to _ERROR_TEXT_MAX chars with an
     explicit marker. Full text still goes to stderr at the call site.
 
-    Total over hostile exceptions: rendering the message runs the
-    exception's own __str__ (arbitrary code that can itself raise) — fall
-    back to the type name, which renders for any exception class."""
+    Total over hostile exceptions: BOTH renderings that run exception-owned
+    code are guarded. The type name is captured first — a metaclass can make
+    __name__ a property that raises — falling back to a literal; the message
+    runs the exception's own __str__ (arbitrary code that can itself raise),
+    falling back to a marker. Neither fallback touches the exception again,
+    so the function returns a string for any exception object."""
     try:
-        text = f"{type(error).__name__}: {error}"
+        type_name = type(error).__name__
+    except BaseException:  # noqa: BLE001 — hostile metaclass __name__ must not escape
+        type_name = "exception"
+    try:
+        text = f"{type_name}: {error}"
     except BaseException:  # noqa: BLE001 — hostile __str__ must not escape the renderer
-        text = f"{type(error).__name__}: <exception str() raised>"
+        text = f"{type_name}: <exception str() raised>"
     text = "".join(ch if ch.isprintable() else " " for ch in text)
     if len(text) > _ERROR_TEXT_MAX:
         text = text[:_ERROR_TEXT_MAX] + "...[truncated]"

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -103,13 +103,22 @@ def _bounded_error_text(error: BaseException) -> str:
 
     Total over hostile exceptions: BOTH renderings that run exception-owned
     code are guarded. The type name is captured first — a metaclass can make
-    __name__ a property that raises — falling back to a literal; the message
-    runs the exception's own __str__ (arbitrary code that can itself raise),
-    falling back to a marker. Neither fallback touches the exception again,
-    so the function returns a string for any exception object."""
+    __name__ a property that raises (caught; falls back to a literal) or
+    return a non-str object whose own __str__/__format__ raises (coerced to a
+    literal by the isinstance guard below, so type_name is provably a str
+    before interpolation); the message then runs the exception's own __str__
+    (arbitrary code that can itself raise), falling back to a marker. After
+    the coercion neither branch can raise on type_name, so the function
+    returns a string for any exception object."""
     try:
         type_name = type(error).__name__
     except BaseException:  # noqa: BLE001 — hostile metaclass __name__ must not escape
+        type_name = "exception"
+    # __name__ can also RETURN (not raise) a non-str object whose own
+    # __str__/__format__ raises; that poisoned value would defeat BOTH
+    # f-string branches below (the fallback re-interpolates type_name too).
+    # Coerce to a guaranteed str so the renderer is total for any exception.
+    if not isinstance(type_name, str):
         type_name = "exception"
     try:
         text = f"{type_name}: {error}"

--- a/pact-plugin/tests/test_bootstrap_gate.py
+++ b/pact-plugin/tests/test_bootstrap_gate.py
@@ -2357,6 +2357,152 @@ class TestBaseExceptionBreadthAtImport:
 
 
 # =============================================================================
+# Cycle-4 regression: __name__ that returns a str SUBCLASS whose formatting
+# hooks raise. isinstance(str_subclass, str) is True, so the cycle-3 isinstance
+# guard waved it through and _bounded_error_text raised out of both f-string
+# branches (str.__format__'s empty-spec path delegates to the overridden
+# __str__). cede8629 uses an EXACT-type guard (type(...) is str) that rejects
+# str subclasses too, collapsing the prefix to "exception". These pins lock the
+# restored exit-0 defer / exit-2 deny; counter-test: revert cede8629 (restore
+# isinstance) → the defer leg raises out of the renderer → exit 1 (fail-open).
+#
+# HAZARD: the hostile str subclass lives entirely in the subprocess scaffold
+# text — no in-process class whose __name__ pytest could bomb on collection.
+# =============================================================================
+
+
+def _break_shared_str_subclass_format_name(scaffold):
+    """shared/__init__.py raises an exception whose metaclass __name__ RETURNS
+    a str SUBCLASS instance whose __format__ raises."""
+    (scaffold / "shared").mkdir(parents=True)
+    (scaffold / "shared" / "__init__.py").write_text(
+        "class _FmtStr(str):\n"
+        "    def __format__(self, spec):\n"
+        "        raise RuntimeError('hostile str-subclass __format__')\n"
+        "class _FmtStrNameMeta(type):\n"
+        "    @property\n"
+        "    def __name__(cls):\n"
+        "        return _FmtStr('HostileFmtName')\n"
+        "class FmtStrNameBomb(Exception, metaclass=_FmtStrNameMeta):\n"
+        "    pass\n"
+        "raise FmtStrNameBomb('boom')\n",
+        encoding="utf-8",
+    )
+
+
+def _break_shared_str_subclass_str_name(scaffold):
+    """shared/__init__.py raises an exception whose metaclass __name__ RETURNS
+    a str SUBCLASS instance whose __str__ raises (str.__format__'s empty-spec
+    delegation to __str__ makes the f-string interpolation raise)."""
+    (scaffold / "shared").mkdir(parents=True)
+    (scaffold / "shared" / "__init__.py").write_text(
+        "class _StrStr(str):\n"
+        "    def __str__(self):\n"
+        "        raise RuntimeError('hostile str-subclass __str__')\n"
+        "class _StrStrNameMeta(type):\n"
+        "    @property\n"
+        "    def __name__(cls):\n"
+        "        return _StrStr('HostileStrName')\n"
+        "class StrStrNameBomb(Exception, metaclass=_StrStrNameMeta):\n"
+        "    pass\n"
+        "raise StrStrNameBomb('boom')\n",
+        encoding="utf-8",
+    )
+
+
+class TestStrSubclassNameReturnCrashPath:
+
+    def _run(self, tmp_path, stdin_text, breaker):
+        import subprocess
+
+        hook_src = Path(__file__).parent.parent / "hooks" / "bootstrap_gate.py"
+        scaffold = tmp_path / "scaffold"
+        scaffold.mkdir(parents=True)
+        (scaffold / "bootstrap_gate.py").write_text(
+            hook_src.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        breaker(scaffold)
+        return subprocess.run(
+            [sys.executable, str(scaffold / "bootstrap_gate.py")],
+            input=stdin_text,
+            capture_output=True,
+            text=True,
+            cwd=str(scaffold),
+            timeout=10,
+        )
+
+    @pytest.mark.parametrize(
+        "breaker",
+        [
+            _break_shared_str_subclass_format_name,
+            _break_shared_str_subclass_str_name,
+        ],
+        ids=["name-returns-str-subclass-format-bomb",
+             "name-returns-str-subclass-str-bomb"],
+    )
+    def test_readonly_defer_intact_under_str_subclass_name(
+        self, tmp_path, breaker,
+    ):
+        """The cycle-4 regression pin: a read-only tool under a module crash
+        whose __name__ RETURNS a hostile str SUBCLASS must take the defer arm
+        at exit 0, decision JSON intact, with the "exception" fallback in the
+        warning. Pre-cede8629 (isinstance guard) the str subclass passed the
+        guard and the renderer raised → exit 1, warning suppressed
+        (fail-open)."""
+        result = self._run(
+            tmp_path, json.dumps(_make_input(tool_name="Read")), breaker
+        )
+        assert result.returncode == 0, (
+            "a str-subclass __name__ must not regress the degraded path to a "
+            f"nonzero exit (the suppressed-warning fail-open): "
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        out = json.loads(result.stdout.strip().splitlines()[0])
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "defer"
+        for field in ("permissionDecisionReason", "additionalContext"):
+            assert "DEGRADED" in hso[field]
+            assert "module imports" in hso[field]
+            assert "failure — exception:" in hso[field], (
+                f"warning must carry the exact-type-coerced fallback: "
+                f"{hso[field]!r}"
+            )
+        assert "systemMessage" in out
+        assert "Hook degraded-defer (bootstrap_gate / module imports)" in (
+            result.stderr
+        )
+
+    @pytest.mark.parametrize(
+        "breaker",
+        [
+            _break_shared_str_subclass_format_name,
+            _break_shared_str_subclass_str_name,
+        ],
+        ids=["name-returns-str-subclass-format-bomb",
+             "name-returns-str-subclass-str-bomb"],
+    )
+    def test_mutating_deny_intact_under_str_subclass_name(
+        self, tmp_path, breaker,
+    ):
+        """Deny-arm twin: a mutating tool under a str-subclass-__name__ module
+        crash still denies at exit 2 (blocking). The deny render's own constant
+        guard carries "<error text unavailable>" when the str subclass bombs
+        its render, so the blocking exit-2 path stays intact."""
+        result = self._run(
+            tmp_path, json.dumps(_make_input(tool_name="Edit")), breaker
+        )
+        assert result.returncode == 2, (
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        out = json.loads(result.stdout.strip().splitlines()[0])
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "deny"
+        assert "module imports" in hso["permissionDecisionReason"]
+
+
+# =============================================================================
 # Marker verification × CLAUDE_PLUGIN_ROOT env fallback — healthy path
 # =============================================================================
 

--- a/pact-plugin/tests/test_bootstrap_gate.py
+++ b/pact-plugin/tests/test_bootstrap_gate.py
@@ -2097,6 +2097,266 @@ class TestHostileNameCrashPath:
 
 
 # =============================================================================
+# Cycle-3 regression: __name__ that RETURNS (not raises) a hostile non-str.
+#
+# The cycle-2 fix (7155516d) guards a metaclass __name__ that RAISES. A
+# metaclass __name__ can instead RETURN a non-str object whose own
+# __format__/__str__ raises — that poisoned value defeats BOTH f-string
+# branches of _bounded_error_text (the except-branch fallback re-interpolates
+# the same type_name), so before b6e9125a the degraded warn path raised out of
+# the renderer and exited 1: a PreToolUse non-blocking error that SUPPRESSED
+# the warning, silently failing open. b6e9125a coerces a non-str type_name to
+# the literal "exception" (isinstance guard). These pins lock the restored
+# exit-0 defer / exit-2 deny under the returns-hostile shape; counter-test:
+# source-revert b6e9125a → the defer leg regresses to exit 1.
+#
+# HAZARD: the hostile metaclass lives entirely in the subprocess scaffold
+# text — no in-process class whose __name__ pytest could bomb on collection.
+# =============================================================================
+
+
+def _break_shared_hostile_format_name(scaffold):
+    """shared/__init__.py raises an exception whose metaclass __name__ RETURNS
+    a non-str object whose __format__ (and __str__) raise. Rendering the
+    caught error's type name interpolates that poisoned value → raises unless
+    the renderer coerces it to a str first (b6e9125a)."""
+    (scaffold / "shared").mkdir(parents=True)
+    (scaffold / "shared" / "__init__.py").write_text(
+        "class _FormatBomb:\n"
+        "    def __format__(self, spec):\n"
+        "        raise RuntimeError('hostile __format__')\n"
+        "    def __str__(self):\n"
+        "        raise RuntimeError('hostile __str__')\n"
+        "class _HostileFormatNameMeta(type):\n"
+        "    @property\n"
+        "    def __name__(cls):\n"
+        "        return _FormatBomb()\n"
+        "class FormatNameBomb(Exception, metaclass=_HostileFormatNameMeta):\n"
+        "    pass\n"
+        "raise FormatNameBomb('boom')\n",
+        encoding="utf-8",
+    )
+
+
+def _break_shared_hostile_int_name(scaffold):
+    """shared/__init__.py raises an exception whose metaclass __name__ RETURNS
+    a non-str int. The int interpolates without raising, but the type name is
+    nonsense ('42: ...'); b6e9125a coerces it to 'exception' so the degraded
+    warning carries the same diagnosable fallback as the raising case."""
+    (scaffold / "shared").mkdir(parents=True)
+    (scaffold / "shared" / "__init__.py").write_text(
+        "class _IntNameMeta(type):\n"
+        "    @property\n"
+        "    def __name__(cls):\n"
+        "        return 42\n"
+        "class IntNameBomb(Exception, metaclass=_IntNameMeta):\n"
+        "    pass\n"
+        "raise IntNameBomb('boom')\n",
+        encoding="utf-8",
+    )
+
+
+class TestHostileNameReturnCrashPath:
+
+    def _run(self, tmp_path, stdin_text, breaker):
+        import subprocess
+
+        hook_src = Path(__file__).parent.parent / "hooks" / "bootstrap_gate.py"
+        scaffold = tmp_path / "scaffold"
+        scaffold.mkdir(parents=True)
+        (scaffold / "bootstrap_gate.py").write_text(
+            hook_src.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        breaker(scaffold)
+        return subprocess.run(
+            [sys.executable, str(scaffold / "bootstrap_gate.py")],
+            input=stdin_text,
+            capture_output=True,
+            text=True,
+            cwd=str(scaffold),
+            timeout=10,
+        )
+
+    @pytest.mark.parametrize(
+        "breaker",
+        [_break_shared_hostile_format_name, _break_shared_hostile_int_name],
+        ids=["name-returns-format-bomb", "name-returns-int"],
+    )
+    def test_readonly_defer_intact_under_hostile_name_return(
+        self, tmp_path, breaker,
+    ):
+        """The cycle-3 regression pin: a read-only tool under a module crash
+        whose __name__ RETURNS a hostile non-str must take the defer arm at
+        exit 0, decision JSON intact, with the "exception" type-name fallback
+        in the warning. Pre-b6e9125a the format-bomb variant exited 1 with the
+        warning suppressed (the renderer raised out of both f-string
+        branches)."""
+        result = self._run(
+            tmp_path, json.dumps(_make_input(tool_name="Read")), breaker
+        )
+        assert result.returncode == 0, (
+            "hostile __name__ RETURN must not regress the degraded path to a "
+            f"nonzero exit (the suppressed-warning fail-open): "
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        out = json.loads(result.stdout.strip().splitlines()[0])
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "defer"
+        for field in ("permissionDecisionReason", "additionalContext"):
+            assert "DEGRADED" in hso[field]
+            assert "module imports" in hso[field]
+            # Coerced fallback fired: the literal "exception", never a raw
+            # non-str type name ("42:") or a render crash.
+            assert "failure — exception:" in hso[field], (
+                f"warning must carry the coerced-name fallback: {hso[field]!r}"
+            )
+        assert "systemMessage" in out
+        assert "Hook degraded-defer (bootstrap_gate / module imports)" in (
+            result.stderr
+        )
+
+    @pytest.mark.parametrize(
+        "breaker",
+        [_break_shared_hostile_format_name, _break_shared_hostile_int_name],
+        ids=["name-returns-format-bomb", "name-returns-int"],
+    )
+    def test_mutating_deny_intact_under_hostile_name_return(
+        self, tmp_path, breaker,
+    ):
+        """Deny-arm twin: a mutating tool under a __name__-returns-hostile
+        module crash still denies at exit 2 (blocking). The deny render has
+        its own guard (constant fallback on the format-bomb; the int renders
+        cleanly), so the blocking exit-2 path stays intact either way."""
+        result = self._run(
+            tmp_path, json.dumps(_make_input(tool_name="Edit")), breaker
+        )
+        assert result.returncode == 2, (
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        out = json.loads(result.stdout.strip().splitlines()[0])
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "deny"
+        assert "module imports" in hso["permissionDecisionReason"]
+
+
+# =============================================================================
+# BaseException-breadth regression (symmetric with the lifecycle-gate pin): a
+# module-level sys.exit() / KeyboardInterrupt AT IMPORT is a BaseException that
+# is NOT an Exception subclass. The import-gauntlet guard (`except
+# BaseException`) is deliberately broad so such a vector is caught and routed
+# to the degraded decision (read-only → defer exit 0; mutating → deny exit 2).
+# None of the _BREAKAGE_VECTORS exercises this (all raise Exception
+# subclasses), so narrowing the guard to `except Exception` would silently
+# fail open: SystemExit/KeyboardInterrupt escapes → exit 1, which for
+# PreToolUse is a non-blocking error → the tool PROCEEDS (mutating) or the
+# defer decision is lost (read-only). These pins lock the breadth.
+#
+# Counter-test: narrow the gauntlet guard to `except Exception` → the crash
+# escapes, no decision JSON prints, exit 1 → both arms below fail.
+# =============================================================================
+
+
+def _break_shared_sys_exit(scaffold):
+    """shared/__init__.py calls sys.exit(1) at import → SystemExit (a
+    BaseException, NOT an Exception) propagates out of the gauntlet import."""
+    (scaffold / "shared").mkdir(parents=True)
+    (scaffold / "shared" / "__init__.py").write_text(
+        "import sys\nsys.exit(1)\n", encoding="utf-8"
+    )
+
+
+def _break_shared_keyboard_interrupt(scaffold):
+    """shared/__init__.py raises KeyboardInterrupt at import → a BaseException
+    that `except Exception` would NOT catch."""
+    (scaffold / "shared").mkdir(parents=True)
+    (scaffold / "shared" / "__init__.py").write_text(
+        "raise KeyboardInterrupt('simulated at import')\n", encoding="utf-8"
+    )
+
+
+class TestBaseExceptionBreadthAtImport:
+
+    def _run(self, tmp_path, stdin_text, breaker):
+        import subprocess
+
+        hook_src = Path(__file__).parent.parent / "hooks" / "bootstrap_gate.py"
+        scaffold = tmp_path / "scaffold"
+        scaffold.mkdir(parents=True)
+        (scaffold / "bootstrap_gate.py").write_text(
+            hook_src.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        breaker(scaffold)
+        return subprocess.run(
+            [sys.executable, str(scaffold / "bootstrap_gate.py")],
+            input=stdin_text,
+            capture_output=True,
+            text=True,
+            cwd=str(scaffold),
+            timeout=10,
+        )
+
+    @pytest.mark.parametrize(
+        "breaker,expected_exc",
+        [
+            (_break_shared_sys_exit, "SystemExit"),
+            (_break_shared_keyboard_interrupt, "KeyboardInterrupt"),
+        ],
+        ids=["import-sys-exit", "import-keyboard-interrupt"],
+    )
+    def test_readonly_defer_intact_under_non_exception_baseexception(
+        self, tmp_path, breaker, expected_exc,
+    ):
+        """A read-only tool under a module-level sys.exit()/KeyboardInterrupt
+        at import takes the defer arm at exit 0 (the gauntlet's `except
+        BaseException` catches the non-Exception BaseException). Narrowing to
+        `except Exception` re-masks: the crash escapes → exit 1, defer lost."""
+        result = self._run(
+            tmp_path, json.dumps(_make_input(tool_name="Read")), breaker
+        )
+        assert result.returncode == 0, (
+            "a non-Exception BaseException at import must be caught by the "
+            f"gauntlet's BaseException breadth (defer exit 0): "
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        out = json.loads(result.stdout.strip().splitlines()[0])
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "defer"
+        assert "DEGRADED" in hso["permissionDecisionReason"]
+        assert "module imports" in hso["permissionDecisionReason"]
+        assert expected_exc in hso["permissionDecisionReason"], (
+            f"degraded warning must name the BaseException type "
+            f"({expected_exc}): {hso['permissionDecisionReason']!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "breaker",
+        [_break_shared_sys_exit, _break_shared_keyboard_interrupt],
+        ids=["import-sys-exit", "import-keyboard-interrupt"],
+    )
+    def test_mutating_deny_intact_under_non_exception_baseexception(
+        self, tmp_path, breaker,
+    ):
+        """A mutating tool under the same non-Exception BaseException at import
+        still denies at exit 2 (blocking). Narrowing the gauntlet to `except
+        Exception` lets the crash escape → exit 1, a non-blocking PreToolUse
+        error → the mutating tool would PROCEED (fail-open)."""
+        result = self._run(
+            tmp_path, json.dumps(_make_input(tool_name="Edit")), breaker
+        )
+        assert result.returncode == 2, (
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        out = json.loads(result.stdout.strip().splitlines()[0])
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "deny"
+        assert "module imports" in hso["permissionDecisionReason"]
+
+
+# =============================================================================
 # Marker verification × CLAUDE_PLUGIN_ROOT env fallback — healthy path
 # =============================================================================
 

--- a/pact-plugin/tests/test_bootstrap_gate.py
+++ b/pact-plugin/tests/test_bootstrap_gate.py
@@ -1962,6 +1962,141 @@ class TestHostileStrCrashPath:
 
 
 # =============================================================================
+# Cycle-2 regression: hostile-metaclass __name__ on the crash path.
+#
+# A metaclass can make type(error).__name__ a property that RAISES. The
+# degraded warn path (_emit_degraded_warning) renders the error inline via
+# _bounded_error_text with NO constant fallback around the call — so before
+# 7155516d the helper's own fallback re-accessed type(error).__name__ and
+# re-raised, the warn path exited 1 (a PreToolUse non-blocking error that
+# SUPPRESSED the warning), and the degraded gate silently failed open. The
+# fix captures the type name once → literal "exception". These pins lock
+# the restored exit-0 defer; counter-test: source-revert 7155516d → the
+# defer leg regresses to exit 1.
+#
+# HAZARD: the breakage modules define the hostile metaclass entirely in the
+# subprocess scaffold text — no in-process class whose __name__ pytest
+# could bomb during collection.
+# =============================================================================
+
+
+def _break_shared_hostile_name(scaffold):
+    """shared/__init__.py raises an exception whose metaclass makes
+    __name__ a raising property (normal __str__). Rendering the caught
+    error's type name runs metaclass code that raises."""
+    (scaffold / "shared").mkdir(parents=True)
+    (scaffold / "shared" / "__init__.py").write_text(
+        "class _HostileNameMeta(type):\n"
+        "    @property\n"
+        "    def __name__(cls):\n"
+        "        raise RuntimeError('hostile __name__')\n"
+        "class NameBomb(Exception, metaclass=_HostileNameMeta):\n"
+        "    pass\n"
+        "raise NameBomb('boom')\n",
+        encoding="utf-8",
+    )
+
+
+def _break_shared_hostile_name_and_str(scaffold):
+    """Both hostile: metaclass __name__ raises AND __str__ raises — both
+    helper fallbacks fire (type name → 'exception', message → marker)."""
+    (scaffold / "shared").mkdir(parents=True)
+    (scaffold / "shared" / "__init__.py").write_text(
+        "class _HostileNameMeta(type):\n"
+        "    @property\n"
+        "    def __name__(cls):\n"
+        "        raise RuntimeError('hostile __name__')\n"
+        "class BothBomb(Exception, metaclass=_HostileNameMeta):\n"
+        "    def __str__(self):\n"
+        "        raise RuntimeError('hostile __str__')\n"
+        "raise BothBomb('boom')\n",
+        encoding="utf-8",
+    )
+
+
+class TestHostileNameCrashPath:
+
+    def _run(self, tmp_path, stdin_text, breaker):
+        import subprocess
+
+        hook_src = Path(__file__).parent.parent / "hooks" / "bootstrap_gate.py"
+        scaffold = tmp_path / "scaffold"
+        scaffold.mkdir(parents=True)
+        (scaffold / "bootstrap_gate.py").write_text(
+            hook_src.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        breaker(scaffold)
+        return subprocess.run(
+            [sys.executable, str(scaffold / "bootstrap_gate.py")],
+            input=stdin_text,
+            capture_output=True,
+            text=True,
+            cwd=str(scaffold),
+            timeout=10,
+        )
+
+    @pytest.mark.parametrize(
+        "breaker",
+        [_break_shared_hostile_name, _break_shared_hostile_name_and_str],
+        ids=["hostile-name", "hostile-name-and-str"],
+    )
+    def test_readonly_defer_intact_under_hostile_name(self, tmp_path, breaker):
+        """The regression pin: a read-only tool under a hostile-__name__
+        (or both-hostile) module crash must take the defer arm at exit 0,
+        decision JSON intact, with the "exception" type-name fallback in
+        the warning. Pre-7155516d this exited 1 with the warning
+        suppressed."""
+        result = self._run(
+            tmp_path, json.dumps(_make_input(tool_name="Read")), breaker
+        )
+        assert result.returncode == 0, (
+            "hostile __name__ must not regress the degraded path to a "
+            f"nonzero exit (the suppressed-warning bug): "
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        out = json.loads(result.stdout.strip().splitlines()[0])
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "defer"
+        for field in ("permissionDecisionReason", "additionalContext"):
+            assert "DEGRADED" in hso[field]
+            assert "module imports" in hso[field]
+            # Type-name fallback fired: the literal "exception", never a
+            # real class name (the metaclass made the name unrenderable).
+            assert "failure — exception:" in hso[field], (
+                f"warning must carry the captured-name fallback: "
+                f"{hso[field]!r}"
+            )
+        assert "systemMessage" in out
+        assert "Hook degraded-defer (bootstrap_gate / module imports)" in (
+            result.stderr
+        )
+
+    @pytest.mark.parametrize(
+        "breaker",
+        [_break_shared_hostile_name, _break_shared_hostile_name_and_str],
+        ids=["hostile-name", "hostile-name-and-str"],
+    )
+    def test_mutating_deny_intact_under_hostile_name(self, tmp_path, breaker):
+        """Deny-arm twin: a mutating tool under hostile __name__ still
+        denies at exit 2 (blocking). The deny render has its OWN constant
+        guard (landed in the prior cycle), so under hostile __name__ its
+        reason carries "<error text unavailable>" rather than the
+        "exception" helper fallback — distinct render site, both total."""
+        result = self._run(
+            tmp_path, json.dumps(_make_input(tool_name="Edit")), breaker
+        )
+        assert result.returncode == 2, (
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        out = json.loads(result.stdout.strip().splitlines()[0])
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "deny"
+        assert "<error text unavailable>" in hso["permissionDecisionReason"]
+
+
+# =============================================================================
 # Marker verification × CLAUDE_PLUGIN_ROOT env fallback — healthy path
 # =============================================================================
 

--- a/pact-plugin/tests/test_bootstrap_gate.py
+++ b/pact-plugin/tests/test_bootstrap_gate.py
@@ -1864,6 +1864,104 @@ class TestDegradedMode:
 
 
 # =============================================================================
+# Hostile-__str__ crash path — every error-text render must fall back
+# =============================================================================
+
+
+def _break_shared_hostile_str(scaffold):
+    """shared/__init__.py raises an exception whose own __str__ raises —
+    the hostile-renderer shape: rendering an exception message runs
+    arbitrary exception-class code, so every interpolation of the caught
+    error on the crash path must fall back instead of letting the render
+    raise. Deliberately NOT in _BREAKAGE_VECTORS: the matrix asserts the
+    exception type is named in the DENY reason, which the raise-proof
+    constant fallback (no type prefix) intentionally does not satisfy."""
+    (scaffold / "shared").mkdir(parents=True)
+    (scaffold / "shared" / "__init__.py").write_text(
+        "class HostileStrError(Exception):\n"
+        "    def __str__(self):\n"
+        "        raise RuntimeError('hostile __str__')\n"
+        "raise HostileStrError()\n",
+        encoding="utf-8",
+    )
+
+
+class TestHostileStrCrashPath:
+
+    def _run(self, tmp_path, stdin_text):
+        import subprocess
+
+        hook_src = Path(__file__).parent.parent / "hooks" / "bootstrap_gate.py"
+        scaffold = tmp_path / "scaffold"
+        scaffold.mkdir(parents=True)
+        (scaffold / "bootstrap_gate.py").write_text(
+            hook_src.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        _break_shared_hostile_str(scaffold)
+        return subprocess.run(
+            [sys.executable, str(scaffold / "bootstrap_gate.py")],
+            input=stdin_text,
+            capture_output=True,
+            text=True,
+            cwd=str(scaffold),
+            timeout=10,
+        )
+
+    def test_mutating_deny_json_intact_under_hostile_str(self, tmp_path):
+        """Hostile __str__ must not suppress the deny: an unguarded render
+        raising before the deny print would exit nonzero-non-2 — a
+        non-blocking PreToolUse error, so the tool call would PROCEED
+        (fail-open). The deny JSON must print with the raise-proof
+        constant in the reason and the exit-2 blocking path intact."""
+        result = self._run(tmp_path, json.dumps(_make_input(tool_name="Edit")))
+        assert result.returncode == 2, (
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        out = json.loads(result.stdout.strip().splitlines()[0])
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "deny"
+        reason = hso["permissionDecisionReason"]
+        assert "module imports" in reason
+        assert "<error text unavailable>" in reason, (
+            f"deny reason must carry the raise-proof constant: {reason!r}"
+        )
+        # Guarded stderr full-text line: placeholder, exit-2 preserved.
+        assert "Hook load error (bootstrap_gate / module imports)" in (
+            result.stderr
+        )
+        assert "<exception str() raised>" in result.stderr
+
+    def test_readonly_defer_intact_under_hostile_str(self, tmp_path):
+        """Degraded warn arm under hostile __str__: the bounded renderer
+        falls back to the type-prefixed placeholder inside the warning
+        (diagnosability preserved — the type name still appears), the
+        defer decision and exit 0 stay intact, and the guarded stderr
+        line carries the placeholder instead of voiding the decision
+        with a nonzero exit."""
+        result = self._run(tmp_path, json.dumps(_make_input(tool_name="Read")))
+        assert result.returncode == 0, (
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        out = json.loads(result.stdout.strip().splitlines()[0])
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert hso["permissionDecision"] == "defer"
+        for field in ("permissionDecisionReason", "additionalContext"):
+            assert "DEGRADED" in hso[field]
+            assert "module imports" in hso[field]
+            assert "HostileStrError: <exception str() raised>" in hso[field], (
+                f"warning must carry the type-prefixed placeholder: "
+                f"{hso[field]!r}"
+            )
+        assert "systemMessage" in out
+        assert "Hook degraded-defer (bootstrap_gate / module imports)" in (
+            result.stderr
+        )
+        assert "<exception str() raised>" in result.stderr
+
+
+# =============================================================================
 # Marker verification × CLAUDE_PLUGIN_ROOT env fallback — healthy path
 # =============================================================================
 

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -4390,3 +4390,122 @@ def test_hostile_name_exception_emits_floor_marker_via_helper_totality(capsys):
     assert marker["error"] != "<error text unavailable>"
     assert out["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
     assert out["systemMessage"] == out["hookSpecificOutput"]["additionalContext"]
+
+
+# =============================================================================
+# Cycle-3: _bounded_error_text total against __name__ that RETURNS (not raises)
+# a hostile non-str object. The cycle-2 try/except guards a __name__ that
+# RAISES, but a metaclass __name__ can instead RETURN a non-str whose own
+# __format__/__str__ raises — that poisoned value defeats BOTH f-string
+# branches, because the except-branch fallback re-interpolates the same
+# type_name. b6e9125a coerces a non-str type_name to the literal "exception"
+# (isinstance guard) BEFORE interpolation, so the renderer is total for any
+# exception object. Counter-test: revert b6e9125a → (i) the int case renders
+# the raw "42: ..." instead of "exception: ...", and (ii)/(iii) the
+# format/str-bomb cases re-raise out of the helper (RuntimeError escapes).
+#
+# HAZARD (mirrors the cycle-2 block): these metaclass __name__ properties
+# return objects, one of which bombs on format/str. Never let pytest repr a
+# hostile instance — pass instances positionally and assert only on the
+# returned STRINGS.
+# =============================================================================
+
+
+class _NameReturnsIntMeta(type):
+    @property
+    def __name__(cls):  # noqa: N805 — metaclass property over the class
+        return 42
+
+
+class _IntNameError(Exception, metaclass=_NameReturnsIntMeta):
+    """type(error).__name__ RETURNS a non-str int (renderable, but not a str)."""
+
+
+class _FormatBomb:
+    """A non-str object whose __format__ (and __str__) raise — interpolating
+    it in an f-string raises."""
+
+    def __format__(self, spec):
+        raise RuntimeError("hostile __format__")
+
+    def __str__(self):
+        raise RuntimeError("hostile __str__")
+
+
+class _NameReturnsFormatBombMeta(type):
+    @property
+    def __name__(cls):  # noqa: N805 — metaclass property over the class
+        return _FormatBomb()
+
+
+class _FormatNameError(Exception, metaclass=_NameReturnsFormatBombMeta):
+    """type(error).__name__ RETURNS an object whose __format__ raises."""
+
+
+class _StrBomb:
+    """A non-str object whose __str__ raises (default __format__ delegates to
+    __str__, so f-string interpolation raises)."""
+
+    def __str__(self):
+        raise RuntimeError("hostile __str__")
+
+
+class _NameReturnsStrBombMeta(type):
+    @property
+    def __name__(cls):  # noqa: N805 — metaclass property over the class
+        return _StrBomb()
+
+
+class _StrNameError(Exception, metaclass=_NameReturnsStrBombMeta):
+    """type(error).__name__ RETURNS an object whose __str__ raises."""
+
+
+def test_bounded_error_text_total_against_hostile_name_return():
+    """The helper returns a clean str for an exception whose metaclass
+    __name__ RETURNS a hostile non-str object — int, __format__-raising, or
+    __str__-raising — all coerced to the "exception" literal before
+    interpolation. Counter-test: revert b6e9125a (the isinstance coercion) →
+    the int case renders "42: msg" (≠ expected) and the format/str-bomb cases
+    re-raise RuntimeError out of the helper.
+
+    Assert on returned STRINGS only; never let pytest repr a hostile
+    instance (the format/str bomb objects bomb on format/str)."""
+    assert tlg._bounded_error_text(_IntNameError("msg")) == "exception: msg"
+    assert tlg._bounded_error_text(_FormatNameError("msg")) == "exception: msg"
+    assert tlg._bounded_error_text(_StrNameError("msg")) == "exception: msg"
+
+
+def test_hostile_name_return_exception_emits_floor_marker_via_helper_totality(
+    capsys,
+):
+    """End-to-end through the crash path: a real __name__-returns-hostile
+    exception renders "exception: ..." in the marker error (the helper handled
+    it via the isinstance coercion), NOT the call-site "<error text
+    unavailable>" constant — proving the helper-totality branch, not the
+    defense-in-depth fallback, carries a genuine returns-hostile exception.
+    Floor marker intact, exit 0. Counter-test: revert b6e9125a → the helper
+    re-raises and the call-site constant fires instead."""
+    with pytest.raises(SystemExit) as exc:
+        tlg._emit_load_failure_advisory("runtime", _FormatNameError("boom"))
+    assert exc.value.code == 0
+    out = json.loads(capsys.readouterr().out.strip())
+    marker = out["pactGateHealth"]
+    assert marker["status"] == "failed"
+    assert marker["stage"] == "runtime"
+    assert marker["error"] == "exception: boom", (
+        f"helper-totality (isinstance coercion) path expected; "
+        f"got {marker['error']!r}"
+    )
+    assert marker["error"] != "<error text unavailable>"
+    assert out["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
+    assert out["systemMessage"] == out["hookSpecificOutput"]["additionalContext"]
+
+
+def test_bounded_error_text_common_cases_unchanged_by_cycle3():
+    """No string-ripple from b6e9125a: the common-case and cycle-2 hostile
+    renderings are unchanged — only a non-str __name__ RETURN newly degrades
+    to "exception:". Guards against the cycle-3 coercion silently altering
+    normal text or the prior hostile-__name__ (raising) fallback."""
+    assert tlg._bounded_error_text(ValueError("plain")) == "ValueError: plain"
+    # Cycle-2 raising-__name__ path still degrades via its own try/except.
+    assert tlg._bounded_error_text(_NameBomb("msg")) == "exception: msg"

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -4306,3 +4306,87 @@ def test_journal_event_renders_non_str_tool_name_as_placeholder(
     ]
     assert len(events) == 1
     assert events[0]["tool_name"] == "<non-str int>"
+
+
+# =============================================================================
+# Cycle-2: _bounded_error_text total against a hostile-metaclass __name__.
+# A metaclass can make type(error).__name__ a property that RAISES; the
+# helper captures the type name once defensively (→ literal "exception")
+# so neither the type-name nor the message render can escape it. Pins the
+# residual review-security found: pre-fix the helper's own fallback
+# re-accessed __name__ and re-raised, crashing the bootstrap degraded path
+# (exit 1, suppressed warning). The bootstrap-path regression pin is the
+# subprocess matrix in test_bootstrap_gate.py::TestHostileNameCrashPath;
+# these are the in-process helper-totality + tlg-path pins.
+#
+# HAZARD: never reference these classes' __name__ in test ids, labels, or
+# assertion reprs — the metaclass property bombs the access itself. Pass
+# instances positionally and assert only on returned STRINGS.
+# =============================================================================
+
+
+class _HostileNameMeta(type):
+    @property
+    def __name__(cls):  # noqa: N805 — metaclass property over the class
+        raise RuntimeError("hostile __name__")
+
+
+class _NameBomb(Exception, metaclass=_HostileNameMeta):
+    """Raising __name__, normal __str__."""
+
+
+class _BothBomb(Exception, metaclass=_HostileNameMeta):
+    """Raising __name__ AND raising __str__."""
+
+    def __str__(self):
+        raise RuntimeError("hostile __str__")
+
+
+def test_bounded_error_text_total_against_hostile_name():
+    """The helper returns a string for an exception whose metaclass
+    __name__ raises — type name captured once → literal "exception", with
+    the message render still guarded for the both-hostile case. Counter-
+    test: revert 7155516d → the fallback re-accesses __name__ and the
+    helper re-raises (RuntimeError escapes)."""
+    # Assert on returned strings ONLY; never let pytest repr a hostile
+    # instance (its default Exception repr accesses __name__).
+    assert tlg._bounded_error_text(_NameBomb("msg")) == "exception: msg"
+    assert tlg._bounded_error_text(_BothBomb("msg")) == (
+        "exception: <exception str() raised>"
+    )
+
+
+def test_bounded_error_text_common_cases_unchanged_by_cycle2():
+    """No string-ripple (shape (b)): the common-case renderings are
+    unchanged — only the hostile-__name__ path degrades to "exception:".
+    Guards against a cycle-2 refactor silently altering the normal text."""
+    assert tlg._bounded_error_text(ValueError("plain")) == "ValueError: plain"
+    # Hostile __str__ but renderable __name__ → real type name preserved.
+    assert tlg._bounded_error_text(_HostileStrError("m")) == (
+        "_HostileStrError: <exception str() raised>"
+    )
+
+
+def test_hostile_name_exception_emits_floor_marker_via_helper_totality(capsys):
+    """End-to-end through the full crash path: a real hostile-__name__
+    exception renders "exception: ..." in the marker error (the helper
+    handled it), NOT the call-site "<error text unavailable>" constant —
+    proving the helper-totality branch, not the defense-in-depth fallback,
+    is what carries a genuine hostile-__name__ exception. Floor marker
+    intact, exit 0."""
+    with pytest.raises(SystemExit) as exc:
+        tlg._emit_load_failure_advisory("runtime", _NameBomb("boom"))
+    assert exc.value.code == 0
+    out = json.loads(capsys.readouterr().out.strip())
+    marker = out["pactGateHealth"]
+    assert marker["status"] == "failed"
+    assert marker["stage"] == "runtime"
+    assert marker["error"] == "exception: boom", (
+        f"helper-totality path expected; got {marker['error']!r}"
+    )
+    # Distinguish from the call-site constant guard (that path only fires
+    # if the whole helper raises — here the helper is total, so it must
+    # NOT appear).
+    assert marker["error"] != "<error text unavailable>"
+    assert out["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
+    assert out["systemMessage"] == out["hookSpecificOutput"]["additionalContext"]

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -4134,12 +4134,19 @@ def test_init_failure_routes_through_runtime_advisory(
 
 
 def test_health_marker_error_text_is_bounded_and_sanitized(capsys):
-    """Direct helper invoke with pathological exception text (1000+ chars,
+    """Direct helper invoke with pathological exception text (600+ chars,
     embedded control characters): every context-bound surface (marker
     error, advisory, systemMessage) carries the SAME sanitized rendering
     truncated at the cap with an explicit marker — while the stderr
-    diagnostic keeps the full raw text (debug-channel split)."""
-    noisy = "a" * 500 + "\x00\x07\x1b" + "b" * 600
+    diagnostic keeps the full raw text (debug-channel split).
+
+    The control characters sit INSIDE the truncation window (sanitized-
+    text indices 62-64, well under the 200-char cap), so the sanitize
+    step itself — not truncation — is what removes them: with the
+    sanitize substitution deleted from _bounded_error_text, the
+    positional and printability asserts below fail. Hostile bytes placed
+    past the cap would make every sanitization assert vacuously true."""
+    noisy = "a" * 50 + "\x00\x07\x1b" + "b" * 600
     err = ValueError(noisy)
     with pytest.raises(SystemExit) as exc:
         tlg._emit_load_failure_advisory("runtime", err)
@@ -4152,6 +4159,14 @@ def test_health_marker_error_text_is_bounded_and_sanitized(capsys):
     assert error_field.endswith(suffix)
     assert len(error_field) == 200 + len(suffix)
     assert error_field.startswith("ValueError: ")
+    # Positional pin: "ValueError: " (12) + 50 a's puts the three control
+    # characters at indices 62-64 — each must have become a space.
+    assert error_field[61] == "a"
+    assert error_field[62:65] == "   ", (
+        f"control characters inside the cap window must be substituted "
+        f"with spaces by sanitization: {error_field[55:70]!r}"
+    )
+    assert error_field[65] == "b"
     assert all(ch.isprintable() for ch in error_field), (
         f"control characters must be sanitized: {error_field!r}"
     )
@@ -4162,5 +4177,132 @@ def test_health_marker_error_text_is_bounded_and_sanitized(capsys):
     assert error_field in out["systemMessage"]
     assert "\x00" not in out["systemMessage"]
 
-    # Debug channel keeps the full raw text (well past the cap).
+    # Debug channel keeps the full raw text — past the cap AND unsanitized
+    # (the raw control bytes survive only on stderr).
     assert "b" * 600 in captured.err
+    assert "\x00\x07\x1b" in captured.err
+
+
+class _HostileStrError(Exception):
+    """Exception whose __str__ raises — the hostile-renderer shape the
+    crash-path floor must survive (rendering an exception message runs
+    arbitrary exception-class code)."""
+
+    def __str__(self):
+        raise RuntimeError("hostile __str__")
+
+
+def test_hostile_str_exception_still_emits_floor_marker(capsys):
+    """An exception whose __str__ raises must not void the floor: the
+    helper falls back to the type-name + placeholder rendering, the full
+    marker still prints, exit stays 0, and the guarded stderr diagnostic
+    carries the placeholder instead of propagating the renderer raise."""
+    err = _HostileStrError()
+    with pytest.raises(SystemExit) as exc:
+        tlg._emit_load_failure_advisory("runtime", err)
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    out = json.loads(captured.out.strip())
+
+    marker = out["pactGateHealth"]
+    assert set(marker) == {"v", "hook", "status", "stage", "error"}
+    assert marker["status"] == "failed"
+    assert marker["stage"] == "runtime"
+    assert marker["error"] == "_HostileStrError: <exception str() raised>"
+
+    hso = out["hookSpecificOutput"]
+    assert hso["hookEventName"] == "PostToolUse"
+    assert marker["error"] in hso["additionalContext"]
+    assert out["systemMessage"] == hso["additionalContext"]
+
+    # Guarded stderr full-text line: placeholder, never a propagated raise.
+    assert "Hook load error (task_lifecycle_gate / runtime)" in captured.err
+    assert "<exception str() raised>" in captured.err
+
+
+def test_renderer_defect_falls_back_to_raise_proof_constant(
+    capsys, monkeypatch,
+):
+    """Defense-in-depth call-site guard: if the (now-total) bounded
+    renderer itself somehow raises, the floor still prints — with the
+    raise-proof CONSTANT. type(error).__name__ is deliberately not the
+    fallback: a hostile metaclass __name__ would re-invoke the same
+    attribute access that just failed, at the one site that must never
+    raise."""
+    monkeypatch.setattr(
+        tlg,
+        "_bounded_error_text",
+        lambda _err: (_ for _ in ()).throw(
+            RuntimeError("simulated renderer defect")
+        ),
+    )
+    with pytest.raises(SystemExit) as exc:
+        tlg._emit_load_failure_advisory("runtime", ValueError("boom"))
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    out = json.loads(captured.out.strip())
+    assert out["pactGateHealth"]["error"] == "<error text unavailable>"
+    assert "<error text unavailable>" in out["systemMessage"]
+    assert out["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
+
+
+def test_journal_event_sanitizes_hostile_tool_name(
+    capsys, monkeypatch, tmp_path, pact_context,
+):
+    """tool_name is attacker-set stdin on the import-stage path — the
+    journal event must carry the same sanitize+bound discipline as the
+    error text: control characters become spaces and over-cap text is
+    truncated with the explicit marker."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "cfg"))
+    pact_context(team_name="test-team", session_id="test-session")
+    hostile = "Task\x00Update" + "x" * 300
+    tlg._emit_gate_health_event(
+        "module imports", "SomeError: detail", {"tool_name": hostile}
+    )
+    captured = capsys.readouterr()
+    assert "gate_health journal emit" not in captured.err, (
+        f"emit must succeed on the working path: {captured.err!r}"
+    )
+    journal = (
+        tmp_path / "cfg" / "pact-sessions" / "project" / "test-session"
+        / "session-journal.jsonl"
+    )
+    events = [
+        json.loads(line)
+        for line in journal.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(events) == 1
+    recorded = events[0]["tool_name"]
+    suffix = "...[truncated]"
+    assert recorded.endswith(suffix)
+    assert len(recorded) == 200 + len(suffix)
+    assert recorded.startswith("Task Update"), (
+        f"control char must become a space: {recorded[:15]!r}"
+    )
+    assert all(ch.isprintable() for ch in recorded)
+
+
+def test_journal_event_renders_non_str_tool_name_as_placeholder(
+    capsys, monkeypatch, tmp_path, pact_context,
+):
+    """A non-string tool_name (type-confused stdin) becomes a typed
+    placeholder in the journal event rather than a raw non-str value."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "cfg"))
+    pact_context(team_name="test-team", session_id="test-session")
+    tlg._emit_gate_health_event(
+        "module imports", "SomeError: detail", {"tool_name": 42}
+    )
+    captured = capsys.readouterr()
+    assert "gate_health journal emit" not in captured.err
+    journal = (
+        tmp_path / "cfg" / "pact-sessions" / "project" / "test-session"
+        / "session-journal.jsonl"
+    )
+    events = [
+        json.loads(line)
+        for line in journal.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(events) == 1
+    assert events[0]["tool_name"] == "<non-str int>"

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -3938,3 +3938,229 @@ def test_M2_value_error_in_task_read_does_not_suppress_gate(
     assert not any(r == "audit_summary_overwrite" for r, _ in advisories), (
         "NUL-byte taskId read degraded to {} → no authored mirror → no overwrite fire"
     )
+
+
+# =============================================================================
+# Crash-path health marker (#951) — runtime-stage legs, journal pin,
+# error bounding. Import-stage subprocess matrix lives in
+# test_task_lifecycle_gate_degraded.py.
+# =============================================================================
+
+
+def _raise_runtime_failure(_input_data):
+    raise RuntimeError("simulated evaluate failure")
+
+
+def test_advisory_output_carries_no_health_marker(
+    capsys, monkeypatch, tmp_path, pact_context,
+):
+    """Healthy advisory shape is unchanged: a real rule firing through a
+    full main() invocation emits hookEventName + additionalContext and
+    NEITHER pactGateHealth NOR systemMessage — the marker decorates only
+    crash paths, never healthy advisories. (The suppress-shape twin pins
+    are byte-identity asserts elsewhere in this file and in the degraded
+    sibling module.)"""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "cfg"))
+    pact_context(team_name="test-team", session_id="test-session")
+    payload = {
+        "tool_name": "TaskCreate",
+        "tool_input": {
+            "subject": "implement foo",
+            "owner": "pact-backend-coder",
+            "addBlockedBy": ["41"],
+            "metadata": {"variety": None},
+        },
+        "tool_response": {},
+    }
+    code, out = _capture_main(payload, capsys)
+    assert code == 0
+    hso = out["hookSpecificOutput"]
+    assert hso["hookEventName"] == "PostToolUse"
+    assert "additionalContext" in hso
+    assert "pactGateHealth" not in out
+    assert "systemMessage" not in out
+
+
+def test_runtime_failure_emits_health_marker_with_runtime_stage(
+    capsys, monkeypatch, tmp_path,
+):
+    """evaluate_lifecycle raising inside main() → exit 0 with the full
+    machine marker at stage "runtime", the systemMessage mirror, and the
+    bounded error text naming the exception type. With no session context
+    resolvable (CLAUDE_PROJECT_DIR unset, config dir sandboxed) the
+    best-effort journal emit deterministically degrades to the
+    append-returned-False stderr disposition — never a raise."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "cfg"))
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    monkeypatch.setattr(tlg, "evaluate_lifecycle", _raise_runtime_failure)
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": "1", "status": "in_progress"},
+        "tool_response": {},
+        "session_id": "health-marker-session",
+    }
+    with patch.object(sys, "stdin", _stdin(payload)):
+        with pytest.raises(SystemExit) as exc:
+            tlg.main()
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    out = json.loads(captured.out.strip())
+    marker = out["pactGateHealth"]
+    assert set(marker) == {"v", "hook", "status", "stage", "error"}
+    assert marker["v"] == 1
+    assert marker["hook"] == "task_lifecycle_gate"
+    assert marker["status"] == "failed"
+    assert marker["stage"] == "runtime"
+    assert "RuntimeError" in marker["error"]
+    assert "simulated evaluate failure" in marker["error"]
+    hso = out["hookSpecificOutput"]
+    assert hso["hookEventName"] == "PostToolUse"
+    assert out["systemMessage"] == hso["additionalContext"]
+    assert "RuntimeError" in hso["additionalContext"]
+    assert "gate_health journal emit skipped" in captured.err, (
+        "no-session journal degradation must surface on the debug channel "
+        "(append_event returned False), never raise"
+    )
+
+
+def test_runtime_failure_writes_gate_health_journal_event(
+    capsys, monkeypatch, tmp_path, pact_context,
+):
+    """The journal channel's ONE pin, on the path where it is contractually
+    expected to work (imports fine, context initialized, context FILE on
+    disk): a runtime failure appends exactly one gate_health event with
+    the full field set to the session journal — and neither stderr
+    disposition line fires.
+
+    Sandbox: the context file lives in tmp_path (pact_context fixture)
+    and CLAUDE_CONFIG_DIR points inside tmp_path, so get_session_dir
+    resolves the journal under the sandbox, never the real ~/.claude."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "cfg"))
+    pact_context(team_name="test-team", session_id="test-session")
+    monkeypatch.setattr(tlg, "evaluate_lifecycle", _raise_runtime_failure)
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": "1", "status": "in_progress"},
+        "tool_response": {},
+        "session_id": "test-session",
+    }
+    with patch.object(sys, "stdin", _stdin(payload)):
+        with pytest.raises(SystemExit) as exc:
+            tlg.main()
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+
+    # The context file's project_dir is /test/project → slug "project";
+    # session_id comes from the context file, not stdin.
+    journal = (
+        tmp_path / "cfg" / "pact-sessions" / "project" / "test-session"
+        / "session-journal.jsonl"
+    )
+    assert journal.exists(), (
+        f"journal not written; stderr={captured.err!r}"
+    )
+    events = [
+        json.loads(line)
+        for line in journal.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    health_events = [e for e in events if e.get("type") == "gate_health"]
+    assert len(health_events) == 1, (
+        f"exactly one gate_health event expected, got {len(health_events)}: "
+        f"{health_events!r}"
+    )
+    event = health_events[0]
+    assert set(event) == {
+        "v", "type", "ts", "hook", "status", "stage", "error", "tool_name",
+    }
+    assert event["v"] == 1
+    assert event["hook"] == "task_lifecycle_gate"
+    assert event["status"] == "failed"
+    assert event["stage"] == "runtime"
+    assert "RuntimeError" in event["error"]
+    assert event["tool_name"] == "TaskUpdate"
+    assert event["ts"]
+
+    # Journal-event error text and marker error text are the same bounded
+    # rendering — one bounding discipline across every context-bound surface.
+    out = json.loads(captured.out.strip())
+    assert event["error"] == out["pactGateHealth"]["error"]
+
+    assert "gate_health journal emit" not in captured.err, (
+        "neither disposition line (skipped / unavailable) may fire on the "
+        "working journal path"
+    )
+
+
+def test_init_failure_routes_through_runtime_advisory(
+    capsys, monkeypatch, tmp_path,
+):
+    """pact_context.init raising inside main() → the runtime crash mask,
+    NOT an unmasked traceback: exit 0 with the stage-"runtime" marker
+    naming the init failure. Pins the guarded-init routing (previously
+    the file's one unmasked crash path). The journal emit's own lazy
+    init call hits the same patched raise inside its guard → the
+    "unavailable" stderr disposition, never a propagated exception."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "cfg"))
+    monkeypatch.setattr(
+        tlg.pact_context,
+        "init",
+        lambda _input_data: (_ for _ in ()).throw(
+            RuntimeError("simulated init failure")
+        ),
+    )
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": "1", "status": "in_progress"},
+        "tool_response": {},
+        "session_id": "init-failure-session",
+    }
+    with patch.object(sys, "stdin", _stdin(payload)):
+        with pytest.raises(SystemExit) as exc:
+            tlg.main()
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    out = json.loads(captured.out.strip())
+    marker = out["pactGateHealth"]
+    assert marker["stage"] == "runtime"
+    assert marker["status"] == "failed"
+    assert "RuntimeError" in marker["error"]
+    assert "simulated init failure" in marker["error"]
+    assert out["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
+    assert "gate_health journal emit unavailable" in captured.err, (
+        "the journal emitter's lazy init hits the same raise and must "
+        "degrade to the unavailable disposition inside its guard"
+    )
+
+
+def test_health_marker_error_text_is_bounded_and_sanitized(capsys):
+    """Direct helper invoke with pathological exception text (1000+ chars,
+    embedded control characters): every context-bound surface (marker
+    error, advisory, systemMessage) carries the SAME sanitized rendering
+    truncated at the cap with an explicit marker — while the stderr
+    diagnostic keeps the full raw text (debug-channel split)."""
+    noisy = "a" * 500 + "\x00\x07\x1b" + "b" * 600
+    err = ValueError(noisy)
+    with pytest.raises(SystemExit) as exc:
+        tlg._emit_load_failure_advisory("runtime", err)
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    out = json.loads(captured.out.strip())
+
+    error_field = out["pactGateHealth"]["error"]
+    suffix = "...[truncated]"
+    assert error_field.endswith(suffix)
+    assert len(error_field) == 200 + len(suffix)
+    assert error_field.startswith("ValueError: ")
+    assert all(ch.isprintable() for ch in error_field), (
+        f"control characters must be sanitized: {error_field!r}"
+    )
+
+    # Same bounded text on every context-bound surface.
+    hso = out["hookSpecificOutput"]
+    assert error_field in hso["additionalContext"]
+    assert error_field in out["systemMessage"]
+    assert "\x00" not in out["systemMessage"]
+
+    # Debug channel keeps the full raw text (well past the cap).
+    assert "b" * 600 in captured.err

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -4509,3 +4509,125 @@ def test_bounded_error_text_common_cases_unchanged_by_cycle3():
     assert tlg._bounded_error_text(ValueError("plain")) == "ValueError: plain"
     # Cycle-2 raising-__name__ path still degrades via its own try/except.
     assert tlg._bounded_error_text(_NameBomb("msg")) == "exception: msg"
+
+
+# =============================================================================
+# Cycle-4: _bounded_error_text total against __name__ that returns a str
+# SUBCLASS whose own __format__/__str__ raises. isinstance(str_subclass, str)
+# is True, so the cycle-3 isinstance guard would WAVE IT THROUGH and the
+# f-string interpolation (incl. str.__format__'s empty-spec delegation to the
+# overridden __str__) would raise out of both branches. cede8629 replaces the
+# guard with an EXACT-type check (type(type_name) is str) that rejects str
+# subclasses too, reducing type_name to an exact str whose __format__/__str__
+# are str's own unpatchable built-ins. Counter-test: revert cede8629 (restore
+# isinstance) → the str-subclass legs RAISE out of the helper.
+#
+# HAZARD (mirrors cycle-2/cycle-3): these metaclass __name__ properties return
+# str-subclass instances that bomb on format/str. Never let pytest repr a
+# hostile instance — pass instances positionally, assert on returned STRINGS.
+# =============================================================================
+
+
+class _RaisingFormatStr(str):
+    """A str SUBCLASS whose __format__ raises — isinstance(_, str) is True, so
+    only an exact-type guard coerces it."""
+
+    def __format__(self, spec):
+        raise RuntimeError("hostile str-subclass __format__")
+
+
+class _RaisingStrStr(str):
+    """A str SUBCLASS whose __str__ raises. str.__format__ with an empty spec
+    delegates to __str__, so f-string interpolation of this instance raises
+    too (verified empirically)."""
+
+    def __str__(self):
+        raise RuntimeError("hostile str-subclass __str__")
+
+
+class _NameReturnsFormatStrMeta(type):
+    @property
+    def __name__(cls):  # noqa: N805 — metaclass property over the class
+        return _RaisingFormatStr("HostileFmtName")
+
+
+class _FmtStrNameError(Exception, metaclass=_NameReturnsFormatStrMeta):
+    """__name__ RETURNS a str SUBCLASS whose __format__ raises."""
+
+
+class _NameReturnsStrSubMeta(type):
+    @property
+    def __name__(cls):  # noqa: N805 — metaclass property over the class
+        return _RaisingStrStr("HostileStrName")
+
+
+class _StrSubNameError(Exception, metaclass=_NameReturnsStrSubMeta):
+    """__name__ RETURNS a str SUBCLASS whose __str__ raises."""
+
+
+class _FmtStrNameRaisingMsgError(Exception, metaclass=_NameReturnsFormatStrMeta):
+    """__name__ RETURNS a hostile str subclass AND the exception's own __str__
+    raises — both halves of the render must be guarded."""
+
+    def __str__(self):
+        raise RuntimeError("hostile error __str__")
+
+
+def test_bounded_error_text_total_against_str_subclass_name():
+    """The exact-type guard coerces a str-SUBCLASS __name__ (which isinstance
+    would wave through) to "exception", so neither the subclass's hostile
+    __format__ nor its hostile __str__ ever runs — the helper returns a clean
+    str. Counter-test: revert cede8629 (restore the isinstance guard) →
+    isinstance(str_subclass, str) is True → the poison passes → the helper
+    raises out of both f-string branches.
+
+    Assert on returned STRINGS only; never let pytest repr a hostile
+    instance."""
+    assert tlg._bounded_error_text(_FmtStrNameError("m")) == "exception: m"
+    assert tlg._bounded_error_text(_StrSubNameError("m")) == "exception: m"
+
+
+def test_bounded_error_text_str_subclass_name_with_raising_error_message():
+    """Both halves hostile: a str-subclass __name__ AND a raising error
+    __str__ → the prefix collapses to "exception" (exact-type guard) and the
+    message half falls back to the guarded placeholder."""
+    assert tlg._bounded_error_text(_FmtStrNameRaisingMsgError("m")) == (
+        "exception: <exception str() raised>"
+    )
+
+
+def test_str_subclass_name_exception_emits_floor_marker_via_helper_totality(
+    capsys,
+):
+    """End-to-end through the crash path: a real str-subclass-__name__
+    exception renders "exception: ..." in the marker error (the exact-type
+    guard handled it), NOT the call-site "<error text unavailable>" constant —
+    the helper-totality branch, not the defense-in-depth fallback, carries it.
+    Floor marker intact, exit 0. Counter-test: revert cede8629 → the helper
+    raises and the call-site constant fires instead."""
+    with pytest.raises(SystemExit) as exc:
+        tlg._emit_load_failure_advisory("runtime", _FmtStrNameError("boom"))
+    assert exc.value.code == 0
+    out = json.loads(capsys.readouterr().out.strip())
+    marker = out["pactGateHealth"]
+    assert marker["status"] == "failed"
+    assert marker["stage"] == "runtime"
+    assert marker["error"] == "exception: boom", (
+        f"helper-totality (exact-type guard) path expected; "
+        f"got {marker['error']!r}"
+    )
+    assert marker["error"] != "<error text unavailable>"
+    assert out["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
+    assert out["systemMessage"] == out["hookSpecificOutput"]["additionalContext"]
+
+
+def test_bounded_error_text_genuine_str_name_unchanged_by_cycle4():
+    """Discriminator pin: the exact-type guard must NOT over-coerce a GENUINE
+    (exact) str __name__ — a normal class keeps its real name. Without this,
+    `type(...) is not str` could be mistaken for a blunt always-coerce. The
+    cycle-2/3 hostile fallbacks are also re-asserted to prove zero churn."""
+    assert tlg._bounded_error_text(ValueError("plain")) == "ValueError: plain"
+    assert tlg._bounded_error_text(_HostileStrError("m")) == (
+        "_HostileStrError: <exception str() raised>"
+    )
+    assert tlg._bounded_error_text(_IntNameError("msg")) == "exception: msg"

--- a/pact-plugin/tests/test_task_lifecycle_gate_degraded.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate_degraded.py
@@ -24,12 +24,16 @@ platform's non-strict output schema strips unknown top-level keys):
   - On a HEALTHY scaffold the output shapes are byte-identical to the
     pre-marker gate: no ``pactGateHealth``, no ``systemMessage``.
 
-Deliberately NOT asserted here: the best-effort ``gate_health`` journal
-event. All three breakage vectors break ``shared/__init__``-level
-imports, which also kills the late lazy import inside the journal
-emitter — those vectors are stdout-marker-only by design. The journal
-channel's one pin lives in the in-process suite, on the runtime path
-where the channel is contractually expected to work.
+Journal-channel split across this module: the three breakage vectors in
+the crash matrix all break ``shared/__init__``-level imports, which also
+kills the late lazy import inside the journal emitter — those vectors
+are stdout-marker-only by design. The import-stage journal-SUCCESS
+shape (a gauntlet-only module is broken while pact_context /
+session_journal stay importable, and a prior hook already wrote the
+session context file) is pinned separately in
+TestImportStageJournalSuccess — the one subprocess leg that exercises
+the crash handler's late stdin read on its success path. The runtime-path journal pin lives in the in-process suite, where
+the channel is contractually expected to work.
 
 Scaffold/vector machinery is imported from tests.test_bootstrap_gate
 (the #942/#950 degraded-mode suite) so the breakage-vector family stays
@@ -256,6 +260,183 @@ class TestHealthyLifecycleGateUnchanged:
             f"stderr={result.stderr!r} stdout={result.stdout!r}"
         )
         assert json.loads(result.stdout.strip()) == {"suppressOutput": True}
+
+
+# =============================================================================
+# Import-stage crash with a LIVE journal channel — partial breakage
+# =============================================================================
+
+
+def _build_partial_breakage_scaffold(tmp_path):
+    """Scaffold for the import-stage-crash-with-live-journal family:
+    ``shared`` is intact EXCEPT for one gauntlet-only module
+    (agent_handoff_marker) — the gauntlet from-import crashes
+    (ModuleNotFoundError) while pact_context/session_journal stay
+    importable — and a prior hook in the session already wrote the
+    context file (the production precondition for the import-stage
+    durable channel). Returns (scaffold, env, session_dir, session_id).
+
+    Includes the premise assert (import-graph-rot guard): the journal
+    channel must import WITHOUT agent_handoff_marker, or this vector no
+    longer isolates "gauntlet broken, journal alive" and the family
+    needs a different gauntlet-only module.
+    """
+    hooks_src = Path(__file__).parent.parent / "hooks"
+    scaffold = tmp_path / "scaffold"
+    scaffold.mkdir(parents=True)
+    (scaffold / "task_lifecycle_gate.py").write_text(
+        (hooks_src / "task_lifecycle_gate.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    shutil.copytree(hooks_src / "shared", scaffold / "shared")
+    (scaffold / "pin_caps.py").write_text(
+        (hooks_src / "pin_caps.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (scaffold / "shared" / "agent_handoff_marker.py").unlink()
+
+    premise = subprocess.run(
+        [sys.executable, "-c",
+         "import shared.pact_context, shared.session_journal"],
+        capture_output=True,
+        text=True,
+        cwd=str(scaffold),
+        timeout=10,
+    )
+    assert premise.returncode == 0, (
+        "vector premise broken: shared.pact_context/session_journal "
+        "no longer import without agent_handoff_marker — pick a "
+        f"different gauntlet-only module. {premise.stderr!r}"
+    )
+
+    # Context-file path mirrors init(): slug from CLAUDE_PROJECT_DIR's
+    # basename + the stdin session_id.
+    env = _scaffold_env(tmp_path)
+    session_id = "lifecycle-degraded-session"
+    session_dir = (
+        Path(env["CLAUDE_CONFIG_DIR"]) / "pact-sessions"
+        / Path(env["CLAUDE_PROJECT_DIR"]).name / session_id
+    )
+    session_dir.mkdir(parents=True)
+    (session_dir / "pact-session-context.json").write_text(
+        json.dumps({
+            "team_name": "degraded-team",
+            "session_id": session_id,
+            "project_dir": env["CLAUDE_PROJECT_DIR"],
+            "plugin_root": "",
+            "started_at": "2026-01-01T00:00:00Z",
+        }),
+        encoding="utf-8",
+    )
+    return scaffold, env, session_dir, session_id
+
+
+class TestImportStageJournalSuccess:
+
+    def test_partial_breakage_writes_import_stage_journal_event(
+        self, tmp_path,
+    ):
+        """Partial-breakage shape: the gauntlet crashes but the crash
+        handler's lazy import of pact_context/session_journal succeeds,
+        the handler reads the still-unconsumed stdin itself, and the
+        durable gate_health event lands in the session journal at stage
+        "module imports" — alongside the full stdout marker.
+
+        This is the only leg exercising the late-stdin-read SUCCESS
+        branch: every crash-matrix vector dies before the read, and the
+        in-process runtime legs always hand input_data in directly.
+        """
+        scaffold, env, session_dir, session_id = (
+            _build_partial_breakage_scaffold(tmp_path)
+        )
+        result = subprocess.run(
+            [sys.executable, str(scaffold / "task_lifecycle_gate.py")],
+            input=json.dumps(_make_gate_input(session_id=session_id)),
+            capture_output=True,
+            text=True,
+            cwd=str(scaffold),
+            timeout=10,
+            env=env,
+        )
+
+        # Stdout marker contract — identical to the crash matrix.
+        out = _assert_crash_marker_shape(result, "ModuleNotFoundError")
+
+        # Durable channel: exactly one gate_health event, full field
+        # set, same bounded error rendering as the stdout marker.
+        journal = session_dir / "session-journal.jsonl"
+        assert journal.exists(), (
+            f"journal not written; stderr={result.stderr!r}"
+        )
+        events = [
+            json.loads(line)
+            for line in journal.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        health_events = [
+            e for e in events if e.get("type") == "gate_health"
+        ]
+        assert len(health_events) == 1, (
+            f"exactly one gate_health event expected: {health_events!r}"
+        )
+        event = health_events[0]
+        assert set(event) == {
+            "v", "type", "ts", "hook", "status", "stage", "error",
+            "tool_name",
+        }
+        assert event["v"] == 1
+        assert event["hook"] == "task_lifecycle_gate"
+        assert event["status"] == "failed"
+        assert event["stage"] == "module imports"
+        assert "ModuleNotFoundError" in event["error"]
+        assert event["tool_name"] == "TaskUpdate"
+        assert event["ts"]
+        assert event["error"] == out["pactGateHealth"]["error"]
+
+        # Neither degradation disposition may fire on the success path.
+        assert "gate_health journal emit" not in result.stderr, (
+            "no skipped/unavailable disposition on the working "
+            f"import-stage journal path: {result.stderr!r}"
+        )
+
+    def test_oversized_stdin_degrades_to_marker_only_without_hang(
+        self, tmp_path,
+    ):
+        """The crash handler's late stdin read is capped: an over-cap
+        frame truncates mid-JSON inside the handler, degrades to the
+        "unavailable" stderr disposition, and the stdout floor marker
+        stays fully intact — no hang, no raise, no journal write, even
+        though the journal channel itself is alive (same live-channel
+        scaffold as the success leg, so the cap — not a dead channel —
+        is what stops the write)."""
+        scaffold, env, session_dir, session_id = (
+            _build_partial_breakage_scaffold(tmp_path)
+        )
+        frame = _make_gate_input(session_id=session_id)
+        # Pad well past the read cap with valid JSON so truncation —
+        # not malformed input — is what breaks the parse.
+        frame["pad"] = "a" * (9 * 1024 * 1024)
+        result = subprocess.run(
+            [sys.executable, str(scaffold / "task_lifecycle_gate.py")],
+            input=json.dumps(frame),
+            capture_output=True,
+            text=True,
+            cwd=str(scaffold),
+            timeout=30,
+            env=env,
+        )
+
+        # Floor marker contract fully intact despite the oversized frame.
+        _assert_crash_marker_shape(result, "ModuleNotFoundError")
+
+        # Best-effort channel degrades inside its guard: unavailable
+        # disposition on stderr, and nothing reaches the journal.
+        assert "gate_health journal emit unavailable" in result.stderr, (
+            f"over-cap frame must degrade in-guard: {result.stderr!r}"
+        )
+        assert not (session_dir / "session-journal.jsonl").exists(), (
+            "truncated frame must not produce a journal event"
+        )
 
 
 # =============================================================================

--- a/pact-plugin/tests/test_task_lifecycle_gate_degraded.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate_degraded.py
@@ -465,3 +465,88 @@ class TestPython39Floor:
             tmp_path, json.dumps(_make_gate_input()), interpreter=py39
         )
         _assert_crash_marker_shape(result, "SyntaxError")
+
+
+# =============================================================================
+# BaseException-breadth regression: a module-level sys.exit() / KeyboardInterrupt
+# AT IMPORT time is a BaseException that is NOT an Exception subclass. The
+# import-gauntlet guard (task_lifecycle_gate.py `except BaseException`) and the
+# crash handler's own `_emit_gate_health_event` guard are deliberately broad so
+# such a vector is caught and the floor marker still prints at exit 0. None of
+# the _BREAKAGE_VECTORS exercises this (all three raise Exception subclasses),
+# so narrowing either guard to `except Exception` would silently re-introduce
+# the #951 masking (SystemExit/KeyboardInterrupt escapes → nonzero exit →
+# stdout JSON ignored → no health marker). These pins lock the breadth.
+#
+# Counter-test: narrow the import-gauntlet guard to `except Exception` → the
+# crash escapes the gauntlet, nothing prints, exit nonzero. Separately narrow
+# the `_emit_gate_health_event` guard to `except Exception` → the marker prints
+# but the lazy re-import's SystemExit escapes before sys.exit(0), so the
+# process exits nonzero and the stdout marker is ignored. Either narrowing
+# fails the `returncode == 0` + marker-present assertions below.
+# =============================================================================
+
+
+def _break_shared_sys_exit(scaffold):
+    """shared/__init__.py calls sys.exit(1) at import time → SystemExit (a
+    BaseException, NOT an Exception) propagates out of the gauntlet import."""
+    (scaffold / "shared").mkdir(parents=True)
+    (scaffold / "shared" / "__init__.py").write_text(
+        "import sys\nsys.exit(1)\n", encoding="utf-8"
+    )
+
+
+def _break_shared_keyboard_interrupt(scaffold):
+    """shared/__init__.py raises KeyboardInterrupt at import time → a
+    BaseException that `except Exception` would NOT catch."""
+    (scaffold / "shared").mkdir(parents=True)
+    (scaffold / "shared" / "__init__.py").write_text(
+        "raise KeyboardInterrupt('simulated at import')\n", encoding="utf-8"
+    )
+
+
+def _run_with_breaker(tmp_path, stdin_text, breaker):
+    """Copy the lifecycle hook into a scaffold, apply an arbitrary breaker
+    (not constrained to the _BREAKAGE_VECTORS dict), run as a subprocess with
+    both config roots sandboxed inside tmp_path."""
+    hook_src = Path(__file__).parent.parent / "hooks" / "task_lifecycle_gate.py"
+    scaffold = tmp_path / "scaffold"
+    scaffold.mkdir(parents=True)
+    (scaffold / "task_lifecycle_gate.py").write_text(
+        hook_src.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    breaker(scaffold)
+    return subprocess.run(
+        [sys.executable, str(scaffold / "task_lifecycle_gate.py")],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        cwd=str(scaffold),
+        timeout=10,
+        env=_scaffold_env(tmp_path),
+    )
+
+
+class TestBaseExceptionBreadthAtImport:
+
+    @pytest.mark.parametrize(
+        "breaker,expected_exc",
+        [
+            (_break_shared_sys_exit, "SystemExit"),
+            (_break_shared_keyboard_interrupt, "KeyboardInterrupt"),
+        ],
+        ids=["import-sys-exit", "import-keyboard-interrupt"],
+    )
+    def test_non_exception_baseexception_at_import_still_emits_marker(
+        self, tmp_path, breaker, expected_exc,
+    ):
+        """A module-level sys.exit(1) / KeyboardInterrupt at import is caught
+        by the gauntlet's `except BaseException`, so the full pactGateHealth
+        marker still emits at exit 0 with the BaseException type named in the
+        bounded error text. Narrowing the gauntlet (or the
+        _emit_gate_health_event) guard to `except Exception` re-masks: the
+        crash escapes → nonzero exit → the stdout marker is ignored."""
+        result = _run_with_breaker(
+            tmp_path, json.dumps(_make_gate_input()), breaker
+        )
+        _assert_crash_marker_shape(result, expected_exc)

--- a/pact-plugin/tests/test_task_lifecycle_gate_degraded.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate_degraded.py
@@ -1,0 +1,286 @@
+"""
+Degraded-mode subprocess coverage for task_lifecycle_gate.py — the
+crash-path health marker (#951).
+
+Sibling to the in-process suite in test_task_lifecycle_gate.py (which
+carries the runtime-stage marker legs, the journal-event pin, and the
+error-bounding pin). This module exercises the IMPORT-stage crash path
+the only way it can be exercised honestly: a real subprocess whose
+`shared` package is deliberately broken, so the module-level
+`except BaseException` gauntlet guard actually fires.
+
+Contract under test (raw stdout, never a platform-relayed channel — the
+platform's non-strict output schema strips unknown top-level keys):
+
+  - On EVERY breakage vector the gate exits 0 (PostToolUse cannot deny)
+    and the first stdout line is intact JSON carrying:
+      * a top-level ``pactGateHealth`` machine marker
+        {v, hook, status, stage, error} with the vector's exception
+        type name inside the bounded ``error`` text,
+      * ``hookSpecificOutput.hookEventName == "PostToolUse"`` (kept
+        intact on every path — the schema-rejection defense),
+      * a ``systemMessage`` mirroring the advisory text,
+    plus a non-empty stderr diagnostic.
+  - On a HEALTHY scaffold the output shapes are byte-identical to the
+    pre-marker gate: no ``pactGateHealth``, no ``systemMessage``.
+
+Deliberately NOT asserted here: the best-effort ``gate_health`` journal
+event. All three breakage vectors break ``shared/__init__``-level
+imports, which also kills the late lazy import inside the journal
+emitter — those vectors are stdout-marker-only by design. The journal
+channel's one pin lives in the in-process suite, on the runtime path
+where the channel is contractually expected to work.
+
+Scaffold/vector machinery is imported from tests.test_bootstrap_gate
+(the #942/#950 degraded-mode suite) so the breakage-vector family stays
+single-source. Both subprocess env vars (CLAUDE_CONFIG_DIR /
+CLAUDE_PROJECT_DIR) are pointed inside tmp_path so no leg can touch the
+real config tree, mirroring the live-probe containment recipe.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.test_bootstrap_gate import _BREAKAGE_VECTORS, _find_python39
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_gate_input(tool_name="TaskUpdate", tool_input=None,
+                     session_id="lifecycle-degraded-session"):
+    """PostToolUse-shaped stdin for the lifecycle gate (vs bootstrap_gate's
+    PreToolUse shape): tool_name + tool_input + tool_response + session_id."""
+    return {
+        "tool_name": tool_name,
+        "tool_input": tool_input or {"taskId": "1", "status": "in_progress"},
+        "tool_response": {},
+        "session_id": session_id,
+    }
+
+
+def _scaffold_env(tmp_path):
+    """Subprocess env with both config-tree roots contained inside tmp_path
+    so neither pact_context.init nor a journal write can ever resolve a
+    path under the real ~/.claude."""
+    env = dict(os.environ)
+    env["CLAUDE_CONFIG_DIR"] = str(tmp_path / "scratch-config")
+    env["CLAUDE_PROJECT_DIR"] = str(tmp_path / "scratch-project")
+    return env
+
+
+def _run_degraded_subprocess(tmp_path, stdin_text, interpreter=None,
+                             vector="syntax-broken-init"):
+    """Run task_lifecycle_gate.py as a subprocess inside a scaffold whose
+    `shared` package is deliberately broken per ``vector`` (a
+    _BREAKAGE_VECTORS key; default = the canonical syntax-broken
+    __init__.py), forcing the import-stage crash path. Returns the
+    CompletedProcess.
+
+    ``interpreter`` defaults to the dev interpreter (sys.executable); the
+    py3.9-floor test passes a discovered 3.9 binary to exercise the
+    stdlib-only crash path on the production system interpreter
+    (GUI-launched macOS sessions run hooks on /usr/bin/python3 = 3.9.x).
+    """
+    hook_src = Path(__file__).parent.parent / "hooks" / "task_lifecycle_gate.py"
+    scaffold = tmp_path / "scaffold"
+    scaffold.mkdir(parents=True)
+    (scaffold / "task_lifecycle_gate.py").write_text(
+        hook_src.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    _BREAKAGE_VECTORS[vector][0](scaffold)
+    return subprocess.run(
+        [interpreter or sys.executable,
+         str(scaffold / "task_lifecycle_gate.py")],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        cwd=str(scaffold),
+        timeout=10,
+        env=_scaffold_env(tmp_path),
+    )
+
+
+def _run_healthy_subprocess(tmp_path, stdin_text):
+    """Run task_lifecycle_gate.py as a subprocess inside a scaffold whose
+    `shared` package is a full copy of the real one — the healthy-path
+    twin of _run_degraded_subprocess, for the key-ABSENCE pins."""
+    hooks_src = Path(__file__).parent.parent / "hooks"
+    scaffold = tmp_path / "scaffold"
+    scaffold.mkdir(parents=True)
+    (scaffold / "task_lifecycle_gate.py").write_text(
+        (hooks_src / "task_lifecycle_gate.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    # shared/__init__.py eagerly imports the hooks/-level sibling pin_caps
+    # (resolvable because the hook's own directory is on sys.path), so the
+    # healthy scaffold needs both the package and that sibling module.
+    shutil.copytree(hooks_src / "shared", scaffold / "shared")
+    (scaffold / "pin_caps.py").write_text(
+        (hooks_src / "pin_caps.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    return subprocess.run(
+        [sys.executable, str(scaffold / "task_lifecycle_gate.py")],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        cwd=str(scaffold),
+        timeout=10,
+        env=_scaffold_env(tmp_path),
+    )
+
+
+def _assert_crash_marker_shape(result, expected_exc, stage="module imports"):
+    """Shared content assertions for a crash-path subprocess result.
+
+    rc==0 is asserted ONLY as the emit-contract precondition (stdout JSON
+    is honored on exit 0) — always paired with content asserts, never rc
+    alone: the health contract itself is content, by acceptance criterion.
+    """
+    assert result.returncode == 0, (
+        f"stderr={result.stderr!r} stdout={result.stdout!r}"
+    )
+    out = json.loads(result.stdout.strip().splitlines()[0])
+
+    # Machine marker: exact key set + field-by-field content.
+    marker = out["pactGateHealth"]
+    assert set(marker) == {"v", "hook", "status", "stage", "error"}
+    assert marker["v"] == 1
+    assert marker["hook"] == "task_lifecycle_gate"
+    assert marker["status"] == "failed"
+    assert marker["stage"] == stage
+    assert expected_exc in marker["error"], (
+        f"marker error must name the exception type ({expected_exc}) "
+        f"so the failure is diagnosable; got {marker['error']!r}"
+    )
+
+    # Platform-facing keys stay intact (schema-rejection defense) and the
+    # human channel mirrors the model channel.
+    hso = out["hookSpecificOutput"]
+    assert hso["hookEventName"] == "PostToolUse"
+    assert stage in hso["additionalContext"]
+    assert expected_exc in hso["additionalContext"]
+    assert out["systemMessage"] == hso["additionalContext"]
+
+    assert result.stderr.strip(), "stderr diagnostic line expected"
+    return out
+
+
+# =============================================================================
+# Import-stage crash matrix — pactGateHealth PRESENT on every vector
+# =============================================================================
+
+
+class TestDegradedLifecycleGate:
+
+    @pytest.mark.parametrize("vector", sorted(_BREAKAGE_VECTORS))
+    def test_subprocess_breakage_vectors_emit_health_marker(
+        self, tmp_path, vector,
+    ):
+        """The import gauntlet guard catches BaseException, so the crash
+        output must be IDENTICAL in shape no matter HOW shared/ broke:
+        syntax-broken __init__.py (SyntaxError), package absent
+        (ModuleNotFoundError), or a failing from-import inside an
+        otherwise-parseable __init__.py (ImportError). Every vector gets
+        the full machine-recognizable pactGateHealth marker with the
+        vector's exception type named in the bounded error text.
+
+        NO journal assert here: all three vectors break shared/__init__-
+        level imports, which also kills the journal emitter's late lazy
+        import — these are the stdout-marker-only rows by design.
+        """
+        result = _run_degraded_subprocess(
+            tmp_path, json.dumps(_make_gate_input()), vector=vector
+        )
+        _assert_crash_marker_shape(result, _BREAKAGE_VECTORS[vector][1])
+
+    def test_subprocess_crash_output_first_line_is_complete_json(
+        self, tmp_path,
+    ):
+        """Single-print discipline: the marker, advisory, and systemMessage
+        all travel in ONE stdout JSON document — the first line parses and
+        already carries every contract key, so a "first stdout line"
+        consumer never needs to scan further."""
+        result = _run_degraded_subprocess(
+            tmp_path, json.dumps(_make_gate_input())
+        )
+        assert result.returncode == 0, (
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        first_line = result.stdout.strip().splitlines()[0]
+        out = json.loads(first_line)
+        assert {"hookSpecificOutput", "systemMessage", "pactGateHealth"} <= set(out)
+
+
+# =============================================================================
+# Healthy scaffold — pactGateHealth ABSENT (byte-identity pins)
+# =============================================================================
+
+
+class TestHealthyLifecycleGateUnchanged:
+
+    def test_subprocess_healthy_suppress_output_is_byte_identical(
+        self, tmp_path,
+    ):
+        """Healthy full path (imports OK, init runs, zero advisories) →
+        stdout is EXACTLY {"suppressOutput": true}. Byte-identity is the
+        strongest absence pin: it forbids pactGateHealth, systemMessage,
+        and any other sibling key in one equality."""
+        result = _run_healthy_subprocess(
+            tmp_path, json.dumps(_make_gate_input())
+        )
+        assert result.returncode == 0, (
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        assert json.loads(result.stdout.strip()) == {"suppressOutput": True}
+
+    def test_subprocess_healthy_short_circuit_suppress_is_byte_identical(
+        self, tmp_path,
+    ):
+        """Non-Task tool short-circuit (deliberate by-design no-op, not a
+        failure) keeps the same byte-identical suppress shape — the
+        marker never decorates a healthy or skipped path."""
+        result = _run_healthy_subprocess(
+            tmp_path, json.dumps(_make_gate_input(tool_name="Read"))
+        )
+        assert result.returncode == 0, (
+            f"stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        assert json.loads(result.stdout.strip()) == {"suppressOutput": True}
+
+
+# =============================================================================
+# py3.9 floor exercise (conditional on an available interpreter)
+# =============================================================================
+
+
+class TestPython39Floor:
+
+    def test_crash_marker_emits_on_python39_floor(self, tmp_path):
+        """The crash path (stdlib preamble + advisory helper + marker
+        emit) must execute on the production system interpreter
+        (GUI-launched macOS sessions run hooks on /usr/bin/python3 =
+        3.9.x). Exercise the canonical syntax vector under a REAL 3.9
+        interpreter when one is discoverable; the static AST floor guard
+        (test_py39_annotation_compat.py) remains the unconditional gate
+        when none is."""
+        py39 = _find_python39()
+        if py39 is None:
+            pytest.skip(
+                "no Python 3.9 interpreter discoverable (python3.9 on PATH "
+                "or /usr/bin/python3 reporting 3.9.x); static floor guard "
+                "test_py39_annotation_compat.py covers the syntax floor"
+            )
+        result = _run_degraded_subprocess(
+            tmp_path, json.dumps(_make_gate_input()), interpreter=py39
+        )
+        _assert_crash_marker_shape(result, "SyntaxError")


### PR DESCRIPTION
## Summary

Closes #951 — `task_lifecycle_gate.py` self-masked import crashes (`except BaseException` → advisory + exit 0), making a crashed run indistinguishable from a healthy one and causing **silent journal/event loss**. This PR adds a content-assertable health surface on the crash path while keeping the healthy path byte-identical.

## What landed

**C1 — floor marker (`c533c140`)**
- Top-level `pactGateHealth` key `{v:1, hook, status:"failed", stage, error}` emitted from `_emit_load_failure_advisory` (single emission point covers both crash stages: module-import and runtime)
- `systemMessage` mirror of the bounded advisory (degraded-visibility convention parity)
- `_bounded_error_text` (cap 200) copied verbatim from `bootstrap_gate.py`; also fixes the previously **unbounded** error interpolation in the existing advisory
- Floor is stdlib-pure, stdin-free, printed first; stderr keeps full raw error text

**C2 — best-effort journal bonus (`3e888d5f`)**
- `_emit_gate_health_event`: guarded late emit of a `gate_health` journal event on the crash path
- Guard wraps the late **imports themselves** — empirically grounded: a live probe showed the fat `shared/__init__` package init fails the late import at package level on `pact_context`-class breakage, so an interior-only guard would let the crash handler crash
- Event type deliberately unregistered (never-load-bearing channel; zero consumers today); two distinct stderr disposition lines discriminate `skipped` vs `unavailable`

**C3 — init move-in (`de233103`)**
- `pact_context.init` moved inside the runtime try: the file's last unmasked crash path now routes through the advisory (marker + journal event)

**TEST (`a12138f1`)** — 12 new legs (suite 8861 → 8873, 0 failed, 0 errors):
- New `tests/test_task_lifecycle_gate_degraded.py`: 3-vector broken-import subprocess matrix asserting full marker content on raw stdout; healthy-path byte-identity pins (the suite's first key-ABSENCE asserts); py3.9-floor leg run live
- In-process legs: runtime-stage marker, the journal channel's one pin (exact 8-key `gate_health` event, fully sandboxed), C3 routing pin, bounded-error truncation leg
- Non-vacuity proven per commit via file-state checkpoints in a detached worktree: pre-C1 → 9 legs RED; C1-only → 3 RED; C1+C2 → 1 RED
- All health assertions on output **content**, never return codes (issue acceptance criterion)

**Version (`624a6928`)** — PATCH bump 4.4.19 → 4.4.20 (canonical 4 files)

## Why

PostToolUse hooks cannot deny, so fail-closed isn't available — visibility is the only posture. Exit codes are uninformative by construction on this path; the platform's stdout schema strips unknown keys (safe but platform-invisible), so raw-stdout subprocess tests are the assertable channel and stdout is the only both-modes-uniform surface. The journal event is best-effort bonus by design: the breakage vectors that crash the hook are the same ones that can break the journal import path.

## Verification

- Full suite: `8873 passed / 13 skipped / 0 failed / 0 errors` (errors token explicitly checked via raw pytest summary)
- Auditor signal: GREEN (all structural ACs verified against `git diff`; byte-identity of the verbatim helper copy proven by sed-range diff; closure-neutrality of lazy imports proven by import set-diff)
- Empirical grounding: 13-leg isolated live probe (scratch env, zero live-tree mutation) corrected one static feasibility claim before design freeze

## Follow-up (tracked separately, post-merge)

- S6/S8 silent-event-loss visibility gap (per blueprint §7.4 sketch) — to be filed as its own issue, bundling `gate_health` registration + `session_resume` surfacing as candidates
