### PR TITLE
feat(journal): per-write mirror for open-task-consumed metadata keys (#1162)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.2",
+      "version": "4.6.3",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.2/       # Plugin version
+│               └── 4.6.3/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.2
+> **Version**: 4.6.3
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/commands/rePACT.md
+++ b/pact-plugin/commands/rePACT.md
@@ -189,6 +189,7 @@ Branch behavior depends on whether rePACT is invoked with a scope contract:
 Before starting, verify:
 1. **Nesting depth**: Read `TaskGet(taskId).metadata.nesting_depth` — if > 1, reject (max depth exceeded). If absent, treat as 0.
 2. **Scope contract**: If this rePACT was dispatched from ATOMIZE, read the scope contract from `TaskGet(taskId).metadata.scope_contract` instead of expecting it inline in the prompt. This ensures scope state survives compaction.
+   - **Journal fallback (covers items 1–2)**: If `TaskGet(taskId)` cannot resolve (task store drained), recover from the session journal instead: run `python3 "{plugin_root}/hooks/shared/session_journal.py" read --session-dir "{session_dir}" --type task_metadata_snapshot` (prints a JSON array), filter to events whose `task_id` matches this task, take the latest-`ts` event, and read `nesting_depth` / `scope_contract` from its `metadata` (honor `_truncated` / `_dropped_keys` markers if present).
 3. **Scope appropriateness**: Is this truly a sub-task of the parent?
 4. **Domain determination**: Single-domain or multi-domain?
 

--- a/pact-plugin/hooks/shared/HOOK_STDIN_DISCRIMINATORS.md
+++ b/pact-plugin/hooks/shared/HOOK_STDIN_DISCRIMINATORS.md
@@ -75,9 +75,11 @@ UserPromptSubmit / PostToolUse) but is NOT read on TaskCompleted — that frame 
 captured for the #917 emit-path, which gates on `team_name` + journal
 writability rather than this predicate. On PreToolUse, `is_lead` is read via the
 match-all `bootstrap_gate` (matcher `''`, so it fires before every tool —
-including `TaskCreate` / `TaskUpdate`) and the `Edit` / `Write` pin gates; there
-is no `TaskCreate` / `TaskUpdate`-matched PreToolUse hook (that matcher is
-PostToolUse-only — `task_lifecycle_gate`, the row above).
+including `TaskCreate` / `TaskUpdate`), the `Edit` / `Write` pin gates, and the
+`TaskUpdate`-matched `handoff_ordering_gate` (which gates both of its rules on
+`is_lead`). `TaskCreate` has no PreToolUse-matched hook — its only
+task-lifecycle observer is the PostToolUse-matched `task_lifecycle_gate` (the
+row above).
 
 ### UserPromptSubmit has no teammate fire path
 

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -910,14 +910,14 @@ def _read_lead_session_id(team_name: str, teams_dir: str | None = None) -> str:
     """Read the top-level ``leadSessionId`` from
     ``~/.claude/teams/{team_name}/config.json``.
 
-    LOGIC-PARITY: the guarded-read shape is a third copy of two existing
-    PRIVATE helpers — ``task_claim_gate._read_lead_session_id`` (same
-    signature including the ``teams_dir`` test override) and
-    ``session_registry._read_lead_session_id`` (INLINED there by design: that
-    module's self-contained-leaf invariant forbids ``shared.*`` imports, so it
-    must not be re-pointed here). Keep all three behaviorally identical; a
-    flagged consolidation may later re-point ``task_claim_gate`` to this
-    shared copy.
+    LOGIC-PARITY: this is the SSOT copy — ``task_claim_gate`` imports it
+    directly (its former inline copy is consolidated here; the ``teams_dir``
+    test override is part of the shared signature). The ONE remaining inline
+    copy is ``session_registry._read_lead_session_id``, INLINED there by
+    design: that module's self-contained-leaf invariant forbids ``shared.*``
+    imports, so it must not be re-pointed here. Keep the two implementations
+    behaviorally identical — the behavioral-parity drift-guard test compares
+    them on the same logical inputs.
 
     Fail-safe: returns "" on any of: unsafe team_name, missing/unreadable
     file, malformed JSON, non-object top-level, or a missing/non-string key.

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -969,6 +969,25 @@ def is_canonical_journal_frame(input_data: dict) -> bool:
         # Team resolution goes through this module's own identity-matched
         # resolver (fail-closed empty on an unknown team, which routes the
         # helper to its "" return and this leg to False).
+        #
+        # DELIBERATE SPLIT — do not unify with the callers' team resolution.
+        # The per-write emit legs (task_lifecycle_gate) resolve their
+        # team_name ONCE from the persisted ctx SSOT
+        # (get_pact_context()["team_name"]) and use it for task reads +
+        # marker namespacing, because the dedup namespace must stay
+        # internally CONSISTENT across every seam that shares those markers
+        # (all gate seams use the same persisted value). THIS predicate
+        # instead answers a session-topology question — "does my session_id
+        # match the REAL platform team's leadSessionId?" — which requires
+        # the identity-ALIGNED resolver: after a resume-divergence the
+        # persisted name can point at a config whose leadSessionId is
+        # stale/wrong, flipping the topology answer. Re-pointing the emit
+        # path to the aligned resolver would fragment the marker namespace
+        # against the pre-existing seams (duplicate events); re-pointing
+        # this predicate to the persisted value would mis-answer topology
+        # after divergence. Divergent outcomes are bounded (skip or
+        # duplicate emit — bias-to-preservation, never a lost canonical
+        # emit), which is why the split is safe as well as intentional.
         lead_session_id = _read_lead_session_id(get_team_name())
         return bool(lead_session_id) and sid == lead_session_id
     except Exception:

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -906,6 +906,75 @@ def classify_session_role(input_data: dict) -> str:
     return "unknown"
 
 
+def _read_lead_session_id(team_name: str, teams_dir: str | None = None) -> str:
+    """Read the top-level ``leadSessionId`` from
+    ``~/.claude/teams/{team_name}/config.json``.
+
+    LOGIC-PARITY: the guarded-read shape is a third copy of two existing
+    PRIVATE helpers — ``task_claim_gate._read_lead_session_id`` (same
+    signature including the ``teams_dir`` test override) and
+    ``session_registry._read_lead_session_id`` (INLINED there by design: that
+    module's self-contained-leaf invariant forbids ``shared.*`` imports, so it
+    must not be re-pointed here). Keep all three behaviorally identical; a
+    flagged consolidation may later re-point ``task_claim_gate`` to this
+    shared copy.
+
+    Fail-safe: returns "" on any of: unsafe team_name, missing/unreadable
+    file, malformed JSON, non-object top-level, or a missing/non-string key.
+    Callers treat "" as "topology unresolvable" and take their own fail-safe
+    branch. Never raises.
+
+    CURRENCY DEPENDENCY (shared with both parity copies): the value is only
+    as current as the platform-maintained team config — a stale
+    ``leadSessionId`` after a session resume can misclassify an in-process
+    frame as tmux (or vice-versa). Consumers must bound that blast radius to
+    coordination-only decisions (see ``is_canonical_journal_frame``).
+    """
+    if not is_safe_path_component(team_name):
+        return ""
+    if teams_dir:
+        config_path = Path(teams_dir) / team_name / "config.json"
+    else:
+        config_path = get_claude_config_dir() / "teams" / team_name / "config.json"
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        lead_session_id = data.get("leadSessionId")
+    except (OSError, json.JSONDecodeError, ValueError, AttributeError, TypeError):
+        return ""
+    return lead_session_id if isinstance(lead_session_id, str) else ""
+
+
+def is_canonical_journal_frame(input_data: dict) -> bool:
+    """True iff THIS process's journal writes land in the canonical
+    (lead-session) journal: the lead frame in either teammateMode, or an
+    in-process teammate frame (session_id == leadSessionId — one process,
+    one session). False for a tmux teammate frame (distinct session_id)
+    and on ANY resolution failure of the topology leg (unreadable team
+    config, missing session_id): skipping defers durability to the
+    completion-time seams — never worse than the shipped baseline — while
+    emitting from a misclassified frame could silo the event AND poison
+    the shared content-hash marker namespace, suppressing a later
+    canonical emit. The is_lead leg is independent of config readability,
+    so lead-written keys keep full both-modes coverage even when the
+    topology leg cannot resolve. Never raises.
+    """
+    try:
+        if is_lead(input_data):
+            return True
+        sid = input_data.get("session_id")
+        if not (isinstance(sid, str) and sid):
+            # Missing/non-string session_id: topology unresolvable — skip
+            # before paying the config read.
+            return False
+        # Team resolution goes through this module's own identity-matched
+        # resolver (fail-closed empty on an unknown team, which routes the
+        # helper to its "" return and this leg to False).
+        lead_session_id = _read_lead_session_id(get_team_name())
+        return bool(lead_session_id) and sid == lead_session_id
+    except Exception:
+        return False
+
+
 def _iter_members(
     team_name: str,
     teams_dir: str | None = None,

--- a/pact-plugin/hooks/shared/session_registry.py
+++ b/pact-plugin/hooks/shared/session_registry.py
@@ -355,9 +355,11 @@ def _read_lead_session_id(team: str) -> str:
 
     Used by ``register()``'s in-process self-guard to compute the runtime
     structural topology signal ``own session_id == leadSessionId`` (in-process)
-    vs ``!=`` (tmux). LOGIC-PARITY with ``task_claim_gate._read_lead_session_id``,
-    INLINED here (not imported) to preserve this module's self-contained-leaf
-    invariant (no ``shared.*`` imports — see module docstring). Reuses the exact
+    vs ``!=`` (tmux). LOGIC-PARITY with the SSOT copy,
+    ``pact_context._read_lead_session_id`` (which ``task_claim_gate`` also
+    imports rather than duplicating), INLINED here (not imported) to preserve
+    this module's self-contained-leaf invariant (no ``shared.*`` imports — see
+    module docstring). Reuses the exact
     ``_is_safe_team_segment`` guard + ``_config_root()`` config-read idiom that
     ``_name_is_team_member`` above already uses, so the read adds no new I/O
     machinery.

--- a/pact-plugin/hooks/shared/task_metadata_snapshot.py
+++ b/pact-plugin/hooks/shared/task_metadata_snapshot.py
@@ -62,6 +62,24 @@ from .session_journal import append_event, get_journal_path, make_event
 # exclude set stays minimal by design.
 SNAPSHOT_EXCLUDE: frozenset[str] = frozenset({"handoff"})
 
+# Keys whose WRITE (TaskCreate/TaskUpdate delta) triggers an immediate
+# whole-payload mirror — the open-task-consumed class that a status-blind
+# whole-store drain destroys while load-bearing (mid-arc readers consume
+# these via TaskGet while the task is still open). The fire predicate is
+# targeted-key-in-delta; the payload is always the full overlay (never a
+# projection), so cross-seam content-hash dedup stays coherent with the
+# completion-time seams. Disjoint from SNAPSHOT_EXCLUDE by test-pinned
+# invariant. NOT here: "variety" (already per-write-mirrored at its write
+# point by the dispatch_variety emit); "intentional_wait" (rides along in
+# the overlay; a wait-only write is not load-bearing alone).
+PER_WRITE_MIRROR_KEYS: frozenset[str] = frozenset({
+    "scope_contract",
+    "nesting_depth",
+    "worktree_path",
+    "teachback_submit",
+    "teachback_rejection",
+})
+
 # Size caps on the canonical serialization (see _canonical_bytes). Empirics
 # over the full journal/task-file population found the largest real value at
 # ~10 KB and no journal event ever ≥ 32 KB, so both caps are anomaly paths:

--- a/pact-plugin/hooks/shared/task_metadata_snapshot.py
+++ b/pact-plugin/hooks/shared/task_metadata_snapshot.py
@@ -72,12 +72,28 @@ SNAPSHOT_EXCLUDE: frozenset[str] = frozenset({"handoff"})
 # invariant. NOT here: "variety" (already per-write-mirrored at its write
 # point by the dispatch_variety emit); "intentional_wait" (rides along in
 # the overlay; a wait-only write is not load-bearing alone).
+#
+# The audit pair is targeted for the same reasons as teachback_submit:
+# audit_summary (the auditor's live verdict) and audit_summary_authored
+# (the overwrite-protection mirror of the authored verdict) are consumed
+# by the lead at CODE-phase close while the audited task is still OPEN,
+# so a status-blind whole-store drain destroys them exactly while
+# load-bearing (a prior drain lost live audit verdicts mid-arc). Both are
+# teammate-written-class keys (the auditor writes from a teammate frame),
+# so they carry the same canonical-frame tmux asymmetry as
+# teachback_submit: in-process frames mirror per-write; a tmux teammate
+# frame defers to the completion seams. audit_summary_authored rides the
+# overlay whenever audit_summary fires (the gate's own writeback lands
+# before the leg's disk read), but stays targeted in its own right so a
+# direct write of the mirror alone is durability-covered too.
 PER_WRITE_MIRROR_KEYS: frozenset[str] = frozenset({
     "scope_contract",
     "nesting_depth",
     "worktree_path",
     "teachback_submit",
     "teachback_rejection",
+    "audit_summary",
+    "audit_summary_authored",
 })
 
 # Size caps on the canonical serialization (see _canonical_bytes). Empirics

--- a/pact-plugin/hooks/task_claim_gate.py
+++ b/pact-plugin/hooks/task_claim_gate.py
@@ -92,7 +92,6 @@ from __future__ import annotations
 import json
 import os
 import sys
-from pathlib import Path
 
 _SUPPRESS_OUTPUT = json.dumps({"suppressOutput": True})
 
@@ -111,6 +110,12 @@ _STDIN_READ_MAX = 8 * 1024 * 1024  # 8 MB
 # catch keeps the exit code clean (0) and the output well-formed.
 try:
     import shared.pact_context as pact_context
+    # SSOT delegation: the shared _read_lead_session_id implementation lives
+    # in shared.pact_context (session_registry keeps the one remaining inline
+    # copy, forced by its self-contained-leaf invariant). The from-import
+    # binds the name as THIS module's attribute, preserving the test seam
+    # that monkeypatches task_claim_gate._read_lead_session_id.
+    from shared.pact_context import _read_lead_session_id
     from shared.session_registry import resolve as registry_resolve
     from shared.task_utils import (
         iter_team_task_jsons,
@@ -198,44 +203,6 @@ def _stdin_team(stdin: dict) -> str:
     on tmux PreToolUse frames). Returns "" when missing/non-string."""
     team = stdin.get("team_name")
     return team if isinstance(team, str) else ""
