### PR TITLE
fix(merge-guard): bind privileged flags (--admin/-R/--no-verify) to the approval (#1042)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.43",
+      "version": "4.4.44",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.43/      # Plugin version
+│               └── 4.4.44/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.43",
+  "version": "4.4.44",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.43
+> **Version**: 4.4.44
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/merge_guard_post.py
+++ b/pact-plugin/hooks/merge_guard_post.py
@@ -379,7 +379,16 @@ def _mint_context_from_bundle(questions: list, answers: dict) -> dict | None:
             return None
 
     # ── Step 5: extract the single distinct command's context to mint. ──
-    return extract_command_context(the_command)
+    # Op/target are derived from `the_command` (region-anchored — preserves the
+    # anti-distractor multiplicity gate above). The privileged-flag scan (#1042)
+    # is widened to the FULL selected-option text so a flag positioned after a
+    # quoted argument (e.g. `gh pr merge 5 --subject "msg" --admin`, written bare)
+    # is not lost to the bare-command region truncation — the read arm scans the
+    # full raw command, so the mint must scan a full surface too for symmetry.
+    return extract_command_context(
+        the_command,
+        flag_scan_text=" ".join(selected_option_texts),
+    )
 
 
 def write_token(context: dict, token_dir: Path | None = None) -> str | None:

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -1054,6 +1054,18 @@ def _token_matches_command(token: dict, command: str) -> bool:
     if token_op is None or cmd_op is None or token_op != cmd_op:
         return False
 
+    # (a2) NEVER-ESCALATE FLAG AXIS (#1042) — the executed command's binding-
+    # relevant flags must EXACTLY equal the approved set. ANY difference (an added
+    # privilege like --admin/-R, OR a dropped constraint) REFUSES. Both sides are
+    # computed by the shared extract_command_context SSOT, so they cannot drift.
+    # Checked AFTER op-type identity and BEFORE the per-op target returns so it
+    # applies uniformly to all four op-classes. A pre-fix token without the key
+    # defaults to the empty set, so any privileged execution mismatches -> REFUSE
+    # (over-block-safe; tokens expire in 5 min, so no backward-compat is needed).
+    # bound_flags is an attribute checked here, never part of pair identity.
+    if set(context.get("bound_flags", [])) != set(cmd.get("bound_flags", [])):
+        return False
+
     # (b) Target axis, per op-class — require a POSITIVE, command-anchored target
     # match. Unextractable or mismatched target -> REFUSE (over-block is the safe
     # #1031 direction; the read side never under-blocks #1032).

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -443,7 +443,186 @@ def _extract_force_push_target_ref(command: str) -> str | None:
     return refspec or None
 
 
-def extract_command_context(command: str) -> dict:
+# -----------------------------------------------------------------------------
+# Privileged-flag binding (#1042). The (operation_type, target) binding above
+# DROPS every dash-flag, so an approved `gh pr merge 5` and an executed
+# `gh pr merge 5 --admin` (branch-protection bypass) reduce to the SAME context
+# and authorize — the flag rides past the checkpoint undetected. The fix adds
+# ONE more binding dimension — `bound_flags` — computed by the SINGLE scanner
+# below, called from the SINGLE site in extract_command_context, so BOTH hook
+# arms inherit it and can never classify a command's flags differently (the same
+# anti-drift property that the shared (op,target) SSOT already guarantees).
+#
+# PRIVILEGED_FLAGS is the op-class-scoped denylist: { op_type -> { canonical_long
+# -> (aliases, value_taking) } }. Membership is PURE DATA — adding or removing a
+# flag is a one-line edit with ZERO scanner/predicate changes, so the security
+# review owns membership without touching logic. A flag's PRESENCE binds it; the
+# read-side set-equality gate then enforces never-escalate.
+#
+# EXCLUDES op-trigger flags that already change op_type (and are therefore
+# already bound through it): --force/-f (force-push), -D (branch-delete), and
+# gh pr close's --delete-branch (the close-danger trigger). Listing them here
+# would double-bind and needlessly over-block. NB the asymmetry: --delete-branch
+# /-d on gh pr MERGE is a post-merge SIDE-EFFECT (deletes the source branch), not
+# a merge op-trigger, so it IS bound on the `merge` class — and -d (merge
+# delete-branch) is a DIFFERENT op from -D (branch force-delete); op-class scoping
+# keeps them from being conflated.
+PRIVILEGED_FLAGS: dict[str, dict[str, tuple[tuple[str, ...], bool]]] = {
+    "merge": {
+        "--admin":         (("--admin",), False),               # bypass branch protection
+        "--delete-branch": (("-d", "--delete-branch"), False),  # side-effect: deletes source branch
+        "--repo":          (("-R", "--repo"), True),            # cross-repo redirect (value-carrying target)
+    },
+    "close": {
+        "--repo":          (("-R", "--repo"), True),            # cross-repo redirect (value-carrying target)
+        # --delete-branch is the close-danger op-trigger (bound via op_type) — NOT listed.
+    },
+    "force-push": {
+        "--no-verify":     (("--no-verify",), False),           # bypass pre-push hook
+    },
+    "branch-delete": {
+        # No bound flags today: branch-delete's privileged effect is its op-trigger
+        # (-D / --delete --force), already bound via op_type. Kept as an explicit
+        # extension point so a future bound flag is a one-line data edit here.
+    },
+}
+
+
+def extract_privileged_flags(command: str, op_type: str | None) -> list[str]:
+    """Scan a command for the privileged dash-flags bound on its op-class (#1042).
+
+    Returns a SORTED list of canonical flag tokens (boolean flags as their
+    canonical long form, e.g. ``--admin``; value-taking flags as
+    ``--repo=<value>``). The read side compares these as SETS for exact equality,
+    so any added privilege OR dropped constraint mismatches and REFUSES.
+
+    The scan is a SINGLE linear ``str.split()`` token-walk against the op-class
+    denylist (``PRIVILEGED_FLAGS``) — constant per-token work, NO regex, no
+    backtracking — so it preserves the bounded/linear extraction invariant
+    (INV-D2) the rest of this module is careful about.
+
+    Normalizes every CLI form to one canonical token: exact long (``--admin``),
+    short alias (``-R`` -> ``--repo``), ``=``-joined (``--repo=x`` / ``-R=x``),
+    attached short value (``-Rx`` -> ``--repo=x``), and combined-short clusters
+    via a general per-character walk (``-sd`` -> ``--delete-branch``;
+    ``-dR owner/repo`` -> ``--delete-branch`` + ``--repo=owner/repo``) so NO bound
+    short is ever dropped regardless of cluster ordering. On the GIT surface
+    ONLY, an unambiguous long-prefix abbreviation is EXPANDED to its canonical
+    flag (``--no-verif`` -> ``--no-verify``) — this is SECURITY-LOAD-BEARING:
+    git's parser accepts abbreviation, so a missed match would be a silent
+    UNDER-block; gh rejects abbreviation, so its surface needs no expansion.
+
+    Args:
+        command: The command (read arm) or full approval surface (mint arm) to
+            scan. The caller decides which; the scanner treats it as one string.
+        op_type: The classified operation type, or None. Selects the denylist;
+            an op_type with no denylist entry (incl. None and the API/un-flagged
+            classes) yields ``[]``.
+
+    Returns:
+        Sorted list of canonical bound-flag tokens; ``[]`` when none are present.
+    """
+    denylist = PRIVILEGED_FLAGS.get(op_type) if op_type is not None else None
+    if not denylist:
+        # op_type is None, unknown, or carries no bound flags (e.g. branch-delete
+        # today). An empty result binds the empty set — over-block-safe and the
+        # correct outcome for the API/un-flagged classes.
+        return []
+
+    # Derive the lookup tables from the denylist ONCE per call. All small,
+    # constant-size structures (the denylist has <=3 entries per op-class), so
+    # the per-token work below stays O(1).
+    alias_to_canonical: dict[str, str] = {}
+    value_taking: set[str] = set()
+    canonical_long_names: list[str] = []
+    for canonical, (aliases, takes_value) in denylist.items():
+        canonical_long_names.append(canonical)
+        if takes_value:
+            value_taking.add(canonical)
+        for alias in aliases:
+            alias_to_canonical[alias] = canonical
+    # git's parse-options expands unambiguous long-prefix abbreviations; gh's
+    # pflag rejects them. Only the git surface needs abbreviation expansion.
+    is_git_surface = op_type in ("force-push", "branch-delete")
+
+    tokens = command.split()
+    found: set[str] = set()
+    i = 0
+    n = len(tokens)
+    while i < n:
+        token = tokens[i]
+        # Non-flag tokens, the bare `-` (stdin) and `--` (end-of-options) marker
+        # never bind. Skipping `--` is load-bearing: it must NOT prefix-match a
+        # sole long flag in the abbreviation branch below.
+        if not token.startswith("-") or token in ("-", "--"):
+            i += 1
+            continue
+
+        if token.startswith("--"):
+            # Long flag: exact denylist hit, or — git surface only — an
+            # unambiguous prefix abbreviation. An inline `=value` is split off.
+            flag_part, has_eq, inline_value = token.partition("=")
+            canonical = alias_to_canonical.get(flag_part)
+            if canonical is None and is_git_surface:
+                prefix_matches = [
+                    name for name in canonical_long_names if name.startswith(flag_part)
+                ]
+                # Exactly one match = unambiguous; >1 is ambiguous (git itself
+                # rejects it, so the command never runs) and binds nothing.
+                if len(prefix_matches) == 1:
+                    canonical = prefix_matches[0]
+            if canonical is None:
+                i += 1
+                continue
+            if canonical in value_taking:
+                if has_eq:                       # --repo=value
+                    found.add(f"{canonical}={inline_value}")
+                    i += 1
+                elif i + 1 < n:                  # --repo value
+                    found.add(f"{canonical}={tokens[i + 1]}")
+                    i += 2
+                else:                            # --repo (value missing; degenerate)
+                    found.add(canonical)
+                    i += 1
+            else:
+                found.add(canonical)             # boolean (ignore any spurious =value)
+                i += 1
+            continue
+
+        # Short cluster (single dash): a general per-character walk that subsumes
+        # the lone short (`-R`), the combined boolean cluster (`-sd`), the
+        # attached short value (`-Rx`), and any mixed ordering (`-dR`, `-Rd`). A
+        # value-taking short consumes the REST of the cluster (or the next token)
+        # as its value and stops the walk — pflag semantics — so no bound short
+        # is ever dropped from a cluster.
+        cluster = token[1:]
+        consumed_next = False
+        j = 0
+        while j < len(cluster):
+            canonical = alias_to_canonical.get("-" + cluster[j])
+            if canonical is None:
+                j += 1
+                continue
+            if canonical in value_taking:
+                remainder = cluster[j + 1:]
+                if remainder.startswith("="):    # `-R=value`
+                    remainder = remainder[1:]
+                if remainder:                    # `-Rvalue`
+                    found.add(f"{canonical}={remainder}")
+                elif i + 1 < n:                  # `-R value`
+                    found.add(f"{canonical}={tokens[i + 1]}")
+                    consumed_next = True
+                else:                            # `-R` (value missing; degenerate)
+                    found.add(canonical)
+                break
+            found.add(canonical)                 # boolean short; keep walking
+            j += 1
+        i += 2 if consumed_next else 1
+
+    return sorted(found)
+
+
+def extract_command_context(command: str, flag_scan_text: str | None = None) -> dict:
     """Extract operation context FROM A COMMAND STRING (never prose).
 
     The shared SSOT both merge-guard hooks call. A key is PRESENT only when
@@ -453,12 +632,28 @@ def extract_command_context(command: str) -> dict:
         pr_number:  str  (merge / close)
         branch:     str  (branch-delete)
         target_ref: str  (force-push, KD-6)
+        bound_flags: list[str]  (#1042) — sorted normalized privileged flags;
+                     ALWAYS present when operation_type is (empty list when none).
+
+    `flag_scan_text` (#1042) widens ONLY the privileged-flag scan to a fuller
+    surface than `command` — the mint arm passes the full selected-option text so
+    a flag positioned after a quoted argument is not lost to region truncation
+    (the read arm passes nothing, scanning the raw command). Op/target are ALWAYS
+    derived from `command` (region-anchored — preserves the anti-distractor
+    multiplicity gate); only the flag scan honors `flag_scan_text`.
     """
     context: dict = {}
     op_type = detect_command_operation_type(command)
     if op_type is None:
         return context
     context["operation_type"] = op_type
+    # bound_flags is computed HERE (the single call site) so both arms inherit it
+    # un-driftably. It is an ATTRIBUTE of the (op,target) pair, never part of pair
+    # identity (_target_value / _collect_pairs ignore it), so flag variation can
+    # never inflate the distinct-pair count and trip the multiplicity refusal.
+    context["bound_flags"] = extract_privileged_flags(
+        flag_scan_text if flag_scan_text is not None else command, op_type
+    )
     if op_type in ("merge", "close"):
         pr_number = _extract_pr_number(command)
         if pr_number is not None:

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -472,6 +472,10 @@ PRIVILEGED_FLAGS: dict[str, dict[str, tuple[tuple[str, ...], bool]]] = {
         "--admin":         (("--admin",), False),               # bypass branch protection
         "--delete-branch": (("-d", "--delete-branch"), False),  # side-effect: deletes source branch
         "--repo":          (("-R", "--repo"), True),            # cross-repo redirect (value-carrying target)
+        # value-carrying SAFETY constraint (pins the merge to a head SHA); binding
+        # it closes the dropped-constraint case — approve with --match-head-commit,
+        # execute without it -> set-equality REFUSES (#1042).
+        "--match-head-commit": (("--match-head-commit",), True),
     },
     "close": {
         "--repo":          (("-R", "--repo"), True),            # cross-repo redirect (value-carrying target)

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -8371,10 +8371,23 @@ class TestGhGlobalFlagBypass:
         assert _token_matches_command(token, "gh --repo owner/repo pr merge 42")
 
     def test_token_pr_mismatch_with_repo_flag(self):
-        """Typed merge token PR-number mismatch detected past a --repo flag."""
+        """Typed merge token PR-number mismatch detected past a --repo flag.
+
+        The token carries the SAME bound flags the command mints (--repo=owner/repo)
+        so the #1042 set-equality flag axis MATCHES — leaving the PR-number axis
+        (42 vs 99) as the sole load-bearing REFUSE reason. Without the matching
+        bound_flags the refusal would ride the flag axis (token []) and this test
+        would stay green even if PR-mismatch detection regressed (vacuous).
+        """
         from merge_guard_pre import _token_matches_command
 
-        token = {"context": {"operation_type": "merge", "pr_number": 42}}
+        token = {
+            "context": {
+                "operation_type": "merge",
+                "pr_number": 42,
+                "bound_flags": ["--repo=owner/repo"],
+            }
+        }
         assert not _token_matches_command(token, "gh --repo owner/repo pr merge 99")
 
     def test_token_op_type_with_repo_flag(self):
@@ -8859,10 +8872,21 @@ class TestGhGlobalFlagBypassEdgeCases:
         )
 
     def test_token_pr_mismatch_with_multiple_flags(self):
-        """PR number mismatch detected past multiple global flags (typed token)."""
+        """PR number mismatch detected past multiple global flags (typed token).
+
+        --repo is bound (#1042); --hostname is not. The token carries the bound
+        --repo so the flag axis matches and the PR-number axis (42 vs 99) is the
+        sole load-bearing mismatch — keeping the test non-vacuous on PR detection.
+        """
         from merge_guard_pre import _token_matches_command
 
-        token = {"context": {"operation_type": "merge", "pr_number": 42}}
+        token = {
+            "context": {
+                "operation_type": "merge",
+                "pr_number": 42,
+                "bound_flags": ["--repo=owner/repo"],
+            }
+        }
         assert not _token_matches_command(
             token, "gh --repo owner/repo --hostname host.com pr merge 99"
         )
@@ -8884,10 +8908,22 @@ class TestGhGlobalFlagBypassEdgeCases:
         )
 
     def test_token_pr_mismatch_close_with_flags(self):
