### PR TITLE
feat(teachback): enumerate canonical schema inline in gate templates + deny-message echo (#958) [v4.4.25]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.24",
+      "version": "4.4.25",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.24/      # Plugin version
+│               └── 4.4.25/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.24",
+  "version": "4.4.25",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.24
+> **Version**: 4.4.25
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/agents/pact-orchestrator.md
+++ b/pact-plugin/agents/pact-orchestrator.md
@@ -371,7 +371,7 @@ Every specialist dispatch is a Task A (TEACHBACK) + Task B (primary work, `block
 
 For non-exempt teammates (everyone except `pact-secretary`):
 
-1. `TaskCreate(subject="{name}: TEACHBACK for {topic}", description="<teachback gate brief; cross-ref to Task B for the mission>")` — create Task A (teachback gate).
+1. `TaskCreate(subject="{name}: TEACHBACK for {topic}", description="<teachback gate brief — instruct the teammate to write metadata.teachback_submit using the CANONICAL field schema (do NOT improvise key names): understanding, most_likely_wrong, least_confident_item, first_action, variety_acknowledgment (an OBJECT); cross-ref to Task B for the mission>")` — create Task A (teachback gate).
 2. `TaskCreate(subject="{name}: {primary work subject}", description="<full mission: CONTEXT / MISSION / INSTRUCTIONS / GUIDELINES per §13 Recommended Agent Prompting Structure>")` — create Task B (primary work).
 3. `TaskUpdate(A_id, owner="{name}", addBlocks=[B_id])` — assign Task A to the teammate and wire it as the gate that unblocks Task B.
 4. `TaskUpdate(B_id, owner="{name}", addBlockedBy=[A_id])` — assign Task B to the same teammate and explicitly mirror the block edge. Do NOT pre-set `status="in_progress"` on either task — the teammate self-claims on arrival. Ensure the Task A brief reminds the teammate to claim Task B (`status="in_progress"`) before any implementation tool-use once it unblocks (the command dispatch templates carry this line) — the teammate flips it, never you.

--- a/pact-plugin/commands/comPACT.md
+++ b/pact-plugin/commands/comPACT.md
@@ -177,7 +177,7 @@ Both are created BEFORE the `Agent(...)` spawn call so the teammate sees them on
 A_id = TaskCreate(
     subject="{specialist}: TEACHBACK for {sub-task}",
     description="DOGFOOD TEACHBACK GATE for {sub-task}.\n\n"
-                "Submit TEACHBACK by writing metadata.teachback_submit (per pact-teachback skill). "
+                "Submit TEACHBACK by writing metadata.teachback_submit using the CANONICAL field schema (do NOT improvise key names): understanding, most_likely_wrong, least_confident_item, first_action, variety_acknowledgment (an OBJECT). See the pact-teachback skill for field semantics. "
                 "SET intentional_wait{reason=awaiting_lead_completion, expected_resolver=team-lead}. Idle. "
                 "DO NOT mark this task completed — team-lead-only completion. Lead will mark completed "
                 "after teachback acceptance, then send a wake-SendMessage confirming Task B is claimable.\n\n"

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -73,7 +73,7 @@ Both are created BEFORE the `Agent(...)` spawn call so the teammate sees them on
 A_id = TaskCreate(
     subject="{role}: TEACHBACK for {feature}",
     description="DOGFOOD TEACHBACK GATE for {feature}.\n\n"
-                "Submit TEACHBACK by writing metadata.teachback_submit (per pact-teachback skill). "
+                "Submit TEACHBACK by writing metadata.teachback_submit using the CANONICAL field schema (do NOT improvise key names): understanding, most_likely_wrong, least_confident_item, first_action, variety_acknowledgment (an OBJECT). See the pact-teachback skill for field semantics. "
                 "SET intentional_wait{reason=awaiting_lead_completion, expected_resolver=team-lead}. Idle. "
                 "DO NOT mark this task completed — team-lead-only completion. Lead will mark completed "
                 "after teachback acceptance, then send a wake-SendMessage confirming Task B is claimable. "

--- a/pact-plugin/commands/peer-review.md
+++ b/pact-plugin/commands/peer-review.md
@@ -155,7 +155,7 @@ Both are created BEFORE the `Agent(...)` spawn call. The reviewer claims A, subm
 A_id = TaskCreate(
     subject="{reviewer-type}: TEACHBACK for review of {feature}",
     description="DOGFOOD TEACHBACK GATE.\n\n"
-                "Submit TEACHBACK by writing metadata.teachback_submit (per pact-teachback skill). "
+                "Submit TEACHBACK by writing metadata.teachback_submit using the CANONICAL field schema (do NOT improvise key names): understanding, most_likely_wrong, least_confident_item, first_action, variety_acknowledgment (an OBJECT). See the pact-teachback skill for field semantics. "
                 "SET intentional_wait{reason=awaiting_lead_completion}. Idle. "
                 "DO NOT mark this task completed — team-lead-only completion.\n\n"
                 "When Task B unblocks, claim it (TaskUpdate status=in_progress) BEFORE any implementation tool-use — it is pre-assigned to you but still pending; you flip it, not the lead.\n\n"

--- a/pact-plugin/commands/rePACT.md
+++ b/pact-plugin/commands/rePACT.md
@@ -228,7 +228,7 @@ Nested PACT cycles' inner-cycle dispatches follow the same A+B shape recursively
 A_id = TaskCreate(
     subject="{scope-prefixed-name}: TEACHBACK for {sub-task}",
     description="DOGFOOD TEACHBACK GATE.\n\n"
-                "Submit TEACHBACK by writing metadata.teachback_submit (per pact-teachback skill). "
+                "Submit TEACHBACK by writing metadata.teachback_submit using the CANONICAL field schema (do NOT improvise key names): understanding, most_likely_wrong, least_confident_item, first_action, variety_acknowledgment (an OBJECT). See the pact-teachback skill for field semantics. "
                 "SET intentional_wait{reason=awaiting_lead_completion}. Idle. "
                 "DO NOT mark this task completed — team-lead-only completion.\n\n"
                 "When Task B unblocks, claim it (TaskUpdate status=in_progress) BEFORE any implementation tool-use — it is pre-assigned to you but still pending; you flip it, not the lead.\n\n"

--- a/pact-plugin/hooks/shared/teachback_schema.py
+++ b/pact-plugin/hooks/shared/teachback_schema.py
@@ -22,6 +22,10 @@ Functions never raise.
 Public surface:
 - TEACHBACK_REQUIRED_FIELDS — canonical 5-tuple per D10 (4 string fields +
   variety_acknowledgment dict).
+- TEACHBACK_OBJECT_FIELDS — the object-valued subset of
+  TEACHBACK_REQUIRED_FIELDS (currently variety_acknowledgment). SSOT for the
+  string/object partition: both the schema echo and the lifecycle gate's
+  string-field validator derive their carve-out filter from it.
 - TEACHBACK_REQUIRED_SUBKEYS — canonical 3-tuple for reasoning_reconstruction
   per pact-ct-teachback.md §When to Method-Reconstruct.
 - TEACHBACK_VARIETY_ACK_VALID_VALUES — enum tuple for
@@ -33,9 +37,13 @@ Public surface:
   (>= 7 → RECOMMENDED, below it → SKIPPED). Derived from
   `variety_scorer.COMPACT_MAX + 1`.
 - TEACHBACK_SCHEMA_ECHO — reusable human-readable echo of the canonical
-  5-field schema (derived from TEACHBACK_REQUIRED_FIELDS), appended to the
-  schema-invalid deny message so a teammate that trips the gate self-corrects
-  in one read.
+  teachback_submit schema. The enumerated field names and the field count are
+  derived from TEACHBACK_REQUIRED_FIELDS (the object field is carved out via
+  TEACHBACK_OBJECT_FIELDS), so the list and count cannot drift from the tuple;
+  the is-an-OBJECT note is hand-maintained. Appended to the LEAD-SIDE
+  schema-invalid completion advisory, so the teammate receives the full schema
+  in one read when the lead relays the rejection (not at their own write
+  moment).
 - validate_reasoning_reconstruction(rr) — pure validator returning None
   on well-formed input or a reason-enum string on rejection.
 - resolve_variety_total(variety, metadata=None) — pure resolver returning
@@ -67,6 +75,13 @@ TEACHBACK_REQUIRED_FIELDS: tuple[str, ...] = (
     "variety_acknowledgment",
 )
 
+# The object-valued subset of TEACHBACK_REQUIRED_FIELDS (variety_acknowledgment
+# is a dict; the rest are strings). SSOT for the string/object partition: both
+# TEACHBACK_SCHEMA_ECHO below and the lifecycle gate's string-field validator
+# derive their "skip the object fields" carve-out from this one tuple, so the
+# partition is defined once and is rename-proof.
+TEACHBACK_OBJECT_FIELDS: tuple[str, ...] = ("variety_acknowledgment",)
+
 # Canonical 3 sub-keys for reasoning_reconstruction per pact-ct-teachback.md
 # §When to Method-Reconstruct. Each value is a non-empty string at submit time.
 TEACHBACK_REQUIRED_SUBKEYS: tuple[str, ...] = (
@@ -94,19 +109,25 @@ TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN: int = PLAN_MODE_MIN
 # keeping the gate's reach to variety_scorer strictly 2-hop via this module.
 TEACHBACK_RECOMMENDED_BAND_MIN: int = COMPACT_MAX + 1
 
-# Human-readable echo of the full canonical teachback_submit schema, derived
-# from TEACHBACK_REQUIRED_FIELDS so the remediation text can never drift from
-# the tuple. The 4 string fields are listed in canonical order, then
-# variety_acknowledgment with the is-an-OBJECT note (the most common wrong
-# shape is a free-text string). Reused by the schema-invalid deny message in
-# task_lifecycle_gate.py so a teammate that trips the gate self-corrects in
-# one read without opening the skill.
+# Human-readable echo of the full canonical teachback_submit schema. The
+# enumerated field names and the field count are derived from
+# TEACHBACK_REQUIRED_FIELDS (the object field is carved out via
+# TEACHBACK_OBJECT_FIELDS), so the list and count cannot drift from the tuple
+# when a field is added or removed; the is-an-OBJECT note is hand-maintained
+# (it would need a manual edit if a second object field were ever added). The
+# string fields are listed in canonical order, then variety_acknowledgment with
+# the is-an-OBJECT note (the most common wrong shape is a free-text string).
+# Appended to the LEAD-SIDE teachback_submit_schema_invalid completion advisory
+# in task_lifecycle_gate.py: the offending teammate receives the full schema in
+# one read when the lead relays the rejection, not directly at their own write
+# moment.
 TEACHBACK_SCHEMA_ECHO: str = (
-    "Expected canonical teachback_submit schema (all 5 fields): "
+    f"Expected canonical teachback_submit schema "
+    f"(all {len(TEACHBACK_REQUIRED_FIELDS)} fields): "
     + ", ".join(
         field
         for field in TEACHBACK_REQUIRED_FIELDS
-        if field != "variety_acknowledgment"
+        if field not in TEACHBACK_OBJECT_FIELDS
     )
     + " (non-empty strings) + variety_acknowledgment (an OBJECT, not a string)."
     " See the pact-teachback skill for field semantics."

--- a/pact-plugin/hooks/shared/teachback_schema.py
+++ b/pact-plugin/hooks/shared/teachback_schema.py
@@ -32,6 +32,10 @@ Public surface:
 - TEACHBACK_RECOMMENDED_BAND_MIN — variety band threshold
   (>= 7 → RECOMMENDED, below it → SKIPPED). Derived from
   `variety_scorer.COMPACT_MAX + 1`.
+- TEACHBACK_SCHEMA_ECHO — reusable human-readable echo of the canonical
+  5-field schema (derived from TEACHBACK_REQUIRED_FIELDS), appended to the
+  schema-invalid deny message so a teammate that trips the gate self-corrects
+  in one read.
 - validate_reasoning_reconstruction(rr) — pure validator returning None
   on well-formed input or a reason-enum string on rejection.
 - resolve_variety_total(variety, metadata=None) — pure resolver returning
@@ -89,6 +93,24 @@ TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN: int = PLAN_MODE_MIN
 # gate's band mapping references a constant instead of hard-coding 7, while
 # keeping the gate's reach to variety_scorer strictly 2-hop via this module.
 TEACHBACK_RECOMMENDED_BAND_MIN: int = COMPACT_MAX + 1
+
+# Human-readable echo of the full canonical teachback_submit schema, derived
+# from TEACHBACK_REQUIRED_FIELDS so the remediation text can never drift from
+# the tuple. The 4 string fields are listed in canonical order, then
+# variety_acknowledgment with the is-an-OBJECT note (the most common wrong
+# shape is a free-text string). Reused by the schema-invalid deny message in
+# task_lifecycle_gate.py so a teammate that trips the gate self-corrects in
+# one read without opening the skill.
+TEACHBACK_SCHEMA_ECHO: str = (
+    "Expected canonical teachback_submit schema (all 5 fields): "
+    + ", ".join(
+        field
+        for field in TEACHBACK_REQUIRED_FIELDS
+        if field != "variety_acknowledgment"
+    )
+    + " (non-empty strings) + variety_acknowledgment (an OBJECT, not a string)."
+    " See the pact-teachback skill for field semantics."
+)
 
 
 def validate_reasoning_reconstruction(rr: object) -> str | None:

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -300,6 +300,7 @@ try:
         TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN,
         TEACHBACK_REQUIRED_FIELDS,
         TEACHBACK_REQUIRED_SUBKEYS,
+        TEACHBACK_SCHEMA_ECHO,
         TEACHBACK_VARIETY_ACK_VALID_VALUES,
         resolve_variety_total,
         validate_reasoning_reconstruction,
@@ -342,7 +343,9 @@ _HANDOFF_REQUIRED_FIELDS = (
 # and the reasoning_reconstruction validator are imported from
 # shared.teachback_schema (SSOT). TEACHBACK_REQUIRED_SUBKEYS and
 # validate_reasoning_reconstruction are consumed by the write-time advisory
-# rules below.
+# rules below. TEACHBACK_SCHEMA_ECHO (also from the SSOT) is appended to the
+# teachback_submit_schema_invalid advisory so the deny message echoes the full
+# canonical schema, not only the offending field(s).
 
 # Required per-dimension rationale fields on metadata.variety (D11).
 # 4-tuple. Each rationale is one sentence explaining THIS dispatch's score
@@ -1170,10 +1173,20 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
                     teachback_submit
                 )
                 if schema_problem:
+                    # Echo the FULL canonical schema (all 5 fields, with the
+                    # variety_acknowledgment-is-an-OBJECT note) after the
+                    # specific problem, so a teammate that trips ANY
+                    # schema-invalid sub-reason — missing field, empty/non-string
+                    # field, OR a malformed variety_acknowledgment (e.g. a
+                    # free-text string) — self-corrects in one read without
+                    # opening the skill. Appended at this single advisory site
+                    # (not per validator branch) because all sub-reasons funnel
+                    # into this one `teachback_submit_schema_invalid` advisory;
+                    # TEACHBACK_SCHEMA_ECHO is the DRY schema-derived string.
                     advisories.append((
                         "teachback_submit_schema_invalid",
                         f"PACT task_lifecycle_gate: Teachback Task {task_id} "
-                        f"{schema_problem}.",
+                        f"{schema_problem}. {TEACHBACK_SCHEMA_ECHO}",
                     ))
 
             # #955 teachback_ack emit — GC-immune mirror of the teammate's

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -296,6 +296,7 @@ try:
     from shared.task_utils import read_task_json
     from shared.teachback_schema import (
         DISPATCH_VARIETY_KEYS,
+        TEACHBACK_OBJECT_FIELDS,
         TEACHBACK_RECOMMENDED_BAND_MIN,
         TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN,
         TEACHBACK_REQUIRED_FIELDS,
@@ -713,10 +714,12 @@ def _validate_teachback_submit_schema(teachback: object) -> str | None:
             f"metadata.teachback_submit missing required fields: "
             f"{', '.join(missing)}"
         )
-    # Non-empty-string check on the 4 string fields; variety_acknowledgment
-    # is a dict, validated by the dedicated sub-validator below.
+    # Non-empty-string check on the string fields; the object fields
+    # (variety_acknowledgment) are validated by the dedicated sub-validator
+    # below. The carve-out derives from TEACHBACK_OBJECT_FIELDS (SSOT) so this
+    # string/object partition stays in lockstep with the schema-echo derivation.
     string_fields = tuple(
-        f for f in TEACHBACK_REQUIRED_FIELDS if f != "variety_acknowledgment"
+        f for f in TEACHBACK_REQUIRED_FIELDS if f not in TEACHBACK_OBJECT_FIELDS
     )
     empty = [
         f for f in string_fields
@@ -1173,15 +1176,17 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
                     teachback_submit
                 )
                 if schema_problem:
-                    # Echo the FULL canonical schema (all 5 fields, with the
+                    # Echo the FULL canonical schema (every field, with the
                     # variety_acknowledgment-is-an-OBJECT note) after the
-                    # specific problem, so a teammate that trips ANY
+                    # specific problem, so the relayed rejection covers ANY
                     # schema-invalid sub-reason — missing field, empty/non-string
                     # field, OR a malformed variety_acknowledgment (e.g. a
-                    # free-text string) — self-corrects in one read without
-                    # opening the skill. Appended at this single advisory site
-                    # (not per validator branch) because all sub-reasons funnel
-                    # into this one `teachback_submit_schema_invalid` advisory;
+                    # free-text string) — in one read. This is the LEAD-SIDE
+                    # completion advisory: the teammate receives the schema when
+                    # the lead relays the rejection, not at their own write
+                    # moment. Appended at this single advisory site (not per
+                    # validator branch) because all sub-reasons funnel into this
+                    # one `teachback_submit_schema_invalid` advisory;
                     # TEACHBACK_SCHEMA_ECHO is the DRY schema-derived string.
                     advisories.append((
                         "teachback_submit_schema_invalid",

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -44,6 +44,10 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import task_lifecycle_gate as tlg  # noqa: E402
+# #958: imported from the SSOT module so the message-body echo assertions
+# below are coupled to the EXACT constant the gate appends — a substring check
+# against this import is non-vacuous (revert the advisory-site append → RED).
+from shared.teachback_schema import TEACHBACK_SCHEMA_ECHO  # noqa: E402
 
 
 # =============================================================================
@@ -1567,6 +1571,18 @@ def test_advisory_when_teachback_submit_missing_required_field(
     assert any(
         rule == "teachback_submit_schema_invalid" for rule, _ in advisories
     ), f"expected R2 for missing {missing_field}, got: {advisories}"
+    # #958 sub-reason (a) — missing required field: the advisory MESSAGE (not
+    # just the rule name) must echo the full canonical schema so a teammate
+    # self-corrects in one read. Non-vacuous: reverting the advisory-site
+    # append drops TEACHBACK_SCHEMA_ECHO from the message → this fails.
+    schema_msgs = [
+        msg for rule, msg in advisories
+        if rule == "teachback_submit_schema_invalid"
+    ]
+    assert TEACHBACK_SCHEMA_ECHO in schema_msgs[0], (
+        f"missing-field advisory must echo full canonical schema, "
+        f"got: {schema_msgs[0]!r}"
+    )
     # Disjoint with R1
     assert not any(
         rule == "teachback_submit_missing" for rule, _ in advisories
@@ -1625,6 +1641,17 @@ def test_advisory_when_teachback_submit_field_is_empty_string(
     advisories = tlg.evaluate_lifecycle(payload)
     assert any(
         rule == "teachback_submit_schema_invalid" for rule, _ in advisories
+    )
+    # #958 sub-reason (b) — empty/non-string string-field: the advisory MESSAGE
+    # must echo the full canonical schema. Non-vacuous: reverting the
+    # advisory-site append drops TEACHBACK_SCHEMA_ECHO from the message → fails.
+    schema_msgs = [
+        msg for rule, msg in advisories
+        if rule == "teachback_submit_schema_invalid"
+    ]
+    assert TEACHBACK_SCHEMA_ECHO in schema_msgs[0], (
+        f"empty-field advisory must echo full canonical schema, "
+        f"got: {schema_msgs[0]!r}"
     )
 
 
@@ -1697,6 +1724,66 @@ def test_advisory_when_variety_ack_is_malformed(
     assert any(
         rule == "teachback_submit_schema_invalid" for rule, _ in advisories
     ), f"expected R2 for {description}, got: {advisories}"
+
+
+def test_schema_invalid_message_echoes_full_schema_for_variety_ack_as_string(
+    tmp_path, monkeypatch, pact_context,
+):
+    """#958 sub-reason (c) — variety_acknowledgment supplied as a free-text
+    STRING. This is the SUBTLE, highest-value path: a string-valued
+    variety_acknowledgment is NOT caught by the empty/non-string string-field
+    branch (which explicitly excludes variety_acknowledgment); it routes
+    through _validate_variety_acknowledgment ('must be object, got str').
+    A per-branch echo edit would have MISSED this case — which is exactly why
+    the echo is appended at the SINGLE schema-invalid advisory funnel. Dedicated
+    (not parametrized) so the routing is self-documenting for future maintainers.
+
+    Asserts both that we exercised the is-OBJECT route AND that the single
+    advisory MESSAGE echoes the full canonical schema. Non-vacuous: reverting
+    the advisory-site append drops TEACHBACK_SCHEMA_ECHO from the message → RED.
+    """
+    pact_context(team_name="test-team", session_id="test-session")
+    _setup_team_inbox(
+        tmp_path, monkeypatch, owner="preparer", team_name="test-team",
+        paired_offset_seconds=30,
+    )
+    # A realistic wrong shape: prose where the OBJECT belongs.
+    tb = _well_formed_teachback_submit(
+        variety_acknowledgment="rationale articulates this dispatch"
+    )
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": "1", "status": "completed"},
+        "tool_response": {
+            "task": {
+                "id": "1",
+                "subject": "preparer: TEACHBACK for foo",
+                "owner": "preparer",
+                "metadata": {"teachback_submit": tb},
+            }
+        },
+    }
+    advisories = tlg.evaluate_lifecycle(payload)
+    schema_msgs = [
+        msg for rule, msg in advisories
+        if rule == "teachback_submit_schema_invalid"
+    ]
+    assert schema_msgs, (
+        f"expected teachback_submit_schema_invalid for variety_ack-as-string, "
+        f"got: {advisories}"
+    )
+    # Proves we hit the _validate_variety_acknowledgment is-OBJECT route (the
+    # short reason names variety_acknowledgment + 'must be object'), NOT the
+    # string-field branch — lowercase 'must be object' is unique to the short
+    # reason and absent from the echo.
+    assert "variety_acknowledgment" in schema_msgs[0]
+    assert "must be object" in schema_msgs[0]
+    # Load-bearing non-vacuity assertion: the full canonical schema echo is
+    # appended after the short reason.
+    assert TEACHBACK_SCHEMA_ECHO in schema_msgs[0], (
+        f"variety_ack-as-string advisory must echo full canonical schema, "
+        f"got: {schema_msgs[0]!r}"
+    )
 
 
 def test_silent_when_variety_ack_is_well_formed_with_concern(

--- a/pact-plugin/tests/test_task_lifecycle_gate.py
+++ b/pact-plugin/tests/test_task_lifecycle_gate.py
@@ -1614,6 +1614,19 @@ def test_advisory_when_teachback_submit_is_non_dict(
     assert any(
         rule == "teachback_submit_schema_invalid" for rule, _ in advisories
     )
+    # #958 Future-2b — teachback_submit-itself-non-dict is also a schema-invalid
+    # sub-reason that funnels into the single teachback_submit_schema_invalid
+    # advisory, so its MESSAGE must carry the full canonical schema echo too.
+    # Non-vacuous: reverting the advisory-site append drops TEACHBACK_SCHEMA_ECHO
+    # from the message → this fails.
+    schema_msgs = [
+        msg for rule, msg in advisories
+        if rule == "teachback_submit_schema_invalid"
+    ]
+    assert TEACHBACK_SCHEMA_ECHO in schema_msgs[0], (
+        f"non-dict teachback_submit advisory must echo full canonical schema, "
+        f"got: {schema_msgs[0]!r}"
+    )
 
 
 def test_advisory_when_teachback_submit_field_is_empty_string(
@@ -1724,6 +1737,21 @@ def test_advisory_when_variety_ack_is_malformed(
     assert any(
         rule == "teachback_submit_schema_invalid" for rule, _ in advisories
     ), f"expected R2 for {description}, got: {advisories}"
+    # #958 Future-2b — echo-presence-per-variant: every malformed-variety_ack
+    # sub-case (non-dict-ack, invalid-enum, missing-concern, empty-concern)
+    # funnels into the SINGLE teachback_submit_schema_invalid advisory, so each
+    # variant's MESSAGE must carry the full canonical schema echo. Pins echo
+    # presence against a hypothetical future per-branch refactor of the single
+    # append site. Non-vacuous: reverting the advisory-site append drops
+    # TEACHBACK_SCHEMA_ECHO from the message → every parametrized variant fails.
+    schema_msgs = [
+        msg for rule, msg in advisories
+        if rule == "teachback_submit_schema_invalid"
+    ]
+    assert TEACHBACK_SCHEMA_ECHO in schema_msgs[0], (
+        f"malformed variety_ack advisory ({description}) must echo full "
+        f"canonical schema, got: {schema_msgs[0]!r}"
+    )
 
 
 def test_schema_invalid_message_echoes_full_schema_for_variety_ack_as_string(

--- a/pact-plugin/tests/test_teachback_schema.py
+++ b/pact-plugin/tests/test_teachback_schema.py
@@ -20,9 +20,12 @@ layered on top by callers.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from shared.teachback_schema import (
+    TEACHBACK_OBJECT_FIELDS,
     TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN,
     TEACHBACK_REQUIRED_FIELDS,
     TEACHBACK_REQUIRED_SUBKEYS,
@@ -127,6 +130,114 @@ class TestSchemaEcho:
         # explicitly flag that variety_acknowledgment is an OBJECT.
         assert "variety_acknowledgment" in TEACHBACK_SCHEMA_ECHO
         assert "OBJECT" in TEACHBACK_SCHEMA_ECHO
+
+
+# ============================================================================
+# TEACHBACK_OBJECT_FIELDS — the string/object partition SSOT (#958 Stage 1).
+# Both TEACHBACK_SCHEMA_ECHO's comma-list carve-out and the lifecycle gate's
+# string-field validator derive their "skip the object fields" set from this
+# one tuple. These tests pin the partition and couple the echo's carve-out
+# back to it so the two cannot silently desync.
+# ============================================================================
+
+
+class TestObjectFieldsPartition:
+    """#958 Future-2 (Stage-1 follow-through): pin TEACHBACK_OBJECT_FIELDS as
+    the string/object partition SSOT."""
+
+    def test_object_fields_is_nonempty_tuple(self):
+        assert isinstance(TEACHBACK_OBJECT_FIELDS, tuple)
+        assert TEACHBACK_OBJECT_FIELDS
+
+    def test_object_fields_subset_of_required(self):
+        # Partition validity: every object field must be a canonical required
+        # field — an object field outside the required tuple would mean the
+        # carve-out skips a name the schema never enforced.
+        assert set(TEACHBACK_OBJECT_FIELDS) <= set(TEACHBACK_REQUIRED_FIELDS)
+
+    def test_variety_acknowledgment_is_an_object_field(self):
+        assert "variety_acknowledgment" in TEACHBACK_OBJECT_FIELDS
+
+    def test_echo_string_list_is_required_minus_object(self):
+        # Structural complement pin: the echo's comma-enumerated string-field
+        # list (the prefix before " (non-empty strings)") must be exactly the
+        # complement TEACHBACK_REQUIRED_FIELDS minus TEACHBACK_OBJECT_FIELDS:
+        # every string field present, every object field absent. This couples
+        # the echo's carve-out to the partition SSOT — if the echo derived its
+        # carve-out from a DIFFERENT partition than TEACHBACK_OBJECT_FIELDS
+        # (e.g. a hardcoded skip of the wrong field), a string field would go
+        # missing from the comma-list and/or an object field would leak in,
+        # failing here.
+        #
+        # NOTE: TEACHBACK_SCHEMA_ECHO is precomputed at import time, so this is a
+        # STRUCTURAL check against the live constant — not a monkeypatch
+        # flow-through (which cannot reach the already-built string).
+        string_fields = tuple(
+            f for f in TEACHBACK_REQUIRED_FIELDS
+            if f not in TEACHBACK_OBJECT_FIELDS
+        )
+        prefix = TEACHBACK_SCHEMA_ECHO.split(" (non-empty strings)")[0]
+        for f in string_fields:
+            assert f in prefix, (
+                f"string field {f!r} must appear in the echo's comma-list; "
+                f"prefix={prefix!r}"
+            )
+        for f in TEACHBACK_OBJECT_FIELDS:
+            assert f not in prefix, (
+                f"object field {f!r} must NOT appear in the echo's string-field "
+                f"comma-list (it belongs in the is-an-OBJECT note); "
+                f"prefix={prefix!r}"
+            )
+
+
+# ============================================================================
+# Doc-surface field enumeration (#958 Future-2a) — the LLM-loaded gate-template
+# surfaces that enumerate the canonical teachback_submit fields must each name
+# EVERY field in TEACHBACK_REQUIRED_FIELDS, so a future field-add can't silently
+# leave a surface stale.
+# ============================================================================
+
+# Hardcoded list of the LLM-loaded surfaces that enumerate the canonical
+# teachback_submit field names. LIMITATION: this list is hardcoded, so a NEW
+# gate-template surface added later is NOT auto-covered — extend this list when
+# adding a surface that enumerates the fields.
+_FIELD_ENUMERATING_SURFACES: tuple[str, ...] = (
+    "agents/pact-orchestrator.md",
+    "commands/orchestrate.md",
+    "commands/peer-review.md",
+    "commands/comPACT.md",
+    "commands/rePACT.md",
+)
+
+# pact-plugin/ root: this test lives at pact-plugin/tests/, so parent.parent.
+_PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestDocSurfaceFieldEnumeration:
+    """#958 Future-2a: each LLM-loaded gate-template surface must name every
+    canonical teachback_submit field. Substring-per-field (robust to rewording).
+
+    LIMITATIONS (documented):
+      - The surface file LIST (_FIELD_ENUMERATING_SURFACES) is hardcoded — a NEW
+        gate-template surface added later is NOT auto-covered.
+      - "understanding" is a common English word, so its per-file presence check
+        is looser than the 4 distinctive snake_case field names; the snake_case
+        fields carry the real anti-drift signal.
+    """
+
+    @pytest.mark.parametrize("surface", _FIELD_ENUMERATING_SURFACES)
+    def test_surface_names_every_required_field(self, surface):
+        path = _PLUGIN_ROOT / surface
+        assert path.is_file(), (
+            f"expected gate-template surface at {path} "
+            f"(surface moved/renamed — update _FIELD_ENUMERATING_SURFACES?)"
+        )
+        text = path.read_text(encoding="utf-8")
+        for field in TEACHBACK_REQUIRED_FIELDS:
+            assert field in text, (
+                f"{surface} must enumerate canonical field {field!r} "
+                f"(stale surface after a field-add?)"
+            )
 
 
 # ============================================================================

--- a/pact-plugin/tests/test_teachback_schema.py
+++ b/pact-plugin/tests/test_teachback_schema.py
@@ -26,6 +26,7 @@ from shared.teachback_schema import (
     TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN,
     TEACHBACK_REQUIRED_FIELDS,
     TEACHBACK_REQUIRED_SUBKEYS,
+    TEACHBACK_SCHEMA_ECHO,
     TEACHBACK_VARIETY_ACK_VALID_VALUES,
     resolve_variety_total,
     validate_reasoning_reconstruction,
@@ -89,6 +90,43 @@ class TestConstants:
         assert TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN == PLAN_MODE_MIN
         assert PLAN_MODE_MIN == ORCHESTRATE_MAX + 1
         assert TEACHBACK_REASONING_RECONSTRUCTION_REQUIRED_MIN <= PLAN_MODE_MAX
+
+
+# ============================================================================
+# TEACHBACK_SCHEMA_ECHO — the remediation string appended to the schema-invalid
+# deny message (#958). Pins the no-hardcoded-copy DERIVATION property and the
+# variety_acknowledgment-is-an-OBJECT note. The gate-side integration (echo is
+# present in the advisory message) is covered in test_task_lifecycle_gate.py;
+# this class pins what the echo SAYS.
+# ============================================================================
+
+
+class TestSchemaEcho:
+    """Pin TEACHBACK_SCHEMA_ECHO's content and its derivation from
+    TEACHBACK_REQUIRED_FIELDS."""
+
+    def test_echo_is_nonempty_string(self):
+        assert isinstance(TEACHBACK_SCHEMA_ECHO, str)
+        assert TEACHBACK_SCHEMA_ECHO.strip()
+
+    def test_echo_names_every_required_field(self):
+        # Derivation pin (no-hardcoded-copy property): EVERY canonical required
+        # field name must appear in the echo. The 4 string fields appear in the
+        # joined list; variety_acknowledgment appears in the is-OBJECT note. A
+        # field added to TEACHBACK_REQUIRED_FIELDS that the echo's derivation
+        # failed to surface would fail here — the echo cannot silently drift
+        # from the enforced tuple.
+        for field in TEACHBACK_REQUIRED_FIELDS:
+            assert field in TEACHBACK_SCHEMA_ECHO, (
+                f"echo must name required field {field!r}; "
+                f"got: {TEACHBACK_SCHEMA_ECHO!r}"
+            )
+
+    def test_echo_notes_variety_acknowledgment_is_an_object(self):
+        # The most common wrong shape is a free-text string, so the echo must
+        # explicitly flag that variety_acknowledgment is an OBJECT.
+        assert "variety_acknowledgment" in TEACHBACK_SCHEMA_ECHO
+        assert "OBJECT" in TEACHBACK_SCHEMA_ECHO
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Reduce recurring teachback friction (#958): teammates intermittently improvise non-canonical `teachback_submit` field-key names because the Task A gate description referenced the `pact-teachback` skill but did not enumerate the field names. Surface the canonical schema where teammates actually read it — proactively in the dispatch templates, and reactively in the gate's schema-invalid deny message. Severity: Minor / ergonomics (NOT a correctness fix — the gate already rejects malformed teachbacks).

## What landed

**Primary — inline enumeration (5 LLM-loaded template surfaces):**
- `commands/orchestrate.md`, `commands/peer-review.md`, `commands/comPACT.md`, `commands/rePACT.md` — the Task A teachback-gate description now lists the canonical 5 fields inline (understanding, most_likely_wrong, least_confident_item, first_action, variety_acknowledgment).
- `agents/pact-orchestrator.md` §11 — same enumeration, author-voice adapted (lead-authoring guidance, not a teammate-facing template string).
- Field-names-only; zero planning artifacts in LLM-loaded files.

**Secondary — full-schema deny echo (DRY):**
- `hooks/shared/teachback_schema.py` — new `TEACHBACK_SCHEMA_ECHO`, derived from `TEACHBACK_REQUIRED_FIELDS` (no hardcoded copy), with the variety_acknowledgment-is-an-OBJECT note.
- `hooks/task_lifecycle_gate.py` — appended at the single `teachback_submit_schema_invalid` advisory funnel, covering all three schema-invalid sub-reasons (missing field, empty/non-string, and variety_acknowledgment-as-string via the `_validate_variety_acknowledgment` is-object route — the subtle path a per-branch edit would have missed).

**Tests:**
- `tests/test_task_lifecycle_gate.py` — message-body echo assertions across all 3 sub-reasons; non-vacuity coupled to the imported SSOT constant (revert the append → RED, proven empirically by counter-test).
- `tests/test_teachback_schema.py` — `TestSchemaEcho` pins the echo derives from `TEACHBACK_REQUIRED_FIELDS` + the is-object note.
- Suite: 9123 passed, 13 skipped, 0 errors.

## Why

Friction-reduction. The canonical schema stays load-bearing (no gate leniency); the goal is first-try hits and one-read self-correction. PATCH bump 4.4.24 → 4.4.25.

Completes the ACs of #958; closure to be confirmed post-merge.