### PR TITLE
Merge-guard over-block tokenizer + hygiene batch + latent under-block closure (v4.4.48)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.47",
+      "version": "4.4.48",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.47/      # Plugin version
+│               └── 4.4.48/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.47",
+  "version": "4.4.48",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.47
+> **Version**: 4.4.48
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/merge_guard_post.py
+++ b/pact-plugin/hooks/merge_guard_post.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 import glob
 import json
 import os
-import re
 import sys
 import time
 from pathlib import Path
@@ -116,16 +115,6 @@ except BaseException as _module_load_error:  # noqa: BLE001 — fail-loud catch-
 # UI suppresses the hook display instead of showing "hook error (No output)".
 _SUPPRESS_OUTPUT = json.dumps({"suppressOutput": True})
 
-# Patterns that indicate an affirmative FREE-TEXT answer. Used ONLY by the
-# free-text arm (an AskUserQuestion with no options); OPTION-mode approval is an
-# exact label match against a non-decline option, never a word allowlist — so a
-# descriptive selected label like "Merge now" is honored (the old allowlist
-# wrongly rejected it). The decline/defer veto runs first and takes precedence.
-AFFIRMATIVE_PATTERNS = re.compile(
-    r"^(y|yes|yeah|yep|sure|ok|okay|confirm|approved?|go\s*ahead|do\s*it|proceed)\b",
-    re.IGNORECASE,
-)
-
 
 def is_merge_question(question: str) -> bool:
     """Command-driven COARSE HINT (KD-9): True iff the text embeds a recognized
@@ -144,18 +133,6 @@ def is_merge_question(question: str) -> bool:
         True if the text contains a recognized destructive command region.
     """
     return locate_command_region(question) is not None
-
-
-def is_affirmative(answer: str) -> bool:
-    """Check if the user's answer is affirmative.
-
-    Args:
-        answer: The user's response text
-
-    Returns:
-        True if the answer indicates approval
-    """
-    return bool(AFFIRMATIVE_PATTERNS.search(answer.strip()))
 
 
 def _selected_option_text(options: object, answer: object) -> str | None:
@@ -318,10 +295,9 @@ def _mint_context_from_bundle(questions: list, answers: dict) -> MintResult:
     # EXPLICIT (shape b): a bundle with NO options anywhere has no clicked option
     # to anchor on → it can NEVER mint. Minting from question prose or a typed
     # free-text answer would make auth depend on un-clicked text — a forbidden
-    # under-block class (security B-NEW-4 / KD-11(6)). AUQ structurally carries
-    # 2-4 options per question (peer-review.md), so this is fail-closed defense
-    # for a theoretical/replayed no-options payload. The per-question decline/
-    # defer veto still runs below for mixed bundles.
+    # under-block class. AUQ structurally carries 2-4 options per question, so this
+    # is fail-closed defense for a theoretical/replayed no-options payload. The
+    # per-question decline/defer veto still runs below for mixed bundles.
     #
     # BACKSTOP — DO NOT remove as "dead code". The step-3b option-anchoring below
     # already refuses a no-options bundle (an empty option surface yields no pair,

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -70,6 +70,7 @@ try:
         cleanup_consumed_tokens as _cleanup_consumed_tokens,
         cleanup_orphan_tokens as _cleanup_orphan_tokens,
         extract_command_context,
+        _single_destructive_leg,
         # Regex prefix constants relocated to shared so the read-side
         # DANGEROUS_PATTERNS bank and the shared classifier compose against
         # identical prefix semantics (#720 Bug B).
@@ -508,7 +509,20 @@ def _token_matches_command(token: dict, command: str) -> bool:
         return False  # F-READ-1: a non-dict context proves nothing — REFUSE
 
     token_op = context.get("operation_type")
-    cmd = extract_command_context(command)
+    # Derive (op, target, bound_flags) from the SINGLE destructive leg, not the
+    # whole command (#1069). When a faithful single destructive op carries a benign
+    # neighbor leg (`gh pr close 1058 ; gh pr view 1058 --repo o/x`), the whole-
+    # command context would (a) bind the neighbor's `--repo` into bound_flags and
+    # over-block the faithful click, AND (b) let _extract_pr_number's first-match-
+    # anywhere scan cross-contaminate the target (the latent under-block: a token
+    # for `gh pr close N1` authorizing `gh pr close N1\ngh pr merge N2`). Isolating
+    # the one is_dangerous leg closes BOTH. _single_destructive_leg returns None on
+    # not-exactly-one dangerous leg (0, or — unreachably here, since is_compound
+    # REFUSES >=2 upstream — many), so we fall back to the WHOLE command: the
+    # existing over-binding scan, the SAFE over-block direction, NEVER a silent
+    # narrowing. Op/target are still derived the SAME way the mint side does (mint
+    # isolates per-region via locate_command_regions), so the two arms cannot drift.
+    cmd = extract_command_context(_single_destructive_leg(command) or command)
     cmd_op = cmd.get("operation_type")
 
     # (a) Operation-type axis — both present AND equal, else REFUSE. A token with

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -1598,12 +1598,26 @@ def _normalize_line_continuations(command: str) -> str:
 # Benign continuation / redirect terminator for the positional target extractors
 # (_extract_force_push_target_ref / _extract_branch_name). Matches a compound
 # operator (`&&`, `||`, `|&`, `;`, `&`, `|`, newline — the _COMPOUND_OPS_RE set)
-# OR a redirect START: an optional leading fd number then `<`/`>`. The redirect
-# arm covers `>`, `>>`, `<`, `2>`, `2>&1` (its leading `2>`), and `>|` (its `>`);
-# `&>` truncates at the bare `&` (matched before the `>`). The `\d*` models bash's
-# fd-prefix redirect parse — `git push origin main2>log` is the word `main` plus a
-# `2>log` redirect — so a redirect FILENAME can never be mistaken for the ref.
-_BENIGN_TERMINATOR_RE = re.compile(r"&&|\|\||\|&|;|&|\||\n|\d*[<>]")
+# OR a redirect START. The redirect arm is `(?<!\S)\d+[<>]|[<>]`: a bare `<`/`>` is
+# ALWAYS a redirect (fd defaults), AND a leading fd-NUMBER (`2>`, `22>`) is a
+# redirect prefix ONLY when it is a standalone token — i.e. NOT preceded by a
+# non-whitespace char. This mirrors bash's IO_NUMBER rule: digits GLUED to the
+# preceding word are PART OF THE WORD, not an fd-number. So `git push origin
+# main2>log` is the bash WORD `main2` plus a `>log` redirect (the refspec is
+# `main2`, NOT `main`); only a whitespace-preceded `2>` (e.g. `main 2>&1`) is an
+# fd-redirect that truncates. The `(?<!\S)` lookbehind also keeps the scan LINEAR
+# on a long digit run — it prunes the redundant in-run start positions that a bare
+# `\d*` would re-scan (the O(n^2) catastrophic-backtracking a `\d*[<>]` exhibits).
+_BENIGN_TERMINATOR_RE = re.compile(r"&&|\|\||\|&|;|&|\||\n|(?<!\S)\d+[<>]|[<>]")
+
+# Process-substitution marker (`>(`/`<(`, allowing one optional space). An UNQUOTED
+# procsub is never an honest force-push/branch-delete form: bash treats
+# `git push --force origin main >(cmd)` as a MULTI-ref push (`>(cmd)` expands to an
+# extra `/dev/fd/N` positional), and `... > >(cmd)` redirects stdout into the
+# procsub FIFO. _executable_prefix ABSTAINS when this appears, rather than
+# truncating at the redirect and mis-deriving a single-ref target. Scanned on the
+# same _mask_shell_quotes view, so a quoted `"a>(b)"` is inert (never an over-block).
+_PROCSUB_MARKER_RE = re.compile(r"[<>] ?\(")
 
 
 def _executable_prefix(command: str) -> str | None:
@@ -1613,15 +1627,23 @@ def _executable_prefix(command: str) -> str | None:
     continuation / redirect detected on the same-length `_mask_shell_quotes` view
     — or the whole command when there is no such terminator. A quoted metachar
     (`"weird>name"`) is masked to spaces on that view, so only an UNQUOTED