-
-
-def _read_lead_session_id(team_name: str, teams_dir: str | None = None) -> str:
-    """Read the top-level ``leadSessionId`` from
-    ``~/.claude/teams/{team_name}/config.json``.
-
-    Mirrors the guarded-read shape of ``pact_context._iter_members``
-    (try/except → default) — net-new read; no hook reads ``leadSessionId``
-    today. Returns "" on any of: unsafe team_name, missing/unreadable file,
-    malformed JSON, non-object top-level, or a missing/non-string key. An empty
-    return routes the caller to the fail-safe in-process/NO-OP default. Never
-    raises.
-
-    CURRENCY DEPENDENCY (the in-process/tmux topology compare rests on this):
-    in-process safety assumes ``config.leadSessionId`` is CURRENT. A STALE value
-    — e.g. after a session resume where the team config retains a prior session's
-    id — could make the caller's ``session_id == leadSessionId`` compare
-    MISCLASSIFY an in-process frame as tmux (or vice-versa). Blast radius is
-    BOUNDED and benign: the discriminator is coordination-only (all frames are the
-    same OS user; no privilege boundary), and the worst misclassification outcome
-    is a benign ``pending → in_progress`` auto-flip of the teammate's OWN
-    owned-unblocked-pending task (in-process misread as tmux) — the very action
-    the teammate was supposed to take — or a missed nudge (tmux misread as
-    in-process). The ``owner == confident_name`` conjunction still bounds it to
-    the resolved teammate's task; no wrong-teammate flip, no escalation.
-    """
-    if not is_safe_path_component(team_name):
-        return ""
-    if teams_dir:
-        config_path = Path(teams_dir) / team_name / "config.json"
-    else:
-        config_path = get_claude_config_dir() / "teams" / team_name / "config.json"
-    try:
-        data = json.loads(config_path.read_text(encoding="utf-8"))
-        lead_session_id = data.get("leadSessionId")
-    except (OSError, json.JSONDecodeError, ValueError, AttributeError, TypeError):
-        return ""
-    return lead_session_id if isinstance(lead_session_id, str) else ""
 
 
 # ─── claim-candidate predicates ──────────────────────────────────────────────
@@ -453,6 +420,15 @@ def _evaluate(stdin: dict) -> str | None:
         return None  # cannot locate config → fail-safe NO-OP
 
     # ── Step 3: topology discriminator (the final D3 signal — a config read) ──
+    # CURRENCY (this gate's blast-radius bound; the generic currency note lives
+    # on the shared helper): the compare below assumes config.leadSessionId is
+    # CURRENT. A stale value (e.g. after a session resume) can misclassify an
+    # in-process frame as tmux or vice-versa — bounded and benign HERE: the
+    # worst outcome is a benign pending→in_progress auto-flip of the teammate's
+    # OWN owned-unblocked-pending task (the very action it was supposed to
+    # take) or a missed nudge. The owner == confident_name conjunction bounds
+    # it to the resolved teammate's task; no wrong-teammate flip, no
+    # escalation.
     lead_session_id = _read_lead_session_id(team_name)
     if not lead_session_id:
         # ASYMMETRY (design note): an UNKNOWN topology (config unreadable / no

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -798,6 +798,26 @@ def _emit_per_write_snapshot(
         pass
 
 
+def _created_task_id(tool_response: object, tool_input: dict) -> str:
+    """Id of the task a TaskCreate just made: tool_response.task.id
+    (canonical — the id does not exist in tool_input), falling back to a
+    harness-echoed tool_input.taskId. "" when unresolvable.
+
+    Extracted from the dispatch_variety emit block (behavior-identical) so
+    the per-write TaskCreate leg and the dispatch_variety emit resolve the
+    id through ONE expression of the create-result post-state shape.
+    """
+    created_task = (
+        tool_response.get("task") if isinstance(tool_response, dict) else None
+    )
+    new_task_id = ""
+    if isinstance(created_task, dict):
+        new_task_id = str(created_task.get("id") or "")
+    if not new_task_id:
+        new_task_id = str(tool_input.get("taskId") or "")
+    return new_task_id
+
+
 # ─── core evaluation ─────────────────────────────────────────────────────────
 
 
@@ -1282,16 +1302,7 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
                 else None
             )
             if isinstance(create_variety, dict) and create_variety:
-                created_task = (
-                    tool_response.get("task")
-                    if isinstance(tool_response, dict)
-                    else None
-                )
-                new_task_id = ""
-                if isinstance(created_task, dict):
-                    new_task_id = str(created_task.get("id") or "")
-                if not new_task_id:
-                    new_task_id = str(tool_input.get("taskId") or "")
+                new_task_id = _created_task_id(tool_response, tool_input)
                 if new_task_id:
                     # §5.1-fidelity projection: mirror ONLY the 4 dimensions +
                     # total, dropping the *_rationale strings — the journal is
@@ -1317,6 +1328,31 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
                         ))
                     except Exception:
                         pass  # fail-open: emit failure never breaks the gate
+
+        # task_metadata_snapshot seam — per-write mirror, TaskCreate leg. A
+        # created task whose initial metadata carries a targeted key
+        # (PER_WRITE_MIRROR_KEYS) mirrors the whole payload immediately —
+        # the create IS the first write of the open-task-consumed class.
+        # SIBLING of the dispatch_variety block above, deliberately NOT
+        # nested under its is_lead gate: this leg carries its own frame
+        # gate (canonical-journal-frame) because targeted keys include
+        # teammate-written classes. The platform-assigned id exists only in
+        # the create response, so resolution goes through _created_task_id;
+        # a missing id skips the emit (coverage degrades by one write,
+        # never breaks the gate — the dispatch_variety posture). The
+        # helper's own read_task_json returns the just-created file (the
+        # platform write lands before PostToolUse), so subject/owner
+        # resolve from disk and the overlay is a near-identity merge.
+        if (
+            isinstance(incoming_metadata, dict)
+            and any(k in PER_WRITE_MIRROR_KEYS for k in incoming_metadata)
+            and pact_context.is_canonical_journal_frame(input_data)
+        ):
+            new_task_id = _created_task_id(tool_response, tool_input)
+            if new_task_id:
+                _emit_per_write_snapshot(
+                    team_name, new_task_id, incoming_metadata
+                )
 
     # ③ TaskUpdate-to-completed rules — paired-send, handoff presence,
     # handoff schema, self-completion

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -298,7 +298,10 @@ try:
         make_event,
         read_events,
     )
