### PR TITLE
Agent Teams: wake/idle message-ordering hardening — disk-first re-read, boundary-drain, one-redundant-confirm (v4.4.52)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.4.51",
+      "version": "4.4.52",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.4.51/      # Plugin version
+│               └── 4.4.52/      # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.4.51",
+  "version": "4.4.52",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.4.51
+> **Version**: 4.4.52
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/agents/pact-orchestrator.md
+++ b/pact-plugin/agents/pact-orchestrator.md
@@ -138,7 +138,7 @@ Certain conditions bypass normal orchestration and escalate directly to user:
 
 When waiting for teammates to complete their tasks, **do not narrate waiting** — saying "Waiting on X..." is a waste of your context window. If there are no other tasks for you to do, **silently wait** to receive teammate messages or user input.
 
-Idle notifications arrive as conversation turns. When a turn carries no actionable content — no blocker, no stage-ready, no question, no user input — emit no reply. Acknowledging every incoming turn is the reflex that produces narrate-the-wait noise. The next meaningful transition triggers the next meaningful reply.
+Idle notifications arrive as conversation turns. When a turn carries no actionable content — no blocker, no stage-ready, no question, no user input — emit no reply. Acknowledging every incoming turn is the reflex that produces narrate-the-wait noise. The next meaningful transition triggers the next meaningful reply. One protocol-defined exception: the single redundant confirm after a crossed wake (an idle notification postdating your wake-send) — see §12 Intentional Waiting.
 
 ---
 
