### PR TITLE
fix(hooks): self-diagnosing dispatch denials for stale-team/store mismatch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.35",
+      "version": "4.4.36",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.35/      # Plugin version
+│               └── 4.4.36/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.35",
+  "version": "4.4.36",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.35
+> **Version**: 4.4.36
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/bootstrap_prompt_gate.py
+++ b/pact-plugin/hooks/bootstrap_prompt_gate.py
@@ -31,8 +31,6 @@ from __future__ import annotations
 
 # ─── stdlib first (used by _emit_load_failure_advisory BEFORE wrapped imports) ─
 import json
-import os
-import re
 import sys
 from typing import NoReturn
 
@@ -97,6 +95,14 @@ try:
     import shared.pact_context as pact_context
     from bootstrap_gate import is_marker_set
     from shared import BOOTSTRAP_MARKER_NAME
+    # Stale-session detector moved to the shared/ leaf (single SSOT, also
+    # consumed by dispatch_gate's deny-message self-diagnosis). Re-bound to the
+    # historical module-private name so this module's existing call site and
+    # the test suite that imports/monkeypatches
+    # `bootstrap_prompt_gate._detect_stale_session_block` stay behavior-identical.
+    from shared.stale_session import (
+        detect_stale_session_block as _detect_stale_session_block,
+    )
 except BaseException as _module_load_error:  # noqa: BLE001 — fail-closed catch-all
     _emit_load_failure_advisory("module imports", _module_load_error)
 
@@ -119,99 +125,11 @@ _SESSION_DIR_HINT = (
     "\n\nPACT_SESSION_DIR={session_dir}"
 )
 
-# Mirrors the Resume-line fallback regex in session_init's
-# _extract_prev_session_dir — the established defensive parse for the
-# session_resume.update_session_info managed block. Parity with
-# claude_md_manager.resolve_project_claude_md_path's existing-file
-# precedence is pinned by test (NOT by a runtime import — every new
-# top-level import here widens the import-failure blast radius the
-# bootstrap-resilience work exists to shrink).
-_RESUME_LINE_RE = re.compile(r"- Resume:\s*`claude --resume\s+([0-9a-f-]+)`")
-
-_STALENESS_WARNING_TEMPLATE = (
-    "\n\nWARNING — stale session block: the project CLAUDE.md 'Current "
-    "Session' block records session {recorded} but this session is "
-    "{actual}. session_init likely failed at SessionStart this session "
-    "(or the CLAUDE.md write failed). Do NOT trust the recorded Team/"
-    "Session dir/Resume lines for THIS session; completing bootstrap "
-    "will rewrite them."
-)
-
-
-def _detect_stale_session_block(input_data: dict) -> str | None:
-    """Detect a stale 'Current Session' block in the project CLAUDE.md.
-
-    When session_init crashes at SessionStart, the previous session's
-    Resume/Team/Session-dir lines survive in CLAUDE.md and misdirect
-    recovery. Compare the recorded Resume-line session_id against this
-    frame's raw stdin session_id; on mismatch, return an advisory warning
-    string for additionalContext composition. Returns None (no warning)
-    when:
-
-      1. stdin session_id is missing or invalid per the canonical
-         _is_unknown_or_missing_session predicate (None/non-string/empty/
-         whitespace-only/`unknown-*` sentinel/C0-control chars) — nothing
-         trustworthy to compare, and an unvalidated stdin id must never be
-         interpolated into the warning text
-      2. CLAUDE_PROJECT_DIR is unset (cannot locate CLAUDE.md)
-      3. neither CLAUDE.md location exists, or reading raises OSError or
-         UnicodeDecodeError (worktrees: CLAUDE.md is gitignored/absent →
-         silent skip; a non-UTF-8/corrupted CLAUDE.md → silent skip — this
-         helper is ADVISORY, so its failure budget is "no warning", never
-         "no bootstrap instruction": an uncaught raise here would propagate
-         to main()'s fail-open and suppress the ENTIRE injection, primary
-         instruction included)
-      4. no Resume line matches the regex (tampered/garbage → no claim)
-      5. recorded session_id equals this session's (healthy resume)
-
-    Stdlib-only two-path read: .claude/CLAUDE.md preferred, legacy
-    ./CLAUDE.md fallback — same existing-file precedence as
-    resolve_project_claude_md_path (parity pinned by test). False
-    positives: none in healthy flows — session_init rewrites the block
-    before the first prompt on startup/clear, and resume keeps the same
-    session_id.
-    """
-    raw_id = input_data.get("session_id")
-    # Canonical validity predicate (shared with the heal gate and
-    # session_init's persist/CLAUDE.md-write gates) — subsumes the plain
-    # truthiness check and additionally rejects non-string, whitespace-only,
-    # `unknown-*` sentinel, and C0-control-char ids, so `actual` below is
-    # never an attacker-shaped or sentinel value interpolated into the
-    # warning. The predicate is total for any input.
-    if pact_context._is_unknown_or_missing_session(raw_id):
-        return None
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
-    if not project_dir:
-        return None
-    try:
-        content = None
-        for candidate in (
-            Path(project_dir) / ".claude" / "CLAUDE.md",
-            Path(project_dir) / "CLAUDE.md",
-        ):
-            if candidate.exists():
-                content = candidate.read_text(encoding="utf-8")
-                break
-        if content is None:
-            return None
-    except (OSError, UnicodeDecodeError):
-        # UnicodeDecodeError (a ValueError, NOT an OSError) from read_text
-        # on a non-UTF-8 CLAUDE.md — e.g. a latin-1 byte from a wrong-editor
-        # save, or the partial/corrupted session_init write this detector
-        # exists to flag. Must be swallowed HERE: this helper composes into
-        # the load-bearing bootstrap instruction by concatenation, and an
-        # escape to main()'s fail-open suppresses the whole injection.
-        return None
-    match = _RESUME_LINE_RE.search(content)
-    if not match:
-        return None
-    recorded = match.group(1)
-    actual = str(raw_id)
-    if recorded != actual:
-        return _STALENESS_WARNING_TEMPLATE.format(
-            recorded=recorded, actual=actual
-        )
-    return None
+# `_detect_stale_session_block` (and its `_RESUME_LINE_RE` /
+# `_STALENESS_WARNING_TEMPLATE` constants) moved to shared/stale_session.py —
+# the single SSOT now also consumed by dispatch_gate. The historical
+# module-private name is re-bound at import time above so this module's call
+# site and tests are behavior-identical.
 
 
 def _check_bootstrap_needed(input_data: dict) -> str | None:

--- a/pact-plugin/hooks/dispatch_gate.py
+++ b/pact-plugin/hooks/dispatch_gate.py
@@ -100,6 +100,7 @@ try:
     )
     from shared.session_journal import append_event, make_event
     from shared.paths import get_claude_config_dir
+    from shared.stale_session import detect_stale_session_block
 except BaseException as _module_load_error:  # noqa: BLE001 — fail-closed catch-all
     _emit_load_failure_deny("module imports", _module_load_error)
 
