### PR TITLE
fix(merge-guard): tune TOKEN_TTL to 900s + derive ORPHAN + fix stale prose (v4.5.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.5.3",
+      "version": "4.5.4",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.5.3/       # Plugin version
+│               └── 4.5.4/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.5.3
+> **Version**: 4.5.4
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -262,7 +262,7 @@ def find_valid_token(token_dir: Path | None = None) -> tuple[dict, str] | tuple[
     # Layer 3 (cross-cutting disk hygiene): reap unconsumed tokens older
     # than ORPHAN_TOKEN_MAX_AGE_SECONDS (12x TOKEN_TTL). Primary trigger
     # — runs on every dangerous-Bash precheck so orphans are bounded
-    # within ~1h of the next destructive command. Fail-open by
+    # within 12x TOKEN_TTL of the next destructive command. Fail-open by
     # construction; cleanup_orphan_tokens swallows all OSError paths.
     _cleanup_orphan_tokens(token_dir)
 
@@ -539,7 +539,7 @@ def _token_matches_command(token: dict, command: str) -> bool:
     # Checked AFTER op-type identity and BEFORE the per-op target returns so it
     # applies uniformly to all four op-classes. A pre-fix token without the key
     # defaults to the empty set, so any privileged execution mismatches -> REFUSE
-    # (over-block-safe; tokens expire in 5 min, so no backward-compat is needed).
+    # (over-block-safe; tokens expire after TOKEN_TTL, so no backward-compat is needed).
     # bound_flags is an attribute checked here, never part of pair identity.
     if set(context.get("bound_flags", [])) != set(cmd.get("bound_flags", [])):
         return False
@@ -587,13 +587,17 @@ def _token_matches_command(token: dict, command: str) -> bool:
 def check_merge_authorization(command: str, token_dir: Path | None = None) -> str | None:
     """Check if a dangerous command is authorized.
 
-    Tokens are single-use: once a token authorizes a command, it is consumed
-    (renamed to .consumed) so that each approval authorizes exactly one operation.
-    The rename is atomic on POSIX filesystems and idempotent — if a concurrent
-    hook invocation already consumed the token, the second invocation recognizes
-    the .consumed file and allows the command. The token's context is validated
-    against the command to ensure the approved operation matches what is being
-    executed.
+    Tokens are bounded-use, not single-use: one approval authorizes up to
+    MAX_USES=2 identical-context attempts within TOKEN_TTL. A SUCCESSFUL
+    operation immediately retires the token (renamed to .consumed) regardless
+    of remaining uses (invariant I-2) — a success never leaves a reusable
+    token — while a FAILED first attempt preserves the token so exactly one
+    identical-context retry stays authorized within TTL (invariant I-4). The
+    .use-N slot claims and the terminal .consumed rename are atomic on POSIX
+    filesystems and idempotent — a concurrent invocation that already retired
+    the token recognizes the .consumed file and allows the command. The token's
+    context is validated against the command to ensure the approved operation
+    matches what is being executed.
 
     Args:
         command: The bash command to check

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -588,11 +588,12 @@ def check_merge_authorization(command: str, token_dir: Path | None = None) -> st
     """Check if a dangerous command is authorized.
 
     Tokens are bounded-use, not single-use: one approval authorizes up to
-    MAX_USES=2 identical-context attempts within TOKEN_TTL. A SUCCESSFUL
+    MAX_USES identical-context attempts within TOKEN_TTL. A SUCCESSFUL
     operation immediately retires the token (renamed to .consumed) regardless
     of remaining uses (invariant I-2) — a success never leaves a reusable
-    token — while a FAILED first attempt preserves the token so exactly one
-    identical-context retry stays authorized within TTL (invariant I-4). The
+    token — while a FAILED first attempt preserves the token so up to
+    MAX_USES-1 identical-context retries stay authorized within TTL
+    (invariant I-4). The
     .use-N slot claims and the terminal .consumed rename are atomic on POSIX
     filesystems and idempotent — a concurrent invocation that already retired
     the token recognizes the .consumed file and allows the command. The token's

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -158,7 +158,7 @@ whose mtime exceeds ORPHAN_TOKEN_MAX_AGE_SECONDS (12x TOKEN_TTL).
 Triggered from merge_guard_pre.find_valid_token (primary, load-bearing
 on every dangerous-Bash precheck) and session_init.main (secondary,
 eager-cleanup at session start). Disk-hygiene defense — not a primary
-security check; the primary check is I-3 TTL expiry at 5 minutes.
+security check; the primary check is I-3 TTL expiry (bounded by TOKEN_TTL).
 """
 
 from __future__ import annotations
@@ -172,8 +172,8 @@ from pathlib import Path
 
 from .paths import get_claude_config_dir
 
-# Token TTL in seconds (5 minutes)
-TOKEN_TTL = 300
+# Token TTL in seconds
+TOKEN_TTL = 900
 
 # Directory for token files. B2 (import-time binding): CLAUDE_CONFIG_DIR is
 # fixed per-process before this module is imported, so an eager SSOT-derived
@@ -204,13 +204,14 @@ MAX_USES = 2
 # O_EXCL to atomically claim one use slot of an N-use token (#720 Bug C).
 USE_MARKER_SUFFIX = ".use-"
 
-# Orphan-token cleanup threshold. Tokens that survive past this window without
-# being consumed or used are reaped as disk hygiene — they cannot be legitimate
-# (TOKEN_TTL=300s already expires them for authorization). 12x TOKEN_TTL gives
-# strong margin against any legitimate in-flight token while aggressively
-# bounding accumulation. Disk-hygiene defense — not a primary security check;
-# the primary check is TOKEN_TTL expiry (invariant I-3).
-ORPHAN_TOKEN_MAX_AGE_SECONDS = 3600
+# Orphan-token cleanup threshold, derived as a fixed multiple of TOKEN_TTL so the
+# two never drift. Tokens that survive past this window without being consumed or
+# used are reaped as disk hygiene — they cannot be legitimate (TOKEN_TTL already
+# expires them for authorization). 12x TOKEN_TTL gives strong margin against any
+# legitimate in-flight token while aggressively bounding accumulation. Disk-hygiene
+# defense — not a primary security check; the primary check is TOKEN_TTL expiry
+# (invariant I-3).
+ORPHAN_TOKEN_MAX_AGE_SECONDS = 12 * TOKEN_TTL
 
 # Layer 1 Block 3 (gh CLI / git semantic signal) per op_type — SEC-S2 cycle-2.
 # Each value is a substring that MUST appear in tool_response.stdout for the
@@ -1637,7 +1638,7 @@ def cleanup_orphan_tokens(
 
     Targets tokens that escaped the normal lifecycle — e.g., when the
     consuming dangerous-Bash command was never executed after authorization,
-    leaving a token to expire silently. TOKEN_TTL (300s) already expires
+    leaving a token to expire silently. TOKEN_TTL already expires
     them for authorization purposes; this helper unlinks them from disk to
     bound accumulation.
 

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -1210,6 +1210,46 @@ class TestNUseSlotMarkerCleanup:
         for slot in range(1, MAX_USES + 1):
             assert Path(token_path + USE_MARKER_SUFFIX + str(slot)).exists()
 
+    def test_reaper_boundary_tracks_token_ttl(self, tmp_path):
+        """Guard: the reaper's staleness boundary IS TOKEN_TTL, not a hardcoded literal.
+
+        Regression-class guard for the reaper-path-vs-auth-path cert-gap. The reaper
+        (cleanup_consumed_tokens) reaps by ``now - mtime > TOKEN_TTL``, so any TTL
+        change silently shifts the boundary: reaper-path *mtime* tests that hardcode
+        an offset (the original ``- 600``) break at the new TTL, while auth-path
+        *stored-expires_at* fixtures do not. This pins the boundary to TOKEN_TTL by
+        aging two ``.consumed`` files that straddle it — both offsets derived from
+        TOKEN_TTL so the test self-adjusts at any TTL. If the reaper threshold is ever
+        replaced with a hardcoded constant, one arm flips and this fails. (The same
+        ``now - mtime > TOKEN_TTL`` predicate governs the ``.use-N`` markers, so
+        pinning one pattern pins the shared boundary.)
+        """
+        from shared.merge_guard_common import TOKEN_TTL, cleanup_consumed_tokens
+
+        # Proportional margin: self-adjusts with TOKEN_TTL and stays comfortably
+        # larger than test-execution wall-clock drift for any realistic TTL.
+        margin = TOKEN_TTL // 10
+        now = time.time()
+
+        within = tmp_path / "merge-authorized-00001.consumed"  # younger than TOKEN_TTL
+        within.write_text('{}')
+        os.utime(within, (now - (TOKEN_TTL - margin), now - (TOKEN_TTL - margin)))
+
+        beyond = tmp_path / "merge-authorized-00002.consumed"  # older than TOKEN_TTL
+        beyond.write_text('{}')
+        os.utime(beyond, (now - (TOKEN_TTL + margin), now - (TOKEN_TTL + margin)))
+
+        cleanup_consumed_tokens(tmp_path)
+
+        assert within.exists(), (
+            "a .consumed file younger than TOKEN_TTL must be RETAINED — the reaper "
+            "boundary must track TOKEN_TTL, not a hardcoded literal"
+        )
+        assert not beyond.exists(), (
+            "a .consumed file older than TOKEN_TTL must be REAPED — the reaper "
+            "boundary must track TOKEN_TTL, not a hardcoded literal"
+        )
+
 
 # =============================================================================
 # Adversarial: command bypass attempts
@@ -11551,6 +11591,8 @@ class TestTokenLifecycleInvariants:
         old_time = time.time() - 7200
         os.utime(token, (old_time, old_time))
 
+        # 3600 is an explicit 1h threshold, intentionally decoupled from the ORPHAN
+        # default (12*TOKEN_TTL); exercises reaper behavior at a chosen value, not the default.
         cleanup_orphan_tokens(tmp_path, max_age_seconds=3600)
 
         assert not token.exists()
@@ -11568,6 +11610,8 @@ class TestTokenLifecycleInvariants:
         token.write_text('{"context": {}}')
         # Default mtime is "just now"
 
+        # 3600 is an explicit 1h threshold, intentionally decoupled from the ORPHAN
+        # default (12*TOKEN_TTL); exercises reaper behavior at a chosen value, not the default.
         cleanup_orphan_tokens(tmp_path, max_age_seconds=3600)
 
         assert token.exists()
@@ -11591,6 +11635,8 @@ class TestTokenLifecycleInvariants:
         for p in (consumed, marker):
             os.utime(p, (old_time, old_time))
 
+        # 3600 is an explicit 1h threshold, intentionally decoupled from the ORPHAN
+        # default (12*TOKEN_TTL); exercises reaper behavior at a chosen value, not the default.
         cleanup_orphan_tokens(tmp_path, max_age_seconds=3600)
 
         # Both preserved — these live in cleanup_consumed_tokens' domain

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -1163,6 +1163,7 @@ class TestNUseSlotMarkerCleanup:
         """`.use-N` markers older than TOKEN_TTL are removed by cleanup."""
         from shared.merge_guard_common import (
             MAX_USES,
+            TOKEN_TTL,
             USE_MARKER_SUFFIX,
             cleanup_consumed_tokens,
         )
@@ -1178,7 +1179,7 @@ class TestNUseSlotMarkerCleanup:
             assert Path(token_path + USE_MARKER_SUFFIX + str(slot)).exists()
 
         # Age them past TTL
-        old_mtime = time.time() - 600
+        old_mtime = time.time() - (2 * TOKEN_TTL)
         for marker in tmp_path.glob("merge-authorized-*.use-*"):
             os.utime(marker, (old_mtime, old_mtime))
         # Age the .consumed file too so it doesn't interfere
@@ -2485,13 +2486,13 @@ class TestTokenSecurity:
         assert isinstance(data["context"], dict)
         assert data["expires_at"] > data["created_at"]
 
-    def test_token_ttl_is_5_minutes(self):
-        """TOKEN_TTL constant must be 300 seconds (5 minutes)."""
+    def test_token_ttl_is_15_minutes(self):
+        """TOKEN_TTL constant must be 900 seconds (15 minutes)."""
         from merge_guard_post import TOKEN_TTL as post_ttl
         from merge_guard_pre import TOKEN_TTL as pre_ttl
 
-        assert post_ttl == 300
-        assert pre_ttl == 300
+        assert post_ttl == 900
+        assert pre_ttl == 900
 
     def test_token_ttl_matches_between_hooks(self):
         """Both hooks must agree on TOKEN_TTL."""
@@ -6296,12 +6297,12 @@ class TestIdempotentTokenConsumption:
 
     def test_cleanup_removes_expired_consumed_tokens(self, tmp_path):
         """_cleanup_consumed_tokens removes .consumed files older than TOKEN_TTL."""
-        from merge_guard_pre import _cleanup_consumed_tokens
+        from merge_guard_pre import _cleanup_consumed_tokens, TOKEN_TTL
 
         # Create a stale .consumed file (mtime far in the past)
         stale = tmp_path / "merge-authorized-00001.consumed"
         stale.write_text('{}')
-        old_mtime = time.time() - 600  # 10 minutes ago
+        old_mtime = time.time() - (2 * TOKEN_TTL)  # older than TTL
         os.utime(str(stale), (old_mtime, old_mtime))
 
         _cleanup_consumed_tokens(tmp_path)
@@ -6339,11 +6340,11 @@ class TestIdempotentTokenConsumption:
 
     def test_cleanup_handles_concurrent_deletion(self, tmp_path):
         """_cleanup_consumed_tokens handles file deleted by concurrent cleanup."""
-        from merge_guard_pre import _cleanup_consumed_tokens
+        from merge_guard_pre import _cleanup_consumed_tokens, TOKEN_TTL
 
         stale = tmp_path / "merge-authorized-00001.consumed"
         stale.write_text('{}')
-        old_mtime = time.time() - 600
+        old_mtime = time.time() - (2 * TOKEN_TTL)
         os.utime(str(stale), (old_mtime, old_mtime))
 
         # Mock os.path.getmtime to raise FileNotFoundError (concurrent deletion)
@@ -6353,12 +6354,12 @@ class TestIdempotentTokenConsumption:
 
     def test_cleanup_mixed_expired_and_fresh(self, tmp_path):
         """_cleanup_consumed_tokens removes only expired files from a mixed set."""
-        from merge_guard_pre import _cleanup_consumed_tokens
+        from merge_guard_pre import _cleanup_consumed_tokens, TOKEN_TTL
 
         # Stale consumed token
         stale = tmp_path / "merge-authorized-00001.consumed"
         stale.write_text('{}')
-        old_mtime = time.time() - 600
+        old_mtime = time.time() - (2 * TOKEN_TTL)
         os.utime(str(stale), (old_mtime, old_mtime))
 
         # Fresh consumed token
@@ -6376,11 +6377,11 @@ class TestIdempotentTokenConsumption:
 
     def test_post_hook_cleanup_removes_expired_consumed(self, tmp_path):
         """Post-hook _cleanup_consumed_tokens removes stale .consumed files."""
-        from merge_guard_post import _cleanup_consumed_tokens
+        from merge_guard_post import _cleanup_consumed_tokens, TOKEN_TTL
 
         stale = tmp_path / "merge-authorized-00001.consumed"
         stale.write_text('{}')
-        old_mtime = time.time() - 600
+        old_mtime = time.time() - (2 * TOKEN_TTL)
         os.utime(str(stale), (old_mtime, old_mtime))
 
         _cleanup_consumed_tokens(tmp_path)
@@ -6404,12 +6405,12 @@ class TestIdempotentTokenConsumption:
 
     def test_write_token_cleans_up_stale_consumed(self, tmp_path):
         """write_token() cleans up stale .consumed files during token creation."""
-        from merge_guard_post import write_token
+        from merge_guard_post import write_token, TOKEN_TTL
 
         # Create a stale .consumed file
         stale = tmp_path / "merge-authorized-00001.consumed"
         stale.write_text('{}')
-        old_mtime = time.time() - 600
+        old_mtime = time.time() - (2 * TOKEN_TTL)
         os.utime(str(stale), (old_mtime, old_mtime))
 
         # Create a new token — should clean up stale consumed files
@@ -6481,12 +6482,12 @@ class TestIdempotentTokenConsumption:
 
     def test_find_valid_token_calls_cleanup(self, tmp_path):
         """find_valid_token() triggers cleanup of stale consumed tokens."""
-        from merge_guard_pre import find_valid_token
+        from merge_guard_pre import find_valid_token, TOKEN_TTL
 
         # Create a stale consumed token
         stale = tmp_path / "merge-authorized-00001.consumed"
         stale.write_text('{}')
-        old_mtime = time.time() - 600
+        old_mtime = time.time() - (2 * TOKEN_TTL)
         os.utime(str(stale), (old_mtime, old_mtime))
 
         find_valid_token(token_dir=tmp_path)
@@ -6673,7 +6674,7 @@ class TestIdempotentTokenConsumption:
 
     def test_full_lifecycle_create_consume_cleanup(self, tmp_path):
         """Full lifecycle: create token -> consume MAX_USES times -> cleanup after TTL."""
-        from shared.merge_guard_common import MAX_USES
+        from shared.merge_guard_common import MAX_USES, TOKEN_TTL
         from merge_guard_post import write_token
         from merge_guard_pre import (
             _cleanup_consumed_tokens,
@@ -6699,7 +6700,7 @@ class TestIdempotentTokenConsumption:
         assert Path(consumed_path).exists()  # Still within TTL
 
         # 4. After TTL, consumed file is cleaned up (along with .use-N markers)
-        old_mtime = time.time() - 600
+        old_mtime = time.time() - (2 * TOKEN_TTL)
         os.utime(consumed_path, (old_mtime, old_mtime))
         for marker in tmp_path.glob("merge-authorized-*.use-*"):
             os.utime(marker, (old_mtime, old_mtime))


### PR DESCRIPTION
## Summary

Two follow-ups surfaced by the #1119 plan-mode decision (which closed #1119 as working-as-designed after establishing that the merge-guard token is already `MAX_USES=2` bounded-use, not strict single-use).

**F1 — docstring truthfulness**: corrected the stale `check_merge_authorization` docstring that claimed "Tokens are single-use" — live behavior is the N=2 bounded-use model (one identical-context retry preserved on failure per I-4; success early-retires per I-2).

**F2 — `TOKEN_TTL` tune (SACROSANCT merge-guard)**: raised `TOKEN_TTL` 300→900s (15 min) to cover realistic slow-remediation gaps between mint and retry (PR conversation resolution + `gh auth refresh` device-flow — the dominant #1116 friction) without forcing re-approval. Derived `ORPHAN_TOKEN_MAX_AGE_SECONDS = 12 * TOKEN_TTL` (was hardcoded 3600) as SSOT so the reap margin self-tracks any future TTL. Value-tied prose/comments and the reaper-path test offsets made self-tracking.

## Why this is safe

Outcome-agnostic validity-window widening: only the window widens — `consume-before-execute`, the `MAX_USES=2` budget, and command classification are untouched. **Over-block is impossible by construction** (a longer TTL only makes a faithful click's token live *longer*, never newly denies it), and it opens **no laundering/under-block vector**. The replay window `== TTL` exactly, bounded by count ≤ MAX_USES + exact `(op,target,flags)` binding + session-scope.

## Certification

- **Full suite**: 10927 passed / 0 failed / 0 errors (independently re-run, errors unmasked)
- **Classification-invariance**: AST-proven — no classifier / consume / O_EXCL / MAX_USES path references `TOKEN_TTL`, so the right-sized cert (replay sign-off + classification-untouched + full-suite) applies rather than a full symmetric bidirectional cert
- **Reaper-path cert-gap** (caught in-cycle): the bump broke 7 `cleanup_consumed_tokens` mtime-age tests (distinct from the auth-path `expires_at` fixtures) — fixed value-independently (`2 * TOKEN_TTL`), self-adjusting on any future TTL; verified non-vacuous via a coupling probe
- Security replay sign-off + architect monotonicity/over-block proof + concordant auditor GREEN

## Version

PATCH → 4.5.4 (internal safety-constant tune + doc/prose/test truthfulness; no new user-facing surface).
