### PR TITLE
Isolate test config-root + correct teams-reaper docstring framing (#1186/#1187/#1185)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.6",
+      "version": "4.6.7",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.6/       # Plugin version
+│               └── 4.6.7/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.6",
+  "version": "4.6.7",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.6
+> **Version**: 4.6.7
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/session_end.py
+++ b/pact-plugin/hooks/session_end.py
@@ -177,14 +177,15 @@ _UUID_PATTERN = re.compile(
     r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\Z'
 )
 
-# Regex for validating PACT team directory names. Intentionally LOOSER
-# than what `generate_team_name` in shared/pact_context.py actually emits —
-# the producer emits `pact-` + `secrets.token_hex(4)` (8 lowercase hex
-# chars, no internal hyphens) or the session-id-prefix fallback
-# (`pact-` + 8 hex chars). This regex accepts any `pact-`-prefixed
-# lowercase-hex-and-hyphen shape so the reaper tolerates future drift
-# in the producer (e.g. a naming scheme that introduces internal
-# hyphens) without silently reaping a live team dir.
+# Regex gating which team directory names the teams-reaper may consider
+# reaping. generate_team_name was migrated to emit `session-<id8>`
+# (shared/pact_context.py); this reaper DELIBERATELY stays `^pact-`-scoped
+# — its historical namespace — because the platform owns teardown of its
+# own `session-*` namespace, so widening toward `session-*` would arm
+# `shutil.rmtree` against live platform-owned dirs. Within the `pact-`
+# namespace the regex accepts any `pact-`-prefixed lowercase-hex-and-hyphen
+# shape to tolerate drift (e.g. a future naming scheme that introduces
+# internal hyphens) without silently reaping a live team dir.
 # Non-matching entries in ~/.claude/teams/ belong to other tooling and
 # MUST NOT be reaped by cleanup_old_teams, even if they're stale by
 # mtime. The reaper treats ~/.claude/teams/ as shared space, not
@@ -446,10 +447,16 @@ def cleanup_old_teams(
 
     Three defense layers:
     1. Name-pattern gate — only directories matching `_TEAM_NAME_PATTERN`
-       (`^pact-[a-f0-9-]+$`) are candidates. This mirrors the INVARIANT
-       documented on `generate_team_name` in shared/pact_context.py. Non-PACT
-       writers that create `~/.claude/teams/foo-bar/` are out of scope:
-       `~/.claude/teams/` is shared space, not PACT-owned space.
+       (`^pact-[a-f0-9-]+$`) are candidates. This gate is DELIBERATELY
+       NARROWER than `generate_team_name`'s current `session-<id8>` output:
+       after the `pact-<id8>` -> `session-<id8>` migration the platform
+       owns teardown of its own `session-*` namespace, so this reaper must
+       NEVER reap live `session-*` dirs (widening `^pact-` to match
+       `session-*` would arm `shutil.rmtree` against platform-owned dirs).
+       See the "Reaper coupling" note on `generate_team_name` in
+       shared/pact_context.py. Non-PACT writers that create
+       `~/.claude/teams/foo-bar/` are out of scope: `~/.claude/teams/` is
+       shared space, not PACT-owned space.
     2. Current-team skip — exact-match skip of `current_team_name`.
     3. Fail-closed on empty `current_team_name` — returns (0, 0) without
        reaping anything. An empty skip key combined with a permissive
@@ -502,10 +509,13 @@ def cleanup_old_teams(
                 continue
             if not entry.is_dir():
                 continue
-            # Name-shape gate: only touch PACT-shaped team dirs. Mirrors
-            # the generate_team_name INVARIANT in shared/pact_context.py. Non-
-            # matching entries belong to other tooling and are out of
-            # scope for this reaper.
+            # Name-shape gate: only touch `pact-`-prefixed team dirs
+            # (legacy/orphaned). DELIBERATELY narrower than
+            # generate_team_name's current `session-<id8>` output: the
+            # platform owns teardown of its own `session-*` namespace, so
+            # this reaper must NEVER reap them (do NOT widen `^pact-` to
+            # match `session-*`). Non-matching entries belong to other
+            # tooling and are out of scope for this reaper.
             if not _TEAM_NAME_PATTERN.match(entry.name):
                 continue
             # Case-insensitive skip (cycle-5 defensive): pact_context's

--- a/pact-plugin/tests/conftest.py
+++ b/pact-plugin/tests/conftest.py
@@ -265,3 +265,91 @@ def _scrub_claude_plugin_root_env():
         os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
     else:
         os.environ["CLAUDE_PLUGIN_ROOT"] = original
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config_root_to_tmp(tmp_path, monkeypatch):
+    """Redirect the Claude Code config/state root to a per-test tmp tree for
+    EVERY test (autouse, opt-OUT), via TWO mechanisms: scrub any inherited
+    CLAUDE_CONFIG_DIR, then redirect ``Path.home()`` -> tmp_path. Runs for EVERY
+    test.
+
+    ``get_claude_config_dir()`` (hooks/shared/paths.py) — the single source of
+    truth every PACT state writer resolves through — honors ``$CLAUDE_CONFIG_DIR``
+    FIRST (precedence-1), falling back to ``Path.home() / ".claude"`` ONLY when
+    the var is unset. The two mechanisms make the redirect DETERMINISTIC
+    regardless of contributor env:
+
+    1. SCRUB CLAUDE_CONFIG_DIR at setup (POP any inherited value; restore the
+       original at teardown) — same posture as the sibling
+       ``_scrub_claude_plugin_root_env``. This makes the HOME fallthrough the
+       LIVE resolution path. A contributor who exports CLAUDE_CONFIG_DIR (their
+       real config) must NOT leak through — exactly the "forgetting is the
+       default" gap #1186 exists to close.
+    2. REDIRECT ``Path.home()`` -> tmp_path (``monkeypatch.setattr``, matching
+       the suite's own isolation convention — e.g. test_artifact_paths_durability
+       and the teammate_mode ``_ModeEnv`` harness). In-process,
+       ``get_claude_config_dir()`` now resolves to ``tmp_path / ".claude"``, so
+       every SSOT-respecting in-process writer (``agent_handoff_marker._marker_dir``
+       = ``get_claude_config_dir() / "teams" / team / namespace``; the registry
+       reaper's default root; etc.) lands under the per-test tmp, NEVER the
+       operator's real ``~/.claude``. This closes #1186's destructive leak (the
+       marker writer is in-process).
+
+    WHY NOT ALSO SET ``HOME`` ENV (deliberate): ``monkeypatch.setattr`` does not
+    cross to subprocesses, so a subprocess test that needs its child to resolve
+    the SAME tmp root must set the env var ITSELF in-body (the established
+    pattern — see test_pact_harvest_cli's subprocess test that does
+    ``monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))``
+    alongside its Path.home patch). A GLOBAL ``HOME`` env override here was
+    tried and REJECTED: it breaks the telegram tests
+    (``test_*_cwd_is_home``), which capture ``home = os.path.expanduser("~")``,
+    then ``patch.dict(os.environ, {}, clear=True)`` and assert the cwd-is-home
+    branch — under a ``HOME`` override the captured value is tmp but the
+    cleared-env ``expanduser`` falls back to the real pwd-home, so cwd no longer
+    equals home. A global ``HOME`` override trades ~3 legitimate tests for ~4
+    accidentally-consistent subprocess tests — a bad trade. Subprocess
+    hermeticity is per-test (the in-body env pattern), not a fixture
+    responsibility; residual non-isolated subprocess tests surface as findings
+    for per-test fixes, not as a fixture gap. #1186's destructive leak
+    (in-process marker writes) is fully closed by the setattr alone.
+
+    CRITICAL — DO NOT SET CLAUDE_CONFIG_DIR HERE. Precedence-1 makes it shadow
+    ``Path.home()`` entirely. The suite's pervasive isolation convention patches
+    ``Path.home()`` (-> a tmp) and relies on the HOME fallthrough being ACTIVE;
+    setting CLAUDE_CONFIG_DIR defeated that convention and broke ~336 tests (all
+    HOME-patchers) while helping none. The SCRUB keeps the fallthrough live (it
+    UNSETS the var); tests that genuinely need a specific config root set
+    CLAUDE_CONFIG_DIR THEMSELVES in-body, and precedence-1 then overrides the
+    scrub for that one test. Verified non-vacuity tests (e.g. test_task_utils
+    ``TestReadTaskJsonResolverEnvSet``: sets CLAUDE_CONFIG_DIR + redirects HOME
+    to an EMPTY dir to certify the env-set path) pass because their in-body
+    patches override BOTH this fixture's scrub and HOME-redirect.
+
+    Concrete leak this guards (#1186): the sibling autouse fixtures snapshot
+    CLAUDE_PROJECT_DIR and scrub CLAUDE_PLUGIN_ROOT but redirect NEITHER HOME
+    nor CLAUDE_CONFIG_DIR — the var (and its HOME fallback) governing every
+    destructive path. ``agent_handoff_marker._marker_dir`` resolved
+    ``get_claude_config_dir() / "teams" / team_name`` internally with no seam, so
+    a test exercising the marker writer against the live resolver wrote
+    test-fixture marker dirs into the operator's real ``~/.claude/teams/`` since
+    ~2026-04-05. This fixture inverts opt-in to opt-OUT: every test gets a
+    throwaway ``tmp_path / ".claude"`` root regardless of ambient env.
+
+    A test that ONLY passed against the real ``~/.claude`` (or the operator's
+    ambient ``CLAUDE_CONFIG_DIR``) was never isolated — under this fixture it
+    surfaces as a failure, which IS the finding: fix the test to be isolated,
+    never by re-pointing at the real home, weakening this redirect, or widening
+    any reaper. ``Path.home`` is patched in-process (what
+    ``get_claude_config_dir`` calls); subprocess tests that need their child to
+    resolve tmp set the env var themselves in-body (see "WHY NOT ALSO SET HOME"
+    above).
+    """
+    _UNSET = object()
+    original_cfg = os.environ.pop("CLAUDE_CONFIG_DIR", _UNSET)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    yield
+    if original_cfg is _UNSET:
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+    else:
+        os.environ["CLAUDE_CONFIG_DIR"] = original_cfg

--- a/pact-plugin/tests/test_conftest_config_root_isolation.py
+++ b/pact-plugin/tests/test_conftest_config_root_isolation.py
@@ -1,0 +1,84 @@
+"""
+Location: pact-plugin/tests/test_conftest_config_root_isolation.py
+Summary: Positive regression pin for the autouse conftest fixture
+         ``_isolate_config_root_to_tmp`` (PR #1189 / #1186). The fixture scrubs
+         ``CLAUDE_CONFIG_DIR`` and redirects ``Path.home()`` -> ``tmp_path`` so
+         every PACT state writer resolves under the per-test tmp, NEVER the
+         operator's real ``~/.claude``. The real-writer suites
+         (test_agent_handoff_marker, test_snapshot_marker_root_fallback, ...)
+         prove the closure MECHANISM — but each SELF-PATCHES ``Path.home``, so
+         they stay green even if the fixture were disabled: a future edit
+         removing or breaking the fixture would reopen #1186 SILENTLY (suite
+         green, destructive leak resumed). This file is the delete-the-fix
+         counter-test that pins the FIXTURE's own closure.
+Used by: pytest.
+"""
+import os
+
+from shared.paths import get_claude_config_dir
+
+
+class TestAutouseConfigRootIsolationPinned:
+    """Pin the autouse ``_isolate_config_root_to_tmp`` fixture's closure.
+
+    DELIBERATELY does NOT self-patch ``Path.home`` and does NOT set
+    ``CLAUDE_CONFIG_DIR`` in-body: it relies SOLELY on the autouse fixture. That
+    is what makes it a delete-the-fix counter-test for the fixture itself,
+    rather than a redundant mechanism assertion (the closure mechanism is
+    already covered by the real-writer suites, which self-patch).
+    """
+
+    def test_resolver_lands_under_tmp_not_real_home(self, tmp_path):
+        """The SSOT resolver ``get_claude_config_dir()`` — every PACT state
+        writer resolves through it — must land under the autouse fixture's
+        ``tmp_path``, NOT the operator's real ``~/.claude``.
+
+        Under the fixture: ``CLAUDE_CONFIG_DIR`` is scrubbed (unset) at setup
+        and ``Path.home()`` -> ``tmp_path``, so the SSOT resolves to
+        ``tmp_path / ".claude"`` (the HOME fallthrough — precedence-1 is empty).
+
+        COUNTER-TEST (the pinning property this file exists for): if the
+        fixture's ``monkeypatch.setattr(Path, "home", ...)`` is removed,
+        ``Path.home()`` is the operator's real home -> ``get_claude_config_dir``
+        resolves to real ``~/.claude`` -> the ``startswith(tmp_path)``
+        assertion FAILS. If the scrub is removed AND an ambient
+        ``CLAUDE_CONFIG_DIR`` is exported, precedence-1 resolves to that
+        ambient value -> the assertion also FAILS. Verified by local
+        fixture-disable (setattr line removed), reverted before staging.
+        """
+        resolved = get_claude_config_dir()
+
+        # (1) Lands under the autouse fixture's tmp, NOT the real home.
+        assert str(resolved).startswith(str(tmp_path)), (
+            f"get_claude_config_dir() resolved to {resolved!r}, NOT under the "
+            f"autouse fixture's tmp_path {str(tmp_path)!r}. The autouse "
+            "_isolate_config_root_to_tmp closure has REGRESSED (Path.home "
+            "setattr removed, or CLAUDE_CONFIG_DIR scrub removed with an "
+            "ambient value leaking through) — #1186's destructive leak would "
+            "resume silently under a green suite."
+        )
+        # (2) Specifically the .claude leaf (the HOME-fallthrough shape), not
+        # some other tmp-rooted path — pins the exact resolution contract.
+        assert resolved == tmp_path / ".claude", (
+            f"expected tmp_path / '.claude', got {resolved!r}"
+        )
+
+    def test_scrub_leaves_claude_config_dir_absent_during_body(self, tmp_path):
+        """Companion observability for the scrub half of the closure: after the
+        autouse fixture's setup scrub fires, ``CLAUDE_CONFIG_DIR`` is absent
+        from ``os.environ`` during the test body, so the HOME fallthrough is
+        the LIVE resolution path (precedence-1 is empty).
+
+        Honest scope of this cell: it is NOT a strong standalone counter-test —
+        a clean ambient env with no ``CLAUDE_CONFIG_DIR`` makes it pass
+        trivially. Paired with the cell above it documents and partially pins
+        the scrub posture: a regression that leaves an inherited
+        ``CLAUDE_CONFIG_DIR`` set would surface here whenever the suite runs
+        under an env that exports it.
+        """
+        assert "CLAUDE_CONFIG_DIR" not in os.environ, (
+            "CLAUDE_CONFIG_DIR is present during the test body — the autouse "
+            "fixture's setup scrub did not fire; a contributor env exporting it "
+            "would leak through and shadow the HOME fallthrough (precedence-1)."
+        )
+        assert get_claude_config_dir() == tmp_path / ".claude"

--- a/pact-plugin/tests/test_memory_cli.py
+++ b/pact-plugin/tests/test_memory_cli.py
@@ -1794,7 +1794,7 @@ class TestCliSubprocess:
 
     # ----- Cycle 3 H3: AMBIGUOUS_PREFIX envelope scrubs $HOME from match contexts -----
 
-    def test_ambiguous_prefix_scrubs_context_in_envelope(self, cli_script_path, cli_db):
+    def test_ambiguous_prefix_scrubs_context_in_envelope(self, monkeypatch, cli_script_path, cli_db):
         """E2E: AMBIGUOUS_PREFIX envelope replaces user $HOME path with '~' in each match context.
 
         Contexts may carry absolute paths from agent notes; piping the envelope
@@ -1803,6 +1803,27 @@ class TestCliSubprocess:
         sites (cmd_get, cmd_update, cmd_delete); this test exercises cmd_get
         as representative.
         """
+        # Subprocess + truncation isolation: the autouse conftest fixture
+        # redirects Path.home() -> tmp_path IN-PROCESS only (setattr does not
+        # cross to the child), and this test verifies $HOME scrubbing, so the
+        # subprocess must read the SAME home the parent captures. Two reasons a
+        # SHORT controlled home is needed here (not the fixture's tmp_path):
+        #  (a) SUBPROCESS: the child reads $HOME, not the setattr — override
+        #      Path.home() AND set $HOME together so parent and child agree.
+        #  (b) TRUNCATION: the envelope's per-match context snippet is capped
+        #      at descriptor_chars=60 (database.py). The fixture's tmp_path is
+        #      ~98 chars on macOS (/private/var/folders/...), so the snippet
+        #      cuts the home path mid-way, before "/Sites/" — _scrub can never
+        #      match the full home and "~/Sites/..." never appears. A short
+        #      home keeps "Note about <home>/Sites/secret-project/file.py"
+        #      (52 chars) inside the 60-char window (same shape as the original
+        #      /Users/mj assumption). This test writes via --db-path (never
+        #      under ~/.claude), so a controlled fake home re-opens no #1186
+        #      leak. See conftest _isolate_config_root_to_tmp "WHY NOT ALSO SET
+        #      HOME ENV".
+        short_home = "/tmp/pmscrub"
+        monkeypatch.setattr(Path, "home", lambda: Path(short_home))
+        monkeypatch.setenv("HOME", short_home)
         home = str(Path.home())
         # Guard against an unresolved tilde — _scrub no-ops if HOME is unset
         # or returns the literal '~', and this test would not be exercising

--- a/pact-plugin/tests/test_pact_harvest_cli.py
+++ b/pact-plugin/tests/test_pact_harvest_cli.py
@@ -251,7 +251,14 @@ class TestResolveSessionDirSubprocess:
             {"project_dir": project_dir, "session_id": session_id}), encoding="utf-8")
         return ctx
 
-    def test_valid_context_exit0_absolute_dir(self, tmp_path):
+    def test_valid_context_exit0_absolute_dir(self, tmp_path, monkeypatch):
+        # Subprocess isolation: the autouse conftest fixture redirects
+        # Path.home() IN-PROCESS only (monkeypatch.setattr does not cross to
+        # the child), so the subprocess must inherit CLAUDE_CONFIG_DIR to
+        # resolve the SAME tmp root as the parent oracle
+        # (pact_context.reconstruct_session_dir). See conftest
+        # _isolate_config_root_to_tmp "WHY NOT ALSO SET HOME ENV".
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
         ctx = self._write_ctx(tmp_path, "/clean/project", "sess-abcd")
         r = _run_cli("resolve-session-dir", "--context-file", str(ctx))
         assert r.returncode == _EXIT_OK
@@ -260,7 +267,7 @@ class TestResolveSessionDirSubprocess:
         # Oracle = the SSOT helper itself (NOT a hand-built path).
         assert out == pact_context.reconstruct_session_dir("/clean/project", "sess-abcd")
 
-    def test_b1_class_drift_both_axes_sanitized_no_drift(self, tmp_path):
+    def test_b1_class_drift_both_axes_sanitized_no_drift(self, tmp_path, monkeypatch):
         """THE critical durability test (the exact bug class cross-lane review
         caught in #927). A project basename with a DOT and a session_id with a
         non-[A-Za-z0-9_-] char must reconstruct the SANITIZED path the WRITER
@@ -270,6 +277,10 @@ class TestResolveSessionDirSubprocess:
         companion: a RAW un-sanitized join DIFFERS — proving the special-char
         input actually triggers sanitization on BOTH axes (slug + session_id),
         which is what clean-basename masking hid."""
+        # Subprocess isolation: see test_valid_context_exit0_absolute_dir —
+        # the child must inherit CLAUDE_CONFIG_DIR to resolve the SAME tmp
+        # root as the parent oracle (pact_context.reconstruct_session_dir).
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
         project_dir = "/Users/x/my.project dir"   # dot AND space in the basename
         session_id = "abc.def 123"                  # dot AND space (non-allowlist)
         ctx = self._write_ctx(tmp_path, project_dir, session_id)
@@ -401,7 +412,7 @@ class TestResolveArtifactsSubprocess:
 #     shared.pact_context (the non-vacuous seam the bootstrap fix addresses).
 # =============================================================================
 class TestImportSeamBootstrap:
-    def test_direct_script_resolves_pact_context_package_chain(self, tmp_path):
+    def test_direct_script_resolves_pact_context_package_chain(self, tmp_path, monkeypatch):
         """The CLI run as a direct script (cwd OUTSIDE the repo) must resolve
         `from shared.pact_context import reconstruct_session_dir` AND
         pact_context's own package-relative imports (from .session_state, etc).
@@ -409,6 +420,10 @@ class TestImportSeamBootstrap:
         is only possible if the bootstrap made `shared` a real package. If a
         future edit removes the sys.path bootstrap, this goes RED (ModuleNotFound
         or a non-zero exit), failing loudly."""
+        # Subprocess isolation: see test_valid_context_exit0_absolute_dir —
+        # the child must inherit CLAUDE_CONFIG_DIR to resolve the SAME tmp
+        # root as the parent oracle (pact_context.reconstruct_session_dir).
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
         ctx = tmp_path / "pact-session-context.json"
         ctx.write_text(json.dumps(
             {"project_dir": "/p", "session_id": "s"}), encoding="utf-8")
@@ -506,7 +521,7 @@ class TestSubcommandArgparseContract:
 #         resolve-artifacts (exit 1 + traceback); it degrades gracefully.
 # =============================================================================
 class TestTraversalAndGracefulTs:
-    def test_traversal_session_id_is_sanitized_no_escape(self, tmp_path):
+    def test_traversal_session_id_is_sanitized_no_escape(self, tmp_path, monkeypatch):
         """A '../../etc/passwd' session_id reconstructs INSIDE pact-sessions
         with the traversal characters neutralized (no '..' segment, stays under
         the sessions root). Oracle = the SSOT reconstruct_session_dir.
@@ -520,6 +535,10 @@ class TestTraversalAndGracefulTs:
         traversal, a session_id-regex-only revert does NOT leave a '..' segment
         (this test stays green under it) — so the structural assertion pins the
         no-escape OUTCOME, not the regex mechanism in isolation."""
+        # Subprocess isolation: see test_valid_context_exit0_absolute_dir —
+        # the child must inherit CLAUDE_CONFIG_DIR to resolve the SAME tmp
+        # root as the parent oracle (pact_context.reconstruct_session_dir).
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
         ctx = tmp_path / "pact-session-context.json"
         ctx.write_text(json.dumps(
             {"project_dir": "/clean/project", "session_id": "../../etc/passwd"}),

--- a/pact-plugin/tests/test_session_end.py
+++ b/pact-plugin/tests/test_session_end.py
@@ -49,7 +49,8 @@ class TestMainEntryPoint:
 
         Default mocks: pact_context.init, get_project_dir,
         get_session_id, get_team_name, get_task_list, append_event,
-        check_unpaused_pr, cleanup_old_sessions.
+        check_unpaused_pr, cleanup_old_sessions, cleanup_old_teams,
+        cleanup_old_tasks, _prune_registry_dead_teams.
 
         Pass keyword overrides to replace defaults (e.g., get_task_list=...).
         """
@@ -65,6 +66,15 @@ class TestMainEntryPoint:
             "cleanup_old_sessions": patch("session_end.cleanup_old_sessions"),
             "cleanup_old_teams": patch("session_end.cleanup_old_teams", return_value=(0, 0)),
             "cleanup_old_tasks": patch("session_end.cleanup_old_tasks", return_value=(0, 0)),
+            # #1187 closer: main() calls _prune_registry_dead_teams() with NO
+            # args, so the default registry_path resolves via
+            # get_claude_config_dir() and would run the REAL reaper against the
+            # operator's .teammate-registry.jsonl under the test. Patch it at
+            # the module attr main() resolves (bare call → session_end global
+            # lookup). return_value=0 matches the int-pruned contract; main()
+            # does not consume it today. Together with conftest's CLAUDE_CONFIG_DIR
+            # redirect, the unrooted registry write is unreachable by construction.
+            "_prune_registry_dead_teams": patch("session_end._prune_registry_dead_teams", return_value=0),
         }
         defaults.update(overrides)
         return defaults


### PR DESCRIPTION
## Summary

Three related pre-existing defects, batched (PATCH tier — test isolation + docstrings; no visible command/agent/behavioral surface change):

- **#1186** (root cause): `tests/conftest.py` had five autouse fixtures that snapshotted `CLAUDE_PROJECT_DIR` and scrubbed `CLAUDE_PLUGIN_ROOT` but redirected NEITHER `HOME` nor `CLAUDE_CONFIG_DIR` — the var governing every destructive path. `agent_handoff_marker._marker_dir` resolved `get_claude_config_dir()/'teams'/team` internally (no seam), so test-fixture marker dirs leaked into the operator's real `~/.claude/teams/` since ~2026-04-05. Adds one autouse fixture (`_isolate_config_root_to_tmp`) that makes isolation **opt-OUT** for every test.
- **#1187**: `_prune_registry_dead_teams` was absent from `_patch_main_deps`, so `main()` ran it unrooted against the operator's real `.teammate-registry.jsonl` (inert only by disk state). Added to `_patch_main_deps`; with the redirect, unreachable by construction.
- **#1185**: `cleanup_old_teams`' docstring falsely claimed its `^pact-` gate "mirrors the INVARIANT" on `generate_team_name` — stale since the `pact-`→`session-` migration, and it misled two prior agents toward the catastrophic widening. Corrected all three false-framing comment sites to state the deliberate divergence.

## Design note — the redirect mechanism

The fixture **scrubs `CLAUDE_CONFIG_DIR` (unset) and redirects `Path.home()` → tmp**, NOT the reverse. `CLAUDE_CONFIG_DIR` has precedence-1 in `get_claude_config_dir()`; *setting* it globally shadows the suite's ~336 `Path.home`-patching tests (their isolation relies on the HOME fallthrough being active). Scrubbing (unset) keeps the fallthrough live and makes the redirect deterministic regardless of contributor env. The HOME-env channel was tried and rejected (fixes 4 subprocess tests, breaks 3 telegram `cwd_is_home` tests). Full rationale in the fixture docstring.

## Commits

- `23b15436` — #1185 docstring (3 false-framing comment sites; comment-only, `_TEAM_NAME_PATTERN` byte-unchanged)
- `296470ef` — #1186 autouse fixture + #1187 `_patch_main_deps` closer
- `4b4da67f` — hermeticize 5 subprocess tests surfaced by the redirect (read-only path-resolution non-hermeticity, not the destructive-leak class)

## Verification

Full suite: **11607 passed, 15 skipped, 0 errors, 0 failed** (independent run; explicit 0-errors scan). Import-hygiene PASS. The destructive leak (#1186) is fully closed by the `Path.home` setattr (the marker writer is in-process).

## Constraints

`^pact-` gate and all reaper logic untouched — the fix lives at the writer's resolution point and the docstrings, never the reaper's scope (widening `^pact-` toward `session-*` would arm `shutil.rmtree` against live platform-owned dirs).

Addresses #1185 #1186 #1187.