@@ -493,6 +494,77 @@ def _journal_decision(decision: str, reason: str | None, rule: str | None,
         pass
 
 
+# Deny rules whose root cause can be a stale-team/store mismatch after a
+# Claude Code restart/fork (the persisted team_name/session_id diverge from
+# the live platform team, so this gate resolves an orphaned task store while
+# Task* tools write the live one). Both surface as misleading denials —
+# ``team_name_unavailable`` (rule ⑥) and ``no_task_assigned`` (rule ⑧) — that
+# never name the real cause. Other deny rules (name validation, plugin-install,
+# registry) are NOT restart-symptoms, so they are deliberately excluded: a
+# stale-session note on them would misdirect recovery.
+_STALE_DIAGNOSABLE_RULES = frozenset({"team_name_unavailable", "no_task_assigned"})
+
+# Actionable re-align guidance appended after the shared detector's stale-block
+# warning. The detector names the live-vs-recorded session_id mismatch; this
+# adds the dispatch-specific recovery (the gate read a different task store
+# than the live session's).
+_STALE_REALIGN_HINT = (
+    " This dispatch denial is likely a STALE-TEAM/STORE MISMATCH, not a "
+    "genuinely missing task: after a Claude Code restart/fork the platform "
+    "minted a new team for the live session while PACT's persisted team_name "
+    "went stale, so this gate read an orphaned task store. To re-align: update "
+    "the `team_name` in this session's pact-session-context.json (and the "
+    "project CLAUDE.md '- Team:' line) to the LIVE platform team, then "
+    "re-dispatch. Completing /PACT:bootstrap also rewrites those records."
+)
+
+
+def _augment_deny_with_stale_diagnosis(
+    rule: str | None, message: str, input_data: dict,
+) -> str:
+    """Return ``message`` augmented with a stale-team/store self-diagnosis when
+    a restart-induced session mismatch is detected, else ``message`` UNCHANGED.
+
+    MESSAGE-ONLY: this never alters the gate DECISION — it is called only after
+    ``evaluate_dispatch`` has already returned DENY, and only rewrites the
+    user-facing ``permissionDecisionReason`` text. The deny still fires on
+    exactly the same inputs.
+
+    NEVER RAISES (the single named place the detection call is wrapped — this
+    is NEW code on a path that runs in EVERY consumer session). Any exception
+    from the detector (unreadable/absent CLAUDE.md, missing keys, a tmux frame
+    with no recorded block, an import-time surprise) falls back to the ORIGINAL
+    ``message``. A thrown exception must NEVER break dispatch; a self-diagnosis
+    is strictly a nicety on top of the already-correct deny.
+
+    Gating:
+      * Only the restart-symptom rules in ``_STALE_DIAGNOSABLE_RULES`` are
+        augmented; other deny rules are returned verbatim (a stale-session note
+        on a name-validation deny would misdirect recovery).
+      * UN-GATED from the bootstrap-marker fast path: detection runs regardless
+        of marker presence. On a restart the marker can be present but stamped
+        for the STALE team, so a marker-gated check would miss exactly the case
+        this diagnoses.
+      * When the shared detector returns None (no mismatch — the healthy case,
+        or CLAUDE.md absent as in worktrees), the ORIGINAL message is preserved
+        verbatim. The augmentation is purely additive on a detected mismatch.
+    """
+    try:
+        if rule not in _STALE_DIAGNOSABLE_RULES:
+            return message
+        if not isinstance(input_data, dict):
+            return message
+        stale_block = detect_stale_session_block(input_data)
+        if not stale_block:
+            return message
+        return message + stale_block + _STALE_REALIGN_HINT
+    except Exception:
+        # Fail-safe: any error in the diagnosis path → original deny message.
+        # The deny itself is unaffected; only the optional self-diagnosis is
+        # dropped. NEVER re-raise out of the dispatch path.
+        return message
+
+
 def main() -> None:
     try:
         input_data = json.load(sys.stdin)
@@ -531,11 +603,17 @@ def main() -> None:
         print(_SUPPRESS_OUTPUT)
         sys.exit(0)
     if decision == "DENY":
+        # MESSAGE-ONLY self-diagnosis: on a restart-symptom deny rule, append a
+        # stale-team/store mismatch explanation + re-align steps when detected.
+        # Journaling above recorded the canonical (un-augmented) reason; this
+        # augments ONLY the user-facing message and never the decision. The
+        # helper is never-raises — on any error the original reason stands.
+        deny_message = _augment_deny_with_stale_diagnosis(rule, reason, input_data)
         print(json.dumps({
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",
                 "permissionDecision": "deny",
-                "permissionDecisionReason": reason,
+                "permissionDecisionReason": deny_message,
             }
         }))
         sys.exit(2)

