### PR TITLE
fix(merge-guard): unify branch_set + mass_target onto injective netstring _canonical_join SSOT (issue 1136)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.5.6",
+      "version": "4.5.7",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,6 +81,13 @@ jobs:
       # These majors run on Node24 (checkout@v4 / setup-python@v5 were Node20,
       # deprecated by GitHub — forced off by 2026-06-16, so re-pinned forward).
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          # Full history so the baked-base cert files can `git show <base-sha>`
+          # (their base-vs-HEAD non-vacuity differentials). The default shallow
+          # clone (fetch-depth: 1) lacks the base commits -> `git show` fails ->
+          # those files abort collection (0 tests run). Full history makes every
+          # differential RUN in CI; the in-file self-skip guards are the fallback.
+          fetch-depth: 0
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.5.6/       # Plugin version
+│               └── 4.5.7/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.5.6",
+  "version": "4.5.7",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.5.6
+> **Version**: 4.5.7
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -556,7 +556,7 @@ def _token_matches_command(token: dict, command: str) -> bool:
         # SSOT), so a scalar token can NOT authorize a set command or vice-versa
         # (the absent-key side fails _both_present_equal), and a {a,b} token can
         # NOT authorize {a,b,c} (unequal canonical strings) while a {b,a} reorder
-        # MATCHES (both canonicalize to `a,b`). The #1032 under-block is closed by
+        # MATCHES (both canonicalize to the SAME string). The #1032 under-block is closed by
         # equality; both sides derive via the ONE extract_command_context SSOT so
         # mint and read cannot drift.
         return (

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -168,6 +168,7 @@ import os
 import re
 import shlex
 import time
+from collections.abc import Sequence
 from pathlib import Path
 
 from .paths import get_claude_config_dir
@@ -875,32 +876,44 @@ def _extract_branch_name(command: str) -> str | None:
     return _strip_surrounding_quotes(positionals[0])
 
 
+def _canonical_join(items: Sequence[str]) -> str:
+    """Netstring/length-prefix encode a sequence of strings into ONE canonical
+    identity STRING, injective by construction (a left-inverse decoder exists), so
+    distinct sequences never collide REGARDLESS of item content — incl. commas, '@',
+    '#', ':' and NUL. Pure + deterministic (no sort, no dedup — the caller supplies a
+    canonical ordered list). Stays a `str` (the token persists as JSON; compared by
+    str()-equality, never decoded). Shared SSOT for branch_set + mass_target (#1136)."""
+    return "".join(f"{len(i)}:{i}" for i in items)
+
+
 def _extract_branch_delete_set(command: str) -> str | None:
     """Extract the canonical MULTI-branch identity of a force-delete command.
 
     The MULTI-target sibling of _extract_branch_name (which owns the SINGLE
     branch). Handles the CLI `git branch -D|--delete --force <a> <b> ...` form
     with TWO OR MORE positional branch names, returning a canonical
-    sort+dedup+quote-strip identity STRING joined on NUL (`\x00`), or None
+    sort+dedup+quote-strip identity STRING (the shared netstring `_canonical_join`
+    SSOT), or None
     when fewer than two branch names are positively extractable (<2 -> defers to
     the scalar _extract_branch_name path — the BOUNDARY discriminator, so a
     command populates EXACTLY ONE of `branch` / `branch_set`).
 
-    Mirrors the _extract_mass_delete_target precedent (#1062b): an
+    Shares the _extract_mass_delete_target encoder (#1062b/#1136): an
     ORDER-INDEPENDENT identity STRING (never a tuple/list — a token persists as
     JSON, and the read side compares via `str()`, so a list<->tuple round-trip
     must never enter the identity), built + canonicalized in this ONE shared SSOT
     so mint and read derive byte-identical strings (D2 symmetry by construction).
-    The join separator is NUL (`\x00`): git forbids control bytes in branch
-    names, so no name can contain it and the joined identity is INJECTIVE —
-    distinct branch SETS never collide. (A bare `,` was NOT injective: a branch
-    literally named `a,b` collided with the set {a, b}, cross-authorizing distinct
-    sets — the F1 review finding. NUL is JSON/str()-safe: json escapes it on dump,
-    restores it on load, and str() is stable, so the round-trip holds.)
+    Encoding is the netstring `_canonical_join` (`len:name` framing): the identity
+    is INJECTIVE by construction and CONTENT-AGNOSTIC, so distinct branch SETS never
+    collide regardless of name content — no separator has to be ref-illegal. (A bare
+    `,` join was NOT injective: a branch literally named `a,b` collided with the set
+    {a, b}, cross-authorizing distinct sets — the F1 review finding; framing closes
+    that class outright. The string is JSON/str()-safe: json round-trips it and str()
+    is stable, so the identity survives token persistence.)
     Set-EQUALITY on this INJECTIVE string then closes the #1032 multi-target
     under-block UNCONDITIONALLY: a `{a,b}` token cannot authorize `{a,b,c}`
     (unequal strings) while a `{b,a}` reorder MATCHES (both canonicalize to the
-    same NUL-joined string).
+    same string).
 
     Uses the SAME tokenization as _extract_branch_name (executable-prefix
     truncation at a benign continuation/redirect via _executable_prefix, then drop
@@ -921,12 +934,13 @@ def _extract_branch_delete_set(command: str) -> str | None:
     if len(positionals) < 2:
         return None
     names = sorted({_strip_surrounding_quotes(t) for t in positionals})
-    # Join on NUL (\x00) — a REF-ILLEGAL separator (git forbids control bytes in
-    # branch names) so no name can contain it -> the identity is INJECTIVE and
-    # distinct sets never collide (the F1 fix; a bare `,` collided a branch named
-    # `a,b` with the set {a, b}). JSON/str()-safe, so D2 mint==read symmetry and
-    # the JSON token round-trip both hold.
-    return "\x00".join(names) or None
+    # Encode via the shared netstring SSOT (_canonical_join): each name is framed as
+    # `len:name`, so the identity is INJECTIVE by construction and CONTENT-AGNOSTIC —
+    # distinct sets never collide regardless of name content, without depending on any
+    # separator being ref-illegal (an earlier bare `,` join collided a branch named
+    # `a,b` with the set {a, b}). JSON/str()-safe, so mint==read symmetry and the JSON
+    # token round-trip both hold.
+    return _canonical_join(names) or None
 
 
 def _extract_force_push_target_ref(command: str) -> str | None:
@@ -1102,14 +1116,15 @@ def _extract_mass_delete_target(command: str) -> str | None:
     benign `-o ci.skip` does not over-bind; privileged flags ride the existing #1042
     `bound_flags` axis. Derived identically on BOTH arms via this ONE SSOT → mint==read
     parity by construction; recognition⟺mintability (the arm returns the op IFF this is
-    non-None) → #1064-impossible. Returns a READABLE tuple, never a hash:
+    non-None) → #1064-impossible. Returns a READABLE netstring identity STRING
+    (`len:value`-framed field tuple; no `@`/`#`/`,` delimiters; #1136), never a hash:
 
-        <sorted-mass-flags>@<remote-or-implicit-marker>[#<sorted-refspecs>]
-        git push --mirror origin               → --mirror@origin
-        git push --mirror                      → --mirror@\\x00implicit (implicit-remote MINTABLE)
-        git push --prune origin refs/heads/main → --prune@origin#refs/heads/main
-        git push origin --delete a b           → --delete@origin#a,b (binds the EXACT deleted set)
-        git push origin :a :b                  → --delete@origin#a,b
+        _canonical_join([<sorted-mass-flags>, <remote-or-implicit-marker>, *<sorted-deduped-refspecs>])
+        git push --mirror origin               → 8:--mirror6:origin
+        git push --mirror                      → 8:--mirror9:\\x00implicit (implicit-remote MINTABLE)
+        git push --prune origin refs/heads/main → 7:--prune6:origin15:refs/heads/main
+        git push origin --delete a b           → 8:--delete6:origin1:a1:b (binds the EXACT deleted set)
+        git push origin :a :b                  → 8:--delete6:origin1:a1:b
 
     BOUNDARY (lead-mandated, no double-classification): a SINGLE-ref delete is owned by
     `_extract_remote_ref_delete_target` (tried FIRST in the recognition arm). This
@@ -1162,10 +1177,11 @@ def _extract_mass_delete_target(command: str) -> str | None:
     else:
         return None
 
-    target = f"{flags_part}@{remote}"
-    if refspecs:
-        target += "#" + ",".join(refspecs)
-    return target
+    # Encode the destructive identity via the shared netstring SSOT (_canonical_join):
+    # framing subsumes the old `@`/`#`/`,` delimiters, so the identity is injective for
+    # ANY field content (closes the #1136 `#`/comma collision class). Dedup refspecs
+    # (a duplicate ref is the same target); empty refspecs frame uniformly (no `#`).
+    return _canonical_join([flags_part, remote, *sorted(set(refspecs))])
 
 
 # -----------------------------------------------------------------------------
@@ -1427,11 +1443,11 @@ def extract_command_context(command: str, flag_scan_text: str | None = None) -> 
         pr_number:  str  (merge / close)
         branch:     str  (branch-delete — SINGLE target, exactly 1 positional)
         branch_set: str  (branch-delete — MULTI target #1129, >=2 positionals) —
-                     canonical sort+dedup+quote-strip names joined on NUL (`\x00`,
-                     a ref-illegal separator → injective, no delimiter collision)
+                     canonical sort+dedup+quote-strip names via the shared netstring _canonical_join (`len:name` framing,
+                     injective by construction, content-agnostic — no delimiter collision)
         target_ref: str  (force-push / push-to-main, KD-6; remote-ref-delete #1062a)
-        mass_target: str (remote-mass-delete #1062b) — normalized identity tuple
-                     <sorted-mass-flags>@<remote-or-implicit-marker>[#<sorted-refspecs>]
+        mass_target: str (remote-mass-delete #1062b) — normalized identity STRING
+                     _canonical_join([<sorted-mass-flags>, <remote-or-implicit-marker>, *<sorted-deduped-refspecs>])
         protected_branch: str (branch-protection #1063) — the branch from the
                      branches/<b>/protection URL path
         bound_flags: list[str]  (#1042) — sorted normalized privileged flags;

--- a/pact-plugin/tests/test_merge_guard_1129_r1_branch_set.py
+++ b/pact-plugin/tests/test_merge_guard_1129_r1_branch_set.py
@@ -34,13 +34,12 @@ from shared.merge_guard_common import (  # noqa: E402
     detect_command_operation_type,
     extract_command_context,
     _extract_branch_delete_set,
+    _canonical_join,
 )
 from merge_guard_pre import _token_matches_command  # noqa: E402
 
 # FORCE flag assembled at runtime — no raw `git branch -D` literal in the source.
 _D = "-" + "D"
-# The canonical branch_set join separator (NUL, ref-illegal → injective; F1 fix).
-_SEP = "\x00"
 
 
 def _cmd(flags: str, names: list[str]) -> str:
@@ -69,7 +68,7 @@ def test_multi_branch_force_delete_mints_branch_set_and_self_matches(flags):
     assert ctx.get("operation_type") == "branch-delete"
     # The additive key is populated with the canonical sorted identity, and the
     # scalar `branch` key stays ABSENT (mutual exclusivity).
-    assert ctx.get("branch_set") == _SEP.join(["A", "B", "C"])
+    assert ctx.get("branch_set") == _canonical_join(["A", "B", "C"])
     assert "branch" not in ctx
     # The faithful click now mints+matches (the over-block cure).
     assert _matches(cmd, cmd) is True
@@ -109,7 +108,7 @@ def test_duplicate_names_dedup_to_same_set():
 
 def test_slashed_branch_names_mint_and_match():
     cmd = _cmd(_D, ["feature/x", "feature/y"])
-    assert extract_command_context(cmd).get("branch_set") == _SEP.join(["feature/x", "feature/y"])
+    assert extract_command_context(cmd).get("branch_set") == _canonical_join(["feature/x", "feature/y"])
     assert _matches(cmd, cmd) is True
 
 
@@ -126,7 +125,7 @@ def test_lowercase_delete_stays_ungated(flags):
 def test_branch_set_is_order_independent_canonical_string():
     a = _extract_branch_delete_set(_cmd(_D, ["A", "B", "C"]))
     b = _extract_branch_delete_set(_cmd(_D, ["C", "B", "A"]))
-    assert a == b == _SEP.join(["A", "B", "C"])
+    assert a == b == _canonical_join(["A", "B", "C"])
     assert isinstance(a, str)  # STRING, never a tuple/list (JSON round-trip safety)
     # Fewer than two positionals -> None -> defers to the scalar `branch` path.
     assert _extract_branch_delete_set(_cmd(_D, ["solo"])) is None

--- a/pact-plugin/tests/test_merge_guard_1129_r1_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1129_r1_cert.py
@@ -240,11 +240,11 @@ class TestTokenPersistenceCanonicalization:
         assert len(tokens) == 1
         payload = json.loads(tokens[0].read_text())
         # The token carries the shared-SSOT context; branch_set is the canonical,
-        # sorted, NUL-joined STRING (#1135 F1 — NUL is git-forbidden in ref names, so
-        # the joined identity is INJECTIVE; a list/tuple would have survived the JSON
+        # sorted, netstring-framed STRING (the shared _canonical_join SSOT, #1136 —
+        # injective by construction); a list/tuple would have survived the JSON
         # round-trip as a list and broken str-comparison matching).
         ctx = payload.get("context", payload)
-        assert ctx.get("branch_set") == "aa\x00bb\x00cc"
+        assert ctx.get("branch_set") == mgc._canonical_join(["aa", "bb", "cc"])
         assert isinstance(ctx.get("branch_set"), str)
         # And a reordered exec of the same set authorizes against the persisted token.
         assert _execute(_cmd(_D, ["bb", "cc", "aa"]), tmp_path) == ALLOW
@@ -260,7 +260,7 @@ class TestGatherCorrectness:
     def test_dash_flag_is_not_gathered_as_a_branch(self, tmp_path):
         # `-r` (a dash-flag) must be dropped; only the two real names form the set.
         cmd = _cmd(_D + " -r", ["origin/x", "origin/y"])
-        assert mgc.extract_command_context(cmd).get("branch_set") == "origin/x\x00origin/y"
+        assert mgc.extract_command_context(cmd).get("branch_set") == mgc._canonical_join(["origin/x", "origin/y"])
         minted, rc = _roundtrip(cmd, cmd, tmp_path)
         assert minted == 1
         assert rc == ALLOW
@@ -374,15 +374,15 @@ class TestCommaNameCollisionClosed:
     """#1135 F1: git ref names PERMIT commas, so the OLD `,`-joined branch_set was
     non-injective — {aa,'bb,cc'} (2 branches) and {aa,bb,cc} (3 branches) both joined
     to `aa,bb,cc`, letting a 2-branch token authorize a 3-branch delete (a cross-set
-    UNDER-BLOCK; the review witness). The NUL join (git-forbidden in ref names) makes
-    the identity INJECTIVE: the two sets now produce distinct strings, so the token no
+    UNDER-BLOCK; the review witness). The netstring _canonical_join SSOT (#1136) makes
+    the identity INJECTIVE by construction: the two sets now produce distinct strings, so the token no
     longer cross-authorizes. The over-block direction is untouched (see the self-match)."""
 
     def test_two_set_and_three_set_no_longer_collide(self):
         two = mgc._extract_branch_delete_set(_cmd(_D, ["aa", "bb,cc"]))       # {aa, 'bb,cc'}
         three = mgc._extract_branch_delete_set(_cmd(_D, ["aa", "bb", "cc"]))  # {aa, bb, cc}
         assert two != three, "comma-named 2-set must not collide with the 3-set (F1)"
-        assert two == "aa\x00bb,cc" and three == "aa\x00bb\x00cc"
+        assert two == mgc._canonical_join(["aa", "bb,cc"]) and three == mgc._canonical_join(["aa", "bb", "cc"])
 
     def test_two_set_token_does_not_authorize_three_set_delete(self, tmp_path):
         # The review's cross-set under-block witness — now REFUSED.
@@ -434,7 +434,7 @@ class TestQuotedBranchNames:
         return _GB + _D + " " + " ".join("'%s'" % n for n in names)
 
     def test_quoted_names_canonicalize_quote_insensitively(self):
-        assert mgc._extract_branch_delete_set(self._q(["aa", "bb"])) == "aa\x00bb"
+        assert mgc._extract_branch_delete_set(self._q(["aa", "bb"])) == mgc._canonical_join(["aa", "bb"])
 
     def test_quoted_mint_authorizes_unquoted_exec(self, tmp_path):
         minted, rc = _roundtrip(self._q(["aa", "bb"]), _cmd(_D, ["aa", "bb"]), tmp_path)

--- a/pact-plugin/tests/test_merge_guard_1129_r2_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1129_r2_cert.py
@@ -81,24 +81,50 @@ _PREFIX_SHA = "6f404f2e"  # R2 pre-F1-fix (whole-command 7d — the HALT #64 reg
 
 
 def _load_classifier(sha):
+    """Load merge_guard_common as it existed at `sha`, or None if unavailable.
+
+    Returns None on any git/exec failure — git missing, or a SHALLOW clone lacking
+    the base/pre-fix commit (CI's default fetch-depth) — so collection SUCCEEDS and the
+    base-vs-HEAD / pre-fix-vs-fixed differential rows self-SKIP (@requires_history)
+    instead of aborting the whole file. Mirrors test_merge_guard_1118_recert._load_module_at.
+    """
     wt = Path(__file__).resolve().parents[2]  # worktree root (tests/../../)
-    src = subprocess.check_output(
-        ["git", "-C", str(wt), "show",
-         sha + ":pact-plugin/hooks/shared/merge_guard_common.py"]
-    ).decode()
+    try:
+        src = subprocess.check_output(
+            ["git", "-C", str(wt), "show",
+             sha + ":pact-plugin/hooks/shared/merge_guard_common.py"],
+            stderr=subprocess.DEVNULL,
+        ).decode()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
     mod = types.ModuleType("merge_guard_common_1129r2_" + sha)
     mod.__file__ = str(wt / "pact-plugin/hooks/shared/merge_guard_common.py")
     mod.__package__ = "shared"  # so its `from shared.x import ...` resolve on sys.path
-    exec(compile(src, mod.__file__, "exec"), mod.__dict__)
+    try:
+        exec(compile(src, mod.__file__, "exec"), mod.__dict__)
+    except Exception:
+        return None
     return mod
 
 
 _BASE = _load_classifier(_BASE_SHA)
 _PREFIX = _load_classifier(_PREFIX_SHA)
-D_BASE = _BASE.is_dangerous_command
-D_PREFIX = _PREFIX.is_dangerous_command
+# None-safe: guarding _load_classifier alone is NOT enough — a bare
+# `_BASE.is_dangerous_command` would AttributeError at import when the base/pre-fix
+# source is unavailable (shallow clone), re-aborting collection. D_BASE/D_PREFIX are
+# only ever called by the @requires_history-guarded differential rows.
+D_BASE = _BASE.is_dangerous_command if _BASE is not None else None
+D_PREFIX = _PREFIX.is_dangerous_command if _PREFIX is not None else None
 D = mgc.is_dangerous_command
 STRIP = mgc._strip_non_executable_content
+
+# Skip the base-vs-HEAD / pre-fix-vs-fixed differential (non-vacuity) rows when the
+# baked history is unavailable (shallow clone); the HEAD-side + absolute rows still
+# run. With fetch-depth:0 in CI both commits are present, so every differential runs.
+requires_history = pytest.mark.skipif(
+    _BASE is None or _PREFIX is None,
+    reason="base-vs-HEAD / pre-fix differential requires merged history (shallow clone / missing history)",
+)
 
 # Destructive verbs assembled at runtime — this file carries no raw literal.
 BD = "git " + "branch " + "-D main"           # destructive branch-delete literal
@@ -161,6 +187,7 @@ class TestOverBlockClosure:
         ("OB6 adjacent-concat", 'gh pr create --title "Fix "\'%s\'' % M5),
         ("OB8 gh release create --title", 'gh release create v1 --title "%s"' % BD),
     ])
+    @requires_history
     def test_over_block_closed_base_true_head_false(self, label, cmd):
         assert D_BASE(cmd) is True, "%s: expected a BASE over-block vector (else vacuous)" % label
         assert D(cmd) is False, "%s: HEAD must CLOSE the faithful-click over-block" % label
@@ -179,6 +206,7 @@ class TestMustNotRegress:
         ("UB3b leg-tail && branch-delete", 'gh pr create --body "x" && %s' % BD),
         ("UB3c leg-tail ; force-push", 'gh pr create --body "x" ; %s' % PF),
     ])
+    @requires_history
     def test_stays_gated_base_and_head(self, label, cmd):
         assert D_BASE(cmd) is True, "%s: must be gated on base" % label
         assert D(cmd) is True, "%s: R2 must NOT narrow detection here" % label
@@ -228,6 +256,7 @@ class TestSubcommandDeleteAcceptedResidualPin:
         ("gh gist delete", 'gh gist delete abc123'),
         ("git tag -d", 'git tag -d oldtag'),
     ])
+    @requires_history
     def test_still_undetected_unchanged(self, label, cmd):
         assert D_BASE(cmd) is False and D(cmd) is False, \
             "%s: accepted-residual PIN — must stay undetected in R2 (hardening tracked in #1137)" % label
@@ -253,6 +282,7 @@ class TestLaunderClosureRoundTrip:
         assert _mint(carrier, tmp_path) == [], "HEAD must mint NO launder token"
         assert _execute(M5 + " --delete-branch", tmp_path) == DENY, "the base-usable laundered exec must DENY at HEAD"
 
+    @requires_history
     def test_gist_base_mint_witness_is_a_usable_launder(self):
         # MINOR-2 (baked base-mint non-vacuity): the BASE (023ee2c3) classifier both GATES
         # the gist carrier AND extracts a USABLE {merge, pr 5, --delete-branch} context from
@@ -302,6 +332,7 @@ class TestF1LegMergeRegression:
     @pytest.mark.parametrize("sep", [";", "&&", "|"])
     @pytest.mark.parametrize("head_label,head", _HEADS)
     @pytest.mark.parametrize("msg_label,tag", _MSGS)
+    @requires_history
     def test_nospace_destructive_head_leg_merge_closed(self, sep, head_label, head, msg_label, tag):
         # `git tag -m <msg><SEP-no-space><destructive-head>` — the F1 eaten-head auth-bypass,
         # across the {gh, curl, wget} head family × {;,&&,|} × {quoted, unquoted} message.
@@ -319,11 +350,13 @@ class TestF1LegMergeRegression:
         assert D(cmd) is True, "mixed-quote message must not leg-merge the tail: %r" % cmd
 
     @pytest.mark.parametrize("sep", [";", "&&", "|"])
+    @requires_history
     def test_safe_control_spaced_separator_no_flip(self, sep):
         # A SPACE before gh keeps the head intact on the pre-fix strip -> no leg-merge.
         cmd = "%s %s %s --delete-branch" % (self._TAG, sep, M5)
         assert D_BASE(cmd) is True and D_PREFIX(cmd) is True and D(cmd) is True
 
+    @requires_history
     def test_safe_control_git_headed_tail_no_flip(self):
         # No-space but git-HEADED tail survives via the permissive _GIT_PREFIX (not eaten).
         cmd = self._TAG + ";" + PF
@@ -333,6 +366,7 @@ class TestF1LegMergeRegression:
         'gh release create v1 --notes "Release v1.0"',
         'gh gist create f.txt --desc "note"',
     ])
+    @requires_history
     def test_other_new_carriers_never_leg_merged(self, carrier):
         # release/gist were already span-scoped (7/7b/7c): the F1-class trigger never
         # leg-merged them (NO second under-block). True on base AND pre-fix AND fixed.
@@ -346,6 +380,7 @@ class TestOverAnchoring:
     -m value. The pre-fix whole-command 7d DID (it matched the trailing `git tag` and
     stripped `git commit`'s -m, leg-merging the gh leg). base=True / pre-fix=False / fixed=True."""
 
+    @requires_history
     def test_over_anchoring_witness_closed(self):
         cmd = 'git commit -m "x";gh pr merge 5;git tag v1'
         assert D_BASE(cmd) is True
@@ -367,6 +402,7 @@ class TestNewCarrierAxisCoverage:
     ]
 
     @pytest.mark.parametrize("label,prefix,suffix", _CARRIERS)
+    @requires_history
     def test_cmdsub_preserved_stays_gated(self, label, prefix, suffix):
         # $()/backtick in the value EXECUTES -> must stay gated (base AND HEAD).
         for val in ['"$(%s)"' % PF, '"`%s`"' % PF]:

--- a/pact-plugin/tests/test_merge_guard_1136_canonical_join_ssot.py
+++ b/pact-plugin/tests/test_merge_guard_1136_canonical_join_ssot.py
@@ -51,22 +51,48 @@ _BASE_SHA = "9256c93c"  # main HEAD — #1136 pre-dates this refactor (comma/@/#
 
 
 def _load_classifier(sha):
+    """Load merge_guard_common as it existed at `sha`, or None if unavailable.
+
+    Returns None on any git/exec failure — git missing, or a SHALLOW clone lacking
+    the base commit (CI's default fetch-depth) — so collection SUCCEEDS and the
+    base-vs-HEAD differential rows self-SKIP (@requires_history) instead of aborting
+    the whole file. Mirrors test_merge_guard_1118_recert._load_module_at.
+    """
     wt = Path(__file__).resolve().parents[2]
-    src = subprocess.check_output(
-        ["git", "-C", str(wt), "show", sha + ":pact-plugin/hooks/shared/merge_guard_common.py"]
-    ).decode()
+    try:
+        src = subprocess.check_output(
+            ["git", "-C", str(wt), "show", sha + ":pact-plugin/hooks/shared/merge_guard_common.py"],
+            stderr=subprocess.DEVNULL,
+        ).decode()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
     mod = types.ModuleType("merge_guard_common_1136_" + sha)
     mod.__file__ = str(wt / "pact-plugin/hooks/shared/merge_guard_common.py")
     mod.__package__ = "shared"
-    exec(compile(src, mod.__file__, "exec"), mod.__dict__)
+    try:
+        exec(compile(src, mod.__file__, "exec"), mod.__dict__)
+    except Exception:
+        return None
     return mod
 
 
 _BASE = _load_classifier(_BASE_SHA)
 CJ = mgc._canonical_join
 MT = mgc._extract_mass_delete_target          # HEAD (netstring)
-MT_BASE = _BASE._extract_mass_delete_target    # base (comma/@/#)
+# None-safe: guarding _load_classifier alone is NOT enough — a bare
+# `_BASE._extract_mass_delete_target` would AttributeError at import when _BASE is None
+# (shallow clone), re-aborting collection. MT_BASE is only ever read by the
+# @requires_history-guarded differential rows, which skip when _BASE is None.
+MT_BASE = _BASE._extract_mass_delete_target if _BASE is not None else None  # base (comma/@/#)
 D = mgc.is_dangerous_command
+
+# Skip the base-vs-HEAD differential (non-vacuity) rows when the base source is
+# unavailable (shallow clone / missing history); the HEAD-side + absolute rows still
+# run. With fetch-depth:0 in CI the base IS present, so every differential runs there.
+requires_history = pytest.mark.skipif(
+    _BASE is None,
+    reason="base-vs-HEAD differential requires merged history (shallow clone / missing history)",
+)
 ALLOW, DENY = 0, 2
 
 # Destructive verbs assembled at runtime — this file carries no raw literal.
@@ -173,13 +199,24 @@ class TestCanonicalJoinInjectivity:
 # ===========================================================================
 class TestUnderBlockClosure:
 
-    def test_comma_identity_base_collides_head_distinct(self):
-        assert MT_BASE(_COMMA_2) == MT_BASE(_COMMA_3) and MT_BASE(_COMMA_2) is not None  # base COLLIDES
+    def test_comma_identity_head_distinct(self):
+        # HEAD-side closure REFUSE — ALWAYS RUNS (unguarded) so CI catches a fix-revert
+        # even on a shallow clone where the base differential below skips.
         assert MT(_COMMA_2) != MT(_COMMA_3)  # HEAD REFUSES
 
-    def test_hash_identity_base_collides_head_distinct(self):
-        assert MT_BASE(_HASH_2) == MT_BASE(_HASH_3) and MT_BASE(_HASH_2) is not None  # base COLLIDES
+    @requires_history
+    def test_comma_identity_base_collides(self):
+        # Base non-vacuity differential (skipped w/o history): base COLLIDES the two sets.
+        assert MT_BASE(_COMMA_2) == MT_BASE(_COMMA_3) and MT_BASE(_COMMA_2) is not None
+
+    def test_hash_identity_head_distinct(self):
+        # HEAD-side closure REFUSE — ALWAYS RUNS (unguarded).
         assert MT(_HASH_2) != MT(_HASH_3)  # HEAD REFUSES
+
+    @requires_history
+    def test_hash_identity_base_collides(self):
+        # Base non-vacuity differential (skipped w/o history): base COLLIDES the two sets.
+        assert MT_BASE(_HASH_2) == MT_BASE(_HASH_3) and MT_BASE(_HASH_2) is not None
 
     def test_comma_collision_closed_at_real_gate(self, tmp_path):
         # HEAD: a token minted for the 2-set does NOT authorize executing the 3-set.
@@ -190,6 +227,7 @@ class TestUnderBlockClosure:
         assert _mint(_HASH_2, tmp_path) == 1
         assert _execute(_HASH_3, tmp_path) == DENY
 
+    @requires_history
     def test_base_encoder_through_real_gate_cross_authorizes(self, tmp_path):
         # DIRECT gate-level non-vacuity for the two closure rows above: patch the BAKED BASE
         # encoder (loaded from 9256c93c) into the ONE SSOT both mint and read derive from, and
@@ -258,22 +296,32 @@ class TestOverBlockSelfMatchCorpus:
 # ===========================================================================
 class TestDoubledSurfaceBaseVsHead:
 
+    @requires_history
     def test_mass_target_collision_flips_base_to_head(self):
         # mass_target: base(comma) COLLIDES -> HEAD(netstring) REFUSES (the #1136 flip).
+        # Base-differential (skipped w/o history); the HEAD `!=` half runs unguarded in
+        # test_comma_identity_head_distinct, so a fix-revert is still caught on a shallow clone.
         assert MT_BASE(_COMMA_2) == MT_BASE(_COMMA_3)
         assert MT(_COMMA_2) != MT(_COMMA_3)
 
-    def test_branch_set_stays_collision_safe_across_the_move(self):
-        # branch_set was ALREADY collision-safe on base (NUL join, R1 F1) -> its non-vacuity is
-        # NOT a base-flip. It must STAY correct across the move onto the shared netstring helper:
-        # a comma-named branch set and a 3-branch set are DISTINCT on BOTH base and HEAD.
+    def test_branch_set_head_collision_safe(self):
+        # HEAD-side: a comma-named branch set and a 3-branch set are DISTINCT at HEAD
+        # (netstring). ALWAYS RUNS (unguarded) so CI catches a fix-revert on a shallow clone.
         _D = "-" + "D"
         two = "git branch " + _D + ' "aa,bb" cc'
         three = "git branch " + _D + " aa bb cc"
         bset = mgc._extract_branch_delete_set
+        assert bset(two) != bset(three)            # stays safe at HEAD (netstring)
+
+    @requires_history
+    def test_branch_set_base_collision_safe(self):
+        # branch_set was ALREADY collision-safe on base (NUL join, R1 F1) -> its non-vacuity is
+        # NOT a base-flip; this differential confirms it stays distinct on base too. Skipped w/o history.
+        _D = "-" + "D"
+        two = "git branch " + _D + ' "aa,bb" cc'
+        three = "git branch " + _D + " aa bb cc"
         bset_base = _BASE._extract_branch_delete_set
         assert bset_base(two) != bset_base(three)  # already safe on base (NUL)
-        assert bset(two) != bset(three)            # stays safe at HEAD (netstring)
 
     def test_branch_set_over_block_intact_across_move(self, tmp_path):
         _D = "-" + "D"

--- a/pact-plugin/tests/test_merge_guard_1136_canonical_join_ssot.py
+++ b/pact-plugin/tests/test_merge_guard_1136_canonical_join_ssot.py
@@ -190,6 +190,22 @@ class TestUnderBlockClosure:
         assert _mint(_HASH_2, tmp_path) == 1
         assert _execute(_HASH_3, tmp_path) == DENY
 
+    def test_base_encoder_through_real_gate_cross_authorizes(self, tmp_path):
+        # DIRECT gate-level non-vacuity for the two closure rows above: patch the BAKED BASE
+        # encoder (loaded from 9256c93c) into the ONE SSOT both mint and read derive from, and
+        # the collision CROSS-AUTHORIZES at the REAL mint->execute gate — a 2-set token ALLOWs
+        # the DISTINCT exec — for BOTH witnesses. This exhibits the bug through the ACTUAL
+        # machinery (not just the pure-function identity), so the HEAD DENY rows are genuine
+        # differentials: a revert of the netstring encoder to the @/#/comma joins reopens this
+        # exact cross-authorization. (Base-through-gate ALLOW verified empirically before adding.)
+        for name, two, three in [("comma", _COMMA_2, _COMMA_3), ("hash", _HASH_2, _HASH_3)]:
+            d = tmp_path / name
+            d.mkdir()
+            with patch.object(mgc, "_extract_mass_delete_target", MT_BASE):
+                assert _mint(two, d) == 1, "%s: base 2-set must mint through the gate" % name
+                assert _execute(three, d) == ALLOW, \
+                    "%s: base collision must cross-authorize at the gate (else HEAD row is vacuous)" % name
+
     # NON-VACUITY note: the coupling proof for these rows is the BAKED BASE column above
     # (MT_BASE, loaded from the real pre-fix source 9256c93c) — it uses the actual @/# encoding
     # and so faithfully reproduces BOTH the comma AND the # collisions on base, asserting HEAD
@@ -209,6 +225,10 @@ class TestOverBlockSelfMatchCorpus:
         ("3-ref delete", PUSH + "origin " + DEL + "a b c"),
         ("comma-in-name", PUSH + "origin " + DEL + '"a,b" c'),
         ("hash-in-name", PUSH + "origin " + DEL + '"a#b" c'),
+        ("hash-in-remote", _HASH_3),  # `#` in the REMOTE (not the ref) — the #-witness's OTHER
+                                      # set. A faithful click here mints+self-matches, so the
+                                      # #-gate-closure DENY below is a WRONG-SET denial, not an
+                                      # unmintable-always-deny artifact (non-vacuity control).
         ("colon-empty-src", PUSH + "origin " + ":a :b"),
         ("mirror implicit", PUSH + "--mirror origin"),
         ("prune", PUSH + "--prune origin refs/heads/x refs/heads/y"),

--- a/pact-plugin/tests/test_merge_guard_1136_canonical_join_ssot.py
+++ b/pact-plugin/tests/test_merge_guard_1136_canonical_join_ssot.py
@@ -1,0 +1,292 @@
+"""
+Location: pact-plugin/tests/test_merge_guard_1136_canonical_join_ssot.py
+Summary: COMPREHENSIVE BIDIRECTIONAL SACROSANCT certification for #1136 — the canonical-join
+         SSOT. The fix folds branch_set + mass_target onto ONE pure NETSTRING/length-prefix
+         helper `_canonical_join(items) = "".join(f"{len(i)}:{i}" for i in items)`; the @/#
+         delimiters are ELIMINATED (closing BOTH the comma AND the # collisions), the
+         `\\x00implicit` sentinel is UNCHANGED, and refspecs are now sorted+DEDUPED.
+
+         Proven against the REAL classifier, base-vs-HEAD, NEVER a byte-diff (#1118):
+           - INJECTIVITY BY CONSTRUCTION: a TOTAL constructive left-inverse decode round-trips
+             every edge (empty list/item, embedded :/digits/NUL, multi-digit lengths) -> a
+             function with a left inverse cannot be non-injective. This is the GOLD-STANDARD
+             bound on the #1118 CONCENTRATION HAZARD (one helper backs both detectors), plus a
+             random-sequence property test (belt-and-suspenders).
+           - #1136 CLOSURE: base(main HEAD 9256c93c) COLLIDES -> HEAD REFUSES, for BOTH the
+             COMMA witness AND the # witness, at the identity level AND the REAL mint->execute
+             gate (token for set X does NOT authorize set Y).
+           - OVER-BLOCK (PRIMARY / cardinal): a faithful single-command mass-delete /
+             branch-delete mints AND self-matches at execute; reorder/dedup still match.
+           - DOUBLED SURFACE: branch_set (already collision-safe on base -> non-vacuity is the
+             OVER-BLOCK direction + "stays correct across the move onto the shared helper")
+             AND mass_target (base comma-COLLIDES -> HEAD REFUSES).
+           - NETSTRING adversarial field contents, \\x00implicit sentinel isolation, the NEW
+             dedup row, and the `+:a` aliases `:a` edge.
+
+NON-VACUITY: the closure rows load the BASE classifier (9256c93c) via `git show`+exec and
+assert base=COLLIDES / HEAD=REFUSES in-test (a revert to comma/@/# joins instantly reds them).
+#1136 PRE-DATES this refactor (reproduce-base-vulnerability-first: the collision is LIVE on
+base). Destructive verbs assembled at runtime (PUSH/DEL) so this file carries no raw literal.
+"""
+import io
+import json
+import random
+import subprocess
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import merge_guard_post  # noqa: E402
+import merge_guard_pre  # noqa: E402
+import shared.merge_guard_common as mgc  # noqa: E402
+from merge_guard_post import main as post_main  # noqa: E402
+from merge_guard_pre import main as pre_main  # noqa: E402
+
+_BASE_SHA = "9256c93c"  # main HEAD — #1136 pre-dates this refactor (comma/@/# joins COLLIDE)
+
+
+def _load_classifier(sha):
+    wt = Path(__file__).resolve().parents[2]
+    src = subprocess.check_output(
+        ["git", "-C", str(wt), "show", sha + ":pact-plugin/hooks/shared/merge_guard_common.py"]
+    ).decode()
+    mod = types.ModuleType("merge_guard_common_1136_" + sha)
+    mod.__file__ = str(wt / "pact-plugin/hooks/shared/merge_guard_common.py")
+    mod.__package__ = "shared"
+    exec(compile(src, mod.__file__, "exec"), mod.__dict__)
+    return mod
+
+
+_BASE = _load_classifier(_BASE_SHA)
+CJ = mgc._canonical_join
+MT = mgc._extract_mass_delete_target          # HEAD (netstring)
+MT_BASE = _BASE._extract_mass_delete_target    # base (comma/@/#)
+D = mgc.is_dangerous_command
+ALLOW, DENY = 0, 2
+
+# Destructive verbs assembled at runtime — this file carries no raw literal.
+PUSH = "git " + "push "
+DEL = "--delete "
+
+
+def _decode(s):
+    """TOTAL constructive LEFT-INVERSE of _canonical_join. decode(CJ(x)) == x for all x ->
+    CJ is injective by exhibited inverse (the #1118 concentration-hazard bound)."""
+    out, i = [], 0
+    while i < len(s):
+        j = s.index(":", i)
+        n = int(s[i:j])
+        item = s[j + 1: j + 1 + n]
+        assert len(item) == n
+        out.append(item)
+        i = j + 1 + n
+    return out
+
+
+def _mint(cmd, tok):
+    env = json.dumps({"tool_name": "AskUserQuestion", "tool_input": {"questions": [{
+        "question": "Proceed?", "options": [
+            {"label": "Yes", "description": "Run `%s`" % cmd},
+            {"label": "Cancel", "description": "Abort"}]}]},
+        "tool_response": {"answers": {"Proceed?": "Yes"}}, "session_id": "cert1136"})
+    with patch.object(merge_guard_post, "TOKEN_DIR", tok), \
+         patch("sys.stdin", io.StringIO(env)), patch("sys.stdout", io.StringIO()):
+        try:
+            post_main()
+        except SystemExit:
+            pass
+    return len(list(tok.glob("merge-authorized-*")))
+
+
+def _execute(cmd, tok):
+    env = json.dumps({"tool_name": "Bash", "tool_input": {"command": cmd}, "session_id": "cert1136"})
+    with patch.object(merge_guard_pre, "TOKEN_DIR", tok), \
+         patch("sys.stdin", io.StringIO(env)), patch("sys.stdout", io.StringIO()), \
+         patch("sys.stderr", io.StringIO()):
+        try:
+            pre_main(); return ALLOW
+        except SystemExit as e:
+            return e.code if isinstance(e.code, int) else ALLOW
+
+
+# Two-ref set with a comma/# INSIDE a ref name vs the three-ref set — the #1136 collisions.
+_COMMA_2 = PUSH + "origin " + DEL + '"a,b" c'    # refs {'a,b', 'c'}
+_COMMA_3 = PUSH + "origin " + DEL + "a b c"       # refs {'a','b','c'}
+_HASH_2 = PUSH + "origin " + DEL + '"a#b" c'      # refs {'a#b','c'}
+_HASH_3 = PUSH + '"origin#a" ' + DEL + "b c"       # remote 'origin#a', refs {'b','c'}
+
+
+# ===========================================================================
+# INJECTIVITY BY CONSTRUCTION — the #1118 concentration-hazard bound.
+# ===========================================================================
+class TestCanonicalJoinInjectivity:
+
+    @pytest.mark.parametrize("items", [
+        [], [""], ["a"], ["", ""], ["", "a"], ["a", ""],
+        ["2", "ab"], ["2:a", "b"], ["10", "x" * 10], ["1", "0" + "x" * 10],
+        ["a:b"], ["a", ":b"], ["a:", "b"], ["a#b"], ["a,b"], ["a@b"],
+        ["\x00implicit"], ["5:xxxxx"], ["100", "y" * 100], ["a\x00b", "c"],
+    ])
+    def test_constructive_left_inverse_round_trips(self, items):
+        # decode(encode(items)) == items for every edge -> CJ is injective (a left inverse
+        # exists). TOTAL: empty list encodes to "" and decodes to [].
+        enc = CJ(items)
+        assert (_decode(enc) if enc != "" else []) == items
+
+    def test_random_sequences_no_collision(self):
+        # Belt-and-suspenders: distinct sequences -> distinct encodings (0 collisions).
+        random.seed(1136)
+        alpha = "ab:0123#,@\x00"
+        seen = {}
+        for _ in range(5000):
+            seq = tuple("".join(random.choice(alpha) for _ in range(random.randint(0, 4)))
+                        for _ in range(random.randint(0, 4)))
+            enc = CJ(list(seq))
+            assert enc not in seen or seen[enc] == seq, "collision: %r and %r" % (seen[enc], seq)
+            seen[enc] = seq
+
+    @pytest.mark.parametrize("x,y", [
+        (["2", "ab"], ["2:a", "b"]),          # digit-boundary
+        (["10", "x" * 10], ["1", "0" + "x" * 10]),  # multi-digit length
+        (["a:b"], ["a", ":b"]),               # embedded ':' split
+        (["a:b"], ["a:", "b"]),
+        (["a#b"], ["a", "b"]),                # old '#' delim now harmless
+        (["a,b"], ["a", "b"]),                # old ',' delim now harmless
+        ([""], []),                           # empty-item vs empty-list
+        (["", "a"], ["a"]),                   # empty-field prefix
+        (["5:xxxxx"], ["5", "xxxxx"]),        # content that LOOKS like a netstring
+        (["a\x00b"], ["a", "b"]),             # NUL-in-field vs 2 fields
+    ])
+    def test_adversarial_field_contents_distinct(self, x, y):
+        # My INDEPENDENTLY-derived adversarial corpus (per lead: no coordination with security;
+        # the fresh peer-review pass derives its own). Compared by STRING-EQUALITY, never decoded.
+        assert CJ(x) != CJ(y)
+
+
+# ===========================================================================
+# #1136 CLOSURE — base COLLIDES -> HEAD REFUSES, BOTH the comma AND the # witnesses.
+# ===========================================================================
+class TestUnderBlockClosure:
+
+    def test_comma_identity_base_collides_head_distinct(self):
+        assert MT_BASE(_COMMA_2) == MT_BASE(_COMMA_3) and MT_BASE(_COMMA_2) is not None  # base COLLIDES
+        assert MT(_COMMA_2) != MT(_COMMA_3)  # HEAD REFUSES
+
+    def test_hash_identity_base_collides_head_distinct(self):
+        assert MT_BASE(_HASH_2) == MT_BASE(_HASH_3) and MT_BASE(_HASH_2) is not None  # base COLLIDES
+        assert MT(_HASH_2) != MT(_HASH_3)  # HEAD REFUSES
+
+    def test_comma_collision_closed_at_real_gate(self, tmp_path):
+        # HEAD: a token minted for the 2-set does NOT authorize executing the 3-set.
+        assert _mint(_COMMA_2, tmp_path) == 1
+        assert _execute(_COMMA_3, tmp_path) == DENY
+
+    def test_hash_collision_closed_at_real_gate(self, tmp_path):
+        assert _mint(_HASH_2, tmp_path) == 1
+        assert _execute(_HASH_3, tmp_path) == DENY
+
+    # NON-VACUITY note: the coupling proof for these rows is the BAKED BASE column above
+    # (MT_BASE, loaded from the real pre-fix source 9256c93c) — it uses the actual @/# encoding
+    # and so faithfully reproduces BOTH the comma AND the # collisions on base, asserting HEAD
+    # distinct. A synthetic list-comma-join neuter would reproduce ONLY the comma collision (the
+    # # collision came from the @/# FIELD structure, not a list join) — so the real baked base
+    # is the structurally-faithful non-vacuity, not an in-file monkeypatch.
+
+
+# ===========================================================================
+# OVER-BLOCK self-match corpus — PRIMARY / cardinal gate. A faithful single-command
+# mass-delete / branch-delete mints AND authorizes its own exec (and reorders/dedups).
+# ===========================================================================
+class TestOverBlockSelfMatchCorpus:
+
+    _MASS = [
+        ("2-ref delete", PUSH + "origin " + DEL + "a b"),
+        ("3-ref delete", PUSH + "origin " + DEL + "a b c"),
+        ("comma-in-name", PUSH + "origin " + DEL + '"a,b" c'),
+        ("hash-in-name", PUSH + "origin " + DEL + '"a#b" c'),
+        ("colon-empty-src", PUSH + "origin " + ":a :b"),
+        ("mirror implicit", PUSH + "--mirror origin"),
+        ("prune", PUSH + "--prune origin refs/heads/x refs/heads/y"),
+    ]
+    _D = "-" + "D"
+    _BRANCH = [
+        ("branch 2", "git branch " + _D + " aa bb"),
+        ("branch 3", "git branch " + _D + " aa bb cc"),
+    ]
+
+    @pytest.mark.parametrize("label,cmd", _MASS + _BRANCH)
+    def test_faithful_click_mints_and_self_matches(self, label, cmd, tmp_path):
+        assert _mint(cmd, tmp_path) == 1, "%s: faithful click must mint" % label
+        assert _execute(cmd, tmp_path) == ALLOW, "%s: faithful click must self-authorize (over-block=cardinal)" % label
+
+    def test_reorder_still_matches(self, tmp_path):
+        assert _mint(PUSH + "origin " + DEL + "a b c", tmp_path) == 1
+        assert _execute(PUSH + "origin " + DEL + "c a b", tmp_path) == ALLOW
+
+    def test_branch_reorder_still_matches(self, tmp_path):
+        assert _mint("git branch " + self._D + " aa bb cc", tmp_path) == 1
+        assert _execute("git branch " + self._D + " cc aa bb", tmp_path) == ALLOW
+
+
+# ===========================================================================
+# DOUBLED SURFACE base-vs-HEAD (the shared helper -> a regression in EITHER must red a row).
+# ===========================================================================
+class TestDoubledSurfaceBaseVsHead:
+
+    def test_mass_target_collision_flips_base_to_head(self):
+        # mass_target: base(comma) COLLIDES -> HEAD(netstring) REFUSES (the #1136 flip).
+        assert MT_BASE(_COMMA_2) == MT_BASE(_COMMA_3)
+        assert MT(_COMMA_2) != MT(_COMMA_3)
+
+    def test_branch_set_stays_collision_safe_across_the_move(self):
+        # branch_set was ALREADY collision-safe on base (NUL join, R1 F1) -> its non-vacuity is
+        # NOT a base-flip. It must STAY correct across the move onto the shared netstring helper:
+        # a comma-named branch set and a 3-branch set are DISTINCT on BOTH base and HEAD.
+        _D = "-" + "D"
+        two = "git branch " + _D + ' "aa,bb" cc'
+        three = "git branch " + _D + " aa bb cc"
+        bset = mgc._extract_branch_delete_set
+        bset_base = _BASE._extract_branch_delete_set
+        assert bset_base(two) != bset_base(three)  # already safe on base (NUL)
+        assert bset(two) != bset(three)            # stays safe at HEAD (netstring)
+
+    def test_branch_set_over_block_intact_across_move(self, tmp_path):
+        _D = "-" + "D"
+        cmd = "git branch " + _D + " aa bb cc"
+        assert _mint(cmd, tmp_path) == 1 and _execute(cmd, tmp_path) == ALLOW
+
+
+# ===========================================================================
+# \x00implicit sentinel isolation + dedup + colon force-delete edge.
+# ===========================================================================
+class TestSentinelDedupAndColonEdge:
+
+    def test_sentinel_disjoint_from_real_remote_and_ref(self):
+        # Framed sentinel 9:\x00implicit is distinct from a real remote 'implicit' (8:implicit)
+        # and from any ref-set encoding — the NUL prefix is load-bearing (kept unchanged).
+        implicit = MT(PUSH + "--mirror")                    # implicit remote -> sentinel
+        real = MT(PUSH + "--mirror implicit")               # explicit remote named 'implicit'
+        assert implicit is not None and real is not None and implicit != real
+        assert "9:\x00implicit" in implicit and "8:implicit" in real
+
+    def test_dedup_collapses_duplicate_ref(self, tmp_path):
+        # `--delete a a b` == `--delete a b` (a duplicate ref is the SAME target). mint==read
+        # symmetry: a token for {a,b} authorizes the duplicate form and vice-versa; and it does
+        # NOT authorize a DIFFERENT set {a,b,c}.
+        assert MT(PUSH + "origin " + DEL + "a a b") == MT(PUSH + "origin " + DEL + "a b")
+        assert _mint(PUSH + "origin " + DEL + "a a b", tmp_path) == 1
+        assert _execute(PUSH + "origin " + DEL + "a b", tmp_path) == ALLOW
+        assert _execute(PUSH + "origin " + DEL + "a b c", tmp_path) == DENY  # NOT outside the set
+
+    def test_colon_force_delete_aliases_same_ref(self, tmp_path):
+        # `+:a` (force empty-source push = delete) aliases `:a`; a token for it authorizes ONLY
+        # the same-ref delete, not a different ref.
+        assert MT(PUSH + "origin +:a :b") == MT(PUSH + "origin :a :b")
+        assert _mint(PUSH + "origin +:a :b", tmp_path) == 1
+        assert _execute(PUSH + "origin :a :b", tmp_path) == ALLOW
+        assert _execute(PUSH + "origin :a :c", tmp_path) == DENY

--- a/pact-plugin/tests/test_merge_guard_op_recognition_completeness.py
+++ b/pact-plugin/tests/test_merge_guard_op_recognition_completeness.py
@@ -281,19 +281,19 @@ class TestRemoteRefDeleteParityMintAndNonVacuity:
 # ===========================================================================
 
 # Faithful mass forms: (command, expected mass_target). mass_target binds the
-# destructive IDENTITY (sorted mass-flags @ remote-or-implicit [# sorted refspecs]),
+# destructive IDENTITY (the netstring _canonical_join of the field tuple),
 # NOT the whole command.
 REMOTE_MASS_DELETE_SPELLINGS = [
-    ("git push --mirror origin", "--mirror@origin"),
-    ("git push --mirror", f"--mirror@{IMPLICIT}"),                 # implicit remote
-    ("git push --prune origin", "--prune@origin"),
-    ("git push --prune origin refs/heads/main", "--prune@origin#refs/heads/main"),
-    ("git push origin --delete a b", "--delete@origin#a,b"),       # multi-ref
-    ("git push origin :a :b", "--delete@origin#a,b"),              # multi colon
-    ("git push origin --mirror", "--mirror@origin"),               # flag after remote
-    ("git push origin --prune", "--prune@origin"),                 # flag after remote
-    ("git push origin --delete a b c", "--delete@origin#a,b,c"),   # three-ref
-    ('git push --mirror "origin"', "--mirror@origin"),             # quoted remote
+    ("git push --mirror origin", mgc._canonical_join(["--mirror", "origin"])),
+    ("git push --mirror", mgc._canonical_join(["--mirror", IMPLICIT])),                 # implicit remote
+    ("git push --prune origin", mgc._canonical_join(["--prune", "origin"])),
+    ("git push --prune origin refs/heads/main", mgc._canonical_join(["--prune", "origin", "refs/heads/main"])),
+    ("git push origin --delete a b", mgc._canonical_join(["--delete", "origin", "a", "b"])),       # multi-ref
+    ("git push origin :a :b", mgc._canonical_join(["--delete", "origin", "a", "b"])),              # multi colon
+    ("git push origin --mirror", mgc._canonical_join(["--mirror", "origin"])),               # flag after remote
+    ("git push origin --prune", mgc._canonical_join(["--prune", "origin"])),                 # flag after remote
+    ("git push origin --delete a b c", mgc._canonical_join(["--delete", "origin", "a", "b", "c"])),   # three-ref
+    ('git push --mirror "origin"', mgc._canonical_join(["--mirror", "origin"])),             # quoted remote
 ]
 
 
@@ -323,7 +323,7 @@ class TestRemoteMassDeleteNoUnderBlock:
         cmd = "git push --mirror"
         assert D(cmd) is True
         assert OP(cmd) == "remote-mass-delete"
-        assert CTX(cmd).get("mass_target") == f"--mirror@{IMPLICIT}"
+        assert CTX(cmd).get("mass_target") == mgc._canonical_join(["--mirror", IMPLICIT])
 
 
 class TestRemoteMassDeleteCrossAuthDistinctness:
@@ -337,21 +337,21 @@ class TestRemoteMassDeleteCrossAuthDistinctness:
         assert CTX("git push origin --delete a b")["mass_target"] != CTX("git push origin --delete a c")["mass_target"]
 
     def test_prune_token_does_not_authorize_mirror(self):
-        tok = token("remote-mass-delete", mass_target="--prune@origin")
+        tok = token("remote-mass-delete", mass_target=mgc._canonical_join(["--prune", "origin"]))
         assert MATCH(tok, "git push --prune origin") is True            # authorizes its own
         assert MATCH(tok, "git push --mirror origin") is False          # not a different identity
 
     def test_mirror_token_does_not_authorize_prune(self):
-        tok = token("remote-mass-delete", mass_target="--mirror@origin")
+        tok = token("remote-mass-delete", mass_target=mgc._canonical_join(["--mirror", "origin"]))
         assert MATCH(tok, "git push --mirror origin") is True
         assert MATCH(tok, "git push --prune origin") is False
 
     def test_distinct_remote_does_not_cross_authorize(self):
-        tok = token("remote-mass-delete", mass_target="--mirror@origin")
+        tok = token("remote-mass-delete", mass_target=mgc._canonical_join(["--mirror", "origin"]))
         assert MATCH(tok, "git push --mirror origin2") is False
 
     def test_refspec_set_closure_a_b_does_not_authorize_a_c(self):
-        tok = token("remote-mass-delete", mass_target="--delete@origin#a,b")
+        tok = token("remote-mass-delete", mass_target=mgc._canonical_join(["--delete", "origin", "a", "b"]))
         assert MATCH(tok, "git push origin --delete a b") is True
         assert MATCH(tok, "git push origin --delete a c") is False
 
@@ -369,8 +369,8 @@ class TestRemoteMassDeleteBoundary:
             # git grammar: `git push --delete a b` => repo=a, ref=b => SINGLE delete
             ("git push --delete a b", "remote-ref-delete", "b"),
             # explicit remote + 2 refs => MULTI => remote-mass-delete
-            ("git push origin --delete a b", "remote-mass-delete", "--delete@origin#a,b"),
-            ("git push --mirror origin", "remote-mass-delete", "--mirror@origin"),
+            ("git push origin --delete a b", "remote-mass-delete", mgc._canonical_join(["--delete", "origin", "a", "b"])),
+            ("git push --mirror origin", "remote-mass-delete", mgc._canonical_join(["--mirror", "origin"])),
         ],
     )
     def test_single_vs_multi_delete_routing(self, cmd, expected_op, expected_target):
