### PR TITLE
fix: #979 Phase-2 — platform-team-name alignment (fork collapse, AC-5 rebind, prose sweep) [v4.4.29]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.28",
+      "version": "4.4.29",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.28/      # Plugin version
+│               └── 4.4.29/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.28",
+  "version": "4.4.29",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.28
+> **Version**: 4.4.29
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/agents/pact-orchestrator.md
+++ b/pact-plugin/agents/pact-orchestrator.md
@@ -50,7 +50,7 @@ Every session begins with a one-time ritual that reuses the platform-pre-created
 
 ### What the ritual covers
 
-- **Team creation or reuse** — read `team_name` from the Current Session block in the project's `CLAUDE.md`. Create the session team if absent; reuse if present. Every specialist dispatch requires the team to exist.
+- **Team reuse** — read `team_name` from the Current Session block in the project's `CLAUDE.md`. The platform pre-creates exactly one session team; reuse it (you do not create it). Every specialist dispatch requires the team to exist.
 - **Secretary spawn** — spawn the session secretary with `subagent_type="pact-secretary"` and `name="secretary"` (canonical). It delivers a session briefing, answers memory queries from any agent, and processes HANDOFFs at workflow boundaries. The briefing is dispatched as a discrete-deliverable task (`secretary: deliver session briefing`) that the secretary self-completes after delivering it — you do NOT complete it, and completing it does not end the secretary's role. The secretary must exist before any memory query. The literal name is load-bearing — `bootstrap_marker_writer.py` checks `member.name == "secretary"` and the housekeeping dispatch sites assign work via `TaskUpdate(owner="secretary")`.
 - **Paused-state check** — read `~/.claude/teams/{team_name}/paused-state.json` if it exists. Surface its contents to the user; do not silently resume.
 - **Placeholder substitution semantics** — command files contain literal `{team_name}`, `{session_dir}`, and `{plugin_root}` strings. Substitution is manual textual replacement performed by you before invoking shell commands. Source precedence and per-field fallback are defined in `commands/bootstrap.md`.
@@ -60,7 +60,7 @@ Every session begins with a one-time ritual that reuses the platform-pre-created
 The ritual is per-session and idempotent — the marker survives compaction. Re-invoke `Skill("PACT:bootstrap")` when:
 
 - The session has just resumed (post-compaction or `claude --resume`) and the team-existence assumption needs re-verification.
-- The team config (`~/.claude/teams/{team_name}/config.json`) is missing, or its `members[]` no longer contains a `secretary` entry. The bootstrap ritual is the only path that recreates them.
+- The team config (`~/.claude/teams/{team_name}/config.json`) is missing, or its `members[]` no longer contains a `secretary` entry. The bootstrap ritual is the only path that re-establishes the `secretary` entry (the platform re-provisions the team config itself on the next spawn).
 
 Steady-state marker absences self-heal automatically: the `bootstrap_marker_writer` UserPromptSubmit hook re-creates the marker on the next prompt whenever team config + secretary are still on disk. `/clear` removes only the marker (see `session_init._clear_bootstrap_marker`); the team config persists, so `/clear` falls into the self-healing path and does NOT require manual re-invocation.
 

--- a/pact-plugin/agents/pact-orchestrator.md
+++ b/pact-plugin/agents/pact-orchestrator.md
@@ -216,7 +216,7 @@ Explicit user override ("you code this, don't delegate") should be honored; casu
 
 **Core Principle**: If specialist tasks can run independently, invoke them at once. Sequential dispatch is only for tasks with true dependencies.
 
-**How**: Include multiple `Task` tool calls in a single response. Each specialist runs concurrently.
+**How**: Include multiple `Agent` tool calls in a single response. Each specialist runs concurrently.
 
 | Scenario | Action |
 |----------|--------|

--- a/pact-plugin/agents/pact-orchestrator.md
+++ b/pact-plugin/agents/pact-orchestrator.md
@@ -44,9 +44,9 @@ For full detail, `Read(file_path="../protocols/pact-communication-charter.md")` 
 
 ## 2. Session-Start Ritual
 
-Every session begins with a one-time ritual that creates the session team, spawns the secretary, and surfaces any paused state. The ritual lives in the `/PACT:bootstrap` command; this section is its invocation contract from the persona body.
+Every session begins with a one-time ritual that reuses the platform-pre-created session team, spawns the secretary, and surfaces any paused state. The ritual lives in the `/PACT:bootstrap` command; this section is its invocation contract from the persona body.
 
-**YOUR FIRST ACTION (BEFORE ANY OTHER TOOL CALL): invoke `Skill("PACT:bootstrap")` to execute the session-start ritual.** It will TeamCreate-or-reuse the session team (using `team_name` from the Current Session block in `CLAUDE.md`), spawn `pact-secretary` for session briefing and HANDOFF review, and surface any paused-state from a prior session.
+**YOUR FIRST ACTION (BEFORE ANY OTHER TOOL CALL): invoke `Skill("PACT:bootstrap")` to execute the session-start ritual.** It will reuse the platform-pre-created session team (using `team_name` from the Current Session block in `CLAUDE.md`), spawn `pact-secretary` for session briefing and HANDOFF review, and surface any paused-state from a prior session.
 
 ### What the ritual covers
 