--- a/pact-plugin/hooks/shared/hook_infra_classifier.py
+++ b/pact-plugin/hooks/shared/hook_infra_classifier.py
@@ -149,8 +149,11 @@ _SEAM_HOOK_HELPER_CLOSURE: dict[str, frozenset[str]] = {
     }),
     "dispatch_gate": frozenset({
         "constants", "dispatch_helpers", "pact_context", "paths",
-        "session_journal", "session_registry", "session_state", "task_utils",
-    }),
+        "session_journal", "session_registry", "session_state",
+        "stale_session", "task_utils",
+    }),  # stale_session reached here via the deny-message self-diagnosis
+         # (dispatch_gate -> shared.stale_session.detect_stale_session_block);
+         # its own transitive pact_context edge was already in this closure.
     "task_lifecycle_gate": frozenset({
         "agent_handoff_marker", "constants", "dispatch_helpers",
         "intentional_wait", "pact_context", "paths", "session_journal",

--- a/pact-plugin/hooks/shared/stale_session.py
+++ b/pact-plugin/hooks/shared/stale_session.py
@@ -6,8 +6,11 @@ Summary: Shared detector for a stale 'Current Session' block in the project
          CLAUDE.md Resume-line id and returns a diagnostic warning on mismatch.
 Used by: bootstrap_prompt_gate.py (UserPromptSubmit injection) and
          dispatch_gate.py (deny-message self-diagnosis at the two team/task
-         deny sites). Single SSOT for the live-vs-recorded session_id mismatch
-         signal so both consumers read one implementation.
+         deny sites). Single SSOT for THIS specific signal — the
+         CLAUDE.md-Resume-line-recorded vs live-stdin session_id mismatch — so
+         both consumers read one implementation. (Scoped deliberately: this is
+         NOT the only restart-detection signal; a context-SSOT-keyed sibling is
+         planned — see the breadcrumb below the constants.)
 
 The detector is the reuse seam for the restart/persistence reliability work:
 after a full Claude Code restart/fork the platform mints a new session-<id8>
@@ -40,6 +43,15 @@ _STALENESS_WARNING_TEMPLATE = (
     "Session dir/Resume lines for THIS session; completing bootstrap "
     "will rewrite them."
 )
+
+# FORWARD NOTE — a SIBLING restart-detection signal is planned for this leaf:
+# an `is_session_restarted`-style check keyed on the PERSISTED CONTEXT SSOT
+# (pact-session-context.json session_id vs the live stdin id), as opposed to
+# THIS detector which keys on the CLAUDE.md Resume-line. The two read different
+# sources (context-file vs CLAUDE.md) and can disagree, so when that sibling
+# lands here the keep-them-SEPARATE vs share-a-common-accessor decision should
+# be made CONSCIOUSLY at that time (not pre-judged now). They are siblings in
+# the same leaf, not a generalization of this function.
 
 
 def detect_stale_session_block(input_data: dict) -> str | None:
@@ -112,7 +124,18 @@ def detect_stale_session_block(input_data: dict) -> str | None:
     recorded = match.group(1)
     actual = str(raw_id)
     if recorded != actual:
+        # Render-bound length cap (defense-in-depth, message-only). The
+        # Resume-line capture is `[0-9a-f-]+` (UNBOUNDED), so a tampered
+        # CLAUDE.md with a 200k-hex id would interpolate a 200k-char warning
+        # into the consumer's surface (a dispatch deny's permissionDecisionReason
+        # / a UserPromptSubmit additionalContext). Cap BOTH AFTER the mismatch
+        # comparison (comparing the FULL values, so two long-but-distinct ids
+        # cannot collide on a shared 64-char prefix and wrongly suppress a real
+        # mismatch). 64 is non-lossy for a 36-char session UUID and needs no
+        # extra import (this leaf is deliberately stdlib-only); both fields are
+        # already control-char-free (recorded is hex-only; actual passed
+        # _is_unknown_or_missing_session), so the length bound is the only need.
         return _STALENESS_WARNING_TEMPLATE.format(
-            recorded=recorded, actual=actual
+            recorded=recorded[:64], actual=actual[:64]
         )
     return None

--- a/pact-plugin/hooks/shared/stale_session.py
+++ b/pact-plugin/hooks/shared/stale_session.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Location: pact-plugin/hooks/shared/stale_session.py
+Summary: Shared detector for a stale 'Current Session' block in the project
+         CLAUDE.md — compares this frame's live stdin session_id against the
+         CLAUDE.md Resume-line id and returns a diagnostic warning on mismatch.
+Used by: bootstrap_prompt_gate.py (UserPromptSubmit injection) and
+         dispatch_gate.py (deny-message self-diagnosis at the two team/task
+         deny sites). Single SSOT for the live-vs-recorded session_id mismatch
+         signal so both consumers read one implementation.
+
+The detector is the reuse seam for the restart/persistence reliability work:
+after a full Claude Code restart/fork the platform mints a new session-<id8>
+team while PACT's persisted session_id/team_name go stale, so the live stdin
+session_id stops matching the CLAUDE.md-recorded one. This module names that
+mismatch once; consumers surface it in their own channel (additionalContext
+for bootstrap_prompt_gate, the deny message for dispatch_gate).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import shared.pact_context as pact_context
+
+# Mirrors the Resume-line fallback regex in session_init's
+# _extract_prev_session_dir — the established defensive parse for the
+# session_resume.update_session_info managed block. Parity with
+# claude_md_manager.resolve_project_claude_md_path's existing-file
+# precedence is pinned by test.
+_RESUME_LINE_RE = re.compile(r"- Resume:\s*`claude --resume\s+([0-9a-f-]+)`")
+
+_STALENESS_WARNING_TEMPLATE = (
+    "\n\nWARNING — stale session block: the project CLAUDE.md 'Current "
+    "Session' block records session {recorded} but this session is "
+    "{actual}. session_init likely failed at SessionStart this session "
+    "(or the CLAUDE.md write failed). Do NOT trust the recorded Team/"
+    "Session dir/Resume lines for THIS session; completing bootstrap "
+    "will rewrite them."
+)
+
+
+def detect_stale_session_block(input_data: dict) -> str | None:
+    """Detect a stale 'Current Session' block in the project CLAUDE.md.
+
+    When session_init crashes at SessionStart, the previous session's
+    Resume/Team/Session-dir lines survive in CLAUDE.md and misdirect
+    recovery. Compare the recorded Resume-line session_id against this
+    frame's raw stdin session_id; on mismatch, return an advisory warning
+    string for additionalContext composition. Returns None (no warning)
+    when:
+
+      1. stdin session_id is missing or invalid per the canonical
+         _is_unknown_or_missing_session predicate (None/non-string/empty/
+         whitespace-only/`unknown-*` sentinel/C0-control chars) — nothing
+         trustworthy to compare, and an unvalidated stdin id must never be
+         interpolated into the warning text
+      2. CLAUDE_PROJECT_DIR is unset (cannot locate CLAUDE.md)
+      3. neither CLAUDE.md location exists, or reading raises OSError or
+         UnicodeDecodeError (worktrees: CLAUDE.md is gitignored/absent →
+         silent skip; a non-UTF-8/corrupted CLAUDE.md → silent skip — this
+         helper is ADVISORY, so its failure budget is "no warning", never
+         "no bootstrap instruction": an uncaught raise here would propagate
+         to a consumer's fail-open and suppress the ENTIRE injection, primary
+         instruction included)
+      4. no Resume line matches the regex (tampered/garbage → no claim)
+      5. recorded session_id equals this session's (healthy resume)
+
+    Stdlib-only two-path read: .claude/CLAUDE.md preferred, legacy
+    ./CLAUDE.md fallback — same existing-file precedence as
+    resolve_project_claude_md_path (parity pinned by test). False
+    positives: none in healthy flows — session_init rewrites the block
+    before the first prompt on startup/clear, and resume keeps the same
+    session_id.
+    """
+    raw_id = input_data.get("session_id")
+    # Canonical validity predicate (shared with the heal gate and
+    # session_init's persist/CLAUDE.md-write gates) — subsumes the plain
+    # truthiness check and additionally rejects non-string, whitespace-only,
+    # `unknown-*` sentinel, and C0-control-char ids, so `actual` below is
+    # never an attacker-shaped or sentinel value interpolated into the
+    # warning. The predicate is total for any input.
+    if pact_context._is_unknown_or_missing_session(raw_id):
+        return None
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
+    if not project_dir:
+        return None
+    try:
+        content = None
+        for candidate in (
+            Path(project_dir) / ".claude" / "CLAUDE.md",
+            Path(project_dir) / "CLAUDE.md",
+        ):
+            if candidate.exists():
+                content = candidate.read_text(encoding="utf-8")
+                break
+        if content is None:
+            return None
+    except (OSError, UnicodeDecodeError):
+        # UnicodeDecodeError (a ValueError, NOT an OSError) from read_text
+        # on a non-UTF-8 CLAUDE.md — e.g. a latin-1 byte from a wrong-editor
+        # save, or the partial/corrupted session_init write this detector
+        # exists to flag. Must be swallowed HERE: this helper composes into
+        # the load-bearing bootstrap instruction by concatenation, and an
+        # escape to a consumer's fail-open suppresses the whole injection.
+        return None
+    match = _RESUME_LINE_RE.search(content)
+    if not match:
+        return None
+    recorded = match.group(1)
+    actual = str(raw_id)
+    if recorded != actual:
+        return _STALENESS_WARNING_TEMPLATE.format(
+            recorded=recorded, actual=actual
+        )
+    return None

--- a/pact-plugin/tests/test_dispatch_gate_stale_diagnosis.py
+++ b/pact-plugin/tests/test_dispatch_gate_stale_diagnosis.py
@@ -1,0 +1,317 @@
+"""
+Stale-team/store-mismatch self-diagnosis at dispatch_gate deny sites.
+
+Cheap-win (PR 1 of the restart/persistence cluster): when a Claude Code
+restart/fork leaves PACT's persisted team_name/session_id stale, this gate
+resolves an orphaned task store while Task* tools write the live one, so every
+pact-* spawn is denied with a MISLEADING message ("no Task assigned…" /
+"team_name unavailable") that never names the real cause. This change surfaces
+the EXISTING shared.stale_session.detect_stale_session_block detection at the
+two restart-symptom deny sites (rule ⑥ team_name_unavailable, rule ⑧
+no_task_assigned), MESSAGE-ONLY.
+
+What this file pins:
+  - BOTH-MODES MATRIX (in-process session_id==leadSessionId AND tmux
+    session_id!=leadSessionId): on a stale-team mismatch the augmented
+    self-diagnosis appears at BOTH deny sites; on no mismatch the ORIGINAL
+    message is preserved verbatim. The augmentation is mode-agnostic, so the
+    matrix is an INVARIANCE proof (same outcome both modes).
+  - NON-VACUITY via PAIRED ENABLE/DISABLE (mismatch-present vs mismatch-absent
+    inputs), not git-revert: the augmentation marker is present iff a mismatch
+    is detected. A test would FAIL if the augmentation were removed.
+  - DECISION UNCHANGED: the gate still DENYs (exit 2) on exactly the same
+    inputs; only the message text changes.
+  - DEFENSIVE never-raises: if the detector raises, the deny still returns the
+    ORIGINAL message and no exception escapes.
+
+Reuses the in-process harness from test_dispatch_gate.py (_run_main / _full_setup
+/ _seed_team) so the both-modes setup matches the rest of the gate's suite.
+"""
+
+import io
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+from test_dispatch_gate import (  # noqa: E402 — sibling harness reuse
+    _make_input,
+    _run_main,
+    _full_setup,
+    _seed_team,
+    _TEAM,
+    _NAME,
+)
+
+# A marker substring unique to the augmentation — asserting on it proves the
+# net-new self-diagnosis text is present without coupling to exact wording.
+_AUGMENT_MARKER = "STALE-TEAM/STORE MISMATCH"
+_REALIGN_MARKER = "pact-session-context.json"
+
+# session_id values for the both-modes matrix.
+_LIVE_SESSION_ID = "test-session"          # the stdin session_id _make_input uses
+_RECORDED_STALE_ID = "0000dead-beef-4000-8000-000000000000"  # != live → stale
+_RECORDED_HEALTHY_ID = _LIVE_SESSION_ID    # == live → healthy (no mismatch)
+
+
+def _write_project_claude_md(monkeypatch, tmp_path, recorded_session_id):
+    """Create a project CLAUDE.md with a '- Resume:' line carrying
+    ``recorded_session_id`` and point CLAUDE_PROJECT_DIR at it, so
+    detect_stale_session_block can compare recorded-vs-live.
+    """
+    project_dir = tmp_path / "claudemd_project"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "CLAUDE.md").write_text(
+        "# Project\n\n## Current Session\n"
+        f"- Resume: `claude --resume {recorded_session_id}`\n"
+        f"- Team: `{_TEAM}`\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project_dir))
+    return project_dir
+
+
+def _seed_team_with_lead(home, team_name, lead_session_id, members=(), tasks=()):
+    """_seed_team variant that also stamps leadSessionId on config.json — the
+    STRUCTURAL mode discriminator (in-process: lead==live; tmux: lead!=live).
+    The augmentation does not key on this, so it is recorded to make the
+    both-modes matrix faithful, not to drive behavior.
+    """
+    _seed_team(home, team_name=team_name, members=members, tasks=tasks)
+    cfg = home / ".claude" / "teams" / team_name / "config.json"
+    data = json.loads(cfg.read_text(encoding="utf-8"))
+    data["leadSessionId"] = lead_session_id
+    cfg.write_text(json.dumps(data), encoding="utf-8")
+
+
+# Mode matrix: (mode_label, leadSessionId). in-process == live id; tmux != live.
+_MODES = [
+    ("in_process", _LIVE_SESSION_ID),
+    ("tmux", "ffff9999-1111-4000-8000-000000000000"),
+]
+
+
+# =============================================================================
+# Rule ⑧ — no_task_assigned deny site
+# =============================================================================
+
+
+@pytest.mark.parametrize("mode_label,lead_id", _MODES)
+def test_no_task_assigned_deny_augmented_on_stale_mismatch(
+    mode_label, lead_id, tmp_path, monkeypatch, capsys
+):
+    """ENABLE leg: a stale recorded-vs-live session_id mismatch augments the
+    rule-⑧ 'no Task assigned' deny with the self-diagnosis, in BOTH modes."""
+    # Seed a team with a task owned by SOMEONE ELSE so has_task_assigned(name)
+    # is False → rule ⑧ DENY fires for _NAME.
+    plugin_root = _full_setup(
+        monkeypatch, tmp_path, tasks=(("someone-else", "pending"),)
+    )
+    _seed_team_with_lead(
+        tmp_path, _TEAM, lead_id, tasks=(("someone-else", "pending"),)
+    )
+    _write_project_claude_md(monkeypatch, tmp_path, _RECORDED_STALE_ID)
+
+    code, out = _run_main(_make_input(), capsys)
+
+    assert code == 2, f"[{mode_label}] decision must still be DENY (exit 2)"
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "no Task assigned" in reason, f"[{mode_label}] original deny preserved"
+    assert _AUGMENT_MARKER in reason, f"[{mode_label}] self-diagnosis augmented"
+    assert _REALIGN_MARKER in reason, f"[{mode_label}] re-align steps present"
+
+
+@pytest.mark.parametrize("mode_label,lead_id", _MODES)
+def test_no_task_assigned_deny_unaugmented_when_no_mismatch(
+    mode_label, lead_id, tmp_path, monkeypatch, capsys
+):
+    """DISABLE leg: when recorded==live (healthy), the rule-⑧ deny keeps its
+    ORIGINAL message verbatim — no augmentation. Paired with the ENABLE test
+    above this is the non-vacuity proof (marker present IFF mismatch)."""
+    _full_setup(monkeypatch, tmp_path, tasks=(("someone-else", "pending"),))
+    _seed_team_with_lead(
+        tmp_path, _TEAM, lead_id, tasks=(("someone-else", "pending"),)
+    )
+    _write_project_claude_md(monkeypatch, tmp_path, _RECORDED_HEALTHY_ID)
+
+    code, out = _run_main(_make_input(), capsys)
+
+    assert code == 2, f"[{mode_label}] decision unchanged (DENY)"
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "no Task assigned" in reason
+    assert _AUGMENT_MARKER not in reason, f"[{mode_label}] NOT augmented (healthy)"
+    assert _REALIGN_MARKER not in reason
+
+
+# =============================================================================
+# Rule ⑥ — team_name_unavailable deny site
+# =============================================================================
+
+
+def _setup_empty_team_name(monkeypatch, tmp_path):
+    """Force rule ⑥ (team_name_unavailable) by writing an EMPTY context
+    team_name — get_team_name() short-circuits empty → DENY fail-closed."""
+    plugin_root = _full_setup(monkeypatch, tmp_path)
+    # Overwrite the context file with an empty team_name (the fail-closed
+    # signal) while keeping plugin_root resolvable so we reach rule ⑥.
+    import shared.pact_context as ctx_module
+    ctx_path = tmp_path / "pact-session-context.json"
+    ctx_path.write_text(
+        json.dumps({
+            "team_name": "",
+            "session_id": _LIVE_SESSION_ID,
+            "project_dir": str(tmp_path / "project"),
+            "plugin_root": str(plugin_root),
+            "started_at": "2026-01-01T00:00:00Z",
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ctx_module, "_context_path", ctx_path)
+    monkeypatch.setattr(ctx_module, "_cache", None)
+    monkeypatch.setattr(ctx_module, "_aligned_cache", None)
+    return plugin_root
+
+
+@pytest.mark.parametrize("mode_label,lead_id", _MODES)
+def test_team_name_unavailable_deny_augmented_on_stale_mismatch(
+    mode_label, lead_id, tmp_path, monkeypatch, capsys
+):
+    """ENABLE leg: the rule-⑥ team_name_unavailable deny is also augmented on a
+    stale mismatch, in BOTH modes."""
+    _setup_empty_team_name(monkeypatch, tmp_path)
+    _seed_team_with_lead(tmp_path, _TEAM, lead_id)
+    _write_project_claude_md(monkeypatch, tmp_path, _RECORDED_STALE_ID)
+
+    code, out = _run_main(_make_input(), capsys)
+
+    assert code == 2, f"[{mode_label}] DENY"
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "team_name is unavailable" in reason or "team_name" in reason
+    assert _AUGMENT_MARKER in reason, f"[{mode_label}] self-diagnosis augmented"
+
+
+@pytest.mark.parametrize("mode_label,lead_id", _MODES)
+def test_team_name_unavailable_deny_unaugmented_when_no_mismatch(
+    mode_label, lead_id, tmp_path, monkeypatch, capsys
+):
+    """DISABLE leg: healthy recorded==live → rule ⑥ keeps original message."""
+    _setup_empty_team_name(monkeypatch, tmp_path)
+    _seed_team_with_lead(tmp_path, _TEAM, lead_id)
+    _write_project_claude_md(monkeypatch, tmp_path, _RECORDED_HEALTHY_ID)
+
+    code, out = _run_main(_make_input(), capsys)
+
+    assert code == 2
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert _AUGMENT_MARKER not in reason, f"[{mode_label}] NOT augmented (healthy)"
+
+
+# =============================================================================
+# Non-symptom deny rules are NOT augmented (avoid misdirecting recovery)
+# =============================================================================
+
+
+def test_non_symptom_deny_not_augmented_even_under_mismatch(
+    tmp_path, monkeypatch, capsys
+):
+    """A name-validation deny (rule ④, not a restart symptom) must NOT receive
+    the stale-team note even when a CLAUDE.md mismatch exists — it would
+    misdirect recovery."""
+    _full_setup(monkeypatch, tmp_path)
+    _write_project_claude_md(monkeypatch, tmp_path, _RECORDED_STALE_ID)
+
+    # An invalid name triggers rule ④ (name_invalid_regex), which is NOT in
+    # _STALE_DIAGNOSABLE_RULES.
+    code, out = _run_main(_make_input(name="Bad Name!"), capsys)
+
+    assert code == 2
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert _AUGMENT_MARKER not in reason
+    assert _REALIGN_MARKER not in reason
+
+
+# =============================================================================
+# Defensive never-raises: detector exception → original message, no escape
+# =============================================================================
+
+
+@pytest.mark.parametrize("mode_label,lead_id", _MODES)
+def test_detector_exception_falls_back_to_original_message(
+    mode_label, lead_id, tmp_path, monkeypatch, capsys
+):
+    """If detect_stale_session_block raises, the deny still returns the ORIGINAL
+    message and the gate still exits 2 — no exception escapes dispatch."""
+    _full_setup(monkeypatch, tmp_path, tasks=(("someone-else", "pending"),))
+    _seed_team_with_lead(
+        tmp_path, _TEAM, lead_id, tasks=(("someone-else", "pending"),)
+    )
+    _write_project_claude_md(monkeypatch, tmp_path, _RECORDED_STALE_ID)
+
+    import dispatch_gate
+
+    def _boom(_input_data):
+        raise RuntimeError("detector blew up")
+
+    # Patch the name the augmentation helper resolves (module global imported
+    # into dispatch_gate), the same seam the helper's never-raises wrap guards.
+    monkeypatch.setattr(dispatch_gate, "detect_stale_session_block", _boom)
+
+    code, out = _run_main(_make_input(), capsys)
+
+    assert code == 2, f"[{mode_label}] deny still fires despite detector raise"
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "no Task assigned" in reason, f"[{mode_label}] original message preserved"
+    assert _AUGMENT_MARKER not in reason, f"[{mode_label}] no partial augmentation"
+
+
+# =============================================================================
+# Helper-direct unit coverage (clean seam the lead's Q1 ruling created)
+# =============================================================================
+
+
+def test_augment_helper_passes_through_non_diagnosable_rule():
+    import dispatch_gate
+    out = dispatch_gate._augment_deny_with_stale_diagnosis(
+        "name_required", "ORIGINAL", {"session_id": "x"}
+    )
+    assert out == "ORIGINAL"
+
+
+def test_augment_helper_passes_through_non_dict_input():
+    import dispatch_gate
+    out = dispatch_gate._augment_deny_with_stale_diagnosis(
+        "no_task_assigned", "ORIGINAL", None
+    )
+    assert out == "ORIGINAL"
+
+
+def test_augment_helper_never_raises_on_detector_error(monkeypatch):
+    import dispatch_gate
+    monkeypatch.setattr(
+        dispatch_gate,
+        "detect_stale_session_block",
+        lambda _d: (_ for _ in ()).throw(ValueError("boom")),
+    )
+    out = dispatch_gate._augment_deny_with_stale_diagnosis(
+        "no_task_assigned", "ORIGINAL", {"session_id": "x"}
+    )
+    assert out == "ORIGINAL"
+
+
+def test_augment_helper_appends_on_detected_mismatch(monkeypatch):
+    import dispatch_gate
+    monkeypatch.setattr(
+        dispatch_gate,
+        "detect_stale_session_block",
+        lambda _d: "\n\nWARNING — stale session block: ...",
+    )
+    out = dispatch_gate._augment_deny_with_stale_diagnosis(
+        "team_name_unavailable", "ORIGINAL", {"session_id": "x"}
+    )
+    assert out.startswith("ORIGINAL")
+    assert _AUGMENT_MARKER in out
+    assert _REALIGN_MARKER in out

--- a/pact-plugin/tests/test_dispatch_gate_stale_diagnosis.py
+++ b/pact-plugin/tests/test_dispatch_gate_stale_diagnosis.py
@@ -315,3 +315,201 @@ def test_augment_helper_appends_on_detected_mismatch(monkeypatch):
     assert out.startswith("ORIGINAL")
     assert _AUGMENT_MARKER in out
     assert _REALIGN_MARKER in out
+
+
+# =============================================================================
+# Both-modes INVARIANCE pinned DIRECTLY: the in-process and tmux legs must
+# produce the SAME deny reason for the same input. The augmentation is
+# mode-agnostic (leadSessionId is read nowhere in the detection / rule-⑥/⑧
+# path), so both legs run the same code today — this assertion turns that
+# documented design property into a guard: a future change that made the
+# augmentation mode-DEPENDENT (keying on leadSessionId) would diverge the two
+# reason strings and fail here. Without it the matrix only proves "each leg
+# augments," not "the two legs agree."
+# =============================================================================
+
+
+def _augmented_reason_for_lead_id(lead_id, tmp_path, monkeypatch, capsys):
+    """Run the rule-⑧ stale-mismatch deny under a given leadSessionId and
+    return the deny reason string."""
+    _full_setup(monkeypatch, tmp_path, tasks=(("someone-else", "pending"),))
+    _seed_team_with_lead(
+        tmp_path, _TEAM, lead_id, tasks=(("someone-else", "pending"),)
+    )
+    _write_project_claude_md(monkeypatch, tmp_path, _RECORDED_STALE_ID)
+    code, out = _run_main(_make_input(), capsys)
+    assert code == 2
+    return out["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def test_both_modes_produce_identical_reason_string(
+    tmp_path, monkeypatch, capsys
+):
+    """INVARIANCE: the augmented deny reason is byte-identical across the
+    in-process (lead==live) and tmux (lead!=live) topologies for the same
+    input. Pins mode-independence directly — a mode-dependent regression
+    would diverge these and fail.
+
+    Each leg gets its own tmp_path subdir + monkeypatch context via the
+    helper so the two runs do not contaminate each other (fresh HOME,
+    fresh pact_context cache reset inside _full_setup/_setup_session).
+    """
+    in_process_lead = _MODES[0][1]   # == _LIVE_SESSION_ID
+    tmux_lead = _MODES[1][1]         # != live
+    assert in_process_lead != tmux_lead, "matrix legs must differ structurally"
+
+    reason_in_process = _augmented_reason_for_lead_id(
+        in_process_lead, tmp_path / "leg_in_process", monkeypatch, capsys
+    )
+    reason_tmux = _augmented_reason_for_lead_id(
+        tmux_lead, tmp_path / "leg_tmux", monkeypatch, capsys
+    )
+
+    assert reason_in_process == reason_tmux, (
+        "augmentation must be mode-INVARIANT: the in-process and tmux legs "
+        "produced different deny reasons, implying the augmentation now keys "
+        "on leadSessionId (the forbidden mode discriminator)"
+    )
+    # And it is the augmented (not the plain) reason that is invariant.
+    assert _AUGMENT_MARKER in reason_in_process
+
+
+# =============================================================================
+# GATE-SITE graceful-degradation integration tests (drive main() end-to-end,
+# not just the detector unit): on a degraded detection input the ORIGINAL
+# deny message stands verbatim — no augmentation, decision unchanged.
+# =============================================================================
+
+
+def test_gate_site_claude_md_absent_falls_back_to_original_message(
+    tmp_path, monkeypatch, capsys
+):
+    """M2: when the project CLAUDE.md is ABSENT (the worktree/gitignored case
+    the PR leans on), the detector returns None → the rule-⑧ deny keeps its
+    ORIGINAL message verbatim, end-to-end through dispatch_gate.main().
+
+    Distinct from the healthy-recorded==live disable leg: there NO file is
+    written at all, and CLAUDE_PROJECT_DIR points at a dir with no CLAUDE.md
+    (neither .claude/CLAUDE.md nor ./CLAUDE.md), exercising the
+    `content is None` branch rather than the recorded==actual branch.
+    """
+    _full_setup(monkeypatch, tmp_path, tasks=(("someone-else", "pending"),))
+    _seed_team_with_lead(
+        tmp_path, _TEAM, _LIVE_SESSION_ID, tasks=(("someone-else", "pending"),)
+    )
+    # Point CLAUDE_PROJECT_DIR at an empty dir — NO CLAUDE.md on either path.
+    empty_project = tmp_path / "no_claude_md_project"
+    empty_project.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(empty_project))
+    assert not (empty_project / "CLAUDE.md").exists()
+    assert not (empty_project / ".claude" / "CLAUDE.md").exists()
+
+    code, out = _run_main(_make_input(), capsys)
+
+    assert code == 2, "decision unchanged (DENY) when CLAUDE.md absent"
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "no Task assigned" in reason, "original deny preserved"
+    assert _AUGMENT_MARKER not in reason, "no augmentation without a CLAUDE.md to compare"
+    assert _REALIGN_MARKER not in reason
+
+
+def test_gate_site_unset_project_dir_falls_back_to_original_message(
+    tmp_path, monkeypatch, capsys
+):
+    """M2 sibling: CLAUDE_PROJECT_DIR UNSET → detector returns None (cannot
+    locate CLAUDE.md) → original deny message, end-to-end."""
+    _full_setup(monkeypatch, tmp_path, tasks=(("someone-else", "pending"),))
+    _seed_team_with_lead(
+        tmp_path, _TEAM, _LIVE_SESSION_ID, tasks=(("someone-else", "pending"),)
+    )
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+
+    code, out = _run_main(_make_input(), capsys)
+
+    assert code == 2
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "no Task assigned" in reason
+    assert _AUGMENT_MARKER not in reason
+
+
+@pytest.mark.parametrize(
+    "bad_session_id",
+    ["", "   ", "unknown-abcd1234", "good\nbad"],
+    ids=["empty", "whitespace_only", "unknown_sentinel", "control_char"],
+)
+def test_gate_site_bad_session_id_falls_back_to_original_message(
+    bad_session_id, tmp_path, monkeypatch, capsys
+):
+    """M3: an invalid/sentinel/control-char stdin session_id makes the detector
+    return None (per _is_unknown_or_missing_session — an unvalidated id must
+    never be interpolated into the warning) → the rule-⑧ deny keeps its
+    ORIGINAL message, even though a stale-recorded CLAUDE.md is present.
+
+    The CLAUDE.md records a DIFFERENT id, so were the bad id naively compared
+    it would 'mismatch' and wrongly augment; the predicate gate must suppress
+    that. Drives main() end-to-end with a hand-built input carrying the bad
+    session_id (the shared _make_input hardcodes a valid one).
+    """
+    _full_setup(monkeypatch, tmp_path, tasks=(("someone-else", "pending"),))
+    _seed_team_with_lead(
+        tmp_path, _TEAM, _LIVE_SESSION_ID, tasks=(("someone-else", "pending"),)
+    )
+    _write_project_claude_md(monkeypatch, tmp_path, _RECORDED_STALE_ID)
+
+    bad_input = _make_input()
+    bad_input["session_id"] = bad_session_id
+
+    code, out = _run_main(bad_input, capsys)
+
+    assert code == 2, "decision unchanged (DENY) under a bad session_id"
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "no Task assigned" in reason, "original deny preserved"
+    assert _AUGMENT_MARKER not in reason, (
+        "a bad/sentinel session_id must NOT be compared or interpolated → "
+        "no augmentation"
+    )
+
+
+# =============================================================================
+# Bounded deny-message length (SEC): a pathologically long recorded/actual
+# session_id must NOT be reflected verbatim into the deny message. Written
+# tolerantly of the exact cap locus (devops owns the hook-side cap) — asserts
+# the full long id is NOT present AND the augmented region is length-bounded.
+# =============================================================================
+
+
+def test_deny_message_bounds_oversized_recorded_session_id(
+    tmp_path, monkeypatch, capsys
+):
+    """SEC: when the CLAUDE.md Resume line records an absurdly long session_id,
+    the augmented deny message must not echo it in full (a cap bounds the
+    reflected id). Robust to the exact cap value/locus: asserts the raw
+    300-char id does not appear verbatim, while the augmentation still fires
+    (a real mismatch is detected).
+
+    The recorded id is hex-shaped (matches _RESUME_LINE_RE's [0-9a-f-]+) so the
+    detector genuinely sees a mismatch vs the live 'test-session'.
+    """
+    oversized = "a" * 300  # hex-class, far exceeds any reasonable id length
+    _full_setup(monkeypatch, tmp_path, tasks=(("someone-else", "pending"),))
+    _seed_team_with_lead(
+        tmp_path, _TEAM, _LIVE_SESSION_ID, tasks=(("someone-else", "pending"),)
+    )
+    _write_project_claude_md(monkeypatch, tmp_path, oversized)
+
+    code, out = _run_main(_make_input(), capsys)
+
+    assert code == 2
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+    # Augmentation fired (a genuine mismatch was detected)...
+    assert _AUGMENT_MARKER in reason, "oversized id is still a real mismatch"
+    # ...but the raw oversized id is NOT reflected verbatim — it is capped.
+    assert oversized not in reason, (
+        "the full oversized recorded session_id must not be echoed into the "
+        "deny message (it must be length-capped)"
+    )
+    # Defense-in-depth, tolerant of the exact cap value: devops's stated cap is
+    # 64, so a contiguous run far above it must not survive. Allow generous
+    # slack (100) so this is not brittle to the precise locus while still
+    # failing on a verbatim 300-char echo.
+    assert "a" * 100 not in reason, "no ~100-char raw-id run should survive the cap"

--- a/pact-plugin/tests/test_stale_session.py
+++ b/pact-plugin/tests/test_stale_session.py
@@ -1,0 +1,238 @@
+"""
+Direct unit tests for the extracted SSOT detector shared/stale_session.py.
+
+detect_stale_session_block compares this frame's live stdin session_id against
+the project CLAUDE.md '- Resume:' line id and returns an advisory warning string
+on mismatch, else None. Both consumers (bootstrap_prompt_gate via additionalContext,
+dispatch_gate via the deny-message augmentation) read this one implementation.
+
+Historically this logic lived in bootstrap_prompt_gate.py and its branch coverage
+rode that module's test file via an aliased import; PR-cycle review (F3) flagged
+that the SSOT module deserves its own direct test file so the coupling cannot rot
+if a future consumer un-aliases or the import graph changes. This file pins the
+detector's contract DIRECTLY:
+
+  - the 5 documented None-returning branches (bad/missing session_id; PROJECT_DIR
+    unset; neither CLAUDE.md exists; read raises OSError/UnicodeDecodeError; no
+    Resume line; recorded==actual healthy),
+  - the two-path .claude/CLAUDE.md-preferred precedence (parity with
+    resolve_project_claude_md_path),
+  - the recorded-id regex shape,
+  - the positive mismatch case (returns the warning naming recorded + actual).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+from shared.stale_session import (  # noqa: E402 — sys.path insert above
+    detect_stale_session_block,
+    _RESUME_LINE_RE,
+)
+
+_LIVE_ID = "11111111-2222-4000-8000-000000000000"
+_RECORDED_DIFFERENT = "99999999-8888-4000-8000-000000000000"
+
+
+def _write_claude_md(dir_path: Path, recorded_id, *, legacy=False):
+    """Write a CLAUDE.md with a Resume line carrying ``recorded_id``.
+
+    legacy=False → ``<dir>/.claude/CLAUDE.md`` (the preferred path).
+    legacy=True  → ``<dir>/CLAUDE.md`` (the legacy fallback path).
+    """
+    if legacy:
+        target = dir_path / "CLAUDE.md"
+        target.parent.mkdir(parents=True, exist_ok=True)
+    else:
+        target = dir_path / ".claude" / "CLAUDE.md"
+        target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        "# Project\n\n## Current Session\n"
+        f"- Resume: `claude --resume {recorded_id}`\n"
+        "- Team: `session-deadbeef`\n",
+        encoding="utf-8",
+    )
+    return target
+
+
+# =============================================================================
+# Positive: a recorded != actual mismatch returns the warning
+# =============================================================================
+
+
+def test_mismatch_returns_warning_naming_recorded_and_actual(tmp_path, monkeypatch):
+    _write_claude_md(tmp_path, _RECORDED_DIFFERENT)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+    result = detect_stale_session_block({"session_id": _LIVE_ID})
+
+    assert result is not None
+    assert _RECORDED_DIFFERENT in result, "warning names the recorded id"
+    assert _LIVE_ID in result, "warning names the actual (live) id"
+    assert "stale session block" in result
+
+
+# =============================================================================
+# None-branch 5: recorded == actual (healthy resume)
+# =============================================================================
+
+
+def test_healthy_recorded_equals_actual_returns_none(tmp_path, monkeypatch):
+    _write_claude_md(tmp_path, _LIVE_ID)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+    assert detect_stale_session_block({"session_id": _LIVE_ID}) is None
+
+
+# =============================================================================
+# None-branch 1: missing / invalid stdin session_id
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [None, "", "   ", "unknown-abcd1234", "good\nbad", 12345],
+    ids=["none", "empty", "whitespace", "unknown_sentinel", "control_char", "non_string"],
+)
+def test_bad_session_id_returns_none(bad_id, tmp_path, monkeypatch):
+    """A missing/blank/sentinel/control-char/non-string id → None: nothing
+    trustworthy to compare, and an unvalidated id must never be interpolated
+    into the warning. CLAUDE.md records a DIFFERENT id, so a naive compare
+    would 'mismatch' — the predicate gate must suppress it."""
+    _write_claude_md(tmp_path, _RECORDED_DIFFERENT)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+    assert detect_stale_session_block({"session_id": bad_id}) is None
+
+
+def test_missing_session_id_key_returns_none(tmp_path, monkeypatch):
+    _write_claude_md(tmp_path, _RECORDED_DIFFERENT)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+    assert detect_stale_session_block({}) is None
+
+
+# =============================================================================
+# None-branch 2: CLAUDE_PROJECT_DIR unset
+# =============================================================================
+
+
+def test_project_dir_unset_returns_none(monkeypatch):
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    assert detect_stale_session_block({"session_id": _LIVE_ID}) is None
+
+
+# =============================================================================
+# None-branch 3: neither CLAUDE.md exists
+# =============================================================================
+
+
+def test_no_claude_md_anywhere_returns_none(tmp_path, monkeypatch):
+    """Empty project dir — neither .claude/CLAUDE.md nor ./CLAUDE.md (the
+    worktree/gitignored case). content stays None → None."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    assert not (tmp_path / "CLAUDE.md").exists()
+    assert not (tmp_path / ".claude" / "CLAUDE.md").exists()
+
+    assert detect_stale_session_block({"session_id": _LIVE_ID}) is None
+
+
+# =============================================================================
+# None-branch 3b: read raises UnicodeDecodeError (non-UTF-8 CLAUDE.md)
+# =============================================================================
+
+
+def test_non_utf8_claude_md_returns_none(tmp_path, monkeypatch):
+    """A corrupted/non-UTF-8 CLAUDE.md (the partial-write this detector exists
+    to flag) raises UnicodeDecodeError on read_text → swallowed → None. The
+    helper is advisory; its failure budget is 'no warning', never a raise that
+    would suppress a consumer's whole injection."""
+    target = tmp_path / ".claude" / "CLAUDE.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    # 0x80 is an invalid UTF-8 start byte → read_text(encoding='utf-8') raises.
+    target.write_bytes(b"# Project\n- Resume: `claude --resume \x80\x81`\n")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+    assert detect_stale_session_block({"session_id": _LIVE_ID}) is None
+
+
+# =============================================================================
+# None-branch 4: no Resume line matches the regex
+# =============================================================================
+
+
+def test_no_resume_line_returns_none(tmp_path, monkeypatch):
+    target = tmp_path / ".claude" / "CLAUDE.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("# Project\n\nNo session block here.\n", encoding="utf-8")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+    assert detect_stale_session_block({"session_id": _LIVE_ID}) is None
+
+
+# =============================================================================
+# Two-path precedence: .claude/CLAUDE.md is preferred over ./CLAUDE.md
+# =============================================================================
+
+
+def test_preferred_claude_md_wins_over_legacy(tmp_path, monkeypatch):
+    """When BOTH .claude/CLAUDE.md and ./CLAUDE.md exist, the preferred
+    .claude/CLAUDE.md is read. Construct a mismatch where the two files
+    disagree: preferred records the LIVE id (→ healthy → None), legacy records
+    a DIFFERENT id (→ would mismatch). Result None proves preferred won."""
+    _write_claude_md(tmp_path, _LIVE_ID, legacy=False)        # preferred: healthy
+    _write_claude_md(tmp_path, _RECORDED_DIFFERENT, legacy=True)  # legacy: stale
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+    # Preferred (.claude/CLAUDE.md) records the live id → healthy → None.
+    assert detect_stale_session_block({"session_id": _LIVE_ID}) is None
+
+
+def test_legacy_claude_md_used_when_preferred_absent(tmp_path, monkeypatch):
+    """When only ./CLAUDE.md exists (no .claude/CLAUDE.md), the legacy path is
+    read and a mismatch there IS detected."""
+    _write_claude_md(tmp_path, _RECORDED_DIFFERENT, legacy=True)
+    assert not (tmp_path / ".claude" / "CLAUDE.md").exists()
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+    result = detect_stale_session_block({"session_id": _LIVE_ID})
+    assert result is not None
+    assert _RECORDED_DIFFERENT in result
+
+
+# =============================================================================
+# Recorded-id regex shape
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "line,expected",
+    [
+        ("- Resume: `claude --resume abc123-def`", "abc123-def"),
+        ("- Resume:   `claude --resume deadbeef`", "deadbeef"),  # extra spaces
+        ("- Resume: `claude --resume 11111111-2222-4000-8000-000000000000`",
+         "11111111-2222-4000-8000-000000000000"),
+    ],
+    ids=["hex_dash", "extra_spaces", "full_uuid"],
+)
+def test_resume_line_regex_extracts_hex_id(line, expected):
+    m = _RESUME_LINE_RE.search(line)
+    assert m is not None
+    assert m.group(1) == expected
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "- Resume: claude --resume abc123",       # no backticks
+        "- Resume: `claude --resume ABC123`",     # uppercase not in [0-9a-f-]
+        "- Resyme: `claude --resume abc123`",     # mistyped label
+        "random text with no resume",
+    ],
+    ids=["no_backticks", "uppercase", "mistyped_label", "no_match"],
+)
+def test_resume_line_regex_rejects_malformed(line):
+    assert _RESUME_LINE_RE.search(line) is None


