### PR TITLE
tests/ unused-import cleanup + F401 CI + L1 gate widening (v4.5.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.5.1",
+      "version": "4.5.2",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,21 +98,23 @@ jobs:
         run: python -m pip install --upgrade pip pytest hypothesis httpx pytest-asyncio ruff
 
       # Import-hygiene lint, two legs. Leg 1: unused imports (F401) + undefined
-      # names (F821) over all consumer-shipped Python (hooks, scripts, telegram,
-      # skills). Leg 2: F821 only, repo-wide including tests/ — F821 is the
+      # names (F821) over all of pact-plugin/ — hooks, scripts, telegram,
+      # skills, AND tests/. Leg 2: F821 only, over the same tree — F821 is the
       # class the behavioral suite structurally cannot reach (undefined names
       # in cold fail-open branches execute only when the rare condition fires).
-      # tests/ is EXCLUDED from the F401 leg: it carries a known pre-existing
-      # unused-import backlog tracked for separate cleanup; widen leg 1 to
-      # pact-plugin/ once that lands. Runs before pytest so a hygiene defect
-      # fails in seconds, not after the multi-minute suite.
+      # Leg 2 is subsumed by leg 1 today; the redundancy is DELIBERATE
+      # structure: it keeps pact-plugin/-wide F821 coverage independent of
+      # leg 1's path list, so a future re-narrowing of leg 1 (e.g. a new
+      # backlog-dir exclusion) cannot silently drop F821 coverage.
+      # Runs before pytest so a hygiene defect fails in seconds, not after
+      # the multi-minute suite.
       # --target-version py39 is LOAD-BEARING: ruff's py37 default false-errors
       # on walrus operators used in the hooks — do not drop the flag.
       # Where an editing session has an LSP server, its diagnostics complement
       # this check at edit time; this step is the mechanical guarantee.
       - name: Import-hygiene lint (F401/F821)
         run: |
-          ruff check --select F401,F821 --target-version py39 pact-plugin/hooks pact-plugin/scripts pact-plugin/telegram pact-plugin/skills
+          ruff check --select F401,F821 --target-version py39 pact-plugin/
           ruff check --select F821 --target-version py39 pact-plugin/
 
       # rootdir must be pact-plugin/ (CWD-relative conftest sys.path + local

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.5.1/       # Plugin version
+│               └── 4.5.2/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.5.1
+> **Version**: 4.5.2
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/tests/test_artifact_paths_durability.py
+++ b/pact-plugin/tests/test_artifact_paths_durability.py
@@ -41,7 +41,6 @@ Run with the 3.13.7 interpreter (default python3 has no pytest):
 
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 
@@ -49,7 +48,6 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
-import shared.pact_context as pact_context  # noqa: E402
 import task_lifecycle_gate as tlg  # noqa: E402
 from shared.session_journal import (  # noqa: E402
     append_event,

--- a/pact-plugin/tests/test_audit_protocol.py
+++ b/pact-plugin/tests/test_audit_protocol.py
@@ -8,7 +8,6 @@ Tests cover:
 4. Auditor agent definition structure
 5. Completion lifecycle: signal-type with audit_summary
 """
-import json
 import sys
 from pathlib import Path
 

--- a/pact-plugin/tests/test_calibration_schema.py
+++ b/pact-plugin/tests/test_calibration_schema.py
@@ -13,7 +13,6 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared.variety_scorer import (
-    LEARNING_II_MIN_MATCHES,
     MAX_SCORE,
     MIN_SCORE,
 )

--- a/pact-plugin/tests/test_checkpoint_builder.py
+++ b/pact-plugin/tests/test_checkpoint_builder.py
@@ -6,7 +6,7 @@ Tests checkpoint assembly, validation, and refresh message generation.
 
 import json
 import os
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 

--- a/pact-plugin/tests/test_claude_md_manager.py
+++ b/pact-plugin/tests/test_claude_md_manager.py
@@ -23,7 +23,6 @@ project CLAUDE.md migration to the PACT_MANAGED boundary structure:
 14. Symlink guard: refuses to operate on symlinks
 """
 
-import os
 import sys
 from pathlib import Path
 

--- a/pact-plugin/tests/test_config_dir_comprehensive.py
+++ b/pact-plugin/tests/test_config_dir_comprehensive.py
@@ -39,7 +39,6 @@ see tests/runbooks/926-config-dir-live-probe.md — platform @-ref resolution
 happens at real session bootstrap, which pytest cannot drive.
 """
 import json
-import os
 from pathlib import Path
 
 import pytest

--- a/pact-plugin/tests/test_config_injection_both_modes.py
+++ b/pact-plugin/tests/test_config_injection_both_modes.py
@@ -43,7 +43,6 @@ from fixtures.role_frames import (
     captured_plain_sessionstart,
     captured_teammate_sessionstart,
     lead_frame_qualified,
-    plain_frame,
     teammate_frame,
 )
 

--- a/pact-plugin/tests/test_dispatch_gate_stale_diagnosis.py
+++ b/pact-plugin/tests/test_dispatch_gate_stale_diagnosis.py
@@ -28,11 +28,9 @@ Reuses the in-process harness from test_dispatch_gate.py (_run_main / _full_setu
 / _seed_team) so the both-modes setup matches the rest of the gate's suite.
 """
 
-import io
 import json
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -44,7 +42,6 @@ from test_dispatch_gate import (  # noqa: E402 — sibling harness reuse
     _full_setup,
     _seed_team,
     _TEAM,
-    _NAME,
 )
 
 # A marker substring unique to the augmentation — asserting on it proves the

--- a/pact-plugin/tests/test_dogfood_livelock_invariant.py
+++ b/pact-plugin/tests/test_dogfood_livelock_invariant.py
@@ -48,13 +48,10 @@ python3 invocation) exits non-blocking, does not emit a systemMessage,
 and does not propagate a blocking exit-2. This subsumes plan R1b.
 """
 import ast
-import errno
 import io
 import json
-import os
 import subprocess
 import sys
-import threading
 from pathlib import Path
 from unittest.mock import patch
 

--- a/pact-plugin/tests/test_emitter_idempotency.py
+++ b/pact-plugin/tests/test_emitter_idempotency.py
@@ -106,7 +106,7 @@ class TestMarkerFailOpen:
         monkeypatch.setenv("HOME", str(tmp_path))
         calls: list[dict] = []
 
-        import agent_handoff_emitter
+        import agent_handoff_emitter  # noqa: F401  # ensure-loaded seam: first-import must precede the Path.mkdir patch below so the injected PermissionError fires at marker-write time, not at module import inside _run_main
         original_mkdir = Path.mkdir
 
         def _mkdir_denied(self_path, *args, **kwargs):

--- a/pact-plugin/tests/test_environment_drift.py
+++ b/pact-plugin/tests/test_environment_drift.py
@@ -12,8 +12,6 @@ import time
 from pathlib import Path
 import sys
 
-import pytest
-
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 

--- a/pact-plugin/tests/test_extract_workflow_state.py
+++ b/pact-plugin/tests/test_extract_workflow_state.py
@@ -5,11 +5,8 @@ Tests the main public API from refresh/__init__.py which is used by
 the PreCompact hook to extract workflow state from transcripts.
 """
 
-import json
 from pathlib import Path
-from unittest.mock import patch
 
-import pytest
 
 import sys
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))