@@ -486,7 +486,7 @@ Teammate self-completion carve-outs (predicate-witnessed): signal-tasks (`metada
 
 ### Teachback Review
 
-Each specialist dispatch is a Task A (TEACHBACK) + Task B (work) pair with `blockedBy=[A]` — see §11 for the canonical sequence. Teammate claims A, writes `metadata.teachback_submit` (5 canonical fields per [pact-teachback](../skills/pact-teachback/SKILL.md)), idles on `awaiting_lead_completion`. **Read-Trigger Precondition**: wait for teammate's wake-signal SendMessage BEFORE the raw JSON read — see [pact-completion-authority §Read-Trigger Precondition](../protocols/pact-completion-authority.md#read-trigger-precondition) for the 4-point rule (Monitor `INBOX_GREW` is alarm-clock not content marker; raw read MUST follow SendMessage receipt; mitigation for residual race). Then read the payload via raw JSON (TaskGet is metadata-blind), apply Validating Incoming Teachbacks below, then accept via the Acceptance two-call atomic pair above; acceptance auto-unblocks Task B. Do NOT mark Task B `completed` or `pending` yourself — the teammate claims on wake.
+Each specialist dispatch is a Task A (TEACHBACK) + Task B (work) pair with `blockedBy=[A]` — see §11 for the canonical sequence. Teammate claims A, writes `metadata.teachback_submit` (5 canonical fields per [pact-teachback](../skills/pact-teachback/SKILL.md)), idles on `awaiting_lead_completion`. **Read-Trigger Precondition**: wait for teammate's wake-signal SendMessage BEFORE the raw JSON read — see [pact-completion-authority §Read-Trigger Precondition](../protocols/pact-completion-authority.md#read-trigger-precondition) for the 3-point rule (wake-signal SendMessage is the content-arrival signal; raw read MUST follow SendMessage receipt; mitigation for residual race). Then read the payload via raw JSON (TaskGet is metadata-blind), apply Validating Incoming Teachbacks below, then accept via the Acceptance two-call atomic pair above; acceptance auto-unblocks Task B. Do NOT mark Task B `completed` or `pending` yourself — the teammate claims on wake.
 
 #### Validating Incoming Teachbacks
 
@@ -536,14 +536,31 @@ This is the L1.5 entailment-mesh discipline — distinct from L2 (purpose) verif
 
 Every agent delivers a structured HANDOFF (6 fields: `produced`, `decisions`, `reasoning_chain`, `uncertainty`, `integration`, `open_questions`) stored in `metadata.handoff`. See [pact-agent-teams §HANDOFF Format](../skills/pact-agent-teams/SKILL.md#handoff-format) for the full schema. If `validate_handoff` warns about a missing HANDOFF, extract available context from the agent's response and update the task. On receipt, **wait for teammate's wake-signal SendMessage** (per [pact-completion-authority §Read-Trigger Precondition](../protocols/pact-completion-authority.md#read-trigger-precondition)) before treating the raw `metadata.handoff` read as authoritative — `TaskGet` is metadata-blind AND raw reads racing the platform-side write produce false-empty responses that have triggered false-positive HANDOFF rejection cycles. Then inspect `metadata.handoff` (raw JSON read) and follow the Completion Authority two-call atomic pair. Do NOT dispatch downstream phases against a teammate-owned task you have not yet marked completed. Note: HANDOFF's `reasoning_chain` (sender's view) is the symmetric counterpart to teachback's `reasoning_reconstruction` (receiver's parallel reconstruction) — see [pact-ct-teachback §Relationship to Existing Protocols](../protocols/pact-ct-teachback.md#relationship-to-existing-protocols).
 
+#### Directive-Reflection Check
+
+Before acting on any teammate boundary message (teachback submit, HANDOFF notify,
+staged-work report, blocker report), verify every directive you sent that teammate
+mid-turn is reflected in the deliverable — delivery is not processing; a mid-turn
+directive renders only at the teammate's next turn boundary. Highest-stakes
+instance: compare reported stage scope against outstanding amendments BEFORE
+committing. Teammates report an inbox drain in boundary messages
+(`boundary-drain: ...`); a missing drain report is a signal to check. Full rule:
+[pact-completion-authority §Directive-Reflection Check](../protocols/pact-completion-authority.md#directive-reflection-check).
+
 ### Intentional Waiting (orchestrator responsibilities)
 
 Teammates signal protocol-defined waits via the `intentional_wait` task metadata (see `pact-agent-teams/SKILL.md::Intentional Waiting` for the teammate-side SET/CLEAR contract). The flag is audit metadata — it documents the wait for your inspection and session review. Your responsibilities:
 
 - **Don't interpret silence as stall.** Read the task metadata before dispatching `/PACT:imPACT`.
+- **Crossed wake — one redundant confirm, then stop.** An idle notification that
+  postdates your wake-send is not a stall: durable-read the task; if the wait is
+  unresolved, send exactly ONE redundant confirm naming the actionable state;
+  further idle ticks are not stalls. Escalate to stall diagnosis only on
+  task-file-mtime plus sustained-silence evidence. Applies under both
+  teammateModes. See [pact-completion-authority §Crossed-Wake Idles](../protocols/pact-completion-authority.md#crossed-wake-idles-one-redundant-confirm-then-stop).
 - **Drive resolution on your own cadence.** Track outstanding waits across your teammates; send the resolving message (approval / commit confirmation / peer reply routed / user decision) when appropriate.
 - **Reading the flag**: `TaskGet` does NOT surface task metadata. Read the task file directly: `cat ~/.claude/tasks/{team}/{taskId}.json | jq .metadata.intentional_wait`. Fields: `reason`, `expected_resolver`, `since`.
-- **Staleness signal**: the 30-min threshold (`wait_stale` in `shared.intentional_wait`) renders the flag stale for your audit and inspection purposes; no hook fires on expiry. If a flagged wait has been pending past 30 min, the teammate should re-SET with a fresh `since` — or the wait has hung and you should investigate and drive resolution.
+- **Staleness signal**: the 30-min threshold (`wait_stale` in `shared.intentional_wait`) renders the flag stale for your audit and inspection purposes; the `missed_wake_scan` hook (UserPromptSubmit + SessionStart) re-surfaces tasks idling on `awaiting_lead_completion` past this threshold, while all other reasons have no hook consumer — inspect manually. If a flagged wait has been pending past 30 min, the teammate should re-SET with a fresh `since` — or the wait has hung and you should investigate and drive resolution.
 - **Don't SET the `intentional_wait` task metadata on your own team-lead task.** TeammateIdle hooks filter by task owner; they don't inspect team-lead state.
 - **`awaiting_lead_completion` is the most common wait you'll see** — set by every teammate after they store HANDOFF or teachback metadata. Resolution = your two-call acceptance pair (or rejection dual-channel pair).
 

--- a/pact-plugin/protocols/pact-agent-stall.md
+++ b/pact-plugin/protocols/pact-agent-stall.md
@@ -5,7 +5,13 @@
 - Task status in `TaskList` shows `in_progress` but no `SendMessage` activity from the teammate
 - Teammate process terminated without sending a completion message or blocker via `SendMessage`
 
-Detection is event-driven: check at signal monitoring points (after dispatch, on TeammateIdle events, on `SendMessage` receipt). If a teammate goes idle without sending a completion message or blocker, treat as stalled immediately.
+Detection is event-driven: check at signal monitoring points (after dispatch, on TeammateIdle events, on `SendMessage` receipt). If a teammate goes idle without sending a completion message or blocker, treat as
+stalled immediately — UNLESS the idle plausibly postdates a wake-signal you just
+sent or the task carries a live `intentional_wait`: those idles are
+delivery-ordering artifacts, not stalls. Apply the one-redundant-confirm rule in
+[pact-completion-authority.md](pact-completion-authority.md#crossed-wake-idles-one-redundant-confirm-then-stop)
+and escalate to stall diagnosis only on task-file-mtime plus sustained-silence
+evidence.
 
 **Relationship to agent state model**: Stall detection is the binary endpoint (active vs. stalled). For finer-grained mid-execution assessment (converging/exploring/stuck), see the agent state model in [pact-variety.md](pact-variety.md#agent-state-model). An agent assessed as "stuck" via progress signals may stall if not intervened upon.
 

--- a/pact-plugin/protocols/pact-communication-charter.md
+++ b/pact-plugin/protocols/pact-communication-charter.md
@@ -87,7 +87,7 @@ Before composing any outbound SendMessage (peer-to-peer or to lead), wait for yo
 
 #### Verify Before Executing
 
-On receiving a state-dependent message, check actual state before executing. If state has advanced past the message's premise, no-op and report.
+On receiving a state-dependent message, check actual state before executing. If state has advanced past the message's premise, no-op and report. Exception: when the fresh read shows exactly the state the sender themselves already resolved, the report carries zero information — suppress it entirely, per [pact-agent-teams §Counter-Confirm Suppression](../skills/pact-agent-teams/SKILL.md#counter-confirm-suppression).
 
 *Failure shape: teammate receives "fix foo.py:42" at idle; their last action already routed past that location (a refactor moved it; tests passed). Without the state-check, the teammate runs a redundant or conflicting operation, undoing prior valid work.*
 

--- a/pact-plugin/protocols/pact-completion-authority.md
+++ b/pact-plugin/protocols/pact-completion-authority.md
@@ -47,6 +47,47 @@ cat ~/.claude/tasks/{team_name}/{taskId}.json | jq .metadata.handoff
 
 Inspect the HANDOFF before flipping status. If `metadata.handoff` is missing or empty, do NOT mark the task completed — request the teammate write the HANDOFF first.
 
+### Crossed-Wake Idles: One Redundant Confirm, Then Stop
+
+Your wake-signal SendMessage races the teammate's turn-end idle notification: inbox
+files are written asynchronously on delivery, so a teammate's idle notification can
+reach you AFTER your wake-send while the teammate has not yet seen the wake. This
+happens at every wait-resolution seam — teachback acceptance, HANDOFF acceptance,
+commit confirmation, rejection — and identically under in-process and tmux
+teammateMode: the race is delivery-ordering, not mode-specific. The idle
+notification alone cannot distinguish "idle because my wake has not landed yet"
+from "idle because the teammate stalled".
+
+1. **On an idle notification that postdates your wake-send**, take a durable read
+   of the teammate's task (raw JSON — `TaskGet` is metadata-blind). If the read
+   shows the wait resolved AND acted on (e.g., the follow-on task claimed), do
+   nothing: the wake landed.
+2. **If the durable read shows the wait unresolved**, send exactly ONE redundant
+   confirm naming the actionable durable state (e.g., "your teachback on Task A was
+   accepted and A is completed on disk; Task B is claimable now"). Name the state,
+   not "checking in" — the confirm must let the teammate act from it alone, because
+   it may render before your original wake.
+3. **Further idle ticks are NOT stalls.** After the one redundant confirm, send no
+   further confirms and do not read subsequent idle notifications as stall
+   evidence. Escalate to stall diagnosis (see [pact-agent-stall.md](pact-agent-stall.md))
+   only on task-file-mtime plus sustained-silence evidence: the task file unchanged
+   AND no inbound SendMessage from the teammate across multiple idle cycles well
+   past your wake-send.
+
+**Non-goal — no hook-based detection.** Do not attempt to close this race with a
+synchronous hook, and reject future proposals to reintroduce one: `SendMessage`
+fires no PreToolUse/PostToolUse event; inbox files are written asynchronously on
+delivery; TeammateIdle notifications fire at turn-end regardless of what has just
+landed in the recipient's inbox. Synchronous wake/send detection is therefore
+dead-by-construction and historically produced near-100% false positives. The
+mitigation layer is: redundant-by-design wake handling on both sides (this rule
+plus the teammate-side disk-first re-read in
+[pact-agent-teams §On Wake](../skills/pact-agent-teams/SKILL.md#on-wake-disk-first-re-read-seam-agnostic))
+plus the duration-keyed `missed_wake_scan` hook that re-surfaces stale
+`awaiting_lead_completion` waits at your next user prompt or session start. The
+two-call atomic pairs above are unchanged by this rule — SendMessage-first ordering
+stays load-bearing.
+
 ---
 
 ## Teachback Review
@@ -114,6 +155,37 @@ The status flip is the load-bearing approval action; the SendMessage is the load
 ### Validating Incoming Teachbacks
 
 When an agent sends a TEACHBACK, **compare it against the task as you dispatched it — check for both misstatements AND omissions of the objective, constraints, or success criteria**. If you spot a misunderstanding, reply with a correction via `SendMessage` before any other action — the agent is already working, so the correction window is short. Prevents **misunderstanding disguised as agreement** from going undetected until TEST phase. Once decided, follow the [Acceptance or Rejection two-call atomic pair](#completion-authority).
+
+### Directive-Reflection Check
+
+Before acting on ANY teammate protocol-boundary message — a teachback submit, a
+HANDOFF notify, a staged-work report you are about to commit, a blocker report —
+verify that every directive you sent that teammate MID-TURN (scope amendments,
+corrections, re-instructions) is actually reflected in the deliverable the boundary
+message describes. Delivery is not processing: a directive delivered while the
+teammate was mid-turn does not render in their context until a later turn boundary,
+so their boundary message can faithfully describe a deliverable that silently
+predates your directive.
+
+- Track outstanding mid-turn directives per teammate (a task-metadata note
+  suffices); at each boundary message, tick them off against the reported scope.
+  This extends [Validating Incoming Teachbacks](#validating-incoming-teachbacks):
+  that check compares the teachback against the task AS DISPATCHED; this check
+  compares the deliverable against directives sent AFTER dispatch.
+- The staged-work-to-commit boundary is the highest-stakes instance: compare the
+  reported stage scope (`git diff --cached --stat`) against every outstanding
+  amendment BEFORE committing. A mismatch means hold the commit and re-instruct.
+- Teammate-side complement: teammates drain their inbox before composing boundary
+  messages and state the drain in the message (see
+  [pact-agent-teams §Boundary-Drain Rule](../skills/pact-agent-teams/SKILL.md#boundary-drain-rule)).
+  A `boundary-drain: inbox empty` report shifts the residual risk to messages still
+  in flight at drain time — your reflection check is the backstop either way, and a
+  boundary message with NO drain report is itself a signal to check more carefully.
+
+A deliverable that reflects pre-directive scope because your directive crossed it
+in flight is a no-fault ordering artifact: reject with corrections naming the
+current scope (per [Rejection Flow](#rejection-flow)) — do not treat it as the
+teammate misunderstanding the original dispatch.
 
 ---
 

--- a/pact-plugin/protocols/pact-completion-authority.md
+++ b/pact-plugin/protocols/pact-completion-authority.md
@@ -62,9 +62,10 @@ from "idle because the teammate stalled".
    of the teammate's task (raw JSON — `TaskGet` is metadata-blind). If the read
    shows the wait resolved AND acted on (e.g., the follow-on task claimed), do
    nothing: the wake landed.
-2. **If the durable read shows the wait unresolved**, send exactly ONE redundant
-   confirm naming the actionable durable state (e.g., "your teachback on Task A was
-   accepted and A is completed on disk; Task B is claimable now"). Name the state,
+2. **If the durable read shows the wait resolved but not yet acted on (or
+   unresolved)**, send exactly ONE redundant confirm naming the actionable durable
+   state (e.g., "your teachback on Task A was accepted and A is completed on disk;
+   Task B is claimable now"). Name the state,
    not "checking in" — the confirm must let the teammate act from it alone, because
    it may render before your original wake.
 3. **Further idle ticks are NOT stalls.** After the one redundant confirm, send no
@@ -74,7 +75,7 @@ from "idle because the teammate stalled".
    AND no inbound SendMessage from the teammate across multiple idle cycles well
    past your wake-send.
 
-**Non-goal — no hook-based detection.** Do not attempt to close this race with a
+**Non-goal — no synchronous hook-based detection.** Do not attempt to close this race with a
 synchronous hook, and reject future proposals to reintroduce one: `SendMessage`
 fires no PreToolUse/PostToolUse event; inbox files are written asynchronously on
 delivery; TeammateIdle notifications fire at turn-end regardless of what has just

--- a/pact-plugin/protocols/pact-completion-authority.md
+++ b/pact-plugin/protocols/pact-completion-authority.md
@@ -182,6 +182,9 @@ predates your directive.
   A `boundary-drain: inbox empty` report shifts the residual risk to messages still
   in flight at drain time — your reflection check is the backstop either way, and a
   boundary message with NO drain report is itself a signal to check more carefully.
+  The drain report always begins with the literal marker `boundary-drain:`, so its
+  presence is mechanically checkable — scan the boundary message text for that
+  substring rather than judging from prose whether a drain was reported.
 
 A deliverable that reflects pre-directive scope because your directive crossed it
 in flight is a no-fault ordering artifact: reject with corrections naming the

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -2258,6 +2258,9 @@ predates your directive.
   A `boundary-drain: inbox empty` report shifts the residual risk to messages still
   in flight at drain time — your reflection check is the backstop either way, and a
   boundary message with NO drain report is itself a signal to check more carefully.
+  The drain report always begins with the literal marker `boundary-drain:`, so its
+  presence is mechanically checkable — scan the boundary message text for that
+  substring rather than judging from prose whether a drain was reported.
 
 A deliverable that reflects pre-directive scope because your directive crossed it
 in flight is a no-fault ordering artifact: reject with corrections naming the

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -2117,6 +2117,47 @@ cat ~/.claude/tasks/{team_name}/{taskId}.json | jq .metadata.handoff
 
 Inspect the HANDOFF before flipping status. If `metadata.handoff` is missing or empty, do NOT mark the task completed — request the teammate write the HANDOFF first.
 
+### Crossed-Wake Idles: One Redundant Confirm, Then Stop
+
+Your wake-signal SendMessage races the teammate's turn-end idle notification: inbox
+files are written asynchronously on delivery, so a teammate's idle notification can
+reach you AFTER your wake-send while the teammate has not yet seen the wake. This
+happens at every wait-resolution seam — teachback acceptance, HANDOFF acceptance,
+commit confirmation, rejection — and identically under in-process and tmux
+teammateMode: the race is delivery-ordering, not mode-specific. The idle
+notification alone cannot distinguish "idle because my wake has not landed yet"
+from "idle because the teammate stalled".
+
+1. **On an idle notification that postdates your wake-send**, take a durable read
+   of the teammate's task (raw JSON — `TaskGet` is metadata-blind). If the read
+   shows the wait resolved AND acted on (e.g., the follow-on task claimed), do
+   nothing: the wake landed.
+2. **If the durable read shows the wait unresolved**, send exactly ONE redundant
+   confirm naming the actionable durable state (e.g., "your teachback on Task A was
+   accepted and A is completed on disk; Task B is claimable now"). Name the state,
+   not "checking in" — the confirm must let the teammate act from it alone, because
+   it may render before your original wake.
+3. **Further idle ticks are NOT stalls.** After the one redundant confirm, send no
+   further confirms and do not read subsequent idle notifications as stall
+   evidence. Escalate to stall diagnosis (see [pact-agent-stall.md](pact-agent-stall.md))
+   only on task-file-mtime plus sustained-silence evidence: the task file unchanged
+   AND no inbound SendMessage from the teammate across multiple idle cycles well
+   past your wake-send.
+
+**Non-goal — no hook-based detection.** Do not attempt to close this race with a
+synchronous hook, and reject future proposals to reintroduce one: `SendMessage`
+fires no PreToolUse/PostToolUse event; inbox files are written asynchronously on
+delivery; TeammateIdle notifications fire at turn-end regardless of what has just
+landed in the recipient's inbox. Synchronous wake/send detection is therefore
+dead-by-construction and historically produced near-100% false positives. The
+mitigation layer is: redundant-by-design wake handling on both sides (this rule
+plus the teammate-side disk-first re-read in
+[pact-agent-teams §On Wake](../skills/pact-agent-teams/SKILL.md#on-wake-disk-first-re-read-seam-agnostic))
+plus the duration-keyed `missed_wake_scan` hook that re-surfaces stale
+`awaiting_lead_completion` waits at your next user prompt or session start. The
+two-call atomic pairs above are unchanged by this rule — SendMessage-first ordering
+stays load-bearing.
+
 ---
 
 ## Teachback Review
@@ -2184,6 +2225,37 @@ The status flip is the load-bearing approval action; the SendMessage is the load
 ### Validating Incoming Teachbacks
 
 When an agent sends a TEACHBACK, **compare it against the task as you dispatched it — check for both misstatements AND omissions of the objective, constraints, or success criteria**. If you spot a misunderstanding, reply with a correction via `SendMessage` before any other action — the agent is already working, so the correction window is short. Prevents **misunderstanding disguised as agreement** from going undetected until TEST phase. Once decided, follow the [Acceptance or Rejection two-call atomic pair](#completion-authority).
+
+### Directive-Reflection Check
+
+Before acting on ANY teammate protocol-boundary message — a teachback submit, a
+HANDOFF notify, a staged-work report you are about to commit, a blocker report —
+verify that every directive you sent that teammate MID-TURN (scope amendments,
+corrections, re-instructions) is actually reflected in the deliverable the boundary
+message describes. Delivery is not processing: a directive delivered while the
+teammate was mid-turn does not render in their context until a later turn boundary,
+so their boundary message can faithfully describe a deliverable that silently
+predates your directive.
+
+- Track outstanding mid-turn directives per teammate (a task-metadata note
+  suffices); at each boundary message, tick them off against the reported scope.
+  This extends [Validating Incoming Teachbacks](#validating-incoming-teachbacks):
+  that check compares the teachback against the task AS DISPATCHED; this check
+  compares the deliverable against directives sent AFTER dispatch.
+- The staged-work-to-commit boundary is the highest-stakes instance: compare the
+  reported stage scope (`git diff --cached --stat`) against every outstanding
+  amendment BEFORE committing. A mismatch means hold the commit and re-instruct.
+- Teammate-side complement: teammates drain their inbox before composing boundary
+  messages and state the drain in the message (see
+  [pact-agent-teams §Boundary-Drain Rule](../skills/pact-agent-teams/SKILL.md#boundary-drain-rule)).
+  A `boundary-drain: inbox empty` report shifts the residual risk to messages still
+  in flight at drain time — your reflection check is the backstop either way, and a
+  boundary message with NO drain report is itself a signal to check more carefully.
+
+A deliverable that reflects pre-directive scope because your directive crossed it
+in flight is a no-fault ordering artifact: reject with corrections naming the
+current scope (per [Rejection Flow](#rejection-flow)) — do not treat it as the
+teammate misunderstanding the original dispatch.
 
 ---
 

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -2138,9 +2138,10 @@ from "idle because the teammate stalled".
    of the teammate's task (raw JSON — `TaskGet` is metadata-blind). If the read
    shows the wait resolved AND acted on (e.g., the follow-on task claimed), do
    nothing: the wake landed.
-2. **If the durable read shows the wait unresolved**, send exactly ONE redundant
-   confirm naming the actionable durable state (e.g., "your teachback on Task A was
-   accepted and A is completed on disk; Task B is claimable now"). Name the state,
+2. **If the durable read shows the wait resolved but not yet acted on (or
+   unresolved)**, send exactly ONE redundant confirm naming the actionable durable
+   state (e.g., "your teachback on Task A was accepted and A is completed on disk;
+   Task B is claimable now"). Name the state,
    not "checking in" — the confirm must let the teammate act from it alone, because
    it may render before your original wake.
 3. **Further idle ticks are NOT stalls.** After the one redundant confirm, send no
@@ -2150,7 +2151,7 @@ from "idle because the teammate stalled".
    AND no inbound SendMessage from the teammate across multiple idle cycles well
    past your wake-send.
 
-**Non-goal — no hook-based detection.** Do not attempt to close this race with a
+**Non-goal — no synchronous hook-based detection.** Do not attempt to close this race with a
 synchronous hook, and reject future proposals to reintroduce one: `SendMessage`
 fires no PreToolUse/PostToolUse event; inbox files are written asynchronously on
 delivery; TeammateIdle notifications fire at turn-end regardless of what has just

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -1450,7 +1450,13 @@ Skip for simple features or when "just build it."
 - Task status in `TaskList` shows `in_progress` but no `SendMessage` activity from the teammate
 - Teammate process terminated without sending a completion message or blocker via `SendMessage`
 
-Detection is event-driven: check at signal monitoring points (after dispatch, on TeammateIdle events, on `SendMessage` receipt). If a teammate goes idle without sending a completion message or blocker, treat as stalled immediately.
+Detection is event-driven: check at signal monitoring points (after dispatch, on TeammateIdle events, on `SendMessage` receipt). If a teammate goes idle without sending a completion message or blocker, treat as
+stalled immediately — UNLESS the idle plausibly postdates a wake-signal you just
+sent or the task carries a live `intentional_wait`: those idles are
+delivery-ordering artifacts, not stalls. Apply the one-redundant-confirm rule in
+[pact-completion-authority.md](pact-completion-authority.md#crossed-wake-idles-one-redundant-confirm-then-stop)
+and escalate to stall diagnosis only on task-file-mtime plus sustained-silence
+evidence.
 
 **Relationship to agent state model**: Stall detection is the binary endpoint (active vs. stalled). For finer-grained mid-execution assessment (converging/exploring/stuck), see the agent state model in [pact-variety.md](pact-variety.md#agent-state-model). An agent assessed as "stuck" via progress signals may stall if not intervened upon.
 

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -37,10 +37,10 @@ A reply to the user that contains content the team-lead needs to act on (a block
 1. Check `TaskList` for tasks assigned to you (by your name)
 2. Claim your assigned task: `TaskUpdate(taskId, status="in_progress")`
 3. Read the task description — it contains your full mission (CONTEXT, MISSION, INSTRUCTIONS, GUIDELINES). If upstream tasks are referenced, read them via `TaskGet`.
-4. **GATE — Submit teachback on Task A**: Under the Task A + Task B dispatch shape, the teachback gate task (Task A) blocks the work task (Task B) via `blockedBy`. Store your teachback in `metadata.teachback_submit` on Task A per the [pact-teachback](../pact-teachback/SKILL.md) skill, **notify the team-lead via SendMessage**, SET `intentional_wait{reason=awaiting_lead_completion}`, and idle. **Ordering invariant**: metadata write FIRST → SendMessage SECOND → `intentional_wait` SET THIRD (load-bearing; see [pact-teachback §Action: store teachback now](../pact-teachback/SKILL.md#action-store-teachback-now) for rationale). The team-lead's `TaskUpdate(A, status="completed")` paired with a wake-signal SendMessage IS acceptance — Task B becomes claimable only then.
+4. **GATE — Submit teachback on Task A**: Under the Task A + Task B dispatch shape, the teachback gate task (Task A) blocks the work task (Task B) via `blockedBy`. Store your teachback in `metadata.teachback_submit` on Task A per the [pact-teachback](../pact-teachback/SKILL.md) skill, **notify the team-lead via SendMessage**, SET `intentional_wait{reason=awaiting_lead_completion}`, and idle. **Ordering invariant**: metadata write FIRST → SendMessage SECOND → `intentional_wait` SET THIRD (load-bearing; see [pact-teachback §Action: store teachback now](../pact-teachback/SKILL.md#action-store-teachback-now) for rationale). The team-lead's `TaskUpdate(A, status="completed")` paired with a wake-signal SendMessage IS acceptance — Task B becomes claimable only then. The teachback notify is a protocol-boundary message — run the [Boundary-Drain Rule](#boundary-drain-rule) before composing it: a scope change that crossed your in-flight turn must be reflected in the teachback you submit, not discovered after acceptance.
    - **DO NOT** call `Edit`, `Write`, or `Bash` for implementation work before storing your teachback
    - See [Teachback](#teachback-conversation-verification) below for the full skill reference
-5. **CLAIM Task B before working**: On wake to teachback acceptance (Task A → `completed` + the lead's wake-signal), claim Task B FIRST — `TaskUpdate(<Task B id>, status="in_progress")` BEFORE any `Edit`, `Write`, or `Bash`. Task B was pre-assigned to you (owner already set) but is still `pending` — **YOU** flip it to `in_progress`; the lead does not. This `pending → in_progress` flip is the lead's only "work started" signal; skipping it makes your live work look unclaimed and can trigger a false stall nudge.
+5. **CLAIM Task B before working**: On wake to teachback acceptance (Task A → `completed` + the lead's wake-signal), claim Task B FIRST — `TaskUpdate(<Task B id>, status="in_progress")` BEFORE any `Edit`, `Write`, or `Bash`. Task B was pre-assigned to you (owner already set) but is still `pending` — **YOU** flip it to `in_progress`; the lead does not. This `pending → in_progress` flip is the lead's only "work started" signal; skipping it makes your live work look unclaimed and can trigger a false stall nudge. The durable Task A read is authoritative: if Task A already shows `completed` on disk, claim Task B and proceed even if the wake-signal message is not yet visible — wake messages can trail the status flip (see [§On Wake: Disk-First Re-Read](#on-wake-disk-first-re-read-seam-agnostic)).
 6. Begin work on Task B — check your agent memory (`~/.claude/agent-memory/<your-name>/`) for relevant patterns and knowledge as part of your working process. When a memory file may be written by concurrent same-named instances across teams, namespace per team (a `## team={your team_id}` section) so instances don't clobber each other.
 
 > **Worktree Scope**: If you are working in a worktree, files that are gitignored (e.g., `CLAUDE.md`) do not exist there. Do not edit or create `CLAUDE.md` — the orchestrator manages it separately. If you need to reference `CLAUDE.md` content, it is auto-loaded into your context. If your task mentions updating `CLAUDE.md`, flag it in your handoff instead of editing it directly.
@@ -120,6 +120,44 @@ Challenge format:
 For consequence-level disagreements:
 > "Concern: [what will go wrong and why]. I'd suggest [alternative]. Flagging this in the HANDOFF regardless."
 
+## Boundary-Drain Rule
+
+Immediately BEFORE composing any protocol-boundary message — a teachback submit
+notify, a HANDOFF notify, a blocker report, or any report that initiates a
+lead-resolved wait (e.g., a staged-work report preceding `awaiting_lead_commit`) —
+you MUST drain your inbox: read
+`~/.claude/teams/{team-name}/inboxes/{your-name}.json` and reconcile any directives
+it contains into your deliverable FIRST. A directive delivered while you are
+mid-turn does not render in your context until a later turn boundary; the boundary
+message is the team-lead's basis for acting on your work, and the drain is your
+last chance to look before they act on your word. This rule applies identically
+under in-process and tmux teammateMode.
+
+Drain mechanics — all four points are load-bearing:
+
+- **Read-only.** Read the inbox file; NEVER write, truncate, or delete it — the
+  platform owns delivery.
+- **Use the Read tool**, not a piped Bash command — Bash permission patterns on
+  `~/.claude/` paths are fragile (see §Bash Commands in ~/.claude/ Paths). The file
+  is a JSON list of pending messages (`from`, `text`, `summary`, `timestamp`); an
+  empty list means nothing is awaiting delivery to you.
+- **Best-effort, fail-safe.** The inbox write is asynchronous: an empty read is NOT
+  a guarantee nothing is in flight, and a read error or missing file means "report
+  the drain as unavailable and proceed", never "block". The drain narrows the miss
+  window; the team-lead's directive-reflection check is the backstop.
+- **Idempotent reconciliation.** Any message you read from the inbox file will ALSO
+  render in your context at a later turn boundary. Reconcile so re-processing is
+  harmless: apply the directive to the deliverable once; when the same message
+  later renders, recognize it as already reconciled — do not re-apply it and do not
+  counter-confirm it (see §Counter-Confirm Suppression).
+
+**State the drain in the boundary message.** Every protocol-boundary message MUST
+carry a one-line drain report: `boundary-drain: inbox empty` or
+`boundary-drain: reconciled <n> directive(s) — <one-line summary>`. This tells the
+team-lead the deliverable already reflects mid-turn directives, or exactly which
+ones it reflects. A boundary message without a drain report tells the team-lead the
+drain may not have run.
+
 ## On Completion — HANDOFF (Required)
 
 When your work is done, you store the HANDOFF and remain `in_progress`. **You do NOT mark your own tasks `completed`** — the team-lead is the authoritative completion signal.
@@ -130,6 +168,9 @@ When your work is done, you store the HANDOFF and remain `in_progress`. **You do
 - All deliverables are staged via `git add`. (`git status` shows your intended changes in "Changes to be committed".)
 - All relevant tests have been run with exit code 0. If no tests apply to your change, you MUST state "no tests applicable" with one-line reasoning in your HANDOFF.
 - The deliverable matches every acceptance criterion in the task description. Tick each one off explicitly before proceeding.
+- The [Boundary-Drain Rule](#boundary-drain-rule) has been executed: your inbox
+  file has been read and any mid-turn directives are reconciled into the
+  deliverable (the HANDOFF notify in Step 2 must carry the drain report).
 
 If ANY precondition is unmet, KEEP WORKING. Do not write `metadata.handoff` to "reserve a spot" or "draft the handoff while tests run." The handoff metadata write is a commitment that the work IS done, NOT a wrap-up artifact you build in parallel with finishing. Phase 2 enforcement (schema field, hook validation, lead-side independent verification) is tracked separately as deferred work.
 
@@ -176,7 +217,7 @@ After wake on acceptance, check `TaskList` for unblocked tasks you OWN or can cl
 
 ## On Rejection (Wake-Signal Receipt)
 
-If the team-lead rejects your teachback or HANDOFF, you wake on the inbound SendMessage. Your task remains `in_progress`; the team-lead has written rejection details to metadata.
+If the team-lead rejects your teachback or HANDOFF, you wake on the inbound SendMessage. Your task remains `in_progress`; the team-lead has written rejection details to metadata. This wake-then-raw-read flow is one instance of the seam-agnostic rule in [§On Wake: Disk-First Re-Read](#on-wake-disk-first-re-read-seam-agnostic); the residual-race mitigation there (never act on a single empty read) applies to the rejection-metadata read below.
 
 **On wake**:
 
@@ -262,15 +303,39 @@ inbox at their next idle boundary, not instantaneously. See
 for verify-before-acting and assume-eventually-seen rules that follow from
 this delivery model.
 
+### Counter-Confirm Suppression
+
+Before sending ANY "crossed messages", "already done", "still awaiting", or similar
+state-clarification message, you MUST take a fresh disk read of the referenced task
+(`status`, `blockedBy`, relevant metadata). If durable state already shows the
+situation resolved — the task you would claim attention for is `completed`, the
+approval or commit you would report as pending is already recorded — send NOTHING.
+Durable state IS the reply: the team-lead reads the same disk. A clarification
+composed from a disk read that predates the team-lead's resolution writes asserts
+state that is false on arrival — pure noise that can seed a politeness loop in both
+directions.
+
+This is the already-resolved specialization of the charter's
+[Verify Before Executing](../../protocols/pact-communication-charter.md#verify-before-executing)
+rule: "no-op and report" still applies when the fresh read shows state has diverged
+in a way the team-lead must act on; when the fresh read shows exactly the state the
+team-lead themselves resolved, the report carries zero information — suppress it.
+
+This suppression rule and [§On Wake: Disk-First Re-Read](#on-wake-disk-first-re-read-seam-agnostic)
+are complements, not substitutes: disk-first fixes how you INTERPRET inbound
+messages; suppression stops stale OUTBOUND noise. Applying one does not discharge
+the other.
+
 ## Intentional Waiting
 
 When your task is `in_progress` but you are legitimately idle awaiting a message
 (teachback approval, inter-commit hold, peer reply, user decision, blocker
 resolution), signal it via the `intentional_wait` task metadata BEFORE going idle.
-There are no in-plugin consumers of this flag; the schema primitives
+This flag has a lead-side consumer: the `missed_wake_scan` hook re-surfaces tasks
+idling on `awaiting_lead_completion` past the staleness threshold at the
+team-lead's next user prompt or session start. The schema primitives
 (`KNOWN_REASONS`, `KNOWN_RESOLVERS`, `wait_stale`) in `shared.intentional_wait`
-are retained as the teammate-facing metadata contract for protocol-defined
-waits. Using the flag documents the wait intent for the team-lead's TaskGet
+define the teammate-facing metadata contract for protocol-defined waits. Using the flag documents the wait intent for the team-lead's TaskGet
 inspection and for post-hoc session review.
 
 ### SET — before going idle
@@ -296,6 +361,53 @@ TaskUpdate(taskId=taskId, metadata={"intentional_wait": None})
 
 Clear on the same turn you take the action that advances state (e.g., when the approval / commit confirmation / peer reply / user decision arrives).
 
+### On Wake: Disk-First Re-Read (Seam-Agnostic)
+
+This rule fires on EVERY wake while you hold ANY `intentional_wait` — every reason
+(`awaiting_lead_completion`, `awaiting_lead_commit`, `awaiting_teachback_approved`,
+and all others), every seam — and, more generally, whenever ANY inbound directive
+could have crossed a turn you had in flight. It applies identically under in-process
+and tmux teammateMode: the race is message-delivery ordering, not mode-specific.
+Inbox delivery is asynchronous, so a wake message can trail the durable write it
+describes, arrive after an unrelated message, or describe a scope your in-flight
+work predates.
+
+1. **Re-read durable state FIRST.** Before acting on any wake-message content,
+   re-read your gate/work tasks from disk — `status`, `blockedBy`, current
+   description, and the relevant metadata keys (`teachback_rejection`,
+   `handoff_rejection`, or whichever key your wait names). Use the raw task file
+   (`~/.claude/tasks/{team_name}/{taskId}.json` via the Read tool) — `TaskGet` does
+   not surface metadata.
+2. **Durable state is authoritative; message content is advisory confirmation.** If
+   durable state shows your wait resolved — the gate task `completed`, a commit
+   confirmation implied by task state, a rejection record present — CLEAR the wait
+   and proceed immediately, even if no wake message describing the resolution is
+   visible yet. Do not wait for the message that durable state has already made
+   redundant.
+3. **If durable state shows the wait unresolved, keep waiting.** A wake that
+   resolves nothing (a crossed or redundant message, a peer ping) gets no reply —
+   return to idle silently per §Idle Discipline and §Counter-Confirm Suppression.
+   If the wake ASSERTS a resolution the disk does not yet show (e.g., "rejected —
+   see metadata" but the metadata read returns empty), the durable write may still
+   be in flight: re-read once after a brief pause; never act on a single empty
+   read; if still empty, keep waiting — the team-lead's follow-up confirm covers
+   the crossed case.
+4. **Crossed mid-turn directives reconcile the same way.** If an inbound directive
+   (a scope change, a correction) could have crossed work you had in flight — your
+   teachback or HANDOFF was being composed when it was sent — re-read the task's
+   CURRENT description and metadata from disk and act on the current state, not on
+   the state your in-flight work assumed. If your already-submitted deliverable
+   reflects the pre-directive scope, revise it on the same task without waiting to
+   be asked.
+
+This rule generalizes the wake-then-raw-read flow of §On Rejection to every wait
+resolution, and it is what makes the team-lead's wake message redundant-by-design:
+ordering-immune at every seam, with no hook required (a synchronous wake-detection
+hook cannot exist — see the non-goal note in
+[pact-completion-authority](../../protocols/pact-completion-authority.md#crossed-wake-idles-one-redundant-confirm-then-stop)).
+The no-poll discipline is unchanged: you still cannot poll while idle; this rule
+fires ON wake, whatever woke you.
+
 ### Vocabulary
 
 | Field | Required | Accepted values |
@@ -309,8 +421,9 @@ Unknown keys are preserved (forward-compat).
 ### Staleness safeguard
 
 The `wait_stale` primitive in `shared.intentional_wait` considers the flag stale after 30
-minutes from `since`. No hook currently enforces this — it's advisory metadata the team-lead may
-inspect via TaskGet. If your wait genuinely takes longer, re-SET with a fresh `since` so
+minutes from `since`. The `missed_wake_scan` hook surfaces `awaiting_lead_completion` waits stale past
+this threshold to the team-lead; for all other reasons the flag is advisory
+metadata the team-lead may inspect via TaskGet. If your wait genuinely takes longer, re-SET with a fresh `since` so
 later inspection reflects the real duration.
 
 ### When NOT to set
@@ -340,6 +453,10 @@ If you cannot proceed:
    ```
 3. Provide a partial HANDOFF with whatever work you completed
 4. Wait for team-lead's response or new instructions
+
+A blocker report is a protocol-boundary message: run the
+[Boundary-Drain Rule](#boundary-drain-rule) before composing it — a mid-turn
+directive may already resolve or re-scope the blocker.
 
 Do not attempt to work around the blocker.
 

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -139,8 +139,9 @@ Drain mechanics — all four points are load-bearing:
   platform owns delivery.
 - **Use the Read tool**, not a piped Bash command — Bash permission patterns on
   `~/.claude/` paths are fragile (see §Bash Commands in ~/.claude/ Paths). The file
-  is a JSON list of pending messages (`from`, `text`, `summary`, `timestamp`); an
-  empty list means nothing is awaiting delivery to you.
+  is a JSON list of pending messages; each message carries `from`, `text`,
+  `timestamp`, and `type` (act on `from` + `text`; other fields vary by platform
+  version). An empty list means nothing is awaiting delivery to you.
 - **Best-effort, fail-safe.** The inbox write is asynchronous: an empty read is NOT
   a guarantee nothing is in flight, and a read error or missing file means "report
   the drain as unavailable and proceed", never "block". The drain narrows the miss
@@ -192,7 +193,7 @@ If ANY precondition is unmet, KEEP WORKING. Do not write `metadata.handoff` to "
 2. **Notify the team-lead**:
    ```
    SendMessage(to="team-lead",
-     message="[{sender}→team-lead] Task complete. [1-2 sentences: what was done + any HIGH uncertainties]",
+     message="[{sender}→team-lead] Task complete. [1-2 sentences: what was done + any HIGH uncertainties] boundary-drain: [inbox empty | reconciled <n> directive(s) — <one-line summary>]",
      summary="Task complete: [brief]")
    ```
 

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -126,7 +126,7 @@ Immediately BEFORE composing any protocol-boundary message — a teachback submi
 notify, a HANDOFF notify, a blocker report, or any report that initiates a
 lead-resolved wait (e.g., a staged-work report preceding `awaiting_lead_commit`) —
 you MUST drain your inbox: read
-`~/.claude/teams/{team-name}/inboxes/{your-name}.json` and reconcile any directives
+`~/.claude/teams/{team_name}/inboxes/{your-name}.json` and reconcile any directives
 it contains into your deliverable FIRST. A directive delivered while you are
 mid-turn does not render in your context until a later turn boundary; the boundary
 message is the team-lead's basis for acting on your work, and the drain is your
@@ -266,7 +266,7 @@ Items 1-2 and 4-6 are required. Item 3 (reasoning chain) is recommended — incl
 ## Peer Communication
 
 Use `SendMessage(to="teammate-name")` for direct coordination.
-Discover teammates via `~/.claude/teams/{team-name}/config.json` or from peer names
+Discover teammates via `~/.claude/teams/{team_name}/config.json` or from peer names
 in your task description.
 
 **Message a peer when:**

--- a/pact-plugin/skills/pact-teachback/SKILL.md
+++ b/pact-plugin/skills/pact-teachback/SKILL.md
@@ -121,7 +121,8 @@ SendMessage(
     to="team-lead",
     message=(
         "[<your-agent-name>→team-lead] Teachback submitted on Task #<A_id>. "
-        "See metadata.teachback_submit. Idling on awaiting_lead_completion."
+        "See metadata.teachback_submit. Idling on awaiting_lead_completion. "
+        "boundary-drain: [inbox empty | reconciled <n> directive(s) — <one-line summary>]"
     ),
     summary="Teachback submitted: <topic>"
 )

--- a/pact-plugin/tests/test_wake_ordering_pinned.py
+++ b/pact-plugin/tests/test_wake_ordering_pinned.py
@@ -55,6 +55,7 @@ Monitor-signal token was present there). Restore with git checkout HEAD --
 recorded in the module-level comment at the bottom of this file.
 """
 
+import re
 from pathlib import Path
 
 import pytest
@@ -80,6 +81,24 @@ def _normalized(path: Path) -> str:
     match against this so an intentional re-wrap of a rule sentence does
     not fail the pin while a re-WORD still does."""
     return " ".join(_raw(path).split())
+
+
+def _lines_outside_fences(path: Path) -> list:
+    """Stripped lines of the file, excluding fenced-code-block content and
+    the fence delimiter lines themselves. A heading-shaped line inside a
+    ``` / ~~~ fence is example text, not a real section heading, and must
+    not satisfy a heading pin (a section deletion that leaves behind a
+    fenced example of its own heading would otherwise stay green)."""
+    lines = []
+    in_fence = False
+    for line in _raw(path).splitlines():
+        stripped = line.strip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            lines.append(stripped)
+    return lines
 
 
 # ---------------------------------------------------------------------------
@@ -109,8 +128,10 @@ def test_rule_heading_present(doc_path: Path, heading: str):
     """Each new rule section must exist as an exact heading line so the
     section is discoverable and its anchor slug is a stable cross-ref
     target. Line-anchored: `#### X` must NOT satisfy a `### X` pin (and
-    vice versa) — heading LEVEL is part of the document contract."""
-    lines = [line.strip() for line in _raw(doc_path).splitlines()]
+    vice versa) — heading LEVEL is part of the document contract. Fenced
+    code blocks are excluded: a heading-shaped line inside an example
+    fence is not a real section."""
+    lines = _lines_outside_fences(doc_path)
     assert heading in lines, (
         f"{doc_path.name}: heading {heading!r} not found as an exact line. "
         f"If the section was intentionally renamed or re-leveled, update "
@@ -143,6 +164,26 @@ PHRASE_PINS = [
     # in-plugin consumers" claim was stale and contradicted the no-hook
     # non-goal note's framing).
     (SKILL, "missed_wake_scan"),
+    # Counter-confirm suppression's operative outcome: when a fresh disk
+    # read shows the situation already resolved, the clarification is
+    # suppressed entirely. Without body pins the section heading survives
+    # a rewrite that guts the rule (verified at authoring time: the whole
+    # section body deleted with every other pin staying green).
+    (SKILL, "send NOTHING"),
+    (SKILL, "Durable state IS the reply"),
+    # The read-only clause of the drain mechanics: the inbox file is
+    # platform-owned; agents must never mutate it.
+    (SKILL, "NEVER write, truncate, or delete"),
+    # The single-empty-read rule's HOME (the On Wake residual-race step).
+    # The shorter "never act on a single empty read" pin above is ALSO
+    # satisfied by the On-Rejection parenthetical cross-ref, so deleting
+    # the rule home alone would keep that pin green; this longer contiguous
+    # span exists only at the rule home.
+    (SKILL, "re-read once after a brief pause; never act on a single empty read"),
+    # The crossed mid-turn directive rule: an already-submitted deliverable
+    # that reflects pre-directive scope is revised proactively, not on
+    # request.
+    (SKILL, "revise it on the same task without waiting to be asked"),
     # --- lead-side completion-authority (+ byte-mirrored SSOT region) ---
     (COMPLETION_AUTHORITY, "exactly ONE redundant confirm"),
     # The behavioral no-hook non-goal note: the race cannot be closed with
@@ -153,11 +194,16 @@ PHRASE_PINS = [
     (COMPLETION_AUTHORITY, "boundary-drain: inbox empty"),
     # The evidence bar for escalating an idle to stall diagnosis.
     (COMPLETION_AUTHORITY, "task-file-mtime plus sustained-silence"),
+    # The directive-reflection aphorism naming the failure mode the check
+    # exists for. Matching is case-sensitive by design; this surface carries
+    # the sentence-initial capitalized form.
+    (COMPLETION_AUTHORITY, "Delivery is not processing"),
     (PROTOCOLS_SSOT, "exactly ONE redundant confirm"),
     (PROTOCOLS_SSOT, "Synchronous wake/send detection is therefore dead-by-construction"),
     (PROTOCOLS_SSOT, "in-process and tmux teammateMode"),
     (PROTOCOLS_SSOT, "boundary-drain: inbox empty"),
     (PROTOCOLS_SSOT, "task-file-mtime plus sustained-silence"),
+    (PROTOCOLS_SSOT, "Delivery is not processing"),
     # --- orchestrator persona ---
     (ORCHESTRATOR, "exactly ONE redundant confirm"),
     # The Wait-in-Silence rule's single protocol-defined exception — without
@@ -171,6 +217,10 @@ PHRASE_PINS = [
     (ORCHESTRATOR, "task-file-mtime plus sustained-silence"),
     # Staleness-signal bullet must name the hook that consumes the flag.
     (ORCHESTRATOR, "missed_wake_scan"),
+    # Same aphorism as the completion-authority pin above; this surface
+    # carries the mid-sentence lowercase form (per-surface casing is
+    # deliberate — do not normalize case to unify these pins).
+    (ORCHESTRATOR, "delivery is not processing"),
     # --- stall-detection protocol (+ byte-mirrored SSOT region) ---
     # The harmonizing exception: post-wake / live-intentional_wait idles are
     # not stall evidence.
@@ -239,8 +289,11 @@ def test_cross_ref_slug_present(doc_path: Path, slug: str):
     """Each referrer surface must carry the literal anchor slug so the
     lazy-load reference resolves. Pin the slug rather than prose link text
     — the slug is what GitHub-flavored markdown navigates to, and a heading
-    rename that forgets a referrer leaves a 404 nav target."""
-    assert slug in _raw(doc_path), (
+    rename that forgets a referrer leaves a 404 nav target. The match is
+    terminator-guarded: the slug must not continue with slug characters
+    ([a-z0-9-]), so a longer future slug that prefix-engulfs a pinned one
+    (e.g. `...-check` inside `...-checklist`) does not satisfy the pin."""
+    assert re.search(re.escape(slug) + r"(?![a-z0-9-])", _raw(doc_path)), (
         f"{doc_path.name}: anchor slug {slug!r} not found. Either the "
         f"cross-ref was removed (the lazy-load path to the full rule is "
         f"gone) or the target heading was renamed without updating this "
@@ -313,11 +366,21 @@ def test_retired_inbox_grew_token_absent(doc_path: Path):
 # ---------------------------------------------------------------------------
 # Counter-test flip-set record (measured at authoring time; see module
 # docstring). With the five surfaces reverted to their pre-hardening state
-# and this module run against them: {45 failed, 8 passed}. Heading pins
-# 8/8 RED, phrase pins 25/25 RED (no pinned phrase pre-existed on any
+# and this module run against them: {53 failed, 8 passed}. Heading pins
+# 8/8 RED, phrase pins 33/33 RED (no pinned phrase pre-existed on any
 # surface), cross-ref pins 11/11 RED, absence pin RED on
 # pact-orchestrator.md (retired token present pre-fix) and GREEN on the
 # other four surfaces (token never present there). The 8 GREEN =
 # anchor-integrity 4/4 (pure functions of module constants — intentionally
 # revert-immune) + the 4 vacuously-satisfied absence pins.
+# Section-body deletion probes (measured after the body-pin additions):
+# gutting the Counter-Confirm Suppression body while keeping its heading
+# fails exactly its 2 body pins; deleting the On Wake residual-race step
+# fails exactly the rule-home span pin while the shorter single-empty-read
+# pin stays green via the On-Rejection parenthetical.
+# Matcher-robustness probes (measured): rewriting a referrer's slug to a
+# longer slug that prefix-engulfs the pinned one flips the slug pin RED
+# (terminator guard); deleting a section heading while leaving a fenced
+# code example of the same heading line flips the heading pin RED
+# (fence exclusion). Neither hardening changes the flip-set above.
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_wake_ordering_pinned.py
+++ b/pact-plugin/tests/test_wake_ordering_pinned.py
@@ -1,0 +1,323 @@
+"""
+Structural pin tests for the wake/idle message-ordering hardening rules.
+
+Pins the reader-facing instruction surfaces that teach both sides of the
+wake/idle delivery-ordering race:
+
+  teammate-side (skills/pact-agent-teams/SKILL.md):
+    - "On Wake: Disk-First Re-Read (Seam-Agnostic)" — durable state is
+      authoritative on every wake; message content is advisory.
+    - "Counter-Confirm Suppression" — fresh disk read before any
+      state-clarification message; suppress when already resolved.
+    - "Boundary-Drain Rule" — inbox drain + drain report before every
+      protocol-boundary message.
+  lead-side (protocols/pact-completion-authority.md + its byte-mirrored
+  region in protocols/pact-protocols.md, and agents/pact-orchestrator.md):
+    - "Crossed-Wake Idles: One Redundant Confirm, Then Stop" — including
+      the behavioral non-goal note that synchronous wake/send detection is
+      dead-by-construction.
+    - "Directive-Reflection Check" — mid-turn directives verified against
+      boundary-message deliverables before acting.
+  stall-detection (protocols/pact-agent-stall.md + its byte-mirrored
+  region in pact-protocols.md):
+    - post-wake / live-intentional_wait idles are delivery-ordering
+      artifacts, not stalls.
+
+PRESENCE pins, not counts. Unlike the Read-Trigger marker phrase (see
+test_read_trigger_precondition_pinned.py EXPECTED_COUNTS), none of these
+phrases is intended to recur a fixed number of times per surface, so count
+pins would add lockstep-maintenance cost without catching a real erosion
+shape. No new EXPECTED_COUNTS-style lockstep is introduced by this module.
+
+PHRASES, not line shapes. Several pinned sentences are hard-wrapped in the
+shipped markdown and several rule sentences share a line with pre-existing
+list-item text (semantically identical markdown renderings). Phrase pins
+therefore match against whitespace-NORMALIZED text (`" ".join(text.split())`)
+so they survive re-wrapping; heading pins match line-anchored raw lines
+(per the section-presence convention in test_read_trigger_precondition_
+pinned.py — substring matching for headings is a phantom-green shape: an
+H4 line contains its H3 prefix as a substring).
+
+Mirror discipline: pact-protocols.md is pinned as its own surface for every
+phrase that lives in a byte-mirrored region (Completion Authority, Agent
+Stall Detection). verify-protocol-extracts.sh enforces byte-parity upstream;
+the duplicate pins here match the actual reader-facing surface set rather
+than relying solely on the upstream script (same rationale as DOC_SURFACES
+in test_read_trigger_precondition_pinned.py).
+
+Counter-test-by-revert (verified at authoring time): with the five doc
+surfaces reverted to their pre-hardening state (git checkout <pre-fix-ref>
+-- <5 doc paths>), every test in this module fails EXCEPT the absence pins
+(which also pass pre-fix only where the retired token was already absent;
+the orchestrator absence pin goes RED pre-fix because the retired
+Monitor-signal token was present there). Restore with git checkout HEAD --
+<paths>. The exact flip-set cardinality observed at authoring time is
+recorded in the module-level comment at the bottom of this file.
+"""
+
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+
+SKILL = PLUGIN_ROOT / "skills" / "pact-agent-teams" / "SKILL.md"
+COMPLETION_AUTHORITY = PLUGIN_ROOT / "protocols" / "pact-completion-authority.md"
+PROTOCOLS_SSOT = PLUGIN_ROOT / "protocols" / "pact-protocols.md"
+ORCHESTRATOR = PLUGIN_ROOT / "agents" / "pact-orchestrator.md"
+AGENT_STALL = PLUGIN_ROOT / "protocols" / "pact-agent-stall.md"
+
+ALL_SURFACES = [SKILL, COMPLETION_AUTHORITY, PROTOCOLS_SSOT, ORCHESTRATOR, AGENT_STALL]
+
+
+def _raw(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _normalized(path: Path) -> str:
+    """Whitespace-normalized file text: any run of whitespace (including
+    newlines from hard-wrapping) collapses to a single space. Phrase pins
+    match against this so an intentional re-wrap of a rule sentence does
+    not fail the pin while a re-WORD still does."""
+    return " ".join(_raw(path).split())
+
+
+# ---------------------------------------------------------------------------
+# Heading pins — line-anchored exact match.
+# ---------------------------------------------------------------------------
+
+HEADING_PINS = [
+    (SKILL, "### On Wake: Disk-First Re-Read (Seam-Agnostic)"),
+    (SKILL, "### Counter-Confirm Suppression"),
+    (SKILL, "## Boundary-Drain Rule"),
+    (COMPLETION_AUTHORITY, "### Crossed-Wake Idles: One Redundant Confirm, Then Stop"),
+    (COMPLETION_AUTHORITY, "### Directive-Reflection Check"),
+    (PROTOCOLS_SSOT, "### Crossed-Wake Idles: One Redundant Confirm, Then Stop"),
+    (PROTOCOLS_SSOT, "### Directive-Reflection Check"),
+    # The orchestrator persona carries a summary of the lead-side check as
+    # an H4 under its Teachback Review section (not a full H3 mirror).
+    (ORCHESTRATOR, "#### Directive-Reflection Check"),
+]
+
+
+@pytest.mark.parametrize(
+    "doc_path, heading",
+    HEADING_PINS,
+    ids=[f"{p.name}::{h.lstrip('# ')[:40]}" for p, h in HEADING_PINS],
+)
+def test_rule_heading_present(doc_path: Path, heading: str):
+    """Each new rule section must exist as an exact heading line so the
+    section is discoverable and its anchor slug is a stable cross-ref
+    target. Line-anchored: `#### X` must NOT satisfy a `### X` pin (and
+    vice versa) — heading LEVEL is part of the document contract."""
+    lines = [line.strip() for line in _raw(doc_path).splitlines()]
+    assert heading in lines, (
+        f"{doc_path.name}: heading {heading!r} not found as an exact line. "
+        f"If the section was intentionally renamed or re-leveled, update "
+        f"this pin AND every cross-ref that targets its anchor slug in "
+        f"lockstep (see the anchor-slug tests in this module)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phrase pins — whitespace-normalized presence.
+# ---------------------------------------------------------------------------
+
+PHRASE_PINS = [
+    # --- teammate-side SKILL ---
+    # The load-bearing interpretation rule for every wake.
+    (SKILL, "Durable state is authoritative"),
+    # Residual-race mitigation: a wake asserting a resolution the disk does
+    # not yet show gets a re-read, never a single-empty-read action.
+    (SKILL, "never act on a single empty read"),
+    # The drain-report convention every protocol-boundary message carries.
+    (SKILL, "boundary-drain: inbox empty"),
+    # The fail-safe branch of the drain mechanics: inbox read errors mean
+    # "report unavailable and proceed", never "block". Pinned so the
+    # fail-open wording is not edited away if inbox persistence changes.
+    (SKILL, "report the drain as unavailable and proceed"),
+    # Both-teammateMode applicability is stated in the rule text itself.
+    (SKILL, "in-process and tmux teammateMode"),
+    # The intentional_wait flag's consumer claim must stay accurate: the
+    # missed_wake_scan hook IS a lead-side consumer (the prior "no
+    # in-plugin consumers" claim was stale and contradicted the no-hook
+    # non-goal note's framing).
+    (SKILL, "missed_wake_scan"),
+    # --- lead-side completion-authority (+ byte-mirrored SSOT region) ---
+    (COMPLETION_AUTHORITY, "exactly ONE redundant confirm"),
+    # The behavioral no-hook non-goal note: the race cannot be closed with
+    # a synchronous hook (SendMessage fires no hook event; inbox writes are
+    # asynchronous-on-delivery; idle notifications are content-blind).
+    (COMPLETION_AUTHORITY, "Synchronous wake/send detection is therefore dead-by-construction"),
+    (COMPLETION_AUTHORITY, "in-process and tmux teammateMode"),
+    (COMPLETION_AUTHORITY, "boundary-drain: inbox empty"),
+    # The evidence bar for escalating an idle to stall diagnosis.
+    (COMPLETION_AUTHORITY, "task-file-mtime plus sustained-silence"),
+    (PROTOCOLS_SSOT, "exactly ONE redundant confirm"),
+    (PROTOCOLS_SSOT, "Synchronous wake/send detection is therefore dead-by-construction"),
+    (PROTOCOLS_SSOT, "in-process and tmux teammateMode"),
+    (PROTOCOLS_SSOT, "boundary-drain: inbox empty"),
+    (PROTOCOLS_SSOT, "task-file-mtime plus sustained-silence"),
+    # --- orchestrator persona ---
+    (ORCHESTRATOR, "exactly ONE redundant confirm"),
+    # The Wait-in-Silence rule's single protocol-defined exception — without
+    # it, the persona's no-reply-to-idle-turns reflex suppresses the one
+    # legitimate redundant confirm.
+    (ORCHESTRATOR, "the single redundant confirm after a crossed wake"),
+    # The replacement content-arrival signal after the Read-Trigger rule was
+    # reframed from the retired Monitor-token 4-point form to 3 points.
+    (ORCHESTRATOR, "wake-signal SendMessage is the content-arrival signal"),
+    (ORCHESTRATOR, "boundary-drain:"),
+    (ORCHESTRATOR, "task-file-mtime plus sustained-silence"),
+    # Staleness-signal bullet must name the hook that consumes the flag.
+    (ORCHESTRATOR, "missed_wake_scan"),
+    # --- stall-detection protocol (+ byte-mirrored SSOT region) ---
+    # The harmonizing exception: post-wake / live-intentional_wait idles are
+    # not stall evidence.
+    (AGENT_STALL, "delivery-ordering artifacts, not stalls"),
+    (AGENT_STALL, "task-file-mtime plus sustained-silence"),
+    (PROTOCOLS_SSOT, "delivery-ordering artifacts, not stalls"),
+]
+
+
+@pytest.mark.parametrize(
+    "doc_path, phrase",
+    PHRASE_PINS,
+    ids=[f"{p.name}::{ph[:40]}" for p, ph in PHRASE_PINS],
+)
+def test_rule_phrase_present(doc_path: Path, phrase: str):
+    """Each load-bearing rule phrase must be present on its surface.
+    Matching is whitespace-normalized: hard-wrap and same-line-rider
+    renderings both satisfy the pin; a re-WORD does not. If a phrase was
+    changed intentionally, update the pin in lockstep — otherwise the rule
+    has eroded on a surface an LLM loads at runtime."""
+    normalized_phrase = " ".join(phrase.split())
+    assert normalized_phrase in _normalized(doc_path), (
+        f"{doc_path.name}: rule phrase {phrase!r} not found "
+        f"(whitespace-normalized match). If the wording was changed "
+        f"intentionally, update this pin in lockstep; otherwise the "
+        f"wake-ordering rule this phrase carries is missing from a "
+        f"runtime-loaded surface."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cross-ref pins — literal anchor slugs (what markdown actually navigates to).
+# ---------------------------------------------------------------------------
+
+CROSSED_WAKE_SLUG = "#crossed-wake-idles-one-redundant-confirm-then-stop"
+DIRECTIVE_REFLECTION_SLUG = "#directive-reflection-check"
+ON_WAKE_SLUG = "#on-wake-disk-first-re-read-seam-agnostic"
+BOUNDARY_DRAIN_SLUG = "#boundary-drain-rule"
+
+CROSS_REF_PINS = [
+    # Orchestrator persona lazy-loads the full rules from the protocol.
+    (ORCHESTRATOR, CROSSED_WAKE_SLUG),
+    (ORCHESTRATOR, DIRECTIVE_REFLECTION_SLUG),
+    # SKILL forward-links the teammate-side rules to the lead-side rule and
+    # to its own sections.
+    (SKILL, CROSSED_WAKE_SLUG),
+    (SKILL, ON_WAKE_SLUG),
+    (SKILL, BOUNDARY_DRAIN_SLUG),
+    # Completion-authority links back to the teammate-side complements.
+    (COMPLETION_AUTHORITY, ON_WAKE_SLUG),
+    (COMPLETION_AUTHORITY, BOUNDARY_DRAIN_SLUG),
+    (PROTOCOLS_SSOT, ON_WAKE_SLUG),
+    (PROTOCOLS_SSOT, BOUNDARY_DRAIN_SLUG),
+    # Stall protocol delegates the crossed-wake handling to the rule.
+    (AGENT_STALL, CROSSED_WAKE_SLUG),
+    (PROTOCOLS_SSOT, CROSSED_WAKE_SLUG),
+]
+
+
+@pytest.mark.parametrize(
+    "doc_path, slug",
+    CROSS_REF_PINS,
+    ids=[f"{p.name}::{s.lstrip('#')[:40]}" for p, s in CROSS_REF_PINS],
+)
+def test_cross_ref_slug_present(doc_path: Path, slug: str):
+    """Each referrer surface must carry the literal anchor slug so the
+    lazy-load reference resolves. Pin the slug rather than prose link text
+    — the slug is what GitHub-flavored markdown navigates to, and a heading
+    rename that forgets a referrer leaves a 404 nav target."""
+    assert slug in _raw(doc_path), (
+        f"{doc_path.name}: anchor slug {slug!r} not found. Either the "
+        f"cross-ref was removed (the lazy-load path to the full rule is "
+        f"gone) or the target heading was renamed without updating this "
+        f"referrer."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Anchor-slug integrity — pinned headings must slugify to the slugs the
+# referrers actually use, so a heading rename cannot silently strand them.
+# ---------------------------------------------------------------------------
+
+
+def _github_slug(heading: str) -> str:
+    """GitHub-flavored-markdown anchor slug for a heading line: strip the
+    leading hashes, lowercase, drop everything but alphanumerics, spaces,
+    and hyphens, then hyphenate spaces."""
+    text = heading.lstrip("#").strip().lower()
+    kept = "".join(ch for ch in text if ch.isalnum() or ch in " -")
+    return "#" + kept.replace(" ", "-")
+
+
+ANCHOR_INTEGRITY = [
+    ("### Crossed-Wake Idles: One Redundant Confirm, Then Stop", CROSSED_WAKE_SLUG),
+    ("### Directive-Reflection Check", DIRECTIVE_REFLECTION_SLUG),
+    ("### On Wake: Disk-First Re-Read (Seam-Agnostic)", ON_WAKE_SLUG),
+    ("## Boundary-Drain Rule", BOUNDARY_DRAIN_SLUG),
+]
+
+
+@pytest.mark.parametrize(
+    "heading, expected_slug",
+    ANCHOR_INTEGRITY,
+    ids=[s.lstrip("#")[:40] for _, s in ANCHOR_INTEGRITY],
+)
+def test_heading_slugifies_to_referenced_anchor(heading: str, expected_slug: str):
+    """The pinned heading text must derive exactly the anchor slug the
+    referrer surfaces use. Combined with the heading-presence and
+    slug-presence pins above, this closes the rename loop: a heading
+    rename fails here unless every referrer moves in lockstep."""
+    assert _github_slug(heading) == expected_slug, (
+        f"Heading {heading!r} slugifies to {_github_slug(heading)!r} but "
+        f"referrers link {expected_slug!r} — the cross-refs would be 404 "
+        f"nav targets."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Absence pin — retired Monitor-signal token.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("doc_path", ALL_SURFACES, ids=lambda p: p.name)
+def test_retired_inbox_grew_token_absent(doc_path: Path):
+    """Regression guard: the Read-Trigger Precondition rule was reframed
+    to key on the wake-signal SendMessage as the content-arrival signal;
+    the Monitor INBOX_GREW event is an alarm clock, not a content marker,
+    and teaching it as part of the read-trigger rule was the drift this
+    change removed. The token must not reappear on any of these surfaces —
+    reintroduction would resurrect the retired signal as instruction text."""
+    assert "INBOX_GREW" not in _raw(doc_path), (
+        f"{doc_path.name}: retired token 'INBOX_GREW' reappeared. The "
+        f"read-trigger rule keys on the wake-signal SendMessage, not the "
+        f"Monitor event; do not reintroduce the event token into "
+        f"instruction surfaces (if a future rule genuinely needs it, "
+        f"update this guard deliberately)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Counter-test flip-set record (measured at authoring time; see module
+# docstring). With the five surfaces reverted to their pre-hardening state
+# and this module run against them: {45 failed, 8 passed}. Heading pins
+# 8/8 RED, phrase pins 25/25 RED (no pinned phrase pre-existed on any
+# surface), cross-ref pins 11/11 RED, absence pin RED on
+# pact-orchestrator.md (retired token present pre-fix) and GREEN on the
+# other four surfaces (token never present there). The 8 GREEN =
+# anchor-integrity 4/4 (pure functions of module constants — intentionally
+# revert-immune) + the 4 vacuously-satisfied absence pins.
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Hardens the Agent Teams instruction surfaces against wake/idle message-ordering races (crossed-wake idles, stale counter-confirms, mid-turn directive misses). Instruction-only — no hooks, no protocol-shape changes; synchronous wake/send detection remains dead-by-construction (unhookable SendMessage + async-on-delivery inbox writes), so the fix makes agents behave correctly *under* the race.

Closes #1081. Follow-up filed: #1088 (pre-existing dangling `#meta-block` anchor, out of scope).

## What landed (5 commits)

1. **`skills/pact-agent-teams/SKILL.md`** — teammate-side: seam-agnostic **On-Wake Disk-First Re-Read** (any `intentional_wait` reason + any crossed inbound directive, per the issue comment's generalized trigger), **Counter-Confirm Suppression** (complement, not substitute), **Boundary-Drain Rule** (mandatory literal inbox-file read before every protocol-boundary message, best-effort/fail-open, idempotent reconciliation, REQUIRED drain statement); fixes stale no-hook claims.
2. **`protocols/pact-completion-authority.md` + `protocols/pact-protocols.md` (byte-identical SSOT mirror) + `agents/pact-orchestrator.md`** — lead-side: **Crossed-Wake Idles: One Redundant Confirm, Then Stop** (incl. the behavioral no-hook non-goal note), **Directive-Reflection Check** (delivery ≠ processing); corrects the stale 4-point-rule summary down to the protocol's 3-point rule (retired token dropped) and stale no-consumer claims.
3. **`protocols/pact-agent-stall.md` + SSOT twin** — harmonizes "treat as stalled immediately" with the new rule: post-wake / live-`intentional_wait` idles are delivery-ordering artifacts, not stalls.
4. **`tests/test_wake_ordering_pinned.py`** — 53 presence pins (line-anchored headings, whitespace-normalized phrases robust to rider/wrap renderings, anchor-slug cross-ref + slug-derivation integrity checks, retired-token absence guards). Counter-tested against pre-hardening text: 45/45 revert-couplable pins flipped RED.
5. **Version bump** → 4.4.52 (PATCH: instruction refinement).

## Why

Live evidence from two orchestration sessions (6+ crossed-wake incidents across three seam types, 5 stale counter-confirms, 1 mid-turn directive miss). The rules were dogfooded during their own implementation: the coder's boundary-drain caught a crossed lead confirm mid-turn and reconciled it idempotently — first in-situ field validation.

## Verification

- All ACs verified against the shipped diff (seam-agnostic wording; both-teammateMode applicability; behavioral no-hook non-goal, zero issue/PR refs in LLM-loaded files; two-call atomic pair + 3-step ordering invariant byte-untouched).
- `verify-protocol-extracts.sh` 19/19 MATCH (mirrors byte-identical by construction — same Edit pair applied to both sides).
- Existing count pins intact ("Ordering invariant" == 3; wake-signal marker phrase 2/2/2/1/2).
- Full suite on the CI-faithful venv (python 3.13 + latest deps per `.github/workflows/tests.yml`): **10430 collected, 0 failed, 0 errors** (explicit errors-token scan).
- Concurrent auditor signal: GREEN (byte-parity, pin counts, verbatim fidelity, cleanliness — verified against `git diff` ground truth).