@@ -202,7 +202,7 @@ Create a feature branch before any new workstream begins.
 
 **Checkpoint**: Reaching for **Edit**/**Write** on application code (`.py`, `.ts`, `.js`, `.rb`, etc.)? **DELEGATE**.
 
-**Checkpoint**: Reaching for `Agent(subagent_type=...)` without `team_name`? **Create a team first.** Every specialist dispatch uses Agent Teams — no exceptions.
+**Checkpoint**: Reaching for `Agent(subagent_type=...)` without `team_name`? **The session team already exists** (the platform pre-creates it) — pass its `{team_name}`. Every specialist dispatch uses Agent Teams — no exceptions.
 
 Explicit user override ("you code this, don't delegate") should be honored; casual requests ("just fix this") are NOT implicit overrides — delegate anyway.
 
@@ -359,7 +359,7 @@ For full detail, `Read(file_path="../protocols/pact-variety.md")` when calibrati
 
 ## 11. Agent Teams Dispatch
 
-> ⚠️ **MANDATORY**: Specialists are spawned as teammates via `Agent(name=..., team_name="{team_name}", subagent_type=...)`. The session team is created at session start per INSTRUCTIONS step 1. The `session_init` hook provides the specific team name in your session context.
+> ⚠️ **MANDATORY**: Specialists are spawned as teammates via `Agent(name=..., team_name="{team_name}", subagent_type=...)`. The session team is pre-created by the platform at session start per INSTRUCTIONS step 1. The `session_init` hook provides the specific team name in your session context.
 >
 > ⚠️ **NEVER** use plain `Agent(subagent_type=...)` without `name` and `team_name` for specialist agents. This bypasses team coordination, task tracking, and `SendMessage` communication.
 
@@ -385,7 +385,7 @@ After your first specialist spawn in a session — and after any subsequent spaw
 
 #### Hook WARN signals are STOP signals
 
-When a PreToolUse hook (`bootstrap_gate`, `dispatch_gate`, `team_guard`, etc.) emits a WARN-shaped advisory or a `permissionDecision: deny` rationale, treat it as a HARD STOP. **WARN means STOP and re-dispatch correctly** — not "note the warning and proceed". Rationalizing past a WARN ("the gate is overly cautious", "this case doesn't apply") is the failure mode the WARN exists to prevent. If a gate fires unexpectedly on a dispatch you believe is correct, the dispatch is likely subtly wrong; investigate before retrying.
+When a PreToolUse hook (`bootstrap_gate`, `dispatch_gate`, etc.) emits a WARN-shaped advisory or a `permissionDecision: deny` rationale, treat it as a HARD STOP. **WARN means STOP and re-dispatch correctly** — not "note the warning and proceed". Rationalizing past a WARN ("the gate is overly cautious", "this case doesn't apply") is the failure mode the WARN exists to prevent. If a gate fires unexpectedly on a dispatch you believe is correct, the dispatch is likely subtly wrong; investigate before retrying.
 
 ### Reuse vs. Spawn Decision
 

--- a/pact-plugin/commands/bootstrap.md
+++ b/pact-plugin/commands/bootstrap.md
@@ -1,5 +1,5 @@
 ---
-description: PACT session-start ritual — team create/reuse, secretary spawn, paused-state surface, bootstrap marker
+description: PACT session-start ritual — resolve the session team (platform-provisioned), secretary spawn, paused-state surface, bootstrap marker
 ---
 
 # Session-Start Ritual
@@ -8,12 +8,11 @@ The persona body's §2 Session-Start Ritual is your invocation contract; this co
 
 ---
 
-## Step 1 — Team create or reuse
+## Step 1 — Resolve the session team
 
 Read `team_name` from the **Current Session** block in the project's `CLAUDE.md` (preferred location: `$CLAUDE_PROJECT_DIR/.claude/CLAUDE.md`; legacy fallback: `$CLAUDE_PROJECT_DIR/CLAUDE.md`). The `session_init` hook writes this block at session start.
 
-- If `~/.claude/teams/{team_name}/config.json` exists → **reuse**: the team is live; do not recreate.
-- If absent → **create** via the Agent Teams `TeamCreate` action with `name={team_name}`. Every specialist dispatch requires the team to exist.
+The platform manages exactly one team per session, named `{team_name}` — it is provisioned automatically; you do not create it (the `TeamCreate`/`TeamDelete` tools no longer exist). Use `{team_name}` for every specialist dispatch.
 
 ## Step 2 — Spawn `pact-secretary`
 

--- a/pact-plugin/commands/comPACT.md
+++ b/pact-plugin/commands/comPACT.md
@@ -154,7 +154,7 @@ See also: [Communication Charter](../protocols/pact-communication-charter.md) fo
 ## Pre-Invocation (Required)
 
 1. **Set up worktree** — If already in a worktree for this feature, reuse it. Otherwise, invoke `/PACT:worktree-setup` with the feature branch name. All subsequent work happens in the worktree.
-2. **Verify session team exists** — The `{team_name}` team should already exist from session start. If not, create it now: `TeamCreate(team_name="{team_name}")`.
+2. **Session team** — The `{team_name}` team is provisioned automatically by the platform — use it for dispatches; you do not create it.
 3. **S2 coordination** (if concurrent) — Check for file conflicts, assign boundaries
 
 > **Teachback**: All dispatched specialists send a TEACHBACK before starting work (see [pact-ct-teachback.md](../protocols/pact-ct-teachback.md)).

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -256,7 +256,7 @@ Sequential execution is the exception requiring explicit justification. When ass
 ---
 
 1. **Set up worktree**: If already in a worktree for this feature, reuse it. Otherwise, invoke `/PACT:worktree-setup` with the feature branch name. This creates both the feature branch and its worktree. All subsequent phases work in the worktree.
-2. **Verify session team exists**: The `{team_name}` team should already exist from session start. If not, create it now: `TeamCreate(team_name="{team_name}")`.
+2. **Session team**: The `{team_name}` team is provisioned automatically by the platform — use it for dispatches; you do not create it.
 3. **Check for plan** in `docs/plans/` matching this task
 
 ### Plan Status Handling

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -711,7 +711,7 @@ Agent(
 )
 ```
 
-Spawn multiple coders in parallel (multiple `Task` calls in one response). Include worktree path and S2 scope boundaries in each task description.
+Spawn multiple coders in parallel (multiple `Agent` calls in one response). Include worktree path and S2 scope boundaries in each task description.
 
 Completed-phase teammates remain as consultants. Do not shutdown during this workflow.
 

--- a/pact-plugin/commands/peer-review.md
+++ b/pact-plugin/commands/peer-review.md
@@ -222,7 +222,7 @@ Agent(
 )
 ```
 
-Spawn all reviewers in parallel (multiple `Task` calls in one response).
+Spawn all reviewers in parallel (multiple `Agent` calls in one response).
 
 **Journal event**: After dispatching all reviewers, write a `review_dispatch` event:
 ```bash

--- a/pact-plugin/commands/peer-review.md
+++ b/pact-plugin/commands/peer-review.md
@@ -119,7 +119,7 @@ This trigger fires only when remediation occurred and changed things. Skip if no
 
 **PR Review Workflow**
 
-**Verify session team exists**: The `{team_name}` team should already exist from session start. If not, create it now: `TeamCreate(team_name="{team_name}")`.
+**Session team**: The `{team_name}` team is provisioned automatically by the platform — use it for dispatches; you do not create it.
 
 Pull request reviews should mirror real-world team practices where multiple reviewers sign off before merging. Dispatch **at least 3 reviewers in parallel** to provide comprehensive review coverage:
 

--- a/pact-plugin/commands/plan-mode.md
+++ b/pact-plugin/commands/plan-mode.md
@@ -100,7 +100,7 @@ Skip specialists clearly not relevant (e.g., skip database engineer for pure UI 
 
 ### Phase 1: Parallel Specialist Consultation
 
-**Verify session team exists**: The `{team_name}` team should already exist from session start. If not, create it now: `TeamCreate(team_name="{team_name}")`.
+**Session team**: The `{team_name}` team is provisioned automatically by the platform — use it for dispatches; you do not create it.
 
 Dispatch relevant specialists **in parallel**, each in **planning-only mode**.
 

--- a/pact-plugin/commands/rePACT.md
+++ b/pact-plugin/commands/rePACT.md
@@ -6,7 +6,7 @@ Run a recursive PACT cycle for this sub-task: $ARGUMENTS
 
 This command initiates a **nested P→A→C→T cycle** for a sub-task that is too complex for simple delegation but should remain part of the current feature work.
 
-**Team behavior**: rePACT spawns sub-scope teammates into the existing session team (`pact-{session_hash}`). No new team is created. Use scope-prefixed names (e.g., `backend-coder-auth-scope`) to distinguish sub-scope teammates from parent-scope teammates.
+**Team behavior**: rePACT spawns sub-scope teammates into the session team (`{team_name}`). The platform provisions the team; rePACT does not create a new one. Use scope-prefixed names (e.g., `backend-coder-auth-scope`) to distinguish sub-scope teammates from parent-scope teammates.
 
 ---
 
@@ -211,7 +211,7 @@ Design the sub-component:
 
 Implement the sub-component:
 
-**Verify session team exists**: The `{team_name}` team should already exist from session start. If not, create it now: `TeamCreate(team_name="{team_name}")`.
+**Session team**: The `{team_name}` team is provisioned automatically by the platform — use it for dispatches; you do not create it.
 
 **Teachback-Gated Dispatch**
 

--- a/pact-plugin/commands/wrap-up.md
+++ b/pact-plugin/commands/wrap-up.md
@@ -125,7 +125,7 @@ esac
 
 The `session_consolidated` write fires under the `true` branch regardless of whether step 6 takes the "PR still open" branch (which ALSO writes `session_paused`) or the "PR merged / no PR" branch (which previously wrote nothing and caused the false-positive warning). `{task_count}` and `{memories_saved}` come from the secretary's consolidation summary (step 1); when the secretary cannot produce exact counts, emit the event with `0` for either field rather than skipping the write — the event's EXISTENCE is the detector signal and the payload is advisory audit trail.
 
-**Recovery note**: The journal lives in `~/.claude/pact-sessions/{slug}/{session_id}/`, independent of the team directory — it survives both natural TTL cleanup and explicit `TeamDelete`. Old session directories are cleaned automatically after 30 days (with paused-session preservation). See [pact-state-recovery.md](../protocols/pact-state-recovery.md) for the full State Recovery Protocol.
+**Recovery note**: The journal lives in `~/.claude/pact-sessions/{slug}/{session_id}/`, independent of the team directory — it survives both natural TTL cleanup and explicit team teardown. Old session directories are cleaned automatically after 30 days (with paused-session preservation). See [pact-state-recovery.md](../protocols/pact-state-recovery.md) for the full State Recovery Protocol.
 
 ## 6. Worktree Cleanup
 
@@ -167,4 +167,3 @@ Use `AskUserQuestion` with these exact options:
 - **"Yes, continue"** (description: "Keep team alive, ready for next task") → On selection: Report "Ready for next task."
 - **"Pause work for now"** (description: "Save session knowledge and pause — resume later") → On selection: invoke `/PACT:pause`
 - **"No, end session"** (description: "Natural cleanup — platform reaps processes, 30-day TTL cleans directories (recommended)") → On selection: Report "Session complete. Teammate processes will be terminated when this session ends. Team and task directories (`~/.claude/teams/`, `~/.claude/tasks/`) are reaped automatically after 30 days by TTL cleanup."
-- **"End session (graceful)"** (description: "Explicit shutdown + TeamDelete — for immediate cleanup or recovery from interrupted sessions") → On selection: Shut down remaining teammates — send `shutdown_request` individually to each active teammate **by name**. Wait for each response. Delete the team (`TeamDelete`). If `TeamDelete` fails because active members remain, report which teammates are still running and ask the user whether to force shutdown or leave them. Report "Session complete."

--- a/pact-plugin/hooks/agent_handoff_emitter.py
+++ b/pact-plugin/hooks/agent_handoff_emitter.py
@@ -74,7 +74,6 @@ from shared.agent_handoff_marker import (
     sanitize_path_component,
     unclaim,
 )
-from shared.pact_context import get_team_name
 from shared.session_journal import append_event, get_journal_path, make_event
 from shared.task_utils import read_task_json
 
@@ -141,16 +140,21 @@ def main() -> None:
             raw_task_subject if not task_subject_was_missing else "(no subject)"
         )
 
-        # Sanitize path-joining components symmetrically with
-        # task_utils.read_task_json. task_id and team_name both flow into
-        # filesystem paths (read_task_json for the status read; the marker
-        # join inside shared.agent_handoff_marker.already_emitted for the
-        # O_EXCL dedup marker). A helper applied at a single producer-side
-        # site ensures the sink paths can never diverge.
+        # task_id (from stdin) is sanitized for the two filesystem sinks it
+        # feeds: read_task_json for the status read, and the marker join inside
+        # shared.agent_handoff_marker.already_emitted for the O_EXCL dedup
+        # marker. team_name is NOT sanitized here: it is read RAW from the
+        # session context (the SSOT minted by pact_context.generate_team_name(),
+        # which produces a "session-<id8>" name constrained to [a-f0-9-] at
+        # production time — path-safe by construction, not an untrusted input).
+        # Reading it raw matches the lead-side emit twin's marker-key derivation
+        # (task_lifecycle_gate._emit_lead_side_agent_handoff reads the same
+        # `get_pact_context().get("team_name", "")`), so all three emit paths
+        # converge on one O_EXCL marker key by construction. The deprecated
+        # stdin `team_name` read is dropped (a teammate-frame stdin value could
+        # diverge from the SSOT and split the marker dir).
         task_id = sanitize_path_component(str(task_id))
-        team_name = sanitize_path_component(
-            str(input_data.get("team_name") or get_team_name()).lower()
-        )
+        team_name = pact_context.get_pact_context().get("team_name", "")
 
         task_data = read_task_json(task_id, team_name)
 
@@ -228,18 +232,21 @@ def main() -> None:
 
         # #917: canonical-journal writability precondition. The O_EXCL marker
         # below is an optimistic "we emitted it" promise claimed BEFORE
-        # append_event. b1 can resolve a team_name for the marker dir (a stdin
-        # team_name on a teammate TaskCompleted frame) while its OWN session
-        # context is unpersisted (teammate persist is is_lead-gated, #877) ->
-        # get_journal_path() == "" -> the append below would FAIL after the
-        # marker is claimed, poisoning it and permanently suppressing the
-        # lead-side b2 emit via already_emitted(). Gate the claim on writability
-        # so a non-writable fire DEFERS to a writable one (the lead's b2)
-        # instead of poisoning. This is a PURE read (get_journal_path does not
-        # create the marker); mark-then-write exactly-once below is unchanged —
-        # only the precondition is added. get_journal_path() and append_event()
-        # resolve from the same _journal_path()/get_session_dir() source, so the
-        # gate cannot false-negative a fire that append would have written.
+        # append_event. On a teammate TaskCompleted frame, b1 resolves the
+        # marker team_name from the session context (get_pact_context, above)
+        # while its OWN session context may be unpersisted (teammate persist is
+        # is_lead-gated, #877) -> get_journal_path() == "" -> the append below
+        # would FAIL after the marker is claimed, poisoning it and permanently
+        # suppressing the lead-side b2 emit via already_emitted(). Gate the claim
+        # on writability so a non-writable fire DEFERS to a writable one (the
+        # lead's b2) instead of poisoning. This is a PURE read (get_journal_path
+        # does not create the marker); mark-then-write exactly-once below is
+        # unchanged — only the precondition is added. The marker team_name and
+        # get_journal_path()/append_event() now resolve from the SAME
+        # get_pact_context()/get_session_dir() source, so a resolvable team_name
+        # implies a resolvable journal path: the gate fires at least as often as
+        # it must and cannot false-negative a fire that append would have
+        # written.
         # F3: this gate is the TWIN of task_lifecycle_gate._emit_lead_side_agent_handoff
         # — keep both in parity. Mark-then-write / O_EXCL contract:
         # shared/agent_handoff_marker.already_emitted.

--- a/pact-plugin/hooks/bootstrap_marker_writer.py
+++ b/pact-plugin/hooks/bootstrap_marker_writer.py
@@ -5,7 +5,8 @@ Summary: Dual-event hook that writes the bootstrap-complete marker once the
          bootstrap ritual's pre-conditions are observable on disk (team config
          exists AND `secretary` is in members[]). Verify-and-refuse semantic:
          hook does NOT create pre-conditions; LLM ritual (commands/bootstrap.md
-         Steps 1-2) still owns TeamCreate + secretary spawn.
+         Steps 1-2) still owns team resolution + secretary spawn (the platform
+         provisions the session team).
 Used by: hooks.json — registered under TWO events, both running this same
          verify-and-refuse logic (#975):
            - UserPromptSubmit (no matcher — fires every prompt): steady-state

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -12,7 +12,7 @@ Performs PACT environment initialization:
 3b. One-time migration: wraps existing project CLAUDE.md in PACT_MANAGED boundary (#404)
 3d. Strips obsolete PACT_START/PACT_END kernel block from ~/.claude/CLAUDE.md (sunsets before v5.0.0)
 4. Checks for stale pinned context entries in project CLAUDE.md (delegated to staleness.py)
-5. Generates session-unique PACT team name and reminds orchestrator to create it
+5. Generates session-unique PACT team name and writes it to the session context (the platform pre-creates the team)
 5b. Writes session resume info (resume command, team, timestamp) to project CLAUDE.md
 6. Checks for in_progress Tasks (resumption context via Task integration)
 7. Restores last session snapshot for cross-session continuity
@@ -639,7 +639,7 @@ def main():
     3b. One-time migration: wraps existing project CLAUDE.md in PACT_MANAGED boundary (#404)
     3d. Strips obsolete PACT_START/PACT_END kernel block from ~/.claude/CLAUDE.md (sunsets before v5.0.0)
     4. Checks for stale pinned context entries in project CLAUDE.md (delegated to staleness.py)
-    5. Generates session-unique PACT team name and reminds orchestrator to create it
+    5. Generates session-unique PACT team name and writes it to the session context (the platform pre-creates the team)
     5b. Writes session resume info (resume command, team, timestamp) to project CLAUDE.md
     6. Checks for in_progress Tasks (resumption context via Task integration)
     7. Restores last session snapshot for cross-session continuity
@@ -1071,13 +1071,6 @@ def main():
                     ),
                 )
 
-        try:
-            team_config = get_claude_config_dir() / "teams" / team_name / "config.json"
-            team_exists = team_config.exists()
-        except OSError:
-            # Fail-open: if filesystem check fails, assume fresh session
-            team_exists = False
-
         # Resolve session_dir early so substitution instructions can include it.
         # get_session_dir() works here because build_context_cache() populated _cache above.
         # Suppress session_dir for the unknown-* sentinel so the literal
@@ -1087,7 +1080,8 @@ def main():
         # below.
         session_dir = get_session_dir() if not session_id_was_missing else ""
 
-        # Build context message based on source × team_exists (5 paths)
+        # Build context message based on source (post-collapse: the team always
+        # exists — the platform pre-creates exactly one team per session).
         # Session placeholder variable substitution instructions tell the orchestrator how to
         # replace {team_name}, {session_dir}, and {plugin_root} in command snippets.
         if session_dir:
@@ -1105,23 +1099,23 @@ def main():
                 f'do not run commands that depend on {{session_dir}} until next clean start. '
                 f'Use `{plugin_root}` wherever {{plugin_root}} appears in commands.'
             )
-        _team_reuse = (
+        # Single platform-managed directive for every session source. The
+        # platform pre-creates exactly one team per session (Claude Code
+        # v2.1.178+), so the team always exists by the time the orchestrator
+        # acts — the directive's only job is to name the team and block until
+        # bootstrap completes. "(provided by the platform for this session)" is
+        # correct for both fresh and resumed sessions, so no team-existence
+        # discrimination is needed. The bootstrap-blocking sentence is the
+        # universal floor: it aligns this guidance with the bootstrap_gate
+        # PreToolUse hook, which already mechanically blocks Edit/Write/Agent
+        # until the bootstrap marker is stamped regardless of session source.
+        _team_directive = (
             f'YOUR PACT ROLE: orchestrator.\n\n'
             f'Invoke Skill("PACT:bootstrap") immediately, without waiting for user input. '
             f'Do this before anything else. '
             f'Do not evaluate whether it is needed. '
             f'You must invoke Skill("PACT:bootstrap") on every session start.\n\n'
-            f'Your team is `{team_name}` (existing — resumed session). '
-            f'Do not call TeamCreate — the team already exists. '
-            f'{_substitutions}'
-        )
-        _team_create = (
-            f'YOUR PACT ROLE: orchestrator.\n\n'
-            f'Invoke Skill("PACT:bootstrap") immediately, without waiting for user input. '
-            f'Do this before anything else. '
-            f'Do not evaluate whether it is needed. '
-            f'You must invoke Skill("PACT:bootstrap") on every session start.\n\n'
-            f'Your team is `{team_name}` (auto-created by the platform for this session). '
+            f'Your team is `{team_name}` (provided by the platform for this session). '
             f'Do not read files, explore code, or respond to the user until bootstrap is complete. '
             f'{_substitutions}'
         )
@@ -1199,12 +1193,15 @@ def main():
             except Exception:
                 pass  # fail-open: no injection; never the orchestrator safety-net
         else:
-            if source == "compact" and team_exists:
-                # Post-compaction: bootstrap directive (in _team_reuse) subsumes
-                # "recover state" guidance; keep concrete task-resumption bullets
-                # for the orchestrator's next actions after bootstrap.
+            # The team always exists (the platform pre-creates it), so the
+            # directive is source-agnostic; the per-source branches differ only
+            # in the recovery/state guidance appended after it.
+            if source == "compact":
+                # Post-compaction: bootstrap directive subsumes "recover state"
+                # guidance; keep concrete task-resumption bullets for the
+                # orchestrator's next actions after bootstrap.
                 context_parts.insert(0, (
-                    f'{_team_reuse} '
+                    f'{_team_directive} '
                     f'After bootstrap, recover session state: '
                     f'(1) Read {get_compact_summary_path()} for prior context, '
                     f'(2) Run TaskList to find in-progress work, '
@@ -1228,10 +1225,10 @@ def main():
                             blockers=find_blockers(tasks),
                         )
                         context_parts.append(_checkpoint_block)
-            elif source == "clear" and team_exists:
+            elif source == "clear":
                 # Context cleared via /clear: no compact-summary, but team and tasks survive
                 context_parts.insert(0, (
-                    f'{_team_reuse} '
+                    f'{_team_directive} '
                     f'CONTEXT CLEARED: Your context was cleared via /clear. '
                     f'State recovery: '
                     f'(1) TaskList for current tasks, '
@@ -1239,50 +1236,30 @@ def main():
                     f"Re-engage secretary: SendMessage(to='secretary', "
                     f"message='Context cleared: deliver fresh briefing with current project state.')."
                 ))
-            elif source == "resume" and team_exists:
+            elif source == "resume":
                 # Normal resume: model retains context, team exists
                 context_parts.insert(0, (
-                    f'{_team_reuse} '
+                    f'{_team_directive} '
                     f'Check session journal for paused state from /PACT:pause.'
                 ))
-            elif source == "startup" and not team_exists:
-                # Fresh session: full initialization
-                context_parts.insert(0, _team_create)
-            elif team_exists:
-                # Anomalous: unexpected source but team exists (e.g., startup + team exists)
-                # Reuse team, note the anomaly
-                context_parts.insert(0, (
-                    f'{_team_reuse} '
-                    f'Note: Unexpected session source "{source}" with existing team — '
-                    f'reusing team. Run TaskList to check current state.'
-                ))
+            elif source == "startup":
+                # Fresh session: bare directive (no extra recovery guidance)
+                context_parts.insert(0, _team_directive)
             else:
-                # Differentiate the no-team branch by whether `source` is a
-                # recognized lifecycle value:
-                #   - known source + no team → informational note (recovery
-                #     hint stays; no WARNING tone). Legitimate first-session-
-                #     after-stale-CLAUDE.md class.
-                #   - unknown source + no team → emit WARNING in
-                #     additionalContext AND stderr for observability (debug
-                #     logs surface the malformed-stdin signal).
-                _KNOWN_SOURCES = {"startup", "resume", "compact", "clear"}
-                if source in _KNOWN_SOURCES:
-                    context_parts.insert(0, (
-                        f'{_team_create} '
-                        f'Session source "{source}" without team — '
-                        f'creating fresh team. Run TaskList to check current state.'
-                    ))
-                else:
-                    print(
-                        f"session_init: unknown source value: {source!r}",
-                        file=sys.stderr,
-                    )
-                    context_parts.insert(0, (
-                        f'{_team_create} '
-                        f'WARNING: Unrecognized session source "{source}" — '
-                        f'previous session state may be lost. '
-                        f'Check TaskList for recovery context.'
-                    ))
+                # Unrecognized lifecycle source value. The team still exists
+                # (platform pre-creates it), so there is no "no team" case to
+                # handle — only an observability concern: surface the malformed
+                # `source` in additionalContext AND on stderr so debug logs
+                # capture the unexpected-stdin signal.
+                print(
+                    f"session_init: unknown source value: {source!r}",
+                    file=sys.stderr,
+                )
+                context_parts.insert(0, (
+                    f'{_team_directive} '
+                    f'Note: unrecognized session source "{source}". '
+                    f'Run TaskList to check current state.'
+                ))
 
         # 5a. Capture the PREVIOUS session's dir from project CLAUDE.md
         # before step 5b overwrites the Current Session block with THIS

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -21,7 +21,7 @@ import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
-from .session_state import SESSION_ID_CONTROL_CHARS_RE
+from .session_state import SESSION_ID_CONTROL_CHARS_RE, is_safe_path_component
 # One-directional import: session_registry is a self-contained leaf (imports
 # nothing from shared.*), so this introduces NO circular import. Used by
 # resolve_agent_name Step 3.5 to recover a tmux teammate's friendly name.
@@ -59,6 +59,23 @@ _EMPTY_CONTEXT = {
     "plugin_root": "",
     "started_at": "",
 }
+
+# Read-boundary path-safety guard for team_name. The persisted value is minted
+# by generate_team_name() ("session-<[a-f0-9-]>"), but get_pact_context()
+# re-validates what it reads back so the path-safety guarantee does NOT rest
+# solely on the producer + the downstream sinks: a future writer that bypasses
+# generate_team_name() (a hand-edited context file, a divergent minter) cannot
+# leak a path-unsafe team_name through the read boundary. Validation reuses
+# is_safe_path_component (the SAME positive allowlist the sinks apply —
+# read_task_json's team-dir guard and the marker derivation), so the read
+# boundary is consistent with, not stricter than, the sinks; it still rejects
+# the path-traversal primitives INFO-1 targets (`/`, `\`, `..`, `.`, NUL, C0
+# controls, whitespace). A non-conforming value is REJECTED TO EMPTY ("") rather
+# than sanitized — an empty team_name is the existing fail-open/defer signal
+# everywhere downstream (the _EMPTY_CONTEXT contract), so an invalid value
+# degrades to the same safe state instead of being silently mutated into a
+# different-but-"valid" name (which could mask a real corruption signal and
+# still target an unintended dir).
 
 
 def reset_for_tests() -> None:
@@ -235,8 +252,27 @@ def get_pact_context() -> dict:
 
     try:
         data = json.loads(ctx_path.read_text(encoding="utf-8"))
+        # Read-boundary path-safety re-validation (defense in depth). A team_name
+        # that is not a safe single path component is rejected to "" — the
+        # existing fail-open/defer signal — rather than passed through raw.
+        # is_safe_path_component is False for empty/non-str input, so an
+        # already-empty value stays "" (a no-op that preserves the empty-context
+        # defer path); every value generate_team_name mints passes, so this is
+        # behavior-preserving today. Log the rejection on stderr (an invalid
+        # persisted team_name is an anomaly worth surfacing in debug logs),
+        # mirroring the read-error stderr path below.
+        raw_team_name = str(data.get("team_name", ""))
+        if raw_team_name and not is_safe_path_component(raw_team_name):
+            print(
+                f"pact_context: rejecting unsafe team_name "
+                f"{raw_team_name!r} from context (using empty)",
+                file=sys.stderr,
+            )
+            team_name = ""
+        else:
+            team_name = raw_team_name
         _cache = {
-            "team_name": str(data.get("team_name", "")),
+            "team_name": team_name,
             "session_id": str(data.get("session_id", "")),
             "project_dir": str(data.get("project_dir", "")),
             "plugin_root": str(data.get("plugin_root", "")),

--- a/pact-plugin/hooks/shared/task_utils.py
+++ b/pact-plugin/hooks/shared/task_utils.py
@@ -467,13 +467,22 @@ def read_task_json(
     base = Path(tasks_base_dir)
 
     task_dirs = []
+    # Case-fold for the team-dir lookup so this status-read sink and the O_EXCL
+    # marker sink treat team_name case IDENTICALLY. The marker SSOT
+    # (agent_handoff_marker._resolve_marker_target) lowercases team_name before
+    # deriving its dir; this reader historically did not, so the two sinks could
+    # diverge on a mixed-case name. Harmless today (generate_team_name mints
+    # lowercase-only "session-[a-f0-9-]"), so this is a latent-only convergence:
+    # for any real value lowered == original. Validate the FOLDED value so a
+    # name that is safe only after folding cannot reach the join.
+    team_name_lc = team_name.lower() if team_name else team_name
     # Bounded containment parity, guard (1): reject a traversal team_name
     # (mirror iter_team_task_jsons's is_safe_path_component return-on-invalid).
     # An unsafe team_name skips the team dir and falls through to the bare-base
     # read, preserving the fail-open {} contract. Legit pact-<slug>/UUID names
     # are single [A-Za-z0-9_-] components and pass unchanged.
-    if team_name and is_safe_path_component(team_name):
-        task_dirs.append(base / team_name)
+    if team_name_lc and is_safe_path_component(team_name_lc):
+        task_dirs.append(base / team_name_lc)
     task_dirs.append(base)
 
     for task_dir in task_dirs:

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -1773,7 +1773,7 @@ When Claude Code Agent Teams reaches stable release, it could serve as an altern
 
 | Interface Element | Agent Teams Mapping |
 |-------------------|---------------------|
-| **Input: scope_contract** | Passed in the teammate spawn prompt via `Task` tool (with `team_name` and `name` parameters) |
+| **Input: scope_contract** | Passed in the teammate spawn prompt via `Agent` tool (with `team_name` and `name` parameters) |
 | **Input: feature_context** | Inherited via CLAUDE.md (auto-loaded by teammates) plus the spawn prompt |
 | **Input: worktree_path** | Worktree working directory (teammate operates in the assigned worktree) |
 | **Input: nesting_depth** | Communicated in the spawn prompt; no nested teams allowed (enforced by Agent Teams) |
@@ -1786,7 +1786,7 @@ When Claude Code Agent Teams reaches stable release, it could serve as an altern
 
 | Tool | Purpose | PACT Mapping |
 |------|---------|--------------|
-| `Task` (with `team_name`, `name`) | Spawn a teammate into the team | One teammate per sub-scope |
+| `Agent` (with `team_name`, `name`) | Spawn a teammate into the team | One teammate per sub-scope |
 | `SendMessage` (type: `"message"`) | Direct message from teammate to team-lead | Handoff delivery, blocker reporting |
 | `SendMessage` (type: `"shutdown_request"`) | Request teammate graceful exit | Sub-scope completion acknowledgment |
 | `TaskCreate`/`TaskUpdate` | Shared task list management | Status tracking across sub-scopes |

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -1133,7 +1133,7 @@ Invoke multiple specialists when:
 ### Pre-Invocation (Required)
 
 1. **Set up worktree** — If already in a worktree for this feature, reuse it. Otherwise, invoke `/PACT:worktree-setup` with the feature branch name. All subsequent work happens in the worktree.
-2. **Verify session team exists** — The `{team_name}` team should already exist from session start. If not, create it now: `TeamCreate(team_name="{team_name}")`.
+2. **Session team** — The `{team_name}` team is provisioned automatically by the platform — use it for dispatches; you do not create it.
 3. **S2 coordination** (if concurrent) — Check for file conflicts, assign boundaries
 
 ### S2 Light Coordination (for parallel comPACT)
@@ -1786,12 +1786,10 @@ When Claude Code Agent Teams reaches stable release, it could serve as an altern
 
 | Tool | Purpose | PACT Mapping |
 |------|---------|--------------|
-| `TeamCreate` | Create a team (with `team_name`, optional `description`) | One team per scoped orchestration |
 | `Task` (with `team_name`, `name`) | Spawn a teammate into the team | One teammate per sub-scope |
 | `SendMessage` (type: `"message"`) | Direct message from teammate to team-lead | Handoff delivery, blocker reporting |
 | `SendMessage` (type: `"shutdown_request"`) | Request teammate graceful exit | Sub-scope completion acknowledgment |
 | `TaskCreate`/`TaskUpdate` | Shared task list management | Status tracking across sub-scopes |
-| `TeamDelete` | Remove team and task directories | Cleanup after scoped orchestration completes |
 
 **Architectural notes**:
 
@@ -2270,7 +2268,7 @@ From most to least durable:
 
 | Source | Location | Survives | Use For |
 |--------|----------|----------|---------|
-| **Session journal** | `~/.claude/pact-sessions/{slug}/{session_id}/session-journal.jsonl` | Compaction, task GC, TeamDelete, crashes | HANDOFFs, phase progress, variety scores, commits, pause state |
+| **Session journal** | `~/.claude/pact-sessions/{slug}/{session_id}/session-journal.jsonl` | Compaction, task GC, team teardown, crashes | HANDOFFs, phase progress, variety scores, commits, pause state |
 | **Task system** | `TaskList` / `TaskGet` | Compaction (summaries only) | Status, blocking, assignment. Task *files* (metadata) may be GC'd |
 | **pact-memory** | `~/.claude/pact-memory/memory.db` | Permanently | Cross-session knowledge (not workflow state) |
 
@@ -2337,7 +2335,7 @@ The journal survives crashes because:
 - **POSIX O_APPEND** guarantees atomic writes — partial writes don't corrupt earlier entries
 - **JSONL format** — each line is self-contained; one malformed line doesn't affect others
 - **Fail-open reads** — `read_events()` silently skips malformed lines
-- **Session-scoped storage** — the journal lives in `~/.claude/pact-sessions/`, not `~/.claude/teams/`, so `TeamDelete` does not remove it
+- **Session-scoped storage** — the journal lives in `~/.claude/pact-sessions/`, not `~/.claude/teams/`, so team teardown does not remove it
 
 The wrap-up command harvests journal events to pact-memory before session close. The journal persists in the sessions directory for 30 days (TTL cleanup), providing a recovery window even if harvest fails. Paused sessions are exempt from TTL cleanup.
 

--- a/pact-plugin/protocols/pact-scope-contract.md
+++ b/pact-plugin/protocols/pact-scope-contract.md
@@ -136,12 +136,10 @@ When Claude Code Agent Teams reaches stable release, it could serve as an altern
 
 | Tool | Purpose | PACT Mapping |
 |------|---------|--------------|
-| `TeamCreate` | Create a team (with `team_name`, optional `description`) | One team per scoped orchestration |
 | `Task` (with `team_name`, `name`) | Spawn a teammate into the team | One teammate per sub-scope |
 | `SendMessage` (type: `"message"`) | Direct message from teammate to team-lead | Handoff delivery, blocker reporting |
 | `SendMessage` (type: `"shutdown_request"`) | Request teammate graceful exit | Sub-scope completion acknowledgment |
 | `TaskCreate`/`TaskUpdate` | Shared task list management | Status tracking across sub-scopes |
-| `TeamDelete` | Remove team and task directories | Cleanup after scoped orchestration completes |
 
 **Architectural notes**:
 

--- a/pact-plugin/protocols/pact-scope-contract.md
+++ b/pact-plugin/protocols/pact-scope-contract.md
@@ -123,7 +123,7 @@ When Claude Code Agent Teams reaches stable release, it could serve as an altern
 
 | Interface Element | Agent Teams Mapping |
 |-------------------|---------------------|
-| **Input: scope_contract** | Passed in the teammate spawn prompt via `Task` tool (with `team_name` and `name` parameters) |
+| **Input: scope_contract** | Passed in the teammate spawn prompt via `Agent` tool (with `team_name` and `name` parameters) |
 | **Input: feature_context** | Inherited via CLAUDE.md (auto-loaded by teammates) plus the spawn prompt |
 | **Input: worktree_path** | Worktree working directory (teammate operates in the assigned worktree) |
 | **Input: nesting_depth** | Communicated in the spawn prompt; no nested teams allowed (enforced by Agent Teams) |
@@ -136,7 +136,7 @@ When Claude Code Agent Teams reaches stable release, it could serve as an altern
 
 | Tool | Purpose | PACT Mapping |
 |------|---------|--------------|
-| `Task` (with `team_name`, `name`) | Spawn a teammate into the team | One teammate per sub-scope |
+| `Agent` (with `team_name`, `name`) | Spawn a teammate into the team | One teammate per sub-scope |
 | `SendMessage` (type: `"message"`) | Direct message from teammate to team-lead | Handoff delivery, blocker reporting |
 | `SendMessage` (type: `"shutdown_request"`) | Request teammate graceful exit | Sub-scope completion acknowledgment |
 | `TaskCreate`/`TaskUpdate` | Shared task list management | Status tracking across sub-scopes |

--- a/pact-plugin/protocols/pact-state-recovery.md
+++ b/pact-plugin/protocols/pact-state-recovery.md
@@ -10,7 +10,7 @@ From most to least durable:
 
 | Source | Location | Survives | Use For |
 |--------|----------|----------|---------|
-| **Session journal** | `~/.claude/pact-sessions/{slug}/{session_id}/session-journal.jsonl` | Compaction, task GC, TeamDelete, crashes | HANDOFFs, phase progress, variety scores, commits, pause state |
+| **Session journal** | `~/.claude/pact-sessions/{slug}/{session_id}/session-journal.jsonl` | Compaction, task GC, team teardown, crashes | HANDOFFs, phase progress, variety scores, commits, pause state |
 | **Task system** | `TaskList` / `TaskGet` | Compaction (summaries only) | Status, blocking, assignment. Task *files* (metadata) may be GC'd |
 | **pact-memory** | `~/.claude/pact-memory/memory.db` | Permanently | Cross-session knowledge (not workflow state) |
 
@@ -77,7 +77,7 @@ The journal survives crashes because:
 - **POSIX O_APPEND** guarantees atomic writes — partial writes don't corrupt earlier entries
 - **JSONL format** — each line is self-contained; one malformed line doesn't affect others
 - **Fail-open reads** — `read_events()` silently skips malformed lines
-- **Session-scoped storage** — the journal lives in `~/.claude/pact-sessions/`, not `~/.claude/teams/`, so `TeamDelete` does not remove it
+- **Session-scoped storage** — the journal lives in `~/.claude/pact-sessions/`, not `~/.claude/teams/`, so team teardown does not remove it
 
 The wrap-up command harvests journal events to pact-memory before session close. The journal persists in the sessions directory for 30 days (TTL cleanup), providing a recovery window even if harvest fails. Paused sessions are exempt from TTL cleanup.
 

--- a/pact-plugin/protocols/pact-workflows.md
+++ b/pact-plugin/protocols/pact-workflows.md
@@ -135,7 +135,7 @@ Invoke multiple specialists when:
 ### Pre-Invocation (Required)
 
 1. **Set up worktree** — If already in a worktree for this feature, reuse it. Otherwise, invoke `/PACT:worktree-setup` with the feature branch name. All subsequent work happens in the worktree.
-2. **Verify session team exists** — The `{team_name}` team should already exist from session start. If not, create it now: `TeamCreate(team_name="{team_name}")`.
+2. **Session team** — The `{team_name}` team is provisioned automatically by the platform — use it for dispatches; you do not create it.
 3. **S2 coordination** (if concurrent) — Check for file conflicts, assign boundaries
 
 ### S2 Light Coordination (for parallel comPACT)

--- a/pact-plugin/skills/README.md
+++ b/pact-plugin/skills/README.md
@@ -6,4 +6,4 @@
 - Examples: `pact-agent-teams`, `pact-memory`, `pact-coding-standards`
 
 ## Auto-Loading
-Skills listed in an agent's frontmatter `skills:` field are automatically loaded when the agent is invoked via the Task tool.
+Skills listed in an agent's frontmatter `skills:` field are automatically loaded when the agent is invoked via the Agent tool.

--- a/pact-plugin/tests/fixtures/emitter.py
+++ b/pact-plugin/tests/fixtures/emitter.py
@@ -48,6 +48,21 @@ def _run_main(stdin_payload, task_data, append_calls, journal_path=WRITABLE_TEST
     UNWRITABLE defer path. The hook imports get_journal_path by value, so the
     patch targets the symbol bound in ``agent_handoff_emitter`` — NOT
     ``session_journal`` — or the gate would read the real resolution.
+
+    The marker ``team_name`` is resolved from the SESSION CONTEXT
+    (``pact_context.get_pact_context()``), NOT from the stdin ``team_name``
+    field — the b1 emitter reads the SSOT context so all three emit paths
+    (b1/b2/b3) converge on one O_EXCL marker key by construction. To model a
+    resolvable-context b1 process, this helper patches ``get_pact_context`` to
+    return a context whose ``team_name`` is taken from the stdin payload's
+    ``team_name`` (the SAME logical name session_init would have persisted to
+    the context). So a payload ``team_name="pact-test"`` still scopes the
+    marker to ``teams/pact-test/`` — the marker now travels through the
+    context channel instead of stdin. (Production guarantees the context
+    team_name is a ``session-<id8>`` value minted by generate_team_name, so a
+    degenerate context team_name cannot occur; tests that probe a degenerate
+    team_name attack via stdin no longer exercise a live path post-rebind —
+    that vector is closed by construction.)
     """
     # Lazy import: sys.path is configured in conftest.py before this module loads.
     # Do not hoist to module-level — sys.path coupling depends on conftest load order.
@@ -57,9 +72,22 @@ def _run_main(stdin_payload, task_data, append_calls, journal_path=WRITABLE_TEST
         append_calls.append(event)
         return True
 
+    # Mirror the context session_init would have persisted: the marker team_name
+    # now flows through get_pact_context(), not stdin. Source it from the stdin
+    # payload's team_name so existing per-test expectations (marker under
+    # teams/<team_name>/) hold under the rebind.
+    _ctx = {
+        "team_name": stdin_payload.get("team_name", ""),
+        "session_id": "",
+        "project_dir": "",
+        "plugin_root": "",
+        "started_at": "",
+    }
+
     with patch("agent_handoff_emitter.read_task_json", return_value=task_data), \
          patch("agent_handoff_emitter.append_event", side_effect=_append_spy), \
          patch("agent_handoff_emitter.get_journal_path", return_value=journal_path), \
+         patch("agent_handoff_emitter.pact_context.get_pact_context", return_value=_ctx), \
          patch("sys.stdin", io.StringIO(json.dumps(stdin_payload))):
         with pytest.raises(SystemExit) as exc_info:
             main()

--- a/pact-plugin/tests/fixtures/emitter.py
+++ b/pact-plugin/tests/fixtures/emitter.py
@@ -38,7 +38,16 @@ VALID_HANDOFF = {
 WRITABLE_TEST_JOURNAL = "/pact-test-session/session-journal.jsonl"
 
 
-def _run_main(stdin_payload, task_data, append_calls, journal_path=WRITABLE_TEST_JOURNAL):
+_USE_STDIN_TEAM_NAME = object()  # sentinel: context team_name mirrors stdin (default)
+
+
+def _run_main(
+    stdin_payload,
+    task_data,
+    append_calls,
+    journal_path=WRITABLE_TEST_JOURNAL,
+    context_team_name=_USE_STDIN_TEAM_NAME,
+):
     """Invoke agent_handoff_emitter.main() with patched IO/deps.
 
     ``journal_path`` is the value the in-hook ``get_journal_path()`` returns
@@ -54,15 +63,22 @@ def _run_main(stdin_payload, task_data, append_calls, journal_path=WRITABLE_TEST
     field — the b1 emitter reads the SSOT context so all three emit paths
     (b1/b2/b3) converge on one O_EXCL marker key by construction. To model a
     resolvable-context b1 process, this helper patches ``get_pact_context`` to
-    return a context whose ``team_name`` is taken from the stdin payload's
-    ``team_name`` (the SAME logical name session_init would have persisted to
-    the context). So a payload ``team_name="pact-test"`` still scopes the
-    marker to ``teams/pact-test/`` — the marker now travels through the
-    context channel instead of stdin. (Production guarantees the context
+    return a context whose ``team_name`` is, by default, taken from the stdin
+    payload's ``team_name`` (the SAME logical name session_init would have
+    persisted to the context). So a payload ``team_name="pact-test"`` still
+    scopes the marker to ``teams/pact-test/`` — the marker now travels through
+    the context channel instead of stdin. (Production guarantees the context
     team_name is a ``session-<id8>`` value minted by generate_team_name, so a
     degenerate context team_name cannot occur; tests that probe a degenerate
     team_name attack via stdin no longer exercise a live path post-rebind —
     that vector is closed by construction.)
+
+    ``context_team_name`` DECOUPLES the two channels. By default it mirrors the
+    stdin ``team_name`` (preserving every existing caller). Pass an explicit
+    value to make the context team_name DIFFER from the stdin team_name — the
+    only way to demonstrate the post-rebind containment property that the stdin
+    ``team_name`` is INERT (a hostile stdin value cannot reach the marker key
+    when the authoritative context team_name is path-safe).
     """
     # Lazy import: sys.path is configured in conftest.py before this module loads.
     # Do not hoist to module-level — sys.path coupling depends on conftest load order.
@@ -74,10 +90,17 @@ def _run_main(stdin_payload, task_data, append_calls, journal_path=WRITABLE_TEST
 
     # Mirror the context session_init would have persisted: the marker team_name
     # now flows through get_pact_context(), not stdin. Source it from the stdin
-    # payload's team_name so existing per-test expectations (marker under
-    # teams/<team_name>/) hold under the rebind.
+    # payload's team_name by default so existing per-test expectations (marker
+    # under teams/<team_name>/) hold under the rebind; an explicit
+    # ``context_team_name`` decouples the channels for the stdin-inert containment
+    # proof.
+    _resolved_ctx_team = (
+        stdin_payload.get("team_name", "")
+        if context_team_name is _USE_STDIN_TEAM_NAME
+        else context_team_name
+    )
     _ctx = {
-        "team_name": stdin_payload.get("team_name", ""),
+        "team_name": _resolved_ctx_team,
         "session_id": "",
         "project_dir": "",
         "plugin_root": "",

--- a/pact-plugin/tests/test_commands_structure.py
+++ b/pact-plugin/tests/test_commands_structure.py
@@ -98,12 +98,12 @@ class TestAskUserQuestionOptions:
 
     # --- wrap-up.md Step 8 ---
 
-    def test_wrapup_has_four_options(self, wrapup_content):
-        """Step 8 session decision has 4 options."""
+    def test_wrapup_has_three_options(self, wrapup_content):
+        """Step 8 session decision has 3 options (graceful option removed — TeamDelete tool gone)."""
         # Extract only from the Session Decision section (after "Session Decision")
         session_section = wrapup_content.split("Session Decision")[1]
         labels = _extract_option_labels(session_section)
-        assert len(labels) == 4, f"wrap-up.md session decision should have 4 options, found {len(labels)}: {labels}"
+        assert len(labels) == 3, f"wrap-up.md session decision should have 3 options, found {len(labels)}: {labels}"
 
     def test_wrapup_yes_continue_option(self, wrapup_content):
         assert '"Yes, continue"' in wrapup_content
@@ -114,8 +114,9 @@ class TestAskUserQuestionOptions:
     def test_wrapup_no_end_session_option(self, wrapup_content):
         assert '"No, end session"' in wrapup_content
 
-    def test_wrapup_graceful_end_session_option(self, wrapup_content):
-        assert '"End session (graceful)"' in wrapup_content
+    def test_wrapup_no_graceful_end_session_option(self, wrapup_content):
+        """Regression guard: graceful option removed (TeamDelete tool gone)."""
+        assert '"End session (graceful)"' not in wrapup_content
 
     def test_wrapup_pause_invokes_pause_command(self, wrapup_content):
         """Pause option should invoke /PACT:pause."""

--- a/pact-plugin/tests/test_dogfood_livelock_invariant.py
+++ b/pact-plugin/tests/test_dogfood_livelock_invariant.py
@@ -299,10 +299,22 @@ def _run_emitter(stdin_payload, task_data, append_calls, tmp_home, monkeypatch):
     # writability gate passes (append_event is spied, so the path is never
     # written — any truthy value satisfies the gate). The journal-unwritable
     # defer path is covered in test_handoff_writability_parity.py.
+    # The marker team_name now resolves from the SESSION CONTEXT (not stdin) —
+    # model the context session_init would have persisted, sourcing team_name
+    # from the stdin payload so the marker stays scoped to teams/<team_name>/.
+    _ctx = {
+        "team_name": stdin_payload.get("team_name", ""),
+        "session_id": "",
+        "project_dir": "",
+        "plugin_root": "",
+        "started_at": "",
+    }
     with patch("agent_handoff_emitter.read_task_json", return_value=task_data), \
          patch("agent_handoff_emitter.append_event", side_effect=_append_spy), \
          patch("agent_handoff_emitter.get_journal_path",
                return_value=WRITABLE_TEST_JOURNAL), \
+         patch("agent_handoff_emitter.pact_context.get_pact_context",
+               return_value=_ctx), \
          patch("sys.stdin", io.StringIO(json.dumps(stdin_payload))):
         with pytest.raises(SystemExit) as exc_info:
             main()

--- a/pact-plugin/tests/test_emitter_idempotency.py
+++ b/pact-plugin/tests/test_emitter_idempotency.py
@@ -231,10 +231,18 @@ class TestMarkerFailOpen:
         # append_event returns None (silent failure), event is lost.
         # get_journal_path patched truthy → the #917 writability gate passes,
         # isolating the residual writable-but-write-fails scenario (see docstring).
+        # Marker team_name now resolves from the session context (not stdin) —
+        # model the persisted context (team_name="pact-test") so the marker
+        # lands at the asserted teams/pact-test/ path.
+        _ctx = {
+            "team_name": "pact-test", "session_id": "", "project_dir": "",
+            "plugin_root": "", "started_at": "",
+        }
         with patch("agent_handoff_emitter.read_task_json", return_value=task_data), \
              patch("agent_handoff_emitter.append_event", side_effect=_append_silent_fail), \
              patch("agent_handoff_emitter.get_journal_path",
                    return_value=WRITABLE_TEST_JOURNAL), \
+             patch("agent_handoff_emitter.pact_context.get_pact_context", return_value=_ctx), \
              patch("sys.stdin", io.StringIO(json.dumps(payload))):
             with pytest.raises(SystemExit) as exc1:
                 main()
@@ -270,6 +278,7 @@ class TestMarkerFailOpen:
              patch("agent_handoff_emitter.append_event", side_effect=_append_succeed), \
              patch("agent_handoff_emitter.get_journal_path",
                    return_value=WRITABLE_TEST_JOURNAL), \
+             patch("agent_handoff_emitter.pact_context.get_pact_context", return_value=_ctx), \
              patch("sys.stdin", io.StringIO(json.dumps(payload))):
             with pytest.raises(SystemExit) as exc2:
                 main()

--- a/pact-plugin/tests/test_emitter_path_sanitization.py
+++ b/pact-plugin/tests/test_emitter_path_sanitization.py
@@ -418,6 +418,14 @@ class TestPathSanitization:
             is covered separately by
             ``test_stdin_team_name_is_inert_post_rebind``.
 
+            DEFENSE-IN-DEPTH, NOT A LIVE VECTOR: in production the context
+            team_name is ALWAYS a ``generate_team_name`` value
+            (``session-[a-f0-9-]``, path-safe by construction — pinned by
+            ``test_marker_team_name_source_is_path_safe``), so a degenerate
+            CONTEXT team_name is impossible-in-prod. This test exercises the
+            #24 empty/dot guard as defense-in-depth on a can't-happen input —
+            do NOT re-read it as a live attack path.
+
             Pre-#24 with team_name='..': marker_dir resolves to
             `home/.claude/teams/../.agent_handoff_emitted`, which Path-
             normalizes to `home/.claude/.agent_handoff_emitted` — a
@@ -537,6 +545,13 @@ class TestPathSanitization:
             collapses). Post-#24 guard returns False on EITHER axis
             being degenerate, so the compound case short-circuits via
             the first matched branch.
+
+            DEFENSE-IN-DEPTH, NOT A LIVE VECTOR: the degenerate CONTEXT
+            team_name axis is impossible-in-prod (the context team_name is
+            always generate_team_name's ``session-[a-f0-9-]`` form — see
+            ``test_marker_team_name_source_is_path_safe``). This compound
+            test is a defensive regression guard on the #24 guard machinery,
+            not a live attack path.
             """
             monkeypatch.setenv("HOME", str(tmp_path))
             # Non-vacuity capture: prove the degenerate team_name reached the

--- a/pact-plugin/tests/test_emitter_path_sanitization.py
+++ b/pact-plugin/tests/test_emitter_path_sanitization.py
@@ -1,4 +1,5 @@
 """Path sanitization tests for agent_handoff_emitter.py."""
+import re
 from pathlib import Path
 
 import pytest
@@ -198,6 +199,25 @@ class TestPathSanitization:
         Pre-#24 guard: `if not team_name or not task_id` caught empty
         string only. Post-#24: extended to `task_id/team_name in
         ("", ".", "..")` — catches the full degenerate set per axis.
+
+        POST-AC-5-REBIND CHANNEL NOTE (the team_name axis):
+        the b1 emitter no longer reads the stdin ``team_name`` field — the
+        marker team_name is resolved from ``get_pact_context()`` (the SSOT
+        source b2/b3 share). So a degenerate value reaching the team_name
+        axis now travels through the AUTHORITATIVE context channel, NOT
+        stdin. The ``_run_main`` helper bridges the per-test stdin
+        ``team_name`` into the patched context (``_ctx["team_name"]``), so
+        the degenerate value still reaches ``already_emitted`` as the marker
+        team_name and the #24 guard is genuinely exercised — these tests
+        defend the residual invariant "a degenerate team_name arriving via
+        the context channel is contained by the #24 guard". The companion
+        ``test_stdin_team_name_is_inert_post_rebind`` proves the OTHER half:
+        a hostile STDIN team_name is inert (cannot reach the marker key)
+        once the context team_name is path-safe. (In production the context
+        team_name is always a ``session-<id8>`` value minted by
+        generate_team_name, so a degenerate CONTEXT team_name cannot occur —
+        these remain regression guards on the guard machinery, not a live
+        production state; see ``test_marker_team_name_source_is_path_safe``.)
         """
 
         @pytest.mark.parametrize(
@@ -385,7 +405,18 @@ class TestPathSanitization:
         def test_degenerate_team_name_values_guarded(
             self, raw_team_name, expected_sanitized, tmp_path, monkeypatch
         ):
-            """team_name axis symmetry.
+            """team_name axis symmetry — degenerate value via the
+            AUTHORITATIVE context channel (post-AC-5-rebind).
+
+            The marker team_name is now resolved from ``get_pact_context()``,
+            not stdin. ``_run_main`` bridges this test's stdin ``team_name``
+            into the patched context, so a degenerate value still reaches
+            ``already_emitted`` as the marker team_name — the #24 guard is
+            genuinely exercised on the context channel (see the non-vacuity
+            assertion below, which proves the degenerate value reached the
+            guard). This is the live containment path; the dropped stdin read
+            is covered separately by
+            ``test_stdin_team_name_is_inert_post_rebind``.
 
             Pre-#24 with team_name='..': marker_dir resolves to
             `home/.claude/teams/../.agent_handoff_emitted`, which Path-
@@ -403,6 +434,23 @@ class TestPathSanitization:
             `("", ".", "..")` and returns False before marker creation.
             """
             monkeypatch.setenv("HOME", str(tmp_path))
+            # Non-vacuity capture: spy the team_name that actually reaches
+            # already_emitted so we PROVE the degenerate value traveled
+            # through the marker-key derivation (a vacuous pass would never
+            # reach the guard). Patch the symbol bound in the hook module.
+            import agent_handoff_emitter as _emitter
+            from shared.agent_handoff_marker import (
+                already_emitted as _real_already_emitted,
+            )
+            seen_team_names: list[str] = []
+
+            def _spy_already_emitted(team_name, task_id, occupant):
+                seen_team_names.append(team_name)
+                return _real_already_emitted(team_name, task_id, occupant)
+
+            monkeypatch.setattr(
+                _emitter, "already_emitted", _spy_already_emitted
+            )
             calls: list[dict] = []
             _run_main(
                 stdin_payload={
@@ -417,6 +465,15 @@ class TestPathSanitization:
                     "metadata": {"handoff": VALID_HANDOFF},
                 },
                 append_calls=calls,
+            )
+            # NON-VACUITY: the degenerate value reached already_emitted as
+            # the marker team_name (via the context channel) — so the #24
+            # guard was the mechanism that returned False, not a no-op path.
+            assert seen_team_names == [raw_team_name], (
+                f"degenerate team_name {raw_team_name!r} did NOT reach "
+                f"already_emitted as the marker team_name (saw "
+                f"{seen_team_names!r}); the test would be vacuous — the #24 "
+                f"guard is not actually being exercised."
             )
             assert len(calls) == 1, (
                 f"degenerate team_name {raw_team_name!r} (sanitizes to "
@@ -466,6 +523,14 @@ class TestPathSanitization:
             simultaneously. Emit invariant must still hold (fail-open
             wins over the compound-pollution failure mode).
 
+            POST-AC-5-REBIND: the degenerate team_name arrives via the
+            AUTHORITATIVE context channel (``_run_main`` bridges stdin
+            ``team_name`` → patched context); the degenerate task_id still
+            arrives via stdin. So the compound case exercises the #24 guard
+            on BOTH the context-sourced team_name axis and the stdin-sourced
+            task_id axis. The non-vacuity assertion below proves the
+            degenerate team_name reached already_emitted's marker key.
+
             Pre-#24: either axis alone could trigger the collapse bug;
             both together produce either home-root pollution (if
             team_name='..') or permanent suppression (if task_id
@@ -474,6 +539,21 @@ class TestPathSanitization:
             the first matched branch.
             """
             monkeypatch.setenv("HOME", str(tmp_path))
+            # Non-vacuity capture: prove the degenerate team_name reached the
+            # marker-key derivation via the context channel (not a no-op).
+            import agent_handoff_emitter as _emitter
+            from shared.agent_handoff_marker import (
+                already_emitted as _real_already_emitted,
+            )
+            seen_team_names: list[str] = []
+
+            def _spy_already_emitted(team_name, task_id, occupant):
+                seen_team_names.append(team_name)
+                return _real_already_emitted(team_name, task_id, occupant)
+
+            monkeypatch.setattr(
+                _emitter, "already_emitted", _spy_already_emitted
+            )
             calls: list[dict] = []
             _run_main(
                 stdin_payload={
@@ -488,6 +568,14 @@ class TestPathSanitization:
                     "metadata": {"handoff": VALID_HANDOFF},
                 },
                 append_calls=calls,
+            )
+            # NON-VACUITY: the degenerate team_name reached already_emitted as
+            # the marker team_name (via the context channel) — so the #24
+            # guard, not a vacuous path, is what contained the compound case.
+            assert seen_team_names == [raw_team_name], (
+                f"compound degenerate team_name {raw_team_name!r} did NOT "
+                f"reach already_emitted as the marker team_name (saw "
+                f"{seen_team_names!r}); the test would be vacuous."
             )
             assert len(calls) == 1, (
                 f"compound degenerate (task_id={raw_task_id!r}, "
@@ -575,4 +663,294 @@ class TestPathSanitization:
                     f"path-traversal attempt {attack_task_id!r} created "
                     f"a file at escape path {escape}."
                 )
+
+
+class TestPostRebindMarkerKeyInvariants:
+    """AC-5 (#979 Phase-2) marker-key invariants on the POST-REBIND emitter.
+
+    The b1 emitter (agent_handoff_emitter.main) resolves the marker
+    ``team_name`` from ``pact_context.get_pact_context()`` — the SSOT source
+    b2/b3 share — and NO LONGER reads the stdin ``team_name`` field
+    (commit "fix(handoff-emitter): resolve marker team name from session
+    context, not stdin"). These tests pin the three properties that change
+    surfaces with that rebind:
+
+    1. ``test_stdin_team_name_is_inert_post_rebind`` — a hostile STDIN
+       team_name cannot reach the marker key when the authoritative context
+       team_name is path-safe (the containment-by-construction property).
+    2. ``test_empty_context_defers_before_marker_claim`` — an unresolvable
+       (empty) context on a teammate frame short-circuits at the #917
+       writability gate BEFORE the O_EXCL marker claim, so it defers to b2/b3
+       and never claims a poisoned/empty-team marker.
+    3. ``test_marker_team_name_source_is_path_safe`` — the SSOT producer
+       ``generate_team_name`` constrains the context team_name to a path-safe
+       ``session-[a-f0-9-]+`` form, so dropping b1's producer-side
+       ``sanitize_path_component`` wrapper on team_name does not open a
+       traversal vector (task_id sanitize remains the stdin-axis guard).
+
+    This is the AC-5 sanitize-drop safety story the security reviewer leans
+    on at peer-review.
+    """
+
+    def test_stdin_team_name_is_inert_post_rebind(self, tmp_path, monkeypatch):
+        """Containment-by-construction: a HOSTILE stdin ``team_name`` is
+        INERT post-rebind. With a path-safe context team_name, a stdin
+        team_name carrying traversal primitives never reaches the marker key
+        — the marker is scoped to the context team_name, and ``already_emitted``
+        receives the context value verbatim, not the stdin value.
+
+        This is the assertion that proves the actual fix (dropping the stdin
+        read). A counter-test reverting :157 back to the stdin-first read
+        (``input_data.get("team_name") or get_team_name()``) would route the
+        hostile stdin value into the marker key and fail the assertions below.
+        """
+        monkeypatch.setenv("HOME", str(tmp_path))
+        import agent_handoff_emitter as _emitter
+        from shared.agent_handoff_marker import (
+            already_emitted as _real_already_emitted,
+            occupant_hash,
+        )
+
+        safe_context_team = "session-deadbeef"
+        hostile_stdin_team = "../../../etc/passwd"
+
+        seen_team_names: list[str] = []
+
+        def _spy_already_emitted(team_name, task_id, occupant):
+            seen_team_names.append(team_name)
+            return _real_already_emitted(team_name, task_id, occupant)
+
+        monkeypatch.setattr(_emitter, "already_emitted", _spy_already_emitted)
+
+        calls: list[dict] = []
+        _run_main(
+            stdin_payload={
+                "task_id": "42",
+                "task_subject": "stdin-inert probe",
+                "teammate_name": "probe-agent",
+                "team_name": hostile_stdin_team,  # hostile — must be ignored
+            },
+            task_data={
+                "status": "completed",
+                "owner": "probe-agent",
+                "metadata": {"handoff": VALID_HANDOFF},
+            },
+            append_calls=calls,
+            context_team_name=safe_context_team,  # authoritative, path-safe
+        )
+
+        # The marker key uses the CONTEXT team_name, never the stdin value.
+        assert seen_team_names == [safe_context_team], (
+            f"the hostile stdin team_name {hostile_stdin_team!r} reached the "
+            f"marker key (saw {seen_team_names!r}); post-rebind the marker "
+            f"team_name MUST come from get_pact_context(), making the stdin "
+            f"field inert. A regression to the stdin-first read would fail here."
+        )
+        assert len(calls) == 1, "writable resolvable-context fire must emit once."
+
+        # The marker landed inside the SAFE context team's scope, not at an
+        # escape path derived from the hostile stdin value.
+        occ = occupant_hash("probe-agent", "stdin-inert probe")
+        safe_marker = (
+            tmp_path / ".claude" / "teams" / safe_context_team
+            / ".agent_handoff_emitted" / f"42-{occ}"
+        )
+        assert safe_marker.exists(), (
+            f"marker must live under the safe context team dir at "
+            f"{safe_marker}; it was not found there."
+        )
+        # NEGATIVE inertness proof (the other half of "stdin never reaches the
+        # marker key"): no filesystem artifact derives from the hostile stdin
+        # token. If the pre-rebind stdin-first read regressed, the stdin value
+        # would sanitize_path_component to "etcpasswd" and scope a marker dir
+        # there — assert that dir does NOT exist, and that the ONLY team dir is
+        # the safe context one.
+        from shared.agent_handoff_marker import sanitize_path_component
+
+        sanitized_stdin_token = sanitize_path_component(
+            str(hostile_stdin_team).lower()
+        )  # what the OLD code would have keyed the marker on
+        teams_dir = tmp_path / ".claude" / "teams"
+        assert not (teams_dir / sanitized_stdin_token).exists(), (
+            f"a team dir keyed on the (sanitized) stdin token "
+            f"{sanitized_stdin_token!r} was created — the hostile stdin "
+            f"team_name reached the marker key. Post-rebind it MUST be inert."
+        )
+        assert not (tmp_path / ".claude" / "etc").exists(), (
+            "hostile stdin team_name created an etc/ path under .claude — "
+            "the stdin value leaked into a filesystem join."
+        )
+        teams_children = (
+            {p.name for p in teams_dir.iterdir()} if teams_dir.exists() else set()
+        )
+        assert teams_children == {safe_context_team}, (
+            f"unexpected team dirs {teams_children - {safe_context_team}} — "
+            f"the hostile stdin team_name must not create any team scope; only "
+            f"the authoritative context team {safe_context_team!r} may appear."
+        )
+
+    def test_empty_context_defers_before_marker_claim(
+        self, tmp_path, monkeypatch
+    ):
+        """#917 × AC-5 (architect §3.6): an UNRESOLVABLE teammate frame —
+        ``get_pact_context()`` returns the empty context — must SHORT-CIRCUIT
+        at the canonical-journal writability gate (``if not get_journal_path()``)
+        BEFORE the O_EXCL marker claim (``already_emitted``). It defers to the
+        lead's b2 and does NOT claim a poisoned/empty-team marker.
+
+        DISTINCT TRIGGER from test_handoff_writability_parity.py's
+        ``test_unwritable_fire_defers_no_marker_no_event``: that test forces
+        ``get_journal_path()==''`` DIRECTLY (independent of context). This test
+        drives unwritability through the EMPTY CONTEXT and lets the REAL
+        ``get_journal_path()`` resolve — proving the post-rebind STRENGTHENING:
+        because the marker team_name and the journal path now derive from the
+        SAME ``get_pact_context()``/``get_session_dir()`` source, an empty
+        context zeroes BOTH (team_name='' AND journal path='') so the defer
+        gate fires at least as often as it must. The marker claim is never
+        reached, so no empty-team marker can be poisoned.
+        """
+        monkeypatch.setenv("HOME", str(tmp_path))
+        import io
+        import json
+        from unittest.mock import patch
+
+        import agent_handoff_emitter as _emitter
+        import shared.pact_context as _pc
+        from shared.agent_handoff_marker import (
+            already_emitted as _real_already_emitted,
+        )
+
+        # Real _EMPTY_CONTEXT (all-empty-string keys) — what get_pact_context
+        # returns when the session context file is missing/unreadable, i.e. a
+        # teammate frame whose context is unpersisted (#877 is_lead-gated).
+        empty_ctx = dict(_pc._EMPTY_CONTEXT)
+
+        reached_marker_claim = {"value": False}
+
+        def _spy_already_emitted(team_name, task_id, occupant):
+            reached_marker_claim["value"] = True
+            return _real_already_emitted(team_name, task_id, occupant)
+
+        monkeypatch.setattr(_emitter, "already_emitted", _spy_already_emitted)
+
+        calls: list[dict] = []
+
+        def _append_spy(event):
+            calls.append(event)
+            return True
+
+        stdin_payload = {
+            "task_id": "42",
+            "task_subject": "empty-context teammate frame",
+            "teammate_name": "probe-agent",
+            # A stdin team_name is present but POST-REBIND it is never read —
+            # the empty context is authoritative.
+            "team_name": "session-whatever",
+        }
+        task_data = {
+            "status": "completed",
+            "owner": "probe-agent",
+            "metadata": {"handoff": VALID_HANDOFF},
+        }
+
+        # CRITICAL: do NOT patch get_journal_path — let it resolve for REAL
+        # from the (empty) context so the shared-source coupling is genuinely
+        # exercised. Only get_pact_context is patched to the empty context.
+        with patch.object(
+            _emitter.pact_context, "get_pact_context", return_value=empty_ctx
+        ), patch.object(
+            _emitter, "read_task_json", return_value=task_data
+        ), patch.object(
+            _emitter, "append_event", side_effect=_append_spy
+        ), patch("sys.stdin", io.StringIO(json.dumps(stdin_payload))):
+            # Sanity: the REAL get_journal_path resolves to '' under empty ctx.
+            assert _emitter.get_journal_path() == "", (
+                "precondition broken: empty context must zero get_journal_path() "
+                "via the shared get_session_dir() source — if it does not, the "
+                "post-rebind shared-source strengthening claim is false."
+            )
+            with pytest.raises(SystemExit) as exc_info:
+                _emitter.main()
+
+        assert exc_info.value.code == 0, "defer path must exit 0 (suppress)."
+        assert reached_marker_claim["value"] is False, (
+            "the emitter reached already_emitted (the O_EXCL marker claim) on "
+            "an empty-context teammate frame — the #917 writability gate at "
+            ":253 must short-circuit BEFORE the marker claim at :269. An empty "
+            "context could otherwise poison a marker keyed on an empty team_name."
+        )
+        assert calls == [], "an unresolvable teammate frame must write no event."
+        # No marker dir of any kind was created (the claim was never reached).
+        teams_dir = tmp_path / ".claude" / "teams"
+        created_markers = (
+            [str(p) for p in teams_dir.rglob(".agent_handoff_emitted")]
+            if teams_dir.exists()
+            else []
+        )
+        assert created_markers == [], (
+            f"a deferred (empty-context) fire claimed marker dir(s): "
+            f"{created_markers}. The defer gate must run before any marker join."
+        )
+
+    @pytest.mark.parametrize(
+        "session_id_input",
+        [
+            "0001639f",          # canonical lowercase hex
+            "deadbeef",          # all hex letters
+            "ABCDEF12",          # uppercase non-[a-f0-9] chars stripped
+            "../../etc",         # traversal primitives stripped
+            "a/b\\c.d",          # slashes + dot stripped
+            "sess ion!",         # space + punctuation stripped
+            "",                  # empty session_id → random hex fallback
+        ],
+    )
+    def test_marker_team_name_source_is_path_safe(self, session_id_input):
+        """AC-5 sanitize-drop safety: the marker team_name SOURCE is path-safe
+        BY CONSTRUCTION, so b1 dropping its producer-side
+        ``sanitize_path_component`` wrapper on team_name does NOT open a
+        traversal vector.
+
+        ``generate_team_name`` is the SSOT producer for every PACT-minted team
+        directory name (pact_context.py INVARIANT). It strips every character
+        outside ``[a-f0-9-]`` from session_id[:8] (falling back to a random hex
+        suffix) and prefixes ``session-``. So its output is ALWAYS
+        ``session-[a-f0-9-]+`` — no ``/``, ``\\``, ``.`` or ``..`` — i.e. it
+        can never produce a degenerate or traversal-bearing team_name. This is
+        the property the security reviewer leans on: with the producer
+        guaranteed path-safe, the consumer-side sanitize on team_name is
+        defense-in-depth that is safe to drop; the stdin-axis traversal guard
+        (task_id ``sanitize_path_component`` at :156) remains.
+
+        If ``generate_team_name``'s charset/regex ever drifts to admit an
+        unsafe character, this test fails — making the sanitize-drop a
+        deliberate, test-gated re-decision rather than a silent regression.
+        """
+        from shared.pact_context import generate_team_name
+
+        team_name = generate_team_name({"session_id": session_id_input})
+
+        # Structural invariant: session- prefix + only [a-f0-9-] thereafter.
+        assert team_name.startswith("session-"), (
+            f"generate_team_name({session_id_input!r}) = {team_name!r} lost the "
+            f"'session-' prefix — the platform-team adoption invariant broke."
+        )
+        suffix = team_name[len("session-"):]
+        assert suffix, (
+            f"generate_team_name({session_id_input!r}) produced an empty suffix "
+            f"{team_name!r}; the random-hex fallback must guarantee non-empty."
+        )
+        assert re.fullmatch(r"[a-f0-9-]+", suffix), (
+            f"generate_team_name({session_id_input!r}) = {team_name!r}; suffix "
+            f"{suffix!r} contains a non-[a-f0-9-] character — a path-unsafe "
+            f"team_name could reach the marker join now that b1 dropped its "
+            f"sanitize wrapper. The AC-5 sanitize-drop safety claim is broken."
+        )
+        # Explicit traversal-primitive absence (the marker-join threat model).
+        assert "/" not in team_name, f"forward slash in team_name {team_name!r}"
+        assert "\\" not in team_name, f"backslash in team_name {team_name!r}"
+        assert ".." not in team_name, f"parent-dir sequence in {team_name!r}"
+        assert "." not in team_name, (
+            f"single dot in team_name {team_name!r} — even a lone '.' is a "
+            f"degenerate marker-key value the #24 guard would have to catch."
+        )
 

--- a/pact-plugin/tests/test_emitter_path_sanitization.py
+++ b/pact-plugin/tests/test_emitter_path_sanitization.py
@@ -213,11 +213,20 @@ class TestPathSanitization:
         the context channel is contained by the #24 guard". The companion
         ``test_stdin_team_name_is_inert_post_rebind`` proves the OTHER half:
         a hostile STDIN team_name is inert (cannot reach the marker key)
-        once the context team_name is path-safe. (In production the context
-        team_name is always a ``session-<id8>`` value minted by
-        generate_team_name, so a degenerate CONTEXT team_name cannot occur —
-        these remain regression guards on the guard machinery, not a live
-        production state; see ``test_marker_team_name_source_is_path_safe``.)
+        once the context team_name is path-safe.
+
+        TWO UPSTREAM GUARDS (a degenerate CONTEXT team_name cannot occur in
+        prod): (1) the context team_name is always a ``session-<id8>`` value
+        minted by generate_team_name (see
+        ``test_marker_team_name_source_is_path_safe``); AND (2) #979 Phase-2
+        hardening #2 (KEPT) re-validates the persisted value at the
+        ``get_pact_context()`` READ BOUNDARY via ``is_safe_path_component``,
+        rejecting any degenerate value to ``""`` before it reaches this sink
+        (see ``test_handoff_writability_parity.py::TestMarkerKeyConvergence``).
+        ``_run_main`` patches ``get_pact_context`` directly, bypassing guard (2)
+        so the #24 SINK guard is exercised in isolation — these remain
+        regression guards on the sink guard machinery (defense-in-depth behind
+        the read boundary), not a live production state.
         """
 
         @pytest.mark.parametrize(
@@ -418,13 +427,24 @@ class TestPathSanitization:
             is covered separately by
             ``test_stdin_team_name_is_inert_post_rebind``.
 
-            DEFENSE-IN-DEPTH, NOT A LIVE VECTOR: in production the context
-            team_name is ALWAYS a ``generate_team_name`` value
-            (``session-[a-f0-9-]``, path-safe by construction — pinned by
-            ``test_marker_team_name_source_is_path_safe``), so a degenerate
-            CONTEXT team_name is impossible-in-prod. This test exercises the
-            #24 empty/dot guard as defense-in-depth on a can't-happen input —
-            do NOT re-read it as a live attack path.
+            DEFENSE-IN-DEPTH, NOT A LIVE VECTOR (two upstream guards now make a
+            degenerate CONTEXT team_name unreachable at this sink in prod):
+              (1) PRODUCER: the context team_name is ALWAYS a
+                  ``generate_team_name`` value (``session-[a-f0-9-]``, path-safe
+                  by construction — pinned by
+                  ``test_marker_team_name_source_is_path_safe``).
+              (2) READ BOUNDARY (#979 Phase-2 hardening #2, KEPT): even a
+                  corrupted / hand-edited persisted context value that WERE
+                  degenerate is rejected to ``""`` by ``get_pact_context()``'s
+                  ``is_safe_path_component`` re-validation BEFORE it reaches this
+                  sink (pinned by
+                  ``test_handoff_writability_parity.py::TestMarkerKeyConvergence``).
+            This test deliberately uses ``_run_main``, which patches
+            ``get_pact_context`` DIRECTLY (bypassing guard 2) to feed the
+            degenerate value to the sink in ISOLATION — so the #24 sink guard is
+            exercised on its own as defense-in-depth BEHIND the read boundary.
+            Do NOT re-read it as a live attack path: in production a degenerate
+            value cannot reach here through either guard.
 
             Pre-#24 with team_name='..': marker_dir resolves to
             `home/.claude/teams/../.agent_handoff_emitted`, which Path-
@@ -547,11 +567,18 @@ class TestPathSanitization:
             the first matched branch.
 
             DEFENSE-IN-DEPTH, NOT A LIVE VECTOR: the degenerate CONTEXT
-            team_name axis is impossible-in-prod (the context team_name is
-            always generate_team_name's ``session-[a-f0-9-]`` form — see
-            ``test_marker_team_name_source_is_path_safe``). This compound
-            test is a defensive regression guard on the #24 guard machinery,
-            not a live attack path.
+            team_name axis is impossible-in-prod behind TWO upstream guards —
+            (1) the context team_name is always generate_team_name's
+            ``session-[a-f0-9-]`` form (see
+            ``test_marker_team_name_source_is_path_safe``), AND (2) #979 Phase-2
+            hardening #2 (KEPT) rejects any degenerate persisted value to ``""``
+            at the ``get_pact_context()`` read boundary before it reaches this
+            sink (see
+            ``test_handoff_writability_parity.py::TestMarkerKeyConvergence``).
+            ``_run_main`` patches ``get_pact_context`` directly (bypassing guard
+            2) so this compound test exercises the #24 SINK guard in isolation —
+            a defensive regression guard behind the read boundary, not a live
+            attack path.
             """
             monkeypatch.setenv("HOME", str(tmp_path))
             # Non-vacuity capture: prove the degenerate team_name reached the
@@ -968,4 +995,117 @@ class TestPostRebindMarkerKeyInvariants:
             f"single dot in team_name {team_name!r} — even a lone '.' is a "
             f"degenerate marker-key value the #24 guard would have to catch."
         )
+
+    def test_marker_key_and_task_read_share_one_team_name_source(
+        self, tmp_path, monkeypatch
+    ):
+        """AC-5 single-source invariant: the marker key (already_emitted) and
+        the task-status read (read_task_json) consume the SAME team_name value.
+
+        Post-rebind both sinks read the one ``team_name`` local resolved once
+        from ``get_pact_context()`` at emitter:157 — read_task_json at :159 and
+        already_emitted at :269. A future edit that re-introduced a second
+        team_name source for either sink (e.g. re-reading stdin for the status
+        read, or sanitizing only one of the two) would split the sinks and the
+        marker dir could diverge from the team dir the status read targeted.
+        This pins the two sinks to one source by spying BOTH and asserting they
+        saw the identical value — regression-proof against a sink split.
+
+        NON-VACUITY: the assertion compares the two captured values directly, so
+        it can only pass when both sinks actually fired with the same string. A
+        split that fed one sink a different team_name would make the captured
+        pair unequal and flip this RED. The companion
+        ``test_stdin_team_name_is_inert_post_rebind`` proves the source is the
+        CONTEXT channel; this test proves the two downstream sinks do not
+        diverge from each other.
+        """
+        monkeypatch.setenv("HOME", str(tmp_path))
+        import io
+        import json
+        from unittest.mock import patch
+
+        import agent_handoff_emitter as _emitter
+        from shared.agent_handoff_marker import (
+            already_emitted as _real_already_emitted,
+        )
+
+        context_team = "session-cafebabe"
+        ctx = {
+            "team_name": context_team,
+            "session_id": "",
+            "project_dir": "",
+            "plugin_root": "",
+            "started_at": "",
+        }
+        task_data = {
+            "status": "completed",
+            "owner": "probe-agent",
+            "metadata": {"handoff": VALID_HANDOFF},
+        }
+
+        marker_team_names: list[str] = []
+        read_team_names: list[str] = []
+        calls: list[dict] = []
+
+        def _spy_already_emitted(team_name, task_id, occupant):
+            marker_team_names.append(team_name)
+            return _real_already_emitted(team_name, task_id, occupant)
+
+        def _spy_read_task_json(task_id, team_name, *args, **kwargs):
+            read_team_names.append(team_name)
+            return task_data
+
+        def _append_spy(event):
+            calls.append(event)
+            return True
+
+        stdin_payload = {
+            "task_id": "42",
+            "task_subject": "single-source probe",
+            "teammate_name": "probe-agent",
+            # A stdin team_name is present but inert post-rebind; the context
+            # channel is authoritative for BOTH sinks.
+            "team_name": "session-stdin-ignored",
+        }
+
+        # Drive main() directly (NOT via _run_main, whose own read_task_json
+        # patch would shadow the spy) so the read_task_json spy actually fires
+        # and captures the team_name the status read consumed.
+        with patch.object(
+            _emitter.pact_context, "get_pact_context", return_value=ctx
+        ), patch.object(
+            _emitter, "read_task_json", side_effect=_spy_read_task_json
+        ), patch.object(
+            _emitter, "already_emitted", side_effect=_spy_already_emitted
+        ), patch.object(
+            _emitter, "append_event", side_effect=_append_spy
+        ), patch.object(
+            _emitter, "get_journal_path",
+            return_value="/pact-test/session-journal.jsonl",
+        ), patch("sys.stdin", io.StringIO(json.dumps(stdin_payload))):
+            with pytest.raises(SystemExit) as exc_info:
+                _emitter.main()
+
+        assert exc_info.value.code == 0, "emit path must exit 0."
+
+        # Both sinks fired exactly once (the emit path ran end-to-end).
+        assert read_team_names == [context_team], (
+            f"read_task_json saw team_name(s) {read_team_names!r}; the status "
+            f"read must consume the context team_name {context_team!r}."
+        )
+        assert marker_team_names == [context_team], (
+            f"already_emitted saw team_name(s) {marker_team_names!r}; the marker "
+            f"key must consume the context team_name {context_team!r}."
+        )
+        # THE INVARIANT: one source feeds both sinks — the captured values are
+        # identical. A sink split (a second team_name source for either) breaks
+        # this equality.
+        assert read_team_names == marker_team_names, (
+            f"team_name SOURCE SPLIT: read_task_json saw {read_team_names!r} but "
+            f"already_emitted saw {marker_team_names!r}. Post-AC-5 both sinks "
+            f"MUST read the single team_name local resolved once from "
+            f"get_pact_context() at emitter:157 — a divergence means a future "
+            f"edit re-introduced a second team_name source for one sink."
+        )
+        assert len(calls) == 1, "the single-source emit path must emit once."
 

--- a/pact-plugin/tests/test_emitter_real_disk.py
+++ b/pact-plugin/tests/test_emitter_real_disk.py
@@ -122,6 +122,16 @@ class TestRealDiskRead:
             # journal so the marker-claim writability gate passes.
             "agent_handoff_emitter.get_journal_path",
             return_value=WRITABLE_TEST_JOURNAL,
+        ), patch(
+            # The team_name passed to read_task_json + the marker key now come
+            # from the SESSION CONTEXT (not stdin). Model the context
+            # session_init persisted (team_name="pact-test") so the on-disk
+            # read resolves the team-scoped task.json written above.
+            "agent_handoff_emitter.pact_context.get_pact_context",
+            return_value={
+                "team_name": "pact-test", "session_id": "", "project_dir": "",
+                "plugin_root": "", "started_at": "",
+            },
         ), patch("sys.stdin", io.StringIO(json.dumps({
             "session_id": "test-session-1",
             "hook_event_name": "TaskCompleted",
@@ -189,6 +199,14 @@ class TestRealDiskRead:
             # #917: writable journal (real-disk fidelity is the task.json read).
             "agent_handoff_emitter.get_journal_path",
             return_value=WRITABLE_TEST_JOURNAL,
+        ), patch(
+            # team_name for read_task_json + marker key now comes from the
+            # session context (not stdin). Model the persisted context.
+            "agent_handoff_emitter.pact_context.get_pact_context",
+            return_value={
+                "team_name": "pact-test", "session_id": "", "project_dir": "",
+                "plugin_root": "", "started_at": "",
+            },
         ), patch("sys.stdin", io.StringIO(json.dumps({
             "session_id": "test-session-1",
             "hook_event_name": "TaskCompleted",

--- a/pact-plugin/tests/test_handoff_writability_parity.py
+++ b/pact-plugin/tests/test_handoff_writability_parity.py
@@ -274,3 +274,340 @@ def test_writability_check_precedes_marker_claim_in_source():
             "O_EXCL test-and-set so a non-writable fire defers without claiming "
             "(#917)."
         )
+
+
+class TestMarkerKeyConvergence:
+    """AC-5 (#979 Phase-2) 3-path marker-key convergence guard.
+
+    All three O_EXCL emit paths must derive the marker key
+    ``(team_name, task_id, occupant)`` IDENTICALLY so they cannot split the
+    dedup marker dir (the #887/#901 divergence class):
+
+      b1 = agent_handoff_emitter.main()                       (TaskCompleted)
+      b2 = _emit_lead_side_agent_handoff via lead TaskUpdate-completed
+      b3 = _emit_lead_side_agent_handoff via the second lead call site
+           (SAME function as b2 — see task_lifecycle_gate; convergence with b1
+           is what these tests pin, and b2≡b3 by construction since they are the
+           SAME callee fed the same function-scope team_name).
+
+    The convergence atoms post-rebind:
+      * team_name — BOTH b1 (emitter:157) and b2/b3 (the caller at the
+        function-scope resolution) read ``get_pact_context().get("team_name","")``.
+      * occupant + already_emitted — SHARED via shared.agent_handoff_marker, so
+        occupant_hash(owner, subject) and the marker join cannot drift.
+
+    These tests feed b1 and b2 the SAME real session context (via the
+    ``pact_context`` fixture, which exercises the REAL get_pact_context — so any
+    read-side normalization applied inside get_pact_context applies to BOTH
+    paths equally) and assert the marker key each passed to already_emitted is
+    byte-identical. A future edit that resolved team_name from a different
+    source on one path — or applied a normalization on one call site only —
+    splits the captured keys and flips these RED.
+    """
+
+    def _capture_b1_marker_key(self, tmp_path, monkeypatch, pact_context):
+        """Drive b1 with a writable journal + the shared context; return the
+        (team_name, task_id, occupant) tuple b1 passed to already_emitted."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        pact_context(team_name=TEAM, session_id="s1")
+        captured: list[tuple] = []
+        real = b1.already_emitted
+
+        def _spy(team_name, task_id, occupant):
+            captured.append((team_name, task_id, occupant))
+            return real(team_name, task_id, occupant)
+
+        task_data = {"status": "completed", "owner": OWNER,
+                     "metadata": {"handoff": HANDOFF}}
+        stdin = {"task_id": TASK_ID, "task_subject": SUBJECT,
+                 "teammate_name": OWNER, "team_name": "stdin-ignored"}
+        with patch.object(b1, "get_journal_path",
+                          return_value=str(tmp_path / "j.jsonl")), \
+             patch.object(b1, "read_task_json", return_value=task_data), \
+             patch.object(b1, "already_emitted", side_effect=_spy), \
+             patch.object(b1, "append_event", side_effect=lambda e: True), \
+             patch("sys.stdin", io.StringIO(json.dumps(stdin))):
+            with pytest.raises(SystemExit):
+                b1.main()
+        assert captured, "b1 never reached already_emitted (setup broke)."
+        return captured[0]
+
+    def _capture_b2_marker_key(self, tmp_path, monkeypatch, pact_context):
+        """Drive b2 (lead TaskUpdate-completed) with the shared context; return
+        the (team_name, task_id, occupant) tuple b2 passed to already_emitted."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        pact_context(team_name=TEAM, session_id="s1")
+        captured: list[tuple] = []
+        real = tlg.already_emitted
+
+        def _spy(team_name, task_id, occupant):
+            captured.append((team_name, task_id, occupant))
+            return real(team_name, task_id, occupant)
+
+        monkeypatch.setattr(tlg, "get_journal_path",
+                            lambda: str(tmp_path / "j.jsonl"))
+        monkeypatch.setattr(tlg, "append_event", lambda e: True)
+        monkeypatch.setattr(tlg, "already_emitted", _spy)
+        task = {"id": TASK_ID, "subject": SUBJECT, "owner": OWNER,
+                "metadata": {"handoff": HANDOFF}}
+        tlg.evaluate_lifecycle({
+            "agent_type": LEAD,
+            "tool_name": "TaskUpdate",
+            "tool_input": {"taskId": TASK_ID, "status": "completed"},
+            "tool_response": {"task": task},
+        })
+        assert captured, "b2 never reached already_emitted (setup broke)."
+        return captured[0]
+
+    def test_b1_b2_derive_identical_marker_key(
+        self, tmp_path, monkeypatch, pact_context
+    ):
+        """b1 and b2, fed the SAME session context + same task identity, must
+        pass the IDENTICAL (team_name, task_id, occupant) key to already_emitted.
+
+        NON-VACUITY: the keys are captured from two independent real drives and
+        compared element-wise; a divergence on ANY atom (a different team_name
+        source, a different occupant derivation, a normalization on one path
+        only) makes the tuples unequal and flips this RED. Per-element asserts
+        localize WHICH atom drifted.
+        """
+        # Separate tmp dirs so neither path's marker side-effect dedups the
+        # other (we are comparing the KEY each derived, not exactly-once here).
+        b1_key = self._capture_b1_marker_key(
+            tmp_path / "b1", monkeypatch, pact_context
+        )
+        b2_key = self._capture_b2_marker_key(
+            tmp_path / "b2", monkeypatch, pact_context
+        )
+
+        assert b1_key[0] == b2_key[0], (
+            f"team_name DIVERGENCE: b1 keyed the marker on {b1_key[0]!r} but b2 "
+            f"on {b2_key[0]!r}. Post-AC-5 both MUST resolve team_name from "
+            f"get_pact_context().get('team_name',''); a split source (or a "
+            f"normalization applied on one path only) breaks the shared dedup "
+            f"marker dir (#887/#901 divergence class)."
+        )
+        assert b1_key[1] == b2_key[1], (
+            f"task_id DIVERGENCE: b1={b1_key[1]!r} b2={b2_key[1]!r}."
+        )
+        assert b1_key[2] == b2_key[2], (
+            f"occupant DIVERGENCE: b1={b1_key[2]!r} b2={b2_key[2]!r}. The "
+            f"occupant_hash(owner, subject) derivation must be shared via "
+            f"shared.agent_handoff_marker so the two paths cannot drift."
+        )
+        assert b1_key == b2_key, (
+            f"3-path marker-key convergence broken: b1={b1_key!r} b2={b2_key!r}."
+        )
+
+    def test_both_paths_resolve_team_name_from_get_pact_context(self):
+        """Source pin backstopping the behavioral convergence: BOTH the b1
+        resolution and the b2/b3 caller resolution read team_name from
+        get_pact_context().get("team_name", ...). Fails if a future edit
+        reintroduces a divergent source (e.g. an input_data/stdin read on b1, or
+        a bespoke team_name resolution at the lead-side call site)."""
+        RESOLVE = 'get_pact_context().get("team_name"'
+        b1_src = inspect.getsource(b1.main)
+        assert RESOLVE in b1_src, (
+            "b1 (agent_handoff_emitter.main) no longer resolves the marker "
+            "team_name from get_pact_context().get('team_name', ...) — the AC-5 "
+            "rebind regressed (a divergent source splits the marker key)."
+        )
+        # b2/b3 resolve team_name at the evaluate_lifecycle function scope and
+        # PASS it into _emit_lead_side_agent_handoff. Pin the resolution at the
+        # caller (evaluate_lifecycle), the source of the team_name b2/b3 use.
+        caller_src = inspect.getsource(tlg.evaluate_lifecycle)
+        assert RESOLVE in caller_src, (
+            "the lead-side caller (task_lifecycle_gate.evaluate_lifecycle) no "
+            "longer resolves team_name from get_pact_context().get('team_name', "
+            "...) before feeding _emit_lead_side_agent_handoff — b2/b3 would "
+            "diverge from b1's marker key."
+        )
+
+    @pytest.mark.parametrize(
+        "unsafe_team_name",
+        [
+            "../../etc",        # parent-dir traversal
+            "session-../x",     # embedded traversal under a valid-looking prefix
+            "a/b",              # path separator
+            "..",               # bare parent-dir
+            "foo bar",          # whitespace (not a safe single component)
+        ],
+    )
+    def test_unsafe_persisted_team_name_handled_identically_on_both_paths(
+        self, unsafe_team_name, tmp_path, monkeypatch, pact_context
+    ):
+        """SHARED-normalization convergence (the strongest #887 divergence
+        guard): an UNSAFE persisted team_name is handled IDENTICALLY on b1 and
+        b2 — BOTH reject-to-empty then fail-open to emit WITHOUT claiming a
+        marker. Neither claims a (traversal-bearing) marker dir; both emit
+        exactly once.
+
+        WHY emit-without-marker (not defer): rev-backend's Group-B read-boundary
+        re-validation lives INSIDE get_pact_context() (the SINGLE shared source
+        all three paths read), so an unsafe persisted team_name is
+        rejected-to-empty ('') for EVERY path at once. An empty team_name then
+        hits the marker layer's degenerate-key guard
+        (agent_handoff_marker: team_name in ('', '.', '..') → return None),
+        which FAILS OPEN: already_emitted returns False (no marker claimed) and
+        the emit proceeds — the deliberate bias to HANDOFF preservation over
+        loss (#24 / #887). The load-bearing convergence property is that BOTH
+        paths reach the SAME outcome: NO traversal-bearing marker dir is created
+        AND both emit exactly once. A future edit that re-validated on ONE
+        path's call site only (re-introducing the per-path split this AC-5 work
+        closes) would let the un-normalized path key a marker on the raw unsafe
+        value (a marker dir under the traversal path appears) while the other
+        rejects — and this test flips RED.
+
+        NON-VACUITY: the matching positive control
+        (test_safe_team_name_survives_on_both_paths) drives the SAME machinery
+        with a SAFE team_name and asserts BOTH paths emit + claim a marker under
+        the SAFE team dir — so the no-traversal-marker here is the shared
+        rejection, not 'never claims a marker'. The is_safe_path_component
+        allowlist (option iii) genuinely rejects each parametrized value (proven
+        by the positive control claiming a real marker where these do not).
+        """
+        # The marker dir for the EMPTY (rejected) team_name lives at
+        # teams//.agent_handoff_emitted — but already_emitted returns before
+        # creating it for a degenerate key. The KEY assertion is that NO marker
+        # dir keyed on the raw unsafe token (the per-path-split symptom) exists.
+        def _unsafe_marker_present(home: Path) -> bool:
+            teams = home / ".claude" / "teams"
+            if not teams.exists():
+                return False
+            # Any team dir that is not empty-named and carries an emitted marker
+            # would be the split symptom; the safe path creates none here.
+            return any(
+                (child / ".agent_handoff_emitted").exists()
+                for child in teams.iterdir()
+                if child.name  # ignore the empty-named degenerate root
+            )
+
+        # b1 path.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "b1")
+        monkeypatch.setenv("HOME", str(tmp_path / "b1"))
+        pact_context(team_name=unsafe_team_name, session_id="s1")
+        b1_calls: list = []
+        b1_stdin = {"task_id": TASK_ID, "task_subject": SUBJECT,
+                    "teammate_name": OWNER, "team_name": "stdin-ignored"}
+        b1_task = {"status": "completed", "owner": OWNER,
+                   "metadata": {"handoff": HANDOFF}}
+        with patch.object(b1, "get_journal_path",
+                          return_value=str(tmp_path / "b1" / "j.jsonl")), \
+             patch.object(b1, "read_task_json", return_value=b1_task), \
+             patch.object(b1, "append_event",
+                          side_effect=lambda e: b1_calls.append(e) or True), \
+             patch("sys.stdin", io.StringIO(json.dumps(b1_stdin))):
+            with pytest.raises(SystemExit):
+                b1.main()
+        b1_emitted = len(b1_calls)
+        b1_unsafe_marker = _unsafe_marker_present(tmp_path / "b1")
+        assert not b1_unsafe_marker, (
+            f"b1 claimed a marker keyed on the raw UNSAFE team_name "
+            f"{unsafe_team_name!r} — get_pact_context's read-boundary "
+            f"reject-to-empty did not apply on the b1 path (per-path split)."
+        )
+
+        # b2 path (fresh context for the b2 HOME).
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "b2")
+        monkeypatch.setenv("HOME", str(tmp_path / "b2"))
+        pact_context(team_name=unsafe_team_name, session_id="s1")
+        b2_calls: list = []
+        monkeypatch.setattr(tlg, "get_journal_path",
+                            lambda: str(tmp_path / "b2" / "j.jsonl"))
+        monkeypatch.setattr(tlg, "append_event",
+                            lambda e: b2_calls.append(e) or True)
+        task = {"id": TASK_ID, "subject": SUBJECT, "owner": OWNER,
+                "metadata": {"handoff": HANDOFF}}
+        tlg.evaluate_lifecycle({
+            "agent_type": LEAD,
+            "tool_name": "TaskUpdate",
+            "tool_input": {"taskId": TASK_ID, "status": "completed"},
+            "tool_response": {"task": task},
+        })
+        b2_emitted = len(b2_calls)
+        b2_unsafe_marker = _unsafe_marker_present(tmp_path / "b2")
+        assert not b2_unsafe_marker, (
+            f"b2 claimed a marker keyed on the raw UNSAFE team_name "
+            f"{unsafe_team_name!r} — the read-boundary reject-to-empty did not "
+            f"apply on the b2 path (per-path split, #887 divergence)."
+        )
+
+        # THE CONVERGENCE INVARIANT: both paths reached the IDENTICAL outcome.
+        assert b1_emitted == b2_emitted, (
+            f"b1 and b2 DIVERGED on an unsafe persisted team_name "
+            f"{unsafe_team_name!r}: b1 emitted {b1_emitted}x, b2 emitted "
+            f"{b2_emitted}x. The shared read-boundary normalization must make "
+            f"both paths behave identically (#887 divergence guard)."
+        )
+        assert b1_emitted == 1, (
+            f"unsafe team_name {unsafe_team_name!r}: expected emit-without-marker "
+            f"(reject-to-empty → #24 degenerate-key fail-open biases to handoff "
+            f"PRESERVATION), got {b1_emitted} emits. If this changed to a defer "
+            f"(0 emits) the fail-open contract regressed — update this pin "
+            f"deliberately."
+        )
+
+    @pytest.mark.parametrize("safe_team_name", ["pact-test", "session-deadbeef"])
+    def test_safe_team_name_survives_on_both_paths(
+        self, safe_team_name, tmp_path, monkeypatch, pact_context
+    ):
+        """Positive control + (iii)-vs-(i) decision pin (security-engineer ask):
+        a SAFE persisted team_name SURVIVES get_pact_context's read-boundary
+        re-validation (== itself) so BOTH b1 and b2 EMIT exactly once.
+
+        ``pact-test`` is the load-bearing case: it is NOT a ``session-`` value,
+        so it would be REJECTED by the tighter producer-exact regex (option i)
+        but is ACCEPTED by the chosen is_safe_path_component allowlist (option
+        iii). Its survival here pins the deliberate choice of (iii) over (i) —
+        if a future edit tightened the read-boundary to session-only, this case
+        flips RED (pact-test → '' → defer), surfacing the regression as a
+        test-gated re-decision. ``session-deadbeef`` is the always-valid
+        control. Together with the unsafe-defer test above, this proves the
+        read-boundary rejection is a real allowlist, not 'always suppress'."""
+        # b1.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "b1")
+        monkeypatch.setenv("HOME", str(tmp_path / "b1"))
+        pact_context(team_name=safe_team_name, session_id="s1")
+        b1_calls: list = []
+        b1_stdin = {"task_id": TASK_ID, "task_subject": SUBJECT,
+                    "teammate_name": OWNER, "team_name": "stdin-ignored"}
+        b1_task = {"status": "completed", "owner": OWNER,
+                   "metadata": {"handoff": HANDOFF}}
+        with patch.object(b1, "get_journal_path",
+                          return_value=str(tmp_path / "b1" / "j.jsonl")), \
+             patch.object(b1, "read_task_json", return_value=b1_task), \
+             patch.object(b1, "append_event",
+                          side_effect=lambda e: b1_calls.append(e) or True), \
+             patch("sys.stdin", io.StringIO(json.dumps(b1_stdin))):
+            with pytest.raises(SystemExit):
+                b1.main()
+        assert len(b1_calls) == 1, (
+            f"b1 did NOT emit for SAFE team_name {safe_team_name!r} — the "
+            f"read-boundary wrongly rejected a valid value (too strict: it "
+            f"should accept the is_safe_path_component allowlist, not session-"
+            f"only)."
+        )
+
+        # b2.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "b2")
+        monkeypatch.setenv("HOME", str(tmp_path / "b2"))
+        pact_context(team_name=safe_team_name, session_id="s1")
+        b2_calls: list = []
+        monkeypatch.setattr(tlg, "get_journal_path",
+                            lambda: str(tmp_path / "b2" / "j.jsonl"))
+        monkeypatch.setattr(tlg, "append_event",
+                            lambda e: b2_calls.append(e) or True)
+        task = {"id": TASK_ID, "subject": SUBJECT, "owner": OWNER,
+                "metadata": {"handoff": HANDOFF}}
+        tlg.evaluate_lifecycle({
+            "agent_type": LEAD,
+            "tool_name": "TaskUpdate",
+            "tool_input": {"taskId": TASK_ID, "status": "completed"},
+            "tool_response": {"task": task},
+        })
+        assert len(b2_calls) == 1, (
+            f"b2 did NOT emit for SAFE team_name {safe_team_name!r} — the "
+            f"read-boundary wrongly rejected a valid value on the b2 path."
+        )

--- a/pact-plugin/tests/test_handoff_writability_parity.py
+++ b/pact-plugin/tests/test_handoff_writability_parity.py
@@ -74,14 +74,24 @@ def _marker_files(home: Path) -> list[str]:
     return sorted(p.name for p in marker_dir.iterdir()) if marker_dir.exists() else []
 
 
-def _drive_b1(*, writable: bool, tmp_path: Path, monkeypatch, append_calls: list, handoff=HANDOFF) -> None:
+def _drive_b1(*, writable: bool, tmp_path: Path, monkeypatch, pact_context, append_calls: list, handoff=HANDOFF) -> None:
     """Fire b1 (agent_handoff_emitter.main) for one handoff-bearing completed
     TaskCompleted frame. `writable` controls the in-hook get_journal_path()
     return ('' = unwritable). `handoff` is the metadata.handoff value (default
     a valid dict; pass a non-dict to exercise the M1 type gate). The real
-    already_emitted runs under the patched HOME; append_event is spied."""
+    already_emitted runs under the patched HOME; append_event is spied.
+
+    b1's marker team_name now resolves from the SESSION CONTEXT
+    (get_pact_context), the SAME source b2 reads — so this driver sets up the
+    real context (team_name=TEAM) via the `pact_context` fixture, exactly as
+    _drive_b2 does. This is the post-rebind convergence: both paths key the
+    O_EXCL marker off the identical context team_name. The writability gate is
+    independent of this (it reads get_journal_path), so the UNWRITABLE-defer
+    #917 property is preserved: an empty journal still defers before the marker
+    claim even with the team_name resolvable."""
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setenv("HOME", str(tmp_path))
+    pact_context(team_name=TEAM, session_id="s1")
     journal = str(tmp_path / "session-journal.jsonl") if writable else ""
     task_data = {"status": "completed", "owner": OWNER, "metadata": {"handoff": handoff}}
     stdin = {
@@ -128,7 +138,7 @@ def _drive_b2(*, writable: bool, tmp_path: Path, monkeypatch, pact_context, appe
 # pact_context, append_calls) fires that path once.
 def _b1_driver(writable, tmp_path, monkeypatch, pact_context, append_calls, handoff=HANDOFF):
     _drive_b1(writable=writable, tmp_path=tmp_path, monkeypatch=monkeypatch,
-              append_calls=append_calls, handoff=handoff)
+              pact_context=pact_context, append_calls=append_calls, handoff=handoff)
 
 
 def _b2_driver(writable, tmp_path, monkeypatch, pact_context, append_calls, handoff=HANDOFF):

--- a/pact-plugin/tests/test_pact_orchestrator_agent.py
+++ b/pact-plugin/tests/test_pact_orchestrator_agent.py
@@ -132,3 +132,38 @@ def test_pact_orchestrator_body_references_soft_protocols():
     assert not missing, (
         f"orchestrator body missing soft-protocol cross-references: {missing}"
     )
+
+
+def test_dispatch_violation_example_retains_literal_task_form():
+    """Carve-out guard (#979 Phase-2 prose sweep over-reach): the dispatch-
+    violation negative example MUST retain the literal ``Task(...)`` form.
+
+    The Phase-2 sweep renamed the teammate-spawn-tool prose ``Task`` -> ``Agent``
+    (the v2.1.178 platform rename). But the DISPATCH PROTOCOL VIOLATION block
+    deliberately shows ``Task(...)`` as the WRONG/malformed spawn shape that the
+    orchestrator must recognize and correct to the canonical ``Agent(...)``. A
+    sweep that rewrote this ``Task(...)`` -> ``Agent(...)`` would corrupt the
+    negative example into "used Agent(...) instead of Agent(...)" — nonsense
+    that destroys the diagnostic. This pins the carve-out: the malformed-shape
+    literal stays ``Task(...)``.
+
+    NON-VACUITY: asserts BOTH the literal ``Task(...)`` is present AND that it
+    sits in the violation context ("instead of" the canonical Agent form). A
+    sweep over-reach removes the ``Task(...)`` token -> this flips RED.
+    """
+    text = ORCHESTRATOR_PATH.read_text()
+    # The malformed-shape literal must survive verbatim.
+    assert "`Task(...)`" in text, (
+        "the dispatch-violation negative example lost its literal `Task(...)` "
+        "malformed-shape token — the #979 Phase-2 spawn-tool prose sweep "
+        "(Task->Agent) over-reached into the carve-out. This example MUST keep "
+        "`Task(...)` to name the WRONG spawn shape the orchestrator corrects."
+    )
+    # And it must sit in the violation framing (wrong form vs canonical Agent),
+    # so the token is the intended diagnostic, not an incidental survivor.
+    assert "`Task(...)` instead of `Agent(...)`" in text, (
+        "the `Task(...)` token is present but no longer framed as the malformed "
+        "shape 'instead of `Agent(...)`'. The dispatch-violation diagnostic "
+        "must contrast the wrong `Task(...)` form against the canonical "
+        "`Agent(...)` form."
+    )

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -3409,6 +3409,16 @@ class TestSourceAwareness:
     ):
         """Helper: run main() with given source and team state.
 
+        FIXTURE-ONLY ``team_exists`` (post-#979-Phase-2 source-only collapse):
+        the production directive no longer branches on team existence — the
+        platform pre-creates exactly one team per session, so ``source`` alone
+        selects the branch. ``team_exists`` here ONLY controls whether the
+        on-disk team-config fixture is written (lines below); it does NOT steer
+        any live code path. It is retained so the directive can still be
+        asserted source-only REGARDLESS of on-disk team state (a meaningful
+        regression: the directive must be identical whether or not the team dir
+        happens to exist). Do not read it as exercising a team_exists branch.
+
         Returns (additionalContext, mock_symlinks_called, _legacy_kernel_called=False).
         """
         from session_init import main
@@ -3446,7 +3456,15 @@ class TestSourceAwareness:
     # --- Path 1: startup + no team (fresh session) ---
 
     def test_startup_no_team_creates_team(self, monkeypatch, tmp_path):
-        """startup + no team: should emit unified platform directive (bare — no extra recovery text)."""
+        """startup + NO on-disk team: emit unified platform directive (bare — no recovery text).
+
+        PAIRS WITH ``test_startup_team_exists_anomalous`` (team_exists=True):
+        post-#979-Phase-2 the two differ ONLY in the on-disk team-config
+        fixture state, and together they pin the source-only invariant — the
+        startup directive is byte-identical whether or not the team dir exists
+        (the collapsed ladder no longer branches on team existence). This
+        no-team case is the bare-directive half.
+        """
         additional, _, _ = self._run_main_with_source(
             monkeypatch, tmp_path, source="startup", team_exists=False
         )
@@ -3454,6 +3472,10 @@ class TestSourceAwareness:
         assert "provided by the platform for this session" in additional
         assert "Do not call TeamCreate" not in additional
         assert "WARNING" not in additional
+        # Bare startup: no post-bootstrap recovery guidance is appended.
+        assert "After bootstrap, recover session state:" not in additional
+        assert "CONTEXT CLEARED" not in additional
+        assert "paused state" not in additional
 
     def test_startup_calls_symlinks(self, monkeypatch, tmp_path):
         """startup should run symlink setup."""
@@ -3548,12 +3570,18 @@ class TestSourceAwareness:
     # --- Path 5: anomalous combinations ---
 
     def test_startup_team_exists_anomalous(self, monkeypatch, tmp_path):
-        """startup + team exists: now takes the normal startup branch (source-only ladder).
+        """startup + EXISTING on-disk team: takes the SAME startup branch (source-only ladder).
 
-        The team_exists dimension is GONE — source determines the branch. startup
-        takes the bare-directive branch regardless of team state. The anomalous
-        parenthetical ("Unexpected ...") is removed; "provided by the platform for
-        this session" is emitted for all sources. 4-sentence directive still fires.
+        PAIRS WITH ``test_startup_no_team_creates_team`` (team_exists=False):
+        this is the team-exists half of the source-only invariant. Post-#979-
+        Phase-2 the team_exists dimension is GONE — `source` alone selects the
+        branch — so startup must yield the SAME bare directive (no "Unexpected"
+        anomalous parenthetical, no recovery text) whether or not the team dir
+        exists. The distinguishing assertion vs the no-team variant is precisely
+        that the output is IDENTICAL despite the differing on-disk fixture: the
+        `"Unexpected" not in` + bare-directive checks below would have FAILED
+        pre-collapse (the old anomalous branch appended an "Unexpected session
+        source ... with existing team" note here).
         """
         additional, _, _ = self._run_main_with_source(
             monkeypatch, tmp_path, source="startup", team_exists=True
@@ -3562,6 +3590,11 @@ class TestSourceAwareness:
         assert "provided by the platform for this session" in additional
         assert "Do not call TeamCreate" not in additional
         assert "Unexpected" not in additional
+        # Source-only invariant: identical to the no-team startup case — the
+        # existing team dir adds NO recovery text and NO anomaly note.
+        assert "After bootstrap, recover session state:" not in additional
+        assert "CONTEXT CLEARED" not in additional
+        assert "paused state" not in additional
         # 4-sentence directive verbatim (all four sentences must be present).
         assert 'Invoke Skill("PACT:bootstrap") immediately, without waiting for user input.' in additional
         assert 'Do this before anything else.' in additional

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -3325,14 +3325,14 @@ class TestTeamResumeDetection:
         return output["hookSpecificOutput"]["additionalContext"]
 
     def test_fresh_session_emits_team_create(self, monkeypatch, tmp_path):
-        """When no team config exists on disk, should emit TeamCreate instruction."""
+        """When no team config exists on disk, should emit unified platform directive."""
         additional = self._run_main_with_team_detection(monkeypatch, tmp_path)
 
-        assert "auto-created by the platform for this session" in additional
+        assert "provided by the platform for this session" in additional
         assert "Do not call TeamCreate" not in additional
 
     def test_resume_session_emits_reuse_instruction(self, monkeypatch, tmp_path):
-        """When team config exists on disk, should emit reuse instruction."""
+        """When team config exists on disk, should emit unified platform directive."""
         # Create the team config file to simulate a resumed session
         team_dir = tmp_path / ".claude" / "teams" / "session-aabb1122"
         team_dir.mkdir(parents=True)
@@ -3340,8 +3340,8 @@ class TestTeamResumeDetection:
 
         additional = self._run_main_with_team_detection(monkeypatch, tmp_path)
 
-        assert "existing — resumed session" in additional
-        assert "Do not call TeamCreate" in additional
+        assert "provided by the platform for this session" in additional
+        assert "Do not call TeamCreate" not in additional
         assert "session-aabb1122" in additional
 
     def test_oserror_falls_back_to_team_create(self, monkeypatch, tmp_path):
@@ -3377,7 +3377,7 @@ class TestTeamResumeDetection:
         assert exc_info.value.code == 0
         output = json.loads(mock_stdout.getvalue())
         additional = output["hookSpecificOutput"]["additionalContext"]
-        assert "auto-created by the platform for this session" in additional
+        assert "provided by the platform for this session" in additional
 
     def test_team_instruction_is_first_in_context(self, monkeypatch, tmp_path):
         """Team instruction should be inserted at position 0 (first in context)."""
@@ -3446,12 +3446,12 @@ class TestSourceAwareness:
     # --- Path 1: startup + no team (fresh session) ---
 
     def test_startup_no_team_creates_team(self, monkeypatch, tmp_path):
-        """startup + no team: should emit TeamCreate instruction."""
+        """startup + no team: should emit unified platform directive (bare — no extra recovery text)."""
         additional, _, _ = self._run_main_with_source(
             monkeypatch, tmp_path, source="startup", team_exists=False
         )
 
-        assert "auto-created by the platform for this session" in additional
+        assert "provided by the platform for this session" in additional
         assert "Do not call TeamCreate" not in additional
         assert "WARNING" not in additional
 
@@ -3466,14 +3466,13 @@ class TestSourceAwareness:
     # --- Path 2: resume + team exists (normal resume) ---
 
     def test_resume_team_exists_reuse(self, monkeypatch, tmp_path):
-        """resume + team exists: should emit reuse instruction with paused-state hint."""
+        """resume + team exists: should emit unified platform directive with paused-state hint."""
         additional, _, _ = self._run_main_with_source(
             monkeypatch, tmp_path, source="resume", team_exists=True
         )
 
-        assert "existing — resumed session" in additional
-        assert "Do not call TeamCreate" in additional
-        assert "session-aabb1122" in additional
+        assert "provided by the platform for this session" in additional
+        assert "Do not call TeamCreate" not in additional
         assert "paused state" in additional
         # Should NOT have recovery instructions for context resets
         assert "compact-summary.txt" not in additional
@@ -3493,19 +3492,18 @@ class TestSourceAwareness:
     def test_compact_team_exists_recovery(self, monkeypatch, tmp_path):
         """compact + team exists: should emit post-bootstrap recovery instructions.
 
-        Post #444: the Primary-layer directive subsumes the "recover state"
-        prefix. The concrete task-resumption bullets (compact-summary, TaskList,
-        secretary re-engage) stay, prefixed by 'After bootstrap, recover
-        session state:'. The Secondary checkpoint block only fires when
-        in_progress tasks exist — get_task_list is patched to None here, so
-        no [POST-COMPACTION CHECKPOINT] block is expected.
+        The unified platform directive is emitted for every source. The concrete
+        task-resumption bullets (compact-summary, TaskList, secretary re-engage)
+        stay, prefixed by 'After bootstrap, recover session state:'. The Secondary
+        checkpoint block only fires when in_progress tasks exist — get_task_list
+        is patched to None here, so no [POST-COMPACTION CHECKPOINT] block is expected.
         """
         additional, _, _ = self._run_main_with_source(
             monkeypatch, tmp_path, source="compact", team_exists=True
         )
 
-        assert "existing — resumed session" in additional
-        assert "Do not call TeamCreate" in additional
+        assert "provided by the platform for this session" in additional
+        assert "Do not call TeamCreate" not in additional
         assert "After bootstrap, recover session state:" in additional
         assert "compact-summary.txt" in additional
         assert "TaskList" in additional
@@ -3526,13 +3524,13 @@ class TestSourceAwareness:
     # --- Path 4: clear + team exists (context intentionally cleared) ---
 
     def test_clear_team_exists_context_cleared(self, monkeypatch, tmp_path):
-        """clear + team exists: should emit CONTEXT CLEARED with recovery."""
+        """clear + team exists: should emit unified platform directive with CONTEXT CLEARED recovery."""
         additional, _, _ = self._run_main_with_source(
             monkeypatch, tmp_path, source="clear", team_exists=True
         )
 
-        assert "existing — resumed session" in additional
-        assert "Do not call TeamCreate" in additional
+        assert "provided by the platform for this session" in additional
+        assert "Do not call TeamCreate" not in additional
         assert "CONTEXT CLEARED" in additional
         assert "TaskList" in additional
         assert "secretary" in additional
@@ -3550,21 +3548,20 @@ class TestSourceAwareness:
     # --- Path 5: anomalous combinations ---
 
     def test_startup_team_exists_anomalous(self, monkeypatch, tmp_path):
-        """startup + team exists: anomalous — should reuse team with note.
-        Full 4-sentence directive must still fire (removes induction
-        dependency from canonical-path coverage — per review-test-engineer
-        LOW 1, each anomalous path independently verifies the verbatim
-        directive rather than inheriting the guarantee from the shared
-        _team_reuse/_team_create strings).
+        """startup + team exists: now takes the normal startup branch (source-only ladder).
+
+        The team_exists dimension is GONE — source determines the branch. startup
+        takes the bare-directive branch regardless of team state. The anomalous
+        parenthetical ("Unexpected ...") is removed; "provided by the platform for
+        this session" is emitted for all sources. 4-sentence directive still fires.
         """
         additional, _, _ = self._run_main_with_source(
             monkeypatch, tmp_path, source="startup", team_exists=True
         )
 
-        assert "existing — resumed session" in additional
-        assert "Do not call TeamCreate" in additional
-        assert "Unexpected" in additional or "Note" in additional
-        assert "TaskList" in additional
+        assert "provided by the platform for this session" in additional
+        assert "Do not call TeamCreate" not in additional
+        assert "Unexpected" not in additional
         # 4-sentence directive verbatim (all four sentences must be present).
         assert 'Invoke Skill("PACT:bootstrap") immediately, without waiting for user input.' in additional
         assert 'Do this before anything else.' in additional
@@ -3572,20 +3569,23 @@ class TestSourceAwareness:
         assert 'You must invoke Skill("PACT:bootstrap") on every session start.' in additional
 
     def test_resume_no_team_anomalous_informational(self, monkeypatch, tmp_path):
-        """R2-B3: resume + no team is anomalous-but-LEGITIMATE (e.g., user
-        ran /clear with no team or compact fired before a team was ever
-        created). Post-R2-B3 this branch emits an INFORMATIONAL note
-        without WARNING tone — the recovery hint stays. Full 4-sentence
-        directive must still fire (LOW 1)."""
+        """resume + no team: now takes the normal resume branch (source-only ladder).
+
+        The team_exists dimension is GONE — source determines the branch. resume
+        takes its own branch regardless of team state, emitting the paused-state
+        hint. "creating fresh team" and WARNING tone are gone. 4-sentence directive
+        still fires. "provided by the platform for this session" is universal.
+        """
         additional, _, _ = self._run_main_with_source(
             monkeypatch, tmp_path, source="resume", team_exists=False
         )
 
-        assert "auto-created by the platform for this session" in additional
-        # R2-B3: WARNING tone removed for known-source + no-team case.
+        assert "provided by the platform for this session" in additional
+        # Source-only ladder: resume branch always emits paused-state hint.
+        assert "paused state" in additional
+        # WARNING and creating-fresh-team are gone (old no-team branch deleted).
         assert "WARNING" not in additional
-        assert 'creating fresh team' in additional
-        assert "TaskList" in additional
+        assert 'creating fresh team' not in additional
         # 4-sentence directive verbatim.
         assert 'Invoke Skill("PACT:bootstrap") immediately, without waiting for user input.' in additional
         assert 'Do this before anything else.' in additional
@@ -3593,14 +3593,21 @@ class TestSourceAwareness:
         assert 'You must invoke Skill("PACT:bootstrap") on every session start.' in additional
 
     def test_compact_no_team_anomalous_informational(self, monkeypatch, tmp_path):
-        """R2-B3: compact + no team — informational note, no WARNING tone."""
+        """compact + no team: now takes the normal compact branch (source-only ladder).
+
+        The team_exists dimension is GONE. compact takes its own branch regardless
+        of team state, emitting post-compaction recovery text. "creating fresh team"
+        and WARNING tone are gone. 4-sentence directive still fires.
+        """
         additional, _, _ = self._run_main_with_source(
             monkeypatch, tmp_path, source="compact", team_exists=False
         )
 
-        assert "auto-created by the platform for this session" in additional
+        assert "provided by the platform for this session" in additional
+        # Source-only ladder: compact branch always emits recovery instructions.
+        assert "After bootstrap, recover session state:" in additional
         assert "WARNING" not in additional
-        assert 'creating fresh team' in additional
+        assert 'creating fresh team' not in additional
         # 4-sentence directive verbatim.
         assert 'Invoke Skill("PACT:bootstrap") immediately, without waiting for user input.' in additional
         assert 'Do this before anything else.' in additional
@@ -3608,14 +3615,21 @@ class TestSourceAwareness:
         assert 'You must invoke Skill("PACT:bootstrap") on every session start.' in additional
 
     def test_clear_no_team_anomalous_informational(self, monkeypatch, tmp_path):
-        """R2-B3: clear + no team — informational note, no WARNING tone."""
+        """clear + no team: now takes the normal clear branch (source-only ladder).
+
+        The team_exists dimension is GONE. clear takes its own branch regardless
+        of team state, emitting CONTEXT CLEARED recovery text. "creating fresh team"
+        and WARNING tone are gone. 4-sentence directive still fires.
+        """
         additional, _, _ = self._run_main_with_source(
             monkeypatch, tmp_path, source="clear", team_exists=False
         )
 
-        assert "auto-created by the platform for this session" in additional
+        assert "provided by the platform for this session" in additional
+        # Source-only ladder: clear branch always emits CONTEXT CLEARED recovery.
+        assert "CONTEXT CLEARED" in additional
         assert "WARNING" not in additional
-        assert 'creating fresh team' in additional
+        assert 'creating fresh team' not in additional
         # 4-sentence directive verbatim.
         assert 'Invoke Skill("PACT:bootstrap") immediately, without waiting for user input.' in additional
         assert 'Do this before anything else.' in additional
@@ -3629,32 +3643,30 @@ class TestSourceAwareness:
     def test_unknown_source_no_team_warns_and_emits_stderr(
         self, raw_source, monkeypatch, tmp_path, capfd
     ):
-        """R2-B3: unrecognized source value + no team — emit WARNING in
-        additionalContext AND stderr observability for debug logs.
+        """Unrecognized source value — new unknown branch (source-only ladder).
 
-        Pre-fix: known-source no-team and unknown-source no-team both
-        produced the same generic WARNING. Post-fix: unknown source is
-        differentiated as the malformed-stdin signal class (legitimate
-        recovery scenarios use the in-KNOWN_SOURCES informational
-        branch); stderr makes the malformation observable to debug-log
-        readers.
-
-        Note: session_init normalizes any non-`_VALID_SOURCES` raw_source
-        to the literal `"unknown"` (cannot inject arbitrary text into
-        additionalContext). So the message + stderr show `"unknown"`,
-        not the raw stdin source value. The parametrize covers the
-        normalization-class spectrum (different raw inputs all collapse
-        to the same `"unknown"` post-normalization)."""
+        Any non-_VALID_SOURCES raw_source normalizes to literal "unknown" and
+        takes the unknown branch. The WARNING and "Unrecognized" tone is GONE;
+        instead a neutral note: 'Note: unrecognized session source "unknown".'
+        The stderr observability line is RETAINED.
+        The unified "provided by the platform for this session" is emitted for
+        all sources including unknown. XSS-clamp: normalization still prevents
+        arbitrary injection ('"unknown"' appears in output, not the raw value).
+        team_exists=False is passed but is now irrelevant (no team_exists dimension).
+        """
         additional, _, _ = self._run_main_with_source(
             monkeypatch, tmp_path, source=raw_source, team_exists=False
         )
 
-        # WARNING tone preserved for malformed-stdin signal class.
-        assert "WARNING" in additional
-        assert "Unrecognized" in additional
-        # Post-normalization the source string is literal "unknown".
+        # Unified directive present for all sources.
+        assert "provided by the platform for this session" in additional
+        # New unknown branch: neutral note with literal "unknown".
         assert '"unknown"' in additional
-        # Stderr observability marker.
+        # Old WARNING/Unrecognized/creating-fresh-team tone is GONE.
+        assert "WARNING" not in additional
+        assert "Unrecognized" not in additional
+        assert "creating fresh team" not in additional
+        # Stderr observability marker is RETAINED.
         captured = capfd.readouterr()
         assert "session_init: unknown source value:" in captured.err
         assert "'unknown'" in captured.err
@@ -3686,24 +3698,30 @@ class TestSourceAwareness:
                 main()
 
         assert exc_info.value.code == 0
-        # Should behave like startup: full init, TeamCreate
+        # Should behave like startup: full init, unified platform directive, no recovery text.
         assert mock_symlinks.called
         output = json.loads(mock_stdout.getvalue())
         additional = output["hookSpecificOutput"]["additionalContext"]
-        assert "auto-created by the platform for this session" in additional
+        assert "provided by the platform for this session" in additional
         assert "POST-COMPACTION" not in additional
         assert "CONTEXT CLEARED" not in additional
 
     def test_unknown_source_with_team_is_anomalous(self, monkeypatch, tmp_path):
-        """Unknown source value + team exists: should reuse team with note.
-        Full 4-sentence directive must still fire (LOW 1: independent
-        verification on each anomalous path)."""
+        """Unknown source value + team exists: now takes the unknown branch (source-only ladder).
+
+        The team_exists dimension is GONE — unrecognized source always takes the
+        unknown branch. "existing — resumed session" and "Unexpected" are gone;
+        "provided by the platform for this session" + note about "unknown" are emitted.
+        4-sentence directive still fires.
+        """
         additional, _, _ = self._run_main_with_source(
             monkeypatch, tmp_path, source="unknown_value", team_exists=True
         )
 
-        assert "existing — resumed session" in additional
-        assert "Unexpected" in additional or "Note" in additional
+        assert "provided by the platform for this session" in additional
+        assert '"unknown"' in additional
+        assert "existing — resumed session" not in additional
+        assert "Unexpected" not in additional
         # 4-sentence directive verbatim.
         assert 'Invoke Skill("PACT:bootstrap") immediately, without waiting for user input.' in additional
         assert 'Do this before anything else.' in additional
@@ -3711,15 +3729,21 @@ class TestSourceAwareness:
         assert 'You must invoke Skill("PACT:bootstrap") on every session start.' in additional
 
     def test_unknown_source_without_team_creates_with_warning(self, monkeypatch, tmp_path):
-        """Unknown source value + no team: should create team with warning.
-        Full 4-sentence directive must still fire (LOW 1: independent
-        verification on each anomalous path)."""
+        """Unknown source value + no team: now takes the unknown branch (source-only ladder).
+
+        The team_exists dimension is GONE — unrecognized source always takes the
+        unknown branch regardless of team state. WARNING is gone; neutral note
+        about "unknown" is emitted. "provided by the platform for this session"
+        is the universal platform parenthetical. 4-sentence directive still fires.
+        """
         additional, _, _ = self._run_main_with_source(
             monkeypatch, tmp_path, source="unknown_value", team_exists=False
         )
 
-        assert "auto-created by the platform for this session" in additional
-        assert "WARNING" in additional
+        assert "provided by the platform for this session" in additional
+        assert '"unknown"' in additional
+        # WARNING is GONE for unknown source (replaced by neutral note).
+        assert "WARNING" not in additional
         # 4-sentence directive verbatim.
         assert 'Invoke Skill("PACT:bootstrap") immediately, without waiting for user input.' in additional
         assert 'Do this before anything else.' in additional
@@ -3757,11 +3781,13 @@ class TestTeamCreateStringFreshSession:
         assert 'Do not evaluate whether it is needed.' in additional
         assert 'You must invoke Skill("PACT:bootstrap") on every session start.' in additional
 
-    def test_contains_team_create_directive(self, monkeypatch, tmp_path):
+    def test_contains_platform_provided_directive(self, monkeypatch, tmp_path):
+        """The unified platform directive must carry the 'provided by the platform for this session'
+        parenthetical for all sources (team-create string is replaced by unified directive)."""
         additional, _, _ = _run_session_init_for_path(
             monkeypatch, tmp_path, source="startup", team_exists=False
         )
-        assert "auto-created by the platform for this session" in additional
+        assert "provided by the platform for this session" in additional
 
     def test_blocks_premature_action(self, monkeypatch, tmp_path):
         """The fresh prelude must instruct the team-lead not to act before bootstrap."""
@@ -3811,15 +3837,19 @@ class TestTeamReuseStringResumedSession:
         assert "Re-invoke if your context is compacted" not in additional
         assert "Your FIRST action must be" not in additional
 
-    def test_contains_existing_team_marker(self, monkeypatch, tmp_path):
+    def test_contains_platform_provided_marker(self, monkeypatch, tmp_path):
+        """The unified platform directive carries 'provided by the platform for this session'
+        for all sources. 'existing — resumed session' and 'Do not call TeamCreate' are GONE
+        (team-reuse string replaced by the unified directive)."""
         additional, _, _ = _run_session_init_for_path(
             monkeypatch, tmp_path, source="resume", team_exists=True
         )
-        assert "existing — resumed session" in additional
-        assert "Do not call TeamCreate" in additional
+        assert "provided by the platform for this session" in additional
+        assert "auto-created by the platform" not in additional
+        assert "Do not call TeamCreate" not in additional
 
     def test_does_not_contain_team_create_directive(self, monkeypatch, tmp_path):
-        """Resume must NOT instruct TeamCreate (team already exists)."""
+        """Resume must NOT contain the old 'auto-created by the platform' team-create string."""
         additional, _, _ = _run_session_init_for_path(
             monkeypatch, tmp_path, source="resume", team_exists=True
         )

--- a/pact-plugin/tests/test_session_journal.py
+++ b/pact-plugin/tests/test_session_journal.py
@@ -2498,8 +2498,19 @@ class TestAgentHandoffEmitterJournalWrite:
 
         with _patch("sys.stdin", stdin), \
              _patch("agent_handoff_emitter.read_task_json", return_value=task_data), \
-             _patch("agent_handoff_emitter.pact_context"), \
-             _patch("agent_handoff_emitter.get_team_name", return_value="pact-test1234"), \
+             _patch(
+                 # The marker team_name now resolves from the session context
+                 # (get_pact_context), not the dropped stdin read / get_team_name
+                 # wrapper. Return a real context dict so the marker key is a
+                 # plain string (a bare-MagicMock pact_context would feed a
+                 # MagicMock team_name into the path join).
+                 "agent_handoff_emitter.pact_context.get_pact_context",
+                 return_value={
+                     "team_name": "pact-test1234", "session_id": "",
+                     "project_dir": "", "plugin_root": "", "started_at": "",
+                 },
+             ), \
+             _patch("agent_handoff_emitter.get_journal_path", return_value="/pact-test/session-journal.jsonl"), \
              _patch("agent_handoff_emitter.append_event", return_value=True) as mock_append, \
              _patch("agent_handoff_emitter.make_event", wraps=None) as mock_make:
 

--- a/pact-plugin/tests/test_task_utils.py
+++ b/pact-plugin/tests/test_task_utils.py
@@ -704,6 +704,50 @@ class TestReadTaskJsonContainmentParity:
             "is_safe_path_component and skip the team dir -> bare-base fall-through"
         )
 
+    def test_mixed_case_team_name_resolves_under_lowercased_dir(self, tmp_path):
+        # Case-fold convergence: read_task_json lowercases team_name BEFORE the
+        # safe-path check + path join, so a mixed-case team_name resolves the
+        # task under the LOWERCASED team dir — matching the marker SSOT
+        # (agent_handoff_marker._resolve_marker_target), which also lowercases.
+        # The on-disk dir is the lowercased name; the lookup uses the mixed-case
+        # form and must still find the task.
+        #
+        # NON-VACUITY: without the .lower() the lookup targets the mixed-case dir
+        # name, which does not exist on a case-sensitive filesystem -> the team
+        # dir is skipped -> fall-through to the bare base (no task file there) ->
+        # {}. Reverting the case-fold flips this RED. (Verified by revert.)
+        #
+        # CASE-SENSITIVITY GUARD: on a case-INSENSITIVE filesystem (macOS APFS
+        # default), the OS itself bridges "Session-..." -> "session-..." on disk,
+        # so the regression is unobservable there (the test would false-green
+        # even with the .lower() removed). Skip unless the tmp filesystem is
+        # genuinely case-sensitive, so the assertion is coupled to the case-fold
+        # rather than to OS path semantics. Linux CI is case-sensitive.
+        from task_utils import read_task_json
+        probe_lower = tmp_path / "casefs_probe"
+        probe_lower.mkdir()
+        if (tmp_path / "CASEFS_PROBE").exists():
+            pytest.skip(
+                "case-insensitive filesystem (e.g. macOS APFS) cannot observe "
+                "the case-fold regression — the OS bridges the case difference"
+            )
+        base = tmp_path / "tasks"
+        lowered_dir = base / "session-deadbeef"
+        lowered_dir.mkdir(parents=True)
+        (lowered_dir / "5.json").write_text(
+            json.dumps({"id": "5", "subject": "CaseFolded"}), encoding="utf-8"
+        )
+        result = read_task_json(
+            "5", "Session-DEADBEEF", tasks_base_dir=str(base)
+        )
+        assert result.get("subject") == "CaseFolded", (
+            "a mixed-case team_name must resolve under the lowercased team dir "
+            "(read_task_json .lower()s before the join, converging with the "
+            "marker SSOT). Without the case-fold the lookup targets the "
+            "mixed-case dir name, misses on a case-sensitive FS, and falls "
+            "through to the bare base -> {}."
+        )
+
 
 class TestReadTaskJsonResolverEnvSet:
     """#926 remediation (was F2/Future, folded in): read_task_json's


### PR DESCRIPTION
## Summary

Phase-2 of the platform-managed-team-name adoption. Phase-1 (PR #980, v4.4.28) restored unattended bootstrap on Claude Code v2.1.178+ by adopting the platform-provided `session-<id8>` team name. Phase-2 completes the alignment: collapse now-equivalent code paths, converge the handoff-emitter marker key, sweep stale tool-name prose, and verify the teardown invariants.

Completes the acceptance criteria of #981. **Closure pending the #982 post-merge live-probe** of the platform's actual team-provisioning behavior — this PR aligns to the documented model (the official agent-teams docs state v2.1.178 removed `TeamCreate`/`TeamDelete` and the platform provisions the team), and #982 verifies that holds at runtime before #981 is closed.

## What landed

- **session_init fork collapse** (`0cc025c9`) — replace the create-vs-reuse directive fork with a single platform-provided directive; retire the `team_exists` probe; collapse the source×existence ladder to source-only while preserving each source's recovery text + the unknown-source warning.
- **AC-5 marker-key convergence** (`111ef077`) — the handoff emitter's marker `team_name` now resolves solely from the session context (dropping the deprecated stdin read), converging it with the other O_EXCL emit paths by construction. The producer-side sanitize wrapper is dropped because the source is path-safe by construction (`generate_team_name` → `session-[a-f0-9-]`); task-id sanitization is unchanged.
- **Removed-tool prose sweep** (`3e8b96fa`, `795e9d4f`, `bc032136`, `f2f0a904`) — strip/repoint `TeamCreate`/`TeamDelete` references across commands/agents/protocols (SSOT source + byte-mirrored extracts edited in lockstep); rename the teammate-spawn-tool prose `Task`→`Agent` (the v2.1.178 rename). The `#662` dual-naming carve-out (transcript-parser fixtures that match the historical literal `Task`) and the dispatch-violation negative example are intentionally preserved.
- **wrap-up graceful-shutdown option removed** (`29b5cf49`) — its action relied on the removed `TeamDelete` tool and is redundant with automatic session-exit cleanup; the session-decision prompt is now 3 options.
- **Teardown verified (no code change)** — `cleanup_old_teams` stays `^pact-`-scoped (NOT broadened to `^session-`, which would risk cross-session data loss in the shared platform namespace); the `cleanup_old_tasks` skip-set is unchanged.
- **Test coverage** (`15eb2b20`, `2c39f9f3`) — pin the post-rebind marker-key invariants (stdin-inert containment, empty-context teammate-frame defer, path-safe source) and re-frame 2 degenerate-name guards to the authoritative context channel; non-vacuity proven by counter-test-by-revert.
- **Version** (`8fd4d5e5`) → v4.4.29 (PATCH).

## Remediation (post-review)

Independent reviews returned APPROVE/PASS with no blocking findings; the optional path-safety + test-hardening suggestions were addressed in this PR:

- **Read-boundary team_name path-safety** (`bdb563de`) — `get_pact_context()` re-validates the persisted `team_name` against the same positive allowlist the downstream path sinks apply, rejecting a non-conforming value to `""` (the existing fail-open signal) with a single stderr log — centralizing the path-safety guarantee at the boundary closest to the data source. Also case-folds the `read_task_json` team-directory lookup so it converges with the marker-derivation comparison. Disposition is preservation (Option A): an empty/rejected `team_name` still emits the handoff un-deduped — it never suppresses.
- **Coverage** (`ade36145`) — pins that an unsafe persisted `team_name` is handled identically on both handoff-emit paths (same no-marker outcome, emits exactly once), with a safe-name positive control, and clarifies the degenerate-name guard tests as defense-in-depth.
- **Case-fold regression pin** (`38f94ebb`) — pins that `read_task_json` resolves a mixed-case `team_name` under the lowercased team directory (the `.lower()` fold). Guarded by a filesystem case-sensitivity probe so it only runs where the fold is observable (case-sensitive CI), closing a zero-coverage gap on the case-fold.

## Review

Three independent passes, all clean:
- **First review** (architect, test, backend, security) — APPROVE, no blocking.
- **Independent verify-only re-review** (fresh adversarial regression-audit + counter-test-by-revert + traversal-closure trace) — all-PASS.
- **Second, fresh blind round** (4 newly-spawned reviewers, blind to the prior round) — 4/4 APPROVE; 0 blocking / 0 minor in-PR. The one actionable item (case-fold coverage gap) was closed in `38f94ebb`.

Out-of-scope future-hardening notes filed as standalone issues: #987 (marker fail-closed convergence), #988 (multi-field read-boundary drift-tripwire).

## Testing

- Full suite (post-remediation): **9186 passed / 0 failed / 0 errors / 14 skipped** (run from the worktree root; module `__file__` confirmed inside the worktree to defeat the wrong-checkout false-green). The 14th skip is the new case-fold pin, which skips on case-insensitive filesystems and runs on case-sensitive CI.
- SSOT-mirror gate `scripts/verify-protocol-extracts.sh`: **19/19 VERIFICATION PASSED**.

## Tier

**PATCH** (v4.4.29) — aligning prose/paths to the already-shipped platform reality. The single user-surface change (wrap-up option removal) removed a *non-functional* option (its underlying tool no longer exists).
