### PR TITLE
fix(hooks): merge_guard hardening — bound ReDoS prefixes + output-side process-sub (#1001, #1002)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.33",
+      "version": "4.4.34",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.33/      # Plugin version
+│               └── 4.4.34/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.33",
+  "version": "4.4.34",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.33
+> **Version**: 4.4.34
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -237,25 +237,45 @@ def _has_pipe_to_shell(command: str) -> bool:
     )
 
 
+# Path-qualified shell token — ReDoS-free (disjoint-segment; STOPS at space/`)`).
+# Trailing (?![\w/]) anchors the shell name as a whole PATH-LEAF token: excludes
+# prefix-of-name (`>(basht)`/`>(teehee)`) AND `>(bash/foo)` (bash is a DIRECTORY,
+# foo the executable) while KEEPING metachar-separated real vectors
+# `>(bash;ls)`/`>(bash&&x)`/`>(bash|cat)` (bash still executes).
+_PROCSUB_SHELL = r"(?:[^\s)/]*/)*(?:bash|sh|zsh)(?![\w/])"
+
+
 def _has_process_substitution_to_shell(command: str) -> bool:
     """Check if a command uses process substitution fed to a shell interpreter.
 
-    Detects BOTH:
-      - input-side  `bash <(echo "...")`  — shell consumes the substitution as
-        its input script (the original guard);
-      - output-side `echo "..." > >(bash)` — a stdout-routing redirect feeds the
-        command's stdout into a shell (#1002). Restricted to stdout-routing
-        redirect operators (`>`, `>>`, `1>`, `1>>`, `&>`, `&>>`) and to the same
-        shell-interpreter target set, so non-shell consumers (`> >(tee ...)`,
-        `> >(cat ...)`) and stderr-only routing (`2> >(bash)`) are NOT matched.
-    Both arms are used only as a strip-SKIP condition: a True result PRESERVES
-    content for the dangerous-pattern scan, so widening this guard is
-    monotonically detection-increasing (INV-D2-safe; cannot create a
-    false-negative).
+    Detects:
+      - input-side  ``bash <(echo "...")``  — the shell consumes the substitution
+        as its input script (the original guard, UNCHANGED);
+      - output-side ``echo "..." > >(bash)`` — the command's stdout is routed into
+        a shell via process substitution. Caught in two forms (#1002):
+          * Arm A — ``>(shell)`` as a stdout-routing REDIRECT TARGET. The operator
+            set is stdout-only (``>``, ``>>``, ``1>``, ``1>>``, ``&>``, ``&>>``,
+            the csh ``>&`` excluding the fd-duplication ``>&N``, and the clobber
+            ``>|``); stderr-only routing (``2>``/``3>``) is excluded by omission.
+          * Arm B — ``>(shell)`` as a command ARGUMENT (tee-fanout & general, e.g.
+            ``... | tee >(bash)``). Keyed on a preceding NON-redirect token (word
+            char, quote, or close-bracket), so ``2> >(bash)`` (preceded by ``>``)
+            is NOT matched — the stderr exclusion holds on this arm too.
+    Both output-side arms accept an optional path prefix (``>(/bin/bash)``,
+    ``>(./sh)``) and require the shell name as a whole path-leaf token: non-shell
+    targets (``> >(tee ...)``, ``> >(cat ...)``), prefix-of-name (``>(teehee)``,
+    ``>(basht)``), and ``>(bash/foo)`` (bash a directory) are NOT matched.
+
+    The guard is consumed ONLY as a strip-SKIP condition: a True result PRESERVES
+    content for the dangerous-pattern scan, so widening it is monotonically
+    detection-increasing (INV-D2-safe; cannot create a false-negative).
     """
     return bool(
-        re.search(r"\b(?:bash|sh|zsh)\s+<\(", command)                                 # input-side (unchanged)
-        or re.search(r"(?:&>>?|1>>?|(?<![0-9])>>?)\s*>\(\s*(?:bash|sh|zsh)\b", command)  # output-side (#1002)
+        re.search(r"\b(?:bash|sh|zsh)\s+<\(", command)                       # input-side (unchanged)
+        # Arm A — redirect TARGET, stdout-routing operators only (stderr excluded by construction):
+        or re.search(r"(?:&>>?|>&(?![0-9])|>\||1>>?|(?<![0-9])>>?)\s*>\(\s*" + _PROCSUB_SHELL, command)
+        # Arm B — procsub as a command ARGUMENT (tee-fanout & general): preceded by a NON-redirect token:
+        or re.search(r"[\w\"')\]}]\s+>\(\s*" + _PROCSUB_SHELL, command)
     )
 
 

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -67,6 +67,8 @@ try:
         _GH_API_PREFIX,
         _GH_PR_MERGE_RE,
         _GH_PR_CLOSE_RE,
+        # Bound for the inline httpie global-flag walks below (#1001).
+        _MAX_GLOBAL_FLAG_TOKENS,
     )
 except BaseException as _module_load_error:  # noqa: BLE001 — fail-closed catch-all
     # Hand-built deny output using only stdlib (json, sys). Cannot rely on any
@@ -90,6 +92,7 @@ except BaseException as _module_load_error:  # noqa: BLE001 — fail-closed catc
 # Note: _GH_GLOBAL_FLAGS, _GH_FLAG_TOKENS, _GIT_GLOBAL_FLAGS, _GH_PREFIX,
 # _GIT_PREFIX, _GH_API_PREFIX, _GH_PR_MERGE_RE, _GH_PR_CLOSE_RE are imported
 # from shared.merge_guard_common above (#720 Bug B relocation).
+# _MAX_GLOBAL_FLAG_TOKENS is also imported (bounds the inline httpie walks, #1001).
 
 # Pre-serialized JSON for allow-path output: tells Claude Code UI to suppress
 # the hook display instead of showing "hook error (No output)".
@@ -167,9 +170,11 @@ try:
     re.compile(r"\bwget\b(?=.*--method=(?:DELETE|PATCH|POST|PUT)\b).*merge", re.IGNORECASE),
     # Alternative HTTP clients: httpie (method is positional arg after 'http'/'https')
     # \bhttps?\s+ ensures word boundary + whitespace (won't match URLs like https://).
-    # (?:\S+\s+)* allows optional flags (e.g., -a user:pass) between command and method.
-    re.compile(r"\bhttps?\s+(?:\S+\s+)*(?:DELETE|PATCH|POST|PUT)\s.*git/refs", re.IGNORECASE),
-    re.compile(r"\bhttps?\s+(?:\S+\s+)*(?:DELETE|PATCH|POST|PUT)\s.*merge", re.IGNORECASE),
+    # (?:\S+\s+){0,K} allows optional flags (e.g., -a user:pass) between command and
+    # method — BOUNDED by _MAX_GLOBAL_FLAG_TOKENS to avoid the O(n^2) multi-anchor
+    # backtracking of the unbounded `*` form (#1001), matching the shared-prefix fix.
+    re.compile(r"\bhttps?\s+(?:\S+\s+){0,%d}(?:DELETE|PATCH|POST|PUT)\s.*git/refs" % _MAX_GLOBAL_FLAG_TOKENS, re.IGNORECASE),
+    re.compile(r"\bhttps?\s+(?:\S+\s+){0,%d}(?:DELETE|PATCH|POST|PUT)\s.*merge"    % _MAX_GLOBAL_FLAG_TOKENS, re.IGNORECASE),
     # Known API detection gaps (defense-in-depth, not a security boundary):
     # - GraphQL mutations: gh api graphql -f query='mutation { ... }' bypasses REST-path matching
     # - gh alias: aliases can hide API calls (tracked in #270)

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -182,9 +182,13 @@ try:
     re.compile(_GIT_PREFIX + r"push\s+\S+\s+HEAD:main\b"),
     re.compile(_GIT_PREFIX + r"push\s+\S+\s+HEAD:master\b"),
     # Regular push to main/master (e.g., local merge then push)
-    # Negative lookahead (?!:) prevents matching refspecs like main:feature-branch
-    re.compile(_GIT_PREFIX + r"push\s+(?:-\S+\s+)*\S+\s+main(?!:)\b"),
-    re.compile(_GIT_PREFIX + r"push\s+(?:-\S+\s+)*\S+\s+master(?!:)\b"),
+    # Negative lookahead (?!:) prevents matching refspecs like main:feature-branch.
+    # The dash-flag walk is BOUNDED {0,K} — defense-in-depth that removes the last
+    # unbounded `*` prefix walk in the push patterns so their linearity is
+    # structural/intrinsic rather than contingent on the global-flag prefix bound
+    # (#1001 family); already linear at HEAD, not a hang-fix.
+    re.compile(_GIT_PREFIX + r"push\s+(?:-\S+\s+){0,%d}\S+\s+main(?!:)\b"   % _MAX_GLOBAL_FLAG_TOKENS),
+    re.compile(_GIT_PREFIX + r"push\s+(?:-\S+\s+){0,%d}\S+\s+master(?!:)\b" % _MAX_GLOBAL_FLAG_TOKENS),
 ]
 
     # _GH_PR_MERGE_RE and _GH_PR_CLOSE_RE relocated to shared.merge_guard_common

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -238,12 +238,25 @@ def _has_pipe_to_shell(command: str) -> bool:
 
 
 def _has_process_substitution_to_shell(command: str) -> bool:
-    """Check if command uses process substitution fed to a shell interpreter.
+    """Check if a command uses process substitution fed to a shell interpreter.
 
