### PR TITLE
fix(merge-guard): HYBRID benign-arg-literal suppressor for is_dangerous_command (#1037)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.44",
+      "version": "4.4.45",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.44/      # Plugin version
+│               └── 4.4.45/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.44",
+  "version": "4.4.45",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.44
+> **Version**: 4.4.45
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -710,6 +710,31 @@ def _blank_inert_quoted_literals(segment: str) -> str:
     return segment
 
 
+# Steps 1-7 replace every non-executable carrier they strip with a placeholder
+# token that always contains "STRIPPED" (echo/printf -> "STRIPPED"; git commit
+# -m -> "-m STRIPPED"; var assignment -> "VAR=STRIPPED"; heredoc ->
+# "<<HEREDOC_STRIPPED"; here-string -> "<<<STRIPPED"; gh-create carrier ->
+# "STRIPPED"). A segment carrying such a placeholder was already transformed by
+# an earlier step; reasoning about the residue's post-strip shape is ambiguous,
+# so step 8 treats it as fail-closed and does NOT suppress it (the substring
+# scan still sees it). Conservative defense-in-depth: it is behaviorally inert on
+# realistic inputs (the whitelisted non-executor verbs grep / gh-comment /
+# pact_memory are NOT carriers, so they never acquire this marker) while removing
+# the placeholder-interaction class entirely.
+_STRIP_PLACEHOLDER_MARKER = "STRIPPED"
+
+
+def _segment_is_suppressible(segment: str) -> bool:
+    """True iff `segment` is a placeholder-free segment led by a whitelisted
+    non-executor verb — the ONLY shape whose quoted literals step 8 may blank.
+    Any steps-1-7 placeholder token in the segment fails closed (no suppression).
+    """
+    return (
+        _STRIP_PLACEHOLDER_MARKER not in segment
+        and _BENIGN_ARG_CARRIER_RE.match(segment) is not None
+    )
+
+
 def _suppress_benign_arg_literals(text: str, command: str) -> str:
     """#1037 HYBRID benign-arg-literal suppressor — the FINAL step of
     _strip_non_executable_content, so BOTH is_dangerous_command and
@@ -728,6 +753,8 @@ def _suppress_benign_arg_literals(text: str, command: str) -> str:
         still execute downstream);
       - a segment whose leading verb is unknown / an executor / wrapper-prefixed
         → left UNCHANGED (the substring scan still blocks it);
+      - a segment carrying ANY steps-1-7 placeholder token ("STRIPPED" et al.)
+        → left UNCHANGED (its post-strip shape is ambiguous — fail closed);
       - an unbalanced quote → not matched by the balanced-span regexes, so the
         literal stays and is scanned.
 
@@ -769,7 +796,7 @@ def _suppress_benign_arg_literals(text: str, command: str) -> str:
         segment = text[pos:separator.start()]
         out.append(
             _blank_inert_quoted_literals(segment)
-            if _BENIGN_ARG_CARRIER_RE.match(segment)
+            if _segment_is_suppressible(segment)
             else segment
         )
         out.append(text[separator.start():separator.end()])  # separator verbatim
@@ -777,7 +804,7 @@ def _suppress_benign_arg_literals(text: str, command: str) -> str:
     last_segment = text[pos:]
     out.append(
         _blank_inert_quoted_literals(last_segment)
-        if _BENIGN_ARG_CARRIER_RE.match(last_segment)
+        if _segment_is_suppressible(last_segment)
         else last_segment
     )
     return "".join(out)

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -676,12 +676,23 @@ _BENIGN_ARG_CARRIER_RE = re.compile(
     re.VERBOSE,
 )
 
-# Balanced quoted-literal idiom shared with step-7 `_gh_carrier_span` (#1000): a
-# double-quoted region (honoring \" escapes) OR a single-quoted region (bash
-# single quotes have no escapes). Used to mask quoted regions in the boundary-
-# detection copy so a shell separator INSIDE a quoted argument is never read as a
-# segment split; mirrors the per-quote patterns in _blank_inert_quoted_literals.
-_QUOTED_LITERAL_RE = re.compile(r"""["](?:[^"\\]|\\.)*["]|'[^']*'""")
+# Balanced quoted-literal idiom (#1000) — the SINGLE SOURCE for the two grammars
+# this module reuses: a double-quoted region (honoring \" escapes) and a
+# single-quoted region (bash single quotes have no escapes). The same two
+# sub-patterns are composed TWO different ways for TWO DISTINCT purposes, so the
+# shared element is the PATTERN STRING, not the usage:
+#   - _QUOTED_LITERAL_RE (combined) masks quoted regions in the boundary-
+#     detection copy so a shell separator INSIDE a quoted argument never splits a
+#     segment;
+#   - _blank_inert_quoted_literals applies the two SEPARATELY (the double-quoted
+#     arm gets the cmd-sub-aware _blank_dq callback; the single-quoted arm always
+#     blanks).
+# (Step-7 `_gh_carrier_span` embeds the same idiom inside a larger VERBOSE
+# alternation; folding that in too is out of scope here — it would restructure
+# that pattern with non-zero behavior/clarity risk.)
+_DQ_LITERAL = r'"(?:[^"\\]|\\.)*"'
+_SQ_LITERAL = r"'[^']*'"
+_QUOTED_LITERAL_RE = re.compile(_DQ_LITERAL + "|" + _SQ_LITERAL)
 
 
 def _blank_inert_quoted_literals(segment: str) -> str:
@@ -701,9 +712,9 @@ def _blank_inert_quoted_literals(segment: str) -> str:
             return match.group(0)  # $()/backtick executes inside double quotes
         return '"' + " " * (len(match.group(0)) - 2) + '"'
 
-    segment = re.sub(r'"(?:[^"\\]|\\.)*"', _blank_dq, segment)
+    segment = re.sub(_DQ_LITERAL, _blank_dq, segment)
     segment = re.sub(
-        r"'[^']*'",
+        _SQ_LITERAL,
         lambda match: "'" + " " * (len(match.group(0)) - 2) + "'",
         segment,
     )

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -734,6 +734,34 @@ def _blank_inert_quoted_literals(segment: str) -> str:
 # the placeholder-interaction class entirely.
 _STRIP_PLACEHOLDER_MARKER = "STRIPPED"
 