-    operator / redirect bounds the prefix. Returns None iff the quote state is
-    ambiguous (an unbalanced / unterminated quote makes `_shell_tokenize` fail) —
-    the caller treats None as an ABSENT target and REFUSES (fail-OPEN to the
-    existing safe over-block; an adversarial quote-elided command is out of scope
-    and is never authorized, only ever over-blocked).
+    operator / redirect bounds the prefix. Returns None (the caller treats None as
+    an ABSENT target and REFUSES — fail-OPEN to the existing safe over-block) iff
+    EITHER the quote state is ambiguous (an unbalanced / unterminated quote makes
+    `_shell_tokenize` fail) OR an unquoted process-substitution marker (`>(`/`<(`)
+    is present (defense-in-depth — never an honest destructive form, and it makes a
+    single-ref target ambiguous). An adversarial quote-elided command is out of
+    scope and is never authorized, only ever over-blocked.
     """
     if _shell_tokenize(command) is None:  # unbalanced/unterminated quote -> abstain
         return None
     masked = _mask_shell_quotes(command)  # same-length; quoted metachars -> spaces
+    # Process-substitution defense-in-depth: an unquoted `>(`/`<(` is never an
+    # honest force-push/branch-delete form (bash makes a single-ref target ambiguous
+    # -> a multi-ref push, or redirects into a FIFO). Abstain rather than truncate
+    # at the redirect and mis-derive the target. Over-block direction only.
+    if _PROCSUB_MARKER_RE.search(masked):
+        return None
     terminator = _BENIGN_TERMINATOR_RE.search(masked)
     return command[: terminator.start()] if terminator else command
 

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -62,28 +62,26 @@ PURE-rm chain (`rm -rf a && rm -rf b`) stay is_dangerous=False and are NEVER gat
 the guard stays out of pure-filesystem commands.
 
 benign-CONTINUATION (the dual of the rm-EXCEPTION; documented so a future sweep does
-NOT "discover" the single-leg mint and "harden" it away): for the gh pr merge/close
-family, a SINGLE recognized destructive op + ANY benign continuation mints a token AND
-the read side authorizes the continued command. "Benign" means the remainder is NOT a
-second destructive git/gh op — it need NOT be read-only (a `tee` or an output redirect
-WRITES a file and is still benign). A benign chain (`gh pr merge 5 && echo ok`,
-`gh pr merge 5 ; echo done`), a backgrounding (`gh pr merge 5 &`), a pipe to a
-pager/filter or `tee` (`gh pr merge 5 | tail`, `gh pr merge 5 | tee log`), or an output
-redirect (`gh pr merge 5 > out.log`) is a faithful single-command click:
+NOT "discover" the single-leg mint and "harden" it away): for EVERY recognized
+destructive op — gh pr merge, gh pr close, git force-push, AND git branch-delete — a
+SINGLE such op + ANY benign continuation mints a token AND the read side authorizes the
+continued command. "Benign" means the remainder is NOT a second destructive git/gh op —
+it need NOT be read-only (a `tee` or an output redirect WRITES a file and is still
+benign). A benign chain (`gh pr merge 5 && echo ok`, `gh pr merge 5 ; echo done`), a
+backgrounding (`gh pr merge 5 &`), a pipe to a pager/filter or `tee`
+(`gh pr merge 5 | tail`, `gh pr merge 5 | tee log`), or an output / fd redirect
+(`gh pr merge 5 > out.log`, `git push --force origin main 2>&1`,
+`git branch -D feature > log`) is a faithful single-command click:
 is_compound_destructive_command refuses ONLY on >=2 destructive legs (one destructive
-leg + benign continuation is NOT compound), and the merge/close read-side target is the
-PR-NUMBER positional, recovered regardless of trailing continuation tokens — so the
-approval still binds. This is the GENERAL single-destructive-op-plus-benign-remainder
-pattern, NOT a recognition allow-list of viewers/filters — do NOT enumerate viewers in
-detection logic (an allow-list drifts and would re-block faithful clicks the count
-already mints).
-KNOWN LIMITATION (fail-safe; do NOT "fix" it here): the SAME continuation appended to a
-force-push or branch-delete currently OVER-blocks on the read side. Their target
-extractor requires an exact positional count (push: remote + refspec; branch: one name),
-so a continuation's tokens are miscounted as extra positionals → the target is
-unextractable → the approved token no longer matches → REFUSE. This refuses a faithful
-click but NEVER under-blocks (the safe direction); the fix belongs to the over-block-
-tokenizer work, not a detection change here.
+leg + benign continuation is NOT compound), and the read-side target is re-derived from
+the SINGLE destructive leg — the merge/close PR-NUMBER positional, the branch-delete
+name, OR the force-push ref — regardless of any trailing continuation / redirect tokens,
+so the approval still binds. (The positional extractors truncate at the first benign
+terminator on the quote-masked view; the read call site isolates the single destructive
+leg before deriving op/target/flags.) This is the GENERAL single-destructive-op-plus-
+benign-remainder pattern, NOT a recognition allow-list of viewers/filters — do NOT
+enumerate viewers in detection logic (an allow-list drifts and would re-block faithful
+clicks the count already mints).
 =============================================================================
 
 Centralizes TOKEN_TTL, TOKEN_DIR, TOKEN_PREFIX, consumed-token cleanup,
@@ -496,7 +494,17 @@ def _extract_branch_name(command: str) -> str | None:
     # reaches here when detect_command_operation_type already classified the
     # command branch-delete, so a -D/--delete flag is present and is dropped
     # with the other dash-flags.
-    branch_match = re.search(_GIT_PREFIX + r"branch\b(.*)$", command)
+    # Truncate at the first benign continuation / redirect on the quote-masked
+    # view BEFORE counting positionals, so a faithful single branch-delete with a
+    # trailing continuation (`git branch -D feature | tail`, `... ; echo done`,
+    # `... > log`) re-derives its one branch name instead of miscounting the
+    # continuation tokens as extra positionals (-> None -> over-block). An
+    # ambiguous quote state makes _executable_prefix return None -> abstain -> the
+    # existing safe over-block (never a silently-authorized malformed command).
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        return None
+    branch_match = re.search(_GIT_PREFIX + r"branch\b(.*)$", prefix)
     if not branch_match:
         return None
     positionals = [t for t in branch_match.group(1).split() if not t.startswith("-")]
@@ -534,7 +542,19 @@ def _extract_force_push_target_ref(command: str) -> str | None:
     # remote-only (implicit branch); >2 = multi-ref/chained -> all ambiguous,
     # REFUSE. A value-taking dash-flag (e.g. `-o opt`) shifts the positional
     # count off 2 -> also refused (conservative over-block).
-    push_match = re.search(_GIT_PREFIX + r"push\b(.*)$", command)
+    # Truncate at the first benign continuation / redirect on the quote-masked
+    # view BEFORE counting positionals, so a faithful single force-push with a
+    # trailing continuation (`git push --force origin main | tail`, `... 2>&1`,
+    # `... > log`, `... && echo done`) re-derives its target instead of
+    # miscounting the continuation tokens as extra positionals (-> None ->
+    # over-block). The redirect filename is structurally outside the positional
+    # window (`... feature > main` yields `feature`, never `main`). An ambiguous
+    # quote state makes _executable_prefix return None -> abstain -> the existing
+    # safe over-block (never a silently-authorized malformed command).
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        return None
+    push_match = re.search(_GIT_PREFIX + r"push\b(.*)$", prefix)
     if not push_match:
         return None
     positionals = [t for t in push_match.group(1).split() if not t.startswith("-")]
@@ -1573,6 +1593,37 @@ def _normalize_line_continuations(command: str) -> str:
     Routed through every floor call site + the new substrate so mint and read join
     lines identically (mint==read by construction)."""
     return command.replace("\\\n", " ")
+
+
+# Benign continuation / redirect terminator for the positional target extractors
+# (_extract_force_push_target_ref / _extract_branch_name). Matches a compound
+# operator (`&&`, `||`, `|&`, `;`, `&`, `|`, newline — the _COMPOUND_OPS_RE set)
+# OR a redirect START: an optional leading fd number then `<`/`>`. The redirect
+# arm covers `>`, `>>`, `<`, `2>`, `2>&1` (its leading `2>`), and `>|` (its `>`);
+# `&>` truncates at the bare `&` (matched before the `>`). The `\d*` models bash's
+# fd-prefix redirect parse — `git push origin main2>log` is the word `main` plus a
+# `2>log` redirect — so a redirect FILENAME can never be mistaken for the ref.
+_BENIGN_TERMINATOR_RE = re.compile(r"&&|\|\||\|&|;|&|\||\n|\d*[<>]")
+
+
+def _executable_prefix(command: str) -> str | None:
+    """The command truncated at the first UNQUOTED compound-op-or-redirect.
+
+    Returns the leading executable span — everything before the first benign
+    continuation / redirect detected on the same-length `_mask_shell_quotes` view
+    — or the whole command when there is no such terminator. A quoted metachar
+    (`"weird>name"`) is masked to spaces on that view, so only an UNQUOTED
+    operator / redirect bounds the prefix. Returns None iff the quote state is
+    ambiguous (an unbalanced / unterminated quote makes `_shell_tokenize` fail) —
+    the caller treats None as an ABSENT target and REFUSES (fail-OPEN to the
+    existing safe over-block; an adversarial quote-elided command is out of scope
+    and is never authorized, only ever over-blocked).
+    """
+    if _shell_tokenize(command) is None:  # unbalanced/unterminated quote -> abstain
+        return None
+    masked = _mask_shell_quotes(command)  # same-length; quoted metachars -> spaces
+    terminator = _BENIGN_TERMINATOR_RE.search(masked)
+    return command[: terminator.start()] if terminator else command
 
 
 # -----------------------------------------------------------------------------

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -1840,6 +1840,66 @@ def _leg_is_destructive(leg: str) -> bool:
     return is_dangerous_command(leg) or _RM_HEAD_RE.match(leg) is not None
 
 
+def _split_into_legs(command: str) -> list[str]:
+    """Split a command into its shell-operator-separated legs (always >=1 leg).
+
+    The single SSOT for leg boundaries: both is_compound_destructive_command (the
+    >=2-destructive-leg refuse) AND _single_destructive_leg (the read-side
+    single-leg isolation) consume this, so the two can never see divergent leg
+    boundaries (the #720/#878 divergence class). A command with no shell operator
+    yields a one-element list (the whole stripped command).
+
+    Operators are detected on the P2-masked + FD-neutralized view so an operator
+    INSIDE a quoted arg (`--subject "a; b"`) or an FD / and-redirect (`2>&1`,
+    `&>`, `>|`) is NOT a separator. Each FD-redirect is replaced by an EQUAL-LENGTH
+    run of spaces (NOT a single space) so the masked view stays SAME-LENGTH as
+    `stripped` and each operator's offsets map 1:1 back to the ORIGINAL legs (which
+    carry the real flag spellings the callers classify). A single-space collapse
+    would shrink the view and mis-slice the legs after a multi-char redirect (e.g.
+    `2>&1 | rm -rf ~`). The leg slices are taken from `stripped`, never the masked
+    `view` — the view exists ONLY to locate the operator offsets.
+    """
+    normalized = _normalize_line_continuations(command)
+    stripped = _strip_non_executable_content(normalized)
+    view = _FD_REDIRECT_RE.sub(
+        lambda m: " " * len(m.group()), _mask_shell_quotes(stripped)
+    )
+    legs, last = [], 0
+    for m in _COMPOUND_OPS_RE.finditer(view):
+        legs.append(stripped[last : m.start()])
+        last = m.end()
+    legs.append(stripped[last:])
+    return legs
+
+
+def _single_destructive_leg(command: str) -> str | None:
+    """The UNIQUE is_dangerous_command leg of a command, or None.
+
+    Returns the single destructive gh/git leg when EXACTLY one leg is dangerous;
+    None when 0 legs are dangerous, or — at the read call site, unreachably — when
+    >=2 are (is_compound_destructive_command REFUSES that upstream, at
+    check_merge_authorization, BEFORE the read seam). The read seam treats None as
+    'abstain to the WHOLE command' (the existing over-binding whole-command scan =
+    the safe over-block direction), NEVER a silent narrowing: a fail-toward-unmasked
+    quote split or any ambiguity can only collapse to the conservative whole-command
+    context, never authorize a narrower one.
+
+    This is the substrate the read side uses to derive (op, target, bound_flags)
+    from the destructive op ALONE — so a privileged flag on a benign NEIGHBOR leg
+    cannot pollute bound_flags (the over-block) and a benign neighbor's PR number
+    cannot cross-contaminate the target via _extract_pr_number's first-match-
+    anywhere scan (the latent under-block). A privileged flag that modifies the
+    destructive op is a token of its OWN simple-command (leg), so it stays bound;
+    only a different statement's flag (past an operator boundary) is dropped.
+    """
+    dangerous = [
+        leg.strip()
+        for leg in _split_into_legs(command)
+        if is_dangerous_command(leg.strip())
+    ]
+    return dangerous[0] if len(dangerous) == 1 else None
+
+
 def is_compound_destructive_command(command: str) -> bool:
     """Detect an agent chaining MULTIPLE destructive operations into one command.
 
@@ -1863,25 +1923,12 @@ def is_compound_destructive_command(command: str) -> bool:
     (one destructive leg). Only >=2 destructive legs are refused (route to
     one-op-at-a-time approval).
     """
-    normalized = _normalize_line_continuations(command)
-    stripped = _strip_non_executable_content(normalized)
-    # Operators are detected on the P2-masked + FD-neutralized view so an operator INSIDE
-    # a quoted arg (`--subject "a; b"`) or an FD/and-redirect (`2>&1`, `&>`, `>|`) is NOT a
-    # separator. Each FD-redirect is replaced by an EQUAL-LENGTH run of spaces (NOT a single
-    # space) so the masked view stays SAME-LENGTH as `stripped` and each operator's offsets
-    # map 1:1 back to the ORIGINAL legs (which carry the real flag spellings for the per-leg
-    # danger classification below). A single-space collapse would shrink the view and
-    # mis-slice the legs after a multi-char redirect (e.g. `2>&1 | rm -rf ~`).
-    compound_view = _FD_REDIRECT_RE.sub(
-        lambda m: " " * len(m.group()), _mask_shell_quotes(stripped)
-    )
-    if not _COMPOUND_OPS_RE.search(compound_view):
-        return False
-    legs, last = [], 0
-    for m in _COMPOUND_OPS_RE.finditer(compound_view):
-        legs.append(stripped[last:m.start()])
-        last = m.end()
-    legs.append(stripped[last:])
+    # Legs come from the shared _split_into_legs SSOT (masked + FD-neutralized split
+    # on _COMPOUND_OPS_RE, slices taken from `stripped`). A command with no operator
+    # yields ONE leg, so the >=2 count below is False — identical to the prior
+    # explicit no-operator short-circuit, without a separate code path that could
+    # drift from the read-side leg isolation.
+    legs = _split_into_legs(command)
     # >=2 DESTRUCTIVE legs → refuse. A leg is destructive via _leg_is_destructive: a
     # recognized git/gh-destructive op (so a non-canonical flag spelling like `-Df` in a
     # leg still counts) OR a plain-`rm` head leg (the documented rm-exception). A single

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -9740,6 +9740,72 @@ class TestCompoundDestructiveCommandRejection:
         ) is False
 
 