-        """PR number mismatch in a close command past global flags (typed)."""
+        """PR number mismatch in a close command past global flags (typed).
+
+        On the close op-class -R/--repo is bound; --delete-branch is the close
+        op-trigger (bound via op_type, NOT in the denylist). The token carries the
+        bound --repo so the flag axis matches and the PR-number axis (100 vs 200)
+        is the sole load-bearing mismatch — keeping the test non-vacuous.
+        """
         from merge_guard_pre import _token_matches_command
 
-        token = {"context": {"operation_type": "close", "pr_number": 100}}
+        token = {
+            "context": {
+                "operation_type": "close",
+                "pr_number": 100,
+                "bound_flags": ["--repo=owner/repo"],
+            }
+        }
         assert not _token_matches_command(
             token, "gh -R owner/repo pr close 200 --delete-branch"
         )
@@ -9092,10 +9128,22 @@ class TestSubcommandFlagsBeforePrNumber:
         assert _token_matches_command(token, "gh pr close --comment done 42")
 
     def test_merge_admin_flag_pr_number_mismatch(self):
-        """'gh pr merge --admin 99' — mismatch with token for PR 42."""
+        """'gh pr merge --admin 99' — mismatch with token for PR 42.
+
+        The token carries the bound --admin so the #1042 flag axis matches and the
+        PR-number axis (42 vs 99) is the sole load-bearing mismatch — non-vacuous
+        on PR detection (without the matching flag the refusal would ride the flag
+        axis and mask a PR-detection regression).
+        """
         from merge_guard_pre import _token_matches_command
 
-        token = {"context": {"operation_type": "merge", "pr_number": 42}}
+        token = {
+            "context": {
+                "operation_type": "merge",
+                "pr_number": 42,
+                "bound_flags": ["--admin"],
+            }
+        }
         assert not _token_matches_command(token, "gh pr merge --admin 99")
 
     def test_merge_admin_flag_with_global_flags(self):
