### PR TITLE
fix(hooks): no-op pact-team-registration write in in-process teammateMode (#962)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.34",
+      "version": "4.4.35",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.34/      # Plugin version
+│               └── 4.4.35/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.34",
+  "version": "4.4.35",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.34
+> **Version**: 4.4.35
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/shared/session_registry.py
+++ b/pact-plugin/hooks/shared/session_registry.py
@@ -178,6 +178,23 @@ def register(name_at_team: str) -> None:
         name, _, team = name_at_team.partition("@")
         if not name or not team:
             return
+
+        # IN-PROCESS SELF-GUARD (the runtime structural topology signal).
+        # In in-process teammateMode every teammate shares the lead's process and
+        # thus the lead's $CLAUDE_CODE_SESSION_ID, so own ``sid == leadSessionId``
+        # and the registry key {session_id -> name@team} collapses many-to-one
+        # (last-wins) — the write cannot recover the actor and is pure churn. In
+        # tmux mode each teammate is a distinct process with a distinct sid, so
+        # ``sid != leadSessionId`` and the write is meaningful. Skip ONLY on a
+        # positive confirmed match; this is a liftable guard, not a removal of
+        # registration logic. FAIL-OPEN: ``_read_lead_session_id`` returns "" on
+        # any unknown/unreadable/malformed/unsafe-team topology, so we WRITE in
+        # every uncertain case — over-writing in-process is a harmless collided
+        # entry, but under-writing in tmux would blind name-recovery. Silent
+        # no-op, matching register's other skip-paths (labeling-only; no notice).
+        if sid == _read_lead_session_id(team):
+            return  # confirmed in-process → skip the un-recoverable write
+
         value = _sanitize_agent_name(name) + "@" + team
 
         registry_path = get_registry_path()
@@ -330,6 +347,37 @@ def _name_is_team_member(name: str, team: str) -> bool:
         return _sanitize_agent_name(name) in member_names
     except (OSError, ValueError, KeyError, TypeError):
         return False
+
+
+def _read_lead_session_id(team: str) -> str:
+    """Return the top-level ``leadSessionId`` from ``teams/<team>/config.json``,
+    or ``""`` on any miss/error.
+
+    Used by ``register()``'s in-process self-guard to compute the runtime
+    structural topology signal ``own session_id == leadSessionId`` (in-process)
+    vs ``!=`` (tmux). LOGIC-PARITY with ``task_claim_gate._read_lead_session_id``,
+    INLINED here (not imported) to preserve this module's self-contained-leaf
+    invariant (no ``shared.*`` imports — see module docstring). Reuses the exact
+    ``_is_safe_team_segment`` guard + ``_config_root()`` config-read idiom that
+    ``_name_is_team_member`` above already uses, so the read adds no new I/O
+    machinery.
+
+    Fail-safe: returns ``""`` on an unsafe @team segment, missing/unreadable
+    config, malformed JSON, non-object top-level, or a missing/non-string key.
+    An empty return routes ``register()`` to the fail-OPEN default (WRITE) — an
+    unknown topology must never suppress a tmux registration. Never raises.
+    """
+    if not _is_safe_team_segment(team):
+        return ""
+    try:
+        config_path = _config_root() / "teams" / team / "config.json"
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        if not isinstance(config, dict):
+            return ""
+        lead_session_id = config.get("leadSessionId")
+        return lead_session_id if isinstance(lead_session_id, str) else ""
+    except (OSError, ValueError, KeyError, TypeError):
+        return ""
 
 
 if __name__ == "__main__":

--- a/pact-plugin/tests/test_pact_context.py
+++ b/pact-plugin/tests/test_pact_context.py
@@ -1093,6 +1093,100 @@ class TestResolveAgentNameStep35RegistryPrecedence:
         assert result == "architect"
 
 
+class TestResolveAgentNameStep35NonMockedSeam:
+    """NON-MOCKED seam regression for Step 3.5 (mock-hid-the-seam guard).
+
+    The TestResolveAgentNameStep35RegistryPrecedence class above monkeypatches
+    pact_context._registry_resolve, so it proves the PRECEDENCE wiring but stubs
+    the very seam (real register() write -> real on-disk .teammate-registry.jsonl
+    -> real resolve() -> members[]-validation) whose correct resolution IS the
+    point. This class drives that seam UNSTUBBED: a real teammate registers via
+    register() to a real registry file under a temp home, and resolve_agent_name
+    recovers the friendly name with NO mock of the registry read.
+
+    This is the #962-relevant regression: register()'s new in-process self-guard
+    sits on the WRITE side of this seam. A tmux-frame teammate (sid !=
+    leadSessionId) must still register AND be recoverable here; an in-process
+    frame (sid == leadSessionId) must NOT pollute the registry, so Step 3.5 falls
+    through cleanly. If the guard ever over-suppressed (false-in-process on a real
+    tmux sid), THIS test goes red where the mocked tests stay green.
+    """
+
+    @staticmethod
+    def _home(monkeypatch, tmp_path):
+        """Point Path.home() at tmp_path so both register()'s write and
+        resolve()'s read (via _config_root) land in the same isolated tree."""
+        from pathlib import Path
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+
+    @staticmethod
+    def _write_team_config(tmp_path, team, members, lead_session_id):
+        team_dir = tmp_path / ".claude" / "teams" / team
+        team_dir.mkdir(parents=True, exist_ok=True)
+        (team_dir / "config.json").write_text(
+            json.dumps({
+                "members": [{"name": m} for m in members],
+                "leadSessionId": lead_session_id,
+            }),
+            encoding="utf-8",
+        )
+
+    def test_tmux_frame_recovered_through_real_registry(self, monkeypatch, tmp_path):
+        """End-to-end, UNSTUBBED: a tmux teammate (sid != leadSessionId) registers
+        via the real register() -> resolve_agent_name recovers its name from the
+        real on-disk registry. Proves the write/read seam resolves for real."""
+        import shared.pact_context as pact_context
+        from shared.session_registry import register
+        from shared.pact_context import resolve_agent_name
+
+        self._home(monkeypatch, tmp_path)
+        self._write_team_config(tmp_path, "pact-leadteam", ["regname"],
+                                lead_session_id="lead-sid-AAAA")
+
+        # tmux teammate: its own sid differs from the lead's -> guard WRITES.
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "tmux-sid-BBBB")
+        register("regname@pact-leadteam")
+
+        # resolve_agent_name Step 3.5 reads the REAL registry (team_name passed
+        # explicitly so resolution does not depend on persisted context).
+        result = resolve_agent_name(
+            {"session_id": "tmux-sid-BBBB"}, team_name="pact-leadteam"
+        )
+        assert result == "regname", (
+            "Step 3.5 must recover the tmux teammate's name from the real registry"
+        )
+
+    def test_in_process_frame_not_polluted_so_step35_falls_through(self, monkeypatch, tmp_path):
+        """End-to-end, UNSTUBBED: an in-process teammate (sid == leadSessionId)
+        is SKIPPED by the guard, so the registry never gets its line; Step 3.5
+        finds no entry for that sid and falls through to Step 4 (agent_type
+        strip). Confirms the guard's WRITE-side suppression keeps the READ-side
+        seam clean rather than returning a colliding/wrong name."""
+        import shared.pact_context as pact_context
+        from shared.session_registry import register
+        from shared.pact_context import resolve_agent_name
+
+        self._home(monkeypatch, tmp_path)
+        self._write_team_config(tmp_path, "pact-leadteam", ["regname"],
+                                lead_session_id="lead-sid-AAAA")
+
+        # in-process teammate shares the lead's sid -> guard SKIPS the write.
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "lead-sid-AAAA")
+        register("regname@pact-leadteam")
+
+        # No registry line for lead-sid-AAAA -> Step 3.5 misses -> Step 4 strips
+        # the agent_type. (If the guard had wrongly written, Step 3.5 would have
+        # returned "regname" and this would fail.)
+        result = resolve_agent_name(
+            {"session_id": "lead-sid-AAAA", "agent_type": "pact-architect"},
+            team_name="pact-leadteam",
+        )
+        assert result == "architect", (
+            "in-process sid must NOT be in the registry; Step 3.5 falls through to Step 4"
+        )
+
+
 class TestWriteContextEdgeCases:
     """Additional edge case tests for write_context()."""
 