### PR DESCRIPTION
## Summary

Message-only cheap-win for the restart/persistence reliability cluster. When a Claude Code restart or fork mints a new session team while PACT's persisted `team_name`/`session_id` go stale, the gate-resolved task store diverges from the live store and dispatch denials show misleading messages (`no Task assigned` / team name unavailable) that never name the real cause. This PR makes the two restart-symptom deny sites **self-diagnose** the stale-team/store mismatch and tell the user how to re-align.

## What landed

- **`hooks/shared/stale_session.py`** (NEW) — extracted SSOT for `detect_stale_session_block` (+ its two constants) out of `bootstrap_prompt_gate.py`, so more than one hook can reuse the live-vs-recorded `session_id` mismatch detector. Behavior-preserving: `bootstrap_prompt_gate` re-binds the historical private name via an aliased import (object identity preserved → existing imports + the test monkeypatch stay unchanged).
- **`hooks/dispatch_gate.py`** — surfaces the detector at the two restart-symptom deny sites (`team_name_unavailable`, no-task-assigned). **Message-only**: the gate decision is untouched; augmentation runs in `main()` *after* `evaluate_dispatch` returns, behind a **never-raises** wrapper, so any detector failure falls back to the original message and can never break dispatch. Not marker-gated (a restart leaves a present-but-stale bootstrap marker). Non-symptom denials are excluded so the re-align hint never misdirects.
- **`hooks/shared/hook_infra_classifier.py`** — `_SEAM_HOOK_HELPER_CLOSURE` updated for `dispatch_gate`'s new import edge.
- **Tests** (`tests/test_dispatch_gate_stale_diagnosis.py`, NEW) — 15 tests: both-modes invariance matrix (in-process + tmux) × enable/disable at both deny sites, paired enable/disable non-vacuity (not git-revert), and a defensive test (detector raises → original message, no escape).
- **v4.4.36** (PATCH).

## Why

Part of the restart/persistence reliability cluster (#994 / #992). This is the **message-only cheap-win** — it improves diagnosis but does not yet repair the underlying stale-team join (where `CLAUDE.md` is absent/unreadable the detector returns `None` → graceful degradation to the original message). The **durable fix** (live-team reconciliation) lands in follow-up PRs.

⚠️ **Do NOT auto-close #994 / #992 on merge** — closure is gated on the durable fix.

## Testing

Full hooks suite green via `rtk proxy python -m pytest`: **9397 passed, 14 skipped, 0 failed, 0 errors**. Behavior-preserving extraction verified (49 bootstrap-gate tests unchanged via the is-identity alias).