@@ -9114,10 +9162,21 @@ class TestSubcommandFlagsBeforePrNumber:
         )
 
     def test_merge_admin_flag_with_global_flags_mismatch(self):
-        """'gh --repo X pr merge --admin 99' — mismatch with combined flags."""
+        """'gh --repo X pr merge --admin 99' — mismatch with combined flags.
+
+        The token carries BOTH bound flags the command mints (--admin and
+        --repo=owner/repo) so the #1042 flag axis matches and the PR-number axis
+        (42 vs 99) is the sole load-bearing mismatch — keeping the test non-vacuous.
+        """
         from merge_guard_pre import _token_matches_command
 
-        token = {"context": {"operation_type": "merge", "pr_number": 42}}
+        token = {
+            "context": {
+                "operation_type": "merge",
+                "pr_number": 42,
+                "bound_flags": ["--admin", "--repo=owner/repo"],
+            }
+        }
         assert not _token_matches_command(
             token, "gh --repo owner/repo pr merge --admin 99"
         )

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -5740,8 +5740,11 @@ class TestSchemaFixEndToEnd:
         from shared.merge_guard_common import MAX_USES, USE_MARKER_SUFFIX
 
         for _ in range(MAX_USES):
+            # #1042: execution flags must match the approval (`gh pr merge 252`,
+            # no privileged flags). --squash is unbound; --delete-branch (a bound
+            # merge side-effect) would now correctly mismatch an unflagged approval.
             pre_input = json.dumps({
-                "tool_input": {"command": "gh pr merge 252 --squash --delete-branch"}
+                "tool_input": {"command": "gh pr merge 252 --squash"}
             })
             with patch("merge_guard_pre.TOKEN_DIR", tmp_path), \
                  patch("sys.stdin", io.StringIO(pre_input)):