@@ -411,9 +411,9 @@ class TestRemoteMassDeleteParityMintAndNonVacuity:
     @pytest.mark.parametrize(
         "cmd,mass_target",
         [
-            ("git push --mirror origin", "--mirror@origin"),
-            ("git push --mirror", f"--mirror@{IMPLICIT}"),
-            ("git push origin --delete a b", "--delete@origin#a,b"),
+            ("git push --mirror origin", mgc._canonical_join(["--mirror", "origin"])),
+            ("git push --mirror", mgc._canonical_join(["--mirror", IMPLICIT])),
+            ("git push origin --delete a b", mgc._canonical_join(["--delete", "origin", "a", "b"])),
         ],
     )
     def test_faithful_click_mints_and_authorizes(self, cmd, mass_target):
@@ -425,8 +425,8 @@ class TestRemoteMassDeleteParityMintAndNonVacuity:
 
     def test_mint_authorize_proof_is_non_vacuous_wrong_target_refused(self):
         cmd = "git push --mirror origin"
-        assert MATCH(token("remote-mass-delete", mass_target="--mirror@origin"), cmd) is True
-        assert MATCH(token("remote-mass-delete", mass_target="--prune@origin"), cmd) is False
+        assert MATCH(token("remote-mass-delete", mass_target=mgc._canonical_join(["--mirror", "origin"])), cmd) is True
+        assert MATCH(token("remote-mass-delete", mass_target=mgc._canonical_join(["--prune", "origin"])), cmd) is False
 
 
 class TestRemoteMassDeleteNoOverBlock:
