### PR TITLE
Merge-guard op-recognition completeness: remote-ref-delete + mass-delete + host-agnostic curl + branch-protection (v4.4.50)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.49",
+      "version": "4.4.50",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.49/      # Plugin version
+│               └── 4.4.50/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.49",
+  "version": "4.4.50",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.49
+> **Version**: 4.4.50
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/merge_guard_post.py
+++ b/pact-plugin/hooks/merge_guard_post.py
@@ -157,14 +157,21 @@ def _selected_option_text(options: object, answer: object) -> str | None:
 
 
 def _target_value(cmd_ctx: dict) -> str | None:
-    """The op-class target value (pr_number / branch / target_ref) from an
-    extracted command context, or None. A located region is a COMPLETE
-    (op, target) pair only when this is non-None — an op without a target
-    contributes NO pair to the multiplicity gate."""
+    """The op-class target value (pr_number / branch / target_ref / mass_target) from an
+    extracted command context, or None. A located region is a COMPLETE (op, target) pair
+    only when this is non-None — an op without a target contributes NO pair to the
+    multiplicity gate.
+
+    MINT-SIDE FOUR-SITE ELEMENT (#1064): every op-class that uses a NEW context key MUST
+    be enumerated here, or the mint cannot extract its target → the op gates on the read
+    side but is gated-but-unmintable. remote-ref-delete reuses `target_ref` (already
+    listed); remote-mass-delete (#1062b) uses the distinct `mass_target` (added here so a
+    mass-delete MINTS a token, not just gates on read)."""
     return (
         cmd_ctx.get("pr_number")
         or cmd_ctx.get("branch")
         or cmd_ctx.get("target_ref")
+        or cmd_ctx.get("mass_target")
     )
 
 

--- a/pact-plugin/hooks/merge_guard_post.py
+++ b/pact-plugin/hooks/merge_guard_post.py
@@ -165,13 +165,14 @@ def _target_value(cmd_ctx: dict) -> str | None:
     MINT-SIDE FOUR-SITE ELEMENT (#1064): every op-class that uses a NEW context key MUST
     be enumerated here, or the mint cannot extract its target → the op gates on the read
     side but is gated-but-unmintable. remote-ref-delete reuses `target_ref` (already
-    listed); remote-mass-delete (#1062b) uses the distinct `mass_target` (added here so a
-    mass-delete MINTS a token, not just gates on read)."""
+    listed); remote-mass-delete (#1062b) uses the distinct `mass_target`; branch-protection
+    (#1063) uses `protected_branch` — both added here so those ops MINT, not just gate."""
     return (
         cmd_ctx.get("pr_number")
         or cmd_ctx.get("branch")
         or cmd_ctx.get("target_ref")
         or cmd_ctx.get("mass_target")
+        or cmd_ctx.get("protected_branch")
     )
 
 

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -565,6 +565,13 @@ def _token_matches_command(token: dict, command: str) -> bool:
         # cross-authorizing a force-push/push-to-main sharing the same target_ref
         # (the lead Q1 distinct-op-class guarantee).
         return _both_present_equal(context.get("target_ref"), cmd.get("target_ref"))
+    if token_op == "remote-mass-delete":
+        # #1062b: bind on the DISTINCT `mass_target` identity tuple (mass-flags +
+        # remote + sorted refspecs). Distinct invocations → distinct tuples, so a
+        # token minted for `git push --prune origin` (--prune@origin) does NOT
+        # authorize `git push --mirror origin` (--mirror@origin) — the lesser→greater
+        # / cross-form closure. An unextractable tuple is ABSENT → REFUSE.
+        return _both_present_equal(context.get("mass_target"), cmd.get("mass_target"))
 
     # Unknown op-class (a typed token whose op is not one of the handled classes)
     # — REFUSE. No terminal allow exists on the read path.

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -572,6 +572,12 @@ def _token_matches_command(token: dict, command: str) -> bool:
         # authorize `git push --mirror origin` (--mirror@origin) — the lesser→greater
         # / cross-form closure. An unextractable tuple is ABSENT → REFUSE.
         return _both_present_equal(context.get("mass_target"), cmd.get("mass_target"))
+    if token_op == "branch-protection":
+        # #1063: bind on the protected branch (PATH-resident, branches/<b>/protection).
+        # op-type identity above keeps a branch-protection token from authorizing a
+        # branch-delete of the same branch name (distinct op-classes). An unextractable
+        # branch is ABSENT → REFUSE.
+        return _both_present_equal(context.get("protected_branch"), cmd.get("protected_branch"))
 
     # Unknown op-class (a typed token whose op is not one of the handled classes)
     # — REFUSE. No terminal allow exists on the read path.

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -551,7 +551,7 @@ def _token_matches_command(token: dict, command: str) -> bool:
         return _both_present_equal(context.get("pr_number"), cmd.get("pr_number"))
     if token_op == "branch-delete":
         return _both_present_equal(context.get("branch"), cmd.get("branch"))
-    if token_op in ("force-push", "push-to-main"):
+    if token_op in ("force-push", "push-to-main", "remote-ref-delete"):
         # KD-6 (SECURITY-RATIFICATION-PENDING): the destination ref must match
         # explicitly — an op-type-only floor would let a 'force-push feature'
         # approval authorize 'force-push main'. An implicit/multi-ref/unparseable
@@ -560,10 +560,14 @@ def _token_matches_command(token: dict, command: str) -> bool:
         # ref), so a faithful plain-push token authorizes its own exec — while a
         # force-push token and a push-to-main token stay DISTINCT ops (op-type
         # identity is checked above), keeping the push→force collapse closed.
+        # #1062a: remote-ref-delete ALSO binds on target_ref (the deleted ref); the
+        # op-type identity checked above keeps a remote-ref-delete token from
+        # cross-authorizing a force-push/push-to-main sharing the same target_ref
+        # (the lead Q1 distinct-op-class guarantee).
         return _both_present_equal(context.get("target_ref"), cmd.get("target_ref"))
 
-    # Unknown op-class (a typed token whose op is not one of the four handled
-    # classes) — REFUSE. No terminal allow exists on the read path.
+    # Unknown op-class (a typed token whose op is not one of the handled classes)
+    # — REFUSE. No terminal allow exists on the read path.
     return False
 
 

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -82,6 +82,31 @@ leg before deriving op/target/flags.) This is the GENERAL single-destructive-op-
 benign-remainder pattern, NOT a recognition allow-list of viewers/filters — do NOT
 enumerate viewers in detection logic (an allow-list drifts and would re-block faithful
 clicks the count already mints).
+
+conservative-RECOGNITION (the design rule behind the accepted compound under-block;
+documented so a future sweep does NOT "discover" these forms and "harden" them into
+faithful-click over-blocks): recognition targets the SINGLE destructive command an honest
+agent runs (the destructive op plus the benign viewers/filters/redirects of benign-
+CONTINUATION above) and ERRS TOWARD LETTING THROUGH — over-blocking a faithful click is
+WRONG BY DEFINITION (the INVARIANT above), worse than missing a buried op. The git-push
+remote-ref-delete (`:ref` / `--delete` / `-d`) and mass-delete (`--mirror` / `--prune` /
+multi-ref) forms need a positional, quote-aware parse, so their recognition is ANCHORED to
+the FIRST executable leg (the _executable_prefix view) — it does NOT chase those ops into
+NON-FIRST compound legs. Chasing them needs a match-anywhere / per-leg scan that fires on a
+quoted `:ref` / `--mirror` mention in a benign leg — an over-block of a faithful click. The
+ACCEPTED price is that these forms run UNGATED when the `git push` is not the first leg:
+  - `cd /repo && git push origin --delete main`
+  - `git fetch && git push --mirror origin`
+  - `NOTE=x ; git push origin :main`
+These are NOT bugs — do NOT "fix" them (the fix re-blocks faithful clicks). httpie
+(`http` / `https` CLI) protection-mutation is likewise ungated: the protection MINT
+classifier covers gh-api / curl / wget only, so an httpie read-floor arm would gate a form
+the mint cannot bind — a gated-but-unmintable over-block. Ungated keeps read == mint.
+NB this first-leg anchoring is SPECIFIC to those parse-dependent forms: the LITERAL
+DANGEROUS_PATTERNS arms (force-push, branch -D, gh pr merge/close, push-to-main, the API
+ref/protection arms) match-anywhere and STILL gate in a non-first leg
+(`cd /repo && git push --force origin main` is caught). When an over-block of a faithful
+click is found, the fix WIDENS the mint, never narrows detection into a new under-block.
 =============================================================================
 
 Centralizes TOKEN_TTL, TOKEN_DIR, TOKEN_PREFIX, consumed-token cleanup,

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -284,6 +284,10 @@ def detect_command_operation_type(command: str) -> str | None:
                           push <remote> :ref / --delete ref / -d ref (incl. implicit
                           remote). Union-arm-only; recognized IFF a single deletable
                           ref is extractable (recognition⟺mintability by construction)