--- a/pact-plugin/tests/test_failure_log.py
+++ b/pact-plugin/tests/test_failure_log.py
@@ -25,11 +25,9 @@ read_failures():
 16. Returns [] on outer exception (fail-open)
 """
 import json
-import os
 import sys
 import threading
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/pact-plugin/tests/test_file_permissions.py
+++ b/pact-plugin/tests/test_file_permissions.py
@@ -9,11 +9,10 @@ Verifies that:
 3. Permission hardening is applied consistently across creation points
 """
 
-import os
 import stat
 import sys
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 

--- a/pact-plugin/tests/test_file_tracker.py
+++ b/pact-plugin/tests/test_file_tracker.py
@@ -16,7 +16,6 @@ import io
 import json
 import os
 import sys
-import time
 from pathlib import Path
 from unittest.mock import patch
 

--- a/pact-plugin/tests/test_file_tracker_composite_key_edges.py
+++ b/pact-plugin/tests/test_file_tracker_composite_key_edges.py
@@ -17,7 +17,6 @@ supplement: the edges that matrix does not exercise —
 
 import json
 
-import pytest
 
 
 class TestCompositeKeyBackwardCompat:

--- a/pact-plugin/tests/test_handoff_ordering_gate.py
+++ b/pact-plugin/tests/test_handoff_ordering_gate.py
@@ -329,7 +329,6 @@ class TestMainRealContextResolution:
     def test_advisory_path_through_real_on_disk_context(
         self, tmp_path, monkeypatch, capsys
     ):
-        import os
         import shared.pact_context as pc
 
         sid = "real-ctx-session-001"

--- a/pact-plugin/tests/test_harness_aware_bootstrap.py
+++ b/pact-plugin/tests/test_harness_aware_bootstrap.py
@@ -70,7 +70,6 @@ cardinality — use SOURCE-ONLY revert of ``pact_context.py`` (GATE 1) /
 measured RED cardinality is documented in this module's HANDOFF.
 """
 
-import hashlib
 import io
 import json
 import sys

--- a/pact-plugin/tests/test_hooks_json.py
+++ b/pact-plugin/tests/test_hooks_json.py
@@ -13,7 +13,6 @@ Tests cover:
 8. SubagentStart matcher covers all PACT agent types
 """
 import json
-import sys
 from pathlib import Path
 
 import pytest

--- a/pact-plugin/tests/test_idle_preamble.py
+++ b/pact-plugin/tests/test_idle_preamble.py
@@ -13,7 +13,7 @@ import io
 import json
 import sys
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 

--- a/pact-plugin/tests/test_import_hygiene.py
+++ b/pact-plugin/tests/test_import_hygiene.py
@@ -18,7 +18,7 @@ Scope boundary — what is swept and why:
     ship to) consumer sessions, so dead imports there are product defects.
     tests/ never ships, but is swept too: the backlog that justified its
     day-one exclusion has been cleared, and the CI ruff leg lints all of
-    pact-plugin/ — this gate sweeps the same tree so the two enforcement
+    pact-plugin/ — this gate sweeps tests/ as well, so the two enforcement
     layers cannot disagree on tests/ scope.
 
 Suppression contract:

--- a/pact-plugin/tests/test_import_hygiene.py
+++ b/pact-plugin/tests/test_import_hygiene.py
@@ -2,22 +2,24 @@
 Location: pact-plugin/tests/test_import_hygiene.py
 Summary: Suite-level import-hygiene gate — a strict-mode unused-import sweep
          over every consumer-shipped Python surface (hooks/, scripts/,
-         telegram/, skills/*/scripts/), plus the pins that keep the gate
-         itself honest: non-vacuity fixtures driven through the gate's own
-         entry point, a no-default signature pin on the predicate's
-         strictness parameter, and a prose pin on the canonical lint-check.sh
-         invocation in the command files.
+         telegram/, skills/*/scripts/) plus the dev-repo tests/ tree, and
+         the pins that keep the gate itself honest: non-vacuity fixtures
+         driven through the gate's own entry point, a no-default signature
+         pin on the predicate's strictness parameter, and a prose pin on the
+         canonical lint-check.sh invocation in the command files.
 Used by: pytest suite. This is the dev-repo enforcement tier of the
          import-hygiene ladder; the consumer-facing tier is
          lint-check.sh --files (advisory strictness). Both tiers call the
          SAME predicate module — one substrate, two declared strictness
          tiers. THIS file is where the suite tier's strictness is declared.
 