+class TestSplitIntoLegsExtractionParity:
+    """Regression gate for the _split_into_legs extraction.
+
+    is_compound_destructive_command's leg split was extracted verbatim into the
+    shared _split_into_legs helper (so the compound-refuse and the read-side
+    single-destructive-leg isolation can never see divergent leg boundaries). This
+    pins that the extraction is BEHAVIOR-IDENTICAL to the prior inline split — the
+    one transcription error that would matter is slicing the legs from the masked
+    `view` instead of `stripped`, which this differential catches. The
+    is_compound_destructive_command verdict suite is the companion gate (the
+    True/False outcomes are the contract); this makes 'identical, not regress'
+    executable at the leg-boundary level.
+    """
+
+    @staticmethod
+    def _old_inline_split(command):
+        """The pre-extraction inline split, reproduced independently (sans the
+        no-operator early-return, which only short-circuited the verdict, not the
+        legs). Slices from `stripped`, offsets located on the masked + FD-
+        neutralized view — exactly as the inline body did."""
+        from shared.merge_guard_common import (
+            _COMPOUND_OPS_RE,
+            _FD_REDIRECT_RE,
+            _mask_shell_quotes,
+            _normalize_line_continuations,
+            _strip_non_executable_content,
+        )
+
+        stripped = _strip_non_executable_content(
+            _normalize_line_continuations(command)
+        )
+        view = _FD_REDIRECT_RE.sub(
+            lambda mm: " " * len(mm.group()), _mask_shell_quotes(stripped)
+        )
+        legs, last = [], 0
+        for mm in _COMPOUND_OPS_RE.finditer(view):
+            legs.append(stripped[last:mm.start()])
+            last = mm.end()
+        legs.append(stripped[last:])
+        return legs
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh pr merge 5",                                   # one leg, no operator
+            "gh pr close 5 -d && git branch -Df victim",       # &&
+            "gh pr merge 100 && gh pr close 999 --delete-branch",
+            "gh pr merge 5 && rm -rf /",                        # gh + rm
+            "gh pr merge 5 ; echo done",                        # ;
+            "gh pr merge 5 | tail",                             # |
+            "gh pr merge 5 > out.log",                          # redirect (one leg)
+            "gh pr merge 5 &",                                  # background
+            "git push --force origin main 2>&1 | rm -rf ~",     # multi-char redirect then |
+            'gh pr merge 5 --subject "a; b" && gh pr close 6',  # quoted ; is inert
+            "gh pr close 1058\ngh pr merge 999 --squash",       # newline operator
+            "gh pr merge 5 --admin ; gh pr view 5 --repo o/x",  # benign neighbor leg
+            'gh pr merge 5 --body "x | y > z"',                 # quoted metachars, one leg
+            "gh pr merge 5 &> out.log",                         # and-redirect (one leg)
+        ],
+    )
+    def test_split_matches_prior_inline_split(self, command):
+        from shared.merge_guard_common import _split_into_legs
+
+        assert _split_into_legs(command) == self._old_inline_split(command)
+
+
 class TestBenignContinuationGuarantee:
     """Pin the 'single destructive op + benign continuation' idiom.
 

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -102,64 +102,10 @@ class TestIsMergeQuestion:
         assert is_merge_question("Run `gh pr merge 5` now?")
 
 
-class TestIsAffirmative:
-    """Tests for merge_guard_post.is_affirmative()."""
-
-    def test_yes(self):
-        from merge_guard_post import is_affirmative
-
-        assert is_affirmative("yes")
-
-    def test_y(self):
-        from merge_guard_post import is_affirmative
-
-        assert is_affirmative("y")
-
-    def test_confirm(self):
-        from merge_guard_post import is_affirmative
-
-        assert is_affirmative("confirm")
-
-    def test_go_ahead(self):
-        from merge_guard_post import is_affirmative
-
-        assert is_affirmative("go ahead")
-
-    def test_approved(self):
-        from merge_guard_post import is_affirmative
-
-        assert is_affirmative("approved")
-
-    def test_proceed(self):
-        from merge_guard_post import is_affirmative
-
-        assert is_affirmative("proceed")
-
-    def test_negative_no(self):
-        from merge_guard_post import is_affirmative
-
-        assert not is_affirmative("no")
-
-    def test_negative_cancel(self):
-        from merge_guard_post import is_affirmative
-
-        assert not is_affirmative("cancel")
-
-    def test_negative_empty(self):
-        from merge_guard_post import is_affirmative
-
-        assert not is_affirmative("")
-
-    def test_with_leading_whitespace(self):
-        from merge_guard_post import is_affirmative
-
-        assert is_affirmative("  yes  ")
-
-    def test_case_insensitive(self):
-        from merge_guard_post import is_affirmative
-
-        assert is_affirmative("YES")
-
+# (removed class TestIsAffirmative — merge_guard_post.is_affirmative and its
+#  AFFIRMATIVE_PATTERNS regex were removed as production-orphaned dead code:
+#  OPTION-mode approval is an exact non-decline label match, never a free-text
+#  word allowlist, so the affirmative prefix matcher had no remaining call site.)
 
 # (removed class TestExtractContext — superseded by the command-anchored
 #  bidirectional suite in test_merge_guard_auth_symmetry.py;
@@ -2084,7 +2030,7 @@ class TestGitCommitMessageStripping:
 
 
 class TestMergeQuestionEdgeCases:
-    """Edge cases for merge question and affirmative detection."""
+    """Edge cases for merge question detection."""
 
     def test_merge_substring_no_longer_false_fires(self):
         """KD-9: is_merge_question is command-driven, so the old 'merge'-as-
@@ -2094,77 +2040,10 @@ class TestMergeQuestionEdgeCases:
 
         assert is_merge_question("The data emerged from the pipeline") is False
 
-    def test_affirmative_with_extra_text(self):
-        """Affirmative followed by additional text."""
-        from merge_guard_post import is_affirmative
-
-        assert is_affirmative("yes please go ahead")
-
-    def test_do_it(self):
-        """'do it' is an affirmative pattern."""
-        from merge_guard_post import is_affirmative
-
-        assert is_affirmative("do it")
-
-    def test_sure(self):
-        """'sure' is affirmative."""
-        from merge_guard_post import is_affirmative
-
-        assert is_affirmative("sure")
-
-    def test_okay(self):
-        """'okay' is affirmative."""
-        from merge_guard_post import is_affirmative
-
-        assert is_affirmative("okay")
-
-    def test_ok(self):
-        """'ok' is affirmative."""
-        from merge_guard_post import is_affirmative
-
-        assert is_affirmative("ok")
-
-    def test_yep(self):
-        """'yep' is affirmative."""
-        from merge_guard_post import is_affirmative
-
-        assert is_affirmative("yep")
-
-    def test_yeah(self):
-        """'yeah' is affirmative."""
-        from merge_guard_post import is_affirmative
-
-        assert is_affirmative("yeah")
-
-    def test_approve(self):
-        """'approve' is affirmative."""
-        from merge_guard_post import is_affirmative
-
-        assert is_affirmative("approve")
-
-    def test_not_affirmative_maybe(self):
-        """'maybe' is NOT affirmative."""
-        from merge_guard_post import is_affirmative
-
-        assert not is_affirmative("maybe")
-
-    def test_not_affirmative_let_me_think(self):
-        """'let me think' is NOT affirmative."""
-        from merge_guard_post import is_affirmative
-
-        assert not is_affirmative("let me think about it")
-
-    def test_not_affirmative_wait(self):
-        """'wait' is NOT affirmative."""
-        from merge_guard_post import is_affirmative
-
-        assert not is_affirmative("wait")
-
-    def test_not_affirmative_dont(self):
-        """'don't' is NOT affirmative."""
-        from merge_guard_post import is_affirmative
-
-        assert not is_affirmative("don't do that")
+    # (removed the is_affirmative test methods — merge_guard_post.is_affirmative
+    #  and its AFFIRMATIVE_PATTERNS regex were removed as production-orphaned dead
+    #  code; OPTION-mode approval is an exact non-decline label match, not a
+    #  free-text word allowlist. is_merge_question coverage stays above.)
 
     # (removed test_extract_pull_request_text / test_extract_branch_with_dots /
     #  test_extract_branch_with_underscores / test_extract_quoted_branch — they

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -9751,40 +9751,23 @@ class TestBenignContinuationGuarantee:
     whole continuation family so a future hardening change cannot silently
     re-break the idiom.
 
-    Two arms over the SAME benign-continuation family, because the read side's
-    target re-derivation behaves differently per op-class:
+    The guarantee is UNIVERSAL across the recognized destructive ops — gh pr
+    merge, gh pr close, git force-push, AND git branch-delete: a single such op
+    plus any benign continuation mints a token AND the read side AUTHORIZES the
+    continued command. Each op's target parser re-derives its target from the
+    single destructive leg regardless of trailing continuation / redirect tokens
+    (the positional extractors truncate at the first benign terminator on the
+    quote-masked view), so the minted single-op token still matches.
 
-      ARM (a) — gh pr merge/close: the read side AUTHORIZES the continued
-        command. The PR-number target parser is continuation-tolerant (it
-        captures the positional directly rather than splitting the tail), so the
-        minted single-op token still matches. This is the guaranteed idiom.
-
-      ARM (b) — force-push / branch-delete: the read side currently OVER-BLOCKS
-        the continued command. Their target parsers split everything after
-        ``push`` / ``branch`` and count the continuation tokens (``|``, ``tail``,
-        ``echo`` …) as extra positionals, tripping the multi-target conservatism
-        so the target is unextractable; the minted token then no longer matches
-        and the read side refuses. This is the fail-safe over-block direction
-        (it refuses a faithful click, never authorizes anything unapproved).
-
-        These arm-(b) asserts are a FLIP-ON-FIX TRIPWIRE for the continuation-
-        tolerant target-parser fix tracked as #1043: once that lands, force-push
-        / branch-delete + continuation will start AUTHORIZING
-        (``check_merge_authorization`` returns None) and these cases must be
-        MOVED to the arm-(a) AUTHORIZED expectation. The test is intentionally
-        coupled to the present behavior so the fix has a red-on-flip target.
-
-    Non-vacuity is anchored three ways:
-      * the CLEAN no-continuation control — the bare force-push / branch-delete
-        AUTHORIZES with the SAME token context, proving arm-(b) refusals are
-        caused by the continuation, not by a wrong token shape (a harness
-        artifact);
+    Non-vacuity is anchored:
       * the ``| bash`` pipe-to-shell boundary — a benign continuation is bounded:
         ``_has_pipe_to_shell`` recognizes ``| bash`` / ``| sh`` as dangerous
         indirection while the benign viewers (``| tail`` / ``| less``) are NOT,
         so 'benign continuation' is not a blanket pipe pass;
       * the >=2-destructive compound contrast — a genuine multi-destructive chain
