### PR TITLE
fix(merge-guard): positional over-block class + busybox/stdbuf closure (#1178)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.5",
+      "version": "4.6.6",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.5/       # Plugin version
+│               └── 4.6.6/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.5",
+  "version": "4.6.6",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.5
+> **Version**: 4.6.6
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -2351,7 +2351,16 @@ def _strip_non_executable_content(command: str) -> str:
                 # (--m -> --message): on `git commit` the ONLY --m* option IS
                 # --message, so a --m-prefix can never over-strip another option's
                 # value. Short arm (-m/bundled -am/attached -mMSG) unchanged.
-                r"((?:--m(?:e(?:s(?:s(?:a(?:g(?:e)?)?)?)?)?)?|-[a-ln-zA-Z]*m)\s*)",
+                # --trailer (#1178) carries a commit TRAILER (`Key: value` metadata
+                # appended to the message) — inert prose git never executes, so a
+                # danger-looking literal in a trailer value must not gate a faithful
+                # click. FLAG-anchored to the --trailer VALUE only (never a bare token),
+                # exactly like --message; disjoint from the --m* arm (t != m after --),
+                # so it can never over-strip another option's value. The `--trailer=VALUE`
+                # equals form is already stripped upstream by the variable-assignment
+                # carrier (which matches `trailer=...` as a NAME=VALUE), so only the SPACE
+                # form reaches here.
+                r"((?:--m(?:e(?:s(?:s(?:a(?:g(?:e)?)?)?)?)?)?|--trailer|-[a-ln-zA-Z]*m)\s*)",
                 _keep_carrier_value,
             ),
             result,
@@ -2469,9 +2478,16 @@ def _strip_non_executable_content(command: str) -> str:
             # ANSI-C `$'…'` + adjacent-concat `"a"'b'` body forms (consumed ATOMICALLY, so
             # no dangling quote → no leg-merge). $()/backtick preserve rides on
             # _keep_carrier_value. `edit` added to the pr alternation (OB1).
+            # --assignee/-a (create) + --add-assignee/--remove-assignee (edit) carry a
+            # GitHub LOGIN value (#1178) — inert API metadata never executed by a shell,
+            # so a danger-looking literal in an assignee value must not gate a faithful
+            # click. VALUE-taking on every carrier-7 verb (login arg), so they join the
+            # value-strip set; -a is admissible here because within these issue/pr verbs
+            # -a is unambiguously --assignee (contrast release -a=--attach, carrier 7b —
+            # a DIFFERENT span, never matched by this gh issue/pr anchor).
             return _strip_flag_values(
                 span_match.group(0),
-                r"((?:--title|--body|-t|-b)\s+)",
+                r"((?:--title|--body|--assignee|--add-assignee|--remove-assignee|-t|-b|-a)\s+)",
                 _keep_carrier_value,
             )
 

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -170,6 +170,7 @@ import shlex
 import time
 from collections.abc import Sequence
 from pathlib import Path
+from typing import NamedTuple
 
 from .paths import get_claude_config_dir
 
@@ -2119,6 +2120,20 @@ def _keep_carrier_value(m: "re.Match") -> str:
     return flag + transformed
 
 