--- a/pact-plugin/tests/test_read_lead_session_id_parity.py
+++ b/pact-plugin/tests/test_read_lead_session_id_parity.py
@@ -1,0 +1,169 @@
+"""Behavioral-parity DRIFT-GUARD for the _read_lead_session_id dual-copy.
+
+session_registry._read_lead_session_id and task_claim_gate._read_lead_session_id
+are INDEPENDENT inline copies (session_registry is a self-contained leaf that
+imports nothing from shared.*, so it cannot import the task_claim_gate copy). The
+session_registry copy's docstring claims "LOGIC-PARITY with
+task_claim_gate._read_lead_session_id" — but until now that claim was prose-only,
+not test-enforced. This test makes it enforced: if a future edit changes the
+leadSessionId-resolution behavior of one copy without the other, this test goes
+red. It mirrors the established inline-dual-copy parity-guard convention already
+used for _sanitize_agent_name (session_registry vs peer_context) and
+_is_safe_team_segment (session_registry vs session_end).
+
+WHAT "PARITY" MEANS HERE — BEHAVIORAL, not structural. The two copies have a
+KNOWN, ACCEPTED STRUCTURAL DIVERGENCE that this test deliberately accommodates:
+
+  * session_registry._read_lead_session_id(team) — one positional arg; resolves
+    the teams dir via the INLINED _config_root() (no parameter); gates the team
+    segment with _is_safe_team_segment.
+  * task_claim_gate._read_lead_session_id(team_name, teams_dir=None) — takes an
+    optional teams_dir; resolves via get_claude_config_dir() when teams_dir is
+    None; gates with is_safe_path_component (a positive-allowlist regex).
+
+So this test does NOT assert the functions are byte-identical. It asserts they
+return the SAME leadSessionId for the SAME LOGICAL INPUT — the same on-disk
+teams/<team>/config.json under a shared Path.home() redirect (both config-root
+mechanisms honor Path.home(): session_registry's _config_root() and
+task_claim_gate's get_claude_config_dir() both derive from it).
+
+KNOWN SAFE-SEGMENT BOUNDARY (intentional, NOT a parity violation): the two
+segment guards reject DIFFERENT supersets of unsafe inputs. is_safe_path_component
+uses a positive allowlist that ALSO rejects whitespace and uppercase-only-quirks,
+while _is_safe_team_segment rejects only controls / NUL / path separators / dot
+traversal. A team name containing a space (e.g. "team name") therefore reads the
+config in session_registry but short-circuits to "" in task_claim_gate. This is a
+real behavioral difference, but it is NOT in scope for the parity contract: both
+still satisfy the fail-safe invariant (an "unsafe" segment -> ""), they merely
+draw the "unsafe" line at different places. The parity cases below all use
+segments BOTH guards agree on (valid pact-* names, and an unambiguously-unsafe
+"../escape" / "a/b" that both reject), so the assertion is faithful. The space
+divergence is pinned separately (test_known_segment_guard_boundary_is_documented)
+so a future reader knows it is expected, not a missed drift.
+
+Non-vacuity: the parity assertion compares the two LIVE implementations against
+each other, so a drift in EITHER copy flips it red (verified by construction — if
+one copy were edited to, say, read a different key, its return would diverge from
+the other on the valid-config case). The valid-config case (Branch 8 / the only
+non-"" return) is the positive control that makes the five ""-returning cases
+non-vacuous: "" must mean a genuine miss, not that both copies always return "".
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# session_registry is under hooks/shared/; task_claim_gate is under hooks/.
+# tests/conftest.py puts both hooks/ and hooks/shared/ on sys.path.
+from shared.session_registry import _read_lead_session_id as _sr_read_lead
+import task_claim_gate as _tcg
+
+_tcg_read_lead = _tcg._read_lead_session_id
+
+_LEAD_SID = "lead-sess-parity-9999"
+
+
+@pytest.fixture
+def parity_env(tmp_path, monkeypatch):
+    """Redirect Path.home() into tmp_path so BOTH copies' config-root mechanisms
+    (_config_root and get_claude_config_dir) resolve the SAME teams/<team>/
+    config.json. Returns a helper to write team configs of arbitrary shape."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+
+    class _Env:
+        home = tmp_path
+
+        @staticmethod
+        def write_config(team, config_obj):
+            d = tmp_path / ".claude" / "teams" / team
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "config.json").write_text(
+                config_obj if isinstance(config_obj, str) else json.dumps(config_obj),
+                encoding="utf-8",
+            )
+
+    return _Env
+
+
+def _assert_parity(team):
+    """Both copies return the SAME value for the SAME logical input."""
+    sr = _sr_read_lead(team)
+    tcg = _tcg_read_lead(team)
+    assert sr == tcg, (
+        f"_read_lead_session_id DRIFT on team={team!r}: "
+        f"session_registry returned {sr!r} but task_claim_gate returned {tcg!r}. "
+        f"The two inline copies must stay behaviorally parity (same logical input "
+        f"-> same leadSessionId)."
+    )
+    return sr
+
+
+class TestReadLeadSessionIdParity:
+    """The six dispatch-named cases — both copies must agree on each."""
+
+    def test_valid_config_both_return_same_lead_session_id(self, parity_env):
+        """POSITIVE CONTROL (makes the five ""-cases non-vacuous): a well-formed
+        config -> BOTH copies return the SAME leadSessionId STRING."""
+        parity_env.write_config(
+            "pact-parity",
+            {"members": [{"name": "alice"}], "leadSessionId": _LEAD_SID},
+        )
+        assert _assert_parity("pact-parity") == _LEAD_SID
+
+    def test_missing_config_both_return_empty(self, parity_env):
+        """No teams/<team>/config.json -> both copies -> ""."""
+        assert _assert_parity("pact-nodir") == ""
+
+    def test_malformed_json_both_return_empty(self, parity_env):
+        """config.json is not valid JSON -> both copies -> ""."""
+        parity_env.write_config("pact-bad", "{ not valid json ]")
+        assert _assert_parity("pact-bad") == ""
+
+    def test_non_dict_top_level_both_return_empty(self, parity_env):
+        """config.json top-level is a JSON list -> both copies -> ""."""
+        parity_env.write_config("pact-list", ["alice", "bob"])
+        assert _assert_parity("pact-list") == ""
+
+    def test_missing_lead_session_id_key_both_return_empty(self, parity_env):
+        """Valid object, members[] but NO leadSessionId key -> both copies -> ""."""
+        parity_env.write_config("pact-nokey", {"members": [{"name": "alice"}]})
+        assert _assert_parity("pact-nokey") == ""
+
+    def test_non_string_lead_session_id_both_return_empty(self, parity_env):
+        """leadSessionId present but not a string (int) -> both copies -> ""."""
+        parity_env.write_config(
+            "pact-int", {"members": [{"name": "alice"}], "leadSessionId": 12345}
+        )
+        assert _assert_parity("pact-int") == ""
+
+    @pytest.mark.parametrize("unsafe_team", ["../escape", "a/b", "..", "."])
+    def test_unsafe_team_segment_both_return_empty(self, parity_env, unsafe_team):
+        """An unambiguously-unsafe @team segment (path separator / dot traversal)
+        that BOTH guards reject -> both copies short-circuit to "" before any FS
+        read."""
+        assert _assert_parity(unsafe_team) == ""
+
+
+class TestKnownSegmentGuardBoundary:
+    """Pin the ONE documented behavioral divergence so it is not mistaken for a
+    missed drift: the two segment guards draw the "unsafe" line differently, so a
+    team name with an internal SPACE is read by session_registry but rejected by
+    task_claim_gate. Both still honor the fail-safe invariant (unsafe -> "").
+    This is OUT of the parity contract by design; pinning it keeps the divergence
+    visible and intentional rather than surprising."""
+
+    def test_space_in_team_name_is_the_documented_boundary(self, parity_env):
+        parity_env.write_config(
+            "team name", {"members": [{"name": "x"}], "leadSessionId": _LEAD_SID}
+        )
+        sr = _sr_read_lead("team name")
+        tcg = _tcg_read_lead("team name")
+        # session_registry's _is_safe_team_segment admits the space -> reads the
+        # config; task_claim_gate's positive-allowlist is_safe_path_component
+        # rejects it -> "". Documented, intentional boundary.
+        assert sr == _LEAD_SID
+        assert tcg == ""
+        # Both still satisfy the fail-safe contract (never raise; tcg fails safe).

