### PR TITLE
feat(journal): mirror load-bearing task metadata via task_metadata_snapshot events (#1147)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.1",
+      "version": "4.6.2",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.1/       # Plugin version
+│               └── 4.6.2/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.1
+> **Version**: 4.6.2
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/agent_handoff_emitter.py
+++ b/pact-plugin/hooks/agent_handoff_emitter.py
@@ -75,6 +75,7 @@ from shared.agent_handoff_marker import (
     unclaim,
 )
 from shared.session_journal import append_event, get_journal_path, make_event
+from shared.task_metadata_snapshot import emit_task_metadata_snapshot
 from shared.task_utils import read_task_json
 
 # Suppress false "hook error" display in Claude Code UI on bare exit paths.
@@ -199,6 +200,38 @@ def main() -> None:
             if task_data.get("status") != "completed":  # Invariant (1b) fallback
                 print(_SUPPRESS_OUTPUT)
                 sys.exit(0)
+
+        # task_metadata_snapshot seam — teammate-frame twin (hermetic; own
+        # gates in the substrate). Positioned immediately AFTER the
+        # transition gate and BEFORE the signal-task bypass: the hardened
+        # exits below (signal gate, handoff-presence gate, writability gate,
+        # marker gate) would make an after-the-emit call unreachable for
+        # exactly the tasks whose seam coverage matters here — self-completed
+        # tasks with sibling metadata but no/malformed handoff, and signal
+        # tasks (which DO snapshot; the agent_handoff suppression below is
+        # untouched). Isolation from the handoff path is carried by the
+        # hermetic try/except, the substrate's read-only payload build and
+        # never-raise contract, and the SEPARATE marker namespace — not by
+        # ordering; this block must not touch any variable the handoff path
+        # consumes below (task_metadata, handoff, occupant, marker state).
+        # The transition gate above IS the stdin-primary/disk-fallback
+        # discipline — the snapshot inherits it by position and adds NO disk
+        # status requirement of its own (the disk write can be mid-flight at
+        # TaskCompleted fire-time). The metadata read is the already-
+        # performed read_task_json result, best-effort: an empty read yields
+        # an empty payload and a clean no-emit. An unresolvable teammate
+        # frame defers inside the substrate (writability precondition — no
+        # claim, no write); the lead-frame seams cover it.
+        try:
+            emit_task_metadata_snapshot(
+                team_name,
+                task_id,
+                task_subject,
+                teammate_name,
+                task_data.get("metadata") or {},
+            )
+        except Exception:
+            pass
 
         # `or {}` handles explicit JSON null in addition to missing key —
         # .get("metadata", {}) returns None when the key is present with a

--- a/pact-plugin/hooks/shared/agent_handoff_marker.py
+++ b/pact-plugin/hooks/shared/agent_handoff_marker.py
@@ -52,6 +52,15 @@ from .paths import get_claude_config_dir
 # most), while keeping the marker filename short.
 _OCCUPANT_HASH_LEN = 16
 
+# Default O_EXCL marker directory name — the agent_handoff event family's
+# namespace. Keyword-only `namespace` parameters below default to this so
+# every pre-existing caller resolves a byte-identical marker path; a sibling
+# event family (task_metadata_snapshot) passes its own module-constant
+# namespace through hard-bound wrappers so the two families' dedup markers
+# can never suppress each other. Namespace values are module constants,
+# never input-derived.
+_DEFAULT_MARKER_NAMESPACE = ".agent_handoff_emitted"
+
 # Signal-task types — tasks that MUST NOT emit a phantom agent_handoff event
 # (a blocker/algedonic completion is a control signal, not a HANDOFF; emitting
 # would pollute read_events("agent_handoff") + mis-route secretary harvest).
@@ -123,24 +132,31 @@ def occupant_hash(teammate_name: str, task_subject: str) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:_OCCUPANT_HASH_LEN]
 
 
-def _marker_dir(team_name: str) -> Path:
+def _marker_dir(
+    team_name: str, *, namespace: str = _DEFAULT_MARKER_NAMESPACE
+) -> Path:
     """
-    Return the per-team marker directory path.
+    Return the per-team marker directory path for one event-family namespace.
 
-    Lives under ~/.claude/teams/{team}/.agent_handoff_emitted/ — a sibling
-    to the team's inboxes/ and config.json. session_end.py's team reaper
-    removes the whole team directory (shutil.rmtree), so the marker dir is
-    cleaned up automatically when the team ages out.
+    Lives under ~/.claude/teams/{team}/{namespace}/ (default
+    .agent_handoff_emitted) — a sibling to the team's inboxes/ and
+    config.json. session_end.py's team reaper removes the whole team
+    directory (shutil.rmtree), so every namespace's marker dir is cleaned
+    up automatically when the team ages out.
 
     Kept task-scoped (not session-scoped) so fire-once semantics survive
     pause/resume: a secretary standing task that spans sessions must emit
     its agent_handoff event exactly once across the whole team lifespan.
     """
-    return get_claude_config_dir() / "teams" / team_name / ".agent_handoff_emitted"
+    return get_claude_config_dir() / "teams" / team_name / namespace
 
 
 def _resolve_marker_target(
-    team_name: str, task_id: str, occupant: str
+    team_name: str,
+    task_id: str,
+    occupant: str,
+    *,
+    namespace: str = _DEFAULT_MARKER_NAMESPACE,
 ) -> "tuple[int | None, str | None]":
     """
     Sanitize + validate + pin the marker directory; return the open directory
@@ -195,7 +211,7 @@ def _resolve_marker_target(
     ):
         return None, None
 
-    marker_dir = _marker_dir(team_name)
+    marker_dir = _marker_dir(team_name, namespace=namespace)
     # Symlink-containment pre-check: if marker_dir already exists as a
     # symlink, refuse to use it (a pre-planted symlink could redirect marker
     # creation outside the team directory). Fail-open emit rather than risk
@@ -251,7 +267,13 @@ def _resolve_marker_target(
     return dir_fd, f"{task_id}-{occupant}"
 
 
-def already_emitted(team_name: str, task_id: str, occupant: str) -> bool:
+def already_emitted(
+    team_name: str,
+    task_id: str,
+    occupant: str,
+    *,
+    namespace: str = _DEFAULT_MARKER_NAMESPACE,
+) -> bool:
     """
     Test-and-set the per-(team, task_id, occupant) marker.
 