-    Detects patterns like ``bash <(echo "...")`` where the output of echo/printf
-    inside ``<(...)`` is executed by the shell interpreter.
+    Detects BOTH:
+      - input-side  `bash <(echo "...")`  — shell consumes the substitution as
+        its input script (the original guard);
+      - output-side `echo "..." > >(bash)` — a stdout-routing redirect feeds the
+        command's stdout into a shell (#1002). Restricted to stdout-routing
+        redirect operators (`>`, `>>`, `1>`, `1>>`, `&>`, `&>>`) and to the same
+        shell-interpreter target set, so non-shell consumers (`> >(tee ...)`,
+        `> >(cat ...)`) and stderr-only routing (`2> >(bash)`) are NOT matched.
+    Both arms are used only as a strip-SKIP condition: a True result PRESERVES
+    content for the dangerous-pattern scan, so widening this guard is
+    monotonically detection-increasing (INV-D2-safe; cannot create a
+    false-negative).
     """
-    return bool(re.search(r"\b(?:bash|sh|zsh)\s+<\(", command))
+    return bool(
+        re.search(r"\b(?:bash|sh|zsh)\s+<\(", command)                                 # input-side (unchanged)
+        or re.search(r"(?:&>>?|1>>?|(?<![0-9])>>?)\s*>\(\s*(?:bash|sh|zsh)\b", command)  # output-side (#1002)
+    )
 
 
 def _has_eval_or_source(command: str) -> bool:

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -241,11 +241,22 @@ def _has_pipe_to_shell(command: str) -> bool:
     )
 
 
-# Path-qualified shell token — ReDoS-free (disjoint-segment; STOPS at space/`)`).
-# Trailing (?![\w/]) anchors the shell name as a whole PATH-LEAF token: excludes
-# prefix-of-name (`>(basht)`/`>(teehee)`) AND `>(bash/foo)` (bash is a DIRECTORY,
-# foo the executable) while KEEPING metachar-separated real vectors
-# `>(bash;ls)`/`>(bash&&x)`/`>(bash|cat)` (bash still executes).
+# Path-qualified shell token. Trailing (?![\w/]) anchors the shell name as a
+# whole PATH-LEAF token: excludes prefix-of-name (`>(basht)`/`>(teehee)`) AND
+# `>(bash/foo)` (bash is a DIRECTORY, foo the executable) while KEEPING
+# metachar-separated real vectors `>(bash;ls)`/`>(bash&&x)`/`>(bash|cat)`
+# (bash still executes).
+#
+# ReDoS — ReDoS-free AS USED, NOT standalone. Both arms anchor this token behind
+# `>\(`, so re.search only attempts it at the handful of `>(` offsets in a real
+# command. STANDALONE the nested `(?:[^\s)/]*/)*` is O(N^2): re.search retries at
+# EVERY start position (multi-offset retry) with an O(N) per-offset forward scan
+# — measured ~4x per input-doubling on pathological no-slash / all-slash input.
+# This is NOT within-match catastrophic backtracking (an anchored re.match is
+# linear, ~2x/double), so an atomic group `(?>...)` would NOT fix it (and atomic
+# groups are unavailable anyway — requires-python >=3.7). DO NOT reuse this token
+# UNGATED; if it is ever needed ungated, bound the path segments
+# `(?:[^\s)/]*/){0,K}` (the F1 mechanism), which caps the per-offset scan.
 _PROCSUB_SHELL = r"(?:[^\s)/]*/)*(?:bash|sh|zsh)(?![\w/])"
 
 
@@ -348,26 +359,40 @@ def _strip_non_executable_content(command: str) -> str:
     """
     result = command
 
+    # Output-side execution-routing flags — computed ONCE for ALL stdout-
+    # producing content carriers (heredoc/echo/commit-msg/here-string/gh-
+    # creation). When the command pipes its output to a shell or feeds a shell
+    # via OUTPUT-side process substitution (`> >(bash)`), a stripped dangerous
+    # literal would still EXECUTE downstream, so those carriers must SKIP
+    # stripping (preserve content → detect). Hoisted above carrier 1 so the
+    # heredoc carrier can consult them too. MONOTONIC: a True flag only ADDS
+    # detection (skip strip → more content scanned); never removes it.
+    piped_to_shell = _has_pipe_to_shell(command)
+    process_sub_to_shell = _has_process_substitution_to_shell(command)
+
     # 1. Strip heredoc bodies: << 'EOF' ... EOF, << EOF ... EOF, << "EOF" ... EOF
     #    Match the heredoc marker, then everything up to and including the
     #    closing marker on its own line.
-    #    GUARD: Skip stripping if the heredoc is fed to a shell interpreter
-    #    (e.g., bash << EOF ... EOF), because the body would execute.
-    def _strip_heredoc(match: re.Match) -> str:
-        # Check what command precedes the heredoc operator
-        start = match.start()
-        preceding = command[:start].rstrip()
-        # If the preceding command is a shell interpreter, preserve content
-        if re.search(r"\b(?:bash|sh|zsh)\s*$", preceding):
-            return match.group(0)  # Preserve — content executes
-        return "<<HEREDOC_STRIPPED"
+    #    GUARD (input-side): the inner check preserves the body if the heredoc
+    #    is fed to a shell interpreter (e.g. bash << EOF ... EOF — body executes).
+    #    GUARD (output-side): the outer piped/process-sub skip preserves the body
+    #    when it is routed to a shell via `| bash` / `> >(bash)`. The two COMPOSE.
+    if not piped_to_shell and not process_sub_to_shell:
+        def _strip_heredoc(match: re.Match) -> str:
+            # Check what command precedes the heredoc operator
+            start = match.start()
+            preceding = command[:start].rstrip()
+            # If the preceding command is a shell interpreter, preserve content
+            if re.search(r"\b(?:bash|sh|zsh)\s*$", preceding):
+                return match.group(0)  # Preserve — content executes
+            return "<<HEREDOC_STRIPPED"
 
-    result = re.sub(
-        r"<<-?\s*['\"]?(\w+)['\"]?.*?\n.*?\n\t*\1\b",
-        _strip_heredoc,
-        result,
-        flags=re.DOTALL,
-    )
+        result = re.sub(
+            r"<<-?\s*['\"]?(\w+)['\"]?.*?\n.*?\n\t*\1\b",
+            _strip_heredoc,
+            result,
+            flags=re.DOTALL,
+        )
 
     # 2. Strip comments: # to end of line
     #    Only strip when # appears at start of line or after whitespace/semicolon
@@ -383,8 +408,7 @@ def _strip_non_executable_content(command: str) -> str:
     #    NOTE: ``bash -c 'dangerous'`` is NOT affected by this stripping —
     #    the echo/printf regex only matches echo/printf commands, so
     #    ``bash -c`` content is implicitly preserved and correctly detected.
-    piped_to_shell = _has_pipe_to_shell(command)
-    process_sub_to_shell = _has_process_substitution_to_shell(command)
+    #    (piped_to_shell / process_sub_to_shell are hoisted to the top.)
     if not piped_to_shell and not process_sub_to_shell:
         # Double-quoted: also guard against command substitution inside
         def _strip_echo_dq(match: re.Match) -> str:
@@ -441,58 +465,65 @@ def _strip_non_executable_content(command: str) -> str:
         )
 
     # 5. Strip git commit -m quoted arguments
-    #    The -m argument to git commit is a message, never executed.
-    #    GUARD: Check for command substitution in double-quoted messages.
-    def _strip_commit_msg_dq(match: re.Match) -> str:
-        if _has_command_substitution(match.group(0)):
-            return match.group(0)  # Preserve — $() executes
-        return match.group(1) + ' -m STRIPPED'
+    #    The -m argument to git commit is a message, never executed directly.
+    #    GUARD (cmd-subst): preserve a double-quoted message containing $()/backtick.
+    #    GUARD (output-side): a commit SUBJECT is echoed to git's stdout, so
+    #    `git commit -m "..." > >(bash)` (or `| bash`) routes it to a shell — the
+    #    outer piped/process-sub skip preserves it for detection (#1002).
+    if not piped_to_shell and not process_sub_to_shell:
+        def _strip_commit_msg_dq(match: re.Match) -> str:
+            if _has_command_substitution(match.group(0)):
+                return match.group(0)  # Preserve — $() executes
+            return match.group(1) + ' -m STRIPPED'
 
-    result = re.sub(
-        r'\b(git\s+commit)\s+-m\s+"(?:[^"\\]|\\.)*"',
-        _strip_commit_msg_dq,
-        result,
-    )
-    result = re.sub(
-        r"\b(git\s+commit)\s+-m\s+'[^']*'",
-        r"\1 -m STRIPPED",
-        result,
-    )
+        result = re.sub(
+            r'\b(git\s+commit)\s+-m\s+"(?:[^"\\]|\\.)*"',
+            _strip_commit_msg_dq,
+            result,
+        )
+        result = re.sub(
+            r"\b(git\s+commit)\s+-m\s+'[^']*'",
+            r"\1 -m STRIPPED",
+            result,
+        )
 
     # 6. Strip here-string quoted arguments: <<< "..." or <<< '...'
     #    Here-strings pass text as stdin, not as a command.
-    #    GUARD: Skip stripping if a shell interpreter precedes the <<<
-    #    (e.g., bash <<< "dangerous"), because the content would execute.
-    #    GUARD: Check for command substitution in double-quoted content.
-    def _strip_herestring_dq(match: re.Match) -> str:
-        # Check what command precedes the <<<
-        start = match.start()
-        preceding = command[:start].rstrip()
-        if re.search(r"\b(?:bash|sh|zsh)\s*$", preceding):
-            return match.group(0)  # Preserve — content executes
-        if _has_command_substitution(match.group(0)):
-            return match.group(0)  # Preserve — $() executes
-        return "<<<STRIPPED"
+    #    GUARD (input-side): the inner check preserves content if a shell
+    #    interpreter precedes the <<< (e.g. bash <<< "dangerous" — executes).
+    #    GUARD (cmd-subst): preserve double-quoted content containing $()/backtick.
+    #    GUARD (output-side): the outer piped/process-sub skip preserves content
+    #    routed to a shell via `| bash` / `> >(bash)`. The guards COMPOSE.
+    if not piped_to_shell and not process_sub_to_shell:
+        def _strip_herestring_dq(match: re.Match) -> str:
+            # Check what command precedes the <<<
+            start = match.start()
+            preceding = command[:start].rstrip()
+            if re.search(r"\b(?:bash|sh|zsh)\s*$", preceding):
+                return match.group(0)  # Preserve — content executes
+            if _has_command_substitution(match.group(0)):
+                return match.group(0)  # Preserve — $() executes
+            return "<<<STRIPPED"
 
-    result = re.sub(
-        r'<<<\s*"(?:[^"\\]|\\.)*"',
-        _strip_herestring_dq,
-        result,
-    )
+        result = re.sub(
+            r'<<<\s*"(?:[^"\\]|\\.)*"',
+            _strip_herestring_dq,
+            result,
+        )
 
-    def _strip_herestring_sq(match: re.Match) -> str:
-        # Check what command precedes the <<<
-        start = match.start()
-        preceding = command[:start].rstrip()
-        if re.search(r"\b(?:bash|sh|zsh)\s*$", preceding):
-            return match.group(0)  # Preserve — content executes
-        return "<<<STRIPPED"
+        def _strip_herestring_sq(match: re.Match) -> str:
+            # Check what command precedes the <<<
+            start = match.start()
+            preceding = command[:start].rstrip()
+            if re.search(r"\b(?:bash|sh|zsh)\s*$", preceding):
+                return match.group(0)  # Preserve — content executes
+            return "<<<STRIPPED"
 