-Scope boundary — "ships to consumers":
+Scope boundary — what is swept and why:
     hooks/, scripts/, telegram/, and skills/*/scripts/ all execute in (or
     ship to) consumer sessions, so dead imports there are product defects.
-    tests/ is deliberately NOT swept: test-file dead imports never ship,
-    and the pre-existing backlog there is tracked as separate cleanup work.
+    tests/ never ships, but is swept too: the backlog that justified its
+    day-one exclusion has been cleared, and the CI ruff leg lints all of
+    pact-plugin/ — this gate sweeps the same tree so the two enforcement
+    layers cannot disagree on tests/ scope.
 
 Suppression contract:
     An intentional unused import (re-export facade, monkeypatch seam,
@@ -80,7 +82,10 @@ def _gate_check(paths):
     return cui.check_paths([str(p) for p in paths], try_scope=L1_TRY_SCOPE)
 
 
-# ─── consumer-shipped Python surfaces ────────────────────────────────────────
+# ─── swept Python surfaces ───────────────────────────────────────────────────
+# hooks/, scripts/, telegram/, skills-scripts ship to consumers; tests/ is
+# the dev-repo-only surface, swept so this gate and the CI ruff leg (which
+# lints all of pact-plugin/) agree on scope.
 
 def _skills_script_files():
     return sorted(PLUGIN_ROOT.glob("skills/*/scripts/**/*.py"))
@@ -91,11 +96,13 @@ TARGET_DIR_SETS = {
     "scripts": lambda: sorted((PLUGIN_ROOT / "scripts").rglob("*.py")),
     "telegram": lambda: sorted((PLUGIN_ROOT / "telegram").rglob("*.py")),
     "skills-scripts": _skills_script_files,
+    "tests": lambda: sorted((PLUGIN_ROOT / "tests").rglob("*.py")),
 }
 
 
-class TestShippedTreeIsClean:
-    """The strict-mode sweep over every consumer-shipped Python surface."""
+class TestSweptTreeIsClean:
+    """The strict-mode sweep over every swept Python surface —
+    consumer-shipped code plus the dev-repo tests/ tree."""
 
     @pytest.mark.parametrize("label", sorted(TARGET_DIR_SETS))
     def test_surface_has_files_to_scan(self, label):
@@ -109,11 +116,78 @@ class TestShippedTreeIsClean:
         assert len(files) > 0  # inline guard: never pass on an empty sweep
         findings = _gate_check(files)
         assert findings == [], (
-            f"unused imports in consumer-shipped surface '{label}' — fix, or "
+            f"unused imports in swept surface '{label}' — fix, or "
             "mark an intentional re-export/probe with "
             "'# noqa: F401  # <category>: <reason>' on the statement's first "
             "line:\n" + "\n".join(findings)
         )
+
+
+class TestTestsSurfaceEnforcement:
+    """Counter-tests proving the tests/ surface is genuinely enforced —
+    each drives the REAL sweep mechanism (the live TARGET_DIR_SETS glob
+    plus `_gate_check`), not a synthetic path list, so a reverted or
+    mis-widened glob turns these red, not silently vacuous. Probes are
+    planted in the live tests/ tree and removed in the same test (the
+    suite runs single-process, so no parallel sweep can observe them)."""
+
+    PROBE = PLUGIN_ROOT / "tests" / "_f401_planted_probe_delete_me.py"
+
+    def test_tests_surface_includes_this_gate_file(self):
+        """Reachability pin: the tests glob must resolve the LIVE tests/
+        tree — proven by the sweep seeing this very file. A glob pointing
+        at a wrong or empty directory passes >0-file guards; it cannot
+        pass this one."""
+        files = TARGET_DIR_SETS["tests"]()
+        assert Path(__file__).resolve() in [p.resolve() for p in files]
+
+    def test_planted_dead_import_fails_tests_sweep_end_to_end(self):
+        """A genuinely unused import planted in the live tests/ tree must
+        be picked up by the surface glob AND flagged by the gate — the
+        end-to-end proof that new tests/ files are enforced."""
+        assert not self.PROBE.exists(), (
+            "leftover probe from a crashed run — delete it; it poisons "
+            "the tests/ sweep"
+        )
+        self.PROBE.write_text("import os\n", encoding="utf-8")
+        try:
+            files = TARGET_DIR_SETS["tests"]()
+            assert self.PROBE in files
+            assert f"{self.PROBE}:1: unused import os" in _gate_check(files)
+        finally:
+            self.PROBE.unlink()
+        assert self.PROBE not in TARGET_DIR_SETS["tests"]()
+
+    def test_strict_flip_would_miss_try_scoped_probe(self):
+        """Strict-flip simulation for the widened surface: a try-scoped
+        dead import planted in the live tests/ tree is caught by the gate
+        under its declared strict tier, and would be MISSED under
+        advisory — proving the sweep's strictness declaration is
+        load-bearing for tests/, not incidental."""
+        assert not self.PROBE.exists()
+        self.PROBE.write_text(
+            "try:\n    import os\nexcept ImportError:\n    pass\n",
+            encoding="utf-8",
+        )
+        try:
+            files = TARGET_DIR_SETS["tests"]()
+            assert self.PROBE in files
+            assert f"{self.PROBE}:2: unused import os" in _gate_check(files)
+            # The flip direction: the same file under the advisory tier
+            # produces no finding at all.
+            assert cui.check_paths([str(self.PROBE)], try_scope="advisory") == []
+        finally:
+            self.PROBE.unlink()
+
+    def test_kept_ensure_loaded_seam_survives_widened_gate(self):
+        """The one reasoned keep in tests/ (an ensure-loaded monkeypatch
+        seam marked with a first-line noqa) passes the gate individually.
+        Localizes the failure if the predicate's noqa recognition ever
+        diverges from the marker convention the keep uses — the sweep
+        would also fail, but this row names the reconciliation."""
+        kept = PLUGIN_ROOT / "tests" / "test_emitter_idempotency.py"
+        assert kept.exists()
+        assert _gate_check([kept]) == []
 
 
 class TestGateNonVacuity:

