### PR TITLE
test(merge-guard): IO_NUMBER edge-case + discriminator pins follow-up (v4.4.49)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.48",
+      "version": "4.4.49",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.48/      # Plugin version
+│               └── 4.4.49/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.48",
+  "version": "4.4.49",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.48
+> **Version**: 4.4.49
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/tests/test_merge_guard_overblock_tokenizers.py
+++ b/pact-plugin/tests/test_merge_guard_overblock_tokenizers.py
@@ -591,6 +591,8 @@ class TestFixADigitGluedRedirectUnderBlock:
         ("git push --force origin main2>>log", "main2"),    # >> append
         ("git push --force origin rel99>log", "rel99"),     # multi-digit
         ("git push --force origin HEAD:main2>log", "main2"),  # refspec dst
+        ("git push --force origin feature2>&1", "feature2"),  # glued fd-DUP (not just >redirect)
+        ("git push --force origin v1.2>log", "v1.2"),       # dotted version ref: the `.` breaks the fd-prefix
     ]
     _BRANCH_DELETE = [
         ("git branch -D feature2>log", "feature2"),
@@ -612,6 +614,8 @@ class TestFixADigitGluedRedirectUnderBlock:
         # break the legitimate spaced fd-redirect.
         assert _extract_force_push_target_ref("git push --force origin main 2>&1") == "main"
         assert _extract_force_push_target_ref("git push --force origin main 22>log") == "main"
+        assert _extract_force_push_target_ref("git push --force origin main 1>&2") == "main"
+        assert _extract_force_push_target_ref("git push --force origin main 2> err.log") == "main"
         assert _extract_branch_name("git branch -D feature 2>&1") == "feature"
 
     def test_force_push_wrong_target_token_refuses_e2e(self, tmp_path):
@@ -632,6 +636,17 @@ class TestFixADigitGluedRedirectUnderBlock:
         ) is not None
         assert check_merge_authorization(
             "git push --force origin main2>log", token_dir=tmp_path
+        ) is None  # AUTHORIZE
+
+    def test_clean_ref_redirect_authorizes_discriminator(self, tmp_path):
+        # Discriminator: a CLEAN ref + redirect (`main>log`, no glued digit) still
+        # authorizes a token-`main` — so it is the DIGIT that shifts the target
+        # (`main2>log` REFUSES, just above), not the bare `>` redirect.
+        assert write_token(
+            {"operation_type": "force-push", "target_ref": "main"}, token_dir=tmp_path
+        ) is not None
+        assert check_merge_authorization(
+            "git push --force origin main>log", token_dir=tmp_path
         ) is None  # AUTHORIZE
 
     def test_branch_delete_wrong_target_token_refuses_e2e(self, tmp_path):
@@ -669,6 +684,9 @@ class TestFixAProcessSubstitutionAbstain:
         "git push --force origin main > >(cmd)",   # redirect-to-procsub
         "git push --force origin main >(cmd)",     # argument-procsub (multi-ref)
         "git push --force origin main >( cmd )",   # one optional space form
+        "git push --force origin main <(cmd)",     # INPUT-procsub direction
+        "git push --force origin main > (x)",      # redirect then spaced procsub
+        "git push --force origin main >(tee log)",  # procsub with a real inner cmd
     ])
     def test_force_push_procsub_extractor_abstains(self, cmd):
         assert _executable_prefix(cmd) is None


### PR DESCRIPTION
## Summary

Test-only follow-up to **#1070** (v4.4.48). Preserves five additional Fix A IO_NUMBER regression cases that were authored during the #1070 peer review *after* the security-cleared snapshot that merged — so they didn't make it into #1070.

## What landed

Additions to `test_merge_guard_overblock_tokenizers.py` (`TestFixADigitGluedRedirectUnderBlock`):

- **Glued fd-duplication** target case (`...2>&1` glued to the ref).
- **Dotted-version ref** (`v1.2`-style) — the `.` breaks the fd-prefix, so the version digits stay part of the ref.
- Two more **spaced-fd-redirect** assertions (`1>&2`, `2> err.log`) confirming the legitimate spaced form still truncates correctly.
- A **discriminator pin**: a clean ref + redirect (no glued digit) still authorizes the short token — proving it is the glued *digit* that shifts the target, not the bare redirect.

No source change; purely additive coverage. PATCH bump v4.4.48 → v4.4.49.

## Verification

Authoritative full suite (py3.14.5): 9988 passed / 0 failed / 0 errors. The fixes these pins guard already shipped and were security-cleared in #1070; this only strengthens the regression net.