@@ -785,8 +785,8 @@ class TestStaleSnapshotIntegration:
     @pytest.mark.parametrize(
         "cmd,mass_target",
         [
-            ("git push origin --delete a b", "--delete@origin#a,b"),
-            ("git push --mirror origin", "--mirror@origin"),
+            ("git push origin --delete a b", mgc._canonical_join(["--delete", "origin", "a", "b"])),
+            ("git push --mirror origin", mgc._canonical_join(["--mirror", "origin"])),
         ],
     )
     def test_formerly_deferred_forms_now_gate_as_mass(self, cmd, mass_target):


### PR DESCRIPTION
## Summary

Addresses **#1136** — the `mass_target` canonical-identity collision, which is a **delimiter _class_**, not a single-delimiter bug. `_extract_mass_delete_target`'s identity `<flags>@<remote>#<refspecs>` was non-injective at **two** git-legal delimiters (the refspec comma AND the `#` remote/refspec boundary), so two distinct destructive sets could share one identity — a cross-set **under-block** (a token minted for one set authorizes a *different* set).

## The fix — one injective netstring SSOT

Replace `mass_target`'s hand-rolled `@`/`#`/`,` joins and `branch_set`'s NUL-join with a single pure length-prefix primitive:

```python
def _canonical_join(items: Sequence[str]) -> str:
    return "".join(f"{len(i)}:{i}" for i in items)
```