+        "remote-mass-delete" - git push MASS delete (#1062b): --mirror / --prune /
+                          multi-ref delete. Union-arm-only; recognized IFF a normalized
+                          mass-target tuple is extractable (single-ref defers to
+                          remote-ref-delete — the BOUNDARY discriminator, no double-classify)
         None            - destructive shape not in the recognized set
                           (read-side caller treats None as "untyped command",
                           which the tightened token-match semantic treats as
@@ -671,6 +675,85 @@ def _extract_remote_ref_delete_target(command: str) -> str | None:
     return None
 
 
+# Sentinel marking an IMPLICIT remote (a `git push --mirror` with no positional
+# remote) in a mass-delete target tuple — keeps the implicit-remote form MINTABLE
+# (a definite, deterministic target) rather than ambiguous. A NUL byte can never
+# appear in a real remote name, so it can never collide with one.
+_IMPLICIT_REMOTE_MARKER = "\x00implicit"
+
+
+def _extract_mass_delete_target(command: str) -> str | None:
+    """Extract a READABLE normalized per-invocation tuple binding the destructive
+    IDENTITY of a `git push` MASS-delete form (#1062b — `--mirror`/`--prune`/multi-ref
+    delete), or None when the command is not such a form. Binds the destructive
+    identity (mass-flags + remote + sorted refspecs), NOT the whole command line, so a
+    benign `-o ci.skip` does not over-bind; privileged flags ride the existing #1042
+    `bound_flags` axis. Derived identically on BOTH arms via this ONE SSOT → mint==read
+    parity by construction; recognition⟺mintability (the arm returns the op IFF this is
+    non-None) → #1064-impossible. Returns a READABLE tuple, never a hash:
+
+        <sorted-mass-flags>@<remote-or-implicit-marker>[#<sorted-refspecs>]
+        git push --mirror origin               → --mirror@origin
+        git push --mirror                      → --mirror@\\x00implicit (implicit-remote MINTABLE)
+        git push --prune origin refs/heads/main → --prune@origin#refs/heads/main
+        git push origin --delete a b           → --delete@origin#a,b (binds the EXACT deleted set)
+        git push origin :a :b                  → --delete@origin#a,b
+
+    BOUNDARY (lead-mandated, no double-classification): a SINGLE-ref delete is owned by
+    `_extract_remote_ref_delete_target` (tried FIRST in the recognition arm). This
+    extractor returns None for a single-ref form, so a command is classified by EXACTLY
+    ONE op-class. Per git grammar (first positional = repository), `git push --delete a b`
+    is repo=a/ref=b = SINGLE (→ remote-ref-delete), while `git push origin --delete a b`
+    is repo=origin/refs=a,b = MASS.
+    """
+    if not re.search(_GIT_PREFIX + r"push\b", command):
+        return None
+    # Single-ref delete is the OTHER op-class — defer to it (the boundary discriminator).
+    if _extract_remote_ref_delete_target(command) is not None:
+        return None
+    after = _tokens_after_push(command)
+    if after is None:
+        return None
+    toks = _shell_tokenize(command)
+    if toks is None:
+        return None
+    gf = _normalized_flags(toks, "git")  # needs --mirror/--prune in _FLAG_SPEC (added #1062b)
+    mass_flags = sorted(f for f in ("--mirror", "--prune") if f in gf)
+    positionals = _push_positionals(after)
+    colon_dsts = [p for p in positionals if re.match(r"^\+?:", p)]
+
+    if mass_flags:
+        # --mirror/--prune: remote = first positional (git grammar) or implicit;
+        # explicit refspecs (if any) are the remaining positionals.
+        remote = _strip_surrounding_quotes(positionals[0]) if positionals else _IMPLICIT_REMOTE_MARKER
+        refspecs = sorted(_strip_surrounding_quotes(p) for p in positionals[1:])
+        flags_part = ",".join(mass_flags)
+    elif "--delete" in gf:
+        # multi-ref --delete (the single-ref case already deferred above): git grammar
+        # repo = first positional, the rest are the deleted refs. Need >=2 refs to be mass.
+        if len(positionals) < 3:
+            return None
+        remote = _strip_surrounding_quotes(positionals[0])
+        refspecs = sorted(_strip_surrounding_quotes(p) for p in positionals[1:])
+        flags_part = "--delete"
+    elif len(colon_dsts) >= 2:
+        # multi empty-source colon delete (`origin :a :b`): remote = first non-colon
+        # positional (or implicit); refs = the colon dsts.
+        non_colon = [p for p in positionals if not re.match(r"^\+?:", p)]
+        remote = _strip_surrounding_quotes(non_colon[0]) if non_colon else _IMPLICIT_REMOTE_MARKER
+        refspecs = sorted(
+            _strip_surrounding_quotes(p).rsplit(":", 1)[1] for p in colon_dsts
+        )
+        flags_part = "--delete"
+    else:
+        return None
+
+    target = f"{flags_part}@{remote}"
+    if refspecs:
+        target += "#" + ",".join(refspecs)
+    return target
+
+
 # -----------------------------------------------------------------------------
 # Privileged-flag binding (#1042). The (operation_type, target) binding above
 # DROPS every dash-flag, so an approved `gh pr merge 5` and an executed
@@ -736,6 +819,13 @@ PRIVILEGED_FLAGS: dict[str, dict[str, tuple[tuple[str, ...], bool]]] = {
         # op_type. Empty entry = explicit #1042 extension point (a future bound flag
         # is a one-line data edit); it adds NO new bound flag, so the set-equality
         # bind is untouched.
+    },
+    "remote-mass-delete": {
+        # No bound flags: remote-mass-delete's privileged effect (the mass destructive
+        # push) IS its op-trigger (--mirror/--prune/multi-ref-delete), bound via op_type
+        # AND folded into the mass_target identity tuple. The --mirror/--prune additions
+        # go to _FLAG_SPEC (danger-condition recognition) ONLY, NOT here, so the #1042
+        # set-equality bind is untouched. Empty entry = explicit extension point.
     },
 }
 
@@ -896,10 +986,12 @@ def extract_command_context(command: str, flag_scan_text: str | None = None) -> 
     positively extracted; ABSENT otherwise (absence — NOT a None value — is the
     fail-closed signal). Possible keys:
         operation_type: "merge" | "close" | "force-push" | "branch-delete"
-                        | "push-to-main" | "remote-ref-delete"
+                        | "push-to-main" | "remote-ref-delete" | "remote-mass-delete"
         pr_number:  str  (merge / close)
         branch:     str  (branch-delete)
         target_ref: str  (force-push / push-to-main, KD-6; remote-ref-delete #1062a)
+        mass_target: str (remote-mass-delete #1062b) — normalized identity tuple
+                     <sorted-mass-flags>@<remote-or-implicit-marker>[#<sorted-refspecs>]
         bound_flags: list[str]  (#1042) — sorted normalized privileged flags;
                      ALWAYS present when operation_type is (empty list when none).
 
@@ -959,6 +1051,14 @@ def extract_command_context(command: str, flag_scan_text: str | None = None) -> 
         ref = _extract_remote_ref_delete_target(command)
         if ref is not None:
             context["target_ref"] = ref
+    elif op_type == "remote-mass-delete":
+        # #1062b: DISTINCT key `mass_target` (not target_ref — the value is a
+        # normalized identity tuple, a different shape from a ref). op-identity-first
+        # in the read switch already prevents cross-op match; a distinct key avoids any
+        # accidental equality with a ref-shaped target_ref. Recognition⟺extractability.
+        mass_target = _extract_mass_delete_target(command)
+        if mass_target is not None:
+            context["mass_target"] = mass_target
     return context
 
 
@@ -1909,6 +2009,12 @@ _FLAG_SPEC: dict[str, dict[str, tuple[str, bool]]] = {
         "--force": ("--force", False),
         "--force-with-lease": ("--force-with-lease", False),
         "--no-verify": ("--no-verify", False),
+        # remote-mass-delete (#1062b) danger-condition booleans — present so
+        # `_normalized_flags` can SEE them for the mass-delete recognition arm. Like
+        # -D/--force, they are op-trigger booleans in _FLAG_SPEC but EXCLUDED from
+        # PRIVILEGED_FLAGS (the #1042 set-equality bind is untouched).
+        "--mirror": ("--mirror", False),
+        "--prune": ("--prune", False),
     },
 }
 
@@ -2028,9 +2134,17 @@ def _flag_condition_danger_op(command: str) -> str | None:
         # (the SAME predicate feeds detect via the fallback AND the is_dangerous
         # union), so this op can NEVER be #1064 gated-but-unmintable. A multi-ref /
         # implicit-current / ambiguous form yields None here → not recognized → the
-        # mass arm (added with #1062b) or the literal floor decides.
+        # mass arm below or the literal floor decides. Tried FIRST = the single-ref-
+        # extractability BOUNDARY discriminator: mass only runs when this returns None.
         if _extract_remote_ref_delete_target(command) is not None:
             return "remote-ref-delete"
+        # remote-mass-delete (#1062b) — mass forms (--mirror/--prune/multi-ref delete),
+        # recognized IFF a normalized mass-target tuple is extractable (the extractor
+        # itself defers to remote-ref-delete for a single ref, so no double-classify).
+        # Recognition⟺mintability by construction → #1064-impossible (implicit-remote
+        # included via the definite \x00implicit marker).
+        if _extract_mass_delete_target(command) is not None:
+            return "remote-mass-delete"
     return None
 
 

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -288,6 +288,9 @@ def detect_command_operation_type(command: str) -> str | None:
                           multi-ref delete. Union-arm-only; recognized IFF a normalized
                           mass-target tuple is extractable (single-ref defers to
                           remote-ref-delete — the BOUNDARY discriminator, no double-classify)
+        "branch-protection" - API mutation WEAKENING branch protection (#1063):
+                          gh-api/curl/wget DELETE|PUT|PATCH on a branches/<b>/protection
+                          endpoint (host-agnostic; POST EXCLUDED = strengthening direction)
         None            - destructive shape not in the recognized set
                           (read-side caller treats None as "untyped command",
                           which the tightened token-match semantic treats as
@@ -340,6 +343,19 @@ def detect_command_operation_type(command: str) -> str | None:
             return "branch-delete"
         if re.search(r"\b(?:PATCH|POST|PUT)\b", command):
             return "force-push"
+    # branch-protection API mutation (#1063): DELETE|PUT|PATCH on a
+    # `branches/<b>/protection` endpoint WEAKENS protection (remove / replace /
+    # modify) — a DISTINCT op-class from branch-delete (it changes a config, not a
+    # ref). POST is EXCLUDED (it ENABLES protection sub-features = strengthening, so
+    # gating it would over-block). Path-disjoint from the git/refs arm above (a
+    # protection URL has no `git/refs`), so no shadowing. Method check is loose like
+    # the git/refs arm; the GAP1 write-gate (is_dangerous + the precise method-gated
+    # DANGEROUS_PATTERNS arms) ensures mint⊆read. `_is_api_form` is gh-api/curl/wget
+    # (NOT httpie) → read==mint for the clients the classifier recognizes (no httpie
+    # arm = no #1064 gated-but-unmintable httpie state).
+    if _is_api_form and re.search(r"branches/.*/protection", command):
+        if re.search(r"\b(?:DELETE|PUT|PATCH)\b", command):
+            return "branch-protection"
     # branch-delete: git branch -D, git branch --delete --force,
     # or git branch --force --delete (matches DANGEROUS_PATTERNS).
     if re.search(_GIT_PREFIX + r"branch\s+.*-D\b", command):
@@ -478,6 +494,17 @@ def _extract_api_ref(command: str) -> str | None:
         r"git/refs/(?:heads/)?([A-Za-z0-9][A-Za-z0-9._/-]*)", command
     )
     return api_match.group(1) if api_match else None
+
+
+def _extract_protection_branch(command: str) -> str | None:
+    """Parse the protected branch from a branch-protection API command's
+    `branches/<branch>/protection` path (#1063). The branch is PATH-resident (the
+    REST resource IS the URL), so carrier-8's body strip never removes it. The
+    non-greedy `(.+?)` correctly handles a slashed branch name (`feature/x`):
+    `branches/feature/x/protection` → `feature/x`. Returns the branch, or None when
+    the command is not a recognized protection form."""
+    m = re.search(r"branches/(.+?)/protection\b", command)
+    return _strip_surrounding_quotes(m.group(1)) if m else None
 
 
 def _extract_branch_name(command: str) -> str | None:
@@ -827,6 +854,12 @@ PRIVILEGED_FLAGS: dict[str, dict[str, tuple[tuple[str, ...], bool]]] = {
         # go to _FLAG_SPEC (danger-condition recognition) ONLY, NOT here, so the #1042
         # set-equality bind is untouched. Empty entry = explicit extension point.
     },
+    "branch-protection": {
+        # No bound flags: branch-protection's privileged effect (weakening protection)
+        # IS its op-trigger (the DELETE|PUT|PATCH method on the protection endpoint),
+        # bound via op_type. Empty entry = explicit #1042 extension point; adds NO new
+        # bound flag, so the set-equality bind is untouched.
+    },
 }
 
 
@@ -987,11 +1020,14 @@ def extract_command_context(command: str, flag_scan_text: str | None = None) -> 
     fail-closed signal). Possible keys:
         operation_type: "merge" | "close" | "force-push" | "branch-delete"
                         | "push-to-main" | "remote-ref-delete" | "remote-mass-delete"
+                        | "branch-protection"
         pr_number:  str  (merge / close)
         branch:     str  (branch-delete)
         target_ref: str  (force-push / push-to-main, KD-6; remote-ref-delete #1062a)
         mass_target: str (remote-mass-delete #1062b) — normalized identity tuple
                      <sorted-mass-flags>@<remote-or-implicit-marker>[#<sorted-refspecs>]
+        protected_branch: str (branch-protection #1063) — the branch from the
+                     branches/<b>/protection URL path
         bound_flags: list[str]  (#1042) — sorted normalized privileged flags;
                      ALWAYS present when operation_type is (empty list when none).
 
@@ -1059,6 +1095,13 @@ def extract_command_context(command: str, flag_scan_text: str | None = None) -> 
         mass_target = _extract_mass_delete_target(command)
         if mass_target is not None:
             context["mass_target"] = mass_target
+    elif op_type == "branch-protection":
+        # #1063: the protected branch is PATH-resident (branches/<b>/protection).
+        # Distinct key `protected_branch`; op-identity-first in the read switch keeps
+        # it from cross-authorizing a branch-delete of the same branch name.
+        protected_branch = _extract_protection_branch(command)
+        if protected_branch is not None:
+            context["protected_branch"] = protected_branch
     return context
 
 
@@ -1319,6 +1362,20 @@ re.compile(r"\bcurl\b(?=.*(?:-X|--request)\s+DELETE\b).*git/refs", re.IGNORECASE
 # host-agnostic (#1061) — see the DELETE arm note above.
 re.compile(_GH_API_PREFIX + r"(?=.*(?:-X|--method)\s+(?:PATCH|POST|PUT)\b).*git/refs", re.IGNORECASE),
 re.compile(r"\bcurl\b(?=.*(?:-X|--request)\s+(?:PATCH|POST|PUT)\b).*git/refs", re.IGNORECASE),
+# Branch-protection API mutation (#1063): DELETE|PUT|PATCH on a
+# `branches/<branch>/protection` endpoint WEAKENS protection (remove / replace /
+# modify whole config). POST is EXCLUDED — it ENABLES protection sub-features
+# (enforce_admins / required_signatures) = the STRENGTHENING direction, so gating it
+# would over-block. HOST-AGNOSTIC (the #1061 lesson — no `.*api.*`). Explicit-method
+# arms only (the protection endpoint has no implicit-POST danger like git/refs). The
+# branch is PATH-resident, so carrier-8 never strips it (no preservation guard needed,
+# unlike the body-resident contents arm). No httpie arm: the mint classifier's
+# `_is_api_form` is gh-api/curl/wget only, so adding an httpie read arm would create a
+# gated-but-unmintable httpie #1064 state — omitted by design (httpie protection is not
+# a charter form).
+re.compile(_GH_API_PREFIX + r"(?=.*(?:-X|--method)\s+(?:DELETE|PUT|PATCH)\b).*branches/.*/protection", re.IGNORECASE),
+re.compile(r"\bcurl\b(?=.*(?:-X|--request)\s+(?:DELETE|PUT|PATCH)\b).*branches/.*/protection", re.IGNORECASE),
+re.compile(r"\bwget\b(?=.*--method=(?:DELETE|PUT|PATCH)\b).*branches/.*/protection", re.IGNORECASE),
 # gh api implicit POST: body param flags (-f, -F, --field, --raw-field, --input)
 # cause gh api to default to POST. Dangerous when targeting git/refs or merge.
 # Negative lookahead excludes explicit GET (which overrides implicit POST).

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -1081,13 +1081,22 @@ re.compile(_GIT_PREFIX + r"branch\s+--force\s+--delete\b"),
 # API-based merge bypasses (require mutating HTTP method to avoid blocking reads)
 re.compile(_GH_API_PREFIX + r"(?=.*(?:-X|--method)\s+(?:PUT|PATCH|POST)\b).*merge", re.IGNORECASE),
 re.compile(r"\bcurl\b(?=.*(?:-X|--request)\s+(?:PUT|PATCH|POST)\b).*api.*merge", re.IGNORECASE),
-# API-based branch deletion via DELETE to git/refs endpoint
+# API-based branch deletion via DELETE to git/refs endpoint.
+# HOST-AGNOSTIC (#1061): the curl arms drop the literal `.*api.*` substring so a
+# truly api-free Enterprise/proxy URL (e.g. https://git.example.com/repos/o/r/git/refs/...)
+# no longer bypasses — bringing curl to parity with the already-host-agnostic
+# gh-api/wget/httpie arms. The `api` key was an as-shipped heuristic (#268/#271), not a
+# deliberated scope ruling; this WIDENS it. The over-block this widening would introduce
+# on a quoted `-d` body mentioning git/refs is closed by carrier-8 (the HTTP-client
+# data-body strip in _strip_non_executable_content) — the body value is stripped while
+# the path-resident ref survives (PATH-vs-BODY invariant).
 re.compile(_GH_API_PREFIX + r"(?=.*(?:-X|--method)\s+DELETE\b).*git/refs", re.IGNORECASE),
-re.compile(r"\bcurl\b(?=.*(?:-X|--request)\s+DELETE\b).*api.*git/refs", re.IGNORECASE),
+re.compile(r"\bcurl\b(?=.*(?:-X|--request)\s+DELETE\b).*git/refs", re.IGNORECASE),
 # API-based ref mutation / force push via mutating method to git/refs endpoint
-# (any mutating operation on git refs via API is inherently dangerous)
+# (any mutating operation on git refs via API is inherently dangerous). Curl arm is
+# host-agnostic (#1061) — see the DELETE arm note above.
 re.compile(_GH_API_PREFIX + r"(?=.*(?:-X|--method)\s+(?:PATCH|POST|PUT)\b).*git/refs", re.IGNORECASE),
-re.compile(r"\bcurl\b(?=.*(?:-X|--request)\s+(?:PATCH|POST|PUT)\b).*api.*git/refs", re.IGNORECASE),
+re.compile(r"\bcurl\b(?=.*(?:-X|--request)\s+(?:PATCH|POST|PUT)\b).*git/refs", re.IGNORECASE),
 # gh api implicit POST: body param flags (-f, -F, --field, --raw-field, --input)
 # cause gh api to default to POST. Dangerous when targeting git/refs or merge.
 # Negative lookahead excludes explicit GET (which overrides implicit POST).
@@ -1096,7 +1105,7 @@ re.compile(_GH_API_PREFIX + r"(?!.*(?:-X|--method)\s+GET\b)(?=.*(?:-f|-F|--field
 # curl implicit POST: --data/-d/--data-raw/--data-binary flags cause curl to
 # default to POST. Dangerous when targeting git/refs or merge API endpoints.
 # Negative lookahead excludes explicit GET (which overrides implicit POST).
-re.compile(r"\bcurl\b(?!.*(?:-X|--request)\s+GET\b)(?=.*(?:--data(?:-(?:raw|binary))?|-d)\s).*api.*git/refs", re.IGNORECASE),
+re.compile(r"\bcurl\b(?!.*(?:-X|--request)\s+GET\b)(?=.*(?:--data(?:-(?:raw|binary))?|-d)\s).*git/refs", re.IGNORECASE),
 re.compile(r"\bcurl\b(?!.*(?:-X|--request)\s+GET\b)(?=.*(?:--data(?:-(?:raw|binary))?|-d)\s).*api.*merge", re.IGNORECASE),
 # Contents API: write operations (PUT/PATCH/POST) to /contents/ endpoint
 # targeting main or master branch. Flags any mutating /contents/ call that
@@ -1496,6 +1505,96 @@ def _strip_non_executable_content(command: str) -> str:
             return span
 
         result = re.sub(_gh_carrier_span, _strip_gh_carrier_span, result)
+
+    # 8. Strip HTTP-client request-body flag VALUES (curl / wget / gh api).
+    #    The #1061 widening (host-agnostic `.*git/refs`) and the #1063
+    #    `.*branches/.*/protection` arms would OTHERWISE fire on the destructive
+    #    path text when it merely appears inside a QUOTED data-body argument
+    #    (`curl -X POST .../log -d 'msg=touched git/refs/heads/x'`) — an over-block
+    #    of a faithful command (the #1037 hard-constraint). A faithful API ref /
+    #    protection mutation ALWAYS carries the destructive resource in the URL
+    #    PATH (REST convention — the resource IS the URL), NEVER the request body,
+    #    so stripping ONLY the data-body VALUE is zero-under-block: a path-resident
+    #    target can never be removed (the PATH-vs-BODY invariant).
+    #
+    #    Surface-scoped to a curl / wget / gh-api command SPAN so a `git push -d
+    #    <ref>` (git's `-d` = --delete, the ref is a positional we DO gate) is never
+    #    mis-stripped — the span anchors only on an HTTP-client head, and git is
+    #    absent from the anchor. TWO value-forms are handled:
+    #      (a) direct-value body flags — `FLAG <quoted-value>`: curl/wget
+    #          -d/--data[-raw|-binary|-ascii|-urlencode]/--body-data/--post-data.
+    #      (b) KEY=VALUE field flags — `FLAG <key>=<quoted-value>`: gh-api
+    #          --field/--raw-field/-f/-F (and curl -F form data). Strip the value
+    #          AFTER the `=`, keeping `flag key=`.
+    #    Surface-awareness falls out of the patterns: curl's bare boolean `-f`
+    #    (--fail) is followed by no `key=<quoted>` token, so form (b) never matches
+    #    it and a `curl -f -X DELETE .../git/refs/...` still gates.
+    #    EVERY flag token is KEPT (only the value is replaced) so the implicit-POST
+    #    lookaheads (`(?=.*(?:--data...|-f|--field|...)\s)`) still fire on a genuine
+    #    implicit-POST. Same execution-routing guards as carriers 3/5/7: skip when
+    #    piped/process-sub to a shell; the double-quoted arms preserve a value
+    #    containing command-substitution `$(`/backtick (it would execute).
+    #    (httpie body params are POSITIONALS, not flags, so they are out of scope —
+    #    a rarer, fails-safe pre-existing FP, documented in the architecture residuals.)
+    if not piped_to_shell and not process_sub_to_shell:
+        # The HTTP-client command span: from a curl/wget/gh-api head up to the first
+        # UNQUOTED shell separator. Quote-aware body (balanced quotes consumed
+        # atomically; disjoint first chars → linear, no ReDoS) — identical shape to
+        # carrier 7's span. The URL positional and the method flag live in this span
+        # but are never matched by the body-flag patterns below (which require a body
+        # FLAG before the value), so they always survive.
+        _http_client_span = (
+            r"\b(?:curl|wget|gh\s+api)\b"
+            r"""(?:[^&|;\n"']+|"(?:[^"\\]|\\.)*"|'[^']*')*"""
+        )
+        # Direct-value body flags (form a).
+        _data_flag = r"(?:--data(?:-(?:raw|binary|ascii|urlencode))?|--body-data|--post-data|-d)"
+        # KEY=VALUE field flags (form b). The `<key>=` requirement is what makes the
+        # strip surface-aware (curl's boolean -f never has a key= after it).
+        _field_flag = r"(?:--field|--raw-field|-F|-f)"
+
+        def _strip_http_body_span(span_match: re.Match) -> str:
+            span = span_match.group(0)
+
+            # CONTENTS-API EXCEPTION (PATH-vs-BODY invariant boundary). The
+            # `.*contents/.*(?:main|master)` arm reads its destructive target — the
+            # branch being written — from the REQUEST BODY (`-d '{"branch":"master"}'`)
+            # or a `?branch=` query, NOT the URL path (the contents API path is
+            # `/contents/{filepath}`, branch-less). This is the ONE gated arm whose
+            # signal is body-resident; stripping its body would REMOVE the main/master
+            # gating signal → an UNDER-BLOCK. The architecture (§3) mandates leaving the
+            # contents arm UNCHANGED, so preserve a contents-API span verbatim. Detected
+            # per-span (a compound's `/log` span is still stripped). git/refs and
+            # branches/protection targets are path-resident, so their bodies stay strippable.
+            if re.search(r"contents/", span):
+                return span
+
+            def _keep_flag_dq(m: re.Match) -> str:
+                # group(1) = the flag (+ key= for form b) up to the opening quote.
+                if _has_command_substitution(m.group(0)):
+                    return m.group(0)  # value contains $()/backtick → executes; keep
+                return m.group(1) + "'STRIPPED'"
+
+            # (a) direct-value body flags — double- then single-quoted.
+            span = re.sub(
+                r"(" + _data_flag + r"\s+)\"(?:[^\"\\]|\\.)*\"", _keep_flag_dq, span
+            )
+            span = re.sub(
+                r"(" + _data_flag + r"\s+)'[^']*'", r"\1'STRIPPED'", span
+            )
+            # (b) KEY=VALUE field flags — double- then single-quoted. `<key>` is a
+            # bare word (letters/digits/._-); the value AFTER `=` is what is stripped.
+            span = re.sub(
+                r"(" + _field_flag + r"\s+[\w.\-]+=)\"(?:[^\"\\]|\\.)*\"",
+                _keep_flag_dq,
+                span,
+            )
+            span = re.sub(
+                r"(" + _field_flag + r"\s+[\w.\-]+=)'[^']*'", r"\1'STRIPPED'", span
+            )
+            return span
+
+        result = re.sub(_http_client_span, _strip_http_body_span, result)
 
     return result
 

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -337,24 +337,32 @@ def detect_command_operation_type(command: str) -> str | None:
     # PATCH/POST/PUT → force-push class (rewrites a ref without PR review)
     # Symmetric with how a force-push or branch-delete token from
     # extract_context() would authorize the equivalent CLI form.
-    _is_api_form = re.search(r"\b(?:gh\s+api|curl|wget)\b", command, re.IGNORECASE)
+    # gh-api recognition uses the TOLERANT `_GH_API_PREFIX` (same as the read floor)
+    # so a `gh -R o/r api ...` global-flag spelling MINTS instead of gating-on-read-
+    # but-not-minting (#1064 over-block). The METHOD checks below are IGNORECASE to
+    # match the IGNORECASE read floor, so a lowercase `-X delete` faithful form MINTS
+    # too. Both are mint-WIDENING (the read floor already gates these forms) — never a
+    # read-floor narrowing. Still gh-api/curl/wget only (NOT httpie), so no new
+    # gated-but-unmintable httpie state.
+    _is_api_form = (
+        re.search(_GH_API_PREFIX, command, re.IGNORECASE)
+        or re.search(r"\b(?:curl|wget)\b", command, re.IGNORECASE)
+    )
     if _is_api_form and "git/refs" in command:
-        if re.search(r"\bDELETE\b", command):
+        if re.search(r"\bDELETE\b", command, re.IGNORECASE):
             return "branch-delete"
-        if re.search(r"\b(?:PATCH|POST|PUT)\b", command):
+        if re.search(r"\b(?:PATCH|POST|PUT)\b", command, re.IGNORECASE):
             return "force-push"
     # branch-protection API mutation (#1063): DELETE|PUT|PATCH on a
     # `branches/<b>/protection` endpoint WEAKENS protection (remove / replace /
     # modify) — a DISTINCT op-class from branch-delete (it changes a config, not a
     # ref). POST is EXCLUDED (it ENABLES protection sub-features = strengthening, so
     # gating it would over-block). Path-disjoint from the git/refs arm above (a
-    # protection URL has no `git/refs`), so no shadowing. Method check is loose like
-    # the git/refs arm; the GAP1 write-gate (is_dangerous + the precise method-gated
-    # DANGEROUS_PATTERNS arms) ensures mint⊆read. `_is_api_form` is gh-api/curl/wget
-    # (NOT httpie) → read==mint for the clients the classifier recognizes (no httpie
-    # arm = no #1064 gated-but-unmintable httpie state).
+    # protection URL has no `git/refs`), so no shadowing. Method check is loose +
+    # IGNORECASE like the git/refs arm; the GAP1 write-gate (is_dangerous + the precise
+    # method-gated DANGEROUS_PATTERNS arms) ensures mint⊆read.
     if _is_api_form and re.search(r"branches/.*/protection", command):
-        if re.search(r"\b(?:DELETE|PUT|PATCH)\b", command):
+        if re.search(r"\b(?:DELETE|PUT|PATCH)\b", command, re.IGNORECASE):
             return "branch-protection"
     # branch-delete: git branch -D, git branch --delete --force,
     # or git branch --force --delete (matches DANGEROUS_PATTERNS).
@@ -682,10 +690,14 @@ def _extract_remote_ref_delete_target(command: str) -> str | None:
     if after is None:
         return None
     positionals = _push_positionals(after)
-    toks = _shell_tokenize(command)
-    if toks is None:
-        return None
-    gf = _normalized_flags(toks, "git")  # git surface maps -d → --delete
+    # CROSS-LEG FIX (review FINDING 1): compute the flag set from the SAME leg as the
+    # positionals — the post-`push` tokens of the executable prefix (`after`), NOT the
+    # whole command. Else a --delete/-d/--mirror/--prune token in a benign CONTINUATION
+    # leg (`git push origin feature && git branch -d old`) leaks in and mislabels the
+    # benign push as a delete (a fail-safe but common over-block). Every delete-relevant
+    # flag is a push SUBCOMMAND option (always after `push`), so the post-push tokens are
+    # the complete + correct scope; nothing real is missed (no read-floor narrowing).
+    gf = _normalized_flags(after, "git")  # git surface maps -d → --delete
     if "--delete" in gf:
         # git grammar: 1 positional = the refspec (implicit remote); 2 = <repo>
         # <refspec>; 0 or ≥3 = ambiguous/multi → defer (mass handles ≥3).
@@ -741,10 +753,12 @@ def _extract_mass_delete_target(command: str) -> str | None:
     after = _tokens_after_push(command)
     if after is None:
         return None
-    toks = _shell_tokenize(command)
-    if toks is None:
-        return None
-    gf = _normalized_flags(toks, "git")  # needs --mirror/--prune in _FLAG_SPEC (added #1062b)
+    # CROSS-LEG FIX (review FINDING 1): flag set from the SAME leg as the positionals
+    # (the post-`push` tokens), NOT the whole command — else a --mirror/--prune/--delete
+    # in a benign continuation leg (`git push origin feature && echo --mirror`) leaks in
+    # and mislabels the benign push as a mass-delete. All mass-relevant flags are push
+    # subcommand options, so post-push is the complete + correct scope.
+    gf = _normalized_flags(after, "git")  # needs --mirror/--prune in _FLAG_SPEC (added #1062b)
     mass_flags = sorted(f for f in ("--mirror", "--prune") if f in gf)
     positionals = _push_positionals(after)
     colon_dsts = [p for p in positionals if re.match(r"^\+?:", p)]
@@ -1821,9 +1835,12 @@ def _strip_non_executable_content(command: str) -> str:
         # atomically; disjoint first chars → linear, no ReDoS) — identical shape to
         # carrier 7's span. The URL positional and the method flag live in this span
         # but are never matched by the body-flag patterns below (which require a body
-        # FLAG before the value), so they always survive.
+        # FLAG before the value), so they always survive. The gh-api head uses the
+        # TOLERANT `_GH_API_PREFIX` (same as the read floor) so a `gh -R o/r api ...`
+        # global-flag spelling's body IS stripped — else the #1037 body-mention
+        # over-block re-opens for that spelling (the strip would not run).
         _http_client_span = (
-            r"\b(?:curl|wget|gh\s+api)\b"
+            r"(?:\bcurl\b|\bwget\b|" + _GH_API_PREFIX + r")"
             r"""(?:[^&|;\n"']+|"(?:[^"\\]|\\.)*"|'[^']*')*"""
         )
         # Direct-value body flags (form a).

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -280,6 +280,10 @@ def detect_command_operation_type(command: str) -> str | None:
                           a force-push)
         "branch-delete" - git branch -D / git branch --delete --force / gh pr close --delete-branch;
                           API DELETE to git/refs (ref removal)
+        "remote-ref-delete" - git push delete of a SINGLE remote ref (#1062a):
+                          push <remote> :ref / --delete ref / -d ref (incl. implicit
+                          remote). Union-arm-only; recognized IFF a single deletable
+                          ref is extractable (recognition⟺mintability by construction)
         None            - destructive shape not in the recognized set
                           (read-side caller treats None as "untyped command",
                           which the tightened token-match semantic treats as
@@ -566,6 +570,107 @@ def _extract_force_push_target_ref(command: str) -> str | None:
     return refspec or None
 
 
+# git-push value-taking OPTION flags whose VALUE token must be skipped when
+# counting refspec positionals (else a contrived `-o ':weird'` push-option leaks
+# a fake delete refspec — the #1037 brittleness class). Their `--flag=value` form
+# carries the value INLINE (one token), so no next-token skip is needed. Used by
+# the remote-ref-delete + remote-mass-delete positional builder below; distinct
+# from the OP-TRIGGER flags (`--delete`/`-d`) which are NOT value-taking (the ref
+# is a separate positional).
+_GIT_PUSH_VALUE_FLAGS = frozenset(
+    {"-o", "--push-option", "--receive-pack", "--exec", "--repo"}
+)
+
+
+def _push_positionals(after_push: list[str]) -> list[str]:
+    """Positional (non-flag) tokens after the `push` subcommand, skipping the value
+    token consumed by a git-push value-taking option flag (`-o opt`, `--repo url`,
+    …). A `--flag=value` form carries its value inline (one token), so only the
+    separate-token form skips a follow-on token. Operates on a quote-aware
+    `_shell_tokenize` view (quotes already stripped), so a quoted `':oldref'` stays
+    ONE token bound to its flag and never leaks as a positional. Shared by both
+    push-delete extractors so they agree on positional boundaries."""
+    positionals: list[str] = []
+    i, n = 0, len(after_push)
+    while i < n:
+        tok = after_push[i]
+        if tok.startswith("-") and tok != "-":
+            flag = tok.split("=", 1)[0]
+            if flag in _GIT_PUSH_VALUE_FLAGS and "=" not in tok and i + 1 < n:
+                i += 2  # consume the option flag's separate value token
+                continue
+            i += 1  # a flag (boolean, op-trigger, or inline-value) — not a positional
+            continue
+        positionals.append(tok)
+        i += 1
+    return positionals
+
+
+def _tokens_after_push(command: str) -> list[str] | None:
+    """The quote-aware token list AFTER the first `push` token, on the executable
+    prefix of `command`, or None when the command is unparseable / has no `push`
+    token. Truncates at the first benign continuation / redirect (via
+    `_executable_prefix`) and abstains (None) on ambiguous quotes / procsub —
+    fail-OPEN to the literal floor, never fail-closed."""
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        return None
+    toks = _shell_tokenize(prefix)
+    if toks is None:
+        return None
+    for idx, tok in enumerate(toks):
+        if tok == "push":
+            return toks[idx + 1:]
+    return None
+
+
+def _extract_remote_ref_delete_target(command: str) -> str | None:
+    """Extract the SINGLE remote ref a `git push` delete would remove (#1062a), or
+    None when the form is implicit-current/multi-ref/ambiguous (→ the caller defers:
+    not recognized as remote-ref-delete; a mass form is picked up by
+    `_extract_mass_delete_target` instead). Reuses the force-push parser MACHINERY
+    (quote-mask + shlex view + value-flag skip) but adapts the positional rule for
+    delete semantics + the implicit-remote forms the force-push parser returns None
+    for (its conservative exactly-2-positional rule). Recognition⟺mintability by
+    construction: the `_flag_condition_danger_op` arm returns `remote-ref-delete`
+    IFF this yields a target, so the op can never reach a #1064 gated-but-unmintable
+    state.
+
+    Recognized (git grammar `git push [<repo>] <refspec>...`):
+        explicit remote, --delete/-d:  `origin --delete feature` → feature
+        implicit remote, --delete/-d:  `git push --delete feature` → feature
+        single-delete-with-repo:       `git push --delete a b` → b (repo=a, ref=b)
+        empty-source colon refspec:    `origin :feature` / `origin +:feature` → feature
+                                       `origin :refs/tags/v1` → refs/tags/v1
+    Deferred (→ None, picked up as remote-mass-delete or not destructive):
+        multi-ref delete (`origin --delete a b`, `origin :a :b`), --mirror/--prune,
+        plain push (`origin feature`), src:dst non-delete (`origin feat:feat`),
+        value-flag colon (`-o ':weird' main`), a delete literal inside a quoted arg.
+    """
+    after = _tokens_after_push(command)
+    if after is None:
+        return None
+    positionals = _push_positionals(after)
+    toks = _shell_tokenize(command)
+    if toks is None:
+        return None
+    gf = _normalized_flags(toks, "git")  # git surface maps -d → --delete
+    if "--delete" in gf:
+        # git grammar: 1 positional = the refspec (implicit remote); 2 = <repo>
+        # <refspec>; 0 or ≥3 = ambiguous/multi → defer (mass handles ≥3).
+        if len(positionals) == 1:
+            return _strip_surrounding_quotes(positionals[0]) or None
+        if len(positionals) == 2:
+            return _strip_surrounding_quotes(positionals[1]) or None
+        return None
+    # No --delete flag: an empty-source colon refspec (`:dst` / `+:dst`) is a delete.
+    # EXACTLY ONE → its dst; ≠1 → defer (0 = not a delete; ≥2 = multi → mass).
+    colon_dsts = [p for p in positionals if re.match(r"^\+?:", p)]
+    if len(colon_dsts) == 1:
+        return _strip_surrounding_quotes(colon_dsts[0]).rsplit(":", 1)[1] or None
+    return None
+
+
 # -----------------------------------------------------------------------------
 # Privileged-flag binding (#1042). The (operation_type, target) binding above
 # DROPS every dash-flag, so an approved `gh pr merge 5` and an executed
@@ -624,6 +729,13 @@ PRIVILEGED_FLAGS: dict[str, dict[str, tuple[tuple[str, ...], bool]]] = {
         # No bound flags today: branch-delete's privileged effect is its op-trigger
         # (-D / --delete --force), already bound via op_type. Kept as an explicit
         # extension point so a future bound flag is a one-line data edit here.
+    },
+    "remote-ref-delete": {
+        # No bound flags: remote-ref-delete's privileged effect (removing a remote
+        # ref) IS its op-trigger (--delete/-d/empty-source colon), already bound via
+        # op_type. Empty entry = explicit #1042 extension point (a future bound flag
+        # is a one-line data edit); it adds NO new bound flag, so the set-equality
+        # bind is untouched.
     },
 }
 
@@ -784,9 +896,10 @@ def extract_command_context(command: str, flag_scan_text: str | None = None) -> 
     positively extracted; ABSENT otherwise (absence — NOT a None value — is the
     fail-closed signal). Possible keys:
         operation_type: "merge" | "close" | "force-push" | "branch-delete"
+                        | "push-to-main" | "remote-ref-delete"
         pr_number:  str  (merge / close)
         branch:     str  (branch-delete)
-        target_ref: str  (force-push, KD-6)
+        target_ref: str  (force-push / push-to-main, KD-6; remote-ref-delete #1062a)
         bound_flags: list[str]  (#1042) — sorted normalized privileged flags;
                      ALWAYS present when operation_type is (empty list when none).
 
@@ -837,6 +950,15 @@ def extract_command_context(command: str, flag_scan_text: str | None = None) -> 
         target_ref = _extract_force_push_target_ref(command)
         if target_ref is not None:
             context["target_ref"] = target_ref
+    elif op_type == "remote-ref-delete":
+        # #1062a: REUSE the `target_ref` key — the parser yields a ref, the key is
+        # semantically right, and the op-class identity (checked FIRST in the read
+        # switch) keeps a remote-ref-delete token from cross-authorizing a
+        # force-push/push-to-main with the same target_ref. Recognition⟺extractability:
+        # detect returned this op IFF the extractor yields a ref, so it is non-None here.
+        ref = _extract_remote_ref_delete_target(command)
+        if ref is not None:
+            context["target_ref"] = ref
     return context
 
 
@@ -1900,6 +2022,15 @@ def _flag_condition_danger_op(command: str) -> str | None:
         gf = _normalized_flags(tokens, "git")
         if "--force" in gf and "--force-with-lease" not in gf:
             return "force-push"
+        # remote-ref-delete (#1062a) — union-arm-only recognition (lead Q2: NO
+        # literal DANGEROUS_PATTERNS ref-delete arm). Recognize IFF a SINGLE
+        # deletable ref is extractable; recognition⟺mintability by construction
+        # (the SAME predicate feeds detect via the fallback AND the is_dangerous
+        # union), so this op can NEVER be #1064 gated-but-unmintable. A multi-ref /
+        # implicit-current / ambiguous form yields None here → not recognized → the
+        # mass arm (added with #1062b) or the literal floor decides.
+        if _extract_remote_ref_delete_target(command) is not None:
+            return "remote-ref-delete"
     return None
 
 

--- a/pact-plugin/tests/test_merge_guard_op_recognition_completeness.py
+++ b/pact-plugin/tests/test_merge_guard_op_recognition_completeness.py
@@ -533,6 +533,61 @@ class TestBranchProtectionSlashedAndMintAndNonVacuity:
 
 
 # ===========================================================================
+# #1061 — host-agnostic curl ref-mutation: gate + mint + authorize + parity
+# ===========================================================================
+
+
+class TestHostAgnosticCurlRefMutationMintAndParity:
+    """#1061 — the curl ref-mutation read floor is now host-agnostic (the literal
+    `.*api.*` was dropped from the curl git/refs DANGEROUS_PATTERNS arms), so an
+    HONEST ref-mutation against a non-api Enterprise/proxy host now ROUTES THROUGH
+    APPROVAL instead of bypassing.
+
+    This class pins the FULL "routes through approval" property for the
+    host-agnostic-widened forms — not merely the read gate (covered by the
+    carrier-8 PATH-vs-BODY positives), but that each MINTS a token AND the minted
+    token AUTHORIZES its own command, with mint==read parity. That directly
+    satisfies the "every gated op must mint" hard constraint for #1061 rather than
+    relying on transitive coverage of the pre-existing API-ref op. The underlying
+    op is the pre-existing API ref-mutation (DELETE -> branch-delete; PATCH/PUT ->
+    force-push); #1061 brings the non-api-host READ floor to parity with the
+    already-host-agnostic mint classifier. (curl commands must be backtick-wrapped
+    in the AUQ option text to mint — pre-existing locate_command_regions substrate
+    behavior; the mint() helper does this.)"""
+
+    @pytest.mark.parametrize(
+        "cmd,expected_op",
+        [
+            # non-api Enterprise / proxy hosts (no `api` substring in the URL)
+            ("curl -X DELETE https://git.example.com/repos/o/r/git/refs/heads/y", "branch-delete"),
+            ("curl --request DELETE https://git.internal.corp/repos/o/r/git/refs/heads/feature", "branch-delete"),
+            ("curl -X PATCH https://git.example.com/repos/o/r/git/refs/heads/y", "force-push"),
+        ],
+    )
+    def test_non_api_host_ref_mutation_gates_classifies_mints_and_authorizes(self, cmd, expected_op):
+        # read gate (the host-agnostic widening)
+        assert D(cmd) is True, f"UNDER-BLOCK: non-api-host ref-mutation not gated: {cmd!r}"
+        assert OP(cmd) == expected_op
+        # mint==read parity
+        assert mgc.is_dangerous_command(cmd) == (mgc.detect_command_operation_type(cmd) is not None)
+        # mints + authorizes its own command (the #1064 "every gated op mints" closure)
+        result = mint(cmd)
+        assert result.context is not None, f"did not mint (refusal={result.refusal_reason}) for {cmd!r}"
+        assert result.context.get("operation_type") == expected_op
+        assert MATCH(token_from_ctx(result.context), cmd) is True
+
+    def test_widening_is_a_superset_api_host_still_gates_and_mints(self):
+        """Control: the api-host form (which gated pre-#1061 too) STILL gates +
+        mints + authorizes — proving #1061 is a strict superset (non-api host
+        ADDED), not a swap that could have dropped the api-host coverage."""
+        cmd = "curl -X DELETE https://api.github.com/repos/o/r/git/refs/heads/y"
+        assert D(cmd) is True
+        result = mint(cmd)
+        assert result.context is not None, f"did not mint (refusal={result.refusal_reason})"
+        assert MATCH(token_from_ctx(result.context), cmd) is True
+
+
+# ===========================================================================
 # CARRIER-8 — PATH-vs-BODY invariant (#1037 over-block mitigation, §9.D/E)
 # ===========================================================================
 

--- a/pact-plugin/tests/test_merge_guard_op_recognition_completeness.py
+++ b/pact-plugin/tests/test_merge_guard_op_recognition_completeness.py
@@ -866,3 +866,196 @@ class TestAcceptedGrainAndAwarenessPins:
         assert D(clean) is True
         assert OP(clean) == "branch-protection"
         assert CTX(clean).get("protected_branch") == "main"
+
+
+# ===========================================================================
+# REVIEW-CYCLE-1 REMEDIATION — over-block fixes locked in (mint widened to match
+# the read floor, NO read-narrowing) + the accepted conservative-recognition
+# limitation pinned as INTENTIONAL forward-protection.
+# ===========================================================================
+
+
+class TestOverBlockGoneRegression:
+    """The review-cycle-1 over-block fixes ripped out over-blocks by WIDENING the
+    mint to match the read floor (never narrowing detection into a new under-block).
+    Each test asserts a FAITHFUL form now routes correctly (gates AND, where a mint
+    is expected, mints AND the token authorizes its own command) so a regression
+    that re-introduces the over-block turns these red. Non-vacuity is intrinsic: the
+    mint+authorize assertions only hold post-fix (pre-fix these were either
+    mislabeled-dangerous or gated-but-unmintable), plus the case-sensitive
+    counter-mutation below + the literal-arm contrast in the sibling class."""
+
+    # --- cross-leg leak: a benign first-leg push is no longer mislabeled a delete ---
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "git push origin feature && git branch -d old",   # && + safe (-d, merged-only) branch delete
+            "git push origin feature ; git branch -d old",    # ; variant
+            "git push origin feature | grep done",            # pipe-to-viewer variant
+        ],
+    )
+    def test_benign_push_not_mislabeled_as_delete(self, cmd):
+        assert D(cmd) is False, f"OVER-BLOCK regressed: benign push mislabeled dangerous: {cmd!r}"
+
+    def test_single_first_leg_delete_still_gates_control(self):
+        """Non-vacuity control for the cross-leg cases: a real single first-leg
+        ref-delete STILL gates, so the D=False assertions above are discriminating,
+        not a blanket 'compound is always safe'."""
+        assert D("git push origin --delete main") is True
+        assert OP("git push origin --delete main") == "remote-ref-delete"
+
+    # --- lowercase / mixed-case HTTP methods now MINT (mint widened to IGNORECASE) ---
+
+    @pytest.mark.parametrize(
+        "cmd,expected_op,target_key,target_val",
+        [
+            ("gh api -X delete repos/o/r/git/refs/heads/y", "branch-delete", "branch", "y"),
+            ("gh api --method delete repos/o/r/git/refs/heads/y", "branch-delete", "branch", "y"),
+            ("gh api -X Delete repos/o/r/branches/main/protection", "branch-protection", "protected_branch", "main"),
+        ],
+    )
+    def test_lowercase_method_gh_api_gates_mints_and_authorizes(self, cmd, expected_op, target_key, target_val):
+        assert D(cmd) is True
+        assert OP(cmd) == expected_op
+        result = mint(cmd)
+        assert result.context is not None, f"did not mint (refusal={result.refusal_reason}) for {cmd!r}"
+        assert result.context.get("operation_type") == expected_op
+        assert result.context.get(target_key) == target_val
+        assert MATCH(token_from_ctx(result.context), cmd) is True
+        # parity equality now holds for the mint-widened lowercase form
+        assert mgc.is_dangerous_command(cmd) == (mgc.detect_command_operation_type(cmd) is not None)
+
+    def test_curl_lowercase_method_protection_mints_and_authorizes(self):
+        """curl + lowercase method + protection PATH gates+mints+authorizes (curl must
+        be backtick-wrapped in the option text to mint — the mint() helper does)."""
+        cmd = "curl -X put https://git.example.com/repos/o/r/branches/main/protection"
+        assert D(cmd) is True
+        assert OP(cmd) == "branch-protection"
+        result = mint(cmd)
+        assert result.context is not None, f"did not mint (refusal={result.refusal_reason})"
+        assert result.context.get("protected_branch") == "main"
+        assert MATCH(token_from_ctx(result.context), cmd) is True
+
+    # --- gh global flag before `api` (gh -R o/r api ...) now MINTS ---
+
+    def test_gh_global_flag_gates_mints_and_authorizes(self):
+        cmd = "gh -R o/r api -X DELETE repos/o/r/branches/main/protection"
+        assert D(cmd) is True
+        assert OP(cmd) == "branch-protection"
+        result = mint(cmd)
+        assert result.context is not None, f"did not mint (refusal={result.refusal_reason})"
+        assert result.context.get("protected_branch") == "main"
+        assert MATCH(token_from_ctx(result.context), cmd) is True
+
+    def test_gh_global_flag_body_mention_not_over_blocked(self):
+        """carrier-8 under the gh -R framing: a git/refs MENTION in a -f field body is
+        NOT over-blocked, while the faithful path-resident protection delete (same
+        gh -R framing) STILL gates — the PATH-vs-BODY invariant holds for gh -R too."""
+        body_mention = "gh -R o/r api -X POST repos/o/r/issues/5 -f note='see git/refs/heads/x'"
+        assert D(body_mention) is False, f"OVER-BLOCK (#1037): gh -R body mention gated: {body_mention!r}"
+        faithful = "gh -R o/r api -X DELETE repos/o/r/branches/main/protection"
+        assert D(faithful) is True
+
+    # --- non-vacuity: in-memory counter-mutation (NOT git-revert; the shared worktree
+    #     holds the architect's staged doc WIP, so a checkout-revert would destroy it) ---
+
+    def test_lowercase_parity_is_non_vacuous_under_case_sensitive_mutation(self, monkeypatch):
+        """Simulate the PRE-FIX case-sensitive detect (the bug) by neutering detect to
+        None for the lowercase form, and assert the mint==read parity equality BREAKS.
+        Proves the widened-form parity assertions are coupled to the mint-widening fix
+        and would go red if it were reverted. In-memory (monkeypatch) by design — a
+        git-revert here would clobber a peer's staged uncommitted edit in the shared
+        worktree."""
+        cmd = "gh api -X delete repos/o/r/git/refs/heads/y"
+        # green before mutation (fix present)
+        assert mgc.is_dangerous_command(cmd) == (mgc.detect_command_operation_type(cmd) is not None)
+        monkeypatch.setattr(mgc, "detect_command_operation_type", lambda _c: None)
+        # read floor still gates (independent path); mutated detect None -> parity breaks
+        assert mgc.is_dangerous_command(cmd) is True
+        assert (mgc.is_dangerous_command(cmd) == (mgc.detect_command_operation_type(cmd) is not None)) is False
+
+
+class TestAcceptedRecognitionLimitationPins:
+    """FORWARD-PROTECTION pins for the ACCEPTED conservative-recognition limitation
+    (the review-cycle-1 SECURITY-HALT disposition). These forms run UNGATED BY
+    DESIGN, and these tests assert that ON PURPOSE — they are the executable tripwire
+    so a future maintainer who 'hardens' recognition into a match-anywhere / per-leg
+    scan (which would re-block faithful clicks) sees these flip RED and STOPS.
+
+    THE PRINCIPLE (do NOT 'fix' these): the git-push remote-ref-delete (:ref /
+    --delete / -d) and mass-delete (--mirror / --prune / multi-ref) forms need a
+    positional, quote-aware parse, so their recognition is ANCHORED to the FIRST
+    executable leg and does NOT chase the op into NON-FIRST compound legs. Chasing it
+    requires a match-anywhere scan that fires on a quoted :ref / --mirror mention in a
+    benign leg = an over-block of a faithful click, which is WRONG BY DEFINITION
+    (worse than missing a buried op). The fix for any over-block WIDENS the mint,
+    never narrows detection into a new under-block.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "cd /repo && git push origin --delete main",   # ref-delete in a non-first leg
+            "git fetch && git push --mirror origin",        # mass-delete in a non-first leg
+            "NOTE=x ; git push origin :main",               # colon-delete after an assignment leg
+        ],
+    )
+    def test_non_first_leg_push_delete_ungated_by_design(self, cmd):
+        """ACCEPTED LIMITATION — do NOT fix. A push-delete/mass-delete in a NON-FIRST
+        compound leg is ungated (first-leg anchoring). If this assertion FAILS, the
+        recognition was hardened into a match-anywhere scan that over-blocks faithful
+        clicks — that is the WRONG fix; re-read the conservative-recognition principle."""
+        assert D(cmd) is False, (
+            f"Recognition was hardened to chase a non-first-leg push-delete — this "
+            f"RE-INTRODUCES a faithful-click over-block. Do NOT 'fix' this form: {cmd!r}"
+        )
+
+    def test_httpie_protection_ungated_by_design(self):
+        """ACCEPTED LIMITATION — do NOT fix by bolting on an httpie read arm. The mint
+        classifier covers gh-api/curl/wget only; an httpie protection READ arm would
+        gate a form the mint cannot bind = a gated-but-unmintable over-block (itself a
+        faithful-click block). Leaving it ungated keeps read == mint. Full httpie
+        gate+mint is a deferred scope expansion, not a half-measure read arm."""
+        assert D("http DELETE https://api.github.com/repos/o/r/branches/main/protection") is False
+
+    @pytest.mark.parametrize(
+        "cmd,expected_op",
+        [
+            ("cd /repo && git push origin main --force", "force-push"),
+            ("cd /repo && git branch -D feature", "branch-delete"),
+            ("cd /repo && gh pr merge 5", "merge"),
+            ("cd /repo && gh api -X DELETE repos/o/r/branches/main/protection", "branch-protection"),
+        ],
+    )
+    def test_literal_arm_contrast_still_gates_non_first_leg(self, cmd, expected_op):
+        """THE BOUND on the accepted-ungated surface (and the non-vacuity for the pins
+        above): the LITERAL DANGEROUS_PATTERNS arms (force-push, branch -D, gh pr
+        merge, the API ref/protection arms) match-anywhere and STILL gate in a
+        NON-FIRST leg. This proves the accepted-ungated set is SPECIFIC to the
+        parse-dependent union-arm push forms — NOT a general compound bypass — so the
+        accepted set cannot silently widen. If a literal arm ever stops gating in a
+        non-first leg, that is a real under-block and this turns red."""
+        assert D(cmd) is True, f"UNDER-BLOCK: literal arm stopped gating in a non-first leg: {cmd!r}"
+        assert OP(cmd) == expected_op
+
+
+class TestParityCanaryReconciledForWidenedForms:
+    """§9.A parity reconciliation (review-cycle-1). After the mint-widening, the mint
+    classifier AGREES with the read floor for the lowercase / mixed-case / global-flag
+    forms, so the mint==read EQUALITY now holds for them (pre-fix these were
+    read=True / detect=None — a gated-but-unmintable over-block). This extends the
+    §9.A canary beyond the uppercase-only forms the original suite covered."""
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "gh api -X delete repos/o/r/git/refs/heads/y",                 # lowercase
+            "gh api --method delete repos/o/r/git/refs/heads/y",          # lowercase --method
+            "gh api -X Delete repos/o/r/branches/main/protection",        # mixed-case
+            "gh -R o/r api -X DELETE repos/o/r/branches/main/protection", # global-flag framing
+            "curl -X put https://git.example.com/repos/o/r/branches/main/protection",  # curl lowercase
+        ],
+    )
+    def test_mint_equals_read_parity_now_holds(self, cmd):
+        assert mgc.is_dangerous_command(cmd) == (mgc.detect_command_operation_type(cmd) is not None)

--- a/pact-plugin/tests/test_merge_guard_op_recognition_completeness.py
+++ b/pact-plugin/tests/test_merge_guard_op_recognition_completeness.py
@@ -1,0 +1,813 @@
+"""Completeness + adversarial regression suite for the merge-guard op-recognition
+closure — a SACROSANCT honest-mistake auth control.
+
+THREAT MODEL (honest-mistake, NOT adversarial defense): a faithful single-command
+click ALWAYS mints + executes; UNDER-BLOCK of an honest destructive form is NEVER
+acceptable; over-block of a faithful form is fails-safe. Adversarial obfuscation
+(quote-elision, interpreter-pipe, $-expansion, var-laundering) is EXPLICITLY OUT
+OF SCOPE.
+
+This suite codifies the architect's TEST surface (the A-I spec) for THREE new
+op-classes plus the HTTP-client data-body strip ("carrier-8"), and goes BEYOND the
+literal enumeration: the literal-floor backstop was removed (it caused over-blocks),
+so the enumeration ITSELF is now the proof that the whole faithful-spelling space
+gates. An un-enumerated faithful spelling that silently fails to gate is an auth
+bypass nothing else catches — so the no-under-block arms HUNT the faithful space
+(refs/heads/ + refs/tags/ colon forms, lease `+:` forms, alternate flag orderings,
+deep-slashed refs, implicit/explicit-remote cross product, multi-flag mass combos).
+
+NON-VACUITY is mandatory on a SACROSANCT control: a green suite that cannot fail is
+worthless. Every recognition arm asserts the EXACT bound target (not just
+is_dangerous), every negative is paired with a discriminating positive, and the
+highest-consequence canaries (mint==read parity, the end-to-end mint authorize
+proof) carry an explicit counter-mutation demonstrating the canary CAN go red.
+
+The three op-classes are enumerated INDEPENDENTLY (per the enlarged blind/Copilot
+review surface): remote-ref-delete, remote-mass-delete, branch-protection each get
+their own no-under-block AND no-over-block classes.
+
+Empirical, not mocked: every test imports + calls the real production functions
+(is_dangerous_command / detect_command_operation_type / extract_command_context and
+the real mint path _mint_context_from_bundle / _target_value / _token_matches_command).
+"""
+
+import contextlib
+import re as _real_re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import shared.merge_guard_common as mgc  # noqa: E402  (module handle for counter-mutation)
+from shared.merge_guard_common import (  # noqa: E402
+    is_dangerous_command as D,
+    detect_command_operation_type as OP,
+    extract_command_context as CTX,
+)
+from merge_guard_pre import _token_matches_command as MATCH  # noqa: E402
+from merge_guard_post import (  # noqa: E402
+    _mint_context_from_bundle,
+    _target_value,
+)
+
+IMPLICIT = "\x00implicit"  # the implicit-remote marker used by remote-mass-delete
+
+
+# ---------------------------------------------------------------------------
+# Helpers — the real mint path and a token builder.
+# ---------------------------------------------------------------------------
+
+def mint(cmd_text):
+    """Drive the REAL mint path: place a faithful command in an affirmative
+    AskUserQuestion option and mint a token bundle. Returns MintResult(context,
+    refusal_reason). curl/wget commands must be backtick-wrapped in the option
+    text to mint (pre-existing locate_command_regions substrate behavior — the
+    bare-curl/wget non-mint is a fail-safe over-block characteristic, accepted)."""
+    question = {
+        "question": "Proceed?",
+        "options": [{"label": "Yes, do it", "description": f"Run `{cmd_text}` now"}],
+        "multiSelect": False,
+    }
+    return _mint_context_from_bundle([question], {"Proceed?": "Yes, do it"})
+
+
+def token_from_ctx(ctx):
+    """Build the pre.py token shape from a minted/extracted context dict."""
+    return {"operation_type": ctx["operation_type"], "context": ctx}
+
+
+def token(op, **ctx_fields):
+    """Construct a token directly for cross-auth / non-authorization probes."""
+    ctx = {"operation_type": op, "bound_flags": [], **ctx_fields}
+    return {"operation_type": op, "context": ctx}
+
+
+class _ContentsGuardDisabledRe:
+    """A drop-in for merge_guard_common's `re` module that forces
+    re.search(r'contents/', ...) to return None — surgically disabling ONLY the
+    carrier-8 contents-API preservation guard (the `if re.search(r"contents/",
+    span): return span` line) so the UNCONDITIONAL body strip can be measured.
+
+    Every other re.* call is delegated to the real module unchanged: the
+    body-strip re.sub calls, and every DANGEROUS_PATTERNS match (those call
+    .search on a *compiled* pattern object, not through mgc.re), are unaffected.
+    This is the seam that lets the assumption-A survey (is contents the SOLE
+    body-resident arm?) be re-proved through the REAL strip machinery rather
+    than a re-implementation."""
+
+    def search(self, pattern, string, *args, **kwargs):  # noqa: A003
+        if pattern == r"contents/":
+            return None
+        return _real_re.search(pattern, string, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(_real_re, name)
+
+
+@contextlib.contextmanager
+def contents_guard_disabled():
+    """Context manager: run the body inside an UNCONDITIONAL carrier-8 body strip
+    (contents preservation guard off)."""
+    saved = mgc.re
+    mgc.re = _ContentsGuardDisabledRe()
+    try:
+        yield
+    finally:
+        mgc.re = saved
+
+
+# ===========================================================================
+# OP-CLASS 1 — remote-ref-delete (#1062a)
+# ===========================================================================
+
+# Every faithful single-ref-delete spelling: (command, expected target_ref).
+# git deletion == EMPTY SOURCE (left of colon): `:ref`, `+:ref`, or `--delete`/
+# `-d <ref>`. Covers the literal §9.B list PLUS the adversarial hunt: refs/heads/
+# + refs/tags/ colon forms, lease `+:`, deep-slashed refs, flag reorder, quoted
+# remote, explicit + implicit remote cross product. Each was verified to gate at
+# the integrated HEAD with the EXACT target shown.
+REMOTE_REF_DELETE_SPELLINGS = [
+    # --- §9.B literal enumeration ---
+    ("git push origin :feature", "feature"),
+    ("git push origin +:feature", "feature"),
+    ("git push origin --delete feature", "feature"),
+    ("git push origin -d feature", "feature"),
+    ("git push origin :refs/tags/v1", "refs/tags/v1"),
+    ("git push -d origin ref", "ref"),
+    ("git push :feature", "feature"),                  # implicit remote
+    ("git push --delete feature", "feature"),          # implicit remote
+    ("git push -d feature", "feature"),                # implicit remote
+    ("git push --delete a b", "b"),                    # git grammar: repo=a, ref=b
+    # --- adversarial hunt (beyond the literal list) ---
+    ("git push origin :refs/heads/feature", "refs/heads/feature"),
+    ("git push origin --delete refs/heads/feature", "refs/heads/feature"),
+    ("git push origin +:refs/heads/feature", "refs/heads/feature"),
+    ("git push origin :refs/tags/v1.0", "refs/tags/v1.0"),
+    ("git push origin --delete refs/tags/v1.0", "refs/tags/v1.0"),
+    ("git push origin -d refs/heads/feature", "refs/heads/feature"),
+    ("git push :refs/heads/feature", "refs/heads/feature"),       # implicit remote
+    ("git push --delete refs/tags/v1.0", "refs/tags/v1.0"),       # implicit remote
+    ("git push +:feature", "feature"),                            # implicit force-delete
+    ("git push -d origin feature", "feature"),                    # flag before remote
+    ("git push origin :release/v1.2.3", "release/v1.2.3"),        # dotted ref
+    ("git push origin --delete feat_x-y", "feat_x-y"),            # underscore/dash
+    ('git push "origin" :feature', "feature"),                    # double-quoted remote
+    ("git push origin :feature/sub/leaf", "feature/sub/leaf"),    # deep-slashed ref
+    ("git push origin -o ci.skip :feature", "feature"),           # value-flag skip + real delete
+]
+
+
+class TestRemoteRefDeleteNoUnderBlock:
+    """§9.B + adversarial hunt — every faithful single-ref-delete spelling MUST
+    gate as remote-ref-delete with the EXACT target_ref. An un-enumerated faithful
+    spelling that fails to gate would be a true under-block; this enumeration IS
+    the completeness proof (it replaced the rejected literal-floor backstop)."""
+
+    @pytest.mark.parametrize("cmd,target", REMOTE_REF_DELETE_SPELLINGS)
+    def test_faithful_spelling_gates_with_exact_target(self, cmd, target):
+        assert D(cmd) is True, f"UNDER-BLOCK: faithful delete not gated: {cmd!r}"
+        assert OP(cmd) == "remote-ref-delete", f"misclassified: {cmd!r} -> {OP(cmd)}"
+        # Exact-target assertion is the non-vacuity guarantee: a stub that always
+        # returned is_dangerous=True would not bind the SPECIFIC ref the operator
+        # approved, so mint==read target binding would be unproven.
+        assert CTX(cmd).get("target_ref") == target, (
+            f"target_ref mismatch for {cmd!r}: got {CTX(cmd).get('target_ref')!r}, want {target!r}"
+        )
+
+
+class TestRemoteRefDeleteNoOverBlock:
+    """§9.C — faithful NON-delete push forms must NOT be classified as
+    remote-ref-delete. The src:dst and quoted-colon (#1037) cases are the
+    over-block class the design must avoid."""
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "git push origin feature",                 # plain push of a non-main branch
+            "git push origin feat:feat",               # src:dst (non-delete update)
+            "git push origin local:remote",            # src:dst both present
+            "git push origin refs/heads/feature:",     # non-empty src, empty dst -> NOT a delete
+            "git push origin +refs/heads/feature:",    # forced non-empty src, empty dst -> NOT a delete
+            "git commit -m 'git push origin :feature'",  # delete literal in commit msg
+        ],
+    )
+    def test_non_delete_form_not_classified_as_ref_delete(self, cmd):
+        assert OP(cmd) != "remote-ref-delete", f"over-classified {cmd!r} as ref-delete"
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "git push origin main -o 'ci.message=cleanup :oldref'",  # quoted colon in push-option (#1037)
+            "git push origin -o ':weird' main",                      # value-flag colon (#1037)
+        ],
+    )
+    def test_quoted_colon_not_read_as_ref_delete(self, cmd):
+        """#1037 brittleness class: a colon mentioned inside a quoted push-option
+        value must not be mis-read as a ref-delete refspec. (These still gate as
+        push-to-main on their own merits — that is asserted in the integration
+        class; here we only assert they are not mis-bound as a ref-delete.)"""
+        assert OP(cmd) != "remote-ref-delete"
+        assert CTX(cmd).get("target_ref") in (None,), (
+            f"{cmd!r} leaked a target_ref: {CTX(cmd).get('target_ref')!r}"
+        )
+
+
+class TestRemoteRefDeleteParityMintAndNonVacuity:
+    """§9.A parity canary + the end-to-end mint authorize proof (the real #1064
+    closure) + non-vacuity counter-mutations for remote-ref-delete."""
+
+    @pytest.mark.parametrize("cmd,_target", REMOTE_REF_DELETE_SPELLINGS)
+    def test_mint_equals_read_parity(self, cmd, _target):
+        """is_dangerous_command (read floor) and detect_command_operation_type
+        (mint classifier) must AGREE so a later edit cannot re-diverge them."""
+        assert mgc.is_dangerous_command(cmd) == (mgc.detect_command_operation_type(cmd) is not None)
+
+    def test_parity_canary_is_non_vacuous_under_detect_mutation(self, monkeypatch):
+        """Counter-mutation proving the parity canary CAN fail: if the mint
+        classifier were neutered to return None for a form the read floor still
+        gates, the parity equality must break. A canary that stays green under
+        this mutation would be vacuous."""
+        cmd = "git push origin :feature"
+        # sanity: green before mutation
+        assert mgc.is_dangerous_command(cmd) == (mgc.detect_command_operation_type(cmd) is not None)
+        monkeypatch.setattr(mgc, "detect_command_operation_type", lambda _c: None)
+        # is_dangerous_command is an INDEPENDENT path (it does not call detect), so
+        # it still gates True while the mutated detect returns None -> parity breaks.
+        assert mgc.is_dangerous_command(cmd) is True
+        assert (mgc.is_dangerous_command(cmd) == (mgc.detect_command_operation_type(cmd) is not None)) is False
+
+    @pytest.mark.parametrize(
+        "cmd,target",
+        [
+            ("git push origin :feature", "feature"),
+            ("git push origin --delete refs/heads/feature", "refs/heads/feature"),
+            ("git push :refs/tags/v1.0", "refs/tags/v1.0"),
+        ],
+    )
+    def test_faithful_click_mints_and_authorizes_its_own_command(self, cmd, target):
+        """End-to-end: a faithful ref-delete in an affirmative AUQ option mints a
+        token whose target_ref re-matches the executed command -> AUTHORIZED. This
+        is the #1064 closure (gated AND mintable), proved through the real mint
+        path, not a read-gate alone."""
+        result = mint(cmd)
+        assert result.context is not None, f"did not mint (refusal={result.refusal_reason}) for {cmd!r}"
+        assert result.context.get("operation_type") == "remote-ref-delete"
+        assert result.context.get("target_ref") == target
+        assert _target_value(result.context) is not None  # mint-side allow-list sees the target
+        assert MATCH(token_from_ctx(result.context), cmd) is True
+
+    def test_mint_authorize_proof_is_non_vacuous_wrong_target_refused(self):
+        """Non-vacuity for the authorize proof: a token whose target_ref is WRONG
+        must NOT authorize the command. If MATCH ignored the target, the green
+        authorize assertion above would be meaningless."""
+        cmd = "git push origin :feature"
+        assert MATCH(token("remote-ref-delete", target_ref="feature"), cmd) is True
+        assert MATCH(token("remote-ref-delete", target_ref="other"), cmd) is False
+
+    def test_cross_op_token_does_not_authorize_ref_delete(self):
+        """A force-push token must NOT authorize a remote-ref-delete of the same
+        ref (distinct op-classes), and vice-versa — the lead-Q1 distinct-op-class
+        guarantee."""
+        assert MATCH(token("force-push", target_ref="feature"), "git push origin :feature") is False
+        assert MATCH(token("remote-ref-delete", target_ref="feature"), "git push --force origin feature") is False
+
+
+# ===========================================================================
+# OP-CLASS 2 — remote-mass-delete (#1062b)
+# ===========================================================================
+
+# Faithful mass forms: (command, expected mass_target). mass_target binds the
+# destructive IDENTITY (sorted mass-flags @ remote-or-implicit [# sorted refspecs]),
+# NOT the whole command.
+REMOTE_MASS_DELETE_SPELLINGS = [
+    ("git push --mirror origin", "--mirror@origin"),
+    ("git push --mirror", f"--mirror@{IMPLICIT}"),                 # implicit remote
+    ("git push --prune origin", "--prune@origin"),
+    ("git push --prune origin refs/heads/main", "--prune@origin#refs/heads/main"),
+    ("git push origin --delete a b", "--delete@origin#a,b"),       # multi-ref
+    ("git push origin :a :b", "--delete@origin#a,b"),              # multi colon
+    ("git push origin --mirror", "--mirror@origin"),               # flag after remote
+    ("git push origin --prune", "--prune@origin"),                 # flag after remote
+    ("git push origin --delete a b c", "--delete@origin#a,b,c"),   # three-ref
+    ('git push --mirror "origin"', "--mirror@origin"),             # quoted remote
+]
+
+
+class TestRemoteMassDeleteNoUnderBlock:
+    """§9.H.b/c/d — every faithful mass form gates as remote-mass-delete with the
+    EXACT mass_target, AND the mint-side allow-list (_target_value) sees it
+    (#1064-impossible canary: recognition and mintability are the same predicate)."""
+
+    @pytest.mark.parametrize("cmd,mass_target", REMOTE_MASS_DELETE_SPELLINGS)
+    def test_faithful_mass_form_gates_with_exact_mass_target(self, cmd, mass_target):
+        assert D(cmd) is True, f"UNDER-BLOCK: faithful mass form not gated: {cmd!r}"
+        assert OP(cmd) == "remote-mass-delete", f"misclassified: {cmd!r} -> {OP(cmd)}"
+        assert CTX(cmd).get("mass_target") == mass_target, (
+            f"mass_target mismatch for {cmd!r}: got {CTX(cmd).get('mass_target')!r}, want {mass_target!r}"
+        )
+
+    @pytest.mark.parametrize("cmd,_mt", REMOTE_MASS_DELETE_SPELLINGS)
+    def test_recognition_implies_mintable_no_1064(self, cmd, _mt):
+        """#1064-impossible: whenever a mass form is recognized, the mint-side
+        _target_value MUST be populated — recognition <=> mintability."""
+        ctx = CTX(cmd)
+        assert ctx.get("mass_target") is not None
+        assert _target_value(ctx) is not None
+
+    def test_implicit_remote_is_mintable(self):
+        """§9.H.b — the target-less implicit-remote mass form mints (no #1064)."""
+        cmd = "git push --mirror"
+        assert D(cmd) is True
+        assert OP(cmd) == "remote-mass-delete"
+        assert CTX(cmd).get("mass_target") == f"--mirror@{IMPLICIT}"
+
+
+class TestRemoteMassDeleteCrossAuthDistinctness:
+    """§9.H.a — no-cross-auth: distinct destructive identities mint distinct
+    tokens, and a token for one mass identity does NOT authorize another (the
+    lesser->greater closure that the rejected coarse sentinel would have reopened)."""
+
+    def test_distinct_mass_identities_are_distinct_targets(self):
+        assert CTX("git push --prune origin")["mass_target"] != CTX("git push --mirror origin")["mass_target"]
+        assert CTX("git push --mirror origin")["mass_target"] != CTX("git push --mirror origin2")["mass_target"]
+        assert CTX("git push origin --delete a b")["mass_target"] != CTX("git push origin --delete a c")["mass_target"]
+
+    def test_prune_token_does_not_authorize_mirror(self):
+        tok = token("remote-mass-delete", mass_target="--prune@origin")
+        assert MATCH(tok, "git push --prune origin") is True            # authorizes its own
+        assert MATCH(tok, "git push --mirror origin") is False          # not a different identity
+
+    def test_mirror_token_does_not_authorize_prune(self):
+        tok = token("remote-mass-delete", mass_target="--mirror@origin")
+        assert MATCH(tok, "git push --mirror origin") is True
+        assert MATCH(tok, "git push --prune origin") is False
+
+    def test_distinct_remote_does_not_cross_authorize(self):
+        tok = token("remote-mass-delete", mass_target="--mirror@origin")
+        assert MATCH(tok, "git push --mirror origin2") is False
+
+    def test_refspec_set_closure_a_b_does_not_authorize_a_c(self):
+        tok = token("remote-mass-delete", mass_target="--delete@origin#a,b")
+        assert MATCH(tok, "git push origin --delete a b") is True
+        assert MATCH(tok, "git push origin --delete a c") is False
+
+
+class TestRemoteMassDeleteBoundary:
+    """§9.H.e — the single-vs-multi --delete boundary. EXACTLY one op-class per
+    command; the git-grammar rationale (first positional == repository) is pinned
+    in the assertions so the implicit-remote 2-token case is not mistaken for a bug."""
+
+    @pytest.mark.parametrize(
+        "cmd,expected_op,expected_target",
+        [
+            # 1 ref -> remote-ref-delete
+            ("git push origin --delete a", "remote-ref-delete", "a"),
+            # git grammar: `git push --delete a b` => repo=a, ref=b => SINGLE delete
+            ("git push --delete a b", "remote-ref-delete", "b"),
+            # explicit remote + 2 refs => MULTI => remote-mass-delete
+            ("git push origin --delete a b", "remote-mass-delete", "--delete@origin#a,b"),
+            ("git push --mirror origin", "remote-mass-delete", "--mirror@origin"),
+        ],
+    )
+    def test_single_vs_multi_delete_routing(self, cmd, expected_op, expected_target):
+        assert OP(cmd) == expected_op, f"{cmd!r} -> {OP(cmd)}, want {expected_op}"
+        ctx = CTX(cmd)
+        if expected_op == "remote-ref-delete":
+            assert ctx.get("target_ref") == expected_target
+        else:
+            assert ctx.get("mass_target") == expected_target
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "git push origin --delete a",
+            "git push --delete a b",
+            "git push origin --delete a b",
+            "git push --mirror origin",
+            "git push origin :a :b",
+        ],
+    )
+    def test_no_double_classification(self, cmd):
+        """No command may populate BOTH target_ref and mass_target — exactly one
+        op-class binds (the single-ref-extractability discriminator)."""
+        ctx = CTX(cmd)
+        assert not (ctx.get("target_ref") and ctx.get("mass_target")), (
+            f"double-classified {cmd!r}: target_ref={ctx.get('target_ref')!r} mass_target={ctx.get('mass_target')!r}"
+        )
+
+
+class TestRemoteMassDeleteParityMintAndNonVacuity:
+    """§9.H.d/f — parity canary extended to remote-mass-delete + the end-to-end
+    mint authorize proof + non-vacuity."""
+
+    @pytest.mark.parametrize("cmd,_mt", REMOTE_MASS_DELETE_SPELLINGS)
+    def test_mint_equals_read_parity(self, cmd, _mt):
+        assert mgc.is_dangerous_command(cmd) == (mgc.detect_command_operation_type(cmd) is not None)
+
+    @pytest.mark.parametrize(
+        "cmd,mass_target",
+        [
+            ("git push --mirror origin", "--mirror@origin"),
+            ("git push --mirror", f"--mirror@{IMPLICIT}"),
+            ("git push origin --delete a b", "--delete@origin#a,b"),
+        ],
+    )
+    def test_faithful_click_mints_and_authorizes(self, cmd, mass_target):
+        result = mint(cmd)
+        assert result.context is not None, f"did not mint (refusal={result.refusal_reason}) for {cmd!r}"
+        assert result.context.get("operation_type") == "remote-mass-delete"
+        assert result.context.get("mass_target") == mass_target
+        assert MATCH(token_from_ctx(result.context), cmd) is True
+
+    def test_mint_authorize_proof_is_non_vacuous_wrong_target_refused(self):
+        cmd = "git push --mirror origin"
+        assert MATCH(token("remote-mass-delete", mass_target="--mirror@origin"), cmd) is True
+        assert MATCH(token("remote-mass-delete", mass_target="--prune@origin"), cmd) is False
+
+
+class TestRemoteMassDeleteNoOverBlock:
+    """Negatives — faithful non-mass forms and a mass literal carried in a commit
+    message (carrier-5 strips it) must stay UNGATED."""
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "git push origin feature",
+            "git push origin feat:feat",
+            "git commit -m 'git push --mirror origin'",
+        ],
+    )
+    def test_non_mass_form_not_classified_as_mass(self, cmd):
+        assert OP(cmd) != "remote-mass-delete"
+
+    def test_commit_msg_mass_literal_is_not_dangerous(self):
+        assert D("git commit -m 'git push --mirror origin'") is False
+
+
+# ===========================================================================
+# OP-CLASS 3 — branch-protection (#1063)
+# ===========================================================================
+
+# Per-client templates; {M} is the HTTP method. Host-agnostic: api and non-api
+# (Enterprise) hosts both gate.
+PROTECTION_CLIENTS = {
+    "gh-api": "gh api -X {M} repos/o/r/branches/main/protection",
+    "gh-api-method": "gh api --method {M} repos/o/r/branches/main/protection",
+    "curl-api-host": "curl -X {M} https://api.github.com/repos/o/r/branches/main/protection",
+    "curl-enterprise-host": "curl -X {M} https://git.example.com/repos/o/r/branches/main/protection",
+    "wget": "wget --method={M} https://git.example.com/repos/o/r/branches/main/protection",
+}
+PROTECTION_GATED_METHODS = ["DELETE", "PUT", "PATCH"]
+
+
+class TestBranchProtectionGate:
+    """§9.E — per-method x client gate, host-agnostic, protected_branch extracted +
+    mintable, mint==read parity."""
+
+    @pytest.mark.parametrize("method", PROTECTION_GATED_METHODS)
+    @pytest.mark.parametrize("client", list(PROTECTION_CLIENTS))
+    def test_weakening_method_gates_per_client(self, method, client):
+        cmd = PROTECTION_CLIENTS[client].format(M=method)
+        assert D(cmd) is True, f"UNDER-BLOCK: {client} {method} not gated: {cmd!r}"
+        assert OP(cmd) == "branch-protection"
+        assert CTX(cmd).get("protected_branch") == "main"
+        assert _target_value(CTX(cmd)) is not None  # mintable
+        # parity
+        assert mgc.is_dangerous_command(cmd) == (mgc.detect_command_operation_type(cmd) is not None)
+
+
+class TestBranchProtectionPostNotGated:
+    """§9.E strengthening direction — POST ENABLES protection sub-features, so it
+    must NOT gate (gating it would over-block)."""
+
+    @pytest.mark.parametrize("client", list(PROTECTION_CLIENTS))
+    def test_post_does_not_gate(self, client):
+        cmd = PROTECTION_CLIENTS[client].format(M="POST")
+        assert OP(cmd) != "branch-protection", f"POST over-classified: {cmd!r}"
+        assert D(cmd) is False, f"POST over-blocked (strengthening): {cmd!r}"
+
+
+class TestBranchProtectionSlashedAndMintAndNonVacuity:
+    """Slashed-branch extraction + the end-to-end mint authorize proof + cross-op
+    closure + non-vacuity counter-mutation."""
+
+    @pytest.mark.parametrize(
+        "cmd,branch",
+        [
+            ("gh api -X DELETE repos/o/r/branches/feature/x/protection", "feature/x"),
+            ("gh api -X PUT repos/o/r/branches/release/1.2/x/protection", "release/1.2/x"),
+            ("curl -X PATCH https://git.example.com/repos/o/r/branches/dev/protection", "dev"),
+        ],
+    )
+    def test_slashed_and_simple_branch_extracted(self, cmd, branch):
+        assert D(cmd) is True
+        assert CTX(cmd).get("protected_branch") == branch
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "gh api -X DELETE repos/o/r/branches/main/protection",
+            "gh api -X PUT repos/o/r/branches/release/x/protection",
+        ],
+    )
+    def test_faithful_click_mints_and_authorizes(self, cmd):
+        result = mint(cmd)
+        assert result.context is not None, f"did not mint (refusal={result.refusal_reason}) for {cmd!r}"
+        assert result.context.get("operation_type") == "branch-protection"
+        assert result.context.get("protected_branch") == CTX(cmd).get("protected_branch")
+        assert MATCH(token_from_ctx(result.context), cmd) is True
+
+    def test_mint_authorize_proof_non_vacuous_wrong_branch_refused(self):
+        cmd = "gh api -X DELETE repos/o/r/branches/main/protection"
+        assert MATCH(token("branch-protection", protected_branch="main"), cmd) is True
+        assert MATCH(token("branch-protection", protected_branch="other"), cmd) is False
+
+    def test_cross_op_closure(self):
+        """A branch-protection token must NOT authorize a CLI branch-delete of the
+        same name (distinct op-classes)."""
+        tok = token("branch-protection", protected_branch="main")
+        assert MATCH(tok, "gh api -X DELETE repos/o/r/branches/main/protection") is True
+        assert MATCH(tok, "git branch -D main") is False
+
+
+# ===========================================================================
+# CARRIER-8 — PATH-vs-BODY invariant (#1037 over-block mitigation, §9.D/E)
+# ===========================================================================
+
+
+class TestCarrier8PathVsBody:
+    """§9.D/E — carrier-8 strips the HTTP-client data BODY but never the URL PATH,
+    so a faithful path-resident target STILL gates after the strip (zero
+    under-block), while a benign command merely MENTIONING a sensitive path inside
+    a quoted body is NOT over-blocked (#1037 FP killed)."""
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # ref in PATH, with and without a body -> STILL gates after carrier-8
+            "curl -X DELETE https://git.example.com/repos/o/r/git/refs/heads/y",
+            "curl -X DELETE https://git.example.com/repos/o/r/git/refs/heads/y -d '{}'",
+            "curl -X DELETE https://git.example.com/repos/o/r/git/refs/heads/y -d 'unrelated body'",
+            "curl -f -X DELETE https://git.example.com/repos/o/r/git/refs/heads/y",  # -f boolean not mis-stripped
+            # protection target in PATH, with a field/body mention -> STILL gates
+            "gh api -X DELETE repos/o/r/branches/main/protection --field reason='see branches/x/protection'",
+            "curl -X DELETE https://git.example.com/repos/o/r/branches/main/protection -d 'note: branches/x/protection'",
+        ],
+    )
+    def test_path_resident_target_survives_body_strip(self, cmd):
+        assert D(cmd) is True, f"UNDER-BLOCK: path-resident target lost to body strip: {cmd!r}"
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # #1037 FP: git/refs / protection MENTIONED only in a quoted body -> UNGATED
+            "curl -X POST https://example.com/log -d 'msg=touched git/refs/heads/x'",
+            'curl -X POST https://example.com/log -d "msg=touched git/refs/heads/x"',
+            "wget --method=POST https://example.com/log --body-data 'x git/refs y'",
+            "gh api -X DELETE repos/o/r/issues/5 --field note='see git/refs/heads/x'",
+            "gh api -X DELETE repos/o/r/issues/5 -f body='touch git/refs/heads/x'",
+            "gh api -X POST repos/o/r/issues/5 --field note='touch branches/x/protection now'",
+            "curl -X POST https://example.com/log -d 'msg=branches/main/protection'",
+        ],
+    )
+    def test_body_only_mention_is_not_over_blocked(self, cmd):
+        assert D(cmd) is False, f"OVER-BLOCK (#1037): body-only mention gated: {cmd!r}"
+
+    def test_carrier8_keeps_flag_strips_body_value(self):
+        """The flag token survives (implicit-POST lookaheads must still fire);
+        only the body VALUE is removed."""
+        stripped = mgc._strip_non_executable_content(
+            "curl -X POST https://example.com/log -d 'git/refs/x'"
+        )
+        assert "-d " in stripped
+        assert "git/refs" not in stripped
+
+    def test_carrier8_does_not_strip_git_push_ref(self):
+        """carrier-8 is HTTP-client-scoped: a `git push -d <ref>` (git surface, not
+        an HTTP client) must keep its ref."""
+        stripped = mgc._strip_non_executable_content("git push -d feature")
+        assert "feature" in stripped
+
+
+# ===========================================================================
+# CONTENTS-API regression + the assumption-A body-resident survey (§9.D)
+# ===========================================================================
+
+
+class TestContentsApiRegression:
+    """§9.D — the body-resident contents-API arm. carrier-8 strips request bodies,
+    but the contents arm reads its destructive target (the main/master branch) from
+    the BODY, so a per-span contents preservation guard keeps it gating. These are
+    the existing TestContentsAPI forms re-pinned AFTER carrier-8 landed."""
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "gh api -X PUT repos/owner/repo/contents/README.md -f branch=main -f sha=abc",
+            "gh api -X PUT repos/owner/repo/contents/README.md -f branch=master",
+            "gh api -X PATCH repos/owner/repo/contents/README.md -f branch=main",
+            'curl -X PUT https://api.github.com/repos/o/r/contents/README.md -d \'{"branch":"main","sha":"abc"}\'',
+            'curl -X PUT https://api.github.com/repos/o/r/contents/README.md -d \'{"branch":"master"}\'',
+        ],
+    )
+    def test_contents_forms_still_gate_after_carrier8(self, cmd):
+        assert D(cmd) is True, f"REGRESSION: contents form no longer gates: {cmd!r}"
+
+    def test_strip_preserves_contents_body_signal(self):
+        """The per-span guard keeps the body-resident main/master signal: stripping
+        a contents command preserves `main`."""
+        stripped = mgc._strip_non_executable_content(
+            'curl -X PUT https://api.github.com/repos/o/r/contents/README.md -d \'{"branch":"main"}\''
+        )
+        assert "main" in stripped
+
+    def test_discriminating_negative_contents_guard_is_load_bearing(self):
+        """DISCRIMINATING NEGATIVE (non-vacuity for the guard): with the contents
+        preservation guard conceptually removed (unconditional body strip), the
+        curl contents form — whose main/master signal is in a QUOTED body value —
+        regresses True->False. This proves the guard is load-bearing: without it,
+        a faithful body-resident contents mutation would UNDER-BLOCK.
+
+        (Refinement surfaced by independent re-verification: only the
+        carrier-8-strippable forms regress — i.e. QUOTED body values. The existing
+        gh-api forms use an UNQUOTED `-f branch=main`, which carrier-8 never strips,
+        so they do not regress under guard-removal; the curl form, with a quoted
+        JSON body, is the true body-resident-strippable case.)"""
+        curl_contents = 'curl -X PUT https://api.github.com/repos/o/r/contents/README.md -d \'{"branch":"main"}\''
+        # guard ON: gates
+        assert D(curl_contents) is True
+        # guard OFF (unconditional strip): regresses -> proves the guard matters
+        with contents_guard_disabled():
+            assert D(curl_contents) is False
+        # guard restored (control): gates again
+        assert D(curl_contents) is True
+
+
+class TestBodyResidentArmSurvey:
+    """Independent re-verification of assumption (A): is contents-API the SOLE
+    gated arm whose destructive target is BODY-resident? Method (NOT trusting the
+    architect's discriminating-negative verdict): enumerate one faithful command
+    per API arm and apply the UNCONDITIONAL body strip (contents guard disabled).
+    The load-bearing invariant is that NO non-contents API arm regresses — every
+    other arm's target is PATH-resident and survives the strip. This is what proves
+    the per-span contents guard is both load-bearing AND sufficient (no second
+    body-resident arm needs a matching guard)."""
+
+    # One faithful destructive command per NON-contents API arm. Each carries a
+    # body flag so the strip has something to remove; each keeps its target in the
+    # URL PATH. (Verified to stay True under the unconditional strip.)
+    NON_CONTENTS_API_ARMS = [
+        "gh api -X PUT repos/o/r/pulls/5/merge -f sha=abc",
+        'curl -X PUT https://api.github.com/repos/o/r/pulls/5/merge -d \'{"sha":"abc"}\'',
+        "gh api -X DELETE repos/o/r/git/refs/heads/y -f note=x",
+        "curl -X DELETE https://git.example.com/repos/o/r/git/refs/heads/y -d 'note=x'",
+        "gh api -X PATCH repos/o/r/git/refs/heads/y -f sha=abc",
+        "curl -X PATCH https://git.example.com/repos/o/r/git/refs/heads/y -d 'sha=abc'",
+        "gh api repos/o/r/git/refs/heads/y -f sha=abc",                       # implicit POST
+        "curl https://git.example.com/repos/o/r/git/refs/heads/y -d 'sha=abc'",  # implicit POST
+        "gh api -X DELETE repos/o/r/branches/main/protection -f note=x",
+        "curl -X DELETE https://git.example.com/repos/o/r/branches/main/protection -d 'note=x'",
+        "wget --method=PUT https://git.example.com/repos/o/r/branches/main/protection --body-data 'x'",
+        "wget --method=DELETE https://git.example.com/repos/o/r/git/refs/heads/y --body-data 'x'",
+    ]
+
+    @pytest.mark.parametrize("cmd", NON_CONTENTS_API_ARMS)
+    def test_non_contents_arm_is_path_resident_survives_unconditional_strip(self, cmd):
+        # baseline: gates
+        assert D(cmd) is True, f"baseline: {cmd!r} should gate"
+        # under the UNCONDITIONAL strip it must STILL gate (target is path-resident)
+        with contents_guard_disabled():
+            assert D(cmd) is True, (
+                f"SECOND BODY-RESIDENT ARM: {cmd!r} regressed under an unconditional "
+                f"body strip -> carrier-8 would under-block it (assumption-A violated)"
+            )
+
+    def test_only_contents_is_body_resident(self):
+        """The asymmetry proof: under the unconditional strip, the contents arm
+        (curl, quoted body) DOES regress while every non-contents arm survives ->
+        contents is the sole body-resident arm and the single per-span guard is
+        sufficient."""
+        contents = 'curl -X PUT https://api.github.com/repos/o/r/contents/README.md -d \'{"branch":"main"}\''
+        with contents_guard_disabled():
+            contents_regressed = D(contents) is False
+            non_contents_survived = all(D(c) for c in self.NON_CONTENTS_API_ARMS)
+        assert contents_regressed, "contents arm did not regress under unconditional strip"
+        assert non_contents_survived, "a non-contents arm regressed -> a second body-resident arm exists"
+
+
+# ===========================================================================
+# OUT-of-charter negatives + integration + accepted-grain / awareness pins
+# ===========================================================================
+
+
+class TestOutOfCharterNegatives:
+    """§9.F — the #1063 charter boundary. Repo/release/api-repo deletion is OUT of
+    charter and MUST stay ungated; a future widening that catches these is a scope
+    violation."""
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "gh repo delete owner/repo",
+            "gh release delete v1",
+            "gh api -X DELETE repos/o/r",
+        ],
+    )
+    def test_out_of_charter_stays_ungated(self, cmd):
+        assert D(cmd) is False, f"SCOPE VIOLATION: out-of-charter form gated: {cmd!r}"
+
+
+class TestStaleSnapshotIntegration:
+    """CODE integration note — the deferred->gated cross-group transition. In the
+    #1062a-only state `git push origin --delete a b` and `git push --mirror origin`
+    were is_dangerous=False; after #1062b they gate as remote-mass-delete. Pin the
+    INTEGRATED-HEAD behavior so a stale pre-integration negative cannot creep back."""
+
+    @pytest.mark.parametrize(
+        "cmd,mass_target",
+        [
+            ("git push origin --delete a b", "--delete@origin#a,b"),
+            ("git push --mirror origin", "--mirror@origin"),
+        ],
+    )
+    def test_formerly_deferred_forms_now_gate_as_mass(self, cmd, mass_target):
+        assert D(cmd) is True
+        assert OP(cmd) == "remote-mass-delete"
+        assert CTX(cmd).get("mass_target") == mass_target
+
+    def test_push_to_main_with_quoted_colon_gates_as_push_to_main(self):
+        """The quoted-colon push-option form is NOT a ref-delete but IS dangerous on
+        its own merits (push-to-main) — the #1037 quoted colon is inert, the
+        push-to-main classification stands."""
+        cmd = "git push origin main -o 'ci.message=cleanup :oldref'"
+        assert D(cmd) is True
+        assert OP(cmd) == "push-to-main"
+        assert OP(cmd) != "remote-ref-delete"
+
+
+class TestAcceptedGrainAndAwarenessPins:
+    """§10 accepted-grain decisions + the auditor awareness pins. These document
+    DELIBERATE, ratified boundaries — they are NOT under-blocks, and pinning them
+    prevents a future reader from mistaking the boundary for a bug."""
+
+    def test_cross_remote_same_named_single_ref_delete_shares_token_accepted_grain(self):
+        """§10 target-grain asymmetry: remote-ref-delete binds ref-ONLY (no remote,
+        per the force-push target_ref precedent), so a token minted for one remote
+        authorizes the SAME-named single-ref delete on a DIFFERENT remote within the
+        single-use window. This is an ACCEPTED honest-mistake grain by explicit
+        decision (the operator approved "delete ref feature"; the remote differs) —
+        documented here as accepted, NOT an under-block."""
+        tok = token("remote-ref-delete", target_ref="feature")
+        assert MATCH(tok, "git push origin :feature") is True
+        assert MATCH(tok, "git push upstream :feature") is True  # ACCEPTED grain (ref-only bind)
+
+    def test_quoted_gh_api_field_value_collides_with_preexisting_var_strip(self):
+        """AWARENESS PIN (pre-existing, OUT-of-scope): a gh-api field value written
+        as a QUOTED `key='value'` (e.g. `-f branch='main'`) collides with the
+        pre-existing shell variable-assignment laundering strip (which rewrites
+        `name='value'` -> `name=STRIPPED`), so a QUOTED-branch contents form is
+        is_dangerous=False. This is NOT introduced by carrier-8 (the var-strip is
+        byte-identical pre/post-PR and produces a bareword `=STRIPPED`, unlike
+        carrier-8's re-quoted `'STRIPPED'`), and var-laundering is explicitly OUT
+        OF SCOPE per the threat model. The faithful/canonical gh-api form uses an
+        UNQUOTED `-f branch=main`, which gates correctly."""
+        # canonical unquoted form: gates
+        assert D("gh api -X PUT repos/o/r/contents/README.md -f branch=main") is True
+        # quoted-value form collides with the pre-existing var-strip (out of scope)
+        assert D("gh api -X PUT repos/o/r/contents/README.md -f branch='main'") is False
+
+    def test_bare_curl_wget_non_mint_is_failsafe_over_block(self):
+        """AUDITOR TEST-NOTE 1 (fail-safe awareness): curl/wget API forms MINT only
+        when the command is QUOTED/backtick-wrapped in the AUQ option text
+        (pre-existing locate_command_regions substrate behavior). A BARE (unwrapped)
+        curl/wget option text does not mint — a fail-safe over-block characteristic,
+        accepted. gh-api mints in every framing (asserted via the backtick-wrapped
+        mint() helper elsewhere)."""
+        bare = {
+            "question": "Proceed?",
+            "options": [{
+                "label": "Yes, do it",
+                # NOTE: no backticks around the command -> bare option text
+                "description": "Run curl -X DELETE https://git.example.com/repos/o/r/git/refs/heads/y now",
+            }],
+            "multiSelect": False,
+        }
+        result = _mint_context_from_bundle([bare], {"Proceed?": "Yes, do it"})
+        # fail-safe: no mint from bare curl text (accepted over-block, not an under-block)
+        assert result.context is None
+
+    def test_protection_command_with_gitrefs_body_still_gates(self):
+        """AUDITOR TEST-NOTE 2 (awareness): a branch-protection command whose data
+        BODY literally contains `git/refs/heads/<x>` may be detect-classified by the
+        pre-existing git/refs body arm, but it STILL gates (mint==read consistent ->
+        self-authorizes). A faithful CLEAN-body protection command binds correctly
+        as branch-protection. Either way is_dangerous holds — strict improvement
+        over base; the collision needs a crafted body (out of honest-mistake scope)."""
+        crafted = "gh api -X DELETE repos/o/r/branches/main/protection -f note='git/refs/heads/x'"
+        assert D(crafted) is True  # gates regardless of the body collision
+        clean = "gh api -X DELETE repos/o/r/branches/main/protection"
+        assert D(clean) is True
+        assert OP(clean) == "branch-protection"
+        assert CTX(clean).get("protected_branch") == "main"


