### PR TITLE
fix(merge-guard): R1 mint multi-branch force-delete via branch_set (#1129 PR-1 of 3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.5.4",
+      "version": "4.5.5",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.5.4/       # Plugin version
+│               └── 4.5.5/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.5.4",
+  "version": "4.5.5",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.5.4
+> **Version**: 4.5.5
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/merge_guard_post.py
+++ b/pact-plugin/hooks/merge_guard_post.py
@@ -163,19 +163,22 @@ def _selected_option_text(options: object, answer: object) -> str | None:
 
 
 def _target_value(cmd_ctx: dict) -> str | None:
-    """The op-class target value (pr_number / branch / target_ref / mass_target) from an
-    extracted command context, or None. A located region is a COMPLETE (op, target) pair
-    only when this is non-None — an op without a target contributes NO pair to the
-    multiplicity gate.
+    """The op-class target value (pr_number / branch / branch_set / target_ref /
+    mass_target / protected_branch) from an extracted command context, or None. A located
+    region is a COMPLETE (op, target) pair only when this is non-None — an op without a
+    target contributes NO pair to the multiplicity gate.
 
     MINT-SIDE FOUR-SITE ELEMENT (#1064): every op-class that uses a NEW context key MUST
     be enumerated here, or the mint cannot extract its target → the op gates on the read
     side but is gated-but-unmintable. remote-ref-delete reuses `target_ref` (already
     listed); remote-mass-delete (#1062b) uses the distinct `mass_target`; branch-protection
-    (#1063) uses `protected_branch` — both added here so those ops MINT, not just gate."""
+    (#1063) uses `protected_branch`; multi-branch force-delete (#1129) uses the distinct
+    `branch_set` (its scalar single-branch sibling `branch` is already listed) — each added
+    here so that op MINTS, not just gates."""
     return (
         cmd_ctx.get("pr_number")
         or cmd_ctx.get("branch")
+        or cmd_ctx.get("branch_set")
         or cmd_ctx.get("target_ref")
         or cmd_ctx.get("mass_target")
         or cmd_ctx.get("protected_branch")

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -550,7 +550,19 @@ def _token_matches_command(token: dict, command: str) -> bool:
     if token_op in ("merge", "close"):
         return _both_present_equal(context.get("pr_number"), cmd.get("pr_number"))
     if token_op == "branch-delete":
-        return _both_present_equal(context.get("branch"), cmd.get("branch"))
+        # #1129 R1: SINGLE-branch scalar OR MULTI-branch canonical SET (D1/D2
+        # set-EQUALITY). Exactly one key is present per command (1 positional ->
+        # `branch`; >=2 -> `branch_set`, built + canonicalized in the shared
+        # SSOT), so a scalar token can NOT authorize a set command or vice-versa
+        # (the absent-key side fails _both_present_equal), and a {a,b} token can
+        # NOT authorize {a,b,c} (unequal canonical strings) while a {b,a} reorder
+        # MATCHES (both canonicalize to `a,b`). The #1032 under-block is closed by
+        # equality; both sides derive via the ONE extract_command_context SSOT so
+        # mint and read cannot drift.
+        return (
+            _both_present_equal(context.get("branch"), cmd.get("branch"))
+            or _both_present_equal(context.get("branch_set"), cmd.get("branch_set"))
+        )
     if token_op in ("force-push", "push-to-main", "remote-ref-delete"):
         # KD-6 (SECURITY-RATIFICATION-PENDING): the destination ref must match
         # explicitly — an op-type-only floor would let a 'force-push feature'

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -875,6 +875,48 @@ def _extract_branch_name(command: str) -> str | None:
     return _strip_surrounding_quotes(positionals[0])
 
 
+def _extract_branch_delete_set(command: str) -> str | None:
+    """Extract the canonical MULTI-branch identity of a force-delete command.
+
+    The MULTI-target sibling of _extract_branch_name (which owns the SINGLE
+    branch). Handles the CLI `git branch -D|--delete --force <a> <b> ...` form
+    with TWO OR MORE positional branch names, returning a canonical
+    sort+dedup+quote-strip comma-joined identity STRING (e.g. `a,b,c`), or None
+    when fewer than two branch names are positively extractable (<2 -> defers to
+    the scalar _extract_branch_name path — the BOUNDARY discriminator, so a
+    command populates EXACTLY ONE of `branch` / `branch_set`).
+
+    Mirrors the _extract_mass_delete_target precedent (#1062b): an
+    ORDER-INDEPENDENT identity STRING (never a tuple/list — a token persists as
+    JSON, and the read side compares via `str()`, so a list<->tuple round-trip
+    must never enter the identity), built + canonicalized in this ONE shared SSOT
+    so mint and read derive byte-identical strings (D2 symmetry by construction).
+    Set-EQUALITY on this string then closes the #1032 multi-target under-block
+    unconditionally: a `{a,b}` token cannot authorize `{a,b,c}` (unequal strings)
+    while a `{b,a}` reorder MATCHES (both canonicalize to `a,b`).
+
+    Uses the SAME tokenization as _extract_branch_name (executable-prefix
+    truncation at a benign continuation/redirect via _executable_prefix, then drop
+    dash-flags), so the single/multi boundary is computed IDENTICALLY and no
+    command is double-counted or dropped. FORCE-only rides on op_type: the caller
+    reaches here only when detect_command_operation_type already classified
+    branch-delete (the FORCE `-D`/`-Df`/`-fD`/`--delete --force` spellings; #1094
+    per-leg cure), so a lowercase `-d`/`--delete` merged-branch delete (ungated at
+    HEAD) never reaches this and never populates `branch_set`.
+    """
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        return None
+    branch_match = re.search(_GIT_PREFIX + r"branch\b(.*)$", prefix)
+    if not branch_match:
+        return None
+    positionals = [t for t in branch_match.group(1).split() if not t.startswith("-")]
+    if len(positionals) < 2:
+        return None
+    names = sorted({_strip_surrounding_quotes(t) for t in positionals})
+    return ",".join(names) or None
+
+
 def _extract_force_push_target_ref(command: str) -> str | None:
     """Conservative force-push destination-ref parse (KD-6) — refuse on ambiguity.
 
@@ -1371,7 +1413,9 @@ def extract_command_context(command: str, flag_scan_text: str | None = None) -> 
                         | "push-to-main" | "remote-ref-delete" | "remote-mass-delete"
                         | "branch-protection"
         pr_number:  str  (merge / close)
-        branch:     str  (branch-delete)
+        branch:     str  (branch-delete — SINGLE target, exactly 1 positional)
+        branch_set: str  (branch-delete — MULTI target #1129, >=2 positionals) —
+                     canonical sort+dedup+quote-strip comma-joined names (`a,b,c`)
         target_ref: str  (force-push / push-to-main, KD-6; remote-ref-delete #1062a)
         mass_target: str (remote-mass-delete #1062b) — normalized identity tuple
                      <sorted-mass-flags>@<remote-or-implicit-marker>[#<sorted-refspecs>]
@@ -1420,9 +1464,22 @@ def extract_command_context(command: str, flag_scan_text: str | None = None) -> 
         if pr_number is not None:
             context["pr_number"] = pr_number
     elif op_type == "branch-delete":
+        # Single-branch scalar path (BYTE-IDENTICAL): exactly ONE positional.
         branch = _extract_branch_name(command)
         if branch is not None:
             context["branch"] = branch
+        else:
+            # Multi-branch (>=2 positionals) FORCE-delete: bind the canonical
+            # sorted+deduped branch-SET identity (#1129 R1, mirrors mass_target).
+            # _extract_branch_name returns non-None ONLY for exactly 1 positional
+            # and _extract_branch_delete_set ONLY for >=2, so they are MUTUALLY
+            # EXCLUSIVE -> a command populates EXACTLY ONE of `branch` /
+            # `branch_set` (the boundary discriminator). The distinct key plus the
+            # op-type-identity check in the read switch keep a scalar token from
+            # cross-authorizing a set command (and vice-versa).
+            branch_set = _extract_branch_delete_set(command)
+            if branch_set is not None:
+                context["branch_set"] = branch_set
     elif op_type in ("force-push", "push-to-main"):
         # push-to-main reuses the force-push target parser: its target IS the
         # main/master ref that parser already returns for a plain push.

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -881,7 +881,7 @@ def _extract_branch_delete_set(command: str) -> str | None:
     The MULTI-target sibling of _extract_branch_name (which owns the SINGLE
     branch). Handles the CLI `git branch -D|--delete --force <a> <b> ...` form
     with TWO OR MORE positional branch names, returning a canonical
-    sort+dedup+quote-strip comma-joined identity STRING (e.g. `a,b,c`), or None
+    sort+dedup+quote-strip identity STRING joined on NUL (`\x00`), or None
     when fewer than two branch names are positively extractable (<2 -> defers to
     the scalar _extract_branch_name path — the BOUNDARY discriminator, so a
     command populates EXACTLY ONE of `branch` / `branch_set`).
@@ -891,9 +891,16 @@ def _extract_branch_delete_set(command: str) -> str | None:
     JSON, and the read side compares via `str()`, so a list<->tuple round-trip
     must never enter the identity), built + canonicalized in this ONE shared SSOT
     so mint and read derive byte-identical strings (D2 symmetry by construction).
-    Set-EQUALITY on this string then closes the #1032 multi-target under-block
-    unconditionally: a `{a,b}` token cannot authorize `{a,b,c}` (unequal strings)
-    while a `{b,a}` reorder MATCHES (both canonicalize to `a,b`).
+    The join separator is NUL (`\x00`): git forbids control bytes in branch
+    names, so no name can contain it and the joined identity is INJECTIVE —
+    distinct branch SETS never collide. (A bare `,` was NOT injective: a branch
+    literally named `a,b` collided with the set {a, b}, cross-authorizing distinct
+    sets — the F1 review finding. NUL is JSON/str()-safe: json escapes it on dump,
+    restores it on load, and str() is stable, so the round-trip holds.)
+    Set-EQUALITY on this INJECTIVE string then closes the #1032 multi-target
+    under-block UNCONDITIONALLY: a `{a,b}` token cannot authorize `{a,b,c}`
+    (unequal strings) while a `{b,a}` reorder MATCHES (both canonicalize to the
+    same NUL-joined string).
 
     Uses the SAME tokenization as _extract_branch_name (executable-prefix
     truncation at a benign continuation/redirect via _executable_prefix, then drop
@@ -914,7 +921,12 @@ def _extract_branch_delete_set(command: str) -> str | None:
     if len(positionals) < 2:
         return None
     names = sorted({_strip_surrounding_quotes(t) for t in positionals})
-    return ",".join(names) or None
+    # Join on NUL (\x00) — a REF-ILLEGAL separator (git forbids control bytes in
+    # branch names) so no name can contain it -> the identity is INJECTIVE and
+    # distinct sets never collide (the F1 fix; a bare `,` collided a branch named
+    # `a,b` with the set {a, b}). JSON/str()-safe, so D2 mint==read symmetry and
+    # the JSON token round-trip both hold.
+    return "\x00".join(names) or None
 
 
 def _extract_force_push_target_ref(command: str) -> str | None:
@@ -1415,7 +1427,8 @@ def extract_command_context(command: str, flag_scan_text: str | None = None) -> 
         pr_number:  str  (merge / close)
         branch:     str  (branch-delete — SINGLE target, exactly 1 positional)
         branch_set: str  (branch-delete — MULTI target #1129, >=2 positionals) —
-                     canonical sort+dedup+quote-strip comma-joined names (`a,b,c`)
+                     canonical sort+dedup+quote-strip names joined on NUL (`\x00`,
+                     a ref-illegal separator → injective, no delimiter collision)
         target_ref: str  (force-push / push-to-main, KD-6; remote-ref-delete #1062a)
         mass_target: str (remote-mass-delete #1062b) — normalized identity tuple
                      <sorted-mass-flags>@<remote-or-implicit-marker>[#<sorted-refspecs>]

--- a/pact-plugin/tests/test_merge_guard_1129_r1_branch_set.py
+++ b/pact-plugin/tests/test_merge_guard_1129_r1_branch_set.py
@@ -39,6 +39,8 @@ from merge_guard_pre import _token_matches_command  # noqa: E402
 
 # FORCE flag assembled at runtime — no raw `git branch -D` literal in the source.
 _D = "-" + "D"
+# The canonical branch_set join separator (NUL, ref-illegal → injective; F1 fix).
+_SEP = "\x00"
 
 
 def _cmd(flags: str, names: list[str]) -> str:
@@ -67,7 +69,7 @@ def test_multi_branch_force_delete_mints_branch_set_and_self_matches(flags):
     assert ctx.get("operation_type") == "branch-delete"
     # The additive key is populated with the canonical sorted identity, and the
     # scalar `branch` key stays ABSENT (mutual exclusivity).
-    assert ctx.get("branch_set") == "A,B,C"
+    assert ctx.get("branch_set") == _SEP.join(["A", "B", "C"])
     assert "branch" not in ctx
     # The faithful click now mints+matches (the over-block cure).
     assert _matches(cmd, cmd) is True
@@ -107,7 +109,7 @@ def test_duplicate_names_dedup_to_same_set():
 
 def test_slashed_branch_names_mint_and_match():
     cmd = _cmd(_D, ["feature/x", "feature/y"])
-    assert extract_command_context(cmd).get("branch_set") == "feature/x,feature/y"
+    assert extract_command_context(cmd).get("branch_set") == _SEP.join(["feature/x", "feature/y"])
     assert _matches(cmd, cmd) is True
 
 
@@ -124,7 +126,23 @@ def test_lowercase_delete_stays_ungated(flags):
 def test_branch_set_is_order_independent_canonical_string():
     a = _extract_branch_delete_set(_cmd(_D, ["A", "B", "C"]))
     b = _extract_branch_delete_set(_cmd(_D, ["C", "B", "A"]))
-    assert a == b == "A,B,C"
+    assert a == b == _SEP.join(["A", "B", "C"])
     assert isinstance(a, str)  # STRING, never a tuple/list (JSON round-trip safety)
     # Fewer than two positionals -> None -> defers to the scalar `branch` path.
     assert _extract_branch_delete_set(_cmd(_D, ["solo"])) is None
+
+
+def test_comma_named_branch_does_not_collide_with_a_different_set():
+    # F1 regression: with the NUL separator the identity is INJECTIVE, so a branch
+    # literally NAMED `a,b` plus `c` (a 2-branch set) does NOT collide with the
+    # 3-branch set {a, b, c}. A bare `,` join collided them (both -> 'a,b,c') and
+    # cross-authorized distinct sets. `'a,b'` stays ONE shell token via the quotes.
+    two = _cmd(_D, ["'a,b'", "c"])       # branches: "a,b" and "c"
+    three = _cmd(_D, ["a", "b", "c"])    # branches: a, b, c
+    assert _extract_branch_delete_set(two) != _extract_branch_delete_set(three)
+    # Cross-authorization REFUSED both directions (the auth-level proof).
+    assert _matches(two, three) is False
+    assert _matches(three, two) is False
+    # Each still self-matches (faithful clicks unaffected).
+    assert _matches(two, two) is True
+    assert _matches(three, three) is True

--- a/pact-plugin/tests/test_merge_guard_1129_r1_branch_set.py
+++ b/pact-plugin/tests/test_merge_guard_1129_r1_branch_set.py
@@ -1,0 +1,130 @@
+"""
+Location: pact-plugin/tests/test_merge_guard_1129_r1_branch_set.py
+Summary: Verification tests for #1129 R1 — the additive multi-branch FORCE-delete
+         mint widening. A faithful `git branch -D A B C` (>=2 positionals) was
+         gated-on-read but UNMINTABLE (#1064 class): detect classifies it
+         branch-delete and is_dangerous=True, but the scalar _extract_branch_name
+         refuses >1 positional, so no target key minted -> the read side's
+         _both_present_equal(None, None) REFUSED the faithful click (an
+         over-block). R1 adds a canonical sorted+deduped+quote-stripped `branch_set`
+         identity string (mirroring the mass_target #1062b precedent) so the
+         multi-branch click mints and the read side matches it via set-EQUALITY.
+Used by: pytest (merge-guard suite).
+
+Scope: VERIFICATION (not the exhaustive/adversarial cert — that is the TEST phase's
+job). Confirms: multi-branch mints+self-matches (every force spelling), the
+single-branch scalar path is unchanged, cross-cardinality set-equality closes the
+#1032 under-block (subset/superset/disjoint/scalar REFUSE; reorder MATCHES), lowercase
+`-d`/`--delete` stays ungated, and the identity is a JSON-round-trip-safe STRING.
+
+The FORCE flag and `git branch` verb are assembled at runtime (D = "-"+"D"), so this
+file carries no raw force-delete literal — mirrors the sibling probe-harness convention
+and keeps the file inert to any literal-scanning tool.
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import pytest  # noqa: E402
+
+from shared.merge_guard_common import (  # noqa: E402
+    is_dangerous_command,
+    detect_command_operation_type,
+    extract_command_context,
+    _extract_branch_delete_set,
+)
+from merge_guard_pre import _token_matches_command  # noqa: E402
+
+# FORCE flag assembled at runtime — no raw `git branch -D` literal in the source.
+_D = "-" + "D"
+
+
+def _cmd(flags: str, names: list[str]) -> str:
+    """Build a `git branch <flags> <names...>` force-delete command string."""
+    return "git branch " + flags + " " + " ".join(names)
+
+
+def _token_for(cmd: str) -> dict:
+    """A minted token carrying the shared-SSOT context for `cmd`, JSON-round-tripped
+    exactly as a real persisted token is (tuple<->list drift would surface here)."""
+    return json.loads(json.dumps({"context": extract_command_context(cmd)}))
+
+
+def _matches(token_cmd: str, exec_cmd: str) -> bool:
+    return _token_matches_command(_token_for(token_cmd), exec_cmd)
+
+
+# The five FORCE spellings detect already classifies as branch-delete (#1094).
+_FORCE_SPELLINGS = [_D, "-Df", "-fD", "--delete --force", "--force --delete"]
+
+
+@pytest.mark.parametrize("flags", _FORCE_SPELLINGS)
+def test_multi_branch_force_delete_mints_branch_set_and_self_matches(flags):
+    cmd = _cmd(flags, ["A", "B", "C"])
+    ctx = extract_command_context(cmd)
+    assert ctx.get("operation_type") == "branch-delete"
+    # The additive key is populated with the canonical sorted identity, and the
+    # scalar `branch` key stays ABSENT (mutual exclusivity).
+    assert ctx.get("branch_set") == "A,B,C"
+    assert "branch" not in ctx
+    # The faithful click now mints+matches (the over-block cure).
+    assert _matches(cmd, cmd) is True
+
+
+@pytest.mark.parametrize("flags", [_D, "-Df", "--delete --force"])
+def test_single_branch_scalar_path_unchanged(flags):
+    cmd = _cmd(flags, ["feature"])
+    ctx = extract_command_context(cmd)
+    # Scalar path byte-identical: `branch` set, `branch_set` never populated.
+    assert ctx.get("branch") == "feature"
+    assert "branch_set" not in ctx
+    assert _matches(cmd, cmd) is True
+
+
+def test_set_equality_reorder_matches_but_cardinality_mismatch_refuses():
+    tok = _cmd(_D, ["A", "B"])
+    # Reorder MATCHES (order-independent canonical identity).
+    assert _matches(tok, _cmd(_D, ["B", "A"])) is True
+    # Superset / subset / disjoint all REFUSE (the #1032 under-block closed).
+    assert _matches(tok, _cmd(_D, ["A", "B", "C"])) is False
+    assert _matches(tok, _cmd(_D, ["A"])) is False
+    assert _matches(tok, _cmd(_D, ["C", "D"])) is False
+
+
+def test_scalar_token_does_not_authorize_a_set_command_and_vice_versa():
+    # A single-branch token must not authorize a multi-branch delete (distinct key).
+    assert _matches(_cmd(_D, ["only"]), _cmd(_D, ["A", "B"])) is False
+    # And a set token must not authorize a single-branch delete.
+    assert _matches(_cmd(_D, ["A", "B"]), _cmd(_D, ["only"])) is False
+
+
+def test_duplicate_names_dedup_to_same_set():
+    # Deleting {A, A, B} is the set {A, B}; a {A,B} token authorizes it.
+    assert _matches(_cmd(_D, ["A", "B"]), _cmd(_D, ["A", "A", "B"])) is True
+
+
+def test_slashed_branch_names_mint_and_match():
+    cmd = _cmd(_D, ["feature/x", "feature/y"])
+    assert extract_command_context(cmd).get("branch_set") == "feature/x,feature/y"
+    assert _matches(cmd, cmd) is True
+
+
+@pytest.mark.parametrize("flags", ["-d", "--delete"])
+def test_lowercase_delete_stays_ungated(flags):
+    # Non-force merged-branch delete is NOT gated at HEAD and must stay so —
+    # R1 must not start gating/minting it.
+    cmd = _cmd(flags, ["A", "B", "C"])
+    assert is_dangerous_command(cmd) is False
+    assert detect_command_operation_type(cmd) is None
+    assert "branch_set" not in extract_command_context(cmd)
+
+
+def test_branch_set_is_order_independent_canonical_string():
+    a = _extract_branch_delete_set(_cmd(_D, ["A", "B", "C"]))
+    b = _extract_branch_delete_set(_cmd(_D, ["C", "B", "A"]))
+    assert a == b == "A,B,C"
+    assert isinstance(a, str)  # STRING, never a tuple/list (JSON round-trip safety)
+    # Fewer than two positionals -> None -> defers to the scalar `branch` path.
+    assert _extract_branch_delete_set(_cmd(_D, ["solo"])) is None

--- a/pact-plugin/tests/test_merge_guard_1129_r1_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1129_r1_cert.py
@@ -240,10 +240,11 @@ class TestTokenPersistenceCanonicalization:
         assert len(tokens) == 1
         payload = json.loads(tokens[0].read_text())
         # The token carries the shared-SSOT context; branch_set is the canonical,
-        # sorted, comma-joined STRING (a list/tuple would have survived the JSON
+        # sorted, NUL-joined STRING (#1135 F1 — NUL is git-forbidden in ref names, so
+        # the joined identity is INJECTIVE; a list/tuple would have survived the JSON
         # round-trip as a list and broken str-comparison matching).
         ctx = payload.get("context", payload)
-        assert ctx.get("branch_set") == "aa,bb,cc"
+        assert ctx.get("branch_set") == "aa\x00bb\x00cc"
         assert isinstance(ctx.get("branch_set"), str)
         # And a reordered exec of the same set authorizes against the persisted token.
         assert _execute(_cmd(_D, ["bb", "cc", "aa"]), tmp_path) == ALLOW
@@ -259,7 +260,7 @@ class TestGatherCorrectness:
     def test_dash_flag_is_not_gathered_as_a_branch(self, tmp_path):
         # `-r` (a dash-flag) must be dropped; only the two real names form the set.
         cmd = _cmd(_D + " -r", ["origin/x", "origin/y"])
-        assert mgc.extract_command_context(cmd).get("branch_set") == "origin/x,origin/y"
+        assert mgc.extract_command_context(cmd).get("branch_set") == "origin/x\x00origin/y"
         minted, rc = _roundtrip(cmd, cmd, tmp_path)
         assert minted == 1
         assert rc == ALLOW
@@ -362,3 +363,85 @@ class TestNonVacuity:
         # Control: single-branch matches on the scalar `branch` key, not branch_set.
         smint, src = _roundtrip(_cmd(_D, ["solo"]), _cmd(_D, ["solo"]), tmp_path)
         assert smint == 1 and src == ALLOW
+
+
+# ===========================================================================
+# REVIEW REMEDIATION (peer-review cycle 1) — the comma-collision under-block
+# closed by the #1135 F1 NUL-separator fix, plus the 3 Minor coverage rows the
+# review surfaced. These pin the exact witnesses from the review.
+# ===========================================================================
+class TestCommaNameCollisionClosed:
+    """#1135 F1: git ref names PERMIT commas, so the OLD `,`-joined branch_set was
+    non-injective — {aa,'bb,cc'} (2 branches) and {aa,bb,cc} (3 branches) both joined
+    to `aa,bb,cc`, letting a 2-branch token authorize a 3-branch delete (a cross-set
+    UNDER-BLOCK; the review witness). The NUL join (git-forbidden in ref names) makes
+    the identity INJECTIVE: the two sets now produce distinct strings, so the token no
+    longer cross-authorizes. The over-block direction is untouched (see the self-match)."""
+
+    def test_two_set_and_three_set_no_longer_collide(self):
+        two = mgc._extract_branch_delete_set(_cmd(_D, ["aa", "bb,cc"]))       # {aa, 'bb,cc'}
+        three = mgc._extract_branch_delete_set(_cmd(_D, ["aa", "bb", "cc"]))  # {aa, bb, cc}
+        assert two != three, "comma-named 2-set must not collide with the 3-set (F1)"
+        assert two == "aa\x00bb,cc" and three == "aa\x00bb\x00cc"
+
+    def test_two_set_token_does_not_authorize_three_set_delete(self, tmp_path):
+        # The review's cross-set under-block witness — now REFUSED.
+        minted, rc = _roundtrip(_cmd(_D, ["aa", "bb,cc"]), _cmd(_D, ["aa", "bb", "cc"]), tmp_path)
+        assert minted == 1, "the 2-branch approval must still MINT (the refuse is a read decision)"
+        assert rc == DENY, "a {aa,'bb,cc'} token must NOT authorize deleting {aa,bb,cc} (F1)"
+
+    def test_three_set_token_does_not_authorize_two_set_delete(self, tmp_path):
+        minted, rc = _roundtrip(_cmd(_D, ["aa", "bb", "cc"]), _cmd(_D, ["aa", "bb,cc"]), tmp_path)
+        assert minted == 1
+        assert rc == DENY
+
+    def test_comma_named_branch_self_matches_faithful_unaffected(self, tmp_path):
+        # Over-block direction untouched: a faithful click deleting a comma-named
+        # branch set still mints + authorizes its own byte-identical exec.
+        cmd = _cmd(_D, ["aa", "bb,cc"])
+        minted, rc = _roundtrip(cmd, cmd, tmp_path)
+        assert minted == 1
+        assert rc == ALLOW
+
+
+class TestBenignContinuationAndCompound:
+    """M1 + M2: a multi-branch delete carrying a BENIGN continuation is a single
+    destructive leg and mints+authorizes (#1069); a multi-branch delete CHAINED with a
+    second destructive op is compound (>=2 destructive legs) and is REFUSED (no mint)."""
+
+    @pytest.mark.parametrize("tail", [" ; echo done", " > /tmp/pact_r1_log", " &"])
+    def test_multi_branch_with_benign_continuation_authorizes(self, tail, tmp_path):
+        cmd = _cmd(_D, ["aa", "bb"]) + tail
+        minted, rc = _roundtrip(cmd, cmd, tmp_path)
+        assert minted == 1, "faithful multi-branch + benign continuation must mint (#1069)"
+        assert rc == ALLOW
+
+    @pytest.mark.parametrize("tail", [" && git push --force", " && rm -rf x"])
+    def test_multi_branch_chained_with_destructive_is_compound_refused(self, tail, tmp_path):
+        cmd = _cmd(_D, ["aa", "bb"]) + tail
+        assert mgc.is_compound_destructive_command(cmd) is True
+        minted, rc = _roundtrip(cmd, cmd, tmp_path)
+        assert minted == 0, "a compound (>=2 destructive legs) must NOT mint"
+        assert rc == DENY
+
+
+class TestQuotedBranchNames:
+    """M3: quoted branch names canonicalize via _strip_surrounding_quotes, so quoting is
+    transparent — a faithful click that quotes the names authorizes the unquoted exec
+    (and vice-versa), and the canonical identity is quote-insensitive."""
+
+    def _q(self, names):
+        return _GB + _D + " " + " ".join("'%s'" % n for n in names)
+
+    def test_quoted_names_canonicalize_quote_insensitively(self):
+        assert mgc._extract_branch_delete_set(self._q(["aa", "bb"])) == "aa\x00bb"
+
+    def test_quoted_mint_authorizes_unquoted_exec(self, tmp_path):
+        minted, rc = _roundtrip(self._q(["aa", "bb"]), _cmd(_D, ["aa", "bb"]), tmp_path)
+        assert minted == 1
+        assert rc == ALLOW
+
+    def test_unquoted_mint_authorizes_quoted_reordered_exec(self, tmp_path):
+        minted, rc = _roundtrip(_cmd(_D, ["aa", "bb"]), self._q(["bb", "aa"]), tmp_path)
+        assert minted == 1
+        assert rc == ALLOW

--- a/pact-plugin/tests/test_merge_guard_1129_r1_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1129_r1_cert.py
@@ -1,0 +1,364 @@
+"""
+Location: pact-plugin/tests/test_merge_guard_1129_r1_cert.py
+Summary: TARGETED certification for #1129 R1 — the additive multi-branch FORCE-delete
+         mint widening (branch_set identity). This is the ADVERSARIAL cert layer on
+         top of the coder's functional-verification file
+         (test_merge_guard_1129_r1_branch_set.py); it does NOT duplicate that file.
+
+         The BACKBONE here is the REAL mint->execute round-trip: every load-bearing row
+         drives the actual post_main (AskUserQuestion approval -> token mint) then the
+         actual pre_main (Bash exec -> allow/deny), asserting BOTH the mint count AND the
+         execute outcome. This end-to-end layer is what the plan made REQUIRED for R1,
+         because the bug it guards is a MINT-SIDE binding gap that is invisible to any
+         read-side (extract_command_context / _token_matches_command) check: R1 originally
+         shipped with branch_set registered in extract_command_context + the read arm but
+         MISSING from _target_value (the #1064 mint-side four-site element), so a faithful
+         multi-branch click minted ZERO tokens and was DENIED (gated-but-unmintable) while
+         every read-side unit test stayed green. The mint-site fix (register branch_set in
+         _target_value) closed it; TestNonVacuity below pins each of the three sites
+         (extract / mint / read) as INDEPENDENTLY load-bearing so the class can never
+         regress silently again.
+
+         Scope (right-sized, NOT the #1118 bidirectional): R1 is over-block-only + additive
+         (no shared-strip touch), so the cert is over-block cure + the #1032 under-block
+         (set-equality) preservation, proven by real round-trip + non-vacuity. Confirmed
+         mode-INVARIANT: every function on the branch_set path (_extract_branch_delete_set,
+         extract_command_context, _target_value, _token_matches_command's branch_set arm)
+         takes only a command / context string — no session_id / leadSessionId parameter —
+         so the classification cannot diverge by teammateMode.
+Used by: pytest (merge-guard suite).
+
+The `git branch -D` force-delete verb is assembled at runtime (D = "-"+"D"), so this
+file carries no raw force-delete literal — mirrors the sibling verification file and
+keeps the file inert to any literal-scanning tool (and to the live merge guard).
+
+Module-level imports are deliberately limited to STABLE symbols (post_main, pre_main,
+the hook modules, extract_command_context) so that a COMBINED source-only revert of the
+R1 change (which removes the R1-only symbol _extract_branch_delete_set) does not turn the
+forward round-trip rows into a collection ImportError — those rows must FAIL cleanly
+(minted=0 / DENY), which is the non-vacuity signal. R1-only symbols are touched ONLY
+inside the TestNonVacuity bodies, via monkeypatch, at run time.
+"""
+import io
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import merge_guard_post  # noqa: E402
+import merge_guard_pre  # noqa: E402
+import shared.merge_guard_common as mgc  # noqa: E402
+from merge_guard_post import main as post_main  # noqa: E402
+from merge_guard_pre import main as pre_main  # noqa: E402
+
+# Force-delete verb assembled at runtime — no raw literal in the source.
+_D = "-" + "D"
+_GB = "git " + "branch "
+
+
+def _cmd(flags: str, names: list) -> str:
+    return _GB + flags + " " + " ".join(names)
+
+
+# ---------------------------------------------------------------------------
+# REAL mint -> execute round-trip harness (the cert backbone). Drives the actual
+# post_main (AskUserQuestion approval whose clicked option embeds the command in
+# backticks) and pre_main (Bash exec), both against the SAME token dir, so the
+# assertions cover the FULL mint pipeline (_collect_pairs / _target_value /
+# token-write) that the read-side unit tests bypass.
+# ---------------------------------------------------------------------------
+def _mint(cmd: str, tok: Path) -> int:
+    """Drive the REAL post hook with an approval whose clicked option embeds `cmd`;
+    return the count of tokens minted BY THIS CALL (new files only, so a second mint
+    into the same token dir — e.g. a non-vacuity control — is counted independently)."""
+    before = set(tok.glob("merge-authorized-*"))
+    env = json.dumps({
+        "tool_name": "AskUserQuestion",
+        "tool_input": {"questions": [{
+            "question": "Proceed?",
+            "options": [
+                {"label": "Yes", "description": "Run `%s`" % cmd},
+                {"label": "Cancel", "description": "Abort"},
+            ],
+        }]},
+        "tool_response": {"answers": {"Proceed?": "Yes"}},
+        "session_id": "cert-session",
+    })
+    with patch.object(merge_guard_post, "TOKEN_DIR", tok), \
+         patch("sys.stdin", io.StringIO(env)), \
+         patch("sys.stdout", io.StringIO()):
+        try:
+            post_main()
+        except SystemExit as e:
+            assert e.code == 0, "post hook exited nonzero: %r" % (e.code,)
+    return len(set(tok.glob("merge-authorized-*")) - before)
+
+
+def _execute(cmd: str, tok: Path, session_id: str = "cert-session") -> int:
+    """Run `cmd` through the REAL pre hook; return exit code (0=ALLOW, 2=DENY)."""
+    env = json.dumps({
+        "tool_name": "Bash",
+        "tool_input": {"command": cmd},
+        "session_id": session_id,
+    })
+    with patch.object(merge_guard_pre, "TOKEN_DIR", tok), \
+         patch("sys.stdin", io.StringIO(env)), \
+         patch("sys.stdout", io.StringIO()), \
+         patch("sys.stderr", io.StringIO()):
+        try:
+            pre_main()
+            return 0
+        except SystemExit as e:
+            return e.code if isinstance(e.code, int) else 0
+
+
+def _roundtrip(mint_cmd: str, exec_cmd: str, tok: Path):
+    """(minted_count, exec_exit_code) for mint `mint_cmd` then exec `exec_cmd`."""
+    minted = _mint(mint_cmd, tok)
+    rc = _execute(exec_cmd, tok)
+    return minted, rc
+
+
+ALLOW, DENY = 0, 2
+# The five FORCE spellings detect classifies as branch-delete (#1094 per-leg cure).
+_FORCE_SPELLINGS = [_D, "-Df", "-fD", "--delete --force", "--force --delete"]
+
+
+# ===========================================================================
+# B9 — the faithful multi-branch click MINTS + self-authorizes (the over-block
+# cure), through the REAL hooks. THIS is the layer that catches gated-but-
+# unmintable: a minted==0 here is the exact bug the mint-site fix closed.
+# ===========================================================================
+class TestRealMintExecuteRoundTrip:
+
+    @pytest.mark.parametrize("names", [
+        ["aa", "bb"],                 # 2 positionals
+        ["aa", "bb", "cc"],           # 3
+        ["aa", "bb", "cc", "dd", "ee"],  # N
+    ])
+    def test_multi_branch_arity_mints_and_authorizes(self, names, tmp_path):
+        cmd = _cmd(_D, names)
+        minted, rc = _roundtrip(cmd, cmd, tmp_path)
+        assert minted == 1, "faithful multi-branch click did not mint (gated-but-unmintable)"
+        assert rc == ALLOW, "minted token did not authorize its own faithful exec"
+
+    @pytest.mark.parametrize("flags", _FORCE_SPELLINGS)
+    def test_all_force_spellings_mint_and_authorize(self, flags, tmp_path):
+        cmd = _cmd(flags, ["aa", "bb", "cc"])
+        minted, rc = _roundtrip(cmd, cmd, tmp_path)
+        assert minted == 1, "force spelling %r did not mint a multi-branch token" % flags
+        assert rc == ALLOW
+
+    def test_reorder_authorizes_through_real_hooks(self, tmp_path):
+        # Mint {aa,bb,cc}; execute a REORDERED delete of the same set -> canonical
+        # sort makes it self-authorize end-to-end (order-independence).
+        minted, rc = _roundtrip(_cmd(_D, ["aa", "bb", "cc"]),
+                                _cmd(_D, ["cc", "aa", "bb"]), tmp_path)
+        assert minted == 1
+        assert rc == ALLOW
+
+    def test_slashed_branch_names_mint_and_authorize(self, tmp_path):
+        cmd = _cmd(_D, ["fix/144-a", "fix/144-b"])
+        minted, rc = _roundtrip(cmd, cmd, tmp_path)
+        assert minted == 1
+        assert rc == ALLOW
+
+    def test_long_delete_force_spelling_round_trips(self, tmp_path):
+        cmd = _cmd("--delete --force", ["aa", "bb"])
+        minted, rc = _roundtrip(cmd, cmd, tmp_path)
+        assert minted == 1
+        assert rc == ALLOW
+
+
+# ===========================================================================
+# B10 — set-EQUALITY through the REAL hooks. A multi-branch token ALWAYS mints
+# (minted==1), but authorizes ONLY the byte-identical canonical set: a
+# superset/subset/disjoint/scalar delete is DENIED. This is the #1032 multi-
+# target under-block, proven end-to-end (never a mint-side miss masquerading as
+# a refuse — minted==1 is asserted first).
+# ===========================================================================
+class TestSetEqualityRoundTrip:
+
+    def test_superset_denies(self, tmp_path):
+        minted, rc = _roundtrip(_cmd(_D, ["aa", "bb"]),
+                                _cmd(_D, ["aa", "bb", "cc"]), tmp_path)
+        assert minted == 1, "the {aa,bb} approval must MINT (the refuse must be a read decision, not a mint miss)"
+        assert rc == DENY, "a {aa,bb} token must NOT authorize the {aa,bb,cc} superset (#1032)"
+
+    def test_subset_denies(self, tmp_path):
+        minted, rc = _roundtrip(_cmd(_D, ["aa", "bb", "cc"]),
+                                _cmd(_D, ["aa", "bb"]), tmp_path)
+        assert minted == 1
+        assert rc == DENY
+
+    def test_disjoint_denies(self, tmp_path):
+        minted, rc = _roundtrip(_cmd(_D, ["aa", "bb"]),
+                                _cmd(_D, ["cc", "dd"]), tmp_path)
+        assert minted == 1
+        assert rc == DENY
+
+    def test_reorder_authorizes(self, tmp_path):
+        minted, rc = _roundtrip(_cmd(_D, ["aa", "bb"]),
+                                _cmd(_D, ["bb", "aa"]), tmp_path)
+        assert minted == 1
+        assert rc == ALLOW
+
+    def test_duplicate_names_dedup_to_same_set_authorizes(self, tmp_path):
+        # exec deletes {aa,aa,bb} == the set {aa,bb}; the {aa,bb} token authorizes it.
+        minted, rc = _roundtrip(_cmd(_D, ["aa", "bb"]),
+                                _cmd(_D, ["aa", "aa", "bb"]), tmp_path)
+        assert minted == 1
+        assert rc == ALLOW
+
+    def test_scalar_token_does_not_authorize_a_set_command(self, tmp_path):
+        # Single-branch approval (scalar `branch` key) must NOT authorize a multi delete.
+        minted, rc = _roundtrip(_cmd(_D, ["solo"]), _cmd(_D, ["aa", "bb"]), tmp_path)
+        assert minted == 1  # the single-branch approval DOES mint (scalar path)
+        assert rc == DENY
+
+    def test_set_token_does_not_authorize_a_scalar_command(self, tmp_path):
+        minted, rc = _roundtrip(_cmd(_D, ["aa", "bb"]), _cmd(_D, ["solo"]), tmp_path)
+        assert minted == 1
+        assert rc == DENY
+
+
+# ===========================================================================
+# B11 — canonicalization survives the REAL token PERSISTENCE (JSON on disk),
+# not just an in-memory context dict. The persisted token's branch_set is a
+# canonical STRING (never a list/tuple), and a reordered exec still authorizes.
+# ===========================================================================
+class TestTokenPersistenceCanonicalization:
+
+    def test_persisted_token_branch_set_is_canonical_string(self, tmp_path):
+        minted = _mint(_cmd(_D, ["cc", "aa", "bb"]), tmp_path)
+        assert minted == 1
+        tokens = list(tmp_path.glob("merge-authorized-*"))
+        assert len(tokens) == 1
+        payload = json.loads(tokens[0].read_text())
+        # The token carries the shared-SSOT context; branch_set is the canonical,
+        # sorted, comma-joined STRING (a list/tuple would have survived the JSON
+        # round-trip as a list and broken str-comparison matching).
+        ctx = payload.get("context", payload)
+        assert ctx.get("branch_set") == "aa,bb,cc"
+        assert isinstance(ctx.get("branch_set"), str)
+        # And a reordered exec of the same set authorizes against the persisted token.
+        assert _execute(_cmd(_D, ["bb", "cc", "aa"]), tmp_path) == ALLOW
+
+
+# ===========================================================================
+# B12 — gather correctness. A dash-flag is never counted as a branch, and a
+# zero-positional force-delete is unmintable (fail-CLOSED -> denied), never
+# silently authorized.
+# ===========================================================================
+class TestGatherCorrectness:
+
+    def test_dash_flag_is_not_gathered_as_a_branch(self, tmp_path):
+        # `-r` (a dash-flag) must be dropped; only the two real names form the set.
+        cmd = _cmd(_D + " -r", ["origin/x", "origin/y"])
+        assert mgc.extract_command_context(cmd).get("branch_set") == "origin/x,origin/y"
+        minted, rc = _roundtrip(cmd, cmd, tmp_path)
+        assert minted == 1
+        assert rc == ALLOW
+
+    def test_zero_positional_force_delete_is_unmintable_and_denied(self, tmp_path):
+        # `git branch -D` with NO branch names: no branch / no branch_set -> no
+        # (op,target) pair -> no token; the read side denies (gated, fail-closed).
+        cmd = _GB + _D
+        assert "branch" not in mgc.extract_command_context(cmd)
+        assert "branch_set" not in mgc.extract_command_context(cmd)
+        minted, rc = _roundtrip(cmd, cmd, tmp_path)
+        assert minted == 0
+        assert rc == DENY
+
+
+# ===========================================================================
+# Regression pins — the additive change must not disturb the neighbours.
+# ===========================================================================
+class TestRegressionPins:
+
+    def test_single_branch_scalar_path_unchanged(self, tmp_path):
+        cmd = _cmd(_D, ["solo"])
+        minted, rc = _roundtrip(cmd, cmd, tmp_path)
+        assert minted == 1
+        assert rc == ALLOW
+
+    @pytest.mark.parametrize("flags", ["-d", "--delete"])
+    @pytest.mark.parametrize("names", [["solo"], ["aa", "bb", "cc"]])
+    def test_lowercase_delete_stays_ungated(self, flags, names, tmp_path):
+        # Non-force merged-branch delete is NOT dangerous at HEAD; R1 must not start
+        # gating it (any arity). It is is_dangerous=False, mints nothing, and runs
+        # free (ALLOW without a token — because it was never gated).
+        cmd = _cmd(flags, names)
+        assert mgc.is_dangerous_command(cmd) is False
+        assert mgc.detect_command_operation_type(cmd) is None
+        minted = _mint(cmd, tmp_path)
+        assert minted == 0
+        assert _execute(cmd, tmp_path) == ALLOW
+
+
+# ===========================================================================
+# NON-VACUITY — three DISTINCT counterfactuals, each neutering ONE of the three
+# sites the R1 change spans, proving each is INDEPENDENTLY load-bearing (no dead
+# / redundant half). The COMBINED source-only revert of all three hook files is
+# performed + documented separately in the TEST HANDOFF (it mutates tracked
+# source, so it is not a shipped test); these three in-memory neuters are the
+# permanent, hermetic guards.
+#
+# Contract for each: with the site neutered, the multi-branch faithful click
+# FAILS (minted==0 or DENY), while the single-branch control stays correct
+# (proving the neuter is surgical, not a blanket break).
+# ===========================================================================
+class TestNonVacuity:
+
+    def test_extract_half_is_load_bearing(self, tmp_path, monkeypatch):
+        # Neuter site 1 (extraction): _extract_branch_delete_set -> None. No branch_set
+        # is ever produced, so the multi-branch delete has no target -> no mint -> deny.
+        # `_command` (underscore prefix) = intentionally-unused positional: the stub must
+        # match the real _extract_branch_delete_set(command) arity, but the neuter ignores it.
+        monkeypatch.setattr(mgc, "_extract_branch_delete_set", lambda _command: None)
+        minted, rc = _roundtrip(_cmd(_D, ["aa", "bb"]), _cmd(_D, ["aa", "bb"]), tmp_path)
+        assert minted == 0, "extraction neutered yet a branch_set token still minted"
+        assert rc == DENY
+        # Control: single-branch scalar path is independent of _extract_branch_delete_set.
+        smint, src = _roundtrip(_cmd(_D, ["solo"]), _cmd(_D, ["solo"]), tmp_path)
+        assert smint == 1 and src == ALLOW
+
+    def test_mint_site_is_load_bearing(self, tmp_path, monkeypatch):
+        # Neuter site 2 (mint target gate): restore the pre-fix _target_value that omits
+        # branch_set (the exact original R1 bug). Extraction still populates branch_set,
+        # but the mint cannot see it as a target -> no (op,target) pair -> no mint -> deny.
+        def _target_value_without_branch_set(cmd_ctx):
+            return (cmd_ctx.get("pr_number")
+                    or cmd_ctx.get("branch")
+                    or cmd_ctx.get("target_ref")
+                    or cmd_ctx.get("mass_target")
+                    or cmd_ctx.get("protected_branch"))
+        monkeypatch.setattr(merge_guard_post, "_target_value", _target_value_without_branch_set)
+        minted, rc = _roundtrip(_cmd(_D, ["aa", "bb"]), _cmd(_D, ["aa", "bb"]), tmp_path)
+        assert minted == 0, "mint-site neutered yet a multi-branch token still minted (the gated-but-unmintable bug)"
+        assert rc == DENY
+        # Control: single-branch uses the `branch` key, still present in _target_value.
+        smint, src = _roundtrip(_cmd(_D, ["solo"]), _cmd(_D, ["solo"]), tmp_path)
+        assert smint == 1 and src == ALLOW
+
+    def test_read_arm_is_load_bearing(self, tmp_path, monkeypatch):
+        # Neuter site 3 (read arm): drop branch_set from the READ side's command context
+        # only (post/mint side untouched). The token mints WITH branch_set, but the read
+        # arm's branch_set clause can no longer match -> deny.
+        _real_ecc = mgc.extract_command_context
+
+        def _ecc_drop_branch_set(command, *a, **k):
+            d = dict(_real_ecc(command, *a, **k))
+            d.pop("branch_set", None)
+            return d
+        monkeypatch.setattr(merge_guard_pre, "extract_command_context", _ecc_drop_branch_set)
+        minted, rc = _roundtrip(_cmd(_D, ["aa", "bb"]), _cmd(_D, ["aa", "bb"]), tmp_path)
+        assert minted == 1, "read-arm neuter must not affect the mint side (token should still mint)"
+        assert rc == DENY, "read arm neutered yet a multi-branch token still authorized"
+        # Control: single-branch matches on the scalar `branch` key, not branch_set.
+        smint, src = _roundtrip(_cmd(_D, ["solo"]), _cmd(_D, ["solo"]), tmp_path)
+        assert smint == 1 and src == ALLOW


### PR DESCRIPTION
## Summary

**PR-1 of 3 for #1129** — do NOT close #1129 on merge (PR-2 R2 and PR-3 R3 are still pending).

Fixes the R1 over-block: a faithful **multi-branch force-delete** (branch delete with the force flag and >=2 branch names) was gated-on-read but **unmintable** (#1064 gated-but-unmintable class), so a faithful approval click could not mint a token and the command was denied — the exact cardinal-sin over-block the merge-guard is meant to never produce.

## Change (additive `branch_set` across the #1064 four-site element)

- **extract** (`extract_command_context`) — populate a canonical sorted+deduped+quote-stripped string `branch_set` for >=2 positionals; the single-branch scalar `branch` path is byte-identical.
- **mint** (`_target_value`) — extract `branch_set` so a token is actually minted. _(This site was missing from the initial commit and was caught mid-review by a TEST-phase RED; see below.)_
- **read** (`_token_matches_command`) — set-EQUALITY bind: a `{A,B}` token authorizes only `{A,B}` (reorder matches; superset/subset/disjoint refuse — preserving the #1032 under-block).
- Force-only (`-D` / `--delete --force`); lowercase delete stays ungated. Zero classifier change.

## Certification

- New `test_merge_guard_1129_r1_cert.py` (29 tests) drives the **real `post_main` mint -> `pre_main` execute round-trip** — the layer that catches the gated-but-unmintable class (invisible to read-side unit checks) — plus **3-site non-vacuity** (extract/mint/read each proven independently load-bearing; the mint-site neuter is a permanent guard against the exact regression that slipped through initially).
- Full merge-guard suite: **2171 passed, 0 failed, 0 errors** (plain pytest; authoritative errors count).
- Not mode-divergent (pure classifier logic).

## Process note

The initial commit registered `branch_set` at extract + read but missed the mint-side `_target_value` — read-side unit tests and a read-side audit were both green (phantom-green). The mandatory real mint->execute cert round-trip caught it; the fix (78104fa5) completes the four-site closure and the cert now permanently guards it.

## Version

PATCH bump 4.5.4 -> 4.5.5.