-    from shared.task_metadata_snapshot import emit_task_metadata_snapshot
+    from shared.task_metadata_snapshot import (
+        PER_WRITE_MIRROR_KEYS,
+        emit_task_metadata_snapshot,
+    )
     from shared.task_utils import is_teachback_subject as _is_teachback_subject
     from shared.task_utils import read_task_json
     from shared.teachback_schema import (
@@ -748,6 +751,50 @@ def _emit_lead_side_agent_handoff(
     except Exception:
         # Fail-open: a journal-emit failure must never break the gate's
         # advisory evaluation or its exit-0 contract.
+        pass
+
+
+def _emit_per_write_snapshot(
+    team_name: str,
+    task_id: str,
+    delta: dict,
+    task: dict | None = None,
+) -> None:
+    """Per-write mirror emit — hermetic; never raises; READ-ONLY on every
+    input (new dicts only: the overlay comprehension builds a fresh
+    mapping; neither ``delta``, ``task``, nor ``task['metadata']`` is
+    written). ``task=None`` → one read_task_json; the TaskUpdate leg passes
+    its already-read task_a (zero marginal disk cost).
+
+    Shared by the TaskCreate and TaskUpdate per-write legs. Degenerate
+    inputs are the substrate's job (sentinel subject, owner normalize,
+    empty-payload no-emit); ``task_id`` sanitization also happens inside
+    ``emit_task_metadata_snapshot()``'s content-key-claim path — no new
+    sanitizer here. A missing/drained task file (``task == {}``) degrades
+    to a delta-only payload — correct: mirror what the write shows us. A
+    None-valued delta key is the platform DELETE op; the overlay drops it
+    so the emit mirrors the post-delete disk state (deduping if unchanged).
+    """
+    try:
+        if task is None:
+            task = read_task_json(task_id, team_name) if team_name else {}
+        if not isinstance(task, dict):
+            task = {}
+        disk_md = (
+            task.get("metadata")
+            if isinstance(task.get("metadata"), dict)
+            else {}
+        )
+        emit_task_metadata_snapshot(
+            team_name,
+            task_id,
+            task.get("subject") or "",
+            task.get("owner"),
+            {**disk_md, **{k: v for k, v in delta.items() if v is not None}},
+        )
+    except Exception:
+        # Exit-0 advisory contract: a mirror failure must never block or
+        # annotate the hooked tool call.
         pass
 
 
@@ -1808,6 +1855,46 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
                 )
             except Exception:
                 pass
+
+        # task_metadata_snapshot seam — OPEN-task per-write mirror. A
+        # metadata write carrying a targeted key (PER_WRITE_MIRROR_KEYS:
+        # the open-task-consumed class that a status-blind whole-store
+        # drain destroys while load-bearing) mirrors the whole overlay
+        # immediately, instead of waiting for a completion-time seam that
+        # a drained task never reaches. SIBLING of the post-completion
+        # backstop above — disjoint by construction on the same
+        # task_a.status read (backstop fires == "completed", this leg
+        # fires otherwise); do not merge the conditions. A COMPLETING
+        # TaskUpdate carrying targeted keys never lands here (status ==
+        # "completed" routes to the completion block, whose lead-completion
+        # seam mirrors the same overlay — no double-fire). Missing task
+        # file / unknown status is treated as open → fire: an over-fire of
+        # already-mirrored content dedups to a no-op on the shared
+        # content-hash marker, while a skipped fire is a durability hole —
+        # over-firing is self-correcting, under-firing is not.
+        #
+        # Frame gate is is_canonical_journal_frame, NOT is_lead: targeted
+        # keys include teammate-written ones (teachback_submit), and the
+        # in-process teammate frame writes the canonical journal (one
+        # process, one session). A tmux teammate frame skips — emitting
+        # there could silo the event AND poison the shared content-hash
+        # marker namespace. Conjunction order is deliberate (perf):
+        # ns-scale registry scan first, already-paid disk-status read
+        # second, the predicate's config.json read LAST (paid only on
+        # matched non-lead frames — rare by construction).
+        if (
+            isinstance(incoming_metadata, dict)
+            and any(k in PER_WRITE_MIRROR_KEYS for k in incoming_metadata)
+            and (
+                task_a.get("status") != "completed"
+                if isinstance(task_a, dict)
+                else True
+            )
+            and pact_context.is_canonical_journal_frame(input_data)
+        ):
+            _emit_per_write_snapshot(
+                team_name, task_id, incoming_metadata, task=task_a
+            )
 
     return advisories
 

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -1918,6 +1918,13 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
         # ns-scale registry scan first, already-paid disk-status read
         # second, the predicate's config.json read LAST (paid only on
         # matched non-lead frames — rare by construction).
+        #
+        # NOTE (deliberate split, applies to BOTH per-write legs): the
+        # predicate resolves its team via the identity-matched
+        # pact_context.get_team_name(), while this leg's emit + task_a
+        # read use the persisted ctx team_name resolved once at function
+        # top — do not unify either direction; full rationale at the
+        # resolver call inside is_canonical_journal_frame.
         if (
             isinstance(incoming_metadata, dict)
             and any(k in PER_WRITE_MIRROR_KEYS for k in incoming_metadata)

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -1847,7 +1847,7 @@ This phase dispatches sub-scopes for independent execution. Each sub-scope runs 
 
 This phase verifies that independently-developed sub-scopes are compatible before comprehensive testing.
 
-**Recover scope state**: Read from `TaskGet(scopeTaskId).metadata` (`scope_contract`, `worktree_path`) for each sub-scope.
+**Recover scope state**: Read from `TaskGet(scopeTaskId).metadata` (`scope_contract`, `worktree_path`) for each sub-scope. If `TaskGet(scopeTaskId)` cannot resolve (task store drained), recover from the session journal instead: run `python3 "{plugin_root}/hooks/shared/session_journal.py" read --session-dir "{session_dir}" --type task_metadata_snapshot` (prints a JSON array), filter to events whose `task_id` matches the scope task, take the latest-`ts` event, and read `scope_contract` / `worktree_path` from its `metadata` (honor `_truncated` / `_dropped_keys` markers if present).
 
 **Merge sub-scope branches**: Before running contract verification, merge each sub-scope's work back:
 1. For each completed sub-scope, merge its suffix branch to the feature branch

--- a/pact-plugin/protocols/pact-scope-phases.md
+++ b/pact-plugin/protocols/pact-scope-phases.md
@@ -34,7 +34,7 @@ This phase dispatches sub-scopes for independent execution. Each sub-scope runs 
 
 This phase verifies that independently-developed sub-scopes are compatible before comprehensive testing.
 
-**Recover scope state**: Read from `TaskGet(scopeTaskId).metadata` (`scope_contract`, `worktree_path`) for each sub-scope.
+**Recover scope state**: Read from `TaskGet(scopeTaskId).metadata` (`scope_contract`, `worktree_path`) for each sub-scope. If `TaskGet(scopeTaskId)` cannot resolve (task store drained), recover from the session journal instead: run `python3 "{plugin_root}/hooks/shared/session_journal.py" read --session-dir "{session_dir}" --type task_metadata_snapshot` (prints a JSON array), filter to events whose `task_id` matches the scope task, take the latest-`ts` event, and read `scope_contract` / `worktree_path` from its `metadata` (honor `_truncated` / `_dropped_keys` markers if present).
 
 **Merge sub-scope branches**: Before running contract verification, merge each sub-scope's work back:
 1. For each completed sub-scope, merge its suffix branch to the feature branch

--- a/pact-plugin/tests/test_commands_structure.py
+++ b/pact-plugin/tests/test_commands_structure.py
@@ -677,7 +677,7 @@ class TestPerLoopDispatchSites:
         ("comPACT.md", 293, "SingleSpecialist"),
         ("peer-review.md", 192, "Reviewers"),
         ("plan-mode.md", 236, "Consultants"),
-        ("rePACT.md", 262, "SubScopeSpecialists"),
+        ("rePACT.md", 263, "SubScopeSpecialists"),
     ]
 
     @staticmethod

--- a/pact-plugin/tests/test_per_write_adversarial_matrix.py
+++ b/pact-plugin/tests/test_per_write_adversarial_matrix.py
@@ -1,0 +1,762 @@
+"""
+Location: pact-plugin/tests/test_per_write_adversarial_matrix.py
+Summary: TEST-phase adversarial/boundary depth for the PER-WRITE mirror path
+         (task_lifecycle_gate's open-task TaskUpdate leg + TaskCreate leg
+         driving the task_metadata_snapshot substrate). The substrate's own
+         boundary arithmetic is pinned in test_snapshot_adversarial_matrix.py;
+         THIS file drives the same hostile classes through the SEAM — the
+         evaluate_lifecycle entrypoint (in-process, REAL journal + REAL
+         markers, no append_event spy except where a write FAILURE is the
+         scenario) and the real hook subprocess.
+
+         Matrix:
+         - Cap-edge payloads through the per-write path (caps IMPORTED from
+           the substrate, never re-declared): per-value cap/cap+1, a whole
+           overlay (disk ∪ delta) over the payload cap, a 5MB jumbo value.
+         - Marker-lookalike values as targeted-key data (provenance, not
+           shape, decides marker identity end-to-end).
+         - Hostile task_ids (traversal fragments, control chars, unicode)
+           through the sanitized content-key claim path — marker containment.
+         - Pathological metadata shapes: deep nesting (intact + serializer
+           breaking), None-riddled deltas, non-dict deltas (incl. a LIST
+           carrying a targeted-key string — the guard-first shape).
+         - Exit-0 advisory contract: a substrate write failure compensates
+           (unclaim) and never alters the advisory return; the mirror adds no
+           advisory across the fire/skip boundary (identical advisories in a
+           canonical vs a tmux frame).
+         - leadSessionId staleness probe: the documented blast radius — a
+           stale-mismatched config downgrades to a skipped emit (baseline
+           durability; no crash, no marker), a stale-equal admit lands the
+           event in THIS process's own resolvable journal (canonical-adjacent,
+           never a silo — a silo additionally requires a false-resolving
+           journal path, which the substrate writability precondition
+           forecloses).
+         - Completing-TaskUpdate disjointness boundary: a completing write
+           carrying a targeted key routes to the completion seam ONLY —
+           exactly one event, with the completion payload, never the
+           per-write overlay.
+         - Real-process depth: per-write dedup across process lifetimes,
+           stale-config skip, hostile-task_id containment, and an oversized
+           stdin frame (the outermost exit-0 boundary).
+Used by: pytest (TEST-phase certification for the per-write mirror).
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import shared.task_metadata_snapshot as tms  # noqa: E402
+import task_lifecycle_gate as tlg  # noqa: E402
+from shared.agent_handoff_marker import sanitize_path_component  # noqa: E402
+from shared.session_journal import read_events  # noqa: E402
+from shared.task_metadata_snapshot import (  # noqa: E402
+    PAYLOAD_CAP,
+    PER_VALUE_CAP,
+    _canonical_bytes,
+)
+
+TEAM = "pact-perwrite-adv"
+LEAD = "PACT:pact-orchestrator"
+TEAMMATE = "pact-backend-coder"
+
+LEAD_SID = "lead-session-0001"
+TMUX_SID = "teammate-session-0002"
+
+SCOPE = {"files": ["a.py"], "boundaries": "backend only"}
+
+
+# =============================================================================
+# In-process harness — REAL journal (read_events), REAL markers; no spy.
+# =============================================================================
+@pytest.fixture
+def home(tmp_path, monkeypatch, pact_context):
+    """Test-scoped HOME with a live session context: journal writes and
+    marker claims land on real tmp disk; read_events resolves the same
+    journal the seam wrote."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    pact_context(team_name=TEAM, session_id=LEAD_SID,
+                 project_dir="/test/project")
+    return tmp_path
+
+
+def _seed_task(home, task_id, *, subject="scope: atomize sub-scope",
+               owner="team-lead", status="in_progress", metadata=None):
+    tasks_dir = home / ".claude" / "tasks" / TEAM
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / f"{task_id}.json").write_text(
+        json.dumps({
+            "id": task_id,
+            "subject": subject,
+            "owner": owner,
+            "status": status,
+            "metadata": metadata if metadata is not None else {},
+        }),
+        encoding="utf-8",
+    )
+
+
+def _seed_team_config(home, lead_session_id=LEAD_SID):
+    team_dir = home / ".claude" / "teams" / TEAM
+    team_dir.mkdir(parents=True, exist_ok=True)
+    (team_dir / "config.json").write_text(
+        json.dumps({"leadSessionId": lead_session_id}), encoding="utf-8"
+    )
+
+
+def _open_write(task_id, metadata, *, agent_type=LEAD, session_id=LEAD_SID):
+    return {
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": task_id, "metadata": metadata},
+        "tool_response": {},
+        "agent_type": agent_type,
+        "session_id": session_id,
+    }
+
+
+def _snapshots():
+    return read_events("task_metadata_snapshot")
+
+
+def _marker_files(home):
+    teams_root = home / ".claude" / "teams"
+    if not teams_root.exists():
+        return []
+    return [
+        p
+        for p in teams_root.rglob("*")
+        if p.is_file() and p.parent.name == tms.SNAPSHOT_MARKER_NAMESPACE
+    ]
+
+
+def _is_marker_shape(value):
+    """Reader-side marker recognition (the harvest consumer's view)."""
+    return isinstance(value, dict) and value.get("_truncated") is True
+
+
+def _journal_line_bytes(home):
+    journal = (home / ".claude" / "pact-sessions" / "project" / LEAD_SID
+               / "session-journal.jsonl")
+    return [
+        line.encode("utf-8")
+        for line in journal.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+class TestPerWriteCapEdges:
+    """Exact cap arithmetic THROUGH the seam. Sizes are derived from the
+    imported substrate constants with the substrate's own _canonical_bytes
+    yardstick — a cap change re-derives the boundary; independent companion
+    assertions (event count, marker shape, bounded line) keep the rows
+    non-vacuous even though the yardstick is shared with the impl."""
+
+    def _value_of_canonical_size(self, size):
+        value = "a" * (size - 2)  # canonical str form is quoted: len = n + 2
+        assert len(_canonical_bytes(value)) == size
+        return value
+
+    def test_targeted_value_exactly_at_cap_survives_verbatim(self, home):
+        value = self._value_of_canonical_size(PER_VALUE_CAP)
+        _seed_task(home, "40")
+        advisories = tlg.evaluate_lifecycle(
+            _open_write("40", {"teachback_submit": value})
+        )
+        assert isinstance(advisories, list)
+        snaps = _snapshots()
+        assert len(snaps) == 1
+        assert snaps[0]["metadata"]["teachback_submit"] == value
+        assert "truncated" not in snaps[0]
+
+    def test_targeted_value_one_over_cap_truncation_marked(self, home):
+        value = self._value_of_canonical_size(PER_VALUE_CAP + 1)
+        _seed_task(home, "41")
+        tlg.evaluate_lifecycle(
+            _open_write("41", {"teachback_submit": value})
+        )
+        snaps = _snapshots()
+        assert len(snaps) == 1
+        marker = snaps[0]["metadata"]["teachback_submit"]
+        assert _is_marker_shape(marker), (
+            "one byte over PER_VALUE_CAP must surface as the truncation "
+            "marker — key existence survives, value is bounded"
+        )
+        assert marker["original_bytes"] == PER_VALUE_CAP + 1
+        assert snaps[0]["truncated"] is True
+
+    def test_whole_overlay_over_payload_cap_bounded_marked(self, home):
+        """disk ∪ delta over PAYLOAD_CAP: the overlay (not either half
+        alone) is what the substrate bounds. Four 13KB disk siblings +
+        a 15KB targeted delta ≈ 67KB > 64KB — the largest value (the
+        targeted key itself) is evicted to a marker, and the emitted
+        LINE stays near the cap."""
+        disk_md = {f"k{i}": "x" * (13 * 1024) for i in range(4)}
+        _seed_task(home, "42", metadata=disk_md)
+        big_scope = "s" * (15 * 1024)
+        tlg.evaluate_lifecycle(_open_write("42", {"scope_contract": big_scope}))
+        snaps = _snapshots()
+        assert len(snaps) == 1
+        payload = snaps[0]["metadata"]
+        assert _is_marker_shape(payload["scope_contract"]), (
+            "largest-first eviction picks the 15KB targeted value"
+        )
+        assert payload["scope_contract"]["original_bytes"] == len(
+            _canonical_bytes(big_scope)
+        )
+        for key in disk_md:
+            assert payload[key] == disk_md[key]
+        assert len(_canonical_bytes(payload)) <= PAYLOAD_CAP
+        lines = _journal_line_bytes(home)
+        assert len(lines) == 1
+        assert len(lines[0]) < PAYLOAD_CAP + 16 * 1024
+
+    def test_jumbo_5mb_targeted_value_no_raise_bounded_line(self, home):
+        _seed_task(home, "43")
+        advisories = tlg.evaluate_lifecycle(
+            _open_write("43", {"teachback_submit": "B" * (5 * 1024 * 1024)})
+        )
+        assert isinstance(advisories, list), "exit-0 contract: no raise"
+        snaps = _snapshots()
+        assert len(snaps) == 1
+        marker = snaps[0]["metadata"]["teachback_submit"]
+        assert _is_marker_shape(marker)
+        assert marker["original_bytes"] == 5 * 1024 * 1024 + 2
+        lines = _journal_line_bytes(home)
+        assert len(lines) == 1
+        assert len(lines[0]) < PAYLOAD_CAP + 16 * 1024, (
+            "the raw 5MB value must never reach the journal line"
+        )
+
+
+class TestMarkerLookalikeThroughPerWrite:
+    """Provenance-not-shape end-to-end: caller data that LOOKS like the
+    substrate's truncation marker is ordinary data at the seam."""
+
+    LOOKALIKE = {"_truncated": True, "original_bytes": 999999999,
+                 "head": "attacker-controlled"}
+
+    def test_small_lookalike_carried_verbatim_and_dedups(self, home):
+        _seed_task(home, "44")
+        payload = _open_write("44", {"scope_contract": dict(self.LOOKALIKE)})
+        tlg.evaluate_lifecycle(payload)
+        tlg.evaluate_lifecycle(payload)  # unchanged rewrite → dedup no-op
+        snaps = _snapshots()
+        assert len(snaps) == 1
+        assert snaps[0]["metadata"]["scope_contract"] == self.LOOKALIKE, (
+            "an under-cap lookalike is ordinary data — carried verbatim, "
+            "never re-interpreted as OUR marker"
+        )
+        assert "truncated" not in snaps[0], (
+            "nothing was truncated; a lookalike must not set the flag"
+        )
+        assert len(_marker_files(home)) == 1
+
+    def test_oversized_lookalike_with_hostile_original_bytes_replaced(
+            self, home):
+        """The dangerous variant: a lookalike whose original_bytes is a
+        hostile NON-INT and whose serialization is over the per-value cap.
+        Shape-tested marker identity would let the hostile field reach the
+        stage-3 int sort (TypeError inside the hermetic emit = silent
+        event loss); provenance tracking replaces the whole value with OUR
+        marker computed from ITS serialization."""
+        hostile = {
+            "_truncated": True,
+            "original_bytes": "not-an-int",
+            "head": "h" * (PER_VALUE_CAP),  # canonical size > PER_VALUE_CAP
+        }
+        _seed_task(home, "45")
+        tlg.evaluate_lifecycle(_open_write("45", {"scope_contract": hostile}))
+        snaps = _snapshots()
+        assert len(snaps) == 1
+        marker = snaps[0]["metadata"]["scope_contract"]
+        assert _is_marker_shape(marker)
+        assert marker["original_bytes"] == len(_canonical_bytes(hostile)), (
+            "OUR marker, computed from the hostile value's serialization — "
+            "an int by construction, not the attacker's string"
+        )
+        assert isinstance(marker["original_bytes"], int)
+        assert snaps[0]["truncated"] is True
+
+
+class TestHostileTaskIdsThroughClaimPath:
+    """Traversal/control-char/unicode task_ids through the per-write leg.
+    The seam adds NO sanitizer of its own — everything rides the substrate's
+    sanitized content-key claim path. Independent companions to the shared
+    sanitize_path_component oracle: no raise, marker CONTAINMENT inside the
+    namespace dir, and event-count sanity."""
+
+    HOSTILE_IDS = [
+        "../../etc/passwd",
+        "task\x00id\r\n",
+        "täsk☃-unicode",
+        "a/b\\c",
+    ]
+
+    def test_hostile_update_ids_no_raise_sanitized_contained(self, home):
+        emitted = 0
+        for task_id in self.HOSTILE_IDS:
+            advisories = tlg.evaluate_lifecycle(
+                _open_write(task_id, {"scope_contract": SCOPE})
+            )
+            assert isinstance(advisories, list), (
+                f"exit-0 contract violated for task_id {task_id!r}"
+            )
+        snaps = _snapshots()
+        emitted = len(snaps)
+        assert emitted >= 1, "the hostile-id class must not kill the emit"
+        sanitized = {sanitize_path_component(str(t))
+                     for t in self.HOSTILE_IDS}
+        for event in snaps:
+            assert event["task_id"] in sanitized, (
+                "the emitted task_id must be the sanitized form — raw "
+                "traversal/control bytes never reach the journal"
+            )
+        self._assert_marker_containment(home)
+        assert not (home / ".claude" / "etc").exists()
+        assert not (home / "etc").exists()
+
+    def test_hostile_create_id_sanitized_contained(self, home):
+        _seed_task(home, "46")
+        payload = {
+            "tool_name": "TaskCreate",
+            "tool_input": {"subject": "scope: sub-scope",
+                           "metadata": {"scope_contract": SCOPE}},
+            "tool_response": {"task": {"id": "../../marker-escape"}},
+            "agent_type": LEAD,
+            "session_id": LEAD_SID,
+        }
+        advisories = tlg.evaluate_lifecycle(payload)
+        assert isinstance(advisories, list)
+        snaps = _snapshots()
+        assert len(snaps) == 1
+        assert snaps[0]["task_id"] == "marker-escape"
+        self._assert_marker_containment(home)
+
+    @staticmethod
+    def _assert_marker_containment(home):
+        teams_root = (home / ".claude" / "teams").resolve()
+        for path in _marker_files(home):
+            resolved = path.resolve()
+            assert resolved.is_relative_to(teams_root), (
+                f"marker escaped the teams root: {resolved}"
+            )
+            assert resolved.parent.name == tms.SNAPSHOT_MARKER_NAMESPACE
+
+
+class TestPathologicalMetadataShapes:
+    def test_deep_nesting_intact_through_seam(self, home):
+        """300-deep nesting survives the overlay + serialization round-trip
+        intact (no flattening, no silent drop)."""
+        nested = "leaf"
+        for _ in range(300):
+            nested = {"d": nested}
+        _seed_task(home, "47")
+        tlg.evaluate_lifecycle(_open_write("47", {"scope_contract": nested}))
+        snaps = _snapshots()
+        assert len(snaps) == 1
+        node = snaps[0]["metadata"]["scope_contract"]
+        for _ in range(300):
+            node = node["d"]
+        assert node == "leaf"
+
+    def test_serializer_breaking_nesting_hermetic_no_marker_poison(
+            self, home):
+        """A nesting deep enough to blow the JSON serializer (RecursionError
+        inside _canonical_bytes) is swallowed by the hermetic emit BEFORE
+        any marker claim: no raise, no event, no poisoned marker — and a
+        later clean fire on the same task emits normally."""
+        nested = "leaf"
+        for _ in range(100_000):
+            nested = {"d": nested}
+        _seed_task(home, "48")
+        advisories = tlg.evaluate_lifecycle(
+            _open_write("48", {"scope_contract": nested})
+        )
+        assert isinstance(advisories, list), "exit-0 contract: no raise"
+        assert _snapshots() == []
+        assert _marker_files(home) == [], (
+            "validate-before-claim: the failed build must claim nothing"
+        )
+        tlg.evaluate_lifecycle(_open_write("48", {"scope_contract": SCOPE}))
+        assert len(_snapshots()) == 1, "recovery fire must not be suppressed"
+
+    def test_none_riddled_delta_top_level_dropped_nested_preserved(
+            self, home):
+        """Top-level None values are the platform DELETE op (dropped from
+        the overlay); None values NESTED inside a targeted value are data
+        and must survive verbatim."""
+        _seed_task(home, "49", metadata={"note": "existing",
+                                         "worktree_path": "/old"})
+        delta = {
+            "scope_contract": {"a": None, "b": {"c": None}},
+            "nesting_depth": None,
+            "junk": None,
+        }
+        tlg.evaluate_lifecycle(_open_write("49", delta))
+        snaps = _snapshots()
+        assert len(snaps) == 1
+        payload = snaps[0]["metadata"]
+        assert payload["scope_contract"] == {"a": None, "b": {"c": None}}
+        assert "nesting_depth" not in payload
+        assert "junk" not in payload
+        assert payload["note"] == "existing"
+        assert payload["worktree_path"] == "/old"
+
+    @pytest.mark.parametrize("bad_delta", [
+        "scope_contract",            # a STRING that equals a targeted key
+        ["scope_contract"],          # a LIST carrying a targeted-key string
+        7,
+        True,
+    ], ids=["str", "list-with-targeted-token", "int", "bool"])
+    def test_non_dict_delta_guard_first_no_emit_no_raise(
+            self, home, bad_delta):
+        """isinstance-dict guards run BEFORE the key scan: a non-dict delta
+        never fires, even when iterating it would yield a targeted-key
+        string (the list row — `any(k in KEYS for k in list)` would match
+        without the guard)."""
+        _seed_task(home, "50")
+        advisories = tlg.evaluate_lifecycle(_open_write("50", bad_delta))
+        assert isinstance(advisories, list)
+        assert _snapshots() == []
+        assert _marker_files(home) == []
+
+
+class TestExitZeroAdvisoryNonInterference:
+    def test_append_failure_compensates_and_preserves_advisories(
+            self, home, monkeypatch):
+        """A journal write failure inside the substrate must (a) roll back
+        the content-key claim (compensating unclaim — a later valid fire
+        can re-emit) and (b) leave the advisory return IDENTICAL to the
+        success path."""
+        _seed_task(home, "51")
+        _seed_task(home, "52")
+        ok_advisories = tlg.evaluate_lifecycle(
+            _open_write("51", {"scope_contract": SCOPE})
+        )
+        assert len(_snapshots()) == 1
+        markers_after_success = len(_marker_files(home))
+        assert markers_after_success == 1
+
+        def _raise(event):
+            raise RuntimeError("journal write failed")
+
+        monkeypatch.setattr(tms, "append_event", _raise)
+        fail_advisories = tlg.evaluate_lifecycle(
+            _open_write("52", {"scope_contract": {"other": "content"}})
+        )
+        assert fail_advisories == ok_advisories, (
+            "a mirror failure must never alter the advisory output"
+        )
+        assert len(_marker_files(home)) == markers_after_success, (
+            "the failed emit's claim must be compensated (unclaimed)"
+        )
+
+    def test_mirror_adds_no_advisory_across_fire_boundary(self, home):
+        """The SAME teachback write (malformed variety_acknowledgment — a
+        known write-time advisory trigger) evaluated in a canonical frame
+        (mirror FIRES) and a tmux frame (mirror SKIPS) must return
+        IDENTICAL, NON-EMPTY advisories: the mirror neither adds nor
+        suppresses an advisory on either side of the fire boundary."""
+        _seed_team_config(home)
+        _seed_task(home, "53",
+                   subject="backend-coder: TEACHBACK for adversarial",
+                   owner="backend-coder")
+        delta = {"teachback_submit": {
+            "understanding": "u",
+            "most_likely_wrong": "m",
+            "least_confident_item": "l",
+            "first_action": "f",
+            "variety_acknowledgment": "free-text string — wrong shape",
+        }}
+        fired = tlg.evaluate_lifecycle(
+            _open_write("53", copy.deepcopy(delta),
+                        agent_type=TEAMMATE, session_id=LEAD_SID)
+        )
+        assert len(_snapshots()) == 1, "canonical frame must fire"
+        skipped = tlg.evaluate_lifecycle(
+            _open_write("53", copy.deepcopy(delta),
+                        agent_type=TEAMMATE, session_id=TMUX_SID)
+        )
+        assert len(_snapshots()) == 1, "tmux frame must skip"
+        assert fired == skipped
+        assert fired, "the oracle advisory must be non-empty (else vacuous)"
+        assert any(
+            rule == "variety_acknowledgment_schema_invalid_at_write_time"
+            for rule, _ in fired
+        )
+
+
+class TestLeadSessionIdStalenessProbe:
+    """The topology compare's documented currency dependency: certify the
+    blast radius is never worse than the shipped baseline."""
+
+    def test_stale_mismatched_config_downgrades_to_skip(self, home):
+        """An in-process teammate whose live session_id no longer matches a
+        STALE leadSessionId (config not refreshed after a resume) is
+        misclassified as tmux → SKIP. Blast radius: a skipped in-process
+        emit — baseline durability (completion seams) — with no crash and
+        no marker claim. This is the accepted direction; the durability
+        loss is bounded, the marker namespace stays clean."""
+        _seed_team_config(home, lead_session_id="stale-pre-resume-sid")
+        _seed_task(home, "54", owner="backend-coder",
+                   subject="backend-coder: TEACHBACK gate")
+        advisories = tlg.evaluate_lifecycle(
+            _open_write("54", {"teachback_submit": {"understanding": "u"}},
+                        agent_type=TEAMMATE, session_id=LEAD_SID)
+        )
+        assert isinstance(advisories, list)
+        assert _snapshots() == []
+        assert _marker_files(home) == []
+
+    def test_stale_equal_admit_lands_in_own_resolvable_journal(self, home):
+        """The admit direction: whatever frame carries session_id ==
+        leadSessionId is admitted, and its emit lands in the journal THIS
+        process's own session context resolves — a readable,
+        canonical-adjacent location, never an unreadable silo. (A true
+        silo requires BOTH a stale-equal id AND a false-resolving journal
+        path; with no resolvable path the substrate's writability
+        precondition defers instead — pinned at the substrate level.)"""
+        _seed_team_config(home, lead_session_id=LEAD_SID)
+        _seed_task(home, "55", owner="backend-coder",
+                   subject="backend-coder: TEACHBACK gate")
+        tlg.evaluate_lifecycle(
+            _open_write("55", {"teachback_submit": {"understanding": "u"}},
+                        agent_type=TEAMMATE, session_id=LEAD_SID)
+        )
+        journal = (home / ".claude" / "pact-sessions" / "project" / LEAD_SID
+                   / "session-journal.jsonl")
+        assert journal.exists(), (
+            "the admitted emit must land in the session-context-resolved "
+            "journal — the location a canonical reader consults"
+        )
+        assert len(_snapshots()) == 1
+
+    def test_config_drained_mid_arc_skips_no_crash(self, home):
+        """teams/config.json deleted between dispatch and write (the drain
+        class this feature exists to survive): topology unresolvable →
+        fail-closed skip, no crash."""
+        _seed_task(home, "56", owner="backend-coder",
+                   subject="backend-coder: TEACHBACK gate")
+        advisories = tlg.evaluate_lifecycle(
+            _open_write("56", {"teachback_submit": {"understanding": "u"}},
+                        agent_type=TEAMMATE, session_id=LEAD_SID)
+        )
+        assert isinstance(advisories, list)
+        assert _snapshots() == []
+        assert _marker_files(home) == []
+
+
+class TestCompletingWriteDisjointnessBoundary:
+    def test_completing_update_with_targeted_key_single_completion_event(
+            self, home):
+        """A COMPLETING TaskUpdate carrying a targeted key in its delta
+        routes to the completion block ONLY. The tool_input delta and the
+        tool_response final metadata deliberately DIFFER: if the per-write
+        leg also fired, its overlay would be a second, distinct content
+        key → TWO events. Exactly one event, carrying the completion
+        payload, proves the status split routes rather than dedups."""
+        _seed_task(home, "57", metadata={"scope_contract": SCOPE})
+        final_md = {"scope_contract": SCOPE, "final_extra": "final"}
+        payload = {
+            "tool_name": "TaskUpdate",
+            "tool_input": {
+                "taskId": "57",
+                "status": "completed",
+                "metadata": {"scope_contract": SCOPE},
+            },
+            "tool_response": {"task": {
+                "id": "57",
+                "subject": "scope: atomize sub-scope",
+                "owner": "team-lead",
+                "metadata": final_md,
+            }},
+            "agent_type": LEAD,
+            "session_id": LEAD_SID,
+        }
+        tlg.evaluate_lifecycle(payload)
+        snaps = _snapshots()
+        assert len(snaps) == 1, (
+            "a completing targeted write is the completion seam's surface — "
+            "a second event means the per-write leg fired across the "
+            "status boundary"
+        )
+        assert snaps[0]["metadata"] == final_md
+
+
+# =============================================================================
+# Real-process depth — own copy of the subprocess harness (kept local so the
+# CODE-phase subprocess file stays untouched; same env-only isolation, same
+# ANTI-MOCK posture: nothing in-process is patched for these rows).
+# =============================================================================
+SUB_TEAM = "session-perwrite-adv"
+SUB_SID = "dddddddd-4444-5555-6666-777777777777"
+SUB_SLUG = "perwrite-adv-project"
+
+HOOKS_DIR = Path(__file__).parent.parent / "hooks"
+
+
+def _sub_seed_home(tmp_path):
+    home = tmp_path / "home"
+    session_dir = home / ".claude" / "pact-sessions" / SUB_SLUG / SUB_SID
+    session_dir.mkdir(parents=True)
+    (session_dir / "pact-session-context.json").write_text(
+        json.dumps({
+            "team_name": SUB_TEAM,
+            "session_id": SUB_SID,
+            "project_dir": f"/tmp/{SUB_SLUG}",
+            "plugin_root": "",
+            "started_at": "2026-01-01T00:00:00Z",
+        }),
+        encoding="utf-8",
+    )
+    tasks_dir = home / ".claude" / "tasks" / SUB_TEAM
+    tasks_dir.mkdir(parents=True)
+    return home, session_dir, tasks_dir
+
+
+def _sub_write_task(tasks_dir, task_id, *, status="in_progress",
+                    metadata=None):
+    (tasks_dir / f"{task_id}.json").write_text(
+        json.dumps({
+            "id": task_id,
+            "owner": "backend-coder",
+            "subject": "scope: sub-scope",
+            "status": status,
+            "metadata": metadata if metadata is not None else {},
+        }),
+        encoding="utf-8",
+    )
+
+
+def _sub_run_gate(stdin_text, home):
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["CLAUDE_PROJECT_DIR"] = f"/tmp/{SUB_SLUG}"
+    return subprocess.run(
+        [sys.executable, str(HOOKS_DIR / "task_lifecycle_gate.py")],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(home),
+        timeout=60,
+    )
+
+
+def _sub_open_write_frame(task_id, metadata, *,
+                          agent_type="PACT:pact-orchestrator",
+                          session_id=SUB_SID):
+    return {
+        "hook_event_name": "PostToolUse",
+        "session_id": session_id,
+        "agent_type": agent_type,
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": task_id, "metadata": metadata},
+        "tool_response": {},
+    }
+
+
+def _sub_snapshots(home):
+    return [
+        json.loads(line)
+        for journal in home.rglob("*.jsonl")
+        for line in journal.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+        and json.loads(line).get("type") == "task_metadata_snapshot"
+    ]
+
+
+def _sub_marker_dir(home):
+    return (home / ".claude" / "teams" / SUB_TEAM
+            / tms.SNAPSHOT_MARKER_NAMESPACE)
+
+
+class TestPerWriteSubprocessDepth:
+    def test_unchanged_rewrite_dedups_across_process_lifetimes(
+            self, tmp_path):
+        """The dedup/churn acceptance criterion at the REAL seam: two full
+        hook process runs of the identical targeted write — fresh
+        interpreter each time, so ONLY the on-disk O_EXCL content-hash
+        marker can carry the dedup — land exactly ONE journal event."""
+        home, _session_dir, tasks_dir = _sub_seed_home(tmp_path)
+        _sub_write_task(tasks_dir, "70")
+        frame = json.dumps(
+            _sub_open_write_frame("70", {"scope_contract": SCOPE})
+        )
+        first = _sub_run_gate(frame, home)
+        second = _sub_run_gate(frame, home)
+        assert first.returncode == 0 and second.returncode == 0
+        assert len(_sub_snapshots(home)) == 1, (
+            "an unchanged targeted rewrite must be a churn no-op across "
+            "real process lifetimes"
+        )
+        marker_dir = _sub_marker_dir(home)
+        assert marker_dir.exists() and len(list(marker_dir.iterdir())) == 1
+
+    def test_stale_config_mismatch_real_process_skips(self, tmp_path):
+        """Staleness probe through the real binary: a teammate frame whose
+        live session_id mismatches the on-disk (stale) leadSessionId skips
+        — zero snapshot events anywhere under HOME, zero markers, exit 0."""
+        home, _session_dir, tasks_dir = _sub_seed_home(tmp_path)
+        team_dir = home / ".claude" / "teams" / SUB_TEAM
+        team_dir.mkdir(parents=True)
+        (team_dir / "config.json").write_text(
+            json.dumps({"leadSessionId": "stale-pre-resume-sid"}),
+            encoding="utf-8",
+        )
+        _sub_write_task(tasks_dir, "71")
+        result = _sub_run_gate(
+            json.dumps(_sub_open_write_frame(
+                "71", {"teachback_submit": {"understanding": "u"}},
+                agent_type="pact-backend-coder",
+            )),
+            home,
+        )
+        assert result.returncode == 0, result.stderr
+        assert _sub_snapshots(home) == []
+        marker_dir = _sub_marker_dir(home)
+        assert not marker_dir.exists() or not any(marker_dir.iterdir())
+
+    def test_hostile_task_id_real_process_contained(self, tmp_path):
+        """Traversal task_id through the real binary: exit 0, sanitized
+        event id, every marker inside the namespace dir."""
+        home, _session_dir, tasks_dir = _sub_seed_home(tmp_path)
+        result = _sub_run_gate(
+            json.dumps(_sub_open_write_frame(
+                "../../marker-escape", {"scope_contract": SCOPE}
+            )),
+            home,
+        )
+        assert result.returncode == 0, result.stderr
+        snaps = _sub_snapshots(home)
+        assert len(snaps) == 1
+        assert snaps[0]["task_id"] == "marker-escape"
+        teams_root = (home / ".claude" / "teams").resolve()
+        for path in teams_root.rglob("*"):
+            if path.is_file() and path.suffix != ".json":
+                assert path.resolve().is_relative_to(teams_root)
+                assert path.parent.name == tms.SNAPSHOT_MARKER_NAMESPACE
+        assert not (home / "etc").exists()
+        assert not (home / ".claude" / "etc").exists()
+
+    def test_oversized_stdin_frame_exit0_suppress_no_write(self, tmp_path):
+        """The outermost exit-0 boundary: a stdin frame larger than the
+        gate's stdin read cap truncates to malformed JSON → suppressOutput,
+        exit 0, and NOTHING lands in any journal (no partial parse can
+        reach the emit path)."""
+        home, _session_dir, _tasks_dir = _sub_seed_home(tmp_path)
+        frame = _sub_open_write_frame("72", {"scope_contract": SCOPE})
+        frame["padding"] = "P" * (9 * 1024 * 1024)  # over the 8MB read cap
+        result = _sub_run_gate(json.dumps(frame), home)
+        assert result.returncode == 0, result.stderr
+        assert json.loads(result.stdout.strip())["suppressOutput"] is True
+        assert _sub_snapshots(home) == []

--- a/pact-plugin/tests/test_per_write_mirror_registry.py
+++ b/pact-plugin/tests/test_per_write_mirror_registry.py
@@ -1,0 +1,218 @@
+"""
+Tests for the per-write mirror foundations: the PER_WRITE_MIRROR_KEYS
+registry constant (shared/task_metadata_snapshot.py) and the
+canonical-journal-frame predicate (shared/pact_context.py).
+
+Covers:
+
+Registry invariants:
+1. PER_WRITE_MIRROR_KEYS is disjoint from SNAPSHOT_EXCLUDE — a targeted key
+   that the substrate then drops from the payload would be a fire that
+   mirrors nothing (silent durability hole), so disjointness is pinned.
+2. Registry is a non-empty frozenset of strings (shape pin only — exact
+   membership is deliberately NOT pinned so a registry extension stays a
+   one-string source diff).
+
+_read_lead_session_id() (shared copy):
+3. Returns the leadSessionId string from a valid team config
+4. teams_dir override is honored
+5. Returns "" on: unsafe team_name, missing config, malformed JSON,
+   non-object top-level, missing key, non-string key value
+
+is_canonical_journal_frame():
+6. Lead frame → True with NO config and NO session_id (is_lead leg is
+   independent of the topology leg's resolvability)
+7. Teammate frame with session_id == leadSessionId → True (in-process
+   topology; the positive control for the topology leg)
+8. Teammate frame with session_id != leadSessionId → False (tmux topology)
+9. Resolution failures all → False: missing session_id, non-string
+   session_id, missing config, malformed config, non-string leadSessionId,
+   empty team context (fail-closed team resolution), empty input frame
+"""
+
+import json
+
+import pytest
+
+import shared.pact_context as ctx_module
+from shared.task_metadata_snapshot import (
+    PER_WRITE_MIRROR_KEYS,
+    SNAPSHOT_EXCLUDE,
+)
+
+
+LEAD_SESSION = "lead-session-0001"
+TEAMMATE_SESSION = "teammate-session-0002"
+
+
+class TestPerWriteMirrorKeysRegistry:
+    """Shape + disjointness pins on the registry constant."""
+
+    def test_disjoint_from_snapshot_exclude(self):
+        """A key in both sets would fire the per-write seam and then have
+        the substrate drop it from the payload — a mirror of nothing."""
+        assert PER_WRITE_MIRROR_KEYS & SNAPSHOT_EXCLUDE == frozenset()
+
+    def test_registry_is_nonempty_frozenset_of_strings(self):
+        assert isinstance(PER_WRITE_MIRROR_KEYS, frozenset)
+        assert PER_WRITE_MIRROR_KEYS
+        assert all(isinstance(k, str) and k for k in PER_WRITE_MIRROR_KEYS)
+
+
+@pytest.fixture
+def teams_root(tmp_path, monkeypatch):
+    """Hermetic claude-config root: both the predicate's config read and
+    get_team_name's identity-match scan resolve under tmp_path."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    teams = tmp_path / "teams"
+    teams.mkdir()
+    return teams
+
+
+def _seed_config(teams, team="test-team", lead_session_id=LEAD_SESSION):
+    """Write a minimal team config carrying leadSessionId."""
+    team_dir = teams / team
+    team_dir.mkdir(exist_ok=True)
+    (team_dir / "config.json").write_text(
+        json.dumps({"leadSessionId": lead_session_id}), encoding="utf-8"
+    )
+    return team_dir
+
+
+class TestReadLeadSessionId:
+    """Unit rows for the shared guarded read-helper. Behavior must stay in
+    LOGIC-PARITY with the two private copies its docstring cross-references."""
+
+    def test_returns_lead_session_id_from_valid_config(self, teams_root):
+        _seed_config(teams_root)
+        assert (
+            ctx_module._read_lead_session_id("test-team") == LEAD_SESSION
+        )
+
+    def test_teams_dir_override_honored(self, tmp_path):
+        teams = tmp_path / "alt-teams"
+        teams.mkdir()
+        _seed_config(teams)
+        result = ctx_module._read_lead_session_id(
+            "test-team", teams_dir=str(teams)
+        )
+        assert result == LEAD_SESSION
+
+    def test_unsafe_team_name_returns_empty(self, teams_root):
+        _seed_config(teams_root)
+        assert ctx_module._read_lead_session_id("../test-team") == ""
+        assert ctx_module._read_lead_session_id("") == ""
+
+    def test_missing_config_returns_empty(self, teams_root):
+        assert ctx_module._read_lead_session_id("test-team") == ""
+
+    def test_malformed_json_returns_empty(self, teams_root):
+        team_dir = teams_root / "test-team"
+        team_dir.mkdir()
+        (team_dir / "config.json").write_text("{not json", encoding="utf-8")
+        assert ctx_module._read_lead_session_id("test-team") == ""
+
+    def test_non_object_top_level_returns_empty(self, teams_root):
+        team_dir = teams_root / "test-team"
+        team_dir.mkdir()
+        (team_dir / "config.json").write_text("[1, 2]", encoding="utf-8")
+        assert ctx_module._read_lead_session_id("test-team") == ""
+
+    def test_missing_key_returns_empty(self, teams_root):
+        team_dir = teams_root / "test-team"
+        team_dir.mkdir()
+        (team_dir / "config.json").write_text(
+            json.dumps({"members": []}), encoding="utf-8"
+        )
+        assert ctx_module._read_lead_session_id("test-team") == ""
+
+    def test_non_string_value_returns_empty(self, teams_root):
+        _seed_config(teams_root, lead_session_id=42)
+        assert ctx_module._read_lead_session_id("test-team") == ""
+
+
+class TestIsCanonicalJournalFrame:
+    """Both-modes topology rows for the frame predicate. Structural signals
+    only: agent_type for the role leg, session_id vs the team config's
+    leadSessionId for the topology leg. False must be the answer on every
+    resolution failure (skip defers durability to the completion-time seams;
+    a misclassified emit could silo the event and poison the shared
+    content-hash marker namespace)."""
+
+    def test_lead_frame_true_without_config_or_session_id(self):
+        """The is_lead leg must be independent of topology resolvability:
+        no context, no team config, no session_id — still True."""
+        assert ctx_module.is_canonical_journal_frame(
+            {"agent_type": "pact-orchestrator"}
+        )
+        assert ctx_module.is_canonical_journal_frame(
+            {"agent_type": "PACT:pact-orchestrator"}
+        )
+
+    def test_in_process_teammate_frame_true(self, teams_root, pact_context):
+        """Positive control for the topology leg: one process, one session —
+        the frame's session_id equals the team config's leadSessionId."""
+        pact_context(team_name="test-team", session_id=LEAD_SESSION)
+        _seed_config(teams_root)
+        assert ctx_module.is_canonical_journal_frame(
+            {"agent_type": "pact-backend-coder", "session_id": LEAD_SESSION}
+        )
+
+    def test_tmux_teammate_frame_false(self, teams_root, pact_context):
+        """A distinct session_id is the tmux teammate signature — skip."""
+        pact_context(team_name="test-team", session_id=TEAMMATE_SESSION)
+        _seed_config(teams_root)
+        assert not ctx_module.is_canonical_journal_frame(
+            {
+                "agent_type": "pact-backend-coder",
+                "session_id": TEAMMATE_SESSION,
+            }
+        )
+
+    def test_missing_session_id_false(self, teams_root, pact_context):
+        pact_context(team_name="test-team", session_id=LEAD_SESSION)
+        _seed_config(teams_root)
+        assert not ctx_module.is_canonical_journal_frame(
+            {"agent_type": "pact-backend-coder"}
+        )
+
+    def test_non_string_session_id_false(self, teams_root, pact_context):
+        pact_context(team_name="test-team", session_id=LEAD_SESSION)
+        _seed_config(teams_root)
+        assert not ctx_module.is_canonical_journal_frame(
+            {"agent_type": "pact-backend-coder", "session_id": 123}
+        )
+
+    def test_missing_config_false(self, teams_root, pact_context):
+        pact_context(team_name="test-team", session_id=LEAD_SESSION)
+        assert not ctx_module.is_canonical_journal_frame(
+            {"agent_type": "pact-backend-coder", "session_id": LEAD_SESSION}
+        )
+
+    def test_malformed_config_false(self, teams_root, pact_context):
+        pact_context(team_name="test-team", session_id=LEAD_SESSION)
+        team_dir = teams_root / "test-team"
+        team_dir.mkdir()
+        (team_dir / "config.json").write_text("{not json", encoding="utf-8")
+        assert not ctx_module.is_canonical_journal_frame(
+            {"agent_type": "pact-backend-coder", "session_id": LEAD_SESSION}
+        )
+
+    def test_non_string_lead_session_id_false(self, teams_root, pact_context):
+        pact_context(team_name="test-team", session_id=LEAD_SESSION)
+        _seed_config(teams_root, lead_session_id=42)
+        assert not ctx_module.is_canonical_journal_frame(
+            {"agent_type": "pact-backend-coder", "session_id": LEAD_SESSION}
+        )
+
+    def test_empty_team_context_false(self, teams_root):
+        """No session context → get_team_name fails closed to "" → the
+        topology leg cannot resolve → False, even with a matching config."""
+        _seed_config(teams_root)
+        assert not ctx_module.is_canonical_journal_frame(
+            {"agent_type": "pact-backend-coder", "session_id": LEAD_SESSION}
+        )
+
+    def test_empty_input_frame_false(self):
+        """Never-raises floor: an empty frame is not canonical."""
+        assert not ctx_module.is_canonical_journal_frame({})

--- a/pact-plugin/tests/test_per_write_mirror_registry.py
+++ b/pact-plugin/tests/test_per_write_mirror_registry.py
@@ -9,23 +9,26 @@ Registry invariants:
 1. PER_WRITE_MIRROR_KEYS is disjoint from SNAPSHOT_EXCLUDE — a targeted key
    that the substrate then drops from the payload would be a fire that
    mirrors nothing (silent durability hole), so disjointness is pinned.
-2. Registry is a non-empty frozenset of strings (shape pin only — exact
+2. Registry is a non-empty frozenset of strings (shape pin — exact
    membership is deliberately NOT pinned so a registry extension stays a
    one-string source diff).
+3. The five ruled keys are a MINIMUM SUBSET of the registry — deletion of
+   a ruled key goes red while extensions stay one-string diffs (the
+   deletion-protection complement of the no-exact-membership choice).
 
 _read_lead_session_id() (shared copy):
-3. Returns the leadSessionId string from a valid team config
-4. teams_dir override is honored
-5. Returns "" on: unsafe team_name, missing config, malformed JSON,
+4. Returns the leadSessionId string from a valid team config
+5. teams_dir override is honored
+6. Returns "" on: unsafe team_name, missing config, malformed JSON,
    non-object top-level, missing key, non-string key value
 
 is_canonical_journal_frame():
-6. Lead frame → True with NO config and NO session_id (is_lead leg is
+7. Lead frame → True with NO config and NO session_id (is_lead leg is
    independent of the topology leg's resolvability)
-7. Teammate frame with session_id == leadSessionId → True (in-process
+8. Teammate frame with session_id == leadSessionId → True (in-process
    topology; the positive control for the topology leg)
-8. Teammate frame with session_id != leadSessionId → False (tmux topology)
-9. Resolution failures all → False: missing session_id, non-string
+9. Teammate frame with session_id != leadSessionId → False (tmux topology)
+10. Resolution failures all → False: missing session_id, non-string
    session_id, missing config, malformed config, non-string leadSessionId,
    empty team context (fail-closed team resolution), empty input frame
 """
@@ -57,6 +60,21 @@ class TestPerWriteMirrorKeysRegistry:
         assert isinstance(PER_WRITE_MIRROR_KEYS, frozenset)
         assert PER_WRITE_MIRROR_KEYS
         assert all(isinstance(k, str) and k for k in PER_WRITE_MIRROR_KEYS)
+
+    def test_ruled_keys_are_minimum_subset(self):
+        """Deletion protection for the ruled keys: a superset assert keeps
+        registry EXTENSIONS a one-string source diff while the silent
+        removal of any ruled key goes red. Without this pin (and with
+        exact membership deliberately unpinned above), dropping a key
+        that no seam test uses as its fire trigger would ship green —
+        un-mirroring that key class with zero test signal."""
+        assert frozenset({
+            "scope_contract",
+            "nesting_depth",
+            "worktree_path",
+            "teachback_submit",
+            "teachback_rejection",
+        }) <= PER_WRITE_MIRROR_KEYS
 
 
 @pytest.fixture

--- a/pact-plugin/tests/test_per_write_mirror_registry.py
+++ b/pact-plugin/tests/test_per_write_mirror_registry.py
@@ -12,7 +12,7 @@ Registry invariants:
 2. Registry is a non-empty frozenset of strings (shape pin — exact
    membership is deliberately NOT pinned so a registry extension stays a
    one-string source diff).
-3. The five ruled keys are a MINIMUM SUBSET of the registry — deletion of
+3. The seven ruled keys are a MINIMUM SUBSET of the registry — deletion of
    a ruled key goes red while extensions stay one-string diffs (the
    deletion-protection complement of the no-exact-membership choice).
 
@@ -74,6 +74,8 @@ class TestPerWriteMirrorKeysRegistry:
             "worktree_path",
             "teachback_submit",
             "teachback_rejection",
+            "audit_summary",
+            "audit_summary_authored",
         }) <= PER_WRITE_MIRROR_KEYS
 
 

