### PR TITLE
fix(merge-guard): R3 scope routing detection to executed surface (#1129 PR-3 of 3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.5.7",
+      "version": "4.5.8",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.5.7/       # Plugin version
+│               └── 4.5.8/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.5.7",
+  "version": "4.5.8",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.5.7
+> **Version**: 4.5.8
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -1873,7 +1873,7 @@ def _has_process_substitution_to_shell(command: str) -> bool:
 # the opener tail and regress the pinned heredoc-pipe/procsub canaries
 # (under-block). Same input-side guard as carrier 1: a shell-fed body
 # (`bash <<EOF`) executes, so it is preserved. The REAL carrier-1 strip is
-# untouched (plan-D5).
+# intentionally left untouched (this excision builds a view-only scan surface).
 _HEREDOC_BODY_RE = re.compile(
     r"(<<-?\s*['\"]?(\w+)['\"]?[^\n]*\n)"   # 1: operator+marker+opener TAIL (kept)
     r"(?:.*?\n)?"                            #    body (excised)
@@ -1895,6 +1895,18 @@ def _excise_heredoc_bodies_for_routing_scan(command: str) -> str:
     return _HEREDOC_BODY_RE.sub(_repl, command)
 
 
+def _excise_and_mask(command: str) -> tuple[str, str]:
+    """Shared prefix for the two routing-flag views (#1129 R3): excise heredoc
+    bodies (opener line + closing marker kept; shell-fed bodies preserved), then
+    space-mask every balanced quoted span via _mask_shell_quotes. Returns
+    (excised, view). ORDER IS LOAD-BEARING: excision FIRST removes stray body
+    quotes that could desync the quote mask. _mask_shell_quotes is SAME-LENGTH,
+    so view and excised align 1:1 by offset."""
+    excised = _excise_heredoc_bodies_for_routing_scan(command)
+    view = _mask_shell_quotes(excised)
+    return excised, view
+
+
 def _executed_surface_view(command: str) -> str:
     """Routing-flag scan surface (#1129 R3): the command with non-executed
     data removed — heredoc BODIES excised (opener line + closing marker kept;
@@ -1907,7 +1919,7 @@ def _executed_surface_view(command: str) -> str:
     that could desync the quote mask. Consumed ONLY by the hoisted
     piped_to_shell / process_sub_to_shell computation; never fed to
     DANGEROUS_PATTERNS and never returned as strip output."""
-    return _mask_shell_quotes(_excise_heredoc_bodies_for_routing_scan(command))
+    return _excise_and_mask(command)[1]
 
 
 def _procsub_anchor_view(command: str) -> str:
@@ -1918,17 +1930,17 @@ def _procsub_anchor_view(command: str) -> str:
     incidental >("ba"sh)->>(    sh) catch is preserved). Re-catches the R3 arm-B
     anchor regression WITHOUT a blanket fill (which breaks the shell-name region ->
     a NEW under-block on >("ba"sh)) and WITHOUT computing arm B over raw (which
-    reverts B3). Relies on _mask_shell_quotes being SAME-LENGTH: view and excised
-    align 1:1 by offset. Consumed ONLY by process_sub_to_shell."""
-    excised = _excise_heredoc_bodies_for_routing_scan(command)
-    view = _mask_shell_quotes(excised)               # space-fill, offsets preserved
+    would re-flag a `>(shell)` sitting inside quoted carrier data). Relies on
+    _mask_shell_quotes being SAME-LENGTH: view and excised align 1:1 by offset.
+    Consumed ONLY by process_sub_to_shell."""
+    excised, view = _excise_and_mask(command)        # excise + space-mask; offsets aligned
     if ">(" not in view:                             # cheap short-circuit (common case)
         return view
     out = list(view)
     for m in re.finditer(r">\(", view):              # each SURVIVING >( on the view
         i = m.start()
         k = i - 1
-        # skip GENUINE whitespace (a space in BOTH view and raw)
+        # skip a genuine UNMASKED bash blank (space OR tab): view==excised at an unmasked position
         while k >= 0 and view[k] == excised[k] and excised[k] in " \t":
             k -= 1
         # stop char masked to space in the view but a CLOSING QUOTE in raw ==
@@ -2050,7 +2062,8 @@ def _strip_non_executable_content(command: str) -> str:
     # space-mask with arm B's LEFT anchor restored immediately-left of a surviving
     # >(shell) whose writer was a masked quoted token — re-catching the R3 arm-B
     # regression (`echo "…" | "tee" >(bash)`) without a blanket fill (which would
-    # regress `>("ba"sh)`) and without computing arm B over raw (which reverts B3).
+    # regress `>("ba"sh)`) and without computing arm B over raw (which would re-flag
+    # a `>(shell)` sitting inside quoted carrier data).
     piped_to_shell = _has_pipe_to_shell(_executed_surface_view(command))
     process_sub_to_shell = _has_process_substitution_to_shell(_procsub_anchor_view(command))
 

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -1929,7 +1929,7 @@ def _procsub_anchor_view(command: str) -> str:
         i = m.start()
         k = i - 1
         # skip GENUINE whitespace (a space in BOTH view and raw)
-        while k >= 0 and view[k] == " " and excised[k] in " \t":
+        while k >= 0 and view[k] == excised[k] and excised[k] in " \t":
             k -= 1
         # stop char masked to space in the view but a CLOSING QUOTE in raw ==
         # a quoted writer token ended here -> reveal its closing quote (in arm B's

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -1910,6 +1910,37 @@ def _executed_surface_view(command: str) -> str:
     return _mask_shell_quotes(_excise_heredoc_bodies_for_routing_scan(command))
 
 
+def _procsub_anchor_view(command: str) -> str:
+    """OUTPUT-SIDE process-substitution routing view (#1129 R3-fix). The space-mask
+    executed-surface view, then arm B's preceding-token ANCHOR restored ONLY
+    immediately-left of a SURVIVING >(shell) whose writer token was a masked quoted
+    span. Everything from >( rightward is viewed EXACTLY as the space-mask (so the
+    incidental >("ba"sh)->>(    sh) catch is preserved). Re-catches the R3 arm-B
+    anchor regression WITHOUT a blanket fill (which breaks the shell-name region ->
+    a NEW under-block on >("ba"sh)) and WITHOUT computing arm B over raw (which
+    reverts B3). Relies on _mask_shell_quotes being SAME-LENGTH: view and excised
+    align 1:1 by offset. Consumed ONLY by process_sub_to_shell."""
+    excised = _excise_heredoc_bodies_for_routing_scan(command)
+    view = _mask_shell_quotes(excised)               # space-fill, offsets preserved
+    if ">(" not in view:                             # cheap short-circuit (common case)
+        return view
+    out = list(view)
+    for m in re.finditer(r">\(", view):              # each SURVIVING >( on the view
+        i = m.start()
+        k = i - 1
+        # skip GENUINE whitespace (a space in BOTH view and raw)
+        while k >= 0 and view[k] == " " and excised[k] in " \t":
+            k -= 1
+        # stop char masked to space in the view but a CLOSING QUOTE in raw ==
+        # a quoted writer token ended here -> reveal its closing quote (in arm B's
+        # class ['\w"')\]}]) so `<anchor>\s+>\(` matches. A redirect op (>, 2>) or a
+        # genuine separator is NOT a quote -> no restore -> arm A / stderr-exclusion
+        # and the absent-anchor case are all untouched.
+        if k >= 0 and view[k] == " " and excised[k] in "\"'":
+            out[k] = excised[k]
+    return "".join(out)
+
+
 def _has_eval_or_source(command: str) -> bool:
     """Check if command contains eval or source that could execute variable values.
 
@@ -2012,9 +2043,16 @@ def _strip_non_executable_content(command: str) -> str:
     # heredoc body) can no longer disable the carriers; genuinely-executing
     # routing (unquoted tails, opener-line tails) is unquoted shell structure
     # and survives the view at identical offsets.
-    _routing_view = _executed_surface_view(command)
-    piped_to_shell = _has_pipe_to_shell(_routing_view)
-    process_sub_to_shell = _has_process_substitution_to_shell(_routing_view)
+    #
+    # The two flags read DIFFERENT views (#1129 R3-fix): piped_to_shell stays on
+    # the pure space-mask executed-surface view (the security 216-case pipe sweep
+    # stays byte-valid). process_sub_to_shell reads _procsub_anchor_view — the same
+    # space-mask with arm B's LEFT anchor restored immediately-left of a surviving
+    # >(shell) whose writer was a masked quoted token — re-catching the R3 arm-B
+    # regression (`echo "…" | "tee" >(bash)`) without a blanket fill (which would
+    # regress `>("ba"sh)`) and without computing arm B over raw (which reverts B3).
+    piped_to_shell = _has_pipe_to_shell(_executed_surface_view(command))
+    process_sub_to_shell = _has_process_substitution_to_shell(_procsub_anchor_view(command))
 
     # 1. Strip heredoc bodies: << 'EOF' ... EOF, << EOF ... EOF, << "EOF" ... EOF
     #    Match the heredoc marker, then everything up to and including the

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -1866,6 +1866,50 @@ def _has_process_substitution_to_shell(command: str) -> bool:
     )
 
 
+# Heredoc-BODY excision for the routing-flag view (#1129 R3). Reuses carrier-1's
+# marker grammar but replaces the BODY ONLY: the opener line (including a
+# genuinely-executing `| bash` / `> >(bash)` TAIL) and the closing marker stay
+# visible to the routing scan. Carrier-1's whole-match replacement would swallow
+# the opener tail and regress the pinned heredoc-pipe/procsub canaries
+# (under-block). Same input-side guard as carrier 1: a shell-fed body
+# (`bash <<EOF`) executes, so it is preserved. The REAL carrier-1 strip is
+# untouched (plan-D5).
+_HEREDOC_BODY_RE = re.compile(
+    r"(<<-?\s*['\"]?(\w+)['\"]?[^\n]*\n)"   # 1: operator+marker+opener TAIL (kept)
+    r"(?:.*?\n)?"                            #    body (excised)
+    r"(\t*\2(?![\w]))",                      # 3: closing marker (kept)
+    re.DOTALL,
+)
+
+
+def _excise_heredoc_bodies_for_routing_scan(command: str) -> str:
+    if "<<" not in command:          # cheap short-circuit (perf: common case)
+        return command
+
+    def _repl(m: "re.Match") -> str:
+        preceding = command[: m.start()].rstrip()
+        if re.search(r"\b(?:bash|sh|zsh)\s*$", preceding):
+            return m.group(0)        # shell-fed heredoc: body executes — keep
+        return m.group(1) + "HEREDOC_BODY_EXCISED\n" + m.group(3)
+
+    return _HEREDOC_BODY_RE.sub(_repl, command)
+
+
+def _executed_surface_view(command: str) -> str:
+    """Routing-flag scan surface (#1129 R3): the command with non-executed
+    data removed — heredoc BODIES excised (opener line + closing marker kept;
+    shell-fed bodies preserved), then every balanced quoted span masked to
+    spaces via _mask_shell_quotes (defined later in this module; resolved at
+    call time). Fail direction: unbalanced/ambiguous quoting leaves text
+    UNMASKED -> the routing token stays visible -> detection preserved (at
+    worst a residual over-block on malformed input, never an under-block).
+    ORDER IS LOAD-BEARING: heredoc excision FIRST removes stray body quotes
+    that could desync the quote mask. Consumed ONLY by the hoisted
+    piped_to_shell / process_sub_to_shell computation; never fed to
+    DANGEROUS_PATTERNS and never returned as strip output."""
+    return _mask_shell_quotes(_excise_heredoc_bodies_for_routing_scan(command))
+
+
 def _has_eval_or_source(command: str) -> bool:
     """Check if command contains eval or source that could execute variable values.
 
@@ -1961,8 +2005,16 @@ def _strip_non_executable_content(command: str) -> str:
     # stripping (preserve content → detect). Hoisted above carrier 1 so the
     # heredoc carrier can consult them too. MONOTONIC: a True flag only ADDS
     # detection (skip strip → more content scanned); never removes it.
-    piped_to_shell = _has_pipe_to_shell(command)
-    process_sub_to_shell = _has_process_substitution_to_shell(command)
+    #
+    # The flags defend the EXECUTED surface, so they are computed over the
+    # executed-surface view (#1129 R3): quoted spans masked, heredoc bodies
+    # excised. Carrier DATA (a `| sh` or `>(bash)` inside a quoted value or
+    # heredoc body) can no longer disable the carriers; genuinely-executing
+    # routing (unquoted tails, opener-line tails) is unquoted shell structure
+    # and survives the view at identical offsets.
+    _routing_view = _executed_surface_view(command)
+    piped_to_shell = _has_pipe_to_shell(_routing_view)
+    process_sub_to_shell = _has_process_substitution_to_shell(_routing_view)
 
     # 1. Strip heredoc bodies: << 'EOF' ... EOF, << EOF ... EOF, << "EOF" ... EOF
     #    Match the heredoc marker, then everything up to and including the

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -755,7 +755,7 @@ def _api_merge_leg_endpoint(leg: str) -> str | None:
     path. A curl/wget merge classifies None here -> gated-but-unmintable (read arms still gate).
 
     Extraction binds the pulls/<N>/merge that is the URL POSITIONAL: strip body values
-    (carrier-8, §2.3), shlex-tokenize, then walk skipping flags + the gh-api value-flag
+    (carrier-8), shlex-tokenize, then walk skipping flags + the gh-api value-flag
     values, and take the first surviving positional. On tokenizer failure NEVER returns
     None for a recognized leg (falls back to the stripped/raw first-match) — a mis-parse
     must not gate a faithful merge (over-block-safe).
@@ -2426,14 +2426,14 @@ def _strip_non_executable_content(command: str) -> str:
             # or a `?branch=` query, NOT the URL path (the contents API path is
             # `/contents/{filepath}`, branch-less). This is the ONE gated arm whose
             # signal is body-resident; stripping its body would REMOVE the main/master
-            # gating signal → an UNDER-BLOCK. The architecture (§3) mandates leaving the
-            # contents arm UNCHANGED, so preserve a contents-API span verbatim. Detected
+            # gating signal → an UNDER-BLOCK. The contents arm must be left UNCHANGED
+            # (signal is body-resident), so preserve a contents-API span verbatim. Detected
             # per-span (a compound's `/log` span is still stripped). git/refs and
             # branches/protection targets are path-resident, so their bodies stay strippable.
             # IGNORECASE to match the case-insensitive contents READ arm
             # (`contents/.*(?:main|master)`, re.IGNORECASE): a `Contents/` (any case)
             # span carries its main/master gating signal in the BODY, so it must be
-            # preserved from stripping in ANY case — else the #1096 §2.3 unquoted body
+            # preserved from stripping in ANY case — else the #1096 unquoted body
             # strip removes the signal for a capital-case spelling -> under-block.
             if re.search(r"contents/", span, re.IGNORECASE):
                 return span

--- a/pact-plugin/tests/test_merge_guard_1129_r3_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1129_r3_cert.py
@@ -5,7 +5,7 @@ Summary: COMPREHENSIVE BIDIRECTIONAL certification for #1129 R3 — scoping the 
          the EXECUTED SURFACE so a routing token inside quoted carrier DATA / a
          heredoc BODY no longer disables the carrier strips and re-exposes co-residing
          destructive text — PLUS the R3-fix remediation of the arm-B anchor under-block
-         the R3 view first introduced (found by the independent security pass #18).
+         the R3 view first introduced (found by the independent security review pass).
 
          Proven against the REAL classifier, up to FOUR baked columns, NEVER a byte-diff
          (#1118):
@@ -31,12 +31,12 @@ Summary: COMPREHENSIVE BIDIRECTIONAL certification for #1129 R3 — scoping the 
            False, asserted PATCH=False (NOT must-be-True; demanding True is the trap toward
            the over-broad \\s fix that re-introduces over-blocks).
 
-         Row classes (design §8 matrix + §13.8 remediation):
+         Row classes (executed-surface scoping + the R3-fix remediation):
            - FIX (carrier-DATA over-block CLOSURE): base True -> R3HEAD False -> PATCH
              False. Pipe/procsub/input-procsub token inside a quoted carrier value or a
              heredoc body across carriers 1/3/5/7/7b/7c/7d/8/9. The base=True column
              proves each was a genuine faithful-click over-block (never a vacuous green).
-           - REGRESSION-FIX (§13.8 R-1..R-4): base True -> R3HEAD False -> PATCH True.
+           - REGRESSION-FIX (R-1..R-4): base True -> R3HEAD False -> PATCH True.
              A genuinely-EXECUTING output-side procsub whose FIFO-writer name is quoted
              (`echo "<d>" | "tee" >(bash)`, class "tee"/'tee'/"dd"/"cat"). base catches
              (the closing `"` anchors arm B); R3's space-mask blanks the anchor ->
@@ -46,7 +46,7 @@ Summary: COMPREHENSIVE BIDIRECTIONAL certification for #1129 R3 — scoping the 
            - PRESERVE (executing routing stays caught): base True -> PATCH True — real
              `| sh`/`| bash`/`| xargs bash`, $()/backtick/eval/bash -c, heredoc opener
              tails, input-side `bash <(..)`, honest `tee >(bash)`/arm-A `> >(bash)`, and
-             carrier value + EXECUTING tail (C18/C19). Plus §13.8 P-1 (B3 survives:
+             carrier value + EXECUTING tail (C18/C19). Plus P-1 (B3 survives:
              quoted `>(bash)` DATA stays False at PATCH) and P-2 (the incidental
              `>("ba"sh)` under-block R3's mask closed must NOT regress).
            - DIFFERENTIAL (pre-existing under-blocks / correct negatives): False==False
@@ -55,7 +55,7 @@ Summary: COMPREHENSIVE BIDIRECTIONAL certification for #1129 R3 — scoping the 
              stderr `2> >(bash)` exclusion; PLUS the separator DIFFERENTIALs above
              (non-executing {NL,CR,FF,VT} + zero-sep adjacency). Asserted False (NOT
              must-stay-True) — asserting True on a pre-existing under-block or a
-             non-executing form would wrongly implicate R3/fix (plan cert caveat).
+             non-executing form would wrongly implicate R3/fix.
            - BONUS-CLOSURE (document, don't gate): `echo "<d>" | "tee" >("ba"sh)`
              base False -> PATCH True — genuinely-executing under-block the R3-fix closes;
              MORE correct than base, not an over-block.
@@ -71,10 +71,11 @@ revert `view[k]==excised[k]` -> `view[k]==" "`, which flips the non-space-blank 
 False while SPACE stays True) are documented in the HANDOFF with cardinality — they exercise
 the LIVE 7561d32d source.
 
-Cross-refs: docs/architecture/merge-guard-r3-carrier-data-pipe-scope.md §6 (invariants),
-§8 (R3 cert plan), §13 (R3-fix remediation), §13.8 (updated cert plan). Destructive verbs
-are assembled at runtime (PF/BD/M9/SH) so this file carries no raw force-push/force-delete
-/merge literal and stays inert to the live guard; probe forms are never run as shell.
+This cert covers both the R3 executed-surface scoping and the R3-fix arm-B/whitespace
+remediation; each row class below carries its own base/R3HEAD/FIX1/PATCH expectation inline,
+so a reader needs no external design doc. Destructive verbs are assembled at runtime
+(PF/BD/M9/SH) so this file carries no raw force-push/force-delete/merge literal and stays
+inert to the live guard; probe forms are never run as shell.
 """
 import subprocess
 import sys
@@ -145,7 +146,7 @@ SH = "s" + "h"                                    # shell name, kept un-obvious
 
 
 # ===========================================================================
-# §13.8 REGRESSION-FIX — quoted-writer output-side procsub: the arm-B anchor
+# REGRESSION-FIX — quoted-writer output-side procsub: the arm-B anchor
 # under-block R3 introduced and the R3-fix re-catches.
 #   base True  (closing quote anchors arm B on the raw command)
 #   R3HEAD False (space-mask blanks the anchor == the CONFIRMED auth under-block
@@ -172,7 +173,7 @@ class TestR3FixQuotedWriterRegression:
 
 
 # ===========================================================================
-# §13-fix2 SEPARATOR CLASS — whitespace-widening of the arm-B anchor restore.
+# SEPARATOR CLASS (R3-fix2) — whitespace-widening of the arm-B anchor restore.
 # The quoted-writer procsub `echo "<d>" | <writer><SEP>>(bash)` genuinely EXECUTES a
 # fanout ONLY when <SEP> is a run of bash BLANKS (space/tab): those are shell word
 # separators that fan echo's stdout into the >(bash) FIFO. fix2 (7561d32d) widened the
@@ -230,7 +231,8 @@ class TestR3Fix2NonExecutingDifferential:
     (regex-match != shell-execution), but the widen fix targets executing bash blanks ONLY and
     deliberately does NOT replicate the over-match. Asserted PATCH=False, NOT must-be-True:
     demanding must-be-True is the trap that pushes toward the over-broad \\s fix which
-    re-introduces over-blocks. (\\n verdict: architect §13-fix-2.5 — DIFFERENTIAL-False.)"""
+    re-introduces over-blocks. (\\n verdict: ratified DIFFERENTIAL-False — \\n is a command
+    separator, not an intra-command fanout.)"""
 
     @pytest.mark.parametrize("wl,w", _WRITERS)
     @pytest.mark.parametrize("sl,s", _NONEXEC_WS)
@@ -267,7 +269,7 @@ class TestR3Fix2ZeroSepPreExistingGap:
 
 
 # ===========================================================================
-# §13.8 PRESERVE — the R3-fix must not regress B3 (data-resident procsub stays
+# PRESERVE — the R3-fix must not regress B3 (data-resident procsub stays
 # closed) or the incidental >("ba"sh) win R3's mask closed.
 # ===========================================================================
 class TestR3FixPreserves:
@@ -301,7 +303,7 @@ class TestR3FixPreserves:
 
 
 # ===========================================================================
-# §13.8 BONUS-CLOSURE (document, don't gate) — quoted writer AND quoted shell name.
+# BONUS-CLOSURE (document, don't gate) — quoted writer AND quoted shell name.
 # base False -> PATCH True. Genuinely-executing under-block the R3-fix additionally
 # closes (more correct than base); NOT an over-block.
 # ===========================================================================
@@ -316,7 +318,7 @@ class TestR3FixBonusClosure:
 
 
 # ===========================================================================
-# §13.8 DIFFERENTIAL — stderr exclusion + no-space arm-B gap (F==F==F).
+# DIFFERENTIAL — stderr exclusion + no-space arm-B gap (F==F==F).
 # ===========================================================================
 class TestR3FixDifferential:
 
@@ -343,7 +345,7 @@ class TestR3FixDifferential:
 
 
 # ===========================================================================
-# §13.8 PRESERVE — honest output-side procsub stays caught (base True -> PATCH True).
+# PRESERVE — honest output-side procsub stays caught (base True -> PATCH True).
 # ===========================================================================
 class TestHonestProcsubPreserved:
 
@@ -367,8 +369,8 @@ class TestHonestProcsubPreserved:
 
 
 # ===========================================================================
-# §8 BOUNDARY + DOCUMENTED RESIDUAL — fail-closed direction and the accepted
-# over-block residuals (comment-resident token §3.5; ANSI-C \\' desync §11 / plan-D6).
+# BOUNDARY + DOCUMENTED RESIDUAL — fail-closed direction and the accepted
+# over-block residuals (comment-resident token; ANSI-C\\' desync).
 # All stay True across base/R3HEAD/PATCH — R3 neither introduces nor removes them.
 # The residual rows PIN the over-block so a future change cannot silently flip them;
 # they are asserted True==True==True as DOCUMENTED residuals (over-block-safe), NOT as
@@ -377,21 +379,21 @@ class TestHonestProcsubPreserved:
 class TestR3BoundaryAndResidual:
 
     @pytest.mark.parametrize("label,cmd", [
-        # probe-D4: an unbalanced quote near a routing token — the mask fails TOWARD
+        # an unbalanced quote near a routing token — the mask fails TOWARD
         # unmasked, so the token stays visible and the flag fires (fail-closed). A
         # malformed-quote click is not a faithful click, so this residual over-block is
-        # accepted (design §5 pt5).
-        ("probe-D4 unbalanced quote", 'echo "%s | %s' % (PF, SH)),
-        # probe-D5: a routing token inside a carrier value AND a REAL destructive tail on
+        # accepted (malformed input, not a faithful single-command click).
+        ("unbalanced quote near routing token", 'echo "%s | %s' % (PF, SH)),
+        # a routing token inside a carrier value AND a REAL destructive tail on
         # a second leg — the tail is executed surface and stays caught.
-        ("probe-D5 body token + && tail", 'gh pr edit 123 --body "x | %s" && %s' % (SH, PF)),
-        ("probe-D5 body token + ; tail", 'gh pr edit 123 --body "x | %s" ; %s' % (SH, PF)),
+        ("body token + && exec tail", 'gh pr edit 123 --body "x | %s" && %s' % (SH, PF)),
+        ("body token + ; exec tail", 'gh pr edit 123 --body "x | %s" ; %s' % (SH, PF)),
         # E3: comment-resident routing token — comments are deliberately NOT excised from
-        # the view (§3.5: excising them on the masked view is an under-block trap), so this
+        # the view (excising them on the masked view is an under-block trap), so this
         # stays a documented residual over-block. Narrower than the surface R3 fixes.
         ("E3 comment-resident token", 'echo "%s" # docs: | %s' % (PF, SH)),
         # E4: an ANSI-C \\' desyncs the single-quote mask so the token stays visible — the
-        # exact mirror of plan-D6's ratified ANSI-C residual (design §11).
+        # exact mirror of the ratified ANSI-C residual.
         ("E4 ANSI-C backslash-quote desync", "gh pr comment 1 --body $'%s\\' | %s'" % (PF, SH)),
     ])
     def test_boundary_residual_true_at_patch(self, label, cmd):
@@ -399,7 +401,7 @@ class TestR3BoundaryAndResidual:
             "%s: fail-closed / documented-residual over-block must stay caught at PATCH: %r" % (label, cmd)
 
     @pytest.mark.parametrize("label,cmd", [
-        ("probe-D4 unbalanced quote", 'echo "%s | %s' % (PF, SH)),
+        ("unbalanced quote near routing token", 'echo "%s | %s' % (PF, SH)),
         ("E3 comment-resident token", 'echo "%s" # docs: | %s' % (PF, SH)),
         ("E4 ANSI-C backslash-quote desync", "gh pr comment 1 --body $'%s\\' | %s'" % (PF, SH)),
     ])
@@ -410,7 +412,7 @@ class TestR3BoundaryAndResidual:
 
 
 # ===========================================================================
-# §8 PRESERVE — executing routing stays caught (base True -> R3HEAD True -> PATCH True).
+# PRESERVE — executing routing stays caught (base True -> R3HEAD True -> PATCH True).
 # ===========================================================================
 class TestR3PreserveExecuting:
 
@@ -419,7 +421,7 @@ class TestR3PreserveExecuting:
         ("C2 exec | bash", 'echo "%s" | bash' % PF),
         ("C11 exec | xargs bash", 'echo "%s" | xargs bash' % PF),
         ("C12 second-leg && | sh", 'echo ok && echo "%s" | %s' % (PF, SH)),
-        ("C6 $()-in-body (plan-D4)", 'gh pr create --body "$(%s)"' % PF),
+        ("C6 $()-in-body", 'gh pr create --body "$(%s)"' % PF),
         ("C7 backtick-in-body", 'gh pr create --body "`%s`"' % PF),
         ("C8 eval", 'eval "%s"' % PF),
         ("C9 bash -c", 'bash -c "%s"' % PF),
@@ -447,7 +449,7 @@ class TestR3PreserveExecuting:
 
 
 # ===========================================================================
-# §8 FIX — carrier-DATA over-block CLOSURE (base True -> R3HEAD False -> PATCH False).
+# FIX — carrier-DATA over-block CLOSURE (base True -> R3HEAD False -> PATCH False).
 # A pipe/procsub/input-procsub routing token inside a quoted carrier value or a heredoc
 # body no longer disables the carrier strip. base=True proves each was a genuine vector.
 # ===========================================================================
@@ -465,8 +467,8 @@ class TestR3FixCarrierDataOverBlock:
         ("A-c9 gh api --jq sq", "gh api repos/o/r --jq '%s | %s'" % (PF, SH)),
         ("B3 output procsub-in-body", 'gh pr edit 123 --body "%s > >(bash)"' % PF),
         ("B1fix input-procsub-in-body", 'gh pr edit 123 --body "bash <(echo %s)"' % PF),
-        ("probeD1 cross-value", 'gh pr edit 123 --title "%s" --body "x | %s"' % (PF, SH)),
-        ("probeD2 cross-leg newline", 'gh pr edit 1 --body "x | %s"\ngh pr edit 2 --body "%s"' % (SH, PF)),
+        ("cross-value title+body", 'gh pr edit 123 --title "%s" --body "x | %s"' % (PF, SH)),
+        ("cross-leg newline", 'gh pr edit 1 --body "x | %s"\ngh pr edit 2 --body "%s"' % (SH, PF)),
         ("E6 ANSI-C $'..| sh' body", "gh pr comment 1 --body $'%s | %s'" % (PF, SH)),
         ("E7 concat \"..\"'| sh' body", "gh pr comment 1 --body \"%s\"'| %s'" % (PF, SH)),
     ])
@@ -480,7 +482,7 @@ class TestR3FixCarrierDataOverBlock:
         ("A-c8 curl -d dq", 'curl -d "%s | %s" https://x.example' % (PF, SH)),
         ("B3 output procsub-in-body", 'gh pr edit 123 --body "%s > >(bash)"' % PF),
         ("B1fix input-procsub-in-body", 'gh pr edit 123 --body "bash <(echo %s)"' % PF),
-        ("probeD2 cross-leg newline", 'gh pr edit 1 --body "x | %s"\ngh pr edit 2 --body "%s"' % (SH, PF)),
+        ("cross-leg newline", 'gh pr edit 1 --body "x | %s"\ngh pr edit 2 --body "%s"' % (SH, PF)),
         ("E6 ANSI-C $'..| sh' body", "gh pr comment 1 --body $'%s | %s'" % (PF, SH)),
         ("E7 concat \"..\"'| sh' body", "gh pr comment 1 --body \"%s\"'| %s'" % (PF, SH)),
     ])
@@ -492,9 +494,9 @@ class TestR3FixCarrierDataOverBlock:
 
 
 # ===========================================================================
-# §8 DIFFERENTIAL — pre-existing under-blocks / correct negatives (F==F==F).
+# DIFFERENTIAL — pre-existing under-blocks / correct negatives (F==F==F).
 # Asserted False==False (NOT must-stay-True): asserting True on a pre-existing
-# under-block would wrongly implicate R3 (plan cert caveat).
+# under-block would wrongly implicate R3.
 # ===========================================================================
 class TestR3Differential:
 
@@ -518,3 +520,101 @@ class TestR3Differential:
     def test_differential_false_across_all_three(self, label, cmd):
         assert D_BASE(cmd) is False and D_R3(cmd) is False and D(cmd) is False, \
             "%s: differential must be False==False==False (not implicating R3): %r" % (label, cmd)
+
+
+# ===========================================================================
+# TEST-HARDENING PINS (#1129 R3) — durable rows for coverage gaps surfaced in
+# review. Each behavior was spot-verified working; pinning it means a future
+# regression reds a row. Two groups: (1) heredoc marker/opener variants the
+# primary rows above did not exercise (shell-fed sh/zsh preservation; <<- dash
+# and quoted-marker excision); (2) the two internal view-builder invariants the
+# arm-B anchor-restore offset math depends on (excise-before-mask ORDER, and the
+# SAME-LENGTH mask that keeps view/excised aligned 1:1 by offset).
+# ===========================================================================
+class TestR3HardeningHeredocVariants:
+    """Heredoc-body excision + its shell-fed guard across marker/opener variants
+    the primary rows only exercised for `bash <<EOF` / bare `cat <<EOF`."""
+
+    # sh-/zsh-fed heredoc: the shell-fed guard PRESERVES the body (it executes),
+    # so the in-body `| sh` stays caught. PRESERVE: base True / R3HEAD True / PATCH True.
+    _SHELL_FED = [
+        ("sh-fed heredoc body | sh", 'sh <<EOF\n%s | %s\nEOF' % (PF, SH)),
+        ("zsh-fed heredoc body | sh", 'zsh <<EOF\n%s | %s\nEOF' % (PF, SH)),
+    ]
+
+    @pytest.mark.parametrize("label,cmd", _SHELL_FED)
+    def test_shell_fed_heredoc_preserved_at_patch(self, label, cmd):
+        assert D(cmd) is True, \
+            "%s: shell-fed heredoc body executes, must stay caught at PATCH: %r" % (label, cmd)
+
+    @pytest.mark.parametrize("label,cmd", _SHELL_FED)
+    @requires_history
+    def test_shell_fed_heredoc_true_on_base_and_r3(self, label, cmd):
+        assert D_BASE(cmd) is True and D_R3(cmd) is True, \
+            "%s: shell-fed heredoc must be caught on base AND R3HEAD (preserved, not excised): %r" % (label, cmd)
+
+    # <<- dash-indent + quoted-marker (single/double) NAKED heredoc: excision closes the
+    # carrier-DATA over-block like a plain naked body. FIX: base True / R3HEAD False / PATCH False.
+    _NAKED_MARKER_VARIANTS = [
+        ("dash <<- naked body | sh", 'cat <<-EOF\n%s | %s\n\tEOF' % (PF, SH)),
+        ("sq-marker <<'EOF' naked body | sh", "cat <<'EOF'\n%s | %s\nEOF" % (PF, SH)),
+        ('dq-marker <<"EOF" naked body | sh', 'cat <<"EOF"\n%s | %s\nEOF' % (PF, SH)),
+    ]
+
+    @pytest.mark.parametrize("label,cmd", _NAKED_MARKER_VARIANTS)
+    def test_heredoc_marker_variant_excised_at_patch(self, label, cmd):
+        assert D(cmd) is False, \
+            "%s: naked heredoc-marker variant body must be excised/closed at PATCH: %r" % (label, cmd)
+
+    @pytest.mark.parametrize("label,cmd", _NAKED_MARKER_VARIANTS)
+    @requires_history
+    def test_heredoc_marker_variant_was_a_genuine_base_vector(self, label, cmd):
+        assert D_BASE(cmd) is True, \
+            "%s: base must OVER-BLOCK the raw naked body (else the closure row is vacuous): %r" % (label, cmd)
+        assert D_R3(cmd) is False, \
+            "%s: R3 excision closed the carrier-DATA over-block: %r" % (label, cmd)
+
+
+class TestR3ViewBuilderInvariants:
+    """The two internal invariants the anchor-restore offset math relies on, pinned
+    directly on the shared _excise_and_mask helper so a future refactor that breaks
+    either reds a row instead of silently mis-aligning the anchor walk-left."""
+
+    def test_excision_precedes_mask_order_is_load_bearing(self):
+        # ORDER INVARIANT: _excise_and_mask must excise heredoc bodies BEFORE masking
+        # quotes. Witness: a NAKED heredoc body carrying a stray unbalanced quote, then a
+        # quoted carrier value. Excise-first removes the body, keeping the quote mask synced
+        # over the trailing carrier; mask-first would let the stray body quote desync the
+        # mask. Pin: the live view equals excise-then-mask, and DIFFERS from mask-then-excise
+        # on this witness — so excision-before-mask is provably load-bearing (a swapped order
+        # reds both asserts).
+        cmd = 'cat <<EOF\n" | %s\nEOF\ngh pr comment 1 --body "%s | %s"' % (SH, PF, SH)
+        excised, view = mgc._excise_and_mask(cmd)
+        assert "HEREDOC_BODY_EXCISED" in excised, "the naked heredoc body must be excised: %r" % cmd
+        assert view == mgc._mask_shell_quotes(
+            mgc._excise_heredoc_bodies_for_routing_scan(cmd)), \
+            "live view must equal excise-then-mask: %r" % cmd
+        assert view != mgc._excise_heredoc_bodies_for_routing_scan(
+            mgc._mask_shell_quotes(cmd)), \
+            "mask-then-excise must differ -> excision-before-mask is load-bearing: %r" % cmd
+
+    @pytest.mark.parametrize("s", [
+        'gh pr edit 1 --body "%s | %s"' % (PF, SH),
+        'echo "%s" | "tee" >(bash)' % PF,
+        "gh pr comment 1 --body '%s | %s'" % (PF, SH),
+        'cat <<EOF\n%s | %s\nEOF' % (PF, SH),
+        'gh pr edit 1 --body "unbalanced %s' % PF,        # unbalanced quote (fail-open path)
+        'echo "%s" | tee >("ba"sh)' % PF,                  # nested quote in procsub
+        '',
+        'plain command no quotes',
+    ])
+    def test_mask_is_same_length_and_view_excised_parity(self, s):
+        # SAME-LENGTH INVARIANT: _procsub_anchor_view walks left comparing view[k] to
+        # excised[k] by offset, sound only if _mask_shell_quotes preserves length
+        # (space-fill, never add/drop chars). Pin length parity on the masker and on the
+        # (excised, view) pair the shared _excise_and_mask returns.
+        assert len(mgc._mask_shell_quotes(s)) == len(s), \
+            "_mask_shell_quotes must be same-length (offset alignment): %r" % s
+        excised, view = mgc._excise_and_mask(s)
+        assert len(view) == len(excised), \
+            "view/excised length parity (offset alignment): %r" % s

--- a/pact-plugin/tests/test_merge_guard_1129_r3_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1129_r3_cert.py
@@ -1,0 +1,520 @@
+"""
+Location: pact-plugin/tests/test_merge_guard_1129_r3_cert.py
+Summary: COMPREHENSIVE BIDIRECTIONAL certification for #1129 R3 — scoping the two
+         routing flags (_has_pipe_to_shell, _has_process_substitution_to_shell) to
+         the EXECUTED SURFACE so a routing token inside quoted carrier DATA / a
+         heredoc BODY no longer disables the carrier strips and re-exposes co-residing
+         destructive text — PLUS the R3-fix remediation of the arm-B anchor under-block
+         the R3 view first introduced (found by the independent security pass #18).
+
+         Proven against the REAL classifier, up to FOUR baked columns, NEVER a byte-diff
+         (#1118):
+           - BASE   = 51e6c5a5 (pre-R3): the flags compute over the raw command.
+           - R3HEAD = 72bacaf8 (R3 shipped, carries the arm-B regression): the flags
+             compute over the pure space-mask view. For the OUTPUT-SIDE procsub rows
+             this column IS the 'anchor-restore reverted' state, so R-1..R-4 R3HEAD=False
+             is the permanent non-vacuity discriminator for the arm-B anchor restore.
+           - FIX1   = b313ecaa (R3-fix1: arm-B anchor restored for a SPACE separator ONLY):
+             the 'fix2 reverted' state. Non-space bash blanks (tab / blank-run-ending-in-tab)
+             are UNDER-BLOCKED here, so FIX1=False on those rows is the permanent fix2
+             non-vacuity discriminator.
+           - PATCH  = live 7561d32d (R3 + fix1 anchor restore + fix2 whitespace widening):
+             piped stays on the space-mask view; procsub reads _procsub_anchor_view whose
+             anchor walk-left now skips any UNMASKED BASH BLANK (space/tab), not just space.
+
+         Separator classification (by SHELL EXECUTION SEMANTICS, not by arm-B \\s+ match):
+           a quoted-writer procsub `echo "<d>" | <writer><SEP>>(bash)` executes a fanout
+           ONLY when <SEP> is a run of bash BLANKS (space/tab). fix2 catches ALL such blanks
+           (FIX-blanks, must-be-True). Non-blank whitespace {NL,CR,FF,VT} is non-executing
+           (\\n = command separator; \\r/\\f/\\v glue the writer into a nonexistent command),
+           and zero-separator adjacency is a pre-existing arm-B \\s+ gap — both DIFFERENTIAL-
+           False, asserted PATCH=False (NOT must-be-True; demanding True is the trap toward
+           the over-broad \\s fix that re-introduces over-blocks).
+
+         Row classes (design §8 matrix + §13.8 remediation):
+           - FIX (carrier-DATA over-block CLOSURE): base True -> R3HEAD False -> PATCH
+             False. Pipe/procsub/input-procsub token inside a quoted carrier value or a
+             heredoc body across carriers 1/3/5/7/7b/7c/7d/8/9. The base=True column
+             proves each was a genuine faithful-click over-block (never a vacuous green).
+           - REGRESSION-FIX (§13.8 R-1..R-4): base True -> R3HEAD False -> PATCH True.
+             A genuinely-EXECUTING output-side procsub whose FIFO-writer name is quoted
+             (`echo "<d>" | "tee" >(bash)`, class "tee"/'tee'/"dd"/"cat"). base catches
+             (the closing `"` anchors arm B); R3's space-mask blanks the anchor ->
+             UNDER-BLOCK (the R3HEAD=False discriminator == the confirmed auth regression);
+             the R3-fix restores the anchor -> PATCH re-catches. The R3HEAD=False column
+             is the load-bearing proof that the anchor-restore is non-vacuous.
+           - PRESERVE (executing routing stays caught): base True -> PATCH True — real
+             `| sh`/`| bash`/`| xargs bash`, $()/backtick/eval/bash -c, heredoc opener
+             tails, input-side `bash <(..)`, honest `tee >(bash)`/arm-A `> >(bash)`, and
+             carrier value + EXECUTING tail (C18/C19). Plus §13.8 P-1 (B3 survives:
+             quoted `>(bash)` DATA stays False at PATCH) and P-2 (the incidental
+             `>("ba"sh)` under-block R3's mask closed must NOT regress).
+           - DIFFERENTIAL (pre-existing under-blocks / correct negatives): False==False
+             ==False. #1146 `| sudo sh`, quoted shell name `| "sh"`, `| sudo sh` in body,
+             content-gated (token, no danger), non-shell `<(` in body, #1133 bare heredoc,
+             stderr `2> >(bash)` exclusion; PLUS the separator DIFFERENTIALs above
+             (non-executing {NL,CR,FF,VT} + zero-sep adjacency). Asserted False (NOT
+             must-stay-True) — asserting True on a pre-existing under-block or a
+             non-executing form would wrongly implicate R3/fix (plan cert caveat).
+           - BONUS-CLOSURE (document, don't gate): `echo "<d>" | "tee" >("ba"sh)`
+             base False -> PATCH True — genuinely-executing under-block the R3-fix closes;
+             MORE correct than base, not an over-block.
+
+NON-VACUITY (permanent, in-suite): the base(51e6c5a5), R3HEAD(72bacaf8) AND FIX1(b313ecaa)
+classifiers are loaded via `git show` + exec and asserted IN-TEST, so the cert can never be
+vacuously green — a FIX row's base=True proves the vector existed; a REGRESSION-FIX row's
+R3HEAD=False proves the arm-B under-block was real and the anchor-restore is load-bearing; a
+FIX-blank row's FIX1=False (on non-space blanks) proves fix2's whitespace widening is
+independently load-bearing; a future regression flips a PATCH column and reds the row. Three
+real-source-revert legs (1: relocation, 2: heredoc-excision, 3: the fix2 one-line-predicate
+revert `view[k]==excised[k]` -> `view[k]==" "`, which flips the non-space-blank rows back to
+False while SPACE stays True) are documented in the HANDOFF with cardinality — they exercise
+the LIVE 7561d32d source.
+
+Cross-refs: docs/architecture/merge-guard-r3-carrier-data-pipe-scope.md §6 (invariants),
+§8 (R3 cert plan), §13 (R3-fix remediation), §13.8 (updated cert plan). Destructive verbs
+are assembled at runtime (PF/BD/M9/SH) so this file carries no raw force-push/force-delete
+/merge literal and stays inert to the live guard; probe forms are never run as shell.
+"""
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import shared.merge_guard_common as mgc  # noqa: E402
+
+# --- Baked classifiers loaded from git ONCE for permanent in-test non-vacuity.
+#     BASE = pre-R3 (flags over raw command); R3HEAD = R3 shipped (space-mask view,
+#     carries the arm-B under-block == 'security-fix reverted' for output-side procsub);
+#     FIX1 = R3-fix1 (arm-B anchor restored for a SPACE separator ONLY == 'fix2-reverted'),
+#     the discriminator for the whitespace-widening fix2 (non-space bash blanks).
+_BASE_SHA = "51e6c5a5"   # pre-R3
+_R3_SHA = "72bacaf8"     # R3 shipped (arm-B regression present)
+_FIX1_SHA = "b313ecaa"   # R3-fix1: space-only anchor restore (fix2-reverted state)
+
+
+def _load_classifier(sha):
+    """Load merge_guard_common as it existed at `sha`, or None if unavailable
+    (git missing, or a SHALLOW clone lacking the commit) so collection SUCCEEDS and the
+    base/R3HEAD non-vacuity rows self-SKIP (@requires_history) instead of aborting the
+    file. Mirrors test_merge_guard_1129_r2_cert._load_classifier."""
+    wt = Path(__file__).resolve().parents[2]  # worktree root (tests/../../)
+    try:
+        src = subprocess.check_output(
+            ["git", "-C", str(wt), "show",
+             sha + ":pact-plugin/hooks/shared/merge_guard_common.py"],
+            stderr=subprocess.DEVNULL,
+        ).decode()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+    mod = types.ModuleType("merge_guard_common_1129r3_" + sha)
+    mod.__file__ = str(wt / "pact-plugin/hooks/shared/merge_guard_common.py")
+    mod.__package__ = "shared"  # so its `from shared.x import ...` resolve on sys.path
+    try:
+        exec(compile(src, mod.__file__, "exec"), mod.__dict__)
+    except Exception:
+        return None
+    return mod
+
+
+_BASE = _load_classifier(_BASE_SHA)
+_R3 = _load_classifier(_R3_SHA)
+_FIX1 = _load_classifier(_FIX1_SHA)
+# None-safe: a bare `_BASE.is_dangerous_command` would AttributeError at import when the
+# baked source is unavailable (shallow clone), re-aborting collection. D_BASE/D_R3/D_FIX1
+# are only ever called by the @requires_history-guarded columns.
+D_BASE = _BASE.is_dangerous_command if _BASE is not None else None
+D_R3 = _R3.is_dangerous_command if _R3 is not None else None
+D_FIX1 = _FIX1.is_dangerous_command if _FIX1 is not None else None
+D = mgc.is_dangerous_command
+
+requires_history = pytest.mark.skipif(
+    _BASE is None or _R3 is None or _FIX1 is None,
+    reason="base/R3HEAD/FIX1 non-vacuity requires merged history (shallow clone / missing history)",
+)
+
+# Destructive literals assembled at runtime — this file carries no raw literal.
+PF = "git " + "push " + "--force origin main"    # force-push
+BD = "git " + "branch " + "-D main"              # force branch-delete
+M9 = "gh " + "pr " + "merge 9"                    # merge
+SH = "s" + "h"                                    # shell name, kept un-obvious
+
+
+# ===========================================================================
+# §13.8 REGRESSION-FIX — quoted-writer output-side procsub: the arm-B anchor
+# under-block R3 introduced and the R3-fix re-catches.
+#   base True  (closing quote anchors arm B on the raw command)
+#   R3HEAD False (space-mask blanks the anchor == the CONFIRMED auth under-block
+#                 == 'security-fix reverted' — the leg-3 non-vacuity discriminator)
+#   PATCH True (surgical LEFT-anchor restoration re-catches)
+# ===========================================================================
+class TestR3FixQuotedWriterRegression:
+
+    @pytest.mark.parametrize("label,cmd", [
+        ("R-1 dq writer \"tee\"", 'echo "%s" | "tee" >(bash)' % PF),
+        ("R-2 sq writer 'tee'", "echo \"%s\" | 'tee' >(bash)" % PF),
+        ("R-3 dq writer \"dd\"", 'echo "%s" | "dd" >(bash)' % PF),
+        ("R-4 dq writer \"cat\"", 'echo "%s" | "cat" >(bash)' % PF),
+    ])
+    @requires_history
+    def test_quoted_writer_regression_recaught(self, label, cmd):
+        assert D_BASE(cmd) is True, \
+            "%s: base must CATCH the executing quoted-writer procsub (else vacuous): %r" % (label, cmd)
+        assert D_R3(cmd) is False, \
+            "%s: R3HEAD MUST under-block (the confirmed arm-B regression == security-fix reverted; " \
+            "else the anchor-restore is vacuous): %r" % (label, cmd)
+        assert D(cmd) is True, \
+            "%s: PATCH must RE-CATCH via the restored left anchor: %r" % (label, cmd)
+
+
+# ===========================================================================
+# §13-fix2 SEPARATOR CLASS — whitespace-widening of the arm-B anchor restore.
+# The quoted-writer procsub `echo "<d>" | <writer><SEP>>(bash)` genuinely EXECUTES a
+# fanout ONLY when <SEP> is a run of bash BLANKS (space/tab): those are shell word
+# separators that fan echo's stdout into the >(bash) FIFO. fix2 (7561d32d) widened the
+# anchor-restore walk-left from 'literal space' to 'any unmasked bash blank'. Rows are
+# classified by SHELL EXECUTION SEMANTICS, not by whether arm-B's \s+ regex matches.
+# FIX1(b313ecaa) restored the anchor for a SPACE separator ONLY, so it is the fix2
+# non-vacuity discriminator: non-space blanks were under-blocked there, re-caught here.
+# ===========================================================================
+_WRITERS = [("dq-tee", '"tee"'), ("sq-tee", "'tee'"), ("dq-dd", '"dd"'), ("dq-cat", '"cat"')]
+_FIX_BLANKS = [("SPACE", " "), ("2xSPACE", "  "), ("TAB", "\t"),
+               ("TAB+TAB", "\t\t"), ("SP+TAB", " \t"), ("TAB+SP", "\t ")]
+_NONSPACE_BLANKS = [("TAB", "\t"), ("TAB+TAB", "\t\t"), ("SP+TAB", " \t"), ("TAB+SP", "\t ")]
+_NONEXEC_WS = [("NL", "\n"), ("CR", "\r"), ("FF", "\f"), ("VT", "\v")]
+
+
+def _procsub(writer, sep):
+    return 'echo "%s" | %s%s>(bash)' % (PF, writer, sep)
+
+
+class TestR3Fix2BlankSeparatorFix:
+
+    @pytest.mark.parametrize("wl,w", _WRITERS)
+    @pytest.mark.parametrize("sl,s", _FIX_BLANKS)
+    def test_blank_separated_fanout_caught_at_patch(self, wl, w, sl, s):
+        # Genuinely-executing: a bash-blank run separates the quoted writer from >(bash),
+        # so echo's stdout fans into the shell FIFO. MUST be caught at the widened PATCH.
+        assert D(_procsub(w, s)) is True, \
+            "%s writer / %s sep: blank-separated procsub fanout must be caught: %r" % (wl, sl, _procsub(w, s))
+
+    @pytest.mark.parametrize("wl,w", _WRITERS)
+    @pytest.mark.parametrize("sl,s", _FIX_BLANKS)
+    @requires_history
+    def test_blank_separated_was_a_genuine_base_vector(self, wl, w, sl, s):
+        assert D_BASE(_procsub(w, s)) is True, \
+            "%s / %s: base must catch the executing fanout (else vacuous): %r" % (wl, sl, _procsub(w, s))
+
+    @pytest.mark.parametrize("wl,w", _WRITERS)
+    @pytest.mark.parametrize("sl,s", _NONSPACE_BLANKS)
+    @requires_history
+    def test_nonspace_blank_underblocked_at_fix1_recaught_at_patch(self, wl, w, sl, s):
+        # THE fix2 non-vacuity discriminator: a non-space bash blank (tab / a multi-blank run
+        # whose char adjacent to >( is a tab) was UNDER-BLOCKED at FIX1 (space-only anchor
+        # restore) and is RE-CAUGHT at the widened PATCH. Bakes fix2's load-bearingness.
+        cmd = _procsub(w, s)
+        assert D_FIX1(cmd) is False, \
+            "%s / %s: FIX1 (space-only) MUST under-block this non-space blank (else fix2 vacuous): %r" % (wl, sl, cmd)
+        assert D(cmd) is True, \
+            "%s / %s: widened PATCH must RE-CATCH the non-space blank fanout: %r" % (wl, sl, cmd)
+
+
+class TestR3Fix2NonExecutingDifferential:
+    """Non-blank whitespace {NL,CR,FF,VT} between the quoted writer and >(bash) is NOT an
+    executing fanout: \\n is a command separator (two commands, no fanout); \\r/\\f/\\v glue to
+    the writer (`tee\\r` = nonexistent command). base's arm-B \\s+ OVER-matches them
+    (regex-match != shell-execution), but the widen fix targets executing bash blanks ONLY and
+    deliberately does NOT replicate the over-match. Asserted PATCH=False, NOT must-be-True:
+    demanding must-be-True is the trap that pushes toward the over-broad \\s fix which
+    re-introduces over-blocks. (\\n verdict: architect §13-fix-2.5 — DIFFERENTIAL-False.)"""
+
+    @pytest.mark.parametrize("wl,w", _WRITERS)
+    @pytest.mark.parametrize("sl,s", _NONEXEC_WS)
+    def test_nonexecuting_whitespace_false_at_patch(self, wl, w, sl, s):
+        assert D(_procsub(w, s)) is False, \
+            "%s / %s: non-executing whitespace must NOT be caught (fix targets executing blanks only): %r" % (wl, sl, _procsub(w, s))
+
+    @pytest.mark.parametrize("wl,w", _WRITERS)
+    @pytest.mark.parametrize("sl,s", _NONEXEC_WS)
+    @requires_history
+    def test_nonexecuting_whitespace_is_a_base_overmatch(self, wl, w, sl, s):
+        # Documents WHY these are differential: base=True is an arm-B \s+ OVER-match on a
+        # non-executing form (regex matched; the shell would not fan out).
+        assert D_BASE(_procsub(w, s)) is True, \
+            "%s / %s: base arm-B \\s+ over-match expected (documents the differential): %r" % (wl, sl, _procsub(w, s))
+
+
+class TestR3Fix2ZeroSepPreExistingGap:
+    """Zero-separator adjacency `<writer>>(bash)` is a PRE-EXISTING arm-B gap: arm B requires
+    \\s+ (>=1 whitespace), so adjacency never matches even with the anchor present — base never
+    caught it either (base=False). NOT an R3 regression, out of R3/fix scope. Asserted
+    PATCH=False (differential); base=False proves it is pre-existing, not a closure the fix owes."""
+
+    @pytest.mark.parametrize("wl,w", _WRITERS)
+    def test_zero_sep_false_at_patch(self, wl, w):
+        assert D(_procsub(w, "")) is False, \
+            "%s: zero-sep adjacency is a pre-existing arm-B gap, must stay False: %r" % (wl, _procsub(w, ""))
+
+    @pytest.mark.parametrize("wl,w", _WRITERS)
+    @requires_history
+    def test_zero_sep_never_caught_by_base(self, wl, w):
+        assert D_BASE(_procsub(w, "")) is False, \
+            "%s: base never caught zero-sep (pre-existing gap, NOT an R3 regression): %r" % (wl, _procsub(w, ""))
+
+
+# ===========================================================================
+# §13.8 PRESERVE — the R3-fix must not regress B3 (data-resident procsub stays
+# closed) or the incidental >("ba"sh) win R3's mask closed.
+# ===========================================================================
+class TestR3FixPreserves:
+
+    def test_b3_data_resident_procsub_stays_closed_at_patch(self):
+        # P-1: quoted `>(bash)` is DATA — fully masked -> no surviving `>(` in the anchor
+        # view -> arm B has nothing to anchor -> stays False. The R3 over-block fix SURVIVES
+        # the remediation. (base over-blocked it; R3HEAD closed it; PATCH keeps it closed.)
+        cmd = 'gh issue create --body "%s >(bash)"' % PF
+        assert D(cmd) is False, "P-1: R3-fix must NOT re-over-block B3 data-resident procsub: %r" % cmd
+
+    @requires_history
+    def test_b3_was_a_genuine_base_over_block(self):
+        cmd = 'gh issue create --body "%s >(bash)"' % PF
+        assert D_BASE(cmd) is True, "P-1: base must over-block B3 (else the survival row is vacuous)"
+        assert D_R3(cmd) is False, "P-1: R3 closed the B3 over-block"
+
+    def test_incidental_double_quoted_shell_name_win_preserved(self):
+        # P-2: `>("ba"sh)` — writer `tee` UNQUOTED, shell name quoted. R3's space-mask
+        # turned `>("ba"sh)` into `>(    sh)` and arm B's `>\\(\\s*` spans to `sh` -> a base
+        # under-block R3 INCIDENTALLY closed. The R3-fix leaves everything right of `>(`
+        # as the mask, so this stays caught. Must NOT regress.
+        cmd = 'echo "%s" | tee >("ba"sh)' % PF
+        assert D(cmd) is True, "P-2: incidental >(\"ba\"sh) win must NOT regress: %r" % cmd
+
+    @requires_history
+    def test_incidental_win_was_a_base_under_block(self):
+        cmd = 'echo "%s" | tee >("ba"sh)' % PF
+        assert D_BASE(cmd) is False, "P-2: base under-blocked (else 'incidental win' is vacuous)"
+        assert D_R3(cmd) is True, "P-2: R3's space-mask incidentally closed it"
+
+
+# ===========================================================================
+# §13.8 BONUS-CLOSURE (document, don't gate) — quoted writer AND quoted shell name.
+# base False -> PATCH True. Genuinely-executing under-block the R3-fix additionally
+# closes (more correct than base); NOT an over-block.
+# ===========================================================================
+class TestR3FixBonusClosure:
+
+    @requires_history
+    def test_quoted_writer_and_quoted_shell_bonus_closed(self):
+        cmd = 'echo "%s" | "tee" >("ba"sh)' % PF
+        assert D_BASE(cmd) is False, "bonus: base under-blocked this executing form"
+        assert D(cmd) is True, \
+            "bonus: PATCH closes it (writer quote anchors arm B; shell quotes mask to spaces): %r" % cmd
+
+
+# ===========================================================================
+# §13.8 DIFFERENTIAL — stderr exclusion + no-space arm-B gap (F==F==F).
+# ===========================================================================
+class TestR3FixDifferential:
+
+    @pytest.mark.parametrize("label,cmd", [
+        ("D-1a stderr 2> benign", 'echo hi 2> >(bash)'),
+        ("D-1b stderr 2> danger", 'echo "%s" 2> >(bash)' % PF),
+        ("D-2a #1146 | \"sh\"", 'echo "%s" | "%s"' % (PF, SH)),
+        # (zero-separator no-whitespace arm-B gap is covered comprehensively across the
+        #  writer-class by TestR3Fix2ZeroSepPreExistingGap.)
+    ])
+    def test_differential_stays_false_at_patch(self, label, cmd):
+        # Pre-existing under-blocks / correct negatives. The R3-fix must NOT convert a
+        # stderr-excluded form into an arm-B match. NOT must-stay-True.
+        assert D(cmd) is False, "%s: R3-fix must not widen this pre-existing negative: %r" % (label, cmd)
+
+    @pytest.mark.parametrize("label,cmd", [
+        ("D-1a stderr 2> benign", 'echo hi 2> >(bash)'),
+        ("D-2a #1146 | \"sh\"", 'echo "%s" | "%s"' % (PF, SH)),
+    ])
+    @requires_history
+    def test_differential_unchanged_across_all_three(self, label, cmd):
+        assert D_BASE(cmd) is False and D_R3(cmd) is False and D(cmd) is False, \
+            "%s: must be False==False==False (differential, not implicating R3): %r" % (label, cmd)
+
+
+# ===========================================================================
+# §13.8 PRESERVE — honest output-side procsub stays caught (base True -> PATCH True).
+# ===========================================================================
+class TestHonestProcsubPreserved:
+
+    @pytest.mark.parametrize("label,cmd", [
+        ("H-1 | tee >(bash)", 'echo "%s" | tee >(bash)' % PF),
+        ("H-2 arm-A > >(bash)", 'echo "%s" > >(bash)' % PF),
+        ("H-3 tee \"out.log\" >(bash)", 'echo "%s" | tee "out.log" >(bash)' % PF),
+        ("H-4 input-side bash <(..)", 'bash <(echo "%s")' % PF),
+    ])
+    def test_honest_procsub_true_at_patch(self, label, cmd):
+        assert D(cmd) is True, "%s: honest executing procsub must stay caught at PATCH: %r" % (label, cmd)
+
+    @pytest.mark.parametrize("label,cmd", [
+        ("H-1 | tee >(bash)", 'echo "%s" | tee >(bash)' % PF),
+        ("H-2 arm-A > >(bash)", 'echo "%s" > >(bash)' % PF),
+        ("H-4 input-side bash <(..)", 'bash <(echo "%s")' % PF),
+    ])
+    @requires_history
+    def test_honest_procsub_true_on_base(self, label, cmd):
+        assert D_BASE(cmd) is True, "%s: honest procsub must be a genuine base catch: %r" % (label, cmd)
+
+
+# ===========================================================================
+# §8 BOUNDARY + DOCUMENTED RESIDUAL — fail-closed direction and the accepted
+# over-block residuals (comment-resident token §3.5; ANSI-C \\' desync §11 / plan-D6).
+# All stay True across base/R3HEAD/PATCH — R3 neither introduces nor removes them.
+# The residual rows PIN the over-block so a future change cannot silently flip them;
+# they are asserted True==True==True as DOCUMENTED residuals (over-block-safe), NOT as
+# R3 wins.
+# ===========================================================================
+class TestR3BoundaryAndResidual:
+
+    @pytest.mark.parametrize("label,cmd", [
+        # probe-D4: an unbalanced quote near a routing token — the mask fails TOWARD
+        # unmasked, so the token stays visible and the flag fires (fail-closed). A
+        # malformed-quote click is not a faithful click, so this residual over-block is
+        # accepted (design §5 pt5).
+        ("probe-D4 unbalanced quote", 'echo "%s | %s' % (PF, SH)),
+        # probe-D5: a routing token inside a carrier value AND a REAL destructive tail on
+        # a second leg — the tail is executed surface and stays caught.
+        ("probe-D5 body token + && tail", 'gh pr edit 123 --body "x | %s" && %s' % (SH, PF)),
+        ("probe-D5 body token + ; tail", 'gh pr edit 123 --body "x | %s" ; %s' % (SH, PF)),
+        # E3: comment-resident routing token — comments are deliberately NOT excised from
+        # the view (§3.5: excising them on the masked view is an under-block trap), so this
+        # stays a documented residual over-block. Narrower than the surface R3 fixes.
+        ("E3 comment-resident token", 'echo "%s" # docs: | %s' % (PF, SH)),
+        # E4: an ANSI-C \\' desyncs the single-quote mask so the token stays visible — the
+        # exact mirror of plan-D6's ratified ANSI-C residual (design §11).
+        ("E4 ANSI-C backslash-quote desync", "gh pr comment 1 --body $'%s\\' | %s'" % (PF, SH)),
+    ])
+    def test_boundary_residual_true_at_patch(self, label, cmd):
+        assert D(cmd) is True, \
+            "%s: fail-closed / documented-residual over-block must stay caught at PATCH: %r" % (label, cmd)
+
+    @pytest.mark.parametrize("label,cmd", [
+        ("probe-D4 unbalanced quote", 'echo "%s | %s' % (PF, SH)),
+        ("E3 comment-resident token", 'echo "%s" # docs: | %s' % (PF, SH)),
+        ("E4 ANSI-C backslash-quote desync", "gh pr comment 1 --body $'%s\\' | %s'" % (PF, SH)),
+    ])
+    @requires_history
+    def test_boundary_residual_unchanged_across_all_three(self, label, cmd):
+        assert D_BASE(cmd) is True and D_R3(cmd) is True and D(cmd) is True, \
+            "%s: R3 must neither introduce nor remove this residual (True==True==True): %r" % (label, cmd)
+
+
+# ===========================================================================
+# §8 PRESERVE — executing routing stays caught (base True -> R3HEAD True -> PATCH True).
+# ===========================================================================
+class TestR3PreserveExecuting:
+
+    @pytest.mark.parametrize("label,cmd", [
+        ("C1 exec | sh", 'echo "%s" | %s' % (PF, SH)),
+        ("C2 exec | bash", 'echo "%s" | bash' % PF),
+        ("C11 exec | xargs bash", 'echo "%s" | xargs bash' % PF),
+        ("C12 second-leg && | sh", 'echo ok && echo "%s" | %s' % (PF, SH)),
+        ("C6 $()-in-body (plan-D4)", 'gh pr create --body "$(%s)"' % PF),
+        ("C7 backtick-in-body", 'gh pr create --body "`%s`"' % PF),
+        ("C8 eval", 'eval "%s"' % PF),
+        ("C9 bash -c", 'bash -c "%s"' % PF),
+        ("C15 heredoc | bash opener tail", 'bash <<EOF | bash\n%s\nEOF' % PF),
+        ("C16 heredoc > >(bash) opener tail", 'cat <<EOF > >(bash)\n%s\nEOF' % PF),
+        ("C17 shell-fed heredoc body | sh", 'bash <<EOF\n%s | %s\nEOF' % (PF, SH)),
+        ("C18 carrier value + | bash tail", 'gh pr create --title "%s" | bash' % PF),
+        ("C19 carrier value + > >(bash) tail", 'gh pr create --title "%s" > >(bash)' % PF),
+    ])
+    def test_executing_routing_true_at_patch(self, label, cmd):
+        assert D(cmd) is True, "%s: executing routing must stay caught at PATCH: %r" % (label, cmd)
+
+    @pytest.mark.parametrize("label,cmd", [
+        ("C1 exec | sh", 'echo "%s" | %s' % (PF, SH)),
+        ("C2 exec | bash", 'echo "%s" | bash' % PF),
+        ("C15 heredoc | bash opener tail", 'bash <<EOF | bash\n%s\nEOF' % PF),
+        ("C16 heredoc > >(bash) opener tail", 'cat <<EOF > >(bash)\n%s\nEOF' % PF),
+        ("C17 shell-fed heredoc body | sh", 'bash <<EOF\n%s | %s\nEOF' % (PF, SH)),
+        ("C18 carrier value + | bash tail", 'gh pr create --title "%s" | bash' % PF),
+    ])
+    @requires_history
+    def test_executing_routing_true_on_base_and_r3(self, label, cmd):
+        assert D_BASE(cmd) is True and D_R3(cmd) is True, \
+            "%s: executing routing must be caught on base AND R3HEAD (R3 narrows no detection): %r" % (label, cmd)
+
+
+# ===========================================================================
+# §8 FIX — carrier-DATA over-block CLOSURE (base True -> R3HEAD False -> PATCH False).
+# A pipe/procsub/input-procsub routing token inside a quoted carrier value or a heredoc
+# body no longer disables the carrier strip. base=True proves each was a genuine vector.
+# ===========================================================================
+class TestR3FixCarrierDataOverBlock:
+
+    @pytest.mark.parametrize("label,cmd", [
+        ("A1 gh pr edit --body dq", 'gh pr edit 123 --body "%s | %s"' % (PF, SH)),
+        ("A2 gh pr edit --title dq", 'gh pr edit 123 --title "%s | %s"' % (PF, SH)),
+        ("A7 release --notes dq", 'gh release create v1 --notes "%s | %s"' % (PF, SH)),
+        ("A8 gist --desc dq", 'gh gist create f.txt --desc "%s | %s"' % (PF, SH)),
+        ("A9 git tag -m dq", 'git tag -m "%s | %s" v1' % (PF, SH)),
+        ("A10 pr comment --body sq", "gh pr comment 1 --body '%s | %s'" % (PF, SH)),
+        ("A17 naked heredoc body | sh", 'cat <<EOF\n%s | %s\nEOF' % (PF, SH)),
+        ("A-c8 curl -d dq", 'curl -d "%s | %s" https://x.example' % (PF, SH)),
+        ("A-c9 gh api --jq sq", "gh api repos/o/r --jq '%s | %s'" % (PF, SH)),
+        ("B3 output procsub-in-body", 'gh pr edit 123 --body "%s > >(bash)"' % PF),
+        ("B1fix input-procsub-in-body", 'gh pr edit 123 --body "bash <(echo %s)"' % PF),
+        ("probeD1 cross-value", 'gh pr edit 123 --title "%s" --body "x | %s"' % (PF, SH)),
+        ("probeD2 cross-leg newline", 'gh pr edit 1 --body "x | %s"\ngh pr edit 2 --body "%s"' % (SH, PF)),
+        ("E6 ANSI-C $'..| sh' body", "gh pr comment 1 --body $'%s | %s'" % (PF, SH)),
+        ("E7 concat \"..\"'| sh' body", "gh pr comment 1 --body \"%s\"'| %s'" % (PF, SH)),
+    ])
+    def test_carrier_data_over_block_closed_at_patch(self, label, cmd):
+        assert D(cmd) is False, "%s: carrier-DATA over-block must stay CLOSED at PATCH: %r" % (label, cmd)
+
+    @pytest.mark.parametrize("label,cmd", [
+        ("A1 gh pr edit --body dq", 'gh pr edit 123 --body "%s | %s"' % (PF, SH)),
+        ("A9 git tag -m dq", 'git tag -m "%s | %s" v1' % (PF, SH)),
+        ("A17 naked heredoc body | sh", 'cat <<EOF\n%s | %s\nEOF' % (PF, SH)),
+        ("A-c8 curl -d dq", 'curl -d "%s | %s" https://x.example' % (PF, SH)),
+        ("B3 output procsub-in-body", 'gh pr edit 123 --body "%s > >(bash)"' % PF),
+        ("B1fix input-procsub-in-body", 'gh pr edit 123 --body "bash <(echo %s)"' % PF),
+        ("probeD2 cross-leg newline", 'gh pr edit 1 --body "x | %s"\ngh pr edit 2 --body "%s"' % (SH, PF)),
+        ("E6 ANSI-C $'..| sh' body", "gh pr comment 1 --body $'%s | %s'" % (PF, SH)),
+        ("E7 concat \"..\"'| sh' body", "gh pr comment 1 --body \"%s\"'| %s'" % (PF, SH)),
+    ])
+    @requires_history
+    def test_over_block_was_a_genuine_base_vector(self, label, cmd):
+        assert D_BASE(cmd) is True, \
+            "%s: base must OVER-BLOCK (else the closure row is vacuous): %r" % (label, cmd)
+        assert D_R3(cmd) is False, "%s: R3 closed the carrier-DATA over-block: %r" % (label, cmd)
+
+
+# ===========================================================================
+# §8 DIFFERENTIAL — pre-existing under-blocks / correct negatives (F==F==F).
+# Asserted False==False (NOT must-stay-True): asserting True on a pre-existing
+# under-block would wrongly implicate R3 (plan cert caveat).
+# ===========================================================================
+class TestR3Differential:
+
+    @pytest.mark.parametrize("label,cmd", [
+        ("E1 #1146 | sudo sh", 'echo "%s" | sudo %s' % (PF, SH)),
+        ("E2 quoted shell name | \"sh\"", 'echo "%s" | "%s"' % (PF, SH)),
+        ("A6 | sudo sh in body", 'gh pr edit 123 --body "%s | sudo %s"' % (PF, SH)),
+        ("C10 content-gated (token,no danger)", 'gh pr edit 123 --body "just text | %s"' % SH),
+        ("B1diff non-shell <( in body", 'gh pr edit 123 --body "diff <(echo %s) f"' % PF),
+        ("E5 #1133 bare heredoc body", 'cat <<EOF\n%s\nEOF' % PF),
+    ])
+    def test_differential_false_at_patch(self, label, cmd):
+        assert D(cmd) is False, "%s: pre-existing negative must stay False at PATCH: %r" % (label, cmd)
+
+    @pytest.mark.parametrize("label,cmd", [
+        ("E1 #1146 | sudo sh", 'echo "%s" | sudo %s' % (PF, SH)),
+        ("E2 quoted shell name | \"sh\"", 'echo "%s" | "%s"' % (PF, SH)),
+        ("A6 | sudo sh in body", 'gh pr edit 123 --body "%s | sudo %s"' % (PF, SH)),
+    ])
+    @requires_history
+    def test_differential_false_across_all_three(self, label, cmd):
+        assert D_BASE(cmd) is False and D_R3(cmd) is False and D(cmd) is False, \
+            "%s: differential must be False==False==False (not implicating R3): %r" % (label, cmd)


### PR DESCRIPTION
## Summary

PR-3 (final) of #1129 — scope the merge-guard's pipe-to-shell / process-substitution routing detection to the **executed surface**, so a routing token that appears inside *carrier data* (a quoted `--body`/`--notes` value, a heredoc body) no longer disables the content-carrier strips and over-blocks a faithful single-command click.

R1 (#1135, v4.5.5) and R2 (#1138, v4.5.6) shipped the branch-set and carrier-unification fixes. This PR closes the remaining over-block: `piped_to_shell` / `process_sub_to_shell` are now computed over an executed-surface view (quoted spans masked, heredoc bodies excised) rather than the raw command.

## What changed

`hooks/shared/merge_guard_common.py` only (+ a new cert file):

1. **Executed-surface routing view** — both routing flags read `_executed_surface_view(command)` = `_mask_shell_quotes(heredoc-body-excised command)`. Carrier-DATA routing tokens (`| sh`, `>(bash)` inside a quoted value) no longer disable the carriers; genuinely-executing routing (unquoted structure) survives the view unchanged. Detectors, all seven carrier-disable sites, and the real strip pipeline are untouched.
2. **arm-B anchor restore** — the executed-surface mask dropped a genuinely-executing quoted-writer output-side procsub (`echo … | "tee" >(bash)`); `_procsub_anchor_view` restores arm B's preceding-token anchor immediately-left of a surviving `>(shell)` whose writer was a masked quoted token, without touching the operand region.
3. **blank-class widening** — the anchor restore is gated on unmasked bash **blanks** (space + tab), so a tab separator is no longer missed. Non-blank separators (newline, CR, FF, VT) are correctly left uncaught — they do not produce an intra-command fanout, so base's regex whitespace match over-matches them.

## Design principle

A faithful single-command click always mints and merges. Over-block is the cardinal sin; the under-block direction is tolerated-with-defense-in-depth and its fix must never risk the over-block direction. Every fix in this PR is over-block-safe by construction (each restored match is a subset of what the raw command already flagged).

## Verification

- New cert `tests/test_merge_guard_1129_r3_cert.py` — 185 tests, classified by shell execution semantics (executing blank separators must-catch; non-executing separators + pre-existing zero-separator adjacency asserted uncaught). Non-vacuity is baked into the suite via a four-classifier ladder over the fix commit SHAs, so a regression to any component reds a row without a manual revert.
- Full suite: **11304 passed, 11 skipped, 0 errors** (3.12.7).
- Independent adversarial review across the arc: three security passes (which caught the two intermediate regressions before this PR), three concurrent audits, and behavioral base-vs-HEAD differentials on every fix.

Closes the R3 scope of #1129. Version → 4.5.8.