@@ -8358,7 +8361,13 @@ class TestGhGlobalFlagBypass:
         (the load-bearing anti-bypass PR extraction is preserved)."""
         from merge_guard_pre import _token_matches_command
 
-        token = {"context": {"operation_type": "merge", "pr_number": 42}}
+        token = {
+            "context": {
+                "operation_type": "merge",
+                "pr_number": 42,
+                "bound_flags": ["--repo=owner/repo"],  # #1042: -R/--repo now bound
+            }
+        }
         assert _token_matches_command(token, "gh --repo owner/repo pr merge 42")
 
     def test_token_pr_mismatch_with_repo_flag(self):
@@ -8372,7 +8381,13 @@ class TestGhGlobalFlagBypass:
         """Typed merge token (op + pr) matching works past a --repo global flag."""
         from merge_guard_pre import _token_matches_command
 
-        token = {"context": {"operation_type": "merge", "pr_number": "42"}}
+        token = {
+            "context": {
+                "operation_type": "merge",
+                "pr_number": "42",
+                "bound_flags": ["--repo=owner/repo"],  # #1042: -R/--repo now bound
+            }
+        }
         assert _token_matches_command(token, "gh --repo owner/repo pr merge 42")
 
     def test_token_op_type_mismatch_with_repo_flag(self):
@@ -8817,7 +8832,13 @@ class TestGhGlobalFlagBypassEdgeCases:
         """PR number extracted correctly past two global flags (typed token)."""
         from merge_guard_pre import _token_matches_command
 
-        token = {"context": {"operation_type": "merge", "pr_number": 42}}
+        token = {
+            "context": {
+                "operation_type": "merge",
+                "pr_number": 42,
+                "bound_flags": ["--repo=owner/repo"],  # #1042: --hostname unbound
+            }
+        }
         assert _token_matches_command(
             token, "gh --repo owner/repo --hostname host.com pr merge 42"
         )
@@ -8826,7 +8847,13 @@ class TestGhGlobalFlagBypassEdgeCases:
         """PR number extracted correctly with --repo=value syntax (typed token)."""
         from merge_guard_pre import _token_matches_command
 
-        token = {"context": {"operation_type": "merge", "pr_number": 42}}
+        token = {
+            "context": {
+                "operation_type": "merge",
+                "pr_number": 42,
+                "bound_flags": ["--repo=owner/repo"],  # #1042: --repo=value form
+            }
+        }
         assert _token_matches_command(
             token, "gh --repo=owner/repo pr merge 42"
         )
@@ -8844,7 +8871,14 @@ class TestGhGlobalFlagBypassEdgeCases:
         """PR number extracted from a close command past global flags (typed)."""
         from merge_guard_pre import _token_matches_command
 
-        token = {"context": {"operation_type": "close", "pr_number": 100}}
+        token = {
+            "context": {
+                "operation_type": "close",
+                "pr_number": 100,
+                "bound_flags": ["--repo=owner/repo"],  # #1042: -R bound; close's
+                # --delete-branch is the op-trigger (bound via op_type), unbound here
+            }
+        }
         assert _token_matches_command(
             token, "gh -R owner/repo pr close 100 --delete-branch"
         )
@@ -8883,7 +8917,11 @@ class TestGhGlobalFlagBypassEdgeCases:
 
         token_data = {
             "expires_at": time.time() + 300,
-            "context": {"operation_type": "merge", "pr_number": 42},
+            "context": {
+                "operation_type": "merge",
+                "pr_number": 42,
+                "bound_flags": ["--repo=owner/repo"],  # #1042: -R/--repo now bound
+            },
         }
         token_path = tmp_path / f"{TOKEN_PREFIX}test"
         token_path.write_text(json.dumps(token_data))
@@ -9013,7 +9051,13 @@ class TestSubcommandFlagsBeforePrNumber:
         """'gh pr merge --admin 42' — PR number extracted past the subcommand flag."""
         from merge_guard_pre import _token_matches_command
 
-        token = {"context": {"operation_type": "merge", "pr_number": 42}}
+        token = {
+            "context": {
+                "operation_type": "merge",
+                "pr_number": 42,
+                "bound_flags": ["--admin"],  # #1042: --admin now bound
+            }
+        }
         assert _token_matches_command(token, "gh pr merge --admin 42")
 
     def test_merge_squash_flag_before_pr_number(self):
@@ -9027,7 +9071,15 @@ class TestSubcommandFlagsBeforePrNumber:
         """'gh pr merge --squash --delete-branch 42' — PR number extracted."""
         from merge_guard_pre import _token_matches_command
 
-        token = {"context": {"operation_type": "merge", "pr_number": 42}}
+        token = {
+            "context": {
+                "operation_type": "merge",
+                "pr_number": 42,
+                # #1042: --delete-branch on MERGE is a bound side-effect; --squash
+                # is a merge-method flag (unbound).
+                "bound_flags": ["--delete-branch"],
+            }
+        }
         assert _token_matches_command(
             token, "gh pr merge --squash --delete-branch 42"
         )
@@ -9050,7 +9102,13 @@ class TestSubcommandFlagsBeforePrNumber:
         """'gh --repo X pr merge --admin 42' — global + subcommand flags."""
         from merge_guard_pre import _token_matches_command
 
-        token = {"context": {"operation_type": "merge", "pr_number": 42}}
+        token = {
+            "context": {
+                "operation_type": "merge",
+                "pr_number": 42,
+                "bound_flags": ["--admin", "--repo=owner/repo"],  # #1042: both bound
+            }
+        }
         assert _token_matches_command(
             token, "gh --repo owner/repo pr merge --admin 42"
         )

--- a/pact-plugin/tests/test_merge_guard_auth_symmetry.py
+++ b/pact-plugin/tests/test_merge_guard_auth_symmetry.py
@@ -729,3 +729,120 @@ class TestOptionAnchoringMint:
         code = _invoke_post([_q(q, opts)], {q: "Yes, merge"}, tmp_path)
         assert code == 0
         assert _minted_tokens(tmp_path) == []
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# #1042 — PRIVILEGED-FLAG BINDING over the real mint→read seam
+# ════════════════════════════════════════════════════════════════════════════
+
+
+class TestPrivilegedFlagMintSymmetry:
+    """A1 — the MINT must scan the FULL selected-option surface for bound flags,
+    NOT the quote-truncated bare-command region. A privileged flag positioned
+    AFTER a quoted argument in a BARE command falls outside
+    locate_command_regions' truncated region (it stops at the first quote); the
+    mint's flag_scan_text widening recovers it so the approved set carries the
+    flag and a faithful re-execution AUTHORIZES while an added flag REFUSES.
+
+    These drive the REAL mint (post.main → write_token → check_merge_authorization)
+    — a hand-built token would bypass the mint widening and be vacuous for the A1
+    claim. Revert-coupling: the AUTHORIZE round-trip is coupled to the C3 mint
+    widening (merge_guard_post.py). A SOURCE-ONLY revert re-mints a flagless token
+    (the truncated region drops the flag) while the read side still scans the full
+    command → {} != {--admin} → REFUSE → the round-trip flips RED (measured
+    cardinality in the TEST HANDOFF)."""
+
+    _CMD_ADMIN_AFTER_QUOTE = 'gh pr merge 5 --subject "ship it" --admin'
+
+    def test_admin_after_quoted_arg_round_trips_via_full_mint_scan(self, tmp_path):
+        """Approve a BARE command with --admin after a quoted --subject; the mint
+        scans the full option text to bind --admin, so the faithful re-execution
+        AUTHORIZES. (Without the C3 full-surface scan the mint binds {} and this
+        flips to REFUSE.)"""
+        q = "Merge this pull request now? The reviewers have signed off."
+        opts = [
+            _opt("Yes, merge", "On approval run: " + self._CMD_ADMIN_AFTER_QUOTE),
+            _opt("Cancel", "Abort"),
+        ]
+        assert _invoke_post([_q(q, opts)], {q: "Yes, merge"}, tmp_path) == 0
+        assert len(_minted_tokens(tmp_path)) == 1
+        assert _authorize(self._CMD_ADMIN_AFTER_QUOTE, tmp_path) is None
+
+    def test_admin_added_after_quote_at_exec_is_blocked(self, tmp_path):
+        """Bypass direction through the real seam: approve the command WITHOUT
+        --admin (subject only); execute WITH --admin appended after the quote. The
+        read side scans the full command and catches the added --admin the approval
+        never carried → REFUSE (coupled to the C2 read gate)."""
+        approved = 'gh pr merge 5 --subject "ship it"'
+        q = "Merge this pull request now?"
+        opts = [_opt("Yes, merge", "On approval run: " + approved), _opt("Cancel", "Abort")]
+        assert _invoke_post([_q(q, opts)], {q: "Yes, merge"}, tmp_path) == 0
+        assert len(_minted_tokens(tmp_path)) == 1
+        assert _authorize(self._CMD_ADMIN_AFTER_QUOTE, tmp_path) is not None
+
+    def test_cross_repo_redirect_blocked_end_to_end(self, tmp_path):
+        """Headline bug end-to-end: approve a bare merge (no -R) through the real
+        mint; an execution that adds -R victim/repo REFUSES (the cross-repo
+        redirect can no longer ride the checkpoint undetected)."""
+        q = "Merge this pull request now?"
+        opts = [_opt("Yes, merge", "On approval run: gh pr merge 5"), _opt("Cancel", "Abort")]
+        assert _invoke_post([_q(q, opts)], {q: "Yes, merge"}, tmp_path) == 0
+        assert len(_minted_tokens(tmp_path)) == 1
+        assert _authorize("gh --repo victim/repo pr merge 5", tmp_path) is not None
+
+
+class TestPrivilegedFlagReadFloorSeam:
+    """The read floor over the REAL on-disk token seam: a forged/seeded approval
+    token with a given bound_flags set is read back by check_merge_authorization
+    and must REFUSE any privileged-flag escalation while AUTHORIZing the exact
+    match. _seed_token writes the token directly (bypassing the write gate) —
+    exactly the hand-crafted-token threat the read floor must withstand.
+
+    Revert-coupling: every REFUSE here is coupled to the C2 set-equality gate
+    (merge_guard_pre.py); a source-only revert flips each to AUTHORIZE → RED. The
+    AUTHORIZE controls confirm the refusal is the FLAG axis (op+target already
+    match), not an unrelated mismatch."""
+
+    def test_flagless_token_denies_admin_execution(self, tmp_path):
+        _seed_token(tmp_path, {"operation_type": "merge", "pr_number": "5", "bound_flags": []})
+        assert _authorize("gh pr merge 5 --admin", tmp_path) is not None
+
+    def test_flagless_token_denies_cross_repo_redirect(self, tmp_path):
+        _seed_token(tmp_path, {"operation_type": "merge", "pr_number": "5", "bound_flags": []})
+        assert _authorize("gh --repo victim/repo pr merge 5", tmp_path) is not None
+
+    def test_admin_token_authorizes_matching_admin(self, tmp_path):
+        """Positive control over the seam: the matching --admin execution AUTHORIZES
+        — so the refusals above are the flag axis, not a target/op mismatch."""
+        _seed_token(
+            tmp_path,
+            {"operation_type": "merge", "pr_number": "5", "bound_flags": ["--admin"]},
+        )
+        assert _authorize("gh pr merge 5 --admin", tmp_path) is None
+
+    def test_flagless_token_denies_no_verify_force_push(self, tmp_path):
+        _seed_token(
+            tmp_path,
+            {"operation_type": "force-push", "target_ref": "main", "bound_flags": []},
+        )
+        assert _authorize("git push --no-verify origin main --force", tmp_path) is not None
+
+    def test_flagless_token_denies_git_no_verif_abbreviation(self, tmp_path):
+        """SECURITY-LOAD-BEARING end-to-end: git accepts the `--no-verif`
+        abbreviation (really disabling the pre-push hook); the read floor expands
+        it on the git surface so a flagless approval REFUSES it (a missed
+        abbreviation would be a silent UNDER-block)."""
+        _seed_token(
+            tmp_path,
+            {"operation_type": "force-push", "target_ref": "main", "bound_flags": []},
+        )
+        assert _authorize("git push --no-verif origin main --force", tmp_path) is not None
+
+    def test_no_verify_token_authorizes_matching_force_push(self, tmp_path):
+        """Positive control: the matching --no-verify execution AUTHORIZES."""
+        _seed_token(
+            tmp_path,
+            {"operation_type": "force-push", "target_ref": "main",
+             "bound_flags": ["--no-verify"]},
+        )
+        assert _authorize("git push --no-verify origin main --force", tmp_path) is None

--- a/pact-plugin/tests/test_merge_guard_auth_symmetry.py
+++ b/pact-plugin/tests/test_merge_guard_auth_symmetry.py
@@ -790,6 +790,50 @@ class TestPrivilegedFlagMintSymmetry:
         assert len(_minted_tokens(tmp_path)) == 1
         assert _authorize("gh --repo victim/repo pr merge 5", tmp_path) is not None
 
+    # ── non-merge op-class real-mint witness (removes the op-agnostic-transfer
+    # dependency for a 2nd op + the value-carrying -R flag): the mint flag-scan is
+    # ONE SSOT call site, but witnessing CLOSE end-to-end through the REAL mint
+    # removes the need to ARGUE that merge coverage transfers. The _seed_token
+    # read-floor cases below FORGE the token and bypass the mint; these drive the
+    # real close mint.
+    #
+    # NB force-push has NO real-mint witness BY STRUCTURAL NECESSITY: its only
+    # bound flag is --no-verify, whose substring "no" trips the pre-existing
+    # decline/defer veto (_DECLINE_DEFER_RE) in _mint_context_from_bundle Step 1,
+    # so a --no-verify approval never mints (over-block-safe — it HOLDS the
+    # force-push, never authorizes an unapproved one). The force-push --no-verify
+    # READ path is therefore covered via _seed_token in TestPrivilegedFlagReadFloorSeam,
+    # which forges the token the real mint cannot produce. ──
+    # NB the close commands carry --delete-branch: that is the close-danger
+    # op-TRIGGER (a bare `gh pr close` is NOT a governed/held op), so a governed
+    # close that the read arm holds must carry it. --delete-branch is bound via
+    # op_type (NOT in the denylist), so it does NOT appear in bound_flags; -R does.
+    def test_close_repo_round_trips_via_real_mint(self, tmp_path):
+        """Approve a governed CLOSE bundle carrying -R through the REAL mint → the
+        minted token binds --repo → the faithful re-execution AUTHORIZES. Witnesses
+        the mint flag-scan on a non-merge op-class with a value-carrying flag."""
+        cmd = "gh pr close 5 --delete-branch -R owner/repo"
+        q = "Close PR 5 and delete its branch now?"
+        opts = [_opt("Yes, close", "On approval run: " + cmd), _opt("Cancel", "Abort")]
+        assert _invoke_post([_q(q, opts)], {q: "Yes, close"}, tmp_path) == 0
+        assert len(_minted_tokens(tmp_path)) == 1
+        assert _authorize(cmd, tmp_path) is None
+
+    def test_close_repo_redirect_added_at_exec_blocked_via_real_mint(self, tmp_path):
+        """Bypass direction through the real close mint: approve a governed close
+        WITHOUT -R; an execution that ADDS -R victim/repo REFUSES (coupled to the
+        C2 read gate)."""
+        q = "Close PR 5 and delete its branch now?"
+        opts = [
+            _opt("Yes, close", "On approval run: gh pr close 5 --delete-branch"),
+            _opt("Cancel", "Abort"),
+        ]
+        assert _invoke_post([_q(q, opts)], {q: "Yes, close"}, tmp_path) == 0
+        assert len(_minted_tokens(tmp_path)) == 1
+        assert _authorize(
+            "gh pr close 5 --delete-branch -R victim/repo", tmp_path
+        ) is not None
+
 
 class TestPrivilegedFlagReadFloorSeam:
     """The read floor over the REAL on-disk token seam: a forged/seeded approval