--- a/pact-plugin/tests/test_import_hygiene.py
+++ b/pact-plugin/tests/test_import_hygiene.py
@@ -85,7 +85,10 @@ def _gate_check(paths):
 # ─── swept Python surfaces ───────────────────────────────────────────────────
 # hooks/, scripts/, telegram/, skills-scripts ship to consumers; tests/ is
 # the dev-repo-only surface, swept so this gate and the CI ruff leg (which
-# lints all of pact-plugin/) agree on scope.
+# lints all of pact-plugin/) cannot disagree on tests/ scope. CI's tree is
+# a strict superset of these five globs (e.g. skills/*/ top-level test
+# files are CI-linted only) — the safe direction: a divergence there is a
+# loud CI red, never a silent gate pass.
 
 def _skills_script_files():
     return sorted(PLUGIN_ROOT.glob("skills/*/scripts/**/*.py"))
@@ -126,12 +129,16 @@ class TestSweptTreeIsClean:
 class TestTestsSurfaceEnforcement:
     """Counter-tests proving the tests/ surface is genuinely enforced —
     each drives the REAL sweep mechanism (the live TARGET_DIR_SETS glob
-    plus `_gate_check`), not a synthetic path list, so a reverted or
-    mis-widened glob turns these red, not silently vacuous. Probes are
-    planted in the live tests/ tree and removed in the same test (the
-    suite runs single-process, so no parallel sweep can observe them)."""
+    plus `_gate_check`), not a synthetic path list, so a reverted,
+    retargeted, or recursion-narrowed glob turns these red, not silently
+    vacuous. Probes are planted in the live tests/ tree one directory
+    level DOWN (tests/fixtures/) — the sweep only sees them through
+    recursive descent, so an rglob→glob mis-narrowing fails here instead
+    of silently dropping subdirectory files. Each probe is removed in
+    the same test (the suite runs single-process, so no parallel sweep
+    can observe it)."""
 
-    PROBE = PLUGIN_ROOT / "tests" / "_f401_planted_probe_delete_me.py"
+    PROBE = PLUGIN_ROOT / "tests" / "fixtures" / "_f401_planted_probe_delete_me.py"
 
     def test_tests_surface_includes_this_gate_file(self):
         """Reachability pin: the tests glob must resolve the LIVE tests/

--- a/pact-plugin/tests/test_intentional_wait.py
+++ b/pact-plugin/tests/test_intentional_wait.py
@@ -315,12 +315,12 @@ class TestModuleConstants:
         # shared package's public API. Vocabulary + format helpers stay
         # module-only to keep the shared package namespace small.
         from shared import wait_stale  # noqa: F401