### PR DESCRIPTION
## Summary

Extends the merge-guard's honest-mistake recognition to three destructive op-classes that previously bypassed the operator's approval click, **host-agnostically**, while holding the line on the guard's governing principle: **a faithful single-command click always mints+executes, and anything that can block a faithful single-command click is wrong by definition.**

Recognition is deliberately **conservative**: it gates the *single destructive command* (plus its benign viewers/filters) and errs toward letting-through. It does **not** chase destructive ops buried in non-first compound legs — doing so needs match-anywhere recognition that would over-block a faithful click. That accepted limitation is documented in the SSOT threat-model header so a future sweep can't "harden" it back into an over-block.

## What landed

Single-command honest-mistake coverage for:
- **#1062a `remote-ref-delete`** — `git push origin :ref` / `--delete` / `-d` (incl. tag/refs colon-refspecs, implicit remote). Distinct op-class so a local branch-delete token can't cross-authorize a remote ref-delete.
- **#1062b `remote-mass-delete`** — `--mirror` / `--prune` / multi-ref `--delete`, with a tight per-invocation binding (no cross-authorization between distinct invocations).
- **#1063 `branch-protection`** — `gh api`/`curl`/`wget -X DELETE|PUT|PATCH .../branches/*/protection`, host-agnostic, POST excluded (strengthening). repo/release/api-repo-delete out of scope (charter).
- **#1061** — the curl `git/refs` gate is host-agnostic (no literal `api` key).
- **carrier-8 (#1037)** — HTTP-body strip so the new arms don't over-block a faithful command that merely mentions these paths in a quoted body; preserves the body-resident contents-API span.

Recognition⟺mintability holds (every gated single-command form mints + authorizes); `#1042` privileged-flag bind untouched. Version **4.4.50** (canonical 4 files).

## Review + remediation

A 4-reviewer panel + an **independent blind security review** + GitHub Copilot. The independent lens found a SACROSANCT under-block the green suite and other reviewers missed (the union-arm ops bypass when the `git push` isn't the first leg of a compound) and several over-blocks. Per the governing principle (over-block prohibition outranks closing a buried-op under-block):

- The **over-blocks came out**, by *widening the mint to match the read floor*, never narrowing read: the #1064 `gh -R`/lowercase gated-but-unmintable cases, the cross-leg flag leak (benign push mislabeled), and a carrier-8 `gh -R` adjacency FP.
- The **compound non-first-leg under-block** (and httpie protection) are kept as an **accepted, documented limitation** — the price of never over-blocking; named explicitly in the SSOT threat-model and pinned in tests (with a literal-arm-contrast tripwire so the accepted surface can't silently widen).

Independent security re-verification **PASS** (over-blocks gone, read floor untouched, accepted surface exactly as documented). Full suite **10205 passed / 0 failed / 0 errors**.

## Issue closure

Closes #1062
Closes #1061

Completes the scoped ACs of #1063 (branch-protection IN; repo/release/api-repo-delete OUT) — **closure pending the post-install live-probe** of the new runtime recognition arms; not auto-closed here.

## Tracked follow-ups (pre-existing / out of scope)

- #1074 — quoted gh-api contents field under-blocks via carrier-4 var-strip.
- #1075 — push-to-main under-blocked when a value-flag sits between remote and the main refspec.
- #1077 — httpie git/refs ref-mutation gates-but-cannot-mint (pre-existing #1064).
- #1078 — force-push extractor has the same cross-leg flag leak fixed here for push-delete.

## Accepted limitations (documented in the SSOT threat-model)

- Destructive push-delete / mass-delete are **ungated when `git push` is not the first leg** of a compound (`cd && git push --delete`, `git fetch && git push --mirror`). Conservative recognition; chasing them would over-block a faithful click. The literal-pattern arms (force-push, branch-delete, `gh pr merge`, push-to-main, the API arms) still gate in any leg.
- httpie protection mutation is ungated (gating it would create a gated-but-unmintable over-block).
