### PR TITLE
fix(hooks): live-probe gate fires under subdir project dir + surfaces WARN to agents (v4.4.32)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.31",
+      "version": "4.4.32",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.31/      # Plugin version
+│               └── 4.4.32/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.31",
+  "version": "4.4.32",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.31
+> **Version**: 4.4.32
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/live_probe_gate.py
+++ b/pact-plugin/hooks/live_probe_gate.py
@@ -204,8 +204,19 @@ def _resolve_repo_root() -> Optional[Path]:
         # be absent -> fall THROUGH to the git-common-dir-parent path (the true
         # repo root), then cwd. Preserves the repo-root case (marker found ->
         # trust it) and the unset case (this branch is skipped).
+        #
+        # The marker read here is repeated by main()'s own _plugin_marker(root)
+        # call after resolution — an intentional, accepted second read: two tiny
+        # file reads on a once-per-merge advisory hook, not worth refactoring the
+        # resolver's signature (e.g. returning the parsed marker) and taking any
+        # regression risk on this load-bearing identity resolver.
         return Path(project_dir)
     try:
+        # git-common-dir parent intentionally resolves to the MAIN checkout (not
+        # the worktree): the plugin marker is git-TRACKED, so it lives at the main
+        # root in every checkout, making it the stable IDENTITY anchor. The diff
+        # (Component C) is computed separately in the process CWD, so the current
+        # worktree's branch changes are still seen correctly.
         result = subprocess.run(
             ["git", "rev-parse", "--git-common-dir"],
             capture_output=True, text=True, timeout=5,
@@ -358,6 +369,13 @@ def _emit_warn(version: str, seam_hooks: frozenset[str]) -> NoReturn:
         f"closing the originating issue. Seam hooks touched: {seam}. "
         f"(Advisory — WARN only.)"
     )
