### PR TITLE
fix(merge-guard): R2 unify carrier-7 + widen data-flag carriers (issue 1129 PR-2 of 3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.5.5",
+      "version": "4.5.6",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.5.5/       # Plugin version
+│               └── 4.5.6/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.5.5",
+  "version": "4.5.6",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.5.5
+> **Version**: 4.5.6
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -1879,6 +1879,20 @@ def _has_command_substitution(quoted_content: str) -> bool:
     return "$(" in quoted_content or "`" in quoted_content
 
 
+def _keep_carrier_value(m: "re.Match") -> str:
+    """Shared $()-preserving value replacer for the gh/git prose-carrier strips (#1129
+    R2): issue/pr create|edit|comment, release create|edit, gist create|edit, git tag
+    -m. Passed as `keep_fn` to _strip_flag_values (arms 1 & 3 — double-quoted + unquoted
+    VALUE-TOKEN). A double-quoted value containing $()/backtick EXECUTES, so it is
+    PRESERVED (stays caught); otherwise the flag(+separator) is kept and the value
+    replaced with the inert `STRIPPED` bareword. Hoisted from carrier-7's former
+    `_strip_dq` so every PR-added carrier shares ONE $()-preserving replacer (the
+    single-quoted arm strips unconditionally, handled inside _strip_flag_values)."""
+    if _has_command_substitution(m.group(0)):
+        return m.group(0)
+    return m.group(1) + "STRIPPED"
+
+
 def _strip_flag_values(span: str, flag_sep_regex: str, keep_fn) -> str:
     """Quote-safe value strip for a flag family within a single command span (#1118
     re-model). KEEPS the flag(+separator) token; replaces the VALUE with a BALANCED
@@ -2144,34 +2158,72 @@ def _strip_non_executable_content(command: str) -> str:
         # op OUTSIDE the body, after an unquoted separator OR a bare escaped quote
         # not following a carrier flag, is NEVER stripped and stays caught).
         _gh_carrier_span = (
-            r"gh\s+(?:issue\s+(?:create|edit|comment)|pr\s+(?:create|comment))\b"
+            r"gh\s+(?:issue\s+(?:create|edit|comment)|pr\s+(?:create|comment|edit))\b"
             r"""(?:[^&|;\n"']+|"(?:[^"\\]|\\.)*"|'[^']*')*"""
         )
 
         def _strip_gh_carrier_span(span_match: re.Match) -> str:
-            span = span_match.group(0)
-
-            # Double-quoted value: preserve if it contains command
-            # substitution ($()/backtick executes inside double quotes).
-            def _strip_dq(m: re.Match) -> str:
-                if _has_command_substitution(m.group(0)):
-                    return m.group(0)
-                return m.group(1) + "STRIPPED"
-
-            span = re.sub(
-                r"((?:--title|--body|-t|-b)\s+)\"(?:[^\"\\]|\\.)*\"",
-                _strip_dq,
-                span,
+            # Migrated (#1129 R2) to the SHARED quote-balanced _strip_flag_values (#1118
+            # machinery, same as carriers 8/9): its 3 arms
+            # (dq→keep_fn / sq→'STRIPPED' / unquoted VALUE-TOKEN→keep_fn) replace the
+            # former inline dq+sq re.sub. The unquoted VALUE-TOKEN arm ADDS coverage of
+            # ANSI-C `$'…'` + adjacent-concat `"a"'b'` body forms (consumed ATOMICALLY, so
+            # no dangling quote → no leg-merge). $()/backtick preserve rides on
+            # _keep_carrier_value. `edit` added to the pr alternation (OB1).
+            return _strip_flag_values(
+                span_match.group(0),
+                r"((?:--title|--body|-t|-b)\s+)",
+                _keep_carrier_value,
             )
-            # Single-quoted value: never expands, no substitution guard.
-            span = re.sub(
-                r"((?:--title|--body|-t|-b)\s+)'[^']*'",
-                r"\1STRIPPED",
-                span,
-            )
-            return span
 
         result = re.sub(_gh_carrier_span, _strip_gh_carrier_span, result)
+
+        # 7b. gh release CREATE/EDIT carrier (#1129 R2). --notes/-n + --title/-t carry API
+        #     prose (never executed). EXCLUDE --notes-file/-F (a FILE, off-line) AND the
+        #     -d/--draft + -p/--prerelease BOOLEANS (arity verified vs gh 2.96.0) — a
+        #     boolean must never enter a value-strip set or the strip mis-consumes the
+        #     following token (PER-CARRIER flag sets, NEVER a union). Subcommand-specific
+        #     (create|edit, NEVER bare `gh release`) so `gh release delete` can never
+        #     start a carrier span. Shared quote-balanced _strip_flag_values + $()-preserve.
+        _gh_release_span = (
+            r"gh\s+release\s+(?:create|edit)\b"
+            r"""(?:[^&|;\n"']+|"(?:[^"\\]|\\.)*"|'[^']*')*"""
+        )
+        result = re.sub(
+            _gh_release_span,
+            lambda m: _strip_flag_values(
+                m.group(0), r"((?:--notes|-n|--title|-t)\s+)", _keep_carrier_value
+            ),
+            result,
+        )
+
+        # 7c. gh gist CREATE/EDIT carrier (#1129 R2). --desc/-d is API prose. `-d` is
+        #     admissible ONLY here (gist -d=--desc VALUE; contrast release -d=--draft
+        #     BOOLEAN — the reason PER-CARRIER flag sets are mandatory). Subcommand-specific
+        #     (create|edit, NEVER bare `gh gist`) so `gh gist delete` never starts a carrier.
+        _gh_gist_span = (
+            r"gh\s+gist\s+(?:create|edit)\b"
+            r"""(?:[^&|;\n"']+|"(?:[^"\\]|\\.)*"|'[^']*')*"""
+        )
+        result = re.sub(
+            _gh_gist_span,
+            lambda m: _strip_flag_values(
+                m.group(0), r"((?:--desc|-d)\s+)", _keep_carrier_value
+            ),
+            result,
+        )
+
+        # 7d. git tag MESSAGE carrier (#1129 R2), FLAG-ANCHORED — NEVER a verb-span.
+        #     `git tag -m/--message` (benign annotation prose) shares the `tag` verb with
+        #     the DESTRUCTIVE `git tag -d/--delete`, so a verb-span would swallow `-d`.
+        #     Gate on `git tag` presence and strip ONLY the -m/--message value → `-d` + the
+        #     target ref stay visible in EVERY ordering. The shared _strip_flag_values
+        #     VALUE-TOKEN stops at the first unquoted separator, so a compound tail
+        #     (`… && git push --force`) falls OUTSIDE the strip and stays caught (leg-locality).
+        if re.search(_GIT_PREFIX + r"tag\b", result):
+            result = _strip_flag_values(
+                result, r"((?:-m|--message)\s+)", _keep_carrier_value
+            )
 
     # 8. Strip HTTP-client request-body flag VALUES (curl / wget / gh api).
     #    The #1061 widening (host-agnostic `.*git/refs`) and the #1063

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -2213,17 +2213,38 @@ def _strip_non_executable_content(command: str) -> str:
             result,
         )
 
-        # 7d. git tag MESSAGE carrier (#1129 R2), FLAG-ANCHORED — NEVER a verb-span.
-        #     `git tag -m/--message` (benign annotation prose) shares the `tag` verb with
-        #     the DESTRUCTIVE `git tag -d/--delete`, so a verb-span would swallow `-d`.
-        #     Gate on `git tag` presence and strip ONLY the -m/--message value → `-d` + the
-        #     target ref stay visible in EVERY ordering. The shared _strip_flag_values
-        #     VALUE-TOKEN stops at the first unquoted separator, so a compound tail
-        #     (`… && git push --force`) falls OUTSIDE the strip and stays caught (leg-locality).
-        if re.search(_GIT_PREFIX + r"tag\b", result):
-            result = _strip_flag_values(
-                result, r"((?:-m|--message)\s+)", _keep_carrier_value
-            )
+        # 7d. git tag MESSAGE carrier (#1129 R2; F1 leg-merge fix, HALT #64) — SPAN-BOUNDED
+        #     + FLAG-ANCHORED. `git tag -m/--message` (benign annotation prose) shares the
+        #     `tag` verb with the DESTRUCTIVE `git tag -d/--delete`, so the strip is
+        #     FLAG-anchored to the -m/--message VALUE only (never touches -d), and BOUNDED
+        #     to a git-tag span whose body (the SAME quote-aware body as 7/7b/7c) STOPS at
+        #     the first UNQUOTED ;/&&/|/newline. The span bound is LOAD-BEARING: the prior
+        #     WHOLE-COMMAND strip let _strip_flag_values arm 3 (unquoted VALUE-TOKEN, which
+        #     does NOT stop at ;&|) re-touch the arm-1 `STRIPPED` bareword and consume
+        #     `STRIPPED;gh` together — EATING the next leg's `gh` head
+        #     (`git tag -m "x";gh pr merge 5 --delete-branch` -> gh gone -> auto-ALLOW). The
+        #     span stops at the separator, so the executing tail stays OUTSIDE and caught.
+        #     The prefix is a NON-gobbling `git <bounded non-separator words> tag`
+        #     (handles global flags like `-C <path>`) whose word class EXCLUDES `;&|` so it
+        #     CANNOT cross an unquoted separator — deliberately NOT `_GIT_PREFIX`, whose
+        #     `(?:\S+\s+){0,N}` gobbler (its `\S+` spans separators) could cross a `;gh …;`
+        #     into a LATER `git tag`, re-opening the leg-merge on a command like
+        #     `git commit -m "x";gh pr merge 5;git tag v1`. Bounded `{0,N}` (same
+        #     _MAX_GLOBAL_FLAG_TOKENS as _GIT_PREFIX) keeps the match linear/sub-quadratic.
+        #     `-d` stays visible (only the -m value strips, within the span); a faithful
+        #     `git tag -m "…" v1` has no unquoted separator -> one span -> OB3 still strips.
+        #     $()/backtick preserve rides on _keep_carrier_value.
+        _git_tag_span = (
+            r"\bgit\s+(?:[^;&|\n\s]+\s+){0,%d}tag\b" % _MAX_GLOBAL_FLAG_TOKENS
+            + r"""(?:[^&|;\n"']+|"(?:[^"\\]|\\.)*"|'[^']*')*"""
+        )
+        result = re.sub(
+            _git_tag_span,
+            lambda mm: _strip_flag_values(
+                mm.group(0), r"((?:-m|--message)\s+)", _keep_carrier_value
+            ),
+            result,
+        )
 
     # 8. Strip HTTP-client request-body flag VALUES (curl / wget / gh api).
     #    The #1061 widening (host-agnostic `.*git/refs`) and the #1063

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -13881,19 +13881,22 @@ class TestD2GhCarrierStrip:
 
     # ---- NEGATIVE: non-carrier gh verbs are NOT exempted ----
 
-    def test_gh_pr_edit_is_not_a_carrier(self):
-        """SECURITY NEGATIVE: `gh pr edit` is NOT in the carrier alternation
-        (only `gh issue edit` + `gh pr create`/`gh issue create` are), so a
-        dangerous literal in its --title is NOT stripped.
+    def test_gh_pr_edit_is_now_a_carrier(self):
+        """#1129 R2 (OB1): `gh pr edit` is NOW an INTENTIONAL carrier — its
+        --title/--body value is non-executing API prose (identical in kind to the
+        already-carried `gh issue edit`), so a dangerous literal there is STRIPPED
+        and the command is NOT flagged. The pre-R2 issue-edit/pr-edit asymmetry (an
+        over-conservative over-block = cardinal-sin OB1) is intentionally removed.
 
-        # non-vacuity: a verb alternation widened to `pr\\s+(?:create|edit)`
-        #   would strip this → is_dangerous returns False → FAILS. Pins the
-        #   pr-edit exclusion (the asymmetry: issue edit IS a carrier, pr edit
-        #   is NOT).
+        # non-vacuity: reverting the `pr edit` carrier (EDIT 1) leaves the literal
+        #   unstripped → is_dangerous returns True → this assertion FAILS. Pins the
+        #   pr-edit INCLUSION. The "non-carrier gh verb is NOT exempted" guardrail is
+        #   pinned separately by the `gh pr review` sibling in
+        #   test_merge_guard_1037_narrow.
         """
         from merge_guard_pre import is_dangerous_command
 
-        assert is_dangerous_command('gh pr edit 5 --title "git branch -D x"')
+        assert not is_dangerous_command('gh pr edit 5 --title "git branch -D x"')
 
     def test_gh_pr_merge_is_not_a_carrier(self):
         """SECURITY NEGATIVE: `gh pr merge` (a real destructive op) is not a
@@ -14260,10 +14263,15 @@ class TestD2QuoteAwareSpanRemediation:
         cmd = 'gh pr close 42 --delete-branch --body "git branch -D x"'
         assert '"git branch -D x"' in _strip_non_executable_content(cmd)
 
-    def test_carveout_pr_edit_not_a_carrier(self):
+    def test_carveout_pr_edit_is_now_a_carrier(self):
+        # #1129 R2 (OB1): `gh pr edit` is NOW an intentional carrier (joins gh issue
+        # edit as a non-executing --title/--body prose carrier), so a dangerous literal
+        # in its value is STRIPPED and NOT flagged. Reverting EDIT 1 flips this True →
+        # the assert FAILS (non-vacuous). The non-carrier-verb guardrail is pinned by
+        # the `gh pr review` sibling in test_merge_guard_1037_narrow.
         from merge_guard_pre import is_dangerous_command
 
-        assert is_dangerous_command('gh pr edit 5 --title "git branch -D x"')
+        assert not is_dangerous_command('gh pr edit 5 --title "git branch -D x"')
 
     # ---- 7.E — ReDoS guard for the span ITSELF (the quote-aware body's own
     #            linear profile; distinct from the M1 D3 ladder ReDoS). ----

--- a/pact-plugin/tests/test_merge_guard_1037_narrow.py
+++ b/pact-plugin/tests/test_merge_guard_1037_narrow.py
@@ -13,7 +13,7 @@ Used by: pytest (merge-guard suite).
 Non-vacuity:
   * ALLOW canaries (proof-class P): the comment-verb membership is what flips them.
     Proven dynamically by VERB-DISCRIMINATION (a carrier verb ALLOWs an inert
-    --body; the SAME --body under a non-carrier sibling verb `gh pr edit` BLOCKs)
+    --body; the SAME --body under a non-carrier sibling verb `gh pr review` BLOCKs)
     + a mechanism assertion (_strip blanks the --body value to STRIPPED, so the
     dangerous literal never reaches DANGEROUS_PATTERNS). Build-time source-revert
     MEASUREMENT (remove the comment verbs from `_gh_carrier_span`): {5 of 5 ALLOW
@@ -76,18 +76,20 @@ class TestNarrowGhCommentCarrierStripAllow:
         [
             (
                 'gh pr comment 5 --body "ref gh pr merge 5"',
-                'gh pr edit 5 --body "ref gh pr merge 5"',
+                'gh pr review 5 --body "ref gh pr merge 5"',
             ),
             (
                 'gh pr comment 8 --body "ref git push --force origin main"',
-                'gh pr edit 8 --body "ref git push --force origin main"',
+                'gh pr review 8 --body "ref git push --force origin main"',
             ),
         ],
     )
     def test_comment_verb_membership_is_load_bearing(self, carrier, sibling):
         # non-vacuity (proof-class P): the comment verb being IN the alternation is
         # what flips these. The identical --body under a NON-carrier sibling verb
-        # (`gh pr edit`, absent from the pr alternation) is NOT stripped and BLOCKs.
+        # (`gh pr review`, absent from the pr alternation — #1129 R2 added `pr edit`
+        # to the carrier set, so `review` is now the discriminating non-carrier sibling)
+        # is NOT stripped and BLOCKs.
         # This is the runnable equivalent of reverting the comment verbs from
         # `_gh_carrier_span` (build-time measured: {5 of 5 ALLOW flip to BLOCK}).
         from merge_guard_pre import is_dangerous_command

--- a/pact-plugin/tests/test_merge_guard_1129_r2_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1129_r2_cert.py
@@ -1,0 +1,233 @@
+"""
+Location: pact-plugin/tests/test_merge_guard_1129_r2_cert.py
+Summary: COMPREHENSIVE BIDIRECTIONAL certification for #1129 R2 — the carrier-7
+         unification (SACROSANCT shared strip/leg pipeline). Proves R2's properties
+         against the REAL classifier, base-vs-HEAD, NEVER a byte-diff (#1118):
+
+           - OB1-8 over-block CLOSURE: each confirmed faithful-click over-block is
+             is_dangerous on BASE (023ee2c3) and NOT on HEAD (R2).
+           - MUST-NOT-REGRESS: genuinely-executing / genuinely-destructive forms stay
+             gated in BOTH base and HEAD (R2 narrows NO detection).
+           - -d SURVIVES -m STRIP: the git-tag -m value strip is flag-anchored and
+             leaves the -d DELETE target visible in every ordering; the release
+             value-strip never consumes the -d/-p BOOLEAN's neighbour.
+           - SUBCOMMAND-DELETE accepted-residual PIN: gh release delete / gh gist
+             delete / git tag -d stay UNDETECTED (base==HEAD==False), byte-unchanged.
+             These under-blocks are a SEPARATE hardening issue, NOT R2's over-block
+             scope — this pins them so a future detection arm can't silently regress.
+           - THE LOAD-BEARING ROW: a REAL post_main->pre_main mint->execute round-trip
+             proving the mint-side launder is WITHHELD at HEAD (the :447 is_dangerous
+             write-gate: mint⊆read, so the carrier strip that drops is_dangerous to
+             False also withholds the launder token — closure is free, no mint-path
+             edit). Non-vacuity for the gist launder is the base-revert witness recorded
+             in the TEST HANDOFF (base mints {merge,5,--delete-branch} + the
+             --delete-branch exec ALLOWs; HEAD mints nothing + DENYs).
+
+NON-VACUITY (base-vs-HEAD): the read-side rows load the BASE classifier (023ee2c3) via
+`git show` + exec and assert base-vs-HEAD IN-TEST, so the cert is permanently
+non-vacuous — a future strip regression flips a HEAD column back and reds the row, and
+the base column proves each form was genuinely a vector (never a vacuous green).
+
+Cross-refs: docs/architecture/1129-r2-carrier7.md §5 (cert matrix); docs/preparation/
+1129-r2-groundtruth.md (empirical OB/launder findings). Destructive verbs are assembled
+at runtime (BD/PF/M5) so this file carries no raw force-delete/force-push literal and
+stays inert to the live guard.
+"""
+import io
+import json
+import subprocess
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import merge_guard_post  # noqa: E402
+import merge_guard_pre  # noqa: E402
+import shared.merge_guard_common as mgc  # noqa: E402
+from merge_guard_post import main as post_main  # noqa: E402
+from merge_guard_pre import main as pre_main  # noqa: E402
+
+# --- BASE classifier (pre-R2, 023ee2c3) loaded ONCE for baked base-vs-HEAD non-vacuity.
+_BASE_SHA = "023ee2c3"
+
+
+def _load_base_classifier():
+    wt = Path(__file__).resolve().parents[2]  # worktree root (tests/../../)
+    src = subprocess.check_output(
+        ["git", "-C", str(wt), "show",
+         _BASE_SHA + ":pact-plugin/hooks/shared/merge_guard_common.py"]
+    ).decode()
+    mod = types.ModuleType("base_merge_guard_common_1129r2")
+    mod.__file__ = str(wt / "pact-plugin/hooks/shared/merge_guard_common.py")
+    mod.__package__ = "shared"  # so its `from shared.x import ...` resolve on sys.path
+    exec(compile(src, mod.__file__, "exec"), mod.__dict__)
+    return mod
+
+
+_BASE = _load_base_classifier()
+D_BASE = _BASE.is_dangerous_command
+D = mgc.is_dangerous_command
+STRIP = mgc._strip_non_executable_content
+
+# Destructive verbs assembled at runtime — this file carries no raw literal.
+BD = "git " + "branch " + "-D main"           # destructive branch-delete literal
+PF = "git " + "push " + "--force origin main"  # destructive force-push literal
+M5 = "gh " + "pr " + "merge 5"                 # destructive merge literal
+ALLOW, DENY = 0, 2
+
+
+# ===========================================================================
+# Real post_main -> pre_main round-trip harness (the launder witness).
+# ===========================================================================
+def _mint(carrier_cmd, tok):
+    """Drive the REAL post hook mint for a faithful carrier click; return the list of
+    minted token contexts (empty when the :447 write-gate withholds)."""
+    env = json.dumps({"tool_name": "AskUserQuestion", "tool_input": {"questions": [{
+        "question": "Proceed?", "options": [
+            {"label": "Yes", "description": "Run `%s`" % carrier_cmd},
+            {"label": "Cancel", "description": "Abort"}]}]},
+        "tool_response": {"answers": {"Proceed?": "Yes"}}, "session_id": "r2cert"})
+    with patch.object(merge_guard_post, "TOKEN_DIR", tok), \
+         patch("sys.stdin", io.StringIO(env)), patch("sys.stdout", io.StringIO()):
+        try:
+            post_main()
+        except SystemExit:
+            pass
+    return [json.loads(f.read_text()).get("context", {})
+            for f in tok.glob("merge-authorized-*")]
+
+
+def _execute(cmd, tok):
+    """Run `cmd` through the REAL pre hook; return exit code (0=ALLOW, 2=DENY)."""
+    env = json.dumps({"tool_name": "Bash", "tool_input": {"command": cmd}, "session_id": "r2cert"})
+    with patch.object(merge_guard_pre, "TOKEN_DIR", tok), \
+         patch("sys.stdin", io.StringIO(env)), patch("sys.stdout", io.StringIO()), \
+         patch("sys.stderr", io.StringIO()):
+        try:
+            pre_main()
+            return ALLOW
+        except SystemExit as e:
+            return e.code if isinstance(e.code, int) else ALLOW
+
+
+# ===========================================================================
+# OB1-8 — faithful-click over-block CLOSURE (base is_dangerous True -> HEAD False).
+# ===========================================================================
+class TestOverBlockClosure:
+
+    @pytest.mark.parametrize("label,cmd", [
+        ("OB1 gh pr edit --body", 'gh pr edit 123 --body "%s"' % BD),
+        ("OB1 gh pr edit -b", 'gh pr edit 123 -b "%s"' % BD),
+        ("OB1 gh pr edit --title", 'gh pr edit 123 --title "%s"' % BD),
+        ("OB2 gh release create --notes", 'gh release create v1 --notes "%s"' % PF),
+        ("OB2 gh release create -n", 'gh release create v1 -n "%s"' % PF),
+        ("OB2 gh release edit --notes", 'gh release edit v1 --notes "%s"' % PF),
+        ("OB3 git tag -m", 'git tag -m "%s" v1' % BD),
+        ("OB3 git tag --message", 'git tag --message "%s" v1' % BD),
+        ("OB4 gh gist create --desc", 'gh gist create f.txt --desc "%s"' % BD),
+        ("OB4 gh gist create -d", 'gh gist create f.txt -d "%s"' % BD),
+        ("OB5 ANSI-C $'...'", "gh pr comment 1 --body $'%s'" % PF),
+        ("OB6 adjacent-concat", 'gh pr create --title "Fix "\'%s\'' % M5),
+        ("OB8 gh release create --title", 'gh release create v1 --title "%s"' % BD),
+    ])
+    def test_over_block_closed_base_true_head_false(self, label, cmd):
+        assert D_BASE(cmd) is True, "%s: expected a BASE over-block vector (else vacuous)" % label
+        assert D(cmd) is False, "%s: HEAD must CLOSE the faithful-click over-block" % label
+
+
+# ===========================================================================
+# MUST-NOT-REGRESS — genuinely executing / destructive forms stay gated (base & HEAD).
+# ===========================================================================
+class TestMustNotRegress:
+
+    @pytest.mark.parametrize("label,cmd", [
+        ("UB1 $()-body executes", 'gh pr create --body "$(%s)"' % PF),
+        ("UB1b backtick executes", 'gh pr create --body "`%s`"' % PF),
+        ("UB2 close --delete-branch", 'gh pr close 5 --delete-branch'),
+        ("UB3 leg-tail && force-push", 'gh pr create --body "x" && %s' % PF),
+        ("UB3b leg-tail && branch-delete", 'gh pr create --body "x" && %s' % BD),
+        ("UB3c leg-tail ; force-push", 'gh pr create --body "x" ; %s' % PF),
+    ])
+    def test_stays_gated_base_and_head(self, label, cmd):
+        assert D_BASE(cmd) is True, "%s: must be gated on base" % label
+        assert D(cmd) is True, "%s: R2 must NOT narrow detection here" % label
+
+
+# ===========================================================================
+# -d SURVIVES -m STRIP + release boolean non-collision (sibling-safety).
+# ===========================================================================
+class TestDSurvivesMStrip:
+
+    @pytest.mark.parametrize("label,cmd", [
+        ("git tag -m then -d", 'git tag -m "msg" -d oldtag'),
+        ("git tag -d then -m", 'git tag -d oldtag -m "msg"'),
+    ])
+    def test_tag_delete_target_visible_after_m_strip(self, label, cmd):
+        # The flag-anchored -m value strip must NOT consume the -d DELETE target in any
+        # ordering (the git-tag verb-collision guard — -m benign shares the verb with -d).
+        stripped = STRIP(cmd)
+        assert "-d oldtag" in stripped, "%s: -d target lost to the -m strip: %r" % (label, stripped)
+
+    def test_release_boolean_not_mis_consumed(self):
+        # -d (=--draft) / -p (=--prerelease) are BOOLEANS for release; the value-strip
+        # (per-carrier set, NOT a union) strips only --title/--notes VALUES and leaves the
+        # boolean -d visible in every ordering.
+        stripped = STRIP('gh release create v1 --title "T" -d --notes "N"')
+        assert "-d" in stripped and "STRIPPED" in stripped
+        assert '"T"' not in stripped and '"N"' not in stripped
+
+    def test_tag_m_compound_tail_stays_caught(self):
+        # Leg-locality: a benign tag -m then a destructive force-push tail stays gated
+        # (the flag-anchored strip does not span past the unquoted separator).
+        assert D('git tag -m "msg" && %s' % PF) is True
+
+
+# ===========================================================================
+# SUBCOMMAND-DELETE accepted-residual PIN (base==HEAD==False; separate hardening issue).
+# ===========================================================================
+class TestSubcommandDeleteAcceptedResidualPin:
+    """gh release delete / gh gist delete / git tag -d are UNDETECTED at HEAD and R2
+    leaves them byte-unchanged. These are tolerated-direction UNDER-blocks tracked as a
+    SEPARATE hardening issue (#1137, NOT R2's over-block scope). This row PINS the
+    accepted residual so a future detection arm cannot silently regress it — it asserts
+    they REMAIN undetected, NOT that they should be gated."""
+
+    @pytest.mark.parametrize("label,cmd", [
+        ("gh release delete", 'gh release delete v1.0'),
+        ("gh gist delete", 'gh gist delete abc123'),
+        ("git tag -d", 'git tag -d oldtag'),
+    ])
+    def test_still_undetected_unchanged(self, label, cmd):
+        assert D_BASE(cmd) is False and D(cmd) is False, \
+            "%s: accepted-residual PIN — must stay undetected in R2 (hardening tracked in #1137)" % label
+
+
+# ===========================================================================
+# LOAD-BEARING — the REAL mint->execute round-trip: launder WITHHELD at HEAD.
+# ===========================================================================
+class TestLaunderClosureRoundTrip:
+    """The :447 is_dangerous write-gate makes mint⊆read: the carrier strip that drops
+    is_dangerous to False also withholds the launder token — no mint-path edit. Proven
+    by the REAL post_main->pre_main round-trip, NOT read-side reasoning (phantom-green
+    #1129). Base-mints witness (non-vacuity) is recorded in the TEST HANDOFF."""
+
+    def test_gist_merge_launder_withheld_at_head(self, tmp_path):
+        # BASE (recorded in HANDOFF): `gh gist create -d "<merge>"` mints
+        # {merge,5,--delete-branch} and `gh pr merge 5 --delete-branch` ALLOWs (the gist
+        # -d is read as merge's --delete-branch alias). HEAD must withhold + DENY.
+        carrier = 'gh gist create -d "%s"' % M5
+        assert D(carrier) is False, "carrier must be non-dangerous at HEAD (strip removed the literal)"
+        assert _mint(carrier, tmp_path) == [], "HEAD must mint NO launder token (:447 write-gate)"
+        assert _execute(M5 + " --delete-branch", tmp_path) == DENY, "the base-usable laundered exec must DENY at HEAD"
+
+    def test_tag_forcepush_launder_withheld_at_head(self, tmp_path):
+        # Mint-level closure (the tag force-push launder is not a usable clean-exec
+        # round-trip on base — see HANDOFF caveat — but R2 still withholds it): the tag
+        # carrier is non-dangerous at HEAD so :447 withholds any force-push token.
+        carrier = 'git tag v1.0 -m "%s"' % PF
+        assert D(carrier) is False
+        assert _mint(carrier, tmp_path) == [], "HEAD must mint NO force-push token from the tag carrier"

--- a/pact-plugin/tests/test_merge_guard_1129_r2_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1129_r2_cert.py
@@ -16,17 +16,38 @@ Summary: COMPREHENSIVE BIDIRECTIONAL certification for #1129 R2 — the carrier-
              These under-blocks are a SEPARATE hardening issue, NOT R2's over-block
              scope — this pins them so a future detection arm can't silently regress.
            - THE LOAD-BEARING ROW: a REAL post_main->pre_main mint->execute round-trip
-             proving the mint-side launder is WITHHELD at HEAD (the :447 is_dangerous
-             write-gate: mint⊆read, so the carrier strip that drops is_dangerous to
-             False also withholds the launder token — closure is free, no mint-path
-             edit). Non-vacuity for the gist launder is the base-revert witness recorded
-             in the TEST HANDOFF (base mints {merge,5,--delete-branch} + the
-             --delete-branch exec ALLOWs; HEAD mints nothing + DENYs).
+             proving the mint-side launder is WITHHELD at HEAD. MECHANISM (architect §1,
+             F1-cycle refinement — primary/secondary, not a blanket ":447"): PRIMARY closure
+             = read-side AUTO-ALLOW — post-R2 is_dangerous(carrier)=False, so
+             check_merge_authorization returns None (ALLOW), NO AskUserQuestion approval is
+             raised, and the mint path is NEVER invoked with the carrier command in the
+             normal flow. SECONDARY backstop = the :447 is_dangerous write-gate (ACCURATE,
+             base-vs-HEAD verified): IF the mint IS driven (an AskUserQuestion whose clicked
+             option carries the carrier command — what THIS cert harness simulates), :447
+             withholds because is_dangerous=False. The gist launder is a real USABLE base
+             launder R2 closes END-TO-END (base mints {merge,5,--delete-branch}, exec
+             `gh pr merge 5 --delete-branch` ALLOWs; HEAD mints nothing + DENYs). The git-tag
+             launder base token IS CLASSIFIED (push-to-main, target 'main"' — CORRUPTED by
+             the closing quote captured inside the -m value), NOT unclassified/vacuous, so
+             R2's git-tag closure is mint-level defense-in-depth, not a usable-exec launder.
+           - F1 LEG-MERGE REGRESSION GUARD (HALT #64, fix 3abfa3dc): the pre-fix
+             whole-command carrier-7d strip let _strip_flag_values consume `STRIPPED<SEP>gh`
+             across an UNQUOTED separator, EATING the head of a no-space gh-headed destructive
+             tail (`git tag -m "x";gh pr merge 5 --delete-branch`) -> is_dangerous=False ->
+             auth-bypass. The span-scope fix restores leg-locality. These rows load a THIRD
+             baked classifier (PRE-FIX R2 6f404f2e) and assert base=True / pre-fix=False /
+             fixed=True (pre-fix is the discriminator). Includes the over-anchoring witness
+             (the non-gobbling git-tag anchor must not cross a separator into a LATER git tag)
+             + SAFE controls (spaced separator, git-headed tail) that must NOT flip.
+           - NEW-CARRIER AXIS COVERAGE (review MINOR-1): the strip axes ($()/backtick
+             preserve, exotic-quote closure, leg-locality) exercised on ALL 3 new carriers
+             (release/gist/git-tag), not just carrier-7.
 
-NON-VACUITY (base-vs-HEAD): the read-side rows load the BASE classifier (023ee2c3) via
-`git show` + exec and assert base-vs-HEAD IN-TEST, so the cert is permanently
-non-vacuous — a future strip regression flips a HEAD column back and reds the row, and
-the base column proves each form was genuinely a vector (never a vacuous green).
+NON-VACUITY (base-vs-HEAD, and pre-fix-vs-fixed for F1): the read-side rows load the BASE
+classifier (023ee2c3) AND the PRE-FIX R2 classifier (6f404f2e) via `git show` + exec and
+assert the discrimination IN-TEST, so the cert is permanently non-vacuous — a future strip
+regression flips a HEAD column back and reds the row, and the base/pre-fix column proves
+each form was genuinely a vector (never a vacuous green).
 
 Cross-refs: docs/architecture/1129-r2-carrier7.md §5 (cert matrix); docs/preparation/
 1129-r2-groundtruth.md (empirical OB/launder findings). Destructive verbs are assembled
@@ -51,25 +72,31 @@ import shared.merge_guard_common as mgc  # noqa: E402
 from merge_guard_post import main as post_main  # noqa: E402
 from merge_guard_pre import main as pre_main  # noqa: E402
 
-# --- BASE classifier (pre-R2, 023ee2c3) loaded ONCE for baked base-vs-HEAD non-vacuity.
-_BASE_SHA = "023ee2c3"
+# --- Baked classifiers loaded from git ONCE for in-test base-vs-HEAD non-vacuity:
+#     BASE (pre-R2) for the OB-closure rows; PRE-FIX R2 (the buggy whole-command
+#     carrier-7d) for the F1 leg-merge regression guard. The F1 discriminator is
+#     pre-fix=False -> fixed=True; BASE has no 7d carrier so it does NOT flip on F1.
+_BASE_SHA = "023ee2c3"    # pre-R2
+_PREFIX_SHA = "6f404f2e"  # R2 pre-F1-fix (whole-command 7d — the HALT #64 regression)
 
 
-def _load_base_classifier():
+def _load_classifier(sha):
     wt = Path(__file__).resolve().parents[2]  # worktree root (tests/../../)
     src = subprocess.check_output(
         ["git", "-C", str(wt), "show",
-         _BASE_SHA + ":pact-plugin/hooks/shared/merge_guard_common.py"]
+         sha + ":pact-plugin/hooks/shared/merge_guard_common.py"]
     ).decode()
-    mod = types.ModuleType("base_merge_guard_common_1129r2")
+    mod = types.ModuleType("merge_guard_common_1129r2_" + sha)
     mod.__file__ = str(wt / "pact-plugin/hooks/shared/merge_guard_common.py")
     mod.__package__ = "shared"  # so its `from shared.x import ...` resolve on sys.path
     exec(compile(src, mod.__file__, "exec"), mod.__dict__)
     return mod
 
 
-_BASE = _load_base_classifier()
+_BASE = _load_classifier(_BASE_SHA)
+_PREFIX = _load_classifier(_PREFIX_SHA)
 D_BASE = _BASE.is_dangerous_command
+D_PREFIX = _PREFIX.is_dangerous_command
 D = mgc.is_dangerous_command
 STRIP = mgc._strip_non_executable_content
 
@@ -210,24 +237,152 @@ class TestSubcommandDeleteAcceptedResidualPin:
 # LOAD-BEARING — the REAL mint->execute round-trip: launder WITHHELD at HEAD.
 # ===========================================================================
 class TestLaunderClosureRoundTrip:
-    """The :447 is_dangerous write-gate makes mint⊆read: the carrier strip that drops
-    is_dangerous to False also withholds the launder token — no mint-path edit. Proven
-    by the REAL post_main->pre_main round-trip, NOT read-side reasoning (phantom-green
-    #1129). Base-mints witness (non-vacuity) is recorded in the TEST HANDOFF."""
+    """PRIMARY closure = read-side auto-allow (is_dangerous=False -> check_merge_authorization
+    returns None -> no approval event -> the mint is NEVER invoked in the normal flow); the
+    :447 is_dangerous write-gate is the ACCURATE SECONDARY backstop THIS harness drives
+    directly (architect §1). Proven by the REAL post_main->pre_main round-trip, NOT read-side
+    reasoning (phantom-green #1129). The gist base-mint witness is baked below (MINOR-2); the
+    git-tag base token IS classified (push-to-main) but its target 'main\"' is CORRUPTED (not
+    a usable launder), so R2's git-tag closure is mint-level defense-in-depth."""
 
     def test_gist_merge_launder_withheld_at_head(self, tmp_path):
-        # BASE (recorded in HANDOFF): `gh gist create -d "<merge>"` mints
-        # {merge,5,--delete-branch} and `gh pr merge 5 --delete-branch` ALLOWs (the gist
-        # -d is read as merge's --delete-branch alias). HEAD must withhold + DENY.
+        # `gh gist create -d "<merge>"` — the gist -d is read as merge's --delete-branch
+        # alias. HEAD must withhold + DENY. (Base-mint proven in the sibling row below.)
         carrier = 'gh gist create -d "%s"' % M5
         assert D(carrier) is False, "carrier must be non-dangerous at HEAD (strip removed the literal)"
-        assert _mint(carrier, tmp_path) == [], "HEAD must mint NO launder token (:447 write-gate)"
+        assert _mint(carrier, tmp_path) == [], "HEAD must mint NO launder token"
         assert _execute(M5 + " --delete-branch", tmp_path) == DENY, "the base-usable laundered exec must DENY at HEAD"
 
+    def test_gist_base_mint_witness_is_a_usable_launder(self):
+        # MINOR-2 (baked base-mint non-vacuity): the BASE (023ee2c3) classifier both GATES
+        # the gist carrier AND extracts a USABLE {merge, pr 5, --delete-branch} context from
+        # it — i.e. a real usable launder EXISTED on base for HEAD to close (not a vacuous
+        # withhold). HEAD classifies it non-dangerous (the -d value is stripped).
+        carrier = 'gh gist create -d "%s"' % M5
+        assert D_BASE(carrier) is True
+        base_ctx = _BASE.extract_command_context(carrier)
+        assert base_ctx.get("operation_type") == "merge"
+        assert base_ctx.get("pr_number") == "5"
+        assert "--delete-branch" in base_ctx.get("bound_flags", [])
+        assert D(carrier) is False  # HEAD: closed
+
     def test_tag_forcepush_launder_withheld_at_head(self, tmp_path):
-        # Mint-level closure (the tag force-push launder is not a usable clean-exec
-        # round-trip on base — see HANDOFF caveat — but R2 still withholds it): the tag
-        # carrier is non-dangerous at HEAD so :447 withholds any force-push token.
+        # Mint-level closure. The git-tag base token IS classified (push-to-main) but its
+        # target 'main"' is CORRUPTED (the closing quote captured inside the -m value), so it
+        # was NEVER a usable clean-exec launder — R2's tag closure is defense-in-depth. The
+        # tag carrier is non-dangerous at HEAD so no push-to-main token mints.
         carrier = 'git tag v1.0 -m "%s"' % PF
         assert D(carrier) is False
-        assert _mint(carrier, tmp_path) == [], "HEAD must mint NO force-push token from the tag carrier"
+        assert _mint(carrier, tmp_path) == [], "HEAD must mint NO push-to-main token from the tag carrier"
+
+
+# ===========================================================================
+# F1 LEG-MERGE REGRESSION GUARD (HALT #64, fix 3abfa3dc) — base / PRE-FIX / fixed.
+# Co-derived vector space with security-engineer #57. The PRE-FIX column (6f404f2e,
+# buggy whole-command 7d) is the discriminator: it MUST be False (the auth-bypass), so
+# these rows can never be vacuously green.
+# ===========================================================================
+class TestF1LegMergeRegression:
+
+    _TAG = 'git tag -a v1 -m "Release v1.0"'
+    # F1 is the EATEN-HEAD family {gh, curl, wget} (security-engineer #57 completeness pass):
+    # the pre-fix whole-command 7d over-consumed `STRIPPED<SEP>` into the next leg and ate ANY
+    # destructive op's HEAD token, not just gh's. curl/wget need a real destructive endpoint
+    # (…/git/refs/…) or the head isn't destructive. Client verbs assembled at runtime (inert).
+    _HEADS = [
+        ("gh-pr-merge--delete-branch", "gh " + "pr merge 5 --delete-branch"),
+        ("gh-pr-close--delete-branch", "gh " + "pr close 5 --delete-branch"),
+        ("gh-api--X-DELETE", "gh " + "api -X DELETE repos/o/r/git/refs/heads/main"),
+        ("curl--X-DELETE", "curl " + "-X DELETE https://api.github.com/repos/o/r/git/refs/heads/main"),
+        ("wget--method-DELETE", "wget " + "--method=DELETE https://api.github.com/repos/o/r/git/refs/heads/main"),
+    ]
+    # Both message quotings are vulnerable pre-fix (arm3 re-touches the arm1 STRIPPED bareword).
+    _MSGS = [("quoted", 'git tag -a v1 -m "Release v1.0"'), ("unquoted", 'git tag -m note')]
+
+    @pytest.mark.parametrize("sep", [";", "&&", "|"])
+    @pytest.mark.parametrize("head_label,head", _HEADS)
+    @pytest.mark.parametrize("msg_label,tag", _MSGS)
+    def test_nospace_destructive_head_leg_merge_closed(self, sep, head_label, head, msg_label, tag):
+        # `git tag -m <msg><SEP-no-space><destructive-head>` — the F1 eaten-head auth-bypass,
+        # across the {gh, curl, wget} head family × {;,&&,|} × {quoted, unquoted} message.
+        cmd = tag + sep + head
+        assert D_BASE(cmd) is True, "base must catch the tail (no 7d carrier): %r" % cmd
+        assert D_PREFIX(cmd) is False, "PRE-FIX 7d MUST leg-merge (the F1 auth-bypass) else vacuous: %r" % cmd
+        assert D(cmd) is True, "fixed span-scope must catch the tail (F1 closed): %r" % cmd
+
+    @pytest.mark.parametrize("tag", ['git tag -m "a\'b"', "git tag -m 'a\"b'"])
+    def test_mixed_quote_message_tail_still_caught(self, tag):
+        # A quote-INSIDE the message: arm1/arm2 consume the quoted span atomically (no dangling
+        # quote), so the no-space gh tail survives and is caught at fixed. Robustness guard
+        # (security-engineer #57 noted it's not an under-block vector, but worth one pin).
+        cmd = tag + ";" + M5 + " --delete-branch"
+        assert D(cmd) is True, "mixed-quote message must not leg-merge the tail: %r" % cmd
+
+    @pytest.mark.parametrize("sep", [";", "&&", "|"])
+    def test_safe_control_spaced_separator_no_flip(self, sep):
+        # A SPACE before gh keeps the head intact on the pre-fix strip -> no leg-merge.
+        cmd = "%s %s %s --delete-branch" % (self._TAG, sep, M5)
+        assert D_BASE(cmd) is True and D_PREFIX(cmd) is True and D(cmd) is True
+
+    def test_safe_control_git_headed_tail_no_flip(self):
+        # No-space but git-HEADED tail survives via the permissive _GIT_PREFIX (not eaten).
+        cmd = self._TAG + ";" + PF
+        assert D_BASE(cmd) is True and D_PREFIX(cmd) is True and D(cmd) is True
+
+    @pytest.mark.parametrize("carrier", [
+        'gh release create v1 --notes "Release v1.0"',
+        'gh gist create f.txt --desc "note"',
+    ])
+    def test_other_new_carriers_never_leg_merged(self, carrier):
+        # release/gist were already span-scoped (7/7b/7c): the F1-class trigger never
+        # leg-merged them (NO second under-block). True on base AND pre-fix AND fixed.
+        cmd = carrier + ";" + M5 + " --delete-branch"
+        assert D_BASE(cmd) is True and D_PREFIX(cmd) is True and D(cmd) is True
+
+
+class TestOverAnchoring:
+    """The F1 fix's git-tag anchor is a NON-gobbling word-class prefix (excludes ;&|), so it
+    cannot cross an unquoted separator into a LATER `git tag` and re-strip an earlier leg's
+    -m value. The pre-fix whole-command 7d DID (it matched the trailing `git tag` and
+    stripped `git commit`'s -m, leg-merging the gh leg). base=True / pre-fix=False / fixed=True."""
+
+    def test_over_anchoring_witness_closed(self):
+        cmd = 'git commit -m "x";gh pr merge 5;git tag v1'
+        assert D_BASE(cmd) is True
+        assert D_PREFIX(cmd) is False, "pre-fix gobbler MUST leg-merge (else the over-anchor guard is vacuous)"
+        assert D(cmd) is True, "fixed non-gobbling anchor must keep the gh leg caught"
+
+
+class TestNewCarrierAxisCoverage:
+    """MINOR-1 (review): the strip axes exercised on carrier-7 (gh pr) are now exercised on
+    ALL 3 NEW carriers (release/gist/git-tag) — they inherit via the shared _strip_flag_values
+    /_VALUE_TOKEN, but the cert now GUARDS it per carrier (a regression to one new carrier's
+    $()-preserve or exotic-quote handling would now red a row)."""
+
+    # (label, value-flag prefix, tag-name suffix needed after the value)
+    _CARRIERS = [
+        ("release --notes", 'gh release create v1 --notes ', ''),
+        ("gist --desc", 'gh gist create f.txt --desc ', ''),
+        ("git-tag -m", 'git tag -m ', ' v1'),
+    ]
+
+    @pytest.mark.parametrize("label,prefix,suffix", _CARRIERS)
+    def test_cmdsub_preserved_stays_gated(self, label, prefix, suffix):
+        # $()/backtick in the value EXECUTES -> must stay gated (base AND HEAD).
+        for val in ['"$(%s)"' % PF, '"`%s`"' % PF]:
+            cmd = prefix + val + suffix
+            assert D_BASE(cmd) is True and D(cmd) is True, "%s: cmd-sub must stay gated: %r" % (label, cmd)
+
+    @pytest.mark.parametrize("label,prefix,suffix", _CARRIERS)
+    def test_exotic_quote_over_block_closed_at_head(self, label, prefix, suffix):
+        # ANSI-C $'...' and adjacent-concat forms are STRIPPED (over-block closed) at HEAD.
+        ansi = prefix + "$'%s'" % PF + suffix
+        concat = prefix + '"a "\'%s\'' % M5 + suffix
+        assert D(ansi) is False, "%s: $'...' over-block not closed: %r" % (label, ansi)
+        assert D(concat) is False, "%s: adjacent-concat over-block not closed: %r" % (label, concat)
+
+    @pytest.mark.parametrize("label,prefix,suffix", _CARRIERS)
+    def test_spaced_compound_tail_caught(self, label, prefix, suffix):
+        # Leg-locality (spaced separator): a destructive tail after the carrier stays caught.
+        cmd = prefix + '"x"' + suffix + " && " + PF
+        assert D(cmd) is True, "%s: spaced compound tail lost: %r" % (label, cmd)


### PR DESCRIPTION
## R2 — carrier-7 unification (PR-2 of 3 for issue 1129)

Second of three PRs fixing merge-guard **faithful-click over-blocks** (issue 1129). Fixes the cardinal-sin direction: a faithful single `gh`/`git` command whose body/notes/description/message value quotes a destructive-looking string should never be blocked.

### What changed (`6f404f2e`)
- **carrier-7 unified** onto the shared quote-balanced `_strip_flag_values`/`_VALUE_TOKEN` primitive (already used by carriers 8/9). This closes the ANSI-C `$'…'` and adjacent-concat quote-form over-blocks **for free** (the token consumes them atomically) and immunizes carrier-7 against the #1118 dangling-quote class by construction.
- **`gh pr edit`** added to the carrier alternation (it strips non-executing `--body`/`--title` prose, identical in kind to the already-carried `gh issue edit` — the pre-existing issue-edit/pr-edit asymmetry was an over-conservative over-block).
- **3 new per-carrier siblings** (subcommand-specific spans, per-carrier flag sets — NOT a union):
  - `gh release create|edit` → strip `--notes`/`-n`, `--title`/`-t` (excludes `--notes-file`/`-F`; `-d`/`-p` are booleans, left visible)
  - `gh gist create|edit` → strip `--desc`/`-d` (gist-scoped)
  - `git tag` → **flag-anchored** `-m`/`--message` value only (never verb-span — `git tag -d` shares the verb and stays visible)
- **3 coupled test updates** (same commit): the two `test_merge_guard.py` pr-edit tests reframed to assert `gh pr edit` IS now a carrier (OB1); the `test_merge_guard_1037_narrow.py` discrimination control re-pointed to `gh pr review` (still-non-carrier sibling — preserves the "non-carrier verb is not exempted" guardrail).

### Why it's safe (SACROSANCT auth control)
- **No mint-path edit.** Launder closure is free by construction: the mint write-gate shares the same `is_dangerous_command` predicate as the read gate (mint⊆read), so a carrier that strips the literal both un-blocks the faithful click AND withholds the launder token.
- **Per-carrier flag sets, not a union** — `-d` is `--desc` (value) for gist but `--draft` (boolean) for release; a shared set would mis-consume the release boolean's neighbor.
- **Sibling-safety** — subcommand-specific spans + git-tag flag-anchoring keep every destructive sibling (`gh release delete`, `gh gist delete`, `git tag -d`) outside every carrier span (byte-unchanged, still undetected — a *separate* tolerated under-block tracked apart from this PR).

### Certification (`d37863ef`) — bidirectional, non-vacuous
28-row cert file with **in-test base-vs-HEAD non-vacuity** (loads the base classifier via `git show` + exec, asserts per-row) + a **real mint→execute round-trip** (not read-side reasoning):
- OB1-8 over-block closure (base `is_dangerous`=True → HEAD=False)
- must-not-regress (`$()`/backtick command-sub, `gh pr close --delete-branch`, compound leg-tails stay gated)
- `-d` survives the `-m` strip (both orderings); release booleans not mis-consumed
- **launder round-trip**: `gh gist create -d "gh pr merge 5"` — base mints a usable `{merge,--delete-branch}` token (base ALLOW) / HEAD withholds (DENY) = **usable-launder closure proven**. `git tag -m` force-push = mint-level closure (documented caveat: base never minted a usable clean-exec launder — the exploratory ground-truth over-claimed it)

Full suite: **11013 passed / 11 skipped / 0 failed / 0 errors** (python 3.12.7).

### Scope
- PR-2 of 3 for issue 1129 — issue stays **open** for PR-3 (R3).
- The undetected destructive siblings (`gh release delete` / `gh gist delete` / `git tag -d`) are a separate hardening item, tracked apart (see the merge-guard undetected-delete issue).
- `v4.5.6` (PATCH, `7ba5c22f`).