--- a/pact-plugin/tests/test_merge_guard_perf.py
+++ b/pact-plugin/tests/test_merge_guard_perf.py
@@ -221,3 +221,49 @@ class TestFlagTokenBoundary:
         cmd = "git push -u -v --no-verify origin main"
         assert is_dangerous_command(cmd) is True
         assert detect_command_operation_type(cmd) == "force-push"
+
+
+# ---------------------------------------------------------------------------
+# Privileged-flag scanner linearity (#1042 INV-D2). extract_privileged_flags is
+# a single str.split() token-walk with constant per-token work (the op-class
+# denylist has <=3 entries; the git-surface abbreviation scan compares a token
+# against a <=1-entry long-name list) — O(n) LINEAR, no regex / no backtracking.
+# Like the push-flag-walk case above it is structurally linear with NO quadratic
+# predecessor to revert to (GREEN-stays-GREEN — no perf counter-test-RED); its
+# guard is the ratio/ceiling, which a future nested-quantifier or per-token
+# rescan regression would trip.
+# ---------------------------------------------------------------------------
+
+from shared.merge_guard_common import extract_privileged_flags  # noqa: E402
+
+
+class TestPrivilegedFlagScannerLinearity:
+    """The #1042 bound-flag scanner scales sub-quadratically on a worst-case
+    many-token witness, through both the short-cluster walk (merge surface) and
+    the git-surface prefix-abbreviation scan (force-push surface)."""
+
+    @pytest.mark.parametrize("op,build", [
+        # merge surface: single-dash cluster walk over unbound shorts (per-token
+        # constant work; no value-consumption short-circuit to confound the shape).
+        ("merge", lambda n: "-x " * n),
+        # force-push surface: every token enters the unambiguous-prefix expansion
+        # scan against the <=1-entry long-name list (the abbreviation branch).
+        ("force-push", lambda n: "--n " * n),
+    ], ids=["merge_short_cluster_walk", "force_push_abbreviation_scan"])
+    def test_scanner_scales_linearly(self, op, build):
+        fn = lambda cmd: extract_privileged_flags(cmd, op)  # noqa: E731
+        t_small, t_large = _measure_scaling(fn, build)
+        ratio = (t_large / t_small) if t_small > 0 else float("inf")
+
+        # PRIMARY: generous absolute ceiling (linear is sub-ms here even at N=4000).
+        assert t_large < 1.0, (
+            f"extract_privileged_flags({op}) on {build(1)!r}*{N_LARGE}: "
+            f"{t_large * 1000:.1f} ms exceeds 1000 ms ceiling — backtracking regression?"
+        )
+        # REINFORCING: scaling ratio across one doubling (linear ~2.0, quadratic ~4.0).
+        assert ratio < RATIO_CEILING, (
+            f"extract_privileged_flags({op}) on {build(1)!r}: "
+            f"t({N_LARGE})/t({N_SMALL}) = {ratio:.2f} >= {RATIO_CEILING} — "
+            f"quadratic scaling regression (t_small={t_small * 1000:.1f} ms, "
+            f"t_large={t_large * 1000:.1f} ms)?"
+        )

--- a/pact-plugin/tests/test_merge_guard_privileged_flags.py
+++ b/pact-plugin/tests/test_merge_guard_privileged_flags.py
@@ -204,6 +204,68 @@ class TestReadArmDroppedConstraintRefuses:
         )
 
 
+class TestMatchHeadCommitDroppedConstraint:
+    """--match-head-commit <sha> is a value-carrying SAFETY constraint (merge only
+    if HEAD is still <sha>) — the canonical DROPPED-CONSTRAINT case set-equality
+    catches that a subset rule (executed ⊆ approved) would silently ALLOW. Bound
+    value-taking on the merge op-class (R4 denylist add).
+
+    NON-VACUITY (essential): the approval token is SCANNER-DERIVED via
+    extract_command_context, NOT hand-built. A hand-built
+    {--match-head-commit=ABC123} token would REFUSE the bare execute REGARDLESS of
+    whether --match-head-commit is in the denylist — the token/cmd asymmetry would
+    drive the refusal, not the binding (vacuous w.r.t. the R4 config add). By
+    deriving the token through the live scanner, a SOURCE-ONLY revert of the R4
+    denylist add makes the scanner bind [] for --match-head-commit → the approval
+    token's bound_flags collapse to {} → {} == {} → the dropped constraint
+    AUTHORIZES → these REFUSE tests flip RED (the dropped-constraint, added, and
+    different-value cases; the identical-match positive stays GREEN)."""
+
+    _APPROVAL = "gh pr merge 5 --match-head-commit ABC123"
+
+    @staticmethod
+    def _scanner_token(approval_command: str) -> dict:
+        """Build the approval token by SCANNING the approval command through the
+        production SSOT, so bound_flags reflect the LIVE denylist (couples the
+        dropped-constraint refusal to the --match-head-commit binding)."""
+        from shared.merge_guard_common import extract_command_context
+
+        return {"context": extract_command_context(approval_command)}
+
+    def test_dropped_constraint_refuses(self):
+        """Approve WITH the safety constraint, execute WITHOUT it → REFUSE — the
+        dropped-constraint direction a subset rule would silently allow."""
+        from merge_guard_pre import _token_matches_command
+
+        assert not _token_matches_command(self._scanner_token(self._APPROVAL), "gh pr merge 5")
+
+    def test_added_constraint_refuses(self):
+        """Approve bare, execute WITH --match-head-commit → REFUSE (added direction;
+        the executed side is scanned live)."""
+        from merge_guard_pre import _token_matches_command
+
+        assert not _token_matches_command(
+            self._scanner_token("gh pr merge 5"), self._APPROVAL
+        )
+
+    def test_different_constraint_value_refuses(self):
+        """Approve --match-head-commit ABC123, execute --match-head-commit DEF456 →
+        REFUSE — a DIFFERENT head-sha is a different binding (the VALUE is bound,
+        not merely the flag's presence)."""
+        from merge_guard_pre import _token_matches_command
+
+        assert not _token_matches_command(
+            self._scanner_token(self._APPROVAL), "gh pr merge 5 --match-head-commit DEF456"
+        )
+
+    def test_identical_constraint_authorizes(self):
+        """Approve and execute with the SAME constraint → AUTHORIZE — a faithful
+        re-execution is not over-blocked."""
+        from merge_guard_pre import _token_matches_command
+
+        assert _token_matches_command(self._scanner_token(self._APPROVAL), self._APPROVAL)
+
+
 # ════════════════════════════════════════════════════════════════════════════
 # READ ARM — bounded over-block: an EXACT (form-invariant) match AUTHORIZES
 # ════════════════════════════════════════════════════════════════════════════
@@ -305,6 +367,9 @@ class TestScannerCanonicalForms:
         # cluster with an UNBOUND short (-s ignored), bound -d kept
         ("gh pr merge 5 -sd", "merge", ["--delete-branch"]),
         ("gh pr merge 5 -d", "merge", ["--delete-branch"]),
+        # --match-head-commit (value-taking SAFETY constraint, R4): spaced + =-joined
+        ("gh pr merge 5 --match-head-commit ABC123", "merge", ["--match-head-commit=ABC123"]),
+        ("gh pr merge 5 --match-head-commit=ABC123", "merge", ["--match-head-commit=ABC123"]),
         # benign: no bound flag → empty set
         ("gh pr merge 5", "merge", []),
         # close op-class: -R bound; --delete-branch is the op-trigger (NOT bound)

--- a/pact-plugin/tests/test_merge_guard_privileged_flags.py
+++ b/pact-plugin/tests/test_merge_guard_privileged_flags.py
@@ -95,6 +95,12 @@ class TestReadArmBypassRefuses:
         ("repo_redirect_equals_joined",
          {"operation_type": "merge", "pr_number": "5", "bound_flags": []},
          "gh pr merge 5 --repo=victim/repo"),
+        # SHORT =-joined (-R=value) — a DISTINCT scanner branch from the long
+        # =-joined form: the short-cluster value path strips a leading `=` off the
+        # cluster remainder. Exercises that `=`-strip (otherwise uncovered).
+        ("repo_redirect_short_equals_joined",
+         {"operation_type": "merge", "pr_number": "5", "bound_flags": []},
+         "gh pr merge 5 -R=victim/repo"),
         # Approved one repo, executed a DIFFERENT repo → still REFUSE.
         ("repo_redirect_different_repo",
          {"operation_type": "merge", "pr_number": "5", "bound_flags": ["--repo=a/x"]},
@@ -225,7 +231,9 @@ class TestReadArmExactMatchAuthorizes:
         "gh pr merge 5 --repo=owner/repo",
         "gh pr merge 5 -R owner/repo",
         "gh pr merge 5 -Rowner/repo",
-    ], ids=["global_long", "equals_joined", "short_spaced", "short_attached"])
+        "gh pr merge 5 -R=owner/repo",
+    ], ids=["global_long", "equals_joined", "short_spaced", "short_attached",
+            "short_equals_joined"])
     def test_repo_form_invariant_match_authorizes(self, command):
         """Approve the canonical --repo=owner/repo; every equivalent -R/--repo form
         of the same repo AUTHORIZES (all normalize to one token)."""