-        from shared.intentional_wait import (
-            canonical_since,  # noqa: F401
-            validate_wait,  # noqa: F401
-            DEFAULT_THRESHOLD_MINUTES,
-            KNOWN_REASONS,  # noqa: F401
-            KNOWN_RESOLVERS,  # noqa: F401
+        from shared.intentional_wait import DEFAULT_THRESHOLD_MINUTES
+        from shared.intentional_wait import (  # noqa: F401  # re-export probe: import IS the test — names must stay importable module-only
+            canonical_since,
+            validate_wait,
+            KNOWN_REASONS,
+            KNOWN_RESOLVERS,
         )
         assert DEFAULT_THRESHOLD_MINUTES == 30
 

--- a/pact-plugin/tests/test_lazy_load_cross_references.py
+++ b/pact-plugin/tests/test_lazy_load_cross_references.py
@@ -23,7 +23,6 @@ guards from day one.
 import re
 from pathlib import Path
 
-import pytest
 
 
 AGENTS_DIR = Path(__file__).parent.parent / "agents"

--- a/pact-plugin/tests/test_memory_graph.py
+++ b/pact-plugin/tests/test_memory_graph.py
@@ -22,7 +22,6 @@ Tests cover:
 """
 import os
 import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest

--- a/pact-plugin/tests/test_memory_init.py
+++ b/pact-plugin/tests/test_memory_init.py
@@ -8,14 +8,12 @@ Tests cover:
 4. Edge cases - graceful degradation, already-installed dependencies
 """
 
-import os
 import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Any
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -666,7 +664,7 @@ class TestEdgeCases:
 
     def test_reset_during_initialization(self):
         """Test that reset during initialization is handled safely."""
-        from memory_init import ensure_memory_ready, reset_initialization, is_initialized
+        from memory_init import ensure_memory_ready, reset_initialization
 
         reset_initialization()
 

--- a/pact-plugin/tests/test_memory_models.py
+++ b/pact-plugin/tests/test_memory_models.py
@@ -15,7 +15,6 @@ import json
 import os
 import sys
 from datetime import datetime, timezone
-from pathlib import Path
 
 import pytest
 

--- a/pact-plugin/tests/test_memory_patterns_docs.py
+++ b/pact-plugin/tests/test_memory_patterns_docs.py
@@ -24,7 +24,6 @@ Mechanism:
 4. Assert no exception was raised.
 """
 import builtins
-import json
 import os
 import re
 import sys

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -10400,7 +10400,7 @@ class TestLegacyTokenBoundary:
         """
         from shared.merge_guard_common import USE_MARKER_SUFFIX
         from merge_guard_post import write_token
-        from merge_guard_pre import _consume_token, find_valid_token
+        from merge_guard_pre import _consume_token
 
         legacy_path = self._write_legacy_token(tmp_path, "100")
         n_use_path = write_token({"operation_type": "merge", "pr_number": "200"}, token_dir=tmp_path)

--- a/pact-plugin/tests/test_merge_guard_pre.py
+++ b/pact-plugin/tests/test_merge_guard_pre.py
@@ -33,11 +33,9 @@ tests pinning the fixes; the new `test_authorization_mismatch_attack` test
 pins the end-to-end attack shape that the heredoc-side fix prevents.
 """
 
-import re
 import sys
 from pathlib import Path
 
-import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 

--- a/pact-plugin/tests/test_missed_wake_scan_integration.py
+++ b/pact-plugin/tests/test_missed_wake_scan_integration.py
@@ -49,7 +49,6 @@ integration-seam gap (this case) = "real check, WRONG path — the mock bypassed
 the broken wiring" -> caught by UN-MOCKING the seam, not by revert alone.
 ================================================================================
 """
-import io
 import json
 import sys
 from datetime import datetime, timedelta, timezone

--- a/pact-plugin/tests/test_pact_context.py
+++ b/pact-plugin/tests/test_pact_context.py
@@ -133,7 +133,6 @@ Library module init() contract:
 
 import json
 import os
-import stat
 import sys
 from pathlib import Path
 
@@ -1136,7 +1135,6 @@ class TestResolveAgentNameStep35NonMockedSeam:
         """End-to-end, UNSTUBBED: a tmux teammate (sid != leadSessionId) registers
         via the real register() -> resolve_agent_name recovers its name from the
         real on-disk registry. Proves the write/read seam resolves for real."""
-        import shared.pact_context as pact_context
         from shared.session_registry import register
         from shared.pact_context import resolve_agent_name
 
@@ -1163,7 +1161,6 @@ class TestResolveAgentNameStep35NonMockedSeam:
         finds no entry for that sid and falls through to Step 4 (agent_type
         strip). Confirms the guard's WRITE-side suppression keeps the READ-side
         seam clean rather than returning a colliding/wrong name."""
-        import shared.pact_context as pact_context
         from shared.session_registry import register
         from shared.pact_context import resolve_agent_name
 

--- a/pact-plugin/tests/test_pact_orchestrator_agent.py
+++ b/pact-plugin/tests/test_pact_orchestrator_agent.py
@@ -16,7 +16,6 @@ commits land.
 """
 from pathlib import Path
 
-import pytest
 
 from helpers import parse_frontmatter
 

--- a/pact-plugin/tests/test_paths.py
+++ b/pact-plugin/tests/test_paths.py
@@ -10,10 +10,7 @@ Two drive modes are exercised:
   - live-globals mode (monkeypatch.setenv + Path.home redirect): proves the
     real seam consumers depend on works without DI.
 """
-import os
 from pathlib import Path
-
-import pytest
 
 from shared.paths import get_claude_config_dir
 

--- a/pact-plugin/tests/test_patterns.py
+++ b/pact-plugin/tests/test_patterns.py
@@ -8,13 +8,11 @@ context extraction, and regex pattern validation.
 import re
 from pathlib import Path
 
-import pytest
 
 import sys
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 from shared.constants import PACT_AGENTS
-from shared.task_utils import find_active_agents  # agent_prefixes is local; we parse source
 
 from refresh.patterns import (
     WORKFLOW_PATTERNS,

--- a/pact-plugin/tests/test_peer_inject.py
+++ b/pact-plugin/tests/test_peer_inject.py
@@ -31,7 +31,6 @@ class TestPeerInject:
     def test_injects_peer_names(self, tmp_path):
         from peer_inject import (
             get_peer_context,
-            _TEACHBACK_REMINDER,
             _COMPLETION_AUTHORITY_NOTE,
         )
 
@@ -60,7 +59,6 @@ class TestPeerInject:
     def test_excludes_spawning_agent(self, tmp_path):
         from peer_inject import (
             get_peer_context,
-            _TEACHBACK_REMINDER,
             _COMPLETION_AUTHORITY_NOTE,
         )
 
@@ -98,7 +96,6 @@ class TestPeerInject:
     def test_alone_message_when_only_member(self, tmp_path):
         from peer_inject import (
             get_peer_context,
-            _TEACHBACK_REMINDER,
             _COMPLETION_AUTHORITY_NOTE,
         )
 
@@ -190,7 +187,6 @@ class TestTeachbackReminder:
     def test_reminder_appended_when_peers_exist(self, tmp_path):
         from peer_inject import (
             get_peer_context,
-            _TEACHBACK_REMINDER,
             _COMPLETION_AUTHORITY_NOTE,
         )
 
@@ -216,7 +212,6 @@ class TestTeachbackReminder:
     def test_reminder_appended_when_alone(self, tmp_path):
         from peer_inject import (
             get_peer_context,
-            _TEACHBACK_REMINDER,
             _COMPLETION_AUTHORITY_NOTE,
         )
 
@@ -555,7 +550,6 @@ class TestBootstrapPreludeAgentName:
         from peer_inject import (
             get_peer_context,
             _TEACHBACK_REMINDER,
-            _COMPLETION_AUTHORITY_NOTE,
         )
 
         team_dir = tmp_path / "teams" / "pact-test"

--- a/pact-plugin/tests/test_per_dispatch_variety.py
+++ b/pact-plugin/tests/test_per_dispatch_variety.py
@@ -32,7 +32,6 @@ import json
 import sys
 from pathlib import Path
 
-import pytest
 
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))

--- a/pact-plugin/tests/test_pin_caps_gate.py
+++ b/pact-plugin/tests/test_pin_caps_gate.py
@@ -21,7 +21,6 @@ Minimum coverage shipped in the code-phase commit:
 import json
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/pact-plugin/tests/test_pin_caps_gate_counter_test.py
+++ b/pact-plugin/tests/test_pin_caps_gate_counter_test.py
@@ -25,7 +25,6 @@ and must be rewritten.
 
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/pact-plugin/tests/test_pin_caps_gate_low_priority.py
+++ b/pact-plugin/tests/test_pin_caps_gate_low_priority.py
@@ -21,7 +21,6 @@ import json
 import sys
 import threading
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/pact-plugin/tests/test_pin_caps_gate_matrix.py
+++ b/pact-plugin/tests/test_pin_caps_gate_matrix.py
@@ -35,7 +35,6 @@ Invariants enforced:
 import json
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/pact-plugin/tests/test_pin_caps_integration.py
+++ b/pact-plugin/tests/test_pin_caps_integration.py
@@ -13,10 +13,8 @@ Covers:
 Risk tier: CRITICAL.
 """
 
-import re
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/pact-plugin/tests/test_pin_staleness_gate.py
+++ b/pact-plugin/tests/test_pin_staleness_gate.py
@@ -12,7 +12,6 @@ Matrix: marker absence/present × CLAUDE.md path match/miss × teammate/team-lea
 import json
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/pact-plugin/tests/test_project_id.py
+++ b/pact-plugin/tests/test_project_id.py
@@ -14,12 +14,9 @@ We replicate the _detect_project_id logic here rather than fighting
 Python's import system, then validate equivalence via a source-check test.
 """
 
-import hashlib
-import inspect
 import os
 import re
 import subprocess
-import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 

--- a/pact-plugin/tests/test_read_lead_session_id_parity.py
+++ b/pact-plugin/tests/test_read_lead_session_id_parity.py
@@ -50,7 +50,6 @@ non-vacuous: "" must mean a genuine miss, not that both copies always return "".
 """
 
 import json
-import sys
 from pathlib import Path
 
 import pytest

--- a/pact-plugin/tests/test_role_gate_flip_and_postcompact.py
+++ b/pact-plugin/tests/test_role_gate_flip_and_postcompact.py
@@ -37,8 +37,6 @@ from fixtures.role_frames import (
     teammate_frame,
 )
 
-import shared.pact_context as pact_context
-
 
 _SESSION_ID = "aabb1122-0000-0000-0000-000000000000"
 

--- a/pact-plugin/tests/test_session_end.py
+++ b/pact-plugin/tests/test_session_end.py
@@ -53,9 +53,6 @@ class TestMainEntryPoint:
 
         Pass keyword overrides to replace defaults (e.g., get_task_list=...).
         """
-        from contextlib import ExitStack
-        from unittest.mock import MagicMock, DEFAULT
-
         defaults = {
             "pact_context_init": patch("session_end.pact_context.init"),
             "get_project_dir": patch("session_end.get_project_dir",
@@ -1386,7 +1383,6 @@ class TestCleanupOldSessionsBoundary:
         directories. The regex explicitly requires lowercase. This test
         verifies the regex behavior by checking the pattern directly.
         """
-        import re
         from session_end import _UUID_PATTERN
 
         # Lowercase should match
@@ -2649,7 +2645,7 @@ class TestCleanupSummaryEvent:
 
         Returns list of append_event call args for inspection.
         """
-        from unittest.mock import patch, MagicMock
+        from unittest.mock import patch
         from contextlib import ExitStack
         import io as _io
 
@@ -3126,7 +3122,7 @@ class TestReaperBehaviorPins:
         either reaper, counts would be stale and this test catches it.
         Uses a recording mock_calls timeline to assert call ordering.
         """
-        from unittest.mock import patch, call
+        from unittest.mock import patch
         from contextlib import ExitStack
         import io as _io
 

--- a/pact-plugin/tests/test_session_end_registry_prune.py
+++ b/pact-plugin/tests/test_session_end_registry_prune.py
@@ -9,7 +9,6 @@ rewrite.
 """
 
 import json
-import os
 import stat
 from pathlib import Path
 

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -39,7 +39,6 @@ Note: restore_last_session() and check_resumption_context() are tested
 in test_session_resume.py (canonical location).
 """
 
-import contextlib
 import io
 import json
 import re

--- a/pact-plugin/tests/test_session_init_role_suppression.py
+++ b/pact-plugin/tests/test_session_init_role_suppression.py
@@ -31,7 +31,6 @@ comprehensiveness add: teammate + plain rows for every write, plus the split.
 
 import io
 import json
-import os
 from pathlib import Path
 from unittest.mock import patch
 

--- a/pact-plugin/tests/test_session_registry.py
+++ b/pact-plugin/tests/test_session_registry.py
@@ -9,7 +9,6 @@ tests live in commit G's test files; this file is the module's own unit suite.)
 """
 
 import json
-import os
 from pathlib import Path
 
 import pytest

--- a/pact-plugin/tests/test_session_registry_concurrency.py
+++ b/pact-plugin/tests/test_session_registry_concurrency.py
@@ -73,7 +73,7 @@ from pathlib import Path
 import pytest
 
 from shared import session_registry
-from shared.session_registry import register, resolve
+from shared.session_registry import resolve
 
 # spawn is macOS's default and the most portable start method; pin it explicitly
 # so the suite behaves identically wherever it runs (fork would inherit the

--- a/pact-plugin/tests/test_session_registry_trust_partition.py
+++ b/pact-plugin/tests/test_session_registry_trust_partition.py
@@ -30,7 +30,6 @@ synthetic import so the negative leg is not a vacuous always-pass.
 
 import ast
 import json
-import re
 from pathlib import Path
 
 import pytest
@@ -276,7 +275,6 @@ class TestSelfLookupOnly:
     """resolve() takes a session_id, never a name; no name-keyed scan API."""
 
     def test_resolve_signature_takes_session_id_not_name(self):
-        from shared import session_registry
         tree = _parse(HOOKS_DIR / "shared" / "session_registry.py")
         resolve_def = next(
             n for n in ast.walk(tree)

--- a/pact-plugin/tests/test_setup_memory.py
+++ b/pact-plugin/tests/test_setup_memory.py
@@ -10,10 +10,8 @@ Tests cover:
 """
 import os
 import sys