@@ -285,7 +307,9 @@ def already_emitted(team_name: str, task_id: str, occupant: str) -> bool:
     compensating-unclaim closes the OTHER suppression source (a marker this
     process claimed but whose journal write then failed) — see unclaim().
     """
-    dir_fd, filename = _resolve_marker_target(team_name, task_id, occupant)
+    dir_fd, filename = _resolve_marker_target(
+        team_name, task_id, occupant, namespace=namespace
+    )
     if dir_fd is None:
         # Degenerate key / symlink-guarded / unresolvable → fail-open emit.
         return False
@@ -307,7 +331,13 @@ def already_emitted(team_name: str, task_id: str, occupant: str) -> bool:
         os.close(dir_fd)
 
 
-def unclaim(team_name: str, task_id: str, occupant: str) -> None:
+def unclaim(
+    team_name: str,
+    task_id: str,
+    occupant: str,
+    *,
+    namespace: str = _DEFAULT_MARKER_NAMESPACE,
+) -> None:
     """
     Compensating rollback (#901, R1) — remove the marker THIS process just
     created when the subsequent journal write FAILED (append_event returned
@@ -332,7 +362,9 @@ def unclaim(team_name: str, task_id: str, occupant: str) -> None:
     Worst case the marker persists and behavior reverts to today's (a poisoned
     marker) — strictly no worse than not having the rollback. Never raises.
     """
-    dir_fd, filename = _resolve_marker_target(team_name, task_id, occupant)
+    dir_fd, filename = _resolve_marker_target(
+        team_name, task_id, occupant, namespace=namespace
+    )
     if dir_fd is None:
         return
     try:

--- a/pact-plugin/hooks/shared/hook_infra_classifier.py
+++ b/pact-plugin/hooks/shared/hook_infra_classifier.py
@@ -138,8 +138,11 @@ _SEAM_HOOK_HELPER_CLOSURE: dict[str, frozenset[str]] = {
     }),
     "agent_handoff_emitter": frozenset({
         "agent_handoff_marker", "constants", "pact_context", "paths",
-        "session_journal", "session_registry", "session_state", "task_utils",
-    }),
+        "session_journal", "session_registry", "session_state",
+        "task_metadata_snapshot", "task_utils",
+    }),  # task_metadata_snapshot reached via the teammate-frame snapshot
+         # seam (emit_task_metadata_snapshot); its own transitive edges
+         # (agent_handoff_marker, session_journal) were already here.
     "session_init": frozenset({
         "claude_md_manager", "constants", "dispatch_helpers", "failure_log",
         "merge_guard_common", "pact_config", "pact_context", "paths",
@@ -170,9 +173,11 @@ _SEAM_HOOK_HELPER_CLOSURE: dict[str, frozenset[str]] = {
     "task_lifecycle_gate": frozenset({
         "agent_handoff_marker", "constants", "dispatch_helpers",
         "intentional_wait", "pact_context", "paths", "session_journal",
-        "session_registry", "session_state", "task_utils", "teachback_schema",
-        "tool_response", "variety_scorer",
-    }),
+        "session_registry", "session_state", "task_metadata_snapshot",
+        "task_utils", "teachback_schema", "tool_response", "variety_scorer",
+    }),  # task_metadata_snapshot reached via the lead-completion +
+         # post-completion-backstop snapshot seams; its transitive edges
+         # were already in this closure.
     "bootstrap_gate": frozenset({
         "constants", "marker_schema", "pact_context",
         "paths", "session_journal", "session_registry",

--- a/pact-plugin/hooks/shared/session_journal.py
+++ b/pact-plugin/hooks/shared/session_journal.py
@@ -127,6 +127,13 @@ _REQUIRED_FIELDS_BY_TYPE: dict[str, dict[str, type]] = {
     # "yes"|"no"|"concern" flag. The GC-immune mirror read by wrap-up Q6's
     # cargo_cult_signal_rate (the task store goes false-empty after GC).
     "teachback_ack": {"task_id": str, "rationale_articulates_this_dispatch": str},
+    # hooks/shared/task_metadata_snapshot.emit_task_metadata_snapshot writes
+    # task_metadata_snapshot at completion (seams in task_lifecycle_gate.py +
+    # agent_handoff_emitter.py) — the GC-immune mirror of non-handoff task
+    # metadata (the N-key generalization of dispatch_variety/teachback_ack).
+    # task_id is the source task; metadata is the size-bounded sibling-key
+    # payload (SNAPSHOT_EXCLUDE'd, truncation-marked — see the substrate module).
+    "task_metadata_snapshot": {"task_id": str, "metadata": dict},
     # commands/orchestrate.md + comPACT.md write phase_transition with
     # phase + status (both quoted strings). session_resume._build_journal_resume
     # subscripts `p["phase"]` — this schema check is the defensive bulwark
@@ -355,6 +362,28 @@ _OPTIONAL_FIELDS_BY_TYPE: dict[str, dict[str, type]] = {
     # missed_wake).
     "teachback_ack": {
         "concern": str,
+    },
+    # hooks/shared/task_metadata_snapshot.emit_task_metadata_snapshot writes
+    # task_metadata_snapshot with these optionals. subject is sentinel-
+    # substituted "(no subject)" when degenerate (never required-invalid,
+    # #917 validate-before-claim); owner is absent for ownerless (e.g.
+    # signal) tasks; task_type mirrors metadata.type so readers distinguish
+    # signal snapshots (signal tasks DO snapshot — the agent_handoff
+    # suppression's reader-purity basis does not transfer to the durability
+    # mirror); truncated is present (True) only when size-bounding fired;
+    # occupant is occupant_hash(owner or "", subject) — the task-id-reuse
+    # discriminator readers join against the agent_handoff event's
+    # (agent, task_subject) identity. The required-fields registration above
+    # ("task_metadata_snapshot": {...}) is what ACTIVATES this optional check
+    # — _validate_event_schema short-circuits on unknown types and would
+    # otherwise skip the optional loop (same activation pattern as
+    # session_end / missed_wake / teachback_ack).
+    "task_metadata_snapshot": {
+        "subject": str,
+        "owner": str,
+        "task_type": str,
+        "truncated": bool,
+        "occupant": str,
     },
     # commands/peer-review.md writes remediation with an optional task_id —
     # the fixer's Task-B task id. The Q5 coverage denominator

--- a/pact-plugin/hooks/shared/task_metadata_snapshot.py
+++ b/pact-plugin/hooks/shared/task_metadata_snapshot.py
@@ -133,7 +133,13 @@ def _truncation_marker(canonical: bytes) -> dict:
 
 
 def _is_marker(value: object) -> bool:
-    """True iff ``value`` is a truncation marker THIS module produced."""
+    """True iff ``value`` has the truncation-marker SHAPE.
+
+    Shape recognition is a TEST/reader oracle only — production marker
+    identity inside build_snapshot_payload is provenance-tracked (the
+    local set of keys that run truncated), never shape-tested, so a
+    caller-supplied lookalike can never be treated as a marker.
+    """
     return (
         isinstance(value, dict)
         and set(value.keys()) == set(_MARKER_KEYS)
@@ -161,17 +167,36 @@ def build_snapshot_payload(
     1. Per-value: each non-excluded value over PER_VALUE_CAP is replaced by
        the truncation marker (see _truncation_marker).
     2. Payload: while the whole payload exceeds PAYLOAD_CAP, the LARGEST
-       remaining un-truncated value is replaced by the marker; ties broken
-       by ascending lexicographic key order (pinned). Markers count toward
-       the total; stage-1 markers are not re-candidates.
-    3. Pathological floor: if all-markers still exceeds the cap, set head
-       to "" in descending original_bytes order (same tie-break); if STILL
-       over, keep whole keys in ascending key order while they fit and
-       record the remainder name-only in a top-level "_dropped_keys" list
-       (ascending). Key existence is never silently lost.
+       remaining not-yet-truncated value is replaced by the marker; ties
+       broken by ascending lexicographic key order (pinned). Markers count
+       toward the total; keys this run already truncated are not
+       re-candidates.
+    3. Pathological floor: if the payload still exceeds the cap, set head
+       to "" across this run's markers in descending original_bytes order
+       (same tie-break); if STILL over, keep whole keys in ascending key
+       order while they fit and record the remainder name-only in a
+       top-level "_dropped_keys" list (ascending). Key existence is never
+       silently lost.
+
+    Marker identity is PROVENANCE-tracked, never shape-tested: a local set
+    records which keys THIS run truncated, and stages 2/3 consult that set
+    only. An input value that merely looks marker-shaped is ordinary
+    caller data — a normal eviction candidate (replaced by OUR marker
+    computed from its serialization) and never sorted by stage 3, whose
+    original_bytes sort therefore only ever sees ints (total by
+    construction).
     """
     payload: dict = {}
     truncated = False
+    # Provenance set — the keys whose payload slot THIS run replaced with a
+    # truncation marker. Marker identity is provenance-tracked, never
+    # shape-tested: an input value that merely LOOKS marker-shaped is
+    # ordinary caller data (a normal stage-2 eviction candidate, replaced
+    # by OUR marker computed from ITS serialization), and stage 3a sorts
+    # only keys in this set — whose markers carry int original_bytes by
+    # construction, making the sort total (a caller lookalike's arbitrary
+    # original_bytes value can never reach it).
+    marker_keys: set[str] = set()
 
     # Stage 1 — per-value cap. Iteration over sorted keys makes the stage
     # order-independent by construction (the output would be equivalent
@@ -184,35 +209,39 @@ def build_snapshot_payload(
         canonical = _canonical_bytes(value)
         if len(canonical) > PER_VALUE_CAP:
             payload[key] = _truncation_marker(canonical)
+            marker_keys.add(key)
             truncated = True
         else:
             payload[key] = value
 
-    # Stage 2 — payload cap: evict largest un-truncated values first.
+    # Stage 2 — payload cap: evict largest not-yet-truncated values first.
+    # Candidacy is provenance-based (key not in marker_keys), so a caller
+    # lookalike is evicted like any ordinary value.
     while len(_canonical_bytes(payload)) > PAYLOAD_CAP:
         candidates = {
             key: len(_canonical_bytes(value))
             for key, value in payload.items()
-            if not _is_marker(value)
+            if key not in marker_keys
         }
         if not candidates:
             break
         largest = max(candidates.values())
         key = min(k for k, size in candidates.items() if size == largest)
         payload[key] = _truncation_marker(_canonical_bytes(payload[key]))
+        marker_keys.add(key)
         truncated = True
 
-    # Stage 3a — empty marker heads, biggest originals first. REBUILD the
-    # marker rather than assigning into it: stage 1 inserts under-cap input
-    # values by REFERENCE, so a caller-supplied value that is already
-    # exactly marker-shaped reaches this loop as a shared object — an
-    # in-place head write would mutate the CALLER's metadata dict and break
-    # the read-only invariant (the seams feed this same object to the
-    # handoff path). Rebuilding is provenance-agnostic: safe for markers we
-    # created and for caller lookalikes alike.
+    # Stage 3a — empty this run's marker heads, biggest originals first.
+    # Provenance-scoped: iterates marker_keys only, so every sorted
+    # original_bytes is an int by construction and no caller object is ever
+    # a target. REBUILD the marker rather than assigning into it — the
+    # structural read-only guarantee (no in-place writes to any payload
+    # value, regardless of provenance) is what keeps the caller's metadata
+    # dict safe even if a future edit widens what reaches this loop; the
+    # seams feed the same object to the handoff path.
     if len(_canonical_bytes(payload)) > PAYLOAD_CAP:
         by_size_desc = sorted(
-            (k for k, v in payload.items() if _is_marker(v)),
+            marker_keys,
             key=lambda k: (-payload[k]["original_bytes"], k),
         )
         for key in by_size_desc:

--- a/pact-plugin/hooks/shared/task_metadata_snapshot.py
+++ b/pact-plugin/hooks/shared/task_metadata_snapshot.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""
+Location: pact-plugin/hooks/shared/task_metadata_snapshot.py
+Summary: SSOT substrate for task_metadata_snapshot journal emission — the
+         GC-immune mirror of non-handoff task metadata (the N-key
+         generalization of the single-key dispatch_variety / teachback_ack
+         mirrors). Owns the exclude set, the dual-cap three-stage
+         size-bounding, the content-key hash, the hard-bound marker-namespace
+         wrappers, and the ONE emit routine shared verbatim by every seam.
+Used by: task_lifecycle_gate.py (lead-completion seam + post-completion
+         backstop seam), agent_handoff_emitter.py (teammate-frame
+         TaskCompleted seam), and the substrate unit-test suite.
+
+Why one substrate: the agent_handoff emit paths drifted-by-construction risk
+(divergent marker keys across two files) was closed by centralizing the
+marker atoms in shared/agent_handoff_marker.py. The snapshot inherits that
+lesson structurally: all three seams call emit_task_metadata_snapshot() and
+nothing snapshot-specific lives in the hooks beyond the thin hermetic call.
+
+Eligibility (deliberately DIFFERENT from the agent_handoff chain — do not
+share or wrap that predicate): non-empty post-SNAPSHOT_EXCLUDE payload AND
+journal writable. No signal-task gate (blocker/algedonic HALT context is
+peak durability value; the agent_handoff suppression's basis is reader
+purity of THAT event type and does not transfer), no teachback-subject gate
+(teachback_submit / rejection siblings are load-bearing), no owner
+requirement (signal tasks may be ownerless).
+
+Supersession: multiple snapshots per task are legal — a changed payload
+after completion re-emits under a new content key; an unchanged payload
+never re-emits (the content-keyed O_EXCL marker dedups across all seams).
+Readers take latest-ts within the (task_id, occupant) group; the occupant
+field is the task-id-reuse discriminator (platform reuses task ids across
+arcs within one team).
+
+Size-bounding invariant: key EXISTENCE is never silently lost — worst case
+a key survives name-only in the payload's top-level "_dropped_keys" list.
+Determinism contract: identical input mapping under ANY insertion order
+produces byte-identical canonical payload bytes and therefore an identical
+payload_hash8 (sizing, truncation heads, and hashing all flow through the
+single _canonical_bytes serialization).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+
+from .agent_handoff_marker import (
+    already_emitted,
+    occupant_hash,
+    sanitize_path_component,
+    unclaim,
+)
+from .session_journal import append_event, get_journal_path, make_event
+
+# Keys never mirrored: only entries with equivalent-or-better journal
+# coverage of the FULL value. metadata.handoff is journaled verbatim as its
+# own agent_handoff event; everything else (teachback_submit, variety incl.
+# rationales, ad-hoc analysis keys, lifecycle flags) is mirrored — a missed
+# key is silent institutional loss while a junk key is bounded bytes, so the
+# exclude set stays minimal by design.
+SNAPSHOT_EXCLUDE: frozenset[str] = frozenset({"handoff"})
+
+# Size caps on the canonical serialization (see _canonical_bytes). Empirics
+# over the full journal/task-file population found the largest real value at
+# ~10 KB and no journal event ever ≥ 32 KB, so both caps are anomaly paths:
+# generous enough to never truncate observed real payloads, bounded enough
+# to protect journal growth and the read path's tail-window scan.
+PER_VALUE_CAP: int = 16 * 1024
+PAYLOAD_CAP: int = 64 * 1024
+HEAD_BYTES: int = 1024
+
+# O_EXCL marker directory for snapshot dedup — a SEPARATE namespace from the
+# agent_handoff marker dir so the two event families can never suppress each
+# other. Module constant, never input-derived.
+SNAPSHOT_MARKER_NAMESPACE: str = ".task_metadata_snapshot_emitted"
+
+# Marker-dict key set used to recognize truncation markers this module
+# itself produced (stage-2 candidate filtering + stage-3 head emptying).
+_MARKER_KEYS = frozenset({"_truncated", "original_bytes", "head"})
+
+
+def _canonical_bytes(value: object) -> bytes:
+    """THE single serialization for sizing, truncation heads, and hashing.
+
+    sort_keys makes the byte form insertion-order-independent, which is what
+    grounds the determinism contract (identical mapping → identical hash).
+    Raises TypeError on non-JSON-serializable input; callers on the emit
+    path are hermetic, and task metadata is JSON-safe by construction
+    (it arrives through TaskUpdate's JSON payload).
+    """
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode(
+        "utf-8"
+    )
+
+
+def _utf8_safe_head(data: bytes, limit: int) -> str:
+    """Return the longest decodable prefix of ``data[:limit]`` as str.
+
+    Cutting a byte string at an arbitrary offset can bisect a multibyte
+    UTF-8 sequence; decoding the raw slice would then raise (or, with
+    errors="replace", inject U+FFFD noise into the marker head). Backing
+    off to the nearest character boundary keeps the head a clean str so
+    the event line itself is always valid JSON (JSONL-poisoning guard).
+    With the pinned _canonical_bytes (json.dumps default ensure_ascii)
+    the canonical form is pure ASCII and the back-off is a no-op; the
+    boundary guard is defense-in-depth should the serialization ever
+    carry raw multibyte bytes.
+    """
+    head = data[:limit]
+    for _ in range(4):  # a UTF-8 sequence is at most 4 bytes
+        try:
+            return head.decode("utf-8")
+        except UnicodeDecodeError:
+            head = head[:-1]
+    return head.decode("utf-8", errors="ignore")
+
+
+def _truncation_marker(canonical: bytes) -> dict:
+    """Build the marker that replaces an over-cap value.
+
+    ``head`` is a *string field containing* the first HEAD_BYTES of the
+    value's canonical serialization (cut at a UTF-8 character boundary),
+    so the marker — and therefore the whole event line — is always valid
+    JSON regardless of what the original value held.
+    """
+    return {
+        "_truncated": True,
+        "original_bytes": len(canonical),
+        "head": _utf8_safe_head(canonical, HEAD_BYTES),
+    }
+
+
+def _is_marker(value: object) -> bool:
+    """True iff ``value`` is a truncation marker THIS module produced."""
+    return (
+        isinstance(value, dict)
+        and set(value.keys()) == set(_MARKER_KEYS)
+        and value.get("_truncated") is True
+    )
+
+
+def build_snapshot_payload(
+    task_metadata: Mapping[str, object],
+) -> tuple[dict, bool]:
+    """Return ``(payload, truncated)`` — the size-bounded mirror payload.
+
+    READ-ONLY on input: never mutates ``task_metadata`` or any value inside
+    it — a new dict is built, and the only dicts ever mutated (stage-3 head
+    emptying) are truncation markers this function itself created. This is
+    load-bearing: at the seams the same metadata object feeds the handoff
+    emit path, and mutating shared state from an "additive" pass is the
+    known silent-regression class on this pipeline.
+
+    Dual-cap three-stage semantics (all sizes = len(_canonical_bytes(x))):
+
+    1. Per-value: each non-excluded value over PER_VALUE_CAP is replaced by
+       the truncation marker (see _truncation_marker).
+    2. Payload: while the whole payload exceeds PAYLOAD_CAP, the LARGEST
+       remaining un-truncated value is replaced by the marker; ties broken
+       by ascending lexicographic key order (pinned). Markers count toward
+       the total; stage-1 markers are not re-candidates.
+    3. Pathological floor: if all-markers still exceeds the cap, set head
+       to "" in descending original_bytes order (same tie-break); if STILL
+       over, keep whole keys in ascending key order while they fit and
+       record the remainder name-only in a top-level "_dropped_keys" list
+       (ascending). Key existence is never silently lost.
+    """
+    payload: dict = {}
+    truncated = False
+
+    # Stage 1 — per-value cap. Iteration over sorted keys makes the stage
+    # order-independent by construction (the output would be equivalent
+    # anyway — canonical bytes sort keys — but sorted iteration keeps every
+    # intermediate deterministic too).
+    for key in sorted(task_metadata):
+        if key in SNAPSHOT_EXCLUDE:
+            continue
+        value = task_metadata[key]
+        canonical = _canonical_bytes(value)
+        if len(canonical) > PER_VALUE_CAP:
+            payload[key] = _truncation_marker(canonical)
+            truncated = True
+        else:
+            payload[key] = value
+
+    # Stage 2 — payload cap: evict largest un-truncated values first.
+    while len(_canonical_bytes(payload)) > PAYLOAD_CAP:
+        candidates = {
+            key: len(_canonical_bytes(value))
+            for key, value in payload.items()
+            if not _is_marker(value)
+        }
+        if not candidates:
+            break
+        largest = max(candidates.values())
+        key = min(k for k, size in candidates.items() if size == largest)
+        payload[key] = _truncation_marker(_canonical_bytes(payload[key]))
+        truncated = True
+
+    # Stage 3a — empty marker heads, biggest originals first.
+    if len(_canonical_bytes(payload)) > PAYLOAD_CAP:
+        by_size_desc = sorted(
+            (k for k, v in payload.items() if _is_marker(v)),
+            key=lambda k: (-payload[k]["original_bytes"], k),
+        )
+        for key in by_size_desc:
+            if len(_canonical_bytes(payload)) <= PAYLOAD_CAP:
+                break
+            if payload[key]["head"]:
+                payload[key]["head"] = ""
+                truncated = True
+
+    # Stage 3b — name-only survival: greedily keep whole keys in ascending
+    # order; everything else is recorded in _dropped_keys. The trial size
+    # conservatively charges the not-yet-decided remainder to _dropped_keys
+    # so the greedy pass can never overshoot the cap mid-iteration.
+    if len(_canonical_bytes(payload)) > PAYLOAD_CAP:
+        ordered = sorted(payload)
+        kept: dict = {}
+        dropped: list[str] = []
+        for index, key in enumerate(ordered):
+            trial = dict(kept)
+            trial[key] = payload[key]
+            trial["_dropped_keys"] = sorted(dropped + ordered[index + 1:])
+            if len(_canonical_bytes(trial)) <= PAYLOAD_CAP:
+                kept[key] = payload[key]
+            else:
+                dropped.append(key)
+        payload = kept
+        if dropped:
+            payload["_dropped_keys"] = sorted(dropped)
+        truncated = True
+
+    return payload, truncated
+
+
+def payload_hash8(payload: dict) -> str:
+    """Content key: sha256 of the canonical payload bytes, first 8 hex chars.
+
+    Computed AFTER truncation (the caller hashes the built payload, never
+    the raw metadata) so the key is stable for a given emitted content —
+    truncation nondeterminism cannot churn the dedup key because there is
+    none: build_snapshot_payload is deterministic.
+    """
+    return hashlib.sha256(_canonical_bytes(payload)).hexdigest()[:8]
+
+
+def snapshot_eligible(payload: dict) -> bool:
+    """True iff the payload is non-empty.
+
+    (Writability is checked inside emit_task_metadata_snapshot — eligibility
+    is payload-presence only. A handoff-only or empty metadata emits
+    nothing: agent_handoff already covers handoff.)
+    """
+    return bool(payload)
+
+
+def snapshot_already_emitted(
+    team_name: str, task_id: str, content_key: str
+) -> bool:
+    """Test-and-set the snapshot marker — hard-bound to the snapshot namespace.
+
+    Thin wrapper over agent_handoff_marker.already_emitted that HARD-BINDS
+    namespace=SNAPSHOT_MARKER_NAMESPACE. Seam code and this module's emit
+    routine call ONLY this wrapper (and snapshot_unclaim) — never the raw
+    marker functions: a forgotten namespace arg would claim in one dir and
+    no-op-unclaim against the other, leaving a poisoned marker; the wrapper
+    makes that impossible by construction.
+    """
+    return already_emitted(
+        team_name, task_id, content_key, namespace=SNAPSHOT_MARKER_NAMESPACE
+    )
+
+
+def snapshot_unclaim(team_name: str, task_id: str, content_key: str) -> None:
+    """Compensating rollback for a claim whose journal write failed.
+
+    Hard-bound twin of snapshot_already_emitted — same namespace constant,
+    same resolver SSOT underneath, so the claim and the rollback can never
+    reference divergent paths.
+    """
+    unclaim(
+        team_name, task_id, content_key, namespace=SNAPSHOT_MARKER_NAMESPACE
+    )
+
+
+def emit_task_metadata_snapshot(
+    team_name: str,
+    task_id: str,
+    subject: object,
+    owner: object,
+    task_metadata: Mapping[str, object] | None,
+) -> None:
+    """The ONE emit routine, shared verbatim by every seam. Never raises.
+
+    Sequence (each early return is a clean no-emit):
+      1. metadata guard — None → {}; non-mapping → return.
+      2. build payload; empty post-exclude payload → return.
+      3. validate-before-claim: sentinel-substitute a degenerate subject,
+         normalize a degenerate owner to None — every emitted field is
+         schema-valid BEFORE any marker claim (a claim-then-schema-reject
+         would poison the marker for later valid fires).
+      4. writability precondition — an unresolvable frame (e.g. an
+         unpersisted tmux teammate context) DEFERS to a writable seam
+         instead of claiming: no journal path → no claim, no write.
+      5. content-key dedup claim (O_EXCL, snapshot namespace).
+      6. occupant discriminator via the shared occupant_hash SSOT.
+      7. append the event (owner/task_type/truncated only when present).
+      8. compensating unclaim on a failed write so a later valid fire can
+         re-emit instead of being permanently suppressed.
+    """
+    try:
+        metadata = task_metadata or {}
+        if not isinstance(metadata, Mapping):
+            return
+
+        payload, truncated = build_snapshot_payload(metadata)
+        if not snapshot_eligible(payload):
+            return
+
+        if not isinstance(subject, str) or not subject.strip():
+            subject = "(no subject)"
+        if not isinstance(owner, str) or not owner.strip():
+            owner = None
+
+        if not get_journal_path():
+            return
+
+        task_id = sanitize_path_component(str(task_id))
+        content_key = payload_hash8(payload)
+        if snapshot_already_emitted(team_name, task_id, content_key):
+            return
+
+        occupant = occupant_hash(owner or "", subject)
+
+        optional: dict = {}
+        if owner:
+            optional["owner"] = owner
+        # Read from the ORIGINAL metadata — the payload copy may have been
+        # truncation-marked (never in practice for a short type string, but
+        # the original is the semantic source either way).
+        task_type = metadata.get("type")
+        if isinstance(task_type, str) and task_type.strip():
+            optional["task_type"] = task_type
+        if truncated:
+            optional["truncated"] = True
+
+        try:
+            written = append_event(
+                make_event(
+                    "task_metadata_snapshot",
+                    task_id=task_id,
+                    metadata=payload,
+                    subject=subject,
+                    occupant=occupant,
+                    **optional,
+                )
+            )
+        except Exception:
+            written = False
+        if not written:
+            snapshot_unclaim(team_name, task_id, content_key)
+    except Exception:
+        # Hermetic: a snapshot failure must never affect the host hook's
+        # contract (exit-0 suppressOutput, advisory evaluation, or the
+        # handoff emit path).
+        pass

--- a/pact-plugin/hooks/shared/task_metadata_snapshot.py
+++ b/pact-plugin/hooks/shared/task_metadata_snapshot.py
@@ -147,11 +147,14 @@ def build_snapshot_payload(
     """Return ``(payload, truncated)`` — the size-bounded mirror payload.
 
     READ-ONLY on input: never mutates ``task_metadata`` or any value inside
-    it — a new dict is built, and the only dicts ever mutated (stage-3 head
-    emptying) are truncation markers this function itself created. This is
-    load-bearing: at the seams the same metadata object feeds the handoff
-    emit path, and mutating shared state from an "additive" pass is the
-    known silent-regression class on this pipeline.
+    it — a new dict is built, and no value object is ever written in place:
+    stage-3a head emptying REBUILDS the marker (``{**marker, "head": ""}``)
+    instead of assigning into it, so even a caller-supplied value that is
+    already exactly marker-shaped (inserted by reference at stage 1) is
+    never written through. This is load-bearing: at the seams the same
+    metadata object feeds the handoff emit path, and mutating shared state
+    from an "additive" pass is the known silent-regression class on this
+    pipeline.
 
     Dual-cap three-stage semantics (all sizes = len(_canonical_bytes(x))):
 
@@ -199,7 +202,14 @@ def build_snapshot_payload(
         payload[key] = _truncation_marker(_canonical_bytes(payload[key]))
         truncated = True
 
-    # Stage 3a — empty marker heads, biggest originals first.
+    # Stage 3a — empty marker heads, biggest originals first. REBUILD the
+    # marker rather than assigning into it: stage 1 inserts under-cap input
+    # values by REFERENCE, so a caller-supplied value that is already
+    # exactly marker-shaped reaches this loop as a shared object — an
+    # in-place head write would mutate the CALLER's metadata dict and break
+    # the read-only invariant (the seams feed this same object to the
+    # handoff path). Rebuilding is provenance-agnostic: safe for markers we
+    # created and for caller lookalikes alike.
     if len(_canonical_bytes(payload)) > PAYLOAD_CAP:
         by_size_desc = sorted(
             (k for k, v in payload.items() if _is_marker(v)),
@@ -209,7 +219,7 @@ def build_snapshot_payload(
             if len(_canonical_bytes(payload)) <= PAYLOAD_CAP:
                 break
             if payload[key]["head"]:
-                payload[key]["head"] = ""
+                payload[key] = {**payload[key], "head": ""}
                 truncated = True
 
     # Stage 3b — name-only survival: greedily keep whole keys in ascending

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -298,6 +298,7 @@ try:
         make_event,
         read_events,
     )
+    from shared.task_metadata_snapshot import emit_task_metadata_snapshot
     from shared.task_utils import is_teachback_subject as _is_teachback_subject
     from shared.task_utils import read_task_json
     from shared.teachback_schema import (
@@ -1307,6 +1308,33 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
             _emit_lead_side_agent_handoff(
                 team_name, task_id, owner, subject, metadata
             )
+            # task_metadata_snapshot seam — lead completion (additive-after;
+            # hermetic). Mirrors non-handoff sibling metadata into the
+            # journal at the lead's acceptance-commit, the completion-time
+            # point that lands BEFORE the boundary-shaped task-store drain
+            # that would destroy the source file. The {**disk, **incoming}
+            # shallow merge mirrors the platform's shallow metadata-merge
+            # semantics and the pass-it-resolved pattern of the handoff
+            # backstop below (order-independent: correct whether or not the
+            # platform's write has landed at fire time). All eligibility,
+            # dedup, and size-bounding live in the substrate; a snapshot
+            # failure must never affect the handoff emit above or this
+            # hook's advisory evaluation.
+            try:
+                incoming_md = (
+                    incoming_metadata
+                    if isinstance(incoming_metadata, dict)
+                    else {}
+                )
+                emit_task_metadata_snapshot(
+                    team_name,
+                    task_id,
+                    subject,
+                    owner,
+                    {**metadata, **incoming_md},
+                )
+            except Exception:
+                pass
 
         # artifact_paths emit BACKSTOP (#927 durability nudge). A FAIL-OPEN
         # advisory: when a PREPARE/ARCHITECT phase task completes but the
@@ -1712,6 +1740,42 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
             _emit_lead_side_agent_handoff(
                 team_name, task_id, owner_bs, subject_bs, meta_for_emit
             )
+
+        # task_metadata_snapshot seam — post-completion backstop (hermetic).
+        # GENERALIZES the handoff backstop above from handoff-only to
+        # any-metadata: a metadata-only TaskUpdate landing on an ALREADY-
+        # completed task (late verification records, a superseding analysis
+        # write) is observed by neither completion-time seam, so it is
+        # mirrored here. Kept a SIBLING block of the handoff backstop — the
+        # fire predicates differ by design (handoff-dict vs any-metadata);
+        # do not merge the conditions. Content-key dedup in the substrate
+        # makes the re-fire idempotent: an unchanged payload no-ops, a
+        # changed one emits a superseding event readers resolve latest-ts.
+        # is_lead-gated like every lead-frame emit: only the lead's process
+        # resolves the canonical journal; a teammate frame self-drops.
+        if (
+            pact_context.is_lead(input_data)
+            and isinstance(incoming_metadata, dict)
+            and incoming_metadata
+            and isinstance(task_a, dict)
+            and task_a
+            and task_a.get("status") == "completed"
+        ):
+            try:
+                disk_md = (
+                    task_a.get("metadata")
+                    if isinstance(task_a.get("metadata"), dict)
+                    else {}
+                )
+                emit_task_metadata_snapshot(
+                    team_name,
+                    task_id,
+                    task_a.get("subject") or "",
+                    task_a.get("owner"),
+                    {**disk_md, **incoming_metadata},
+                )
+            except Exception:
+                pass
 
     return advisories
 

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -1316,7 +1316,10 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
             # shallow merge mirrors the platform's shallow metadata-merge
             # semantics and the pass-it-resolved pattern of the handoff
             # backstop below (order-independent: correct whether or not the
-            # platform's write has landed at fire time). All eligibility,
+            # platform's write has landed at fire time). A None-valued
+            # incoming key is the platform's DELETE op (set-to-null removes
+            # the key), so the overlay drops it rather than mirroring a
+            # phantom null the post-state no longer carries. All eligibility,
             # dedup, and size-bounding live in the substrate; a snapshot
             # failure must never affect the handoff emit above or this
             # hook's advisory evaluation.
@@ -1331,7 +1334,14 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
                     task_id,
                     subject,
                     owner,
-                    {**metadata, **incoming_md},
+                    {
+                        **metadata,
+                        **{
+                            k: v
+                            for k, v in incoming_md.items()
+                            if v is not None
+                        },
+                    },
                 )
             except Exception:
                 pass
@@ -1751,6 +1761,10 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
         # do not merge the conditions. Content-key dedup in the substrate
         # makes the re-fire idempotent: an unchanged payload no-ops, a
         # changed one emits a superseding event readers resolve latest-ts.
+        # A None-valued incoming key is the platform's DELETE op (set-to-null
+        # removes the key), so the overlay drops it rather than mirroring a
+        # phantom null the disk state no longer carries; a delete-ONLY write
+        # therefore mirrors the disk state as-is (deduping if unchanged).
         # is_lead-gated like every lead-frame emit: only the lead's process
         # resolves the canonical journal; a teammate frame self-drops.
         if (
@@ -1772,7 +1786,14 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
                     task_id,
                     task_a.get("subject") or "",
                     task_a.get("owner"),
-                    {**disk_md, **incoming_metadata},
+                    {
+                        **disk_md,
+                        **{
+                            k: v
+                            for k, v in incoming_metadata.items()
+                            if v is not None
+                        },
+                    },
                 )
             except Exception:
                 pass

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -671,6 +671,17 @@ def _emit_lead_side_agent_handoff(
     this hook's livelock-safe exit-0 posture; never raises to the caller).
     """
     try:
+        # #1165 parity: sanitize task_id at intake, mirroring b1's intake
+        # pattern (agent_handoff_emitter sanitizes before its filesystem
+        # sinks). Covers BOTH b2 call sites (acceptance-commit + the
+        # write-after-completion backstop route through this function).
+        # Without this, a pathological task_id yields a b1/b2 divergence:
+        # the emitted event's task_id form differs from b1's (breaking the
+        # reader's cross-family join) and the O_EXCL marker key can split
+        # (b1 claims the sanitized form, b2 the raw form → dedup miss →
+        # double emit). The marker resolver's own internal sanitization is
+        # retained — this intake pass is what aligns the EVENT field.
+        task_id = sanitize_path_component(str(task_id))
         # Emit-eligibility (mirrors b1). owner-empty / teachback / signal-task
         # / handoff-absent all suppress, same as the emitter's bypass gates.
         # #917 R2 (validate-before-claim): also reject a WHITESPACE-only owner —

--- a/pact-plugin/skills/pact-handoff-harvest/SKILL.md
+++ b/pact-plugin/skills/pact-handoff-harvest/SKILL.md
@@ -91,6 +91,21 @@ for task_id in unprocessed:
 
 Read all HANDOFFs before proceeding to extraction.
 
+### Step 3.1: Resolve Sibling Metadata (three-tier snapshot fallback)
+
+A HANDOFF may reference sibling metadata keys on its task (verification records, parked analyses, teachback history, variety rationales). Those siblings die with the task file when the task store drains — but every completed task's non-handoff metadata is also mirrored into the journal as a `task_metadata_snapshot` event. Resolve sibling keys through this three-tier fallback:
+
+1. **Task file** (freshest; may be drained): `read_task_metadata(task_id)` — the raw task JSON's `metadata` object, exactly as in the Step 3 pseudocode.
+2. **Snapshot fallback** (GC-proof): read the mirrored snapshots via the existing subcommand (explicit `--session-dir`, masked-read-safe):
+
+   ```bash
+   SNAPSHOTS=$(python3 "{plugin_root}/hooks/shared/session_journal.py" read \
+                 --session-dir "$SESSION_DIR" --type task_metadata_snapshot)
+   ```
+
+   As in Step 1, `read` prints a **JSON ARRAY** — parse the whole stdout once, then iterate. Each event carries `task_id`, `metadata` (the size-bounded sibling-key payload), `subject`, `occupant`, and optionally `owner` / `task_type` / `truncated`. **Selection**: filter to events with the matching `task_id`; because the platform reuses task_ids across arcs, when you are resolving siblings FOR an `agent_handoff` event, additionally filter to events whose `occupant` equals `occupant_hash(agent, task_subject)` computed from that handoff event's own fields with the SAME shared function (`python3 -c "import sys; sys.path.insert(0, '{plugin_root}/hooks'); from shared.agent_handoff_marker import occupant_hash; print(occupant_hash(sys.argv[1], sys.argv[2]))" "$AGENT" "$TASK_SUBJECT"`) — never a local reimplementation. Aggregate (whole-arc) reads apply the arc-scoped `--since` bound first, exactly as Step 10 does for `variety_assessed`. Take the **latest-`ts`** event within the match, **last-wins on an equal `ts`** (journal events stamp `ts` at second granularity, so a same-second re-emit ties; the later line in journal order is the authoritative one — the same tie-break the artifact-paths supersede uses) — a task may legally carry multiple snapshots (a changed payload after completion re-emits; the latest is the authoritative end-state). A value of shape `{"_truncated": true, ...}` or a top-level `_dropped_keys` list means the full value lived only in the task file — note the truncation in your synthesis, don't fake the missing content.
+3. **Graceful degrade**: neither source resolves → record the gap (task_id, key, timestamp) exactly as Step 3's report-gap tier does; never invent content.
+
 ### Step 3.5: Resolve and Read Phase Artifacts (always)
 
 Each phase's HANDOFF is the **distilled frame**; the phase's disk artifact (e.g. `docs/preparation/{feature}.md`, `docs/architecture/{feature}.md`, `docs/plans/{slug}-plan.md`, `docs/review/…`) is the **fuller substance**. The lead writes a path-only `artifact_paths` journal event pointing at each phase's artifact(s); that event lives in the journal (outside any worktree), so it survives `git worktree remove` even though the pointed-at file is worktree-ephemeral. **Always** resolve these events and fold the artifact substance into the same synthesis the HANDOFF drives.
@@ -215,6 +230,7 @@ After processing HANDOFFs, gather calibration metrics for the orchestrator's var
     summary="Calibration check: variety {X}")
   ```
 - On team-lead's response, compute the full CalibrationRecord and save to pact-memory with entities `['orchestration_calibration', '{domain}']`
+- **Consumer exclusivity guard**: the calibration aggregation reads `dispatch_variety` events ONLY. `task_metadata_snapshot` events also carry `variety` payloads, but the snapshot is a recovery/breadth source for sibling-key CONTENT (Step 3.1) and must NEVER become an additive second numerator for the coverage ratio — counting both would double-count dispatches.
 
 ---
 

--- a/pact-plugin/tests/test_marker_namespace.py
+++ b/pact-plugin/tests/test_marker_namespace.py
@@ -1,0 +1,102 @@
+"""
+Location: pact-plugin/tests/test_marker_namespace.py
+Summary: Tests for the keyword-only marker `namespace` parameter on
+         agent_handoff_marker's resolver/claim/rollback trio, and the
+         cross-namespace independence pair between the agent_handoff
+         default namespace and the task_metadata_snapshot namespace
+         (via the substrate's hard-bound wrappers).
+Used by: pytest. The byte-identical-DEFAULT proof is the existing
+         test_agent_handoff_marker.py suite passing UNMODIFIED — this file
+         only covers what that suite structurally cannot: the non-default
+         namespace and the two-namespace interaction.
+"""
+
+from pathlib import Path
+
+from shared.agent_handoff_marker import (
+    _DEFAULT_MARKER_NAMESPACE,
+    _marker_dir,
+    already_emitted,
+    unclaim,
+)
+from shared.task_metadata_snapshot import (
+    SNAPSHOT_MARKER_NAMESPACE,
+    snapshot_already_emitted,
+    snapshot_unclaim,
+)
+
+TEAM = "team-ns"
+TASK = "7"
+KEY = "aaaabbbb"  # content-key / occupant slot — just a string to the marker
+
+
+class TestNamespaceParameter:
+    def test_default_dir_name_unchanged(self, tmp_path, monkeypatch):
+        """The default namespace resolves the pre-refactor directory name —
+        the constant pins the byte-identical-default contract."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert _DEFAULT_MARKER_NAMESPACE == ".agent_handoff_emitted"
+        assert _marker_dir(TEAM).name == ".agent_handoff_emitted"
+        assert _marker_dir(TEAM) == _marker_dir(
+            TEAM, namespace=_DEFAULT_MARKER_NAMESPACE
+        )
+
+    def test_namespace_changes_leaf_dir_only(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        default_dir = _marker_dir(TEAM)
+        snapshot_dir = _marker_dir(TEAM, namespace=SNAPSHOT_MARKER_NAMESPACE)
+        assert snapshot_dir.name == ".task_metadata_snapshot_emitted"
+        assert snapshot_dir.parent == default_dir.parent
+
+    def test_claim_and_dedup_in_custom_namespace(self, tmp_path, monkeypatch):
+        """Claim/dedup semantics are namespace-scoped and unchanged: first
+        call claims (False), second dedups (True), unclaim re-opens."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        namespace = SNAPSHOT_MARKER_NAMESPACE
+        assert (
+            already_emitted(TEAM, TASK, KEY, namespace=namespace) is False
+        )
+        assert already_emitted(TEAM, TASK, KEY, namespace=namespace) is True
+        unclaim(TEAM, TASK, KEY, namespace=namespace)
+        assert (
+            already_emitted(TEAM, TASK, KEY, namespace=namespace) is False
+        )
+
+
+class TestCrossNamespaceIndependence:
+    """The ratified independence pair: neither event family's marker can
+    suppress the other's."""
+
+    def test_handoff_claim_does_not_suppress_snapshot(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        # Claim the HANDOFF marker (default namespace) for (team, task).
+        assert already_emitted(TEAM, TASK, KEY) is False
+        assert already_emitted(TEAM, TASK, KEY) is True  # positive control
+        # The snapshot family still claims fresh.
+        assert snapshot_already_emitted(TEAM, TASK, KEY) is False
+
+    def test_snapshot_claim_does_not_suppress_handoff(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        # Claim the SNAPSHOT marker for (team, task).
+        assert snapshot_already_emitted(TEAM, TASK, KEY) is False
+        assert snapshot_already_emitted(TEAM, TASK, KEY) is True
+        # The handoff family still claims fresh.
+        assert already_emitted(TEAM, TASK, KEY) is False
+
+    def test_snapshot_unclaim_never_touches_handoff_marker(
+        self, tmp_path, monkeypatch
+    ):
+        """The hard-bound wrapper rollback removes ONLY the snapshot-
+        namespace marker — the poisoned-marker shape a forgotten namespace
+        arg would produce is impossible through the wrappers."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert already_emitted(TEAM, TASK, KEY) is False
+        assert snapshot_already_emitted(TEAM, TASK, KEY) is False
+        snapshot_unclaim(TEAM, TASK, KEY)
+        # Snapshot marker gone; handoff marker still owned.
+        assert snapshot_already_emitted(TEAM, TASK, KEY) is False
+        assert already_emitted(TEAM, TASK, KEY) is True

--- a/pact-plugin/tests/test_session_journal.py
+++ b/pact-plugin/tests/test_session_journal.py
@@ -3335,6 +3335,14 @@ class TestValidateEventSchemaPerType:
             "task_id": "41",
             "rationale_articulates_this_dispatch": "yes",
         },
+        # Required fields only — subject/owner/task_type/truncated/occupant
+        # are optional (see TestValidateOptionalFieldTypes); the missing-field
+        # test removes each sample key and expects rejection, which only
+        # holds for required ones.
+        "task_metadata_snapshot": {
+            "task_id": "9",
+            "metadata": {"teachback_submit": {"understanding": "x"}},
+        },
         "phase_transition": {"phase": "CODE", "status": "started"},
         "checkpoint": {"phase": "CODE"},
         "agent_dispatch": {"agent": "coder", "task_id": "1", "phase": "CODE"},
@@ -4182,6 +4190,90 @@ class TestValidateOptionalFieldTypes:
         assert reason == (
             f"optional field 'concern' for type 'teachback_ack' must "
             f"be str, got {got_name}"
+        )
+
+    def test_task_metadata_snapshot_optionals_declared(self):
+        """task_metadata_snapshot declares its five optional fields.
+
+        Pins the field-name → type contract for the snapshot event's
+        optional payload (subject sentinel, ownerless-task owner absence,
+        signal-task task_type mirror, truncation flag, task-id-reuse
+        occupant discriminator). The required-fields registration for
+        task_metadata_snapshot is what activates this optional check —
+        _validate_event_schema short-circuits on unknown types.
+        """
+        from shared.session_journal import _OPTIONAL_FIELDS_BY_TYPE
+
+        assert _OPTIONAL_FIELDS_BY_TYPE.get("task_metadata_snapshot") == {
+            "subject": str,
+            "owner": str,
+            "task_type": str,
+            "truncated": bool,
+            "occupant": str,
+        }
+
+    def test_task_metadata_snapshot_full_optional_payload_passes(self):
+        """A snapshot event carrying every optional field, correctly typed,
+        validates clean — the full (owned, signal-typed, truncated) shape."""
+        from shared.session_journal import _validate_event_schema, make_event
+
+        event = make_event(
+            "task_metadata_snapshot",
+            task_id="9",
+            metadata={"teachback_submit": {"understanding": "x"}},
+            subject="backend-coder: implement thing",
+            owner="backend-coder",
+            task_type="blocker",
+            truncated=True,
+            occupant="a1b2c3d4e5f60718",
+        )
+        ok, reason = _validate_event_schema(event)
+        assert ok is True
+        assert reason == "ok"
+
+    def test_task_metadata_snapshot_optionals_absent_passes(self):
+        """Required-only snapshot (ownerless, untruncated) validates clean —
+        optional absence is valid by definition."""
+        from shared.session_journal import _validate_event_schema, make_event
+
+        event = make_event(
+            "task_metadata_snapshot",
+            task_id="9",
+            metadata={"variety": {"total": 7}},
+        )
+        ok, reason = _validate_event_schema(event)
+        assert ok is True
+        assert reason == "ok"
+
+    @pytest.mark.parametrize(
+        "field, bad_value, expected_name, got_name",
+        [
+            ("subject", 42, "str", "int"),
+            ("owner", ["backend-coder"], "str", "list"),
+            ("task_type", 1, "str", "int"),
+            ("truncated", "yes", "bool", "str"),
+            ("occupant", 0xA1B2, "str", "int"),
+        ],
+        ids=["subject", "owner", "task_type", "truncated", "occupant"],
+    )
+    def test_task_metadata_snapshot_wrong_type_rejected(
+        self, field, bad_value, expected_name, got_name
+    ):
+        """task_metadata_snapshot with a mis-typed optional field fails
+        validation with the canonical optional-field reason format."""
+        from shared.session_journal import _validate_event_schema, make_event
+
+        event = make_event(
+            "task_metadata_snapshot",
+            task_id="9",
+            metadata={"variety": {"total": 7}},
+            **{field: bad_value},
+        )
+        ok, reason = _validate_event_schema(event)
+        assert ok is False, f"{field}={bad_value!r} should be rejected"
+        assert reason == (
+            f"optional field '{field}' for type 'task_metadata_snapshot' "
+            f"must be {expected_name}, got {got_name}"
         )
 
     def test_cleanup_summary_all_fields_pass(self):

--- a/pact-plugin/tests/test_snapshot_adversarial_matrix.py
+++ b/pact-plugin/tests/test_snapshot_adversarial_matrix.py
@@ -1,0 +1,354 @@
+"""
+Location: pact-plugin/tests/test_snapshot_adversarial_matrix.py
+Summary: TEST-phase adversarial/boundary depth for task_metadata_snapshot —
+         exact cap boundaries (per-value and payload, computed against the
+         imported substrate constants, never re-declared), the dual-cap
+         interaction case (N same-size values each under the per-value cap
+         whose total exceeds the payload cap), jumbo emit-level payloads
+         over a REAL tmp journal, pathological-input characterizations
+         (non-JSON-serializable values; NaN floats), the §6 task-id-reuse
+         occupant join, and the substrate-level writability defer.
+
+         Complements (never duplicates) the CODE-phase suites: the
+         substrate unit file pins stage semantics with synthetic jumbos;
+         THIS file pins the exact boundary arithmetic, the emit-level
+         behavior of hostile inputs through the REAL append_event/
+         read_events pair, and the reader-side join contract.
+
+Harness: the L2 exemplar seam (test_agent_handoff_emitter_integration.py) —
+Path.home -> tmp + the pact_context fixture; REAL journal writes and reads,
+no append_event spy. Characterization tests are labeled as such in their
+docstrings: they document CURRENT behavior for the pending-disposition
+record, not an endorsed contract.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+from shared.agent_handoff_marker import occupant_hash  # noqa: E402
+from shared.session_journal import read_events  # noqa: E402
+from shared.task_metadata_snapshot import (  # noqa: E402
+    PAYLOAD_CAP,
+    PER_VALUE_CAP,
+    _canonical_bytes,
+    build_snapshot_payload,
+    emit_task_metadata_snapshot,
+    payload_hash8,
+)
+
+TEAM = "pact-advmatrix"
+SID = "cccccccc-3333-4444-5555-666666666666"
+
+
+def _is_marker_shape(value: object) -> bool:
+    """Reader-side marker recognition (the harvest consumer's view)."""
+    return isinstance(value, dict) and value.get("_truncated") is True
+
+
+@pytest.fixture
+def live_env(tmp_path, monkeypatch, pact_context):
+    """Real tmp home + real session context: append_event/read_events
+    resolve a REAL on-disk journal; markers land on real tmp disk."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    pact_context(team_name=TEAM, session_id=SID, project_dir="/test/project")
+    return tmp_path
+
+
+class TestPerValueCapExactBoundary:
+    """cap-1 / cap / cap+1 on the canonical size of a single value.
+
+    A str value's canonical form is the quoted string: len = n + 2. The
+    triple is derived from the imported PER_VALUE_CAP, so a cap change
+    re-derives the boundary instead of silently passing stale arithmetic.
+    """
+
+    def _value_of_canonical_size(self, size: int) -> str:
+        value = "a" * (size - 2)
+        assert len(_canonical_bytes(value)) == size
+        return value
+
+    def test_one_under_cap_kept_verbatim(self):
+        value = self._value_of_canonical_size(PER_VALUE_CAP - 1)
+        payload, truncated = build_snapshot_payload({"k": value})
+        assert payload["k"] == value
+        assert truncated is False
+
+    def test_exactly_at_cap_kept_verbatim(self):
+        value = self._value_of_canonical_size(PER_VALUE_CAP)
+        payload, truncated = build_snapshot_payload({"k": value})
+        assert payload["k"] == value
+        assert truncated is False
+
+    def test_one_over_cap_marked(self):
+        value = self._value_of_canonical_size(PER_VALUE_CAP + 1)
+        payload, truncated = build_snapshot_payload({"k": value})
+        marker = payload["k"]
+        assert _is_marker_shape(marker)
+        assert marker["original_bytes"] == PER_VALUE_CAP + 1
+        assert truncated is True
+
+
+class TestPayloadCapExactBoundary:
+    """Exact payload-cap arithmetic with every value under the per-value cap.
+
+    Four fixed 13KB values + one pad value sized so the WHOLE canonical
+    payload lands exactly at PAYLOAD_CAP (then +1). Sizes are measured with
+    the substrate's own _canonical_bytes — the same yardstick stage 2 uses.
+    """
+
+    def _payload_at(self, total: int) -> dict:
+        fixed = {f"k{i}": "x" * (13 * 1024) for i in range(4)}
+        base = dict(fixed)
+        base["pad"] = ""
+        remainder = total - len(_canonical_bytes(base))
+        assert remainder > 0, "fixed part must sit under the target"
+        metadata = dict(fixed)
+        metadata["pad"] = "p" * remainder
+        assert len(_canonical_bytes(metadata)) == total
+        for value in metadata.values():
+            assert len(_canonical_bytes(value)) <= PER_VALUE_CAP
+        return metadata
+
+    def test_exactly_at_payload_cap_untouched(self):
+        metadata = self._payload_at(PAYLOAD_CAP)
+        payload, truncated = build_snapshot_payload(metadata)
+        assert payload == metadata
+        assert truncated is False
+
+    def test_one_over_payload_cap_single_largest_first_eviction(self):
+        metadata = self._payload_at(PAYLOAD_CAP + 1)
+        payload, truncated = build_snapshot_payload(metadata)
+        assert truncated is True
+        markers = [k for k, v in payload.items() if _is_marker_shape(v)]
+        # The four 13KB values tie as largest (pad is smaller); ascending
+        # lexicographic tie-break pins the victim to k0. One eviction
+        # (~13KB -> ~1KB marker) lands the payload far back under cap.
+        assert markers == ["k0"]
+        assert payload["k0"]["original_bytes"] == len(
+            _canonical_bytes(metadata["k0"])
+        )
+        assert len(_canonical_bytes(payload)) <= PAYLOAD_CAP
+        for key in ("k1", "k2", "k3", "pad"):
+            assert payload[key] == metadata[key]
+
+
+class TestDualCapInteraction:
+    """The five-15KB case: each value under PER_VALUE_CAP, total over
+    PAYLOAD_CAP — only the payload cap fires, with exact marker placement
+    and insertion-order-independent bytes/hash."""
+
+    FIVE = {k: k * (15 * 1024) for k in ("a", "b", "c", "d", "e")}
+
+    def test_exactly_one_eviction_at_lexicographically_smallest_tie(self):
+        payload, truncated = build_snapshot_payload(self.FIVE)
+        assert truncated is True
+        markers = [k for k, v in payload.items() if _is_marker_shape(v)]
+        assert markers == ["a"], (
+            "equal sizes tie -> ascending key order picks 'a'; exactly one "
+            "eviction suffices (15KB value -> ~1KB marker)"
+        )
+        for key in ("b", "c", "d", "e"):
+            assert payload[key] == self.FIVE[key]
+        assert len(_canonical_bytes(payload)) <= PAYLOAD_CAP
+
+    def test_insertion_order_shuffles_byte_identical_and_same_hash(self):
+        orders = [
+            ("a", "b", "c", "d", "e"),
+            ("e", "d", "c", "b", "a"),
+            ("c", "a", "e", "b", "d"),
+        ]
+        results = []
+        for order in orders:
+            metadata = {k: self.FIVE[k] for k in order}
+            payload, _ = build_snapshot_payload(metadata)
+            results.append(
+                (_canonical_bytes(payload), payload_hash8(payload))
+            )
+        assert len({r[0] for r in results}) == 1, "byte-identical payloads"
+        assert len({r[1] for r in results}) == 1, "identical content keys"
+
+    def test_distinct_sizes_evict_strictly_largest_not_key_order(self):
+        # Non-tie control: 'z' holds the largest value, so largest-first
+        # must pick 'z' even though it is lexicographically last — proving
+        # the size criterion dominates and the key order is only the
+        # tie-break.
+        metadata = {
+            "a": "a" * (12 * 1024),
+            "m": "m" * (13 * 1024),
+            "z": "z" * (15 * 1024),
+            "q": "q" * (14 * 1024),
+            "f": "f" * (12 * 1024),
+        }
+        payload, truncated = build_snapshot_payload(metadata)
+        assert truncated is True
+        markers = [k for k, v in payload.items() if _is_marker_shape(v)]
+        assert markers == ["z"]
+
+
+class TestJumboEmitLevel:
+    """A multi-MB value through the ONE emit routine over a REAL journal:
+    never raises, lands exactly one bounded, strictly-valid JSONL line."""
+
+    def test_5mb_value_emits_bounded_valid_event(self, live_env):
+        emit_task_metadata_snapshot(
+            TEAM, "77", "jumbo", "owner-x",
+            {"blob": "B" * (5 * 1024 * 1024), "note": "small sibling"},
+        )
+        events = read_events("task_metadata_snapshot")
+        assert len(events) == 1
+        event = events[0]
+        assert event["truncated"] is True
+        assert _is_marker_shape(event["metadata"]["blob"])
+        assert event["metadata"]["blob"]["original_bytes"] == (
+            5 * 1024 * 1024 + 2
+        )
+        assert event["metadata"]["note"] == "small sibling"
+
+        journal = (live_env / ".claude" / "pact-sessions" / "project" / SID
+                   / "session-journal.jsonl")
+        lines = [ln for ln in
+                 journal.read_text(encoding="utf-8").splitlines() if ln]
+        assert len(lines) == 1
+        assert len(lines[0].encode("utf-8")) < PAYLOAD_CAP + 16 * 1024, (
+            "the event line must stay near the payload cap, never carry "
+            "the raw 5MB value"
+        )
+        # Strict JSON validity of the line (reject NaN/Infinity tokens).
+        json.loads(
+            lines[0],
+            parse_constant=lambda c: (_ for _ in ()).throw(
+                ValueError(f"non-strict JSON constant {c}")
+            ),
+        )
+
+
+class TestPathologicalInputCharacterization:
+    """CHARACTERIZATION (not endorsement): current behavior of inputs that
+    the platform's JSON layer cannot produce but a direct Python caller
+    could. Documented for the pending-disposition record; if a disposition
+    ruling changes the semantics, update these alongside it."""
+
+    def test_non_serializable_value_no_event_no_marker_poison(
+            self, live_env):
+        """A non-JSON-serializable value (set) raises TypeError inside
+        _canonical_bytes DURING payload build — before any marker claim —
+        and the hermetic emit swallows it. CHARACTERIZATION: the snapshot
+        is silently dropped (whole event, including serializable siblings),
+        but no marker is claimed, so nothing is poisoned: a later fire with
+        clean metadata emits normally."""
+        emit_task_metadata_snapshot(
+            TEAM, "88", "subj", "own",
+            {"bad": {1, 2, 3}, "good": "sibling"},
+        )
+        assert read_events("task_metadata_snapshot") == []
+        marker_dir = (live_env / ".claude" / "teams" / TEAM
+                      / ".task_metadata_snapshot_emitted")
+        assert not marker_dir.exists() or not any(marker_dir.iterdir()), (
+            "validate-before-claim: the failed build must not claim"
+        )
+        # Recovery leg: same task, clean metadata -> emits.
+        emit_task_metadata_snapshot(TEAM, "88", "subj", "own",
+                                    {"good": "sibling"})
+        assert len(read_events("task_metadata_snapshot")) == 1
+
+    def test_nan_float_writes_spec_invalid_line_python_reader_tolerates(
+            self, live_env):
+        """CHARACTERIZATION of the NaN wrinkle (reported in the TEST-phase
+        HANDOFF): json.dumps defaults to allow_nan=True, so a float('nan')
+        metadata value survives the build and append_event writes a line
+        containing the bare NaN token — which is NOT spec-valid JSON.
+        Python's own read_events tolerates it (parse_constant default),
+        so the journal file is not poisoned for in-repo readers, but any
+        strict consumer (jq, non-Python tooling) rejects that line.
+        Unreachable via the platform (JSON cannot carry NaN); reachable
+        only by a direct Python caller."""
+        emit_task_metadata_snapshot(
+            TEAM, "99", "subj", "own", {"x": float("nan"), "y": "ok"},
+        )
+        events = read_events("task_metadata_snapshot")
+        assert len(events) == 1, "Python-side read tolerates the line"
+        assert events[0]["metadata"]["y"] == "ok"
+
+        journal = (live_env / ".claude" / "pact-sessions" / "project" / SID
+                   / "session-journal.jsonl")
+        line = journal.read_text(encoding="utf-8").splitlines()[0]
+        assert "NaN" in line, "the bare token is on disk"
+        with pytest.raises(ValueError):
+            json.loads(
+                line,
+                parse_constant=lambda c: (_ for _ in ()).throw(
+                    ValueError(f"strict reject {c}")
+                ),
+            )
+
+
+class TestTaskIdReuseOccupantJoin:
+    """§6 ruling: the occupant field must discriminate a reused task_id —
+    a reader holding (owner, subject) selects ITS snapshot, not the other
+    arc's, via the shared occupant_hash SSOT."""
+
+    def test_same_task_id_two_occupants_join_selects_each(self, live_env):
+        emit_task_metadata_snapshot(
+            TEAM, "5", "arc-1: design", "architect",
+            {"variety": {"total": 6}},
+        )
+        emit_task_metadata_snapshot(
+            TEAM, "5", "arc-2: implement", "backend-coder",
+            {"variety": {"total": 9}},
+        )
+        events = read_events("task_metadata_snapshot")
+        assert len(events) == 2, "different occupants -> both events"
+
+        arc1 = [e for e in events
+                if e["occupant"] == occupant_hash("architect",
+                                                  "arc-1: design")]
+        arc2 = [e for e in events
+                if e["occupant"] == occupant_hash("backend-coder",
+                                                  "arc-2: implement")]
+        assert len(arc1) == 1 and arc1[0]["metadata"]["variety"]["total"] == 6
+        assert len(arc2) == 1 and arc2[0]["metadata"]["variety"]["total"] == 9
+
+    def test_ownerless_occupant_discriminates_via_subject(self, live_env):
+        emit_task_metadata_snapshot(
+            TEAM, "6", "signal: halt build", None, {"type": "blocker",
+                                                    "ctx": "one"},
+        )
+        emit_task_metadata_snapshot(
+            TEAM, "6", "signal: halt deploy", None, {"type": "blocker",
+                                                     "ctx": "two"},
+        )
+        events = read_events("task_metadata_snapshot")
+        assert len(events) == 2
+        halt_build = [e for e in events
+                      if e["occupant"] == occupant_hash("",
+                                                        "signal: halt build")]
+        assert len(halt_build) == 1
+        assert halt_build[0]["metadata"]["ctx"] == "one"
+        assert "owner" not in halt_build[0]
+
+
+class TestWritabilityDeferSubstrate:
+    """The substrate's own defer leg with NO session context at all (the
+    unpersisted-frame topology): no journal path -> no event, no claim —
+    DEFER-not-poison at the lowest level, complementing the coder's seam-C
+    stdin-frame test."""
+
+    def test_no_context_no_event_no_marker_claim(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        # No pact_context fixture write: get_journal_path resolves "".
+        emit_task_metadata_snapshot(
+            TEAM, "11", "subj", "own", {"k": "v"},
+        )
+        marker_dir = (tmp_path / ".claude" / "teams" / TEAM
+                      / ".task_metadata_snapshot_emitted")
+        assert not marker_dir.exists(), (
+            "an unwritable frame must claim NOTHING (a claim here would "
+            "permanently suppress the writable seam's later emit)"
+        )

--- a/pact-plugin/tests/test_snapshot_provenance_semantics.py
+++ b/pact-plugin/tests/test_snapshot_provenance_semantics.py
@@ -1,0 +1,269 @@
+"""
+Location: pact-plugin/tests/test_snapshot_provenance_semantics.py
+Summary: Assertion suite for the PROVENANCE-tracked marker-identity ruling
+         in build_snapshot_payload (freeze doc §3): marker identity is a
+         local this-run set, never a shape test. A caller value that merely
+         LOOKS marker-shaped is ordinary data — a normal stage-2 eviction
+         candidate re-markered with its TRUE sizes — and stage 3's
+         original_bytes sort only ever sees this run's own int-bearing
+         markers (total by construction). Extends the YELLOW-1 adversarial
+         class (caller-owned marker-shaped input) from stage 3a to every
+         stage, and pins the totality invariant: every input key survives
+         in the payload or in _dropped_keys.
+
+============================ NON-VACUITY ========================================
+The lookalike-eviction assertions are coupled to the provenance mechanism by
+a behavioral discriminator, not by presence: under the superseded
+shape-tested candidacy, a lookalike was eviction-EXEMPT and its bogus
+original_bytes survived verbatim (and a non-int original_bytes raised
+TypeError inside the hermetic emit = silently dropped snapshot). Reverting
+the provenance commit flips test_lookalike_is_evicted_with_true_sizes,
+test_all_lookalike_payload_*, and test_non_int_original_bytes_* to red.
+================================================================================
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+from shared.session_journal import read_events  # noqa: E402
+from shared.task_metadata_snapshot import (  # noqa: E402
+    PAYLOAD_CAP,
+    PER_VALUE_CAP,
+    _canonical_bytes,
+    build_snapshot_payload,
+    emit_task_metadata_snapshot,
+)
+
+TEAM = "pact-provenance"
+SID = "dddddddd-4444-5555-6666-777777777777"
+
+
+def _lookalike(head_chars: int, original_bytes: object = 999_999_999) -> dict:
+    """A caller value with EXACTLY the marker shape but caller-owned
+    content: a bogus original_bytes and an arbitrary-size head."""
+    return {
+        "_truncated": True,
+        "original_bytes": original_bytes,
+        "head": "L" * head_chars,
+    }
+
+
+def _marker_shaped(value: object) -> bool:
+    return (
+        isinstance(value, dict)
+        and set(value.keys()) == {"_truncated", "original_bytes", "head"}
+        and value.get("_truncated") is True
+    )
+
+
+@pytest.fixture
+def live_env(tmp_path, monkeypatch, pact_context):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    pact_context(team_name=TEAM, session_id=SID, project_dir="/test/project")
+    return tmp_path
+
+
+class TestLookalikeIsOrdinaryValue:
+    def test_lookalike_untouched_when_no_cap_pressure(self):
+        # Ordinary-data semantics cut both ways: with no cap in play a
+        # lookalike passes through VERBATIM (bogus original_bytes and all),
+        # exactly like any other value.
+        look = _lookalike(64)
+        payload, truncated = build_snapshot_payload({"look": look, "k": "v"})
+        assert payload["look"] == look
+        assert truncated is False
+
+    def test_lookalike_is_evicted_with_true_sizes(self):
+        # The behavioral discriminator vs shape-tested candidacy: the
+        # lookalike is the LARGEST value in an over-payload-cap mapping, so
+        # largest-first eviction must pick IT — and re-marker it with sizes
+        # computed from ITS serialization, discarding the bogus
+        # original_bytes. (Shape-tested candidacy left it exempt and evicted
+        # the next-largest real value instead.)
+        look = _lookalike(15 * 1024)
+        look_size = len(_canonical_bytes(look))
+        metadata = {
+            "look": look,
+            "b": "b" * (13 * 1024),
+            "c": "c" * (13 * 1024),
+            "d": "d" * (13 * 1024),
+            "e": "e" * (13 * 1024),
+        }
+        assert len(_canonical_bytes(metadata)) > PAYLOAD_CAP
+        payload, truncated = build_snapshot_payload(metadata)
+        assert truncated is True
+        evicted = payload["look"]
+        assert _marker_shaped(evicted)
+        assert evicted["original_bytes"] == look_size, (
+            "OUR marker must carry the lookalike's TRUE canonical size, "
+            "not its caller-authored 999999999"
+        )
+        assert evicted["original_bytes"] != 999_999_999
+        # head = prefix of the LOOKALIKE's canonical serialization.
+        assert evicted["head"] == (
+            _canonical_bytes(look)[:1024].decode("utf-8")
+        )
+        for key in ("b", "c", "d", "e"):
+            assert payload[key] == metadata[key]
+
+    def test_lookalike_over_per_value_cap_marked_at_stage1(self):
+        look = _lookalike(20 * 1024)  # canonical > PER_VALUE_CAP
+        look_size = len(_canonical_bytes(look))
+        assert look_size > PER_VALUE_CAP
+        payload, truncated = build_snapshot_payload({"look": look})
+        assert truncated is True
+        assert _marker_shaped(payload["look"])
+        assert payload["look"]["original_bytes"] == look_size
+
+    def test_nested_marker_shape_is_never_consulted(self):
+        # Marker shape NESTED inside a value is plain data at every stage:
+        # small -> verbatim; the whole OUTER value over-cap -> one OUR
+        # marker for the outer value.
+        small = {"inner": _lookalike(32)}
+        payload, truncated = build_snapshot_payload({"n": small})
+        assert payload["n"] == small
+        assert truncated is False
+
+        big = {"inner": _lookalike(20 * 1024)}
+        payload, truncated = build_snapshot_payload({"n": big})
+        assert _marker_shaped(payload["n"])
+        assert payload["n"]["original_bytes"] == len(_canonical_bytes(big))
+        assert truncated is True
+
+
+class TestStage3TotalityUnderLookalikes:
+    def test_all_lookalike_payload_over_cap_builds_without_error(self):
+        # Under shape-tested candidacy an all-lookalike over-cap payload had
+        # ZERO stage-2 candidates (all exempt) and stage 3a sorted the
+        # lookalikes' caller-owned original_bytes. Under provenance they are
+        # ordinary values: evicted normally, and stage 3 sees only this
+        # run's own markers.
+        metadata = {
+            f"k{i}": _lookalike(15 * 1024, original_bytes=999_999_999 - i)
+            for i in range(5)
+        }
+        assert len(_canonical_bytes(metadata)) > PAYLOAD_CAP
+        payload, truncated = build_snapshot_payload(metadata)
+        assert truncated is True
+        assert len(_canonical_bytes(payload)) <= PAYLOAD_CAP
+        assert set(payload) == set(metadata)
+
+    def test_non_int_original_bytes_lookalike_builds_and_emits(
+            self, live_env):
+        # FOCUS assertion (ruled in-arc): a lookalike whose original_bytes
+        # is NOT an int, inside a >PAYLOAD_CAP mapping, must neither raise
+        # in the builder nor silently drop the snapshot at the emit level.
+        # (Pre-provenance: stage 3a's sort hit TypeError on the str, the
+        # hermetic emit swallowed it, and the snapshot vanished.)
+        metadata = {
+            f"k{i}": _lookalike(15 * 1024, original_bytes="NOT-AN-INT")
+            for i in range(5)
+        }
+        assert len(_canonical_bytes(metadata)) > PAYLOAD_CAP
+
+        payload, truncated = build_snapshot_payload(metadata)  # no raise
+        assert truncated is True
+        assert len(_canonical_bytes(payload)) <= PAYLOAD_CAP
+
+        emit_task_metadata_snapshot(TEAM, "31", "subj", "own", metadata)
+        events = read_events("task_metadata_snapshot")
+        assert len(events) == 1, (
+            "the snapshot must EMIT (no drop): a TypeError inside the "
+            "hermetic guard would silently destroy the mirror this feature "
+            "exists to provide"
+        )
+        assert events[0]["truncated"] is True
+
+    def test_mixed_lookalike_and_real_values_deep_pressure_totality(self):
+        # Drive through stages 2 + 3a + 3b with lookalikes in the mix
+        # (non-int original_bytes included): every input key must survive
+        # in the payload or by name in _dropped_keys — never silently lost.
+        metadata: dict = {
+            f"big{i:04d}": "x" * (17 * 1024) for i in range(1400)
+        }
+        metadata.update({
+            f"look{i:04d}": _lookalike(15 * 1024,
+                                       original_bytes="NOT-AN-INT")
+            for i in range(100)
+        })
+        metadata["small"] = "tiny"
+        payload, truncated = build_snapshot_payload(metadata)
+        assert truncated is True
+        assert len(_canonical_bytes(payload)) <= PAYLOAD_CAP
+
+        dropped = payload.get("_dropped_keys", [])
+        surviving = (set(payload) - {"_dropped_keys"}) | set(dropped)
+        assert surviving == set(metadata), (
+            "totality: every input key in payload or _dropped_keys"
+        )
+        assert dropped == sorted(dropped)
+        # The whole event line the payload would produce stays strict JSON.
+        json.loads(json.dumps({"metadata": payload}))
+
+
+class TestReadOnlyInputAcrossStages:
+    """YELLOW-1 class extension: the caller's metadata (fed to the handoff
+    path at the seams) must be deep-intact after builds that traverse each
+    stage — including stage-2 eviction OF a lookalike and the 3b floor."""
+
+    def test_stage2_lookalike_eviction_leaves_caller_intact(self):
+        metadata = {
+            "look": _lookalike(15 * 1024),
+            "b": "b" * (13 * 1024),
+            "c": "c" * (13 * 1024),
+            "d": "d" * (13 * 1024),
+            "e": "e" * (13 * 1024),
+        }
+        before = copy.deepcopy(metadata)
+        build_snapshot_payload(metadata)
+        assert metadata == before
+
+    def test_stage3_floor_with_lookalikes_leaves_caller_intact(self):
+        metadata: dict = {
+            f"big{i:04d}": "x" * (17 * 1024) for i in range(1400)
+        }
+        metadata["look"] = _lookalike(15 * 1024,
+                                      original_bytes="NOT-AN-INT")
+        before = copy.deepcopy(metadata)
+        build_snapshot_payload(metadata)
+        assert metadata == before
+
+
+class TestDroppedKeysNameCollisionCharacterization:
+    """CHARACTERIZATION (not endorsement — reported in the TEST-phase
+    HANDOFF): "_dropped_keys" is a reserved name only on the OUTPUT side.
+    A caller metadata key literally named "_dropped_keys" passes through
+    verbatim under no pressure (reader ambiguity: indistinguishable from a
+    builder-authored list), and when the stage-3b floor fires, the
+    builder's own list CLOBBERS the caller's value — the caller content is
+    lost with no marker and no drop record. Unreachable in practice (needs
+    >1200 keys post-head-emptying AND that exact key name); documented so a
+    disposition ruling can cite observed behavior."""
+
+    def test_no_pressure_caller_dropped_keys_passes_through(self):
+        payload, truncated = build_snapshot_payload(
+            {"_dropped_keys": ["caller", "data"], "k": "v"}
+        )
+        assert payload["_dropped_keys"] == ["caller", "data"]
+        assert truncated is False
+
+    def test_floor_clobbers_caller_dropped_keys_value(self):
+        metadata: dict = {
+            f"key{i:04d}": "x" * (17 * 1024) for i in range(1500)
+        }
+        metadata["_dropped_keys"] = ["caller", "data"]
+        payload, truncated = build_snapshot_payload(metadata)
+        assert truncated is True
+        # Current behavior: the slot holds the BUILDER's drop list; the
+        # caller's ["caller", "data"] is gone without a trace.
+        assert payload["_dropped_keys"] != ["caller", "data"]
+        assert "caller" not in payload["_dropped_keys"]
+        assert all(k.startswith("key") for k in payload["_dropped_keys"])

--- a/pact-plugin/tests/test_snapshot_roundtrip.py
+++ b/pact-plugin/tests/test_snapshot_roundtrip.py
@@ -1,0 +1,216 @@
+"""
+Location: pact-plugin/tests/test_snapshot_roundtrip.py
+Summary: Acceptance round-trip for the journal-mirror durability contract —
+         write load-bearing metadata keys on a task, emit the snapshot at
+         a (real) lead completion, DRAIN the task file, and recover the
+         keys from the journal alone; plus the journal-also-removed
+         collapse leg (graceful degrade to an explicit gap, never invented
+         content). Uses a REAL on-disk journal (no append spies) so the
+         write→read cycle exercises the production serialization,
+         validation, and read paths end to end.
+Used by: pytest (the acceptance-criteria trace: load-bearing keys survive
+         task GC via journal events).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import shared.session_journal as session_journal  # noqa: E402
+import task_lifecycle_gate as tlg  # noqa: E402
+
+TEAM = "pact-test"
+LEAD = "PACT:pact-orchestrator"
+
+LOAD_BEARING = {
+    "teachback_submit": {
+        "understanding": "implement the mirror",
+        "first_action": "read the contract",
+    },
+    "variety": {"novelty": 2, "scope": 3, "uncertainty": 2, "risk": 3,
+                "total": 10},
+    "consultation_analysis": {"axes": ["scope", "risks"], "verdict": "go"},
+    "r2_verification": {"verified": True, "anchors": ["gate.py:1306"]},
+}
+
+
+def _seed_task(tmp_path, team, task_id, **fields):
+    tasks_dir = tmp_path / ".claude" / "tasks" / team
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    task_file = tasks_dir / f"{task_id}.json"
+    task_file.write_text(
+        json.dumps({"id": task_id, **fields}), encoding="utf-8"
+    )
+    return task_file
+
+
+def _completion_frame(task_id, subject, owner, metadata):
+    return {
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": task_id, "status": "completed"},
+        "tool_response": {
+            "task": {
+                "id": task_id,
+                "subject": subject,
+                "owner": owner,
+                "metadata": metadata,
+            }
+        },
+        "agent_type": LEAD,
+    }
+
+
+class TestAcceptanceRoundTrip:
+    def test_keys_survive_task_drain_via_journal(
+        self, tmp_path, monkeypatch, pact_context
+    ):
+        """Write keys → complete (real journal write) → delete the task
+        file → recover every load-bearing key from the journal alone."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        session_dir = tmp_path / "session"
+        monkeypatch.setattr(
+            session_journal, "_get_session_dir", lambda: str(session_dir)
+        )
+        pact_context(team_name=TEAM, session_id="s1")
+
+        task_file = _seed_task(
+            tmp_path,
+            TEAM,
+            "9",
+            subject="backend-coder: implement the mirror",
+            owner="backend-coder",
+            status="completed",
+            metadata=dict(LOAD_BEARING),
+        )
+        tlg.evaluate_lifecycle(
+            _completion_frame(
+                "9",
+                "backend-coder: implement the mirror",
+                "backend-coder",
+                dict(LOAD_BEARING),
+            )
+        )
+
+        # The drain: whole task-store destruction at a workflow boundary.
+        task_file.unlink()
+        assert not task_file.exists()
+
+        events = session_journal.read_events_from(
+            str(session_dir), "task_metadata_snapshot"
+        )
+        assert len(events) == 1
+        event = events[0]
+        assert event["task_id"] == "9"
+        assert event["subject"] == "backend-coder: implement the mirror"
+        assert event["owner"] == "backend-coder"
+        # Every load-bearing key recovered byte-equal from the journal.
+        assert event["metadata"] == LOAD_BEARING
+        assert "handoff" not in event["metadata"]
+
+    def test_journal_also_removed_collapses_to_explicit_gap(
+        self, tmp_path, monkeypatch, pact_context
+    ):
+        """The collapse leg: task file AND journal gone → the read returns
+        an empty list (an explicit, recordable gap) — no crash, no invented
+        content."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        session_dir = tmp_path / "session"
+        monkeypatch.setattr(
+            session_journal, "_get_session_dir", lambda: str(session_dir)
+        )
+        pact_context(team_name=TEAM, session_id="s1")
+
+        task_file = _seed_task(
+            tmp_path,
+            TEAM,
+            "10",
+            subject="backend-coder: collapse leg",
+            owner="backend-coder",
+            status="completed",
+            metadata=dict(LOAD_BEARING),
+        )
+        tlg.evaluate_lifecycle(
+            _completion_frame(
+                "10",
+                "backend-coder: collapse leg",
+                "backend-coder",
+                dict(LOAD_BEARING),
+            )
+        )
+        task_file.unlink()
+        journal = session_dir / "session-journal.jsonl"
+        assert journal.exists()
+        journal.unlink()
+
+        events = session_journal.read_events_from(
+            str(session_dir), "task_metadata_snapshot"
+        )
+        assert events == []
+
+    def test_supersession_latest_ts_is_end_state(
+        self, tmp_path, monkeypatch, pact_context
+    ):
+        """A post-completion metadata change re-emits; after the drain the
+        LATEST snapshot for the (task_id, occupant) group is the
+        authoritative end-state readers must take."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        session_dir = tmp_path / "session"
+        monkeypatch.setattr(
+            session_journal, "_get_session_dir", lambda: str(session_dir)
+        )
+        pact_context(team_name=TEAM, session_id="s1")
+
+        subject = "backend-coder: supersession probe"
+        _seed_task(
+            tmp_path,
+            TEAM,
+            "11",
+            subject=subject,
+            owner="backend-coder",
+            status="completed",
+            metadata=dict(LOAD_BEARING),
+        )
+        tlg.evaluate_lifecycle(
+            _completion_frame(
+                "11", subject, "backend-coder", dict(LOAD_BEARING)
+            )
+        )
+        # Late verification write on the already-completed task (backstop).
+        amended = {**LOAD_BEARING, "r2_verification": {"verified": False}}
+        _seed_task(
+            tmp_path,
+            TEAM,
+            "11",
+            subject=subject,
+            owner="backend-coder",
+            status="completed",
+            metadata=amended,
+        )
+        tlg.evaluate_lifecycle(
+            {
+                "tool_name": "TaskUpdate",
+                "tool_input": {
+                    "taskId": "11",
+                    "metadata": {"r2_verification": {"verified": False}},
+                },
+                "tool_response": {},
+                "agent_type": LEAD,
+            }
+        )
+
+        events = session_journal.read_events_from(
+            str(session_dir), "task_metadata_snapshot"
+        )
+        ours = [e for e in events if e["task_id"] == "11"]
+        assert len(ours) == 2, "changed payload must re-emit (supersession)"
+        # Reader rule: latest-ts, LAST-wins on an equal ts (make_event
+        # stamps at second granularity, so a same-second re-emit ties;
+        # journal order breaks the tie — the same semantics as the
+        # resolve_latest_artifacts supersede). sorted() is stable, so the
+        # last element is the latest-ts, last-written event.
+        latest = sorted(ours, key=lambda e: e["ts"])[-1]
+        assert latest["metadata"]["r2_verification"] == {"verified": False}
+        # Both events carry the same occupant — the reader's join key.
+        assert ours[0]["occupant"] == ours[1]["occupant"]

--- a/pact-plugin/tests/test_snapshot_seam_emitter.py
+++ b/pact-plugin/tests/test_snapshot_seam_emitter.py
@@ -1,0 +1,298 @@
+"""
+Location: pact-plugin/tests/test_snapshot_seam_emitter.py
+Summary: Seam tests for the task_metadata_snapshot emission point inside
+         agent_handoff_emitter.py — the teammate-frame twin positioned
+         after the transition gate and before the signal-task bypass.
+         Covers: snapshot emission for no-handoff sibling-bearing tasks
+         (the class unreachable after the emitter's hardened exits),
+         signal-task INCLUSION with the unconditional pinned leg
+         (agent_handoff suppression for signal tasks unchanged),
+         stdin-primary discipline (no disk status requirement of the
+         snapshot's own), writability DEFER-not-poison, gate inheritance
+         (owner + transition gates sit above the seam), and content-key
+         dedup across re-fires.
+Used by: pytest (CODE-phase verification; matrix depth is TEST phase work).
+"""
+
+import pytest
+
+import shared.task_metadata_snapshot as tms
+from fixtures.emitter import VALID_HANDOFF, _run_main
+
+SIBLINGS = {
+    "teachback_submit": {"understanding": "u"},
+    "variety": {"total": 9},
+}
+
+
+@pytest.fixture
+def snapshot_events(monkeypatch):
+    """Spy on the SUBSTRATE's bindings: capture snapshot appends and make
+    the substrate's writability precondition pass (the emitter fixture only
+    patches the emitter module's own get_journal_path symbol)."""
+    events: list[dict] = []
+
+    def _spy(event):
+        events.append(event)
+        return True
+
+    monkeypatch.setattr(tms, "append_event", _spy)
+    monkeypatch.setattr(
+        tms, "get_journal_path", lambda: "/tmp/x/session-journal.jsonl"
+    )
+    return events
+
+
+def _stdin(task_id="5", subject="backend-coder: build thing",
+           teammate="backend-coder", **extra):
+    payload = {
+        "task_id": task_id,
+        "task_subject": subject,
+        "teammate_name": teammate,
+        "team_name": "pact-test",
+    }
+    payload.update(extra)
+    return payload
+
+
+class TestSeamCEmits:
+    def test_completion_with_siblings_snapshots_and_handoff_emits(
+        self, tmp_path, monkeypatch, snapshot_events
+    ):
+        """Happy path: both event families emit — the snapshot mirrors the
+        siblings, the agent_handoff carries the handoff, and the two use
+        independent markers."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        calls: list[dict] = []
+        exit_code = _run_main(
+            stdin_payload=_stdin(),
+            task_data={
+                "status": "completed",
+                "owner": "backend-coder",
+                "metadata": {**SIBLINGS, "handoff": VALID_HANDOFF},
+            },
+            append_calls=calls,
+        )
+        assert exit_code == 0
+        assert [e["type"] for e in calls] == ["agent_handoff"]
+        assert len(snapshot_events) == 1
+        event = snapshot_events[0]
+        assert event["type"] == "task_metadata_snapshot"
+        assert event["task_id"] == "5"
+        assert event["owner"] == "backend-coder"
+        assert event["metadata"] == SIBLINGS
+        assert "handoff" not in event["metadata"]
+
+    def test_no_handoff_siblings_still_snapshot(
+        self, tmp_path, monkeypatch, snapshot_events
+    ):
+        """The seam-position payoff: a self-completed task with sibling
+        metadata but NO handoff (e.g. a rejected-teachback gate task) is
+        unreachable after the handoff-presence exit — the snapshot still
+        emits from the pre-gate position while agent_handoff correctly
+        stays silent."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        calls: list[dict] = []
+        exit_code = _run_main(
+            stdin_payload=_stdin(task_id="6"),
+            task_data={
+                "status": "completed",
+                "owner": "backend-coder",
+                "metadata": {
+                    "teachback_submit": {"understanding": "u"},
+                    "teachback_rejection": {"reason": "missing field"},
+                },
+            },
+            append_calls=calls,
+        )
+        assert exit_code == 0
+        assert calls == [], "no handoff → no agent_handoff event"
+        assert len(snapshot_events) == 1
+        assert set(snapshot_events[0]["metadata"]) == {
+            "teachback_submit",
+            "teachback_rejection",
+        }
+
+    def test_signal_task_snapshots_handoff_suppression_pinned(
+        self, tmp_path, monkeypatch, snapshot_events
+    ):
+        """Signal-task INCLUSION with the unconditional leg: a blocker task
+        snapshots (task_type mirrored) while the emitter's signal-task
+        agent_handoff suppression stays exactly as pinned."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        calls: list[dict] = []
+        exit_code = _run_main(
+            stdin_payload=_stdin(task_id="7", subject="HALT: security"),
+            task_data={
+                "status": "completed",
+                "owner": "security-engineer",
+                "metadata": {
+                    "type": "blocker",
+                    "halt_context": {"reason": "injection vector"},
+                    "handoff": VALID_HANDOFF,
+                },
+            },
+            append_calls=calls,
+        )
+        assert exit_code == 0
+        assert calls == [], "signal task must not emit agent_handoff (pinned)"
+        assert len(snapshot_events) == 1
+        assert snapshot_events[0]["task_type"] == "blocker"
+        assert snapshot_events[0]["metadata"]["type"] == "blocker"
+
+    def test_stdin_primary_no_own_disk_status_requirement(
+        self, tmp_path, monkeypatch, snapshot_events
+    ):
+        """hook_event_name == TaskCompleted passes the transition gate even
+        when the platform's disk write is mid-flight (disk status still
+        in_progress) — the snapshot inherits the gate by position and must
+        not add a disk status check of its own."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        calls: list[dict] = []
+        exit_code = _run_main(
+            stdin_payload=_stdin(
+                task_id="8", hook_event_name="TaskCompleted"
+            ),
+            task_data={
+                "status": "in_progress",  # mid-flight persist
+                "owner": "backend-coder",
+                "metadata": dict(SIBLINGS),
+            },
+            append_calls=calls,
+        )
+        assert exit_code == 0
+        assert len(snapshot_events) == 1
+
+    def test_refire_same_content_dedups(
+        self, tmp_path, monkeypatch, snapshot_events
+    ):
+        """The platform Stop-sweep re-dispatches TaskCompleted; identical
+        content dedups to one event via the content-keyed marker."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        for _ in range(3):
+            _run_main(
+                stdin_payload=_stdin(task_id="9"),
+                task_data={
+                    "status": "completed",
+                    "owner": "backend-coder",
+                    "metadata": dict(SIBLINGS),
+                },
+                append_calls=[],
+            )
+        assert len(snapshot_events) == 1
+
+
+class TestSeamCGateInheritance:
+    def test_transition_gate_exit_precedes_seam(
+        self, tmp_path, monkeypatch, snapshot_events
+    ):
+        """Neither hook_event_name nor disk status completed → the
+        transition gate exits BEFORE the seam: no snapshot."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        exit_code = _run_main(
+            stdin_payload=_stdin(task_id="10"),
+            task_data={
+                "status": "in_progress",
+                "owner": "backend-coder",
+                "metadata": dict(SIBLINGS),
+            },
+            append_calls=[],
+        )
+        assert exit_code == 0
+        assert snapshot_events == []
+
+    def test_owner_gate_exit_precedes_seam(
+        self, tmp_path, monkeypatch, snapshot_events
+    ):
+        """No owner and no teammate_name → the owner gate exits BEFORE the
+        seam (ownerless coverage belongs to the lead-frame seams)."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        exit_code = _run_main(
+            stdin_payload=_stdin(task_id="11", teammate=""),
+            task_data={
+                "status": "completed",
+                "owner": "",
+                "metadata": dict(SIBLINGS),
+            },
+            append_calls=[],
+        )
+        assert exit_code == 0
+        assert snapshot_events == []
+
+
+class TestSeamCWritabilityDefer:
+    def test_unwritable_frame_defers_not_poisons(
+        self, tmp_path, monkeypatch
+    ):
+        """DEFER-not-poison: an unresolvable teammate frame (substrate
+        writability precondition fails) neither emits NOR claims the
+        marker; a later writable fire for the SAME content emits — proving
+        no poisoned marker was left behind."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        events: list[dict] = []
+
+        def _spy(event):
+            events.append(event)
+            return True
+
+        monkeypatch.setattr(tms, "append_event", _spy)
+        task_data = {
+            "status": "completed",
+            "owner": "backend-coder",
+            "metadata": dict(SIBLINGS),
+        }
+        # Unwritable frame: substrate's own journal-path resolution empty.
+        monkeypatch.setattr(tms, "get_journal_path", lambda: "")
+        _run_main(
+            stdin_payload=_stdin(task_id="12"),
+            task_data=task_data,
+            append_calls=[],
+        )
+        assert events == [], "unwritable frame must not emit"
+        # Writable re-fire (e.g. the lead-frame seam or a later b1 fire).
+        monkeypatch.setattr(
+            tms, "get_journal_path", lambda: "/tmp/x/journal.jsonl"
+        )
+        _run_main(
+            stdin_payload=_stdin(task_id="12"),
+            task_data=task_data,
+            append_calls=[],
+        )
+        assert len(events) == 1, (
+            "the deferred fire must re-emit — an unwritable frame that "
+            "claimed the marker would have poisoned this"
+        )
+
+    def test_failed_write_unclaims_for_retry(
+        self, tmp_path, monkeypatch
+    ):
+        """Compensating unclaim: a claim whose append fails is rolled back
+        so a later healthy fire re-emits."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        events: list[dict] = []
+        monkeypatch.setattr(
+            tms, "get_journal_path", lambda: "/tmp/x/journal.jsonl"
+        )
+        task_data = {
+            "status": "completed",
+            "owner": "backend-coder",
+            "metadata": dict(SIBLINGS),
+        }
+        monkeypatch.setattr(tms, "append_event", lambda event: False)
+        _run_main(
+            stdin_payload=_stdin(task_id="13"),
+            task_data=task_data,
+            append_calls=[],
+        )
+
+        def _spy(event):
+            events.append(event)
+            return True
+
+        monkeypatch.setattr(tms, "append_event", _spy)
+        _run_main(
+            stdin_payload=_stdin(task_id="13"),
+            task_data=task_data,
+            append_calls=[],
+        )
+        assert len(events) == 1, "rolled-back claim must allow the re-emit"

--- a/pact-plugin/tests/test_snapshot_seams_gate.py
+++ b/pact-plugin/tests/test_snapshot_seams_gate.py
@@ -1,0 +1,430 @@
+"""
+Location: pact-plugin/tests/test_snapshot_seams_gate.py
+Summary: Seam tests for the task_metadata_snapshot emission points inside
+         task_lifecycle_gate.py — the lead-completion seam (additive-after
+         the lead-side agent_handoff emit) and the post-completion backstop
+         seam (the any-metadata generalization of the handoff backstop).
+         Covers the both-modes matrix (lead vs teammate frames — the
+         is_lead runtime structural signal), signal-task INCLUSION with the
+         unconditional agent_handoff-suppression leg, eligibility
+         (handoff-only → no snapshot), ownerless emission, incoming-metadata
+         merge, and content-key dedup/supersession across re-fires.
+Used by: pytest (CODE-phase verification for the gate seams; edge/matrix
+         depth is TEST phase work).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import shared.task_metadata_snapshot as tms  # noqa: E402
+import task_lifecycle_gate as tlg  # noqa: E402
+from fixtures.emitter import VALID_HANDOFF  # noqa: E402
+
+TEAM = "pact-test"
+LEAD = "PACT:pact-orchestrator"
+TEAMMATE = "pact-devops-engineer"
+
+SIBLINGS = {
+    "teachback_submit": {"understanding": "u", "first_action": "f"},
+    "variety": {"total": 10},
+}
+
+
+@pytest.fixture
+def snapshot_events(monkeypatch):
+    """Spy on the SUBSTRATE's append_event binding — the gate seams route
+    snapshot writes through shared.task_metadata_snapshot, not through the
+    gate module's own append_event."""
+    events: list[dict] = []
+
+    def _spy(event):
+        events.append(event)
+        return True
+
+    monkeypatch.setattr(tms, "append_event", _spy)
+    return events
+
+
+@pytest.fixture
+def handoff_events(monkeypatch):
+    """Spy on the GATE's append_event binding (agent_handoff and advisory
+    journal writes) — the unconditional-leg oracle for signal suppression."""
+    events: list[dict] = []
+
+    def _spy(event):
+        events.append(event)
+        return True
+
+    monkeypatch.setattr(tlg, "append_event", _spy)
+    return events
+
+
+def _completion_payload(
+    *,
+    agent_type=LEAD,
+    task_id="42",
+    subject="devops: implement the thing",
+    owner="devops",
+    metadata=None,
+    incoming_metadata=None,
+):
+    """A TaskUpdate(status=completed) PostToolUse frame with post-state via
+    tool_response.task (the gate's preferred source)."""
+    task = {
+        "id": task_id,
+        "subject": subject,
+        "owner": owner,
+        "metadata": metadata if metadata is not None else dict(SIBLINGS),
+    }
+    tool_input = {"taskId": task_id, "status": "completed"}
+    if incoming_metadata is not None:
+        tool_input["metadata"] = incoming_metadata
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": tool_input,
+        "tool_response": {"task": task},
+    }
+    if agent_type is not None:
+        payload["agent_type"] = agent_type
+    return payload
+
+
+def _seed_task(tmp_path, team, task_id, **fields):
+    """Write ~/.claude/tasks/{team}/{id}.json under the test-scoped HOME so
+    the gate's read_task_json resolves the on-disk post-state."""
+    tasks_dir = tmp_path / ".claude" / "tasks" / team
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    payload = {"id": task_id, **fields}
+    (tasks_dir / f"{task_id}.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+def _metadata_only_payload(task_id, metadata, agent_type=LEAD):
+    """A metadata-only TaskUpdate (no status key → lands in the write-time
+    block) — the post-completion backstop's fire surface."""
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": task_id, "metadata": metadata},
+        "tool_response": {},
+    }
+    if agent_type is not None:
+        payload["agent_type"] = agent_type
+    return payload
+
+
+def _snapshots(events):
+    return [e for e in events if e.get("type") == "task_metadata_snapshot"]
+
+
+# =============================================================================
+# Seam A — lead completion
+# =============================================================================
+class TestSeamALeadCompletion:
+    def test_lead_completion_emits_one_snapshot(
+        self, tmp_path, monkeypatch, pact_context, snapshot_events
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(_completion_payload())
+        snaps = _snapshots(snapshot_events)
+        assert len(snaps) == 1
+        event = snaps[0]
+        assert event["task_id"] == "42"
+        assert event["subject"] == "devops: implement the thing"
+        assert event["owner"] == "devops"
+        assert event["metadata"] == SIBLINGS
+        assert "handoff" not in event["metadata"]
+        assert isinstance(event["occupant"], str) and event["occupant"]
+
+    def test_handoff_key_excluded_but_siblings_mirrored(
+        self, tmp_path, monkeypatch, pact_context, snapshot_events
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        metadata = {**SIBLINGS, "handoff": VALID_HANDOFF}
+        tlg.evaluate_lifecycle(_completion_payload(metadata=metadata))
+        snaps = _snapshots(snapshot_events)
+        assert len(snaps) == 1
+        assert snaps[0]["metadata"] == SIBLINGS
+
+    def test_handoff_only_metadata_no_snapshot(
+        self, tmp_path, monkeypatch, pact_context, snapshot_events
+    ):
+        """Post-exclude payload is empty → ineligible → clean no-emit
+        (agent_handoff already covers handoff)."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(
+            _completion_payload(metadata={"handoff": VALID_HANDOFF})
+        )
+        assert _snapshots(snapshot_events) == []
+
+    def test_teammate_frame_no_snapshot(
+        self, tmp_path, monkeypatch, pact_context, snapshot_events
+    ):
+        """Both-modes matrix, teammate leg: a non-lead frame must not emit —
+        its context has no canonical journal (the tmux-mode teammate
+        completion is covered by the TaskCompleted seam instead)."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(_completion_payload(agent_type=TEAMMATE))
+        assert _snapshots(snapshot_events) == []
+
+    def test_teammate_frame_positive_control(
+        self, tmp_path, monkeypatch, pact_context, snapshot_events
+    ):
+        """The identical fixture under the LEAD frame emits — the
+        suppression above is the is_lead gate, nothing else."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(_completion_payload(agent_type=LEAD))
+        assert len(_snapshots(snapshot_events)) == 1
+
+    def test_signal_task_snapshot_emits_handoff_stays_suppressed(
+        self,
+        tmp_path,
+        monkeypatch,
+        pact_context,
+        snapshot_events,
+        handoff_events,
+    ):
+        """Signal-task INCLUSION with the unconditional leg: a blocker task
+        DOES snapshot (task_type mirrored) while the agent_handoff emit for
+        the same frame stays suppressed (that event family's reader-purity
+        basis is untouched)."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        metadata = {
+            "type": "blocker",
+            "blocker_context": {"halted_on": "auth bypass"},
+            "handoff": VALID_HANDOFF,
+        }
+        tlg.evaluate_lifecycle(_completion_payload(metadata=metadata))
+        snaps = _snapshots(snapshot_events)
+        assert len(snaps) == 1, "signal tasks DO snapshot"
+        assert snaps[0]["task_type"] == "blocker"
+        assert snaps[0]["metadata"]["type"] == "blocker"
+        assert "handoff" not in snaps[0]["metadata"]
+        # Unconditional leg: no agent_handoff event for the signal task.
+        assert [
+            e for e in handoff_events if e.get("type") == "agent_handoff"
+        ] == []
+
+    def test_teachback_task_snapshots(
+        self, tmp_path, monkeypatch, pact_context, snapshot_events
+    ):
+        """No teachback gate on the snapshot: teachback_submit siblings are
+        enumerated load-bearing keys."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(
+            _completion_payload(
+                subject="devops: TEACHBACK for thing CODE",
+                metadata={"teachback_submit": {"understanding": "u"}},
+            )
+        )
+        assert len(_snapshots(snapshot_events)) == 1
+
+    def test_ownerless_task_snapshots_without_owner_field(
+        self, tmp_path, monkeypatch, pact_context, snapshot_events
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(_completion_payload(owner=""))
+        snaps = _snapshots(snapshot_events)
+        assert len(snaps) == 1
+        assert "owner" not in snaps[0]
+
+    def test_incoming_metadata_merged_over_disk_view(
+        self, tmp_path, monkeypatch, pact_context, snapshot_events
+    ):
+        """The completing frame's tool_input.metadata is shallow-merged over
+        the post-state view — correct whether or not the platform's write
+        landed before the hook fired."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(
+            _completion_payload(
+                metadata={"variety": {"total": 10}},
+                incoming_metadata={"r2_verification": {"verified": True}},
+            )
+        )
+        snaps = _snapshots(snapshot_events)
+        assert len(snaps) == 1
+        assert snaps[0]["metadata"] == {
+            "variety": {"total": 10},
+            "r2_verification": {"verified": True},
+        }
+
+    def test_unchanged_recompletion_dedups_changed_supersedes(
+        self, tmp_path, monkeypatch, pact_context, snapshot_events
+    ):
+        """Content-key dedup: identical payload re-fires collapse to one
+        event; a changed payload emits a superseding second event."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        payload = _completion_payload(task_id="77")
+        tlg.evaluate_lifecycle(payload)
+        tlg.evaluate_lifecycle(payload)
+        assert len(_snapshots(snapshot_events)) == 1
+        changed = _completion_payload(
+            task_id="77",
+            metadata={**SIBLINGS, "r2_verification": {"verified": True}},
+        )
+        tlg.evaluate_lifecycle(changed)
+        assert len(_snapshots(snapshot_events)) == 2
+
+
+# =============================================================================
+# Seam B — post-completion backstop
+# =============================================================================
+class TestSeamBPostCompletionBackstop:
+    def test_late_metadata_write_on_completed_task_snapshots(
+        self, tmp_path, monkeypatch, pact_context, snapshot_events
+    ):
+        """A metadata-only TaskUpdate landing on an already-completed task
+        (the write-after-completion class) emits a snapshot with the merged
+        disk+incoming payload."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        _seed_task(
+            tmp_path,
+            TEAM,
+            "55",
+            subject="devops: late write probe",
+            owner="devops",
+            status="completed",
+            metadata={"variety": {"total": 8}},
+        )
+        tlg.evaluate_lifecycle(
+            _metadata_only_payload(
+                "55", {"r2_verification": {"verified": True}}
+            )
+        )
+        snaps = _snapshots(snapshot_events)
+        assert len(snaps) == 1
+        assert snaps[0]["task_id"] == "55"
+        assert snaps[0]["metadata"] == {
+            "variety": {"total": 8},
+            "r2_verification": {"verified": True},
+        }
+
+    def test_open_task_metadata_write_no_backstop_fire(
+        self, tmp_path, monkeypatch, pact_context, snapshot_events
+    ):
+        """The backstop keys on disk status == completed — a metadata write
+        on an OPEN task is normal mid-task traffic, not a missed mirror
+        (its completion-time snapshot will cover it)."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        _seed_task(
+            tmp_path,
+            TEAM,
+            "56",
+            subject="devops: open task",
+            owner="devops",
+            status="in_progress",
+            metadata={},
+        )
+        tlg.evaluate_lifecycle(
+            _metadata_only_payload("56", {"scope_contract": {"files": []}})
+        )
+        assert _snapshots(snapshot_events) == []
+
+    def test_teammate_frame_no_backstop_fire(
+        self, tmp_path, monkeypatch, pact_context, snapshot_events
+    ):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        _seed_task(
+            tmp_path,
+            TEAM,
+            "57",
+            subject="devops: teammate frame probe",
+            owner="devops",
+            status="completed",
+            metadata={},
+        )
+        tlg.evaluate_lifecycle(
+            _metadata_only_payload(
+                "57", {"note": "late"}, agent_type=TEAMMATE
+            )
+        )
+        assert _snapshots(snapshot_events) == []
+
+    def test_unchanged_backstop_refire_dedups_against_seam_a(
+        self, tmp_path, monkeypatch, pact_context, snapshot_events
+    ):
+        """Cross-seam dedup: seam A emitted at completion; a later
+        metadata-only re-write of the SAME content no-ops on the shared
+        content-keyed marker."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        # Seam A fire at completion.
+        tlg.evaluate_lifecycle(
+            _completion_payload(
+                task_id="58",
+                subject="devops: cross-seam dedup",
+                metadata={"variety": {"total": 9}},
+            )
+        )
+        assert len(_snapshots(snapshot_events)) == 1
+        # Later metadata-only write carrying the SAME resolved content.
+        _seed_task(
+            tmp_path,
+            TEAM,
+            "58",
+            subject="devops: cross-seam dedup",
+            owner="devops",
+            status="completed",
+            metadata={"variety": {"total": 9}},
+        )
+        tlg.evaluate_lifecycle(
+            _metadata_only_payload("58", {"variety": {"total": 9}})
+        )
+        assert len(_snapshots(snapshot_events)) == 1, (
+            "identical content must dedup across seams via the shared "
+            "content-keyed marker"
+        )
+
+    def test_handoff_backstop_and_snapshot_backstop_both_fire_sibling(
+        self, tmp_path, monkeypatch, pact_context, snapshot_events,
+        handoff_events,
+    ):
+        """The two backstops are SIBLING blocks: a late write that sets
+        handoff PLUS a sibling key triggers both — the handoff backstop
+        re-emits agent_handoff, the snapshot backstop mirrors the sibling
+        (handoff still excluded from the snapshot payload)."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        _seed_task(
+            tmp_path,
+            TEAM,
+            "59",
+            subject="devops: dual backstop",
+            owner="devops",
+            status="completed",
+            metadata={},
+        )
+        tlg.evaluate_lifecycle(
+            _metadata_only_payload(
+                "59",
+                {
+                    "handoff": VALID_HANDOFF,
+                    "r2_verification": {"verified": True},
+                },
+            )
+        )
+        handoffs = [
+            e for e in handoff_events if e.get("type") == "agent_handoff"
+        ]
+        snaps = _snapshots(snapshot_events)
+        assert len(handoffs) == 1
+        assert len(snaps) == 1
+        assert snaps[0]["metadata"] == {"r2_verification": {"verified": True}}

--- a/pact-plugin/tests/test_snapshot_seams_gate.py
+++ b/pact-plugin/tests/test_snapshot_seams_gate.py
@@ -262,6 +262,32 @@ class TestSeamALeadCompletion:
             "r2_verification": {"verified": True},
         }
 
+    def test_null_delete_incoming_key_not_mirrored(
+        self, tmp_path, monkeypatch, pact_context, snapshot_events
+    ):
+        """The platform's metadata merge treats a None-valued key as
+        DELETE-the-key, so the seam's overlay must drop it — a deleted key
+        must appear in the snapshot neither as a value nor as a phantom
+        null (the post-state view already reflects the deletion)."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        tlg.evaluate_lifecycle(
+            _completion_payload(
+                metadata={"variety": {"total": 10}},
+                incoming_metadata={
+                    "parked_analysis": None,
+                    "r2_verification": {"verified": True},
+                },
+            )
+        )
+        snaps = _snapshots(snapshot_events)
+        assert len(snaps) == 1
+        assert snaps[0]["metadata"] == {
+            "variety": {"total": 10},
+            "r2_verification": {"verified": True},
+        }
+        assert "parked_analysis" not in snaps[0]["metadata"]
+
     def test_unchanged_recompletion_dedups_changed_supersedes(
         self, tmp_path, monkeypatch, pact_context, snapshot_events
     ):
@@ -392,6 +418,53 @@ class TestSeamBPostCompletionBackstop:
             "identical content must dedup across seams via the shared "
             "content-keyed marker"
         )
+
+    def test_delete_only_late_write_mirrors_disk_without_phantom_null(
+        self, tmp_path, monkeypatch, pact_context, snapshot_events
+    ):
+        """A late delete-only TaskUpdate (all incoming values None — the
+        platform's DELETE op) must mirror the disk state as-is: the deleted
+        key appears neither as a value nor as a phantom null."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        _seed_task(
+            tmp_path,
+            TEAM,
+            "60",
+            subject="devops: delete-only late write",
+            owner="devops",
+            status="completed",
+            metadata={"variety": {"total": 8}},
+        )
+        tlg.evaluate_lifecycle(
+            _metadata_only_payload("60", {"obsolete_note": None})
+        )
+        snaps = _snapshots(snapshot_events)
+        assert len(snaps) == 1
+        assert snaps[0]["metadata"] == {"variety": {"total": 8}}
+        assert "obsolete_note" not in snaps[0]["metadata"]
+
+    def test_delete_only_late_write_on_empty_disk_no_emit(
+        self, tmp_path, monkeypatch, pact_context, snapshot_events
+    ):
+        """Delete-only incoming over EMPTY disk metadata filters to an empty
+        overlay → empty payload → ineligible → clean no-emit (no nulls-only
+        noise snapshot)."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s1")
+        _seed_task(
+            tmp_path,
+            TEAM,
+            "61",
+            subject="devops: delete-only empty disk",
+            owner="devops",
+            status="completed",
+            metadata={},
+        )
+        tlg.evaluate_lifecycle(
+            _metadata_only_payload("61", {"obsolete_note": None})
+        )
+        assert _snapshots(snapshot_events) == []
 
     def test_handoff_backstop_and_snapshot_backstop_both_fire_sibling(
         self, tmp_path, monkeypatch, pact_context, snapshot_events,

--- a/pact-plugin/tests/test_snapshot_subprocess_seam.py
+++ b/pact-plugin/tests/test_snapshot_subprocess_seam.py
@@ -1,0 +1,403 @@
+"""
+Location: pact-plugin/tests/test_snapshot_subprocess_seam.py
+Summary: REAL-PROCESS end-to-end coverage for the task_metadata_snapshot
+         stdin-to-journal path — the hook binaries run as SUBPROCESSES with
+         real stdin frames, a real env-isolated HOME (context file, task
+         store, marker dirs), and the REAL session journal on disk. Closes
+         the in-process-patching gap: the CODE-phase seam suites drive
+         main()/evaluate_lifecycle in-process with append_event spied, so
+         the real append_event schema validation, the real O_EXCL marker
+         filesystem, and the real pact_context env resolution
+         (CLAUDE_PROJECT_DIR + stdin session_id) are never exercised
+         together on one code path. Here they are.
+
+         Also closes the harvest read seam as a real CLI subprocess: the
+         skill's documented command (session_journal.py read --session-dir
+         --type task_metadata_snapshot) is run verbatim against the journal
+         the hook subprocess produced — a full produce -> register ->
+         consume round-trip through real entrypoints (a missed
+         _REQUIRED_FIELDS_BY_TYPE registration cannot pass this green:
+         append_event validates per-type only for registered types, and the
+         CLI read returns the typed events only if the write landed).
+
+================================ ANTI-MOCK INVARIANT ===========================
+Nothing in this file monkeypatches ANY module under test — no Path.home
+redirect, no pact_context fixture, no append_event spy. Isolation is
+process-level only: HOME + CLAUDE_PROJECT_DIR env vars on the subprocess.
+If a future edit converts these to in-process calls with patched seams, the
+file's reason to exist is gone — revert that edit.
+
+============================ NON-VACUITY ========================================
+Same-fixture negative controls: (a) no task file on disk -> neither event
+(proves the real read_task_json seam is load-bearing); (b) the CLI read of a
+journal with no snapshot events returns an empty array (proves the typed
+read is coupled to the write, not an always-true parse).
+
+Counter-test-by-revert (source-only; production is committed, test files
+stage separately): restoring the six production files to their pre-arc shape
+(`git checkout main -- <hooks paths>`) must fail every test in this file that
+asserts a task_metadata_snapshot event, with ZERO failures among the
+pre-existing agent_handoff suites. The measured cardinality is documented in
+the TEST-phase HANDOFF (task metadata + journal mirror).
+================================================================================
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HOOKS_DIR = Path(__file__).parent.parent / "hooks"
+
+# For the occupant-join oracle only (computing the expected discriminator
+# with the shared SSOT fn) — the modules under test run in SUBPROCESSES and
+# are never imported, patched, or stubbed here.
+sys.path.insert(0, str(HOOKS_DIR))
+
+TEAM = "session-subproc"
+SID = "bbbbbbbb-2222-3333-4444-555555555555"
+SLUG = "subproc-project"
+
+VALID_HANDOFF = {
+    "produced": "did the thing",
+    "decisions": "chose X",
+    "reasoning_chain": "because",
+    "uncertainty": "none",
+    "integration": "n/a",
+    "open_questions": "none",
+}
+
+SIBLINGS = {
+    "teachback_submit": {"understanding": "u", "first_action": "f"},
+    "variety": {"total": 8, "novelty": 2},
+    "consultation_analysis": "full five-section analysis text",
+}
+
+
+def _seed_home(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Build the real on-disk world the hook resolves: session context file,
+    task-store dir, and return (home, session_dir, tasks_dir)."""
+    home = tmp_path / "home"
+    session_dir = home / ".claude" / "pact-sessions" / SLUG / SID
+    session_dir.mkdir(parents=True)
+    (session_dir / "pact-session-context.json").write_text(
+        json.dumps({
+            "team_name": TEAM,
+            "session_id": SID,
+            "project_dir": f"/tmp/{SLUG}",
+            "plugin_root": "",
+            "started_at": "2026-01-01T00:00:00Z",
+        }),
+        encoding="utf-8",
+    )
+    tasks_dir = home / ".claude" / "tasks" / TEAM
+    tasks_dir.mkdir(parents=True)
+    return home, session_dir, tasks_dir
+
+
+def _write_task(tasks_dir: Path, task_id: str, *, owner="architect",
+                subject="design X", status="completed", metadata=None) -> None:
+    task = {
+        "id": task_id,
+        "owner": owner,
+        "subject": subject,
+        "status": status,
+        "metadata": metadata if metadata is not None else {},
+    }
+    (tasks_dir / f"{task_id}.json").write_text(
+        json.dumps(task), encoding="utf-8"
+    )
+
+
+def _run_hook(hook_filename: str, stdin_obj: dict, home: Path,
+              ) -> subprocess.CompletedProcess:
+    hook_path = HOOKS_DIR / hook_filename
+    assert hook_path.exists(), f"hook missing at {hook_path}"
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    # pact_context.init computes the session dir slug from
+    # CLAUDE_PROJECT_DIR's basename; without it get_session_dir() is ""
+    # and every journal write silently defers.
+    env["CLAUDE_PROJECT_DIR"] = f"/tmp/{SLUG}"
+    return subprocess.run(
+        [sys.executable, str(hook_path)],
+        input=json.dumps(stdin_obj),
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(home),
+        timeout=30,
+    )
+
+
+def _emitter_frame(task_id: str, *, subject="design X") -> dict:
+    return {
+        "hook_event_name": "TaskCompleted",
+        "session_id": SID,
+        "task_id": task_id,
+        "task_subject": subject,
+        "team_name": TEAM,
+    }
+
+
+def _gate_completion_frame(task_id: str, *, subject="design X",
+                           owner="architect", metadata=None) -> dict:
+    """A lead-frame PostToolUse TaskUpdate(status=completed) with post-state
+    via tool_response.task — task_lifecycle_gate's preferred source."""
+    return {
+        "hook_event_name": "PostToolUse",
+        "session_id": SID,
+        "agent_type": "PACT:pact-orchestrator",
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": task_id, "status": "completed"},
+        "tool_response": {"task": {
+            "id": task_id,
+            "subject": subject,
+            "owner": owner,
+            "metadata": metadata if metadata is not None else dict(SIBLINGS),
+        }},
+    }
+
+
+def _read_journal(session_dir: Path) -> list[dict]:
+    journal = session_dir / "session-journal.jsonl"
+    if not journal.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in journal.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _typed(events: list[dict], event_type: str) -> list[dict]:
+    return [e for e in events if e.get("type") == event_type]
+
+
+class TestSeamCSubprocess:
+    """agent_handoff_emitter.py as a real process: stdin -> real journal."""
+
+    def test_completion_emits_both_events_end_to_end(self, tmp_path):
+        home, session_dir, tasks_dir = _seed_home(tmp_path)
+        _write_task(tasks_dir, "7",
+                    metadata={"handoff": VALID_HANDOFF, **SIBLINGS})
+
+        result = _run_hook("agent_handoff_emitter.py",
+                           _emitter_frame("7"), home)
+
+        assert result.returncode == 0, (
+            f"exit non-zero. stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        assert json.loads(result.stdout.strip())["suppressOutput"] is True
+
+        events = _read_journal(session_dir)
+        handoffs = _typed(events, "agent_handoff")
+        snapshots = _typed(events, "task_metadata_snapshot")
+        assert len(handoffs) == 1, "handoff emission must be unaffected"
+        assert len(snapshots) == 1, (
+            "exactly one snapshot event must land in the REAL journal when "
+            "the real hook process resolves the real task store; got %d"
+            % len(snapshots)
+        )
+        snap = snapshots[0]
+        assert snap["task_id"] == "7"
+        # The occupant discriminator must be computable by a reader holding
+        # only the agent_handoff event's (agent, task_subject) — the §6
+        # task-id-reuse join. Computed here with the same shared SSOT fn.
+        from shared.agent_handoff_marker import occupant_hash
+        assert snap["occupant"] == occupant_hash(
+            handoffs[0]["agent"], handoffs[0]["task_subject"]
+        )
+        payload = snap["metadata"]
+        assert "handoff" not in payload, "SNAPSHOT_EXCLUDE must hold end-to-end"
+        assert payload["teachback_submit"] == SIBLINGS["teachback_submit"]
+        assert payload["variety"] == SIBLINGS["variety"]
+        assert (payload["consultation_analysis"]
+                == SIBLINGS["consultation_analysis"])
+        assert snap["subject"] == "design X"
+        assert snap["owner"] == "architect"
+        assert "truncated" not in snap, "no truncation on a small payload"
+
+    def test_no_handoff_siblings_still_snapshot_no_handoff_event(
+            self, tmp_path):
+        # The seam-C position (after the transition gate, BEFORE the
+        # handoff-presence exit) is only observable in the real exit ladder:
+        # a task with siblings but no handoff must snapshot even though the
+        # emitter exits before its own handoff emit.
+        home, session_dir, tasks_dir = _seed_home(tmp_path)
+        _write_task(tasks_dir, "8", metadata=dict(SIBLINGS))
+
+        result = _run_hook("agent_handoff_emitter.py",
+                           _emitter_frame("8"), home)
+
+        assert result.returncode == 0
+        events = _read_journal(session_dir)
+        assert len(_typed(events, "task_metadata_snapshot")) == 1
+        assert len(_typed(events, "agent_handoff")) == 0
+
+    def test_signal_task_snapshot_included_handoff_suppressed(self, tmp_path):
+        # D1 end-to-end in a real process: blocker tasks DO snapshot; the
+        # agent_handoff suppression for signal tasks stays pinned.
+        home, session_dir, tasks_dir = _seed_home(tmp_path)
+        _write_task(tasks_dir, "9", metadata={
+            "type": "blocker",
+            "halt_context": "HALT: broken build",
+            "handoff": VALID_HANDOFF,
+        })
+
+        result = _run_hook("agent_handoff_emitter.py",
+                           _emitter_frame("9"), home)
+
+        assert result.returncode == 0
+        events = _read_journal(session_dir)
+        snapshots = _typed(events, "task_metadata_snapshot")
+        assert len(snapshots) == 1, "D1: signal tasks DO snapshot"
+        assert snapshots[0]["task_type"] == "blocker"
+        assert snapshots[0]["metadata"]["halt_context"] == "HALT: broken build"
+        assert len(_typed(events, "agent_handoff")) == 0, (
+            "unconditional leg: agent_handoff suppression for signal tasks"
+        )
+
+    def test_negative_control_no_task_file_neither_event(self, tmp_path):
+        home, session_dir, _tasks_dir = _seed_home(tmp_path)
+
+        result = _run_hook("agent_handoff_emitter.py",
+                           _emitter_frame("7"), home)
+
+        assert result.returncode == 0
+        assert _read_journal(session_dir) == [], (
+            "no task on disk -> the real read seam yields nothing; a green "
+            "here with events present means the emit is decoupled from the "
+            "real read (the inert-seam failure class)"
+        )
+
+    def test_rerun_same_content_dedups_via_real_marker(self, tmp_path):
+        # Two full process runs: the second must be suppressed by the real
+        # on-disk O_EXCL marker (fresh interpreter each run, so nothing
+        # in-process can carry the dedup — only the filesystem can).
+        home, session_dir, tasks_dir = _seed_home(tmp_path)
+        _write_task(tasks_dir, "7",
+                    metadata={"handoff": VALID_HANDOFF, **SIBLINGS})
+
+        first = _run_hook("agent_handoff_emitter.py", _emitter_frame("7"), home)
+        second = _run_hook("agent_handoff_emitter.py", _emitter_frame("7"), home)
+
+        assert first.returncode == 0 and second.returncode == 0
+        events = _read_journal(session_dir)
+        assert len(_typed(events, "task_metadata_snapshot")) == 1, (
+            "content-key marker must dedup across real process lifetimes"
+        )
+        marker_dir = (home / ".claude" / "teams" / TEAM
+                      / ".task_metadata_snapshot_emitted")
+        assert marker_dir.exists() and any(marker_dir.iterdir()), (
+            "the snapshot marker namespace dir must exist on real disk"
+        )
+
+    def test_changed_content_supersedes_with_second_event(self, tmp_path):
+        home, session_dir, tasks_dir = _seed_home(tmp_path)
+        _write_task(tasks_dir, "7", metadata=dict(SIBLINGS))
+        first = _run_hook("agent_handoff_emitter.py", _emitter_frame("7"), home)
+
+        changed = dict(SIBLINGS)
+        changed["r2_verification"] = {"verdict": "GO"}
+        _write_task(tasks_dir, "7", metadata=changed)
+        second = _run_hook("agent_handoff_emitter.py", _emitter_frame("7"), home)
+
+        assert first.returncode == 0 and second.returncode == 0
+        snapshots = _typed(_read_journal(session_dir),
+                           "task_metadata_snapshot")
+        assert len(snapshots) == 2, (
+            "a changed payload is a new content key -> superseding event"
+        )
+        assert "r2_verification" in snapshots[-1]["metadata"]
+        assert "r2_verification" not in snapshots[0]["metadata"]
+
+
+class TestSeamASubprocess:
+    """task_lifecycle_gate.py as a real process: lead completion frame ->
+    real journal (the CODE-phase suite spies append_event; this leg proves
+    the same frame lands a schema-valid event through the real writer)."""
+
+    def test_lead_completion_lands_snapshot_in_real_journal(self, tmp_path):
+        home, session_dir, tasks_dir = _seed_home(tmp_path)
+        _write_task(tasks_dir, "42", status="completed",
+                    metadata=dict(SIBLINGS))
+
+        result = _run_hook("task_lifecycle_gate.py",
+                           _gate_completion_frame("42"), home)
+
+        assert result.returncode == 0, (
+            f"exit non-zero. stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        snapshots = _typed(_read_journal(session_dir),
+                           "task_metadata_snapshot")
+        assert len(snapshots) == 1
+        assert snapshots[0]["task_id"] == "42"
+        assert "handoff" not in snapshots[0]["metadata"]
+
+    def test_teammate_frame_no_snapshot_in_real_journal(self, tmp_path):
+        # Both-modes: the same frame under a teammate agent_type must not
+        # fire the lead-completion seam (is_lead structural signal).
+        home, session_dir, tasks_dir = _seed_home(tmp_path)
+        _write_task(tasks_dir, "42", status="completed",
+                    metadata=dict(SIBLINGS))
+
+        frame = _gate_completion_frame("42")
+        frame["agent_type"] = "pact-devops-engineer"
+        result = _run_hook("task_lifecycle_gate.py", frame, home)
+
+        assert result.returncode == 0
+        assert _typed(_read_journal(session_dir),
+                      "task_metadata_snapshot") == []
+
+
+class TestHarvestCliReadSeam:
+    """The harvest skill's documented consumer command, run verbatim as a
+    real CLI subprocess against a journal a real hook subprocess wrote."""
+
+    def _cli_read(self, session_dir: Path, home: Path) -> list[dict]:
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        result = subprocess.run(
+            [sys.executable,
+             str(HOOKS_DIR / "shared" / "session_journal.py"),
+             "read", "--session-dir", str(session_dir),
+             "--type", "task_metadata_snapshot"],
+            capture_output=True, text=True, env=env, timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+        return json.loads(result.stdout)
+
+    def test_cli_read_recovers_snapshot_after_task_drain(self, tmp_path):
+        # Acceptance criterion end-to-end with REAL entrypoints on both
+        # sides: hook subprocess writes; the task store is drained (real
+        # unlink — the drain-shaped destruction model); the skill's CLI
+        # read recovers the payload from the journal alone.
+        home, session_dir, tasks_dir = _seed_home(tmp_path)
+        _write_task(tasks_dir, "7", metadata=dict(SIBLINGS))
+        assert _run_hook("agent_handoff_emitter.py",
+                         _emitter_frame("7"), home).returncode == 0
+
+        (tasks_dir / "7.json").unlink()  # the drain
+        assert not (tasks_dir / "7.json").exists()
+
+        recovered = self._cli_read(session_dir, home)
+        assert len(recovered) == 1
+        assert recovered[0]["metadata"]["teachback_submit"] == (
+            SIBLINGS["teachback_submit"]
+        )
+
+    def test_cli_read_empty_when_no_snapshot_events(self, tmp_path):
+        # Negative control for the typed read: a journal with only an
+        # agent_handoff event yields an EMPTY snapshot array.
+        home, session_dir, tasks_dir = _seed_home(tmp_path)
+        _write_task(tasks_dir, "7", metadata={"handoff": VALID_HANDOFF})
+        assert _run_hook("agent_handoff_emitter.py",
+                         _emitter_frame("7"), home).returncode == 0
+
+        events = _read_journal(session_dir)
+        assert len(_typed(events, "agent_handoff")) == 1
+        assert self._cli_read(session_dir, home) == []

--- a/pact-plugin/tests/test_snapshot_subprocess_seam.py
+++ b/pact-plugin/tests/test_snapshot_subprocess_seam.py
@@ -35,10 +35,20 @@ read is coupled to the write, not an always-true parse).
 
 Counter-test-by-revert (source-only; production is committed, test files
 stage separately): restoring the six production files to their pre-arc shape
-(`git checkout main -- <hooks paths>`) must fail every test in this file that
-asserts a task_metadata_snapshot event, with ZERO failures among the
-pre-existing agent_handoff suites. The measured cardinality is documented in
-the TEST-phase HANDOFF (task metadata + journal mirror).
+(`git checkout main -- <hooks paths>`; the substrate module is absent on
+main, so delete it) must fail every test in this file that asserts a
+task_metadata_snapshot event, with ZERO failures among the pre-existing
+agent_handoff suites. Measured expected cardinality (snapshot-family suites
+run with --continue-on-collection-errors): 19 behavioral FAILURES — 9
+test_session_journal schema cases + all 3 test_snapshot_roundtrip + exactly
+the 7 tests in THIS file that assert snapshot events (the 3 absence-controls
+pass as designed) — plus 6 collection ERRORS (89 tests unimportable: the
+substrate deletion breaks the importing suites — an expected artifact of the
+revert, not behavioral protection; that count grows as those suites grow, so
+re-derive it via --collect-only rather than trusting 89). AND the 281
+pre-existing agent_handoff/gate/marker pin tests pass with ZERO failures on
+the same reverted tree — that zero IS the no-regression-to-handoff
+guarantee.
 ================================================================================
 """
 

--- a/pact-plugin/tests/test_task_id_sanitization_parity.py
+++ b/pact-plugin/tests/test_task_id_sanitization_parity.py
@@ -1,0 +1,209 @@
+"""
+Location: pact-plugin/tests/test_task_id_sanitization_parity.py
+Summary: Cross-family task_id sanitization parity (#1165) — every journal
+         emit family (b1 agent_handoff, lead-side b2 agent_handoff, and the
+         task_metadata_snapshot seams A/B/C) must stamp the IDENTICAL
+         sanitized task_id form for identical pathological input, and the
+         sanitize helper must stay the single shared SSOT binding (no
+         inline duplicates). Guards the reader-side cross-family join
+         (harvest SKILL.md filters snapshots by the handoff event's
+         task_id) and the shared O_EXCL marker key (a form split between
+         b1 and b2 would miss dedup and double-emit).
+Used by: pytest (CODE-phase verification for the sanitization intake
+         alignment; matrix depth is TEST phase work).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import shared.agent_handoff_marker as ahm
+import shared.task_metadata_snapshot as tms
+import task_lifecycle_gate as tlg
+from fixtures.emitter import VALID_HANDOFF, _run_main
+
+TEAM = "pact-test"
+LEAD = "PACT:pact-orchestrator"
+
+# Path traversal + separator + C0 control in one input. Its sanitized form
+# is stable under repeated application, so single-pass (b1/b2 intake, the
+# substrate's internal pass at seams A/B) and double-pass (seam C: emitter
+# intake + substrate) call chains must all converge on the same form.
+PATHOLOGICAL_TASK_ID = "../7\x00x"
+
+
+@pytest.fixture
+def snapshot_events(monkeypatch):
+    """Spy on the SUBSTRATE's append binding (seams A/B/C route snapshot
+    writes through shared.task_metadata_snapshot)."""
+    events: list[dict] = []
+
+    def _spy(event):
+        events.append(event)
+        return True
+
+    monkeypatch.setattr(tms, "append_event", _spy)
+    return events
+
+
+@pytest.fixture
+def gate_events(monkeypatch):
+    """Spy on the GATE's append binding (the lead-side b2 agent_handoff)."""
+    events: list[dict] = []
+
+    def _spy(event):
+        events.append(event)
+        return True
+
+    monkeypatch.setattr(tlg, "append_event", _spy)
+    return events
+
+
+def _seed_task(tmp_path, team, task_id, **fields):
+    tasks_dir = tmp_path / ".claude" / "tasks" / team
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    payload = {"id": task_id, **fields}
+    (tasks_dir / f"{task_id}.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+class TestTaskIdSanitizationParity:
+    def test_all_emit_families_identical_task_id_form(
+        self, tmp_path, monkeypatch, pact_context, snapshot_events,
+        gate_events,
+    ):
+        """#1165 acceptance: b1 agent_handoff, b2 lead-side agent_handoff,
+        and snapshot seams A, B, and C all stamp the identical sanitized
+        task_id for the same pathological raw input. Per-leg metadata
+        contents and owners differ so the content-keyed snapshot dedup and
+        the occupant-keyed handoff dedup cannot collapse legs into each
+        other — five independent emits, one task_id form."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        pact_context(team_name=TEAM, session_id="s1")
+        expected = ahm.sanitize_path_component(str(PATHOLOGICAL_TASK_ID))
+        assert expected == "7x"  # self-check: the exemplar sanitizes cleanly
+
+        # Legs 1+2 — gate completion frame: b2 agent_handoff + seam A
+        # snapshot fire from ONE evaluate_lifecycle call.
+        tlg.evaluate_lifecycle({
+            "tool_name": "TaskUpdate",
+            "tool_input": {
+                "taskId": PATHOLOGICAL_TASK_ID,
+                "status": "completed",
+            },
+            "tool_response": {"task": {
+                "id": PATHOLOGICAL_TASK_ID,
+                "subject": "devops: parity probe seam a",
+                "owner": "devops",
+                "metadata": {
+                    "variety": {"total": 7},
+                    "handoff": VALID_HANDOFF,
+                },
+            }},
+            "agent_type": LEAD,
+        })
+        b2_handoffs = [
+            e for e in gate_events if e.get("type") == "agent_handoff"
+        ]
+        seam_a_snaps = [
+            e for e in snapshot_events
+            if e.get("type") == "task_metadata_snapshot"
+        ]
+        assert len(b2_handoffs) == 1
+        assert len(seam_a_snaps) == 1
+
+        # Leg 3 — seam B backstop: metadata-only write on an already-
+        # completed disk task. This leg uses the NUL-FREE traversal exemplar:
+        # seam B requires a resolvable disk task file, and read_task_json's
+        # path sanitization strips separators/dotdot but not NUL, so a
+        # NUL-bearing id targets a filesystem-invalid filename and fail-opens
+        # to {} — the backstop is unreachable for NUL ids by construction.
+        # Both exemplars sanitize to the same expected form, so the
+        # cross-family identity assertion below is unaffected.
+        seam_b_raw = "../7x"
+        assert ahm.sanitize_path_component(seam_b_raw) == expected
+        _seed_task(
+            tmp_path,
+            TEAM,
+            expected,
+            subject="devops: parity probe seam b",
+            owner="devops",
+            status="completed",
+            metadata={"variety": {"total": 5}},
+        )
+        tlg.evaluate_lifecycle({
+            "tool_name": "TaskUpdate",
+            "tool_input": {
+                "taskId": seam_b_raw,
+                "metadata": {"r2_verification": {"verified": True}},
+            },
+            "tool_response": {},
+            "agent_type": LEAD,
+        })
+        seam_b_snaps = [
+            e for e in snapshot_events
+            if e.get("type") == "task_metadata_snapshot"
+        ][1:]
+        assert len(seam_b_snaps) == 1
+
+        # Legs 4+5 — b1 emitter frame: b1 agent_handoff + seam C snapshot
+        # from one main() run. Different owner → different occupant, so the
+        # b1 marker cannot collide with b2's claim above.
+        monkeypatch.setattr(
+            tms, "get_journal_path",
+            lambda: "/pact-test-session/session-journal.jsonl",
+        )
+        b1_calls: list[dict] = []
+        exit_code = _run_main(
+            stdin_payload={
+                "task_id": PATHOLOGICAL_TASK_ID,
+                "task_subject": "backend-coder: parity probe seam c",
+                "teammate_name": "backend-coder",
+                "team_name": TEAM,
+                "hook_event_name": "TaskCompleted",
+            },
+            task_data={
+                "status": "completed",
+                "owner": "backend-coder",
+                "metadata": {
+                    "teachback_submit": {"understanding": "u"},
+                    "handoff": VALID_HANDOFF,
+                },
+            },
+            append_calls=b1_calls,
+        )
+        assert exit_code == 0
+        b1_handoffs = [
+            e for e in b1_calls if e.get("type") == "agent_handoff"
+        ]
+        seam_c_snaps = [
+            e for e in snapshot_events
+            if e.get("type") == "task_metadata_snapshot"
+        ][2:]
+        assert len(b1_handoffs) == 1
+        assert len(seam_c_snaps) == 1
+
+        forms = {
+            "b1_agent_handoff": b1_handoffs[0]["task_id"],
+            "b2_agent_handoff": b2_handoffs[0]["task_id"],
+            "seam_a_snapshot": seam_a_snaps[0]["task_id"],
+            "seam_b_snapshot": seam_b_snaps[0]["task_id"],
+            "seam_c_snapshot": seam_c_snaps[0]["task_id"],
+        }
+        assert set(forms.values()) == {expected}, forms
+
+    def test_sanitize_helper_is_single_ssot_binding(self):
+        """Every emit-path module binds THE shared sanitize function object
+        from shared.agent_handoff_marker — an inline reimplementation (a
+        module-local regex copy) would break this identity and reopen the
+        cross-family drift class."""
+        from agent_handoff_emitter import (
+            sanitize_path_component as emitter_binding,
+        )
+
+        assert tlg.sanitize_path_component is ahm.sanitize_path_component
+        assert emitter_binding is ahm.sanitize_path_component
+        assert tms.sanitize_path_component is ahm.sanitize_path_component

--- a/pact-plugin/tests/test_task_metadata_snapshot.py
+++ b/pact-plugin/tests/test_task_metadata_snapshot.py
@@ -257,6 +257,54 @@ class TestPathologicalFloor:
         ), "kept keys precede the first dropped key in ascending order"
 
 
+class TestReadOnlyAdversarialMarkerShapedInput:
+    """The read-only invariant must hold for INPUT values that are already
+    exactly marker-shaped: stage 1 inserts under-cap values by reference,
+    so stage-3a head-emptying must REBUILD the marker rather than write
+    through the shared reference into the caller's dict."""
+
+    def _adversarial_metadata(self):
+        """A >PAYLOAD_CAP all-marker payload whose FIRST 3a-emptying target
+        (largest original_bytes) is a caller-owned marker-shaped value."""
+        metadata = {
+            # Caller-owned marker lookalike, under PER_VALUE_CAP (inserted
+            # by reference at stage 1), with the largest original_bytes so
+            # stage 3a reaches it first.
+            "caller_marker": {
+                "_truncated": True,
+                "original_bytes": 10**9,
+                "head": "caller-owned-head",
+            },
+        }
+        # Enough genuinely over-cap values that the all-marker payload
+        # (~1KB head each) exceeds PAYLOAD_CAP and stage 3a must run.
+        for index in range(70):
+            metadata[f"key{index:03d}"] = _jumbo_str(PER_VALUE_CAP + 100)
+        return metadata
+
+    def test_caller_marker_shaped_value_not_mutated(self):
+        metadata = self._adversarial_metadata()
+        before = copy.deepcopy(metadata)
+        payload, truncated = build_snapshot_payload(metadata)
+        assert truncated is True
+        assert _size(payload) <= PAYLOAD_CAP
+        # The pathological path DID empty the lookalike's head in the
+        # emitted payload (largest original_bytes goes first)...
+        assert payload["caller_marker"]["head"] == ""
+        # ...but the CALLER's object is untouched — the invariant under test.
+        assert metadata == before
+        assert metadata["caller_marker"]["head"] == "caller-owned-head"
+
+    def test_whole_input_intact_on_pathological_path(self):
+        """Belt-and-suspenders sweep: nothing anywhere in the input mapping
+        (keys, nested dicts, marker lookalikes) changes across the build,
+        even when stage 3a empties many heads."""
+        metadata = self._adversarial_metadata()
+        before = copy.deepcopy(metadata)
+        build_snapshot_payload(metadata)
+        assert metadata == before
+
+
 class TestDeterminismAndHash:
     def test_insertion_order_shuffles_identical_payload_and_hash(self):
         """Identical mapping under any insertion order → byte-identical

--- a/pact-plugin/tests/test_task_metadata_snapshot.py
+++ b/pact-plugin/tests/test_task_metadata_snapshot.py
@@ -256,6 +256,32 @@ class TestPathologicalFloor:
             kept < dropped[0] for kept in surviving
         ), "kept keys precede the first dropped key in ascending order"
 
+    def test_dropped_keys_census_overrun_is_the_documented_residual(self):
+        """PINNED characterization of the documented residual: when the
+        name-only key census ALONE exceeds PAYLOAD_CAP, the final payload
+        exceeds the cap — the _dropped_keys list is deliberately unbounded
+        because key EXISTENCE is never silently lost, and that invariant
+        outranks the cap in this doubly-pathological corner. The overrun is
+        bounded by the key-name mass (itself bounded by the source task
+        file's own size), the payload stays valid JSON, and the build does
+        not crash. A future change that restores the cap here by sacrificing
+        the existence invariant must flip this test consciously, not by
+        accident."""
+        metadata = {
+            ("k" * 200 + f"{index:05d}"): _jumbo_str(PER_VALUE_CAP + 10)
+            for index in range(400)
+        }
+        payload, truncated = build_snapshot_payload(metadata)
+        assert truncated is True
+        # The overrun IS the residual: the census cannot fit, so the cap is
+        # exceeded rather than any key name dropped.
+        assert _size(payload) > PAYLOAD_CAP
+        # And the overrun is EXACTLY the name-only census — nothing else is
+        # kept, so the excess is O(key-name mass) by construction.
+        assert payload == {"_dropped_keys": sorted(metadata)}
+        # The event line remains valid JSON (JSONL-poisoning guard).
+        assert json.loads(json.dumps(payload)) == payload
+
 
 class TestReadOnlyAdversarialMarkerShapedInput:
     """The read-only invariant must hold for INPUT values that are already

--- a/pact-plugin/tests/test_task_metadata_snapshot.py
+++ b/pact-plugin/tests/test_task_metadata_snapshot.py
@@ -1,0 +1,308 @@
+"""
+Location: pact-plugin/tests/test_task_metadata_snapshot.py
+Summary: Unit tests for the task_metadata_snapshot substrate's pure layer —
+         dual-cap three-stage size-bounding semantics, determinism under
+         insertion-order shuffles, UTF-8 boundary safety of truncation
+         heads, hash-after-truncation, exclude-set application, and the
+         read-only-input contract of build_snapshot_payload.
+Used by: pytest (CODE-phase verification for the substrate module); the
+         emit-routine seam behavior is covered by the seam suites, and the
+         marker cross-namespace independence pair lives with the marker
+         namespace tests.
+"""
+
+import copy
+import json
+
+import pytest
+
+from shared.task_metadata_snapshot import (
+    HEAD_BYTES,
+    PAYLOAD_CAP,
+    PER_VALUE_CAP,
+    SNAPSHOT_EXCLUDE,
+    _canonical_bytes,
+    _is_marker,
+    _utf8_safe_head,
+    build_snapshot_payload,
+    payload_hash8,
+    snapshot_eligible,
+)
+
+
+def _size(value: object) -> int:
+    return len(_canonical_bytes(value))
+
+
+def _jumbo_str(target_canonical_bytes: int) -> str:
+    """A plain-ASCII string whose canonical serialization is a bit over
+    ``target_canonical_bytes`` (canonical form adds two quote bytes)."""
+    return "x" * target_canonical_bytes
+
+
+class TestCanonicalBytes:
+    def test_insertion_order_independent(self):
+        """sort_keys makes canonical bytes identical for any dict order."""
+        a = {"b": 1, "a": {"y": 2, "x": 3}}
+        b = {"a": {"x": 3, "y": 2}, "b": 1}
+        assert _canonical_bytes(a) == _canonical_bytes(b)
+
+    def test_compact_separators(self):
+        assert _canonical_bytes({"a": 1, "b": [1, 2]}) == b'{"a":1,"b":[1,2]}'
+
+
+class TestUtf8SafeHead:
+    """The truncation-head cut must never bisect a multibyte character.
+
+    With the pinned _canonical_bytes (json.dumps default ensure_ascii) the
+    canonical form is pure ASCII, so these cases exercise the helper's
+    defense-in-depth contract directly with synthetic multibyte bytes.
+    """
+
+    def test_ascii_cut_is_exact(self):
+        assert _utf8_safe_head(b"abcdef", 4) == "abcd"
+
+    @pytest.mark.parametrize("cut", [1, 2, 3])
+    def test_multibyte_straddle_backs_off(self, cut):
+        """Cutting inside a 4-byte character yields the empty prefix, not a
+        decode error or replacement noise."""
+        emoji = "\U0001f600".encode("utf-8")  # 4 bytes
+        assert _utf8_safe_head(emoji, cut) == ""
+
+    def test_multibyte_boundary_kept(self):
+        two_chars = ("é" * 2).encode("utf-8")  # 2 × 2-byte chars
+        assert _utf8_safe_head(two_chars, 3) == "é"
+        assert _utf8_safe_head(two_chars, 4) == "éé"
+
+    def test_limit_beyond_data_returns_all(self):
+        assert _utf8_safe_head(b"ab", 10) == "ab"
+
+
+class TestBuildSnapshotPayloadBasics:
+    def test_handoff_excluded_everything_else_kept(self):
+        metadata = {
+            "handoff": {"produced": "p"},
+            "teachback_submit": {"understanding": "u"},
+            "variety": {"total": 7},
+            "intentional_wait": {"reason": "awaiting_lead_completion"},
+        }
+        payload, truncated = build_snapshot_payload(metadata)
+        assert "handoff" not in payload
+        assert payload["teachback_submit"] == {"understanding": "u"}
+        assert payload["variety"] == {"total": 7}
+        assert payload["intentional_wait"] == {
+            "reason": "awaiting_lead_completion"
+        }
+        assert truncated is False
+
+    def test_exclude_set_is_handoff_only(self):
+        """Pins the ratified minimal exclude set — a missed key is silent
+        loss while a junk key is bounded bytes."""
+        assert SNAPSHOT_EXCLUDE == frozenset({"handoff"})
+
+    def test_handoff_only_metadata_yields_ineligible_payload(self):
+        payload, truncated = build_snapshot_payload({"handoff": {"k": "v"}})
+        assert payload == {}
+        assert truncated is False
+        assert snapshot_eligible(payload) is False
+
+    def test_empty_metadata_ineligible(self):
+        payload, _ = build_snapshot_payload({})
+        assert snapshot_eligible(payload) is False
+
+    def test_non_empty_payload_eligible(self):
+        payload, _ = build_snapshot_payload({"variety": {"total": 7}})
+        assert snapshot_eligible(payload) is True
+
+    def test_input_not_mutated(self):
+        """READ-ONLY contract: the input mapping (and its nested values)
+        is byte-identical after the build, even when truncation fires."""
+        metadata = {
+            "handoff": {"produced": "p"},
+            "big": _jumbo_str(PER_VALUE_CAP + 100),
+            "nested": {"a": [1, 2, {"b": "c"}]},
+        }
+        before = copy.deepcopy(metadata)
+        build_snapshot_payload(metadata)
+        assert metadata == before
+
+
+class TestPerValueCap:
+    def test_over_cap_value_replaced_by_marker(self):
+        big = _jumbo_str(PER_VALUE_CAP + 100)
+        payload, truncated = build_snapshot_payload({"big": big, "small": 1})
+        assert truncated is True
+        assert payload["small"] == 1
+        marker = payload["big"]
+        assert _is_marker(marker)
+        assert marker["original_bytes"] == _size(big)
+        # Head is the first HEAD_BYTES of the canonical serialization —
+        # a str field CONTAINING the serialized prefix (starts with the
+        # opening quote of the canonical JSON string form).
+        assert marker["head"] == _canonical_bytes(big)[:HEAD_BYTES].decode(
+            "utf-8"
+        )
+        assert marker["head"].startswith('"')
+        assert len(marker["head"]) == HEAD_BYTES
+
+    def test_at_cap_value_kept(self):
+        # Canonical form of a str adds 2 quote bytes: aim exactly at the cap.
+        exact = "x" * (PER_VALUE_CAP - 2)
+        assert _size(exact) == PER_VALUE_CAP
+        payload, truncated = build_snapshot_payload({"exact": exact})
+        assert payload["exact"] == exact
+        assert truncated is False
+
+    def test_marker_event_line_is_valid_json(self):
+        big = _jumbo_str(PER_VALUE_CAP + 100)
+        payload, _ = build_snapshot_payload({"big": big})
+        line = json.dumps(payload)
+        assert json.loads(line)["big"]["_truncated"] is True
+
+
+class TestPayloadCapLargestFirst:
+    def test_largest_untruncated_evicted_first(self):
+        """Three values under the per-value cap whose sum exceeds the
+        payload cap: eviction order is largest-first."""
+        largest = _jumbo_str(PER_VALUE_CAP - 100)
+        middle = _jumbo_str(PER_VALUE_CAP - 200)
+        small = "keep-me"
+        metadata = {}
+        # Enough near-cap values to exceed PAYLOAD_CAP (64K / ~16K each → 5+).
+        for index in range(4):
+            metadata[f"mid{index}"] = middle
+        metadata["z_largest"] = largest
+        metadata["a_small"] = small
+        payload, truncated = build_snapshot_payload(metadata)
+        assert truncated is True
+        assert _size(payload) <= PAYLOAD_CAP
+        # The single largest value was evicted (it is a marker now)...
+        assert _is_marker(payload["z_largest"])
+        # ...and the small value survived intact.
+        assert payload["a_small"] == small
+
+    def test_tie_broken_by_ascending_key(self):
+        """Equal-size values: the lexicographically smallest key is evicted
+        first (pinned tie-break)."""
+        same = _jumbo_str(PER_VALUE_CAP - 100)
+        metadata = {f"k{index}": same for index in range(5)}
+        payload, truncated = build_snapshot_payload(metadata)
+        assert truncated is True
+        assert _size(payload) <= PAYLOAD_CAP
+        markers = [k for k, v in sorted(payload.items()) if _is_marker(v)]
+        kept = [k for k, v in sorted(payload.items()) if not _is_marker(v)]
+        # Eviction consumed a prefix of the ascending key order.
+        assert markers == sorted(metadata)[: len(markers)]
+        assert kept == sorted(metadata)[len(markers):]
+
+    def test_stage1_markers_not_recandidates(self):
+        """A value already marker-replaced by stage 1 is not evicted again —
+        stage 2 candidates are un-truncated values only."""
+        stage1_big = _jumbo_str(PER_VALUE_CAP * 5)
+        near_cap = _jumbo_str(PER_VALUE_CAP - 100)
+        metadata = {"jumbo": stage1_big}
+        for index in range(5):
+            metadata[f"mid{index}"] = near_cap
+        payload, _ = build_snapshot_payload(metadata)
+        marker = payload["jumbo"]
+        assert _is_marker(marker)
+        # Stage-1 marker retains its head (only stage 3a empties heads).
+        assert marker["head"] != ""
+        assert marker["original_bytes"] == _size(stage1_big)
+
+
+class TestPathologicalFloor:
+    def test_heads_emptied_descending_original_bytes(self):
+        """So many over-cap values that all-markers-with-heads exceeds the
+        payload cap: heads are emptied, biggest originals first."""
+        # Each marker with head ≈ 1KB+overhead; need > 64K of markers → 70+.
+        metadata = {
+            f"key{index:03d}": _jumbo_str(PER_VALUE_CAP + 1000 + index)
+            for index in range(70)
+        }
+        payload, truncated = build_snapshot_payload(metadata)
+        assert truncated is True
+        assert _size(payload) <= PAYLOAD_CAP
+        assert all(_is_marker(v) for v in payload.values())
+        emptied = [k for k, v in payload.items() if v["head"] == ""]
+        kept_heads = [k for k, v in payload.items() if v["head"] != ""]
+        # Descending original_bytes = descending index here, so the emptied
+        # set is a suffix of the index order and every emptied original is
+        # >= every kept-head original.
+        if emptied and kept_heads:
+            min_emptied = min(payload[k]["original_bytes"] for k in emptied)
+            max_kept = max(payload[k]["original_bytes"] for k in kept_heads)
+            assert min_emptied >= max_kept
+
+    def test_dropped_keys_floor_names_survive(self):
+        """Beyond all-markers-empty-heads capacity: keys survive name-only
+        in _dropped_keys — existence is never silently lost."""
+        # Empty-head markers are ~60 bytes each; > 64K needs > ~1100 keys.
+        metadata = {
+            f"key{index:05d}": _jumbo_str(PER_VALUE_CAP + 100)
+            for index in range(1500)
+        }
+        payload, truncated = build_snapshot_payload(metadata)
+        assert truncated is True
+        assert _size(payload) <= PAYLOAD_CAP
+        dropped = payload.get("_dropped_keys")
+        assert isinstance(dropped, list) and dropped
+        assert dropped == sorted(dropped)
+        surviving = set(payload) - {"_dropped_keys"}
+        # Every input key is accounted for: kept whole or named in the list.
+        assert surviving | set(dropped) == set(metadata)
+        # Kept keys are the ascending-order prefix survivors.
+        assert all(
+            kept < dropped[0] for kept in surviving
+        ), "kept keys precede the first dropped key in ascending order"
+
+
+class TestDeterminismAndHash:
+    def test_insertion_order_shuffles_identical_payload_and_hash(self):
+        """Identical mapping under any insertion order → byte-identical
+        canonical payload and identical payload_hash8 (both with and
+        without truncation in play)."""
+        base = {
+            "teachback_submit": {"understanding": "u", "first_action": "f"},
+            "variety": {"total": 10},
+            "big": _jumbo_str(PER_VALUE_CAP + 500),
+            "analysis": ["a", "b", {"c": 1}],
+        }
+        orders = [
+            dict(sorted(base.items())),
+            dict(sorted(base.items(), reverse=True)),
+            {
+                "big": base["big"],
+                "analysis": base["analysis"],
+                "variety": base["variety"],
+                "teachback_submit": base["teachback_submit"],
+            },
+        ]
+        results = [build_snapshot_payload(order) for order in orders]
+        canon = {_canonical_bytes(payload) for payload, _ in results}
+        hashes = {payload_hash8(payload) for payload, _ in results}
+        assert len(canon) == 1
+        assert len(hashes) == 1
+        assert all(truncated is True for _, truncated in results)
+
+    def test_hash_after_truncation_not_raw_metadata(self):
+        """The content key is computed on the TRUNCATED payload: two raw
+        inputs that differ only beyond the truncation point collapse to
+        the same emitted content and the same hash."""
+        prefix = _jumbo_str(PER_VALUE_CAP + 5000)
+        a = {"big": prefix + "AAAA"}
+        b = {"big": prefix + "BBBB"}
+        payload_a, _ = build_snapshot_payload(a)
+        payload_b, _ = build_snapshot_payload(b)
+        # Same length + same head → identical markers, despite raw diff.
+        assert payload_a == payload_b
+        assert payload_hash8(payload_a) == payload_hash8(payload_b)
+        # And a genuinely different payload gets a different key.
+        payload_c, _ = build_snapshot_payload({"big": prefix + "AAAAA"})
+        assert payload_hash8(payload_c) != payload_hash8(payload_a)
+
+    def test_hash8_shape(self):
+        payload, _ = build_snapshot_payload({"variety": {"total": 7}})
+        key = payload_hash8(payload)
+        assert len(key) == 8
+        assert all(ch in "0123456789abcdef" for ch in key)

--- a/pact-plugin/tests/test_task_metadata_snapshot.py
+++ b/pact-plugin/tests/test_task_metadata_snapshot.py
@@ -260,24 +260,24 @@ class TestPathologicalFloor:
 class TestReadOnlyAdversarialMarkerShapedInput:
     """The read-only invariant must hold for INPUT values that are already
     exactly marker-shaped: stage 1 inserts under-cap values by reference,
-    so stage-3a head-emptying must REBUILD the marker rather than write
-    through the shared reference into the caller's dict."""
+    and no stage may ever write through that shared reference into the
+    caller's dict. Under provenance identity the lookalike is ordinary
+    data — evicted and re-markered on the pathological path — and the
+    caller's object stays byte-identical throughout."""
 
     def _adversarial_metadata(self):
-        """A >PAYLOAD_CAP all-marker payload whose FIRST 3a-emptying target
-        (largest original_bytes) is a caller-owned marker-shaped value."""
+        """A >PAYLOAD_CAP pathological payload containing a caller-owned
+        marker-shaped value (under PER_VALUE_CAP, inserted by reference at
+        stage 1) among genuinely over-cap jumbos."""
         metadata = {
-            # Caller-owned marker lookalike, under PER_VALUE_CAP (inserted
-            # by reference at stage 1), with the largest original_bytes so
-            # stage 3a reaches it first.
             "caller_marker": {
                 "_truncated": True,
                 "original_bytes": 10**9,
                 "head": "caller-owned-head",
             },
         }
-        # Enough genuinely over-cap values that the all-marker payload
-        # (~1KB head each) exceeds PAYLOAD_CAP and stage 3a must run.
+        # Enough genuinely over-cap values that the payload exceeds
+        # PAYLOAD_CAP (~1KB marker head each) and stage 3a must run.
         for index in range(70):
             metadata[f"key{index:03d}"] = _jumbo_str(PER_VALUE_CAP + 100)
         return metadata
@@ -288,10 +288,14 @@ class TestReadOnlyAdversarialMarkerShapedInput:
         payload, truncated = build_snapshot_payload(metadata)
         assert truncated is True
         assert _size(payload) <= PAYLOAD_CAP
-        # The pathological path DID empty the lookalike's head in the
-        # emitted payload (largest original_bytes goes first)...
-        assert payload["caller_marker"]["head"] == ""
-        # ...but the CALLER's object is untouched — the invariant under test.
+        # The lookalike was treated as ordinary data: evicted by stage 2
+        # and replaced by OUR marker carrying its TRUE serialized size
+        # (its claimed billion is ignored).
+        slot = payload["caller_marker"]
+        assert _is_marker(slot)
+        assert isinstance(slot["original_bytes"], int)
+        assert slot["original_bytes"] == _size(before["caller_marker"])
+        # And the CALLER's object is untouched — the invariant under test.
         assert metadata == before
         assert metadata["caller_marker"]["head"] == "caller-owned-head"
 
@@ -303,6 +307,75 @@ class TestReadOnlyAdversarialMarkerShapedInput:
         before = copy.deepcopy(metadata)
         build_snapshot_payload(metadata)
         assert metadata == before
+
+
+class TestProvenanceMarkerIdentity:
+    """Marker identity is PROVENANCE-tracked, never shape-tested: only
+    markers this run built are eviction-exempt and stage-3-sorted. An
+    input value that merely looks marker-shaped is ordinary caller data."""
+
+    def test_lookalike_is_ordinary_eviction_candidate(self):
+        """A large marker-shaped input is evicted by stage 2 like any value
+        and replaced by OUR marker computed from ITS serialization — never
+        trusted as an already-truncated marker (its claimed original_bytes
+        is ignored in favor of the true serialized size)."""
+        big_lookalike = {
+            "_truncated": True,
+            "original_bytes": 10**9,  # claimed — must NOT be believed
+            "head": "x" * (PER_VALUE_CAP - 2048),  # large but under cap
+        }
+        metadata = {"z_lookalike": big_lookalike}
+        # Ordinary near-cap values so the payload exceeds PAYLOAD_CAP and
+        # stage 2 must evict; the lookalike is among the largest.
+        for index in range(5):
+            metadata[f"mid{index}"] = _jumbo_str(PER_VALUE_CAP - 4096)
+        payload, truncated = build_snapshot_payload(metadata)
+        assert truncated is True
+        assert _size(payload) <= PAYLOAD_CAP
+        slot = payload["z_lookalike"]
+        assert _is_marker(slot), "evicted lookalike is re-markered by US"
+        # OUR marker records the TRUE serialized size of the lookalike
+        # dict, not its claimed billion.
+        assert slot["original_bytes"] == _size(big_lookalike)
+        # And the head is the serialized prefix of the lookalike itself.
+        assert slot["head"].startswith('{"_truncated":true')
+        # Caller object untouched.
+        assert big_lookalike["original_bytes"] == 10**9
+
+    def test_non_int_original_bytes_lookalike_no_drop(self):
+        """The totality payoff: a lookalike whose original_bytes is a
+        non-int must not crash the stage-3 sort (which now touches only
+        markers WE built, int by construction) — the >64KB snapshot is
+        BUILT, not dropped."""
+        metadata = {
+            "poison": {
+                "_truncated": True,
+                "original_bytes": "not-an-int",
+                "head": "h",
+            },
+        }
+        for index in range(70):
+            metadata[f"key{index:03d}"] = _jumbo_str(PER_VALUE_CAP + 100)
+        payload, truncated = build_snapshot_payload(metadata)
+        assert truncated is True
+        assert _size(payload) <= PAYLOAD_CAP
+        assert payload, "snapshot payload must be built, not dropped"
+
+    def test_totality_every_input_key_in_payload_or_dropped(self):
+        """Totality invariant across lookalikes + jumbos on the deep
+        pathological path: every input key appears in the payload or in
+        _dropped_keys — existence is never silently lost."""
+        metadata = {
+            "lk_int": {"_truncated": True, "original_bytes": 7, "head": "h"},
+            "lk_str": {"_truncated": True, "original_bytes": "x", "head": "h"},
+        }
+        for index in range(1500):
+            metadata[f"key{index:05d}"] = _jumbo_str(PER_VALUE_CAP + 100)
+        payload, _ = build_snapshot_payload(metadata)
+        assert _size(payload) <= PAYLOAD_CAP
+        surviving = set(payload) - {"_dropped_keys"}
+        dropped = set(payload.get("_dropped_keys", []))
+        assert surviving | dropped == set(metadata)
 
 
 class TestDeterminismAndHash:


### PR DESCRIPTION
## Summary

Implements #1147: makes the session journal the durable mirror for **all** load-bearing task metadata — not just `metadata.handoff` — so platform task-store destruction cannot destroy institutional data.

New `task_metadata_snapshot` journal event emitted from the existing three-seam topology (lead-side completion + post-completion backstop in `task_lifecycle_gate.py`; teammate-frame TaskCompleted twin in `agent_handoff_emitter.py`) via one shared SSOT substrate (`hooks/shared/task_metadata_snapshot.py`), with:

- **Full-mirror payload** — `SNAPSHOT_EXCLUDE = {"handoff"}` only (PREPARE found ~24 wild ad-hoc keys the audit table missed — allowlists are structurally incomplete)
- **Deterministic dual-cap truncation** — 16KB/value + 64KB/payload, canonical serialization (insertion-order-independent by construction), largest-first eviction, `_dropped_keys` floor: key existence is never silently lost
- **Provenance-tracked marker identity** — the builder tracks which keys IT truncated (no shape-testing of caller data); read-only input invariant (auditor YELLOW-1 fixed with RED→GREEN proof)
- **Content-hash markers** (separate namespace via a byte-identical-default param on the shared marker resolvers) — unchanged content dedups across seams; changed content supersedes, latest-ts + occupant-join reads
- **Signal-task inclusion (ratified)** — blocker/algedonic tasks DO snapshot (HALT context is peak durability value); `agent_handoff` suppression for them is unchanged and pinned
- **Harvest three-tier fallback** — task file → latest-ts snapshot event (occupant join, arc-scoped) → graceful degrade

## Empirical grounding (PREPARE)

Falsified the issue's "~20-min GC window" model: destruction is **whole-store, status-blind drains at workflow boundaries** (no age/status reaper; verified live). Caps confirmed against full-population measurement (largest real payload 10.1KB). #551 race not falsified on CC 2.1.207 — seam C inherits stdin-primary discipline. Follow-ups filed: #1162 (per-write mirror for open-task-consumed keys), #1163 (pathological-input dispositions).

## Testing

- 117 new tests (unit, seam, subprocess real-hook, adversarial matrix, provenance semantics, GC-drain round-trip, both-modes matrix, cross-family sanitization parity)
- Full suite: **10,959 passed / 15 skipped / 0 failed / 0 errors** (plain pytest, bare scope from pact-plugin/, final HEAD 534f6baa)
- No-regression to handoff journaling is a **measured property**: source-revert counter-test — all snapshot tests fail, ZERO failures among 281 pre-existing pin tests; marker suite passes byte-UNMODIFIED
- Concurrent auditor: GREEN after YELLOW-1 remediation

## Version

PATCH bump → 4.6.2 (internal hook rule + schema fields; no user-visible surface change)

Closes #1147


## Review

3 fresh reviewers (design coherence / coverage+vacuity / behavioral data-flow): **0 Blocking**. All Minors fixed in-PR (phantom-null overlay filter `af54fc22`; census-overrun characterization pin `4fbdb997`; cardinality docstring `9afe7616`). Synthesis: `docs/review/` (session artifact). Residuals documented: census cap-overrun corner (bounded by key-name mass), one-content-version race bound, #1162, #1163, #1166 (sanitization SSOT unification). Also folds #1165 (task_id sanitization parity + b1/b2 marker-key split fix, `534f6baa`).

