### PR TITLE
chore(runbooks): log merge-guard auth-symmetry live-probe run (v4.4.43)

### DIFF
--- a/pact-plugin/tests/runbooks/RUNBOOK_RUN_DATES.md
+++ b/pact-plugin/tests/runbooks/RUNBOOK_RUN_DATES.md
@@ -147,3 +147,9 @@ This is a single-verdict empirical probe (not a per-mode live-probe), so the den
 This file is required infrastructure for the fallback-ladder evaluation;
 do not delete or rename. Contents are append-only — historical runs are
 the calibration record.
+
+## merge-guard-auth-symmetry-live-probe (#1031 false-REJECT + #1032 false-AUTHORIZE)
+
+| Run date (UTC) | Operator | Plugin version | Verdict | Harness-independence evidence | Notes (real cases; deny paths; stub gate) |
+| -------------- | -------- | -------------- | ------- | ----------------------------- | ----------------------------------------- |
+| 2026-06-26 | michael-wojcik | 4.4.43 | #1031 PASS · #1032 PASS · stub PASS | DUAL independent harnesses — security-engineer (primary) + test-engineer (clean-room: re-derived envelopes from source, did NOT read peer); verdicts CONVERGE; test-engineer subprocess==in-process 10/10 + R-B positive control proves mint capability | Post-install probe of the INSTALLED v4.4.43 hooks (not pytest). Mode-independent (file-on-disk token store; session scoping intentionally INERT → every deny on the (op,target) axis alone). #1031: R-A minted pr 1029 not prose distractor 1028; R-B minted pr 1034 from clicked-option command only (padded question ignored); R-C kept full colon-bearing branch origin:feature → all PRE allow exit0 + consume. #1032: A1/A1b/A2/A3/A4/A5 NO-MINT (step-3b option-anchoring / no-options fail-closed) → DENY-NOTOKEN exit2; A6 token-exists-mismatch (valid {merge,1029} token vs force-push exec, _token_matches_command False) → DENY-MISMATCH exit2, token unchanged. Stub gate AST-confirmed + full-source-read: NO unconditional always-allow in check_merge_authorization. No HALT. Gated closure (#924 discipline) satisfied → #1031/#1032 closed. |


### PR DESCRIPTION
## Summary
Appends the post-install **logged live-probe** run row for the merge_guard auth-symmetry fix (v4.4.43) to the append-only calibration ledger (`pact-plugin/tests/runbooks/RUNBOOK_RUN_DATES.md`). This is the durable record of the gated live-probe that satisfied closure of #1031 (false-REJECT) and #1032 (false-AUTHORIZE) — both now closed.

## What landed
- One new ledger section + run row: `2026-06-26 · michael-wojcik · 4.4.43 · #1031 PASS · #1032 PASS · stub PASS`.

## How the probe ran (recorded in the row)
- Drove the **INSTALLED** v4.4.43 hooks (not the pytest suite) via **two independent harnesses** — a primary security probe + a clean-room independent verifier that re-derived the envelope shapes from source (no peer contamination).
- Verdicts converged; harness-faithfulness discharged via a positive control (R-B mint+consume proves the harness can mint) and a subprocess-vs-in-process classifier cross-check (10/10).
- #1031: R-A/R-B/R-C authorize the real command-anchored target. #1032: A1/A1b/A2/A3/A4/A5 no-mint (step-3b option-anchoring / no-options fail-closed) + A6 token-exists-mismatch (read arm). Stub gate AST-confirmed — no unconditional always-allow. No HALT.

## Why
Per the gated-issue-close discipline (#924), closure of #1031/#1032 was gated on a logged live-probe of the installed build. This row is that log's durable home (the runbook itself writes only to the ephemeral installed-cache copy).

## Version
No bump — pure append-only calibration-log entry; no behavioral, test-suite, or doc-content change to the plugin.
