### PR TITLE
HANDOFF + artifact durability: artifact_paths event + always-read harvest (v4.4.42, #927)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.41",
+      "version": "4.4.42",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.41/      # Plugin version
+│               └── 4.4.42/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.41",
+  "version": "4.4.42",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.41
+> **Version**: 4.4.42
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -494,7 +494,18 @@ Agent(
 Completed-phase teammates remain as consultants. Do not shutdown during this workflow.
 
 **Before next phase**:
-- [ ] Outputs exist in `docs/preparation/`
+- [ ] **Artifact exists and is non-empty** — for a PREPARE phase that **ran** (not skipped), the expected per-feature artifact at `docs/preparation/{feature}.md` (and any additional produced files, e.g. `environment-model-{feature}.md`) MUST exist on disk and be non-empty before you complete the phase task or emit below. A missing or empty artifact is a **failure to investigate**, not an absence of work: do **NOT** complete the phase, do **NOT** emit, and INVESTIGATE first (specialist wrote to the wrong location, produced nothing, or used a different slug), then resolve it. A **skipped** PREPARE phase is exempt — it legitimately produces no artifact, so neither the check nor the emit applies.
+- [ ] **Emit `artifact_paths`** — before marking the PREPARE phase task completed, glob the worktree's `docs/preparation/` directory and write a path-only `artifact_paths` journal event so the artifact is recoverable after garbage-collection independently of any HANDOFF. Enumerate the full absolute path list yourself (do NOT read paths from a HANDOFF — a recovery pointer must not depend on the thing it recovers). If the glob finds nothing, do NOT emit an empty event (the missing-artifact case above already covers that anomaly).
+  ```bash
+  set -e
+  trap 'rc=$?; echo "[JOURNAL WRITE FAILED] orchestrate.md (bash line $LINENO): \"${BASH_COMMAND%%$'\''\n'\''*}\" exit=$rc" >&2; exit $rc' ERR
+  SJ="{plugin_root}/hooks/shared/session_journal.py"
+  # Enumerate this feature's PREPARE artifacts (worktree-isolated → this feature only).
+  # Emit only when ≥1 non-empty path is found; an empty result is the missing-artifact anomaly, not an event.
+  python3 "$SJ" write --type artifact_paths --session-dir '{session_dir}' --stdin <<'JSON'
+  {"workflow": "prepare", "feature": "{feature}", "paths": ["{absolute_path_1}", "{absolute_path_2}"], "task_id": "{prepare_task_id}"}
+JSON
+  ```
 - [ ] Specialist HANDOFF received
 - [ ] If blocker reported → `/PACT:imPACT`
 - [ ] **S4 Checkpoint** (see [pact-s4-checkpoints.md](../protocols/pact-s4-checkpoints.md)): Environment stable? Model aligned? Plan viable? Optionally query secretary for S4 pattern check (variety 7+). See [pact-orchestrator §Memory Management](../agents/pact-orchestrator.md#memory-management).
@@ -589,7 +600,18 @@ Agent(
 Completed-phase teammates remain as consultants. Do not shutdown during this workflow.
 
 **Before next phase**:
-- [ ] Outputs exist in `docs/architecture/`
+- [ ] **Artifact exists and is non-empty** — for an ARCHITECT phase that **ran** (not skipped), the expected per-feature artifact at `docs/architecture/{feature}.md` (and any additional produced files) MUST exist on disk and be non-empty before you complete the phase task or emit below. A missing or empty artifact is a **failure to investigate**, not an absence of work: do **NOT** complete the phase, do **NOT** emit, and INVESTIGATE first (specialist wrote to the wrong location, produced nothing, or used a different slug), then resolve it. A **skipped** ARCHITECT phase is exempt — it legitimately produces no artifact, so neither the check nor the emit applies.
+- [ ] **Emit `artifact_paths`** — before marking the ARCHITECT phase task completed, glob the worktree's `docs/architecture/` directory and write a path-only `artifact_paths` journal event so the artifact is recoverable after garbage-collection independently of any HANDOFF. Enumerate the full absolute path list yourself (do NOT read paths from a HANDOFF). If the glob finds nothing, do NOT emit an empty event (the missing-artifact case above covers that anomaly).
+  ```bash
+  set -e
+  trap 'rc=$?; echo "[JOURNAL WRITE FAILED] orchestrate.md (bash line $LINENO): \"${BASH_COMMAND%%$'\''\n'\''*}\" exit=$rc" >&2; exit $rc' ERR
+  SJ="{plugin_root}/hooks/shared/session_journal.py"
+  # Enumerate this feature's ARCHITECT artifacts (worktree-isolated → this feature only).
+  # Emit only when ≥1 non-empty path is found; an empty result is the missing-artifact anomaly, not an event.
+  python3 "$SJ" write --type artifact_paths --session-dir '{session_dir}' --stdin <<'JSON'
+  {"workflow": "architect", "feature": "{feature}", "paths": ["{absolute_path_1}", "{absolute_path_2}"], "task_id": "{architect_task_id}"}
+JSON
+  ```
 - [ ] Specialist HANDOFF received
 - [ ] If blocker reported → `/PACT:imPACT`
 - [ ] **S4 Checkpoint**: Environment stable? Model aligned? Plan viable?
@@ -755,6 +777,16 @@ The auditor stores its final signal as `metadata.audit_summary` via `TaskUpdate`
   python3 "{plugin_root}/hooks/shared/session_journal.py" write \
     --type commit --session-dir '{session_dir}' --stdin <<'JSON'
   {"sha": "{short_sha}", "message": "{first_line}", "phase": "CODE"}
+JSON
+  ```
+- [ ] **Emit `artifact_paths` for auditor decision-logs (conditional, capture-if-present)** — if a concurrent auditor produced decision-log artifacts, glob `docs/decision-logs/{feature}-*.md`; when ≥1 is present, write a path-only `artifact_paths` event (`workflow=code-auditor`) so they harvest. Unlike PREPARE/ARCHITECT, this is **capture-if-present, not flag-if-missing**: the auditor is optional, so absence is normal — emit nothing and do NOT flag a missing artifact.
+  ```bash
+  set -e
+  trap 'rc=$?; echo "[JOURNAL WRITE FAILED] orchestrate.md (bash line $LINENO): \"${BASH_COMMAND%%$'\''\n'\''*}\" exit=$rc" >&2; exit $rc' ERR
+  SJ="{plugin_root}/hooks/shared/session_journal.py"
+  # Best-effort: only when the glob found ≥1 decision-log; if none, skip this emit entirely (auditor is optional).
+  python3 "$SJ" write --type artifact_paths --session-dir '{session_dir}' --stdin <<'JSON'
+  {"workflow": "code-auditor", "feature": "{feature}", "paths": ["{absolute_decision_log_path}"]}
 JSON
   ```
 - [ ] **Process coder HANDOFFs** (non-blocking):

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -506,6 +506,7 @@ Completed-phase teammates remain as consultants. Do not shutdown during this wor
   {"workflow": "prepare", "feature": "{feature}", "paths": ["{absolute_path_1}", "{absolute_path_2}"], "task_id": "{prepare_task_id}"}
 JSON
   ```
+- [ ] **Complete the PREPARE phase task** — ONLY after the artifact check and the `artifact_paths` emit above: `TaskUpdate(prepareTaskId, status="completed")`. This ordering is load-bearing: the emit MUST land before the phase-task completion so the durability pointer is on disk by the time completion is observed. (A skipped PREPARE phase completes earlier with `metadata.skipped=true` and runs neither the check nor the emit.)
 - [ ] Specialist HANDOFF received
 - [ ] If blocker reported → `/PACT:imPACT`
 - [ ] **S4 Checkpoint** (see [pact-s4-checkpoints.md](../protocols/pact-s4-checkpoints.md)): Environment stable? Model aligned? Plan viable? Optionally query secretary for S4 pattern check (variety 7+). See [pact-orchestrator §Memory Management](../agents/pact-orchestrator.md#memory-management).
@@ -612,6 +613,7 @@ Completed-phase teammates remain as consultants. Do not shutdown during this wor
   {"workflow": "architect", "feature": "{feature}", "paths": ["{absolute_path_1}", "{absolute_path_2}"], "task_id": "{architect_task_id}"}
 JSON
   ```
+- [ ] **Complete the ARCHITECT phase task** — ONLY after the artifact check and the `artifact_paths` emit above: `TaskUpdate(architectTaskId, status="completed")`. This ordering is load-bearing: the emit MUST land before the phase-task completion so the durability pointer is on disk by the time completion is observed. (A skipped ARCHITECT phase completes earlier with `metadata.skipped=true` and runs neither the check nor the emit.)
 - [ ] Specialist HANDOFF received
 - [ ] If blocker reported → `/PACT:imPACT`
 - [ ] **S4 Checkpoint**: Environment stable? Model aligned? Plan viable?

--- a/pact-plugin/commands/peer-review.md
+++ b/pact-plugin/commands/peer-review.md
@@ -279,7 +279,16 @@ See also: [Communication Charter](../protocols/pact-communication-charter.md) fo
 ---
 
 **After all reviews complete**:
-1. Synthesize findings into a unified review summary with consolidated recommendations
+1. Synthesize findings into a unified review summary with consolidated recommendations, written to `docs/review/`. After writing it, confirm the review doc exists on disk and is non-empty before continuing.
+   - **Emit `artifact_paths`**: write a path-only `artifact_paths` journal event pointing at the review doc(s) so the consolidated review is recoverable after garbage-collection independently of any HANDOFF. The review doc is the lead's own product — enumerate its absolute path(s) here, not from any HANDOFF.
+     ```bash
+     set -e
+     trap 'rc=$?; echo "[JOURNAL WRITE FAILED] peer-review.md (bash line $LINENO): \"${BASH_COMMAND%%$'\''\n'\''*}\" exit=$rc" >&2; exit $rc' ERR
+     python3 "{plugin_root}/hooks/shared/session_journal.py" write \
+       --type artifact_paths --session-dir '{session_dir}' --stdin <<'JSON'
+     {"workflow": "peer-review", "feature": "{feature}", "paths": ["{absolute_review_doc_path}"]}
+JSON
+     ```
 2. **Journal events**: Write a `review_finding` event for each synthesized finding:
    ```bash
    set -e

--- a/pact-plugin/commands/plan-mode.md
+++ b/pact-plugin/commands/plan-mode.md
@@ -194,7 +194,7 @@ Each consultant dispatch creates **two tasks**, not one:
 - **Task A** — TEACHBACK gate. `subject = "{specialist}: TEACHBACK for plan consultation on {feature}"`, owner = consultant. Description: lightweight understanding-confirm of the consultation scope.
 - **Task B** — primary consultation. `subject = "{specialist}: plan consultation for {feature}"`, owner = consultant, `blockedBy = [<Task A id>]`.
 
-Both are created BEFORE the `Agent(...)` spawn call. The consultant claims A, submits teachback metadata, idles on `awaiting_lead_completion`. You review and accept via the two-call atomic pair: `SendMessage(to=consultant, ...)` FIRST, then `TaskUpdate(A, status="completed")` — see [Teachback Review](../protocols/pact-completion-authority.md#teachback-review) for the rationale. On accept, the consultant wakes to claim B and produce the consultation HANDOFF.
+Both are created BEFORE the `Agent(...)` spawn call. The consultant claims A, submits teachback metadata, idles on `awaiting_lead_completion`. You review and accept via the two-call atomic pair: `SendMessage(to=consultant, ...)` FIRST, then `TaskUpdate(A, status="completed")` — see [Teachback Review](../protocols/pact-completion-authority.md#teachback-review) for the rationale. On accept, the consultant wakes to claim B and produce the consultation HANDOFF. The consultant writes the HANDOFF and signals stage-ready, then idles — **you (the lead) complete Task B**, not the consultant. Lead-side completion is what reliably journals the consultation HANDOFF; a consultant self-completing their own Task B can leave the HANDOFF unrecorded.
 
 ```
 # A-FIRST ORDERING (required): create Task A (the teachback gate) BEFORE Task B so the gate gets the LOWER id. Creating Task B first — giving the gate the HIGHER id — is WRONG: it inverts the intuitive "lower id = earlier" reading. The blocking wiring below legitimately names both ids because it runs AFTER both tasks exist.
@@ -353,6 +353,27 @@ TaskUpdate(
 ```
 
 Save the synthesized plan to `docs/plans/{feature-slug}-plan.md`.
+
+**Plan-doc self-check**: after writing the plan, confirm `docs/plans/{feature-slug}-plan.md` exists on disk and is non-empty before continuing. An empty or missing plan doc is a failure to investigate (the synthesis did not land), not a no-op — resolve it before completing the planning task.
+
+**Emit `artifact_paths`**: write a path-only `artifact_paths` journal event pointing at the plan doc so it (and the consultation work it synthesizes) is recoverable after garbage-collection independently of any HANDOFF. The plan doc is the lead's own product, so the lead knows its absolute path directly — enumerate it here, not from any HANDOFF.
+
+```bash
+set -e
+trap 'rc=$?; echo "[JOURNAL WRITE FAILED] plan-mode.md (bash line $LINENO): \"${BASH_COMMAND%%$'\''\n'\''*}\" exit=$rc" >&2; exit $rc' ERR
+SJ="{plugin_root}/hooks/shared/session_journal.py"
+python3 "$SJ" write --type artifact_paths --session-dir '{session_dir}' --stdin <<'JSON'
+{"workflow": "plan-mode", "feature": "{feature-slug}", "paths": ["{absolute_plan_doc_path}"]}
+JSON
+```
+
+**Trigger a harvest** (consult-only durability): plan-mode is a consultation-only flow with no later CODE/peer-review boundary to trigger memory harvest, so the plan doc and the consultation HANDOFFs would otherwise never reach pact-memory. Create a secretary harvest task after writing the plan so the `artifact_paths` event resolves and the consultation HANDOFFs distill into institutional memory:
+
+```
+TaskCreate(subject="secretary: harvest plan-mode consultation",
+  description="Harvest HANDOFFs and artifact_paths for team {team_name}. Follow the Standard Harvest workflow in your pact-handoff-harvest skill, resolving artifact_paths events to read the plan doc and any consultation artifacts off disk. Report summary when done.")
+TaskUpdate(taskId, owner="secretary")
+```
 
 **Handling existing plans**:
 

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -565,6 +565,47 @@ def get_session_dir() -> str:
     return str(_build_session_path(slug, session_id))
 
 
+def reconstruct_session_dir(project_dir: str, session_id: str) -> str:
+    """Reconstruct the absolute session directory from explicit context-file
+    fields — the off-lead, frame-independent counterpart to get_session_dir().
+
+    An off-lead reader (notably the `pact-secretary` harvest, which runs in a
+    teammate frame where get_session_dir() false-returns '') resolves the dir by
+    reading `pact-session-context.json` and passing its `project_dir` +
+    `session_id` fields here. Both fields are persisted RAW (write_context stores
+    the caller-supplied values; init() sanitizes only the PATH segment it builds,
+    not the stored field — see build_context_cache / the write_context contract),
+    so this helper MUST reproduce the writer's path-sanitization to land on the
+    SAME on-disk directory init() wrote to:
+
+      - session_id: sanitized via _UNSAFE_SLUG_CHARS_RE (mirrors the substitution
+        init() applies to the id before building the context path).
+      - slug: derived as Path(project_dir).name and sanitized + traversal-guarded
+        inside _build_session_path (the single source of truth for the slug leg).
+
+    Routing BOTH axes through the writer's derivation (the regex for the id, the
+    shared path-builder for the slug) makes this SSOT-by-construction: an off-lead
+    reconstruction cannot drift from the writer, and a future change to either
+    guard updates both the writer and this reader at once. Without this, a
+    project basename or session_id containing a non-`[A-Za-z0-9_-]` character
+    (e.g. a dot or space) would reconstruct a DIFFERENT directory than the one the
+    journal was written to → the off-lead read silently returns 0 events.
+
+    Args:
+        project_dir: The `project_dir` field from pact-session-context.json.
+        session_id: The `session_id` field from pact-session-context.json (raw).
+
+    Returns:
+        The absolute session directory path, or '' if either input is falsy
+        (matching get_session_dir()'s empty-on-unavailable contract).
+    """
+    if not project_dir or not session_id:
+        return ""
+    safe_id = _UNSAFE_SLUG_CHARS_RE.sub("_", str(session_id))
+    slug = Path(project_dir).name
+    return str(_build_session_path(slug, safe_id))
+
+
 def get_plugin_root() -> str:
     """Convenience: return plugin_root from context. Falls back to the
     CLAUDE_PLUGIN_ROOT env var (exported into every hook process by the

--- a/pact-plugin/hooks/shared/pact_harvest.py
+++ b/pact-plugin/hooks/shared/pact_harvest.py
@@ -80,7 +80,11 @@ def _resolve_session_dir(context_file: str) -> int:
 
     try:
         raw = Path(context_file).read_text()
-    except OSError as exc:
+    except (OSError, ValueError) as exc:
+        # ValueError covers an embedded NUL byte in the path (Path/open raises
+        # "embedded null byte"). Unreachable via the CLI (execve strips NUL
+        # from argv) but guarded so a NUL/bad path is bad-input (exit 2), never
+        # an uncaught exit-1 crash — same handling as the missing-file case.
         print(
             f"pact_harvest: cannot read context file {context_file!r}: {exc}",
             file=sys.stderr,

--- a/pact-plugin/hooks/shared/pact_harvest.py
+++ b/pact-plugin/hooks/shared/pact_harvest.py
@@ -1,0 +1,236 @@
+"""
+Location: pact-plugin/hooks/shared/pact_harvest.py
+Summary: Harvest-domain CLI exposing the two journal-adjacent resolutions the
+         pact-handoff-harvest skill needs but session_journal.py does not:
+         off-lead session-dir reconstruction and artifact_paths supersede.
+Used by: pact-handoff-harvest/SKILL.md (Steps 0 and 3.5), invoked as a direct
+         script — python3 {plugin_root}/hooks/shared/pact_harvest.py <subcommand>.
+         NOT a lifecycle hook: this file MUST NOT be registered in hooks.json.
+
+Why this file exists: the secretary runs the harvest OFF-LEAD (a teammate
+frame), where pact_context.get_session_dir() / read_events() false-return ''
+and silently yield 0 events. The skill therefore needs explicit-path,
+masked-read-safe entry points. The journal READS (agent_handoff,
+variety_assessed) reuse session_journal.py's existing `read` subcommand (DRY —
+no read-events mirror here). This file adds only the two pieces session_journal
+does not already expose:
+  - resolve-session-dir: wraps pact_context.reconstruct_session_dir (Step 0).
+  - resolve-artifacts:    wraps session_journal.resolve_latest_artifacts, doing
+                          the artifact_paths read then the supersede (Step 3.5).
+
+Subcommand I/O contract (stdout = DATA only, stderr = diagnostics):
+  - exit 0: resolved successfully (INCLUDING a legitimately-empty result).
+  - exit 2: unresolvable / bad input — the skill's "report the gap and STOP,
+            do NOT fall back to a path-less read" trigger. The skill keys this
+            branch on the EXIT CODE, never on parsing stdout for emptiness, so
+            a stray byte cannot defeat it.
+  - exit 1: reserved for an uncaught internal error.
+Note: this 0/2/1 contract intentionally differs from session_journal.py's CLI
+(its _validate_cli_session_dir returns 1 on bad --session-dir). Here 1 is
+reserved for internal errors, so bad input is 2; both are non-zero, so the
+skill's `if ! out=$(...); then stop; fi` gate works for either CLI.
+
+Sibling imports use the same lazy dual-import as session_journal.py (package
+path first, bare path fallback for the direct-script run where shared/ is
+sys.path[0]). Done INSIDE the handlers so tests can monkeypatch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Make the package-path import (`from shared.X import Y`) resolvable when this
+# file is run as a direct script. In script mode Python puts the script's OWN
+# directory (`hooks/shared/`) on sys.path[0], NOT `hooks/`, so `from shared.X`
+# would raise ModuleNotFoundError AND the bare `from X` fallback would import a
+# sibling (e.g. pact_context) as a TOP-LEVEL module — breaking ITS own
+# package-relative imports (`from .session_state import ...`). Putting `hooks/`
+# (the parent of this file's `shared/` dir) on sys.path makes `shared` a real
+# package, so the sibling's relative imports resolve. Idempotent: skip if
+# already present (e.g. when imported as `shared.pact_harvest` from hooks/tests).
+_HOOKS_DIR = str(Path(__file__).resolve().parent.parent)
+if _HOOKS_DIR not in sys.path:
+    sys.path.insert(0, _HOOKS_DIR)
+
+# Exit codes (see module docstring for the contract).
+_EXIT_OK = 0
+_EXIT_INTERNAL_ERROR = 1
+_EXIT_UNRESOLVED = 2
+
+
+def _resolve_session_dir(context_file: str) -> int:
+    """Handle `resolve-session-dir`: reconstruct the absolute session dir.
+
+    Reads `project_dir` + `session_id` out of the context file and calls
+    pact_context.reconstruct_session_dir (the off-lead, SSOT path resolver).
+    On success prints the absolute session_dir (single line) to stdout and
+    returns 0. On any failure — missing/unreadable/invalid-JSON context file,
+    missing fields, or a falsy '' return from reconstruct_session_dir — prints
+    a one-line diagnostic to stderr, prints nothing to stdout, and returns 2.
+    """
+    # Lazy dual-import (package path for hooks/tests, bare for direct-script).
+    try:
+        from shared.pact_context import reconstruct_session_dir
+    except ImportError:  # pragma: no cover - exercised via direct-script run
+        from pact_context import reconstruct_session_dir  # type: ignore[no-redef]
+
+    try:
+        raw = Path(context_file).read_text()
+    except OSError as exc:
+        print(
+            f"pact_harvest: cannot read context file {context_file!r}: {exc}",
+            file=sys.stderr,
+        )
+        return _EXIT_UNRESOLVED
+
+    try:
+        ctx = json.loads(raw)
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(
+            f"pact_harvest: invalid JSON in context file {context_file!r}: "
+            f"{exc}",
+            file=sys.stderr,
+        )
+        return _EXIT_UNRESOLVED
+
+    if not isinstance(ctx, dict):
+        print(
+            f"pact_harvest: context file {context_file!r} is not a JSON object",
+            file=sys.stderr,
+        )
+        return _EXIT_UNRESOLVED
+
+    project_dir = ctx.get("project_dir")
+    session_id = ctx.get("session_id")
+    session_dir = reconstruct_session_dir(project_dir, session_id)
+    if not session_dir:
+        print(
+            "pact_harvest: could not reconstruct session_dir (missing/empty "
+            "project_dir or session_id in context file)",
+            file=sys.stderr,
+        )
+        return _EXIT_UNRESOLVED
+
+    print(session_dir)
+    return _EXIT_OK
+
+
+def _resolve_artifacts(session_dir: str, feature: str) -> int:
+    """Handle `resolve-artifacts`: emit the superseded paths-by-workflow object.
+
+    Reads this session's `artifact_paths` events (explicit-path, masked-read-
+    safe) and applies the supersede-by-(workflow, feature)-latest-ts dedup via
+    resolve_latest_artifacts. Prints a single-line JSON object
+    `{workflow: [abs_path, ...]}` (empty -> `{}`) to stdout and returns 0.
+    Returns 2 on an empty or non-absolute --session-dir (a bad-input stop
+    trigger), mirroring session_journal's read checks but remapped to this
+    CLI's exit-2 contract.
+    """
+    rc = _validate_session_dir_arg(session_dir)
+    if rc != _EXIT_OK:
+        return rc
+
+    # Lazy dual-import (package path for hooks/tests, bare for direct-script).
+    try:
+        from shared.session_journal import (
+            read_events_from,
+            resolve_latest_artifacts,
+        )
+    except ImportError:  # pragma: no cover - exercised via direct-script run
+        from session_journal import (  # type: ignore[no-redef]
+            read_events_from,
+            resolve_latest_artifacts,
+        )
+
+    events = read_events_from(session_dir, "artifact_paths")
+    resolved = resolve_latest_artifacts(events, feature)
+    print(json.dumps(resolved, separators=(",", ":")))
+    return _EXIT_OK
+
+
+def _validate_session_dir_arg(session_dir: str) -> int:
+    """Validate `--session-dir`, returning 0 ok or 2 (this CLI's bad-input code).
+
+    Mirrors session_journal._validate_cli_session_dir's two checks (non-empty,
+    absolute) but returns this CLI's exit-2 bad-input code rather than its
+    exit-1 — here 1 is reserved for an uncaught internal error. An empty or
+    relative session_dir would otherwise resolve a stray journal under the
+    caller's CWD.
+    """
+    if not session_dir:
+        print(
+            "pact_harvest: --session-dir must be non-empty",
+            file=sys.stderr,
+        )
+        return _EXIT_UNRESOLVED
+    if not Path(session_dir).is_absolute():
+        print(
+            "pact_harvest: --session-dir must be an absolute path",
+            file=sys.stderr,
+        )
+        return _EXIT_UNRESOLVED
+    return _EXIT_OK
+
+
+def main() -> int:
+    """CLI entry point for harvest-domain resolutions.
+
+    Subcommands:
+        resolve-session-dir — reconstruct the absolute session dir off-lead
+            from a pact-session-context.json (Step 0).
+        resolve-artifacts   — emit the superseded artifact paths-by-workflow
+            object for one feature (Step 3.5).
+
+    Returns:
+        0 ok (incl. legitimately-empty), 2 unresolved/bad-input (skill stop
+        trigger), 1 reserved for an uncaught internal error.
+    """
+    parser = argparse.ArgumentParser(
+        description="PACT harvest CLI — off-lead session-dir + artifact "
+        "supersede resolutions for the pact-handoff-harvest skill.",
+    )
+    sub = parser.add_subparsers(dest="command")
+    sub.required = True
+
+    # --- resolve-session-dir ---
+    session_p = sub.add_parser(
+        "resolve-session-dir",
+        help="Reconstruct the absolute session dir from a context file",
+    )
+    session_p.add_argument(
+        "--context-file",
+        required=True,
+        help="Absolute path to pact-session-context.json",
+    )
+
+    # --- resolve-artifacts ---
+    artifacts_p = sub.add_parser(
+        "resolve-artifacts",
+        help="Emit the superseded artifact paths-by-workflow for a feature",
+    )
+    artifacts_p.add_argument(
+        "--session-dir",
+        required=True,
+        help="Absolute session directory path",
+    )
+    artifacts_p.add_argument(
+        "--feature",
+        required=True,
+        help="Feature slug to resolve artifacts for",
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "resolve-session-dir":
+        return _resolve_session_dir(args.context_file)
+    if args.command == "resolve-artifacts":
+        return _resolve_artifacts(args.session_dir, args.feature)
+    return _EXIT_INTERNAL_ERROR
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pact-plugin/hooks/shared/pact_harvest.py
+++ b/pact-plugin/hooks/shared/pact_harvest.py
@@ -130,13 +130,23 @@ def _resolve_artifacts(session_dir: str, feature: str) -> int:
     safe) and applies the supersede-by-(workflow, feature)-latest-ts dedup via
     resolve_latest_artifacts. Prints a single-line JSON object
     `{workflow: [abs_path, ...]}` (empty -> `{}`) to stdout and returns 0.
-    Returns 2 on an empty or non-absolute --session-dir (a bad-input stop
-    trigger), mirroring session_journal's read checks but remapped to this
-    CLI's exit-2 contract.
+    Returns 2 on an empty, non-absolute, or out-of-tree --session-dir (a
+    bad-input stop trigger): the empty/non-absolute checks mirror
+    session_journal's read checks (remapped to this CLI's exit-2 contract),
+    and the containment check (see `_session_dir_is_contained`) rejects any
+    path outside the pact-sessions root so a stray journal under an unrelated
+    directory cannot be read.
     """
     rc = _validate_session_dir_arg(session_dir)
     if rc != _EXIT_OK:
         return rc
+
+    if not _session_dir_is_contained(session_dir):
+        print(
+            "pact_harvest: --session-dir is outside the pact-sessions root",
+            file=sys.stderr,
+        )
+        return _EXIT_UNRESOLVED
 
     # Lazy dual-import (package path for hooks/tests, bare for direct-script).
     try:
@@ -178,6 +188,40 @@ def _validate_session_dir_arg(session_dir: str) -> int:
         )
         return _EXIT_UNRESOLVED
     return _EXIT_OK
+
+
+def _session_dir_is_contained(session_dir: str) -> bool:
+    """Return True iff `session_dir` resolves UNDER the pact-sessions root.
+
+    Defense-in-depth on top of `_validate_session_dir_arg`: a --session-dir
+    outside `<config>/pact-sessions/` has no legitimate journal, so reading one
+    there would surface an unrelated `session-journal.jsonl`. The root derives
+    from `get_claude_config_dir()` — the env-or-home SSOT in shared/paths.py,
+    never a hardcoded `~/.claude` — so it tracks $CLAUDE_CONFIG_DIR. Both the
+    root and the candidate are `.resolve()`d (symlink-normalized) and compared
+    via `Path.parents` containment, mirroring `_build_session_path`'s own
+    traversal guard: a legit `<config>/pact-sessions/<slug>/<id>` (two levels
+    under the root) always passes; only an out-of-tree path is rejected.
+
+    Fail-CLOSED (return False -> the caller's exit-2 bad-input path) when the
+    root cannot be derived (`get_claude_config_dir()` -> `Path.home()` can
+    raise RuntimeError) or either `.resolve()` raises (OSError on a symlink
+    loop, ValueError on an embedded NUL): an unverifiable path is treated as
+    bad input rather than read blindly. This is theoretical on the live path —
+    Step 0 already resolved the same root to PRODUCE the session_dir.
+    """
+    # Lazy dual-import (package path for hooks/tests, bare for direct-script).
+    try:
+        from shared.paths import get_claude_config_dir
+    except ImportError:  # pragma: no cover - exercised via direct-script run
+        from paths import get_claude_config_dir  # type: ignore[no-redef]
+
+    try:
+        root = (get_claude_config_dir() / "pact-sessions").resolve()
+        candidate = Path(session_dir).resolve()
+    except (OSError, RuntimeError, ValueError):
+        return False
+    return candidate == root or root in candidate.parents
 
 
 def main() -> int:
@@ -231,9 +275,12 @@ def main() -> int:
 
     if args.command == "resolve-session-dir":
         return _resolve_session_dir(args.context_file)
-    if args.command == "resolve-artifacts":
-        return _resolve_artifacts(args.session_dir, args.feature)
-    return _EXIT_INTERNAL_ERROR
+    # `sub.required = True` guarantees the only remaining choice is
+    # resolve-artifacts; argparse exits 2 before main() runs for any missing or
+    # unknown subcommand, so this fall-through is exhaustive. An uncaught
+    # exception inside a handler is what yields the `_EXIT_INTERNAL_ERROR` (1)
+    # contract — Python's default exit on an unhandled exception.
+    return _resolve_artifacts(args.session_dir, args.feature)
 
 
 if __name__ == "__main__":

--- a/pact-plugin/hooks/shared/session_journal.py
+++ b/pact-plugin/hooks/shared/session_journal.py
@@ -206,6 +206,28 @@ _REQUIRED_FIELDS_BY_TYPE: dict[str, dict[str, type]] = {
     # activates the _OPTIONAL_FIELDS_BY_TYPE enforcement below (same pattern
     # as session_end and cleanup_summary).
     "session_consolidated": {},
+    # The lead-frame command emit sites (plan-mode.md, peer-review.md, and
+    # orchestrate.md's PREPARE/ARCHITECT/CODE phase-output validation) write
+    # artifact_paths via the CLI write path — a path-only, GC-durable pointer
+    # to each phase's on-disk artifact(s). It outlives `git worktree remove`
+    # because the journal lives under ~/.claude/pact-sessions/, outside the
+    # worktree; only the pointed-at file is worktree-ephemeral. The secretary
+    # resolves these events at harvest and distills the artifact substance into
+    # pact-memory. `workflow` is the lowercase phase/workflow tag (one of
+    # plan-mode / prepare / architect / peer-review / code-auditor) and the
+    # dedup/precedence axis; `feature` is the slug scoping the event to one arc;
+    # `paths` is the PLURAL full-enumeration list of worktree-absolute artifact
+    # paths (a phase may write >1 file).
+    #
+    # Validator-depth caveat: `paths` is typed `list`, so the schema check
+    # enforces only isinstance(value, list) — it does NOT descend into the list
+    # to require each element be a non-empty str (the per-field empty-string
+    # guard applies to `str` fields only). Per-element path validity is the
+    # WRITER's responsibility: the emit sites drop empty/invalid entries and
+    # drop the whole emit when the glob found nothing (an empty paths list
+    # passes isinstance but is meaningless — that "missing artifact" case is the
+    # task_lifecycle_gate backstop's job, NOT a zero-length event).
+    "artifact_paths": {"workflow": str, "feature": str, "paths": list},
 }
 
 
@@ -301,6 +323,17 @@ _OPTIONAL_FIELDS_BY_TYPE: dict[str, dict[str, type]] = {
     # denominator). The required-fields registration above
     # ("remediation": {...}) activates this optional check.
     "remediation": {
+        "task_id": str,
+    },
+    # The lead-frame emit sites write artifact_paths with an optional `task_id`
+    # — the phase task id the lead completed when emitting (provenance /
+    # cross-link). Absent for plan-mode/peer-review syntheses that have no phase
+    # task; present (and a non-empty str) for the PREPARE/ARCHITECT/CODE phase
+    # emits. The required-fields registration above ("artifact_paths": {...})
+    # is what ACTIVATES this optional check — _validate_event_schema
+    # short-circuits on unknown types and would otherwise skip the optional loop
+    # (same activation pattern as session_end / missed_wake / teachback_ack).
+    "artifact_paths": {
         "task_id": str,
     },
 }

--- a/pact-plugin/hooks/shared/session_journal.py
+++ b/pact-plugin/hooks/shared/session_journal.py
@@ -685,11 +685,21 @@ def resolve_latest_artifacts(
     merged across events. A phase re-run that regenerates its doc in place
     therefore supersedes the prior emit instead of duplicating it.
 
+    Tie-break = LAST-wins: when two events for the same `(workflow, feature)`
+    carry an equal `ts`, the one iterated later (the more-recently-written in
+    journal order) wins — see `_ts_supersedes`. `make_event` stamps `ts` at
+    second granularity, so a same-second double-emit is resolved to the last
+    write, which is the authoritative complete snapshot.
+
     Defensive: non-dict entries and events missing `workflow`/`feature`/
     `paths` are skipped (parity with the `_read_events_at` `isinstance(...,
-    dict)` guard). A missing/unparseable `ts` never wins a supersede — it is
-    treated as older than any parseable timestamp — so a malformed event
-    cannot mask a well-formed later one.
+    dict)` guard). Timestamp handling is FAIL-OPEN (see `_ts_supersedes`): a
+    missing/unparseable `ts` on a candidate does not let it supersede a
+    well-formed incumbent, and an unresolved incumbent ts is replaced by any
+    well-formed candidate. A pair of parseable-but-incomparable timestamps
+    (e.g. one tz-aware, one tz-naive) is caught at the comparison and keeps
+    the incumbent rather than raising — the resolution never crashes on a
+    malformed `ts`.
 
     Args:
         events: Candidate journal events (typically all `artifact_paths`
@@ -699,8 +709,8 @@ def resolve_latest_artifacts(
 
     Returns:
         `{workflow: paths}` — one key per workflow with a surviving event,
-        valued by that workflow's superseded (latest-`ts`) complete path-list.
-        Empty dict if no event matches.
+        valued by that workflow's superseded (latest-`ts`, last-wins on a
+        tie) complete path-list. Empty dict if no event matches.
     """
     latest_by_workflow: dict[str, dict[str, Any]] = {}
     for event in events:
@@ -713,7 +723,7 @@ def resolve_latest_artifacts(
         if not isinstance(workflow, str) or not isinstance(paths, list):
             continue
         prior = latest_by_workflow.get(workflow)
-        if prior is None or _ts_is_newer(event.get("ts"), prior.get("ts")):
+        if prior is None or _ts_supersedes(event.get("ts"), prior.get("ts")):
             latest_by_workflow[workflow] = event
     return {
         workflow: event["paths"]
@@ -721,18 +731,30 @@ def resolve_latest_artifacts(
     }
 
 
-def _ts_is_newer(candidate_ts: Any, incumbent_ts: Any) -> bool:
-    """Return True if `candidate_ts` is strictly newer than `incumbent_ts`.
+def _ts_supersedes(candidate_ts: Any, incumbent_ts: Any) -> bool:
+    """Return True if a later-iterated `candidate_ts` should supersede the
+    incumbent — i.e. the candidate is newer than OR EQUAL TO the incumbent.
 
-    Used by `resolve_latest_artifacts` to pick the latest-`ts` event per
+    Used by `resolve_latest_artifacts` to pick the surviving event per
     workflow. Timestamps are PARSED (via `_parse_ts`), never lexically
     string-compared — see `_parse_ts` for the `Z` vs `+00:00` rationale.
 
-    Fail-safe tie-breaking: an unparseable/missing `candidate_ts` is treated
-    as NOT newer (returns False), so a malformed timestamp never supersedes a
-    well-formed event. An unparseable `incumbent_ts` loses to any parseable
-    candidate (returns True), so a malformed earlier event is replaced by a
-    well-formed later one.
+    Tie-break = LAST-wins (`>=`, not `>`): on an equal `ts`, the candidate
+    (iterated later, hence the more-recently-written event in journal order)
+    supersedes. Each `artifact_paths` emit is a COMPLETE snapshot, so the
+    last write for a `(workflow, feature)` is the authoritative one even when
+    two emits collide in the same wall-clock second (`make_event` stamps `ts`
+    at second granularity).
+
+    Fail-open comparison (matches the in-house `_ts_ge` pattern): the parse
+    AND the comparison are guarded. A missing/unparseable `candidate_ts`
+    returns False, so a malformed candidate never supersedes a well-formed
+    incumbent. A missing/unparseable `incumbent_ts` returns True, so a
+    well-formed candidate replaces a malformed incumbent. If the parsed
+    values are themselves incomparable (e.g. one tz-aware `...Z` ts and one
+    tz-naive ts both parse but raise `TypeError` on `>=`), the comparison is
+    caught and the candidate does NOT supersede (returns False) — fail-open
+    keeps the incumbent rather than crashing the whole resolution.
     """
     try:
         candidate = _parse_ts(candidate_ts)
@@ -742,7 +764,10 @@ def _ts_is_newer(candidate_ts: Any, incumbent_ts: Any) -> bool:
         incumbent = _parse_ts(incumbent_ts)
     except (ValueError, TypeError):
         return True
-    return candidate > incumbent
+    try:
+        return candidate >= incumbent
+    except TypeError:
+        return False
 
 
 def _parse_ts(value: Any) -> datetime:

--- a/pact-plugin/hooks/shared/session_journal.py
+++ b/pact-plugin/hooks/shared/session_journal.py
@@ -693,7 +693,11 @@ def resolve_latest_artifacts(
 
     Defensive: non-dict entries and events missing `workflow`/`feature`/
     `paths` are skipped (parity with the `_read_events_at` `isinstance(...,
-    dict)` guard). Timestamp handling is FAIL-OPEN (see `_ts_supersedes`): a
+    dict)` guard), and any non-string element inside a surviving event's
+    `paths` list is dropped from the emitted list (the same isinstance-guard
+    discipline applied at element granularity, so a malformed path entry can
+    never flow through to the JSON output). Timestamp handling is FAIL-OPEN
+    (see `_ts_supersedes`): a
     missing/unparseable `ts` on a candidate does not let it supersede a
     well-formed incumbent, and an unresolved incumbent ts is replaced by any
     well-formed candidate. A pair of parseable-but-incomparable timestamps
@@ -710,7 +714,8 @@ def resolve_latest_artifacts(
     Returns:
         `{workflow: paths}` — one key per workflow with a surviving event,
         valued by that workflow's superseded (latest-`ts`, last-wins on a
-        tie) complete path-list. Empty dict if no event matches.
+        tie) complete path-list, with any non-string element filtered out.
+        Empty dict if no event matches.
     """
     latest_by_workflow: dict[str, dict[str, Any]] = {}
     for event in events:
@@ -726,7 +731,7 @@ def resolve_latest_artifacts(
         if prior is None or _ts_supersedes(event.get("ts"), prior.get("ts")):
             latest_by_workflow[workflow] = event
     return {
-        workflow: event["paths"]
+        workflow: [p for p in event["paths"] if isinstance(p, str)]
         for workflow, event in latest_by_workflow.items()
     }
 
@@ -770,8 +775,25 @@ def _ts_supersedes(candidate_ts: Any, incumbent_ts: Any) -> bool:
         return False
 
 
+def _normalize_trailing_z(value: Any) -> str:
+    """Rewrite a SINGLE trailing `Z` UTC designator to `+00:00`, leaving any
+    interior `Z` intact.
+
+    The anchor is TRAILING-ONLY (`str.endswith`, no `re` dependency): an
+    interior `Z` is not a valid ISO-8601 field, so leaving it intact lets the
+    downstream `fromisoformat` reject the whole string rather than a blanket
+    `.replace("Z", "+00:00")` rewriting it mid-string. On `_parse_ts`'s
+    return/raise the trailing-only and replace-all forms are observationally
+    identical (any interior `Z` is unparseable either way); the anchor matters
+    at the STRING layer, which this helper isolates and makes testable.
+    """
+    s = str(value)
+    return s[:-1] + "+00:00" if s.endswith("Z") else s
+
+
 def _parse_ts(value: Any) -> datetime:
-    """Parse an ISO-8601 timestamp, normalizing a trailing `Z` to `+00:00`.
+    """Parse an ISO-8601 timestamp, normalizing a trailing `Z` to `+00:00`
+    (via `_normalize_trailing_z`).
 
     `make_event` stamps `ts` as `...Z` while `canonical_since()` emits
     `...+00:00`; normalizing lets the two compare as equal-instant
@@ -780,7 +802,7 @@ def _parse_ts(value: Any) -> datetime:
     `Z` ts. Raises ValueError/TypeError on missing/malformed input; callers
     decide the fail-open policy.
     """
-    return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    return datetime.fromisoformat(_normalize_trailing_z(value))
 
 
 def _ts_ge(event_ts: Any, since: str | None) -> bool:

--- a/pact-plugin/hooks/shared/session_journal.py
+++ b/pact-plugin/hooks/shared/session_journal.py
@@ -462,6 +462,25 @@ def _validate_event_schema(event: dict[str, Any]) -> tuple[bool, str]:
                 f"field '{field}' for type '{event_type}' must be "
                 f"non-empty string",
             )
+    # artifact_paths element-level guard (belt-and-suspenders): the generic
+    # per-field check above is SHALLOW — it confirms `paths` is a `list` but
+    # does not descend into its elements. The locked design makes per-element
+    # validity the writer's responsibility (the emit sites drop empty/invalid
+    # paths and skip an empty glob); this schema-layer check augments that with
+    # a defensive backstop so a writer that bypasses the emit-site discipline
+    # cannot land a `paths` list holding a non-str or empty/whitespace-only
+    # element on disk, where a downstream reader would treat it as a real path.
+    # Scoped to artifact_paths ONLY — other list-typed required fields
+    # (s2_state_seeded.agents, review_dispatch.reviewers, remediation.items)
+    # keep their existing shallow contract and are untouched.
+    if event_type == "artifact_paths":
+        for element in event["paths"]:
+            if not isinstance(element, str) or not element.strip():
+                return (
+                    False,
+                    "field 'paths' for type 'artifact_paths' must contain "
+                    "only non-empty strings",
+                )
     # Per-type optional field checks. Absent fields pass (that's what
     # "optional" means); present fields must match the declared type.
     # Symmetric with required-field checks: rejects bool in int fields,
@@ -690,11 +709,16 @@ def _read_events_at(
     Reads with `errors="replace"` so a single invalid byte sequence
     (e.g., from a botched write or a truncated multibyte character)
     substitutes U+FFFD for the bad bytes instead of raising
-    UnicodeDecodeError. A malformed byte range corrupts at most its
-    own line; the per-line `json.loads` then drops that line and every
-    other event in the file is still returned. Without this, one bad
-    byte would cause the outer `except Exception` to drop the whole
-    file and hide all of its otherwise-valid events.
+    UnicodeDecodeError. A bad line corrupts at most its own line; every
+    other event in the file is still returned. Two per-line hazards are
+    isolated: (1) a line that fails to parse as JSON is dropped by the
+    `except (json.JSONDecodeError, ValueError)` below; (2) a line that
+    parses as valid JSON but is NOT a dict (e.g. `[1,2,3]`, `"str"`,
+    `42`, `null`) is dropped by the `isinstance(event, dict)` guard —
+    without that guard, `.get()` on a non-dict value raises
+    AttributeError (not in the except tuple), which would propagate to
+    the outer `except Exception` and drop the WHOLE file, hiding every
+    otherwise-valid event behind one bad line.
 
     `since`: when set, only events whose `ts` is >= `since` (inclusive,
     parsed via `_ts_ge`) are returned — the arc-scope filter. None/empty
@@ -713,6 +737,16 @@ def _read_events_at(
                 continue
             try:
                 event = json.loads(line)
+                # A line can be valid JSON yet NOT a dict (e.g. `[1,2,3]`,
+                # `"str"`, `42`, `null`). `.get()` on such a value raises
+                # AttributeError — which is NOT in the except tuple below, so it
+                # would propagate to the outer `except Exception` and drop the
+                # WHOLE file's events (every event hidden behind one bad line).
+                # Skip a non-dict line exactly like a malformed one so it
+                # corrupts at most itself, preserving the per-line isolation the
+                # docstring promises.
+                if not isinstance(event, dict):
+                    continue
                 if event_type and event.get("type") != event_type:
                     continue
                 if not _ts_ge(event.get("ts"), since):
@@ -805,7 +839,14 @@ def _scan_lines_for_event(
 
     Shared by tail-window and full-slurp scan paths. Skips blank lines and
     silently drops malformed JSON (symmetric with the pre-optimization
-    contract: corrupted lines never poison the scan).
+    contract: corrupted lines never poison the scan). A line that parses as
+    valid JSON but is NOT a dict (e.g. `[1,2,3]`, `"str"`, `42`, `null`) is
+    skipped by the `isinstance(event, dict)` guard — parity with
+    `_read_events_at`: without it, `.get()` on a non-dict value raises
+    AttributeError (not in the except tuple), which would propagate to the
+    caller's outer `except Exception` and abort the whole reverse scan,
+    making `read_last_event*` return None (e.g. `session_end` would conclude
+    the session was never paused).
 
     `since`: when set, an event matching `event_type` whose `ts` is < `since`
     (parsed via `_ts_ge`) is skipped — the reverse scan then returns the
@@ -817,6 +858,8 @@ def _scan_lines_for_event(
             continue
         try:
             event = json.loads(line)
+            if not isinstance(event, dict):
+                continue
             if event.get("type") == event_type and _ts_ge(
                 event.get("ts"), since
             ):

--- a/pact-plugin/hooks/shared/session_journal.py
+++ b/pact-plugin/hooks/shared/session_journal.py
@@ -666,6 +666,85 @@ def read_events_from(
     return _read_events_at(journal, event_type, since)
 
 
+def resolve_latest_artifacts(
+    events: list[dict[str, Any]],
+    feature: str,
+) -> dict[str, list[str]]:
+    """Resolve the superseded artifact path-list per workflow for one feature.
+
+    Pure (no I/O): the caller supplies already-read `artifact_paths` events
+    (e.g. `read_events_from(session_dir, "artifact_paths")`) and the feature
+    slug; this returns one entry per workflow that emitted artifacts for that
+    feature, valued by that workflow's latest path-list.
+
+    Supersede semantics: filter to `e["feature"] ==
+    feature`; group by `e["workflow"]`; within each group keep the
+    latest-`ts` event. Each `artifact_paths` event carries the COMPLETE
+    path-list for its `(workflow, feature)` (a full enumeration per emit,
+    not a delta), so the latest event is self-sufficient — paths are NEVER
+    merged across events. A phase re-run that regenerates its doc in place
+    therefore supersedes the prior emit instead of duplicating it.
+
+    Defensive: non-dict entries and events missing `workflow`/`feature`/
+    `paths` are skipped (parity with the `_read_events_at` `isinstance(...,
+    dict)` guard). A missing/unparseable `ts` never wins a supersede — it is
+    treated as older than any parseable timestamp — so a malformed event
+    cannot mask a well-formed later one.
+
+    Args:
+        events: Candidate journal events (typically all `artifact_paths`
+            events for the session). Any list of dicts is accepted; the
+            feature/type filtering happens here.
+        feature: The feature slug to resolve (matched against `e["feature"]`).
+
+    Returns:
+        `{workflow: paths}` — one key per workflow with a surviving event,
+        valued by that workflow's superseded (latest-`ts`) complete path-list.
+        Empty dict if no event matches.
+    """
+    latest_by_workflow: dict[str, dict[str, Any]] = {}
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        if event.get("feature") != feature:
+            continue
+        workflow = event.get("workflow")
+        paths = event.get("paths")
+        if not isinstance(workflow, str) or not isinstance(paths, list):
+            continue
+        prior = latest_by_workflow.get(workflow)
+        if prior is None or _ts_is_newer(event.get("ts"), prior.get("ts")):
+            latest_by_workflow[workflow] = event
+    return {
+        workflow: event["paths"]
+        for workflow, event in latest_by_workflow.items()
+    }
+
+
+def _ts_is_newer(candidate_ts: Any, incumbent_ts: Any) -> bool:
+    """Return True if `candidate_ts` is strictly newer than `incumbent_ts`.
+
+    Used by `resolve_latest_artifacts` to pick the latest-`ts` event per
+    workflow. Timestamps are PARSED (via `_parse_ts`), never lexically
+    string-compared — see `_parse_ts` for the `Z` vs `+00:00` rationale.
+
+    Fail-safe tie-breaking: an unparseable/missing `candidate_ts` is treated
+    as NOT newer (returns False), so a malformed timestamp never supersedes a
+    well-formed event. An unparseable `incumbent_ts` loses to any parseable
+    candidate (returns True), so a malformed earlier event is replaced by a
+    well-formed later one.
+    """
+    try:
+        candidate = _parse_ts(candidate_ts)
+    except (ValueError, TypeError):
+        return False
+    try:
+        incumbent = _parse_ts(incumbent_ts)
+    except (ValueError, TypeError):
+        return True
+    return candidate > incumbent
+
+
 def _parse_ts(value: Any) -> datetime:
     """Parse an ISO-8601 timestamp, normalizing a trailing `Z` to `+00:00`.
 

--- a/pact-plugin/hooks/shared/session_journal.py
+++ b/pact-plugin/hooks/shared/session_journal.py
@@ -755,11 +755,15 @@ def _ts_supersedes(candidate_ts: Any, incumbent_ts: Any) -> bool:
     AND the comparison are guarded. A missing/unparseable `candidate_ts`
     returns False, so a malformed candidate never supersedes a well-formed
     incumbent. A missing/unparseable `incumbent_ts` returns True, so a
-    well-formed candidate replaces a malformed incumbent. If the parsed
-    values are themselves incomparable (e.g. one tz-aware `...Z` ts and one
-    tz-naive ts both parse but raise `TypeError` on `>=`), the comparison is
-    caught and the candidate does NOT supersede (returns False) — fail-open
-    keeps the incumbent rather than crashing the whole resolution.
+    well-formed candidate replaces a malformed incumbent.
+
+    Naive/aware coercion: if a parsed value is tz-NAIVE (only possible from a
+    corrupted/externally-merged journal — `make_event` always stamps aware
+    `...Z`), it is assumed UTC and coerced to tz-aware before the comparison,
+    so a naive-vs-aware pair compares by actual INSTANT (the later instant
+    wins) instead of raising `TypeError`. The comparison stays wrapped in a
+    `try/except TypeError` that fail-opens (returns False, keeps the incumbent)
+    for any residual uncomparable pair, so the resolution never crashes.
     """
     try:
         candidate = _parse_ts(candidate_ts)
@@ -769,6 +773,12 @@ def _ts_supersedes(candidate_ts: Any, incumbent_ts: Any) -> bool:
         incumbent = _parse_ts(incumbent_ts)
     except (ValueError, TypeError):
         return True
+    # Coerce a tz-naive value to tz-aware UTC so a naive-vs-aware pair compares
+    # by instant rather than raising TypeError (which the outer guard would turn
+    # into a fail-open keep-stale). Assuming UTC is the safe interpretation; a
+    # naive ts only arises from a corrupted journal (make_event always stamps Z).
+    candidate = candidate if candidate.tzinfo is not None else candidate.replace(tzinfo=timezone.utc)
+    incumbent = incumbent if incumbent.tzinfo is not None else incumbent.replace(tzinfo=timezone.utc)
     try:
         return candidate >= incumbent
     except TypeError:

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -293,7 +293,12 @@ try:
     )
     from shared.dispatch_helpers import trustworthy_actor_name
     from shared.intentional_wait import is_self_complete_exempt, is_teachback_exempt
-    from shared.session_journal import append_event, get_journal_path, make_event
+    from shared.session_journal import (
+        append_event,
+        get_journal_path,
+        make_event,
+        read_events,
+    )
     from shared.task_utils import is_teachback_subject as _is_teachback_subject
     from shared.task_utils import read_task_json
     from shared.teachback_schema import (
@@ -369,6 +374,86 @@ _NO_RESOLVABLE_TOTAL = (
     "no resolvable total (need an integer 4-16 under key 'total', "
     "or a recoverable fallback)"
 )
+
+
+# ─── artifact_paths emit backstop (durability nudge) ─────────────────────────
+#
+# Maps a phase-task subject PREFIX to its artifact_paths `workflow` tag, but
+# ONLY for the phases that MUST emit a durable artifact pointer — PREPARE and
+# ARCHITECT, which write recoverable disk artifacts (docs/preparation/,
+# docs/architecture/) that the git-immune, GC-durable journal event protects.
+# CODE:/TEST:/ATOMIZE:/CONSOLIDATE: phases are DELIBERATELY ABSENT: their output
+# is git-tracked (CODE/TEST) or non-artifact (ATOMIZE/CONSOLIDATE), so a missing
+# artifact_paths event is expected, not an anomaly — leaving them out makes the
+# backstop silently skip them. The `workflow` values mirror the lowercase enum
+# in session_journal's artifact_paths registration (plan-mode / prepare /
+# architect / peer-review / code-auditor); only the two phase-task-backed
+# workflows appear here (plan-mode / peer-review are command syntheses with no
+# phase-completion TaskUpdate for this PostToolUse hook to observe).
+_ARTIFACT_EMIT_PHASE_WORKFLOWS = {
+    "PREPARE:": "prepare",
+    "ARCHITECT:": "architect",
+}
+
+
+def _phase_artifact_requirement(subject: str) -> "tuple[str, str] | None":
+    """Map a phase-task subject to its (workflow, feature) artifact key, or
+    None when this subject does not require an artifact_paths emit.
+
+    Returns None (skip the backstop nudge) for:
+      - a non-PREPARE/ARCHITECT subject (CODE/TEST/ATOMIZE/CONSOLIDATE/other →
+        exempt by design — their artifacts are git-tracked or absent), and
+      - a malformed phase subject with no ": " feature separator (rare; the
+        orchestrate command creates phase tasks as exactly "PREPARE: {feature}"
+        / "ARCHITECT: {feature}", so a missing separator is degenerate — fail
+        open as a no-op rather than nudging on an unresolvable feature slug).
+
+    The feature slug is the subject suffix after the "{PHASE}: " prefix; it must
+    equal the orchestrate {feature-slug} that the lead-frame emit site writes as
+    the event's `feature` field, so the (workflow, feature) presence check
+    aligns with the dedup SSOT key. Pure; never raises.
+    """
+    if not isinstance(subject, str):
+        return None
+    for prefix, workflow in _ARTIFACT_EMIT_PHASE_WORKFLOWS.items():
+        if subject.startswith(prefix):
+            # Split on the canonical "{PHASE}: " separator; the suffix is the
+            # feature slug. A subject that startswith the bare prefix but has no
+            # ": " (e.g. "PREPAREthing") cannot match prefix anyway; one that is
+            # exactly the prefix with nothing after yields an empty slug → skip.
+            _, sep, suffix = subject.partition(": ")
+            feature = suffix.strip()
+            if not sep or not feature:
+                return None
+            return workflow, feature
+    return None
+
+
+def _artifact_paths_event_present(workflow: str, feature: str) -> bool:
+    """Return True iff an artifact_paths journal event exists for this
+    (workflow, feature) in the CURRENT session's journal.
+
+    Uses the IMPLICIT read_events() (lead-frame): this backstop is is_lead-gated
+    at its single call site, so get_session_dir() resolves the canonical journal
+    in the lead's process. The off-lead masked-read hazard (read_events()
+    false-returning [] for a teammate frame) is strictly the SECRETARY HARVEST
+    reader's concern — that reader runs off-lead and MUST use
+    read_events_from(session_dir); this backstop does not, because it never runs
+    off-lead. The hook frame carries no worktree/session_dir to pass anyway.
+
+    Fail-OPEN by construction: read_events swallows its own errors and returns []
+    (treated as "absent" → the nudge fires). A false nudge is non-blocking and
+    self-corrects; a false-silence (missing the forgotten emit) is the dangerous
+    error this presence check exists to prevent, so absent-on-error is safe-side.
+    Pure read; never raises (read_events is internally fail-open).
+    """
+    events = read_events("artifact_paths")
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        if event.get("workflow") == workflow and event.get("feature") == feature:
+            return True
+    return False
 
 
 # `_is_teachback_subject` (the canonical Teachback Task subject predicate) was
@@ -1223,6 +1308,49 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
             _emit_lead_side_agent_handoff(
                 team_name, task_id, owner, subject, metadata
             )
+
+        # artifact_paths emit BACKSTOP (#927 durability nudge). A FAIL-OPEN
+        # advisory: when a PREPARE/ARCHITECT phase task completes but the
+        # lead-frame emit site forgot to write the durable artifact_paths
+        # pointer, nudge so the GC-immune recovery pointer isn't silently
+        # missed. The pointer is what survives `git worktree remove` and lets
+        # the secretary distill the disk artifact at harvest; without it, that
+        # phase degrades to HANDOFF-only recovery (the #927 failure path).
+        #
+        # is_lead-gated, mirroring the lead-side emit above: only the lead's
+        # process resolves the canonical journal via the implicit read, and only
+        # the lead is the writer the nudge is aimed at. A teammate self-
+        # completion has no populated context and is correctly skipped.
+        #
+        # This hook canNOT glob (no worktree path in the PostToolUse frame) — it
+        # only DETECTS the missing emit (the journal read is path-independent in
+        # the lead frame) and nudges; it never blocks the TaskUpdate. EXEMPT:
+        #   - CODE:/TEST:/ATOMIZE:/CONSOLIDATE:/other subjects → not in the
+        #     phase→workflow map → _phase_artifact_requirement returns None →
+        #     silent (their artifacts are git-tracked or non-existent).
+        #   - skipped phases (metadata.skipped is true) → no artifact produced.
+        # Emit ordering is satisfied by construction: the emit site fires at
+        # phase-output validation BEFORE the lead completes the phase task, so by
+        # this PostToolUse(completed) the event is already on disk (a synchronous
+        # journal append). Fail-open covers any residual race.
+        if pact_context.is_lead(input_data) and metadata.get("skipped") is not True:
+            requirement = _phase_artifact_requirement(subject)
+            if requirement is not None:
+                workflow, feature = requirement
+                if not _artifact_paths_event_present(workflow, feature):
+                    advisories.append((
+                        "artifact_paths_emit_missing",
+                        f"PACT task_lifecycle_gate: phase Task {task_id} "
+                        f"({subject!r}) completed without an artifact_paths "
+                        f"journal event for (workflow={workflow!r}, "
+                        f"feature={feature!r}). The lead-frame emit (glob the "
+                        f"phase's docs/ output + write --type artifact_paths) "
+                        "appears to have been skipped — the GC-durable recovery "
+                        "pointer is missing, so this phase's disk artifact will "
+                        "degrade to HANDOFF-only at harvest. Emit the "
+                        "artifact_paths event for this phase before the worktree "
+                        "is torn down. Advisory only — not blocking.",
+                    ))
 
         # Teachback-subject completion-time checks: teachback_submit presence
         # + schema. R1/R2 are disjoint on the missing-vs-malformed split:

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -1328,7 +1328,11 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
         #   - CODE:/TEST:/ATOMIZE:/CONSOLIDATE:/other subjects → not in the
         #     phase→workflow map → _phase_artifact_requirement returns None →
         #     silent (their artifacts are git-tracked or non-existent).
-        #   - skipped phases (metadata.skipped is true) → no artifact produced.
+        #   - skipped phases (metadata.skipped is exactly True) → no artifact
+        #     produced. The guard uses a strict `is not True` identity check, so
+        #     ONLY the boolean True exempts; a truthy-but-non-True value
+        #     (1, "yes", etc.) does NOT count as skipped and the backstop still
+        #     fires — fail-safe toward nudging on an ambiguous skip marker.
         # Emit ordering is satisfied by construction: the emit site fires at
         # phase-output validation BEFORE the lead completes the phase task, so by
         # this PostToolUse(completed) the event is already on disk (a synchronous

--- a/pact-plugin/skills/pact-handoff-harvest/SKILL.md
+++ b/pact-plugin/skills/pact-handoff-harvest/SKILL.md
@@ -32,23 +32,22 @@ Resolve the absolute session directory **before any journal read**, and reuse th
 
 **Why this is load-bearing (not optional):** you run **off-lead** (a `pact-secretary` teammate). `read_events(...)` derives its path implicitly via `pact_context.get_session_dir()`, which **false-returns `''` in a teammate frame** (no persisted lead session context) → the read silently returns **0 events**. Off-lead, that would make the entire harvest — HANDOFF discovery, artifact recovery, and calibration — a silent no-op. `read_events_from(session_dir, ...)` takes the directory **explicitly** and is frame-independent (the same form the Orphaned-Recovery path below already uses).
 
-Reconstruct the directory from the per-session context file (the same construction `get_session_dir()` uses, but driven off the on-disk context file rather than the lead-gated helper that false-returns off-lead):
+Reconstruct the directory from the per-session context file by calling the shared SSOT helper `reconstruct_session_dir(project_dir, session_id)` (in `shared.pact_context`) — the off-lead, frame-independent counterpart to `get_session_dir()`. **Do NOT hand-build the path** (no manual `Path(project_dir).name` + `get_claude_config_dir()/pact-sessions/...` join): the writer sanitizes both the slug and the `session_id` (via `_UNSAFE_SLUG_CHARS_RE` and the shared `_build_session_path`), so a raw join would land on a DIFFERENT directory than the one the journal was written to whenever the project basename or `session_id` contains a non-`[A-Za-z0-9_-]` character (e.g. a dot or space) → the off-lead read silently returns 0 events. The helper routes both axes through the writer's derivation, so the reconstruction is SSOT-by-construction and cannot drift.
 
 1. Read `pact-session-context.json` from the session dir your dispatch placed you in (the same file the Orphaned-Recovery path references). It carries `session_id` and `project_dir`.
-2. Reconstruct: `slug = Path(project_dir).name`; then join `get_claude_config_dir() / "pact-sessions" / slug / session_id`. Use `get_claude_config_dir()` (from `shared.paths`) — do NOT hardcode `~/.claude`.
+2. Call `reconstruct_session_dir(ctx["project_dir"], ctx["session_id"])` to get the absolute session dir.
 
 ```python
 import json, sys
 from pathlib import Path
 sys.path.insert(0, "{hooks_dir}")
-from shared.paths import get_claude_config_dir
+from shared.pact_context import reconstruct_session_dir
 
 ctx = json.loads(Path("{context_file}").read_text())  # pact-session-context.json
-slug = Path(ctx["project_dir"]).name
-session_dir = str(get_claude_config_dir() / "pact-sessions" / slug / ctx["session_id"])
+session_dir = reconstruct_session_dir(ctx["project_dir"], ctx["session_id"])
 ```
 
-If the context file is missing or unreadable, **report the gap to the team-lead and stop** — do NOT fall back to the path-less `read_events(...)` (that silently re-introduces the off-lead false-empty bug). An unresolved `session_dir` is a reportable gap, not a degrade-to-implicit case.
+If the context file is missing/unreadable, or `reconstruct_session_dir` returns `''` (a falsy `project_dir`/`session_id`), **report the gap to the team-lead and stop** — do NOT fall back to the path-less `read_events(...)` (that silently re-introduces the off-lead false-empty bug). An unresolved `session_dir` is a reportable gap, not a degrade-to-implicit case.
 
 ### Step 1: Task Discovery
 

--- a/pact-plugin/skills/pact-handoff-harvest/SKILL.md
+++ b/pact-plugin/skills/pact-handoff-harvest/SKILL.md
@@ -28,32 +28,37 @@ When reviewing multiple HANDOFFs, read ALL of them before saving any memories. T
 
 ### Step 0: Resolve the Session Directory (do this once)
 
-Resolve the absolute session directory **before any journal read**, and reuse that one value for every journal read below (Step 1 `agent_handoff`, Step 3.5 `artifact_paths`, and Step 10 `variety_assessed`). **Every journal read in this skill MUST pass this explicit `session_dir`** via `read_events_from(session_dir, ...)` — never the path-less `read_events(...)`.
+Resolve the absolute session directory **before any journal read**, and reuse that one value (`$SESSION_DIR`) for every journal read below (Step 1 `agent_handoff`, Step 3.5 `artifact_paths`, and Step 10 `variety_assessed`). **Every journal read in this skill MUST pass this explicit `--session-dir`** — never a path-less read.
 
-**Why this is load-bearing (not optional):** you run **off-lead** (a `pact-secretary` teammate). `read_events(...)` derives its path implicitly via `pact_context.get_session_dir()`, which **false-returns `''` in a teammate frame** (no persisted lead session context) → the read silently returns **0 events**. Off-lead, that would make the entire harvest — HANDOFF discovery, artifact recovery, and calibration — a silent no-op. `read_events_from(session_dir, ...)` takes the directory **explicitly** and is frame-independent (the same form the Orphaned-Recovery path below already uses).
+**Why this is load-bearing (not optional):** you run **off-lead** (a `pact-secretary` teammate). The implicit-path read (`read_events(...)` with no `--session-dir`) derives its path via `pact_context.get_session_dir()`, which **false-returns `''` in a teammate frame** (no persisted lead session context) → the read silently returns **0 events**. Off-lead, that would make the entire harvest — HANDOFF discovery, artifact recovery, and calibration — a silent no-op. Passing an explicit `--session-dir` is frame-independent and masked-read-safe.
 
-Reconstruct the directory from the per-session context file by calling the shared SSOT helper `reconstruct_session_dir(project_dir, session_id)` (in `shared.pact_context`) — the off-lead, frame-independent counterpart to `get_session_dir()`. **Do NOT hand-build the path** (no manual `Path(project_dir).name` + `get_claude_config_dir()/pact-sessions/...` join): the writer sanitizes both the slug and the `session_id` (via `_UNSAFE_SLUG_CHARS_RE` and the shared `_build_session_path`), so a raw join would land on a DIFFERENT directory than the one the journal was written to whenever the project basename or `session_id` contains a non-`[A-Za-z0-9_-]` character (e.g. a dot or space) → the off-lead read silently returns 0 events. The helper routes both axes through the writer's derivation, so the reconstruction is SSOT-by-construction and cannot drift.
+Resolve the directory with the `pact_harvest.py resolve-session-dir` subcommand, which reads `pact-session-context.json` and routes the reconstruction through the SSOT helper `reconstruct_session_dir` (it sanitizes both the slug and the `session_id` the same way the writer did, so the reconstructed path cannot drift from where the journal was actually written — a hand-built `{slug}/{session_id}` join would land on a DIFFERENT directory whenever the project basename or `session_id` contains a non-`[A-Za-z0-9_-]` character):
 
-1. Read `pact-session-context.json` from the session dir your dispatch placed you in (the same file the Orphaned-Recovery path references). It carries `session_id` and `project_dir`.
-2. Call `reconstruct_session_dir(ctx["project_dir"], ctx["session_id"])` to get the absolute session dir.
-
-```python
-import json, sys
-from pathlib import Path
-sys.path.insert(0, "{hooks_dir}")
-from shared.pact_context import reconstruct_session_dir
-
-ctx = json.loads(Path("{context_file}").read_text())  # pact-session-context.json
-session_dir = reconstruct_session_dir(ctx["project_dir"], ctx["session_id"])
+```bash
+if ! SESSION_DIR=$(python3 "{plugin_root}/hooks/shared/pact_harvest.py" \
+       resolve-session-dir --context-file "{context_file}"); then
+  # Nonzero exit (2) = unresolvable: context file missing/unreadable/invalid,
+  # or reconstruct_session_dir returned ''. Report the gap to the team-lead
+  # and STOP — do NOT proceed to any journal read.
+  echo "HARVEST GAP: could not resolve session_dir; reporting and stopping." >&2
+fi
+# On success $SESSION_DIR holds the absolute session dir; reuse it for every read below.
 ```
 
-If the context file is missing/unreadable, or `reconstruct_session_dir` returns `''` (a falsy `project_dir`/`session_id`), **report the gap to the team-lead and stop** — do NOT fall back to the path-less `read_events(...)` (that silently re-introduces the off-lead false-empty bug). An unresolved `session_dir` is a reportable gap, not a degrade-to-implicit case.
+**Key the report-gap-and-stop branch on the subcommand's EXIT CODE**, never on parsing stdout for emptiness — a nonzero exit is unambiguous and cannot be defeated by a stray byte. On a nonzero exit, **report the gap to the team-lead and stop** — do NOT fall back to a path-less read (that silently re-introduces the off-lead false-empty bug). An unresolved `session_dir` is a reportable gap, not a degrade-to-implicit case.
 
 ### Step 1: Task Discovery
 
 You have two sources for finding completed agent tasks, in priority order:
 
-1. **Session journal** (primary, GC-proof): `{session_dir}/session-journal.jsonl` (the `session_dir` resolved in Step 0) — read `agent_handoff` events via `python3 -c "import sys; sys.path.insert(0, '{hooks_dir}'); from shared.session_journal import read_events_from; import json; [print(json.dumps(e)) for e in read_events_from('{session_dir}', 'agent_handoff')]"`. Each event contains `{"type": "agent_handoff", "agent": "...", "task_id": "...", "task_subject": "...", "handoff": {...}, "ts": "..."}` — full HANDOFF content inline, garbage-collection-proof. **Deduplicate**: extract unique task_ids only.
+1. **Session journal** (primary, GC-proof): `$SESSION_DIR/session-journal.jsonl` (the `$SESSION_DIR` resolved in Step 0) — read `agent_handoff` events via the existing `session_journal.py read` subcommand (explicit `--session-dir`, masked-read-safe):
+
+   ```bash
+   EVENTS=$(python3 "{plugin_root}/hooks/shared/session_journal.py" read \
+              --session-dir "$SESSION_DIR" --type agent_handoff)
+   ```
+
+   `read` prints a **JSON ARRAY** to stdout (`[ {...}, {...} ]`), NOT one JSON object per line. So parse the whole stdout once — `json.loads(EVENTS)` → a list of event dicts — then iterate the list (do **not** iterate line-by-line). Each event is `{"type": "agent_handoff", "agent": "...", "task_id": "...", "task_subject": "...", "handoff": {...}, "ts": "..."}` — full HANDOFF content inline, garbage-collection-proof. **Deduplicate**: extract unique task_ids only.
 2. **`TaskList`** (supplementary): Read `TaskList` for completed tasks owned by agents. Useful as a cross-reference and for catching tasks where the completion hook didn't fire. Note: the platform garbage-collects older task files during long sessions, so `TaskList` may be incomplete.
 
 If none of these sources have completed agent tasks, report "No pending HANDOFFs to review" and complete — this is normal when HANDOFFs were already processed by an earlier trigger (idempotent).
@@ -90,7 +95,17 @@ Read all HANDOFFs before proceeding to extraction.
 
 Each phase's HANDOFF is the **distilled frame**; the phase's disk artifact (e.g. `docs/preparation/{feature}.md`, `docs/architecture/{feature}.md`, `docs/plans/{slug}-plan.md`, `docs/review/…`) is the **fuller substance**. The lead writes a path-only `artifact_paths` journal event pointing at each phase's artifact(s); that event lives in the journal (outside any worktree), so it survives `git worktree remove` even though the pointed-at file is worktree-ephemeral. **Always** resolve these events and fold the artifact substance into the same synthesis the HANDOFF drives.
 
-1. **Resolve** (masked-read-safe — uses the Step 0 `session_dir`): `events = read_events_from(session_dir, "artifact_paths")`. Filter to `event["feature"] == <this feature>`. Group the survivors by `event["workflow"]`; within each `workflow` group take the **latest-`ts`** event (supersede-by-`(workflow, feature)`). Each event carries the **COMPLETE** path-list for that `(workflow, feature)` (a full enumeration per emit, not a delta), so the latest event is self-sufficient — never merge across events. Result: one path-list per `(workflow, feature)`.
+1. **Resolve** (masked-read-safe — uses the Step 0 `$SESSION_DIR`): call the `pact_harvest.py resolve-artifacts` subcommand, which reads the `artifact_paths` events and applies the supersede-by-`(workflow, feature)`-latest-`ts` dedup for you:
+
+   ```bash
+   ARTIFACTS=$(python3 "{plugin_root}/hooks/shared/pact_harvest.py" resolve-artifacts \
+                 --session-dir "$SESSION_DIR" --feature "{feature}")
+   # stdout is a single-line JSON object {workflow: [abs_path, ...]}, e.g.:
+   # {"prepare":["/abs/docs/preparation/{feature}.md"],"architect":["/abs/docs/architecture/{feature}.md"]}
+   # Empty (no artifacts for this feature) -> {}. Parse with json.loads, iterate keys.
+   ```
+
+   The subcommand already filters to this feature, groups by `workflow`, takes the **latest-`ts`** event per `(workflow, feature)`, and returns only the resolved set. Each `artifact_paths` event carries the **COMPLETE** path-list for its `(workflow, feature)` (a full enumeration per emit, not a delta), so the latest event is self-sufficient — the supersede never merges across events. Result (the JSON object): one path-list per `(workflow, feature)`.
 2. **Read** each path in the surviving events' `paths` lists off disk. Paths are full-absolute; read them **while the worktree is live** (the `worktree-cleanup` harvest-before-teardown guard guarantees this ordering at the single teardown chokepoint). If a path no longer resolves (file already gone — the accepted abnormal-teardown edge), skip it, note the gap, and degrade to HANDOFF-only for that artifact.
 3. **Synthesize ONE entry from BOTH sources together** (NOT verbatim, NOT a second entry). For each work unit, produce a SINGLE pact-memory entry synthesized from the HANDOFF **and** its artifact: the artifact is the fuller substance, the HANDOFF is the distilled frame. A ~19 KB artifact becomes a **richer-but-bounded** entry (a few hundred tokens of decisions/lessons informed by the full substance) — do NOT store the raw artifact. Substance flows into the entry's `context`/`decisions`; put the artifact's path in an entity `notes` field (NOT a `files` field — that field is rejected on save).
 4. **Dedup** — reuse the existing mechanism; do NOT invent a content-diff. Against existing memory: the Step 6 save-vs-update entity+topic protocol, unchanged — the synthesized HANDOFF+artifact entry enriches an existing entry exactly as a HANDOFF-only entry does. Against the HANDOFF's own content: the only new rule is **sequencing** — because step 3 synthesizes the HANDOFF and artifact into ONE entry, there is no separate artifact-entry to dedup; the single synthesis IS the dedup. (Idempotency: the existing processed-task ledger of Step 2/Step 8 extends to mark a `(workflow, feature)` artifact as read, so an incremental or consolidation re-harvest does not re-read and re-distill the same artifact.)
@@ -188,7 +203,7 @@ Gaps: {any HANDOFFs that were thin or missing}",
 ### Step 10: Gather Calibration Data
 
 After processing HANDOFFs, gather calibration metrics for the orchestrator's variety scoring feedback loop:
-- Read `initial_variety_score` from the journal's `variety_assessed` event (GC-proof, survives the task-store drain), using the Step 0 `session_dir`: `python3 -c "import sys; sys.path.insert(0, '{hooks_dir}'); from shared.session_journal import read_events_from; import json; [print(json.dumps(e)) for e in read_events_from('{session_dir}', 'variety_assessed')]"`. **Select the event for THIS feature** — `variety_assessed` events carry a `task_id`, and a resumed/multi-feature session holds one per feature (plus, because the platform reuses task_ids across arcs, the current feature's id can match a PRIOR arc too). So do NOT take the first event: filter to events whose `task_id` matches the feature task being harvested and take the **latest-`ts`** match — the `resolve_arc_start(events, feature_task_id)` semantics the wrap-up retrospective uses (`shared/variety_divergence.resolve_arc_start` is the canonical implementation). Then resolve the scalar total from that event's `variety` dict via the pure `resolve_variety_total(variety)` helper (`shared/teachback_schema.py`) rather than indexing `variety['total']` directly — it prefers the canonical `total` key, falls through a documented fallback chain, and returns `None` instead of raising `KeyError` if the dict is malformed or `total` is missing. If no `variety_assessed` event matches this feature (e.g., a feature dispatched without a variety emit), or `resolve_variety_total` returns `None`, ask the team-lead for the variety score instead.
+- Read `initial_variety_score` from the journal's `variety_assessed` event (GC-proof, survives the task-store drain), using the Step 0 `$SESSION_DIR` via the existing `session_journal.py read` subcommand: `python3 "{plugin_root}/hooks/shared/session_journal.py" read --session-dir "$SESSION_DIR" --type variety_assessed`. As in Step 1, `read` prints a **JSON ARRAY** — `json.loads` the whole stdout into a list, then iterate (not line-by-line). **Select the event for THIS feature** — `variety_assessed` events carry a `task_id`, and a resumed/multi-feature session holds one per feature (plus, because the platform reuses task_ids across arcs, the current feature's id can match a PRIOR arc too). So do NOT take the first event: filter to events whose `task_id` matches the feature task being harvested and take the **latest-`ts`** match — the `resolve_arc_start(events, feature_task_id)` semantics the wrap-up retrospective uses (`shared/variety_divergence.resolve_arc_start` is the canonical implementation). Then resolve the scalar total from that event's `variety` dict via the pure `resolve_variety_total(variety)` helper (`shared/teachback_schema.py`) rather than indexing `variety['total']` directly — it prefers the canonical `total` key, falls through a documented fallback chain, and returns `None` instead of raising `KeyError` if the dict is malformed or `total` is missing. If no `variety_assessed` event matches this feature (e.g., a feature dispatched without a variety emit), or `resolve_variety_total` returns `None`, ask the team-lead for the variety score instead.
 - Scan `TaskList` for blocker count (tasks with "BLOCKER:" in subject). Note: `TaskList` may be incomplete in long sessions due to garbage collection — report what's available.
 - Scan `TaskList` for phase rerun count (retry/redo phase tasks)
 - Note domain from feature task description

--- a/pact-plugin/skills/pact-handoff-harvest/SKILL.md
+++ b/pact-plugin/skills/pact-handoff-harvest/SKILL.md
@@ -26,11 +26,35 @@ Determine which variant to run from the task subject/description: "harvest" or "
 
 When reviewing multiple HANDOFFs, read ALL of them before saving any memories. This lets you deduplicate and consolidate across HANDOFFs before committing to pact-memory — producing cleaner entries than saving after each individual HANDOFF.
 
+### Step 0: Resolve the Session Directory (do this once)
+
+Resolve the absolute session directory **before any journal read**, and reuse that one value for every journal read below (Step 1 `agent_handoff`, Step 3.5 `artifact_paths`, and Step 10 `variety_assessed`). **Every journal read in this skill MUST pass this explicit `session_dir`** via `read_events_from(session_dir, ...)` — never the path-less `read_events(...)`.
+
+**Why this is load-bearing (not optional):** you run **off-lead** (a `pact-secretary` teammate). `read_events(...)` derives its path implicitly via `pact_context.get_session_dir()`, which **false-returns `''` in a teammate frame** (no persisted lead session context) → the read silently returns **0 events**. Off-lead, that would make the entire harvest — HANDOFF discovery, artifact recovery, and calibration — a silent no-op. `read_events_from(session_dir, ...)` takes the directory **explicitly** and is frame-independent (the same form the Orphaned-Recovery path below already uses).
+
+Reconstruct the directory from the per-session context file (the same construction `get_session_dir()` uses, but driven off the on-disk context file rather than the lead-gated helper that false-returns off-lead):
+
+1. Read `pact-session-context.json` from the session dir your dispatch placed you in (the same file the Orphaned-Recovery path references). It carries `session_id` and `project_dir`.
+2. Reconstruct: `slug = Path(project_dir).name`; then join `get_claude_config_dir() / "pact-sessions" / slug / session_id`. Use `get_claude_config_dir()` (from `shared.paths`) — do NOT hardcode `~/.claude`.
+
+```python
+import json, sys
+from pathlib import Path
+sys.path.insert(0, "{hooks_dir}")
+from shared.paths import get_claude_config_dir
+
+ctx = json.loads(Path("{context_file}").read_text())  # pact-session-context.json
+slug = Path(ctx["project_dir"]).name
+session_dir = str(get_claude_config_dir() / "pact-sessions" / slug / ctx["session_id"])
+```
+
+If the context file is missing or unreadable, **report the gap to the team-lead and stop** — do NOT fall back to the path-less `read_events(...)` (that silently re-introduces the off-lead false-empty bug). An unresolved `session_dir` is a reportable gap, not a degrade-to-implicit case.
+
 ### Step 1: Task Discovery
 
 You have two sources for finding completed agent tasks, in priority order:
 
-1. **Session journal** (primary, GC-proof): `~/.claude/pact-sessions/{slug}/{session_id}/session-journal.jsonl` — read `agent_handoff` events via `python3 -c "import sys; sys.path.insert(0, '{hooks_dir}'); from shared.session_journal import read_events; import json; [print(json.dumps(e)) for e in read_events('agent_handoff')]"`. Each event contains `{"type": "agent_handoff", "agent": "...", "task_id": "...", "task_subject": "...", "handoff": {...}, "ts": "..."}` — full HANDOFF content inline, garbage-collection-proof. **Deduplicate**: extract unique task_ids only.
+1. **Session journal** (primary, GC-proof): `{session_dir}/session-journal.jsonl` (the `session_dir` resolved in Step 0) — read `agent_handoff` events via `python3 -c "import sys; sys.path.insert(0, '{hooks_dir}'); from shared.session_journal import read_events_from; import json; [print(json.dumps(e)) for e in read_events_from('{session_dir}', 'agent_handoff')]"`. Each event contains `{"type": "agent_handoff", "agent": "...", "task_id": "...", "task_subject": "...", "handoff": {...}, "ts": "..."}` — full HANDOFF content inline, garbage-collection-proof. **Deduplicate**: extract unique task_ids only.
 2. **`TaskList`** (supplementary): Read `TaskList` for completed tasks owned by agents. Useful as a cross-reference and for catching tasks where the completion hook didn't fire. Note: the platform garbage-collects older task files during long sessions, so `TaskList` may be incomplete.
 
 If none of these sources have completed agent tasks, report "No pending HANDOFFs to review" and complete — this is normal when HANDOFFs were already processed by an earlier trigger (idempotent).
@@ -62,6 +86,15 @@ for task_id in unprocessed:
 ```
 
 Read all HANDOFFs before proceeding to extraction.
+
+### Step 3.5: Resolve and Read Phase Artifacts (always)
+
+Each phase's HANDOFF is the **distilled frame**; the phase's disk artifact (e.g. `docs/preparation/{feature}.md`, `docs/architecture/{feature}.md`, `docs/plans/{slug}-plan.md`, `docs/review/…`) is the **fuller substance**. The lead writes a path-only `artifact_paths` journal event pointing at each phase's artifact(s); that event lives in the journal (outside any worktree), so it survives `git worktree remove` even though the pointed-at file is worktree-ephemeral. **Always** resolve these events and fold the artifact substance into the same synthesis the HANDOFF drives.
+
+1. **Resolve** (masked-read-safe — uses the Step 0 `session_dir`): `events = read_events_from(session_dir, "artifact_paths")`. Filter to `event["feature"] == <this feature>`. Group the survivors by `event["workflow"]`; within each `workflow` group take the **latest-`ts`** event (supersede-by-`(workflow, feature)`). Each event carries the **COMPLETE** path-list for that `(workflow, feature)` (a full enumeration per emit, not a delta), so the latest event is self-sufficient — never merge across events. Result: one path-list per `(workflow, feature)`.
+2. **Read** each path in the surviving events' `paths` lists off disk. Paths are full-absolute; read them **while the worktree is live** (the `worktree-cleanup` harvest-before-teardown guard guarantees this ordering at the single teardown chokepoint). If a path no longer resolves (file already gone — the accepted abnormal-teardown edge), skip it, note the gap, and degrade to HANDOFF-only for that artifact.
+3. **Synthesize ONE entry from BOTH sources together** (NOT verbatim, NOT a second entry). For each work unit, produce a SINGLE pact-memory entry synthesized from the HANDOFF **and** its artifact: the artifact is the fuller substance, the HANDOFF is the distilled frame. A ~19 KB artifact becomes a **richer-but-bounded** entry (a few hundred tokens of decisions/lessons informed by the full substance) — do NOT store the raw artifact. Substance flows into the entry's `context`/`decisions`; put the artifact's path in an entity `notes` field (NOT a `files` field — that field is rejected on save).
+4. **Dedup** — reuse the existing mechanism; do NOT invent a content-diff. Against existing memory: the Step 6 save-vs-update entity+topic protocol, unchanged — the synthesized HANDOFF+artifact entry enriches an existing entry exactly as a HANDOFF-only entry does. Against the HANDOFF's own content: the only new rule is **sequencing** — because step 3 synthesizes the HANDOFF and artifact into ONE entry, there is no separate artifact-entry to dedup; the single synthesis IS the dedup. (Idempotency: the existing processed-task ledger of Step 2/Step 8 extends to mark a `(workflow, feature)` artifact as read, so an incremental or consolidation re-harvest does not re-read and re-distill the same artifact.)
 
 ### Step 4: Extract Institutional Knowledge
 
@@ -156,7 +189,7 @@ Gaps: {any HANDOFFs that were thin or missing}",
 ### Step 10: Gather Calibration Data
 
 After processing HANDOFFs, gather calibration metrics for the orchestrator's variety scoring feedback loop:
-- Read `initial_variety_score` from the journal's `variety_assessed` event (GC-proof, survives the task-store drain): `python3 -c "import sys; sys.path.insert(0, '{hooks_dir}'); from shared.session_journal import read_events; import json; [print(json.dumps(e)) for e in read_events('variety_assessed')]"`. **Select the event for THIS feature** — `variety_assessed` events carry a `task_id`, and a resumed/multi-feature session holds one per feature (plus, because the platform reuses task_ids across arcs, the current feature's id can match a PRIOR arc too). So do NOT take the first event: filter to events whose `task_id` matches the feature task being harvested and take the **latest-`ts`** match — the `resolve_arc_start(events, feature_task_id)` semantics the wrap-up retrospective uses (`shared/variety_divergence.resolve_arc_start` is the canonical implementation). Then resolve the scalar total from that event's `variety` dict via the pure `resolve_variety_total(variety)` helper (`shared/teachback_schema.py`) rather than indexing `variety['total']` directly — it prefers the canonical `total` key, falls through a documented fallback chain, and returns `None` instead of raising `KeyError` if the dict is malformed or `total` is missing. If no `variety_assessed` event matches this feature (e.g., a feature dispatched without a variety emit), or `resolve_variety_total` returns `None`, ask the team-lead for the variety score instead.
+- Read `initial_variety_score` from the journal's `variety_assessed` event (GC-proof, survives the task-store drain), using the Step 0 `session_dir`: `python3 -c "import sys; sys.path.insert(0, '{hooks_dir}'); from shared.session_journal import read_events_from; import json; [print(json.dumps(e)) for e in read_events_from('{session_dir}', 'variety_assessed')]"`. **Select the event for THIS feature** — `variety_assessed` events carry a `task_id`, and a resumed/multi-feature session holds one per feature (plus, because the platform reuses task_ids across arcs, the current feature's id can match a PRIOR arc too). So do NOT take the first event: filter to events whose `task_id` matches the feature task being harvested and take the **latest-`ts`** match — the `resolve_arc_start(events, feature_task_id)` semantics the wrap-up retrospective uses (`shared/variety_divergence.resolve_arc_start` is the canonical implementation). Then resolve the scalar total from that event's `variety` dict via the pure `resolve_variety_total(variety)` helper (`shared/teachback_schema.py`) rather than indexing `variety['total']` directly — it prefers the canonical `total` key, falls through a documented fallback chain, and returns `None` instead of raising `KeyError` if the dict is malformed or `total` is missing. If no `variety_assessed` event matches this feature (e.g., a feature dispatched without a variety emit), or `resolve_variety_total` returns `None`, ask the team-lead for the variety score instead.
 - Scan `TaskList` for blocker count (tasks with "BLOCKER:" in subject). Note: `TaskList` may be incomplete in long sessions due to garbage collection — report what's available.
 - Scan `TaskList` for phase rerun count (retry/redo phase tasks)
 - Note domain from feature task description

--- a/pact-plugin/skills/worktree-cleanup/SKILL.md
+++ b/pact-plugin/skills/worktree-cleanup/SKILL.md
@@ -36,6 +36,18 @@ git worktree list
 
 Present the list and ask: "Which worktree should I remove?"
 
+### Step 1.5: Harvest docs/ Artifacts Before Teardown
+
+`git worktree remove` deletes the worktree's `docs/` directory **irrecoverably** — that directory is gitignored and worktree-ephemeral, so the phase artifacts it holds (`docs/preparation/`, `docs/architecture/`, `docs/plans/`, `docs/review/`, `docs/decision-logs/`) are gone the instant the worktree is removed. Those artifacts are the **fuller substance** behind each phase's distilled HANDOFF. This step is the single chokepoint that protects them for **all** teardown callers — `peer-review` auto-cleanup, CONSOLIDATE sub-scope early-teardown, and manual `/PACT:worktree-cleanup` alike — so harvest MUST precede remove.
+
+Glob the target worktree's `docs/` for artifacts, then apply this conditional guard:
+
+- **Artifacts exist AND a secretary/team is reachable** (the normal workflow-driven teardown): trigger a secretary harvest of the worktree's `docs/` artifacts and **confirm it completes before** proceeding to Step 2. The secretary reads + distills each artifact into pact-memory (its `pact-handoff-harvest` Step 3.5 resolves `artifact_paths` events and reads the disk artifacts while the worktree is still live — this guard is what guarantees that liveness). Do NOT remove the worktree until the harvest is confirmed done.
+- **Artifacts exist but no secretary/team is reachable** (e.g. a manual cleanup in a fresh session with no active team): do NOT silently delete. Surface a **loud warning** that the worktree's `docs/` artifacts have NOT been harvested and will be **irrecoverably deleted** by removal, and let the user decide whether to proceed, harvest manually first, or abort.
+- **No `docs/` artifacts in the worktree**: nothing to protect — proceed directly to Step 2.
+
+This guard is conditional by design: it must NOT unconditionally block, or it would break the no-team manual-cleanup path. (A user who chooses `--force` past the loud warning is the accepted out-of-scope edge.)
+
 ### Step 2: Navigate to Repo Root and Remove the Worktree
 
 Before removal, the shell's working directory must NOT be inside the worktree being removed. Compute the repo root, `cd` to it, and remove the worktree — all in a single bash call. This is critical because if the shell CWD is inside the deleted worktree, all subsequent commands will fail.

--- a/pact-plugin/tests/test_artifact_paths_durability.py
+++ b/pact-plugin/tests/test_artifact_paths_durability.py
@@ -1,0 +1,592 @@
+"""
+#927 HANDOFF + artifact durability — comprehensive durability tests.
+
+Covers the four committed seams of the artifact_paths durability mechanism:
+  - session_journal.py     — artifact_paths event schema + read_events_from
+                             vs the off-lead-masked read_events (the masked-read
+                             seam) + supersede-by-(workflow,feature) latest-ts.
+  - task_lifecycle_gate.py — the lead-frame, fail-open emit BACKSTOP that nudges
+                             when a PREPARE/ARCHITECT phase completes with no
+                             artifact_paths event for its (workflow, feature).
+
+DISCIPLINE (per the locked plan + this session's plan-mode strategy):
+  - BOTH-MODES AXIS = is_lead / agent_type, NOT session_id. The emit/handoff/
+    backstop path keys on agent_type (LEAD = 'PACT:pact-orchestrator' /
+    'pact-orchestrator'; TEAMMATE = a pact-* type). The teammate-frame leg
+    asserts the backstop is ABSENT (the by-design lead-process-only boundary),
+    never present. Constructing a session_id-topology fixture here would test a
+    gate input this surface does not read (see the both-modes-axis-is-surface-
+    specific lesson banked in plan-mode).
+  - PHANTOM-GREEN GUARD: phase-task subjects + owners are seeded from THIS
+    session's real on-disk task shapes ('PREPARE: handoff-artifact-durability',
+    'ARCHITECT: handoff-artifact-durability', bare owner 'devops-engineer'),
+    not a synthetic shape the code expects. A fixture using owner
+    'pact-devops-engineer' (the agentType, not the owner) is the #1028 fake.
+  - DETERMINISM: reproduce the END-STATE (direct evaluate_lifecycle / read drive
+    + real on-disk journal file ops), never the async race. No sleeps, no
+    SendMessage, no real GC timing — GC/worktree-teardown is a real file removal.
+  - NON-MOCKED seam integration for the masked-read seam + the backstop journal
+    read: both task_lifecycle_gate and agent_handoff_emitter are in
+    SEAM_DEPENDENT_HOOKS, so these tests drive a REAL on-disk journal via
+    append_event/read_events_from over a tmp-redirected HOME + pact_context —
+    they never mock read_events / read_events_from / the gate.
+  - NON-VACUITY: source-removal counter-tests (remove the journal SOURCE and
+    prove recovery collapses) + a masked-read inversion (prove the off-lead leg
+    is false-empty for the RIGHT reason, not a missing fixture).
+
+Run with the 3.13.7 interpreter (default python3 has no pytest):
+    /Users/mj/.pyenv/versions/3.13.7/bin/python3 -m pytest \
+        pact-plugin/tests/test_artifact_paths_durability.py -rA
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import shared.pact_context as pact_context  # noqa: E402
+import task_lifecycle_gate as tlg  # noqa: E402
+from shared.session_journal import (  # noqa: E402
+    append_event,
+    make_event,
+    read_events,
+    read_events_from,
+)
+
+# --- agent_type axis constants (the both-modes discriminator for this surface) ---
+LEAD = "PACT:pact-orchestrator"
+LEAD_BARE = "pact-orchestrator"
+TEAMMATE = "pact-devops-engineer"
+
+# --- production-real seeds (this session's actual on-disk task shapes) ---
+FEATURE = "handoff-artifact-durability"
+PREPARE_SUBJECT = f"PREPARE: {FEATURE}"
+ARCHITECT_SUBJECT = f"ARCHITECT: {FEATURE}"
+# A real specialist owner is a BARE name; the pact-* token is the agentType
+# (config.json members[].agentType), NOT the owner. Phantom-green ground truth.
+BARE_OWNER = "devops-engineer"
+
+TEAM = "session-artifact-dur"
+SID = "aaaaaaaa-1111-2222-3333-444444444444"
+PROJECT_DIR = "/test/project"
+
+
+def _artifact_event(workflow, feature=FEATURE, paths=None, task_id=None, ts=None):
+    """Build a real artifact_paths event via make_event (auto-sets v/ts).
+
+    ts override lets a test pin supersede ordering deterministically.
+    """
+    if paths is None:
+        paths = [f"/abs/docs/{workflow}/{feature}.md"]
+    fields = {"workflow": workflow, "feature": feature, "paths": paths}
+    if task_id is not None:
+        fields["task_id"] = task_id
+    event = make_event("artifact_paths", **fields)
+    if ts is not None:
+        event["ts"] = ts
+    return event
+
+
+@pytest.fixture
+def live_env(tmp_path, monkeypatch, pact_context):
+    """Redirect HOME + session context to a tmp tree so append_event /
+    read_events / read_events_from write+read a REAL on-disk session journal.
+
+    Mirrors test_pr4_drain_survival_harvest.live_env — the canonical non-mocked
+    seam harness. Returns (tmp_path, session_dir) where session_dir is the
+    absolute on-disk session directory the explicit reader resolves.
+    """
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    pact_context(team_name=TEAM, session_id=SID, project_dir=PROJECT_DIR)
+    slug = Path(PROJECT_DIR).name
+    session_dir = tmp_path / ".claude" / "pact-sessions" / slug / SID
+    return tmp_path, str(session_dir)
+
+
+def _journal_file(tmp_path: Path) -> Path:
+    """Resolve the single on-disk journal file under the tmp sessions root —
+    so a non-vacuity arm can remove the SOURCE and prove recovery collapses."""
+    sessions_root = tmp_path / ".claude" / "pact-sessions"
+    matches = list(sessions_root.rglob("session-journal.jsonl"))
+    assert len(matches) == 1, f"expected one tmp journal, found {matches!r}"
+    return matches[0]
+
+
+def _payload(*, agent_type, subject, task_id="40", skipped=None, owner=None):
+    """Build a TaskUpdate(status=completed) PostToolUse frame for
+    evaluate_lifecycle. The both-modes axis is agent_type (is_lead reads it
+    directly); session_id is supplied by the live_env pact_context only for
+    journal-seam resolution, never as the gate discriminator."""
+    metadata: dict = {}
+    if skipped is not None:
+        metadata["skipped"] = skipped
+    task = {"id": task_id, "subject": subject, "owner": owner, "metadata": metadata}
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": task_id, "status": "completed"},
+        "tool_response": {"task": task},
+    }
+    if agent_type is not None:
+        payload["agent_type"] = agent_type
+    return payload
+
+
+def _has_backstop_advisory(advisories) -> bool:
+    return any(code == "artifact_paths_emit_missing" for code, _ in advisories)
+
+
+# =============================================================================
+# P2-6 SCHEMA — artifact_paths validates required {workflow,feature,paths:list}
+#                + optional task_id; list is a first-class registered type.
+# =============================================================================
+class TestSchema:
+    def test_valid_event_appends(self, live_env):
+        _tmp, session_dir = live_env
+        assert append_event(_artifact_event("prepare")) is True
+        events = read_events_from(session_dir, "artifact_paths")
+        assert len(events) == 1
+        assert events[0]["workflow"] == "prepare"
+        assert events[0]["feature"] == FEATURE
+        assert isinstance(events[0]["paths"], list)
+        assert events[0]["v"] == 1
+        assert "ts" in events[0]
+
+    def test_optional_task_id_accepted(self, live_env):
+        _tmp, session_dir = live_env
+        assert append_event(_artifact_event("architect", task_id="17")) is True
+        ev = read_events_from(session_dir, "artifact_paths")[0]
+        assert ev["task_id"] == "17"
+
+    @pytest.mark.parametrize("missing", ["workflow", "feature", "paths"])
+    def test_missing_required_field_rejected(self, live_env, missing):
+        """A required field absent → append_event refuses to write (returns
+        False), so the malformed event never lands in the journal."""
+        _tmp, session_dir = live_env
+        ev = _artifact_event("prepare")
+        del ev[missing]
+        assert append_event(ev) is False
+        assert read_events_from(session_dir, "artifact_paths") == []
+
+    def test_paths_wrong_type_rejected(self, live_env):
+        """paths typed `list` — a str fails isinstance(value, list)."""
+        _tmp, session_dir = live_env
+        ev = _artifact_event("prepare")
+        ev["paths"] = "/abs/docs/prepare/x.md"  # str, not list
+        assert append_event(ev) is False
+        assert read_events_from(session_dir, "artifact_paths") == []
+
+    def test_paths_list_is_first_class_multi(self, live_env):
+        """The PLURAL list is first-class: a >1-path enumeration is preserved
+        whole (a phase can write multiple files)."""
+        _tmp, session_dir = live_env
+        paths = [f"/abs/docs/prepare/{FEATURE}.md",
+                 f"/abs/docs/prepare/environment-model-{FEATURE}.md"]
+        assert append_event(_artifact_event("prepare", paths=paths)) is True
+        ev = read_events_from(session_dir, "artifact_paths")[0]
+        assert ev["paths"] == paths
+
+    def test_empty_paths_list_passes_isinstance_writer_caveat(self, live_env):
+        """Validator-depth caveat (arch §1.2): the schema checks
+        isinstance(paths, list) but does NOT descend into elements, so an EMPTY
+        list passes the validator. This pins the documented shallowness — the
+        WRITER (emit site) is responsible for dropping empty-glob emits; an
+        empty event is meaningless but not schema-rejected."""
+        _tmp, session_dir = live_env
+        assert append_event(_artifact_event("prepare", paths=[])) is True
+        ev = read_events_from(session_dir, "artifact_paths")[0]
+        assert ev["paths"] == []
+
+
+# =============================================================================
+# P0-2 ALWAYS-READ mechanics — read_events_from resolves the event;
+#       supersede-by-(workflow,feature) latest-ts picks the latest.
+# =============================================================================
+class TestAlwaysReadAndSupersede:
+    def test_read_events_from_resolves_event(self, live_env):
+        _tmp, session_dir = live_env
+        append_event(_artifact_event("architect", paths=["/abs/a.md"]))
+        events = read_events_from(session_dir, "artifact_paths")
+        assert [e["paths"] for e in events] == [["/abs/a.md"]]
+
+    def test_supersede_latest_ts_wins_per_workflow_feature(self, live_env):
+        """A re-emit for the same (workflow, feature) supersedes by latest-ts.
+        The resolver groups by (workflow, feature) and takes the latest event;
+        each event carries the COMPLETE path-list (not a delta)."""
+        _tmp, session_dir = live_env
+        append_event(_artifact_event(
+            "prepare", paths=["/abs/OLD.md"], ts="2026-06-25T01:00:00Z"))
+        append_event(_artifact_event(
+            "prepare", paths=["/abs/NEW.md"], ts="2026-06-25T02:00:00Z"))
+        events = read_events_from(session_dir, "artifact_paths")
+        # Both events persist (append-only journal); supersede is a READ-time
+        # resolution. Replicate the resolver: group by (workflow,feature), take
+        # latest-ts.
+        from datetime import datetime
+
+        def _key(e):
+            return datetime.fromisoformat(e["ts"].replace("Z", "+00:00"))
+        prepare = [e for e in events
+                   if e["workflow"] == "prepare" and e["feature"] == FEATURE]
+        latest = max(prepare, key=_key)
+        assert latest["paths"] == ["/abs/NEW.md"]
+        assert len(prepare) == 2  # both on disk; supersede is read-time only
+
+    def test_distinct_workflows_not_superseded(self, live_env):
+        """Supersede is per-(workflow,feature): prepare and architect events for
+        the same feature are distinct artifact sets, both survive resolution."""
+        _tmp, session_dir = live_env
+        append_event(_artifact_event("prepare", paths=["/abs/prep.md"]))
+        append_event(_artifact_event("architect", paths=["/abs/arch.md"]))
+        events = read_events_from(session_dir, "artifact_paths")
+        by_wf = {e["workflow"]: e["paths"] for e in events}
+        assert by_wf == {"prepare": ["/abs/prep.md"], "architect": ["/abs/arch.md"]}
+
+
+# =============================================================================
+# P0-3 FAILURE-PATH recovery — with the HANDOFF absent, the artifact is STILL
+#       resolvable via the artifact_paths pointer (HANDOFF-independent).
+# P0-1 BOUNDARY SEAL is exercised by TestBackstopBothModes (teammate-frame leg).
+# =============================================================================
+class TestFailurePathRecovery:
+    def test_artifact_resolvable_with_no_handoff_event(self, live_env):
+        """The durability guarantee: artifact recovery does NOT depend on any
+        agent_handoff event. Seed ONLY an artifact_paths event (no handoff) and
+        prove the pointer + disk read recover the substance."""
+        tmp_path, session_dir = live_env
+        artifact = tmp_path / "docs" / "prepare" / f"{FEATURE}.md"
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_text("PREPARE SUBSTANCE — recovered without a handoff",
+                            encoding="utf-8")
+        append_event(_artifact_event("prepare", paths=[str(artifact)]))
+
+        # No agent_handoff events exist at all.
+        assert read_events_from(session_dir, "agent_handoff") == []
+        # Yet the artifact is fully resolvable via the pointer.
+        events = read_events_from(session_dir, "artifact_paths")
+        assert len(events) == 1
+        recovered = Path(events[0]["paths"][0]).read_text(encoding="utf-8")
+        assert "recovered without a handoff" in recovered
+
+    def test_recovery_collapses_when_journal_source_removed(self, live_env):
+        """NON-VACUITY (source-removal): recovery is journal-SOURCED. Remove the
+        journal file and the artifact_paths read collapses to empty — proving
+        the recovery is not silently rescued by some surviving read."""
+        tmp_path, session_dir = live_env
+        append_event(_artifact_event("prepare", paths=["/abs/x.md"]))
+        assert len(read_events_from(session_dir, "artifact_paths")) == 1
+        _journal_file(tmp_path).unlink()
+        assert read_events_from(session_dir, "artifact_paths") == []
+
+
+# =============================================================================
+# P2-7 MASKED-READ SEAM — read_events() off-lead returns false-empty while
+#       read_events_from(session_dir) returns events. THE load-bearing dual-mode
+#       constraint (the secretary harvests off-lead). Non-mocked seam.
+# =============================================================================
+class TestMaskedReadSeam:
+    def test_implicit_read_resolves_when_context_present(self, live_env):
+        """Positive control: with the session context resolvable (the lead-frame
+        analogue — get_session_dir resolves), the implicit read_events() DOES
+        see the event. Proves the false-empty below is the off-lead masking, not
+        a missing fixture."""
+        _tmp, session_dir = live_env
+        append_event(_artifact_event("prepare"))
+        assert len(read_events("artifact_paths")) == 1
+        assert len(read_events_from(session_dir, "artifact_paths")) == 1
+
+    def test_implicit_read_false_empty_off_lead_explicit_resolves(
+        self, live_env, monkeypatch
+    ):
+        """THE seam: off-lead, get_session_dir() false-returns '' (teammate frame
+        has no persisted session context) → read_events() silently returns [].
+        read_events_from(session_dir, ...) with the explicit absolute dir still
+        resolves the SAME on-disk event. This is why the harvest MUST use
+        read_events_from."""
+        tmp_path, session_dir = live_env
+        append_event(_artifact_event("prepare"))
+        # Sanity: the event is really on disk.
+        assert _journal_file(tmp_path).exists()
+
+        # Simulate the off-lead frame: get_session_dir resolves '' (the real
+        # false-empty path — session_id/project_dir unavailable in a teammate
+        # frame). We patch get_session_dir at the resolution seam, NOT the read
+        # function itself (the read stays unmocked over the real journal).
+        monkeypatch.setattr(
+            "shared.session_journal._get_session_dir", lambda: ""
+        )
+        assert read_events("artifact_paths") == []  # false-empty off-lead
+        # The explicit reader is frame-independent — still finds the event.
+        assert len(read_events_from(session_dir, "artifact_paths")) == 1
+
+    def test_explicit_reader_empty_session_dir_returns_empty(self, live_env):
+        """read_events_from with an empty session_dir returns [] (the documented
+        empty-arg contract) — so a caller that fails to resolve session_dir gets
+        a visible empty, not a crash. Pins the no-silent-fallback boundary."""
+        _tmp, _session_dir = live_env
+        append_event(_artifact_event("prepare"))
+        assert read_events_from("", "artifact_paths") == []
+
+
+# =============================================================================
+# P0-1 BOUNDARY SEAL + P1-5 BACKSTOP — both-modes (is_lead/agent_type) matrix.
+#   The backstop fires a FAIL-OPEN advisory when a PREPARE/ARCHITECT phase
+#   completes with no artifact_paths event for its (workflow,feature).
+#   The teammate-frame leg asserts the backstop is ABSENT (lead-process-only
+#   boundary — the by-design self-drop; doubles as the empirical seal).
+# =============================================================================
+class TestBackstopBothModes:
+    @pytest.mark.parametrize("subject,workflow", [
+        (PREPARE_SUBJECT, "prepare"),
+        (ARCHITECT_SUBJECT, "architect"),
+    ])
+    def test_lead_missing_emit_fires_advisory(self, live_env, subject, workflow):
+        """LEAD frame + PREPARE/ARCHITECT complete + NO artifact_paths event for
+        (workflow,feature) → the nudge fires. The recovery pointer is missing."""
+        _tmp, _session_dir = live_env
+        advisories = tlg.evaluate_lifecycle(_payload(agent_type=LEAD, subject=subject))
+        assert _has_backstop_advisory(advisories), (
+            f"lead frame, {subject!r}, no emit → backstop must nudge"
+        )
+
+    def test_lead_with_emit_present_no_advisory(self, live_env):
+        """LEAD frame + the artifact_paths event PRESENT for (prepare,feature) →
+        no nudge. Same-fixture positive control proving the advisory above is the
+        presence check, not an unconditional fire."""
+        _tmp, _session_dir = live_env
+        append_event(_artifact_event("prepare"))
+        advisories = tlg.evaluate_lifecycle(
+            _payload(agent_type=LEAD, subject=PREPARE_SUBJECT))
+        assert not _has_backstop_advisory(advisories)
+
+    @pytest.mark.parametrize("lead_spelling", [LEAD, LEAD_BARE])
+    def test_both_lead_spellings_fire(self, live_env, lead_spelling):
+        """is_lead accepts both LEAD_AGENT_TYPES spellings."""
+        _tmp, _session_dir = live_env
+        advisories = tlg.evaluate_lifecycle(
+            _payload(agent_type=lead_spelling, subject=PREPARE_SUBJECT))
+        assert _has_backstop_advisory(advisories)
+
+    def test_teammate_frame_no_advisory_boundary_seal(self, live_env):
+        """BOUNDARY SEAL (P0-1): a teammate (off-lead) frame self-completing the
+        SAME PREPARE phase with NO emit produces NO backstop advisory — the
+        lead-process-only boundary. The teammate frame has no resolvable journal;
+        the backstop is is_lead-gated and correctly self-drops. This is the
+        accepted by-design boundary, asserted ABSENT (not present)."""
+        _tmp, _session_dir = live_env
+        advisories = tlg.evaluate_lifecycle(
+            _payload(agent_type=TEAMMATE, subject=PREPARE_SUBJECT))
+        assert not _has_backstop_advisory(advisories), (
+            "teammate frame must NOT nudge — lead-process-only boundary"
+        )
+
+    def test_teammate_then_lead_same_fixture_proves_gate_is_role(self, live_env):
+        """Non-vacuity for the boundary seal: the SAME (subject, no-emit) fixture
+        that is SILENT under the teammate frame FIRES under the lead frame —
+        proving the suppression is the is_lead role gate, not a missing
+        precondition."""
+        _tmp, _session_dir = live_env
+        teammate = tlg.evaluate_lifecycle(
+            _payload(agent_type=TEAMMATE, subject=PREPARE_SUBJECT))
+        lead = tlg.evaluate_lifecycle(
+            _payload(agent_type=LEAD, subject=PREPARE_SUBJECT))
+        assert not _has_backstop_advisory(teammate)
+        assert _has_backstop_advisory(lead)
+
+    @pytest.mark.parametrize("agent_type", ["", None])
+    def test_empty_or_missing_agent_type_no_advisory(self, live_env, agent_type):
+        """is_lead('') and is_lead(missing) are False (fail-safe default) → the
+        backstop self-drops, never nudges a non-lead frame."""
+        _tmp, _session_dir = live_env
+        advisories = tlg.evaluate_lifecycle(
+            _payload(agent_type=agent_type, subject=PREPARE_SUBJECT))
+        assert not _has_backstop_advisory(advisories)
+
+
+# =============================================================================
+# P1-5 BACKSTOP exemptions — skipped phases + non-artifact phases are exempt;
+#       the advisory NEVER blocks.
+# =============================================================================
+class TestBackstopExemptions:
+    @pytest.mark.parametrize("subject", [
+        f"CODE: {FEATURE}",
+        f"TEST: {FEATURE}",
+        f"ATOMIZE: {FEATURE}",
+        f"CONSOLIDATE: {FEATURE}",
+        f"backend-coder: implement {FEATURE}",  # a specialist work task
+    ])
+    def test_non_artifact_phase_exempt(self, live_env, subject):
+        """CODE/TEST/ATOMIZE/CONSOLIDATE/specialist subjects are NOT in the
+        phase→workflow map → _phase_artifact_requirement returns None → no nudge
+        (their artifacts are git-tracked or non-existent)."""
+        _tmp, _session_dir = live_env
+        advisories = tlg.evaluate_lifecycle(
+            _payload(agent_type=LEAD, subject=subject))
+        assert not _has_backstop_advisory(advisories)
+
+    def test_skipped_phase_exempt(self, live_env):
+        """A PREPARE phase marked metadata.skipped=True produced no artifact →
+        exempt even under the lead frame with no emit."""
+        _tmp, _session_dir = live_env
+        advisories = tlg.evaluate_lifecycle(
+            _payload(agent_type=LEAD, subject=PREPARE_SUBJECT, skipped=True))
+        assert not _has_backstop_advisory(advisories)
+
+    def test_advisory_never_blocks(self, live_env):
+        """The backstop is advisory-only: evaluate_lifecycle returns a list of
+        (code, message) advisories — it does NOT raise and does NOT emit a deny.
+        The nudge being present is informational; the TaskUpdate is never
+        blocked."""
+        _tmp, _session_dir = live_env
+        # No raise, returns a list, advisory present but harmless.
+        advisories = tlg.evaluate_lifecycle(
+            _payload(agent_type=LEAD, subject=PREPARE_SUBJECT))
+        assert isinstance(advisories, list)
+        for entry in advisories:
+            assert isinstance(entry, tuple) and len(entry) == 2
+
+
+# =============================================================================
+# P2-6 unit — _phase_artifact_requirement maps subjects to (workflow, feature)
+#       or None. Phantom-green-seeded from real subject shapes.
+# =============================================================================
+class TestPhaseArtifactRequirement:
+    def test_prepare_maps(self):
+        assert tlg._phase_artifact_requirement(PREPARE_SUBJECT) == ("prepare", FEATURE)
+
+    def test_architect_maps(self):
+        assert tlg._phase_artifact_requirement(ARCHITECT_SUBJECT) == ("architect", FEATURE)
+
+    @pytest.mark.parametrize("subject", [
+        f"CODE: {FEATURE}", f"TEST: {FEATURE}", f"ATOMIZE: {FEATURE}",
+        f"CONSOLIDATE: {FEATURE}", "random subject", "",
+    ])
+    def test_non_phase_returns_none(self, subject):
+        assert tlg._phase_artifact_requirement(subject) is None
+
+    def test_malformed_no_separator_returns_none(self):
+        """A subject startswith the prefix-token but no ': ' separator → degenerate
+        → None (fail open, no nudge on an unresolvable feature slug)."""
+        assert tlg._phase_artifact_requirement("PREPARE") is None
+        assert tlg._phase_artifact_requirement("PREPARE:") is None
+
+    def test_non_string_returns_none(self):
+        assert tlg._phase_artifact_requirement(None) is None
+        assert tlg._phase_artifact_requirement(123) is None
+
+
+# =============================================================================
+# P1-4 TIMING — the artifact_paths event/journal lives OUTSIDE the worktree
+#       (survives worktree teardown); paths are full-absolute.
+# =============================================================================
+class TestWorktreeSurvivalAndAbsolutePaths:
+    def test_journal_lives_outside_worktree(self, live_env):
+        """The journal resolves under ~/.claude/pact-sessions/, NOT under any
+        worktree — so a `git worktree remove` (modeled as removing a worktree
+        subtree) cannot touch it.
+
+        The LOAD-BEARING invariant is the PATH RELATIONSHIP: the journal abspath
+        is NOT a descendant of the worktree dir. Asserted via os.path.commonpath
+        (the journal/worktree common ancestor is NOT the worktree itself) — this
+        is the assertion that fails if a regression ever resolves the journal
+        INSIDE the worktree, at any nesting depth. Structural + real file ops."""
+        import os
+        tmp_path, session_dir = live_env
+        append_event(_artifact_event("prepare"))
+        journal = _journal_file(tmp_path).resolve()
+        sessions_root = (tmp_path / ".claude" / "pact-sessions").resolve()
+        worktree_dir = (tmp_path / "worktrees" / "feature-x").resolve()
+        worktree_dir.mkdir(parents=True, exist_ok=True)
+
+        # Path-relationship invariant: the journal is NOT under the worktree.
+        # commonpath(journal, worktree) == worktree IFF journal is inside the
+        # worktree — so the journal is outside exactly when it is NOT the
+        # worktree. (Equivalent not-descendant form: no startswith of the
+        # worktree dir + os.sep.)
+        common = os.path.commonpath([str(journal), str(worktree_dir)])
+        assert common != str(worktree_dir), (
+            f"journal {journal} must NOT be a descendant of worktree "
+            f"{worktree_dir} (commonpath={common})"
+        )
+        assert not str(journal).startswith(str(worktree_dir) + os.sep)
+        # And it IS under the (worktree-independent) sessions root.
+        assert os.path.commonpath([str(journal), str(sessions_root)]) == str(sessions_root)
+
+    def test_event_survives_worktree_subtree_removal(self, live_env):
+        """END-STATE determinism for 'survives git worktree remove': remove the
+        worktree subtree entirely (the real teardown effect on disk) and prove
+        the artifact_paths event is STILL resolvable from the journal."""
+        import shutil
+        tmp_path, session_dir = live_env
+        worktree_dir = tmp_path / "worktrees" / "feature-x"
+        (worktree_dir / "docs").mkdir(parents=True, exist_ok=True)
+        append_event(_artifact_event("prepare", paths=["/abs/docs/prepare/x.md"]))
+
+        # Model `git worktree remove`: the whole worktree subtree is deleted.
+        shutil.rmtree(worktree_dir)
+
+        # The journal (outside the worktree) is untouched; the pointer survives.
+        events = read_events_from(session_dir, "artifact_paths")
+        assert len(events) == 1
+        assert events[0]["paths"] == ["/abs/docs/prepare/x.md"]
+
+    def test_emitted_paths_are_absolute(self, live_env):
+        """The recovery pointer must be full-absolute (the harvest reads paths
+        off disk from any cwd). A relative path would be unresolvable at harvest
+        time from the secretary's frame."""
+        _tmp, session_dir = live_env
+        append_event(_artifact_event(
+            "architect", paths=["/abs/docs/architect/x.md", "/abs/docs/architect/y.md"]))
+        ev = read_events_from(session_dir, "artifact_paths")[0]
+        for p in ev["paths"]:
+            assert Path(p).is_absolute(), f"path must be absolute: {p!r}"
+
+
+# =============================================================================
+# P2-8 EDGES — missing artifact, malformed handoff coexistence, signal-task
+#       independence.
+# =============================================================================
+class TestEdges:
+    def test_missing_artifact_file_pointer_still_resolves(self, live_env):
+        """The event resolves even when the pointed-at file is already gone (the
+        accepted abnormal-teardown edge). The RESOLVER sees the pointer; the
+        read-off-disk step is where the gap is noted + degrades to HANDOFF-only.
+        This pins that the event layer is independent of file existence."""
+        _tmp, session_dir = live_env
+        append_event(_artifact_event("prepare", paths=["/abs/gone/missing.md"]))
+        events = read_events_from(session_dir, "artifact_paths")
+        assert len(events) == 1
+        assert not Path(events[0]["paths"][0]).exists()  # file gone; pointer survives
+
+    def test_artifact_paths_independent_of_agent_handoff(self, live_env):
+        """artifact_paths and agent_handoff are distinct event types — reading
+        one never returns the other; the durability pointer is independent of
+        HANDOFF presence in BOTH directions."""
+        _tmp, session_dir = live_env
+        append_event(_artifact_event("prepare"))
+        append_event(make_event(
+            "agent_handoff", agent=BARE_OWNER, task_id="27",
+            task_subject="devops-engineer: implement #927 journal mechanics",
+            handoff={"produced": "x", "decisions": "y", "uncertainty": "n",
+                     "integration": "n", "reasoning_chain": "b", "open_questions": "n"},
+        ))
+        artifacts = read_events_from(session_dir, "artifact_paths")
+        handoffs = read_events_from(session_dir, "agent_handoff")
+        assert len(artifacts) == 1 and artifacts[0]["type"] == "artifact_paths"
+        assert len(handoffs) == 1 and handoffs[0]["type"] == "agent_handoff"
+
+    def test_feature_scoping_filters_other_features(self, live_env):
+        """feature scopes the event to one arc: an artifact_paths event for a
+        DIFFERENT feature is not confused with this one (the multi-feature/
+        resumed-session disambiguation)."""
+        _tmp, session_dir = live_env
+        append_event(_artifact_event("prepare", feature=FEATURE, paths=["/abs/this.md"]))
+        append_event(_artifact_event("prepare", feature="other-feature", paths=["/abs/other.md"]))
+        events = read_events_from(session_dir, "artifact_paths")
+        this_feature = [e for e in events if e["feature"] == FEATURE]
+        assert len(this_feature) == 1
+        assert this_feature[0]["paths"] == ["/abs/this.md"]

--- a/pact-plugin/tests/test_artifact_paths_durability.py
+++ b/pact-plugin/tests/test_artifact_paths_durability.py
@@ -246,6 +246,42 @@ class TestAlwaysReadAndSupersede:
         by_wf = {e["workflow"]: e["paths"] for e in events}
         assert by_wf == {"prepare": ["/abs/prep.md"], "architect": ["/abs/arch.md"]}
 
+    def test_supersede_3_events_non_monotonic_order_independent(self, live_env):
+        """M1 (coverage gap closed): supersede picks latest-`ts` regardless of
+        the events' INSERTION order in the journal. The 2-event monotonic case
+        above cannot catch an order-dependent resolver (e.g. one that takes the
+        LAST-appended event instead of the latest-`ts`). Here the latest-`ts`
+        event (03:00) is appended in the MIDDLE of three re-emits — a correct
+        max-by-`ts` resolver still selects it; a take-last-appended bug would
+        wrongly select the 02:00 event.
+
+        Probe-confirmed sound against the journal's read order; this test PINS
+        that order-independence so a future resolver (executable or prose) can't
+        regress to insertion-order without going RED."""
+        _tmp, session_dir = live_env
+        append_event(_artifact_event(
+            "prepare", paths=["/abs/v1.md"], ts="2026-06-25T01:00:00Z"))
+        append_event(_artifact_event(
+            "prepare", paths=["/abs/v3-LATEST.md"], ts="2026-06-25T03:00:00Z"))
+        append_event(_artifact_event(
+            "prepare", paths=["/abs/v2.md"], ts="2026-06-25T02:00:00Z"))
+        events = read_events_from(session_dir, "artifact_paths")
+        from datetime import datetime
+
+        def _key(e):
+            return datetime.fromisoformat(e["ts"].replace("Z", "+00:00"))
+        prepare = [e for e in events
+                   if e["workflow"] == "prepare" and e["feature"] == FEATURE]
+        assert len(prepare) == 3
+        latest = max(prepare, key=_key)
+        assert latest["paths"] == ["/abs/v3-LATEST.md"], (
+            "latest-ts must win even when appended non-last"
+        )
+        # And the take-last-appended bug would have picked v2 (02:00) — assert
+        # the resolver does NOT collapse to insertion order.
+        assert prepare[-1]["paths"] == ["/abs/v2.md"]  # last-appended is v2
+        assert latest["paths"] != prepare[-1]["paths"]  # latest-ts != last-appended
+
 
 # =============================================================================
 # P0-3 FAILURE-PATH recovery — with the HANDOFF absent, the artifact is STILL
@@ -590,3 +626,135 @@ class TestEdges:
         this_feature = [e for e in events if e["feature"] == FEATURE]
         assert len(this_feature) == 1
         assert this_feature[0]["paths"] == ["/abs/this.md"]
+
+
+# =============================================================================
+# REMEDIATION REGRESSIONS — each must FAIL against the pre-fix code (non-vacuity)
+# and PASS once the corresponding remediation fix lands.
+# =============================================================================
+
+class TestF1NonDictLineDoesNotPoisonWholeFile:
+    """F1 regression (review FUTURE-1, promoted to in-PR fix): a single
+    valid-JSON-but-NON-DICT journal line ('[1,2,3]', '"str"', 'null') must NOT
+    drop the WHOLE file's events.
+
+    PRE-FIX: _read_events_at calls event.get('type') on every parsed line; a
+    non-dict parses fine, then .get() raises AttributeError, which escapes the
+    per-line (JSONDecodeError, ValueError) catch and propagates to the outer
+    except Exception → the entire file returns []. So a single non-dict line
+    silently drops ALL artifact_paths events AND ALL HANDOFFs at harvest — the
+    exact #927 silent-total-loss failure class.
+
+    POST-FIX (devops isinstance(event, dict) guard in _read_events_at): the
+    non-dict line is skipped per-line and the valid events survive.
+
+    This test FAILS pre-fix (returns 0) and PASSES post-fix (returns the valid
+    events) — non-vacuous by construction.
+    """
+
+    @pytest.mark.parametrize("bad_line", ["[1,2,3]", '"a string"', "null", "42"])
+    def test_nondict_line_skipped_valid_events_survive(self, live_env, bad_line):
+        tmp_path, session_dir = live_env
+        # Append two valid events via the real writer so the journal exists.
+        append_event(_artifact_event("prepare", paths=["/abs/p.md"]))
+        append_event(_artifact_event("architect", paths=["/abs/a.md"]))
+        # Inject a valid-JSON-but-non-dict line BETWEEN them on disk (real file).
+        journal = _journal_file(tmp_path)
+        lines = journal.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 2
+        journal.write_text(
+            lines[0] + "\n" + bad_line + "\n" + lines[1] + "\n", encoding="utf-8"
+        )
+        # The two valid artifact_paths events MUST still be returned (not 0).
+        events = read_events_from(session_dir, "artifact_paths")
+        by_wf = {e.get("workflow"): e.get("paths") for e in events
+                 if isinstance(e, dict)}
+        assert by_wf == {"prepare": ["/abs/p.md"], "architect": ["/abs/a.md"]}, (
+            f"a non-dict line ({bad_line!r}) must not poison the whole file; "
+            f"got {events!r}"
+        )
+
+
+class TestB1SessionDirReconstructSanitizationParity:
+    """B1 regression: the harvest's session-dir reconstruction MUST apply the
+    SAME path sanitization the writer applies, on BOTH axes (project-basename
+    slug + session_id), so the reconstructed path equals the writer's stored
+    path. Otherwise the harvest looks in the wrong directory and silently finds
+    no journal.
+
+    The writer (_build_session_path) runs the slug through
+    _UNSAFE_SLUG_CHARS_RE (e.g. 'my.project' → 'my_project'). The PRE-FIX
+    harvest reconstruction was a RAW join (Path(project_dir).name joined as-is),
+    so a DOTTED basename diverged → path mismatch → recovery miss. The clean-slug
+    suite cannot catch this because a no-special-char slug sanitizes to itself.
+
+    POST-FIX (devops reconstruct_session_dir helper): reconstruction applies the
+    same sanitization → paths match.
+
+    Probe-confirmed divergence: writer 'my_project' vs raw-join 'my.project'.
+    """
+
+    DOTTED_PROJECT = "/Users/x/my.project"
+    # session_id carrying a non-allowlist '.' — exercises the SECOND
+    # sanitization axis (the writer's init() sanitizes session_id too).
+    SESSION_ID = "abc.def-123"
+
+    def _writer_effective_path(self):
+        """The path the REAL writer actually writes the journal to.
+
+        ORACLE FIDELITY (load-bearing): the writer is init(), which sanitizes
+        BOTH the slug AND the session_id via _UNSAFE_SLUG_CHARS_RE BEFORE
+        calling _build_session_path. So the effective on-disk path uses the
+        SANITIZED session_id, not the raw one. Building the oracle from
+        _build_session_path(slug, RAW_session_id) would be a WRONG oracle (it
+        skips init's session_id sanitization) and would produce a false
+        mismatch — the parity bug is on the SLUG axis, and the helper must
+        mirror init on BOTH axes. We reproduce init's exact construction here.
+        """
+        import shared.pact_context as pc
+        from pathlib import Path
+        slug = Path(self.DOTTED_PROJECT).name
+        safe_slug = pc._UNSAFE_SLUG_CHARS_RE.sub("_", slug)
+        safe_sid = pc._UNSAFE_SLUG_CHARS_RE.sub("_", self.SESSION_ID)
+        return str(pc._build_session_path(safe_slug, safe_sid))
+
+    def test_raw_join_diverges_from_writer_path_documents_the_bug(self):
+        """Characterize the pre-fix bug directly: a RAW join over a dotted
+        basename (Path(project_dir).name joined as-is, no sanitization) does NOT
+        match the writer's sanitized path. This is the demonstration that the
+        pre-fix harvest raw-join missed the journal; the parity test below is the
+        regression guard that the helper fixes it."""
+        import shared.paths as paths
+        from pathlib import Path
+        slug = Path(self.DOTTED_PROJECT).name  # 'my.project' — keeps the dot
+        raw = str(paths.get_claude_config_dir()
+                  / "pact-sessions" / slug / self.SESSION_ID)
+        assert raw != self._writer_effective_path(), (
+            "expected the raw-join ('my.project') to diverge from the writer's "
+            "sanitized path ('my_project') on a dotted basename — if equal, the "
+            "bug premise is gone"
+        )
+
+    def test_reconstruct_helper_matches_writer_path(self):
+        """The remediation helper reconstructs the SAME path the writer wrote to,
+        applying the writer's sanitization on BOTH axes (slug + session_id).
+        PASSES post-fix (helper present + sanitization-parity); the clean-slug
+        suite cannot catch a sanitization-axis regression because a no-special-
+        char slug sanitizes to itself.
+
+        Helper name/location: shared.pact_context.reconstruct_session_dir
+        (devops #44). If absent (pre-fix), the assert below names it as the
+        expected pre-fix FAIL.
+        """
+        import shared.pact_context as pc
+        reconstruct = getattr(pc, "reconstruct_session_dir", None)
+        assert reconstruct is not None, (
+            "PRE-FIX: reconstruct_session_dir not yet landed (devops #44) — "
+            "expected pre-fix FAIL; flips to PASS post-fix."
+        )
+        got = str(reconstruct(self.DOTTED_PROJECT, self.SESSION_ID))
+        assert got == self._writer_effective_path(), (
+            f"harvest reconstruct {got!r} must equal the writer's effective "
+            f"path {self._writer_effective_path()!r} (sanitization parity on "
+            f"slug + session_id)"
+        )

--- a/pact-plugin/tests/test_artifact_paths_durability.py
+++ b/pact-plugin/tests/test_artifact_paths_durability.py
@@ -56,6 +56,7 @@ from shared.session_journal import (  # noqa: E402
     make_event,
     read_events,
     read_events_from,
+    read_last_event_from,
 )
 
 # --- agent_type axis constants (the both-modes discriminator for this surface) ---
@@ -673,6 +674,48 @@ class TestF1NonDictLineDoesNotPoisonWholeFile:
             f"a non-dict line ({bad_line!r}) must not poison the whole file; "
             f"got {events!r}"
         )
+
+
+class TestF1SiblingScanPathLastEventSurvivesNonDictLine:
+    """F1 sibling (the SECOND read path devops hardened in the same fix): the
+    REVERSE-scan path `_scan_lines_for_event` — reached via `read_last_event_from`
+    — must ALSO survive a non-dict line. F1 above covers the FORWARD read
+    (`read_events_from` → `_read_events_at`); this covers the reverse read.
+
+    PRE-FIX: the reverse scan calls `event.get(...)` on each parsed line; a
+    non-dict line raises AttributeError, escapes the per-line
+    (JSONDecodeError, ValueError) catch, propagates to the outer except, and the
+    scan returns None — so `read_last_event_from` reports the target event as
+    'not found' even though it is present. Distinct, concrete consequence (per
+    the production docstring): `session_end` would conclude the session was
+    NEVER paused.
+
+    POST-FIX (devops `isinstance(event, dict)` guard in `_scan_lines_for_event`,
+    parity with `_read_events_at`): the non-dict line is skipped and the target
+    event is found.
+
+    Non-vacuous: FAILS pre-fix (None), PASSES post-fix. Counter-test: revert
+    session_journal.py → 4 RED (same fix file as the forward-read F1).
+    """
+
+    @pytest.mark.parametrize("bad_line", ["[1,2,3]", '"a string"', "null", "42"])
+    def test_nondict_line_does_not_hide_last_event(self, live_env, bad_line):
+        tmp_path, session_dir = live_env
+        # A target artifact_paths event, then a non-dict line AFTER it on disk —
+        # so the REVERSE scan hits the bad line BEFORE reaching the target.
+        append_event(_artifact_event("prepare", paths=["/abs/p.md"]))
+        journal = _journal_file(tmp_path)
+        lines = journal.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        journal.write_text(lines[0] + "\n" + bad_line + "\n", encoding="utf-8")
+        # The reverse scan must skip the trailing non-dict line and find the
+        # target — not return None.
+        ev = read_last_event_from(session_dir, "artifact_paths")
+        assert ev is not None, (
+            f"a trailing non-dict line ({bad_line!r}) must not hide the last "
+            f"event in the reverse scan (read_last_event_from returned None)"
+        )
+        assert ev.get("paths") == ["/abs/p.md"]
 
 
 class TestB1SessionDirReconstructSanitizationParity:

--- a/pact-plugin/tests/test_commands_structure.py
+++ b/pact-plugin/tests/test_commands_structure.py
@@ -669,9 +669,9 @@ class TestPerLoopDispatchSites:
     # (relative_command_path, lead_in_line_number_1based, role_or_phase_label).
     SITES = [
         ("orchestrate.md", 463, "PREPARE"),
-        ("orchestrate.md", 558, "ARCHITECT"),
-        ("orchestrate.md", 681, "CODE"),
-        ("orchestrate.md", 816, "TEST"),
+        ("orchestrate.md", 569, "ARCHITECT"),
+        ("orchestrate.md", 703, "CODE"),
+        ("orchestrate.md", 848, "TEST"),
         ("comPACT.md", 233, "MultipleSpecialists"),
         ("comPACT.md", 293, "SingleSpecialist"),
         ("peer-review.md", 192, "Reviewers"),

--- a/pact-plugin/tests/test_commands_structure.py
+++ b/pact-plugin/tests/test_commands_structure.py
@@ -669,9 +669,9 @@ class TestPerLoopDispatchSites:
     # (relative_command_path, lead_in_line_number_1based, role_or_phase_label).
     SITES = [
         ("orchestrate.md", 463, "PREPARE"),
-        ("orchestrate.md", 569, "ARCHITECT"),
-        ("orchestrate.md", 703, "CODE"),
-        ("orchestrate.md", 848, "TEST"),
+        ("orchestrate.md", 570, "ARCHITECT"),
+        ("orchestrate.md", 705, "CODE"),
+        ("orchestrate.md", 850, "TEST"),
         ("comPACT.md", 233, "MultipleSpecialists"),
         ("comPACT.md", 293, "SingleSpecialist"),
         ("peer-review.md", 192, "Reviewers"),

--- a/pact-plugin/tests/test_pact_harvest_cli.py
+++ b/pact-plugin/tests/test_pact_harvest_cli.py
@@ -55,6 +55,7 @@ _HOOKS_DIR = Path(__file__).parent.parent / "hooks"
 sys.path.insert(0, str(_HOOKS_DIR))
 
 import shared.pact_context as pact_context  # noqa: E402
+from shared.pact_harvest import _resolve_session_dir  # noqa: E402
 from shared.session_journal import (  # noqa: E402
     append_event,
     make_event,
@@ -242,6 +243,22 @@ class TestResolveSessionDirSubprocess:
         )
         # And concretely: the dot/space are gone from BOTH path segments.
         assert "my_project_dir" in out and "abc_def_123" in out
+
+    def test_nul_byte_path_is_bad_input_not_crash(self, capsys):
+        """A context-file path with an embedded NUL byte raises ValueError from
+        Path.read_text ('embedded null byte') — it must be handled as bad-input
+        (exit 2 + empty stdout + stderr diagnostic), NOT an uncaught exit-1
+        crash. Exercised IN-PROCESS by calling the handler directly: the CLI
+        subprocess can't carry a NUL in argv (execve strips it), so the guard is
+        unreachable via _run_cli; this is the only way to drive the path.
+        Regression-proof: dropping ValueError from the read's except clause lets
+        the ValueError escape the handler -> this raises instead of returning 2,
+        going RED."""
+        rc = _resolve_session_dir("/tmp/ctx\x00.json")
+        assert rc == _EXIT_UNRESOLVED, "NUL path must be bad-input (exit 2), not a crash"
+        captured = capsys.readouterr()
+        assert captured.out == "", "exit-2 path must emit EMPTY stdout"
+        assert "embedded null byte" in captured.err
 
     @pytest.mark.parametrize("scenario", ["missing_file", "bad_json", "not_object",
                                           "falsy_project", "falsy_session"])

--- a/pact-plugin/tests/test_pact_harvest_cli.py
+++ b/pact-plugin/tests/test_pact_harvest_cli.py
@@ -161,6 +161,35 @@ class TestResolveLatestArtifacts:
         assert resolve_latest_artifacts([good, no_ts], self.FEATURE) == {"prepare": ["/good.md"]}
         assert resolve_latest_artifacts([no_ts, good], self.FEATURE) == {"prepare": ["/good.md"]}
 
+    def test_equal_ts_tie_break_is_last_wins(self):
+        """Same-second double-emit: on a byte-IDENTICAL ts in the same
+        (workflow, feature) group, the LAST-written event (iterated later in
+        journal order) supersedes — `make_event` stamps ts at second
+        granularity, so two emits of the same phase doc can collide and the
+        authoritative one is the later complete snapshot. Both orderings are
+        asserted so the result tracks journal order, not insertion luck: a
+        first-wins (`>` instead of `>=`) regression flips BOTH and goes RED."""
+        first = _art_event("prepare", self.FEATURE, ["/first.md"], "2026-06-25T01:00:00Z")
+        second = _art_event("prepare", self.FEATURE, ["/second.md"], "2026-06-25T01:00:00Z")
+        assert resolve_latest_artifacts([first, second], self.FEATURE) == {"prepare": ["/second.md"]}
+        assert resolve_latest_artifacts([second, first], self.FEATURE) == {"prepare": ["/first.md"]}
+
+    def test_parseable_naive_vs_aware_ts_does_not_crash(self):
+        """A parseable-but-tz-NAIVE ts (date-only) alongside the normal aware
+        ...Z ts must NOT crash the resolution. Both parse via _parse_ts but are
+        incomparable (offset-naive vs offset-aware), which a strict
+        `candidate > incumbent` OUTSIDE the parse-guard would let raise
+        TypeError, escaping resolve_latest_artifacts. The fail-open guard keeps
+        the incumbent instead. Regression-proof: reverting the comparison-guard
+        makes this raise TypeError -> RED. Trigger requires a corrupted journal
+        (make_event always stamps aware-Z); this pins graceful degradation."""
+        aware = _art_event("prepare", self.FEATURE, ["/aware.md"], "2026-06-25T03:00:00Z")
+        naive = {"type": "artifact_paths", "workflow": "prepare",
+                 "feature": self.FEATURE, "paths": ["/naive.md"], "ts": "2026-06-25"}
+        # Must not raise in either order; result is fail-open (incumbent kept).
+        assert resolve_latest_artifacts([aware, naive], self.FEATURE) == {"prepare": ["/aware.md"]}
+        assert resolve_latest_artifacts([naive, aware], self.FEATURE) == {"prepare": ["/naive.md"]}
+
 
 # =============================================================================
 # (2) SUBPROCESS — resolve-session-dir contract + THE B1-CLASS DRIFT PARITY.
@@ -353,3 +382,90 @@ class TestReadEmitsJsonArrayContract:
             "1/10 parse); a regression to JSONL would break the reused read"
         )
         assert len(parsed) == 1 and parsed[0]["type"] == "agent_handoff"
+
+
+# =============================================================================
+# (6) ARGPARSE CONTRACT — a missing or unknown subcommand must exit NON-ZERO
+#     (argparse's 2), so the skill's `if ! out=$(...); then stop; fi` gate
+#     still STOPS rather than falling through to a path-less read. `sub.required
+#     = True` is what enforces this; a regression to required=False would let a
+#     no-arg invocation exit 0 (return _EXIT_INTERNAL_ERROR is unreachable today
+#     but a silent contract change) — this pins the stop-gate-compatible code.
+# =============================================================================
+class TestSubcommandArgparseContract:
+    def test_no_subcommand_exits_nonzero_stop_gate(self):
+        """No subcommand -> argparse error -> exit 2 (non-zero). The skill keys
+        its stop branch on the exit code, so any non-zero is a stop; assert it
+        is NOT 0 and concretely the argparse 2."""
+        r = _run_cli()
+        assert r.returncode != _EXIT_OK, "no-subcommand must not exit 0"
+        assert r.returncode == 2, f"expected argparse exit 2, got {r.returncode}"
+
+    def test_unknown_subcommand_exits_nonzero_stop_gate(self):
+        """An invalid subcommand choice -> argparse error -> exit 2."""
+        r = _run_cli("definitely-not-a-subcommand")
+        assert r.returncode != _EXIT_OK, "unknown-subcommand must not exit 0"
+        assert r.returncode == 2, f"expected argparse exit 2, got {r.returncode}"
+
+
+# =============================================================================
+# (7) TRAVERSAL DEFENSE + GRACEFUL-TS — through the real CLI.
+#     (a) A traversal session_id ('../../etc/passwd') must be SANITIZED away,
+#         leaving no '..' segment that could escape the pact-sessions tree.
+#     (b) A corrupted journal with a parseable-but-naive ts must NOT crash
+#         resolve-artifacts (exit 1 + traceback); it degrades gracefully.
+# =============================================================================
+class TestTraversalAndGracefulTs:
+    def test_traversal_session_id_is_sanitized_no_escape(self, tmp_path):
+        """A '../../etc/passwd' session_id reconstructs INSIDE pact-sessions
+        with the traversal characters collapsed (no '..' segment, stays under
+        the sessions root). Oracle = the SSOT reconstruct_session_dir; the
+        independent non-vacuity check is the structural 'no ..' / 'under root'
+        assertion (a sanitization regression would leave a '..' segment)."""
+        ctx = tmp_path / "pact-session-context.json"
+        ctx.write_text(json.dumps(
+            {"project_dir": "/clean/project", "session_id": "../../etc/passwd"}),
+            encoding="utf-8")
+        r = _run_cli("resolve-session-dir", "--context-file", str(ctx))
+        assert r.returncode == _EXIT_OK
+        out = r.stdout.strip()
+        # Parity with the SSOT writer-derivation (load-bearing).
+        assert out == pact_context.reconstruct_session_dir(
+            "/clean/project", "../../etc/passwd")
+        # Non-vacuity: the traversal is neutralized — no '..' path segment, and
+        # the resolved dir stays under the pact-sessions tree.
+        parts = Path(out).parts
+        assert ".." not in parts, f"traversal not sanitized: {out!r}"
+        assert "pact-sessions" in parts
+        sessions_idx = parts.index("pact-sessions")
+        # Everything after pact-sessions is the sanitized slug + session_id —
+        # no segment escapes upward.
+        assert all(p != ".." for p in parts[sessions_idx:])
+
+    def test_resolve_artifacts_naive_ts_does_not_crash_via_cli(
+        self, tmp_path, monkeypatch, pact_context):
+        """End-to-end: a corrupted journal carrying one aware-Z and one
+        parseable-but-naive ts for the same (workflow, feature) must NOT crash
+        the CLI. Before the comparison-guard fix this exited 1 with a TypeError
+        traceback; now it exits 0 and emits a valid JSON object (the incumbent
+        survives, fail-open). Regression-proof: reverting the guard makes this
+        exit 1 -> RED."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name="t", session_id="sid-naive", project_dir="/proj")
+        slug = Path("/proj").name
+        session_dir = tmp_path / ".claude" / "pact-sessions" / slug / "sid-naive"
+        feature = "feat-naive"
+        append_event(_art_event("prepare", feature, ["/aware.md"], "2026-06-25T03:00:00Z"))
+        # A hand-corrupted naive (date-only) ts — only reachable via a mangled
+        # journal, since make_event always stamps aware-Z.
+        append_event({"v": 1, "type": "artifact_paths", "workflow": "prepare",
+                      "feature": feature, "paths": ["/naive.md"], "ts": "2026-06-25"})
+        r = _run_cli("resolve-artifacts", "--session-dir", str(session_dir),
+                     "--feature", feature)
+        assert r.returncode == _EXIT_OK, (
+            f"naive-vs-aware ts must degrade gracefully, not crash; "
+            f"rc={r.returncode} stderr={r.stderr!r}"
+        )
+        assert "TypeError" not in r.stderr
+        # A valid JSON object is emitted; the well-formed aware event survives.
+        assert json.loads(r.stdout) == {"prepare": ["/aware.md"]}

--- a/pact-plugin/tests/test_pact_harvest_cli.py
+++ b/pact-plugin/tests/test_pact_harvest_cli.py
@@ -177,21 +177,33 @@ class TestResolveLatestArtifacts:
         assert resolve_latest_artifacts([first, second], self.FEATURE) == {"prepare": ["/second.md"]}
         assert resolve_latest_artifacts([second, first], self.FEATURE) == {"prepare": ["/first.md"]}
 
-    def test_parseable_naive_vs_aware_ts_does_not_crash(self):
-        """A parseable-but-tz-NAIVE ts (date-only) alongside the normal aware
-        ...Z ts must NOT crash the resolution. Both parse via _parse_ts but are
-        incomparable (offset-naive vs offset-aware), which a strict
-        `candidate > incumbent` OUTSIDE the parse-guard would let raise
-        TypeError, escaping resolve_latest_artifacts. The fail-open guard keeps
-        the incumbent instead. Regression-proof: reverting the comparison-guard
-        makes this raise TypeError -> RED. Trigger requires a corrupted journal
-        (make_event always stamps aware-Z); this pins graceful degradation."""
-        aware = _art_event("prepare", self.FEATURE, ["/aware.md"], "2026-06-25T03:00:00Z")
-        naive = {"type": "artifact_paths", "workflow": "prepare",
-                 "feature": self.FEATURE, "paths": ["/naive.md"], "ts": "2026-06-25"}
-        # Must not raise in either order; result is fail-open (incumbent kept).
-        assert resolve_latest_artifacts([aware, naive], self.FEATURE) == {"prepare": ["/aware.md"]}
-        assert resolve_latest_artifacts([naive, aware], self.FEATURE) == {"prepare": ["/naive.md"]}
+    def test_naive_vs_aware_ts_compares_by_utc_assumed_instant(self):
+        """A parseable-but-tz-NAIVE ts is assumed UTC and compared by actual
+        INSTANT against an aware `...Z` ts — instead of raising TypeError and
+        fail-open keeping the (possibly stale) incumbent. No crash either way.
+        Trigger requires a corrupted journal (make_event always stamps aware-Z).
+
+        Key case (the LOW fix): when the NAIVE value is the LATER instant it now
+        SUPERSEDES the earlier aware incumbent. RED-on-revert: dropping the
+        coerce-to-aware makes `candidate >= incumbent` raise TypeError -> the
+        kept outer try/except returns False -> the stale aware incumbent is kept
+        -> the first assertion flips RED."""
+        aware_early = _art_event(
+            "prepare", self.FEATURE, ["/aware.md"], "2026-06-25T01:00:00Z")
+        naive_late = {"type": "artifact_paths", "workflow": "prepare",
+                      "feature": self.FEATURE, "paths": ["/naive.md"],
+                      "ts": "2026-06-25T05:00:00"}  # naive -> 05:00 UTC > 01:00
+        # Naive value is the later instant -> supersedes the aware incumbent.
+        assert resolve_latest_artifacts(
+            [aware_early, naive_late], self.FEATURE) == {"prepare": ["/naive.md"]}
+        # Symmetric: an aware value later than a naive one still wins (no crash).
+        aware_late = _art_event(
+            "prepare", self.FEATURE, ["/aware2.md"], "2026-06-25T09:00:00Z")
+        naive_early = {"type": "artifact_paths", "workflow": "prepare",
+                       "feature": self.FEATURE, "paths": ["/naive2.md"],
+                       "ts": "2026-06-25T02:00:00"}
+        assert resolve_latest_artifacts(
+            [naive_early, aware_late], self.FEATURE) == {"prepare": ["/aware2.md"]}
 
     def test_mixed_z_and_offset_ts_compare_by_instant_last_wins(self):
         """Belt-and-suspenders: a `...Z` ts and an equal-instant `...+00:00` ts
@@ -534,10 +546,11 @@ class TestTraversalAndGracefulTs:
         self, tmp_path, monkeypatch, pact_context):
         """End-to-end: a corrupted journal carrying one aware-Z and one
         parseable-but-naive ts for the same (workflow, feature) must NOT crash
-        the CLI. Before the comparison-guard fix this exited 1 with a TypeError
-        traceback; now it exits 0 and emits a valid JSON object (the incumbent
-        survives, fail-open). Regression-proof: reverting the guard makes this
-        exit 1 -> RED."""
+        the CLI. The naive ts is assumed UTC and compared by instant: here the
+        aware 03:00Z event is the LATER instant, so it survives over the 00:00
+        (UTC-assumed) naive event. Exits 0 with valid JSON and no TypeError
+        traceback. (Before any naive/aware handling this raised TypeError ->
+        exit 1.)"""
         # CLAUDE_CONFIG_DIR (not just Path.home) so the SUBPROCESS's --session-dir
         # containment check resolves the same tmp root — the home monkeypatch is
         # not inherited by the child; the env var is.
@@ -559,7 +572,7 @@ class TestTraversalAndGracefulTs:
             f"rc={r.returncode} stderr={r.stderr!r}"
         )
         assert "TypeError" not in r.stderr
-        # A valid JSON object is emitted; the well-formed aware event survives.
+        # A valid JSON object is emitted; the later-instant aware event survives.
         assert json.loads(r.stdout) == {"prepare": ["/aware.md"]}
 
 

--- a/pact-plugin/tests/test_pact_harvest_cli.py
+++ b/pact-plugin/tests/test_pact_harvest_cli.py
@@ -1,0 +1,355 @@
+"""
+Durable test suite for the pact_harvest CLI extraction (#1034/#927).
+
+Covers the harvest-domain CLI (hooks/shared/pact_harvest.py) + the pure
+resolve_latest_artifacts helper (hooks/shared/session_journal.py), which replace
+the previously-untestable inline-Python glue the pact-handoff-harvest skill ran.
+(This closes the #927 review's MINOR-2: the supersede was prose only.)
+
+THREAT MODEL → TEST MAPPING (why each block exists):
+  - The secretary runs the harvest OFF-LEAD, where pact_context.get_session_dir()
+    / read_events() false-return '' → 0 events silently. The CLI exists to give
+    the skill explicit-path, masked-read-safe entry points. So the load-bearing
+    tests are: (a) the B1-CLASS DRIFT PARITY — resolve-session-dir on a
+    special-char project_dir/session_id reconstructs the SANITIZED path the
+    writer actually wrote to (NO drift); this is the exact bug class clean-
+    basename masking hid in #927 and only cross-lane review caught. (b) The
+    EXIT-CODE contract (0=proceed-incl-empty, 2=stop, never 1) — the skill keys
+    its "report the gap and STOP, do not fall back to a path-less read" branch on
+    the exit code, never on parsing stdout. (c) The IMPORT-SEAM — the direct-
+    script sys.path bootstrap that makes `from shared.pact_context` resolve;
+    without it the CLI is dead in script mode (pact_context has package-relative
+    imports). (d) The ARRAY-PARSE contract the rewritten skill Steps 1/10 rely on.
+
+FIDELITY SPLIT (lead-confirmed): TRUE direct-script subprocess for the CLI
+contract / exit-code / empty-stdout / import-seam tests (those properties only
+exist in script mode); in-process direct calls for the pure helper units.
+
+B1-ORACLE DISCIPLINE (lead-confirmed, avoids the #927 wrong-oracle near-miss):
+the expected sanitized path is DERIVED from the SSOT — reconstruct_session_dir
+called directly — NOT hand-built. A hand-built path that under-sanitizes would
+agree with a buggy CLI (vacuous green). A companion assertion proves a raw
+un-sanitized join DIFFERS, so the special-char input actually triggers
+sanitization (defeating clean-basename masking).
+
+NON-VACUITY: documented per-test in the HANDOFF; spot-proven via source mutation
+(flip an exit code / break supersede / remove the bootstrap → the matching test
+goes RED). The B1 parity test's raw-join-differs companion is its in-suite
+non-vacuity guard.
+
+Run on the 3.13.7 interpreter (default python3 has no pytest):
+    /Users/mj/.pyenv/versions/3.13.7/bin/python3 -m pytest \
+        pact-plugin/tests/test_pact_harvest_cli.py -rA
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).parent.parent / "hooks"
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import shared.pact_context as pact_context  # noqa: E402
+from shared.session_journal import (  # noqa: E402
+    append_event,
+    make_event,
+    resolve_latest_artifacts,
+)
+
+_CLI = _HOOKS_DIR / "shared" / "pact_harvest.py"
+_PY = "/Users/mj/.pyenv/versions/3.13.7/bin/python3"
+
+# Exit-code contract (must match pact_harvest.py).
+_EXIT_OK = 0
+_EXIT_INTERNAL_ERROR = 1
+_EXIT_UNRESOLVED = 2
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    """Invoke the CLI as a TRUE direct-script subprocess (script mode — the
+    only mode where the sys.path bootstrap, exit codes, and stdout contract
+    actually exist). Uses the same interpreter the suite runs under."""
+    return subprocess.run(
+        [sys.executable, str(_CLI), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _art_event(workflow, feature, paths, ts, task_id=None):
+    fields = {"workflow": workflow, "feature": feature, "paths": paths}
+    if task_id is not None:
+        fields["task_id"] = task_id
+    ev = make_event("artifact_paths", **fields)
+    ev["ts"] = ts
+    return ev
+
+
+# =============================================================================
+# (1) PURE UNIT — resolve_latest_artifacts (in-process; no subprocess needed).
+# =============================================================================
+class TestResolveLatestArtifacts:
+    FEATURE = "feat-x"
+
+    def test_supersede_latest_ts_wins_per_workflow(self):
+        events = [
+            _art_event("prepare", self.FEATURE, ["/OLD.md"], "2026-06-25T01:00:00Z"),
+            _art_event("prepare", self.FEATURE, ["/NEW.md"], "2026-06-25T03:00:00Z"),
+            _art_event("prepare", self.FEATURE, ["/MID.md"], "2026-06-25T02:00:00Z"),
+        ]
+        assert resolve_latest_artifacts(events, self.FEATURE) == {"prepare": ["/NEW.md"]}
+
+    def test_complete_path_list_never_merged_across_events(self):
+        """Each event carries the COMPLETE list; supersede REPLACES, never
+        unions. The latest event's 1-path list wins whole over a prior 2-path
+        list — a merge bug would yield 3 paths."""
+        events = [
+            _art_event("prepare", self.FEATURE, ["/a.md", "/b.md"], "2026-06-25T01:00:00Z"),
+            _art_event("prepare", self.FEATURE, ["/c.md"], "2026-06-25T02:00:00Z"),
+        ]
+        assert resolve_latest_artifacts(events, self.FEATURE) == {"prepare": ["/c.md"]}
+
+    def test_distinct_workflows_both_kept(self):
+        events = [
+            _art_event("prepare", self.FEATURE, ["/p.md"], "2026-06-25T01:00:00Z"),
+            _art_event("architect", self.FEATURE, ["/a.md"], "2026-06-25T01:00:00Z"),
+        ]
+        assert resolve_latest_artifacts(events, self.FEATURE) == {
+            "prepare": ["/p.md"], "architect": ["/a.md"]}
+
+    def test_wrong_feature_excluded(self):
+        events = [
+            _art_event("prepare", self.FEATURE, ["/mine.md"], "2026-06-25T01:00:00Z"),
+            _art_event("prepare", "other-feat", ["/other.md"], "2026-06-25T02:00:00Z"),
+        ]
+        assert resolve_latest_artifacts(events, self.FEATURE) == {"prepare": ["/mine.md"]}
+
+    def test_empty_events_returns_empty_dict(self):
+        assert resolve_latest_artifacts([], self.FEATURE) == {}
+
+    @pytest.mark.parametrize("bad", [
+        [1, 2, 3], "a string", None, 42,
+        {"feature": FEATURE, "paths": ["/x.md"], "ts": "2026-06-25T01:00:00Z"},  # no workflow
+        {"workflow": "prepare", "feature": FEATURE, "ts": "2026-06-25T01:00:00Z"},  # no paths
+        {"workflow": "prepare", "feature": FEATURE, "paths": "/x.md", "ts": "2026-06-25T01:00:00Z"},  # paths not list
+    ])
+    def test_malformed_events_skipped_defensively(self, bad):
+        """Non-dict entries and dicts missing workflow/paths (or paths-not-list)
+        are skipped — parity with the _read_events_at isinstance(dict) guard."""
+        good = _art_event("prepare", self.FEATURE, ["/good.md"], "2026-06-25T05:00:00Z")
+        assert resolve_latest_artifacts([bad, good], self.FEATURE) == {"prepare": ["/good.md"]}
+
+    def test_bad_ts_never_supersedes_good(self):
+        """A missing/unparseable ts is treated as older than any parseable ts,
+        so a malformed later event cannot mask a well-formed one — regardless of
+        insertion order (both orderings asserted)."""
+        good = _art_event("prepare", self.FEATURE, ["/good.md"], "2026-06-25T02:00:00Z")
+        bad = {"type": "artifact_paths", "workflow": "prepare",
+               "feature": self.FEATURE, "paths": ["/bad.md"], "ts": "not-a-ts"}
+        assert resolve_latest_artifacts([good, bad], self.FEATURE) == {"prepare": ["/good.md"]}
+        assert resolve_latest_artifacts([bad, good], self.FEATURE) == {"prepare": ["/good.md"]}
+
+    def test_missing_ts_never_supersedes_good(self):
+        good = _art_event("prepare", self.FEATURE, ["/good.md"], "2026-06-25T02:00:00Z")
+        no_ts = {"type": "artifact_paths", "workflow": "prepare",
+                 "feature": self.FEATURE, "paths": ["/nots.md"]}
+        assert resolve_latest_artifacts([good, no_ts], self.FEATURE) == {"prepare": ["/good.md"]}
+        assert resolve_latest_artifacts([no_ts, good], self.FEATURE) == {"prepare": ["/good.md"]}
+
+
+# =============================================================================
+# (2) SUBPROCESS — resolve-session-dir contract + THE B1-CLASS DRIFT PARITY.
+# =============================================================================
+class TestResolveSessionDirSubprocess:
+    def _write_ctx(self, tmp_path, project_dir, session_id):
+        ctx = tmp_path / "pact-session-context.json"
+        ctx.write_text(json.dumps(
+            {"project_dir": project_dir, "session_id": session_id}), encoding="utf-8")
+        return ctx
+
+    def test_valid_context_exit0_absolute_dir(self, tmp_path):
+        ctx = self._write_ctx(tmp_path, "/clean/project", "sess-abcd")
+        r = _run_cli("resolve-session-dir", "--context-file", str(ctx))
+        assert r.returncode == _EXIT_OK
+        out = r.stdout.strip()
+        assert Path(out).is_absolute()
+        # Oracle = the SSOT helper itself (NOT a hand-built path).
+        assert out == pact_context.reconstruct_session_dir("/clean/project", "sess-abcd")
+
+    def test_b1_class_drift_both_axes_sanitized_no_drift(self, tmp_path):
+        """THE critical durability test (the exact bug class cross-lane review
+        caught in #927). A project basename with a DOT and a session_id with a
+        non-[A-Za-z0-9_-] char must reconstruct the SANITIZED path the WRITER
+        wrote to — NO drift.
+
+        ORACLE = reconstruct_session_dir called directly (the SSOT). Non-vacuity
+        companion: a RAW un-sanitized join DIFFERS — proving the special-char
+        input actually triggers sanitization on BOTH axes (slug + session_id),
+        which is what clean-basename masking hid."""
+        project_dir = "/Users/x/my.project dir"   # dot AND space in the basename
+        session_id = "abc.def 123"                  # dot AND space (non-allowlist)
+        ctx = self._write_ctx(tmp_path, project_dir, session_id)
+        r = _run_cli("resolve-session-dir", "--context-file", str(ctx))
+        assert r.returncode == _EXIT_OK
+        out = r.stdout.strip()
+
+        # (a) parity with the SSOT writer-derivation (the load-bearing assertion).
+        expected = pact_context.reconstruct_session_dir(project_dir, session_id)
+        assert out == expected, f"CLI {out!r} drifted from SSOT {expected!r}"
+
+        # (b) NON-VACUITY: a raw un-sanitized join would land elsewhere — so the
+        # special-char input genuinely exercises sanitization (not a no-op).
+        from shared.paths import get_claude_config_dir
+        raw = str(get_claude_config_dir() / "pact-sessions"
+                  / Path(project_dir).name / session_id)
+        assert out != raw, (
+            "special-char input must be sanitized away from the raw join — if "
+            "equal, the drift case is vacuous (no sanitization exercised)"
+        )
+        # And concretely: the dot/space are gone from BOTH path segments.
+        assert "my_project_dir" in out and "abc_def_123" in out
+
+    @pytest.mark.parametrize("scenario", ["missing_file", "bad_json", "not_object",
+                                          "falsy_project", "falsy_session"])
+    def test_unresolvable_exit2_empty_stdout(self, tmp_path, scenario):
+        """Every bad-input path → exit 2 + EMPTY stdout (the skill's stop gate
+        keys on the exit code; stdout must carry no data to mis-parse)."""
+        if scenario == "missing_file":
+            target = str(tmp_path / "does-not-exist.json")
+        elif scenario == "bad_json":
+            f = tmp_path / "bad.json"; f.write_text("{not json", encoding="utf-8")
+            target = str(f)
+        elif scenario == "not_object":
+            f = tmp_path / "arr.json"; f.write_text("[1,2,3]", encoding="utf-8")
+            target = str(f)
+        elif scenario == "falsy_project":
+            target = str(self._write_ctx(tmp_path, "", "sess-abcd"))
+        else:  # falsy_session
+            target = str(self._write_ctx(tmp_path, "/clean/project", ""))
+        r = _run_cli("resolve-session-dir", "--context-file", target)
+        assert r.returncode == _EXIT_UNRESOLVED, f"{scenario}: expected exit 2"
+        assert r.stdout == "", f"{scenario}: stdout must be EMPTY on exit 2"
+
+    def test_exit_code_is_2_never_1_on_bad_input(self, tmp_path):
+        """Bad input is EXACTLY 2, never 1 (1 is reserved for internal errors).
+        Pins the documented divergence from session_journal's exit-1 CLI."""
+        r = _run_cli("resolve-session-dir", "--context-file",
+                     str(tmp_path / "nope.json"))
+        assert r.returncode == _EXIT_UNRESOLVED
+        assert r.returncode != _EXIT_INTERNAL_ERROR
+
+
+# =============================================================================
+# (3) SUBPROCESS — resolve-artifacts contract.
+# =============================================================================
+class TestResolveArtifactsSubprocess:
+    FEATURE = "feat-y"
+
+    @pytest.fixture
+    def session_with_events(self, tmp_path, monkeypatch, pact_context):
+        """Build a REAL on-disk journal at a resolvable session dir so the CLI's
+        read_events_from resolves it (non-mocked seam)."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name="t", session_id="sid-harvest", project_dir="/proj")
+        slug = Path("/proj").name
+        session_dir = tmp_path / ".claude" / "pact-sessions" / slug / "sid-harvest"
+        return str(session_dir)
+
+    def test_supersede_and_shape_one_line_json(self, session_with_events):
+        sd = session_with_events
+        append_event(_art_event("prepare", self.FEATURE, ["/OLD.md"], "2026-06-25T01:00:00Z"))
+        append_event(_art_event("prepare", self.FEATURE, ["/NEW.md"], "2026-06-25T02:00:00Z"))
+        append_event(_art_event("architect", self.FEATURE, ["/arch.md"], "2026-06-25T01:00:00Z"))
+        r = _run_cli("resolve-artifacts", "--session-dir", sd, "--feature", self.FEATURE)
+        assert r.returncode == _EXIT_OK
+        # One-line compact JSON object.
+        assert "\n" not in r.stdout.strip()
+        assert json.loads(r.stdout) == {"prepare": ["/NEW.md"], "architect": ["/arch.md"]}
+
+    def test_wrong_feature_excluded(self, session_with_events):
+        sd = session_with_events
+        append_event(_art_event("prepare", self.FEATURE, ["/mine.md"], "2026-06-25T01:00:00Z"))
+        append_event(_art_event("prepare", "other", ["/other.md"], "2026-06-25T02:00:00Z"))
+        r = _run_cli("resolve-artifacts", "--session-dir", sd, "--feature", self.FEATURE)
+        assert r.returncode == _EXIT_OK
+        assert json.loads(r.stdout) == {"prepare": ["/mine.md"]}
+
+    def test_empty_result_is_empty_object_exit0(self, session_with_events):
+        """A legitimately-empty result is {} at exit 0 (NOT a stop trigger)."""
+        sd = session_with_events
+        r = _run_cli("resolve-artifacts", "--session-dir", sd, "--feature", "no-such-feat")
+        assert r.returncode == _EXIT_OK
+        assert json.loads(r.stdout) == {}
+
+    @pytest.mark.parametrize("bad_dir", ["", "relative/dir"])
+    def test_bad_session_dir_exit2_empty_stdout(self, bad_dir):
+        r = _run_cli("resolve-artifacts", "--session-dir", bad_dir, "--feature", self.FEATURE)
+        assert r.returncode == _EXIT_UNRESOLVED
+        assert r.stdout == ""
+
+
+# =============================================================================
+# (4) IMPORT-SEAM — the direct-script sys.path bootstrap resolves
+#     shared.pact_context (the non-vacuous seam the bootstrap fix addresses).
+# =============================================================================
+class TestImportSeamBootstrap:
+    def test_direct_script_resolves_pact_context_package_chain(self, tmp_path):
+        """The CLI run as a direct script (cwd OUTSIDE the repo) must resolve
+        `from shared.pact_context import reconstruct_session_dir` AND
+        pact_context's own package-relative imports (from .session_state, etc).
+        Proven end-to-end: resolve-session-dir produces a correct abs path, which
+        is only possible if the bootstrap made `shared` a real package. If a
+        future edit removes the sys.path bootstrap, this goes RED (ModuleNotFound
+        or a non-zero exit), failing loudly."""
+        ctx = tmp_path / "pact-session-context.json"
+        ctx.write_text(json.dumps(
+            {"project_dir": "/p", "session_id": "s"}), encoding="utf-8")
+        # Run from an arbitrary cwd (tmp_path) to exercise script-mode sys.path.
+        r = subprocess.run(
+            [sys.executable, str(_CLI), "resolve-session-dir",
+             "--context-file", str(ctx)],
+            capture_output=True, text=True, cwd=str(tmp_path),
+        )
+        assert r.returncode == _EXIT_OK, (
+            f"direct-script import seam broke (rc={r.returncode}); "
+            f"stderr={r.stderr!r}"
+        )
+        assert r.stdout.strip() == pact_context.reconstruct_session_dir("/p", "s")
+        assert "ModuleNotFoundError" not in r.stderr
+        assert "ImportError" not in r.stderr
+
+
+# =============================================================================
+# (5) ARRAY-PARSE CONTRACT — session_journal's `read` CLI emits a JSON ARRAY
+#     (the contract SKILL.md Steps 1/10 now parse). A future switch back to
+#     JSONL would break the skill's reused read — this guards it.
+# =============================================================================
+class TestReadEmitsJsonArrayContract:
+    def test_session_journal_read_cli_emits_json_array(self, tmp_path, monkeypatch, pact_context):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name="t", session_id="sid-arr", project_dir="/proj")
+        slug = Path("/proj").name
+        session_dir = str(tmp_path / ".claude" / "pact-sessions" / slug / "sid-arr")
+        append_event(make_event(
+            "agent_handoff", agent="devops-engineer", task_id="1",
+            task_subject="x", handoff={"produced": "p", "decisions": "d",
+            "uncertainty": "n", "integration": "n", "reasoning_chain": "r",
+            "open_questions": "n"}))
+        sj = str(_HOOKS_DIR / "shared" / "session_journal.py")
+        r = subprocess.run(
+            [sys.executable, sj, "read", "--session-dir", session_dir,
+             "--type", "agent_handoff"],
+            capture_output=True, text=True,
+        )
+        assert r.returncode == 0, f"read failed: {r.stderr!r}"
+        parsed = json.loads(r.stdout)
+        assert isinstance(parsed, list), (
+            "session_journal read MUST emit a JSON ARRAY (the contract Steps "
+            "1/10 parse); a regression to JSONL would break the reused read"
+        )
+        assert len(parsed) == 1 and parsed[0]["type"] == "agent_handoff"

--- a/pact-plugin/tests/test_pact_harvest_cli.py
+++ b/pact-plugin/tests/test_pact_harvest_cli.py
@@ -57,6 +57,8 @@ sys.path.insert(0, str(_HOOKS_DIR))
 import shared.pact_context as pact_context  # noqa: E402
 from shared.pact_harvest import _resolve_session_dir  # noqa: E402
 from shared.session_journal import (  # noqa: E402
+    _normalize_trailing_z,
+    _parse_ts,
     append_event,
     make_event,
     resolve_latest_artifacts,
@@ -191,6 +193,41 @@ class TestResolveLatestArtifacts:
         assert resolve_latest_artifacts([aware, naive], self.FEATURE) == {"prepare": ["/aware.md"]}
         assert resolve_latest_artifacts([naive, aware], self.FEATURE) == {"prepare": ["/naive.md"]}
 
+    def test_mixed_z_and_offset_ts_compare_by_instant_last_wins(self):
+        """Belt-and-suspenders: a `...Z` ts and an equal-instant `...+00:00` ts
+        for the same (workflow, feature) must be compared as the SAME instant —
+        so the tie resolves LAST-wins (the later-iterated event survives),
+        regardless of which spelling came first. A LEXICAL string compare would
+        be WRONG here ('+' 0x2B sorts before 'Z' 0x5A), so reverting
+        _ts_supersedes/_parse_ts to compare the raw strings flips the
+        Z-then-offset ordering RED — that is this test's non-vacuity hook (on
+        3.13 fromisoformat parses a bare 'Z' natively, so the Z->+00:00
+        normalization itself is not the discriminator; the parsed-not-lexical
+        comparison is)."""
+        z_ts = "2026-06-25T01:00:00Z"
+        offset_ts = "2026-06-25T01:00:00+00:00"
+        z_first = _art_event("prepare", self.FEATURE, ["/z.md"], z_ts)
+        offset_first = _art_event("prepare", self.FEATURE, ["/offset.md"], offset_ts)
+        # Same instant -> last-wins; the discriminating ordering is z-then-offset
+        # (a lexical compare would keep /z.md instead of the later /offset.md).
+        assert resolve_latest_artifacts(
+            [z_first, offset_first], self.FEATURE) == {"prepare": ["/offset.md"]}
+        assert resolve_latest_artifacts(
+            [offset_first, z_first], self.FEATURE) == {"prepare": ["/z.md"]}
+
+    def test_non_string_path_elements_filtered_from_output(self):
+        """A surviving event whose `paths` list carries non-string elements
+        (int, None, dict) emits ONLY its string entries — the element-level
+        isinstance guard, parity with the event-level non-dict skip. Reverting
+        the filter (emitting `event["paths"]` raw) leaks the non-string entries
+        -> RED."""
+        ev = {"type": "artifact_paths", "workflow": "prepare",
+              "feature": self.FEATURE,
+              "paths": ["/good.md", 123, None, {"x": 1}, "/also.md"],
+              "ts": "2026-06-25T01:00:00Z"}
+        assert resolve_latest_artifacts([ev], self.FEATURE) == {
+            "prepare": ["/good.md", "/also.md"]}
+
 
 # =============================================================================
 # (2) SUBPROCESS — resolve-session-dir contract + THE B1-CLASS DRIFT PARITY.
@@ -299,8 +336,16 @@ class TestResolveArtifactsSubprocess:
     @pytest.fixture
     def session_with_events(self, tmp_path, monkeypatch, pact_context):
         """Build a REAL on-disk journal at a resolvable session dir so the CLI's
-        read_events_from resolves it (non-mocked seam)."""
+        read_events_from resolves it (non-mocked seam).
+
+        CLAUDE_CONFIG_DIR is set (not just Path.home) because the CLI runs as a
+        SUBPROCESS: `monkeypatch.setattr(Path, "home", ...)` patches only this
+        test process, NOT the child, so the subprocess's --session-dir
+        containment check would resolve the REAL home and falsely reject this
+        tmp session dir. The env var IS inherited by the subprocess, making the
+        child's get_claude_config_dir() agree with this fixture's root."""
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
         pact_context(team_name="t", session_id="sid-harvest", project_dir="/proj")
         slug = Path("/proj").name
         session_dir = tmp_path / ".claude" / "pact-sessions" / slug / "sid-harvest"
@@ -402,12 +447,13 @@ class TestReadEmitsJsonArrayContract:
 
 
 # =============================================================================
-# (6) ARGPARSE CONTRACT — a missing or unknown subcommand must exit NON-ZERO
-#     (argparse's 2), so the skill's `if ! out=$(...); then stop; fi` gate
-#     still STOPS rather than falling through to a path-less read. `sub.required
-#     = True` is what enforces this; a regression to required=False would let a
-#     no-arg invocation exit 0 (return _EXIT_INTERNAL_ERROR is unreachable today
-#     but a silent contract change) — this pins the stop-gate-compatible code.
+# (6) ARGPARSE CONTRACT — a missing/unknown subcommand OR a missing required
+#     argument must exit NON-ZERO (argparse's 2), so the skill's
+#     `if ! out=$(...); then stop; fi` gate still STOPS rather than falling
+#     through to a path-less read. `sub.required = True` (plus each subcommand's
+#     `required=True` arguments) is what enforces this; a regression to
+#     required=False would let an under-specified invocation exit 0 — this pins
+#     the stop-gate-compatible contract.
 # =============================================================================
 class TestSubcommandArgparseContract:
     def test_no_subcommand_exits_nonzero_stop_gate(self):
@@ -424,6 +470,21 @@ class TestSubcommandArgparseContract:
         assert r.returncode != _EXIT_OK, "unknown-subcommand must not exit 0"
         assert r.returncode == 2, f"expected argparse exit 2, got {r.returncode}"
 
+    @pytest.mark.parametrize("argv", [
+        ["resolve-session-dir"],                       # missing --context-file
+        ["resolve-artifacts", "--feature", "f"],       # missing --session-dir
+        ["resolve-artifacts", "--session-dir", "/x"],  # missing --feature
+    ])
+    def test_missing_required_arg_exits_2_empty_stdout(self, argv):
+        """A subcommand invoked WITHOUT a required argument -> argparse error ->
+        exit 2 with EMPTY stdout (the stop gate keys on the non-zero code, and
+        no data may leak to stdout for the skill to mis-parse). A regression
+        that dropped `required=True` on any of these would let the invocation
+        reach a handler with a None arg -> RED here."""
+        r = _run_cli(*argv)
+        assert r.returncode == 2, f"{argv}: expected argparse exit 2, got {r.returncode}"
+        assert r.stdout == "", f"{argv}: stdout must be EMPTY on exit 2"
+
 
 # =============================================================================
 # (7) TRAVERSAL DEFENSE + GRACEFUL-TS — through the real CLI.
@@ -435,10 +496,18 @@ class TestSubcommandArgparseContract:
 class TestTraversalAndGracefulTs:
     def test_traversal_session_id_is_sanitized_no_escape(self, tmp_path):
         """A '../../etc/passwd' session_id reconstructs INSIDE pact-sessions
-        with the traversal characters collapsed (no '..' segment, stays under
-        the sessions root). Oracle = the SSOT reconstruct_session_dir; the
-        independent non-vacuity check is the structural 'no ..' / 'under root'
-        assertion (a sanitization regression would leave a '..' segment)."""
+        with the traversal characters neutralized (no '..' segment, stays under
+        the sessions root). Oracle = the SSOT reconstruct_session_dir.
+
+        What this verifies is the OUTCOME — the resolved dir provably stays
+        under the pact-sessions root with no upward-escaping '..' segment — NOT
+        which layer enforces it. Two defense-in-depth layers cooperate: the
+        session_id regex sanitization in reconstruct_session_dir AND
+        _build_session_path's own resolve()/containment/basename-fallback
+        traversal guard. Because that second layer alone already neutralizes the
+        traversal, a session_id-regex-only revert does NOT leave a '..' segment
+        (this test stays green under it) — so the structural assertion pins the
+        no-escape OUTCOME, not the regex mechanism in isolation."""
         ctx = tmp_path / "pact-session-context.json"
         ctx.write_text(json.dumps(
             {"project_dir": "/clean/project", "session_id": "../../etc/passwd"}),
@@ -449,8 +518,10 @@ class TestTraversalAndGracefulTs:
         # Parity with the SSOT writer-derivation (load-bearing).
         assert out == pact_context.reconstruct_session_dir(
             "/clean/project", "../../etc/passwd")
-        # Non-vacuity: the traversal is neutralized — no '..' path segment, and
-        # the resolved dir stays under the pact-sessions tree.
+        # Structural outcome: the traversal is neutralized — no '..' path
+        # segment survives, and the resolved dir stays under the pact-sessions
+        # tree (guaranteed jointly by the sanitization + _build_session_path
+        # traversal guard).
         parts = Path(out).parts
         assert ".." not in parts, f"traversal not sanitized: {out!r}"
         assert "pact-sessions" in parts
@@ -467,7 +538,11 @@ class TestTraversalAndGracefulTs:
         traceback; now it exits 0 and emits a valid JSON object (the incumbent
         survives, fail-open). Regression-proof: reverting the guard makes this
         exit 1 -> RED."""
+        # CLAUDE_CONFIG_DIR (not just Path.home) so the SUBPROCESS's --session-dir
+        # containment check resolves the same tmp root — the home monkeypatch is
+        # not inherited by the child; the env var is.
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
         pact_context(team_name="t", session_id="sid-naive", project_dir="/proj")
         slug = Path("/proj").name
         session_dir = tmp_path / ".claude" / "pact-sessions" / slug / "sid-naive"
@@ -486,3 +561,85 @@ class TestTraversalAndGracefulTs:
         assert "TypeError" not in r.stderr
         # A valid JSON object is emitted; the well-formed aware event survives.
         assert json.loads(r.stdout) == {"prepare": ["/aware.md"]}
+
+
+# =============================================================================
+# (8) SESSION-DIR CONTAINMENT — resolve-artifacts rejects a --session-dir
+#     OUTSIDE the pact-sessions root (defense-in-depth) but NEVER a legit one.
+#     The root derives from get_claude_config_dir() (driven by CLAUDE_CONFIG_DIR
+#     here, which the subprocess inherits) so the child agrees with the test's
+#     configured root — NOT the real home.
+# =============================================================================
+class TestSessionDirContainment:
+    def _configure_root(self, tmp_path, monkeypatch):
+        """Point both this process and the CLI subprocess at a tmp config root.
+        Path.home for the in-process journal write; CLAUDE_CONFIG_DIR (inherited
+        by the subprocess) for the child's containment-root derivation."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
+
+    def test_legit_contained_session_dir_passes(
+        self, tmp_path, monkeypatch, pact_context):
+        """A session dir UNDER <config>/pact-sessions/ resolves normally
+        (exit 0) — containment must NOT over-reject the canonical layout. Guards
+        the false-rejection direction: a too-strict predicate would flip this to
+        exit 2."""
+        self._configure_root(tmp_path, monkeypatch)
+        pact_context(team_name="t", session_id="sid-contained", project_dir="/proj")
+        slug = Path("/proj").name
+        session_dir = tmp_path / ".claude" / "pact-sessions" / slug / "sid-contained"
+        append_event(_art_event("prepare", "feat-c", ["/c.md"], "2026-06-25T01:00:00Z"))
+        r = _run_cli("resolve-artifacts", "--session-dir", str(session_dir),
+                     "--feature", "feat-c")
+        assert r.returncode == _EXIT_OK, (
+            f"legit contained session-dir must pass; rc={r.returncode} "
+            f"stderr={r.stderr!r}")
+        assert json.loads(r.stdout) == {"prepare": ["/c.md"]}
+
+    def test_out_of_tree_session_dir_rejected_exit2_empty_stdout(
+        self, tmp_path, monkeypatch):
+        """An ABSOLUTE --session-dir OUTSIDE the pact-sessions root is bad input
+        -> exit 2 + EMPTY stdout + stderr diagnostic, so a stray journal under
+        an unrelated directory is never read. Non-vacuity: with the containment
+        check reverted, read_events_from would simply return [] -> '{}' at exit
+        0, so asserting exit 2 here goes RED on revert."""
+        self._configure_root(tmp_path, monkeypatch)
+        # Absolute (clears the non-empty + absolute checks) but NOT under
+        # <tmp>/.claude/pact-sessions — must be rejected by containment.
+        outside = tmp_path / "outside-tree" / "sid-x"
+        r = _run_cli("resolve-artifacts", "--session-dir", str(outside),
+                     "--feature", "feat-c")
+        assert r.returncode == _EXIT_UNRESOLVED, (
+            f"out-of-tree session-dir must be exit 2; rc={r.returncode} "
+            f"stderr={r.stderr!r}")
+        assert r.stdout == "", "exit-2 path must emit EMPTY stdout"
+        assert "pact-sessions root" in r.stderr
+
+
+# =============================================================================
+# (9) _parse_ts TRAILING-Z ANCHOR — only a SINGLE trailing `Z` is rewritten to
+#     `+00:00`; an interior `Z` is left intact (a blanket replace-all would
+#     mangle it mid-string). The string-level normalization is isolated in
+#     _normalize_trailing_z so the trailing-only anchor is directly testable —
+#     at the _parse_ts return/raise layer the two forms are observationally
+#     identical (any interior Z is unparseable either way).
+# =============================================================================
+class TestParseTsTrailingZAnchor:
+    def test_trailing_z_parses_as_utc_no_regression(self):
+        """A legit trailing-Z ts parses to the SAME UTC-aware instant as its
+        explicit `+00:00` spelling — the anchor preserves the normal-path
+        behavior (and the pre-3.11 trailing-Z support fromisoformat lacked)."""
+        assert _parse_ts("2026-06-25T01:00:00Z") == _parse_ts(
+            "2026-06-25T01:00:00+00:00")
+        assert _parse_ts("2026-06-25T01:00:00Z").utcoffset().total_seconds() == 0
+
+    def test_only_trailing_z_normalized_interior_preserved(self):
+        """The anchor rewrites ONLY the final `Z`; interior `Z`s are left
+        intact. A multi-`Z` string is the discriminator: trailing-only touches
+        just the last one. RED-on-revert: the old blanket `.replace("Z",
+        "+00:00")` rewrites EVERY `Z` -> '2026+00:0006+00:0001+00:00', so this
+        equality flips RED under the revert."""
+        assert _normalize_trailing_z("2026Z06Z01Z") == "2026Z06Z01+00:00"
+        # A string with NO trailing Z is returned byte-for-byte unchanged.
+        assert _normalize_trailing_z(
+            "2026-06-25T00:00:00+00:00") == "2026-06-25T00:00:00+00:00"

--- a/pact-plugin/tests/test_session_journal.py
+++ b/pact-plugin/tests/test_session_journal.py
@@ -3272,6 +3272,11 @@ class TestValidateEventSchemaPerType:
         "session_end": {},  # No required fields; baseline-only.
         "cleanup_summary": {},  # No required fields; optional-only (#412 Fix B).
         "session_consolidated": {},  # No required fields; optional-only (#453 Fix B).
+        "artifact_paths": {
+            "workflow": "prepare",
+            "feature": "handoff-artifact-durability",
+            "paths": ["/tmp/wt/docs/preparation/handoff-artifact-durability.md"],
+        },
     }
 
     def test_samples_mirror_required_fields_dict(self):


### PR DESCRIPTION
## Summary

Implements the unified **A+B artifact-durability model** for #927: a lead-written `artifact_paths` journal event (the GC-durable, HANDOFF-independent pointer) plus a harvest behavior change so the secretary **always reads and synthesizes** each phase's disk artifact into pact-memory — closing the blind spot where consultation/phase HANDOFFs were lost on specialist self-completion, and capturing the full artifact substance (~4× the HANDOFF distillation) on the happy path too.

## What landed

- **`feat(journal)` `d7b148b9`** — register the `artifact_paths` event `{workflow, feature, paths[], task_id?}` in both validator tables + a lead-frame, **fail-open** backstop in `task_lifecycle_gate.py` that nudges when a PREPARE/ARCHITECT phase completes without its artifact_paths pointer (PREPARE/ARCHITECT-only, skipped-exempt, never blocks).
- **`feat(commands)` `192dc9be`** — lead-frame emits at plan-mode synthesis, orchestrate PREPARE/ARCHITECT completion, peer-review synthesis, + a conditional CODE code-auditor site; strict per-feature artifact validation (hard-stop-and-investigate); plan-mode consult-only harvest trigger.
- **`feat(harvest)` `df88cf20`** — harvest resolves `artifact_paths` (`read_events_from`, supersede-by-`(workflow,feature)` latest-ts) → reads + distils the disk artifact alongside the HANDOFF. **Plus a distinct correctness fix**: migrate the existing Standard Harvest reads off the path-less `read_events()` — which silently returns 0 events off-lead, breaking tmux harvest and the dual-mode contract — to `read_events_from(session_dir)`.
- **`feat(worktree-cleanup)` `d39d5a1b`** — conditional harvest-before-teardown guard (single chokepoint for all teardown callers; loud irrecoverable-loss warning if no team is reachable).
- **`test` `f6b5eb78`** — 48-test durability suite (boundary seal, always-read, failure-path, worktree-survival, backstop, schema, masked-read seam). Both-modes axis = `is_lead`/`agent_type`; source-only-revert counter-tests pin non-vacuity (coupling map disclosed honestly).
- **`chore(release)` `c9777d67`** — v4.4.42 (PATCH; internal harvest/journal infrastructure, no user-facing surface change).

## Why

#927 root cause: all journal-emit paths are `is_lead`-gated, so a specialist self-completing mid-turn journals **0 events**, and eager GC then reaps the task file. A recovery pointer must be **independent of the failure it recovers from** — so the lead enumerates `artifact_paths` by globbing the conventional `docs/` dir (HANDOFF-independent), the journal lives outside the worktree (survives `git worktree remove`), and the harvest always reads the disk artifact. Full design: `docs/plans/consultation-handoff-durability-plan.md`.

Suite: **9618 passed / 0 failed / 0 errors**. Concurrent auditor signal: **GREEN**.

Implements #927; closure pending a post-install harvest live-probe (verify a fresh installed session's harvest actually resolves + reads a real `artifact_paths` event). Follow-up #1033 tracks the deferred zero-loss-on-abort / committed-artifact durability.
