### PR TITLE
fix(merge-guard): stop over-holding read-only gh-api diagnostics (#1118)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.5.2",
+      "version": "4.5.3",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.5.2/       # Plugin version
+│               └── 4.5.3/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.5.2
+> **Version**: 4.5.3
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -2183,6 +2183,97 @@ def _strip_non_executable_content(command: str) -> str:
 
         result = re.sub(_http_client_span, _strip_http_body_span, result)
 
+    # 9. Strip gh-api CLIENT-SIDE OUTPUT-SELECTOR + non-target flag VALUES (#1118).
+    #    Carrier 8 removes the merge/git-refs FP substring from request-BODY values,
+    #    but a gh-api command's output selectors (--jq/-q jq filter, --template/-t Go
+    #    template) and other non-target value flags (-H/--header, --input body-file
+    #    name, --hostname, -p/--preview) still carry it, so a graphql/REST READ whose
+    #    --jq names a response field like `mergeStateStatus` is OVER-BLOCKED by the
+    #    .*merge implicit-POST arm. These VALUES can NEVER be the request ENDPOINT or
+    #    METHOD (jq/template run on the RESPONSE client-side; a header is request
+    #    metadata; --input names a local file; a hostname/preview name is not the
+    #    resource — the endpoint is always the URL positional), so stripping ONLY the
+    #    value is zero-under-block (the CLIENT-vs-SERVER analogue of carrier 8's
+    #    PATH-vs-BODY invariant). gh-api's flag vocabulary is FINITE + DOCUMENTED, so
+    #    this surface is BOUNDED (unlike curl/wget's unbounded value-flag vocabulary
+    #    -> WON'T-FIX by construction, #1098). Scoped to a gh-api span ONLY (its OWN
+    #    _GH_API_PREFIX anchor, NARROWER than carrier 8's shared curl/wget/gh-api
+    #    span): -q/-t/-H/-p are gh-api short flags here, so the strip never touches
+    #    curl -t (--telnet-option), wget -t (--tries), or gh pr create -t (--title,
+    #    carrier 7). Every flag token is KEPT (only the value is replaced) so the
+    #    implicit-POST lookaheads still fire on a genuine write (a real mutation via
+    #    --input to a path-resident endpoint keeps its --input flag and stays HELD;
+    #    its destructive target lives in the URL positional, which is never stripped).
+    #    CONTENTS-API early-return mirrors carrier 8: never touch a contents/ span (its
+    #    main/master gating signal is body/positional-resident). --cache is OUT (its
+    #    duration grammar provably cannot carry the substring — a genuine non-source,
+    #    not a residual); every other non-target value flag is IN. Same execution-
+    #    routing guards as carriers 3/5/7/8: skip when piped/process-sub to a shell;
+    #    the double-quoted arm preserves a value containing command substitution
+    #    `$(`/backtick (it would execute). ADDITIVE-PURE: a self-contained carrier that
+    #    only REMOVES incidental FP substrings from non-gating values — it adds no arm
+    #    and modifies no existing danger path, so it cannot open a new under-block.
+    if not piped_to_shell and not process_sub_to_shell:
+        # The gh-api command span: from a gh-api head up to the first UNQUOTED shell
+        # separator. Quote-aware body (balanced quotes consumed atomically; disjoint
+        # first chars -> linear, no ReDoS) — identical shape to carriers 7/8, but
+        # anchored on gh-api ONLY (no curl/wget head), so -q/-t/-H/-p can never be
+        # mis-read as a curl/wget short flag. The URL positional and the -X/--method
+        # flag live in this span but are never matched by the selector-flag arms below
+        # (which require a selector FLAG directly before the value), so they survive.
+        _gh_api_selector_span = (
+            r"(?:" + _GH_API_PREFIX + r")"
+            r"""(?:[^&|;\n"']+|"(?:[^"\\]|\\.)*"|'[^']*')*"""
+        )
+        # Long forms BEFORE short forms; the trailing `\s+` (added at each use) prevents
+        # `-t` matching inside `--template` and `-p` matching inside the boolean
+        # `--paginate` (deliberately NOT in the set — it carries no value). -q/-t/-H/-p
+        # are gh-api short flags (safe: this span is gh-api-only); --input/--hostname/
+        # --preview have no colliding short form here.
+        _selector_flag = (
+            r"(?:--jq|--template|--header|--input|--hostname|--preview"
+            r"|-q|-t|-H|-p)"
+        )
+
+        def _keep_selector_dq(m: re.Match) -> str:
+            # group(1) = the flag (+ trailing whitespace) up to the opening quote.
+            # Preserve a value that contains command substitution ($()/backtick) — it
+            # would EXECUTE and must stay visible to the danger arms (mirrors carrier
+            # 8's _keep_flag_dq; a SEPARATE helper here to keep this carrier +N / -0).
+            if _has_command_substitution(m.group(0)):
+                return m.group(0)
+            return m.group(1) + "'STRIPPED'"
+
+        def _strip_gh_api_selectors(span_match: re.Match) -> str:
+            span = span_match.group(0)
+            # CONTENTS-API exception (IGNORECASE, mirrors carrier 8): a contents span
+            # carries its main/master gating signal in the body/positional, so preserve
+            # the span verbatim (an output selector on a contents span is a rare, fail-
+            # safe pre-existing residual, not in #1118 scope).
+            if re.search(r"contents/", span, re.IGNORECASE):
+                return span
+            # double-quoted value (preserve command-substitution)
+            span = re.sub(
+                r"(" + _selector_flag + r"\s+)\"(?:[^\"\\]|\\.)*\"",
+                _keep_selector_dq,
+                span,
+            )
+            # single-quoted value (never expands)
+            span = re.sub(
+                r"(" + _selector_flag + r"\s+)'[^']*'", r"\1'STRIPPED'", span
+            )
+            # UNQUOTED value (#1096 §2.3) — runs AFTER the quoted arms; the value's
+            # first char is a NON-quote (`[^\s'"]`), so a quoted value already handled
+            # above is never re-touched. Anchored on the selector-flag prefix, so the
+            # URL POSITIONAL endpoint (never preceded by such a prefix) is never matched
+            # -> a real destructive target in the path is never removed (over-block-safe).
+            span = re.sub(
+                r"(" + _selector_flag + r"\s+)[^\s'\"]\S*", _keep_selector_dq, span
+            )
+            return span
+
+        result = re.sub(_gh_api_selector_span, _strip_gh_api_selectors, result)
+
     return result
 
 

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -286,6 +286,18 @@ _GH_PREFIX = r"\bgh\s+" + _GH_GLOBAL_FLAGS
 _GIT_PREFIX = r"\bgit\s+" + _GIT_GLOBAL_FLAGS
 _GH_API_PREFIX = _GH_PREFIX + r"api\b"
 
+# The quote-BALANCED value token (#1118 re-model) — the single Q-SAFE primitive both
+# carrier 8 and carrier 9 consume via _strip_flag_values. A value token is a maximal run
+# of {unquoted non-quote char | complete single-quoted span | complete double-quoted
+# span}, ending at unquoted whitespace. Because it consumes quoted spans ATOMICALLY it can
+# never bite a PARTIAL quoted span (a lone quote is neither `[^\s'"]` nor a complete
+# `"…"`/`'…'`), so it structurally CANNOT emit a dangling quote into the `stripped` string
+# that _mask_shell_quotes / _slice_stripped_legs consume — the root-cause fix for the
+# SEC-1/SEC-2 leg-merge regression. Assembled from the module's own quote-span fragments
+# (`[^\s'"]`, `'[^']*'`, `"(?:[^"\\]|\\.)*"`); the three alternatives have disjoint first
+# chars → linear, no ReDoS (same property as carriers 7/8's spans).
+_VALUE_TOKEN = r"""(?:[^\s'"]|'[^']*'|"(?:[^"\\]|\\.)*")+"""
+
 # Pre-compiled patterns for the operation-type classifier (consistent with
 # DANGEROUS_PATTERNS style).
 _GH_PR_MERGE_RE = re.compile(_GH_PREFIX + r"pr\s+merge\b")
@@ -1796,6 +1808,28 @@ def _has_command_substitution(quoted_content: str) -> bool:
     return "$(" in quoted_content or "`" in quoted_content
 
 
+def _strip_flag_values(span: str, flag_sep_regex: str, keep_fn) -> str:
+    """Quote-safe value strip for a flag family within a single command span (#1118
+    re-model). KEEPS the flag(+separator) token; replaces the VALUE with a BALANCED
+    placeholder. Three arms by value-quoting (order load-bearing: quoted arms first, so
+    the unquoted VALUE-TOKEN arm never re-touches an already-stripped quoted value):
+      1. double-quoted value  -> keep_fn (preserves $()/backtick cmd-sub — it executes)
+      2. single-quoted value  -> unconditional 'STRIPPED' (single quotes never expand)
+      3. unquoted VALUE TOKEN  -> keep_fn (Q-SAFE: consumes a COMPLETE quote-balanced token
+                                  incl. embedded quoted spans, so it can NEVER emit a
+                                  dangling quote that would merge legs — the SEC-1/SEC-2
+                                  root-cause fix).
+    `flag_sep_regex` MUST be ONE capturing group (keep_fn uses m.group(1); the sq arm
+    backrefs `\\1`) and must introduce no OTHER capturing group. SHARED by carriers 8 & 9
+    so the two value strips can never drift again (the shared non-quote-aware matcher was
+    the #1118 root cause).
+    """
+    span = re.sub(flag_sep_regex + r'"(?:[^"\\]|\\.)*"', keep_fn, span)     # 1
+    span = re.sub(flag_sep_regex + r"'[^']*'", r"\1'STRIPPED'", span)       # 2
+    span = re.sub(flag_sep_regex + _VALUE_TOKEN, keep_fn, span)             # 3
+    return span
+
+
 def _strip_non_executable_content(command: str) -> str:
     """Strip shell content that is clearly non-executable before pattern matching.
 
@@ -2147,72 +2181,63 @@ def _strip_non_executable_content(command: str) -> str:
                     return m.group(0)  # value contains $()/backtick → executes; keep
                 return m.group(1) + "'STRIPPED'"
 
-            # (a) direct-value body flags — double- then single-quoted.
-            span = re.sub(
-                r"(" + _data_flag + r"\s+)\"(?:[^\"\\]|\\.)*\"", _keep_flag_dq, span
-            )
-            span = re.sub(
-                r"(" + _data_flag + r"\s+)'[^']*'", r"\1'STRIPPED'", span
-            )
-            # (b) KEY=VALUE field flags — double- then single-quoted. `<key>` is a
-            # bare word (letters/digits/._-); the value AFTER `=` is what is stripped.
-            span = re.sub(
-                r"(" + _field_flag + r"\s+[\w.\-]+=)\"(?:[^\"\\]|\\.)*\"",
-                _keep_flag_dq,
-                span,
-            )
-            span = re.sub(
-                r"(" + _field_flag + r"\s+[\w.\-]+=)'[^']*'", r"\1'STRIPPED'", span
-            )
-            # (#1096 §2.3) UNQUOTED body/field values — closes the endpoint-decoy the
-            # quoted-only arms above miss (`-f note=pulls/5/merge`, `-d body`), and the
-            # #1037 unquoted-body read-floor over-block (carrier-8 feeds is_dangerous).
-            # Runs AFTER the quoted arms, and the value's first char is a NON-quote
-            # (`[^\s'"]`), so a quoted value already handled above is never re-touched.
-            # Anchored on the body-flag(+key=) prefix, so the URL POSITIONAL endpoint
-            # (never preceded by such a prefix) is never matched -> never stripped
-            # (over-block-safe). Reuses _keep_flag_dq: a $()/backtick value executes and
-            # is kept; otherwise the 'STRIPPED' placeholder replaces the bare value.
-            span = re.sub(
-                r"(" + _data_flag + r"\s+)[^\s'\"]\S*", _keep_flag_dq, span
-            )
-            span = re.sub(
-                r"(" + _field_flag + r"\s+[\w.\-]+=)[^\s'\"]\S*", _keep_flag_dq, span
+            # Body flag VALUES via the SHARED quote-safe strip (#1118 re-model, FIX-A).
+            # Each call does 3 arms (dq / sq / unquoted VALUE-TOKEN); the unquoted arm now
+            # consumes a COMPLETE quote-balanced token, so an embedded-quote body value
+            # (`-f k=x"y z"`, a jq-ish `-d '...' ` payload) can no longer leave a dangling
+            # quote that mis-pairs in _mask_shell_quotes and MERGES legs — the pre-existing
+            # carrier-8 under-block (#1118 review). This closes the endpoint-decoy the
+            # quoted-only arms miss (`-f note=pulls/5/merge`, `-d body`) + the #1037
+            # unquoted-body read-floor over-block, over-block-safely: the arm is anchored on
+            # the body-flag(+key=) prefix, so the URL POSITIONAL endpoint (never preceded by
+            # such a prefix) is never matched. SPACE-form separator ONLY here — carrier-8's
+            # `=`-joined-flag completeness (`--field=k=v`) is a DIFFERENT, deferred issue
+            # (#1125); this commit fixes ONLY carrier-8's quote-safety.
+            # (a) direct-value body flags -d/--data*; (b) key=value field flags -f/-F/--field.
+            span = _strip_flag_values(span, r"(" + _data_flag + r"\s+)", _keep_flag_dq)
+            span = _strip_flag_values(
+                span, r"(" + _field_flag + r"\s+[\w.\-]+=)", _keep_flag_dq
             )
             return span
 
         result = re.sub(_http_client_span, _strip_http_body_span, result)
 
-    # 9. Strip gh-api CLIENT-SIDE OUTPUT-SELECTOR + non-target flag VALUES (#1118).
-    #    Carrier 8 removes the merge/git-refs FP substring from request-BODY values,
-    #    but a gh-api command's output selectors (--jq/-q jq filter, --template/-t Go
-    #    template) and other non-target value flags (-H/--header, --input body-file
-    #    name, --hostname, -p/--preview) still carry it, so a graphql/REST READ whose
-    #    --jq names a response field like `mergeStateStatus` is OVER-BLOCKED by the
-    #    .*merge implicit-POST arm. These VALUES can NEVER be the request ENDPOINT or
-    #    METHOD (jq/template run on the RESPONSE client-side; a header is request
-    #    metadata; --input names a local file; a hostname/preview name is not the
-    #    resource — the endpoint is always the URL positional), so stripping ONLY the
-    #    value is zero-under-block (the CLIENT-vs-SERVER analogue of carrier 8's
-    #    PATH-vs-BODY invariant). gh-api's flag vocabulary is FINITE + DOCUMENTED, so
-    #    this surface is BOUNDED (unlike curl/wget's unbounded value-flag vocabulary
-    #    -> WON'T-FIX by construction, #1098). Scoped to a gh-api span ONLY (its OWN
-    #    _GH_API_PREFIX anchor, NARROWER than carrier 8's shared curl/wget/gh-api
-    #    span): -q/-t/-H/-p are gh-api short flags here, so the strip never touches
-    #    curl -t (--telnet-option), wget -t (--tries), or gh pr create -t (--title,
-    #    carrier 7). Every flag token is KEPT (only the value is replaced) so the
-    #    implicit-POST lookaheads still fire on a genuine write (a real mutation via
-    #    --input to a path-resident endpoint keeps its --input flag and stays HELD;
-    #    its destructive target lives in the URL positional, which is never stripped).
-    #    CONTENTS-API early-return mirrors carrier 8: never touch a contents/ span (its
-    #    main/master gating signal is body/positional-resident). --cache is OUT (its
-    #    duration grammar provably cannot carry the substring — a genuine non-source,
-    #    not a residual); every other non-target value flag is IN. Same execution-
-    #    routing guards as carriers 3/5/7/8: skip when piped/process-sub to a shell;
-    #    the double-quoted arm preserves a value containing command substitution
-    #    `$(`/backtick (it would execute). ADDITIVE-PURE: a self-contained carrier that
-    #    only REMOVES incidental FP substrings from non-gating values — it adds no arm
-    #    and modifies no existing danger path, so it cannot open a new under-block.
+    # 9. Strip gh-api CLIENT-SIDE OUTPUT-SELECTOR + non-target flag VALUES (#1118), via
+    #    the SHARED quote-safe _strip_flag_values helper.
+    #    Carrier 8 removes the merge/git-refs FP substring from request-BODY values, but a
+    #    gh-api command's output selectors (--jq/-q jq filter, --template/-t Go template)
+    #    and other non-target value flags (-H/--header, --input body-file name, --hostname,
+    #    -p/--preview) still carry it, so a graphql/REST READ whose --jq names a response
+    #    field like `mergeStateStatus` is OVER-BLOCKED by the .*merge implicit-POST arm.
+    #    These VALUES can NEVER be the request ENDPOINT or METHOD (jq/template run on the
+    #    RESPONSE client-side; a header is request metadata; --input names a local file; a
+    #    hostname/preview name is not the resource — the endpoint is always the URL
+    #    positional), so stripping ONLY the value is zero-under-block (the CLIENT-vs-SERVER
+    #    analogue of carrier 8's PATH-vs-BODY invariant). gh-api's flag vocabulary is FINITE
+    #    + DOCUMENTED, so this surface is BOUNDED (unlike curl/wget's unbounded value-flag
+    #    vocabulary -> WON'T-FIX by construction, #1098). Scoped to a gh-api span ONLY (its
+    #    OWN _GH_API_PREFIX anchor, NARROWER than carrier 8's shared curl/wget/gh-api span),
+    #    and the FORM-AWARE `_selector_flagsep` is token-boundary anchored (`(?<!\S)`), so
+    #    -q/-t/-H/-p can never mis-strip curl -t (--telnet-option), wget -t (--tries),
+    #    gh pr create -t (--title, carrier 7), or a `-q` mid-token. Every flag token is KEPT
+    #    (only the value is replaced) so the implicit-POST lookaheads still fire on a genuine
+    #    write (a real mutation via --input to a path-resident endpoint keeps its --input
+    #    flag and stays HELD; its destructive target lives in the URL positional, never
+    #    stripped). CONTENTS-API early-return mirrors carrier 8: never touch a contents/ span
+    #    (its main/master gating signal is body/positional-resident). --cache is OUT (its
+    #    duration grammar provably cannot carry the substring).
+    #
+    #    QUOTE-SAFETY (#1118 re-model): the value strip goes through the SHARED
+    #    _strip_flag_values (quote-BALANCED _VALUE_TOKEN) + the FORM-AWARE separator (space /
+    #    =-long / =-short / attached-short). The PRIOR shipped carrier 9 used a
+    #    non-quote-aware unquoted arm (`[^\s'"]\S*`) + a `\s+`-only separator; its earlier
+    #    "additive-pure / cannot open a new under-block" claim was FALSIFIED by the #1118
+    #    review — on an embedded-quote value it emitted a DANGLING quote that mis-paired in
+    #    _mask_shell_quotes, MERGED legs, and regressed the guard in BOTH directions (SEC-1
+    #    over-block + SEC-2 under-block). This is NOT +N/-0; correctness is proven by
+    #    BIDIRECTIONAL base-vs-HEAD-vs-PATCH testing, never byte-diff. Same execution-routing
+    #    guards as carriers 3/5/7/8: skip when piped/process-sub to a shell; the double-
+    #    quoted arm preserves a value containing command substitution `$(`/backtick.
     if not piped_to_shell and not process_sub_to_shell:
         # The gh-api command span: from a gh-api head up to the first UNQUOTED shell
         # separator. Quote-aware body (balanced quotes consumed atomically; disjoint
@@ -2225,21 +2250,26 @@ def _strip_non_executable_content(command: str) -> str:
             r"(?:" + _GH_API_PREFIX + r")"
             r"""(?:[^&|;\n"']+|"(?:[^"\\]|\\.)*"|'[^']*')*"""
         )
-        # Long forms BEFORE short forms; the trailing `\s+` (added at each use) prevents
-        # `-t` matching inside `--template` and `-p` matching inside the boolean
-        # `--paginate` (deliberately NOT in the set — it carries no value). -q/-t/-H/-p
-        # are gh-api short flags (safe: this span is gh-api-only); --input/--hostname/
-        # --preview have no colliding short form here.
-        _selector_flag = (
-            r"(?:--jq|--template|--header|--input|--hostname|--preview"
-            r"|-q|-t|-H|-p)"
+        # FORM-AWARE, token-anchored separator (#1118 re-model, FIX-B). gh (cobra/pflag)
+        # accepts a flag value four ways: space (`--jq x`), =-long (`--jq=x`), =-short
+        # (`-q=x`), attached-short (`-qx`). Long flags require a separator; short flags may
+        # attach. `(?<!\S)` anchors the flag at a token boundary, so `-q`/`-t`/`-H`/`-p`
+        # never match inside a positional (`some-q-endpoint`) or an already-stripped value.
+        # Long forms BEFORE short forms (so `--template` is not read as `-t` + `emplate`).
+        # Boolean flags (`--paginate`, `--slurp`, …) carry no value and are absent from the
+        # set. Wrapped in ONE capturing group at the call site (see _strip_flag_values).
+        _selector_flagsep = (
+            r"(?<!\S)(?:"
+            r"(?:--jq|--template|--header|--input|--hostname|--preview)(?:\s+|=)"
+            r"|(?:-q|-t|-H|-p)(?:\s+|=)?"
+            r")"
         )
 
         def _keep_selector_dq(m: re.Match) -> str:
-            # group(1) = the flag (+ trailing whitespace) up to the opening quote.
+            # group(1) = the flag(+separator) captured by the wrapped _selector_flagsep.
             # Preserve a value that contains command substitution ($()/backtick) — it
-            # would EXECUTE and must stay visible to the danger arms (mirrors carrier
-            # 8's _keep_flag_dq; a SEPARATE helper here to keep this carrier +N / -0).
+            # would EXECUTE and must stay visible to the danger arms (same shape as carrier
+            # 8's _keep_flag_dq; both are passed as keep_fn to the shared _strip_flag_values).
             if _has_command_substitution(m.group(0)):
                 return m.group(0)
             return m.group(1) + "'STRIPPED'"
@@ -2252,23 +2282,16 @@ def _strip_non_executable_content(command: str) -> str:
             # safe pre-existing residual, not in #1118 scope).
             if re.search(r"contents/", span, re.IGNORECASE):
                 return span
-            # double-quoted value (preserve command-substitution)
-            span = re.sub(
-                r"(" + _selector_flag + r"\s+)\"(?:[^\"\\]|\\.)*\"",
-                _keep_selector_dq,
-                span,
-            )
-            # single-quoted value (never expands)
-            span = re.sub(
-                r"(" + _selector_flag + r"\s+)'[^']*'", r"\1'STRIPPED'", span
-            )
-            # UNQUOTED value (#1096 §2.3) — runs AFTER the quoted arms; the value's
-            # first char is a NON-quote (`[^\s'"]`), so a quoted value already handled
-            # above is never re-touched. Anchored on the selector-flag prefix, so the
-            # URL POSITIONAL endpoint (never preceded by such a prefix) is never matched
-            # -> a real destructive target in the path is never removed (over-block-safe).
-            span = re.sub(
-                r"(" + _selector_flag + r"\s+)[^\s'\"]\S*", _keep_selector_dq, span
+            # Selector flag VALUES via the SHARED quote-safe strip (FIX-A + FIX-B). One call
+            # does all three arms (dq / sq / unquoted VALUE-TOKEN) across all four value-
+            # attachment forms. The unquoted arm consumes a COMPLETE quote-balanced token, so
+            # an embedded-quote selector value (a jq `.a+" "+.b`, a Go template
+            # `{{.n}}" "{{.t}}`, `-q x"y z"`) can no longer leave a dangling quote that merges
+            # legs (SEC-1/SEC-2). Anchored on the selector-flag(+separator) prefix, so the URL
+            # POSITIONAL endpoint (never preceded by such a prefix) is never matched -> a real
+            # destructive target in the path is never removed (over-block-safe).
+            span = _strip_flag_values(
+                span, r"(" + _selector_flagsep + r")", _keep_selector_dq
             )
             return span
 

--- a/pact-plugin/tests/test_merge_guard_1118_output_selector.py
+++ b/pact-plugin/tests/test_merge_guard_1118_output_selector.py
@@ -1,0 +1,159 @@
+"""
+Location: pact-plugin/tests/test_merge_guard_1118_output_selector.py
+Summary: Bidirectional regression matrix for the #1118 carrier-9 output-selector strip —
+         the NEW additive `_strip_non_executable_content` pass that blanks the VALUES of
+         gh-api client-side non-target flags (--jq/-q, --template/-t, --header/-H,
+         --input, --hostname, --preview/-p) within a gh-api-only span. Locks in:
+         Direction 1 — a faithful gh-api READ whose output selector / header / body-file
+         name / hostname / preview value carries a `merge`/`git/refs` substring now
+         ALLOWs (was an OVER-BLOCK by the .*merge implicit-POST arm — a SACROSANCT
+         cardinal-sin cure); Direction 2 — every intentionally-held gh-api/CLI WRITE
+         STAYS held, because its destructive target lives in the URL positional or the
+         -X/--method flag (never a stripped value), and a contents/ span is preserved
+         verbatim.
+Used by: pytest (merge-guard suite).
+
+Non-vacuity (red-on-revert): the mechanism class asserts carrier 9 actually blanks a
+READ's --jq value (so `mergeStateStatus` no longer reaches the danger arms) AND leaves a
+WRITE's endpoint positional (`merges`) intact. Reverting carrier 9 makes the READ's
+substring survive -> is_dangerous flips to True -> the Direction-1 asserts fail. The
+Direction-2 asserts are DISCRIMINATING negatives (each pins the SPECIFIC is_dangerous
+True + the op_type the guard classifies it as), not a "matrix executes" smoke check.
+
+Dangerous substrings are constructed at runtime (M / MS / GR) so this file carries no raw
+`gh pr merge` / `git/refs` literal — mirrors the architect probe-harness convention and
+keeps the file inert to any literal-scanning tool.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import pytest  # noqa: E402
+
+from shared.merge_guard_common import (  # noqa: E402
+    is_dangerous_command,
+    detect_command_operation_type,
+    _strip_non_executable_content,
+)
+
+# Dangerous substrings assembled at runtime — never a raw literal in the source.
+M = "mer" + "ge"                 # merge
+MS = "mer" + "geStateStatus"     # a graphql/REST response field name
+GR = "git" + "/refs"             # git/refs
+
+
+# --------------------------------------------------------------------------------------
+# Direction 1 — over-blocked READS must now ALLOW (is_dangerous is False).
+# --------------------------------------------------------------------------------------
+class TestReadsFlipToAllow:
+    """A faithful gh-api read whose non-target value carries a merge/git-refs substring
+    is no longer held. The two NEW maximal-set shapes (--hostname, --preview) are
+    included explicitly per the lead-ratified strip set."""
+
+    READS = {
+        "graphql_jq_single_quote": f"gh api graphql -f query='q' --jq '.data.repo.pr.{MS}'",
+        "graphql_jq_double_quote": f'gh api graphql -f query="q" --jq ".data.repo.pr.{MS}"',
+        "graphql_no_jq":           "gh api graphql -f query='q'",
+        "rest_jq_mergeable":       f"gh api repos/o/r/pulls/1 -f foo=bar --jq '.{M}able'",
+        "rest_template":           f"gh api repos/o/r/pulls/1 -f foo=bar -t '{{{{.{MS}}}}}'",
+        "rest_header":             f'gh api repos/o/r/pulls/1 -f foo=bar -H "Accept: application/vnd.github.{M}-preview+json"',
+        "input_merge_named_file":  f"gh api repos/o/r/issues/1/comments --input {M}-notes.json",
+        "input_gitrefs_named_file":f"gh api repos/o/r/issues/1/comments --input {GR}-notes.json",
+        "jq_no_body_flag":         f"gh api repos/o/r/pulls/1 --jq '.{M}able'",
+        "gh_pr_view_not_gh_api":   f"gh pr view 1116 --json {MS} --jq '.{MS}'",
+        "hostname_new_shape":      f"gh api --hostname {M}.example.com -f q=x repos/o/r/pulls/1",
+        "preview_new_shape":       f"gh api --preview {M}-info -f q=x repos/o/r/pulls/1",
+    }
+
+    @pytest.mark.parametrize("command", READS.values(), ids=list(READS.keys()))
+    def test_read_now_allows(self, command):
+        assert is_dangerous_command(command) is False
+
+
+# --------------------------------------------------------------------------------------
+# Direction 2 — intentionally-held WRITES must STAY held (discriminating negatives).
+# Each asserts the SPECIFIC is_dangerous True AND the op_type the guard classifies it as,
+# proving it is held for the right reason and that carrier 9 did not alter the target.
+# --------------------------------------------------------------------------------------
+class TestWritesStayHeld:
+
+    def test_gh_pr_merge_held(self):
+        cmd = f"gh pr {M} 1116 --squash"
+        assert is_dangerous_command(cmd) is True
+        assert detect_command_operation_type(cmd) == M
+
+    def test_api_merges_body_flag_held(self):
+        # Endpoint `…/merges` (positional) survives carrier 9; the -f body value is
+        # carrier 8's domain. Held via the implicit-POST .*merge API arm; op_type None.
+        cmd = f"gh api repos/o/r/{M}s -f base=main -f head=x"
+        assert is_dangerous_command(cmd) is True
+        assert detect_command_operation_type(cmd) is None
+
+    def test_api_merges_input_held(self):
+        # --input arms implicit-POST and its VALUE is stripped, but the real target
+        # `…/merges` is the positional endpoint (never stripped) -> still held.
+        cmd = f"gh api repos/o/r/{M}s --input body.json"
+        assert is_dangerous_command(cmd) is True
+        assert detect_command_operation_type(cmd) is None
+
+    def test_api_delete_gitrefs_held(self):
+        cmd = f"gh api -X DELETE repos/o/r/{GR}/heads/x"
+        assert is_dangerous_command(cmd) is True
+        assert detect_command_operation_type(cmd) == "branch-delete"
+
+    def test_api_delete_gitrefs_with_selectors_held(self):
+        # Selector values (--input, -t) are stripped; the git/refs positional + -X DELETE
+        # gating signals survive -> stays held with an unchanged classification.
+        cmd = f"gh api -X DELETE repos/o/r/{GR}/heads/x --input b.json -t '{{{{.x}}}}'"
+        assert is_dangerous_command(cmd) is True
+        assert detect_command_operation_type(cmd) == "branch-delete"
+
+    def test_api_put_branch_protection_held(self):
+        cmd = "gh api -X PUT repos/o/r/branches/main/protection -f x=y"
+        assert is_dangerous_command(cmd) is True
+        assert detect_command_operation_type(cmd) == "branch-protection"
+
+    def test_contents_put_span_preserved_held(self):
+        # Contents-API early-return: the span is preserved verbatim, so the body-resident
+        # main/master gating signal is never removed even though a --jq selector is present.
+        cmd = f"gh api -X PUT repos/o/r/contents/f.txt -f branch=main --jq '.{M}able'"
+        assert is_dangerous_command(cmd) is True
+        assert detect_command_operation_type(cmd) is None
+
+
+# --------------------------------------------------------------------------------------
+# Mechanism / non-vacuity — proves carrier 9 does the work (red-on-revert anchor).
+# --------------------------------------------------------------------------------------
+class TestCarrier9Mechanism:
+
+    def test_read_selector_value_is_blanked(self):
+        # The --jq value carrying the response-field substring is removed from the
+        # analysis surface, so it never reaches the .*merge arm.
+        stripped = _strip_non_executable_content(
+            f"gh api graphql -f query='q' --jq '.{MS}'"
+        )
+        assert MS not in stripped
+
+    def test_write_endpoint_positional_survives(self):
+        # The DESTRUCTIVE target lives in the URL positional and is NEVER stripped —
+        # this is the invariant that keeps every Direction-2 write held.
+        stripped = _strip_non_executable_content(f"gh api repos/o/r/{M}s -f base=main")
+        assert f"{M}s" in stripped
+
+    def test_gh_api_template_short_flag_stripped_in_span(self):
+        # -t is --template WITHIN a gh-api span, so its value IS blanked (the short-flag
+        # arm of carrier 9 fires only under the gh-api anchor).
+        stripped = _strip_non_executable_content(
+            f"gh api repos/o/r/pulls/1 -f foo=bar -t '.{M}'"
+        )
+        assert M not in stripped
+
+    def test_curl_header_not_treated_as_selector(self):
+        # Scope isolation: carrier 9's -H strip is gh-api-anchored. The SAME -H on a
+        # curl command is outside the gh-api span (and -H is not carrier 8's domain),
+        # so its value survives — proving carrier 9 never applies globally.
+        stripped = _strip_non_executable_content(
+            f'curl -H "X-Thing: {M}" https://api.example.com/foo'
+        )
+        assert M in stripped

--- a/pact-plugin/tests/test_merge_guard_1118_output_selector.py
+++ b/pact-plugin/tests/test_merge_guard_1118_output_selector.py
@@ -1,7 +1,7 @@
 """
 Location: pact-plugin/tests/test_merge_guard_1118_output_selector.py
 Summary: Bidirectional regression matrix for the #1118 carrier-9 output-selector strip —
-         the NEW additive `_strip_non_executable_content` pass that blanks the VALUES of
+         the `_strip_non_executable_content` selector value-strip (re-modeled quote-safe) that blanks the VALUES of
          gh-api client-side non-target flags (--jq/-q, --template/-t, --header/-H,
          --input, --hostname, --preview/-p) within a gh-api-only span. Locks in:
          Direction 1 — a faithful gh-api READ whose output selector / header / body-file

--- a/pact-plugin/tests/test_merge_guard_1118_output_selector_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1118_output_selector_cert.py
@@ -16,9 +16,9 @@ Summary: TEST-phase CERTIFICATION matrix for the #1118 carrier-9 output-selector
          NON-VACUITY: empirical red-on-revert was MEASURED at cert time by loading the HEAD~1
          (pre-carrier-9) module and confirming every Direction-1 read was is_dangerous=True
          there and False under the shipped module (9/9 flip; 0 held-write flips) — recorded
-         in the TEST HANDOFF. That measurement is a cert-time artifact, NOT shipped here: a
-         `git show HEAD~1` harness is fragile once further commits land / after squash-merge,
-         and the repo ships no such revert harness. The git-independent shipped red-on-revert
+         in the TEST HANDOFF. That cert-time-only stance is now SUPERSEDED: the base-vs-HEAD-vs-PATCH
+         differential IS shipped as a permanent suite (test_merge_guard_1118_recert.py — pinned
+         base/HEAD SHAs, self-skipping on a shallow clone). The git-independent shipped red-on-revert
          anchor is the coder file's TestCarrier9Mechanism (it asserts a read's selector value
          is blanked; reverting carrier 9 makes the substring survive -> those asserts fail —
          verified: at HEAD~1, `mergeStateStatus` DOES survive the strip). The LOAD-BEARING

--- a/pact-plugin/tests/test_merge_guard_1118_output_selector_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1118_output_selector_cert.py
@@ -1,0 +1,209 @@
+"""
+Location: pact-plugin/tests/test_merge_guard_1118_output_selector_cert.py
+Summary: TEST-phase CERTIFICATION matrix for the #1118 carrier-9 output-selector strip,
+         EXPANDING the coder's regression file (test_merge_guard_1118_output_selector.py)
+         with adversarial-edge + boundary coverage against the REAL is_dangerous_command /
+         detect_command_operation_type. Carrier 9 blanks the VALUES of gh-api client-side
+         non-target flags (-q/--jq, -t/--template, -H/--header, --input, --hostname,
+         -p/--preview) inside a gh-api-only span, keeping the flag tokens.
+
+         Asymmetric gates (merge-guard purpose be1bf393): PRIMARY = no faithful READ is ever
+         over-blocked (Direction 1 — cardinal sin); co-equal security = no NEW under-block
+         (Direction 2 held writes + the command-substitution carve-out). Direction-2 asserts
+         are DISCRIMINATING negatives (specific is_dangerous True AND the op_type the guard
+         classifies), never "matrix runs".
+
+         NON-VACUITY: empirical red-on-revert was MEASURED at cert time by loading the HEAD~1
+         (pre-carrier-9) module and confirming every Direction-1 read was is_dangerous=True
+         there and False under the shipped module (9/9 flip; 0 held-write flips) — recorded
+         in the TEST HANDOFF. That measurement is a cert-time artifact, NOT shipped here: a
+         `git show HEAD~1` harness is fragile once further commits land / after squash-merge,
+         and the repo ships no such revert harness. The git-independent shipped red-on-revert
+         anchor is the coder file's TestCarrier9Mechanism (it asserts a read's selector value
+         is blanked; reverting carrier 9 makes the substring survive -> those asserts fail —
+         verified: at HEAD~1, `mergeStateStatus` DOES survive the strip). The LOAD-BEARING
+         cmd-substitution edge below carries its own in-process non-vacuity (the payload verb
+         must survive the strip, else an under-block).
+
+Used by: pytest (merge-guard suite).
+
+Dangerous substrings are assembled at runtime (M / MS / GR / PR_MERGE) so this file carries
+no raw `gh pr merge` / `git/refs` literal — mirrors the coder file + architect probe-harness
+convention and keeps the file inert to any literal-scanning tool.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import pytest  # noqa: E402
+
+from shared.merge_guard_common import (  # noqa: E402
+    is_dangerous_command,
+    detect_command_operation_type,
+    _strip_non_executable_content,
+)
+
+# Dangerous substrings assembled at runtime — never a raw literal in the source.
+M = "mer" + "ge"                  # merge
+MS = "mer" + "geStateStatus"      # a graphql/REST response field name
+GR = "git" + "/refs"              # git/refs
+PR_MERGE = f"gh pr {M} 5"         # command-substitution payload (a real destructive verb)
+
+
+# --------------------------------------------------------------------------------------
+# Direction 1 (PRIMARY gate) — additional over-blocked READS that must now ALLOW.
+# Extends the coder file's 12 reads with boundary/collision shapes: short-flag forms,
+# multi-selector combos, escaped quotes, the --paginate boolean (must NOT be mis-stripped
+# as -p), an explicit -X GET read, and broader non-gh-api gh reads.
+# --------------------------------------------------------------------------------------
+class TestDirection1ReadsExpanded:
+    READS = {
+        # Multiple selectors on one read, each carrying a merge substring.
+        "multi_selector_combo": f"gh api repos/o/r/pulls/1 -f q=x --jq '.{M}able' -t '{{{{.{MS}}}}}' -H 'X-{M}: 1'",
+        # Double-quoted jq value with escaped inner quotes (quote-aware span must consume it).
+        "selector_escaped_quote": f'gh api repos/o/r/pulls/1 -f q=x --jq ".a[\\"{M}\\"]"',
+        # -q short form of --jq.
+        "q_short_jq_form": f"gh api repos/o/r/pulls/1 -f q=x -q '.{M}able'",
+        # -p short preview with a comma-multi-value (single token; no spurious leg).
+        "p_preview_comma_multi": f"gh api -p {M}-info,other-info repos/o/r/pulls/1 -f q=x",
+        # Explicit GET read with a selector — stays allow.
+        "explicit_get_with_selector": f"gh api -X GET repos/o/r/pulls/1 -f q=x --jq '.{M}able'",
+        # --paginate is a BOOLEAN (no value) — the -p arm requires trailing whitespace+value,
+        # so --paginate is never mis-stripped; only --jq's value is blanked -> read allows.
+        "paginate_boolean_untouched": f"gh api repos/o/r/pulls/1 --paginate --jq '.{M}able'",
+        # Broader non-gh-api gh reads (carrier 9 never touches a non-gh-api span).
+        "gh_pr_checks": "gh pr checks 1116",
+        "gh_issue_view": "gh issue view 1116",
+        "gh_release_list": "gh release list",
+    }
+
+    @pytest.mark.parametrize("command", READS.values(), ids=list(READS.keys()))
+    def test_read_now_allows(self, command):
+        assert is_dangerous_command(command) is False
+
+    def test_paginate_boolean_survives_strip(self):
+        # Mechanism: --paginate is preserved verbatim; only the --jq value is blanked.
+        stripped = _strip_non_executable_content(
+            f"gh api repos/o/r/pulls/1 --paginate --jq '.{M}able'"
+        )
+        assert "--paginate" in stripped
+        assert MS not in stripped and f".{M}able" not in stripped
+
+
+# --------------------------------------------------------------------------------------
+# Direction 2 (co-equal security gate) — additional intentionally-held WRITES that must
+# STAY held with the RIGHT op_type. Complements the coder's TestWritesStayHeld with the
+# #1096 gh-api pulls/merge PUT arm and the maximal-set --hostname/--preview held rows
+# (§6 rows 19/20): the destructive target survives in the URL positional / -X method even
+# when carrier 9 blanks the non-target selector values.
+# --------------------------------------------------------------------------------------
+class TestDirection2HeldExpanded:
+
+    def test_api_pulls_merge_put_held(self):
+        # #1096 gh-api merge arm: endpoint positional pulls/5/merge survives carrier 9.
+        cmd = f"gh api -X PUT repos/o/r/pulls/5/{M} -f merge_method=squash"
+        assert is_dangerous_command(cmd) is True
+        assert detect_command_operation_type(cmd) == M
+
+    def test_api_merges_hostname_held(self):
+        # §6 row 19: --hostname value stripped, but the /merges positional + implicit-POST
+        # (-f) survive -> still held; op None (implicit-POST merge API, not a classified verb).
+        cmd = f"gh api --hostname ghe.io repos/o/r/{M}s -f base=main"
+        assert is_dangerous_command(cmd) is True
+        assert detect_command_operation_type(cmd) is None
+
+    def test_api_delete_gitrefs_hostname_preview_held(self):
+        # §6 row 20: --hostname AND -p values stripped, but git/refs positional + -X DELETE
+        # survive -> stays branch-delete. Proves stripping multiple non-target values never
+        # removes the path/method gating signal.
+        cmd = f"gh api -X DELETE --hostname x.io repos/o/r/{GR}/heads/x -p somepreview"
+        assert is_dangerous_command(cmd) is True
+        assert detect_command_operation_type(cmd) == "branch-delete"
+
+
+# --------------------------------------------------------------------------------------
+# LOAD-BEARING adversarial edge — command substitution inside a selector value.
+# Falsifies the double-quote _keep_selector_dq cmd-sub CARVE-OUT: a `$(...)` in a
+# DOUBLE-quoted value really executes when the shell runs the command, so carrier 9 must
+# PRESERVE it (leave the embedded verb visible to the danger arms) — else stripping it is
+# an UNDER-BLOCK. A SINGLE-quoted `$(...)` is literal shell text (never executes), so
+# stripping it is correct and the command is a genuine read -> allow. The single/double
+# asymmetry is shell-semantic-faithful, not accidental.
+# --------------------------------------------------------------------------------------
+class TestCommandSubstitutionCarveOut:
+
+    def test_double_quote_cmdsub_stays_held(self):
+        # `$(gh pr merge 5)` in a DOUBLE-quoted -H value executes at runtime -> must stay held.
+        cmd = f'gh api -H "X: $({PR_MERGE})" repos/o/r/pulls/1'
+        assert is_dangerous_command(cmd) is True
+        assert detect_command_operation_type(cmd) == M
+
+    def test_double_quote_cmdsub_payload_survives_strip(self):
+        # In-process non-vacuity for the carve-out: the embedded destructive verb MUST remain
+        # on the analysis surface. If the carve-out were removed, this substring would be
+        # blanked and is_dangerous would drop to False (the under-block this edge guards).
+        cmd = f'gh api -H "X: $({PR_MERGE})" repos/o/r/pulls/1'
+        stripped = _strip_non_executable_content(cmd)
+        assert f"gh pr {M}" in stripped
+
+    def test_single_quote_cmdsub_allows(self):
+        # `$(...)` inside a SINGLE-quoted value is literal (never executes) -> a genuine read.
+        # Carrier 9 blanks it and the command correctly ALLOWs (curing the HEAD~1 over-block).
+        cmd = f"gh api -H 'X: $({PR_MERGE})' repos/o/r/pulls/1"
+        assert is_dangerous_command(cmd) is False
+
+
+# --------------------------------------------------------------------------------------
+# Selector value carrying shell separators — the strip neutralizes embedded metachars, so
+# no spurious destructive leg is injected and the read allows.
+# --------------------------------------------------------------------------------------
+class TestSelectorValueNeutralization:
+
+    def test_separator_in_selector_no_spurious_leg(self):
+        cmd = 'gh api -H "X: a; touch y" -f q=x repos/o/r/pulls/1'
+        assert is_dangerous_command(cmd) is False
+
+    def test_separator_payload_blanked_from_surface(self):
+        # Mechanism: the ` ; touch y` payload is inside the -H value and is replaced by the
+        # 'STRIPPED' placeholder, so it can never be re-parsed as a separate command leg.
+        cmd = 'gh api -H "X: a; touch y" -f q=x repos/o/r/pulls/1'
+        stripped = _strip_non_executable_content(cmd)
+        assert "touch" not in stripped
+
+
+# --------------------------------------------------------------------------------------
+# Direction-2 sibling — a HELD write whose selector value ALSO carries a benign merge
+# substring: it stays held via the path/method signal, proving the strip of the non-target
+# value never weakens a real gating signal (dispatch item 1, Direction 2).
+# --------------------------------------------------------------------------------------
+class TestHeldWriteWithBenignSelectorSubstring:
+
+    def test_delete_gitrefs_with_benign_merge_header_held(self):
+        cmd = f"gh api -X DELETE repos/o/r/{GR}/heads/x -H 'X-{M}: 1'"
+        assert is_dangerous_command(cmd) is True
+        assert detect_command_operation_type(cmd) == "branch-delete"
+
+
+# --------------------------------------------------------------------------------------
+# Scope isolation — carrier 9's -q/-t/-H/-p are gh-api SHORT flags, matched only under the
+# gh-api span anchor. The SAME short flags on curl/wget mean something else (curl -t =
+# --telnet-option, wget -t = --tries) and MUST NOT be stripped. Complements the coder
+# file's curl -H isolation test with the -t short-flag collisions named in the design's
+# risk table.
+# --------------------------------------------------------------------------------------
+class TestScopeIsolationExpanded:
+
+    def test_curl_short_t_value_survives(self):
+        # curl -t (--telnet-option) is outside the gh-api span -> its value is NOT stripped.
+        stripped = _strip_non_executable_content(
+            f"curl -t {M}-opt https://api.example.com/x"
+        )
+        assert M in stripped
+
+    def test_wget_short_t_value_survives(self):
+        # wget -t (--tries) is outside the gh-api span -> its value is NOT stripped.
+        stripped = _strip_non_executable_content(
+            f"wget -t {M} https://api.example.com/x"
+        )
+        assert M in stripped

--- a/pact-plugin/tests/test_merge_guard_1118_recert.py
+++ b/pact-plugin/tests/test_merge_guard_1118_recert.py
@@ -1,0 +1,339 @@
+"""
+Location: pact-plugin/tests/test_merge_guard_1118_recert.py
+Summary: Bidirectional base-vs-HEAD-vs-PATCH re-cert matrix for the #1118 QUOTE-SAFE re-model
+         (design §7). The shipped carrier 9 (space-only, commit 38f76965) had a quote-unsafe
+         value strip whose dangling `"` merged legs and defeated per-leg isolation in BOTH
+         directions (SEC-1 over-block / SEC-2 under-block), plus an incomplete cure (RED-1:
+         `=`/attached flag spellings) and a shared carrier-8 flaw. The PATCH (commit 6d71a816,
+         current HEAD) replaces the non-quote-aware `[^\\s'"]\\S*` matcher with a shared
+         quote-BALANCED `_VALUE_TOKEN` consumed via `_strip_flag_values` by BOTH carriers 8 & 9,
+         and a form-aware `_selector_flagsep` (space / =-long / =-short / attached-short).
+
+         WHY THIS SUITE EXISTS (design §2.4): the original 44-test matrix was SPACE-FORM-ONLY and
+         proved `+N/-0` additive SOURCE, not additive BEHAVIOR — it gave ZERO coverage for the
+         embedded-quote leg-merge (SEC-1/SEC-2), the attached-spelling over-block (RED-1), the
+         carrier-8 twin, or the leg-count mechanism. That coverage gap is why the regression
+         shipped. This suite locks the whole class permanently, asserting a base-vs-HEAD-vs-PATCH
+         DIFFERENTIAL (not a bare pass) so each cure row is non-vacuous by construction.
+
+         base  = c5e9b324 (no carrier 9)         — the correct pre-carrier-9 behavior
+         HEAD  = 38f76965 (buggy space-only)     — the regressed behavior the PATCH fixes
+         PATCH = 6d71a816 (quote-safe re-model)  — the live/shipped module (current HEAD)
+
+         The base/HEAD modules load via the __package__='shared' git-show harness (they are
+         permanent merged commits). When history is unavailable (shallow clone), the DIFFERENTIAL
+         rows self-SKIP; the absolute PATCH assertions (held battery, cmd-sub, over-match anchor,
+         leg-count, structural guards, graphql residual) always run.
+Used by: pytest (merge-guard suite).
+
+Dangerous substrings are assembled at runtime (M / GR / PR_MERGE) so this file carries no raw
+`gh pr merge` / `git/refs` literal — mirrors the coder + cert files' probe-harness convention.
+"""
+import subprocess
+import sys
+import importlib.util
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import pytest  # noqa: E402
+
+import shared.merge_guard_common as PATCH  # noqa: E402  (live module == current HEAD == the PATCH)
+
+# Dangerous substrings assembled at runtime — never a raw literal in the source.
+M = "mer" + "ge"                 # merge
+GR = "git" + "/refs"             # git/refs
+PR_MERGE = f"gh pr {M} 5"        # a real destructive verb, for the cmd-sub carve-out edge
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]  # tests -> pact-plugin -> worktree root
+_MGC_PATH = "pact-plugin/hooks/shared/merge_guard_common.py"
+_BASE_SHA = "c5e9b324"   # pre-carrier-9 baseline (permanent merged commit)
+_HEAD_SHA = "38f76965"   # buggy space-only original carrier 9 (permanent merged commit)
+
+
+def _load_module_at(sha):
+    """Load the merge_guard_common module as it existed at `sha`, or None if unavailable.
+
+    Execs the historical single-file source with __package__='shared' so its sole relative
+    import (`from .paths import get_claude_config_dir`) resolves against the LIVE, unchanged
+    shared.paths (only merge_guard_common.py changed across these revisions). NON-DISRUPTIVE:
+    reads via `git show`, never checks out — HEAD is untouched. Returns None on any failure
+    (git missing, shallow clone lacking the commit) so the differential rows self-skip.
+    """
+    try:
+        src = subprocess.check_output(
+            ["git", "show", f"{sha}:{_MGC_PATH}"],
+            cwd=str(_REPO_ROOT), text=True, stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+    spec = importlib.util.spec_from_loader(f"shared._mgc_{sha}", loader=None)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = "shared"
+    try:
+        exec(compile(src, f"<{_MGC_PATH}@{sha}>", "exec"), mod.__dict__)
+    except Exception:
+        return None
+    return mod
+
+
+_BASE = _load_module_at(_BASE_SHA)
+_HEAD = _load_module_at(_HEAD_SHA)
+_HISTORY_OK = _BASE is not None and _HEAD is not None
+
+# Skip the base-vs-HEAD differential rows when history is unavailable; the absolute PATCH
+# assertions still run. The differential IS the non-vacuity proof (each cure row measures a
+# real base->PATCH behavior change), so it runs wherever the merged history is present (dev CI).
+requires_history = pytest.mark.skipif(
+    not _HISTORY_OK,
+    reason=f"base ({_BASE_SHA}) / HEAD ({_HEAD_SHA}) source unavailable (shallow clone); "
+           "differential rows need the merged history. Absolute PATCH rows still run.",
+)
+
+
+def _isd_triple(cmd):
+    return (_BASE.is_dangerous_command(cmd),
+            _HEAD.is_dangerous_command(cmd),
+            PATCH.is_dangerous_command(cmd))
+
+
+def _op_triple(cmd):
+    return (_BASE.detect_command_operation_type(cmd),
+            _HEAD.detect_command_operation_type(cmd),
+            PATCH.detect_command_operation_type(cmd))
+
+
+# ======================================================================================
+# §7.1 SEC-1 — embedded-quote leg-merge OVER-BLOCK cured (base=False, HEAD=True, PATCH=False)
+# ======================================================================================
+@requires_history
+class TestSEC1OverBlockCured:
+    SEC1 = {
+        "merge_path":   f'gh api repos/o/r/pulls/5/{M} -X GET -q p"q r" && gh api "x/y" -X POST -f a=b',
+        "gitrefs_path": f'gh api repos/o/r/{GR}/heads/x -X GET -q p"q r" && gh api "x/y" -X POST -f a=b',
+    }
+
+    @pytest.mark.parametrize("cmd", SEC1.values(), ids=list(SEC1.keys()))
+    def test_sec1_differential(self, cmd):
+        # base ALLOWED the faithful compound; the leg-merge NEWLY BLOCKED it at HEAD (cardinal
+        # sin); PATCH restores allow. A bare PATCH=False would be vacuous — the base=False /
+        # HEAD=True legs prove the row measures the real cure.
+        assert _isd_triple(cmd) == (False, True, False)
+
+
+# ======================================================================================
+# §7.2 SEC-2 — embedded-quote leg-merge UNDER-BLOCK closed (base=True, HEAD=False, PATCH=True)
+# ======================================================================================
+@requires_history
+class TestSEC2UnderBlockClosed:
+    SEC2 = {
+        "input_dq":  f'gh api repos/o/r/{M}s --input b.json -q x"y z" && gh api "repos/o/r" -X GET',
+        "jq_concat": f'gh api repos/o/r/{M}s --input b.json -q .a+" "+.b && gh api "repos/o/r" -X GET',
+        "template":  f'gh api repos/o/r/{M}s --input b.json -t {{{{.n}}}}" "{{{{.t}}}} && gh api "repos/o/r" -X GET',
+    }
+
+    @pytest.mark.parametrize("cmd", SEC2.values(), ids=list(SEC2.keys()))
+    def test_sec2_differential(self, cmd):
+        # A real /merges mutation ESCAPED at HEAD (the merged leg leaked leg-2's -X GET into the
+        # .*merge negative lookahead). base held it; PATCH restores the hold.
+        assert _isd_triple(cmd) == (True, False, True)
+
+
+# ======================================================================================
+# §7.3 Carrier-8 shared flaw — pre-existing under-block FIXED (base=False, HEAD=False, PATCH=True)
+# ======================================================================================
+@requires_history
+class TestCarrier8TwinFixed:
+    def test_carrier8_body_flag_quote_unsafe_fixed(self):
+        # Carrier 8's body-flag arm had the SAME non-quote-aware matcher -> a real mutation
+        # escaped at BOTH base and HEAD; the shared quote-safe _VALUE_TOKEN closes it at PATCH.
+        cmd = f'gh api repos/o/r/{M}s -f k=x"y z" && gh api "o/r" -X GET'
+        assert _isd_triple(cmd) == (False, False, True)
+
+
+# ======================================================================================
+# §7.4 RED-1 — attached/adjacent selector spellings cured (base=True, HEAD=True, PATCH=False)
+# ======================================================================================
+class TestRED1AttachmentFormsCured:
+    FORMS = {
+        "jq_eq_long":        f"gh api graphql -f query=x --jq=.{M}able",
+        "template_eq_long":  f"gh api repos/o/r/pulls/1 -f q=x --template=.{M}able",
+        "header_eq_long":    f"gh api repos/o/r/pulls/1 -f q=x --header=X-{M}:1",
+        "hostname_eq_long":  f"gh api --hostname={M}.example.com -f q=x repos/o/r/pulls/1",
+        "preview_eq_long":   f"gh api -f q=x --preview={M}-info repos/o/r/pulls/1",
+        "q_eq_short":        f"gh api graphql -f query=x -q=.{M}able",
+        "q_attached_short":  f"gh api graphql -f query=x -q.{M}able",
+    }
+
+    @pytest.mark.parametrize("cmd", FORMS.values(), ids=list(FORMS.keys()))
+    def test_attached_form_now_allows_at_patch(self, cmd):
+        # Absolute PATCH assertion (always runs): every attachment spelling of a faithful read
+        # is no longer over-blocked.
+        assert PATCH.is_dangerous_command(cmd) is False
+
+    @requires_history
+    @pytest.mark.parametrize("cmd", FORMS.values(), ids=list(FORMS.keys()))
+    def test_attached_form_differential(self, cmd):
+        # base AND HEAD both over-blocked the attached spelling (the space-only cure missed it);
+        # PATCH cures it. The base=True / HEAD=True legs make the PATCH=False non-vacuous.
+        assert _isd_triple(cmd) == (True, True, False)
+
+    def test_held_write_with_attached_selector_stays_held(self):
+        # Stripping an attached-short selector value must NOT unblock a real write: the -X DELETE
+        # git/refs target lives in the URL positional, never a stripped value.
+        cmd = f"gh api -X DELETE repos/o/r/{GR}/heads/x -q.{M}able"
+        assert PATCH.is_dangerous_command(cmd) is True
+        assert PATCH.detect_command_operation_type(cmd) == "branch-delete"
+
+
+# ======================================================================================
+# §7.5 MINT divergence restored (op: base=None, HEAD=merge, PATCH=None)
+# ======================================================================================
+@requires_history
+class TestMintDivergenceRestored:
+    def test_sec1_compound_op_classification(self):
+        # The mint path shares the strip pipeline, so the SEC-1 leg-merge mis-bound the compound
+        # to op='merge' at HEAD (a mint mis-bind). PATCH restores op=None (no spurious mint).
+        cmd = f'gh api repos/o/r/pulls/5/{M} -X GET -q p"q r" && gh api "x/y" -X POST -f a=b'
+        assert _op_triple(cmd) == (None, "merge", None)
+
+
+# ======================================================================================
+# §7.6 HELD-write regression guard — discriminating negatives @ PATCH (True + op unchanged)
+# ======================================================================================
+class TestHeldWriteBattery:
+    HELD = {
+        "pr_merge":        (f"gh pr {M} 1116 --squash", M),
+        "merges_body":     (f"gh api repos/o/r/{M}s -f base=main -f head=x", None),
+        "merges_input":    (f"gh api repos/o/r/{M}s --input body.json", None),
+        "delete_gitrefs":  (f"gh api -X DELETE repos/o/r/{GR}/heads/x", "branch-delete"),
+        "put_protection":  ("gh api -X PUT repos/o/r/branches/main/protection -f x=y", "branch-protection"),
+        "contents_main":   (f"gh api -X PUT repos/o/r/contents/f.txt -f branch=main --jq '.{M}able'", None),
+        "put_pulls_merge": (f"gh api -X PUT repos/o/r/pulls/5/{M} -f merge_method=squash", M),
+    }
+
+    @pytest.mark.parametrize("cmd,expected_op", HELD.values(), ids=list(HELD.keys()))
+    def test_held_write_stays_held_with_op(self, cmd, expected_op):
+        assert PATCH.is_dangerous_command(cmd) is True
+        assert PATCH.detect_command_operation_type(cmd) == expected_op
+
+
+# ======================================================================================
+# §7.7 cmd-sub carve-out + over-match anchor negatives @ PATCH
+# ======================================================================================
+class TestCmdSubCarveOut:
+    def test_double_quote_cmdsub_stays_held(self):
+        # A double-quoted $(...) executes at runtime -> the value is PRESERVED, the embedded verb
+        # stays visible to the danger arms, and the command stays held (merge).
+        cmd = f'gh api -H "X: $({PR_MERGE})" repos/o/r/pulls/1'
+        assert PATCH.is_dangerous_command(cmd) is True
+        assert PATCH.detect_command_operation_type(cmd) == M
+
+    def test_single_quote_cmdsub_allows(self):
+        # A single-quoted $(...) is literal shell text (never executes) -> stripped -> allow.
+        cmd = f"gh api -H 'X: $({PR_MERGE})' repos/o/r/pulls/1"
+        assert PATCH.is_dangerous_command(cmd) is False
+
+
+class TestOverMatchAnchorNegatives:
+    def test_mid_token_dash_q_in_positional_not_stripped(self):
+        # `(?<!\S)` anchors the selector flag at a token boundary, so a `-q` embedded inside a
+        # positional (`some-q-...`) is NOT read as the --jq short flag: the token survives verbatim
+        # in the stripped surface (proving the strip did not mis-consume the following chars).
+        cmd = f"gh api repos/o/r/some-q-{M}able -f x=y"
+        stripped = PATCH._strip_non_executable_content(cmd)
+        assert f"some-q-{M}able" in stripped
+
+    def test_dash_q_inside_quoted_selector_value_allows(self):
+        # A `-q` sequence inside a quoted --jq value is part of the (whole-stripped) value, never a
+        # second selector flag -> the read allows.
+        cmd = f"gh api repos/o/r/pulls/1 -f x=y --jq '.name-q.{M}able'"
+        assert PATCH.is_dangerous_command(cmd) is False
+
+
+# ======================================================================================
+# §7.8 Leg-count regression guard — the mechanism-level signature of the leg-merge bug
+# ======================================================================================
+class TestLegCountRegressionGuard:
+    SEC1 = f'gh api repos/o/r/pulls/5/{M} -X GET -q p"q r" && gh api "x/y" -X POST -f a=b'
+
+    def test_patch_splits_two_legs(self):
+        # Absolute PATCH mechanism guard: the dangling-quote compound splits into 2 legs (the
+        # quote-safe strip never merges them). This is the mechanism the regression corrupted.
+        assert len(PATCH._split_into_legs(self.SEC1)) == 2
+
+    @requires_history
+    def test_leg_count_differential(self):
+        # The regression signature: base=2 legs (correct), HEAD=1 leg (merged — the bug), PATCH=2
+        # (restored). Pins that the mechanism cannot silently regress to the merged state.
+        assert len(_BASE._split_into_legs(self.SEC1)) == 2
+        assert len(_HEAD._split_into_legs(self.SEC1)) == 1
+        assert len(PATCH._split_into_legs(self.SEC1)) == 2
+
+
+# ======================================================================================
+# §7.9 Unbalanced-quote-within-token edge — base-equivalent (introduces no new over/under-block)
+# ======================================================================================
+class TestUnbalancedTokenBaseEquivalence:
+    UNBAL = f'gh api repos/o/r/pulls/1 -f q=x -q a"b'  # `a"b` is itself a shell syntax error
+
+    def test_patch_equals_base_on_unbalanced_token(self):
+        # The consumer matches `a`, cannot consume the unterminated `"b`, and leaves the
+        # pre-existing lone `"` — base-equivalent (such input already fails _shell_tokenize /
+        # fails-toward-unmasked at the same offset). Non-faithful; never a new over/under-block.
+        assert PATCH.is_dangerous_command(self.UNBAL) is False
+
+    @requires_history
+    def test_unbalanced_token_differential_is_inert(self):
+        assert _BASE.is_dangerous_command(self.UNBAL) == PATCH.is_dangerous_command(self.UNBAL)
+
+
+# ======================================================================================
+# §7.10 Structural group-index guards — pin the shared helper's capturing-group contract
+# ======================================================================================
+class TestStructuralGroupIndexGuards:
+    def test_value_token_is_non_capturing(self):
+        # The shared _VALUE_TOKEN primitive MUST stay non-capturing (0 groups): keep_fn reads
+        # m.group(1) = the flag+separator, and the sq arm backrefs \1 = the flag+separator. A stray
+        # capturing group in _VALUE_TOKEN would shift those indices and silently mis-strip.
+        import re
+        assert re.compile(PATCH._VALUE_TOKEN).groups == 0
+
+    def test_strip_flag_values_group1_contract(self):
+        # Behavioral pin of the group-index contract via the importable shared helper: with a
+        # ONE-group flag_sep_regex, both the dq/unquoted keep_fn (m.group(1)) and the sq arm (\1)
+        # must resolve to the flag+separator. A group-count drift would raise or mis-render here.
+        def _keep(m):
+            return m.group(1) + "'STRIPPED'"
+        # single-quoted value -> sq arm's \1 backref
+        assert PATCH._strip_flag_values("-q '.secret'", r"(-q\s+)", _keep) == "-q 'STRIPPED'"
+        # unquoted VALUE-TOKEN -> keep_fn's m.group(1)
+        assert PATCH._strip_flag_values("-q .secret", r"(-q\s+)", _keep) == "-q 'STRIPPED'"
+
+    def test_sq_flag_token_round_trip_through_real_pipeline(self):
+        # Through the REAL _strip_non_executable_content (exercising the function-local
+        # _selector_flagsep): a held write's -q selector keeps its flag+separator and its value
+        # becomes the balanced 'STRIPPED' placeholder (no dangling quote).
+        cmd = f"gh api -X DELETE repos/o/r/{GR}/heads/x -q '.{M}able'"
+        stripped = PATCH._strip_non_executable_content(cmd)
+        assert "-q " in stripped
+        assert "'STRIPPED'" in stripped
+        assert f".{M}able" not in stripped
+
+
+# ======================================================================================
+# YELLOW-2 (from the Task #21 review) — graphql-mutation residual is a DOCUMENTED, UNCHANGED gap
+# ======================================================================================
+class TestGraphqlMutationResidualDocumented:
+    def test_graphql_mutation_under_block_residual_unchanged(self):
+        # The graphql-mutation gap (a `-f query='mutation{...}'` bypasses REST-path matching) is a
+        # SEPARATE tracked residual, deliberately NOT closed by #1118. Pin it as is_dangerous=False
+        # at PATCH so the documented residual cannot silently drift (over- OR under-block) unnoticed.
+        cmd = f"gh api graphql -f query='mutation{{ {M}PullRequest(input:{{}}) {{ number }} }}'"
+        assert PATCH.is_dangerous_command(cmd) is False
+
+    @requires_history
+    def test_graphql_mutation_residual_is_preexisting(self):
+        # Unchanged across base and PATCH — confirms #1118 neither introduced nor closed it.
+        cmd = f"gh api graphql -f query='mutation{{ {M}PullRequest(input:{{}}) {{ number }} }}'"
+        assert _BASE.is_dangerous_command(cmd) == PATCH.is_dangerous_command(cmd) is False

--- a/pact-plugin/tests/test_merge_guard_1118_recert.py
+++ b/pact-plugin/tests/test_merge_guard_1118_recert.py
@@ -33,6 +33,7 @@ import subprocess
 import sys
 import importlib.util
 from pathlib import Path
+from typing import Any
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
@@ -68,7 +69,7 @@ def _load_module_at(sha):
     except (subprocess.CalledProcessError, FileNotFoundError, OSError):
         return None
     spec = importlib.util.spec_from_loader(f"shared._mgc_{sha}", loader=None)
-    mod = importlib.util.module_from_spec(spec)
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]  # spec is never None here
     mod.__package__ = "shared"
     try:
         exec(compile(src, f"<{_MGC_PATH}@{sha}>", "exec"), mod.__dict__)
@@ -77,8 +78,12 @@ def _load_module_at(sha):
     return mod
 
 
-_BASE = _load_module_at(_BASE_SHA)
-_HEAD = _load_module_at(_HEAD_SHA)
+# Annotated Any: dynamically exec'd modules have no static type; the attribute accesses
+# below (is_dangerous_command / detect_command_operation_type / _split_into_legs) are
+# guarded at runtime by _HISTORY_OK (the @requires_history skip), so silence the editor-only
+# reportOptionalMemberAccess without a runtime assert.
+_BASE: Any = _load_module_at(_BASE_SHA)
+_HEAD: Any = _load_module_at(_HEAD_SHA)
 _HISTORY_OK = _BASE is not None and _HEAD is not None
 
 # Skip the base-vs-HEAD differential rows when history is unavailable; the absolute PATCH

--- a/pact-plugin/tests/test_merge_guard_1118_recert.py
+++ b/pact-plugin/tests/test_merge_guard_1118_recert.py
@@ -86,8 +86,10 @@ _HISTORY_OK = _BASE is not None and _HEAD is not None
 # real base->PATCH behavior change), so it runs wherever the merged history is present (dev CI).
 requires_history = pytest.mark.skipif(
     not _HISTORY_OK,
-    reason=f"base ({_BASE_SHA}) / HEAD ({_HEAD_SHA}) source unavailable (shallow clone); "
-           "differential rows need the merged history. Absolute PATCH rows still run.",
+    reason=f"NON-VACUITY DIFFERENTIAL SKIPPED — base ({_BASE_SHA}) / HEAD ({_HEAD_SHA}) source "
+           "unavailable (shallow clone / missing history). Every regression SHAPE is still "
+           "guarded by an always-run absolute PATCH assertion; only the base->PATCH "
+           "behavior-change PROOF did not run this session.",
 )
 
 
@@ -106,7 +108,6 @@ def _op_triple(cmd):
 # ======================================================================================
 # §7.1 SEC-1 — embedded-quote leg-merge OVER-BLOCK cured (base=False, HEAD=True, PATCH=False)
 # ======================================================================================
-@requires_history
 class TestSEC1OverBlockCured:
     SEC1 = {
         "merge_path":   f'gh api repos/o/r/pulls/5/{M} -X GET -q p"q r" && gh api "x/y" -X POST -f a=b',
@@ -114,17 +115,24 @@ class TestSEC1OverBlockCured:
     }
 
     @pytest.mark.parametrize("cmd", SEC1.values(), ids=list(SEC1.keys()))
+    def test_sec1_allows_at_patch(self, cmd):
+        # ALWAYS-RUN absolute recurrence guard (the lesson of the arc — guard the SHAPE, not only
+        # the differential): the faithful embedded-quote compound is NOT over-blocked at the
+        # committed PATCH. Fails if the leg-merge over-block ever returns, regardless of git history.
+        assert PATCH.is_dangerous_command(cmd) is False
+
+    @requires_history
+    @pytest.mark.parametrize("cmd", SEC1.values(), ids=list(SEC1.keys()))
     def test_sec1_differential(self, cmd):
-        # base ALLOWED the faithful compound; the leg-merge NEWLY BLOCKED it at HEAD (cardinal
-        # sin); PATCH restores allow. A bare PATCH=False would be vacuous — the base=False /
-        # HEAD=True legs prove the row measures the real cure.
+        # NON-VACUITY layer: base ALLOWED the faithful compound; the leg-merge NEWLY BLOCKED it at
+        # HEAD (cardinal sin); PATCH restores allow. The base=False / HEAD=True legs prove the
+        # absolute row above measures the REAL cure, not a vacuous pass.
         assert _isd_triple(cmd) == (False, True, False)
 
 
 # ======================================================================================
 # §7.2 SEC-2 — embedded-quote leg-merge UNDER-BLOCK closed (base=True, HEAD=False, PATCH=True)
 # ======================================================================================
-@requires_history
 class TestSEC2UnderBlockClosed:
     SEC2 = {
         "input_dq":  f'gh api repos/o/r/{M}s --input b.json -q x"y z" && gh api "repos/o/r" -X GET',
@@ -133,22 +141,36 @@ class TestSEC2UnderBlockClosed:
     }
 
     @pytest.mark.parametrize("cmd", SEC2.values(), ids=list(SEC2.keys()))
+    def test_sec2_held_at_patch(self, cmd):
+        # ALWAYS-RUN absolute recurrence guard: the real /merges mutation is HELD at the committed
+        # PATCH. Fails if the leg-merge under-block (a mutation escaping to allow) ever returns.
+        assert PATCH.is_dangerous_command(cmd) is True
+
+    @requires_history
+    @pytest.mark.parametrize("cmd", SEC2.values(), ids=list(SEC2.keys()))
     def test_sec2_differential(self, cmd):
-        # A real /merges mutation ESCAPED at HEAD (the merged leg leaked leg-2's -X GET into the
-        # .*merge negative lookahead). base held it; PATCH restores the hold.
+        # NON-VACUITY layer: the mutation ESCAPED at HEAD (the merged leg leaked leg-2's -X GET
+        # into the .*merge negative lookahead). base held it; PATCH restores the hold.
         assert _isd_triple(cmd) == (True, False, True)
 
 
 # ======================================================================================
 # §7.3 Carrier-8 shared flaw — pre-existing under-block FIXED (base=False, HEAD=False, PATCH=True)
 # ======================================================================================
-@requires_history
 class TestCarrier8TwinFixed:
+    CMD = f'gh api repos/o/r/{M}s -f k=x"y z" && gh api "o/r" -X GET'
+
+    def test_carrier8_held_at_patch(self):
+        # ALWAYS-RUN absolute recurrence guard: the quote-unsafe carrier-8 body-flag escape is
+        # closed — the mutation is HELD at the committed PATCH.
+        assert PATCH.is_dangerous_command(self.CMD) is True
+
+    @requires_history
     def test_carrier8_body_flag_quote_unsafe_fixed(self):
-        # Carrier 8's body-flag arm had the SAME non-quote-aware matcher -> a real mutation
-        # escaped at BOTH base and HEAD; the shared quote-safe _VALUE_TOKEN closes it at PATCH.
-        cmd = f'gh api repos/o/r/{M}s -f k=x"y z" && gh api "o/r" -X GET'
-        assert _isd_triple(cmd) == (False, False, True)
+        # NON-VACUITY layer: carrier 8's body-flag arm had the SAME non-quote-aware matcher -> a
+        # real mutation escaped at BOTH base and HEAD; the shared quote-safe _VALUE_TOKEN closes it
+        # at PATCH (base=False, HEAD=False, PATCH=True).
+        assert _isd_triple(self.CMD) == (False, False, True)
 
 
 # ======================================================================================
@@ -189,13 +211,20 @@ class TestRED1AttachmentFormsCured:
 # ======================================================================================
 # §7.5 MINT divergence restored (op: base=None, HEAD=merge, PATCH=None)
 # ======================================================================================
-@requires_history
 class TestMintDivergenceRestored:
+    CMD = f'gh api repos/o/r/pulls/5/{M} -X GET -q p"q r" && gh api "x/y" -X POST -f a=b'
+
+    def test_sec1_compound_op_none_at_patch(self):
+        # ALWAYS-RUN absolute mint recurrence guard: the SEC-1 compound does NOT mis-bind to a
+        # merge op at the committed PATCH (no spurious mint). Fails if the leg-merge mint mis-bind
+        # returns — the mint path shares the strip pipeline, so this is a distinct regression axis.
+        assert PATCH.detect_command_operation_type(self.CMD) is None
+
+    @requires_history
     def test_sec1_compound_op_classification(self):
-        # The mint path shares the strip pipeline, so the SEC-1 leg-merge mis-bound the compound
-        # to op='merge' at HEAD (a mint mis-bind). PATCH restores op=None (no spurious mint).
-        cmd = f'gh api repos/o/r/pulls/5/{M} -X GET -q p"q r" && gh api "x/y" -X POST -f a=b'
-        assert _op_triple(cmd) == (None, "merge", None)
+        # NON-VACUITY layer: the SEC-1 leg-merge mis-bound the compound to op='merge' at HEAD (a
+        # mint mis-bind). base=None, HEAD='merge', PATCH=None.
+        assert _op_triple(self.CMD) == (None, "merge", None)
 
 
 # ======================================================================================


### PR DESCRIPTION
## Summary

Fixes #1118 — the merge-guard was over-holding read-only `gh api` diagnostics (`gh api graphql -f query=… --jq '…mergeStateStatus…'`, etc.) because a benign `merge`/`git-refs` substring surviving in a client-side output-selector value tripped the `.*merge` implicit-POST arm.

> **⚠️ This PR went through a regression-and-remediation cycle. Read the history below — the certification argument is BIDIRECTIONAL testing, NOT additive-purity.**

## Final shipped design (commit `6d71a816`)

A **quote-balanced** value-token consumer, `_VALUE_TOKEN` = `(?:[^\s'"]|'[^']*'|"(?:[^"\\]|\\.)*")+`, that consumes quoted spans **atomically** and therefore can never emit a dangling quote. It is factored into a **shared** `_strip_flag_values(span, flag_sep, keep_fn)` helper consumed by **BOTH carrier 8 and carrier 9** (closing the drift vector between them):

- **Carrier 8** (body flags `-f`/`-F`/`--field`/`--raw-field`/`-d`): gets the quote-safe consumer (FIX-A). This also fixes carrier-8's identical *pre-existing* dangling-quote under-block. Its space-form separator is unchanged (`=`-form body-flag completeness is deferred to #1125).
- **Carrier 9** (selector flags `-q`/`--jq`, `-t`/`--template`, `-H`/`--header`, `--input`, `--hostname`, `-p`/`--preview`): gets the quote-safe consumer **plus** a form-aware, token-anchored separator covering all four gh flag-value attachment forms — space / `=`-long / `=`-short / attached-short (FIX-A + FIX-B). This cures the original over-block **in every spelling** (addressing GitHub Copilot's `--jq=value` finding on the first revision).

The mint-side classifier (`detect_command_operation_type`) shares the same strip pipeline, so mint correctness is restored **for free**.

### Certification: bidirectional, not additive-purity

**The original approach's `+N/-0` "additive-purity ⇒ cannot open an under-block" certificate was FALSIFIED and is abandoned.** Adding a stage that mutates the shared `stripped` string does *not* guarantee additive *behavior* — the added stage can corrupt the leg-splitting that pre-existing per-leg arms consume. This PR **rewrites** carriers 8 & 9's value arms (`+112/-89` in the hook); correctness is proven by a **base-vs-HEAD-vs-PATCH** differential, not by byte-diff.

Shipped regression coverage: `test_merge_guard_1118_recert.py` (42 tests) asserts the full three-way differential — each cure row hardcodes `(base, HEAD, PATCH)` so it reds if the fix ever regresses. Full suite: **10927 passed, 0 failed, 0 errors**.

## History (why the cycle)

1. **Original fix** (`38f76965`): an *additive* carrier 9 (space-form selector strip). It cured the demonstrated over-block but its non-quote-aware unquoted arm bit a partial token on an embedded-quote value (e.g. the jq idiom `.a + " " + .b`), leaving a dangling quote that corrupted `_mask_shell_quotes` leg-splitting → **merged compound legs** → defeated per-leg isolation in **both directions**: a cardinal-sin **over-block** (SEC-1) and a security **under-block** (SEC-2).
2. **Independent adversarial review** caught the regression (by tracing behavioral data-flow, not the byte-diff) — the additive-purity certificate had hidden it.
3. **Remediation** (`6d71a816` + `291039a7`): the quote-safe shared design above, bidirectionally re-certified against the committed bytes.

## Separate tracked residuals (own bidirectional sweeps)

- **#1125** — `--input=`/`--field=` attached-form body flags evade the implicit-POST danger-arm lookahead (under-block; different mechanism).
- **#1126** — `gh api graphql` mutations not gated (documented under-block gap).
- **#1127** — git/refs whole-command mint over-classification (mint/read asymmetry; low-impact).

## Version

`v4.5.3` (PATCH).

---

Completes ACs of #1118; closure pending a post-install live-probe against the installed plugin.