-from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
 

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -15,8 +15,6 @@ Tests cover:
 
 import inspect
 import os
-import re
-import subprocess
 import sys
 import textwrap
 from datetime import datetime, timedelta
@@ -174,7 +172,7 @@ class TestCheckPinnedStaleness:
 
     def test_over_budget_adds_warning(self, tmp_path):
         """Should add token budget warning when pinned content exceeds budget."""
-        from session_init import check_pinned_staleness, PINNED_CONTEXT_TOKEN_BUDGET
+        from session_init import check_pinned_staleness
 
         # Create a lot of pinned content that exceeds the budget
         big_content = "word " * 1500  # Should exceed 1200 token budget

--- a/pact-plugin/tests/test_step_extractor.py
+++ b/pact-plugin/tests/test_step_extractor.py
@@ -4,16 +4,13 @@ Tests for the step_extractor module.
 Tests step detection, pending action extraction, and context gathering.
 """
 
-import json
 from pathlib import Path
-
-import pytest
 
 import sys
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 sys.path.insert(0, str(Path(__file__).parent))
 
-from refresh.transcript_parser import Turn, ToolCall, parse_transcript
+from refresh.transcript_parser import Turn, parse_transcript
 from refresh.workflow_detector import WorkflowInfo
 from refresh.step_extractor import (
     StepInfo,
@@ -29,10 +26,8 @@ from refresh.step_extractor import (
 
 from fixtures.refresh_system import (
     create_peer_review_transcript,
-    create_orchestrate_transcript,
     make_user_message,
     make_assistant_message,
-    make_task_call,
     create_transcript_lines,
 )
 

--- a/pact-plugin/tests/test_symlinks.py
+++ b/pact-plugin/tests/test_symlinks.py
@@ -18,8 +18,6 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 # Add hooks directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 

--- a/pact-plugin/tests/test_task_integration.py
+++ b/pact-plugin/tests/test_task_integration.py
@@ -13,7 +13,6 @@ build_refresh_from_tasks in #444).
 """
 
 import json