+# WHOLE-COMMAND fail-closed guard: bash constructs whose grammar the single-line
+# balanced-quote mask + _COMPOUND_OPS_RE segment split CANNOT model. If the
+# ORIGINAL command contains ANY of these, the suppressor runs NOT AT ALL
+# (suppress nothing) — over-block is INV-D2-safe; an under-block is never. Two
+# were VERIFIED PR-introduced under-blocks; the rest are the same regex-vs-bash-
+# grammar class, cast wide because guard-list COMPLETENESS is the residual risk:
+#   \' \"  — a BACKSLASH-ESCAPED quote is a LITERAL char in bash, NOT a string
+#            opener; the mask mis-pairs it with a later real quote and masks a
+#            real `;`/`|` separator + the executing op into ONE pseudo-quoted span
+#            → the segment under-splits and the op is blanked (CLASS 1). The
+#            pattern also matches `\\'` (escaped-backslash-then-real-opener) →
+#            over-block, which is safe; we do NOT try to count backslashes (that
+#            grammar-modelling is exactly what caused the bug).
+#   <( >(  — PROCESS SUBSTITUTION hosts its OWN command (`grep x <(bash -c "OP")`),
+#            so a whitelisted leading verb is not the only executor (CLASS 2).
+#   $'     — ANSI-C quoting has its own escape grammar (`$'\''` is an escaped
+#            quote) that the single-quote regex mis-handles.
+#   <<     — heredoc / here-string bodies are multi-line; the single-line regexes
+#            cannot bound them (also matches `<<<`).
+# DELIBERATELY NOT listed: `$(` / backtick are already handled (the per-literal
+# _blank_dq guard preserves any double-quoted literal containing them, and an
+# UNQUOTED substitution is never blanked), so listing them would only over-block
+# benign unrelated uses such as a path `"$(dir)/f"`; other backslash escapes
+# (`\;` `\&` `\|`) affect only SPLITTING (lean over-block, never under-block);
+# a bare `(` would over-block `grep "(foo)"`; backslash line-continuation is
+# normalized away before _strip runs. Add to this set when in doubt — fail-closed.
+_SUPPRESS_UNSAFE_RE = re.compile(r"""\\['"]|<\(|>\(|\$'|<<""")
+
 
 def _segment_is_suppressible(segment: str) -> bool:
     """True iff `segment` is a placeholder-free segment led by a whitelisted
@@ -762,6 +790,10 @@ def _suppress_benign_arg_literals(text: str, command: str) -> str:
       - any whole-command indirection guard True (pipe / process-sub to a shell,
         eval/source, eval+heredoc) → suppress NOTHING (a blanked literal could
         still execute downstream);
+      - the whole command contains a regex-unmodellable construct
+        (`_SUPPRESS_UNSAFE_RE`: backslash-escaped quote, process substitution,
+        ANSI-C `$'`, heredoc/here-string) → suppress NOTHING (the mask/split
+        cannot be trusted; over-block, never under-block);
       - a segment whose leading verb is unknown / an executor / wrapper-prefixed
         → left UNCHANGED (the substring scan still blocks it);
       - a segment carrying ANY steps-1-7 placeholder token ("STRIPPED" et al.)
@@ -790,6 +822,17 @@ def _suppress_benign_arg_literals(text: str, command: str) -> str:
         or _has_eval_or_source(command)
         or _has_eval_with_heredoc(command)
     ):
+        return text
+
+    # WHOLE-COMMAND fail-closed on regex-vs-bash-grammar mismatches: if the
+    # ORIGINAL command contains a construct the single-line mask/split regexes
+    # cannot model (backslash-escaped quote, process substitution, ANSI-C quoting,
+    # heredoc/here-string — see _SUPPRESS_UNSAFE_RE), do NOT suppress at all. This
+    # is checked WHOLE-COMMAND (not per-segment) on purpose: it removes the
+    # segment-attribution reasoning entirely, so a mis-parse can never blank an
+    # executing op. Over-block only (the benign #1037 carriers contain none of
+    # these); under-block impossible.
+    if _SUPPRESS_UNSAFE_RE.search(command):
         return text
 
     # Boundary-detection copy (length-preserving; positions map 1:1 to `text`):

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -564,6 +564,15 @@ def _strip_non_executable_content(command: str) -> str:
 
         result = re.sub(_gh_carrier_span, _strip_gh_carrier_span, result)
 
+    # 8. Suppress dangerous literals that are provably inert quoted arguments of
+    #    a WHITELISTED non-executor segment (#1037 HYBRID). FINAL strip step, so
+    #    both is_dangerous_command AND is_compound_destructive_command inherit it
+    #    by construction (§5.8). Fail-closed: blanks ONLY on positive proof; any
+    #    ambiguity preserves content for the DANGEROUS_PATTERNS scan (the
+    #    authority). Guards/segment-split SSOT are defined just below the
+    #    compound-operator regexes.
+    result = _suppress_benign_arg_literals(result, command)
+
     return result
 
 
@@ -639,6 +648,139 @@ _COMPOUND_OPS_RE = re.compile(r"&&|\|\||;|\||\n")
 # merge_guard hooks run under bash (Claude Code's default shell), so `|&` is
 # out of scope. If the shell ever changes, add an arm for `|\s*&` here.
 _FD_REDIRECT_RE = re.compile(r"\d*[<>]&\d+|>\|")
+
+
+# Positive whitelist of SHELL-INERT-arg leading verbs (#1037 HYBRID). A command
+# segment led by one of these sends its quoted arguments to an API, prints them,
+# or searches them — it NEVER executes them as a command, so a dangerous-looking
+# quoted literal in such a segment is provably inert. EVERY arg-executing verb is
+# ABSENT BY CONSTRUCTION: python/python3 -c, perl -e, ruby -e, node -e, awk,
+# eval, sh -c, bash -c, source/dot, xargs — an unrecognized leading verb (incl.
+# any wrapper/runner like sudo/env/timeout) is the FAIL-CLOSED default (no
+# suppression → the substring scan still blocks). python -c is DELIBERATELY
+# excluded though it looks benign in `python3 -c "x='gh pr merge 5'"`: it
+# executes its argument, so `python3 -c "import os; os.system('gh pr merge 5')"`
+# would run the merge — suppressing its literal would be an UNDER-BLOCK (== a
+# #1042 binding bypass on the is_dangerous_command path). Each verb requires a
+# complete-token boundary (?![\w-]) so `git commit-tree` / `grepfoo` do NOT
+# match. Case-sensitive (shell verbs are): a case variant fails closed.
+# gh-comment mirrors the step-7 carrier convention (no global-flag prefix walk).
+_BENIGN_ARG_CARRIER_RE = re.compile(
+    r"""\s*(?:
+        echo(?![\w-])
+      | grep(?![\w-])
+      | pact_memory\s+search(?![\w-])
+      | gh\s+(?:issue|pr)\s+comment(?![\w-])
+      | git\s+commit(?![\w-])
+    )""",
+    re.VERBOSE,
+)
+
+# Balanced quoted-literal idiom shared with step-7 `_gh_carrier_span` (#1000): a
+# double-quoted region (honoring \" escapes) OR a single-quoted region (bash
+# single quotes have no escapes). Used to mask quoted regions in the boundary-
+# detection copy so a shell separator INSIDE a quoted argument is never read as a
+# segment split; mirrors the per-quote patterns in _blank_inert_quoted_literals.
+_QUOTED_LITERAL_RE = re.compile(r"""["](?:[^"\\]|\\.)*["]|'[^']*'""")
+
+
+def _blank_inert_quoted_literals(segment: str) -> str:
+    """Blank-with-space the single- and double-quoted literals in a segment whose
+    leading verb is a proven non-executor of its arguments.
+
+    A double-quoted literal containing command substitution ($()/backtick) is
+    PRESERVED — it executes regardless of the outer verb — mirroring the carrier
+    strips (steps 3/5/7). Single-quoted literals never expand. Blank-with-space
+    (quotes kept, inner content replaced by spaces) neutralizes any
+    DANGEROUS_PATTERNS match while preserving length and word boundaries. An
+    unbalanced quote is simply not matched by these balanced-span regexes, so its
+    content is left intact for the scan (fail-closed by omission).
+    """
+    def _blank_dq(match: re.Match) -> str:
+        if _has_command_substitution(match.group(0)):
+            return match.group(0)  # $()/backtick executes inside double quotes
+        return '"' + " " * (len(match.group(0)) - 2) + '"'
+
+    segment = re.sub(r'"(?:[^"\\]|\\.)*"', _blank_dq, segment)
+    segment = re.sub(
+        r"'[^']*'",
+        lambda match: "'" + " " * (len(match.group(0)) - 2) + "'",
+        segment,
+    )
+    return segment
+
+
+def _suppress_benign_arg_literals(text: str, command: str) -> str:
+    """#1037 HYBRID benign-arg-literal suppressor — the FINAL step of
+    _strip_non_executable_content, so BOTH is_dangerous_command and
+    is_compound_destructive_command inherit it by construction (§5.8).
+
+    Removes a dangerous-looking literal ONLY on POSITIVE proof it is an inert
+    quoted argument of a WHITELISTED non-executor segment with NO indirection
+    guard firing. DANGEROUS_PATTERNS + .search() remain the AUTHORITY: this only
+    blanks provably-inert literals BEFORE the scan; it never weakens the scan, so
+    a suppressor bug reverts to over-block (an acceptable false positive per
+    INV-D2), never under-block.
+
+    FAIL-CLOSED on every ambiguity:
+      - any whole-command indirection guard True (pipe / process-sub to a shell,
+        eval/source, eval+heredoc) → suppress NOTHING (a blanked literal could
+        still execute downstream);
+      - a segment whose leading verb is unknown / an executor / wrapper-prefixed
+        → left UNCHANGED (the substring scan still blocks it);
+      - an unbalanced quote → not matched by the balanced-span regexes, so the
+        literal stays and is scanned.
+
+    Segment boundaries come from the ONE segment-split SSOT (_COMPOUND_OPS_RE)
+    over a boundary-detection copy in which FD-redirect tokens AND balanced
+    quoted regions are masked to spaces (length-preserving). The quoted-region
+    mask is QUOTE-AWARENESS modeled on step-7 `_gh_carrier_span` (#1000):
+    balanced quotes are consumed atomically, so a separator INSIDE a quoted
+    argument (`grep "a ; gh pr merge 5"`) does NOT split the segment, and a
+    clobber `>|` or FD redirect `2>&1` is never mistaken for a separator either.
+    Boundaries are applied to the ORIGINAL text by span, so a non-whitelisted
+    segment's dangerous literal is never touched. An UNBALANCED quote is not
+    matched by the mask, so its separators still split — fail-closed (the
+    leading verb's literal then stays un-blanked and the scan blocks it).
+    """
+    # Whole-command indirection guards computed on the ORIGINAL command: if it
+    # routes output to a shell or contains eval/source, even a whitelisted
+    # segment's literal could execute downstream. Fail closed: suppress nothing.
+    if (
+        _has_pipe_to_shell(command)
+        or _has_process_substitution_to_shell(command)
+        or _has_eval_or_source(command)
+        or _has_eval_with_heredoc(command)
+    ):
+        return text
+
+    # Boundary-detection copy (length-preserving; positions map 1:1 to `text`):
+    # mask FD-redirect tokens AND balanced quoted regions to spaces so neither a
+    # redirect (`>|` / `2>&1`) NOR a separator INSIDE a quoted argument is read
+    # as a segment boundary. The quoted-region mask reuses the step-7
+    # `_gh_carrier_span` balanced-quote idiom (#1000) — quotes consumed
+    # atomically — so `grep "a ; gh pr merge 5"` stays ONE segment.
+    masked = _FD_REDIRECT_RE.sub(lambda m: " " * len(m.group(0)), text)
+    masked = _QUOTED_LITERAL_RE.sub(lambda m: " " * len(m.group(0)), masked)
+
+    out = []
+    pos = 0
+    for separator in _COMPOUND_OPS_RE.finditer(masked):
+        segment = text[pos:separator.start()]
+        out.append(
+            _blank_inert_quoted_literals(segment)
+            if _BENIGN_ARG_CARRIER_RE.match(segment)
+            else segment
+        )
+        out.append(text[separator.start():separator.end()])  # separator verbatim
+        pos = separator.end()
+    last_segment = text[pos:]
+    out.append(
+        _blank_inert_quoted_literals(last_segment)
+        if _BENIGN_ARG_CARRIER_RE.match(last_segment)
+        else last_segment
+    )
+    return "".join(out)
 
 
 def is_dangerous_command(command: str) -> bool:

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -13355,7 +13355,7 @@ class Test1037BenignArgSuppressorAllowPositives:
     def test_allow_positives_nonvacuity_revert_reblocks(self, monkeypatch):
         # non-vacuity (proof-class P): a source-only revert of the suppressor
         # (-> identity) flips EVERY #1037 ALLOW-positive back to BLOCK.