- `branch_set  = _canonical_join(sorted(set(names)))`
- `mass_target = _canonical_join([flags_part, remote, *sorted(set(refspecs))])`

Netstring framing is **injective by construction** (a total left-inverse decode exists) and **content-agnostic**, so it eliminates the `@`/`#` structural delimiters and closes the whole class at once — no separator has to be ref-illegal. The `\x00implicit` remote sentinel is unchanged (its NUL keeps `9:\x00implicit` disjoint from a real remote `implicit` = `8:implicit` under framing). Refspecs are now deduped (a duplicate ref is the same destructive target).

## Why it is safe

- **Over-block closed by construction** (the cardinal invariant): mint (`merge_guard_post._target_value`) and read (`merge_guard_pre._token_matches_command`) derive the identity from the same `_canonical_join` via the one `extract_command_context` SSOT, so a faithful single-command click self-matches. No mint/read call site is split.
- **Under-block closed**: both the comma witness and the `#` witness now REFUSE at the real mint->execute gate (a 2-set token no longer authorizes a 3-set exec).

## Certification

52-row bidirectional cert (`test_merge_guard_1136_canonical_join_ssot.py`), baked against the real base classifier (`git show 9256c93c` + exec) for permanent non-vacuity:
- Injectivity by **exhibited inverse** — a total constructive left-inverse decode round-tripping all edges (empty list/item, embedded `:`/digits/NUL, multi-digit lengths) + a 5000-random property test — bounds the shared-helper concentration hazard.
- Base COLLIDES -> HEAD REFUSES for both witnesses, at the identity level and the real gate.
- Comprehensive over-block self-match corpus, doubled-surface base-vs-HEAD, sentinel isolation, the dedup row, the `+:` force-delete edge.

Full suite: **11114 passed / 11 skipped / 0 failed / 0 errors** (python 3.12.7). PATCH bump to **v4.5.7**.

Design plan: `docs/plans/merge-guard-nul-join-ssot-plan.md` (5-specialist consultation, empirically ground-truthed against the real classifier).