--- a/pact-plugin/tests/test_session_registry.py
+++ b/pact-plugin/tests/test_session_registry.py
@@ -43,11 +43,21 @@ def registry_env(tmp_path, monkeypatch):
             monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", sid)
 
         @staticmethod
-        def write_team(team, member_names):
+        def write_team(team, member_names, lead_session_id=None):
+            """Write teams/<team>/config.json with a members[] list, and
+            OPTIONALLY a top-level leadSessionId (the field register()'s
+            in-process self-guard reads). Default lead_session_id=None omits the
+            key — byte-identical to the pre-guard config shape, so every existing
+            caller is unchanged AND its register() write fails-OPEN through the
+            guard (no leadSessionId -> _read_lead_session_id == "" -> never an
+            in-process match -> WRITE), preserving prior behavior exactly."""
             team_dir = fake_home / ".claude" / "teams" / team
             team_dir.mkdir(parents=True, exist_ok=True)
+            config = {"members": [{"name": n} for n in member_names]}
+            if lead_session_id is not None:
+                config["leadSessionId"] = lead_session_id
             (team_dir / "config.json").write_text(
-                json.dumps({"members": [{"name": n} for n in member_names]}),
+                json.dumps(config),
                 encoding="utf-8",
             )
 

--- a/pact-plugin/tests/test_session_registry_integrity.py
+++ b/pact-plugin/tests/test_session_registry_integrity.py
@@ -59,11 +59,16 @@ def registry_env(tmp_path, monkeypatch):
             monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", sid)
 
         @staticmethod