-        # MEASURED {7 of 7 flip RED}; the SHOULD_BLOCK controls stay blocked
+        # MEASURED {8 of 8 flip RED}; the SHOULD_BLOCK controls stay blocked
         # (cardinality split) — so the ALLOW assertions are coupled to the
         # suppressor, not vacuous.
         from merge_guard_pre import (
@@ -13371,7 +13371,7 @@ class Test1037BenignArgSuppressorAllowPositives:
             c for c in self.ALLOW
             if is_dangerous_command(c) or is_compound_destructive_command(c)
         ]
-        assert len(reblocked) == len(self.ALLOW)  # all 7 flip RED under revert
+        assert len(reblocked) == len(self.ALLOW)  # all 8 flip RED under revert
         still = [c for c in self.SHOULD_BLOCK if is_dangerous_command(c)]
         assert len(still) == len(self.SHOULD_BLOCK)  # controls unaffected
 

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -13252,3 +13252,382 @@ class TestD2QuoteAwareSpanRemediation:
 # (removed class TestD3LadderReDoSPerfBound — superseded by the command-anchored
 #  bidirectional suite in test_merge_guard_auth_symmetry.py;
 #  it exercised the dropped prose classifier extract_context.)
+
+
+# =============================================================================
+# #1037 — HYBRID benign-arg-literal suppressor: comprehensive coverage
+#
+# The suppressor (_suppress_benign_arg_literals, the FINAL step of
+# _strip_non_executable_content) blanks-with-space a dangerous-looking QUOTED
+# literal ONLY when it is a provably-inert argument of a WHITELISTED non-executor
+# segment (echo / grep / pact_memory search / gh issue|pr comment / git commit)
+# with NO indirection guard firing. DANGEROUS_PATTERNS + .search() remain the
+# AUTHORITY; a suppressor bug reverts to OVER-block (an acceptable false positive
+# per INV-D2), never UNDER-block. Both is_dangerous_command and
+# is_compound_destructive_command inherit the suppressor through _strip, so the
+# canaries below exercise both call sites.
+#
+# Every non-vacuity mutation + cardinality in this section was MEASURED against
+# the committed suppressor (empirical, not asserted). Two proof classes:
+#   * proof-class P (ALLOW-positives, NEGATIVE assertions `assert not blocked`):
+#     a whole-suppressor revert (-> identity) flips the #1037 ALLOW set back to
+#     BLOCK while the paired controls stay BLOCK — a cardinality SPLIT that
+#     defeats negative-test phantom-green — PLUS an exclusion-guard MECHANISM
+#     assertion (the literal is neutralized in _strip output, not merely
+#     is_dangerous->False).
+#   * proof-class C (under-block canaries, POSITIVE assertions): a revert leaves
+#     a canary trivially green (blocked before AND after), so non-vacuity needs a
+#     BROADEN/WEAKEN mutation. Sub-class A (suppressor-restraint) flips under a
+#     TARGETED single-guard neuter (isolated cardinality, defense-in-depth-clean).
+#     Sub-class B (pre-existing-guard regression, suppressor-NEUTRAL: the danger
+#     is a BARE command the suppressor never touches) flips ONLY under a COMBINED
+#     over-strip (blank bare dangerous tokens) — named as such, never
+#     mis-attributed to a #1037 gate.
+#
+# All mutation tests use pytest `monkeypatch`, which auto-restores the patched
+# module attribute after each test — so no module-level state leaks across the
+# full-suite run (the order-dependent module-cache hazard, #845).
+# =============================================================================
+
+
+class Test1037BenignArgSuppressorAllowPositives:
+    """#1037 false-positive CLOSURE: a whitelisted non-executor segment quoting a
+    dangerous-looking literal is now ALLOWED. NEGATIVE assertions (phantom-green
+    risk) guarded by pair-revert controls + an exclusion-guard mechanism assertion."""
+
+    # #1037-suppressor-DEPENDENT FP closures only. `echo "..."` and
+    # `git commit -m "..."` are EXCLUDED: they are allowed by the PRE-EXISTING
+    # echo carrier-strip / commit-msg strip (a whole-suppressor revert leaves
+    # them allowed — MEASURED), so they are not #1037 ALLOW-positives.
+    ALLOW = [
+        'gh pr comment 5 --body "see gh pr merge 5 for context"',
+        'gh issue comment 12 --body "do not git push --force origin main"',
+        'grep -n "gh pr merge" notes.md',
+        'pact_memory search "gh pr merge approval flow"',
+        'git commit -am "wire up gh pr merge 5 handler"',
+        # quote-aware boundary: a shell separator INSIDE the quoted arg must NOT
+        # split the segment (the boundary mask consumes balanced quotes atomically).
+        'grep "a ; gh pr merge 5" file',
+        'gh pr comment 5 --body "do it; gh pr merge 9 then ship"',
+        # cross-segment clearing: a REAL separator between TWO whitelisted
+        # segments clears the inert literal in EACH, per-segment (the placeholder-
+        # gated per-segment suppressor preserves cross-segment FP clearing).
+        'echo "note" ; grep "gh pr merge 5" file',
+    ]
+
+    # PAIR-REVERT controls: structurally-adjacent lines that MUST stay BLOCK no
+    # matter what the suppressor does, so a mutation that flips ALLOW keeps these
+    # blocked (cardinality split) — the ALLOW assertions cannot be vacuously green.
+    SHOULD_BLOCK = [
+        'gh pr merge 5',                                    # the bare destructive op
+        'grep "x" file ; gh pr merge 5',                   # real (unquoted) separator splits
+        'gh pr comment 5 --body "ok" && gh pr merge 999',  # chained second op
+    ]
+
+    @pytest.mark.parametrize("command", ALLOW)
+    def test_benign_arg_literal_now_allowed(self, command):
+        from merge_guard_pre import (
+            is_dangerous_command,
+            is_compound_destructive_command,
+        )
+
+        assert not is_dangerous_command(command)
+        assert not is_compound_destructive_command(command)
+
+    @pytest.mark.parametrize("command", SHOULD_BLOCK)
+    def test_paired_control_still_blocked(self, command):
+        from merge_guard_pre import is_dangerous_command
+
+        assert is_dangerous_command(command)
+
+    def test_suppressor_neutralizes_literal_in_strip_output(self):
+        # exclusion-guard MECHANISM assertion (#933): prove the suppressor REMOVES
+        # the dangerous literal from the _strip output — not merely that
+        # is_dangerous->False (a different guard could satisfy that). The carrier
+        # shell stays intact; only the inert literal is blanked.
+        from merge_guard_pre import _strip_non_executable_content
+
+        stripped = _strip_non_executable_content('grep -n "gh pr merge" notes.md')
+        assert "gh pr merge" not in stripped
+        assert stripped.startswith("grep -n")
+        assert "notes.md" in stripped
+
+    def test_allow_positives_nonvacuity_revert_reblocks(self, monkeypatch):
+        # non-vacuity (proof-class P): a source-only revert of the suppressor
+        # (-> identity) flips EVERY #1037 ALLOW-positive back to BLOCK.
+        # MEASURED {7 of 7 flip RED}; the SHOULD_BLOCK controls stay blocked
+        # (cardinality split) — so the ALLOW assertions are coupled to the
+        # suppressor, not vacuous.
+        from merge_guard_pre import (
+            is_dangerous_command,
+            is_compound_destructive_command,
+        )
+
+        monkeypatch.setattr(
+            "merge_guard_pre._suppress_benign_arg_literals",
+            lambda text, command: text,
+        )
+        reblocked = [
+            c for c in self.ALLOW
+            if is_dangerous_command(c) or is_compound_destructive_command(c)
+        ]
+        assert len(reblocked) == len(self.ALLOW)  # all 7 flip RED under revert
+        still = [c for c in self.SHOULD_BLOCK if is_dangerous_command(c)]
+        assert len(still) == len(self.SHOULD_BLOCK)  # controls unaffected
+
+
+class Test1037SuppressorRestraintCanaries:
+    """Sub-class A under-block canaries: a dangerous QUOTED literal inside a
+    WHITELISTED carrier segment that STAYS BLOCK because a SPECIFIC #1037 gate
+    fires. Each gate has a TARGETED single-guard neuter that flips ONLY its
+    target group (defense-in-depth-clean cardinality, MEASURED). proof-class C —
+    a revert leaves these trivially green, so the neuter is the non-vacuity proof."""
+
+    CMD_SUBST = [
+        'grep "$(gh pr merge 9)"',
+        'gh pr comment 5 --body "$(gh pr merge 9)"',
+    ]
+
+    @pytest.mark.parametrize("command", CMD_SUBST)
+    def test_cmd_subst_in_whitelisted_dq_stays_blocked(self, command):
+        from merge_guard_pre import is_dangerous_command
+
+        assert is_dangerous_command(command)
+
+    def test_cmd_subst_compound_form_caught_by_compound_call_site(self):
+        # both call sites: a compound form is also caught by is_compound.
+        from merge_guard_pre import is_compound_destructive_command
+
+        assert is_compound_destructive_command('echo "$(gh pr merge 9)" && ls')
+
+    def test_cmd_subst_canary_nonvacuity(self, monkeypatch):
+        # non-vacuity: neuter the per-literal cmd-subst preservation
+        # (_has_command_substitution -> False) -> the dq literal is blanked and
+        # the scan no longer matches. MEASURED {2 of 2 flip}; isolated (no other
+        # canary group flips under this neuter).
+        from merge_guard_pre import is_dangerous_command
+
+        monkeypatch.setattr(
+            "merge_guard_pre._has_command_substitution",
+            lambda quoted_content: False,
+        )
+        flipped = [c for c in self.CMD_SUBST if not is_dangerous_command(c)]
+        assert len(flipped) == len(self.CMD_SUBST)
+
+    PIPE_TO_SHELL = [
+        'grep "gh pr merge 5" file | bash',
+        'echo "gh pr merge 5" | sh',
+    ]
+
+    @pytest.mark.parametrize("command", PIPE_TO_SHELL)
+    def test_pipe_to_shell_with_whitelisted_carrier_stays_blocked(self, command):
+        from merge_guard_pre import (
+            is_dangerous_command,
+            is_compound_destructive_command,
+        )
+
+        assert is_dangerous_command(command)
+        assert is_compound_destructive_command(command)  # compound `|` shape
+
+    def test_pipe_to_shell_canary_nonvacuity(self, monkeypatch):
+        # non-vacuity: neuter the whole-command pipe-to-shell guard -> the
+        # whitelisted segment's literal is blanked, so the downstream shell would
+        # execute it unprotected. MEASURED {2 of 2 flip}; isolated.
+        from merge_guard_pre import is_dangerous_command
+
+        monkeypatch.setattr(
+            "merge_guard_pre._has_pipe_to_shell", lambda command: False
+        )
+        flipped = [c for c in self.PIPE_TO_SHELL if not is_dangerous_command(c)]
+        assert len(flipped) == len(self.PIPE_TO_SHELL)
+
+    def test_proc_sub_to_shell_with_whitelisted_carrier_stays_blocked(self):
+        from merge_guard_pre import is_dangerous_command
+
+        assert is_dangerous_command('echo "gh pr merge 5" > >(bash)')
+
+    def test_proc_sub_canary_nonvacuity(self, monkeypatch):
+        # non-vacuity: neuter the whole-command process-substitution-to-shell
+        # guard -> the echo literal is blanked. MEASURED {1}; isolated.
+        from merge_guard_pre import is_dangerous_command
+
+        monkeypatch.setattr(
+            "merge_guard_pre._has_process_substitution_to_shell",
+            lambda command: False,
+        )
+        assert not is_dangerous_command('echo "gh pr merge 5" > >(bash)')
+
+    def test_unbalanced_quote_in_whitelisted_segment_stays_blocked(self):
+        from merge_guard_pre import is_dangerous_command
+
+        assert is_dangerous_command('grep "gh pr merge 5')
+
+    def test_unbalanced_quote_canary_nonvacuity(self, monkeypatch):
+        # non-vacuity: the balanced-span blank regexes do NOT match an unbalanced
+        # quote (fail-closed by omission). A broaden that also blanks a trailing
+        # unbalanced double-quote flips it. MEASURED {1}; isolated (the tight
+        # unbalanced-only broaden leaves the cmd-subst / pipe canaries unchanged).
+        import re as _re
+
+        import merge_guard_pre as _mg
+
+        original = _mg._blank_inert_quoted_literals
+
+        def broadened(segment):
+            s = original(segment)
+            return _re.sub(r'"[^"]*$', lambda m: '"' + " " * (len(m.group(0)) - 1), s)
+
+        monkeypatch.setattr("merge_guard_pre._blank_inert_quoted_literals", broadened)
+        from merge_guard_pre import is_dangerous_command
+
+        assert not is_dangerous_command('grep "gh pr merge 5')
+
+    # python -c / bash -c / sh -c EXECUTE their argument, so they are absent from
+    # the positive whitelist by construction — the single most load-bearing
+    # under-block-safety property (suppressing their literal == a #1042 binding
+    # bypass on the is_dangerous path).
+    EXECUTOR_VERBS = [
+        "python3 -c \"import os; os.system('gh pr merge 5')\"",
+        'bash -c "gh pr merge 42"',
+        "sh -c 'gh pr merge 5'",
+    ]
+
+    @pytest.mark.parametrize("command", EXECUTOR_VERBS)
+    def test_executor_verb_not_whitelisted_stays_blocked(self, command):
+        from merge_guard_pre import is_dangerous_command
+
+        assert is_dangerous_command(command)
+
+    def test_executor_exclusion_nonvacuity(self, monkeypatch):
+        # non-vacuity: the executor verbs stay BLOCK ONLY because they are ABSENT
+        # from the positive whitelist. Adding them flips ALL of them.
+        # MEASURED {3 of 3 flip}; isolated.
+        import re as _re
+
+        broadened = _re.compile(
+            r"""\s*(?:
+                echo(?![\w-])
+              | grep(?![\w-])
+              | pact_memory\s+search(?![\w-])
+              | gh\s+(?:issue|pr)\s+comment(?![\w-])
+              | git\s+commit(?![\w-])
+              | python3?\s+-c(?![\w-])
+              | bash\s+-c(?![\w-])
+              | sh\s+-c(?![\w-])
+            )""",
+            _re.VERBOSE,
+        )
+        monkeypatch.setattr("merge_guard_pre._BENIGN_ARG_CARRIER_RE", broadened)
+        from merge_guard_pre import is_dangerous_command
+
+        flipped = [c for c in self.EXECUTOR_VERBS if not is_dangerous_command(c)]
+        assert len(flipped) == len(self.EXECUTOR_VERBS)
+
+
+class Test1037RegressionCanaries:
+    """Sub-class B under-block canaries: the dangerous op is a BARE command the
+    suppressor NEVER touches (it only blanks quoted literals in whitelisted
+    segments). These prove the suppressor did not REGRESS the pre-existing
+    substring-scan / segment-split detection. They are suppressor-NEUTRAL: a
+    whole-suppressor revert leaves them BLOCK (trivially green), so their
+    non-vacuity is a COMBINED over-strip (a hypothetical suppressor rewritten to
+    blank BARE dangerous tokens) — NOT a single-guard neuter."""
+
+    REGRESSION = [
+        'echo safe && gh pr merge 999',                    # compound, bare 2nd op
+        'gh pr comment 5 --body "ok" && gh pr merge 999',  # whitelisted seg1 + bare 2nd op
+        'sudo grep "gh pr merge 5" file',                  # wrapper/runner prefix (sudo)
+        'GH_TOKEN=abc gh pr merge 5',                      # env-var assignment prefix
+        'CMD="gh pr merge 5"; $CMD',                       # variable expansion
+        'grep "x" file ; gh pr merge 5',                   # real (unquoted) separator
+    ]
+
+    @pytest.mark.parametrize("command", REGRESSION)
+    def test_bare_destructive_op_stays_blocked(self, command):
+        from merge_guard_pre import is_dangerous_command
+
+        assert is_dangerous_command(command)
+
+    COMPOUND_REGRESSION = [
+        'echo safe && gh pr merge 999',
+        'gh pr comment 5 --body "ok" && gh pr merge 999',
+        'CMD="gh pr merge 5"; $CMD',
+        'grep "x" file ; gh pr merge 5',
+    ]
+
+    @pytest.mark.parametrize("command", COMPOUND_REGRESSION)
+    def test_compound_regression_caught_by_compound_call_site(self, command):
+        from merge_guard_pre import is_compound_destructive_command
+
+        assert is_compound_destructive_command(command)
+
+    def test_regression_canaries_are_suppressor_neutral(self, monkeypatch):
+        # discrimination: a whole-suppressor revert leaves ALL of these BLOCK
+        # (they do not depend on the suppressor). MEASURED {0 of 6 flip} — this is
+        # WHY a revert cannot prove them and the combined over-strip is required.
+        from merge_guard_pre import is_dangerous_command
+
+        monkeypatch.setattr(
+            "merge_guard_pre._suppress_benign_arg_literals",
+            lambda text, command: text,
+        )
+        flipped = [c for c in self.REGRESSION if not is_dangerous_command(c)]
+        assert flipped == []  # suppressor-neutral
+
+    def test_regression_canaries_nonvacuity_combined_overstrip(self, monkeypatch):
+        # non-vacuity (proof-class C, COMBINED over-strip): a hypothetical
+        # suppressor rewritten to blank BARE dangerous tokens (not just quoted
+        # literals in whitelisted segments) WOULD open an under-block on every one
+        # of these. MEASURED {6 of 6 flip} — proves the canaries would CATCH such
+        # an over-broad rewrite.
+        import re as _re
+
+        def overstrip(text, command):
+            for pat in (
+                r"gh\s+pr\s+merge\s+\d+",
+                r"git\s+push\s+.*--force",
+                r"git\s+branch\s+-D\s+\S+",
+            ):
+                text = _re.sub(pat, lambda m: " " * len(m.group(0)), text)
+            return text
+
+        monkeypatch.setattr("merge_guard_pre._suppress_benign_arg_literals", overstrip)
+        from merge_guard_pre import is_dangerous_command
+
+        flipped = [c for c in self.REGRESSION if not is_dangerous_command(c)]
+        assert len(flipped) == len(self.REGRESSION)
+
+
+class Test1037FpFnSymmetry:
+    """#1037 opened NO under-block (security #1 / #720): the suppressor is a
+    strip-stage addition, so it must not regress the compound-shape detection
+    that closes the spaceless FD-redirect|pipe adjacency bypass."""
+
+    def test_spaceless_fd_pipe_bypass_still_closed(self):
+        from merge_guard_pre import is_compound_destructive_command
+
+        assert is_compound_destructive_command(
+            "gh pr merge 100 2>&1|gh pr merge 999 --admin"
+        )
+
+    def test_symmetric_benign_spaceless_not_flagged(self):
+        # symmetric counter-test: the SAME spaceless FD|pipe shape with
+        # NON-destructive ops is NOT flagged -> the closure detects the
+        # destructive payload, it does not over-block the shape.
+        from merge_guard_pre import is_compound_destructive_command
+
+        assert not is_compound_destructive_command("echo hi 2>&1|grep x")
+
+    def test_spaceless_bypass_survives_suppressor_revert(self, monkeypatch):
+        # the suppressor does NOT touch this line (no whitelisted-segment quoted
+        # literal); under a whole-suppressor revert it stays is_compound=True ->
+        # the closure is suppressor-independent (no regression possible).
+        from merge_guard_pre import is_compound_destructive_command
+
+        monkeypatch.setattr(
+            "merge_guard_pre._suppress_benign_arg_literals",
+            lambda text, command: text,
+        )
+        assert is_compound_destructive_command(
+            "gh pr merge 100 2>&1|gh pr merge 999 --admin"
+        )

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -13523,6 +13523,31 @@ class Test1037SuppressorRestraintCanaries:
         flipped = [c for c in self.EXECUTOR_VERBS if not is_dangerous_command(c)]
         assert len(flipped) == len(self.EXECUTOR_VERBS)
 