@@ -285,6 +293,9 @@ class TestScannerCanonicalForms:
         ("gh --repo owner/repo pr merge 5", "merge", ["--repo=owner/repo"]),
         ("gh pr merge 5 --repo=owner/repo", "merge", ["--repo=owner/repo"]),
         ("gh pr merge 5 -Rowner/repo", "merge", ["--repo=owner/repo"]),
+        # short =-joined (-R=value): exercises the cluster-path `=`-strip, a
+        # DISTINCT branch from the long --repo=value form above.
+        ("gh pr merge 5 -R=owner/repo", "merge", ["--repo=owner/repo"]),
         # combined-short cluster: -d boolean kept, -R consumes the next token
         ("gh pr merge 5 -dR owner/repo", "merge", ["--delete-branch", "--repo=owner/repo"]),
         # combined-short cluster, attached value: -d boolean, -R consumes "owner/repo"
@@ -298,6 +309,7 @@ class TestScannerCanonicalForms:
         ("gh pr merge 5", "merge", []),
         # close op-class: -R bound; --delete-branch is the op-trigger (NOT bound)
         ("gh pr close 5 -R x/y", "close", ["--repo=x/y"]),
+        ("gh pr close 5 -R=x/y", "close", ["--repo=x/y"]),  # short =-joined on close
         ("gh pr close 5 --delete-branch", "close", []),
         # force-push: --no-verify (exact)
         ("git push --no-verify origin main --force", "force-push", ["--no-verify"]),