-        is still classified compound and refused even with a token.
+        is still classified compound and refused even with a token;
+      * the wrong-target / privileged-flag-absent negatives — a continuation can
+        never authorize a MISMATCHED target or a token missing a bound flag.
     """
 
     # The benign continuation family: pipe-to-viewer, output redirect,
@@ -9797,11 +9780,15 @@ class TestBenignContinuationGuarantee:
         "&", "&& echo done", "; echo done",
     ]
 
-    # ARM (a) ops: (label, base destructive command, mint context). The read side
-    # AUTHORIZES the continued command. ``close`` carries ``--delete-branch`` (its
-    # danger trigger), so its token context MUST bind that flag — the read-side
-    # set-equality flag gate refuses otherwise — exactly as the mint side extracts
-    # it from the approval text. ``merge`` carries no privileged flag.
+    # All recognized destructive ops: (label, base destructive command, mint
+    # context). The read side AUTHORIZES the continued command for EVERY one —
+    # the force-push / branch-delete target parsers are now continuation-tolerant
+    # (they truncate at the first benign terminator before counting positionals),
+    # so they join merge / close in this guarantee. ``close`` carries
+    # ``--delete-branch`` (its danger trigger), so its token context MUST bind
+    # that flag — the read-side set-equality flag gate refuses otherwise — exactly
+    # as the mint side extracts it from the approval text. ``merge`` /
+    # ``force-push`` / ``branch-delete`` carry no privileged flag.
     _AUTHORIZED_OPS = [
         ("merge", "gh pr merge 5", {"operation_type": "merge", "pr_number": "5"}),
         (
@@ -9810,12 +9797,6 @@ class TestBenignContinuationGuarantee:
             {"operation_type": "close", "pr_number": "7",
              "bound_flags": ["--delete-branch"]},
         ),
-    ]
-
-    # ARM (b) ops: (label, base destructive command, mint context). The read side
-    # currently OVER-BLOCKS the continued command. The CLEAN base command
-    # authorizes with the same context (test_arm_b_clean_control_authorizes).
-    _OVERBLOCK_OPS = [
         (
             "force-push",
             "git push --force origin main",
@@ -9830,13 +9811,14 @@ class TestBenignContinuationGuarantee:
 
     @pytest.mark.parametrize("cont", _BENIGN_CONTINUATIONS)
     @pytest.mark.parametrize("op_label,base,ctx", _AUTHORIZED_OPS)
-    def test_arm_a_merge_close_continuation_authorizes(
+    def test_single_destructive_op_continuation_authorizes(
         self, tmp_path, op_label, base, ctx, cont
     ):
-        """ARM (a): merge/close + a benign continuation mints AND authorizes.
+        """A single destructive op + a benign continuation mints AND authorizes.
 
         One destructive leg (dangerous, NOT compound); the single-op approval
-        token authorizes the continued command. This is the guaranteed idiom.
+        token authorizes the continued command. Holds for EVERY recognized op
+        (merge / close / force-push / branch-delete) — the guaranteed idiom.
         """
         from merge_guard_post import write_token
         from merge_guard_pre import (
@@ -9850,53 +9832,6 @@ class TestBenignContinuationGuarantee:
         assert is_compound_destructive_command(cmd) is False
         assert write_token(dict(ctx), token_dir=tmp_path) is not None
         assert check_merge_authorization(cmd, token_dir=tmp_path) is None
-
-    @pytest.mark.parametrize("cont", _BENIGN_CONTINUATIONS)
-    @pytest.mark.parametrize("op_label,base,ctx", _OVERBLOCK_OPS)
-    def test_arm_b_forcepush_branchdelete_continuation_overblocks(
-        self, tmp_path, op_label, base, ctx, cont
-    ):
-        """ARM (b): force-push/branch-delete + a benign continuation is the CURRENT
-        over-block. One destructive leg (dangerous, NOT compound) and the single-op
-        token mints, but the read side REFUSES because the continuation defeats the
-        target re-derivation.
-
-        A MATCHING token is minted so the refusal is specifically the
-        continuation-induced target-mismatch over-block — NOT the trivial
-        no-token path (which would never flip). FLIP-ON-FIX TRIPWIRE: when the
-        continuation-tolerant target-parser fix (#1043) lands, these cases will
-        AUTHORIZE (check_merge_authorization is None) and must move to arm (a).
-        """
-        from merge_guard_post import write_token
-        from merge_guard_pre import (
-            check_merge_authorization,
-            is_compound_destructive_command,
-            is_dangerous_command,
-        )
-
-        cmd = f"{base} {cont}"
-        assert is_dangerous_command(cmd) is True
-        assert is_compound_destructive_command(cmd) is False
-        assert write_token(dict(ctx), token_dir=tmp_path) is not None
-        # Refused: the current over-block. The is_compound=False assert above is
-        # the discriminator that this refusal is the target-mismatch path, NOT the
-        # compound gate.
-        assert check_merge_authorization(cmd, token_dir=tmp_path) is not None
-
-    @pytest.mark.parametrize("op_label,base,ctx", _OVERBLOCK_OPS)
-    def test_arm_b_clean_control_authorizes(self, tmp_path, op_label, base, ctx):
-        """Non-vacuity control for arm (b): the CLEAN no-continuation force-push /
-        branch-delete AUTHORIZES with the SAME token context used in arm (b).
-
-        Proves the arm-(b) refusals are caused by the appended continuation, not
-        by a wrong token shape — and that this exact token context is what should
-        authorize the continued command once the #1043 parser fix lands.
-        """
-        from merge_guard_post import write_token
-        from merge_guard_pre import check_merge_authorization
-
-        assert write_token(dict(ctx), token_dir=tmp_path) is not None
-        assert check_merge_authorization(base, token_dir=tmp_path) is None
 
     @pytest.mark.parametrize(
         "cmd",
@@ -11005,14 +10940,13 @@ class TestEnvelopeIntegration:
                 post_main()
         return exc_info.value.code
 
-    def test_bug_a_envelope_fd_redirect_conservatively_over_blocks(self, tmp_path):
-        """Full envelope: Bug A surface, post-fix. The approval mints a
-        force-push token, but `git push origin main 2>&1` now CONSERVATIVELY
-        OVER-BLOCKS: the `2>&1` redirect is counted as a third positional by
-        `_extract_force_push_target_ref`, so the destination ref is
-        unparseable → ABSENT → REFUSE. This is the SAFE #1031 direction (an
-        over-block, NOT a #1032 under-block). Candidate KD-6 follow-up: strip
-        shell redirections before the force-push positional count.
+    def test_bug_a_envelope_fd_redirect_authorizes(self, tmp_path):
+        """Full envelope: Bug A surface, post over-block-tokenizer fix. The approval
+        mints a push-to-main token, and `git push origin main 2>&1` now AUTHORIZES:
+        `_extract_force_push_target_ref` truncates at the `2>&1` redirect before the
+        positional count, so the destination re-derives to `main` and matches the
+        token. The redirect filename is structurally outside the positional window,
+        so this is a faithful-click authorize, NOT a #1032 under-block.
         """
         # Step 1: approve via post hook — option-anchored (#32): the command
         # lives in the CLICKED option's description.
@@ -11027,13 +10961,13 @@ class TestEnvelopeIntegration:
         tokens = list(tmp_path.glob("merge-authorized-*"))
         assert len(tokens) == 1
 
-        # Step 2: run the FD-redirect command through pre hook → conservatively
-        # over-blocked (the redirect defeats the 2-positional ref parse).
-        pre_code, pre_stdout = self._invoke_pre(
+        # Step 2: run the FD-redirect command through pre hook → now AUTHORIZES
+        # (the redirect is truncated before the 2-positional ref parse, so the
+        # destination re-derives to `main` and matches the minted token).
+        pre_code, _pre_stdout = self._invoke_pre(
             "git push origin main 2>&1", tmp_path
         )
-        assert pre_code == 2  # Over-blocked (safe direction)
-        assert '"permissionDecision": "deny"' in pre_stdout
+        assert pre_code == 0  # Authorized (faithful click; redirect re-derived)
 
     def test_bug_b_envelope_joes_bare_push_authorizes(self, tmp_path):
         """Full envelope: Bug B surface. AskUserQuestion question with quoted-command

--- a/pact-plugin/tests/test_merge_guard_auth_symmetry.py
+++ b/pact-plugin/tests/test_merge_guard_auth_symmetry.py
@@ -542,15 +542,16 @@ class TestMintReadParity:
 
 
 class TestShellRedirectIsolation:
-    """A trailing shell redirect (`2>&1`) is tolerated by the merge/close target
-    extractor (the pr-number regex anchors on the digit positional and ignores
-    later tokens), but it DEFEATS the positional-counting ref parsers for BOTH
-    force-push (`origin main 2>&1` = 3 positionals → unparseable → REFUSE) AND —
-    post-#30 multi-target hardening — branch-delete (`-D x 2>&1` = 2 positionals
-    → multi-target → REFUSE). Both over-blocks are the SAFE #1031 direction (NOT
-    a #1032 under-block). Candidate follow-up (KD-6, security-owned): strip
-    recognized shell redirections before the positional split — now covering
-    force-push AND branch-delete."""
+    """A trailing shell redirect (`2>&1`) is tolerated by ALL the target
+    extractors. The merge/close pr-number regex always anchored on the digit
+    positional; the force-push and branch-delete positional parsers now truncate
+    at the first benign terminator on the quote-masked view BEFORE counting
+    positionals, so a redirect / continuation no longer inflates the count. A
+    faithful single force-push / branch-delete with a trailing redirect therefore
+    AUTHORIZES — the target is re-derived from the executable prefix, and the
+    redirect filename is structurally outside the positional window, so it can
+    never become the target (the over-block is fixed WITHOUT opening a #1032
+    under-block; a wrong/extra real positional still counts off → REFUSE)."""
 
     def _seed_typed(self, tmp_path, context):
         from merge_guard_post import write_token
@@ -560,25 +561,26 @@ class TestShellRedirectIsolation:
         self._seed_typed(tmp_path, {"operation_type": "merge", "pr_number": "5"})
         assert _authorize("gh pr merge 5 2>&1", tmp_path) is None
 
-    def test_branch_delete_with_redirect_over_blocks(self, tmp_path):
-        """Post-#30: the `2>&1` redirect is counted as a second positional, so
-        even a single-branch delete with a redirect conservatively OVER-BLOCKS
-        (the branch ref is unparseable → REFUSE). SAFE #1031 direction, NOT a
-        #1032 under-block. Same KD-6 redirect-strip follow-up class as force-push
-        (the follow-up now covers branch-delete too)."""
+    def test_branch_delete_with_redirect_authorizes(self, tmp_path):
+        """A single-branch delete with a trailing `2>&1` redirect AUTHORIZES: the
+        positional parser truncates at the redirect before counting, so the branch
+        ref re-derives to `x` and matches the token. (Previously this over-blocked
+        — the redirect was miscounted as a second positional; the over-block-
+        tokenizer fix removes it without opening a #1032 under-block.)"""
         self._seed_typed(tmp_path, {"operation_type": "branch-delete", "branch": "x"})
-        assert _authorize("git branch -D x 2>&1", tmp_path) is not None
-        # Sanity: WITHOUT the redirect the same token authorizes (isolates the
-        # over-block to the redirect-induced positional miscount).
+        assert _authorize("git branch -D x 2>&1", tmp_path) is None
+        # Companion: WITHOUT the redirect the same token also authorizes.
         assert _authorize("git branch -D x", tmp_path) is None
 
-    def test_force_push_with_redirect_over_blocks(self, tmp_path):
-        """Even WITH a matching force-push token, the `2>&1` redirect makes the
-        ref unparseable → conservative REFUSE (documented over-block)."""
+    def test_force_push_with_redirect_authorizes(self, tmp_path):
+        """A faithful force-push with a trailing `2>&1` redirect AUTHORIZES: the ref
+        parser truncates at the redirect before counting positionals, so the
+        destination re-derives to `main` and matches the token. (Previously this
+        over-blocked; the fix re-derives the target from the executable prefix and
+        the redirect filename can never become the ref — no #1032 under-block.)"""
         self._seed_typed(tmp_path, {"operation_type": "force-push", "target_ref": "main"})
-        assert _authorize("git push --force origin main 2>&1", tmp_path) is not None
-        # Sanity: WITHOUT the redirect the same token authorizes (isolates the
-        # over-block to the redirect-induced positional miscount).
+        assert _authorize("git push --force origin main 2>&1", tmp_path) is None
+        # Companion: WITHOUT the redirect the same token also authorizes.
         assert _authorize("git push --force origin main", tmp_path) is None
 
 

--- a/pact-plugin/tests/test_merge_guard_overblock_tokenizers.py
+++ b/pact-plugin/tests/test_merge_guard_overblock_tokenizers.py
@@ -449,3 +449,119 @@ class TestMintReadParityCanary:
         mint_ctx = extract_command_context("git push --force origin main")
         assert read_ctx == mint_ctx
         assert read_ctx.get("target_ref") == "main"
+
+
+# ═══════════════ #1069 — CLOSE op-class leg-isolation (review gap) ════════════
+class TestFixBCloseOpLegIsolation:
+    """Close op-class coverage for the #1069 leg-isolation, symmetric to the merge
+    pins above (which centered merge). Close is the higher-stakes op: its danger
+    trigger ``--delete-branch`` is IRREVERSIBLE, so an isolation regression here
+    would mis-delete a branch. The closing mechanism (_single_destructive_leg +
+    _extract_pr_number) is op-AGNOSTIC and already regression-guarded by the merge
+    pins; these make the close op explicit and guard a future op-specific divergence.
+
+    The CLOSE latent exec: a bare reversible ``gh pr close 1058`` (NOT dangerous)
+    chained with an IRREVERSIBLE ``gh pr close 999 --delete-branch``. Exactly one
+    leg is dangerous (the delete-close), so is_compound does NOT catch it; pre-#1069
+    the whole-command first-match scan bled pr_number=1058 (from the reversible
+    close leg), so a token approved for closing+deleting 1058's branch would
+    AUTHORIZE deleting 999's branch."""
+
+    _CLOSE_LATENT_EXEC = "gh pr close 1058\ngh pr close 999 --delete-branch"
+
+    def test_discriminator_is_target_mismatch_not_compound(self):
+        assert is_dangerous_command(self._CLOSE_LATENT_EXEC) is True
+        assert is_compound_destructive_command(self._CLOSE_LATENT_EXEC) is False
+        assert _single_destructive_leg(self._CLOSE_LATENT_EXEC) == (
+            "gh pr close 999 --delete-branch"
+        )
+
+    def test_close_token_for_wrong_pr_refuses(self, tmp_path):
+        # UNDER-BLOCK pin: token approved to delete 1058's branch must NOT authorize
+        # deleting 999's branch. Non-vacuity (Fix-B revert): _single_destructive_leg
+        # -> whole re-opens the bleed (whole pr_number=1058) -> AUTHORIZE = RED.
+        assert write_token(
+            {"operation_type": "close", "pr_number": "1058",
+             "bound_flags": ["--delete-branch"]},
+            token_dir=tmp_path,
+        ) is not None
+        assert check_merge_authorization(
+            self._CLOSE_LATENT_EXEC, token_dir=tmp_path
+        ) is not None  # REFUSE
+
+    def test_close_token_for_real_deleted_pr_authorizes_control(self, tmp_path):
+        # Non-vacuity control: a token for the PR actually delete-closed (999)
+        # AUTHORIZES the same exec -> the mismatch refusal is target-discrimination.
+        assert write_token(
+            {"operation_type": "close", "pr_number": "999",
+             "bound_flags": ["--delete-branch"]},
+            token_dir=tmp_path,
+        ) is not None
+        assert check_merge_authorization(
+            self._CLOSE_LATENT_EXEC, token_dir=tmp_path
+        ) is None  # AUTHORIZE
+
+    def test_close_benign_neighbor_flag_does_not_overblock(self, tmp_path):
+        # OVER-BLOCK fix (close flag-pollution): a benign neighbor's --repo on a
+        # different leg is dropped from the close leg's bound_flags, so the faithful
+        # delete-close AUTHORIZES with its matching token.
+        cmd = "gh pr close 5 --delete-branch ; gh pr view 5 --repo o/x"
+        assert write_token(
+            {"operation_type": "close", "pr_number": "5",
+             "bound_flags": ["--delete-branch"]},
+            token_dir=tmp_path,
+        ) is not None
+        assert check_merge_authorization(cmd, token_dir=tmp_path) is None  # AUTHORIZE
+
+    def test_close_delete_branch_flag_on_leg_stays_bound(self, tmp_path):
+        # UNDER-BLOCK guard (close analog of merge's --admin-stays-bound): a token
+        # for a bare reversible close must NOT authorize an IRREVERSIBLE delete-close
+        # — --delete-branch on the close leg stays bound, so the no-delete-branch
+        # token is REFUSED (the bare->delete-variant escalation is closed). Non-
+        # vacuity is the flag-drop mutation (strip dash-tokens -> --delete-branch
+        # dropped -> AUTHORIZE = RED), NOT a whole-command revert (which binds MORE).
+        cmd = "gh pr close 5 --delete-branch ; gh pr view 5"
+        assert write_token(
+            {"operation_type": "close", "pr_number": "5"}, token_dir=tmp_path
+        ) is not None
+        assert check_merge_authorization(cmd, token_dir=tmp_path) is not None  # REFUSE
+
+    def test_close_faithful_delete_close_authorizes_companion(self, tmp_path):
+        # Companion to the guard: the FAITHFUL token (binding --delete-branch) for the
+        # same exec AUTHORIZES — so the refusal above is the missing-flag escalation,
+        # not a trivial no-match.
+        cmd = "gh pr close 5 --delete-branch ; gh pr view 5"
+        assert write_token(
+            {"operation_type": "close", "pr_number": "5",
+             "bound_flags": ["--delete-branch"]},
+            token_dir=tmp_path,
+        ) is not None
+        assert check_merge_authorization(cmd, token_dir=tmp_path) is None  # AUTHORIZE
+
+
+# ════════════════ destructive-leg ORDER independence (review gap) ════════════
+class TestDestructiveLegOrderIndependence:
+    """_single_destructive_leg isolates the unique dangerous leg regardless of its
+    POSITION among benign neighbors. The pins above place the destructive leg first;
+    these place it SECOND (and amid multiple neighbors), so a future change keying on
+    leg ORDER rather than leg DANGER is caught."""
+
+    def test_destructive_leg_second_admin_stays_bound(self, tmp_path):
+        # Destructive leg SECOND: --admin on the (second) merge leg still binds -> a
+        # no-flag token is REFUSED, exactly as when the merge leg is first.
+        cmd = "gh pr view 5 ; gh pr merge 5 --admin"
+        assert _single_destructive_leg(cmd) == "gh pr merge 5 --admin"
+        assert write_token(
+            {"operation_type": "merge", "pr_number": "5"}, token_dir=tmp_path
+        ) is not None
+        assert check_merge_authorization(cmd, token_dir=tmp_path) is not None  # REFUSE
+
+    def test_destructive_leg_amid_multiple_neighbors_target_isolated(self, tmp_path):
+        # One dangerous merge leg amid two benign neighbors: the target (999) is the
+        # merge leg's, so a token for a DIFFERENT pr (1) is REFUSED (no cross-leg bleed).
+        cmd = "gh pr view 5 ; gh pr merge 999 ; gh pr view 6"
+        assert _single_destructive_leg(cmd) == "gh pr merge 999"
+        assert write_token(
+            {"operation_type": "merge", "pr_number": "1"}, token_dir=tmp_path
+        ) is not None
+        assert check_merge_authorization(cmd, token_dir=tmp_path) is not None  # REFUSE

--- a/pact-plugin/tests/test_merge_guard_overblock_tokenizers.py
+++ b/pact-plugin/tests/test_merge_guard_overblock_tokenizers.py
@@ -565,3 +565,138 @@ class TestDestructiveLegOrderIndependence:
             {"operation_type": "merge", "pr_number": "1"}, token_dir=tmp_path
         ) is not None
         assert check_merge_authorization(cmd, token_dir=tmp_path) is not None  # REFUSE
+
+
+# ════════ #1043 — IO_NUMBER-faithful digit-glued redirect (BLOCKING fix) ═════
+class TestFixADigitGluedRedirectUnderBlock:
+    """The review-BLOCKING under-block: the redirect terminator modeled bash's
+    fd-number prefix as ``\\d*``, which greedily ate the trailing digits of a ref
+    GLUED to an unquoted redirect — ``git push --force origin main2>log`` (bash word
+    ``main2`` + a ``>log`` redirect) truncated to ``main``, so a token approved for
+    ``main`` authorized a destructive op on ``main2``. The fix recognizes an
+    fd-number prefix only when whitespace-delimited (``(?<!\\S)\\d+[<>]|[<>]`` —
+    bash's IO_NUMBER rule), so the digit-glued ref is extracted FAITHFULLY.
+
+    Non-vacuity is the FINE mutation (revert ONLY the IO_NUMBER arm to ``\\d*[<>]``)
+    — a coarse ``_executable_prefix``->identity mutation does NOT pin the boundary
+    (a spaced-only suite would survive it). Verified: under ``\\d*[<>]`` the digit-
+    glued pins flip RED (fp(main2>log)->'main', token-main AUTHORIZEs the under-block);
+    the SPACED fd-redirect cases stay GREEN under both (they are not the boundary).
+    """
+
+    # (command, bash-faithful target) — the digit is PART OF THE WORD, never an fd.
+    _FORCE_PUSH = [
+        ("git push --force origin main2>log", "main2"),     # > glued
+        ("git push --force origin main2<log", "main2"),     # < direction
+        ("git push --force origin main2>>log", "main2"),    # >> append
+        ("git push --force origin rel99>log", "rel99"),     # multi-digit
+        ("git push --force origin HEAD:main2>log", "main2"),  # refspec dst
+    ]
+    _BRANCH_DELETE = [
+        ("git branch -D feature2>log", "feature2"),
+        ("git branch -D rel99<log", "rel99"),
+        ("git branch -D feature22>>log", "feature22"),
+    ]
+
+    @pytest.mark.parametrize("cmd,target", _FORCE_PUSH)
+    def test_force_push_digit_glued_target_is_bash_faithful(self, cmd, target):
+        assert _extract_force_push_target_ref(cmd) == target
+
+    @pytest.mark.parametrize("cmd,target", _BRANCH_DELETE)
+    def test_branch_delete_digit_glued_target_is_bash_faithful(self, cmd, target):
+        assert _extract_branch_name(cmd) == target
+
+    def test_whitespace_delimited_fd_redirect_still_truncates(self):
+        # Regression: a WHITESPACE-delimited fd-number IS a real fd-redirect, so the
+        # ref is the word before it (`main` / `feature`), not glued. The fix must not
+        # break the legitimate spaced fd-redirect.
+        assert _extract_force_push_target_ref("git push --force origin main 2>&1") == "main"
+        assert _extract_force_push_target_ref("git push --force origin main 22>log") == "main"
+        assert _extract_branch_name("git branch -D feature 2>&1") == "feature"
+
+    def test_force_push_wrong_target_token_refuses_e2e(self, tmp_path):
+        # SACROSANCT under-block pin (real auth path): a token for `main` must NOT
+        # authorize `git push --force origin main2>log` (which force-pushes `main2`).
+        assert write_token(
+            {"operation_type": "force-push", "target_ref": "main"}, token_dir=tmp_path
+        ) is not None
+        assert check_merge_authorization(
+            "git push --force origin main2>log", token_dir=tmp_path
+        ) is not None  # REFUSE
+
+    def test_force_push_real_target_token_authorizes_control(self, tmp_path):
+        # Non-vacuity control: a token for the ACTUAL ref (`main2`) AUTHORIZES the
+        # same exec -> the refusal above is target-discrimination, not a no-match.
+        assert write_token(
+            {"operation_type": "force-push", "target_ref": "main2"}, token_dir=tmp_path
+        ) is not None
+        assert check_merge_authorization(
+            "git push --force origin main2>log", token_dir=tmp_path
+        ) is None  # AUTHORIZE
+
+    def test_branch_delete_wrong_target_token_refuses_e2e(self, tmp_path):
+        assert write_token(
+            {"operation_type": "branch-delete", "branch": "feature"}, token_dir=tmp_path
+        ) is not None
+        assert check_merge_authorization(
+            "git branch -D feature2>log", token_dir=tmp_path
+        ) is not None  # REFUSE
+
+    def test_branch_delete_real_target_token_authorizes_control(self, tmp_path):
+        assert write_token(
+            {"operation_type": "branch-delete", "branch": "feature2"}, token_dir=tmp_path
+        ) is not None
+        assert check_merge_authorization(
+            "git branch -D feature2>log", token_dir=tmp_path
+        ) is None  # AUTHORIZE
+
+
+# ════════════ #1043 — process-substitution abstain (over-block defense) ══════
+class TestFixAProcessSubstitutionAbstain:
+    """An UNQUOTED process substitution (``>(``/``<(``) is never an honest force-push
+    / branch-delete form: bash treats ``git push --force origin main >(cmd)`` as a
+    MULTI-ref push (``>(cmd)`` expands to an extra ``/dev/fd/N`` positional) and
+    ``... > >(cmd)`` redirects stdout into the procsub FIFO. _executable_prefix
+    ABSTAINS (returns None) rather than truncating at the redirect and mis-deriving a
+    single-ref target — the over-block (fail-safe) direction.
+
+    Non-vacuity is the FINE mutation (disable _PROCSUB_MARKER_RE): without the
+    abstain, ``main > >(cmd)`` truncates at the bare ``>`` to ``main`` and a token-
+    ``main`` AUTHORIZEs -> the pins flip RED. (Distinct mutation from the IO_NUMBER
+    revert — the two mechanisms are independent.)"""
+
+    @pytest.mark.parametrize("cmd", [
+        "git push --force origin main > >(cmd)",   # redirect-to-procsub
+        "git push --force origin main >(cmd)",     # argument-procsub (multi-ref)
+        "git push --force origin main >( cmd )",   # one optional space form
+    ])
+    def test_force_push_procsub_extractor_abstains(self, cmd):
+        assert _executable_prefix(cmd) is None
+        assert _extract_force_push_target_ref(cmd) is None
+
+    @pytest.mark.parametrize("cmd", [
+        "git branch -D feature >(cmd)",
+        "git branch -D feature > >(cmd)",
+    ])
+    def test_branch_delete_procsub_extractor_abstains(self, cmd):
+        assert _executable_prefix(cmd) is None
+        assert _extract_branch_name(cmd) is None
+
+    def test_quoted_procsub_is_inert_not_overblocked(self):
+        # The marker is scanned on the _mask_shell_quotes view, so a QUOTED `>(` is
+        # masked to spaces -> NOT an abstain -> the literal refspec is preserved (no
+        # spurious over-block on a quoted value).
+        assert _extract_force_push_target_ref('git push --force origin "a>(b)"') == "a>(b)"
+
+    def test_force_push_procsub_refuses_e2e(self, tmp_path):
+        # Over-block pin (real auth path): even with a matching-looking `main` token,
+        # the procsub command REFUSES (abstain -> absent target -> no match).
+        assert write_token(
+            {"operation_type": "force-push", "target_ref": "main"}, token_dir=tmp_path
+        ) is not None
+        assert check_merge_authorization(
+            "git push --force origin main > >(cmd)", token_dir=tmp_path
+        ) is not None  # REFUSE
+        assert check_merge_authorization(
+            "git push --force origin main >(cmd)", token_dir=tmp_path
+        ) is not None  # REFUSE

--- a/pact-plugin/tests/test_merge_guard_overblock_tokenizers.py
+++ b/pact-plugin/tests/test_merge_guard_overblock_tokenizers.py
@@ -1,0 +1,451 @@
+"""Merge-guard over-block tokenizer batch — comprehensive + adversarial TEST surfaces.
+
+Proves the three committed source fixes WORK and introduce ZERO under-block. The
+SACROSANCT honest-mistake threat model governs: over-block (refusing a faithful
+click) is fails-safe but a bug; UNDER-block (letting an honest destructive op
+through ungated, or authorizing the WRONG target) is NEVER acceptable.
+
+Fixes under test (committed; this suite pins them):
+  • #1043 — _extract_force_push_target_ref / _extract_branch_name truncate at the
+    first benign terminator on the quote-masked view BEFORE counting positionals
+    (_executable_prefix / _BENIGN_TERMINATOR_RE), so a faithful single force-push /
+    branch-delete + benign continuation re-derives its target instead of
+    over-blocking. The redirect FILENAME is structurally outside the positional
+    window, so it can never become the target.
+  • #1069 — the read seam derives (op, target, bound_flags) from the SINGLE
+    is_dangerous leg (_single_destructive_leg) instead of the whole command. This
+    closes (a) flag pollution from a benign neighbor leg (over-block) and (b) the
+    latent target cross-contamination UNDER-block (_extract_pr_number's
+    first-match-anywhere scan bleeding a reversible close-leg's PR number into a
+    merge-leg's target).
+  • #1059 — the mint-side flag scan space-replaces markdown command-wrapper
+    delimiters (_strip_command_wrapper) so mint bound_flags == read bound_flags for
+    a backtick-wrapped value-flag (shipped v4.4.46; pinned here).
+
+NON-VACUITY (per-pin mutation map; the mechanism DIFFERS per pin — a single
+"revert Fix B" control does NOT discriminate every pin). Evidence recorded in the
+TEST-phase HANDOFF; mutations exercised in-process against the SUT:
+  • Latent target under-block (TestFixBLatentUnderBlockClosure): monkeypatch
+    _single_destructive_leg → whole `command` (faithfully reproduces pre-#1069,
+    since the seam is `_single_destructive_leg(command) or command`) → the mismatch
+    pin flips REFUSE→AUTHORIZE (RED). DISCRIMINATOR via Fix-B revert.
+  • Flag-scan over-block fix (TestFixBFlagScanNarrowing, the --squash AUTHORIZE
+    case): same whole-command mutation → AUTHORIZE→REFUSE (RED). DISCRIMINATOR via
+    Fix-B revert.
+  • Flag-scan under-block GUARD (the --admin REFUSE case): the whole-command
+    mutation binds MORE flags → stays REFUSE (NOT a discriminator). Its non-vacuity
+    needs a FLAG-DROPPING mutation (strip dash-tokens from the isolated leg) →
+    REFUSE→AUTHORIZE (RED). DISCRIMINATOR via flag-drop mutation.
+  • Fix A extractor pins: monkeypatch _executable_prefix → identity (no
+    truncation) re-opens the positional over-block / mis-count → the target pins
+    flip (RED).
+  • Force-push/branch-delete wrong-target (TestForcePushBranchDeleteDefensiveWrongTarget):
+    DEFENSIVE — the cross-contamination variant is non-reproducing as an under-block
+    on this code (exact-positional-count extractors fail-safe to over-block, unlike
+    _extract_pr_number). Non-vacuity is anchored by the matching-target companion
+    (the SAME command AUTHORIZES the correct target), proving the refusal is
+    target-discrimination, not a trivial no-token refuse.
+
+Auth-path convention: check_merge_authorization returns a string (REFUSE / deny
+reason) or None (AUTHORIZE). The pre-hook envelope exit code is 2 (DENY) / 0
+(AUTHORIZE). write_token(context, token_dir=tmp) mints; both are the REAL seam
+(token_dir is a production param, not a stubbed mock).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import patch
+
+import pytest
+
+from merge_guard_post import _strip_command_wrapper, main as _post_main, write_token
+from merge_guard_pre import check_merge_authorization, main as _pre_main
+from shared.merge_guard_common import (
+    _executable_prefix,
+    _extract_branch_name,
+    _extract_force_push_target_ref,
+    _single_destructive_leg,
+    extract_command_context,
+    is_compound_destructive_command,
+    is_dangerous_command,
+)
+
+# The canonical benign-continuation family Fix A / Fix B must tolerate (same 13
+# forms as TestBenignContinuationGuarantee._BENIGN_CONTINUATIONS): pipe-to-viewer,
+# output / fd redirect, background, and benign chain. None is a second destructive
+# leg; none may inflate a positional count or pollute a bound-flag set.
+_BENIGN_CONTINUATIONS = [
+    "| tail", "| head", "| grep merged", "| cat", "| wc -l",
+    "| tee /tmp/out", "| less",
+    "> out.log", "2>&1", "&> out.log",
+    "&", "&& echo done", "; echo done",
+]
+
+# The latent under-block exec (design §10.2): a reversible `gh pr close 1058`
+# (NOT dangerous) chained with a real merge of a DIFFERENT PR. Pre-#1069 the
+# whole-command first-match scan bled pr_number=1058 (from the close leg) into the
+# merge context, so a token approved for merge 1058 authorized merging 999. Exactly
+# one leg is dangerous (the merge), so is_compound does NOT catch it.
+_LATENT_UNDERBLOCK_EXEC = "gh pr close 1058\ngh pr merge 999 --squash"
+
+
+# ───────────────────────────── envelope helpers (real seam, no mocks) ─────────
+def _invoke_post(question: str, tmp, answer: str, options: list) -> int:
+    """Drive merge_guard_post.main() in-process over a real stdin envelope with
+    TOKEN_DIR redirected to tmp. Returns the process exit code (0 = minted)."""
+    envelope = json.dumps({
+        "tool_name": "AskUserQuestion",
+        "tool_input": {"questions": [{"question": question, "options": options}]},
+        "tool_response": {"answers": {question: answer}},
+        "session_id": "test-overblock-tokenizers",
+    })
+    with patch("merge_guard_post.TOKEN_DIR", tmp), \
+         patch("sys.stdin", io.StringIO(envelope)):
+        with pytest.raises(SystemExit) as exc:
+            _post_main()
+    return exc.value.code
+
+
+def _invoke_pre(command: str, tmp) -> tuple[int, str]:
+    """Drive merge_guard_pre.main() in-process. Returns (exit_code, stdout).
+    exit 2 = DENY, exit 0 = AUTHORIZE."""
+    envelope = json.dumps({
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "session_id": "test-overblock-tokenizers",
+    })
+    out = io.StringIO()
+    with patch("merge_guard_pre.TOKEN_DIR", tmp), \
+         patch("sys.stdin", io.StringIO(envelope)), \
+         patch("sys.stdout", out):
+        with pytest.raises(SystemExit) as exc:
+            _pre_main()
+    return exc.value.code, out.getvalue()
+
+
+# ═══════════════════════════════ #1059 — flag-scan wrapper strip ═════════════
+class TestStripCommandWrapper1059:
+    """#1059 unit: _strip_command_wrapper space-replaces the markdown command
+    wrapper delimiters (backtick + curly quotes) so the mint's privileged-flag
+    scan matches the read side's on the bare command. Space-REPLACE (never
+    delete) is load-bearing — it preserves token boundaries so a wrapper char
+    BETWEEN a value and a flag reveals the flag instead of gluing it."""
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("`gh pr merge 5 --repo o/x`", " gh pr merge 5 --repo o/x "),  # backtick -> space
+        ("--repo owner/x`", "--repo owner/x "),                        # trailing backtick
+        ("‘a’“b”", " a  b "),                      # curly single + double quotes
+        ("plain --admin", "plain --admin"),                            # no wrapper -> untouched
+        ("'straight' --admin", "'straight' --admin"),                  # straight quotes preserved
+    ])
+    def test_wrapper_delimiters_become_spaces(self, raw, expected):
+        assert _strip_command_wrapper(raw) == expected
+
+    def test_space_replace_preserves_token_boundary_reveals_flag(self):
+        """The crux: a backtick BETWEEN a value and a flag must become a SPACE,
+        not be deleted (deletion would glue `owner/x--admin` and HIDE --admin from
+        the flag scan — a silent privileged-flag drop = under-block surface)."""
+        out = _strip_command_wrapper("owner/x`--admin")
+        assert out == "owner/x --admin"
+        assert "--admin" in out.split()  # surfaces as its own token
+
+
+class TestMintReadFlagParity1059:
+    """#1059 end-to-end: a faithful click whose command carries a backtick-wrapped
+    value-flag (`--repo owner/x`) mints and AUTHORIZES, because the mint's
+    flag-scan surface (stripped) yields the SAME bound_flags as the read side's on
+    the bare command. Pins the v4.4.46 over-block fix."""
+
+    _BARE = "gh pr merge 5 --repo owner/x"
+    _OPTION_TEXT = "Run `gh pr merge 5 --repo owner/x`"
+
+    def test_mint_bound_flags_equal_read_bound_flags(self):
+        read_ctx = extract_command_context(self._BARE)
+        mint_ctx = extract_command_context(
+            self._BARE, flag_scan_text=_strip_command_wrapper(self._OPTION_TEXT)
+        )
+        assert mint_ctx["bound_flags"] == read_ctx["bound_flags"] == ["--repo=owner/x"]
+
+    def test_strip_is_load_bearing_nonvacuity(self):
+        """Without the wrapper strip the trailing backtick is captured INTO the
+        flag value (`owner/x\\``), desyncing mint from read — the exact #1059
+        over-block. Proves the parity assertion above is coupled to the strip."""
+        read_ctx = extract_command_context(self._BARE)
+        unstripped = extract_command_context(self._BARE, flag_scan_text=self._OPTION_TEXT)
+        assert unstripped["bound_flags"] != read_ctx["bound_flags"]
+
+    def test_backtick_value_flag_click_authorizes_e2e(self, tmp_path):
+        """Real seam: a token minted with the stripped flag-scan surface authorizes
+        the faithful bare command (mint==read parity → AUTHORIZE)."""
+        mint_ctx = extract_command_context(
+            self._BARE, flag_scan_text=_strip_command_wrapper(self._OPTION_TEXT)
+        )
+        assert write_token(dict(mint_ctx), token_dir=tmp_path) is not None
+        assert check_merge_authorization(self._BARE, token_dir=tmp_path) is None  # AUTHORIZE
+
+
+# ═══════════════════════ #1043 — Fix A extractor robustness ══════════════════
+class TestFixAForcePushContinuationTarget:
+    """#1043: _extract_force_push_target_ref re-derives the SAME target across the
+    full benign-continuation family. Direct extractor-level pin (finer than the
+    end-to-end authorize): the truncation happens at the extractor, so mint and
+    read inherit it identically.
+
+    Non-vacuity: monkeypatch _executable_prefix → identity (no truncation) and the
+    continuation tokens inflate the positional count → None (the pre-#1043
+    over-block). Recorded in HANDOFF."""
+
+    @pytest.mark.parametrize("cont", _BENIGN_CONTINUATIONS)
+    def test_target_rederived_across_continuation(self, cont):
+        assert _extract_force_push_target_ref(f"git push --force origin main {cont}") == "main"
+
+
+class TestFixABranchDeleteContinuationTarget:
+    """#1043: _extract_branch_name re-derives the SAME branch across the full
+    benign-continuation family. Direct extractor-level pin."""
+
+    @pytest.mark.parametrize("cont", _BENIGN_CONTINUATIONS)
+    def test_name_rederived_across_continuation(self, cont):
+        assert _extract_branch_name(f"git branch -D victim {cont}") == "victim"
+
+
+class TestFixAUnderBlockNegatives:
+    """#1043 §10.3: the under-block negatives — Fix A may ONLY turn an over-block
+    (None) into a correct target for a clearly-benign continuation, or stay None.
+    It must NEVER mint a WRONG target that could match a token. Each case proves a
+    distinct guard."""
+
+    def test_redirect_filename_never_becomes_forcepush_target(self):
+        # `... feature > main`: the redirect filename `main` is structurally OUTSIDE
+        # the positional window → target is `feature`, never `main`.
+        assert _extract_force_push_target_ref("git push --force origin feature > main") == "feature"
+
+    def test_redirect_target_is_the_real_ref_not_the_filename(self):
+        # Symmetric control: when the ref IS main, a redirect to a same-named file
+        # still yields `main` from the positional window (not the redirect path).
+        assert _extract_force_push_target_ref("git push --force origin main > /tmp/main") == "main"
+
+    def test_genuine_multiref_forcepush_refuses(self):
+        # A real extra positional (not a continuation) keeps the count off 2 → None.
+        assert _extract_force_push_target_ref("git push --force origin main feature") is None
+
+    def test_genuine_extra_positional_before_redirect_refuses(self):
+        # The truncation strips the redirect, NOT a real extra positional → 3 → None.
+        assert _extract_force_push_target_ref("git push --force origin main extra > log") is None
+
+    def test_quoted_metachar_preserved_in_refspec(self):
+        # A quoted `>` is masked → not a terminator → the refspec value is preserved.
+        assert _extract_force_push_target_ref('git push --force origin "weird>name"') == "weird>name"
+
+    def test_unbalanced_quote_abstains_forcepush(self):
+        # Adversarial quote-elision (out of scope): _shell_tokenize fails →
+        # _executable_prefix None → extractor None → the existing safe over-block.
+        assert _executable_prefix('git push --force origin "main') is None
+        assert _extract_force_push_target_ref('git push --force origin "main') is None
+
+    def test_multitarget_branch_delete_refuses(self):
+        # >1 positional branch name → None (the #1032 multi-target under-block guard).
+        assert _extract_branch_name("git branch -D a b") is None
+
+    def test_branch_delete_redirect_filename_never_becomes_name(self):
+        assert _extract_branch_name("git branch -D victim > feature") == "victim"
+
+    def test_branch_delete_extra_positional_before_redirect_refuses(self):
+        assert _extract_branch_name("git branch -D feature extra > log") is None
+
+    def test_branch_delete_unbalanced_quote_abstains(self):
+        assert _extract_branch_name('git branch -D "victim') is None
+
+
+# ═══════════════════ #1069 — latent target cross-contamination ═══════════════
+class TestFixBLatentUnderBlockClosure:
+    """#1069 §10.2 — the SACROSANCT centerpiece. A token approved for `gh pr merge
+    1058` must NOT authorize executing `gh pr close 1058 ; gh pr merge 999` (which
+    actually merges 999). The reversible close-leg is NOT dangerous, so exactly ONE
+    leg is dangerous (the merge 999) → is_compound does NOT catch it; the read seam
+    isolates that leg → target 999 ≠ token 1058 → REFUSE.
+
+    Non-vacuity (Fix-B revert discriminator): monkeypatch _single_destructive_leg →
+    whole command re-opens the bleed (whole ctx pr_number=1058 from the close leg)
+    → the mismatch pin flips REFUSE→AUTHORIZE. The token{merge,999} control proves
+    the REFUSE is the target-mismatch path, not a trivial no-match refuse."""
+
+    def test_discriminator_is_target_mismatch_not_compound(self):
+        # Pin the premise: the exec is dangerous (a real merge) but NOT compound
+        # (one destructive leg) — so a refusal can only be the isolated-leg target
+        # mismatch, never the compound gate.
+        assert is_dangerous_command(_LATENT_UNDERBLOCK_EXEC) is True
+        assert is_compound_destructive_command(_LATENT_UNDERBLOCK_EXEC) is False
+        assert _single_destructive_leg(_LATENT_UNDERBLOCK_EXEC) == "gh pr merge 999 --squash"
+
+    def test_token_for_wrong_pr_refuses_function_seam(self, tmp_path):
+        assert write_token(
+            {"operation_type": "merge", "pr_number": "1058"}, token_dir=tmp_path
+        ) is not None
+        assert check_merge_authorization(
+            _LATENT_UNDERBLOCK_EXEC, token_dir=tmp_path
+        ) is not None  # REFUSE
+
+    def test_token_for_real_merged_pr_authorizes_control(self, tmp_path):
+        # Non-vacuity control: a token for the PR actually merged (999) AUTHORIZES
+        # the SAME exec — so the mismatch refusal above is target-discrimination.
+        assert write_token(
+            {"operation_type": "merge", "pr_number": "999"}, token_dir=tmp_path
+        ) is not None
+        assert check_merge_authorization(
+            _LATENT_UNDERBLOCK_EXEC, token_dir=tmp_path
+        ) is None  # AUTHORIZE
+
+    def test_token_for_wrong_pr_denies_full_envelope(self, tmp_path):
+        # Real executed auth path: mint merge-1058 via the post hook, then run the
+        # cross-contaminating exec through the pre hook → DENY (exit 2).
+        post_code = _invoke_post(
+            "Merge PR 1058?", tmp_path, answer="Yes, merge",
+            options=[
+                {"label": "Yes, merge", "description": "Run `gh pr merge 1058`"},
+                {"label": "Cancel", "description": "Abort"},
+            ],
+        )
+        assert post_code == 0
+        token = json.loads(next(tmp_path.glob("merge-authorized-*")).read_text())
+        assert token["context"]["pr_number"] == "1058"
+        pre_code, _ = _invoke_pre(_LATENT_UNDERBLOCK_EXEC, tmp_path)
+        assert pre_code == 2  # DENY (would be 0 under the pre-#1069 under-block)
+
+    def test_token_for_real_merged_pr_authorizes_full_envelope(self, tmp_path):
+        post_code = _invoke_post(
+            "Merge PR 999?", tmp_path, answer="Yes, merge",
+            options=[
+                {"label": "Yes, merge", "description": "Run `gh pr merge 999`"},
+                {"label": "Cancel", "description": "Abort"},
+            ],
+        )
+        assert post_code == 0
+        pre_code, _ = _invoke_pre(_LATENT_UNDERBLOCK_EXEC, tmp_path)
+        assert pre_code == 0  # AUTHORIZE (the real merged PR)
+
+
+# ═══════════════════ #1069 — flag-scan narrowing (BLIND-VERIFICATION AIM) ════
+class TestFixBFlagScanNarrowing:
+    """#1069 §10.1 — the ONE place fix-direction (bind fewer flags) coincides with
+    under-block-direction (drop a flag). Two distinct properties:
+
+      OVER-BLOCK FIX (a benign neighbor's flag must NOT pollute): a non-privileged
+        op + a neighbor carrying `--repo` AUTHORIZES a no-flag token. (Fix-B revert
+        discriminator: whole-command binds the neighbor's --repo → REFUSE.)
+
+      UNDER-BLOCK GUARD (the op's OWN privileged flag must STAY bound): `--admin`
+        on the destructive leg REFUSES a no-flag token. NOT a Fix-B-revert
+        discriminator (whole-command binds MORE → still REFUSE); its non-vacuity is
+        a FLAG-DROPPING mutation (strip dash-tokens from the isolated leg →
+        AUTHORIZE). The exactly-one-dangerous-leg invariant (is_compound REFUSES
+        >=2 upstream) means the only reachable narrowing is dropping a NEIGHBOR's
+        flag — the op's own flag is structurally on its leg."""
+
+    def test_benign_neighbor_flag_does_not_overblock(self, tmp_path):
+        # `--squash` is non-privileged; the neighbor's `--repo` is on a DIFFERENT
+        # leg → dropped → no-flag token AUTHORIZES (the over-block fix).
+        cmd = "gh pr merge 5 --squash ; gh pr view 5 --repo o/x"
+        assert write_token(
+            {"operation_type": "merge", "pr_number": "5"}, token_dir=tmp_path
+        ) is not None
+        assert check_merge_authorization(cmd, token_dir=tmp_path) is None  # AUTHORIZE
+
+    def test_privileged_flag_on_destructive_leg_stays_bound(self, tmp_path):
+        # `--admin` is on the destructive merge leg → bound → a no-flag token is
+        # REFUSED (never-escalate preserved). The under-block guard.
+        cmd = "gh pr merge 5 --admin ; gh pr view 5 --repo o/x"
+        assert write_token(
+            {"operation_type": "merge", "pr_number": "5"}, token_dir=tmp_path
+        ) is not None
+        assert check_merge_authorization(cmd, token_dir=tmp_path) is not None  # REFUSE
+
+    @pytest.mark.parametrize("cont", _BENIGN_CONTINUATIONS)
+    def test_admin_stays_bound_across_all_continuations(self, cont, tmp_path):
+        # Defensive matrix: NO benign continuation can strip `--admin` off the
+        # destructive leg. A no-flag token is REFUSED for every form.
+        cmd = f"gh pr merge 5 --admin {cont}"
+        assert is_compound_destructive_command(cmd) is False
+        assert write_token(
+            {"operation_type": "merge", "pr_number": "5"}, token_dir=tmp_path
+        ) is not None
+        assert check_merge_authorization(cmd, token_dir=tmp_path) is not None  # REFUSE
+
+    def test_exec_extra_privileged_flag_on_leg_still_refuses(self, tmp_path):
+        # The #1042 bind is byte-unchanged: a token binding --admin must still
+        # REFUSE an exec adding a SECOND merge-privileged flag (--match-head-commit)
+        # on the ISOLATED destructive leg — leg-isolation does not weaken the bind.
+        assert write_token(
+            {"operation_type": "merge", "pr_number": "5", "bound_flags": ["--admin"]},
+            token_dir=tmp_path,
+        ) is not None
+        cmd = "gh pr merge 5 --admin --match-head-commit deadbeef ; gh pr view 5"
+        assert check_merge_authorization(cmd, token_dir=tmp_path) is not None  # REFUSE
+
+
+# ═══════════ force-push / branch-delete DEFENSIVE wrong-target pin ═══════════
+class TestForcePushBranchDeleteDefensiveWrongTarget:
+    """The force-push / branch-delete target cross-contamination variant is
+    NON-reproducing as an under-block on this code (the exact-positional-count
+    extractors fail-safe to over-block, unlike _extract_pr_number's
+    first-match-anywhere). Pinned DEFENSIVELY so a future regression cannot
+    silently open it.
+
+    Non-vacuity is anchored by the matching-target companion: the SAME command
+    AUTHORIZES the correct target — so the wrong-target refusal is
+    target-discrimination, not a trivial no-token refuse."""
+
+    _FP_EXEC = 'git push --force origin feature ; echo "push main"'
+    _BD_EXEC = "git branch -D feature ; echo done"
+
+    def test_forcepush_wrong_target_refuses(self, tmp_path):
+        assert write_token(
+            {"operation_type": "force-push", "target_ref": "main"}, token_dir=tmp_path
+        ) is not None
+        assert check_merge_authorization(self._FP_EXEC, token_dir=tmp_path) is not None  # REFUSE
+
+    def test_forcepush_matching_target_authorizes_companion(self, tmp_path):
+        assert write_token(
+            {"operation_type": "force-push", "target_ref": "feature"}, token_dir=tmp_path
+        ) is not None
+        assert check_merge_authorization(self._FP_EXEC, token_dir=tmp_path) is None  # AUTHORIZE
+
+    def test_branch_delete_wrong_target_refuses(self, tmp_path):
+        assert write_token(
+            {"operation_type": "branch-delete", "branch": "main"}, token_dir=tmp_path
+        ) is not None
+        assert check_merge_authorization(self._BD_EXEC, token_dir=tmp_path) is not None  # REFUSE
+
+    def test_branch_delete_matching_target_authorizes_companion(self, tmp_path):
+        assert write_token(
+            {"operation_type": "branch-delete", "branch": "feature"}, token_dir=tmp_path
+        ) is not None
+        assert check_merge_authorization(self._BD_EXEC, token_dir=tmp_path) is None  # AUTHORIZE
+
+
+# ═══════════════════════ mint == read parity canary (§7) ═════════════════════
+class TestMintReadParityCanary:
+    """The cross-cutting invariant: for a faithful destructive op + benign neighbor
+    carrying a flag, the READ side's isolated-leg context EQUALS the MINT side's
+    single-command context (op, target, AND bound_flags). The #1069 read isolation
+    brings the read into per-leg parity with the mint (which already isolates per
+    region via locate_command_regions)."""
+
+    def test_read_isolated_leg_context_equals_minted_command_context(self):
+        executed = "gh pr merge 5 --admin ; gh pr view 5 --repo owner/x"
+        minted_command = "gh pr merge 5 --admin"
+        read_ctx = extract_command_context(_single_destructive_leg(executed))
+        mint_ctx = extract_command_context(minted_command)
+        assert read_ctx == mint_ctx
+        assert read_ctx["bound_flags"] == ["--admin"]  # the neighbor's --repo is NOT bound
+
+    def test_canary_force_push_with_redirect_parity(self):
+        # A faithful force-push + redirect: read isolates the leg, both arms derive
+        # target_ref=main with no bound flags.
+        executed = "git push --force origin main > out.log"
+        read_ctx = extract_command_context(_single_destructive_leg(executed))
+        mint_ctx = extract_command_context("git push --force origin main")
+        assert read_ctx == mint_ctx
+        assert read_ctx.get("target_ref") == "main"


### PR DESCRIPTION
## Summary

PR-2 of the merge-guard roadmap: the **OVER-BLOCK direction** (fails-safe) — stop the guard from refusing faithful single-command clicks — plus one production-orphan hygiene removal. In the course of the over-block work, PREPARE confirmed (and this PR closes) a **pre-existing latent UNDER-block** in the same whole-string extraction, so the batch also hardens a real auth-bypass.

SACROSANCT honest-mistake threat model throughout: over-block of a faithful form is fails-safe but a bug to fix; **under-block of an honest destructive form is never acceptable**. FAIL-OPEN: every ambiguous parse abstains to the literal floor (the existing safe-refuse), never fail-closed. `mint == read` parity preserved; the #1042 privileged-flag set-equality bind is byte-unchanged.

## What landed

- **#1043** — redirect/continuation-robust force-push/branch-delete target extractors. They required an exact positional count, so any benign continuation (pipe, chain, background, redirect) was miscounted and over-blocked a faithful click. Now truncate at the first benign terminator on the quote-masked view before counting (quote-aware: a delimiter inside a quoted refspec/filename is never stripped). Broadens the SSOT threat-model note to the universal single-destructive-op + benign-continuation guarantee and removes the obsolete KNOWN LIMITATION block.
- **#1069** — read-side single-destructive-leg isolation. Token matching derived context from the whole command, so a benign neighbor leg's flag polluted `bound_flags` (over-block) **and** the PR-number extractor's first-match-anywhere scan cross-contaminated the target (the latent under-block: a token minted for one PR number could authorize a compound acting on a *different* one). Now derive op/target/flags from the single dangerous leg, falling back to the whole command (the safe over-block direction) when there isn't exactly one. Closes the under-block.
- **#1045** — remove the production-orphaned `is_affirmative` / `AFFIRMATIVE_PATTERNS` (no call site) + the now-dead import; strip an in-session design label from a step-0 comment.
- **#1059** — add the missing `mint == read` parity regression test (the fix itself shipped in v4.4.46).

## Verification

- 72 new adversarial tests (`test_merge_guard_overblock_tokenizers.py`), each under-block pin proven **NON-VACUOUS** via a per-pin SUT mutation (whole-command revert for the discriminating pins; a flag-dropping mutation for the op-leg-flag guard, which is otherwise defensive-by-invariant).
- Concurrent auditor empirical GREEN (executed the real functions: op-leg flags stay bound, only neighbor flags drop; latent under-block closed).
- Authoritative full suite (py3.14.5, deps present): **9954 passed / 0 failed / 0 errors**.
- ⚠️ Env note: run the full-suite gate in a python with `pysqlite3`/`sqlite_vec` (py3.14.5); py3.11 yields 25 pre-existing **environmental** memory-subsystem failures that are NOT regressions.

## Version

PATCH **4.4.47 → 4.4.48** (over-block + hygiene; no visible behavioral-capability change).

Closes #1043, #1069, #1045, #1059.