--- a/pact-plugin/tests/test_per_write_snapshot_seam.py
+++ b/pact-plugin/tests/test_per_write_snapshot_seam.py
@@ -422,3 +422,107 @@ class TestPerWriteFirePredicate:
         snaps = _snapshots(snapshot_events)
         assert len(snaps) == 1
         assert snaps[0]["metadata"] == {"scope_contract": SCOPE}
+
+
+# =============================================================================
+# TaskCreate leg
+# =============================================================================
+class TestPerWriteTaskCreateLeg:
+    def _create_payload(self, task_id, metadata, subject="scope: sub-scope"):
+        """A TaskCreate PostToolUse frame: the platform-assigned id exists
+        only in the create response (tool_response.task.id)."""
+        return {
+            "tool_name": "TaskCreate",
+            "tool_input": {"subject": subject, "metadata": metadata},
+            "tool_response": {"task": {"id": task_id}},
+            "agent_type": LEAD,
+            "session_id": LEAD_SID,
+        }
+
+    def test_create_with_targeted_key_emits_keyed_to_response_id(
+        self, home, pact_context, snapshot_events
+    ):
+        """TaskCreate carrying a targeted key → 1 snapshot keyed to
+        tool_response.task.id, with subject/owner resolved from the
+        just-created on-disk file (platform write lands before
+        PostToolUse) overlaid with the incoming delta."""
+        pact_context(team_name=TEAM, session_id=LEAD_SID)
+        _seed_task(
+            home,
+            TEAM,
+            "70",
+            subject="scope: sub-scope",
+            owner="team-lead",
+            status="pending",
+            metadata={"scope_contract": SCOPE},
+        )
+        tlg.evaluate_lifecycle(
+            self._create_payload("70", {"scope_contract": SCOPE})
+        )
+        snaps = _snapshots(snapshot_events)
+        assert len(snaps) == 1
+        event = snaps[0]
+        assert event["task_id"] == "70"
+        assert event["subject"] == "scope: sub-scope"
+        assert event["metadata"] == {"scope_contract": SCOPE}
+
+    def test_create_without_targeted_key_no_emit(
+        self, home, pact_context, snapshot_events
+    ):
+        """Byte-identical default on the create surface: an untargeted
+        initial metadata emits nothing."""
+        pact_context(team_name=TEAM, session_id=LEAD_SID)
+        tlg.evaluate_lifecycle(
+            self._create_payload("71", {"note": "plain create"})
+        )
+        assert _snapshots(snapshot_events) == []
+
+    def test_create_with_unresolvable_id_skips(
+        self, home, pact_context, snapshot_events
+    ):
+        """Missing id → skip (coverage degrades by one write; the gate is
+        never broken) — the dispatch_variety posture."""
+        pact_context(team_name=TEAM, session_id=LEAD_SID)
+        payload = {
+            "tool_name": "TaskCreate",
+            "tool_input": {
+                "subject": "scope: sub-scope",
+                "metadata": {"scope_contract": SCOPE},
+            },
+            "tool_response": {},
+            "agent_type": LEAD,
+            "session_id": LEAD_SID,
+        }
+        tlg.evaluate_lifecycle(payload)
+        assert _snapshots(snapshot_events) == []
+
+    def test_tmux_teammate_create_no_event_no_marker(
+        self, home, pact_context
+    ):
+        """The create leg carries its own frame gate: a tmux teammate frame
+        (session_id != leadSessionId) writes nothing anywhere and claims no
+        marker."""
+        pact_context(team_name=TEAM, session_id=TMUX_SID)
+        _seed_team_config(home)
+        _seed_task(
+            home,
+            TEAM,
+            "72",
+            subject="scope: sub-scope",
+            owner="team-lead",
+            status="pending",
+            metadata={},
+        )
+        payload = {
+            "tool_name": "TaskCreate",
+            "tool_input": {
+                "subject": "scope: sub-scope",
+                "metadata": {"scope_contract": SCOPE},
+            },
+            "tool_response": {"task": {"id": "72"}},
+            "agent_type": TEAMMATE,
+            "session_id": TMUX_SID,
+        }
+        tlg.evaluate_lifecycle(payload)
+        assert _journal_files(home) == []
+        assert _marker_files(home) == []