+    # The WARN now rests SOLELY on this additionalContext channel — there is no
+    # secondary backstop (no stderr echo, no journal write). That is acceptable-
+    # by-design: this is a NON-BLOCKING advisory, so a missed reminder degrades
+    # to the (pre-existing) procedural CLAUDE.md pin, never to a blocked merge or
+    # a false "checked & clear" signal. The channel's runtime delivery is the
+    # subject of the post-merge tmux re-probe (924-locus-b-dogfood-probe.md),
+    # which confirms additionalContext actually surfaces before #924 closes.
     print(json.dumps({
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",  # MUST be the literal event name

--- a/pact-plugin/hooks/live_probe_gate.py
+++ b/pact-plugin/hooks/live_probe_gate.py
@@ -34,8 +34,10 @@ Posture (the two load-bearing invariants):
 Used by: hooks.json PreToolUse hook (matcher: Bash), registered after
 merge_guard_pre.py.
 Input: JSON from stdin with tool_input.command.
-Output: {"suppressOutput": true} + exit 0 (silent), or a stderr WARN advisory
-        + {"suppressOutput": true} + exit 0.
+Output: {"suppressOutput": true} + exit 0 (silent), or a WARN advisory via
+        {"hookSpecificOutput": {"hookEventName": "PreToolUse",
+        "additionalContext": ...}} on stdout + exit 0 (the channel that
+        surfaces to an agent operator; exit-0 stderr does not).
 """
 
 from __future__ import annotations
@@ -194,7 +196,14 @@ def _resolve_repo_root() -> Optional[Path]:
     checkout) -> cwd. Distinct from the diff, which is computed in the current
     worktree (Component C)."""
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
-    if project_dir:
+    if project_dir and _plugin_marker(Path(project_dir)) is not None:
+        # Trust CLAUDE_PROJECT_DIR only when the git-TRACKED plugin marker
+        # actually resolves AT that root. A teammate's CLAUDE_PROJECT_DIR is its
+        # cwd = the `pact-plugin` SUBDIR, where the marker would resolve to
+        # `.../pact-plugin/pact-plugin/.claude-plugin/plugin.json` (doubled) and
+        # be absent -> fall THROUGH to the git-common-dir-parent path (the true
+        # repo root), then cwd. Preserves the repo-root case (marker found ->
+        # trust it) and the unset case (this branch is skipped).
         return Path(project_dir)
     try:
         result = subprocess.run(
@@ -322,27 +331,39 @@ def _has_satisfied_row(root: Path, version: str, waiver_ok: bool) -> bool:
 
 
 def _emit_warn(version: str, seam_hooks: frozenset[str]) -> NoReturn:
-    """Emit a NON-BLOCKING advisory (exit 0) via the merge_guard `[security]`
-    stderr precedent, then silent-allow on stdout.
+    """Emit a NON-BLOCKING advisory (exit 0) via a PreToolUse
+    `hookSpecificOutput.additionalContext` field on stdout, which DOES surface
+    to an agent operator.
 
-    The exact platform surfacing of a PreToolUse stderr-on-exit-0 line is
-    verified at runtime in the TEST-phase dogfood live-probe (this hook is its
-    own first probe subject). If stderr-on-exit-0 proves not surfaced, the
-    fallback is a non-deny `hookSpecificOutput` informational field — isolated
-    in THIS function so the swap is a one-function change, not a main() rewrite.
+    Surfacing channel (the load-bearing decision): a PreToolUse stderr line on
+    exit 0 is NOT fed to the agent (only an exit-2 deny's stderr is) — proven by
+    the #924 tmux dogfood, where the prior stderr advisory was invisible across
+    two EMIT_WARN triggers. The fix mirrors the verified sibling
+    `task_claim_gate.py`'s exact informational shape: print
+    `{"hookSpecificOutput": {"hookEventName": "PreToolUse",
+    "additionalContext": <text>}}` to stdout and exit 0. `hookEventName` MUST be
+    the literal "PreToolUse" (the platform invariant). `suppressOutput` is
+    deliberately NOT co-emitted: it suppresses stdout and would defeat the
+    additionalContext surfacing. Posture is unchanged — advisory only, exit 0,
+    never a permissionDecision=deny. Isolated to THIS function so the channel
+    swap is a one-function change, not a main() rewrite.
     """
     seam = ", ".join(sorted(seam_hooks)) if seam_hooks else "(none — PRIMARY only)"
-    print(
+    advisory = (
         f"[live-probe-gate] This branch touches the hooks/ tree but no fresh "
         f"both-modes live-probe row exists in RUNBOOK_RUN_DATES.md for version "
         f"{version or '<unknown>'}. Per the hook-infra gate, log a live-probe "
         f"(tmux mandatory; in-process real-or-faithful-synthetic) — or an "
         f"auditable WAIVED row for a non-seam (hooks/-only) change — before "
         f"closing the originating issue. Seam hooks touched: {seam}. "
-        f"(Advisory — WARN only.)",
-        file=sys.stderr,
+        f"(Advisory — WARN only.)"
     )
-    print(_SUPPRESS_OUTPUT)
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",  # MUST be the literal event name
+            "additionalContext": advisory,  # informational — NOT permissionDecision
+        }
+    }))
     sys.exit(0)
 
 

--- a/pact-plugin/tests/runbooks/924-locus-b-dogfood-probe.md
+++ b/pact-plugin/tests/runbooks/924-locus-b-dogfood-probe.md
@@ -38,15 +38,19 @@ gh pr merge <N> --squash    # PreToolUse(Bash) fires live_probe_gate.py
 ```
 
 **VERIFY** (the gate):
-- **(a) SURFACE:** the operator sees the `[live-probe-gate]` advisory on stderr
-  naming version `4.4.13`, the touched seam hooks, and the "log a live-probe …
-  before closing the originating issue" instruction.
-- **(b) NON-BLOCKING:** the command still runs (exit 0; `suppressOutput` on
-  stdout) — the advisory NEVER blocks the merge (WARN-not-BLOCK).
+- **(a) SURFACE:** the operator (agent) sees the `[live-probe-gate]` advisory
+  via the PreToolUse `hookSpecificOutput.additionalContext` field (surfaced on
+  stdout, exit 0) naming the version, the touched seam hooks, and the "log a
+  live-probe … before closing the originating issue" instruction. (The prior
+  stderr-on-exit-0 channel was confirmed NOT surfaced to the agent — the
+  Finding-B fix moved the advisory to additionalContext, the channel that does.)
+- **(b) NON-BLOCKING:** the command still runs (exit 0) — the advisory NEVER
+  blocks the merge (WARN-not-BLOCK). The WARN path emits only the
+  `hookSpecificOutput` field (no `suppressOutput`, which would hide it); the
+  silent path still emits `{"suppressOutput": true}`.
 - **(c) FALLBACK CHECK (the gate's own first-probe finding):** confirm the
-  stderr line is actually surfaced by the platform for a PreToolUse exit-0 hook.
-  **If stderr-on-exit-0 is NOT surfaced**, switch `_emit_warn` to the isolated
-  `hookSpecificOutput` informational fallback (a one-function change) and re-probe.
+  `additionalContext` line is actually surfaced by the platform for a PreToolUse
+  exit-0 hook (the agent-visible reminder is the whole point of the gate).
 - **(d) SILENCE-AFTER-PROBE:** run the REAL both-mode live-probe for the seam
   hooks this PR touches (per `live-probe-template.md`), log the `4.4.13`
   both-mode PASS row in `RUNBOOK_RUN_DATES.md`, then re-run `gh pr merge` /

--- a/pact-plugin/tests/test_live_probe_gate_dogfood.py
+++ b/pact-plugin/tests/test_live_probe_gate_dogfood.py
@@ -7,7 +7,8 @@ locus-b advisory). The gate is its OWN first probe subject. Two layers here:
   touches hooks/ with NO satisfied RUNBOOK row for the current plugin version
   emits the non-blocking WARN; a satisfied both-mode PASS row -> silent. Drives
   main() end-to-end through the REAL git diff + REAL plugin.json + REAL RUNBOOK
-  reads (the freshness seam), asserting stderr WARN + exit 0.
+  reads (the freshness seam), asserting the WARN surfaces via the stdout
+  hookSpecificOutput.additionalContext channel + exit 0.
 
   FRESHNESS-SPEC (real temp files): _has_satisfied_row must accept a GENUINE
   both-mode PASS row and REJECT (a) a substring-`pass`-but-not-genuine token
@@ -388,45 +389,50 @@ def _run_main(root: Path, command: str, monkeypatch, capsys) -> tuple[int, str]:
         g.main()
     except SystemExit as e:
         code = int(e.code or 0)
-    err = capsys.readouterr().err
-    return code, err
+    # The WARN advisory surfaces via STDOUT hookSpecificOutput.additionalContext
+    # (not stderr — a PreToolUse exit-0 stderr line is not fed to the agent). The
+    # silent path prints only {"suppressOutput": true} to stdout, which carries
+    # no "live-probe-gate" marker, so a marker-substring check stays correct in
+    # both directions.
+    out = capsys.readouterr().out
+    return code, out
 
 
 class TestDogfoodWarnPath:
     def test_warns_on_hooks_diff_with_no_satisfied_row(self, tmp_path, monkeypatch, capsys):
         root = _make_git_repo(tmp_path, "| h |\n", touch_hooks=True)  # no row
-        code, err = _run_main(root, "gh pr merge 999 --squash", monkeypatch, capsys)
+        code, out = _run_main(root, "gh pr merge 999 --squash", monkeypatch, capsys)
         assert code == 0, "advisory must always exit 0 (WARN-not-BLOCK)"
-        assert "live-probe-gate" in err and VERSION in err, (
+        assert "live-probe-gate" in out and VERSION in out, (
             "a hooks/-touching merge with no satisfied row must WARN; got "
-            f"stderr={err!r}"
+            f"stdout={out!r}"
         )
 
     def test_silent_when_genuine_pass_row_exists(self, tmp_path, monkeypatch, capsys):
         root = _make_git_repo(tmp_path, "| h |\n" + GENUINE_PASS_ROW, touch_hooks=True)
-        code, err = _run_main(root, "gh pr merge 999 --squash", monkeypatch, capsys)
+        code, out = _run_main(root, "gh pr merge 999 --squash", monkeypatch, capsys)
         assert code == 0
-        assert "live-probe-gate" not in err, "a fresh both-mode PASS row -> silent"
+        assert "live-probe-gate" not in out, "a fresh both-mode PASS row -> silent"
 
     def test_silent_on_non_hook_diff(self, tmp_path, monkeypatch, capsys):
         root = _make_git_repo(tmp_path, "| h |\n", touch_hooks=False)  # docs only
-        code, err = _run_main(root, "gh pr merge 999 --squash", monkeypatch, capsys)
+        code, out = _run_main(root, "gh pr merge 999 --squash", monkeypatch, capsys)
         assert code == 0
-        assert "live-probe-gate" not in err, "a non-hooks PR must not WARN"
+        assert "live-probe-gate" not in out, "a non-hooks PR must not WARN"
 
     def test_silent_on_non_merge_command(self, tmp_path, monkeypatch, capsys):
         root = _make_git_repo(tmp_path, "| h |\n", touch_hooks=True)
-        code, err = _run_main(root, "git status", monkeypatch, capsys)
+        code, out = _run_main(root, "git status", monkeypatch, capsys)
         assert code == 0
-        assert "live-probe-gate" not in err, "non merge/close command -> not our concern"
+        assert "live-probe-gate" not in out, "non merge/close command -> not our concern"
 
     def test_checks_actual_not_claimed_coverage(self, tmp_path, monkeypatch, capsys):
         # The dogfood gate keys on the ACTUAL hooks/ diff + ACTUAL RUNBOOK row,
         # never a claimed/asserted coverage flag: a real hooks/ change with no
         # row WARNs even though the suite is green. (Green tests != probed.)
         root = _make_git_repo(tmp_path, "| h |\n", touch_hooks=True)
-        _, err = _run_main(root, "gh pr close 999", monkeypatch, capsys)
-        assert "live-probe-gate" in err
+        _, out = _run_main(root, "gh pr close 999", monkeypatch, capsys)
+        assert "live-probe-gate" in out
 
     def test_config_dir_independence_forged_runbook_does_not_false_satisfy(
             self, tmp_path, monkeypatch, capsys):
@@ -453,10 +459,133 @@ class TestDogfoodWarnPath:
         # assertion — not the forged row happening to be empty/unsatisfied.
         assert g._has_satisfied_row(forged, VERSION, waiver_ok=False) is True
         monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(forged))
-        code, err = _run_main(root, "gh pr merge 1 --squash", monkeypatch, capsys)
+        code, out = _run_main(root, "gh pr merge 1 --squash", monkeypatch, capsys)
         assert code == 0, "advisory must always exit 0 (WARN-not-BLOCK)"
-        assert "live-probe-gate" in err, (
+        assert "live-probe-gate" in out, (
             "the gate must key off CLAUDE_PROJECT_DIR (repo root) and IGNORE "
             "CLAUDE_CONFIG_DIR — a forged satisfied RUNBOOK under a non-default "
             "CLAUDE_CONFIG_DIR must NOT false-satisfy the gate (security #55 regression)"
         )
+
+
+# ── FINDING A: _resolve_repo_root must validate the marker at CLAUDE_PROJECT_DIR ──
+
+class TestResolveRepoRootMarkerGuard:
+    """The CLAUDE_PROJECT_DIR resolver matrix. A teammate's CLAUDE_PROJECT_DIR is
+    its cwd = the `pact-plugin` SUBDIR, where the marker would double to
+    `.../pact-plugin/pact-plugin/.claude-plugin/plugin.json` and be absent. The
+    resolver must trust CLAUDE_PROJECT_DIR ONLY when the marker resolves at that
+    root, else fall through to the git-common-dir-parent path (the true root)."""
+
+    def _git_repo_root(self, tmp: Path) -> Path:
+        """A real git repo whose root carries the plugin marker, so the
+        git-common-dir-parent fallback resolves to it."""
+        root = _make_root(tmp, "| h |\n")
+        _git(root, "init", "-q")
+        _git(root, "config", "user.email", "t@t.t")
+        _git(root, "config", "user.name", "t")
+        _git(root, "add", "-A")
+        _git(root, "commit", "-q", "-m", "base")
+        return root
+
+    def test_subdir_project_dir_falls_through_to_repo_root(
+            self, tmp_path, monkeypatch):
+        # CLAUDE_PROJECT_DIR = the pact-plugin SUBDIR (marker absent there) ->
+        # the resolver must NOT trust it; it falls through to the git-common-dir
+        # parent = the repo root (marker FOUND). This is the Finding-A regression.
+        root = self._git_repo_root(tmp_path)
+        subdir = root / "pact-plugin"
+        assert g._plugin_marker(subdir) is None, (
+            "precondition: the marker must NOT resolve at the subdir (the bug's "
+            "double-pact-plugin path) — else this test is vacuous"
+        )
+        monkeypatch.chdir(root)  # so git-common-dir resolves to this repo
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(subdir))
+        resolved = g._resolve_repo_root()
+        assert resolved is not None and g._plugin_marker(resolved) is not None, (
+            "a subdir CLAUDE_PROJECT_DIR must fall through to a root where the "
+            f"marker resolves; got {resolved!r} (marker "
+            f"{g._plugin_marker(resolved) if resolved else None!r})"
+        )
+        assert resolved.resolve() == root.resolve(), (
+            "the fall-through must land on the true repo root"
+        )
+
+    def test_repo_root_project_dir_is_trusted_unchanged(
+            self, tmp_path, monkeypatch):
+        # CLAUDE_PROJECT_DIR = the repo root (marker FOUND) -> trusted unchanged
+        # (the canonical lead-driven-merge case must NOT regress).
+        root = _make_root(tmp_path, "| h |\n")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(root))
+        resolved = g._resolve_repo_root()
+        assert resolved == Path(str(root)), (
+            "a repo-root CLAUDE_PROJECT_DIR (marker FOUND) must be returned as-is"
+        )
+
+    def test_unset_project_dir_uses_git_common_dir_parent(
+            self, tmp_path, monkeypatch):
+        # CLAUDE_PROJECT_DIR unset -> the guarded branch is skipped, behavior
+        # unchanged: git-common-dir parent = the repo root.
+        root = self._git_repo_root(tmp_path)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.chdir(root)
+        resolved = g._resolve_repo_root()
+        assert resolved is not None and resolved.resolve() == root.resolve(), (
+            "unset CLAUDE_PROJECT_DIR must resolve to the git-common-dir parent "
+            f"(repo root); got {resolved!r}"
+        )
+
+
+# ── FINDING B: _emit_warn surfaces via stdout hookSpecificOutput.additionalContext ──
+
+class TestEmitWarnSurfacingShape:
+    """The advisory must surface on the channel an agent operator actually sees:
+    a PreToolUse exit-0 stdout `hookSpecificOutput.additionalContext` (mirrors
+    the verified sibling task_claim_gate.py). exit-0 stderr is NOT fed to the
+    agent, so the prior stderr advisory was invisible (#924 dogfood Finding B)."""
+
+    def _run_emit(self, capsys, version="4.4.13",
+                  seam=frozenset({"session_init.py"})):
+        code = 0
+        try:
+            g._emit_warn(version, seam)
+        except SystemExit as e:
+            code = int(e.code or 0)
+        captured = capsys.readouterr()
+        return code, captured.out, captured.err
+
+    def test_emits_hookspecificoutput_additionalcontext_on_stdout(self, capsys):
+        code, out, err = self._run_emit(capsys)
+        assert code == 0, "advisory must exit 0 (WARN-not-BLOCK)"
+        payload = json.loads(out)  # must be valid JSON on stdout
+        hso = payload["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse", (
+            "hookEventName MUST be the literal 'PreToolUse' (platform invariant)"
+        )
+        ctx = hso["additionalContext"]
+        assert "live-probe-gate" in ctx and "4.4.13" in ctx, (
+            "the advisory prose (marker + version) must ride additionalContext"
+        )
+        assert "session_init.py" in ctx, "seam-hooks must appear in the advisory"
+
+    def test_no_suppressoutput_and_nothing_on_stderr(self, capsys):
+        # suppressOutput would hide stdout and defeat additionalContext surfacing;
+        # it must NOT be co-emitted. And the advisory must no longer go to stderr
+        # (the channel that is invisible to the agent on exit 0).
+        _, out, err = self._run_emit(capsys)
+        payload = json.loads(out)
+        assert "suppressOutput" not in payload, (
+            "suppressOutput must NOT be co-emitted — it suppresses the stdout "
+            "additionalContext the agent needs to see"
+        )
+        assert "live-probe-gate" not in err, (
+            "the advisory must surface via stdout, not stderr (exit-0 stderr is "
+            "not fed to the agent)"
+        )
+
+    def test_unknown_version_renders_placeholder(self, capsys):
+        # Defensive: an empty version must not crash and must render the
+        # '<unknown>' placeholder in the surfaced advisory.
+        _, out, _ = self._run_emit(capsys, version="")
+        ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+        assert "<unknown>" in ctx

--- a/pact-plugin/tests/test_live_probe_gate_dogfood.py
+++ b/pact-plugin/tests/test_live_probe_gate_dogfood.py
@@ -467,6 +467,57 @@ class TestDogfoodWarnPath:
             "CLAUDE_CONFIG_DIR must NOT false-satisfy the gate (security #55 regression)"
         )
 
+    def test_waiver_row_silences_end_to_end_on_non_seam_hooks_diff(
+            self, tmp_path, monkeypatch, capsys):
+        # WAIVER PATH end-to-end through main(): a hooks/-only diff that touches
+        # NO seam hook classifies waiver_required=True, so main() calls
+        # _has_satisfied_row(..., waiver_ok=True) and an auditable WAIVED row
+        # satisfies -> silent. Previously the waiver_ok=True branch was covered
+        # only at the _has_satisfied_row UNIT level (TestFreshnessRowSpec /
+        # TestPerModePassParsing), never driven through main(). `some_hook.py`
+        # (what _make_git_repo touches) is NOT a seam hook -> waiver_required=True.
+        waived = f"| 2026-06-08 | op | {VERSION} | WAIVED | n/a | hooks/-only, no seam change |\n"
+        root = _make_git_repo(tmp_path, "| h |\n" + waived, touch_hooks=True)
+
+        # Sanity-pin the precondition this test depends on: the touched diff is a
+        # non-seam hooks/ change (waiver_required=True). If a future fixture makes
+        # some_hook.py a seam hook, waiver_ok would be False and this test would
+        # silently change meaning -> assert it explicitly.
+        from shared.hook_infra_classifier import classify_diff  # noqa: E402
+        assert classify_diff(["pact-plugin/hooks/some_hook.py"]).waiver_required is True, (
+            "precondition: the touched hooks/ file must be a NON-seam change "
+            "(waiver_required=True) — else this does not exercise the waiver path"
+        )
+
+        # NON-VACUITY: spy that main() reached the freshness check AND passed
+        # waiver_ok=True (the waiver branch), not waiver_ok=False. A silent exit
+        # alone would not prove the WAIVED row is what silenced the gate.
+        real = g._has_satisfied_row
+        seen: list[bool] = []
+
+        def _spy(root_arg, version, waiver_ok):
+            seen.append(waiver_ok)
+            return real(root_arg, version, waiver_ok=waiver_ok)
+
+        monkeypatch.setattr(g, "_has_satisfied_row", _spy)
+        code, out = _run_main(root, "gh pr merge 999 --squash", monkeypatch, capsys)
+        assert code == 0
+        assert seen == [True], (
+            "main() must reach _has_satisfied_row with waiver_ok=True for a "
+            f"non-seam hooks/ diff (the waiver branch); got calls={seen!r}"
+        )
+        assert "live-probe-gate" not in out, (
+            "an auditable WAIVED row must satisfy the gate on a non-seam hooks/ "
+            f"diff (waiver_ok=True) -> silent; got {out!r}"
+        )
+        # CONTRAST (attributes the silence to the waiver branch): the SAME WAIVED
+        # row does NOT satisfy when waiver_ok=False — so the end-to-end silence
+        # above is the waiver path, not a row that would satisfy regardless.
+        assert real(root, VERSION, waiver_ok=False) is False, (
+            "the WAIVED row must NOT satisfy under waiver_ok=False — proving the "
+            "e2e silence is specifically the waiver_required=True branch"
+        )
+
 
 # ── FINDING A: _resolve_repo_root must validate the marker at CLAUDE_PROJECT_DIR ──
 
@@ -591,12 +642,19 @@ class TestEmitWarnSurfacingShape:
         assert "<unknown>" in ctx
 
     def test_advisory_prose_is_byte_unchanged_by_the_channel_swap(self, capsys):
-        # Finding B moved the advisory from stderr to additionalContext WITHOUT
-        # altering a single character of the prose. Pin the EXACT surfaced text
-        # against the canonical template so a future channel/format change cannot
-        # silently mangle the operator-facing wording. The expected string is the
-        # pre-fix f-string verbatim (extracted from 402c5e3f^); if it drifts, the
-        # fix changed more than the channel — which #932 explicitly forbids.
+        # GREEN-TREE DRIFT-DETECTOR (not a correctness-derivation, and not a
+        # counter-test-by-revert assertion): on the fixed tree this pins the EXACT
+        # surfaced additionalContext text against a hand-typed literal of the
+        # pre-swap f-string, so a FUTURE edit that mangles the operator-facing
+        # wording (while keeping the channel) fails here. NOTE on its revert
+        # behavior: under a source-only revert of the fix the advisory goes to
+        # stderr and stdout carries no hookSpecificOutput, so this test flips RED
+        # at the `json.loads(out)["hookSpecificOutput"]` EXTRACTION (KeyError) —
+        # BEFORE the `ctx == expected` byte-compare ever runs. So its non-vacuity-
+        # under-revert proves only that the CHANNEL moved; the byte-equality check
+        # itself is a standing guard exercised on the green tree, where it catches
+        # prose drift. The expected string is hand-typed (NOT re-derived from the
+        # SUT's f-string at runtime), so it is not tautological.
         _, out, _ = self._run_emit(
             capsys, version="4.4.13", seam=frozenset({"session_init.py"}))
         ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
@@ -798,19 +856,52 @@ class TestFindingASubdirEndToEnd:
             f"silently self-disabling); got stdout={out!r}"
         )
 
-    def test_subdir_project_dir_silent_when_satisfied_row_exists(
+    def test_subdir_project_dir_silent_via_satisfied_row_at_resolved_root(
             self, tmp_path, monkeypatch, capsys):
-        # Control: the reconnection does NOT over-fire — under the same subdir
-        # CPD, a GENUINE satisfied row correctly silences the gate. This proves
-        # the subdir fall-through reaches the REAL repo-root RUNBOOK (where the
-        # satisfied row lives), not merely that it always WARNs.
+        # ISOLATES the fall-through (not merely the no-WARN output): under a
+        # subdir CPD with a GENUINE satisfied row, the gate must be silenced
+        # BECAUSE the fall-through reached the REAL repo-root RUNBOOK and read
+        # the row there — NOT because the gate fail-safed silent at the marker
+        # check. A bare "live-probe-gate not in out" assertion CANNOT tell those
+        # apart (both produce no WARN); pre-fix the subdir CPD resolves to the
+        # marker-less subdir, main() silent-allows at the marker==None check, and
+        # _has_satisfied_row is NEVER reached. So we SPY _has_satisfied_row and
+        # assert (a) it WAS called (the gate reached the freshness branch = the
+        # fall-through resolved a marker-bearing root and passed marker/diff/
+        # primary) and (b) it was called with the resolved REPO ROOT, not the
+        # subdir. The spy makes this NON-VACUOUS: pre-fix the call never happens,
+        # so assertion (a) flips RED on the unfixed tree.
         root = _make_git_repo(
             tmp_path, "| h |\n" + GENUINE_PASS_ROW, touch_hooks=True)
         subdir = root / "pact-plugin"
+
+        real_has_satisfied_row = g._has_satisfied_row
+        seen_roots: list[Path] = []
+
+        def _spy(root_arg, version, waiver_ok):
+            seen_roots.append(root_arg)
+            return real_has_satisfied_row(root_arg, version, waiver_ok=waiver_ok)
+
+        monkeypatch.setattr(g, "_has_satisfied_row", _spy)
         code, out = self._run_main_with_project_dir(
             root, subdir, "gh pr merge 999 --squash", monkeypatch, capsys)
         assert code == 0
+        # (a) the freshness check was actually reached (fall-through engaged) —
+        # this is the non-vacuous part: pre-fix the gate silent-allows before it.
+        assert seen_roots, (
+            "the fall-through must reach _has_satisfied_row (pre-fix it never "
+            "does — the subdir resolves marker-less and the gate silent-allows "
+            "at the marker check); an empty call list means the gate self-"
+            "disabled, not that the row silenced it"
+        )
+        # (b) it was called with the resolved REPO ROOT (where the RUNBOOK lives),
+        # not the subdir CPD — proving the fall-through landed on the true root.
+        assert seen_roots[0].resolve() == root.resolve(), (
+            "_has_satisfied_row must be called with the resolved repo ROOT, not "
+            f"the subdir; got {seen_roots[0]!r} (subdir was {subdir!r})"
+        )
+        # and the genuine row at that root silences the gate (no over-fire).
         assert "live-probe-gate" not in out, (
-            "under a subdir CPD, a fresh both-mode PASS row at the resolved repo "
-            f"root must silence the gate (fall-through reaches it); got {out!r}"
+            "a fresh both-mode PASS row at the resolved repo root must silence "
+            f"the gate; got {out!r}"
         )

--- a/pact-plugin/tests/test_live_probe_gate_dogfood.py
+++ b/pact-plugin/tests/test_live_probe_gate_dogfood.py
@@ -589,3 +589,228 @@ class TestEmitWarnSurfacingShape:
         _, out, _ = self._run_emit(capsys, version="")
         ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
         assert "<unknown>" in ctx
+
+    def test_advisory_prose_is_byte_unchanged_by_the_channel_swap(self, capsys):
+        # Finding B moved the advisory from stderr to additionalContext WITHOUT
+        # altering a single character of the prose. Pin the EXACT surfaced text
+        # against the canonical template so a future channel/format change cannot
+        # silently mangle the operator-facing wording. The expected string is the
+        # pre-fix f-string verbatim (extracted from 402c5e3f^); if it drifts, the
+        # fix changed more than the channel — which #932 explicitly forbids.
+        _, out, _ = self._run_emit(
+            capsys, version="4.4.13", seam=frozenset({"session_init.py"}))
+        ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+        expected = (
+            "[live-probe-gate] This branch touches the hooks/ tree but no fresh "
+            "both-modes live-probe row exists in RUNBOOK_RUN_DATES.md for version "
+            "4.4.13. Per the hook-infra gate, log a live-probe "
+            "(tmux mandatory; in-process real-or-faithful-synthetic) — or an "
+            "auditable WAIVED row for a non-seam (hooks/-only) change — before "
+            "closing the originating issue. Seam hooks touched: session_init.py. "
+            "(Advisory — WARN only.)"
+        )
+        assert ctx == expected, (
+            "the additionalContext prose must be BYTE-IDENTICAL to the pre-swap "
+            "stderr advisory (Finding B moved only the channel, never the text); "
+            f"got {ctx!r}"
+        )
+
+    def test_multiple_seam_hooks_are_sorted_and_joined(self, capsys):
+        # The seam list is `", ".join(sorted(...))` — verify the deterministic
+        # sorted rendering (not set-iteration order) so the advisory is stable.
+        _, out, _ = self._run_emit(
+            capsys, seam=frozenset({"session_init.py", "task_claim_gate.py"}))
+        ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+        assert "Seam hooks touched: session_init.py, task_claim_gate.py." in ctx, (
+            "seam hooks must render sorted + comma-joined (deterministic order)"
+        )
+
+    def test_primary_only_renders_none_placeholder(self, capsys):
+        # An empty seam set (PRIMARY-only change, no seam hook touched) renders
+        # the "(none — PRIMARY only)" placeholder, not an empty fragment.
+        _, out, _ = self._run_emit(capsys, seam=frozenset())
+        ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+        assert "Seam hooks touched: (none — PRIMARY only)." in ctx
+
+
+class TestSilentPathSuppressOutputNegativeControl:
+    """NEGATIVE CONTROL for Finding B: the WARN path drops suppressOutput so its
+    additionalContext surfaces — but the SILENT path (the fail-safe / satisfied
+    exit) MUST still emit `{"suppressOutput": true}`. If a future edit dropped
+    suppressOutput from the silent path too, the gate would leak an empty
+    {} stdout on every non-firing command (the dominant case) — noise the
+    suppressOutput contract exists to prevent. This asserts the asymmetry that
+    Finding B deliberately introduced: suppressOutput on silent, NOT on WARN."""
+
+    def test_silent_allow_emits_suppressoutput_true(self, capsys):
+        code = 0
+        try:
+            g._silent_allow()
+        except SystemExit as e:
+            code = int(e.code or 0)
+        out = capsys.readouterr().out
+        assert code == 0, "silent-allow must exit 0"
+        payload = json.loads(out)
+        assert payload == {"suppressOutput": True}, (
+            "the silent path must emit exactly {'suppressOutput': true} (the "
+            f"non-firing-command contract); got {payload!r}"
+        )
+
+    def test_warn_and_silent_suppressoutput_asymmetry(self, capsys):
+        # The load-bearing asymmetry in ONE assertion: WARN must NOT carry
+        # suppressOutput (it would hide additionalContext); SILENT MUST carry it.
+        try:
+            g._silent_allow()
+        except SystemExit:
+            pass
+        silent = json.loads(capsys.readouterr().out)
+        try:
+            g._emit_warn("4.4.13", frozenset({"session_init.py"}))
+        except SystemExit:
+            pass
+        warn = json.loads(capsys.readouterr().out)
+        assert silent.get("suppressOutput") is True and "suppressOutput" not in warn, (
+            "asymmetry violated: silent must suppress stdout, WARN must NOT "
+            f"(silent={silent!r}, warn-keys={list(warn)!r})"
+        )
+
+
+# ── FINDING A: resolver-matrix EDGE cases (beyond the devops 3-case matrix) ──
+
+class TestResolveRepoRootMatrixEdges:
+    """Edge cases on the _resolve_repo_root marker-guard matrix that the devops
+    verification set (subdir-falls-through / repo-root-trusted / unset) does NOT
+    cover: (1) a SUBDIR whose marker IS present must be TRUSTED (the guard must
+    not over-trigger and reject a legitimately-marker-bearing CLAUDE_PROJECT_DIR);
+    (2) the THIRD-tier cwd fallback when CLAUDE_PROJECT_DIR's marker is absent AND
+    git-common-dir is also unresolvable. Together with the devops 3 these pin all
+    four reachable resolver outcomes."""
+
+    def test_marker_bearing_project_dir_is_trusted_even_if_named_like_a_subdir(
+            self, tmp_path, monkeypatch):
+        # The guard trusts CLAUDE_PROJECT_DIR IFF the marker resolves there — it
+        # keys on marker PRESENCE, not on the path's name. A directory that
+        # happens to sit one level down but DOES carry the plugin marker must be
+        # returned as-is (no spurious fall-through). Builds the marker AT a nested
+        # dir and points CLAUDE_PROJECT_DIR at it.
+        nested = tmp_path / "checkouts" / "a"
+        _make_root(nested, "| h |\n")  # plants the marker AT `nested`
+        assert g._plugin_marker(nested) is not None, (
+            "precondition: the marker must resolve at the nested dir — else this "
+            "test does not exercise the trust-when-present branch"
+        )
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(nested))
+        # cwd is elsewhere (no git): if the guard wrongly fell through, it would
+        # NOT land on `nested`. Trusting the marker-bearing CPD is the assertion.
+        monkeypatch.chdir(tmp_path)
+        resolved = g._resolve_repo_root()
+        assert resolved == Path(str(nested)), (
+            "a marker-bearing CLAUDE_PROJECT_DIR must be trusted as-is regardless "
+            f"of its path depth; got {resolved!r}"
+        )
+
+    def test_cwd_fallback_when_marker_absent_and_git_unresolvable(
+            self, tmp_path, monkeypatch):
+        # THIRD-TIER fallback: CLAUDE_PROJECT_DIR set to a marker-LESS subdir
+        # (guard skips it) AND git-common-dir unresolvable -> Path.cwd(). Force
+        # the git failure DETERMINISTICALLY by monkeypatching subprocess.run to
+        # raise FileNotFoundError (git-not-found), rather than relying on ambient
+        # filesystem git state (a no-.git tmp dir can still discover an ambient
+        # parent .git and is flaky across environments). The cwd is a marker-less
+        # temp dir, so the resolver returns it (the documented last-resort tier).
+        subdir = tmp_path / "pact-plugin"  # marker would double here -> absent
+        subdir.mkdir(parents=True, exist_ok=True)
+        assert g._plugin_marker(subdir) is None, (
+            "precondition: marker absent at the subdir -> guard must skip it"
+        )
+
+        def _git_unavailable(*args, **kwargs):
+            raise FileNotFoundError("git not found (simulated)")
+
+        monkeypatch.setattr(g.subprocess, "run", _git_unavailable)
+        cwd = tmp_path / "elsewhere"
+        cwd.mkdir(parents=True, exist_ok=True)
+        monkeypatch.chdir(cwd)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(subdir))
+        resolved = g._resolve_repo_root()
+        assert resolved == Path(cwd), (
+            "marker-absent CPD + git unresolvable must fall to Path.cwd() (the "
+            f"third resolver tier); got {resolved!r}"
+        )
+        # And the gate fail-safes silent at this cwd (no marker there) — the
+        # resolver's last tier feeds main()'s marker check, which silent-allows.
+        assert g._plugin_marker(resolved) is None, (
+            "the cwd fallback lands on a marker-less dir here, so main() will "
+            "silent-allow — the documented fail-safe, not a WARN"
+        )
+
+
+# ── FINDING A: END-TO-END — main() reconnects under a SUBDIR CLAUDE_PROJECT_DIR ──
+
+class TestFindingASubdirEndToEnd:
+    """The HIGHEST-VALUE Finding-A test: drive main() END-TO-END with
+    CLAUDE_PROJECT_DIR = the `pact-plugin` SUBDIR (the exact teammate topology
+    #932 documents) and assert the gate FIRES (WARNs) instead of silently
+    self-disabling. The resolver unit tests prove the address math; THIS proves
+    the gate actually reconnects to the live RUNBOOK/diff seam through the fixed
+    resolver — the regression #932 reported was a SILENT self-disable visible
+    only at the main() level, not at the resolver in isolation.
+
+    NON-VACUITY: under the pre-fix unconditional `return Path(project_dir)`, the
+    subdir CPD resolves to the (marker-less) subdir, main()'s marker check is
+    None -> silent-allow -> NO WARN. So these tests FLIP red on the pre-fix tree
+    (counter-test-by-revert of 402c5e3f confirms the cardinality)."""
+
+    def _run_main_with_project_dir(self, root, project_dir, command,
+                                   monkeypatch, capsys):
+        """Like _run_main but pins CLAUDE_PROJECT_DIR to an ARBITRARY dir (here
+        the subdir) rather than the repo root, so we exercise the Finding-A
+        fall-through. cwd is the repo root so git-common-dir resolves to it."""
+        import io
+        monkeypatch.chdir(root)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project_dir))
+        monkeypatch.setattr(sys, "stdin", io.StringIO(
+            json.dumps({"tool_input": {"command": command}})))
+        code = 0
+        try:
+            g.main()
+        except SystemExit as e:
+            code = int(e.code or 0)
+        return code, capsys.readouterr().out
+
+    def test_subdir_project_dir_main_still_warns(
+            self, tmp_path, monkeypatch, capsys):
+        # The Finding-A regression repro: a hooks/-touching merge from a process
+        # whose CLAUDE_PROJECT_DIR is the pact-plugin subdir, with NO satisfied
+        # row, MUST still WARN (the gate must reconnect via git-common-dir).
+        root = _make_git_repo(tmp_path, "| h |\n", touch_hooks=True)  # no row
+        subdir = root / "pact-plugin"
+        assert g._plugin_marker(subdir) is None, (
+            "precondition: marker absent at the subdir CPD — else the fall-"
+            "through that THIS test exercises never engages (vacuous)"
+        )
+        code, out = self._run_main_with_project_dir(
+            root, subdir, "gh pr merge 999 --squash", monkeypatch, capsys)
+        assert code == 0, "advisory must always exit 0 (WARN-not-BLOCK)"
+        assert "live-probe-gate" in out and VERSION in out, (
+            "a hooks/-touching merge under a SUBDIR CLAUDE_PROJECT_DIR must WARN "
+            "(Finding A: the gate reconnects via git-common-dir instead of "
+            f"silently self-disabling); got stdout={out!r}"
+        )
+
+    def test_subdir_project_dir_silent_when_satisfied_row_exists(
+            self, tmp_path, monkeypatch, capsys):
+        # Control: the reconnection does NOT over-fire — under the same subdir
+        # CPD, a GENUINE satisfied row correctly silences the gate. This proves
+        # the subdir fall-through reaches the REAL repo-root RUNBOOK (where the
+        # satisfied row lives), not merely that it always WARNs.
+        root = _make_git_repo(
+            tmp_path, "| h |\n" + GENUINE_PASS_ROW, touch_hooks=True)
+        subdir = root / "pact-plugin"
+        code, out = self._run_main_with_project_dir(
+            root, subdir, "gh pr merge 999 --squash", monkeypatch, capsys)
+        assert code == 0
+        assert "live-probe-gate" not in out, (
+            "under a subdir CPD, a fresh both-mode PASS row at the resolved repo "
+            f"root must silence the gate (fall-through reaches it); got {out!r}"
+        )


### PR DESCRIPTION
## Summary

Fixes the two efficacy defects in the live-probe gate (`pact-plugin/hooks/live_probe_gate.py`) surfaced by the #924 tmux dogfood. **Implements the #932 code fixes (Finding A + Finding B); closure of #932 and #924 is pending the tmux re-probe** per `pact-plugin/tests/runbooks/924-locus-b-dogfood-probe.md` — that requires a real tmux teammate-mode session and is out of scope for this in-process change.

## What landed

**Finding A — gate self-disabled under a subdir `CLAUDE_PROJECT_DIR`.**
`_resolve_repo_root` returned `CLAUDE_PROJECT_DIR` unconditionally, so a process whose `CLAUDE_PROJECT_DIR` is the `pact-plugin` subdir resolved a doubled `pact-plugin/pact-plugin` marker path, found no plugin marker, and silently self-disabled — shadowing the correct git-common-dir fallback. The early return is now guarded on the plugin marker actually resolving at that root; otherwise it falls through to the existing git-common-dir-parent path, then cwd. One guarded branch — the **repo-root and unset cases are behaviorally unchanged**.

**Finding B — WARN advisory invisible to agent operators.**
`_emit_warn` printed its advisory to stderr on exit 0, which PreToolUse does not surface to an agent (only an exit-2 deny's stderr surfaces). The advisory now emits on stdout as `hookSpecificOutput.additionalContext` (`hookEventName: "PreToolUse"`), mirroring the verified sibling `task_claim_gate.py`. **Advisory prose is byte-unchanged and the gate still always exits 0 (non-blocking).** No `suppressOutput` co-emit on the WARN path (it would re-hide the advisory).

## Tests

- Comprehensive resolver matrix (repo-root / subdir / unset) + edge cases (marker-bearing dir trusted regardless of depth; cwd third-tier fallback) + an **end-to-end `main()`-WARNs-under-subdir** integration test (proves the gate *reconnects*, not just the resolver unit).
- Finding B: surfacing-shape assertions, advisory-prose byte-equivalence, and the silent-vs-WARN `suppressOutput` asymmetry negative control.
- **Non-vacuity** established by a source-only revert with clean per-finding failure attribution.
- Full hook suite: **9247 passed, 0 failed, 0 errors** (rtk proxy, explicit errors-token scan).

## Why

The gate exists to remind an operator to run the post-merge live-probe before closing a hook-infra issue. Both defects let it silently no-op for the dominant agent-driven-merge case — defeating its purpose. These fixes restore the intended advisory behavior.

Version: PATCH 4.4.31 → 4.4.32.

## Not closing yet

This PR does **not** close #932 or #924. Their closure is gated on a clean tmux re-probe per `924-locus-b-dogfood-probe.md` (which logs a satisfied both-mode row) — a real tmux teammate-mode session, sequenced post-merge.