--- a/pact-plugin/tests/test_merge_guard_privileged_flags.py
+++ b/pact-plugin/tests/test_merge_guard_privileged_flags.py
@@ -1,0 +1,426 @@
+"""Privileged-flag binding RED matrix + CLI-form normalization.
+
+SACROSANCT merge-gate control (risk tier CRITICAL). Before this binding, the
+guard bound an approval to its execution by (operation_type, target) only and
+DROPPED every dash-flag — so a privileged flag added at execution time rode past
+the checkpoint undetected:
+
+    approve `gh pr merge 5`  →  execute `gh pr merge 5 --admin`     (branch-protection bypass)
+    approve `gh pr merge 5`  →  execute `gh pr merge 5 -R victim/x` (cross-repo redirect)
+    approve `git push origin main --force` → execute `... --no-verify` (pre-push-hook bypass)
+
+The fix adds a `bound_flags` binding dimension enforced as a never-escalate
+SET-EQUALITY rule: the executed command's binding-relevant flags must EXACTLY
+equal the approved set, so ANY added privilege OR dropped constraint REFUSES.
+
+Layering (which guard each test exercises):
+  * READ ARM — `_token_matches_command(token, command)`: the executed `command`
+    is scanned LIVE by the real `extract_command_context` SSOT; only the approval
+    (token) side is hand-built. Asserts REFUSE on any flag difference and
+    AUTHORIZE on an exact, FORM-INVARIANT match.
+  * SCANNER — `extract_privileged_flags(command, op_type)`: direct output pins for
+    the CLI-form normalization (short / long / =-joined / attached-short /
+    combined-short cluster / git-surface prefix abbreviation), incl. the pflag
+    `-Rd` value-consumption subtlety and the git-vs-gh abbreviation asymmetry.
+  * MULTIPLICITY — `_collect_pairs`: flag variation is a pair ATTRIBUTE, never part
+    of (op,target) identity, so it cannot inflate the distinct-pair count and trip
+    the SACROSANCT divergence-refusal.
+
+The A1 full-text MINT symmetry (the mint must scan the FULL selected-option
+surface, not the quote-truncated bare-command region) is proven through the REAL
+mint seam in test_merge_guard_auth_symmetry.py — a hand-built token would bypass
+the mint widening and be vacuous for that claim.
+
+Non-vacuity (counter-test-by-revert; measured cardinality in the TEST HANDOFF):
+  * The read-arm REFUSE matrix is coupled to the C2 set-equality gate in
+    merge_guard_pre.py. A SOURCE-ONLY revert of that gate makes every REFUSE flip
+    to AUTHORIZE → these tests go RED. (They also die under a C1 revert, which
+    removes the `bound_flags` key entirely — but C2 is the clean source-only
+    target since it does not touch the scanner module.) The behavioral tests here
+    import only STABLE symbols, so they still COLLECT under either revert.
+  * The scanner-form output pins are coupled to the C1 scanner in
+    merge_guard_common.py: a form the scanner mishandles changes the asserted
+    canonical token → RED at HEAD. The git-vs-gh asymmetry control pins the
+    security-load-bearing `is_git_surface` branch (a missed git abbreviation is an
+    UNDER-block). A C1 source-only revert removes `extract_privileged_flags`
+    (ImportError), so these pins isolate the scanner by exact output, not revert.
+"""
+
+import pytest
+
+
+def _refuses(token_context: dict, command: str) -> bool:
+    """True iff the read arm REFUSES (does not authorize) `command` for a token
+    carrying `token_context`. The command's bound_flags are scanned LIVE by the
+    production SSOT; only the approval side is hand-built."""
+    from merge_guard_pre import _token_matches_command
+
+    return not _token_matches_command({"context": token_context}, command)
+
+
+def _authorizes(token_context: dict, command: str) -> bool:
+    from merge_guard_pre import _token_matches_command
+
+    return _token_matches_command({"context": token_context}, command)
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# READ ARM — the bypass matrix: every privileged-flag difference REFUSES
+# ════════════════════════════════════════════════════════════════════════════
+
+
+class TestReadArmBypassRefuses:
+    """A privileged flag ADDED at execution past a flagless (or differently-
+    flagged) approval REFUSES — the headline #1042 bypasses, across every CLI
+    form and op-class."""
+
+    # (id, approved-token-context, executed-command)
+    _BYPASS = [
+        # --admin (branch-protection bypass) added past a flagless approval.
+        ("admin_add_bf_empty",
+         {"operation_type": "merge", "pr_number": "5", "bound_flags": []},
+         "gh pr merge 5 --admin"),
+        # A pre-fix token with NO bound_flags key defaults to the empty set, so a
+        # privileged execution still mismatches (over-block-safe; tokens expire).
+        ("admin_add_no_key",
+         {"operation_type": "merge", "pr_number": "5"},
+         "gh pr merge 5 --admin"),
+        # -R/--repo cross-repo redirect — the headline bug — in every form.
+        ("repo_redirect_global_long",
+         {"operation_type": "merge", "pr_number": "5", "bound_flags": []},
+         "gh --repo victim/repo pr merge 5"),
+        ("repo_redirect_attached_short",
+         {"operation_type": "merge", "pr_number": "5", "bound_flags": []},
+         "gh pr merge 5 -Rvictim/repo"),
+        ("repo_redirect_equals_joined",
+         {"operation_type": "merge", "pr_number": "5", "bound_flags": []},
+         "gh pr merge 5 --repo=victim/repo"),
+        # Approved one repo, executed a DIFFERENT repo → still REFUSE.
+        ("repo_redirect_different_repo",
+         {"operation_type": "merge", "pr_number": "5", "bound_flags": ["--repo=a/x"]},
+         "gh -R b/y pr merge 5"),
+        # -d/--delete-branch on MERGE is a post-merge side-effect (deletes the
+        # source branch) — bound on the merge op-class.
+        ("delete_branch_add_short",
+         {"operation_type": "merge", "pr_number": "5", "bound_flags": []},
+         "gh pr merge 5 -d"),
+        # --no-verify (pre-push-hook bypass) added on a force-push.
+        ("no_verify_add",
+         {"operation_type": "force-push", "target_ref": "main", "bound_flags": []},
+         "git push --no-verify origin main --force"),
+        # Cross-repo redirect on the CLOSE op-class.
+        ("close_repo_redirect",
+         {"operation_type": "close", "pr_number": "5", "bound_flags": []},
+         "gh -R victim/repo pr close 5"),
+    ]
+
+    @pytest.mark.parametrize(
+        "ctx,command", [(c, cmd) for (_id, c, cmd) in _BYPASS],
+        ids=[c[0] for c in _BYPASS],
+    )
+    def test_added_privileged_flag_refuses(self, ctx, command):
+        assert _refuses(ctx, command)
+
+    def test_git_no_verif_abbreviation_refuses(self):
+        """SECURITY-LOAD-BEARING: git's parse-options accepts an unambiguous
+        long-prefix ABBREVIATION, so `git push --no-verif ...` REALLY disables the
+        pre-push hook. Matching only the exact `--no-verify` would scan the
+        abbreviation to [] → [] == [] → AUTHORIZE → a silent UNDER-block. The
+        git-surface prefix expansion (--no-verif → --no-verify) makes the executed
+        set {--no-verify} != {} → REFUSE. This is the one normalization gap whose
+        omission under-blocks rather than over-blocks (architect §7.1)."""
+        assert _refuses(
+            {"operation_type": "force-push", "target_ref": "main", "bound_flags": []},
+            "git push --no-verif origin main --force",
+        )
+
+    def test_git_no_verify_short_prefix_abbreviation_refuses(self):
+        """Even a very short unambiguous prefix (`--no-v`, `--no`) of the sole
+        force-push denylist flag expands and REFUSES — the abbreviation closure is
+        not limited to a one-character truncation."""
+        assert _refuses(
+            {"operation_type": "force-push", "target_ref": "main", "bound_flags": []},
+            "git push --no-v origin main --force",
+        )
+
+
+class TestReadArmCombinedShortClusterRefuses:
+    """The combined-short cluster is the under-block the lead required CLOSED (not
+    shipped-and-flagged): a boolean-only cluster parser would DROP a value-taking
+    short embedded mid-cluster (the -R in `-dR owner/repo`), so an unapproved
+    cross-repo redirect would ride a `-dR` cluster past a `-d`-only approval. The
+    general per-character walk captures every bound short regardless of ordering."""
+
+    def test_mixed_cluster_dR_adds_unapproved_repo_refuses(self):
+        """Approved `-d` (delete-branch) only; executed `-dR owner/repo` adds an
+        unapproved --repo=owner/repo → REFUSE. (The cluster yields
+        {--delete-branch, --repo=owner/repo} vs the approved {--delete-branch}.)"""
+        assert _refuses(
+            {"operation_type": "merge", "pr_number": "5", "bound_flags": ["--delete-branch"]},
+            "gh pr merge 5 -dR owner/repo",
+        )
+
+    def test_mixed_cluster_Rd_value_consumption_refuses(self):
+        """pflag semantics: in `-Rd owner/repo` the value-taking -R consumes the
+        cluster remainder `d` as its value (→ --repo=d) and STOPS, so the approved
+        {--delete-branch} never matches {--repo=d} → REFUSE. Pins that the cluster
+        walk follows real pflag value-consumption, not naive per-char booleans."""
+        assert _refuses(
+            {"operation_type": "merge", "pr_number": "5", "bound_flags": ["--delete-branch"]},
+            "gh pr merge 5 -Rd owner/repo",
+        )
+
+    def test_attached_cluster_dRvalue_adds_unapproved_repo_refuses(self):
+        """`-dRowner/repo` (boolean -d then value-taking -R with attached value)
+        binds {--delete-branch, --repo=owner/repo}; a flagless approval REFUSES —
+        no bound short is dropped from the attached-value cluster form."""
+        assert _refuses(
+            {"operation_type": "merge", "pr_number": "5", "bound_flags": []},
+            "gh pr merge 5 -dRowner/repo",
+        )
+
+
+class TestReadArmDroppedConstraintRefuses:
+    """Set-equality is symmetric: an approval that carried a bound flag, executed
+    WITHOUT it, also REFUSES (the dropped-constraint direction a subset rule would
+    silently allow). Over-block-safe — the operator re-approves."""
+
+    def test_approved_admin_executed_bare_refuses(self):
+        assert _refuses(
+            {"operation_type": "merge", "pr_number": "5", "bound_flags": ["--admin"]},
+            "gh pr merge 5",
+        )
+
+    def test_approved_repo_executed_bare_refuses(self):
+        assert _refuses(
+            {"operation_type": "merge", "pr_number": "5", "bound_flags": ["--repo=owner/repo"]},
+            "gh pr merge 5",
+        )
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# READ ARM — bounded over-block: an EXACT (form-invariant) match AUTHORIZES
+# ════════════════════════════════════════════════════════════════════════════
+
+
+class TestReadArmExactMatchAuthorizes:
+    """Matching flags AUTHORIZE — the binding does not over-block a faithful
+    re-execution, and it is FORM-INVARIANT (an approval in one CLI form authorizes
+    an execution in any equivalent form, because both canonicalize identically)."""
+
+    def test_admin_exact_match_authorizes(self):
+        assert _authorizes(
+            {"operation_type": "merge", "pr_number": "5", "bound_flags": ["--admin"]},
+            "gh pr merge 5 --admin",
+        )
+
+    def test_clean_no_flag_match_authorizes(self):
+        assert _authorizes(
+            {"operation_type": "merge", "pr_number": "5", "bound_flags": []},
+            "gh pr merge 5",
+        )
+
+    @pytest.mark.parametrize("command", [
+        "gh --repo owner/repo pr merge 5",
+        "gh pr merge 5 --repo=owner/repo",
+        "gh pr merge 5 -R owner/repo",
+        "gh pr merge 5 -Rowner/repo",
+    ], ids=["global_long", "equals_joined", "short_spaced", "short_attached"])
+    def test_repo_form_invariant_match_authorizes(self, command):
+        """Approve the canonical --repo=owner/repo; every equivalent -R/--repo form
+        of the same repo AUTHORIZES (all normalize to one token)."""
+        assert _authorizes(
+            {"operation_type": "merge", "pr_number": "5", "bound_flags": ["--repo=owner/repo"]},
+            command,
+        )
+
+    @pytest.mark.parametrize("command", [
+        "git push --no-verify origin main --force",
+        "git push --no-verif origin main --force",
+    ], ids=["exact", "git_abbreviation"])
+    def test_no_verify_abbreviation_invariant_match_authorizes(self, command):
+        """Approve --no-verify; both the exact form and the git abbreviation
+        AUTHORIZE (the abbreviation expands to the same canonical token) — the
+        expansion does not introduce a spurious over-block on a faithful re-run."""
+        assert _authorizes(
+            {"operation_type": "force-push", "target_ref": "main", "bound_flags": ["--no-verify"]},
+            command,
+        )
+
+    @pytest.mark.parametrize("command", [
+        "gh pr merge 5 -d",
+        "gh pr merge 5 --delete-branch",
+    ], ids=["short", "long"])
+    def test_delete_branch_form_invariant_match_authorizes(self, command):
+        assert _authorizes(
+            {"operation_type": "merge", "pr_number": "5", "bound_flags": ["--delete-branch"]},
+            command,
+        )
+
+    def test_admin_plus_repo_combined_match_authorizes(self):
+        """Two bound flags approved and executed (order/placement-invariant) →
+        AUTHORIZE."""
+        assert _authorizes(
+            {"operation_type": "merge", "pr_number": "5",
+             "bound_flags": ["--admin", "--repo=owner/repo"]},
+            "gh --repo owner/repo pr merge 5 --admin",
+        )
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# SCANNER — extract_privileged_flags: CLI-form canonicalization output pins
+# ════════════════════════════════════════════════════════════════════════════
+
+
+class TestScannerCanonicalForms:
+    """Direct output pins for the scanner's form normalization (the C1 contract).
+    Every CLI form of a bound flag canonicalizes to ONE token so the read-side
+    set-equality is form-invariant."""
+
+    _FORMS = [
+        # --admin (boolean)
+        ("gh pr merge 5 --admin", "merge", ["--admin"]),
+        # -R/--repo (value-taking) — all forms → --repo=owner/repo
+        ("gh pr merge 5 -R owner/repo", "merge", ["--repo=owner/repo"]),
+        ("gh --repo owner/repo pr merge 5", "merge", ["--repo=owner/repo"]),
+        ("gh pr merge 5 --repo=owner/repo", "merge", ["--repo=owner/repo"]),
+        ("gh pr merge 5 -Rowner/repo", "merge", ["--repo=owner/repo"]),
+        # combined-short cluster: -d boolean kept, -R consumes the next token
+        ("gh pr merge 5 -dR owner/repo", "merge", ["--delete-branch", "--repo=owner/repo"]),
+        # combined-short cluster, attached value: -d boolean, -R consumes "owner/repo"
+        ("gh pr merge 5 -dRowner/repo", "merge", ["--delete-branch", "--repo=owner/repo"]),
+        # pflag value-consumption: -Rd → -R takes the cluster remainder "d" and STOPS
+        ("gh pr merge 5 -Rd owner/repo", "merge", ["--repo=d"]),
+        # cluster with an UNBOUND short (-s ignored), bound -d kept
+        ("gh pr merge 5 -sd", "merge", ["--delete-branch"]),
+        ("gh pr merge 5 -d", "merge", ["--delete-branch"]),
+        # benign: no bound flag → empty set
+        ("gh pr merge 5", "merge", []),
+        # close op-class: -R bound; --delete-branch is the op-trigger (NOT bound)
+        ("gh pr close 5 -R x/y", "close", ["--repo=x/y"]),
+        ("gh pr close 5 --delete-branch", "close", []),
+        # force-push: --no-verify (exact)
+        ("git push --no-verify origin main --force", "force-push", ["--no-verify"]),
+    ]
+
+    @pytest.mark.parametrize(
+        "command,op,expected", _FORMS,
+        ids=[f"{op}:{cmd}" for (cmd, op, expected) in _FORMS],
+    )
+    def test_canonical_output(self, command, op, expected):
+        from shared.merge_guard_common import extract_privileged_flags
+
+        assert extract_privileged_flags(command, op) == expected
+
+    @pytest.mark.parametrize("op", [None, "api", "branch-delete"])
+    def test_unflagged_op_classes_bind_empty_set(self, op):
+        """None / API / the (today) flagless branch-delete class yield [] — the
+        over-block-safe default for op-classes with no denylist entry."""
+        from shared.merge_guard_common import extract_privileged_flags
+
+        assert extract_privileged_flags("git push --no-verify origin main", op) == []
+
+
+class TestGitGhAbbreviationAsymmetry:
+    """The is_git_surface branch is SECURITY-LOAD-BEARING (architect §7.1): git
+    EXPANDS unambiguous long-prefix abbreviations (a miss under-blocks), gh REJECTS
+    them (the command errors out, so a miss cannot bypass). The scanner expands on
+    the git surface ONLY."""
+
+    @pytest.mark.parametrize("command", [
+        "git push --no-verif origin main --force",
+        "git push --no-ver origin main --force",
+        "git push --no-v origin main --force",
+        "git push --no origin main --force",
+    ], ids=["no-verif", "no-ver", "no-v", "no"])
+    def test_git_surface_expands_unambiguous_prefix(self, command):
+        from shared.merge_guard_common import extract_privileged_flags
+
+        assert extract_privileged_flags(command, "force-push") == ["--no-verify"]
+
+    def test_gh_surface_does_not_expand_abbreviation(self):
+        """gh rejects abbreviation, so `--admi` is NOT expanded to --admin on the
+        merge (gh) surface → [] (no spurious over-block; gh would error the command
+        anyway). The contrast with the git case above pins the asymmetry."""
+        from shared.merge_guard_common import extract_privileged_flags
+
+        assert extract_privileged_flags("gh pr merge 5 --admi", "merge") == []
+        # Control: the SAME logical intent on the git surface DOES expand.
+        assert extract_privileged_flags(
+            "git push --no-verif origin main", "force-push"
+        ) == ["--no-verify"]
+
+
+class TestEndOfOptionsMarkerOverBlock:
+    """Documented OVER-BLOCK edge: the scanner does NOT treat `--` (end-of-options)
+    as a terminator, so a privileged flag positioned AFTER `--` is still bound —
+    even though gh/git would treat post-`--` tokens as positionals (and would
+    likely not honor --admin as a flag at all). This is over-block-SAFE and
+    arm-SYMMETRIC: both arms call the same SSOT, so an identical approve/execute
+    pair still MATCHES → AUTHORIZE; the binding only ever over-refuses a DIVERGENT
+    pair, never under-blocks. Pinned so a future `--`-handling change cannot
+    silently flip it into an UNDER-block (binding [] past `--` would let
+    `approve bare / execute -- --admin` AUTHORIZE)."""
+
+    def test_scanner_does_not_terminate_on_double_dash(self):
+        """Arm-symmetric by construction: the shared SSOT binds --admin past `--`,
+        so BOTH arms classify it identically (no per-arm `--` divergence)."""
+        from shared.merge_guard_common import extract_privileged_flags
+
+        assert extract_privileged_flags("gh pr merge 5 -- --admin", "merge") == ["--admin"]
+
+    def test_symmetric_double_dash_pair_authorizes(self):
+        """approve `... -- --admin` / execute the SAME → AUTHORIZE: both arms bind
+        --admin, so the over-block does not perturb a faithful re-execution."""
+        assert _authorizes(
+            {"operation_type": "merge", "pr_number": "5", "bound_flags": ["--admin"]},
+            "gh pr merge 5 -- --admin",
+        )
+
+    def test_divergent_double_dash_pair_refuses_as_over_block(self):
+        """approve bare / execute `... -- --admin` → REFUSE: the executed --admin
+        (still bound past `--`) was never approved. Over-block-safe — re-approval
+        recovers; this is never an under-block."""
+        assert _refuses(
+            {"operation_type": "merge", "pr_number": "5", "bound_flags": []},
+            "gh pr merge 5 -- --admin",
+        )
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# MULTIPLICITY — bound_flags is a pair ATTRIBUTE, not (op,target) identity
+# ════════════════════════════════════════════════════════════════════════════
+
+
+class TestFlagVariationIsPairAttribute:
+    """Flag variation must NOT change the distinct-(op,target) count: bound_flags
+    is excluded from pair identity, so a bundle whose surfaces differ only by a
+    privileged flag stays ONE pair and cannot spuriously trip the SACROSANCT
+    multiplicity (>1 distinct pair) refusal."""
+
+    def test_flag_variation_does_not_inflate_pair_count(self):
+        from merge_guard_post import _collect_pairs
+
+        pairs = _collect_pairs(["Approve: gh pr merge 5", "Execute: gh pr merge 5 --admin"])
+        assert len(pairs) == 1
+        assert ("merge", "5") in pairs
+
+    def test_many_flag_forms_same_pr_stay_one_pair(self):
+        from merge_guard_post import _collect_pairs
+
+        pairs = _collect_pairs([
+            "gh pr merge 5 --admin",
+            "gh pr merge 5 -R owner/repo",
+            "gh pr merge 5 -d",
+        ])
+        assert len(pairs) == 1
+        assert ("merge", "5") in pairs
+
+    def test_different_pr_still_two_pairs_control(self):
+        """Control: a genuine target divergence (different PR) DOES count as two
+        distinct pairs — so the single-pair result above is the flag-attribute
+        property, not a degenerate collapse of everything to one pair."""
+        from merge_guard_post import _collect_pairs
+
+        pairs = _collect_pairs(["gh pr merge 5 --admin", "gh pr merge 6"])
+        assert len(pairs) == 2


