### PR TITLE
fix(journal): unify empty-team dedup posture via session-dir marker fallback (#1169)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.3",
+      "version": "4.6.4",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.3/       # Plugin version
+│               └── 4.6.4/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.3",
+  "version": "4.6.4",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.3
+> **Version**: 4.6.4
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/shared/agent_handoff_marker.py
+++ b/pact-plugin/hooks/shared/agent_handoff_marker.py
@@ -233,6 +233,19 @@ def _resolve_marker_target(
         if not root_dir or not Path(root_dir).is_absolute():
             return None, None
         base = Path(root_dir)
+        # Pre-create the base itself at 0o700 when absent: the shared mkdir
+        # below applies mode= to the FINAL component (the namespace dir)
+        # only, so parents it creates get umask-default permissions — a
+        # claim that materializes a missing base (e.g. a session dir the
+        # journal writer has not created yet) would otherwise leave it
+        # looser than every other creator, which mkdirs the base as its own
+        # 0o700 leaf. exist_ok keeps an already-present base's mode
+        # untouched; on failure, refuse the target (fail-open emit),
+        # consistent with the shared mkdir's OSError posture below.
+        try:
+            base.mkdir(parents=True, exist_ok=True, mode=0o700)
+        except OSError:
+            return None, None
         marker_dir = base / namespace
 
     # Symlink-containment pre-check: if marker_dir already exists as a

--- a/pact-plugin/hooks/shared/agent_handoff_marker.py
+++ b/pact-plugin/hooks/shared/agent_handoff_marker.py
@@ -157,6 +157,7 @@ def _resolve_marker_target(
     occupant: str,
     *,
     namespace: str = _DEFAULT_MARKER_NAMESPACE,
+    root_dir: "str | Path | None" = None,
 ) -> "tuple[int | None, str | None]":
     """
     Sanitize + validate + pin the marker directory; return the open directory
@@ -169,6 +170,16 @@ def _resolve_marker_target(
     sites is the #877/#878 parallel-path-rot class — a single derivation makes
     alignment structural rather than a convention two sites must each remember.
 
+    root_dir (keyword-only, default None) is a caller-owned root override:
+    when provided, team_name is IGNORED (the caller owns root policy) and the
+    marker dir becomes {root_dir}/{namespace} with root_dir itself as the
+    containment base. A falsy or non-absolute root_dir is treated as "no
+    valid target" (same fail-open signal as a degenerate team). The default
+    None keeps the team-scoped derivation byte-identical to the pre-override
+    behavior. Only the (marker_dir, containment base) selection branches —
+    the guard/pin flow below is single-copy for both roots, so the override
+    cannot diverge from the team path's symlink/TOCTOU/dir_fd hazards.
+
     Returns (dir_fd, filename) on success — the caller MUST os.close(dir_fd).
     Returns (None, None) on any degenerate-key / symlink / containment /
     resolution failure; the caller fail-opens (already_emitted → emit;
@@ -179,42 +190,54 @@ def _resolve_marker_target(
     to the fd, cannot be redirected through a symlinked directory swapped in
     after this resolution.
     """
-    # Centralized normalization (SSOT): case-fold + sanitize team_name HERE so
-    # every caller derives a BYTE-IDENTICAL marker dir regardless of what it
-    # passed in — b1 (agent_handoff_emitter) pre-lowercases for its
-    # read_task_json path, b2 (task_lifecycle_gate) does not; folding .lower()
-    # in here makes the two structurally identical and closes the dormant
-    # case-drift (the #887 divergence shape one level up). Idempotent w.r.t.
-    # b1's external .lower(). The normalized value flows into BOTH _marker_dir()
-    # and the TOCTOU team_base below, keeping the containment check consistent.
-    team_name = sanitize_path_component(team_name.lower())
     task_id = sanitize_path_component(task_id)
     occupant = sanitize_path_component(occupant)
 
     # Degenerate post-sanitization values collapse the marker path onto an
-    # existing directory:
-    #   _marker_dir(".")  → .../teams/./.agent_handoff_emitted
-    #   _marker_dir("..") → .../teams/../.agent_handoff_emitted
-    # For the filename, the composite key f"{task_id}-{occupant}" no longer
-    # collapses on a degenerate task_id alone ("." → ".-<hash>", a normal
-    # file) — but the task_id guard is retained for defense + behavioral
-    # parity with the pre-occupant key, and a missing occupant (only possible
-    # if a caller bypasses occupant_hash()) is treated as "no valid key".
-    # In every degenerate case: signal "no valid target" so the caller
-    # fail-opens (already_emitted emits rather than suppresses; unclaim no-ops).
-    if (
-        not team_name
-        or team_name in (".", "..")
-        or not task_id
-        or task_id in (".", "..")
-        or not occupant
-    ):
+    # existing directory (see the team guard below for the dir-collapse
+    # shape). For the filename, the composite key f"{task_id}-{occupant}" no
+    # longer collapses on a degenerate task_id alone ("." → ".-<hash>", a
+    # normal file) — but the task_id guard is retained for defense +
+    # behavioral parity with the pre-occupant key, and a missing occupant
+    # (only possible if a caller bypasses occupant_hash()) is treated as "no
+    # valid key". These key guards apply under EITHER root. In every
+    # degenerate case: signal "no valid target" so the caller fail-opens
+    # (already_emitted emits rather than suppresses; unclaim no-ops).
+    if not task_id or task_id in (".", "..") or not occupant:
         return None, None
 
-    marker_dir = _marker_dir(team_name, namespace=namespace)
+    if root_dir is None:
+        # Centralized normalization (SSOT): case-fold + sanitize team_name
+        # HERE so every caller derives a BYTE-IDENTICAL marker dir regardless
+        # of what it passed in — b1 (agent_handoff_emitter) pre-lowercases
+        # for its read_task_json path, b2 (task_lifecycle_gate) does not;
+        # folding .lower() in here makes the two structurally identical and
+        # closes the dormant case-drift (the #887 divergence shape one level
+        # up). Idempotent w.r.t. b1's external .lower(). The normalized value
+        # flows into BOTH _marker_dir() and the TOCTOU containment base,
+        # keeping the containment check consistent.
+        #
+        # Degenerate team values collapse the marker path onto an existing
+        # directory:
+        #   _marker_dir(".")  → .../teams/./.agent_handoff_emitted
+        #   _marker_dir("..") → .../teams/../.agent_handoff_emitted
+        team_name = sanitize_path_component(team_name.lower())
+        if not team_name or team_name in (".", ".."):
+            return None, None
+        marker_dir = _marker_dir(team_name, namespace=namespace)
+        base = get_claude_config_dir() / "teams" / team_name
+    else:
+        # Caller-owned root: team_name is ignored (root policy lives with
+        # the caller). A falsy or relative root cannot anchor a containment
+        # check → no valid target, fail-open.
+        if not root_dir or not Path(root_dir).is_absolute():
+            return None, None
+        base = Path(root_dir)
+        marker_dir = base / namespace
+
     # Symlink-containment pre-check: if marker_dir already exists as a
     # symlink, refuse to use it (a pre-planted symlink could redirect marker
-    # creation outside the team directory). Fail-open emit rather than risk
+    # creation outside the containment base). Fail-open emit rather than risk
     # writing to an attacker-controlled location.
     if marker_dir.is_symlink():
         return None, None
@@ -226,19 +249,18 @@ def _resolve_marker_target(
 
     # TOCTOU containment re-check (closes the window between the is_symlink()
     # pre-check above and this mkdir): a symlink race could swap marker_dir
-    # to a directory OUTSIDE the team base between the two operations, and
-    # mkdir(exist_ok=True) silently follows an existing symlink. Re-resolve
-    # both paths and verify marker_dir is still contained within the team
-    # base. commonpath (not str.startswith — defeats the /teams/foo vs
+    # to a directory OUTSIDE the containment base between the two operations,
+    # and mkdir(exist_ok=True) silently follows an existing symlink.
+    # Re-resolve both paths and verify marker_dir is still contained within
+    # the base. commonpath (not str.startswith — defeats the /teams/foo vs
     # /teams/foobar prefix-collision) is the robust containment test; chosen
     # over Path.is_relative_to because pyproject pins requires-python >=3.7
     # and is_relative_to is 3.9+. On breach OR any resolution error: fail-open
     # emit (return None) WITHOUT writing a marker at the escaped path —
     # consistent with the is_symlink() pre-check's fail-open posture.
-    team_base = get_claude_config_dir() / "teams" / team_name
     try:
         real_marker = os.path.realpath(marker_dir)
-        real_base = os.path.realpath(team_base)
+        real_base = os.path.realpath(base)
         if os.path.commonpath([real_marker, real_base]) != real_base:
             return None, None
     except (OSError, ValueError):
@@ -273,9 +295,14 @@ def already_emitted(
     occupant: str,
     *,
     namespace: str = _DEFAULT_MARKER_NAMESPACE,
+    root_dir: "str | Path | None" = None,
 ) -> bool:
     """
     Test-and-set the per-(team, task_id, occupant) marker.
+
+    root_dir is a caller-policy root override (see _resolve_marker_target),
+    resolved through the same SSOT as unclaim() so the claim and the rollback
+    can never diverge.
 
     Returns True iff a prior fire for the same key already created the marker
     (caller should suppress the journal write). Returns False on fresh fires —
@@ -308,7 +335,7 @@ def already_emitted(
     process claimed but whose journal write then failed) — see unclaim().
     """
     dir_fd, filename = _resolve_marker_target(
-        team_name, task_id, occupant, namespace=namespace
+        team_name, task_id, occupant, namespace=namespace, root_dir=root_dir
     )
     if dir_fd is None:
         # Degenerate key / symlink-guarded / unresolvable → fail-open emit.
@@ -337,6 +364,7 @@ def unclaim(
     occupant: str,
     *,
     namespace: str = _DEFAULT_MARKER_NAMESPACE,
+    root_dir: "str | Path | None" = None,
 ) -> None:
     """
     Compensating rollback (#901, R1) — remove the marker THIS process just
@@ -345,6 +373,10 @@ def unclaim(
     the marker exists but no journal entry was written, so already_emitted()
     suppresses every later fire for the key forever (the silent-permanent-loss
     residual the writability gate only narrowed, not closed).
+
+    root_dir is a caller-policy root override (see _resolve_marker_target),
+    resolved through the same SSOT as already_emitted() so the rollback can
+    never target a root that diverges from the claim.
 
     Caller contract: invoke ONLY when this process OWNS the marker — i.e.
     already_emitted() returned False on THIS fire (a fresh O_EXCL create).
@@ -363,7 +395,7 @@ def unclaim(
     marker) — strictly no worse than not having the rollback. Never raises.
     """
     dir_fd, filename = _resolve_marker_target(
-        team_name, task_id, occupant, namespace=namespace
+        team_name, task_id, occupant, namespace=namespace, root_dir=root_dir
     )
     if dir_fd is None:
         return

--- a/pact-plugin/hooks/shared/pact_context.py
+++ b/pact-plugin/hooks/shared/pact_context.py
@@ -954,7 +954,11 @@ def is_canonical_journal_frame(input_data: dict) -> bool:
     completion-time seams — never worse than the shipped baseline — while
     emitting from a misclassified frame could silo the event AND poison
     the shared content-hash marker namespace, suppressing a later
-    canonical emit. The is_lead leg is independent of config readability,
+    canonical emit. On an empty-team frame the teammate-completion seams
+    starve by construction (no team namespace to read task state from),
+    so the effective deferral target is the lead-completion seam, whose
+    snapshot substrate dedups under the session-dir marker root when the
+    team is empty. The is_lead leg is independent of config readability,
     so lead-written keys keep full both-modes coverage even when the
     topology leg cannot resolve. Never raises.
     """

--- a/pact-plugin/hooks/shared/task_metadata_snapshot.py
+++ b/pact-plugin/hooks/shared/task_metadata_snapshot.py
@@ -28,9 +28,12 @@ requirement (signal tasks may be ownerless).
 Supersession: multiple snapshots per task are legal — a changed payload
 after completion re-emits under a new content key; an unchanged payload
 never re-emits (the content-keyed O_EXCL marker dedups across all seams).
-Readers take latest-ts within the (task_id, occupant) group; the occupant
-field is the task-id-reuse discriminator (platform reuses task ids across
-arcs within one team).
+The content-key marker claims under the team root, or under the session-dir
+root when team_name is empty (dedup-resolvable ⇔ journal-resolvable — both
+derive from the same session context, so an emit that can reach the journal
+can always claim its dedup marker). Readers take latest-ts within the
+(task_id, occupant) group; the occupant field is the task-id-reuse
+discriminator (platform reuses task ids across arcs within one team).
 
 Size-bounding invariant: key EXISTENCE is never silently lost — worst case
 a key survives name-only in the payload's top-level "_dropped_keys" list.
@@ -52,6 +55,7 @@ from .agent_handoff_marker import (
     sanitize_path_component,
     unclaim,
 )
+from .pact_context import get_session_dir
 from .session_journal import append_event, get_journal_path, make_event
 
 # Keys never mirrored: only entries with equivalent-or-better journal
@@ -109,6 +113,23 @@ HEAD_BYTES: int = 1024
 # agent_handoff marker dir so the two event families can never suppress each
 # other. Module constant, never input-derived.
 SNAPSHOT_MARKER_NAMESPACE: str = ".task_metadata_snapshot_emitted"
+
+
+def _snapshot_marker_root(team_name: str) -> str | None:
+    """Marker-root policy for the snapshot family (the ONE place it lives).
+
+    Non-empty team -> None (default team-scoped root, path-identical to
+    the pre-fallback behavior). Empty team -> the session directory, so
+    dedup resolvability is equal-by-construction to journal resolvability
+    (get_journal_path derives from the same get_session_dir); the
+    "empty team + resolvable journal" fail-open gap cannot reopen. An
+    unresolvable session dir returns "" — the resolver treats a falsy
+    root as no-valid-target and fail-opens, which the emit path never
+    reaches (its writability precondition already returned).
+    """
+    if team_name:
+        return None
+    return get_session_dir()
 
 # Marker-dict key set used to recognize truncation markers this module
 # itself produced (stage-2 candidate filtering + stage-3 head emptying).
@@ -341,9 +362,17 @@ def snapshot_already_emitted(
     marker functions: a forgotten namespace arg would claim in one dir and
     no-op-unclaim against the other, leaving a poisoned marker; the wrapper
     makes that impossible by construction.
+
+    The marker root is likewise hard-bound: it comes from
+    _snapshot_marker_root, the family's single root-policy site, so the
+    claim and the rollback derive the same root by construction.
     """
     return already_emitted(
-        team_name, task_id, content_key, namespace=SNAPSHOT_MARKER_NAMESPACE
+        team_name,
+        task_id,
+        content_key,
+        namespace=SNAPSHOT_MARKER_NAMESPACE,
+        root_dir=_snapshot_marker_root(team_name),
     )
 
 
@@ -351,11 +380,15 @@ def snapshot_unclaim(team_name: str, task_id: str, content_key: str) -> None:
     """Compensating rollback for a claim whose journal write failed.
 
     Hard-bound twin of snapshot_already_emitted — same namespace constant,
-    same resolver SSOT underneath, so the claim and the rollback can never
-    reference divergent paths.
+    same root policy (_snapshot_marker_root), same resolver SSOT underneath,
+    so the claim and the rollback can never reference divergent paths.
     """
     unclaim(
-        team_name, task_id, content_key, namespace=SNAPSHOT_MARKER_NAMESPACE
+        team_name,
+        task_id,
+        content_key,
+        namespace=SNAPSHOT_MARKER_NAMESPACE,
+        root_dir=_snapshot_marker_root(team_name),
     )
 
 

--- a/pact-plugin/tests/test_snapshot_empty_team_dedup_cert.py
+++ b/pact-plugin/tests/test_snapshot_empty_team_dedup_cert.py
@@ -384,3 +384,54 @@ class TestResolverGuardOrderFailOpen:
         )
         unclaim(bad_team, degenerate_task_id, "k1")  # must not raise
         assert list(home.rglob("*-k1")) == []
+
+
+# =============================================================================
+# Healing transition — context repaired mid-session flips the marker root
+# =============================================================================
+class TestHealingTransition:
+    def test_heal_appends_exactly_one_duplicate_never_suppresses(
+        self, home, pact_context
+    ):
+        """Context repaired mid-session (empty team heals to a real team,
+        same session): the session-root marker claimed while the team was
+        empty is INVISIBLE to the teams-namespace check, so the first
+        healed emit of the identical payload APPENDS (bias-to-
+        preservation — the canonical emit is never suppressed by the
+        degenerate-state marker) and claims under the team root. The two
+        marker populations coexist disjointly on disk, and a further
+        identical healed emit is suppressed by the team-root marker — the
+        transition costs EXACTLY one duplicate append, no more."""
+        team = "pact-heal"
+        pact_context(team_name="", session_id="s-heal")
+        session_dir = pact_context_module.get_session_dir()
+        assert session_dir, "harness: session dir must resolve"
+
+        emit_task_metadata_snapshot("", "88", "subject", "owner", PAYLOAD_A)
+
+        assert len(_snapshot_events(session_dir)) == 1
+        assert len(_marker_files(Path(session_dir))) == 1
+
+        # Heal: same session_id/project_dir (same session dir, same
+        # journal), team_name now non-empty — as after a context repair.
+        pact_context(team_name=team, session_id="s-heal")
+        assert pact_context_module.get_session_dir() == session_dir
+
+        emit_task_metadata_snapshot(team, "88", "subject", "owner", PAYLOAD_A)
+
+        assert len(_snapshot_events(session_dir)) == 2, (
+            "the healed canonical emit was suppressed by the "
+            "degenerate-state session-root marker"
+        )
+        team_root = home / ".claude" / "teams" / team
+        assert len(_marker_files(team_root)) == 1
+        assert len(_marker_files(Path(session_dir))) == 1, (
+            "the healed emit disturbed the session-root population"
+        )
+
+        # The duplicate bound is exactly one: the team-root marker now
+        # suppresses further identical emits.
+        emit_task_metadata_snapshot(team, "88", "subject", "owner", PAYLOAD_A)
+
+        assert len(_snapshot_events(session_dir)) == 2
+        assert len(_marker_files(team_root)) == 1

--- a/pact-plugin/tests/test_snapshot_empty_team_dedup_cert.py
+++ b/pact-plugin/tests/test_snapshot_empty_team_dedup_cert.py
@@ -1,0 +1,386 @@
+"""
+Location: pact-plugin/tests/test_snapshot_empty_team_dedup_cert.py
+Summary: Bidirectional certification of the snapshot family's empty-team
+         dedup posture (session-dir marker-root fallback), at the seam
+         level. Close direction (no durability regression): a targeted
+         per-write TaskUpdate on an empty-team lead frame still mirrors
+         (delta-only payload — the disk read is team-guarded) AND claims
+         the content-key marker under the session dir; a symlinked
+         fallback marker dir fails open (emit, never a marker through the
+         symlink) and recovers to claiming once the fault clears; a
+         changed payload supersedes with a second event + second marker.
+         Open direction (bounded churn): an identical targeted per-write
+         repeat is suppressed to exactly one event; a lead-completion
+         emit and a per-write emit of identical content collapse to one
+         event via the shared content-hash namespace under the session
+         root; a failed journal append compensating-unclaims the
+         session-root marker so a retry re-emits (claim/rollback root
+         parity). Both-teammate-modes matrix (standing merge gate): the
+         same targeted write under a lead frame emits + claims the
+         session root, under an in-process teammate frame (session_id
+         equal to the lead session, empty team) the topology leg
+         fail-closes before any substrate call, and under a tmux
+         teammate frame (distinct session_id, all-empty derived context)
+         the writability precondition defers before any claim — frames
+         are constructed from agent_type / session_id only, no mode flag
+         anywhere. Plus a guard-order pin: a non-string team_name paired
+         with a degenerate task_id fails open at the resolver (no raise,
+         nothing created) because the key guards run before the team
+         derivation. Runs against the REAL marker SSOT and a REAL
+         on-disk journal (no mocking of agent_handoff_marker internals);
+         the only patched binding is the module-under-test's
+         append_event, and only in the rollback-parity rows where the
+         journal-write failure IS the fault being injected.
+Used by: pytest. Companion file test_snapshot_marker_root_fallback.py
+         covers the substrate-surface rows (first-fire emits + claims,
+         identical direct repeat suppressed, no-journal defer, the
+         healthy-team two-root regression pin, and the falsy/relative
+         root_dir resolver guards); this file certifies the seam-level
+         and fault-path behavior on top of those.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import shared.pact_context as pact_context_module  # noqa: E402
+import shared.session_journal as session_journal  # noqa: E402
+import shared.task_metadata_snapshot as tms  # noqa: E402
+import task_lifecycle_gate as tlg  # noqa: E402
+from shared.agent_handoff_marker import already_emitted, unclaim  # noqa: E402
+from shared.task_metadata_snapshot import (  # noqa: E402
+    SNAPSHOT_MARKER_NAMESPACE,
+    emit_task_metadata_snapshot,
+)
+
+LEAD = "PACT:pact-orchestrator"
+TEAMMATE = "pact-devops-engineer"
+
+SCOPE = {"files": ["hooks/shared/example.py"], "boundaries": "backend only"}
+PAYLOAD_A = {"scope_contract": SCOPE}
+PAYLOAD_B = {"scope_contract": {**SCOPE, "boundaries": "widened"}}
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    """Test-scoped HOME: the journal, the session dir, and every marker
+    root resolve under tmp_path."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    return tmp_path
+
+
+def _snapshot_events(session_dir: str) -> list:
+    return session_journal.read_events_from(
+        session_dir, "task_metadata_snapshot"
+    )
+
+
+def _marker_files(root: Path) -> list:
+    marker_dir = root / SNAPSHOT_MARKER_NAMESPACE
+    if not marker_dir.is_dir():
+        return []
+    return sorted(p.name for p in marker_dir.iterdir())
+
+
+def _open_write_payload(task_id, metadata, agent_type=LEAD, session_id=None):
+    """A metadata-only TaskUpdate (no status key) — the per-write mirror's
+    fire surface. The frame carries ONLY structural signals (agent_type,
+    session_id); there is no mode flag to carry."""
+    payload = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": task_id, "metadata": metadata},
+        "tool_response": {},
+    }
+    if agent_type is not None:
+        payload["agent_type"] = agent_type
+    if session_id is not None:
+        payload["session_id"] = session_id
+    return payload
+
+
+def _completion_payload(task_id, subject, owner, metadata):
+    """A lead TaskUpdate(status=completed) frame with post-state supplied
+    via tool_response.task — drives the lead-completion seam without a
+    team-scoped disk read (which an empty team cannot perform)."""
+    return {
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": task_id, "status": "completed"},
+        "tool_response": {
+            "task": {
+                "id": task_id,
+                "subject": subject,
+                "owner": owner,
+                "metadata": metadata,
+            }
+        },
+        "agent_type": LEAD,
+    }
+
+
+# =============================================================================
+# Close direction — no durability regression in the degenerate state
+# =============================================================================
+class TestEmptyTeamCloseDirection:
+    def test_per_write_targeted_key_emits_delta_only_and_claims_session_root(
+        self, home, pact_context
+    ):
+        """Empty team + resolvable journal, lead frame: a targeted
+        metadata write through the REAL gate path appends exactly one
+        event AND claims the content-key marker under the session dir.
+        The payload is delta-only and the subject degrades to the
+        sentinel: the team-scoped task-file read is guarded off on an
+        empty team, so the write itself is all the seam can mirror."""
+        pact_context(team_name="", session_id="s-pw-lead")
+        session_dir = pact_context_module.get_session_dir()
+        assert session_dir, "harness: session dir must resolve"
+
+        tlg.evaluate_lifecycle(
+            _open_write_payload("81", PAYLOAD_A, session_id="s-pw-lead")
+        )
+
+        events = _snapshot_events(session_dir)
+        assert len(events) == 1
+        assert events[0]["metadata"] == PAYLOAD_A
+        assert events[0]["subject"] == "(no subject)"
+        assert "owner" not in events[0]
+        markers = _marker_files(Path(session_dir))
+        assert len(markers) == 1
+        assert markers[0].startswith("81-")
+
+    def test_symlinked_marker_dir_fails_open_then_recovers(
+        self, home, pact_context
+    ):
+        """Subsystem fault under the fallback root: with the session-dir
+        marker dir pre-planted as a symlink, the emit still appends
+        (fail-open — the marker-broken posture survives under the new
+        root) and NO marker is written through the symlink. Clearing the
+        fault proves the vector is live: the same payload re-emits (the
+        faulted fire never claimed) and the marker now lands at exactly
+        the path the symlink had occupied."""
+        pact_context(team_name="", session_id="s-fault")
+        session_dir = Path(pact_context_module.get_session_dir())
+        session_dir.mkdir(parents=True, exist_ok=True)
+        escape = home / "escape-target"
+        escape.mkdir()
+        planted = session_dir / SNAPSHOT_MARKER_NAMESPACE
+        os.symlink(escape, planted)
+
+        emit_task_metadata_snapshot("", "82", "subject", "owner", PAYLOAD_A)
+
+        assert len(_snapshot_events(str(session_dir))) == 1
+        assert list(escape.iterdir()) == [], (
+            "a marker escaped through the symlinked dir"
+        )
+
+        # Fault cleared: the prior fire claimed nothing, so the same
+        # payload fires again and claims at the real path — proving the
+        # planted path IS the live marker target, not a lookalike.
+        planted.unlink()
+        emit_task_metadata_snapshot("", "82", "subject", "owner", PAYLOAD_A)
+
+        assert len(_snapshot_events(str(session_dir))) == 2
+        markers = _marker_files(session_dir)
+        assert len(markers) == 1
+        assert markers[0].startswith("82-")
+
+    def test_changed_payload_supersedes_with_second_event_and_marker(
+        self, home, pact_context
+    ):
+        """Supersession semantics intact in the degenerate state: two
+        DIFFERENT payloads for the same task produce two events and two
+        distinct content-key markers under the session root."""
+        pact_context(team_name="", session_id="s-supersede")
+        session_dir = pact_context_module.get_session_dir()
+
+        emit_task_metadata_snapshot("", "83", "subject", "owner", PAYLOAD_A)
+        emit_task_metadata_snapshot("", "83", "subject", "owner", PAYLOAD_B)
+
+        assert len(_snapshot_events(session_dir)) == 2
+        markers = _marker_files(Path(session_dir))
+        assert len(markers) == 2
+        assert markers[0] != markers[1]
+
+
+# =============================================================================
+# Open direction — churn is bounded to one claim per content key
+# =============================================================================
+class TestEmptyTeamBoundedChurn:
+    def test_identical_per_write_repeat_suppressed_to_one_event(
+        self, home, pact_context
+    ):
+        """The unbounded-duplicate case this posture exists to close: two
+        identical targeted TaskUpdate writes through the REAL gate path
+        collapse to exactly ONE event and ONE marker — the second fire
+        claims nothing new and appends nothing."""
+        pact_context(team_name="", session_id="s-repeat")
+        session_dir = pact_context_module.get_session_dir()
+
+        payload = _open_write_payload("84", PAYLOAD_A, session_id="s-repeat")
+        tlg.evaluate_lifecycle(payload)
+        tlg.evaluate_lifecycle(payload)
+
+        assert len(_snapshot_events(session_dir)) == 1
+        assert len(_marker_files(Path(session_dir))) == 1
+
+    def test_cross_seam_dedup_completion_then_per_write(
+        self, home, pact_context
+    ):
+        """Cross-seam dedup restored on the session root: a
+        lead-completion emit of payload P then a per-write emit whose
+        overlay resolves to the identical P dedup on the SHARED
+        content-hash namespace — one event total, exactly as the team
+        root dedups across seams for a healthy team."""
+        pact_context(team_name="", session_id="s-xseam")
+        session_dir = pact_context_module.get_session_dir()
+
+        tlg.evaluate_lifecycle(
+            _completion_payload("85", "subject", "owner", PAYLOAD_A)
+        )
+        assert len(_snapshot_events(session_dir)) == 1
+
+        tlg.evaluate_lifecycle(
+            _open_write_payload("85", PAYLOAD_A, session_id="s-xseam")
+        )
+        assert len(_snapshot_events(session_dir)) == 1
+        assert len(_marker_files(Path(session_dir))) == 1
+
+    @pytest.mark.parametrize("fail_mode", ["returns_false", "raises"])
+    def test_failed_append_unclaims_session_marker_and_retry_reemits(
+        self, home, pact_context, monkeypatch, fail_mode
+    ):
+        """Claim/rollback parity through the single root-derivation
+        helper: when the journal append fails AFTER the session-root
+        claim, the compensating unclaim removes the marker (resolved
+        through the SAME root), so a later retry re-emits instead of
+        being permanently suppressed. Both failure shapes are covered:
+        append_event returning False and append_event raising. The
+        patch target is the module-under-test's own append_event
+        binding — the journal-write failure IS the injected fault; the
+        marker claim, root resolution, and unclaim all stay real."""
+        pact_context(team_name="", session_id=f"s-unclaim-{fail_mode}")
+        session_dir = pact_context_module.get_session_dir()
+
+        real_append = tms.append_event
+        failing = {"active": True}
+
+        def _flaky(event):
+            if failing["active"]:
+                if fail_mode == "raises":
+                    raise OSError("journal write failed")
+                return False
+            return real_append(event)
+
+        monkeypatch.setattr(tms, "append_event", _flaky)
+
+        emit_task_metadata_snapshot("", "86", "subject", "owner", PAYLOAD_A)
+
+        assert _snapshot_events(session_dir) == []
+        assert _marker_files(Path(session_dir)) == [], (
+            "a failed append left a poisoned session-root marker — the "
+            "compensating unclaim did not resolve the fallback root"
+        )
+
+        failing["active"] = False
+        emit_task_metadata_snapshot("", "86", "subject", "owner", PAYLOAD_A)
+
+        assert len(_snapshot_events(session_dir)) == 1
+        assert len(_marker_files(Path(session_dir))) == 1
+
+
+# =============================================================================
+# Both-teammate-modes matrix — standing merge gate. The SAME targeted
+# write is driven under three frames distinguished ONLY by the runtime
+# structural signals (agent_type; session_id vs the session context) —
+# no mode flag exists in the inputs or the assertions.
+# =============================================================================
+class TestEmptyTeamBothModesMatrix:
+    def test_lead_frame_emits_and_claims_session_root(
+        self, home, pact_context
+    ):
+        """Lead frame (agent_type in the lead set), empty team: the
+        per-write leg is admitted by the is_lead leg independently of
+        team/config resolvability — emit + session-dir claim."""
+        pact_context(team_name="", session_id="s-mode-lead")
+        session_dir = pact_context_module.get_session_dir()
+
+        tlg.evaluate_lifecycle(
+            _open_write_payload(
+                "87", PAYLOAD_A, agent_type=LEAD, session_id="s-mode-lead"
+            )
+        )
+
+        assert len(_snapshot_events(session_dir)) == 1
+        assert len(_marker_files(Path(session_dir))) == 1
+
+    def test_in_process_teammate_frame_no_emit_no_claim(
+        self, home, pact_context
+    ):
+        """Teammate frame whose session_id equals the session context's
+        own id (the in-process shape), empty team: the topology leg
+        fail-closes on the empty team BEFORE any config read or
+        substrate call — no event lands anywhere, no marker dir is
+        created anywhere. Unchanged fail-safe default behavior."""
+        pact_context(team_name="", session_id="s-mode-inproc")
+
+        tlg.evaluate_lifecycle(
+            _open_write_payload(
+                "87",
+                PAYLOAD_A,
+                agent_type=TEAMMATE,
+                session_id="s-mode-inproc",
+            )
+        )
+
+        assert list(home.rglob("*.jsonl")) == []
+        assert list(home.rglob(SNAPSHOT_MARKER_NAMESPACE)) == []
+
+    def test_tmux_teammate_frame_no_emit_no_claim(self, home, pact_context):
+        """Teammate frame with a DISTINCT session_id and the all-empty
+        derived context (the tmux teammate's context file is absent at
+        its derived path): the writability precondition defers before
+        any claim — the fallback-root code is never reached. No event
+        anywhere, no marker anywhere."""
+        pact_context(team_name="", session_id="", project_dir="")
+        assert pact_context_module.get_session_dir() == ""
+
+        tlg.evaluate_lifecycle(
+            _open_write_payload(
+                "87",
+                PAYLOAD_A,
+                agent_type=TEAMMATE,
+                session_id="s-mode-tmux-other",
+            )
+        )
+
+        assert list(home.rglob("*.jsonl")) == []
+        assert list(home.rglob(SNAPSHOT_MARKER_NAMESPACE)) == []
+
+
+# =============================================================================
+# Resolver guard-order pin — the key guards run before the team derivation
+# =============================================================================
+class TestResolverGuardOrderFailOpen:
+    @pytest.mark.parametrize("bad_team", [123, None, 3.5])
+    @pytest.mark.parametrize("degenerate_task_id", ["", ".", ".."])
+    def test_non_string_team_with_degenerate_task_id_fails_open(
+        self, home, bad_team, degenerate_task_id
+    ):
+        """A non-string team_name paired with a degenerate task_id fails
+        open at the resolver — no raise, never claims, nothing created —
+        because the task_id/occupant key guards run BEFORE the team
+        derivation touches team_name. (A non-string team with a VALID
+        key still raises inside the hermetic emit wrapper as before;
+        this pin covers only the guard-order surface that changed.)"""
+        assert (
+            already_emitted(bad_team, degenerate_task_id, "k1") is False
+        )
+        assert (
+            already_emitted(bad_team, degenerate_task_id, "k1") is False
+        )
+        unclaim(bad_team, degenerate_task_id, "k1")  # must not raise
+        assert list(home.rglob("*-k1")) == []

--- a/pact-plugin/tests/test_snapshot_marker_root_fallback.py
+++ b/pact-plugin/tests/test_snapshot_marker_root_fallback.py
@@ -1,0 +1,141 @@
+"""
+Location: pact-plugin/tests/test_snapshot_marker_root_fallback.py
+Summary: Verification tests for the snapshot family's session-dir marker-root
+         fallback — when team_name is empty but the journal resolves, the
+         content-key dedup marker claims under the session directory instead
+         of silently disabling dedup (fail-open). Covers: empty-team first
+         fire emits AND claims under the session root; an identical repeat is
+         suppressed; the healthy-team marker path is byte-identical to the
+         pre-fallback behavior (no session-dir marker dir is created); an
+         unresolvable journal still defers before any claim; and a falsy or
+         relative root_dir at the resolver level fails open (emit, no marker).
+         Runs against the REAL marker SSOT and a REAL on-disk journal (no
+         mocking of agent_handoff_marker internals) so claim, dedup, and
+         append exercise the production paths end to end.
+Used by: pytest. The comprehensive bidirectional certification suite
+         (cross-seam dedup, unclaim parity, both-modes matrix, subsystem-
+         fault fail-open) is authored in the test phase; this file proves
+         the implementation works.
+"""
+
+from pathlib import Path
+
+import shared.pact_context as pact_context_module
+import shared.session_journal as session_journal
+from shared.agent_handoff_marker import already_emitted, unclaim
+from shared.task_metadata_snapshot import (
+    SNAPSHOT_MARKER_NAMESPACE,
+    emit_task_metadata_snapshot,
+)
+
+TEAM = "pact-test"
+PAYLOAD = {"scope_contract": {"files": ["hooks/shared/example.py"]}}
+
+
+def _snapshot_events(session_dir: str) -> list:
+    return session_journal.read_events_from(
+        session_dir, "task_metadata_snapshot"
+    )
+
+
+def _marker_files(root: Path) -> list:
+    marker_dir = root / SNAPSHOT_MARKER_NAMESPACE
+    if not marker_dir.is_dir():
+        return []
+    return sorted(p.name for p in marker_dir.iterdir())
+
+
+class TestEmptyTeamSessionRootFallback:
+    def test_first_fire_emits_and_claims_under_session_dir(
+        self, tmp_path, monkeypatch, pact_context
+    ):
+        """Empty team + resolvable journal: the emit appends exactly one
+        event AND claims the content-key marker under the session dir —
+        dedup is enabled, not silently disabled."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name="", session_id="s-fallback")
+        session_dir = pact_context_module.get_session_dir()
+        assert session_dir, "harness: session dir must resolve"
+
+        emit_task_metadata_snapshot("", "5", "subject", "owner", PAYLOAD)
+
+        events = _snapshot_events(session_dir)
+        assert len(events) == 1
+        assert events[0]["metadata"] == PAYLOAD
+        markers = _marker_files(Path(session_dir))
+        assert len(markers) == 1
+        assert markers[0].startswith("5-")
+
+    def test_identical_repeat_is_suppressed(
+        self, tmp_path, monkeypatch, pact_context
+    ):
+        """The bounded-churn direction: a second emit of a byte-identical
+        payload claims nothing new and appends nothing."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name="", session_id="s-dedup")
+        session_dir = pact_context_module.get_session_dir()
+
+        emit_task_metadata_snapshot("", "5", "subject", "owner", PAYLOAD)
+        emit_task_metadata_snapshot("", "5", "subject", "owner", PAYLOAD)
+
+        assert len(_snapshot_events(session_dir)) == 1
+        assert len(_marker_files(Path(session_dir))) == 1
+
+    def test_unresolvable_journal_defers_before_any_claim(
+        self, tmp_path, monkeypatch, pact_context
+    ):
+        """All-empty context (the unpersisted-teammate shape): the
+        writability precondition still returns before the fallback root is
+        ever consulted — no event, no marker anywhere, no exception."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name="", session_id="", project_dir="")
+        assert pact_context_module.get_session_dir() == ""
+
+        emit_task_metadata_snapshot("", "5", "subject", "owner", PAYLOAD)
+
+        marker_dirs = list(tmp_path.rglob(SNAPSHOT_MARKER_NAMESPACE))
+        assert marker_dirs == []
+        journals = list(tmp_path.rglob("session-journal.jsonl"))
+        assert journals == []
+
+
+class TestHealthyTeamTwoRootRegression:
+    def test_marker_path_identical_and_no_session_dir_marker(
+        self, tmp_path, monkeypatch, pact_context
+    ):
+        """Non-empty team: the marker lands at the pre-fallback team-scoped
+        path and NO session-dir marker dir is created — the fallback branch
+        is unreachable while team_name is non-empty."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name=TEAM, session_id="s-healthy")
+        session_dir = pact_context_module.get_session_dir()
+
+        emit_task_metadata_snapshot(TEAM, "9", "subject", "owner", PAYLOAD)
+
+        assert len(_snapshot_events(session_dir)) == 1
+        team_root = tmp_path / ".claude" / "teams" / TEAM
+        team_markers = _marker_files(team_root)
+        assert len(team_markers) == 1
+        assert team_markers[0].startswith("9-")
+        assert _marker_files(Path(session_dir)) == []
+
+
+class TestRootDirResolverGuards:
+    def test_falsy_root_dir_fails_open(self, tmp_path, monkeypatch):
+        """An empty root_dir is 'no valid target': never claims (repeat
+        calls stay False → caller emits) and creates nothing."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert already_emitted("", "5", "k1", root_dir="") is False
+        assert already_emitted("", "5", "k1", root_dir="") is False
+        unclaim("", "5", "k1", root_dir="")  # must not raise
+        assert list(tmp_path.rglob("5-k1")) == []
+
+    def test_relative_root_dir_fails_open(self, tmp_path, monkeypatch):
+        """A relative root cannot anchor the containment check → same
+        fail-open signal, nothing created."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        relative = "relative/marker/root"
+        assert already_emitted("", "5", "k1", root_dir=relative) is False
+        assert already_emitted("", "5", "k1", root_dir=relative) is False
+        unclaim("", "5", "k1", root_dir=relative)  # must not raise
+        assert list(tmp_path.rglob("5-k1")) == []

--- a/pact-plugin/tests/test_snapshot_marker_root_fallback.py
+++ b/pact-plugin/tests/test_snapshot_marker_root_fallback.py
@@ -7,8 +7,11 @@ Summary: Verification tests for the snapshot family's session-dir marker-root
          fire emits AND claims under the session root; an identical repeat is
          suppressed; the healthy-team marker path is byte-identical to the
          pre-fallback behavior (no session-dir marker dir is created); an
-         unresolvable journal still defers before any claim; and a falsy or
-         relative root_dir at the resolver level fails open (emit, no marker).
+         unresolvable journal still defers before any claim; a falsy or
+         relative root_dir at the resolver level fails open (emit, no marker);
+         and a session dir materialized BY the fallback claim is created
+         0o700 (mode-pinned under a controlled umask) while a pre-existing
+         session dir's mode is never altered.
          Runs against the REAL marker SSOT and a REAL on-disk journal (no
          mocking of agent_handoff_marker internals) so claim, dedup, and
          append exercise the production paths end to end.
@@ -18,6 +21,8 @@ Used by: pytest. The comprehensive bidirectional certification suite
          the implementation works.
 """
 
+import os
+import stat
 from pathlib import Path
 
 import shared.pact_context as pact_context_module
@@ -118,6 +123,53 @@ class TestHealthyTeamTwoRootRegression:
         assert len(team_markers) == 1
         assert team_markers[0].startswith("9-")
         assert _marker_files(Path(session_dir)) == []
+
+
+class TestFallbackRootMaterializationMode:
+    def test_claim_materialized_session_dir_is_0o700(
+        self, tmp_path, monkeypatch, pact_context
+    ):
+        """A session dir materialized BY the fallback claim must be 0o700,
+        matching every other creator of the dir (which mkdirs it as its own
+        0o700 leaf). Pinned under an explicit umask: mkdir's mode= applies
+        to the final component only, so without the branch-local base
+        pre-create the session dir would land at umask default."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name="", session_id="s-mode-pin")
+        session_dir = Path(pact_context_module.get_session_dir())
+        assert not session_dir.exists(), "harness: dir must be claim-created"
+
+        prior_umask = os.umask(0o022)
+        try:
+            emit_task_metadata_snapshot("", "5", "subject", "owner", PAYLOAD)
+        finally:
+            os.umask(prior_umask)
+
+        assert session_dir.is_dir(), "claim must have materialized the dir"
+        assert stat.S_IMODE(session_dir.stat().st_mode) == 0o700
+        marker_dir = session_dir / SNAPSHOT_MARKER_NAMESPACE
+        assert stat.S_IMODE(marker_dir.stat().st_mode) == 0o700
+        assert len(_snapshot_events(str(session_dir))) == 1
+
+    def test_existing_session_dir_mode_untouched(
+        self, tmp_path, monkeypatch, pact_context
+    ):
+        """The pre-create is exist_ok — a session dir that already exists
+        keeps its mode exactly (no chmod side effect on the healthy path)."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        pact_context(team_name="", session_id="s-mode-keep")
+        session_dir = Path(pact_context_module.get_session_dir())
+        session_dir.mkdir(parents=True)
+        session_dir.chmod(0o750)
+
+        prior_umask = os.umask(0o022)
+        try:
+            emit_task_metadata_snapshot("", "5", "subject", "owner", PAYLOAD)
+        finally:
+            os.umask(prior_umask)
+
+        assert stat.S_IMODE(session_dir.stat().st_mode) == 0o750
+        assert len(_snapshot_events(str(session_dir))) == 1
 
 
 class TestRootDirResolverGuards:


### PR DESCRIPTION
## Summary

Closes the empty-team dedup fail-open at the snapshot seams with a single, consistently-applied posture: a **session-dir-anchored marker fallback (two-root scheme)**. When a lead frame has an empty `team_name` but a resolvable journal, the snapshot family now claims its content-hash dedup marker under `{session_dir}/.task_metadata_snapshot_emitted/` instead of fail-opening past dedup entirely. Healthy-team markers do not move — the default path is byte-identical (regression-pinned).

Refs #1169.

## Why this posture

- **Blanket fail-closed rejected**: on an empty-team frame the teammate-completion seams starve by construction, so the lead seam's emit is the *only* mirror that fires — skipping it creates zero-mirror sessions (the unrecoverable under-mirror direction).
- **Status-quo fail-open rejected**: unbounded duplicate appends on the high-fire per-write leg (worst case priced at hundreds of KB to ~10 MB per corrupted session), and it silently inherits a prior fail-direction ruling whose premise (a functioning dedup marker) is void in exactly this state.
- **The fallback restores that premise**: dedup resolvability becomes equal-by-construction to journal resolvability — both derive from the same two context fields, and the writability precondition runs before any claim. The gap cannot reopen structurally.

**Scoping note (deliberate)**: "consistent across seams" is a *claim-path* property, achieved at the single shared marker routine. Teammate-completion seams (B/C) still starve on empty team — documented as accepted structural behavior, not equalized (that would be scope expansion).

## Threat model & certification

Under-mirror is the cardinal direction; duplicate-append is the tolerated one. Certification is bidirectional:

- **Close direction**: every emit that fired pre-change still fires; no-journal defer, healthy-team two-root byte-identity, and marker-subsystem-fault fail-open all pinned (fault row includes a recovery control leg proving the planted path is the live vector).
- **Open direction**: the issue's named defect — unbounded identical per-write duplicates — is empirically closed to **≤1 duplicate per content-key per session-dir** (~1.1 KB median event). The cross-resumed-session factor (one possible re-emit per newly minted session dir) is by-construction, bias-to-preservation. The counter-test **reproduces the base defect under source-only revert** (two events with dedup globally off), so the cert is non-vacuous end-to-end.
- **Both-modes standing gate**: identical empty-team input under lead frame (emits + claims), in-process teammate (topology fail-closed), and tmux teammate (defers before any claim) — keyed on runtime structural signals only, no mode flag.

## What changed

- `agent_handoff_marker.py` — keyword-only `root_dir` plumbing in the marker SSOT; guard/symlink/TOCTOU/dir-fd flow stays single-copy; falsy or non-absolute root fails open as before. Guard-order delta: non-str `team_name` + degenerate `task_id` now fails open instead of raising (strictly safer; pinned).
- `task_metadata_snapshot.py` — `_snapshot_marker_root` is the ONE root-policy site, consumed by both hard-bound wrappers (claim/rollback root symmetry by construction), keyed on the seam-passed persisted `team_name` (the deliberate resolver split is preserved).
- `pact_context.py` — docstring-only: documents the effective deferral target on empty-team frames.
- Tests: substrate-surface verification file (6 tests) + seam-level bidirectional certification suite (19 tests) — one assertion per behavior across the two files.

## Verification

- Full suite: **11,004 passed / 15 skipped / 0 failed / 0 errors** (plain proxy-bypassed pytest, errors token explicitly checked)
- Concurrent auditor: **GREEN** — R4 single-copy proven by AST call census; `pact_context.py` proven docstring-only by AST-dump equality; both transcription-fidelity judgment calls verified faithful
- Non-vacuity: source-only revert → 21 fail / 4 pass (the 4 are the unchanged-behavior regression pins); fail-closed matrix rows separately falsified via predicate-force-open probe
- Import hygiene: PASS on all touched files

## Residuals (tracked separately)

- Session-dir markers have no reaper — accepted: 0-byte files, corrupted-context sessions only
- `agent_handoff` event family inherits the same degenerate-guard fail-open (lower exposure) — follow-up issue
- `write_context` non-empty `team_name` guard — follow-up issue
- Stale-leadSessionId residual: geometry unchanged by the two-root scheme (disjoint input classes); durably recorded in #1169

## Version

PATCH bump 4.6.3 → 4.6.4 (internal behavior hardening; no user-facing surface change).