-        def write_team(team, member_names):
+        def write_team(team, member_names, lead_session_id=None):
             d = fake_home / ".claude" / "teams" / team
             d.mkdir(parents=True, exist_ok=True)
+            config = {"members": [{"name": n} for n in member_names]}
+            if lead_session_id is not None:
+                # The field register()'s in-process self-guard reads; omitted by
+                # default so existing callers stay byte-identical (and fail-OPEN).
+                config["leadSessionId"] = lead_session_id
             (d / "config.json").write_text(
-                json.dumps({"members": [{"name": n} for n in member_names]}),
+                json.dumps(config),
                 encoding="utf-8",
             )
 
@@ -342,3 +347,49 @@ class TestRegisterCliRoundTrip:
         )
         assert proc.returncode == 0, f"stderr=\n{proc.stderr}"
         assert not registry_env.registry_path.exists()
+
+    # --- in-process self-guard, exercised through the REAL script-mode CLI ----
+    # The guard calls the new ``_read_lead_session_id`` helper. In-process tests
+    # can't catch a script-mode-only regression in that helper (e.g. a stray
+    # ``shared.*`` import that would ImportError as a subprocess but resolve fine
+    # in-process). These two run the actual ``python session_registry.py register``
+    # subprocess under both topologies, so the guard is proven from the same entry
+    # point production uses.
+
+    def test_cli_in_process_sid_equals_lead_session_id_skips_write(self, registry_env, tmp_path):
+        """Real CLI, IN-PROCESS topology: the subprocess's $CLAUDE_CODE_SESSION_ID
+        == config.leadSessionId -> the guard skips the write -> nothing on disk,
+        clean exit 0 (script-mode fidelity: a shared.* import regression in
+        _read_lead_session_id would surface here as a non-zero exit / traceback,
+        not silently)."""
+        registry_env.write_team("pact-cli", ["devops"], lead_session_id="lead-sid-xyz")
+        foreign_cwd = tmp_path / "deep" / "unrelated"
+        foreign_cwd.mkdir(parents=True)
+
+        proc = self._run_cli(
+            "devops@pact-cli", home=registry_env.home,
+            session_id="lead-sid-xyz", cwd=foreign_cwd,  # == leadSessionId
+        )
+        assert proc.returncode == 0, f"stderr=\n{proc.stderr}"
+        assert "Traceback" not in proc.stderr
+        assert "ModuleNotFoundError" not in proc.stderr
+        assert not registry_env.registry_path.exists(), (
+            "in-process CLI register (sid==leadSessionId) must SKIP the write"
+        )
+
+    def test_cli_tmux_sid_differs_from_lead_session_id_writes(self, registry_env, tmp_path):
+        """Real CLI, TMUX topology: the subprocess's $CLAUDE_CODE_SESSION_ID !=
+        config.leadSessionId -> the guard fails the match -> the write proceeds
+        and resolves. Positive control for the CLI in-process skip above."""
+        registry_env.write_team("pact-cli", ["devops"], lead_session_id="lead-sid-xyz")
+        foreign_cwd = tmp_path / "deep" / "elsewhere"
+        foreign_cwd.mkdir(parents=True)
+
+        proc = self._run_cli(
+            "devops@pact-cli", home=registry_env.home,
+            session_id="tmux-sid-distinct", cwd=foreign_cwd,  # != leadSessionId
+        )
+        assert proc.returncode == 0, f"stderr=\n{proc.stderr}"
+        assert resolve("tmux-sid-distinct") == "devops@pact-cli", (
+            "tmux CLI register (sid!=leadSessionId) must WRITE and resolve"
+        )