-    result = re.sub(
-        r"<<<\s*'[^']*'",
-        _strip_herestring_sq,
-        result,
-    )
+        result = re.sub(
+            r"<<<\s*'[^']*'",
+            _strip_herestring_sq,
+            result,
+        )
 
     # 7. Strip gh issue/pr CREATION-carrier quoted arguments.
     #    `gh issue create/edit` and `gh pr create` accept --title/--body

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -121,31 +121,36 @@ LAYER1_SUCCESS_STDOUT_PATTERNS: dict[str, str | None] = {
 # pattern bank without duplicating regex source.
 # -----------------------------------------------------------------------------
 
-# Upper bound on global-flag tokens between a CLI tool and its subcommand.
+# Upper bound on flag tokens in a CLI flag region. Governs BOTH the global-flag
+# prefix between a tool and its subcommand (e.g. `git -c k=v ... push`) AND the
+# push-dash-flag walk between `push` and its refspec (e.g. `git push -u -f main`).
 # Eliminates the O(n^2) multi-anchor backtracking of the unbounded `*` form
 # (#1001) while preserving the "matches any token" semantics EXACTLY for any
-# command with <= _MAX_GLOBAL_FLAG_TOKENS global tokens — i.e. every realistic
-# command (the heaviest realistic git global-flag count, e.g.
-# `git -c a=1 -c b=2 -C /p --git-dir=/g --work-tree=/w push ...`, is ~10
-# tokens; gh is ~2). 32 is ~3x that headroom, and is a fixed modest constant so
-# per-anchor work is O(32)=O(1) regardless of input length.
+# command with <= _MAX_GLOBAL_FLAG_TOKENS flag tokens in that region — i.e. every
+# realistic command (the heaviest realistic git global-flag count, e.g.
+# `git -c a=1 -c b=2 -C /p --git-dir=/g --work-tree=/w push ...`, is ~10 tokens;
+# gh is ~2; push dash-flags ~2-3). 64 is generous headroom over that, and is a
+# fixed modest constant so per-anchor work is O(64)=O(1) regardless of input length.
 #
-# ACCEPTED RESIDUAL (honest INV-D2 accounting): a command with >32 *valid*
-# global tokens before its verb is NOT impossible — `git -c k=v` is a
-# legitimate, repeatable pair, so e.g. `git -c a=1 -c b=2 ...(17 pairs=34
+# ACCEPTED RESIDUAL (honest INV-D2 accounting): a command with >64 *valid* flag
+# tokens before its verb/refspec is NOT impossible — `git -c k=v` is a
+# legitimate, repeatable pair, so e.g. `git -c a=1 -c b=2 ...(33 pairs=66
 # tokens)... push --force` DOES execute yet exceeds the bound, so the bounded
 # form misses a real destructive op the unbounded form caught. This is a
 # NARROW residual under-block, accepted as a documented tradeoff against the
 # O(n^2) DoS, justified by the THREAT MODEL: #1001's input is operator/LLM-
 # authored command text (defense-in-depth, NOT adversarial network input), and
-# padding 17+ `-c` pairs to evade one's OWN merge guard is self-defeating (the
-# author would simply write the command directly). It is a relaxation of
-# INV-D2, not a no-op — stated plainly rather than papered over.
-# DO NOT raise this to a value comparable to realistic input lengths (that
-# reintroduces per-anchor O(N) cost). It MAY be raised modestly (e.g. 64) as
-# zero-cost defense-in-depth if security review deems the residual material —
-# 64 is still a fixed modest constant, still O(1)/linear.
-_MAX_GLOBAL_FLAG_TOKENS = 32
+# padding 33+ `-c` pairs to evade one's OWN merge guard is self-defeating (the
+# author would simply write the command directly). The push-dash-flag walk
+# carries the SAME residual class but is even less reachable (push dash-flags are
+# not meaningfully infinitely-repeatable; a flag with a non-dash value, e.g.
+# `-o <opt>`, already breaks the walk). It is a relaxation of INV-D2, not a
+# no-op — stated plainly rather than papered over.
+# This was raised 32 -> 64 as zero-cost defense-in-depth (doubles the >K-residual
+# headroom; still a fixed modest constant, still O(1)/linear). DO NOT raise it to
+# a value comparable to realistic input lengths (that reintroduces per-anchor
+# O(N) cost).
+_MAX_GLOBAL_FLAG_TOKENS = 64
 
 # Optional global flags between CLI tool and subcommand — BOUNDED (was `*`).
 _GH_GLOBAL_FLAGS  = r"(?:\S+\s+){0,%d}" % _MAX_GLOBAL_FLAG_TOKENS
@@ -213,7 +218,7 @@ def detect_command_operation_type(command: str) -> str | None:
     if re.search(_GIT_PREFIX + r"push\s+\S+\s+HEAD:(?:main|master)\b", command):
         return "force-push"
     if re.search(
-        _GIT_PREFIX + r"push\s+(?:-(?!-force-with-lease\b)\S+\s+)*\S+\s+(?:main|master)(?!:)\b",
+        _GIT_PREFIX + r"push\s+(?:-(?!-force-with-lease\b)\S+\s+){0,%d}\S+\s+(?:main|master)(?!:)\b" % _MAX_GLOBAL_FLAG_TOKENS,
         command,
     ):
         return "force-push"

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -121,15 +121,38 @@ LAYER1_SUCCESS_STDOUT_PATTERNS: dict[str, str | None] = {
 # pattern bank without duplicating regex source.
 # -----------------------------------------------------------------------------
 
-# Optional global flags between CLI tool and subcommand.
-# (?:\S+\s+)* matches zero or more flag+value tokens (e.g., --repo owner/repo).
-_GH_GLOBAL_FLAGS = r"(?:\S+\s+)*"  # broad — keep for DANGEROUS_PATTERNS (matches any token)
-# Tight variant for PR-number extraction: only flag-shaped tokens
-# (`-x`, `--long`, optionally `--flag value`). Prevents the capture group
-# from greedily walking past the PR positional into heredoc body content,
-# 2>&1 redirects, or trailing positional-digit tokens.
-_GH_FLAG_TOKENS = r"(?:-\S*(?:\s+\S+)?\s+)*"
-_GIT_GLOBAL_FLAGS = r"(?:\S+\s+)*"
+# Upper bound on global-flag tokens between a CLI tool and its subcommand.
+# Eliminates the O(n^2) multi-anchor backtracking of the unbounded `*` form
+# (#1001) while preserving the "matches any token" semantics EXACTLY for any
+# command with <= _MAX_GLOBAL_FLAG_TOKENS global tokens — i.e. every realistic
+# command (the heaviest realistic git global-flag count, e.g.
+# `git -c a=1 -c b=2 -C /p --git-dir=/g --work-tree=/w push ...`, is ~10
+# tokens; gh is ~2). 32 is ~3x that headroom, and is a fixed modest constant so
+# per-anchor work is O(32)=O(1) regardless of input length.
+#
+# ACCEPTED RESIDUAL (honest INV-D2 accounting): a command with >32 *valid*
+# global tokens before its verb is NOT impossible — `git -c k=v` is a
+# legitimate, repeatable pair, so e.g. `git -c a=1 -c b=2 ...(17 pairs=34
+# tokens)... push --force` DOES execute yet exceeds the bound, so the bounded
+# form misses a real destructive op the unbounded form caught. This is a
+# NARROW residual under-block, accepted as a documented tradeoff against the
+# O(n^2) DoS, justified by the THREAT MODEL: #1001's input is operator/LLM-
+# authored command text (defense-in-depth, NOT adversarial network input), and
+# padding 17+ `-c` pairs to evade one's OWN merge guard is self-defeating (the
+# author would simply write the command directly). It is a relaxation of
+# INV-D2, not a no-op — stated plainly rather than papered over.
+# DO NOT raise this to a value comparable to realistic input lengths (that
+# reintroduces per-anchor O(N) cost). It MAY be raised modestly (e.g. 64) as
+# zero-cost defense-in-depth if security review deems the residual material —
+# 64 is still a fixed modest constant, still O(1)/linear.
+_MAX_GLOBAL_FLAG_TOKENS = 32
+
+# Optional global flags between CLI tool and subcommand — BOUNDED (was `*`).
+_GH_GLOBAL_FLAGS  = r"(?:\S+\s+){0,%d}" % _MAX_GLOBAL_FLAG_TOKENS
+# Tight variant for PR-number extraction — UNCHANGED (already linear; requires
+# a leading `-` per token so it fails fast; used only by _GH_PR_NUMBER_RE).
+_GH_FLAG_TOKENS   = r"(?:-\S*(?:\s+\S+)?\s+)*"
+_GIT_GLOBAL_FLAGS = r"(?:\S+\s+){0,%d}" % _MAX_GLOBAL_FLAG_TOKENS
 
 # Composed prefixes for DRY usage across all patterns.
 _GH_PREFIX = r"\bgh\s+" + _GH_GLOBAL_FLAGS

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -124,33 +124,36 @@ LAYER1_SUCCESS_STDOUT_PATTERNS: dict[str, str | None] = {
 # Upper bound on flag tokens in a CLI flag region. Governs BOTH the global-flag
 # prefix between a tool and its subcommand (e.g. `git -c k=v ... push`) AND the
 # push-dash-flag walk between `push` and its refspec (e.g. `git push -u -f main`).
-# Eliminates the O(n^2) multi-anchor backtracking of the unbounded `*` form
-# (#1001) while preserving the "matches any token" semantics EXACTLY for any
+# The global-flag prefix bound eliminates the O(n^2) multi-anchor backtracking of
+# the unbounded `*` form (#1001); the push-dash-flag walk bound is defense-in-
+# depth structural-linearity (that walk was already linear once the prefix is
+# bounded — bounding the inner walk makes its linearity intrinsic rather than
+# contingent). Both preserve the "matches any token" semantics EXACTLY for any
 # command with <= _MAX_GLOBAL_FLAG_TOKENS flag tokens in that region — i.e. every
 # realistic command (the heaviest realistic git global-flag count, e.g.
 # `git -c a=1 -c b=2 -C /p --git-dir=/g --work-tree=/w push ...`, is ~10 tokens;
-# gh is ~2; push dash-flags ~2-3). 64 is generous headroom over that, and is a
-# fixed modest constant so per-anchor work is O(64)=O(1) regardless of input length.
+# gh is ~2; push dash-flags ~2-3). 32 is ~3x that headroom, and is a fixed modest
+# constant so per-anchor work is O(32)=O(1) regardless of input length.
 #
-# ACCEPTED RESIDUAL (honest INV-D2 accounting): a command with >64 *valid* flag
+# ACCEPTED RESIDUAL (honest INV-D2 accounting): a command with >32 *valid* flag
 # tokens before its verb/refspec is NOT impossible — `git -c k=v` is a
-# legitimate, repeatable pair, so e.g. `git -c a=1 -c b=2 ...(33 pairs=66
+# legitimate, repeatable pair, so e.g. `git -c a=1 -c b=2 ...(17 pairs=34
 # tokens)... push --force` DOES execute yet exceeds the bound, so the bounded
 # form misses a real destructive op the unbounded form caught. This is a
 # NARROW residual under-block, accepted as a documented tradeoff against the
 # O(n^2) DoS, justified by the THREAT MODEL: #1001's input is operator/LLM-
 # authored command text (defense-in-depth, NOT adversarial network input), and
-# padding 33+ `-c` pairs to evade one's OWN merge guard is self-defeating (the
+# padding 17+ `-c` pairs to evade one's OWN merge guard is self-defeating (the
 # author would simply write the command directly). The push-dash-flag walk
 # carries the SAME residual class but is even less reachable (push dash-flags are
 # not meaningfully infinitely-repeatable; a flag with a non-dash value, e.g.
 # `-o <opt>`, already breaks the walk). It is a relaxation of INV-D2, not a
 # no-op — stated plainly rather than papered over.
-# This was raised 32 -> 64 as zero-cost defense-in-depth (doubles the >K-residual
-# headroom; still a fixed modest constant, still O(1)/linear). DO NOT raise it to
-# a value comparable to realistic input lengths (that reintroduces per-anchor
-# O(N) cost).
-_MAX_GLOBAL_FLAG_TOKENS = 64
+# DO NOT raise this constant casually: a larger cap scales the per-anchor work,
+# and on a pathological multi-anchor input the constant factor grows measurably
+# (a larger value carries a real, if modest, cost — it is not free). Keep it a
+# small fixed value so per-anchor work stays O(1)/linear.
+_MAX_GLOBAL_FLAG_TOKENS = 32
 
 # Optional global flags between CLI tool and subcommand — BOUNDED (was `*`).
 _GH_GLOBAL_FLAGS  = r"(?:\S+\s+){0,%d}" % _MAX_GLOBAL_FLAG_TOKENS

--- a/pact-plugin/tests/test_merge_guard_output_side_process_sub.py
+++ b/pact-plugin/tests/test_merge_guard_output_side_process_sub.py
@@ -180,3 +180,119 @@ def test_input_side_functional_parity_unchanged():
     `bash <(echo '<danger>')` is dangerous; `cat <(...)` is not."""
     assert is_dangerous_command('bash <(echo "gh pr merge 42")') is True
     assert is_dangerous_command('cat <(echo "gh pr merge 42")') is False
+
+
+# ===========================================================================
+# Remediation (PR #1003, commit E 98bf4f4e) — F2 output-side COMPLETENESS.
+#
+# The single output-side arm was replaced by TWO arms + a shared path-qualified
+# shell token ``_PROCSUB_SHELL = (?:[^\s)/]*/)*(?:bash|sh|zsh)(?![\w/])``:
+#   * Arm A — redirect TARGET; operator set adds the csh ``>&`` (excl. fd-dup
+#     ``>&N``) and the clobber ``>|`` (closes the test-engineer `>&`/`>|` finding);
+#   * Arm B — procsub as a command ARGUMENT (``| tee >(bash)`` / general fanout),
+#     keyed on a preceding NON-redirect token so ``2> >(bash)`` is still excluded.
+#   * path prefix ``(?:[^\s)/]*/)*`` accepts ``>(/bin/bash)`` / ``>(./sh)``;
+#   * trailing ``(?![\w/])`` anchors the shell name as a whole PATH-LEAF token:
+#     KEEPS metachar-separated real vectors ``>(bash;ls)`` / ``>(bash&&x)`` /
+#     ``>(bash|cat)`` (bash still executes — empirically confirmed), while
+#     DROPPING suffix-of-name ``>(basht)`` / ``>(mysh)`` and ``>(bash/foo)``
+#     (bash a directory). `(?![\w/])` was chosen over `\b` (over-blocks bash/foo)
+#     and over `(?=[\s)])` (UNDER-blocks the metachar vectors — fix-introduced
+#     INV-D2 holes); design §12.1.
+#
+# Counter-test-by-revert (non-vacuity, ephemeral — see remediation HANDOFF):
+#   * positives — removal-revert the relevant arm/piece (e.g. drop the `>&`/`>|`
+#     operators, or the path prefix, or Arm B) → the corresponding positive RED;
+#   * exclusions — DISTINCT broaden-mutation (a removal-revert can't falsify an
+#     exclusion): widen `(?![\w/])`->`\b` re-introduces the `>(bash/foo)`/suffix
+#     over-blocks → those negatives flip RED.
+# ===========================================================================
+
+# Guard-unit positives (payload irrelevant — the guard keys on redirect/arg syntax).
+_REMEDIATION_POSITIVES_GUARD = [
+    'echo "x" >& >(bash)',        # csh stdout+stderr synonym of `&>` (Arm A)
+    'echo "x" >| >(bash)',        # clobber-override redirect (Arm A)
+    'echo "x" > >(/bin/bash)',    # absolute path-qualified target
+    'echo "x" > >(./sh)',         # relative path-qualified target
+    'echo "x" > >(/usr/bin/zsh)', # abs-path zsh
+    'echo "x" | tee >(bash)',     # tee-fanout — procsub as command arg (Arm B)
+    'echo "x" | tee -a >(bash)',  # tee -a fanout (Arm B)
+    'echo "x" > >(bash;ls)',      # metachar `;` — bash executes before the sep
+    'echo "x" > >(bash&&y)',      # metachar `&&`
+    'echo "x" > >(bash|cat)',     # metachar `|`
+]
+
+# Guard-unit NEW exclusions (over-block bound — must stay False).
+_REMEDIATION_NEGATIVES_GUARD = [
+    'echo "x" > >(/usr/bin/tee)',  # path-qualified NON-shell target
+    'echo "x" > >(teehee)',        # shell name is not a whole leaf (prefix-of-name)
+    'echo "x" > >(basht)',         # `bash` + trailing word char (suffix-of-name)
+    'echo "x" > >(mysh)',          # `sh` as a name suffix
+    'echo "x" > >(bash/foo)',      # `bash` is a DIRECTORY, `foo` the executable
+]
+
+# Functional positives — DANGEROUS payload so the strip-skip is OBSERVABLE
+# through is_dangerous_command (anti-phantom-green).
+_REMEDIATION_FUNCTIONAL_POSITIVES = [
+    'echo "gh pr merge 42" >& >(bash)',
+    'echo "gh pr merge 42" >| >(bash)',
+    'echo "gh pr merge 42" > >(/bin/bash)',
+    'echo "gh pr merge 42" > >(./sh)',
+    'echo "gh pr merge 42" | tee >(bash)',
+    'echo "gh pr merge 42" | tee -a >(bash)',
+    'echo "gh pr merge 42" > >(bash;ls)',
+    'echo "gh pr merge 42" > >(bash&&y)',
+    'echo "gh pr merge 42" > >(bash|cat)',
+    "echo 'git branch -D real' > >(/bin/bash)",  # branch-delete payload, path-qualified
+]
+
+# Functional NEW exclusions — dangerous payload routed where it never reaches a
+# shell (non-shell target / non-leaf shell name), so it stays stripped/benign.
+_REMEDIATION_FUNCTIONAL_NEGATIVES = [
+    'echo "gh pr merge 42" > >(/usr/bin/tee)',
+    'echo "gh pr merge 42" > >(teehee)',
+    'echo "gh pr merge 42" > >(basht)',
+    'echo "gh pr merge 42" > >(mysh)',
+    'echo "gh pr merge 42" > >(bash/foo)',
+]
+
+
+@pytest.mark.parametrize("command", _REMEDIATION_POSITIVES_GUARD)
+def test_remediation_guard_detects_new_output_side_forms(command):
+    """`>&`/`>|`/path-qualified/tee-fanout/metachar-separated procsub-to-shell
+    forms are now detected by the two-arm guard."""
+    assert _has_process_substitution_to_shell(command) is True
+
+
+@pytest.mark.parametrize("command", _REMEDIATION_NEGATIVES_GUARD)
+def test_remediation_guard_excludes_nonleaf_and_nonshell(command):
+    """Path-qualified non-shell, prefix/suffix-of-name, and path-dir targets are
+    NOT matched (the `(?![\\w/])` path-leaf over-block bound)."""
+    assert _has_process_substitution_to_shell(command) is False
+
+
+@pytest.mark.parametrize("command", _REMEDIATION_FUNCTIONAL_POSITIVES)
+def test_remediation_new_forms_are_dangerous(command):
+    """A dangerous literal echo'd into a newly-covered output-side shell
+    process-sub is now caught (previously under-blocked)."""
+    assert is_dangerous_command(command) is True
+
+
+@pytest.mark.parametrize("command", _REMEDIATION_FUNCTIONAL_NEGATIVES)
+def test_remediation_new_exclusions_stay_stripped(command):
+    """A dangerous literal routed to a non-shell or non-leaf-shell target never
+    reaches a shell, so the carrier strips it and it stays non-dangerous."""
+    assert is_dangerous_command(command) is False
+
+
+def test_carrier7_gh_create_output_side_now_over_blocks():
+    """DOCUMENTING test (review f-1): with the output-side guard widened, the
+    carrier-7 gh-create form ``gh issue create --title "<danger>" > >(bash)`` now
+    OVER-blocks — the procsub makes the guard skip the strip, so the title literal
+    is scanned and matched. This is INV-D2-ACCEPTABLE (over-block, never an
+    under-block) and monotonic-safe. In reality the danger does NOT reach bash
+    (gh's stdout is the issue URL, not the title), so this is a benign-but-
+    suspicious form being conservatively flagged. Pinned so the over-block is
+    intentional and visible, not a future surprise."""
+    cmd = 'gh issue create --title "gh pr merge 42" > >(bash)'
+    assert is_dangerous_command(cmd) is True

--- a/pact-plugin/tests/test_merge_guard_output_side_process_sub.py
+++ b/pact-plugin/tests/test_merge_guard_output_side_process_sub.py
@@ -296,3 +296,75 @@ def test_carrier7_gh_create_output_side_now_over_blocks():
     intentional and visible, not a future surprise."""
     cmd = 'gh issue create --title "gh pr merge 42" > >(bash)'
     assert is_dangerous_command(cmd) is True
+
+
+# ===========================================================================
+# Carrier-gating completeness (PR #1003, commit 5623c938) — security #41
+# MEDIUM-1. F2's output-side detection must be wired into EVERY stdout-producing
+# content-stripping carrier, not just echo (#3) and gh-creation (#7). Carriers
+# #1 (heredoc), #5 (commit-msg), #6 (here-string) are now gated on
+# `not piped_to_shell and not process_sub_to_shell` (the two flags are hoisted
+# once to the top of _strip_non_executable_content and compose with each
+# carrier's existing input-side/cmd-subst guards). A dangerous literal carried by
+# #1/#5/#6 and routed to a shell via OUTPUT-side procsub (`> >(bash)`) OR a pipe
+# (`| bash`) is now PRESERVED (strip skipped) → detected, where it was previously
+# stripped → under-blocked. Empirically confirmed the routing is real: a benign
+# `cat <<< "echo PWN" > >(bash)` and `cat <<EOF ... echo PWN ... EOF > >(bash)`
+# both EXECUTE in live bash (the carrier's stdout reaches the shell). Carriers #2
+# (comments — bash no-op) and #4 (var-assign — emits no stdout) are deliberately
+# NOT gated and stay benign.
+#
+# The gate keys on BOTH flags, so each carrier is covered with a procsub form AND
+# a pipe form. Counter-test-by-revert (per-carrier non-vacuity — see HANDOFF):
+# ungating ONE carrier (its `if not piped... and not procsub:` → `if True:`,
+# always-strip = the pre-fix bug) flips ONLY that carrier's positives RED, proving
+# each carrier's gate is INDEPENDENTLY load-bearing (not "some shared gate catches
+# it").
+# ===========================================================================
+
+# Heredoc witnesses are multi-line (marker / body / closing) with the dangerous
+# literal in the BODY and the shell routing on the `cat` line.
+_HEREDOC_PROCSUB = 'cat <<EOF > >(bash)\n; gh pr merge 42\nEOF'
+_HEREDOC_PIPE = 'cat <<EOF | bash\n; gh pr merge 42\nEOF'
+_HEREDOC_BARE = 'cat <<EOF\n; gh pr merge 42\nEOF'
+
+# Positives — dangerous payload routed to a shell; the gate preserves it for the
+# scan. Leading `;` chains the op after whatever prefix the carrier prepends to
+# stdout (e.g. git's commit-summary line). DANGEROUS payload = anti-phantom-green.
+_CARRIER_GATING_POSITIVES = [
+    'git commit -m "; gh pr merge 42" > >(bash)',   # #5 commit-msg, output-side procsub
+    'git commit -m "; gh pr merge 42" | bash',      # #5 commit-msg, pipe-to-shell
+    'cat <<< "; gh pr merge 42" > >(bash)',         # #6 here-string, procsub
+    'cat <<< "; gh pr merge 42" | bash',            # #6 here-string, pipe
+    _HEREDOC_PROCSUB,                                # #1 heredoc, procsub
+    _HEREDOC_PIPE,                                   # #1 heredoc, pipe
+]
+
+# Negatives — no-regression (bare carriers still stripped), over-block control
+# (benign payload → no spurious block even with procsub), and the two UNGATED
+# carriers (#2 comment, #4 var-assign) staying benign.
+_CARRIER_GATING_NEGATIVES = [
+    'git commit -m "; gh pr merge 42"',          # #5 bare — stripped as before (no regression)
+    'cat <<< "; gh pr merge 42"',                # #6 bare — stripped
+    _HEREDOC_BARE,                               # #1 bare — stripped
+    'git commit -m "safe message" > >(bash)',    # over-block control — benign payload, no block
+    'X="; gh pr merge 42" > >(bash)',            # #4 var-assign UNGATED — emits no stdout → benign
+    'echo "hi" > >(bash)  # ; gh pr merge 42',   # #2 comment UNGATED — bash no-op → benign
+]
+
+
+@pytest.mark.parametrize("command", _CARRIER_GATING_POSITIVES)
+def test_gated_carrier_routed_to_shell_is_dangerous(command):
+    """A dangerous literal carried by heredoc/commit-msg/here-string and routed to
+    a shell (output-side procsub OR pipe) is now PRESERVED by the carrier gate and
+    detected (previously stripped → under-blocked; security #41 MEDIUM-1)."""
+    assert is_dangerous_command(command) is True
+
+
+@pytest.mark.parametrize("command", _CARRIER_GATING_NEGATIVES)
+def test_gated_carrier_no_regression_and_ungated_stay_benign(command):
+    """No-regression: the same carriers WITHOUT shell-routing still strip → benign.
+    Over-block control: a benign commit message with procsub is not spuriously
+    flagged. Ungated carriers #2 (comment) and #4 (var-assign) stay benign because
+    a comment is a bash no-op and a var-assign emits no stdout."""
+    assert is_dangerous_command(command) is False

--- a/pact-plugin/tests/test_merge_guard_output_side_process_sub.py
+++ b/pact-plugin/tests/test_merge_guard_output_side_process_sub.py
@@ -1,0 +1,182 @@
+"""Output-side process-substitution-to-shell detection (#1002 / F2).
+
+What F2 fixes
+-------------
+``_has_process_substitution_to_shell`` (``merge_guard_pre.py``) originally only
+matched the *input-side* form ``bash <(...)`` — a shell consuming a process
+substitution as its input script. It missed the **output-side** form
+``cmd > >(bash)``, where a stdout-routing redirect feeds ``cmd``'s stdout into a
+shell. For the echo/printf strip carrier (carrier 3, the only true stdout
+vector — PREPARE §3.1), ``echo "gh pr merge 42" > >(bash)`` feeds the dangerous
+literal to bash, yet the original guard returned ``False`` so the carrier
+stripped the echo argument and ``is_dangerous_command`` read it as safe => a real
+**under-block**.
+
+F2 adds the output-side arm
+``(?:&>>?|1>>?|(?<![0-9])>>?)\\s*>\\(\\s*(?:bash|sh|zsh)\\b``:
+
+* operators are restricted to **stdout-routing** redirects — ``>``, ``>>``,
+  ``1>``, ``1>>``, ``&>``, ``&>>``. The ``(?<![0-9])`` on the bare-``>`` arm
+  excludes a digit-prefixed fd (so ``2>``/``3>`` stderr routing is NOT matched;
+  ``1>`` is still caught by its own explicit arm);
+* the target is restricted to the **shell interpreter** set ``bash|sh|zsh`` —
+  the same set as the input-side guard — so non-shell consumers
+  (``> >(tee ...)``, ``> >(cat ...)``, ``> >(grep ...)``) are NOT matched.
+
+INV-D2 monotonicity
+-------------------
+The guard is consumed only as a strip-SKIP condition: ``True`` => skip the strip
+=> preserve content => MORE detection. Widening it can only *add* detection, so
+it cannot introduce a false-negative. The only real risk is over-block (matching
+a non-shell consumer or stderr routing), which the negatives below bound.
+
+Counter-test-by-revert (non-vacuity)
+------------------------------------
+* **Under-block guarantee (positives)** — removal-revert: delete the output-side
+  arm (restore input-side-only). Every functional positive carries a *dangerous*
+  payload (``gh pr merge 42`` / ``git branch -D x``) so the strip-skip vs
+  strip-run difference changes the OBSERVABLE: ``is_dangerous_command`` flips
+  True->False (under-block returns) => RED. The guard-unit positives flip
+  True->False directly.
+* **Over-block-bound guarantees (exclusions)** — a removal-revert leaves an
+  exclusion still-``False`` (no flip = vacuous), so each exclusion is proven by
+  the DISTINCT *broadening* mutation that would defeat it:
+  - drop ``(?<![0-9])`` => ``2>``/``3>`` over-match => the stderr negatives flip
+    (guard False->True; functional not-dangerous->dangerous) => RED;
+  - widen the target ``(?:bash|sh|zsh)`` => ``\\S+`` => ``tee``/``cat``/``grep``
+    over-match => the non-shell-target negatives flip => RED.
+  The functional exclusion negatives also carry dangerous payloads so the
+  broaden mutation exposes them through ``is_dangerous_command``.
+
+The input-side preservation contract (``bash <(echo 'gh pr merge 42')`` dangerous;
+``cat/grep <(...)`` not; the pinned ``> >(tee push.log)`` not-compound case) is
+pinned by the existing suite in ``test_merge_guard.py`` (§7.1); this module adds
+the new output-side coverage and re-pins the input-side parity that F2 must not
+disturb.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+from merge_guard_pre import (  # noqa: E402
+    _has_process_substitution_to_shell,
+    is_dangerous_command,
+)
+
+
+# ---------------------------------------------------------------------------
+# Guard-unit tests — directly on _has_process_substitution_to_shell (cheap,
+# precise; payload is irrelevant to the guard, which keys on redirect syntax).
+# ---------------------------------------------------------------------------
+
+# Output-side positives the widened guard MUST now detect (design §4.5).
+_OUTPUT_SIDE_POSITIVES = [
+    'echo "x" > >(bash)',          # canonical stdout -> shell
+    'echo "x" > >(sh)',            # sh target
+    'echo "x" > >(zsh)',           # zsh target
+    'echo "x" 1> >(bash)',         # explicit fd-1
+    'echo "x" &> >(bash)',         # stdout+stderr
+    'echo "x" >> >(bash)',         # append-style
+    'echo "x" >  >(bash)',         # extra whitespace between > and >(
+    'echo "x" > >( bash )',        # whitespace inside the substitution
+]
+
+# Exclusions the guard MUST NOT match. Each is defeated only by a *broadening*
+# mutation (named), never by removing the output-side arm — hence the
+# counter-test uses the distinct broaden per exclusion, not a removal-revert.
+_GUARD_NEGATIVES = [
+    'echo "x" 2> >(bash)',                      # stderr fd-2 (drop (?<![0-9]) to defeat)
+    'echo "x" 3> >(bash)',                      # fd-3 (drop (?<![0-9]) to defeat)
+    "git push origin main > >(tee push.log)",   # pinned not-compound; tee not a shell
+    'echo "x" > >(cat)',                        # non-shell target (widen target to defeat)
+    'echo "x" > >(grep foo)',                   # non-shell target
+    'echo "x" > file.log',                      # plain file redirect, no process-sub
+]
+
+# Input-side behavior F2 must leave UNCHANGED (the original guard).
+_INPUT_SIDE_POSITIVES = ["bash <(echo x)", "sh <(echo x)", "zsh <(echo x)"]
+_INPUT_SIDE_NEGATIVES = ["cat <(echo x)", "grep <(echo x)", "echo x", 'echo "just text"']
+
+
+@pytest.mark.parametrize("command", _OUTPUT_SIDE_POSITIVES)
+def test_guard_detects_output_side_to_shell(command):
+    """Output-side stdout-routing redirect into a shell interpreter is detected."""
+    assert _has_process_substitution_to_shell(command) is True
+
+
+@pytest.mark.parametrize("command", _GUARD_NEGATIVES)
+def test_guard_excludes_stderr_and_non_shell_targets(command):
+    """stderr routing (2>/3>) and non-shell consumers (tee/cat/grep) and plain
+    file redirects are NOT matched (over-block bound)."""
+    assert _has_process_substitution_to_shell(command) is False
+
+
+@pytest.mark.parametrize("command", _INPUT_SIDE_POSITIVES)
+def test_guard_input_side_unchanged_positive(command):
+    """Input-side `bash/sh/zsh <(...)` still detected (F2 is additive)."""
+    assert _has_process_substitution_to_shell(command) is True
+
+
+@pytest.mark.parametrize("command", _INPUT_SIDE_NEGATIVES)
+def test_guard_input_side_unchanged_negative(command):
+    """Non-shell input-side consumers and plain echo still not matched."""
+    assert _has_process_substitution_to_shell(command) is False
+
+
+# ---------------------------------------------------------------------------
+# Functional tests — through is_dangerous_command. Positives and exclusion
+# negatives carry a DANGEROUS payload so the strip-skip vs strip-run difference
+# is OBSERVABLE (non-vacuous under the counter-test mutations).
+# ---------------------------------------------------------------------------
+
+# (command, dangerous-payload) — now-detected output-side under-blocks.
+_FUNCTIONAL_POSITIVES = [
+    'echo "gh pr merge 42" > >(bash)',
+    'echo "gh pr merge 42" > >(sh)',
+    'echo "gh pr merge 42" > >(zsh)',
+    'echo "gh pr merge 42" 1> >(bash)',
+    'echo "gh pr merge 42" &> >(bash)',
+    'echo "gh pr merge 42" >> >(bash)',
+    'echo "gh pr merge 42" >  >(bash)',
+    'echo "gh pr merge 42" > >( bash )',
+    "echo 'gh pr merge 42' > >(bash)",          # single-quoted carrier
+    'printf "gh pr merge 42" > >(bash)',         # printf carrier
+    'echo "git branch -D x" > >(bash)',          # branch-delete payload
+]
+
+# Exclusion negatives — dangerous payload routed where it never reaches a shell,
+# so it stays stripped and non-dangerous. The broaden mutation named in the
+# module docstring makes each flip to dangerous => RED (non-vacuity).
+_FUNCTIONAL_NEGATIVES = [
+    'echo "gh pr merge 42" 2> >(bash)',          # stderr — not an echo-stdout vector (OQ1)
+    'echo "gh pr merge 42" 3> >(bash)',          # fd-3
+    'echo "git branch -D x" > >(tee out.log)',   # tee not a shell
+    'echo "gh pr merge 42" > >(cat)',            # cat not a shell
+    'echo "gh pr merge 42" > >(grep foo)',       # grep not a shell
+    'echo "gh pr merge 42" > push.log',          # plain file redirect
+]
+
+
+@pytest.mark.parametrize("command", _FUNCTIONAL_POSITIVES)
+def test_output_side_to_shell_is_dangerous(command):
+    """A dangerous literal echo/printf'd into an output-side shell process-sub is
+    now caught (previously stripped => under-blocked)."""
+    assert is_dangerous_command(command) is True
+
+
+@pytest.mark.parametrize("command", _FUNCTIONAL_NEGATIVES)
+def test_output_side_non_shell_and_stderr_stay_stripped(command):
+    """A dangerous literal routed to a non-shell consumer or to stderr never
+    reaches a shell, so the carrier strips it and it stays non-dangerous."""
+    assert is_dangerous_command(command) is False
+
+
+def test_input_side_functional_parity_unchanged():
+    """The input-side carrier-3 preservation contract is undisturbed by F2:
+    `bash <(echo '<danger>')` is dangerous; `cat <(...)` is not."""
+    assert is_dangerous_command('bash <(echo "gh pr merge 42")') is True
+    assert is_dangerous_command('cat <(echo "gh pr merge 42")') is False

--- a/pact-plugin/tests/test_merge_guard_output_side_process_sub.py
+++ b/pact-plugin/tests/test_merge_guard_output_side_process_sub.py
@@ -368,3 +368,51 @@ def test_gated_carrier_no_regression_and_ungated_stay_benign(command):
     flagged. Ungated carriers #2 (comment) and #4 (var-assign) stay benign because
     a comment is a bash no-op and a var-assign emits no stdout."""
     assert is_dangerous_command(command) is False
+
+
+# ===========================================================================
+# MINOR form-pins (PR #1003, review m-1 + m-2) — append-fd + tab output-side
+# forms. Each was EMPIRICALLY classified in real bash (does the payload reach a
+# shell = a genuine vector?) BEFORE pinning, so a non-vector is never asserted as
+# a false positive:
+#
+#   GENUINE VECTORS (bash routes the payload to the shell — `echo PWN` executes):
+#     `1>> >(bash)`, `&>> >(bash)` (append-fd, space), `>\t>(bash)` (tab between
+#     `>` and `>(`). Pinned below with a dangerous payload.
+#
+#   NON-VECTORS — bash SYNTAX ERRORS (NOT pinned): the NO-SPACE forms
+#     `>>(bash)`, `1>>(bash)`, `&>>(bash)` raise `bash: syntax error near
+#     unexpected token '('` (rc=2) — the `>>`/`1>>`/`&>>` append operator requires
+#     a filename, and `(bash)` (a subshell) is not a valid redirect target, so the
+#     command never runs. The merge-guard regex over-detects them (is_dangerous
+#     True, because `>>?\s*>\(` matches `>>(` as `>`+`>(`), which is INV-D2-
+#     ACCEPTABLE (a conservative over-block of a non-executable form) but NOT a
+#     required behavior — so they are deliberately NOT pinned as vectors.
+#
+# Non-vacuity (counter-test-by-revert, ephemeral — see HANDOFF):
+#   * tab form — CLEAN isolated counter-test: tightening Arm A's first `\s*`
+#     (operator->`>(`) to a literal space ` *` flips ONLY the tab positive RED
+#     (proves the `\s*` tab-handling is load-bearing).
+#   * append forms (`1>> >(bash)`/`&>> >(bash)`) — OVER-DETERMINED: they are caught
+#     by the GENERIC embedded `> >(bash)` shape (the bare `(?<![0-9])>>?` op + the
+#     procsub), NOT uniquely by the `1>>?`/`&>>?` operators — EMPIRICALLY, dropping
+#     `1>>?`/`&>>?` flips NOTHING. So there is no per-operator counter-test for
+#     them; their non-vacuity is the shared whole-Arm-A removal (which flips every
+#     output-side redirect positive, incl. the basic `> >(bash)`).
+# ===========================================================================
+
+# Genuine-vector output-side form variants — dangerous payload (anti-phantom-green).
+_MINOR_FORM_POSITIVES = [
+    'echo "; gh pr merge 42" 1>> >(bash)',   # m-1 append fd-1 (space)
+    'echo "; gh pr merge 42" &>> >(bash)',   # m-1 append stdout+stderr (space)
+    'echo "; gh pr merge 42" >\t>(bash)',    # m-2 tab whitespace between > and >(
+]
+
+
+@pytest.mark.parametrize("command", _MINOR_FORM_POSITIVES)
+def test_append_fd_and_tab_output_side_forms_are_dangerous(command):
+    """Append-fd (`1>>`/`&>>`) and tab-whitespace output-side procsub-to-shell
+    forms are genuine vectors (empirically: the payload reaches bash and executes)
+    and are detected. The no-space `>>(bash)`/`1>>(bash)`/`&>>(bash)` forms are
+    bash SYNTAX ERRORS (non-vectors) and are deliberately NOT pinned here."""
+    assert is_dangerous_command(command) is True

--- a/pact-plugin/tests/test_merge_guard_perf.py
+++ b/pact-plugin/tests/test_merge_guard_perf.py
@@ -104,45 +104,119 @@ def _best_time(fn, arg, k=_K):
     return best
 
 
-def _measure_scaling(fn, token):
-    """Return (t_small, t_large) best-of-K times on the witness ``token * N``."""
+# gh multi-anchor witness (review m-3 — the `_GH_GLOBAL_FLAGS` bound had no direct
+# perf witness). Measured quadratic counter-factual (revert `_GH_GLOBAL_FLAGS`
+# `{0,K}`->`*`): is_dangerous ~7.3 s at N=4000 (2.0 s ceiling fine), but
+# detect_command_operation_type only ~1.8 s (two gh-prefix classifier patterns,
+# not the ~21-pattern read bank) — so detect/gh gets a TIGHTER 1.0 s ceiling, the
+# same per-surface calibration as httpie. Bounded: ~0.08 s / ~0.02 s.
+_CEIL_GH_READ = 2.0
+_CEIL_GH_DETECT = 1.0
+
+# Push-flag-walk witness (`git push ` + `-x ` * N). The push-dash-flag walk is a
+# SINGLE-anchor walk (one `git`/`push`), so even unbounded it is O(N) LINEAR, not
+# quadratic — it was already linear at HEAD (the F1 outer `_GIT_PREFIX` bound caps
+# the multi-anchor interaction; design §12.2). This case PINS structural linearity
+# (ratio < 3.0): a future nested-quantifier regression in the push patterns would
+# trip it. It is GREEN-stays-GREEN — reverting the `{0,64}` push bound keeps it
+# linear, so there is NO perf counter-test-RED for it; the bound's non-vacuity is
+# the >K-RESIDUAL FLIP in TestFlagTokenBoundary, not a perf revert. Bounded ~6 ms.
+_CEIL_PUSHWALK = 1.0
+
+
+def _measure_scaling(fn, build):
+    """Return (t_small, t_large) best-of-K times on the witness ``build(N)``."""
     # Warm up once (regex objects are compiled at import; this primes caches).
-    fn(token * 100)
-    t_small = _best_time(fn, token * N_SMALL)
-    t_large = _best_time(fn, token * N_LARGE)
+    fn(build(100))
+    t_small = _best_time(fn, build(N_SMALL))
+    t_large = _best_time(fn, build(N_LARGE))
     return t_small, t_large
 
 
-# (id, function, witness token, absolute-ceiling-seconds)
+# (id, function, witness builder build(N)->str, absolute-ceiling-seconds)
 _CASES = [
-    ("is_dangerous_command/git", is_dangerous_command, "git x ", _CEIL_GIT),
-    ("detect_command_operation_type/git", detect_command_operation_type, "git x ", _CEIL_GIT),
-    ("is_dangerous_command/httpie", is_dangerous_command, "http x ", _CEIL_HTTPIE),
+    ("is_dangerous_command/git", is_dangerous_command, lambda n: "git x " * n, _CEIL_GIT),
+    ("detect_command_operation_type/git", detect_command_operation_type, lambda n: "git x " * n, _CEIL_GIT),
+    ("is_dangerous_command/httpie", is_dangerous_command, lambda n: "http x " * n, _CEIL_HTTPIE),
+    # --- remediation additions (PR #1003) ---
+    ("is_dangerous_command/gh", is_dangerous_command, lambda n: "gh x " * n, _CEIL_GH_READ),
+    ("detect_command_operation_type/gh", detect_command_operation_type, lambda n: "gh x " * n, _CEIL_GH_DETECT),
+    ("is_dangerous_command/push-flag-walk", is_dangerous_command, lambda n: "git push " + "-x " * n, _CEIL_PUSHWALK),
+    ("detect_command_operation_type/push-flag-walk", detect_command_operation_type, lambda n: "git push " + "-x " * n, _CEIL_PUSHWALK),
 ]
 
 
 @pytest.mark.parametrize(
-    "fn,token,abs_ceiling",
-    [(fn, token, ceil) for (_id, fn, token, ceil) in _CASES],
+    "fn,build,abs_ceiling",
+    [(fn, build, ceil) for (_id, fn, build, ceil) in _CASES],
     ids=[c[0] for c in _CASES],
 )
-def test_global_flag_prefix_scaling_is_subquadratic(fn, token, abs_ceiling):
-    """The bounded global-flag prefixes must scale sub-quadratically on the
-    many-anchor witness through both detection paths and the inline httpie
-    copies. Restoring the unbounded ``*`` form makes the ratio ~4x and the
-    N=4000 wall-clock exceed the ceiling => RED."""
-    t_small, t_large = _measure_scaling(fn, token)
+def test_global_flag_prefix_scaling_is_subquadratic(fn, build, abs_ceiling):
+    """The bounded global-flag prefixes / push-flag walk must scale
+    sub-quadratically on the worst-case witness through both detection paths, the
+    inline httpie copies, the gh prefix (review m-3), and the push-flag walk
+    (structural-linearity pin, §12.2). Restoring an unbounded `*` form on a
+    MULTI-anchor witness (git/gh/httpie) makes the ratio ~4x and the N=4000
+    wall-clock exceed the ceiling => RED. The push-flag-walk witness is
+    single-anchor (already linear, defense-in-depth) so it stays GREEN under
+    revert — its non-vacuity lives in TestFlagTokenBoundary's >K-residual flip."""
+    t_small, t_large = _measure_scaling(fn, build)
     ratio = (t_large / t_small) if t_small > 0 else float("inf")
+    witness = build(1)
 
     # PRIMARY: generous absolute wall-clock ceiling (flake-resistant).
     assert t_large < abs_ceiling, (
-        f"{fn.__name__} on {token!r}*{N_LARGE}: {t_large * 1000:.1f} ms exceeds "
+        f"{fn.__name__} on {witness!r}*{N_LARGE}: {t_large * 1000:.1f} ms exceeds "
         f"{abs_ceiling * 1000:.0f} ms ceiling — unbounded O(n^2) backtracking regression?"
     )
 
     # REINFORCING: scaling ratio across one doubling (linear ~2.0, quadratic ~4.0).
     assert ratio < RATIO_CEILING, (
-        f"{fn.__name__} on {token!r}: t({N_LARGE})/t({N_SMALL}) = {ratio:.2f} "
+        f"{fn.__name__} on {witness!r}: t({N_LARGE})/t({N_SMALL}) = {ratio:.2f} "
         f">= {RATIO_CEILING} — quadratic scaling regression "
         f"(t_small={t_small * 1000:.1f} ms, t_large={t_large * 1000:.1f} ms)?"
     )
+
+
+# ---------------------------------------------------------------------------
+# Flag-token bound — FUNCTIONAL boundary + the accepted >K residual (#1001 /
+# remediation §12.2-12.3). The same `_MAX_GLOBAL_FLAG_TOKENS` (=64) that bounds
+# the scaling above also bounds the push-dash-flag walk between `push` and its
+# refspec. These tests pin the K=64 boundary and the accepted >K residual
+# under-block, and document why the push-walk bound's non-vacuity is the
+# >K-residual FLIP (not a perf revert).
+# ---------------------------------------------------------------------------
+
+from shared.merge_guard_common import _MAX_GLOBAL_FLAG_TOKENS  # noqa: E402
+
+
+class TestFlagTokenBoundary:
+    """K=64 push-flag-walk boundary + accepted >K residual under-block."""
+
+    def test_within_bound_push_to_main_is_detected(self):
+        """A push-to-main with EXACTLY _MAX_GLOBAL_FLAG_TOKENS (64) dash-flags is
+        still within the bound, so the refspec is reachable and it IS detected
+        (force-push class) on both the read bank and the classifier."""
+        cmd = "git push " + "-x " * _MAX_GLOBAL_FLAG_TOKENS + "origin main"
+        assert is_dangerous_command(cmd) is True
+        assert detect_command_operation_type(cmd) == "force-push"
+
+    def test_past_bound_push_to_main_is_the_accepted_residual(self):
+        """ACCEPTED >K RESIDUAL (documented, INV-D2 relaxation — §12.3): a
+        push-to-main padded with MORE than _MAX_GLOBAL_FLAG_TOKENS dash-flags
+        exceeds the bound, the refspec becomes unreachable, and it is NOT detected.
+        This is the deliberate, threat-model-justified tradeoff vs the O(n^2) DoS
+        (an operator padding 65+ no-op flags to evade their OWN guard is
+        self-defeating). Pinning it makes the residual VISIBLE: un-bounding the
+        walk (`{0,K}`->`*`) flips this to detected — which is the push-walk bound's
+        non-vacuity witness (see this test's counter-test in the remediation HANDOFF)."""
+        cmd = "git push " + "-x " * (_MAX_GLOBAL_FLAG_TOKENS + 1) + "origin main"
+        assert is_dangerous_command(cmd) is False
+        assert detect_command_operation_type(cmd) is None
+
+    def test_realistic_flag_count_push_to_main_is_detected(self):
+        """A realistic push-to-main with a handful of dash-flags (well within K)
+        is detected — the bound does not perturb any realistic command."""
+        cmd = "git push -u -v --no-verify origin main"
+        assert is_dangerous_command(cmd) is True
+        assert detect_command_operation_type(cmd) == "force-push"

--- a/pact-plugin/tests/test_merge_guard_perf.py
+++ b/pact-plugin/tests/test_merge_guard_perf.py
@@ -118,7 +118,7 @@ _CEIL_GH_DETECT = 1.0
 # quadratic — it was already linear at HEAD (the F1 outer `_GIT_PREFIX` bound caps
 # the multi-anchor interaction; design §12.2). This case PINS structural linearity
 # (ratio < 3.0): a future nested-quantifier regression in the push patterns would
-# trip it. It is GREEN-stays-GREEN — reverting the `{0,64}` push bound keeps it
+# trip it. It is GREEN-stays-GREEN — reverting the `{0,32}` push bound keeps it
 # linear, so there is NO perf counter-test-RED for it; the bound's non-vacuity is
 # the >K-RESIDUAL FLIP in TestFlagTokenBoundary, not a perf revert. Bounded ~6 ms.
 _CEIL_PUSHWALK = 1.0
@@ -180,9 +180,9 @@ def test_global_flag_prefix_scaling_is_subquadratic(fn, build, abs_ceiling):
 
 # ---------------------------------------------------------------------------
 # Flag-token bound — FUNCTIONAL boundary + the accepted >K residual (#1001 /
-# remediation §12.2-12.3). The same `_MAX_GLOBAL_FLAG_TOKENS` (=64) that bounds
+# remediation §12.2-12.3). The same `_MAX_GLOBAL_FLAG_TOKENS` (=32) that bounds
 # the scaling above also bounds the push-dash-flag walk between `push` and its
-# refspec. These tests pin the K=64 boundary and the accepted >K residual
+# refspec. These tests pin the K=32 boundary and the accepted >K residual
 # under-block, and document why the push-walk bound's non-vacuity is the
 # >K-residual FLIP (not a perf revert).
 # ---------------------------------------------------------------------------
@@ -191,12 +191,13 @@ from shared.merge_guard_common import _MAX_GLOBAL_FLAG_TOKENS  # noqa: E402
 
 
 class TestFlagTokenBoundary:
-    """K=64 push-flag-walk boundary + accepted >K residual under-block."""
+    """K=32 push-flag-walk boundary + accepted >K residual under-block."""
 
     def test_within_bound_push_to_main_is_detected(self):
-        """A push-to-main with EXACTLY _MAX_GLOBAL_FLAG_TOKENS (64) dash-flags is
+        """A push-to-main with EXACTLY _MAX_GLOBAL_FLAG_TOKENS (32) dash-flags is
         still within the bound, so the refspec is reachable and it IS detected
-        (force-push class) on both the read bank and the classifier."""
+        (force-push class) on both the read bank and the classifier. (Empirical
+        boundary: -x*32 detected; -x*33 the first missed — the residual below.)"""
         cmd = "git push " + "-x " * _MAX_GLOBAL_FLAG_TOKENS + "origin main"
         assert is_dangerous_command(cmd) is True
         assert detect_command_operation_type(cmd) == "force-push"
@@ -206,7 +207,7 @@ class TestFlagTokenBoundary:
         push-to-main padded with MORE than _MAX_GLOBAL_FLAG_TOKENS dash-flags
         exceeds the bound, the refspec becomes unreachable, and it is NOT detected.
         This is the deliberate, threat-model-justified tradeoff vs the O(n^2) DoS
-        (an operator padding 65+ no-op flags to evade their OWN guard is
+        (an operator padding 33+ no-op flags to evade their OWN guard is
         self-defeating). Pinning it makes the residual VISIBLE: un-bounding the
         walk (`{0,K}`->`*`) flips this to detected — which is the push-walk bound's
         non-vacuity witness (see this test's counter-test in the remediation HANDOFF)."""

--- a/pact-plugin/tests/test_merge_guard_perf.py
+++ b/pact-plugin/tests/test_merge_guard_perf.py
@@ -1,0 +1,148 @@
+"""Worst-case performance-bound regression tests for the merge-guard global-flag
+prefixes (#1001 / F1).
+
+Root cause being pinned
+-----------------------
+``_GH_GLOBAL_FLAGS`` / ``_GIT_GLOBAL_FLAGS`` in
+``shared/merge_guard_common.py`` were ``(?:\\S+\\s+)*`` — an unbounded greedy
+walk of "any token". ``\\S`` and ``\\s`` are disjoint, so a single walk is
+internally unambiguous; the quadratic is the *multi-anchor* interaction: on a
+command text with many ``git``/``gh`` anchor tokens, ``re.search`` retries the
+walk at every anchor and each retry greedily consumes to end-of-string looking
+for the following verb (``push``/``pr``/``branch``/``api``). Per-anchor cost
+O(N) × N anchors = **O(N^2)**.
+
+The fix bounds the walk to ``(?:\\S+\\s+){0,32}`` (``_MAX_GLOBAL_FLAG_TOKENS``),
+so each anchor consumes at most 32 tokens => O(32)=O(1) per anchor => the whole
+scan is **linear**. The same unbounded shape lived in two inline httpie copies
+in ``merge_guard_pre.py`` and was bounded identically; those are pinned here too.
+
+Functions pinned
+----------------
+Both detection paths embed the prefix constants and were INDEPENDENTLY quadratic
+(PREPARE probe E):
+
+* ``is_dangerous_command``            — the read-side ``DANGEROUS_PATTERNS`` bank
+  (also carries the inline httpie patterns);
+* ``detect_command_operation_type``   — the shared classifier, called by BOTH
+  the pre- and post-hooks.
+
+Witness
+-------
+``"git x " * N`` (and ``"http x " * N`` for the httpie copies): many anchors,
+**no shell separators** — the pure pathological shape that maximises the
+multi-anchor retry cost. Each ``x`` is a non-verb token, so the scan runs every
+prefix pattern to completion (no early dangerous-match short-circuit).
+
+Assertion strategy (CI-robust — NOT exact-ms; design §7.2)
+----------------------------------------------------------
+Two mutually reinforcing assertions per case:
+
+* **Absolute wall-clock ceiling** (PRIMARY discriminator). Bounded/linear is
+  ~0.06–0.18 s at N=4000 here; a 4–5x-slower CI box stays well under the
+  ceiling. The unbounded/quadratic form is ~1.9 s (httpie) to ~6 s (git) at
+  N=4000. The ceiling sits an order of magnitude clear of linear and below
+  quadratic, so it cannot flap on a slow machine yet still trips on a
+  regression.
+* **Scaling ratio** ``t(2N)/t(N) < 3.0`` across one doubling. Linear ≈ 2.0,
+  quadratic ≈ 4.0; 3.0 is the midpoint. ``best-of-K`` minimum timing suppresses
+  upward scheduler/GC noise (a slow sample never lowers the min).
+
+Counter-test-by-revert (non-vacuity)
+------------------------------------
+Restore the unbounded ``*`` form (shared constants for the git/detect cases; the
+inline httpie literals for the httpie case) and re-run: the ratio returns to
+~4x AND the N=4000 wall-clock blows past the ceiling => the targeted case goes
+RED. Expected cardinality: reverting the shared constants reds the two git/detect
+cases; reverting the httpie inline literals reds the httpie case.
+"""
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+from merge_guard_pre import is_dangerous_command  # noqa: E402
+from shared.merge_guard_common import detect_command_operation_type  # noqa: E402
+
+# N_LARGE = 2 * N_SMALL — the scaling-ratio doubling. N is large enough that the
+# unbounded quadratic is unmistakable (~6 s for the git bank) yet the bounded
+# form stays well under ~0.2 s, so the test runs in a few seconds.
+N_SMALL = 2000
+N_LARGE = 4000
+
+# best-of-K minimum: the dominant timing noise is upward (scheduler preemption,
+# GC), and a minimum is a clean lower bound on the true cost that a slow sample
+# cannot inflate. K=5 gives five chances at a clean large-N measurement, which
+# is what keeps the small-absolute-time httpie ratio from flaking.
+_K = 5
+
+# Linear ~2.0x per doubling; quadratic ~4.0x. 3.0 is the midpoint.
+RATIO_CEILING = 3.0
+
+# Per-case absolute ceilings. The git/detect bank's quadratic is ~6 s at N=4000,
+# so 2.0 s is generous yet trips hard on regression. The httpie copies' quadratic
+# is only ~1.9 s at N=4000 (two patterns, not ~21), so it gets a tighter 1.0 s
+# ceiling — still ~15x the bounded ~0.06 s, comfortably above any slow-CI linear
+# run and below the ~1.9 s quadratic.
+_CEIL_GIT = 2.0
+_CEIL_HTTPIE = 1.0
+
+
+def _best_time(fn, arg, k=_K):
+    """Minimum wall-clock of ``fn(arg)`` over k runs (suppresses upward noise)."""
+    best = float("inf")
+    for _ in range(k):
+        t0 = time.perf_counter()
+        fn(arg)
+        dt = time.perf_counter() - t0
+        if dt < best:
+            best = dt
+    return best
+
+
+def _measure_scaling(fn, token):
+    """Return (t_small, t_large) best-of-K times on the witness ``token * N``."""
+    # Warm up once (regex objects are compiled at import; this primes caches).
+    fn(token * 100)
+    t_small = _best_time(fn, token * N_SMALL)
+    t_large = _best_time(fn, token * N_LARGE)
+    return t_small, t_large
+
+
+# (id, function, witness token, absolute-ceiling-seconds)
+_CASES = [
+    ("is_dangerous_command/git", is_dangerous_command, "git x ", _CEIL_GIT),
+    ("detect_command_operation_type/git", detect_command_operation_type, "git x ", _CEIL_GIT),
+    ("is_dangerous_command/httpie", is_dangerous_command, "http x ", _CEIL_HTTPIE),
+]
+
+
+@pytest.mark.parametrize(
+    "fn,token,abs_ceiling",
+    [(fn, token, ceil) for (_id, fn, token, ceil) in _CASES],
+    ids=[c[0] for c in _CASES],
+)
+def test_global_flag_prefix_scaling_is_subquadratic(fn, token, abs_ceiling):
+    """The bounded global-flag prefixes must scale sub-quadratically on the
+    many-anchor witness through both detection paths and the inline httpie
+    copies. Restoring the unbounded ``*`` form makes the ratio ~4x and the
+    N=4000 wall-clock exceed the ceiling => RED."""
+    t_small, t_large = _measure_scaling(fn, token)
+    ratio = (t_large / t_small) if t_small > 0 else float("inf")
+
+    # PRIMARY: generous absolute wall-clock ceiling (flake-resistant).
+    assert t_large < abs_ceiling, (
+        f"{fn.__name__} on {token!r}*{N_LARGE}: {t_large * 1000:.1f} ms exceeds "
+        f"{abs_ceiling * 1000:.0f} ms ceiling — unbounded O(n^2) backtracking regression?"
+    )
+
+    # REINFORCING: scaling ratio across one doubling (linear ~2.0, quadratic ~4.0).
+    assert ratio < RATIO_CEILING, (
+        f"{fn.__name__} on {token!r}: t({N_LARGE})/t({N_SMALL}) = {ratio:.2f} "
+        f">= {RATIO_CEILING} — quadratic scaling regression "
+        f"(t_small={t_small * 1000:.1f} ms, t_large={t_large * 1000:.1f} ms)?"
+    )


### PR DESCRIPTION
## Summary

Hardens the `merge_guard` PreToolUse(Bash) security control by closing two pre-existing defects surfaced during the #933 / PR #1000 review. Both are scoped, INV-D2-aware fixes with non-vacuous regression proofs.

## What landed

**F1 — bound O(n²) backtracking in global-flag prefixes (#1001)** · `45c406cf`
- The pre-existing unbounded `(?:\S+\s+)*` in `_GH_GLOBAL_FLAGS` / `_GIT_GLOBAL_FLAGS` (`shared/merge_guard_common.py`) and the two inline httpie copies (`merge_guard_pre.py`) walk across shell separators and never self-terminate → O(n²) on a many-anchor witness. Bounded to `(?:\S+\s+){0,32}` via a new `_MAX_GLOBAL_FLAG_TOKENS` constant. Empirically linear on both independently-quadratic call sites (`is_dangerous_command` + `detect_command_operation_type`).
- Fixed in the SHARED module to preserve the #720 pre/post classifier centralization.

**F2 — catch output-side process-substitution under-block (#1002)** · `1d921b4c`
- `_has_process_substitution_to_shell` matched only input-side `bash <(...)`, missing the output-side `… > >(bash)` form. For the echo/printf carriers (the only true stdout vectors), `echo "<danger>" > >(bash)` was a real under-block. Added an output-side arm, kept pre-local (post has no execution-gating strip surface — no #720 asymmetry).
- INV-D2 monotonically safe by construction (the guard is a strip-SKIP condition; widening only adds detection). Over-block bounded to shell targets (`tee`/`cat`/`2>` excluded).

**Tests** · `be4de4ae` (#1001 perf), `247c4d22` (#1002 output-side)
- New `test_merge_guard_perf.py`: scaling-ratio + generous absolute ceiling on both quadratic paths + the httpie copy.
- New `test_merge_guard_output_side_process_sub.py`: 39 cases (output-side positives with dangerous payloads, stderr/non-shell/plain-file exclusions, input-side parity).
- Bidirectional counter-test-by-revert proves every guarantee is coupled to the fix (removal-revert for the under-block positive; distinct broaden-mutations for each over-block exclusion).
- Full suite: 9290 passed, 0 failures, 0 errors.

**Version** · `d9ed2379` — PATCH bump to 4.4.34 (hardening, not a new user-facing capability).

## Why

`merge_guard` is a security control governed by INV-D2: never weaken detection of a real executing destructive op; over-block is acceptable, under-block is a hole. F2 closes a real under-block; F1 removes a DoS without changing the match set within the realistic envelope.

## Known residual (documented, accepted)

F1's `{0,32}` bound carries a narrow, threat-model-justified residual under-block: a command with >32 *valid* global tokens (e.g. `git -c k=v` × 17 = 34 tokens, `push --force`) executes yet is missed. Accepted as a documented tradeoff vs the O(n²) DoS under the operator/LLM-authored threat model (not adversarial network input; self-padding to evade one's own guard is self-defeating). `_MAX_GLOBAL_FLAG_TOKENS` is raisable to 64 (still O(1)) if deemed material.

Closes #1001
Closes #1002