+    def test_known_accepted_over_block_b_guard_marker_collision(self, monkeypatch):
+        # (b)-guard marker-collision over-block; non-vacuous via _segment_is_suppressible
+        # revert (flips BLOCK->ALLOW); intentional INV-D2-acceptable over-block, do NOT
+        # "fix". The (b) placeholder guard skips suppression for any segment whose
+        # literal contains the steps-1-7 marker "STRIPPED" — it is the quoted ARG, not
+        # the verb, that carries it — so a whitelisted carrier whose literal merely
+        # CONTAINS "STRIPPED" is over-blocked: WITHOUT (b) the suppressor blanks grep's
+        # literal -> ALLOW; WITH (b) the literal survives the scan -> BLOCK.
+        from merge_guard_pre import is_dangerous_command
+
+        over_blocked = 'grep "STRIPPED gh pr merge 5" file'
+        assert is_dangerous_command(over_blocked)  # over-block (the (b) guard fires)
+        # discrimination: the SAME line WITHOUT the marker is ALLOWED.
+        assert not is_dangerous_command('grep "gh pr merge 5" file')
+        # non-vacuity (proof-class P): revert the (b) placeholder check (restore the
+        # pre-refinement whitelist-only _segment_is_suppressible) -> the over-block
+        # flips BLOCK->ALLOW, proving the placeholder check is the load-bearing cause.
+        import merge_guard_pre as _mg
+
+        monkeypatch.setattr(
+            "merge_guard_pre._segment_is_suppressible",
+            lambda segment: _mg._BENIGN_ARG_CARRIER_RE.match(segment) is not None,
+        )
+        assert not is_dangerous_command(over_blocked)  # flips BLOCK->ALLOW
+
 
 class Test1037RegressionCanaries:
     """Sub-class B under-block canaries: the dangerous op is a BARE command the

--- a/pact-plugin/tests/test_merge_guard_1037_smoke.py
+++ b/pact-plugin/tests/test_merge_guard_1037_smoke.py
@@ -1,0 +1,58 @@
+"""
+Location: pact-plugin/tests/test_merge_guard_1037_smoke.py
+Summary: CODE-phase smoke for the #1037 HYBRID benign-arg-literal suppressor in
+         merge_guard_pre.py. A minimal go/no-go: a whitelisted false-positive is
+         now ALLOWED, and the under-block guards still BLOCK. The COMPREHENSIVE
+         ALLOW-positives + per-guard under-block canaries are the test-engineer's
+         TEST-phase work (test_merge_guard.py); this file is intentionally small.
+Used by: pytest (merge-guard suite).
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import pytest
+
+from merge_guard_pre import is_dangerous_command
+
+
+# Whitelisted non-executor segments whose quoted arg merely NAMES a dangerous
+# command — previously a false-positive BLOCK (#1037), now correctly ALLOWED.
+ALLOWED_FALSE_POSITIVES = [
+    'gh pr comment 5 --body "see gh pr merge 5 for context"',
+    'gh issue comment 12 --body "do not git push --force origin main"',
+    'grep -n "gh pr merge" notes.md',
+    'pact_memory search "gh pr merge approval flow"',
+    'git commit -am "wire up gh pr merge 5 handler"',
+    # Quote-aware segment split: a shell separator INSIDE the quoted arg must NOT
+    # split the segment (modeled on step-7 _gh_carrier_span). These were
+    # over-blocked before the quote-aware boundary mask.
+    'grep "a ; gh pr merge 5" file',
+    'gh pr comment 5 --body "do it; gh pr merge 9 then ship"',
+    "git commit -am 'fix: gh pr merge 7 | follow-up'",
+]
+
+# Must STILL be blocked — the suppressor must never open an under-block. Each
+# exercises a distinct fail-closed path (indirection guard, cmd-subst inside a
+# whitelisted arg, an arg-executing verb that is NOT whitelisted, a chained
+# second op, and the bare destructive op itself).
+STILL_BLOCKED = [
+    'grep "gh pr merge 5" file | bash',                       # pipe-to-shell guard
+    'grep "$(gh pr merge 5)" file',                           # cmd-subst executes in dq
+    "python3 -c \"import os; os.system('gh pr merge 5')\"",   # python -c NOT whitelisted
+    'gh pr comment 5 --body "ok" && gh pr merge 999',         # chained destructive op
+    'gh pr merge 5',                                          # bare destructive op
+    'grep "x" file ; gh pr merge 5',                          # REAL unquoted sep still splits
+]
+
+
+@pytest.mark.parametrize("command", ALLOWED_FALSE_POSITIVES)
+def test_whitelisted_arg_literal_false_positive_now_allowed(command):
+    assert is_dangerous_command(command) is False
+
+
+@pytest.mark.parametrize("command", STILL_BLOCKED)
+def test_suppressor_never_opens_an_under_block(command):
+    assert is_dangerous_command(command) is True