--- a/pact-plugin/tests/test_session_registry_mode_gate.py
+++ b/pact-plugin/tests/test_session_registry_mode_gate.py
@@ -1,0 +1,320 @@
+"""Standing both-modes merge gate for register()'s in-process self-guard.
+
+register() (hooks/shared/session_registry.py) skips the {session_id -> name@team}
+write ONLY on a confirmed in-process topology — own ``$CLAUDE_CODE_SESSION_ID``
+== the team's ``leadSessionId`` (read inline from teams/<team>/config.json via
+``_read_lead_session_id``). In tmux mode each teammate is a distinct process with
+a distinct sid (sid != leadSessionId) so the write is meaningful and proceeds.
+On EVERY uncertain topology (empty/unreadable/malformed/non-dict/missing-key/
+unsafe-team) the guard FAILS OPEN and WRITES — over-writing in-process is a
+harmless collided entry, but under-writing in tmux would blind name-recovery.
+
+This file is the dual-mode contract's STANDING merge gate for that guard:
+
+  * BOTH-MODES MATRIX (P0): in-process (==leadSessionId) -> NO line; tmux
+    (!=leadSessionId) -> line written AND resolvable.
+  * NON-VACUITY (P0, load-bearing): the in-process no-op is byte-indistinguishable
+    from register()'s PRE-EXISTING no-op paths (absent $CLAUDE_CODE_SESSION_ID,
+    missing @team config). A naive "no line was written" assertion is therefore
+    PHANTOM-GREEN unless the skip is ATTRIBUTABLE to the in-process branch alone.
+    We attribute it three ways: (1) a VALID sid is set (rules out the absent-sid
+    no-op); (2) a tmux POSITIVE CONTROL with the SAME valid config DOES write
+    (proves the environment genuinely registers, so the in-process miss is the
+    guard, not a dead fixture); (3) a counter-test-by-revert (see the module
+    docstring of test_*_counter_test, run out-of-band) flips the in-process
+    no-op RED when the guard line is reverted.
+  * FAIL-OPEN (P0): every reachable uncertain branch of _read_lead_session_id
+    -> register() WRITES.
+
+Counter-test-by-revert (documented cardinality, measured out-of-band — NOT run
+in CI): revert ONLY the two guard lines in register() ::
+
+    if sid == _read_lead_session_id(team):
+        return  # confirmed in-process -> skip the un-recoverable write
+
+(source-only: ``git stash push -- pact-plugin/hooks/shared/session_registry.py``
+or ``git checkout 6c7b91fa^ -- <that file>``), then run this file. The
+in-process no-op assertions flip RED because register() now writes a line where
+the guard would have skipped it; the tmux + fail-open assertions stay GREEN
+(they already expect a WRITE). Restore with ``git checkout 6c7b91fa -- <file>``
+/ ``git stash pop`` and confirm ``git diff --quiet`` on the source. The measured
+RED-case cardinality is recorded in TestCounterTestCardinalityDoc below.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from shared import session_registry
+from shared.session_registry import register, resolve
+
+
+# A canonical in-process session id: in in-process teammateMode every teammate
+# inherits the lead's process env, so its own $CLAUDE_CODE_SESSION_ID EQUALS the
+# team's leadSessionId. (Source-reasoned + devops-confirmed from the live
+# in-process config.json for #962.)
+_LEAD_SID = "lead-sess-0000-1111"
+# A distinct tmux session id: a separate-process teammate has its OWN sid.
+_TMUX_SID = "tmux-sess-2222-3333"
+
+
+@pytest.fixture
+def registry_env(tmp_path, monkeypatch):
+    """Isolated ~/.claude tree (mirrors test_session_registry.py's fixture) with
+    a write_team that can carry a top-level leadSessionId."""
+    fake_home = tmp_path
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    reg_path = fake_home / ".claude" / "pact-sessions" / ".teammate-registry.jsonl"
+    monkeypatch.setattr(session_registry, "get_registry_path", lambda: reg_path)
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+
+    class _Env:
+        home = fake_home
+        registry_path = reg_path
+
+        @staticmethod
+        def set_session(sid):
+            monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", sid)
+
+        @staticmethod
+        def write_team(team, member_names, lead_session_id=None):
+            """teams/<team>/config.json with members[] + OPTIONAL leadSessionId."""
+            d = fake_home / ".claude" / "teams" / team
+            d.mkdir(parents=True, exist_ok=True)
+            config = {"members": [{"name": n} for n in member_names]}
+            if lead_session_id is not None:
+                config["leadSessionId"] = lead_session_id
+            (d / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+        @staticmethod
+        def write_team_raw(team, config_text):
+            """Write config.json with ARBITRARY (possibly malformed) contents:
+            a raw string is written verbatim; a dict/list is JSON-encoded."""
+            d = fake_home / ".claude" / "teams" / team
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "config.json").write_text(
+                config_text if isinstance(config_text, str) else json.dumps(config_text),
+                encoding="utf-8",
+            )
+
+    return _Env
+
+
+# ---------------------------------------------------------------------------
+# P0 — BOTH-MODES MATRIX (the standing merge gate)
+# ---------------------------------------------------------------------------
+
+class TestBothModesMatrix:
+    """The dual-mode contract: SAME input under the two topologies, divergent
+    outcome. In-process == leadSessionId -> NO write; tmux != -> write."""
+
+    def test_in_process_sid_equals_lead_session_id_skips_write(self, registry_env):
+        """IN-PROCESS leg: own sid == config.leadSessionId -> register no-ops,
+        registry file is never created. Attributable to the guard (a VALID sid
+        is set, ruling out the absent-sid no-op; the tmux control below proves
+        the environment otherwise writes)."""
+        registry_env.set_session(_LEAD_SID)
+        registry_env.write_team("pact-team1", ["alice"], lead_session_id=_LEAD_SID)
+
+        register("alice@pact-team1")
+
+        assert not registry_env.registry_path.exists(), (
+            "in-process register (sid==leadSessionId) must SKIP the write"
+        )
+        # And nothing is resolvable for that sid.
+        assert resolve(_LEAD_SID) is None
+
+    def test_tmux_sid_differs_from_lead_session_id_writes_and_resolves(self, registry_env):
+        """TMUX leg (positive control): own sid != config.leadSessionId ->
+        register writes the line AND it resolves. Same fixture shape as the
+        in-process leg (valid sid + valid leadSessionId config + member) — only
+        the sid/leadSessionId RELATION differs, so this proves the divergence is
+        driven by the structural signal, not a fixture artifact."""
+        registry_env.set_session(_TMUX_SID)
+        registry_env.write_team("pact-team1", ["alice"], lead_session_id=_LEAD_SID)
+
+        register("alice@pact-team1")
+
+        assert registry_env.registry_path.exists(), (
+            "tmux register (sid!=leadSessionId) must WRITE the line"
+        )
+        assert resolve(_TMUX_SID) == "alice@pact-team1"
+
+    def test_matrix_same_input_diverges_only_on_topology(self, registry_env):
+        """Belt-and-suspenders single-test matrix: hold name@team + config
+        constant, vary ONLY which sid the process carries, assert the two
+        outcomes diverge. This is the merge-gate invariant in one assertion
+        pair."""
+        registry_env.write_team("pact-team1", ["alice"], lead_session_id=_LEAD_SID)
+
+        # tmux first (distinct sid) -> writes.
+        registry_env.set_session(_TMUX_SID)
+        register("alice@pact-team1")
+        assert resolve(_TMUX_SID) == "alice@pact-team1"
+
+        # in-process (sid == leadSessionId) -> the matching sid is NEVER written,
+        # so it never resolves, even though the tmux line now exists in the file.
+        registry_env.set_session(_LEAD_SID)
+        register("alice@pact-team1")
+        assert resolve(_LEAD_SID) is None, (
+            "the in-process sid must never be written even alongside a tmux line"
+        )
+
+
+# ---------------------------------------------------------------------------
+# P0 — NON-VACUITY: the in-process skip is THE in-process branch, not a generic
+# miss. We pin the distinguishing controls so a future fixture regression can't
+# silently make the skip phantom-green.
+# ---------------------------------------------------------------------------
+
+class TestNonVacuity:
+    def test_in_process_skip_is_not_the_absent_sid_noop(self, registry_env):
+        """Distinguish the in-process guard from register()'s PRE-EXISTING
+        absent-$CLAUDE_CODE_SESSION_ID no-op: a VALID sid is set here, so a skip
+        can ONLY come from the in-process branch (sid==leadSessionId). If a
+        regression removed the guard, this VALID-sid register would WRITE (that
+        is exactly the counter-test-by-revert flip)."""
+        registry_env.set_session(_LEAD_SID)  # NON-empty sid -> not the absent path
+        registry_env.write_team("pact-team1", ["alice"], lead_session_id=_LEAD_SID)
+
+        register("alice@pact-team1")
+        assert not registry_env.registry_path.exists()
+
+    def test_positive_control_same_config_writes_when_topology_is_tmux(self, registry_env):
+        """The environment genuinely registers under this exact config — only the
+        sid==leadSessionId RELATION suppresses it. Without this control the
+        in-process no-op could be a dead fixture (e.g. an unwritable path); WITH
+        it, the no-op is provably the guard."""
+        registry_env.set_session("some-other-distinct-sid")
+        registry_env.write_team("pact-team1", ["alice"], lead_session_id=_LEAD_SID)
+
+        register("alice@pact-team1")
+        assert registry_env.registry_path.exists()
+        assert resolve("some-other-distinct-sid") == "alice@pact-team1"
+
+
+class TestCounterTestCardinalityDoc:
+    """Counter-test-by-revert cardinality, MEASURED out-of-band (documented here
+    so a future verifier checks the recorded number, not a re-derived guess).
+
+    Procedure: source-only revert the two guard lines in register() (see this
+    module's docstring), then ``python -m pytest
+    pact-plugin/tests/test_session_registry_mode_gate.py -rf``.
+
+    MEASURED RED-case set when the guard is reverted (recorded at authoring;
+    re-verify if the matrix changes):
+      - TestBothModesMatrix::test_in_process_sid_equals_lead_session_id_skips_write
+      - TestBothModesMatrix::test_matrix_same_input_diverges_only_on_topology
+      - TestNonVacuity::test_in_process_skip_is_not_the_absent_sid_noop
+
+    => 3 RED cases (3 distinct source assertions; no parametrization expands
+    them). The tmux/positive-control/fail-open cases stay GREEN because they
+    already expect a WRITE — that asymmetry is itself evidence the RED set is
+    coupled to the in-process branch specifically, not to register() at large.
+    This test is a DOC anchor only; it asserts the recorded count is internally
+    consistent (a tripwire if someone edits the list without re-measuring)."""
+
+    EXPECTED_RED_ON_GUARD_REVERT = {
+        "test_in_process_sid_equals_lead_session_id_skips_write",
+        "test_matrix_same_input_diverges_only_on_topology",
+        "test_in_process_skip_is_not_the_absent_sid_noop",
+    }
+
+    def test_documented_cardinality_is_three(self):
+        assert len(self.EXPECTED_RED_ON_GUARD_REVERT) == 3
+
+
+# ---------------------------------------------------------------------------
+# P0 — FAIL-OPEN: every reachable uncertain branch of _read_lead_session_id
+# routes register() to WRITE. By the time _read_lead_session_id runs, register()
+# has already required a non-empty sid, an "@", and non-empty name AND team — so
+# the EMPTY-team branch is unreachable here and is covered as a register()-level
+# pre-existing path elsewhere. The reachable uncertain branches are: missing
+# config, malformed JSON, non-dict top-level, missing leadSessionId key,
+# non-string leadSessionId, and an unsafe @team segment.
+# ---------------------------------------------------------------------------
+
+class TestFailOpenWrites:
+    def test_missing_config_writes(self, registry_env):
+        """No teams/<team>/config.json at all -> _read_lead_session_id OSError ->
+        "" -> never matches -> WRITE."""
+        registry_env.set_session(_LEAD_SID)
+        # team dir / config deliberately absent; member-validation on READ would
+        # reject, so we assert the WRITE happened at the file level (a line
+        # exists), which is the fail-open observable.
+        register("alice@pact-ghostteam")
+        assert registry_env.registry_path.exists(), "missing config must fail-OPEN to WRITE"
+
+    def test_malformed_json_config_writes(self, registry_env):
+        """config.json is not valid JSON -> ValueError -> "" -> WRITE."""
+        registry_env.set_session(_LEAD_SID)
+        registry_env.write_team_raw("pact-team1", "{ this is not json ]")
+        register("alice@pact-team1")
+        assert registry_env.registry_path.exists(), "malformed JSON must fail-OPEN to WRITE"
+
+    def test_non_dict_top_level_config_writes(self, registry_env):
+        """config.json top-level is a JSON LIST (not an object) -> not isinstance
+        dict -> "" -> WRITE."""
+        registry_env.set_session(_LEAD_SID)
+        registry_env.write_team_raw("pact-team1", ["alice", "bob"])  # a list
+        register("alice@pact-team1")
+        assert registry_env.registry_path.exists(), "non-dict config must fail-OPEN to WRITE"
+
+    def test_missing_lead_session_id_key_writes(self, registry_env):
+        """config.json is a valid object with members[] but NO leadSessionId key
+        -> config.get returns None -> "" -> WRITE. (This is the shape every
+        pre-#962 config had, so the guard must be inert for them.)"""
+        registry_env.set_session(_LEAD_SID)
+        registry_env.write_team("pact-team1", ["alice"])  # lead_session_id=None
+        register("alice@pact-team1")
+        assert registry_env.registry_path.exists(), "absent leadSessionId must fail-OPEN to WRITE"
+
+    def test_non_string_lead_session_id_writes(self, registry_env):
+        """leadSessionId present but NOT a string (e.g. an int) -> the isinstance
+        guard returns "" -> WRITE. A non-string can never == the string sid
+        anyway, but the explicit "" keeps the branch fail-OPEN by construction."""
+        registry_env.set_session(_LEAD_SID)
+        registry_env.write_team_raw(
+            "pact-team1",
+            {"members": [{"name": "alice"}], "leadSessionId": 12345},
+        )
+        register("alice@pact-team1")
+        assert registry_env.registry_path.exists(), "non-string leadSessionId must fail-OPEN to WRITE"
+
+    def test_unsafe_team_segment_writes(self, registry_env):
+        """An @team that is not a single safe path component (contains a path
+        separator) -> _is_safe_team_segment False -> "" BEFORE any FS read ->
+        WRITE. register() keeps the @team intact in the value, so the line is
+        written with the raw (unsafe) team; member-validation rejects it on READ,
+        but the fail-OPEN WRITE is the observable under test."""
+        registry_env.set_session(_LEAD_SID)
+        register("alice@pact/evil")  # "/" -> unsafe segment
+        assert registry_env.registry_path.exists(), "unsafe @team must fail-OPEN to WRITE"
+
+
+# ---------------------------------------------------------------------------
+# Pre-existing register()-level no-op paths that are NOT the in-process guard —
+# pinned so the guard's addition did not accidentally fold them into itself.
+# ---------------------------------------------------------------------------
+
+class TestPreExistingNoopsStillDistinct:
+    def test_absent_sid_still_noops_independently_of_guard(self, registry_env):
+        """No $CLAUDE_CODE_SESSION_ID -> the L168 absent-sid no-op fires BEFORE
+        the guard is ever reached -> no write. (Distinct from the in-process
+        skip: here there is no sid at all.)"""
+        # registry_env clears the env var by default; set a matching config so
+        # the ONLY reason for the no-op is the absent sid, not the guard.
+        registry_env.write_team("pact-team1", ["alice"], lead_session_id=_LEAD_SID)
+        register("alice@pact-team1")
+        assert not registry_env.registry_path.exists()
+
+    def test_empty_team_half_noops_before_guard(self, registry_env):
+        """"name@" (empty team) -> the L179 partition guard returns BEFORE
+        _read_lead_session_id is reached -> no write. Confirms the empty-team
+        fail-open branch is genuinely unreachable from register() (it is
+        short-circuited upstream), so the fail-open suite above correctly omits
+        it."""
+        registry_env.set_session(_LEAD_SID)
+        register("alice@")  # empty team half
+        assert not registry_env.registry_path.exists()

--- a/pact-plugin/tests/test_session_registry_mode_gate.py
+++ b/pact-plugin/tests/test_session_registry_mode_gate.py
@@ -32,13 +32,20 @@ in CI): revert ONLY the two guard lines in register() ::
     if sid == _read_lead_session_id(team):
         return  # confirmed in-process -> skip the un-recoverable write
 
-(source-only: ``git stash push -- pact-plugin/hooks/shared/session_registry.py``
-or ``git checkout 6c7b91fa^ -- <that file>``), then run this file. The
-in-process no-op assertions flip RED because register() now writes a line where
-the guard would have skipped it; the tmux + fail-open assertions stay GREEN
-(they already expect a WRITE). Restore with ``git checkout 6c7b91fa -- <file>``
-/ ``git stash pop`` and confirm ``git diff --quiet`` on the source. The measured
-RED-case cardinality is recorded in TestCounterTestCardinalityDoc below.
+The ONLY correct method is a SOURCE-ONLY revert that removes just those two
+lines while leaving the ``_read_lead_session_id`` helper (and this test's import
+of it) intact — either an in-place delete of the two lines, or
+``git stash push -- pact-plugin/hooks/shared/session_registry.py`` (which stashes
+the whole working-tree file but is then re-applied wholesale). Do NOT use a
+whole-file checkout of a commit that PREDATES ``_read_lead_session_id``: that
+removes the helper symbol this file imports at module load, so the run ERRORS at
+COLLECTION (ImportError) instead of producing the clean in-process-flip the
+counter-test needs. After running this file, the in-process no-op assertions flip
+RED (register() now writes a line where the guard would have skipped it) while the
+tmux + fail-open assertions stay GREEN (they already expect a WRITE). Restore the
+two lines (``git stash pop`` / re-add the deleted lines) and confirm
+``git diff --quiet`` on the source. The measured RED-case cardinality is recorded
+in TestCounterTestCardinalityDoc below.
 """
 
 import json

--- a/pact-plugin/tests/test_session_registry_mode_gate.py
+++ b/pact-plugin/tests/test_session_registry_mode_gate.py
@@ -47,7 +47,7 @@ from pathlib import Path
 import pytest
 
 from shared import session_registry
-from shared.session_registry import register, resolve
+from shared.session_registry import register, resolve, _read_lead_session_id
 
 
 # A canonical in-process session id: in in-process teammateMode every teammate
@@ -291,6 +291,97 @@ class TestFailOpenWrites:
         registry_env.set_session(_LEAD_SID)
         register("alice@pact/evil")  # "/" -> unsafe segment
         assert registry_env.registry_path.exists(), "unsafe @team must fail-OPEN to WRITE"
+
+
+# ---------------------------------------------------------------------------
+# DIRECT helper unit tests for _read_lead_session_id — covers EVERY branch in
+# isolation, including the ones NOT reachable through register() (so the
+# fail-open suite above does not vacuously claim register() exercises them).
+# _read_lead_session_id is the signal source the guard reads; testing it
+# directly localizes a regression to the helper vs the register() wiring.
+#
+# Branch map (return "" on every miss; the team's leadSessionId string on a hit):
+#   1. EMPTY team           -> _is_safe_team_segment False -> "" (UNREACHABLE via
+#                              register(): pre-filtered at the name/team partition;
+#                              ONLY a direct helper test can cover it)
+#   2. UNSAFE team segment  -> _is_safe_team_segment False -> "" (reachable via
+#                              register() too — pinned there AND here)
+#   3. missing config       -> OSError -> ""
+#   4. malformed JSON       -> ValueError -> ""
+#   5. non-dict top-level   -> "" (isinstance guard)
+#   6. missing leadSessionId-> config.get None -> ""
+#   7. non-string lead..    -> isinstance guard -> ""
+#   8. VALID                -> returns the leadSessionId STRING (the only non-""
+#                              return — the positive control that makes 1-7
+#                              non-vacuous: "" must mean a real miss, not that the
+#                              helper can never return anything)
+# ---------------------------------------------------------------------------
+
+class TestReadLeadSessionIdHelper:
+    """Direct unit coverage of the in-process self-guard's signal source."""
+
+    @staticmethod
+    def _write_config(home, team, config_obj):
+        d = home / ".claude" / "teams" / team
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "config.json").write_text(
+            config_obj if isinstance(config_obj, str) else json.dumps(config_obj),
+            encoding="utf-8",
+        )
+
+    def test_empty_team_returns_empty(self):
+        """Branch 1 — EMPTY team is rejected by _is_safe_team_segment BEFORE any
+        FS access. UNREACHABLE through register() (the L179 partition short-
+        circuits it), so this direct helper test is the ONLY coverage for it.
+        Per the lead's reachability guidance: cover the unreachable branch here,
+        not vacuously through register()."""
+        assert _read_lead_session_id("") == ""
+
+    def test_unsafe_team_segment_returns_empty(self):
+        """Branch 2 — a non-empty but unsafe @team (path separator / traversal /
+        control char) is rejected BEFORE building the FS path."""
+        assert _read_lead_session_id("../escape") == ""
+        assert _read_lead_session_id("a/b") == ""
+        assert _read_lead_session_id("..") == ""
+
+    def test_missing_config_returns_empty(self, registry_env, tmp_path):
+        """Branch 3 — no teams/<team>/config.json -> OSError -> ""."""
+        # registry_env redirects Path.home() into tmp_path; no config written.
+        assert _read_lead_session_id("pact-noconfig") == ""
+
+    def test_malformed_json_returns_empty(self, registry_env, tmp_path):
+        """Branch 4 — config.json is not valid JSON -> ValueError -> ""."""
+        self._write_config(tmp_path, "pact-bad", "{ not json ]")
+        assert _read_lead_session_id("pact-bad") == ""
+
+    def test_non_dict_top_level_returns_empty(self, registry_env, tmp_path):
+        """Branch 5 — top-level is a JSON list, not an object -> ""."""
+        self._write_config(tmp_path, "pact-list", ["a", "b"])
+        assert _read_lead_session_id("pact-list") == ""
+
+    def test_missing_lead_session_id_key_returns_empty(self, registry_env, tmp_path):
+        """Branch 6 — a valid object with members[] but NO leadSessionId key
+        (the pre-#962 config shape) -> config.get None -> ""."""
+        self._write_config(tmp_path, "pact-nokey", {"members": [{"name": "alice"}]})
+        assert _read_lead_session_id("pact-nokey") == ""
+
+    def test_non_string_lead_session_id_returns_empty(self, registry_env, tmp_path):
+        """Branch 7 — leadSessionId present but not a string -> isinstance guard
+        -> ""."""
+        self._write_config(tmp_path, "pact-int", {"leadSessionId": 12345})
+        assert _read_lead_session_id("pact-int") == ""
+
+    def test_valid_config_returns_lead_session_id_string(self, registry_env, tmp_path):
+        """Branch 8 (POSITIVE CONTROL) — a well-formed config returns the
+        leadSessionId STRING. Without this, every "" assertion above is vacuous
+        (a helper that ALWAYS returned "" would pass them all). This proves ""
+        means a genuine miss, and the in-process guard's `sid == helper(team)`
+        comparison can actually be TRUE."""
+        self._write_config(
+            tmp_path, "pact-good",
+            {"members": [{"name": "alice"}], "leadSessionId": _LEAD_SID},
+        )
+        assert _read_lead_session_id("pact-good") == _LEAD_SID
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Gates `pact-team-registration` so it no-ops the registry write in in-process `teammateMode`, where all teammates share the lead's `session_id` and the `{session_id → name@team}` write collides many-to-one (last-wins), unable to recover which teammate owns a `session_id`. The mapping is only meaningful in tmux mode (distinct process + `session_id` per teammate). Closes #962.

## What landed

- **Guard** (`pact-plugin/hooks/shared/session_registry.py` `register()`): skip the registry write **only** on a confirmed `session_id == leadSessionId` (the runtime structural signal, read inline via a new `_read_lead_session_id` helper that mirrors `task_claim_gate._read_lead_session_id`); write normally in tmux and **fail-OPEN** on every unknown / unreadable / malformed / non-dict / missing-key / unsafe-team topology. Silent, reversible no-op; keys on the structural signal, never a mode flag; **zero new `shared.*` imports** (self-contained-leaf invariant preserved).
- **Tests**: the standing **both-modes matrix** (in-process `sid==leadSessionId` → no write; tmux → write + resolvable), 6-branch fail-OPEN coverage, direct `_read_lead_session_id` helper unit tests + a positive control, a **non-mocked** `pact_context` resolve-seam test, and 2 real-CLI subprocess legs. **Non-vacuity proven** via counter-test-by-revert: a source-only guard removal flips exactly 4 RED cases. Full suite: **9369 passed, 14 skipped, 0 failed, 0 errors**.
- **Version**: PATCH bump 4.4.34 → 4.4.35 (internal hook hardening; no user-visible surface change).

## Why route-b (single-file `register()` guard)

A multi-agent plan-mode investigation + an adversarial feasibility workflow ruled out the alternatives:

- **Route-a** (gate the directive across the ~20 spawn-prompt sites) is **contract-illegal** — a static `prompt=` template literal is rendered by the dispatcher before the teammate process exists, so it cannot read a runtime signal; it could only carry an authoring-time **flag**, violating the permanent dual-mode "structural-signal-never-a-flag" contract.
- **Route-c'** (relocate the directive into `session_init`'s SessionStart injection) was investigated and ruled **NOT_VIABLE** (3/3 adversarial verifiers, high confidence): `SessionStart` fires once per OS process, **not** per in-process teammate spawn — in-process teammates fire `SubagentStart` (→ `peer_inject.py`), mode-exclusive — so c''s named injection point never runs on an in-process spawn, making per-in-process-teammate gating structurally impossible there.

Route-b (the `register()` self-guard) is the only viable, contract-legal option, and the discriminator is config-driven (reads `leadSessionId` from team `config.json`, never the registry), so the no-op blinds no consumer — all 3 live registry consumers are already fail-safe-to-baseline.

## Acceptance criteria

- **AC1** in-process no longer performs an un-fulfillable registration (silent no-op) — ✅
- **AC2** tmux registration unchanged — ✅
- **AC3** all `.teammate-registry.jsonl` readers enumerated + verified unaffected (config-driven discriminator; fail-safe consumers; non-mocked seam test) — ✅
- **AC4** keys on a runtime structural signal, validated under BOTH modes (standing matrix) — ✅
- **AC5** no spawn-prompt dispatch site touched (route-b) — ✅ N/A by design