### PR DESCRIPTION
## Summary

Closes a SACROSANCT merge-guard bypass: privileged flags (`--admin`, `-R/--repo`, `--no-verify`) rode past the `(operation, target)` authorization binding because the shared command-context extractor dropped all dash-flags. An approved force-merge and the same command executed with `--admin` bound identically — so a branch-protection-bypassing flag executed undetected. Same binding-integrity class as #1031/#1032.

## What landed

- **C1** (`merge_guard_common.py`): `PRIVILEGED_FLAGS` op-class-scoped denylist + a linear `extract_privileged_flags` scanner, surfaced as a `bound_flags` dimension computed **once** in the shared SSOT — both hook arms inherit it (un-driftable). `bound_flags` is a pair **attribute**, never part of pair identity.
- **C2** (`merge_guard_pre.py`): a never-escalate **set-equality** gate on `bound_flags` in the read path — any added privilege OR dropped constraint refuses, unconditionally.
- **C3** (`merge_guard_post.py`): the mint widened to scan the full selected-option surface (flag after a quoted argument not lost; read/mint symmetry).
- **Peer-review addition**: `--match-head-commit` bound (value-taking) — closes the **dropped-constraint** direction (approve carrying a head-SHA pin, execute without it → refuse).
- **Tests**: a RED bypass matrix with measured per-mechanism non-vacuity, A1 mint-seam coverage via the real `write_token → check_merge_authorization` path, scanner-linearity witness, `-R=value`/`--match-head-commit` form coverage, and a `--` end-of-options over-block witness.

The fix decomposes "privileged flag" into three effect-classes — privilege (`--admin`), target-identity (`-R/--repo`), side-effect (`--delete-branch`) — bound by one set-equality mechanism. Combined-short clusters (`-dR owner/repo`) and the git-only unambiguous-prefix abbreviation under-block (`--no-verif` → `--no-verify`) are handled; op-trigger flags already bound via `op_type` are excluded.

## Verification

- **Full suite**: 9771 passed, 15 skipped, **0 errors** (py3.13.7; errors-count explicitly scanned, not the rtk-masked summary).
- **Non-vacuity** (counter-test-by-revert, measured): C2 gate revert → 25 read-arm REFUSE RED; C3 mint revert → 1 RED; `is_git_surface=False` mutation → 9 abbreviation RED / 11 exact GREEN; `--match-head-commit` revert → 5 RED (scanner-derived token, provably coupled).
- **No-touch surface** (pair identity / `#797` lifecycle / SEAM / `hooks.json`) verified UNCHANGED against `git diff`.

## Peer review

Unanimous **PASS — 0 Blocking** across an independent four-arm review (CODE-phase auditor + architect design-fidelity + test-engineer coverage-matrix + security-engineer adversarial, the last under an independence guard). The one residual under-block found — the dropped-constraint `--match-head-commit` case — was **closed in-cycle** (commits above), then verify-only re-reviewed GREEN. One **Future** item remains: shell-quote obfuscation of the command token, a **pre-existing** boundary of the guard's literal-string threat model (op-token obfuscation already bypasses the whole guard), accepted by design — not a #1042 regression.

Bumps plugin **4.4.43 → 4.4.44** (PATCH — security hardening). Completes the acceptance criteria of #1042; closure pending a post-install live-probe of the installed v4.4.44 merge_guard (runtime-hook gate, per the #1031/#1032 precedent).