--- a/pact-plugin/tests/test_merge_guard_1037_smoke.py
+++ b/pact-plugin/tests/test_merge_guard_1037_smoke.py
@@ -32,6 +32,10 @@ ALLOWED_FALSE_POSITIVES = [
     'grep "a ; gh pr merge 5" file',
     'gh pr comment 5 --body "do it; gh pr merge 9 then ship"',
     "git commit -am 'fix: gh pr merge 7 | follow-up'",
+    # Placeholder fail-closed is PER-SEGMENT: an earlier-step placeholder in one
+    # segment (echo -> "echo STRIPPED") must not block a clean sibling segment's
+    # suppression. The grep segment still clears.
+    'echo "note" ; grep "gh pr merge 5" file',
 ]
 
 # Must STILL be blocked — the suppressor must never open an under-block. Each

--- a/pact-plugin/tests/test_merge_guard_1037_smoke.py
+++ b/pact-plugin/tests/test_merge_guard_1037_smoke.py
@@ -49,6 +49,20 @@ STILL_BLOCKED = [
     'gh pr comment 5 --body "ok" && gh pr merge 999',         # chained destructive op
     'gh pr merge 5',                                          # bare destructive op
     'grep "x" file ; gh pr merge 5',                          # REAL unquoted sep still splits
+    # CLASS 1 (escaped-quote grammar): \' / \" is a LITERAL char in bash, not a
+    # string opener — the regex mis-pairs it and masks the ; + op into one span.
+    # Whole-command fail-closed on \'/\" blocks these (op survives for the scan).
+    "grep a\\' ; gh pr merge 5 \\'b",                         # sq escaped-quote under-block
+    'grep a\\" ; gh pr merge 5 \\"b',                         # dq escaped-quote under-block
+    # CLASS 2 (process substitution hosts an executor): <(...) runs its own
+    # command, so a whitelisted leading verb is not the only executor. Whole-
+    # command fail-closed on <( / >( blocks these (incl --admin #1042 bypass).
+    'grep x <(bash -c "gh pr merge 5")',                      # procsub-hosted merge
+    'grep x <(bash -c "gh pr merge 5 --admin")',             # procsub + #1042-bypass flag
+    'grep x <(bash -c "git push --force origin main")',      # procsub-hosted force-push
+    # Broader regex-vs-grammar fail-closed (over-block, defense-in-depth): ANSI-C
+    # quoting $'...' has its own escape grammar the sq regex mis-handles.
+    "grep $'gh pr merge 5'",                                  # ANSI-C quoting fail-closed
 ]
 
 