+def _strip_inert_dq_value(m: "re.Match") -> str:
+    """Replace an inert double-quoted positional value with the bareword ``STRIPPED``;
+    span-scope a value that contains ``$()``/backtick (executing spans preserved VERBATIM
+    in the SAME dq context, surrounding inert literal stripped); FAIL-SAFE preserve-whole on
+    a span the scanner cannot resolve. Byte-identical to the echo/printf carrier's dq-arg
+    strip; used by the general inert-default positional strip (#1178, carrier 10) so a
+    non-flag-anchored quoted positional is stripped with the SAME $()-preserve + fail-safe
+    discipline as the flag-anchored carriers."""
+    if not _has_command_substitution(m.group(0)):
+        return "STRIPPED"
+    transformed = _preserve_substitution_spans(m.group(0))
+    return m.group(0) if transformed is None else transformed
+
+
 def _strip_flag_values(span: str, flag_sep_regex: str, keep_fn) -> str:
     """Quote-safe value strip for a flag family within a single command span (#1118
     re-model). KEEPS the flag(+separator) token; replaces the VALUE with a BALANCED
@@ -2850,6 +2865,23 @@ def _strip_non_executable_content(command: str) -> str:
 
         result = re.sub(_gh_api_selector_span, _strip_gh_api_selectors, result)
 
+    # 10. GENERAL inert-default positional strip (#1178) — the strip-inert-by-default
+    #     inversion. For each shell-operator leg whose head is NEITHER a shell-string executor
+    #     / modeled wrapper (a) NOR an http-client (b), AND whose masked surface is NOT itself
+    #     dangerous (c), the quoted POSITIONAL values are INERT (POSIX argv of an unrecognized
+    #     command is never executed by the outer shell), so a danger-looking literal there must
+    #     not gate a faithful click — strip them (dq span-scopes $()/backtick; sq → bareword)
+    #     while PRESERVING executor / http-client / dangerous legs verbatim so every executing
+    #     arg stays caught and every destructive target survives for mint/read binding.
+    #     MONOTONIC toward False (only removes inert quoted content; never synthesizes a danger
+    #     token) so it can only CLOSE an over-block, never open one. Runs LAST (after the
+    #     flag-anchored carriers 1–9 have stripped their prose) under the SAME output-routing
+    #     skip. Leg slicing reuses the _slice_stripped_legs substrate on the in-progress result
+    #     (NOT _split_into_legs → re-strip recursion), rejoined with the ORIGINAL separators so
+    #     downstream leg boundaries are byte-unchanged.
+    if not piped_to_shell and not process_sub_to_shell:
+        result = _strip_inert_positional_legs(result)
+
     return result
 
 
@@ -3195,6 +3227,411 @@ def _flag_condition_danger_op(command: str) -> str | None:
     return None
 
 
+# =============================================================================
+# #1178 GENERAL inert-default positional strip — catalog, preserve-predicate,
+# wrapper recursion, and the carrier-10 leg strip.
+#
+# The strip-inert-by-DEFAULT inversion (design of record, SOUND-BOUNDED): a leg whose head
+# is an UNRECOGNIZED command has POSIX-argv-inert quoted positionals (the outer shell never
+# executes them), so a danger-looking literal there must not gate a faithful click — strip
+# it. A leg is PRESERVED (not stripped) iff its quoted content is load-bearing for a True
+# verdict: (a) its head hands a quoted string to a shell/interpreter (executor), or wraps a
+# command that does (modeled wrapper, RECURSED); (b) its head is an http-client whose
+# destructive target is a quoted URL that masking hides; or (c) its masked surface is itself
+# dangerous (a bare-token git/gh op whose quoted TARGET must survive mint/read binding). The
+# strip is MONOTONIC toward False: it only ever REPLACES an inert quoted value with STRIPPED
+# (or a $()-span-scoped value) — it never synthesizes a danger token — so it can only CLOSE
+# an over-block (True->False), never OPEN one; the whole safety burden reduces to preserve-
+# predicate completeness on the load-bearing legs.
+# =============================================================================
+
+# (a) Shell-string executors / interpreters. TOKEN-EQUALITY on the basename-normalized head
+# (C1 CARDINAL — NEVER substring/\b: a substring scan sees `bash` in `bash-completion` /
+# `python` in `python-config` and would wrongly PRESERVE an inert command's quoted arg,
+# re-opening the over-block). Bounded per-FAMILY patterns fold version/alias variants into
+# ONE member (python[0-9.]* / node|nodejs / ksh(93)?) so a real versioned interpreter is
+# caught while distinct tokens (python-config, node-gyp) are NOT (^…$ anchors the whole
+# token). busybox is a WRAPPER (its applet/executor is the 2nd token) → the wrapper set below.
+_SHELL_STRING_EXECUTORS = re.compile(
+    r"^(?:"
+    r"sh|bash|zsh|dash|ash|fish|csh|tcsh"                # POSIX + common shells
+    r"|ksh(?:93)?|rksh|mksh"                             # ksh family (ksh93 != ksh)
+    r"|eval|expect|watch"                               # string runners
+    r"|ssh|rsh|remsh|slogin|su"                         # remote / user-switch (-c / a command)
+    r"|python[0-9.]*|perl|ruby[0-9.]*|nodejs|node|php|awk|gawk"  # interpreters (-c/-e/-r)
+    r")$"
+)
+
+# (a) Modeled exec-WRAPPERS whose (possibly nested) executor's quoted arg executes. Split by
+# grammar tractability. RECURSE: the wrapper's own args are a bounded, well-known skip from
+# the head to the nested command, which _is_preserve_leg then RE-EVALUATES (nested executor →
+# preserve, case A caught; nested inert → strip, case B freed). sudo is RECURSE (≈ doas + a
+# bigger flag table; -i/-s/-e = shell/edit forms → preserve): sudo is ubiquitous and
+# `sudo logger "…"` / `sudo mycmd "…"` over-blocks are COMMON, not contrived, so coarse-
+# preserving it would retain a cardinal over-block. COARSE: grammars whose nested-command
+# boundary is NOT reliably skippable — find's `-exec CMD` is `;`/`+`-terminated with `{}`
+# placeholders; flock has a leading LOCKFILE positional + a `-c "STR"` string-exec arm (flock
+# -c runs via sh -c) + FD forms; busybox's applet is the 2nd token; stdbuf uses attached
+# `-oL` value forms — preserved WHOLE (over-block-safe: `flock -c "STR"`/`busybox sh -c` stay
+# CAUGHT; the `flock /lock mycmd "…"` wrapped-inert over-block is a contrived, tracked
+# residual). Enumerating EVERY wrapper is the #1098 wall (D1): an unmodeled custom wrapper's
+# under-block is a tolerated residual.
+_EXEC_WRAPPERS_RECURSE = frozenset({
+    "nohup", "setsid", "nice", "doas", "sudo", "timeout", "xargs", "env",
+    # Nameable exec-prefix family (#1178, user ruling = Option X + RECURSION). All 13 nameable
+    # exec-prefixes RECURSE (via _WRAPPER_GRAMMAR) so `<prefix> bash -c "danger"` stays CAUGHT
+    # AND the faithful inert `<prefix> mycmd "danger"` FREES — the over-block is CLOSEABLE, so
+    # it MUST be closed ("contrived" is not a valid exception under the user principle; only a
+    # by-construction-unclosable residual like curl/wget is acceptable). Per-prefix arg-skip
+    # grammar below, each BIDIRECTIONALLY certified (bash -c caught ∧ mycmd freed ∧ value-flag-
+    # before-executor caught). The ONLY tolerated under-block residual is the genuinely-CUSTOM
+    # (myrunner-style) exec-wrapper tail (ratified D1 — enumerating every wrapper = the #1098 wall).
+    "time", "exec", "command", "chrt", "taskset", "ionice", "unbuffer",
+    "proxychains", "torsocks", "catchsegv", "nocache", "eatmydata", "rlwrap",
+})
+_EXEC_WRAPPERS_COARSE = frozenset({
+    # Plan-ratified members (pre-escalation). find's -exec CMD is ;/+-terminated with {}
+    # placeholders; flock has a lockfile positional + a -c string-exec arm; busybox's applet is
+    # the 2nd token; stdbuf uses attached -oL value forms — all COARSE preserve-whole (their
+    # `<wrapper> bash -c "danger"` stays caught; the wrapped-inert over-block is a contrived,
+    # tracked residual). The nameable exec-prefix family RECURSES (above), not here.
+    "find", "flock", "busybox", "stdbuf",
+})
+
+# (b) http-client heads whose destructive target is a quoted URL that _mask_shell_quotes
+# blanks (so the danger battery on the masked surface CANNOT see it) → preserving is the
+# load-bearing #1098-consistent exclusion (a strip would UNDER-block). curl/wget matched by
+# shlex basename head (catches a quoted "curl": base-True via \bcurl\b + a .* lookahead that
+# spans the closing quote). gh api is matched on the masked surface via _GH_API_PREFIX (an
+# unquoted `gh api`; a quoted "gh" api is base-FALSE — \bgh\s+ is broken by the closing quote
+# — so it needs no preserve).
+_HTTP_CLIENT_HEADS = frozenset({"curl", "wget"})
+
+# Recognized git/gh TOOL heads. Carrier 10 PRESERVES these legs wholesale and DEFERS to their
+# dedicated carriers (5 git commit / 7 gh issue-pr / 7b-e / 8 curl-body / 9 gh-api selector) +
+# the danger floor: re-stripping a value those carriers intentionally preserved is an
+# under-block (a git commit -m/tag $() fail-safe value, a `git -c` config dot-guard value, an
+# expanded var), and a DANGEROUS git/gh leg's target must survive for binding. Non-carrier
+# git/gh prose (e.g. `git log --grep "…git branch -D…"`) stays a benign over-block RESIDUAL —
+# never an under-block. (curl/wget/gh-api are the http-client heads above / the gh-api masked
+# clause, handled separately.)
+_TOOL_HEADS = frozenset({"git", "gh"})
+
+# Bounded recursion depth for nested wrappers (`timeout nice bash -c …`). Beyond this →
+# fail-safe PRESERVE. 3 covers realistic nesting; the guard prevents pathological recursion.
+_MAX_WRAPPER_DEPTH = 3
+
+class _WrapperGrammar(NamedTuple):
+    """Per-wrapper own-arg grammar for the recursion walk. bool_flags = flags to skip (token
+    only); value_flags = flags whose NEXT token is a value to skip too; shell_flags = flags
+    that invoke a shell / make the arg the command → PRESERVE the whole leg; positionals =
+    count of leading NON-flag positional args to skip before the command (timeout's DURATION =
+    1). Long =forms (`--flag=x`) collapse to one token; env NAME=VALUE is handled generically.
+    An UNRECOGNIZED dash-flag (unknown arity) → PRESERVE — skipping the wrong number of tokens
+    could land PAST the executor = the under-block the fail-safe forbids."""
+    bool_flags: "frozenset[str]"
+    value_flags: "frozenset[str]"
+    shell_flags: "frozenset[str]"
+    positionals: int
+
+
+_WRAPPER_GRAMMAR: "dict[str, _WrapperGrammar]" = {
+    "nohup":   _WrapperGrammar(frozenset(), frozenset(), frozenset(), 0),
+    "setsid":  _WrapperGrammar(frozenset({"-c", "-f", "-w", "--ctty", "--fork", "--wait"}), frozenset(), frozenset(), 0),
+    "nice":    _WrapperGrammar(frozenset(), frozenset({"-n", "--adjustment"}), frozenset(), 0),
+    "doas":    _WrapperGrammar(frozenset({"-L", "-n"}), frozenset({"-C", "-u"}), frozenset({"-s"}), 0),
+    "timeout": _WrapperGrammar(frozenset({"--preserve-status", "--foreground", "-v", "--verbose"}), frozenset({"-s", "--signal", "-k", "--kill-after"}), frozenset(), 1),
+    "xargs":   _WrapperGrammar(frozenset({"-0", "--null", "-r", "--no-run-if-empty", "-t", "--verbose", "-p", "--interactive", "-x", "--exit", "-o", "--open-tty"}), frozenset({"-I", "-i", "-n", "--max-args", "-L", "--max-lines", "-P", "--max-procs", "-s", "--max-chars", "-d", "--delimiter", "-E", "-e", "-a", "--arg-file"}), frozenset(), 0),
+    "env":     _WrapperGrammar(frozenset({"-i", "--ignore-environment", "-0", "--null", "-v"}), frozenset({"-u", "--unset", "-C", "--chdir"}), frozenset({"-S", "--split-string"}), 0),
+    # sudo (≈ doas + a bigger table). shell/edit forms {-i,-s,-e} → preserve (no explicit CMD).
+    # -h OMITTED (ambiguous help-vs-host) → unrecognized → preserve (over-block-safe). Value
+    # flags (-u/-g/-C/-p/-R/-r/-T/-t/-U/-D) verified vs sudo(8). Arity errors here would
+    # under-block, so the value/bool split is cert-pinned per Q2 (value-flag-before-executor).
+    "sudo":    _WrapperGrammar(frozenset({"-A", "--askpass", "-B", "--bell", "-b", "--background", "-E", "--preserve-env", "-H", "--set-home", "-K", "--remove-timestamp", "-k", "--reset-timestamp", "-l", "--list", "-n", "--non-interactive", "-P", "--preserve-groups", "-S", "--stdin", "-V", "--version", "-v", "--validate"}), frozenset({"-C", "--close-from", "-D", "--chdir", "-g", "--group", "-p", "--prompt", "-R", "--chroot", "-r", "--role", "-T", "--command-timeout", "-t", "--type", "-U", "--other-user", "-u", "--user"}), frozenset({"-i", "--login", "-s", "--shell", "-e", "--edit"}), 0),
+    # Nameable exec-prefixes (#1178 Option X, RECURSION). Each bidirectionally certified (bash -c
+    # caught ∧ mycmd freed ∧ value-flag-before-executor caught). Unlisted flags → unrecognized →
+    # PRESERVE (fail-safe: an unmodeled option over-blocks rather than mis-skips past the
+    # executor). time = bash keyword (-p) + /usr/bin/time (-o/-f value). chrt/taskset carry a
+    # leading PRIORITY/MASK positional + a -p/--pid operate-on-existing-PID form (no CMD → shell/
+    # preserve). ionice: -c/-n class values. proxychains: -f config. torsocks: -d/-a/-p/-P/-u/-s
+    # values. rlwrap: large value set (-b/-C/-D/-e/-f/-g/-H/-l/-O/-P/-q/-s/-S/-t/-w/-z); -a/-m/-p
+    # are OPTIONAL-ATTACHED (bool unless attached). catchsegv/nocache/eatmydata take no options.
+    "time":        _WrapperGrammar(frozenset({"-a", "-p", "-q", "-v", "-V", "--append", "--portability", "--quiet", "--verbose", "--version", "--help"}), frozenset({"-o", "-f", "--output", "--format"}), frozenset(), 0),
+    "exec":        _WrapperGrammar(frozenset({"-c", "-l"}), frozenset({"-a"}), frozenset(), 0),
+    "command":     _WrapperGrammar(frozenset({"-p", "-V", "-v"}), frozenset(), frozenset(), 0),
+    "chrt":        _WrapperGrammar(frozenset({"-f", "-b", "-o", "-r", "-i", "-d", "-R", "-m", "-a", "-v", "--fifo", "--batch", "--other", "--rr", "--idle", "--deadline", "--reset-on-fork", "--all-tasks", "--verbose"}), frozenset(), frozenset({"-p", "--pid"}), 1),
+    "taskset":     _WrapperGrammar(frozenset({"-a", "--all-tasks", "-c", "--cpu-list"}), frozenset(), frozenset({"-p", "--pid"}), 1),
+    "ionice":      _WrapperGrammar(frozenset({"-t", "--ignore"}), frozenset({"-c", "--class", "-n", "--classdata"}), frozenset({"-p", "--pid"}), 0),
+    "unbuffer":    _WrapperGrammar(frozenset({"-p"}), frozenset(), frozenset(), 0),
+    "proxychains": _WrapperGrammar(frozenset({"-q", "--quiet"}), frozenset({"-f", "--config"}), frozenset(), 0),
+    "torsocks":    _WrapperGrammar(frozenset({"-h", "-q", "-i", "--isolate", "-H", "-V", "--version", "--help", "--shell"}), frozenset({"-d", "--debug", "-a", "--address", "-p", "--port", "-P", "--control-port", "-u", "--user", "-s", "--socks5"}), frozenset(), 0),
+    "catchsegv":   _WrapperGrammar(frozenset(), frozenset(), frozenset(), 0),
+    "nocache":     _WrapperGrammar(frozenset(), frozenset({"-n"}), frozenset(), 0),
+    "eatmydata":   _WrapperGrammar(frozenset(), frozenset(), frozenset(), 0),
+    "rlwrap":      _WrapperGrammar(frozenset({"-A", "-c", "-h", "-i", "-I", "-n", "-N", "-o", "-r", "-R", "-U", "-W", "-x", "-a", "-m", "-p", "--always-readline", "--complete-filenames", "--case-insensitive", "--no-children", "--one-shot", "--remember", "--quiet", "--help"}), frozenset({"-b", "-C", "-D", "-e", "-f", "-g", "-H", "-l", "-O", "-P", "-q", "-s", "-S", "-t", "-w", "-z", "--break-chars", "--command-name", "--history-no-dupes", "--forget-matching", "--file", "--history-filename", "--logfile", "--substitute-prompt", "--prompt", "--quote-characters", "--histsize", "--set-terminal-name", "--wait-before-prompt", "--filter"}), frozenset(), 0),
+}
+
+
+def _stripped_surface_danger(stripped: str) -> bool:
+    """The literal danger battery over an ALREADY-STRIPPED (or MASKED) surface: the
+    DANGEROUS_PATTERNS scan + the four per-leg literal-arm families + the additive
+    normalized-flag condition. Factored out of ``is_dangerous_command`` (behavior-identical)
+    so the #1178 preserve-predicate can consult the SAME danger predicate on a masked leg
+    WITHOUT re-entering ``_strip_non_executable_content`` (which would recurse — the predicate
+    runs INSIDE that strip). SURFACE-AGNOSTIC: it neither strips nor masks, only matches, so a
+    ``_mask_shell_quotes(leg)`` surface is safe (masking is idempotent for these regexes).
+    The SSOT for "is this surface dangerous" — the read floor and the preserve predicate can
+    never drift."""
+    for pattern in DANGEROUS_PATTERNS:
+        if pattern.search(stripped):
+            return True
+    # Literal arms matched PER-LEG over the SAME surface (identical provenance to the read
+    # floor). Legs computed ONCE and shared by all four arm loops.
+    legs = _slice_stripped_legs(stripped)
+    for _leg in legs:
+        if any(arm.search(_leg) for arm in _FORCE_PUSH_LITERAL_ARMS):
+            return True
+    for _leg in legs:
+        if any(arm.search(_leg) for arm in _CLOSE_LITERAL_ARMS):
+            return True
+    for _leg in legs:
+        if any(arm.search(_leg) for arm in _API_LITERAL_ARMS):
+            return True
+    for _leg in legs:
+        if any(arm.search(_leg) for arm in _BRANCH_DELETE_LITERAL_ARMS):
+            return True
+    if _flag_condition_danger_op(stripped) is not None:
+        return True
+    return False
+
+
+def _leg_token_spans(leg: str) -> "list[tuple[int, int]]":
+    """Quote-aware shell-token spans (start, end) into `leg`: a token is a maximal run with NO
+    UNQUOTED whitespace (a quoted or backslash-escaped whitespace stays INSIDE the token).
+    Mirrors the ``_mask_shell_quotes`` scanner exactly (backslash-escape outside quotes; `\\`
+    honored inside "…" but not '…'), so an embedded quoted span (`FOO=a"b c"d` = ONE token) never
+    SPLITS a token and a quoted head (`"timeout"`) stays token[0] — the two failure modes a
+    masked-`\\S+` tokenization has (an internal-quote span erases to spaces and either splits the
+    token or erases a quoted head, misaligning the walk). Callers reach here only on a balanced
+    leg (``_is_preserve_leg`` preserves an unbalanced one up front), so quotes always close."""
+    spans: list[tuple[int, int]] = []
+    i, n = 0, len(leg)
+    tok_start = -1
+    while i < n:
+        c = leg[i]
+        if c.isspace():
+            if tok_start >= 0:
+                spans.append((tok_start, i))
+                tok_start = -1
+            i += 1
+            continue
+        if tok_start < 0:
+            tok_start = i
+        if c == "\\":
+            i += 2
+            continue
+        if c == "'" or c == '"':
+            q = c
+            i += 1
+            while i < n:
+                if q == '"' and leg[i] == "\\":
+                    i += 2
+                    continue
+                if leg[i] == q:
+                    i += 1
+                    break
+                i += 1
+            continue
+        i += 1
+    if tok_start >= 0:
+        spans.append((tok_start, n))
+    return spans
+
+
+def _wrapper_nested_command(leg: str, head: str) -> "str | None":
+    """For a RECURSE-set wrapper leg, return the ORIGINAL-string substring of the nested
+    command (quotes intact) for ``_is_preserve_leg`` to recurse on, or None → FAIL-SAFE
+    PRESERVE. Tokens + offsets come from ``_leg_token_spans`` (quote-aware: an adjacent-concat
+    arg stays ONE token, a quoted head stays token[0]); flag recognition reads the RAW token
+    text (a NAME= prefix / a dash-flag is before any quote), and the returned slice indexes the
+    ORIGINAL leg so the nested command keeps its quotes. Returns None on ANY uncertainty: an
+    unrecognized dash-flag (unknown arity → can't safely skip its value = the mis-skip-past-
+    executor under-block), a shell-invocation flag (env -S / sudo -i,-s,-e / doas -s / …), a
+    value-flag at end-of-tokens, or no nested command."""
+    g = _WRAPPER_GRAMMAR[head]
+    spans = _leg_token_spans(leg)    # spans[0] is the wrapper head (quoted or not)
+    i, n = 1, len(spans)
+    # PHASE 1 — the wrapper's OWN flags (which PRECEDE any positional / the command). Stopping
+    # flag-consumption once a non-flag or `--` is seen is load-bearing: a wrapper flag that
+    # COLLIDES with a nested-command flag (taskset's `-c`=--cpu-list vs `bash -c`) must NOT be
+    # re-consumed AFTER the positional — else `taskset MASK bash -c "danger"`'s `-c` (bash's)
+    # would be eaten as taskset's, mis-locating the command → under-block.
+    while i < n:
+        start, end = spans[i]
+        tok = leg[start:end]
+        if tok == "--":
+            i += 1
+            break                                # end-of-options; rest is positionals + command
+        if tok.startswith("-") and tok != "-":
+            flagname = tok.split("=", 1)[0]
+            if flagname in g.shell_flags:
+                return None                      # shell-invocation form → preserve
+            if flagname in g.value_flags:
+                i += 1 if "=" in tok else 2      # --flag=value one token; --flag value two
+                continue
+            if flagname in g.bool_flags:
+                i += 1
+                continue
+            return None                          # unrecognized dash-flag → preserve
+        break                                    # first non-flag token → positionals / command
+    # PHASE 2 — the wrapper's leading POSITIONALS (timeout DURATION, chrt PRIORITY, taskset MASK).
+    for _ in range(g.positionals):
+        if i >= n:
+            return None                          # ran out (positional missing) → preserve
+        i += 1
+    # PHASE 3 — env NAME=VALUE assignments (env has positionals=0; they precede the command).
+    if head == "env":
+        while i < n and re.match(r"^[A-Za-z_]\w*=", leg[spans[i][0]:spans[i][1]]):
+            i += 1
+    # PHASE 4 — the nested command head.
+    if i >= n:
+        return None                              # no command → preserve
+    cmd_start, cmd_end = spans[i]
+    if leg[cmd_start:cmd_end].startswith("-"):
+        return None                              # a bare dash-flag is never a real command → preserve
+    return leg[cmd_start:]                        # nested command head (original, quotes intact)
+
+
+def _leg_command_word(leg: str) -> "str | None":
+    """Return the leg SUBSTRING starting at the TRUE command word — skipping any LEADING
+    env-assignment (`NAME=value`, quoted OR bare: `LC_ALL=C`, `FOO="a b"`) and redirection
+    (`>`, `2>`, `&>`, `2>/dev/null`, `2>&1`, `< in`…) tokens that PRECEDE the command. Returns
+    None when the leg is ONLY assignments/redirects (no command). SECURITY (#1178 head-
+    displacement): a leading assignment/redirect displaces tokens[0], so `_is_preserve_leg`
+    must compute the head on the TRUE command — else `LC_ALL=C bash -c "danger"` reads head
+    `LC_ALL=C`, no preserve clause fires, and the executor's danger arg is stripped = a
+    destructive UNDER-block. Mirrors the env WRAPPER's own NAME=VALUE skip (grammar PHASE 3)
+    at the leg top level for the BARE prefix form. Quote-aware via _leg_token_spans."""
+    spans = _leg_token_spans(leg)
+    k, n = 0, len(spans)
+    while k < n:
+        start, end = spans[k]
+        tok = leg[start:end]
+        # NAME=value / NAME+=value / NAME= (empty) assignment — the `\+?` covers the append
+        # form (`PATH+=/x`); the whole token is skipped so an embedded '='/'$'/quote in the value
+        # (`FOO=a=b`, `FOO=$HOME`, `FOO="a b"` → carrier-4-stripped to `FOO=STRIPPED`) stays inside
+        # the skipped token. (carrier 4 already stripped a non-expanded quoted RHS to NAME=STRIPPED
+        # BEFORE carrier 10, so quotes are not relied on surviving.)
+        if re.match(r"^[A-Za-z_]\w*\+?=", tok):
+            k += 1
+            continue
+        if re.match(r"^(?:[0-9]*(?:&?[<>]|<>)|&>>?)", tok):   # redirection operator
+            k += 1
+            # a BARE operator (`>`, `>>`, `2>`, `<`, `&>`, and SPACED-target `>&`/`<&`/`2>&`, `>|`)
+            # consumes the NEXT token as its target; a self-contained form (`2>&1`/`3>&2`/`>&2`
+            # fd-dup, `2>/dev/null`/`>file` attached target) does not. The `[<>]&` alt classifies a
+            # spaced redirect-both (`>& file`) as BARE (architect finding — else the walk lands on
+            # `file` and misses the real executor = under-block); `2>&1`/`>&2` stay self-contained
+            # (a trailing fd digit fails the fullmatch).
+            if re.fullmatch(r"[0-9]*(?:[<>]{1,2}|[<>]&|>\|)|&>>?", tok):
+                k += 1
+            continue
+        return leg[start:]                               # the true command word
+    return None                                          # only assignments/redirects → no command
+
+
+def _is_preserve_leg(leg: str, _depth: int = 0) -> bool:
+    """True iff this single leg's quoted-arg values must be PRESERVED (not stripped) by the
+    #1178 general inert-default strip — see the catalog block above for clauses (a)/(b)/(c).
+    FAIL-SAFE to PRESERVE (True) on any ambiguity (unparseable quotes, uncertain wrapper
+    boundary, recursion depth): preserving is the OVER-BLOCK-safe direction (it can only leave
+    an over-block unclosed, never open an under-block)."""
+    if _shell_tokenize(leg) is None:
+        return True                                      # unbalanced quote → fail-safe preserve
+    # (d1) a QUOTED variable-assignment RHS that survived the variable-assignment carrier (4)
+    # is an EXPANDED value: carrier 4 strips a non-expanded `NAME="…"` to `NAME=STRIPPED`, and
+    # when eval/source is present it skips entirely (preserving all) — either way, a `NAME="…"`
+    # / `NAME='…'` still QUOTED here is one carrier 4 kept because it executes via its expansion
+    # (`FOO="gh pr merge 5" && $FOO`, `export CMD="…" && eval $CMD`). Carrier 10 must NOT
+    # re-strip it (under-block). Covers leading (`FOO=`) and builder (`export/declare NAME=`)
+    # forms alike. NOTE: this un-anchored regex also matches a `--flag="v"` (the `flag="`
+    # inside) — but carrier 4 pre-strips flag-attached literals before carrier 10, so it is a
+    # no-op there; and either way the false-match direction is always PRESERVE (over-block-safe,
+    # never under-block).
+    if re.search(r"""[A-Za-z_]\w*=["']""", leg):
+        return True
+    # HEAD-DISPLACEMENT guard (#1178 SEC): compute the head clauses on the TRUE command word
+    # (skip leading env-assignment / redirection prefixes) — else a leading `LC_ALL=C` / bare
+    # `FOO=bar` / `2>/dev/null` displaces tokens[0] and the real executor is missed (under-block).
+    cmd_leg = _leg_command_word(leg)
+    if cmd_leg is not None:
+        tokens = _shell_tokenize(cmd_leg)
+        if tokens:
+            head = os.path.basename(tokens[0])
+            if head in _TOOL_HEADS:                      # (d2) git/gh → defer to carriers 5/7/8/9
+                return True
+            if _SHELL_STRING_EXECUTORS.match(head):      # (a) executor / interpreter
+                return True
+            if head in _HTTP_CLIENT_HEADS:               # (b) curl/wget (quoted head via shlex)
+                return True
+            if head in _EXEC_WRAPPERS_COARSE:            # (a) wrapper, boundary not skippable
+                return True
+            if head in _EXEC_WRAPPERS_RECURSE:           # (a) wrapper, recurse to nested command
+                if _depth >= _MAX_WRAPPER_DEPTH:
+                    return True                          # depth guard → fail-safe preserve
+                nested = _wrapper_nested_command(cmd_leg, head)
+                if nested is None:
+                    return True                          # uncertain boundary → fail-safe preserve
+                return _is_preserve_leg(nested, _depth + 1)
+    masked = _mask_shell_quotes(leg)                     # tail checks on the WHOLE leg (conservative)
+    # (d3) an unquoted process substitution `<(cmd)` / `>(cmd)` EXECUTES cmd, so its quoted args
+    # may execute — preserve. Masking blanks a quoted `"<("`, so only a REAL procsub triggers.
+    if _PROCSUB_MARKER_RE.search(masked):
+        return True
+    if re.search(_GH_API_PREFIX, masked):                # (b) gh api (unquoted `gh api`)
+        return True
+    return _stripped_surface_danger(masked)              # (c) bare-token danger (defense-in-depth)
+
+
+def _maybe_strip_leg(leg: str) -> str:
+    """Strip a leg's quoted positional VALUES iff it is inert (not preserved); else verbatim.
+    dq span-scopes $()/backtick (via _strip_inert_dq_value); sq → bareword STRIPPED. The verb +
+    unquoted structure stay intact; the leg carries NO shell-operator separator (those are
+    outside the leg), so this never re-slices."""
+    if _is_preserve_leg(leg):
+        return leg
+    stripped = re.sub(r'"(?:[^"\\]|\\.)*"', _strip_inert_dq_value, leg)
+    stripped = re.sub(r"'[^']*'", "STRIPPED", stripped)
+    # QUOTE-BALANCE fail-safe (#1118 leg-merge guard): the per-span dq regex is NOT
+    # $()-nesting-aware, so on an exotic nested-quote value (`"a $(b "c") d"`) it can mis-pair
+    # and emit an unbalanced leg. An unbalanced leg fed downstream could let _mask_shell_quotes
+    # pair a stray quote ACROSS a separator and MERGE legs (under-block). shlex is the oracle:
+    # we only reach here with a balanced ORIGINAL (an unbalanced one preserved at the top), so
+    # if the strip broke balance, preserve the ORIGINAL leg rather than emit a dangling quote.
+    if _shell_tokenize(stripped) is None:
+        return leg
+    return stripped
+
+
+def _strip_inert_positional_legs(result: str) -> str:
+    """Carrier-10 core (#1178): slice `result` into shell-operator legs — the SAME masked +
+    FD-neutralize substrate as ``_slice_stripped_legs``, but RETAINING the original separators
+    — and strip each INERT (non-preserved) leg's quoted positional values, emitting preserve
+    legs verbatim. Rejoined with the ORIGINAL separators so a downstream re-slice of this
+    result sees byte-unchanged leg boundaries. Slices via this in-line walk (NOT
+    ``_split_into_legs``, which re-strips → recursion)."""
+    view = _FD_REDIRECT_RE.sub(
+        lambda m: " " * len(m.group()), _mask_shell_quotes(result)
+    )
+    out, last = [], 0
+    for m in _COMPOUND_OPS_RE.finditer(view):
+        out.append(_maybe_strip_leg(result[last:m.start()]))
+        out.append(result[m.start():m.end()])            # ORIGINAL separator, verbatim
+        last = m.end()
+    out.append(_maybe_strip_leg(result[last:]))
+    return "".join(out)
+
+
 def is_dangerous_command(command: str) -> bool:
     """Check if a bash command is a dangerous git operation.
 
@@ -3217,58 +3654,12 @@ def is_dangerous_command(command: str) -> bool:
     # any matching (so this floor + the substrate join lines identically).
     command = _normalize_line_continuations(command)
     stripped = _strip_non_executable_content(command)
-    for pattern in DANGEROUS_PATTERNS:
-        if pattern.search(stripped):
-            return True
-    # Literal force-push arms, matched PER-LEG (#1082): leg boundaries come from
-    # _slice_stripped_legs over this SAME `stripped` text — identical strip
-    # provenance to _split_into_legs (normalize + strip, above), so read-floor legs
-    # and substrate legs can never diverge, and the strip is not recomputed. An arm
-    # fires iff push and the force-class flag co-occur within ONE leg, in ANY leg
-    # position (the match-anywhere purpose, per leg). The legs are computed ONCE
-    # here and shared by all four literal-arm loops below (force-push, close, API,
-    # branch-delete).
-    legs = _slice_stripped_legs(stripped)
-    for _leg in legs:
-        if any(arm.search(_leg) for arm in _FORCE_PUSH_LITERAL_ARMS):
-            return True
-    # Literal close arms, matched PER-LEG (#1087): same leg substrate and strip
-    # provenance as the force-push loop above. An arm fires iff `gh pr close` and
-    # `--delete-branch` co-occur within ONE leg — so the ambiguous cross-leg
-    # multi-close is is_dangerous=False here, the mint write-gate refuses (no token),
-    # and the escalated-single laundering channel is structurally closed.
-    for _leg in legs:
-        if any(arm.search(_leg) for arm in _CLOSE_LITERAL_ARMS):
-            return True
-    # Literal API danger arms, matched PER-LEG (#1086): same leg substrate and strip
-    # provenance as the loops above. An arm fires iff the API client, its mutating
-    # method (or implicit-POST body flag), and the target endpoint co-occur within ONE
-    # leg — so a method/body-flag token in a benign continuation leg no longer
-    # over-blocks the compound, while a same-leg dangerous API call still gates. The
-    # negative-lookahead arms operate within-leg (correct exclusion/inclusion direction).
-    for _leg in legs:
-        if any(arm.search(_leg) for arm in _API_LITERAL_ARMS):
-            return True
-    # Literal branch-delete arms, matched PER-LEG (#1094): same leg substrate and
-    # strip provenance as the loops above. An arm fires iff `git branch` and the
-    # force-delete flag co-occur within ONE leg — a stray `-D` / `--delete --force`
-    # token in a benign continuation leg no longer gates the compound (and the
-    # formerly-mintable ambiguous compound is is_dangerous=False, so the mint
-    # write-gate refuses → no token → the laundering substrate is structurally
-    # closed), while a same-leg force-delete still gates in ANY leg position.
-    # Clustered/split flag spellings remain the union arm's job (below).
-    for _leg in legs:
-        if any(arm.search(_leg) for arm in _BRANCH_DELETE_LITERAL_ARMS):
-            return True
-    # ADDITIVE union arm (INV-AU): a quote-aware normalized-flag danger CONDITION across
-    # every flag spelling the literal floor misses — `-d`/`-cd` close delete, `-Df`/`-fD`/
-    # `--delete -f` branch force-delete. Runs on the STRIPPED surface (same as the floor)
-    # so a flag spelled inside a comment / heredoc / echo / var-assignment does NOT false-
-    # trigger; the shlex tokenizer keeps a quoted argument as ONE token so a flag inside a
-    # quoted value is never read as a flag. The literal floor stays the fail-closed default.
-    if _flag_condition_danger_op(stripped) is not None:
-        return True
-    return False
+    # The literal danger battery (DANGEROUS_PATTERNS + the four per-leg literal-arm families +
+    # the additive normalized-flag condition) is the SSOT _stripped_surface_danger — factored
+    # out so the #1178 general-strip preserve-predicate can consult the SAME predicate on a
+    # masked leg without re-entering the strip (recursion). Behavior-identical to the prior
+    # inline battery.
+    return _stripped_surface_danger(stripped)
 
 
 # A plain `rm` head token at a compound leg's start. DELIBERATELY rm-SPECIFIC and used

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -3256,6 +3256,7 @@ _SHELL_STRING_EXECUTORS = re.compile(
     r"^(?:"
     r"sh|bash|zsh|dash|ash|fish|csh|tcsh"                # POSIX + common shells
     r"|ksh(?:93)?|rksh|mksh"                             # ksh family (ksh93 != ksh)
+    r"|hush|lash|msh"                                   # busybox exec-shell applets (run a -c string)
     r"|eval|expect|watch"                               # string runners
     r"|ssh|rsh|remsh|slogin|su"                         # remote / user-switch (-c / a command)
     r"|python[0-9.]*|perl|ruby[0-9.]*|nodejs|node|php|awk|gawk"  # interpreters (-c/-e/-r)
@@ -3268,14 +3269,19 @@ _SHELL_STRING_EXECUTORS = re.compile(
 # preserve, case A caught; nested inert → strip, case B freed). sudo is RECURSE (≈ doas + a
 # bigger flag table; -i/-s/-e = shell/edit forms → preserve): sudo is ubiquitous and
 # `sudo logger "…"` / `sudo mycmd "…"` over-blocks are COMMON, not contrived, so coarse-
-# preserving it would retain a cardinal over-block. COARSE: grammars whose nested-command
-# boundary is NOT reliably skippable — find's `-exec CMD` is `;`/`+`-terminated with `{}`
-# placeholders; flock has a leading LOCKFILE positional + a `-c "STR"` string-exec arm (flock
-# -c runs via sh -c) + FD forms; busybox's applet is the 2nd token; stdbuf uses attached
-# `-oL` value forms — preserved WHOLE (over-block-safe: `flock -c "STR"`/`busybox sh -c` stay
-# CAUGHT; the `flock /lock mycmd "…"` wrapped-inert over-block is a contrived, tracked
-# residual). Enumerating EVERY wrapper is the #1098 wall (D1): an unmodeled custom wrapper's
-# under-block is a tolerated residual.
+# preserving it would retain a cardinal over-block. busybox + stdbuf are ALSO RECURSE: busybox's
+# applet is simply token[1] (empty own-flag grammar → nested command = token[1..]), and stdbuf's
+# only options are the -i/-o/-e buffering-mode VALUE-flags (attached `-oL` / separated `-o L` /
+# long `--output=L`) skippable by the phased walk — so their wrapped-inert over-block is CLOSEABLE
+# and MUST be closed. COARSE (still): grammars whose nested-command boundary is NOT reliably
+# skippable — find's `-exec CMD` is `;`/`+`-terminated with `{}` placeholders; flock has a leading
+# LOCKFILE positional + a `-c "STR"` string-exec arm (flock -c runs via sh -c) + FD forms —
+# preserved WHOLE (over-block-safe: `flock -c "STR"` stays CAUGHT; the `flock /lock mycmd "…"`
+# wrapped-inert over-block is a contrived, tracked residual). Enumerating EVERY wrapper is the
+# #1098 wall (D1): an unmodeled custom wrapper's under-block is a tolerated residual. NOTE:
+# recursing busybox requires its exec-capable shell applets (sh/ash/hush/lash/msh + awk) to be
+# recognized preserve-heads — hush/lash/msh were added to _SHELL_STRING_EXECUTORS so
+# `busybox hush -c "danger"` stays CAUGHT after the flip (else a fix-introduced under-block).
 _EXEC_WRAPPERS_RECURSE = frozenset({
     "nohup", "setsid", "nice", "doas", "sudo", "timeout", "xargs", "env",
     # Nameable exec-prefix family (#1178, user ruling = Option X + RECURSION). All 13 nameable
@@ -3288,14 +3294,19 @@ _EXEC_WRAPPERS_RECURSE = frozenset({
     # (myrunner-style) exec-wrapper tail (ratified D1 — enumerating every wrapper = the #1098 wall).
     "time", "exec", "command", "chrt", "taskset", "ionice", "unbuffer",
     "proxychains", "torsocks", "catchsegv", "nocache", "eatmydata", "rlwrap",
+    # busybox + stdbuf RECURSE (F2 closure): busybox = empty own-flag grammar, applet = token[1]
+    # (its exec-capable shell applets sh/ash/hush/lash/msh + awk are recognized preserve-heads so
+    # `busybox sh -c "danger"` stays caught while `busybox mycmd "danger"` frees); stdbuf = -i/-o/-e
+    # buffering-mode VALUE-flags (attached `-oL` handled by the phased walk's short-value branch).
+    "busybox", "stdbuf",
 })
 _EXEC_WRAPPERS_COARSE = frozenset({
-    # Plan-ratified members (pre-escalation). find's -exec CMD is ;/+-terminated with {}
-    # placeholders; flock has a lockfile positional + a -c string-exec arm; busybox's applet is
-    # the 2nd token; stdbuf uses attached -oL value forms — all COARSE preserve-whole (their
-    # `<wrapper> bash -c "danger"` stays caught; the wrapped-inert over-block is a contrived,
-    # tracked residual). The nameable exec-prefix family RECURSES (above), not here.
-    "find", "flock", "busybox", "stdbuf",
+    # Plan-ratified members whose nested-command boundary is NOT reliably skippable: find's -exec
+    # CMD is ;/+-terminated with {} placeholders; flock has a lockfile positional + a -c string-exec
+    # arm — both COARSE preserve-whole (their `<wrapper> bash -c "danger"` stays caught; the
+    # wrapped-inert over-block is a contrived, tracked residual). busybox/stdbuf moved to RECURSE
+    # (above, F2). The nameable exec-prefix family RECURSES, not here.
+    "find", "flock",
 })
 
 # (b) http-client heads whose destructive target is a quoted URL that _mask_shell_quotes
@@ -3369,6 +3380,15 @@ _WRAPPER_GRAMMAR: "dict[str, _WrapperGrammar]" = {
     "nocache":     _WrapperGrammar(frozenset(), frozenset({"-n"}), frozenset(), 0),
     "eatmydata":   _WrapperGrammar(frozenset(), frozenset(), frozenset(), 0),
     "rlwrap":      _WrapperGrammar(frozenset({"-A", "-c", "-h", "-i", "-I", "-n", "-N", "-o", "-r", "-R", "-U", "-W", "-x", "-a", "-m", "-p", "--always-readline", "--complete-filenames", "--case-insensitive", "--no-children", "--one-shot", "--remember", "--quiet", "--help"}), frozenset({"-b", "-C", "-D", "-e", "-f", "-g", "-H", "-l", "-O", "-P", "-q", "-s", "-S", "-t", "-w", "-z", "--break-chars", "--command-name", "--history-no-dupes", "--forget-matching", "--file", "--history-filename", "--logfile", "--substitute-prompt", "--prompt", "--quote-characters", "--histsize", "--set-terminal-name", "--wait-before-prompt", "--filter"}), frozenset(), 0),
+    # busybox + stdbuf (#1178 F2). busybox: the wrapper-usage form is `busybox APPLET [args]` with NO
+    # own-flags before the applet — empty grammar, positionals=0, so the nested command is token[1]
+    # (the applet); its exec-capable shell applets (sh/ash/hush/lash/msh) + awk are recognized
+    # preserve-heads. stdbuf: the -i/-o/-e buffering-mode VALUE-flags (long --input/--output/--error);
+    # the MODE value attaches (`-oL`), separates (`-o L`), or long-equals (`--output=L`) — the
+    # attached-short form is consumed by _wrapper_nested_command's PHASE-1 short-value branch. no
+    # shell forms, positionals=0. --help/--version are unlisted → unrecognized → preserve (over-block-safe).
+    "busybox":     _WrapperGrammar(frozenset(), frozenset(), frozenset(), 0),
+    "stdbuf":      _WrapperGrammar(frozenset(), frozenset({"-i", "-o", "-e", "--input", "--output", "--error"}), frozenset(), 0),
 }
 
 
@@ -3480,6 +3500,19 @@ def _wrapper_nested_command(leg: str, head: str) -> "str | None":
                 i += 1 if "=" in tok else 2      # --flag=value one token; --flag value two
                 continue
             if flagname in g.bool_flags:
+                i += 1
+                continue
+            # ATTACHED-SHORT-VALUE getopt form (`-oL` = short value-flag `-o` + glued value `L`).
+            # A SHORT flag only (`-X`, single dash + one char), whose 2-char prefix is a DECLARED
+            # value_flag, with the value glued on (len > 2). The glued remainder is the value, so
+            # the whole token is consumed (i += 1). GENERAL across RECURSE wrappers (getopt-universal:
+            # `-Xvalue` always binds the value to -X), never bundled-boolean shorts (the prefix must be
+            # a value_flag). Cannot swallow the nested command: a command never starts with `-` (the
+            # PHASE-4 bare-dash guard), and PHASE-1 stops at the first non-flag, so an executor's own
+            # `-c` (which follows the non-flag command head) is never reached here. MONOTONIC: it only
+            # ADVANCES past a wrapper option, never synthesizes danger — so it can only CLOSE an
+            # over-block (recurse to an inert nested command), never open an under-block.
+            if len(tok) > 2 and tok[1] != "-" and tok[:2] in g.value_flags:
                 i += 1
                 continue
             return None                          # unrecognized dash-flag → preserve

--- a/pact-plugin/tests/test_merge_guard_1037_narrow.py
+++ b/pact-plugin/tests/test_merge_guard_1037_narrow.py
@@ -175,17 +175,17 @@ class TestNarrowGhCommentCarrierStripBlock:
 
         assert is_dangerous_command('python3 -c "print(' + _SQ + "gh pr merge 42" + _SQ + ')"')
 
-    def test_general_grep_papercut_still_blocks(self):
-        # SUPPRESSOR-NEUTRAL regression guard: a bare `grep "...op..."` is a known
-        # #1037 over-block papercut the NARROW fix deliberately does NOT address
-        # (out of scope — only gh-comment). The carrier-strip never touches grep (not
-        # a gh carrier verb), so NO carrier mutation flips this; it is caught by the
-        # base substring scan. Asserted so a future change cannot silently ALLOW grep
-        # without the proper fix. (NOTE: `echo "...op..."` is correctly ALLOWED by the
-        # pre-existing echo carrier-strip — it is NOT a BLOCK canary.)
+    def test_general_grep_papercut_now_closed(self):
+        # The `grep "...op..."` over-block papercut this #1037 NARROW fix deliberately left
+        # OUT OF SCOPE (only gh-comment) is CLOSED by the #1178 general inert-default positional
+        # strip — "the proper fix" this pin previously guarded against a suppressor faking. grep
+        # is an unrecognized head, so its quoted pattern is POSIX-argv-inert (never executed);
+        # carrier 10 strips it exactly like the echo carrier-strip -> ALLOW is CORRECT (a
+        # faithful `grep "gh pr merge 5" file` no longer gates). Flipped from block to allow when
+        # #1178 landed; the general strip is the general fix the papercut awaited.
         from merge_guard_pre import is_dangerous_command
 
-        assert is_dangerous_command('grep "gh pr merge 5" file')
+        assert not is_dangerous_command('grep "gh pr merge 5" file')
 
 
 class TestNarrowGhCommentInertAllow:

--- a/pact-plugin/tests/test_merge_guard_1140_carrier5_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1140_carrier5_cert.py
@@ -694,7 +694,9 @@ class TestCarrier4NonRegression:
         # C4 anchor. It was False before #1140 and the anchor widening must not break it.
         cmd = 'git commit --message="run %s later"' % BD
         assert D(cmd) is False, "carrier-4 --message= must stay False at HEAD: %r" % cmd
-        if D_BASE is not None:
+        # Gate on ALL three baselines (mirrors `requires_history`, L149): D_FIRSTFIX/D_FIXR are
+        # squashed-away non-ancestors -> None in a clean/CI clone; the HEAD control above always runs.
+        if None not in (D_BASE, D_FIRSTFIX, D_FIXR):
             assert D_BASE(cmd) is False and D_FIRSTFIX(cmd) is False and D_FIXR(cmd) is False, \
                 "carrier-4 --message= must be non-regressed across ALL baselines: %r" % cmd
 

--- a/pact-plugin/tests/test_merge_guard_1140_carrier5_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1140_carrier5_cert.py
@@ -1553,25 +1553,40 @@ class TestEchoPrintfCarveoutControls:
 
 
 class TestEchoPrintfDeferredBoundary:
-    # DEFERRED-BOUNDARY pins — the STILL-OPEN positional over-block class the carve-out did NOT touch
-    # (it is echo/printf-only by construction). One REPRESENTATIVE PER CARRIER (C5/C7/C8), deliberately
-    # NOT an exhaustive enumeration: the cert's job is to RECORD the boundary (echo/printf multi-arg
-    # CLOSED vs the structural positional class DEFERRED), not to pin the deferred class — that is the
-    # dedicated anchor-coverage audit's job, and over-pinning would couple this cert to a class it does
-    # not fix. Each carrier's non-message positional/flag value is NOT stripped, so a danger literal
-    # there over-blocks — True==both, structurally untouched by the carve-out. Every example uses a
-    # PLAIN danger literal (NO substitution) — that IS the no-substitution proof: the over-block does
-    # not depend on a $(), it is the structural positional gap, so a future reader does not mistake
-    # True==both for a carve-out miss. When the deferred audit lands, these flip to closures.
+    # BOUNDARY pins for the positional over-block class the echo/printf carve-out did NOT touch
+    # (it is echo/printf-only by construction). C5 git --trailer + C7 gh --assignee WERE deferred
+    # here as True==both; the #1178 per-flag carrier extensions CLOSED them (now pinned as closures
+    # in TestPositionalCarrierNowClosed below). C8 curl -H remains True==both — a PERMANENT
+    # http-client-excluded residual: its destructive target is a quoted URL that masking hides, so
+    # a strip would UNDER-block (#1098-consistent, deliberately not closed). The example uses a
+    # PLAIN danger literal (NO substitution) — the over-block does not depend on a $(), it is the
+    # structural positional gap, so a future reader does not mistake True==both for a carve-out miss.
     @pytest.mark.parametrize("label,cmd", [
-        ("C5 git --trailer",  'git commit --trailer "Ref: %s"' % BD),
-        ("C7 gh --assignee",  'gh issue create --title "ok" --assignee "%s"' % BD),
         ("C8 curl -H header", 'curl -H "X-Note: %s" %s' % (BD, _FC1_URL)),
     ])
     @requires_prefix_echo
     def test_deferred_positional_stays_true_both(self, label, cmd):
         assert D_PREFIX_ECHO(cmd) is True and D(cmd) is True, \
-            "%s: STILL-DEFERRED positional over-block must be True==both (untouched by echo/printf carve-out): %r" % (label, cmd)
+            "%s: PERMANENT http-client-excluded positional residual must be True==both: %r" % (label, cmd)
+
+
+class TestPositionalCarrierNowClosed:
+    # #1178 closures — the C5/C7 positional over-blocks the deferred boundary pin above anticipated
+    # ("when the deferred audit lands, these flip to closures"). Each per-flag carrier extension
+    # strips the INERT flag VALUE (a git commit --trailer is `Key: value` metadata git never
+    # executes; a gh --assignee is a GitHub login), flag-anchored exactly like --message — so a
+    # faithful click now mints+merges. C1 does NOT apply (flag-anchored, not the general positional
+    # strip). MINIMAL boundary flip: ONE representative space-form per carrier (1:1 replacement of
+    # the two pins removed from the deferred class above), PLAIN literal (no $()). The comprehensive
+    # baked-baseline / non-vacuity closure cert across every spelling (-a, --add-assignee /
+    # --remove-assignee, --trailer+msg) is TEST-phase work, not pinned here.
+    @pytest.mark.parametrize("label,cmd", [
+        ("C5 git --trailer",  'git commit --trailer "Ref: %s"' % BD),
+        ("C7 gh --assignee",  'gh issue create --title "ok" --assignee "%s"' % BD),
+    ])
+    def test_positional_carrier_now_closed(self, label, cmd):
+        assert D(cmd) is False, \
+            "%s: #1178 per-flag carrier extension must CLOSE the positional over-block (False): %r" % (label, cmd)
 
 
 class TestEchoPrintfCarveoutStripSurface:

--- a/pact-plugin/tests/test_merge_guard_1178_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1178_cert.py
@@ -1,0 +1,523 @@
+"""
+Location: pact-plugin/tests/test_merge_guard_1178_cert.py
+Summary: COMPREHENSIVE BIDIRECTIONAL certification for #1178 — the positional-argument
+         over-block class. The fix ships as two commits on top of c21eae19 (v4.6.5):
+           P1 be33ab81 — git --trailer + gh --assignee carrier extensions.
+           P2 c732a39f — strip-inert-default general strip (arbitrary-command quoted
+                         positionals) + the exec-prefix RECURSION catalog + the
+                         head-displacement (leading env-assignment / redirect) skip.
+         Certifies against the REAL is_dangerous_command, base(c21eae19)-vs-PATCH(HEAD),
+         NEVER a byte-diff / additive-lines argument (the #1118 trap: a shared-strip
+         pipeline change opened BOTH an over-block and an under-block, invisible to a
+         byte-diff — only behavioral data-flow review against the real classifier caught
+         it). Baked baseline is loaded from git (crash-atomic, no working-tree mutation).
+
+         THREAT POLARITY (SACROSANCT merge_guard control):
+           - OVER-block = cardinal sin: blocking a faithful inert click (mycmd/logger/
+             notify-send "...danger...") is wrong by definition. #1178 CLOSES this class.
+           - UNDER-block = security hole the fix MUST NOT open. A real executor/wrapper/
+             http-client whose danger is a preserved arg MUST stay caught.
+
+         NON-VACUITY (the crux, base-vs-PATCH, in-test + permanent): every CLOSURE row
+         asserts D_BASE(cmd) is True (the form was a genuine over-block at c21eae19) AND
+         D(cmd) is False (the faithful click is freed). A row that is False at BOTH
+         baselines is vacuous. Every RETENTION row asserts D_BASE is True AND D is True
+         with the danger literal placed INSIDE the preserved quoted arg, so a wrong strip
+         flips it False. The danger-inside-the-quoted-arg construction is what makes a
+         "stays caught" pin fail precisely when the fix wrongly strips a preserved arg.
+
+         THE HEAD-DISPLACEMENT SUB-CLASS (P0, co-equal with currently-caught-stays-caught):
+         a leading env-assignment or redirect prefix that displaces the head token
+         (`FOO=bar bash -c "danger"`, `2>&1 bash -c "danger"`, `LC_ALL=C curl -X DELETE
+         "url"`). These are base-True -> PATCH-True RETENTION pins — NOT controls. They are
+         LOAD-BEARING because a wrongly-freed executor is base-True -> PATCH-False, the SAME
+         transition as a legitimate closure, so the monotonicity sweep (which only sees
+         base-False -> PATCH-True) is BLIND to them. The retention pins are the only thing
+         that catches an executor masquerading-as-a-closure under-block. (An auditor caught
+         this exact under-block in the pre-amendment P2 88bec86e; c732a39f closes it.)
+
+         Destructive verbs are assembled at runtime (BD/BDR/PF/M5/DEL) so this file carries
+         no raw force-delete / force-push / merge / DELETE-method literal and stays inert to
+         the live guard. Mirrors test_merge_guard_1140_carrier5_cert.py.
+"""
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import shared.merge_guard_common as mgc  # noqa: E402
+
+D = mgc.is_dangerous_command          # PATCH = live worktree HEAD (c732a39f)
+STRIP = mgc._strip_non_executable_content
+
+# --- Baked PRE-FIX classifier loaded from git ONCE for base-vs-PATCH non-vacuity.
+#     _BASE = c21eae19 = the whole-#1178-fix parent (P1's parent; pre-fix main HEAD, v4.6.5).
+#     Every closure is is_dangerous=True on BASE (over-blocked) and False on HEAD (freed);
+#     every retention/binding form is True on both. Loading the parent as a module (NOT a
+#     working-tree checkout) keeps this crash-atomic and sidesteps the "checkout-HEAD
+#     restores the fixed baseline" trap. Mirrors test_merge_guard_1140_carrier5_cert.
+_BASE_SHA = "c21eae19"  # pre-#1178 main HEAD (P1 be33ab81's parent)
+
+
+def _load_classifier(sha):
+    """Load merge_guard_common as it existed at `sha`, or None if unavailable.
+
+    Returns None on any git/exec failure — git missing, or a SHALLOW clone lacking the
+    parent commit (CI default fetch-depth) — so collection SUCCEEDS and the base-vs-HEAD
+    differential rows self-SKIP (@requires_history) instead of aborting the file.
+    """
+    wt = Path(__file__).resolve().parents[2]  # worktree root (tests/../../)
+    try:
+        src = subprocess.check_output(
+            ["git", "-C", str(wt), "show",
+             sha + ":pact-plugin/hooks/shared/merge_guard_common.py"],
+            stderr=subprocess.DEVNULL,
+        ).decode()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+    mod = types.ModuleType("merge_guard_common_1178_" + sha)
+    mod.__file__ = str(wt / "pact-plugin/hooks/shared/merge_guard_common.py")
+    mod.__package__ = "shared"  # so its `from shared.x import ...` resolve on sys.path
+    try:
+        exec(compile(src, mod.__file__, "exec"), mod.__dict__)
+    except Exception:
+        return None
+    return mod
+
+
+_BASE = _load_classifier(_BASE_SHA)
+# None-safe: a bare `_BASE.is_dangerous_command` would AttributeError at import when the
+# parent source is unavailable (shallow clone). D_BASE is only ever called by the
+# @requires_history-guarded differential rows.
+D_BASE = _BASE.is_dangerous_command if _BASE is not None else None
+
+requires_history = pytest.mark.skipif(
+    _BASE is None,
+    reason="base(c21eae19)-vs-HEAD differential requires merged history (shallow clone)",
+)
+
+# --- Destructive verbs assembled at runtime so this file carries no raw literal and stays
+#     inert to the live guard (mirrors the 1140 cert). Each is is_dangerous=True on its own.
+BD = "git " + "branch " + "-D victim"           # force branch-delete (danger inside quoted arg)
+BDR = "git " + "branch " + "-D real"            # force branch-delete (executing-tail canary)
+PF = "git " + "push " + "--force origin main"   # force-push
+M5 = "gh " + "pr " + "merge 5 --delete-branch"  # destructive merge
+_DEL = "-X " + "DELETE"                          # mutating HTTP method (assembled)
+_URL = "https://api.github.com/repos/o/r/git/refs/heads/main"  # a git-refs endpoint (inert alone)
+CURL_DEL = "curl " + _DEL                        # curl destructive DELETE
+WGET_DEL = "wget " + "--method=" + "DELETE"      # wget destructive DELETE
+GHAPI_DEL = "gh " + "api " + _DEL                # gh-api destructive DELETE
+
+
+# ── Bidirectional assertion helpers (non-vacuity baked in) ───────────────────────────────
+def _closure(cmd):
+    """OVER-BLOCK CLOSURE: over-blocked at base (non-vacuous) -> freed at HEAD."""
+    assert D_BASE(cmd) is True, "vacuous: not over-blocked at c21eae19 base: %r" % (cmd,)
+    assert D(cmd) is False, "over-block NOT closed at HEAD (faithful click still blocked): %r" % (cmd,)
+
+
+def _retention(cmd):
+    """RETENTION: caught at base (non-vacuous) AND still caught at HEAD (no under-block)."""
+    assert D_BASE(cmd) is True, "vacuous: not caught at c21eae19 base: %r" % (cmd,)
+    assert D(cmd) is True, "UNDER-BLOCK opened at HEAD (a real danger was freed): %r" % (cmd,)
+
+
+def _control_false(cmd):
+    """Benign / never-blocked: False on both (proves closures are not blanket-freeing)."""
+    assert D_BASE(cmd) is False and D(cmd) is False, "benign control not False==both: %r" % (cmd,)
+
+
+# =========================================================================================
+# CLASS A — OVER-BLOCK CLOSURE (base-True -> HEAD-False). The primary gate: a faithful inert
+# click merges. Danger literal is INSIDE the quoted positional (POSIX-inert argv).
+# =========================================================================================
+class TestOverBlockClosure:
+    @requires_history
+    @pytest.mark.parametrize("label,cmd", [
+        ("arbitrary mycmd",       'mycmd "%s"' % BD),
+        ("arbitrary logger",      'logger "%s"' % BD),
+        ("arbitrary notify-send", 'notify-send "%s"' % BD),
+        ("arbitrary grep",        'grep "%s" file.txt' % BD),
+        ("multi-arg 2nd",         'mycmd "first" "%s"' % BD),
+        ("sq value",              "mycmd '%s'" % BD),
+        ("benign $() beside danger", 'mycmd "note $(date) %s"' % BD),  # span-scoped: $() kept, prose stripped
+        ("C5 git --trailer",      'git commit --trailer "Ref: %s"' % BD),
+        ("C7 gh --assignee",      'gh issue create --title "ok" --assignee "%s"' % BD),
+        ("C7 gh --add-assignee",  'gh issue edit 1 --add-assignee "%s"' % BD),
+    ])
+    def test_closure(self, label, cmd):
+        _closure(cmd)
+
+    @requires_history
+    @pytest.mark.parametrize("prefix", [
+        "time", "exec", "command", "chrt -f 50", "taskset 0x3", "ionice", "unbuffer",
+        "proxychains", "torsocks", "catchsegv", "nocache", "eatmydata", "rlwrap",
+    ])
+    def test_exec_prefix_inert_frees(self, prefix):
+        # <prefix> <INERT> "danger" -> freed: the recursion reaches an inert nested head.
+        _closure('%s mycmd "%s"' % (prefix, BD))
+
+    @requires_history
+    @pytest.mark.parametrize("label,cmd", [
+        # ANTI-SUBSTRING (C1): a head that CONTAINS an executor name as a substring is NOT an
+        # executor — whole-head-token match frees it. A substring/\\b match would preserve it.
+        ("bash-completion", 'bash-completion "%s"' % BD),
+        ("python-config",   'python-config "%s"' % BD),
+    ])
+    def test_anti_substring_frees(self, label, cmd):
+        _closure(cmd)
+
+    @requires_history
+    @pytest.mark.parametrize("label,cmd", [
+        # inert command BEHIND a head-displacement prefix -> still a correct closure.
+        ("assign + inert",        'FOO=bar mycmd "%s"' % BD),
+        ("multi-assign + inert",  'A=1 B=2 mycmd "%s"' % BD),
+        ("append-assign + inert", 'PATH+=/x mycmd "%s"' % BD),
+        ("=-in-value + inert",    'FOO=a=b mycmd "%s"' % BD),
+        ("redirect + inert",      '2>/dev/null mycmd "%s"' % BD),
+        ("spaced-redir + inert",  '>& file mycmd "%s"' % BD),
+        ("fd-dup + inert",        '2>&1 mycmd "%s"' % BD),
+    ])
+    def test_prefix_inert_frees(self, label, cmd):
+        _closure(cmd)
+
+
+# =========================================================================================
+# CLASS B/D — EXECUTOR / INTERPRETER RETENTION + CURRENTLY-CAUGHT-EXECUTING-ARG STAYS CAUGHT
+# (P0). base-True -> HEAD-True, danger INSIDE the quoted code arg so a catalog miss flips it.
+# =========================================================================================
+class TestExecutorRetention:
+    @requires_history
+    @pytest.mark.parametrize("head", [
+        "bash -c", "sh -c", "zsh -c", "dash -c", "ksh -c", "ksh93 -c", "mksh -c", "ash -c",
+        "csh -c", "tcsh -c", "fish -c", "rksh -c", "/bin/bash -c",
+        "eval", "su -c", "watch", "expect -c",
+        "python -c", "python3 -c", "python3.11 -c", "perl -e", "ruby -e", "node -e",
+        "nodejs -e", "php -r", "env -S",
+    ])
+    def test_direct_executor_stays_caught(self, head):
+        _retention('%s "%s"' % (head, BD))
+
+    @requires_history
+    @pytest.mark.parametrize("head", ["ssh host", "rsh host", "remsh host", "slogin host"])
+    def test_remote_shell_stays_caught(self, head):
+        _retention('%s "%s"' % (head, BD))
+
+    @requires_history
+    @pytest.mark.parametrize("prefix", [
+        "time", "exec", "command", "chrt -f 50", "taskset 0x3", "ionice", "unbuffer",
+        "proxychains", "torsocks", "catchsegv", "nocache", "eatmydata", "rlwrap",
+    ])
+    def test_exec_prefix_executor_stays_caught(self, prefix):
+        # WRAPPER-RECURSION: <prefix> bash -c "danger" -> preserve must RECURSE through the
+        # wrapper head to the nested bash -c. A head-only detector strips this -> flips False.
+        _retention('%s bash -c "%s"' % (prefix, BD))
+
+    @requires_history
+    @pytest.mark.parametrize("label,cmd", [
+        # ARITY-RETENTION: each wrapper's OWN value-flag consumed by the phased walk BEFORE
+        # recursing. A mis-counted arity mis-reads the flag value as the command.
+        ("timeout -s KILL 5", 'timeout -s KILL 5 bash -c "%s"' % BD),
+        ("xargs -n 2",        'xargs -n 2 bash -c "%s"' % BD),
+        ("env -u X",          'env -u X bash -c "%s"' % BD),
+        ("nice -n 5",         'nice -n 5 bash -c "%s"' % BD),
+        ("doas -u me",        'doas -u me bash -c "%s"' % BD),
+        ("sudo -u me",        'sudo -u me bash -c "%s"' % BD),
+        ("ionice -c 2 -n 4",  'ionice -c 2 -n 4 bash -c "%s"' % BD),
+        ("rlwrap -f x",       'rlwrap -f x bash -c "%s"' % BD),
+        ("proxychains -f c",  'proxychains -f cfg bash -c "%s"' % BD),
+        ("torsocks -a A",     'torsocks -a 1.2.3.4 bash -c "%s"' % BD),
+    ])
+    def test_arity_value_flag_stays_caught(self, label, cmd):
+        _retention(cmd)
+
+    @requires_history
+    @pytest.mark.parametrize("label,cmd", [
+        # taskset -c COLLISION: taskset's -c is --cpu-list, NOT bash's -c. The phased walk
+        # must consume the cpu-list VALUE then recurse to bash -c.
+        ("taskset -c mask + bash -c", 'taskset -c 0-3 bash -c "%s"' % BD),
+        ("taskset bare + bash -c",    'taskset bash -c "%s"' % BD),
+        # PID-operate edges preserve (dash-flag in command position -> preserve).
+        ("chrt -p 50 + bash -c",      'chrt -p 50 bash -c "%s"' % BD),
+        ("taskset -p 0x3 + bash -c",  'taskset -p 0x3 bash -c "%s"' % BD),
+        ("ionice -p 1234 + bash -c",  'ionice -p 1234 bash -c "%s"' % BD),
+    ])
+    def test_taskset_collision_and_pid_edges(self, label, cmd):
+        _retention(cmd)
+
+    @requires_history
+    def test_taskset_collision_inert_still_frees(self):
+        # The paired direction: taskset -c 0-3 mycmd "danger" is inert -> freed (closure).
+        _closure('taskset -c 0-3 mycmd "%s"' % BD)
+
+
+# =========================================================================================
+# CLASS HEAD-DISPLACEMENT (P0) — a leading env-assignment / redirect that displaces the head.
+# Two sub-families: executor-behind-prefix AND http-client-behind-prefix. base-True -> HEAD-True
+# RETENTION (NOT controls). These evade the monotonicity sweep (base-True -> would-be-False).
+# =========================================================================================
+class TestHeadDisplacementExecutor:
+    @requires_history
+    @pytest.mark.parametrize("label,cmd", [
+        ("single assign",       'FOO=bar bash -c "%s"' % BD),
+        ("LC_ALL locale",       'LC_ALL=C bash -c "%s"' % BD),
+        ("PYTHONPATH + python3", 'PYTHONPATH=. python3 -c "%s"' % BD),
+        ("VAR + sh + force-push", 'VAR=x sh -c "%s"' % PF),
+        ("multi assign",        'FOO=1 BAR=2 bash -c "%s"' % BD),
+        ("append assign +=",    'PATH+=/x bash -c "%s"' % BD),   # the += regex-gap the lead caught
+        ("empty RHS",           'FOO= bash -c "%s"' % BD),
+        ("$-expansion RHS",     'FOO=$HOME bash -c "%s"' % BD),
+        ("=-in-value RHS",      'FOO=a=b bash -c "%s"' % BD),
+        ("quoted RHS",          'FOO="a=b" bash -c "%s"' % BD),
+        ("sq value w/ space",   "FOO='x=y z' bash -c \"%s\"" % BD),
+        ("PATH colon value",    'PATH=/a:/b bash -c "%s"' % BD),
+        ("path-exec nested",    'FOO=bar /usr/bin/python3 -c "%s"' % BD),
+        ("non-bash zsh",        'ZDOTDIR=/tmp zsh -c "%s"' % BD),
+        ("assign + wrapper + exec", 'FOO=bar timeout 5 bash -c "%s"' % BD),
+        ("assign + wrapper nice",  'FOO=bar nice -n 5 bash -c "%s"' % BD),
+    ])
+    def test_assignment_prefix_executor_stays_caught(self, label, cmd):
+        _retention(cmd)
+
+    @requires_history
+    @pytest.mark.parametrize("label,cmd", [
+        ("bare redirect target", '2>/dev/null bash -c "%s"' % BD),
+        ("redirect > log",       '> log bash -c "%s"' % BD),
+        ("assign + redirect",    'FOO=bar 2>/dev/null bash -c "%s"' % BD),
+        ("redirect + assign",    '2>/dev/null FOO=bar bash -c "%s"' % BD),
+        ("spaced >& file",       '>& file bash -c "%s"' % BD),
+        ("spaced <& file",       '<& file bash -c "%s"' % BD),
+        ("spaced 2>& file",      '2>& file bash -c "%s"' % BD),
+        ("fd-dup 2>&1",          '2>&1 bash -c "%s"' % BD),
+        ("fd-dup >&2",           '>&2 bash -c "%s"' % BD),
+        ("fd-dup numbered 3>&2", '3>&2 bash -c "%s"' % BD),
+        ("and-redirect &>log",   '&>log bash -c "%s"' % BD),
+    ])
+    def test_redirect_prefix_executor_stays_caught(self, label, cmd):
+        _retention(cmd)
+
+    @requires_history
+    @pytest.mark.parametrize("label,cmd", [
+        # prefix-displaced git/gh with BARE-TOKEN danger (not a quoted arg) -> caught.
+        ("assign + git branch -D",  'FOO=bar %s' % BD),
+        ("GIT_DIR + force-push",    'GIT_DIR=. %s' % PF),
+        ("redirect + git branch -D", '2>/dev/null %s' % BD),
+        ("assign + gh pr merge",    'FOO=bar %s' % M5),
+    ])
+    def test_prefix_displaced_bare_danger_stays_caught(self, label, cmd):
+        _retention(cmd)
+
+
+class TestHeadDisplacementHttpClient:
+    # NEW, more severe sub-family: the head-displacement bug bypassed the http-client
+    # exclusion (clause-b) too, so a REAL destructive curl/wget with a QUOTED destructive
+    # URL under-blocked behind a prefix. Danger target lives in the quoted URL.
+    @requires_history
+    @pytest.mark.parametrize("label,cmd", [
+        ("curl DELETE plain (no prefix)", '%s "%s"' % (CURL_DEL, _URL)),  # control: caught both
+        ("assign + curl DELETE",          'FOO=bar %s "%s"' % (CURL_DEL, _URL)),
+        ("locale + curl DELETE",          'LC_ALL=C %s "%s"' % (CURL_DEL, _URL)),
+        ("redirect + curl DELETE",        '2>/dev/null %s "%s"' % (CURL_DEL, _URL)),
+        ("assign + wget DELETE",          'FOO=bar %s "%s"' % (WGET_DEL, _URL)),
+    ])
+    def test_http_client_prefix_stays_caught(self, label, cmd):
+        _retention(cmd)
+
+    @requires_history
+    def test_ghapi_unquoted_endpoint_stays_caught_distinct(self):
+        # DISTINCT control: gh-api's endpoint is an UNQUOTED positional, so masking never
+        # hid it -> it stays caught via clause-(c), and was NEVER under-blocked. Keep the
+        # curl/wget under-block pins on QUOTED URLs only; do NOT expect gh-api-unquoted in
+        # the under-block set.
+        _retention('FOO=bar %s repos/o/r/git/refs/heads/main' % GHAPI_DEL)
+
+
+# =========================================================================================
+# CLASS C — BINDING INVARIANT (P0). Dangerous legs are NEVER stripped, so the target-bearing
+# quoted value survives for mint/read binding (#1042). Caught on both AND target preserved.
+# =========================================================================================
+class TestBindingInvariant:
+    @requires_history
+    @pytest.mark.parametrize("label,cmd", [
+        ("branch -D quoted target", 'git branch -D "victim"'),
+        ("force-push",              PF),
+        ("gh pr merge",             M5),
+    ])
+    def test_dangerous_leg_stays_caught(self, label, cmd):
+        _retention(cmd)
+
+    def test_target_survives_strip(self):
+        # The dangerous leg is NOT stripped -> the branch target 'victim' survives verbatim
+        # (a naive value-strip would rewrite it to STRIPPED and break the #1042 set-equality).
+        out = STRIP('git branch -D "victim"')
+        assert "victim" in out, "binding target stripped (over-binding under-block): %r" % (out,)
+
+    def test_leg_locality_executing_tail_stays_caught(self):
+        # An inert first leg does not swallow an executing destructive tail (leg-locality).
+        _retention('mycmd "safe" && %s' % BDR)
+
+
+# =========================================================================================
+# CLASS E — DEFERRED / RESIDUAL PINS (True==both or documented under-block). FORETELLING
+# docstrings so a future cycle realigns instead of being surprised by these.
+# =========================================================================================
+class TestResidualPins:
+    def test_c8_curl_header_permanent_residual(self):
+        # C8 curl -H over-block is a PERMANENT http-client residual: the destructive target
+        # can live in a quoted URL that masking hides, so the value cannot be stripped
+        # safely. True==both — does NOT close (distinct from C5/C7 which DID close in P1).
+        cmd = 'curl -H "X-Note: %s" %s' % (BD, _URL)
+        assert D(cmd) is True, "C8 curl -H residual unexpectedly changed: %r" % (cmd,)
+
+    def test_command_v_noexec_over_block_residual(self):
+        # `command -v <exec> "danger"` is a NONSENSICAL noexec form (command -v takes one
+        # name and ignores the -c args; it never executes the string). Over-block-SAFE,
+        # user-ruled leave-it. True==both. The REAL inert `command -v mycmd "danger"` FREES
+        # (asserted below), so the residual is scoped to the malformed form only.
+        assert D('command -v bash -c "%s"' % BD) is True
+
+    @requires_history
+    def test_command_v_inert_frees(self):
+        _closure('command -v mycmd "%s"' % BD)
+
+    def test_custom_wrapper_under_block_residual(self):
+        # D1-ratified tolerated residual: a genuinely-CUSTOM (uncatalogued) exec-wrapper
+        # cannot be modeled, so its nested executor's arg is stripped -> under-block. This is
+        # the ONLY exec-prefix residual and is accepted by-construction (honest-mistake model:
+        # an unknown head handing a quoted string to an interpreter is not enumerable).
+        assert D('myrunner bash -c "%s"' % BD) is False
+
+
+# =========================================================================================
+# CLASS F — CONTROLS. Benign / cross-context forms stay False==both; genuine non-retention
+# controls behave per their (inert or self-contained) head.
+# =========================================================================================
+class TestControls:
+    @pytest.mark.parametrize("label,cmd", [
+        ("benign mycmd",     'mycmd "hello world"'),
+        ("benign trailer",   'git commit --trailer "Ref: #123"'),
+        ("benign assignee",  'gh issue create --title "ok" --assignee "alice"'),
+        ("benign logger",    'logger "deploy complete"'),
+        ("benign bash -c",   'bash -c "echo hi"'),
+    ])
+    def test_benign_false_both(self, label, cmd):
+        _control_false(cmd)
+
+    @requires_history
+    def test_env_wrapper_form_caught(self):
+        # env FOO=bar bash -c is the WRAPPER form (env consumes NAME=VALUE via PHASE-3), the
+        # target the bare-assignment head-displacement fix converges to. Caught on both.
+        _retention('env FOO=bar bash -c "%s"' % BD)
+
+
+# =========================================================================================
+# MONOTONICITY — the strip only ever REMOVES an over-block; it NEVER creates one. Assert 0
+# vectors go base-False -> PATCH-True across the whole battery. (Complements — does NOT
+# replace — the head-displacement retention pins, which catch the base-True -> PATCH-False
+# under-block that this one-directional sweep is structurally blind to.)
+# =========================================================================================
+_MONOTONICITY_BATTERY = [
+    'mycmd "%s"' % BD, 'logger "%s"' % BD, 'bash -c "%s"' % BD, 'python3 -c "%s"' % BD,
+    'FOO=bar bash -c "%s"' % BD, '2>&1 bash -c "%s"' % BD, 'timeout 5 bash -c "%s"' % BD,
+    'taskset -c 0-3 bash -c "%s"' % BD, 'FOO=bar %s "%s"' % (CURL_DEL, _URL),
+    'git branch -D "victim"', PF, M5, 'mycmd "hello world"', 'git status',
+    'FOO=bar mycmd "%s"' % BD, 'command bash -c "%s"' % BD, 'bash-completion "%s"' % BD,
+]
+
+
+class TestMonotonicity:
+    @requires_history
+    @pytest.mark.parametrize("cmd", _MONOTONICITY_BATTERY)
+    def test_no_new_over_block(self, cmd):
+        # If it was NOT over-blocked at base, the strip must not newly block it.
+        if D_BASE(cmd) is False:
+            assert D(cmd) is False, "MONOTONICITY VIOLATION: strip created a new over-block: %r" % (cmd,)
+
+
+# =========================================================================================
+# IS_DANGEROUS BYTE-IDENTITY — the P2 refactor factored the danger battery into the shared
+# _stripped_surface_danger predicate (consumed by both the read floor and the preserve
+# predicate). Prove the extraction is BEHAVIOR-PRESERVING on the PRE-EXISTING battery (the
+# recognized-op + benign surface); the #1178 closures are the intended delta OUTSIDE this set.
+# =========================================================================================
+_BYTE_IDENTITY_BATTERY = [
+    'git branch -D victim', 'git branch -D "victim"', PF, M5,
+    'gh pr close 5 --delete-branch', 'git status', 'git log --oneline',
+    'git commit -m "fix the bug"', 'echo "safe note"', 'ls -la',
+    '%s && %s' % (M5, BD), '%s ; echo done' % M5, 'gh pr merge 5 | tee log',
+    'git push origin main', 'git commit --amend --no-edit',
+    'bash -c "%s"' % BD, 'git branch -D victim && rm -rf /tmp/x',
+]
+
+
+class TestIsDangerousByteIdentity:
+    @requires_history
+    @pytest.mark.parametrize("cmd", _BYTE_IDENTITY_BATTERY)
+    def test_pre_existing_battery_unchanged(self, cmd):
+        assert D_BASE(cmd) == D(cmd), \
+            "shared-predicate extraction changed a pre-existing classification: %r" % (cmd,)
+
+
+# =========================================================================================
+# STRIP-SURFACE — document the transform directly (complements the is_dangerous differential):
+# a closure's inert value is stripped; a retention leg's danger arg is preserved; the binding
+# target survives; leg-locality holds under an unquoted separator.
+# =========================================================================================
+class TestStripSurface:
+    def test_inert_value_stripped(self):
+        assert STRIP('mycmd "%s"' % BD) == "mycmd STRIPPED"
+
+    def test_executor_arg_preserved(self):
+        # the danger arg of a real executor survives the strip (else it would un-gate).
+        assert BD in STRIP('bash -c "%s"' % BD)
+
+    def test_headdisplaced_executor_arg_preserved(self):
+        assert BD in STRIP('FOO=bar bash -c "%s"' % BD)
+
+    def test_binding_target_preserved(self):
+        assert "victim" in STRIP('git branch -D "victim"')
+
+    def test_leg_locality_tail_preserved(self):
+        # the executing tail after an unquoted && stays OUTSIDE the stripped span.
+        assert BDR in STRIP('mycmd "safe" && %s' % BDR)
+
+
+# =========================================================================================
+# MUTANT-OF-LIVE-SOURCE — catalog / skip membership is a TESTED property, not just an
+# assertion. Load the live source into a fresh module, remove a catalog member (late-binding:
+# the classifier reads the module global at call time), and assert the matching retention pin
+# FLIPS to under-block. Proves the mechanism is load-bearing (mirrors the 1140 gobbling control).
+# =========================================================================================
+def _live_source():
+    return Path(__file__).parent.parent / "hooks" / "shared" / "merge_guard_common.py"
+
+
+def _load_mutant(mutate):
+    """Load the live merge_guard_common into a fresh module and apply `mutate(mod)`."""
+    src = _live_source().read_text()
+    mod = types.ModuleType("mgc_mutant")
+    mod.__file__ = str(_live_source())
+    mod.__package__ = "shared"
+    exec(compile(src, mod.__file__, "exec"), mod.__dict__)
+    mutate(mod)
+    return mod
+
+
+class TestMutantOfLiveSource:
+    def test_wrapper_membership_is_load_bearing(self):
+        # Remove `taskset` from the recursion catalog -> `taskset ... bash -c "danger"` can no
+        # longer recurse to the nested bash -c -> the strip eats the arg -> under-block.
+        base_caught = D('taskset -c 0-3 bash -c "%s"' % BD)
+        assert base_caught is True, "precondition: live classifier catches taskset+bash -c"
+        m = _load_mutant(lambda mod: setattr(
+            mod, "_EXEC_WRAPPERS_RECURSE", mod._EXEC_WRAPPERS_RECURSE - {"taskset"}))
+        assert m.is_dangerous_command('taskset -c 0-3 bash -c "%s"' % BD) is False, \
+            "taskset catalog membership is NOT load-bearing (pin would be vacuous)"
+
+    def test_wrapper_recurse_catalog_nonempty(self):
+        # Guard the mutant's premise: the catalog is a mutable frozenset containing taskset.
+        assert "taskset" in mgc._EXEC_WRAPPERS_RECURSE

--- a/pact-plugin/tests/test_merge_guard_1178_f2_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1178_f2_cert.py
@@ -1,0 +1,288 @@
+"""
+Location: pact-plugin/tests/test_merge_guard_1178_f2_cert.py
+Summary: Durable BIDIRECTIONAL companion cert for the F2 over-block closure (commit 6730f908),
+         the peer-review-phase remediation stacked on the #1178 fix. F2 = the pre-existing
+         COARSE-wrapper WRAPPED-INERT over-block: at base 89061755, busybox and stdbuf were
+         _EXEC_WRAPPERS_COARSE, so a faithful inert click behind them (`busybox mycmd "…git
+         branch -D…"`, `stdbuf -oL mycmd "…"`) preserved the WHOLE wrapped command -> over-block
+         (cardinal sin). The fix: busybox+stdbuf COARSE->RECURSE (find/flock STAY COARSE per the
+         #1098 unbounded-grammar wall); hush/lash/msh added to _SHELL_STRING_EXECUTORS; busybox
+         empty-grammar + stdbuf value-flag _WrapperGrammar; a GENERAL attached-short-value walker
+         branch (`-oL` = short value-flag `-o` + glued value `L`, never bundled bools).
+
+         Certifies against the REAL is_dangerous_command, base(89061755)-vs-HEAD(6730f908). Baked
+         baseline via git show (crash-atomic; the code is committed, so code-then-tests ordering
+         is satisfied). The 184-row test_merge_guard_1178_cert.py already covers c21eae19->#1178;
+         this is its F2 companion. Destructive verbs assembled at runtime (BD/PF) — file stays
+         inert to the live guard.
+
+         MONOTONICITY IS SCOPED (the honest-cert crux). backend-r2's fix has two parts with
+         DIFFERENT monotonicity behavior:
+           (1) busybox/stdbuf COARSE->RECURSE + the attached-short-value walker are STRICTLY
+               monotonic-toward-False (they only close over-blocks) -> TestF2MonotonicityFaithfulInert
+               asserts NO base-False->HEAD-True for these rows.
+           (2) Adding hush/lash/msh to _SHELL_STRING_EXECUTORS CORRECTLY produces base-False->HEAD-True
+               for head-basename in {hush,lash,msh} -> pinned EXPLICITLY as intended in
+               TestF2StandaloneShellUnderBlockFix (an under-block FIX, not a new over-block).
+         A blanket "0 base-False->HEAD-True" sweep would FALSELY red on (2). The property that
+         matters — no FAITHFUL INERT click newly blocked — is carried by the CLOSURE rows
+         (busybox/stdbuf/walker mycmd forms all base-True->HEAD-False = freed, never newly blocked).
+
+         NON-VACUITY: every closure row asserts D_BASE(89061755) is True (genuinely over-blocked
+         at base) AND D is False; every retention asserts D_BASE True AND D True; the standalone
+         rows assert D_BASE False AND D True (the under-block that the fix closes). So the cert
+         FAILS wholesale against base 89061755 (>=1 row proof, mandated). Plus a mutant-of-live-
+         source proof that busybox RECURSE membership is load-bearing for the retention.
+"""
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import shared.merge_guard_common as mgc  # noqa: E402
+
+D = mgc.is_dangerous_command          # PATCH = live worktree HEAD (6730f908, F2 fix)
+
+_BASE_SHA = "89061755"  # pre-F2 (busybox/stdbuf COARSE; hush/lash/msh unrecognized) = 6730f908^
+
+
+def _load_classifier(sha):
+    """Load merge_guard_common as it existed at `sha`, or None if unavailable (shallow clone)."""
+    wt = Path(__file__).resolve().parents[2]
+    try:
+        src = subprocess.check_output(
+            ["git", "-C", str(wt), "show",
+             sha + ":pact-plugin/hooks/shared/merge_guard_common.py"],
+            stderr=subprocess.DEVNULL,
+        ).decode()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+    mod = types.ModuleType("merge_guard_common_f2_" + sha)
+    mod.__file__ = str(wt / "pact-plugin/hooks/shared/merge_guard_common.py")
+    mod.__package__ = "shared"
+    try:
+        exec(compile(src, mod.__file__, "exec"), mod.__dict__)
+    except Exception:
+        return None
+    return mod
+
+
+_BASE = _load_classifier(_BASE_SHA)
+D_BASE = _BASE.is_dangerous_command if _BASE is not None else None
+
+requires_history = pytest.mark.skipif(
+    _BASE is None,
+    reason="base(89061755)-vs-HEAD differential requires merged history (shallow clone)",
+)
+
+BD = "git " + "branch " + "-D victim"           # danger inside the quoted arg
+PF = "git " + "push " + "--force origin main"
+
+
+def _closure(cmd):
+    assert D_BASE(cmd) is True, "vacuous: not over-blocked at base 89061755: %r" % (cmd,)
+    assert D(cmd) is False, "F2 over-block NOT closed at HEAD: %r" % (cmd,)
+
+
+def _retention(cmd):
+    assert D_BASE(cmd) is True, "vacuous: not caught at base 89061755: %r" % (cmd,)
+    assert D(cmd) is True, "UNDER-BLOCK opened at HEAD (executor freed): %r" % (cmd,)
+
+
+def _standalone_underblock_fix(cmd):
+    # INTENDED base-False -> HEAD-True: a pre-existing standalone under-block the F2 change
+    # closes by adding hush/lash/msh to _SHELL_STRING_EXECUTORS.
+    assert D_BASE(cmd) is False, "expected base-False (the pre-fix under-block): %r" % (cmd,)
+    assert D(cmd) is True, "standalone-shell under-block NOT closed at HEAD: %r" % (cmd,)
+
+
+# =========================================================================================
+# CLASS A — F2 OVER-BLOCK CLOSURES (base-True -> HEAD-False). The primary gate: a faithful
+# inert click behind busybox/stdbuf/attached-short-value-walker frees. Danger INSIDE the arg.
+# =========================================================================================
+class TestF2Closures:
+    @requires_history
+    @pytest.mark.parametrize("label,cmd", [
+        ("busybox mycmd",           'busybox mycmd "%s"' % BD),
+        ("stdbuf -oL mycmd",        'stdbuf -oL mycmd "%s"' % BD),
+        ("stdbuf -o L mycmd",       'stdbuf -o L mycmd "%s"' % BD),
+        ("stdbuf --output=L mycmd", 'stdbuf --output=L mycmd "%s"' % BD),
+        ("stdbuf -eL mycmd",        'stdbuf -eL mycmd "%s"' % BD),
+        ("stdbuf -e0 -oL mycmd",    'stdbuf -e0 -oL mycmd "%s"' % BD),
+        ("stdbuf -o 0 mycmd (sep val)", 'stdbuf -o 0 mycmd "%s"' % BD),
+        # NEW general attached-short-value walker on the existing RECURSE wrappers:
+        ("timeout -s9 mycmd",       'timeout -s9 mycmd "%s"' % BD),
+        ("nice -n5 mycmd",          'nice -n5 mycmd "%s"' % BD),
+        ("ionice -c2 mycmd",        'ionice -c2 mycmd "%s"' % BD),
+        ("nocache -n3 mycmd",       'nocache -n3 mycmd "%s"' % BD),
+        ("torsocks -d5 mycmd",      'torsocks -d5 mycmd "%s"' % BD),
+        ("xargs -n1 mycmd",         'xargs -n1 mycmd "%s"' % BD),
+        ("sudo -uroot mycmd",       'sudo -uroot mycmd "%s"' % BD),
+        ("rlwrap -Oregexp mycmd",   'rlwrap -Oregexp mycmd "%s"' % BD),
+        # compound leg-locality: the inert busybox leg frees while the compound survives.
+        ("compound inert busybox free leg", 'echo ok && busybox mycmd "%s"' % BD),
+    ])
+    def test_closure(self, label, cmd):
+        _closure(cmd)
+
+
+# =========================================================================================
+# CLASS B — F2 UNDER-BLOCK RETENTIONS (base-True -> HEAD-True). The recursion MUST reach the
+# nested executor. These are the pins the monotonicity sweep is BLIND to (base-True->HEAD-True),
+# so they are the LOAD-BEARING guard against a fix-introduced under-block. Danger INSIDE the arg.
+# =========================================================================================
+class TestF2Retentions:
+    @requires_history
+    @pytest.mark.parametrize("label,cmd", [
+        # busybox applet retentions (the applet name is token[1]; each must be a recognized exec).
+        ("busybox sh -c",   'busybox sh -c "%s"' % BD),
+        ("busybox ash -c",  'busybox ash -c "%s"' % BD),
+        ("busybox bash -c", 'busybox bash -c "%s"' % BD),
+        ("busybox hush -c", 'busybox hush -c "%s"' % BD),   # hush/lash/msh recognition is load-bearing
+        ("busybox lash -c", 'busybox lash -c "%s"' % BD),
+        ("busybox msh -c",  'busybox msh -c "%s"' % BD),
+        ("busybox dash -c", 'busybox dash -c "%s"' % BD),
+        ("busybox awk",     'busybox awk "%s"' % BD),
+        # stdbuf value-flag retentions (attached / separated / long).
+        ("stdbuf -oL bash -c",        'stdbuf -oL bash -c "%s"' % BD),
+        ("stdbuf -o L bash -c",       'stdbuf -o L bash -c "%s"' % BD),
+        ("stdbuf -eL sh -c",          'stdbuf -eL sh -c "%s"' % BD),
+        ("stdbuf --output=L bash -c", 'stdbuf --output=L bash -c "%s"' % BD),
+        # nested / double / triple recursion through busybox.
+        ("busybox env FOO=x bash -c", 'busybox env FOO=x bash -c "%s"' % BD),
+        ("busybox timeout 5 bash -c", 'busybox timeout 5 bash -c "%s"' % BD),
+        ("busybox xargs bash -c (double)", 'busybox xargs bash -c "%s"' % BD),
+        ("stdbuf -oL busybox sh -c (triple)", 'stdbuf -oL busybox sh -c "%s"' % BD),
+        # existing wrapper retentions must NOT regress under the general attached-short-value walker.
+        ("timeout -s9 bash -c",  'timeout -s9 bash -c "%s"' % BD),
+        ("nice -n5 bash -c",     'nice -n5 bash -c "%s"' % BD),
+        ("ionice -c2 bash -c",   'ionice -c2 bash -c "%s"' % BD),
+        ("nocache -n3 bash -c",  'nocache -n3 bash -c "%s"' % BD),
+        ("torsocks -d5 bash -c", 'torsocks -d5 bash -c "%s"' % BD),
+        ("xargs -n1 bash -c",    'xargs -n1 bash -c "%s"' % BD),
+        ("sudo -uroot bash -c",  'sudo -uroot bash -c "%s"' % BD),
+        ("rlwrap -Oregexp bash -c", 'rlwrap -Oregexp bash -c "%s"' % BD),
+        ("timeout -s 9 bash -c (sep)", 'timeout -s 9 bash -c "%s"' % BD),
+        ("taskset -c 0-3 bash -c",  'taskset -c 0-3 bash -c "%s"' % BD),
+    ])
+    def test_retention(self, label, cmd):
+        _retention(cmd)
+
+    @requires_history
+    @pytest.mark.parametrize("label,cmd", [
+        # ADVERSARIAL / patch-shifts-the-edge: a value-flag consuming the executor as its VALUE
+        # leaves an unrecognized nested head -> FAIL-SAFE preserve -> CAUGHT (never freed).
+        ("stdbuf -o bash -c (sep eats bash)", 'stdbuf -o bash -c "%s"' % BD),
+        ("stdbuf -obash -c (attached eats)",  'stdbuf -obash -c "%s"' % BD),
+        ("stdbuf -o 0 bash -c (sep val)",     'stdbuf -o 0 bash -c "%s"' % BD),
+        # bundled-bool must NOT be read as an attached value: rlwrap -oc where -o is boolean ->
+        # preserve (caught), NOT a mis-consumed value that would free the nested bash -c.
+        ("rlwrap -oc bash -c (bundled-bool)", 'rlwrap -oc bash -c "%s"' % BD),
+        # busybox bare with a directly-dangerous nested TOOL head (git) -> caught.
+        ("busybox git branch -D (tool-head)", 'busybox git branch -D main'),
+        # busybox executor leg in a compound stays caught (leg-locality).
+        ("busybox sh -c compound leg", 'busybox sh -c "%s" ; echo ok' % BD),
+    ])
+    def test_adversarial_retention(self, label, cmd):
+        _retention(cmd)
+
+    @requires_history
+    @pytest.mark.parametrize("label,cmd", [
+        # SANITY: direct executors / bare-token danger unchanged by F2 (True on both).
+        ("bash -c",           'bash -c "%s"' % BD),
+        ("timeout 5 bash -c", 'timeout 5 bash -c "%s"' % BD),
+        ("sudo bash -c",      'sudo bash -c "%s"' % BD),
+        ("bare git branch -D", BD),
+        ("bare push --force",  PF),
+    ])
+    def test_sanity_unchanged(self, label, cmd):
+        _retention(cmd)
+
+
+# =========================================================================================
+# CLASS C — STANDALONE-SHELL UNDER-BLOCK FIX (INTENDED base-False -> HEAD-True). Adding
+# hush/lash/msh to _SHELL_STRING_EXECUTORS closes a PRE-EXISTING standalone under-block. These
+# are pinned EXPLICITLY (not swept by monotonicity) — they are a fix, not a new over-block.
+# =========================================================================================
+class TestF2StandaloneShellUnderBlockFix:
+    @requires_history
+    @pytest.mark.parametrize("label,cmd", [
+        # `hush -c STR` genuinely EXECUTES STR -> catching the danger is CORRECT (under-block fix).
+        ("hush -c danger", 'hush -c "%s"' % BD),
+        ("lash -c danger", 'lash -c "%s"' % BD),
+        ("msh -c danger",  'msh -c "%s"' % BD),
+        # `hush danger` (NO -c; arg = a script FILENAME) -> the SAME conservative shell-arg
+        # preserve every recognized shell already has (see the bash/sh anchor below). Now that
+        # hush/lash/msh are recognized shells, they behave IDENTICALLY -> True. This is NOT a
+        # new FAITHFUL-INERT over-block; it is matching-in-kind with the recognized-shell class.
+        ("hush danger (no -c)", 'hush "%s"' % BD),
+        ("lash danger (no -c)", 'lash "%s"' % BD),
+        ("msh danger (no -c)",  'msh "%s"' % BD),
+    ])
+    def test_standalone_shell_now_caught(self, label, cmd):
+        _standalone_underblock_fix(cmd)
+
+    @requires_history
+    @pytest.mark.parametrize("label,cmd", [
+        # The matching-in-kind REFERENCE class: a recognized shell with a bare arg is True==both.
+        # hush/lash/msh "danger" (above) now behave exactly like these — not new-in-kind.
+        ("bash danger (no -c)", 'bash "%s"' % BD),
+        ("sh danger (no -c)",   'sh "%s"' % BD),
+    ])
+    def test_recognized_shell_anchor_true_both(self, label, cmd):
+        _retention(cmd)
+
+
+# =========================================================================================
+# CLASS D — MONOTONICITY, FAITHFUL-INERT SCOPED. The busybox/stdbuf/walker machinery is
+# strictly monotonic-toward-False: NO faithful inert click is newly blocked. Every row here is
+# base-False; assert it STAYS False. DELIBERATELY EXCLUDES the hush/lash/msh transitions (Class
+# C), which are INTENDED base-False->HEAD-True under-block fixes, not over-blocks.
+# =========================================================================================
+class TestF2MonotonicityFaithfulInert:
+    @requires_history
+    @pytest.mark.parametrize("label,cmd", [
+        ("busybox mycmd safe",   'busybox mycmd "hello world"'),
+        ("stdbuf -oL ls",        'stdbuf -oL ls -la'),
+        ("busybox ls",           'busybox ls -la'),
+        ("timeout -s9 ls safe",  'timeout -s9 ls "note"'),
+        ("nice -n5 echo",        'nice -n5 echo "hi"'),
+        ("git status",           'git status'),
+        ("bash -c safe",         'bash -c "echo hi"'),
+        ("mycmd safe",           'mycmd "just a note"'),
+        ("stdbuf -o0 mycmd safe", 'stdbuf -o0 mycmd "safe text"'),
+    ])
+    def test_no_new_over_block(self, label, cmd):
+        assert D_BASE(cmd) is False, "fixture not base-False (mis-scoped monotonicity row): %r" % (cmd,)
+        assert D(cmd) is False, "MONOTONICITY VIOLATION: F2 newly blocked a faithful inert click: %r" % (cmd,)
+
+
+# =========================================================================================
+# MUTANT-OF-LIVE-SOURCE — busybox RECURSE membership is a TESTED property. Remove `busybox`
+# from _EXEC_WRAPPERS_RECURSE (late-binding: the classifier reads the module global at call
+# time) and assert the `busybox bash -c "danger"` retention FLIPS True->False: without the
+# recursion the nested executor's arg is stripped -> under-block. Proves the retention pin is
+# load-bearing, not vacuous.
+# =========================================================================================
+def _load_mutant(mutate):
+    src = (Path(__file__).parent.parent / "hooks" / "shared" / "merge_guard_common.py").read_text()
+    mod = types.ModuleType("mgc_f2_mutant")
+    mod.__file__ = str(Path(__file__).parent.parent / "hooks" / "shared" / "merge_guard_common.py")
+    mod.__package__ = "shared"
+    exec(compile(src, mod.__file__, "exec"), mod.__dict__)
+    mutate(mod)
+    return mod
+
+
+class TestF2MutantOfLiveSource:
+    def test_busybox_recurse_membership_is_load_bearing(self):
+        assert "busybox" in mgc._EXEC_WRAPPERS_RECURSE, "precondition: F2 added busybox to RECURSE"
+        assert D('busybox bash -c "%s"' % BD) is True, "precondition: live catches busybox bash -c"
+        m = _load_mutant(lambda mod: setattr(
+            mod, "_EXEC_WRAPPERS_RECURSE", mod._EXEC_WRAPPERS_RECURSE - {"busybox"}))
+        assert m.is_dangerous_command('busybox bash -c "%s"' % BD) is False, \
+            "busybox RECURSE membership is NOT load-bearing (retention pin would be vacuous)"


### PR DESCRIPTION
## Summary

Closes the structural positional-argument over-block class in the merge-guard (issue #1178): a danger-looking literal inside an **inert command's quoted argument** no longer blocks a faithful single-command click, while every genuinely-destructive form stays caught and routed through the approval mint.

Merge-guard design principle held throughout: *a faithful single-command click always mints and merges; anything that blocks one is wrong by definition and comes out — no "contrived/adversarial" exceptions.* The only accepted over-block residuals are genuinely by-construction-unclosable (curl/wget #1098 boundary) or non-faithful (malformed `command -v <exec>` noexec).

## Commits (3)

1. **`be33ab81`** — P1: close `git commit --trailer` + `gh --assignee` positional over-blocks via flag-anchored carrier extensions (low blast radius).
2. **`c732a39f`** — P2: `strip-inert-default` general strip. An unrecognized command's quoted positional is POSIX-inert argv → stripped by default; a curated keep-visible set is preserved (shell-string executors via basename-normalized whole-head-token match + version families; exec-prefix wrappers via arity-aware recursion; http-clients excluded; anything the shared danger battery flags). Command-head detection skips leading env-assignments (`NAME=`/`NAME+=`) and redirections to reach the true command word.
3. **`89061755`** — comprehensive 184-row bidirectional non-vacuous cert (baked base-vs-PATCH via git-show-exec, danger-inside-arg premise, mutant-of-live-source catalog proof).

## Why it's sound (not another curl/wget wall)

The cardinal over-block direction is sound **by construction** (argv inertness → zero completeness burden); only the tolerated under-block direction carries a **bounded** enumeration (the shell-string-executor + exec-prefix catalog is a finite language feature, unlike curl's unbounded flag vocabulary). The strip is **monotonic toward allow** — it never synthesizes a danger token, so it can only close over-blocks, never create one.

## Verification

- Auditor's independent behavioral re-review: **127 vectors, 0 fails** against the frozen commit (both under-block sub-classes closed, sound parts intact, no new over-block).
- Comprehensive cert: **184 non-vacuous rows** (0 skipped — baked base loaded), full suite **11488 passed / 0 failed / 0 errors**.
- The layered adversarial discipline (concurrent auditor + independent commit-gate + architect/test ground-truth) caught **four under-blocks a fully-green suite never saw** — all pre-merge: env-assignment/http-client head-displacement, `NAME+=` append, spaced-redirect `>& file`, fd-dup classification. All closed.

## Accepted residuals (documented)

- `curl -H "…danger…" url` — http-client quoted-URL target hidden by masking (#1098-consistent; do not attempt a curl-flag-parsing fix).
- Genuinely-custom uncatalogued exec-wrapper under-block (D1-tolerated; the unbounded-custom tail).
- Malformed `command -v <exec> "…"` noexec form (never executes; not a faithful command).

SACROSANCT control — reviewed against the honest-mistake threat model.