-import os
 import sys
 from pathlib import Path
 from typing import Any

--- a/pact-plugin/tests/test_task_utils.py
+++ b/pact-plugin/tests/test_task_utils.py
@@ -9,7 +9,6 @@ Tests cover:
 5. find_blockers: blocker/algedonic task detection
 """
 import json
-import os
 import sys
 from pathlib import Path
 from unittest.mock import patch

--- a/pact-plugin/tests/test_teachback_reasoning_reconstruction.py
+++ b/pact-plugin/tests/test_teachback_reasoning_reconstruction.py
@@ -33,8 +33,6 @@ import ast
 import json
 from pathlib import Path
 
-import pytest
-
 from shared.intentional_wait import TEACHBACK_EXEMPT_AGENT_TYPES
 from shared.teachback_schema import (
     TEACHBACK_REQUIRED_SUBKEYS,

--- a/pact-plugin/tests/test_teammate_idle.py
+++ b/pact-plugin/tests/test_teammate_idle.py
@@ -19,7 +19,6 @@ Tests cover:
 - Concurrent multi-agent tracking independence.
 """
 import json
-import os
 import sys
 from pathlib import Path
 from unittest.mock import patch

--- a/pact-plugin/tests/test_telegram_client.py
+++ b/pact-plugin/tests/test_telegram_client.py
@@ -14,7 +14,6 @@ Tests cover:
 9. Security: unauthorized chat_id rejection, inbound sanitization
 """
 
-import asyncio
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -27,9 +26,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from telegram.telegram_client import (
     TelegramClient,
     TelegramAPIError,
-    API_BASE,
-    POLL_TIMEOUT,
-    MAX_RETRIES,
 )
 
 

--- a/pact-plugin/tests/test_telegram_config.py
+++ b/pact-plugin/tests/test_telegram_config.py
@@ -12,11 +12,8 @@ Tests cover:
 8. Security: no credentials in error messages, permission enforcement
 """
 
-import os
-import stat
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -33,7 +30,6 @@ from telegram.config import (
     load_config,
     load_config_safe,
     parse_env_file,
-    VALID_MODES,
     DEFAULT_MODE,
 )
 

--- a/pact-plugin/tests/test_telegram_content_filter.py
+++ b/pact-plugin/tests/test_telegram_content_filter.py
@@ -14,7 +14,6 @@ Tests cover:
 import sys
 from pathlib import Path
 
-import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 

--- a/pact-plugin/tests/test_telegram_deps.py
+++ b/pact-plugin/tests/test_telegram_deps.py
@@ -8,13 +8,10 @@ Tests cover:
 4. get_optional_dependency_status: voice transcription availability
 """
 
-import importlib
 import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -24,7 +21,6 @@ from telegram.deps import (
     get_dependency_status,
     get_optional_dependency_status,
     REQUIRED_PACKAGES,
-    REQUIREMENTS_FILE,
 )
 
 

--- a/pact-plugin/tests/test_telegram_notify.py
+++ b/pact-plugin/tests/test_telegram_notify.py
@@ -17,7 +17,7 @@ import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
-from unittest.mock import MagicMock, patch, mock_open
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -30,8 +30,6 @@ from telegram.notify import (
     _build_session_summary,
     send_notification,
     main,
-    ENV_FILE,
-    HTTP_TIMEOUT,
 )
 
 

--- a/pact-plugin/tests/test_telegram_routing.py
+++ b/pact-plugin/tests/test_telegram_routing.py
@@ -11,7 +11,6 @@ Tests cover:
 6. Edge cases: corrupted files, concurrent access, lock contention
 """
 
-import asyncio
 import fcntl
 import json
 import os