### PR DESCRIPTION
## Summary

Resolves the #1037 `is_dangerous_command` substring-scan false-positive in the SACROSANCT merge-guard: benign command lines that merely **quote** a dangerous literal (a `gh issue/pr comment --body`, `grep`, `git commit -am`, `pact_memory search` argument) were over-blocked. This adds a HYBRID benign-arg-literal suppressor that runs **before** the unchanged `DANGEROUS_PATTERNS` scan, blanking provably-inert quoted literals of shell-inert-arg verbs only — never weakening detection.

**Completes ACs of #1037; closure pending post-install live-probe** (observable detection behavior changes — a previously-blocked benign line is now allowed).

## What landed (squashed from 4 commits)

- HYBRID suppressor `_suppress_benign_arg_literals` as the final step of `_strip_non_executable_content`, inherited by **both** call sites (`is_dangerous_command` + `is_compound_destructive_command`). Positive verb-whitelist (echo, grep, pact_memory search, gh issue/pr comment, git commit), fail-closed default.
- Quote-aware segment split (masks balanced quoted regions before `_COMPOUND_OPS_RE` separator-finding, reusing the #1000 `_gh_carrier_span` idiom; one segment SSOT).
- Placeholder-fail-closed defensive margin (`_segment_is_suppressible`).
- 42 comprehensive tests (measured non-vacuity; A/B suppressor-restraint-vs-neutral canary split; FP↔FN symmetry).
- Version bump → 4.4.45 (PATCH; over-block correctness, no user-facing capability change).

## SACROSANCT safety (INV-D2: over-block OK, under-block NEVER)

Three nested fail-closed gates keep it under-block-safe by construction (a suppressor bug reverts to over-block, never under-block):
1. **whole-command indirection** — any pipe-to-shell / process-sub / eval / command-substitution on the ORIGINAL command → suppress nothing;
2. **per-segment leading-verb whitelist** — a chained/wrapper-prefixed dangerous op stays caught;
3. **per-literal balanced-quote** — `$()`-containing double-quotes preserved; arg-executors (`python -c`, `eval`, `sh -c`) stay over-blocked by construction.

## Verification

- **Independent adversarial security re-probe = SAFE** (~80 probes on the final code, 0 under-blocks; mask/blank quote-pairing desync proven over-block-only; `$()` across all 3 quote contexts correct).
- **#1042/#1031/#1032 regression gate green** — no REFUSE→AUTHORIZE flip in the privileged-flag binding matrix (binding/token layer structurally untouched; this PR touches only `merge_guard_pre.py` + tests).
- **Full suite**: 9829 passed / 15 skipped / 0 failed / 0 errors (3.13.7 + 3.14.5).

## Known accepted residual (INV-D2-safe over-block)

The placeholder-guard introduces a narrow new over-block: a benign carrier whose quoted literal contains the substring `STRIPPED` is over-blocked (documented in-code). Over-block, not under-block — acceptable.

## Out of scope (tracked separately)

- #1053: pre-existing `subprocess.run` list-form under-block (DANGEROUS_PATTERNS substring gap) — not introduced or affected by this PR.