--- a/pact-plugin/tests/test_per_write_snapshot_seam.py
+++ b/pact-plugin/tests/test_per_write_snapshot_seam.py
@@ -8,9 +8,10 @@ Summary: Seam tests for the per-write task_metadata_snapshot mirror inside
          is_lead + session_id-vs-leadSessionId structural signals), the
          byte-identical default for untargeted traffic, unchanged-rewrite
          dedup, cross-seam dedup against the lead-completion seam,
-         delete-only (None-valued targeted key) semantics, and the
+         delete-only (None-valued targeted key) semantics, the
          rejection-cycle catch-up (a teachback_rejection-triggered fire
-         carries the on-disk teachback_submit sibling). The tmux teammate
+         carries the on-disk teachback_submit sibling), and the audit
+         verdict class (audit_summary as fire trigger). The tmux teammate
          row asserts WHERE events land (no journal file, no marker claim),
          not merely that nothing raises.
 Used by: pytest (CODE-phase verification for the per-write seam; adversarial
@@ -417,6 +418,44 @@ class TestPerWriteFirePredicate:
         assert snaps[0]["metadata"] == {
             "teachback_submit": {"understanding": "revised u2"},
             "teachback_rejection": {"reason": "first_action too vague"},
+        }
+
+    def test_audit_summary_fire_mirrors_overlay(
+        self, home, pact_context, snapshot_events
+    ):
+        """audit_summary as the fire TRIGGER: an open-task write of the
+        audit verdict mirrors the whole overlay immediately — the verdict
+        class a status-blind drain destroys while the lead still consumes
+        it. The delta carries ONLY audit_summary, so this row also goes
+        red if the key leaves the registry. Lead frame with NO
+        audit_summary_authored on disk on purpose: the gate's
+        authored-verdict preservation machinery (non-lead MIRROR write,
+        lead overwrite advisory) stays out of this row — it pins the
+        snapshot seam, not the advisory layer."""
+        pact_context(team_name=TEAM, session_id=LEAD_SID)
+        # Neutral subject per the file's established discipline: it must
+        # not pattern-match any write-time advisory rule.
+        _seed_task(
+            home,
+            TEAM,
+            "75",
+            subject="backend-coder: implement parser fix",
+            owner="backend-coder",
+            status="in_progress",
+            metadata={"note": "existing"},
+        )
+        tlg.evaluate_lifecycle(
+            _open_write_payload(
+                "75",
+                {"audit_summary": {"signal": "YELLOW", "findings": "gap"}},
+                session_id=LEAD_SID,
+            )
+        )
+        snaps = _snapshots(snapshot_events)
+        assert len(snaps) == 1
+        assert snaps[0]["metadata"] == {
+            "note": "existing",
+            "audit_summary": {"signal": "YELLOW", "findings": "gap"},
         }
 
     def test_completed_disk_status_routes_to_backstop_not_this_leg(

--- a/pact-plugin/tests/test_per_write_snapshot_seam.py
+++ b/pact-plugin/tests/test_per_write_snapshot_seam.py
@@ -526,3 +526,50 @@ class TestPerWriteTaskCreateLeg:
         tlg.evaluate_lifecycle(payload)
         assert _journal_files(home) == []
         assert _marker_files(home) == []
+
+
+# =============================================================================
+# READ-ONLY payload build (shared-object identity)
+# =============================================================================
+class TestReadOnlyPayloadBuild:
+    def test_shared_metadata_object_deep_unchanged_after_fire(
+        self, home, pact_context, snapshot_events
+    ):
+        """The certification row for the READ-ONLY contract: ONE metadata
+        object travels through the whole gate (advisory evaluation + the
+        per-write leg's overlay build) and comes out deep-equal to its
+        pre-call copy — no by-reference mutation, no key injection, no
+        None-filter applied in place. The emitted payload is a FRESH
+        mapping, not the caller's object."""
+        import copy
+
+        pact_context(team_name=TEAM, session_id=LEAD_SID)
+        _seed_task(
+            home,
+            TEAM,
+            "73",
+            subject="scope: atomize sub-scope",
+            owner="team-lead",
+            status="in_progress",
+            metadata={"note": "existing"},
+        )
+        shared_delta = {
+            "scope_contract": SCOPE,
+            "teachback_submit": {"understanding": "u"},
+            "worktree_path": None,
+        }
+        before = copy.deepcopy(shared_delta)
+        tlg.evaluate_lifecycle(
+            _open_write_payload("73", shared_delta, session_id=LEAD_SID)
+        )
+        assert shared_delta == before, (
+            "the gate mutated the caller's metadata object — READ-ONLY "
+            "payload-build contract violated"
+        )
+        snaps = _snapshots(snapshot_events)
+        assert len(snaps) == 1
+        assert snaps[0]["metadata"] is not shared_delta
+        # The None-valued key was dropped from the EMITTED overlay only —
+        # never from the caller's object (asserted deep-equal above).
+        assert "worktree_path" not in snaps[0]["metadata"]
+        assert snaps[0]["metadata"]["note"] == "existing"

--- a/pact-plugin/tests/test_per_write_snapshot_seam.py
+++ b/pact-plugin/tests/test_per_write_snapshot_seam.py
@@ -7,8 +7,10 @@ Summary: Seam tests for the per-write task_metadata_snapshot mirror inside
          (lead / in-process teammate / tmux teammate / tmux lead — the
          is_lead + session_id-vs-leadSessionId structural signals), the
          byte-identical default for untargeted traffic, unchanged-rewrite
-         dedup, cross-seam dedup against the lead-completion seam, and
-         delete-only (None-valued targeted key) semantics. The tmux teammate
+         dedup, cross-seam dedup against the lead-completion seam,
+         delete-only (None-valued targeted key) semantics, and the
+         rejection-cycle catch-up (a teachback_rejection-triggered fire
+         carries the on-disk teachback_submit sibling). The tmux teammate
          row asserts WHERE events land (no journal file, no marker claim),
          not merely that nothing raises.
 Used by: pytest (CODE-phase verification for the per-write seam; adversarial
@@ -380,6 +382,42 @@ class TestPerWriteFirePredicate:
         assert len(snaps) == 1
         assert snaps[0]["metadata"] == {"worktree_path": "/tmp/wt"}
         assert "scope_contract" not in snaps[0]["metadata"]
+
+    def test_rejection_fire_carries_on_disk_submit_sibling(
+        self, home, pact_context, snapshot_events
+    ):
+        """teachback_rejection as the fire TRIGGER (lead-written, so it
+        fires in BOTH teammate modes): the whole-payload overlay drags the
+        teammate's ON-DISK teachback_submit revision into the same event —
+        the rejection-cycle catch-up that gives the teammate-written class
+        its tmux durability. The delta carries ONLY the rejection, so this
+        row also goes red if teachback_rejection leaves the registry."""
+        pact_context(team_name=TEAM, session_id=LEAD_SID)
+        # Neutral subject on purpose: this row pins the MIRROR overlay,
+        # not the write-time teachback advisory rules — a teachback-pattern
+        # subject would entangle the two layers.
+        _seed_task(
+            home,
+            TEAM,
+            "74",
+            subject="backend-coder: implement parser fix",
+            owner="backend-coder",
+            status="in_progress",
+            metadata={"teachback_submit": {"understanding": "revised u2"}},
+        )
+        tlg.evaluate_lifecycle(
+            _open_write_payload(
+                "74",
+                {"teachback_rejection": {"reason": "first_action too vague"}},
+                session_id=LEAD_SID,
+            )
+        )
+        snaps = _snapshots(snapshot_events)
+        assert len(snaps) == 1
+        assert snaps[0]["metadata"] == {
+            "teachback_submit": {"understanding": "revised u2"},
+            "teachback_rejection": {"reason": "first_action too vague"},
+        }
 
     def test_completed_disk_status_routes_to_backstop_not_this_leg(
         self, home, pact_context, snapshot_events

--- a/pact-plugin/tests/test_per_write_snapshot_seam.py
+++ b/pact-plugin/tests/test_per_write_snapshot_seam.py
@@ -1,0 +1,424 @@
+"""
+Location: pact-plugin/tests/test_per_write_snapshot_seam.py
+Summary: Seam tests for the per-write task_metadata_snapshot mirror inside
+         task_lifecycle_gate.py — the open-task TaskUpdate leg that fires
+         when a metadata delta carries a targeted key (PER_WRITE_MIRROR_KEYS)
+         in a canonical journal frame. Covers the both-modes frame matrix
+         (lead / in-process teammate / tmux teammate / tmux lead — the
+         is_lead + session_id-vs-leadSessionId structural signals), the
+         byte-identical default for untargeted traffic, unchanged-rewrite
+         dedup, cross-seam dedup against the lead-completion seam, and
+         delete-only (None-valued targeted key) semantics. The tmux teammate
+         row asserts WHERE events land (no journal file, no marker claim),
+         not merely that nothing raises.
+Used by: pytest (CODE-phase verification for the per-write seam; adversarial
+         payload edges and live-mode depth are TEST phase work).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import shared.task_metadata_snapshot as tms  # noqa: E402
+import task_lifecycle_gate as tlg  # noqa: E402
+
+TEAM = "pact-test"
+LEAD = "PACT:pact-orchestrator"
+TEAMMATE = "pact-devops-engineer"
+
+LEAD_SID = "lead-session-0001"
+TMUX_SID = "teammate-session-0002"
+
+SCOPE = {"files": ["a.py"], "boundaries": "backend only"}
+
+
+@pytest.fixture
+def snapshot_events(monkeypatch):
+    """Spy on the SUBSTRATE's append_event binding — the per-write leg routes
+    snapshot writes through shared.task_metadata_snapshot. Marker claims stay
+    REAL (under the test HOME), so dedup rows exercise the actual O_EXCL
+    content-key path."""
+    events: list[dict] = []
+
+    def _spy(event):
+        events.append(event)
+        return True
+
+    monkeypatch.setattr(tms, "append_event", _spy)
+    return events
+
+
+def _snapshots(events):
+    return [e for e in events if e.get("type") == "task_metadata_snapshot"]
+
+
+def _seed_task(tmp_path, team, task_id, **fields):
+    """Write ~/.claude/tasks/{team}/{id}.json under the test-scoped HOME so
+    the gate's read_task_json resolves the on-disk state."""
+    tasks_dir = tmp_path / ".claude" / "tasks" / team
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    payload = {"id": task_id, **fields}
+    (tasks_dir / f"{task_id}.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+def _seed_team_config(tmp_path, team=TEAM, lead_session_id=LEAD_SID):
+    """Write ~/.claude/teams/{team}/config.json carrying leadSessionId —
+    the topology leg's compare source."""
+    team_dir = tmp_path / ".claude" / "teams" / team
+    team_dir.mkdir(parents=True, exist_ok=True)
+    (team_dir / "config.json").write_text(
+        json.dumps({"leadSessionId": lead_session_id}), encoding="utf-8"
+    )
+
+
+def _open_write_payload(task_id, metadata, agent_type=LEAD, session_id=None):
+    """A metadata-only TaskUpdate (no status key → lands in the write-time
+    block) — the per-write mirror's fire surface."""
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": task_id, "metadata": metadata},
+        "tool_response": {},
+    }
+    if agent_type is not None:
+        payload["agent_type"] = agent_type
+    if session_id is not None:
+        payload["session_id"] = session_id
+    return payload
+
+
+def _completion_payload(task_id, subject, owner, metadata):
+    """A lead TaskUpdate(status=completed) frame with post-state via
+    tool_response.task — drives the lead-completion seam for the
+    cross-seam dedup row."""
+    return {
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": task_id, "status": "completed"},
+        "tool_response": {
+            "task": {
+                "id": task_id,
+                "subject": subject,
+                "owner": owner,
+                "metadata": metadata,
+            }
+        },
+        "agent_type": LEAD,
+    }
+
+
+def _journal_files(tmp_path):
+    """Every journal file under the test HOME — the WHERE-it-lands oracle."""
+    return list(tmp_path.rglob("*.jsonl"))
+
+
+def _marker_files(tmp_path):
+    """Every claimed snapshot content-hash marker under the test HOME."""
+    teams_root = tmp_path / ".claude" / "teams"
+    if not teams_root.exists():
+        return []
+    return [
+        p
+        for p in teams_root.rglob("*")
+        if p.is_file() and p.parent.name == tms.SNAPSHOT_MARKER_NAMESPACE
+    ]
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    """Test-scoped HOME: tasks dir, teams dir (config + markers), and the
+    journal resolution all land under tmp_path."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    return tmp_path
+
+
+# =============================================================================
+# Frame matrix — rows keyed by (agent_type, session_id vs leadSessionId)
+# =============================================================================
+class TestPerWriteFrameMatrix:
+    def test_lead_frame_open_task_targeted_key_emits(
+        self, home, pact_context, snapshot_events
+    ):
+        """Lead frame (in-process), open task + targeted key → 1 snapshot
+        carrying the disk∪delta overlay."""
+        pact_context(team_name=TEAM, session_id=LEAD_SID)
+        _seed_task(
+            home,
+            TEAM,
+            "60",
+            subject="scope: atomize sub-scope",
+            owner="team-lead",
+            status="in_progress",
+            metadata={"note": "existing"},
+        )
+        tlg.evaluate_lifecycle(
+            _open_write_payload(
+                "60", {"scope_contract": SCOPE}, session_id=LEAD_SID
+            )
+        )
+        snaps = _snapshots(snapshot_events)
+        assert len(snaps) == 1
+        event = snaps[0]
+        assert event["task_id"] == "60"
+        assert event["subject"] == "scope: atomize sub-scope"
+        assert event["owner"] == "team-lead"
+        assert event["metadata"] == {
+            "note": "existing",
+            "scope_contract": SCOPE,
+        }
+
+    def test_in_process_teammate_frame_emits(
+        self, home, pact_context, snapshot_events
+    ):
+        """Teammate frame, session_id == leadSessionId (in-process): the
+        topology leg admits the frame — positive control proving the gate
+        is NOT is_lead-only (the teammate-written teachback_submit leg
+        would otherwise be dead by construction)."""
+        pact_context(team_name=TEAM, session_id=LEAD_SID)
+        _seed_team_config(home)
+        _seed_task(
+            home,
+            TEAM,
+            "61",
+            subject="backend-coder: TEACHBACK gate",
+            owner="backend-coder",
+            status="in_progress",
+            metadata={},
+        )
+        tlg.evaluate_lifecycle(
+            _open_write_payload(
+                "61",
+                {"teachback_submit": {"understanding": "u"}},
+                agent_type=TEAMMATE,
+                session_id=LEAD_SID,
+            )
+        )
+        snaps = _snapshots(snapshot_events)
+        assert len(snaps) == 1
+        assert snaps[0]["metadata"] == {
+            "teachback_submit": {"understanding": "u"}
+        }
+
+    def test_tmux_teammate_frame_no_event_anywhere_no_marker(
+        self, home, pact_context
+    ):
+        """Teammate frame, session_id != leadSessionId (tmux): skip by
+        predicate. NO spy here on purpose — this row asserts WHERE writes
+        land: ZERO journal files anywhere under the test HOME and ZERO
+        content-hash markers claimed. A silo'd emit or a poisoned shared
+        marker (suppressing a later canonical emit) is the hazard the
+        frame gate exists to exclude."""
+        pact_context(team_name=TEAM, session_id=TMUX_SID)
+        _seed_team_config(home)  # leadSessionId=LEAD_SID != TMUX_SID
+        _seed_task(
+            home,
+            TEAM,
+            "62",
+            subject="backend-coder: TEACHBACK gate",
+            owner="backend-coder",
+            status="in_progress",
+            metadata={},
+        )
+        tlg.evaluate_lifecycle(
+            _open_write_payload(
+                "62",
+                {"teachback_submit": {"understanding": "u"}},
+                agent_type=TEAMMATE,
+                session_id=TMUX_SID,
+            )
+        )
+        assert _journal_files(home) == []
+        assert _marker_files(home) == []
+
+    def test_tmux_lead_frame_emits(self, home, pact_context, snapshot_events):
+        """Lead frame with a session_id that does NOT match the seeded
+        leadSessionId: the is_lead leg is independent of the topology
+        compare, so the lead keeps full both-modes coverage."""
+        pact_context(team_name=TEAM, session_id="lead-tmux-other")
+        _seed_team_config(home, lead_session_id="a-different-lead")
+        _seed_task(
+            home,
+            TEAM,
+            "63",
+            subject="scope: atomize sub-scope",
+            owner="team-lead",
+            status="in_progress",
+            metadata={},
+        )
+        tlg.evaluate_lifecycle(
+            _open_write_payload(
+                "63",
+                {"worktree_path": "/tmp/wt"},
+                session_id="lead-tmux-other",
+            )
+        )
+        assert len(_snapshots(snapshot_events)) == 1
+
+
+# =============================================================================
+# Fire-predicate semantics
+# =============================================================================
+class TestPerWriteFirePredicate:
+    def test_non_targeted_key_no_emit(
+        self, home, pact_context, snapshot_events
+    ):
+        """Byte-identical default: untargeted traffic never reaches the
+        leg — an open-task write of a non-registry key emits nothing."""
+        pact_context(team_name=TEAM, session_id=LEAD_SID)
+        _seed_task(
+            home,
+            TEAM,
+            "64",
+            subject="devops: open task",
+            owner="devops",
+            status="in_progress",
+            metadata={},
+        )
+        tlg.evaluate_lifecycle(
+            _open_write_payload(
+                "64", {"note": "mid-task"}, session_id=LEAD_SID
+            )
+        )
+        assert _snapshots(snapshot_events) == []
+
+    def test_unchanged_targeted_rewrite_dedups(
+        self, home, pact_context, snapshot_events
+    ):
+        """An identical targeted rewrite no-ops on the REAL content-hash
+        marker: two fires, one event, one marker."""
+        pact_context(team_name=TEAM, session_id=LEAD_SID)
+        _seed_task(
+            home,
+            TEAM,
+            "65",
+            subject="scope: atomize sub-scope",
+            owner="team-lead",
+            status="in_progress",
+            metadata={},
+        )
+        payload = _open_write_payload(
+            "65", {"scope_contract": SCOPE}, session_id=LEAD_SID
+        )
+        tlg.evaluate_lifecycle(payload)
+        tlg.evaluate_lifecycle(payload)
+        assert len(_snapshots(snapshot_events)) == 1
+        assert len(_marker_files(home)) == 1
+
+    def test_cross_seam_dedup_with_completion(
+        self, home, pact_context, snapshot_events
+    ):
+        """Whole-payload mirroring makes the per-write emit and a later
+        acceptance completion with identical final content collapse into
+        ONE event (shared content-key marker across seams); changed
+        content emits a superseding second event."""
+        pact_context(team_name=TEAM, session_id=LEAD_SID)
+        _seed_task(
+            home,
+            TEAM,
+            "66",
+            subject="scope: atomize sub-scope",
+            owner="team-lead",
+            status="in_progress",
+            metadata={},
+        )
+        tlg.evaluate_lifecycle(
+            _open_write_payload(
+                "66", {"scope_contract": SCOPE}, session_id=LEAD_SID
+            )
+        )
+        assert len(_snapshots(snapshot_events)) == 1
+        # Acceptance completion with the IDENTICAL final content → dedup.
+        tlg.evaluate_lifecycle(
+            _completion_payload(
+                "66",
+                "scope: atomize sub-scope",
+                "team-lead",
+                {"scope_contract": SCOPE},
+            )
+        )
+        assert len(_snapshots(snapshot_events)) == 1
+        # Changed content at completion → superseding second event.
+        tlg.evaluate_lifecycle(
+            _completion_payload(
+                "66",
+                "scope: atomize sub-scope",
+                "team-lead",
+                {"scope_contract": {**SCOPE, "boundaries": "widened"}},
+            )
+        )
+        assert len(_snapshots(snapshot_events)) == 2
+
+    def test_delete_only_targeted_write_mirrors_post_delete_state(
+        self, home, pact_context, snapshot_events
+    ):
+        """A None-valued targeted key is the platform DELETE op and COUNTS
+        as a fire: the overlay drops the None and mirrors the post-delete
+        disk state (the platform applied the delete before PostToolUse)."""
+        pact_context(team_name=TEAM, session_id=LEAD_SID)
+        _seed_task(
+            home,
+            TEAM,
+            "67",
+            subject="scope: atomize sub-scope",
+            owner="team-lead",
+            status="in_progress",
+            # Post-delete disk state: scope_contract already removed by the
+            # platform; a sibling survives.
+            metadata={"worktree_path": "/tmp/wt"},
+        )
+        tlg.evaluate_lifecycle(
+            _open_write_payload(
+                "67", {"scope_contract": None}, session_id=LEAD_SID
+            )
+        )
+        snaps = _snapshots(snapshot_events)
+        assert len(snaps) == 1
+        assert snaps[0]["metadata"] == {"worktree_path": "/tmp/wt"}
+        assert "scope_contract" not in snaps[0]["metadata"]
+
+    def test_completed_disk_status_routes_to_backstop_not_this_leg(
+        self, home, pact_context, snapshot_events
+    ):
+        """Disjointness with the post-completion backstop on the same
+        task_a.status read: a targeted write on an ALREADY-completed task
+        is the backstop's surface, and the two legs together emit exactly
+        ONE event (they would dedup on content anyway; the status split
+        means only one leg fires at all)."""
+        pact_context(team_name=TEAM, session_id=LEAD_SID)
+        _seed_task(
+            home,
+            TEAM,
+            "68",
+            subject="scope: atomize sub-scope",
+            owner="team-lead",
+            status="completed",
+            metadata={},
+        )
+        tlg.evaluate_lifecycle(
+            _open_write_payload(
+                "68", {"scope_contract": SCOPE}, session_id=LEAD_SID
+            )
+        )
+        assert len(_snapshots(snapshot_events)) == 1
+
+    def test_missing_task_file_treated_open_delta_only_payload(
+        self, home, pact_context, snapshot_events
+    ):
+        """Fail-toward-mirroring: a missing/drained task file at fire time
+        is treated as open and mirrors the delta-only payload (mirror what
+        the write shows us) — over-firing dedups, under-firing loses the
+        exact write the drain hazard targets."""
+        pact_context(team_name=TEAM, session_id=LEAD_SID)
+        tlg.evaluate_lifecycle(
+            _open_write_payload(
+                "69", {"scope_contract": SCOPE}, session_id=LEAD_SID
+            )
+        )
+        snaps = _snapshots(snapshot_events)
+        assert len(snaps) == 1
+        assert snaps[0]["metadata"] == {"scope_contract": SCOPE}

--- a/pact-plugin/tests/test_read_lead_session_id_parity.py
+++ b/pact-plugin/tests/test_read_lead_session_id_parity.py
@@ -1,25 +1,31 @@
-"""Behavioral-parity DRIFT-GUARD for the _read_lead_session_id dual-copy.
+"""Behavioral-parity DRIFT-GUARD for the two _read_lead_session_id
+implementations.
 
-session_registry._read_lead_session_id and task_claim_gate._read_lead_session_id
-are INDEPENDENT inline copies (session_registry is a self-contained leaf that
-imports nothing from shared.*, so it cannot import the task_claim_gate copy). The
-session_registry copy's docstring claims "LOGIC-PARITY with
-task_claim_gate._read_lead_session_id" — but until now that claim was prose-only,
-not test-enforced. This test makes it enforced: if a future edit changes the
-leadSessionId-resolution behavior of one copy without the other, this test goes
-red. It mirrors the established inline-dual-copy parity-guard convention already
-used for _sanitize_agent_name (session_registry vs peer_context) and
-_is_safe_team_segment (session_registry vs session_end).
+shared.pact_context._read_lead_session_id is the SSOT implementation;
+task_claim_gate consumes it via a from-import (a module-attribute binding, so
+the established task_claim_gate._read_lead_session_id patch seam survives —
+this file exercises the gate's binding, which IS the pact_context function).
+session_registry._read_lead_session_id is the ONE remaining inline copy: that
+module is a self-contained leaf that imports nothing from shared.*, so it
+cannot be re-pointed to the SSOT. Its docstring claims LOGIC-PARITY with the
+pact_context copy; this test makes that claim enforced — if a future edit
+changes the leadSessionId-resolution behavior of either implementation without
+the other, this test goes red. It mirrors the established inline-copy
+parity-guard convention already used for _sanitize_agent_name
+(session_registry vs peer_context) and _is_safe_team_segment
+(session_registry vs session_end).
 
-WHAT "PARITY" MEANS HERE — BEHAVIORAL, not structural. The two copies have a
-KNOWN, ACCEPTED STRUCTURAL DIVERGENCE that this test deliberately accommodates:
+WHAT "PARITY" MEANS HERE — BEHAVIORAL, not structural. The two implementations
+have a KNOWN, ACCEPTED STRUCTURAL DIVERGENCE that this test deliberately
+accommodates:
 
   * session_registry._read_lead_session_id(team) — one positional arg; resolves
     the teams dir via the INLINED _config_root() (no parameter); gates the team
     segment with _is_safe_team_segment.
-  * task_claim_gate._read_lead_session_id(team_name, teams_dir=None) — takes an
-    optional teams_dir; resolves via get_claude_config_dir() when teams_dir is
-    None; gates with is_safe_path_component (a positive-allowlist regex).
+  * pact_context._read_lead_session_id(team_name, teams_dir=None) — the SSOT
+    copy the gate binds; takes an optional teams_dir; resolves via
+    get_claude_config_dir() when teams_dir is None; gates with
+    is_safe_path_component (a positive-allowlist regex).
 
 So this test does NOT assert the functions are byte-identical. It asserts they
 return the SAME leadSessionId for the SAME LOGICAL INPUT — the same on-disk

--- a/pact-plugin/tests/test_snapshot_seams_gate.py
+++ b/pact-plugin/tests/test_snapshot_seams_gate.py
@@ -344,9 +344,14 @@ class TestSeamBPostCompletionBackstop:
     def test_open_task_metadata_write_no_backstop_fire(
         self, tmp_path, monkeypatch, pact_context, snapshot_events
     ):
-        """The backstop keys on disk status == completed — a metadata write
-        on an OPEN task is normal mid-task traffic, not a missed mirror
-        (its completion-time snapshot will cover it)."""
+        """The backstop keys on disk status == completed — a NON-TARGETED
+        metadata write on an OPEN task is normal mid-task traffic and fires
+        no seam at all: not the backstop (status is open), and not the
+        per-write mirror (the key is outside PER_WRITE_MIRROR_KEYS). This
+        pins the backstop's completed-only predicate AND the per-write
+        leg's byte-identical default for untargeted traffic; the per-write
+        fire on TARGETED open-task keys is asserted by the per-write seam
+        tests."""
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         pact_context(team_name=TEAM, session_id="s1")
         _seed_task(
@@ -359,7 +364,7 @@ class TestSeamBPostCompletionBackstop:
             metadata={},
         )
         tlg.evaluate_lifecycle(
-            _metadata_only_payload("56", {"scope_contract": {"files": []}})
+            _metadata_only_payload("56", {"note": "mid-task working note"})
         )
         assert _snapshots(snapshot_events) == []
 

--- a/pact-plugin/tests/test_snapshot_subprocess_seam.py
+++ b/pact-plugin/tests/test_snapshot_subprocess_seam.py
@@ -172,6 +172,47 @@ def _gate_completion_frame(task_id: str, *, subject="design X",
     }
 
 
+def _gate_open_write_frame(task_id: str, metadata: dict, *,
+                           agent_type="PACT:pact-orchestrator",
+                           session_id=SID) -> dict:
+    """A metadata-only PostToolUse TaskUpdate (no status key) — the
+    per-write mirror leg's fire surface."""
+    return {
+        "hook_event_name": "PostToolUse",
+        "session_id": session_id,
+        "agent_type": agent_type,
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": task_id, "metadata": metadata},
+        "tool_response": {},
+    }
+
+
+def _seed_team_config(home: Path, *, lead_session_id: str) -> None:
+    """Write ~/.claude/teams/{TEAM}/config.json — the topology leg's
+    leadSessionId compare source, resolved by the REAL hook process."""
+    team_dir = home / ".claude" / "teams" / TEAM
+    team_dir.mkdir(parents=True, exist_ok=True)
+    (team_dir / "config.json").write_text(
+        json.dumps({"leadSessionId": lead_session_id}), encoding="utf-8"
+    )
+
+
+def _cli_read_snapshots(session_dir: Path, home: Path) -> list[dict]:
+    """The harvest skill's documented consumer command, run verbatim as a
+    real CLI subprocess."""
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    result = subprocess.run(
+        [sys.executable,
+         str(HOOKS_DIR / "shared" / "session_journal.py"),
+         "read", "--session-dir", str(session_dir),
+         "--type", "task_metadata_snapshot"],
+        capture_output=True, text=True, env=env, timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
 def _read_journal(session_dir: Path) -> list[dict]:
     journal = session_dir / "session-journal.jsonl"
     if not journal.exists():
@@ -369,17 +410,9 @@ class TestHarvestCliReadSeam:
     real CLI subprocess against a journal a real hook subprocess wrote."""
 
     def _cli_read(self, session_dir: Path, home: Path) -> list[dict]:
-        env = os.environ.copy()
-        env["HOME"] = str(home)
-        result = subprocess.run(
-            [sys.executable,
-             str(HOOKS_DIR / "shared" / "session_journal.py"),
-             "read", "--session-dir", str(session_dir),
-             "--type", "task_metadata_snapshot"],
-            capture_output=True, text=True, env=env, timeout=30,
-        )
-        assert result.returncode == 0, result.stderr
-        return json.loads(result.stdout)
+        # Delegates to the module-level helper shared with the per-write
+        # drain-recovery rows.
+        return _cli_read_snapshots(session_dir, home)
 
     def test_cli_read_recovers_snapshot_after_task_drain(self, tmp_path):
         # Acceptance criterion end-to-end with REAL entrypoints on both
@@ -411,3 +444,142 @@ class TestHarvestCliReadSeam:
         events = _read_journal(session_dir)
         assert len(_typed(events, "agent_handoff")) == 1
         assert self._cli_read(session_dir, home) == []
+
+
+class TestPerWriteSubprocess:
+    """task_lifecycle_gate.py as a real process: OPEN-task metadata-only
+    TaskUpdate frames carrying targeted keys -> real journal. The non-mocked
+    seam-integration rows for the per-write mirror leg: real append_event
+    schema validation, real O_EXCL marker filesystem, real pact_context env
+    resolution, and the real teams/config.json topology read, all on one
+    code path."""
+
+    SCOPE = {"files": ["a.py"], "boundaries": "backend only"}
+
+    def test_open_task_targeted_write_lands_snapshot_in_real_journal(
+            self, tmp_path):
+        home, session_dir, tasks_dir = _seed_home(tmp_path)
+        _write_task(tasks_dir, "80", status="in_progress",
+                    metadata={"note": "existing"})
+
+        result = _run_hook(
+            "task_lifecycle_gate.py",
+            _gate_open_write_frame("80", {"scope_contract": self.SCOPE}),
+            home,
+        )
+
+        assert result.returncode == 0, (
+            f"exit non-zero. stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        snapshots = _typed(_read_journal(session_dir),
+                           "task_metadata_snapshot")
+        assert len(snapshots) == 1, (
+            "exactly one snapshot must land in the REAL journal for an "
+            "open-task targeted write; got %d" % len(snapshots)
+        )
+        assert snapshots[0]["task_id"] == "80"
+        assert snapshots[0]["metadata"]["scope_contract"] == self.SCOPE
+        assert snapshots[0]["metadata"]["note"] == "existing"
+
+    def test_open_task_untargeted_write_no_snapshot(self, tmp_path):
+        # Negative control: the identical frame shape with a non-targeted
+        # key must leave the real journal untouched (byte-identical
+        # default through the real process).
+        home, session_dir, tasks_dir = _seed_home(tmp_path)
+        _write_task(tasks_dir, "80", status="in_progress", metadata={})
+
+        result = _run_hook(
+            "task_lifecycle_gate.py",
+            _gate_open_write_frame("80", {"note": "mid-task"}),
+            home,
+        )
+
+        assert result.returncode == 0
+        assert _typed(_read_journal(session_dir),
+                      "task_metadata_snapshot") == []
+
+    def test_in_process_teammate_frame_emits_via_real_config_read(
+            self, tmp_path):
+        # Topology leg through the REAL config file: a teammate frame whose
+        # session_id equals the on-disk leadSessionId emits (the gate that
+        # makes teammate-written targeted keys recoverable in-process).
+        home, session_dir, tasks_dir = _seed_home(tmp_path)
+        _seed_team_config(home, lead_session_id=SID)
+        _write_task(tasks_dir, "81", status="in_progress", metadata={})
+
+        result = _run_hook(
+            "task_lifecycle_gate.py",
+            _gate_open_write_frame(
+                "81",
+                {"teachback_submit": {"understanding": "u"}},
+                agent_type="pact-backend-coder",
+            ),
+            home,
+        )
+
+        assert result.returncode == 0
+        snapshots = _typed(_read_journal(session_dir),
+                           "task_metadata_snapshot")
+        assert len(snapshots) == 1
+        assert snapshots[0]["metadata"]["teachback_submit"] == {
+            "understanding": "u"
+        }
+
+    def test_tmux_teammate_frame_no_event_no_marker_real_process(
+            self, tmp_path):
+        # The silo row through a real process: a distinct session_id must
+        # produce NO journal write and NO marker claim anywhere on disk.
+        home, session_dir, tasks_dir = _seed_home(tmp_path)
+        _seed_team_config(home, lead_session_id="another-lead-session")
+        _write_task(tasks_dir, "82", status="in_progress", metadata={})
+
+        result = _run_hook(
+            "task_lifecycle_gate.py",
+            _gate_open_write_frame(
+                "82",
+                {"teachback_submit": {"understanding": "u"}},
+                agent_type="pact-backend-coder",
+            ),
+            home,
+        )
+
+        assert result.returncode == 0
+        # ZERO snapshot events in ANY journal under the test HOME. (The
+        # gate's pre-existing lifecycle_decision advisory record is not the
+        # mirror's emit and is out of scope for this row.)
+        all_journal_events = [
+            json.loads(line)
+            for journal in home.rglob("*.jsonl")
+            for line in journal.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert _typed(all_journal_events, "task_metadata_snapshot") == []
+        marker_dir = (home / ".claude" / "teams" / TEAM
+                      / ".task_metadata_snapshot_emitted")
+        assert not marker_dir.exists() or not any(marker_dir.iterdir()), (
+            "a skipped frame must claim nothing in the shared marker "
+            "namespace (a poisoned marker would suppress a later "
+            "canonical emit)"
+        )
+
+    def test_drain_recovery_targeted_write_unlink_cli_read(self, tmp_path):
+        # Open-task drain-recovery end-to-end with REAL entrypoints on both
+        # sides: the per-write leg mirrors the targeted key while the task
+        # is OPEN; the task store is drained (real unlink); the skill's CLI
+        # read recovers the key from the journal alone — the exact loss
+        # scenario the per-write mirror exists to close.
+        home, session_dir, tasks_dir = _seed_home(tmp_path)
+        _write_task(tasks_dir, "83", status="in_progress", metadata={})
+        assert _run_hook(
+            "task_lifecycle_gate.py",
+            _gate_open_write_frame("83", {"scope_contract": self.SCOPE}),
+            home,
+        ).returncode == 0
+
+        (tasks_dir / "83.json").unlink()  # the drain
+        assert not (tasks_dir / "83.json").exists()
+
+        recovered = _cli_read_snapshots(session_dir, home)
+        assert len(recovered) == 1
+        assert recovered[0]["task_id"] == "83"
+        assert recovered[0]["metadata"]["scope_contract"] == self.SCOPE


### PR DESCRIPTION
## Summary

Per-write journal mirroring for the open-task-consumed metadata key class — the narrow complement to the completion-time `task_metadata_snapshot` mechanism merged in #1164. Completion-time snapshots cover completed tasks; this PR covers keys consumed **mid-arc on open tasks** (`scope_contract`, `nesting_depth`, `worktree_path`, `teachback_submit`, `teachback_rejection`) that whole-store drains destroy before completion.

Closes gap documented in #1162.

## Design (frozen at ARCHITECT, four explicit rulings)

- **R1** — teachback class INCLUDED, gated on a new canonical-journal-frame predicate (`is_lead OR session_id == leadSessionId`, fail-closed): writability-only gating was rejected because a false-resolving tmux frame could silo an event AND poison the shared content-hash marker namespace. tmux asymmetry is a named, documented coverage property with one accepted minutes-scale residual (pre-first-lead-touch drain).
- **R2** — `worktree_path` joins the v1 class (same lead ATOMIZE write, CONSOLIDATE read-back, zero marginal cost).
- **R3** — WHOLE-payload mirror: targeted-key projection would defeat cross-seam content-hash dedup (an acceptance completion could never hash-equal), increasing event count.
- **R4** — REUSE the `task_metadata_snapshot` event type: reader semantics unchanged, harvest three-tier fallback resolves latest-ts per (task_id, occupant), calibration consumer-exclusivity guard stays valid as written.

## Implementation

- `PER_WRITE_MIRROR_KEYS` registry (SSOT) beside `SNAPSHOT_EXCLUDE` with test-pinned disjointness; zero substrate emit-path changes.
- `is_canonical_journal_frame` in `shared/pact_context.py` (structural signals only; in-process fail-safe default).
- Two gate legs: non-completing TaskUpdate (targeted-key-in-delta → `{**disk, **delta}` overlay emit) and TaskCreate (via response task id, `_created_task_id` extraction shared with the dispatch-variety block — its tests pass unmodified).
- READ-ONLY payload build; exit-0 advisory contract on every new path (DEFER not poison).
- Recovery docs: CONSOLIDATE + rePACT Phase 0 journal-fallback clauses (SSOT-mirrored same commit, 19/19 extract match).

## Certification

- Concurrent audit: GREEN-VERIFIED across 7 certification points, per-commit `git show` verification, independent suite re-run.
- TEST phase (CRITICAL tier): 25-test adversarial matrix (cap edges via imported constants, marker-lookalikes, hostile task_ids through the sanitized claim path, leadSessionId staleness probe both directions, exit-0 under substrate write failure, real-process dedup across interpreter lifetimes).
- Behavioral base-vs-HEAD certification (real subprocesses, 8 input classes, 8/8): untargeted traffic byte-identical; targeted traffic differs by exactly the new snapshot events; advisory stdout byte-equal on all classes.
- Issue-AC non-vacuity by targeted mutation: each AC's test family goes RED under its mechanism's revert and ONLY its family (4 directional mutations, import-resolution pre-checked).
- Full suite: 10,976 passed / 15 skipped / 0 failed / 0 errors (plain pytest AND rtk proxy, errors token explicitly absent).

## Both-modes coverage

Lead-written keys (scope_contract, nesting_depth, worktree_path, teachback_rejection): both modes. Teammate-written teachback_submit: in-process per-write + acceptance-time completion coverage in both modes; tmux per-write deferral is the one named residual, structurally fail-closed (zero events, zero markers — asserted WHERE, not merely no-error).