@@ -26,15 +25,11 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from telegram.config import get_or_create_session_id
 from telegram.routing import (
-    COORDINATOR_DIR,
-    HEARTBEAT_INTERVAL,
-    MAX_INBOX_ENTRIES,
     MAX_ROUTING_TABLE_ENTRIES,
     READER_POLL_INTERVAL,
     STALE_SESSION_TTL,
     DirectRouter,
     FileBasedRouter,
-    UpdateRouter,
     count_active_sessions,
     register_session,
     unregister_session,

--- a/pact-plugin/tests/test_telegram_server.py
+++ b/pact-plugin/tests/test_telegram_server.py
@@ -52,7 +52,6 @@ from telegram.server import (
     _polling_loop,
     create_server,
     lifespan,
-    POLL_INTERVAL,
     ERROR_BACKOFF,
 )
 from telegram.tools import ToolContext

--- a/pact-plugin/tests/test_token_budget.py
+++ b/pact-plugin/tests/test_token_budget.py
@@ -12,11 +12,9 @@ Tests cover:
 import os
 import re
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
-import pytest
 
 # Add paths for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts"))

--- a/pact-plugin/tests/test_tool_response.py
+++ b/pact-plugin/tests/test_tool_response.py
@@ -14,7 +14,6 @@ fields, missing fields).
 import sys
 from pathlib import Path
 
-import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 

--- a/pact-plugin/tests/test_track_files.py
+++ b/pact-plugin/tests/test_track_files.py
@@ -14,7 +14,7 @@ Tests cover:
 import io
 import json
 import sys
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 

--- a/pact-plugin/tests/test_transcript_parser.py
+++ b/pact-plugin/tests/test_transcript_parser.py
@@ -24,7 +24,6 @@ from refresh.transcript_parser import (
     find_task_calls_to_agent,
     find_trigger_turn_index,
 )
-from refresh.constants import LARGE_FILE_THRESHOLD_BYTES
 
 
 class TestTurnDataclass:

--- a/pact-plugin/tests/test_vector_dimension_fixes.py
+++ b/pact-plugin/tests/test_vector_dimension_fixes.py
@@ -16,14 +16,12 @@ Risk tier: STANDARD — well-understood pattern fix.
 """
 
 import json
-import logging
 import os
 import struct
 import sys
 import tempfile
 from pathlib import Path
-from typing import Any, Dict
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/pact-plugin/tests/test_workflow_detector.py
+++ b/pact-plugin/tests/test_workflow_detector.py
@@ -4,10 +4,8 @@ Tests for the workflow_detector module.
 Tests workflow trigger detection, termination checking, and confidence scoring.
 """
 
-import json
 from pathlib import Path
 
-import pytest
 
 import sys
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
@@ -26,12 +24,8 @@ from refresh.workflow_detector import (
 
 from fixtures.refresh_system import (
     create_peer_review_transcript,
-    create_orchestrate_transcript,
-    create_no_workflow_transcript,
-    create_terminated_workflow_transcript,
     make_user_message,
     make_assistant_message,
-    make_task_call,
     create_transcript_lines,
 )
 

--- a/pact-plugin/tests/test_working_memory_parser.py
+++ b/pact-plugin/tests/test_working_memory_parser.py
@@ -19,7 +19,6 @@ sys.path is set up by tests/conftest.py (adds hooks/ and skills/pact-memory/
 scripts/ to sys.path), so no per-file sys.path manipulation is needed here.
 """
 
-import pytest
 
 
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_working_memory_resolver_and_lock_release.py
+++ b/pact-plugin/tests/test_working_memory_resolver_and_lock_release.py
@@ -32,8 +32,6 @@ Used by: pytest (the working_memory edge-path gate).
 import sys
 from pathlib import Path
 
-import pytest
-
 _SCRIPTS_DIR = str(
     Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts"
 )

--- a/pact-plugin/tests/test_working_memory_worktree_sync.py
+++ b/pact-plugin/tests/test_working_memory_worktree_sync.py
@@ -34,7 +34,6 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "skills", "pact-memory"))
 
 from scripts.working_memory import _resolve_display_claude_md_path, sync_to_claude_md
-from scripts import working_memory as wm
 from scripts.memory_api import PACTMemory
 
 

--- a/pact-plugin/tests/test_worktree_guard.py
+++ b/pact-plugin/tests/test_worktree_guard.py
@@ -15,9 +15,7 @@ Tests cover:
 """
 import io
 import json
-import os
 import sys
-import tempfile
 from pathlib import Path
 from unittest.mock import patch
 


### PR DESCRIPTION
## Summary

Completes the tests/ unused-import cleanup deferred from the import-hygiene lint arc, and widens both enforcement layers (CI ruff leg + L1 suite gate) to cover `pact-plugin/tests/`. Completes ACs of #1117.

## What landed

- **CI leg 1 widened** to `pact-plugin/` (F401+F821), tests/-exclusion comment retired; leg 2 (F821 floor) kept as deliberate structure so tree-wide F821 coverage stays independent of leg 1's path list.
- **138 F401 findings resolved across 75 test files**: 137 deletions, each cleared by a five-point AST-anchored whole-tree consumer scan (name loads, cross-module/facade consumers, test imports, attribute-patch targets, string-literal patch targets); 1 reasoned keep — an ensure-loaded ordering seam (`test_emitter_idempotency.py`) with first-line `# noqa: F401`, auditor-validated.
- **L1 suite gate widened** to sweep tests/, restoring dual-layer agreement, with 4 counter-tests: self-inclusion reachability pin, end-to-end planted probe, strict-flip simulation, and a noqa-recognition pin for the kept seam.
- Version bump to 4.5.2 (PATCH).

## Why

tests/ was deliberately excluded from F401 coverage while it carried a known backlog. The backlog is now zero, so the exclusion's own documented rationale is retired and both layers enforce the same surface — a future dead import in tests/ fails CI and the suite gate identically, with the same first-line-noqa escape hatch.

## Verification

- Full suite: 10,834 passed / 11 skipped / 0 failed / 0 errors
- Both CI legs exit 0 at HEAD; issue done-command (`ruff check --select F401 --target-version py39 pact-plugin/tests/`) clean
- Counter-tests mutation-falsified (gate-entry removal, strictness flip, noqa-neuter each produce the predicted exact failure sets)
- Concurrent auditor: GREEN (census 138/75 exact; per-commit set-diffs empty against dispatched cohorts)
