### PR TITLE
fix(merge-guard): close over-block residuals + gh pr close positional class (v4.6.10)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.9",
+      "version": "4.6.10",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.9/       # Plugin version
+│               └── 4.6.10/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.9",
+  "version": "4.6.10",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.9
+> **Version**: 4.6.10
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -98,7 +98,7 @@ _executable_prefix view), deriving both POSITIONALS and FLAGS from that ONE leg
 force/delete flag in a benign continuation leg mislabel a benign first-leg op — the
 cross-leg flag leak).
 
-ANY-LEG reach is the CALLERS' (`_PER_LEG_PUSH_OPS`, below): they re-invoke this same arm on
+ANY-LEG reach is the CALLERS' (`_PER_LEG_OPS`, below): they re-invoke this same arm on
 each ISOLATED leg. That is NOT a match-anywhere scan — the distinction is the whole
 point. A match-anywhere scan fires on a quoted `:ref` / `--mirror` mention in a benign
 leg (a faithful-click over-block); a per-leg re-invocation runs the SAME positional,
@@ -127,7 +127,7 @@ per-leg rather than match-anywhere: the LITERAL danger arms (the DANGEROUS_PATTE
 match in ANY leg position (`cd /repo && git push --force origin main` is caught); and the
 accurate refspec-DST predicate `_flag_condition_danger_op` is additionally invoked PER-LEG
 by its callers (detect_command_operation_type + _stripped_surface_danger), filtered to
-`_PER_LEG_PUSH_OPS` — so `cd /repo && git push origin main` is caught. That filter carries ALL
+`_PER_LEG_OPS` — so `cd /repo && git push origin main` is caught. That filter carries ALL
 SIX union-arm classes, so the delete/mirror/:ref forms gate in any leg too. The two
 mechanisms OVERLAP on some forms (e.g. `cd /repo && git branch -D temp` is covered by
 both); when proving either one is load-bearing, isolate it — an assertion that exercises
@@ -572,7 +572,7 @@ def detect_command_operation_type(command: str) -> str | None:
     # `bash -c 'gh pr merge 5' && git push origin main` stays merge, not push-to-main).
     for _leg in legs:
         _lop = _flag_condition_danger_op(_leg)
-        if _lop in _PER_LEG_PUSH_OPS:
+        if _lop in _PER_LEG_OPS:
             return _lop
     return None
 
@@ -3683,7 +3683,7 @@ _PUSH_MAIN_DST_RE = re.compile(
 # evaluated on an ISOLATED leg, which is its own first leg, so the dangerous-leg count is
 # unchanged by this filter), and a >=2-dangerous-leg compound is refused at the pair level
 # regardless of which label it carries — so this re-labels a verdict that never authorizes.
-_PER_LEG_PUSH_OPS = (
+_PER_LEG_OPS = (
     "push-to-main",
     "force-push",
     "branch-delete",
@@ -3699,7 +3699,7 @@ def _flag_condition_danger_op(command: str) -> str | None:
     op-class ("close" / "branch-delete" / "force-push" / "remote-ref-delete" /
     "remote-mass-delete" / "push-to-main") iff a condition fires, else None.
     FIRST-LEG-ANCHORED (extending the conservative-RECOGNITION posture to this arm).
-    NOTE: callers ALSO invoke this per-leg for every class in `_PER_LEG_PUSH_OPS`
+    NOTE: callers ALSO invoke this per-leg for every class in `_PER_LEG_OPS`
     (detect_command_operation_type + _stripped_surface_danger) to catch a recognized op
     in a NON-first leg — this function itself stays first-leg-anchored; the per-leg reach
     is the callers'. That split is what makes per-leg coverage safe: each call still sees
@@ -4134,7 +4134,7 @@ def _stripped_surface_danger(stripped: str) -> bool:
     """The literal danger battery over an ALREADY-STRIPPED (or MASKED) surface: the
     DANGEROUS_PATTERNS scan + the four per-leg literal-arm families + the additive
     whole-surface normalized-flag condition + the PER-LEG op loop
-    (_flag_condition_danger_op per leg, filtered to _PER_LEG_PUSH_OPS, for any recognized op in
+    (_flag_condition_danger_op per leg, filtered to _PER_LEG_OPS, for any recognized op in
     a NON-first leg). Factored out of ``is_dangerous_command`` (behavior-identical)
     so the #1178 preserve-predicate can consult the SAME danger predicate on a masked leg
     WITHOUT re-entering ``_strip_non_executable_content`` (which would recurse — the predicate
@@ -4165,11 +4165,11 @@ def _stripped_surface_danger(stripped: str) -> bool:
     # PER-LEG arms: the whole-surface union call above is FIRST-LEG-anchored, so a recognized
     # op in a NON-first leg (`cd /repo && git push origin main`, `cd /repo && git push origin
     # --delete feature`) needs a per-leg call — the SAME union arm per leg, filtered by the
-    # SAME shared _PER_LEG_PUSH_OPS constant the detect loop uses (→ mint==read by construction).
+    # SAME shared _PER_LEG_OPS constant the detect loop uses (→ mint==read by construction).
     # leg[0] is harmlessly re-checked (the loop runs only after the whole-surface call
     # returned None).
     for _leg in legs:
-        if _flag_condition_danger_op(_leg) in _PER_LEG_PUSH_OPS:
+        if _flag_condition_danger_op(_leg) in _PER_LEG_OPS:
             return True
     return False
 

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -815,6 +815,135 @@ def _extract_pr_number(command: str) -> str | None:
     return match.group(1)
 
 
+# A `gh pr close` PR URL: host + owner/repo + the /pull/<N> segment. Anchored on
+# the LITERAL `/pull/` path element, so digits inside owner/repo (`o/r-123`) are
+# never mistaken for the PR number; `(\d+)(?![\w-])` stops exactly at the PR
+# number, so a trailing path (`/pull/5/files`), query (`?diff=split`), or
+# fragment (`#c-9`) cannot extend or replace it. Matches ANY host (github.com AND
+# GitHub Enterprise) so an enterprise URL is not an over-block.
+_GH_PULL_URL_RE = re.compile(
+    r"https?://([\w.-]+)/([\w.-]+/[\w.-]+)/pull/(\d+)(?![\w-])"
+)
+
+# The COMPLETE set of value-taking flags on `gh pr close` (verified against
+# `gh pr close --help`): `-R/--repo` and `-c/--comment`. `-d/--delete-branch` is
+# boolean. This set is used to strip a flag's VALUE from the positional scan so a
+# repo (`--repo o/r`) or comment (`-c "msg"`) value is never mistaken for the
+# {number|url|branch} target.
+#
+# WHY gh IS SOLVABLE WHERE curl/wget IS NOT (the #1098 WON'T-FIX contrast): gh's
+# value-flag vocabulary for a given subcommand is BOUNDED and documented (two
+# flags here), so this set can be COMPLETE for current gh — every faithful form
+# is handled, zero over-block today. curl/wget's value-flag vocabulary is
+# unbounded and version-growing, which is why a sound extractor there is
+# impossible and #1098 closed WON'T-FIX. Bounded => completable is the whole
+# reason gh-close has a real fix.
+#
+# FAIL-SAFE (future gh flags only): a value-taking flag NOT listed here has its
+# value counted as a positional, making a 2-positional command ABSTAIN (an
+# over-block — the SAFE, VISIBLE direction; fixable by adding the flag), never a
+# mis-bind/under-block/launder. Convert a potential silent launder into a visible
+# over-block, because an over-block comes out and a launder does not.
+_GH_CLOSE_VALUE_LONG = frozenset({"--repo", "--comment"})
+_GH_CLOSE_VALUE_SHORT = frozenset("Rc")
+
+
+def _gh_close_positionals(tokens: "list[str]") -> "list[str] | None":
+    """The positional args of a ``gh pr close`` token list, with value-taking
+    flags AND their values removed (cobra semantics: clustered shorts, ``=``-joined
+    and attached values all handled). Returns the positionals after ``close``, or
+    None if ``close`` is absent. A repo/comment VALUE can never survive as a
+    positional, so it can never be mis-bound as the {number|url|branch} target."""
+    try:
+        i = tokens.index("close") + 1
+    except ValueError:
+        return None
+    positionals: "list[str]" = []
+    n = len(tokens)
+    while i < n:
+        tok = tokens[i]
+        if tok.startswith("--"):
+            flag, has_eq, _v = tok.partition("=")
+            # `--repo value` / `--comment value` consume the NEXT token; the
+            # `=`-joined and boolean/unknown long forms are self-contained.
+            i += 2 if (flag in _GH_CLOSE_VALUE_LONG and not has_eq) else 1
+            continue
+        if tok.startswith("-") and tok != "-":
+            # Short cluster (cobra): a value-taking short consumes the REST of the
+            # cluster as its attached value, or — if it is the last char — the NEXT
+            # token. Booleans before it (`-dR value` = -d + -R value) don't matter.
+            body = tok[1:]
+            consumes_next = False
+            for j, ch in enumerate(body):
+                if ch in _GH_CLOSE_VALUE_SHORT:
+                    consumes_next = j == len(body) - 1   # `-R value`; else `-Rvalue`
+                    break
+            i += 2 if consumes_next else 1
+            continue
+        positionals.append(tok)
+        i += 1
+    return positionals
+
+
+def _extract_close_target(command: str) -> str | None:
+    """The close-target identity for a faithful ``gh pr close`` command, across
+    all three positional forms gh accepts (``{<number> | <url> | <branch>}``).
+
+    Returns one of FOUR disjoint identity namespaces (so no spelling can ever
+    set-equal another):
+
+    - bare PR number -> the digits (``"5"``). Repo-IMPLICIT, exactly as the
+      pre-existing number-close identity already is.
+    - github/enterprise PR URL -> ``"url:<host>/<owner>/<repo>#<N>"``. HOST- and
+      repo-QUALIFIED on purpose: a URL names an explicit repo, so binding only
+      the number would let it set-equal a bare ``"5"`` and authorize closing PR
+      #5 in a DIFFERENT repo (cross-repo target confusion). The number is parsed
+      from the ``/pull/<N>`` segment gh itself resolves, so the identity IS the
+      PR the command closes.
+    - single branch positional -> ``"branch:<name>"``. Name-only (repo-implicit
+      like the number form — a bare branch carries no repo). Branch names may
+      contain ``/`` (``feature/foo``), so slashes are allowed; a token carrying
+      ``://`` is an UNRECOGNIZED url form (not a github ``/pull/`` URL) -> abstain
+      rather than mint a garbage ``branch:`` identity.
+    - none of the above (incl. the NO-positional form ``gh pr close -d``, which
+      gh itself refuses) -> ``None`` (abstain; the read floor still gates, but a
+      command gh will not run has no faithful click to over-block).
+
+    LEG-LOCAL: everything is derived from ``_executable_prefix(command)`` (the
+    first executable leg), so a URL/branch mentioned in a benign continuation leg
+    is never picked up (no cross-leg identity injection). Dash-prefixed tokens
+    are dropped from the positional scan, so a flag can never be bound as the
+    target. Numeric precedence matches gh's own: a bare digit is always the PR
+    number, so a branch literally named ``5`` is indistinguishable from PR #5 to
+    BOTH gh and this guard (documented, not a collision — the two resolve to the
+    same command)."""
+    number = _extract_pr_number(command)
+    if number is not None:
+        return number
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        return None  # unbalanced quote / procsub -> abstain (existing safe posture)
+    tokens = _shell_tokenize(prefix)
+    if tokens is None:
+        return None  # unparseable -> abstain
+    positionals = _gh_close_positionals(tokens)
+    # Exactly ONE positional is a single-target close. 0 (the no-arg form gh
+    # refuses) or >=2 (ambiguous / an unlisted value-flag's value survived) ->
+    # abstain; the >=2 case is the over-block-safe fail direction.
+    if positionals is None or len(positionals) != 1:
+        return None
+    target = _strip_surrounding_quotes(positionals[0])
+    # Classify the SINGLE positional. It is a genuine positional (value-flag
+    # values already stripped), so a URL here IS the PR the command closes, never
+    # a --comment/--body value.
+    url = _GH_PULL_URL_RE.search(target)
+    if url is not None:
+        return "url:" + url.group(1) + "/" + url.group(2) + "#" + url.group(3)
+    if "://" in target:
+        return None  # unrecognized URL form -> abstain, never a garbage branch id
+    return "branch:" + target
+
+
 def _extract_api_ref(command: str) -> str | None:
     """Parse the ref from an API ref-mutation command's `git/refs/<ref>` path.
 
@@ -1859,9 +1988,15 @@ def extract_command_context(command: str, flag_scan_text: str | None = None) -> 
         flag_scan_text if flag_scan_text is not None else command, op_type
     )
     if op_type in ("merge", "close"):
-        pr_number = _extract_pr_number(command)
-        if pr_number is None and op_type == "merge":
-            pr_number = _extract_api_merge_pr(command)   # #1096 API pulls/<N>/merge
+        # close accepts {<number>|<url>|<branch>} — bind whichever the command
+        # carries so EVERY faithful close form MINTS (not just the number form).
+        # merge keeps the number-only extractor (+ the #1096 API pulls/<N> path).
+        if op_type == "close":
+            pr_number = _extract_close_target(command)
+        else:
+            pr_number = _extract_pr_number(command)
+            if pr_number is None:
+                pr_number = _extract_api_merge_pr(command)   # #1096 API pulls/<N>/merge
         if pr_number is not None:
             context["pr_number"] = pr_number
     elif op_type == "branch-delete":

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -1521,11 +1521,26 @@ def _extract_mass_delete_target(command: str) -> str | None:
 # EXCLUDES op-trigger flags that already change op_type (and are therefore
 # already bound through it): --force/-f (force-push), -D (branch-delete), and
 # gh pr close's --delete-branch (the close-danger trigger). Listing them here
-# would double-bind and needlessly over-block. NB the asymmetry: --delete-branch
-# /-d on gh pr MERGE is a post-merge SIDE-EFFECT (deletes the source branch), not
-# a merge op-trigger, so it IS bound on the `merge` class — and -d (merge
-# delete-branch) is a DIFFERENT op from -D (branch force-delete); op-class scoping
-# keeps them from being conflated.
+# would double-bind and needlessly over-block.
+#
+# THE EXCLUSION IS PER-CLASS, NOT GLOBAL — it is the flag's ROLE ON THAT CLASS
+# that decides, and the same flag can have different roles on different classes.
+# The rule: EXCLUDE A TRIGGER FROM THE CLASS IT TRIGGERS; BIND IT WHERE IT IS A
+# MODIFIER. Worked instances, all three of which look like exceptions until the
+# rule is stated this way:
+#   - --delete-branch/-d TRIGGERS `close`, but on gh pr MERGE it is a post-merge
+#     SIDE-EFFECT (deletes the source branch), so it IS bound on `merge`. (And -d
+#     on merge is a DIFFERENT op from -D branch force-delete; op-class scoping
+#     keeps them from being conflated.) It is ALSO bound on `close` itself, for
+#     the narrower reason spelled out at that entry: op_type folds bare-close and
+#     close --delete-branch into ONE op, so there the trigger does not
+#     discriminate and the flag binding is what separates them.
+#   - --mirror/--prune TRIGGER `remote-mass-delete`, but on `remote-ref-delete`
+#     they are scope-widening MODIFIERS, so they ARE bound there — that binding
+#     is what stops a single-branch-delete approval from authorizing a wholesale
+#     remote wipe.
+# So "is this flag an op-trigger?" is the WRONG question at this table. The right
+# one is "is it a trigger OF THIS CLASS?"
 PRIVILEGED_FLAGS: dict[str, dict[str, tuple[tuple[str, ...], bool]]] = {
     "merge": {
         "--admin":         (("--admin",), False),               # bypass branch protection
@@ -1569,18 +1584,48 @@ PRIVILEGED_FLAGS: dict[str, dict[str, tuple[tuple[str, ...], bool]]] = {
         # extension point so a future bound flag is a one-line data edit here.
     },
     "remote-ref-delete": {
-        # No bound flags: remote-ref-delete's privileged effect (removing a remote
-        # ref) IS its op-trigger (--delete/-d/empty-source colon), already bound via
-        # op_type. Empty entry = explicit #1042 extension point (a future bound flag
-        # is a one-line data edit); it adds NO new bound flag, so the set-equality
-        # bind is untouched.
+        # The op-TRIGGER here is --delete/-d/empty-source colon, already bound via
+        # op_type. These three are MODIFIERS on top of that trigger, so binding them
+        # adds a dimension the identity did not previously capture.
+        #
+        # --mirror/--prune are LOAD-BEARING on this class. A single-ref delete's
+        # identity is otherwise the bare ref (`main`), so an approval for
+        # `git push origin :main` (delete ONE branch) set-equaled an execution of
+        # `git push origin --mirror :main` — which deletes EVERY remote ref with no
+        # local counterpart. Single-branch approval, wholesale remote wipe. The
+        # single-ref extractor wins the boundary discriminator, so the scope-changing
+        # flag rode an identity that did not capture it. Binding closes it.
+        "--mirror":    (("--mirror",), False),
+        "--prune":     (("--prune",), False),
+        # bypasses the pre-push hook — a privilege, not a target change
+        "--no-verify": (("--no-verify",), False),
     },
     "remote-mass-delete": {
-        # No bound flags: remote-mass-delete's privileged effect (the mass destructive
-        # push) IS its op-trigger (--mirror/--prune/multi-ref-delete), bound via op_type
-        # AND folded into the mass_target identity tuple. The --mirror/--prune additions
-        # go to _FLAG_SPEC (danger-condition recognition) ONLY, NOT here, so the #1042
-        # set-equality bind is untouched. Empty entry = explicit extension point.
+        # DELIBERATELY NARROWER THAN ITS SIBLING, and the asymmetry is not cosmetic:
+        # exclude a trigger from the class it triggers; bind it where it is a modifier.
+        # --mirror/--prune are the op-TRIGGER for this class, and _extract_mass_delete_target
+        # EMBEDS them in the identity netstring (`git push --mirror origin` binds
+        # '8:--mirror6:origin', `--prune` binds '7:--prune6:origin'). So a --mirror/--prune
+        # escalation on this class ALREADY refuses at the identity layer, and binding them
+        # here changes no outcome TODAY — a cert row for it would be vacuous, and on a
+        # control whose dominant failure mode is checks that prove nothing, an entry that
+        # reads as protection while proving nothing is a real cost.
+        #
+        # VACUOUS TODAY IS NOT THE SAME CLAIM AS INERT, and the difference decides the
+        # design. Binding them here WOULD matter if the identity ever coarsened (see the
+        # COUPLING note below) — so the choice is not "redundant vs useful", it is
+        # "auditable now, with the coupling pinned" vs "silently defended, unverifiably".
+        # We take the first: narrow entry + a load-bearing pin on what it depends on.
+        #
+        # COUPLING — LOAD-BEARING, pinned by test, not left implicit. This narrowness
+        # DEPENDS on mass_target continuing to EMBED the flag. Measured under a coarsened
+        # mass_target (remote only): the split binding lets the --mirror/--prune escalation
+        # OPEN, while a symmetric binding would keep it closed. So the redundancy is NOT
+        # inert — split is chosen for auditability and is safety-equivalent to symmetric
+        # ONLY while that embedding holds.
+        # REMEDY: if you coarsen mass_target, you MUST bind --mirror and --prune HERE in
+        # the same commit. See test_mass_target_embeds_the_scope_flag_in_its_identity.
+        "--no-verify": (("--no-verify",), False),
     },
     "branch-protection": {
         # No bound flags: branch-protection's privileged effect (weakening protection)

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -819,10 +819,23 @@ def _extract_pr_number(command: str) -> str | None:
 # the LITERAL `/pull/` path element, so digits inside owner/repo (`o/r-123`) are
 # never mistaken for the PR number; `(\d+)(?![\w-])` stops exactly at the PR
 # number, so a trailing path (`/pull/5/files`), query (`?diff=split`), or
-# fragment (`#c-9`) cannot extend or replace it. Matches ANY host (github.com AND
-# GitHub Enterprise) so an enterprise URL is not an over-block.
+# fragment (`#c-9`) cannot extend or replace it. The host char class accepts a
+# PORT (`ghe.corp:8443`) and USERINFO (`user@github.com`) so a faithful GHE-with-
+# port or userinfo url MINTS — gh RUNS both (empirically confirmed), so leaving
+# them target=None was a gated-but-unmintable over-block. The widen is HOST-
+# SEGMENT ONLY: the owner/repo group and the `/pull/(\d+)(?![\w-])` anchor are
+# unchanged, so the PR number still resolves exactly (no anchor drift). The host
+# is captured VERBATIM into the minted identity (NOT normalized): distinct
+# spellings mint distinct identities (`user@github.com` != `github.com`,
+# `ghe.corp:8443` != `ghe.corp`), so a token binds ONLY its own exact command and
+# can NEVER cross-authorize a different host/PR (mint==read by construction; over-
+# block-safe, never a launder — a deceptive `github.com@evil.com` mints its own
+# verbatim id and authorizes only that exact typed command). STILL UNMATCHED: a
+# BRACKETED IPv6-literal host (`https://[::1]/o/r/pull/9`) — `[`/`]` are outside
+# the class — a non-realistic faithful form that stays a safe-direction over-
+# block; widen to include `[]` only if a real gh IPv6 form ever appears.
 _GH_PULL_URL_RE = re.compile(
-    r"https?://([\w.-]+)/([\w.-]+/[\w.-]+)/pull/(\d+)(?![\w-])"
+    r"https?://([\w.@:-]+)/([\w.-]+/[\w.-]+)/pull/(\d+)(?![\w-])"
 )
 
 # The COMPLETE set of value-taking flags on `gh pr close` (verified against
@@ -958,6 +971,8 @@ def _extract_close_target(command: str) -> str | None:
     if positionals is None or len(positionals) != 1:
         return None
     target = _strip_surrounding_quotes(positionals[0])
+    if not target:
+        return None  # empty/degenerate positional -> abstain, never a garbage id
     # Classify the SINGLE positional (value-flag values already stripped, so a
     # digit/url/branch here IS the target, never a --repo/--comment value).
     if target.isdigit():

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -83,44 +83,57 @@ benign-remainder pattern, NOT a recognition allow-list of viewers/filters — do
 enumerate viewers in detection logic (an allow-list drifts and would re-block faithful
 clicks the count already mints).
 
-conservative-RECOGNITION (the design rule behind the accepted compound under-block;
-documented so a future sweep does NOT "discover" these forms and "harden" them into
-faithful-click over-blocks): recognition targets the SINGLE destructive command an honest
-agent runs (the destructive op plus the benign viewers/filters/redirects of benign-
-CONTINUATION above) and ERRS TOWARD LETTING THROUGH — over-blocking a faithful click is
-WRONG BY DEFINITION (the INVARIANT above), worse than missing a buried op. The ENTIRE
-flag-condition union arm (_flag_condition_danger_op) needs a positional, quote-aware
-parse — the close/branch-delete/force-push flag conditions AND the git-push
-remote-ref-delete (`:ref` / `--delete` / `-d`) / mass-delete (`--mirror` / `--prune` /
-multi-ref) extractors — so its recognition is ANCHORED to the FIRST executable leg (the
-_executable_prefix view): it does NOT chase those ops into NON-FIRST compound legs, and
-it derives FLAGS from that same leg (deriving flags from the WHOLE command while
-positionals came from the first leg let a force/delete flag in a benign continuation leg
-mislabel a benign first-leg op — the cross-leg flag leak). Chasing them needs a
-match-anywhere / per-leg scan that fires on a quoted `:ref` / `--mirror` mention in a
-benign leg — an over-block of a faithful click. The ACCEPTED price is that these forms
-run UNGATED when the destructive op is not the first leg:
+conservative-RECOGNITION (the design rule; documented so a future sweep does NOT
+"discover" these forms and "harden" them into faithful-click over-blocks): recognition
+targets the SINGLE destructive command an honest agent runs (the destructive op plus the
+benign viewers/filters/redirects of benign-CONTINUATION above) and ERRS TOWARD LETTING
+THROUGH — over-blocking a faithful click is WRONG BY DEFINITION (the INVARIANT above),
+worse than missing a buried op. The ENTIRE flag-condition union arm
+(_flag_condition_danger_op) needs a positional, quote-aware parse — the
+close/branch-delete/force-push flag conditions AND the git-push remote-ref-delete
+(`:ref` / `--delete` / `-d`) / mass-delete (`--mirror` / `--prune` / multi-ref)
+extractors — so THIS FUNCTION is ANCHORED to the FIRST executable leg (the
+_executable_prefix view), deriving both POSITIONALS and FLAGS from that ONE leg
+(deriving flags from the WHOLE command while positionals came from the first leg let a
+force/delete flag in a benign continuation leg mislabel a benign first-leg op — the
+cross-leg flag leak).
+
+ANY-LEG reach is the CALLERS' (`_PER_LEG_PUSH_OPS`, below): they re-invoke this same arm on
+each ISOLATED leg. That is NOT a match-anywhere scan — the distinction is the whole
+point. A match-anywhere scan fires on a quoted `:ref` / `--mirror` mention in a benign
+leg (a faithful-click over-block); a per-leg re-invocation runs the SAME positional,
+quote-aware parse on a leg that is its own first leg, so a mention inside a benign leg
+is a mention, not an op. Leg-locality is preserved BY CONSTRUCTION: the derivation is
+per-leg on both axes, so the cross-leg flag leak cannot reappear through this route.
+Consequently these forms DO gate in any leg position:
   - `cd /repo && git push origin --delete main`
   - `git fetch && git push --mirror origin`
   - `NOTE=x ; git push origin :main`
-  - `cd /repo && git branch -Df temp`   (cluster force-delete; idiomatic `-D` still caught per-leg, in any leg)
-  - `cd /repo && gh pr close 5 -d`      (short `-d` close; spelled `--delete-branch` still caught per-leg, in any leg)
-These are NOT bugs — do NOT "fix" them (the fix re-blocks faithful clicks). httpie
+  - `cd /repo && git branch -Df temp`   (cluster force-delete)
+  - `cd /repo && gh pr close 5 -d`      (short `-d` close)
+The earlier design accepted these as UNGATED, on the premise that reaching them required
+a match-anywhere scan. That premise was false — the per-leg predicate reaches them with
+no match-anywhere behavior — and leaving them ungated was a good-faith-reachable
+under-block, so they were closed. What must NOT be "fixed" is the literal arms' word
+boundary: granting delete tokens match-anywhere coverage IS the over-block this design
+rule guards, and it remains guarded. httpie
 (`http` / `https` CLI) is likewise WHOLLY ungated by design — ref-mutation, merge, AND
 protection-mutation — because the MINT classifier covers gh-api / curl / wget only; ANY
 httpie read-floor arm re-creates a gated-but-unmintable over-block. Ungated keeps read == mint.
-NB this first-leg anchoring is SPECIFIC to those parse-dependent forms: the LITERAL
-danger arms (the DANGEROUS_PATTERNS bank + the per-leg literal-arm tuples: force-push,
-branch-delete, close, API ref/protection) match in ANY leg position (per-leg for the
-tuple arms) and STILL gate in a non-first leg
-(`cd /repo && git push --force origin main` is caught). PUSH-TO-MAIN (and the `+refspec`
-force spelling) are ALSO gated in ANY leg (#1195 OBS-E/F-PL): the accurate refspec-DST
-predicate `_flag_condition_danger_op` is additionally invoked PER-LEG by its callers
-(detect_command_operation_type + _stripped_surface_danger), filtered to
-`_PER_LEG_PUSH_OPS` — so `cd /repo && git push origin main` is caught. (delete/mirror/:ref
-non-first-leg forms above STAY ungated — the per-leg push filter excludes them.) When an
-over-block of a faithful click is found, the fix WIDENS the mint, never narrows detection
-into a new under-block.
+NB the first-leg anchoring is a property of `_flag_condition_danger_op` ITSELF, not of the
+guard's leg coverage. TWO independent mechanisms deliver ANY-LEG reach, and both are
+per-leg rather than match-anywhere: the LITERAL danger arms (the DANGEROUS_PATTERNS bank
++ the per-leg literal-arm tuples: force-push, branch-delete, close, API ref/protection)
+match in ANY leg position (`cd /repo && git push --force origin main` is caught); and the
+accurate refspec-DST predicate `_flag_condition_danger_op` is additionally invoked PER-LEG
+by its callers (detect_command_operation_type + _stripped_surface_danger), filtered to
+`_PER_LEG_PUSH_OPS` — so `cd /repo && git push origin main` is caught. That filter carries ALL
+SIX union-arm classes, so the delete/mirror/:ref forms gate in any leg too. The two
+mechanisms OVERLAP on some forms (e.g. `cd /repo && git branch -D temp` is covered by
+both); when proving either one is load-bearing, isolate it — an assertion that exercises
+the whole pipeline passes while one mechanism is silently dead. When an over-block of a
+faithful click is found, the fix WIDENS the mint, never narrows detection into a new
+under-block.
 =============================================================================
 
 Centralizes TOKEN_TTL, TOKEN_DIR, TOKEN_PREFIX, consumed-token cleanup,
@@ -550,12 +563,12 @@ def detect_command_operation_type(command: str) -> str | None:
     )
     if op is not None:
         return op
-    # PER-LEG push arms (OBS-E/F-PL): restore the ANY-LEG push-to-main/force-push coverage
-    # the removed whole-string DANGEROUS_PATTERNS rows carried — the union arm is FIRST-LEG-
-    # anchored, so a push in a non-first leg (`cd /repo && git push origin main`) needs a
-    # per-leg call. CALLER-LEVEL (not inside _detect_op_pass): reached ONLY after BOTH passes
-    # return None, so every existing classification is byte-stable (the api-merge additive
-    # precedent), and the raw-fallback gh-pr arms still run before this (so
+    # PER-LEG arms: the union arm is FIRST-LEG-anchored, so any op it recognizes in a
+    # non-first leg (`cd /repo && git push origin main`, `cd /repo && git push origin
+    # --delete feature`) needs a per-leg call. CALLER-LEVEL (not inside _detect_op_pass):
+    # reached ONLY after BOTH passes return None, so no command that already classifies
+    # changes verdict (the api-merge additive precedent), and the raw-fallback gh-pr arms
+    # still run before this (so
     # `bash -c 'gh pr merge 5' && git push origin main` stays merge, not push-to-main).
     for _leg in legs:
         _lop = _flag_condition_danger_op(_leg)
@@ -3598,17 +3611,41 @@ _PUSH_MAIN_DST_RE = re.compile(
     r"(?![\w./@+-])"         # ... as a COMPLETE ref: no continuation char follows
 )
 
-# OBS-E/F-PL (#1195) — per-leg push-op filter. The push-to-main + force-push detection lives
-# in the whole-command `_flag_condition_danger_op`, which is FIRST-LEG-ANCHORED — so a push in
-# a NON-first leg (`cd /repo && git push origin main`) was lost when the whole-string
-# DANGEROUS_PATTERNS push-to-main rows were removed (unlike branch-delete/force-push, push-to-
-# main had no per-leg literal arm). The caller-level per-leg loops (in
+# Per-leg op filter. `_flag_condition_danger_op` is FIRST-LEG-ANCHORED, so any op it
+# recognizes is LOST when the destructive command is not the first leg
+# (`cd /repo && git push origin main`). The caller-level per-leg loops (in
 # detect_command_operation_type + _stripped_surface_danger) restore ANY-LEG coverage by calling
 # the SAME union arm per leg, filtered to these classes — a THIN caller, no second predicate.
-# Reached ONLY after the existing pipeline returns None/False, so every existing classification
-# is byte-stable. force-push is in the filter (not just push-to-main) so a non-first-leg
-# clustered/`+refspec` force spelling gates too (sibling consistency with `cd && push --force`).
-_PER_LEG_PUSH_OPS = ("push-to-main", "force-push")
+# Reached ONLY after the existing pipeline returns None/False, so no command that ALREADY
+# gates changes its verdict.
+#
+# ALL SIX union-arm classes are listed. The four delete/close classes were added to close a
+# good-faith-reachable UNDER-BLOCK: `cd /repo && git push origin --delete feature` ran
+# COMPLETELY UNGATED. Widening this FILTER — rather than adding per-leg LITERAL arms — is
+# what keeps that fix over-block-free: literal arms were measured at 3 cardinal over-blocks
+# (e.g. `git push origin feature -o "note: use --mirror for backups"`) versus 0 here, because
+# the delete families need a positional, value-aware parse a regex cannot do. The filter reuses
+# the parse the union arm already performs on an ISOLATED leg, so a quoted `--mirror` mention
+# in a benign leg is never a match.
+#
+# Filtering both consumers on this ONE constant is what makes mint == read by construction:
+# a class added here reaches detect and the read floor in the same edit, so they cannot drift.
+#
+# CAVEAT (leg precedence): both loops return on the FIRST leg whose op is in this tuple. On a
+# compound carrying TWO ops from this set, an EARLIER leg now wins where a later one used to
+# — e.g. `cd /repo && git branch -Df temp && git push origin main` classifies branch-delete,
+# not push-to-main. Every such command has >=2 independently-dangerous legs (per-leg danger is
+# evaluated on an ISOLATED leg, which is its own first leg, so the dangerous-leg count is
+# unchanged by this filter), and a >=2-dangerous-leg compound is refused at the pair level
+# regardless of which label it carries — so this re-labels a verdict that never authorizes.
+_PER_LEG_PUSH_OPS = (
+    "push-to-main",
+    "force-push",
+    "branch-delete",
+    "close",
+    "remote-ref-delete",
+    "remote-mass-delete",
+)
 
 
 def _flag_condition_danger_op(command: str) -> str | None:
@@ -3617,10 +3654,12 @@ def _flag_condition_danger_op(command: str) -> str | None:
     op-class ("close" / "branch-delete" / "force-push" / "remote-ref-delete" /
     "remote-mass-delete" / "push-to-main") iff a condition fires, else None.
     FIRST-LEG-ANCHORED (extending the conservative-RECOGNITION posture to this arm).
-    NOTE (#1195 OBS-E/F-PL): callers ALSO invoke this per-leg for the push classes
-    (detect_command_operation_type + _stripped_surface_danger, filtered to
-    `_PER_LEG_PUSH_OPS`) to catch a push-to-main/force-push in a NON-first leg — this
-    function itself stays first-leg-anchored; the per-leg reach is the callers'.
+    NOTE: callers ALSO invoke this per-leg for every class in `_PER_LEG_PUSH_OPS`
+    (detect_command_operation_type + _stripped_surface_danger) to catch a recognized op
+    in a NON-first leg — this function itself stays first-leg-anchored; the per-leg reach
+    is the callers'. That split is what makes per-leg coverage safe: each call still sees
+    ONE isolated leg and derives flags AND positionals from it, so widening the caller's
+    filter can never introduce the cross-leg flag leak.
     Every surface consulted here — the token list, the coarse-shape prefixes,
     and the extractor inputs — derives from `_executable_prefix(command)`, because
     deriving FLAGS from the whole command while POSITIONALS came from the first
@@ -4049,9 +4088,9 @@ _WRAPPER_GRAMMAR: "dict[str, _WrapperGrammar]" = {
 def _stripped_surface_danger(stripped: str) -> bool:
     """The literal danger battery over an ALREADY-STRIPPED (or MASKED) surface: the
     DANGEROUS_PATTERNS scan + the four per-leg literal-arm families + the additive
-    whole-surface normalized-flag condition + the PER-LEG push-op loop (#1195 OBS-E/F-PL:
-    _flag_condition_danger_op per leg, filtered to _PER_LEG_PUSH_OPS, for a push-to-main /
-    force-push in a NON-first leg). Factored out of ``is_dangerous_command`` (behavior-identical)
+    whole-surface normalized-flag condition + the PER-LEG op loop
+    (_flag_condition_danger_op per leg, filtered to _PER_LEG_PUSH_OPS, for any recognized op in
+    a NON-first leg). Factored out of ``is_dangerous_command`` (behavior-identical)
     so the #1178 preserve-predicate can consult the SAME danger predicate on a masked leg
     WITHOUT re-entering ``_strip_non_executable_content`` (which would recurse — the predicate
     runs INSIDE that strip). SURFACE-AGNOSTIC: it neither strips nor masks, only matches, so a
@@ -4078,11 +4117,12 @@ def _stripped_surface_danger(stripped: str) -> bool:
             return True
     if _flag_condition_danger_op(stripped) is not None:
         return True
-    # PER-LEG push arms (OBS-E/F-PL): the whole-surface union call above is FIRST-LEG-
-    # anchored, so a push-to-main/force-push in a NON-first leg (`cd /repo && git push origin
-    # main`) needs a per-leg call — the SAME union arm per leg, filtered to the push classes
-    # (the shared _PER_LEG_PUSH_OPS constant → mint==read with the detect loop). leg[0] is
-    # harmlessly re-checked (the loop runs only after the whole-surface call returned None).
+    # PER-LEG arms: the whole-surface union call above is FIRST-LEG-anchored, so a recognized
+    # op in a NON-first leg (`cd /repo && git push origin main`, `cd /repo && git push origin
+    # --delete feature`) needs a per-leg call — the SAME union arm per leg, filtered by the
+    # SAME shared _PER_LEG_PUSH_OPS constant the detect loop uses (→ mint==read by construction).
+    # leg[0] is harmlessly re-checked (the loop runs only after the whole-surface call
+    # returned None).
     for _leg in legs:
         if _flag_condition_danger_op(_leg) in _PER_LEG_PUSH_OPS:
             return True

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -839,11 +839,25 @@ _GH_PULL_URL_RE = re.compile(
 # impossible and #1098 closed WON'T-FIX. Bounded => completable is the whole
 # reason gh-close has a real fix.
 #
-# FAIL-SAFE (future gh flags only): a value-taking flag NOT listed here has its
-# value counted as a positional, making a 2-positional command ABSTAIN (an
-# over-block — the SAFE, VISIBLE direction; fixable by adding the flag), never a
-# mis-bind/under-block/launder. Convert a potential silent launder into a visible
-# over-block, because an over-block comes out and a launder does not.
+# BEHAVIOR ON AN UNLISTED VALUE-FLAG — two sub-cases, stated honestly (NOT
+# "never a mis-bind"):
+#  (a) the flag's value is an EXTRA token alongside a real target
+#      (`gh pr close feature --newflag x`) -> TWO positionals -> ABSTAIN
+#      (over-block, the SAFE/VISIBLE direction; fixable by listing the flag).
+#  (b) the flag's value is the SOLE positional-shaped token
+#      (`gh pr close --newflag 5`, NO real target) -> that value is bound as the
+#      target. BUT such a command has no valid {number|url|branch} positional, so
+#      gh ITSELF REJECTS it -> it is NON-FAITHFUL. Minting from it is a
+#      confused-deputy: an adversary must get the user to APPROVE a command gh
+#      won't run, then reuse the token on a real one. ADVERSARIAL-ONLY, tolerated
+#      under the good-faith model (a good-faith user never approves a command that
+#      cannot execute). This is a DOCUMENTED RESIDUAL, not closed here — see
+#      test_unknown_value_flag_on_nonfaithful_close_is_adversarial_only.
+# `--repo`/`-c/--comment` are LISTED, so the security-reported FAITHFUL mis-bind
+# (`gh pr close --repo 5/6 feature` shadowing the branch with the repo digit) is
+# fully closed. curl/wget contrast (#1098): gh's per-subcommand value-flag set is
+# bounded/documented so the FAITHFUL forms are completely covered; curl/wget's is
+# unbounded, so no sound extractor exists there.
 _GH_CLOSE_VALUE_LONG = frozenset({"--repo", "--comment"})
 _GH_CLOSE_VALUE_SHORT = frozenset("Rc")
 
@@ -916,10 +930,21 @@ def _extract_close_target(command: str) -> str | None:
     target. Numeric precedence matches gh's own: a bare digit is always the PR
     number, so a branch literally named ``5`` is indistinguishable from PR #5 to
     BOTH gh and this guard (documented, not a collision — the two resolve to the
-    same command)."""
-    number = _extract_pr_number(command)
-    if number is not None:
-        return number
+    same command).
+
+    SINGLE VALUE-FLAG SSOT (structural — do NOT reintroduce a second list): ALL
+    three forms (number, url, branch) are classified from the ONE positional that
+    ``_gh_close_positionals`` returns, which strips value-flag values via the
+    single ``_GH_CLOSE_VALUE_*`` set. The number path deliberately does NOT call
+    ``_extract_pr_number`` — that function's value-flag handling is (a) long-form
+    only (blind to ``-R``) and (b) a DIFFERENT, incomplete flag list, so routing
+    close numbers through it re-created the two-lists-diverge mis-bind: on
+    ``gh pr close --repo 5/6 feature`` / ``-R 5/6 feature`` its regex backtracks
+    to grab the repo's leading digit as the PR (shadowing the branch), which
+    LAUNDERED an approved branch-close into a different-PR close. Deriving every
+    close form from the one value-flag-complete positional walk makes that
+    divergence impossible by construction. (merge still uses ``_extract_pr_number``
+    — its value-flags differ; this SSOT is close-scoped.)"""
     prefix = _executable_prefix(command)
     if prefix is None:
         return None  # unbalanced quote / procsub -> abstain (existing safe posture)
@@ -933,9 +958,10 @@ def _extract_close_target(command: str) -> str | None:
     if positionals is None or len(positionals) != 1:
         return None
     target = _strip_surrounding_quotes(positionals[0])
-    # Classify the SINGLE positional. It is a genuine positional (value-flag
-    # values already stripped), so a URL here IS the PR the command closes, never
-    # a --comment/--body value.
+    # Classify the SINGLE positional (value-flag values already stripped, so a
+    # digit/url/branch here IS the target, never a --repo/--comment value).
+    if target.isdigit():
+        return target  # bare PR number — gh's number precedence, repo-implicit
     url = _GH_PULL_URL_RE.search(target)
     if url is not None:
         return "url:" + url.group(1) + "/" + url.group(2) + "#" + url.group(3)

--- a/pact-plugin/tests/fixtures/merge_guard_baseline/merge_guard_common_172a77dd.py
+++ b/pact-plugin/tests/fixtures/merge_guard_baseline/merge_guard_common_172a77dd.py
@@ -1,0 +1,4674 @@
+"""
+Location: pact-plugin/hooks/shared/merge_guard_common.py
+Summary: Shared constants and utilities for the merge guard hook pair.
+Used by: merge_guard_pre.py (PreToolUse) and merge_guard_post.py (PostToolUse)
+
+================================ THREAT MODEL ================================
+HONEST-MISTAKE PREVENTION — read this BEFORE "hardening" the guard.
+
+The merge guard exists to route an HONEST destructive command through the
+operator's AskUserQuestion approval click: it catches an agent about to run a
+real destructive git/gh operation BY MISTAKE and asks the operator to confirm.
+It is NOT an adversarial sandbox and makes NO attempt to stop a determined
+evader.
+
+INVARIANT (supersedes everything): a faithful single-command click ALWAYS mints
+a token and executes. A faithful operator clicks the option carrying the command
+(`gh pr merge 5`, `gh pr close 5 --delete-branch`, even `gh pr merge 5 --admin`)
+→ it mints → the command runs. ANYTHING that can block a faithful single-command
+click is WRONG BY DEFINITION — over-blocking a faithful click is a worse failure
+than not catching an obfuscated one.
+
+EXPLICITLY OUT OF SCOPE (these are NOT bugs; do NOT "fix" them — a blind
+adversarial sweep that "finds" them must NOT re-trigger hardening, because the
+hardening that catches them also blocks faithful clicks):
+  - quote-concat / quote-elision in the op keyword: `gh pr ''merge`,
+    `gh pr "merge"`, `g'h' pr merge`, `gh pr m'erge'` — an honest agent does not
+    obfuscate the command it intends to run.
+  - command-as-data via an interpreter pipe / substitution / eval:
+    `echo '...' | sh`, `$(echo '...')`, `eval "$CMD"` — deliberate evasion, not a
+    mistake.
+  - runtime $-expansion hiding the op or a flag: `gh pr $VERB 5`,
+    `gh pr merge 5 $FLAGS` — the hook only sees the pre-expansion literal an
+    honest agent typed.
+  - attached / equals API flag-spelling evading the literal pattern:
+    `gh api -XDELETE`, `--method=DELETE`.
+A metachar/quote SUPPRESSOR for the above (the removed shell-semantic over-block
+layer) re-blocks faithful clicks — e.g. it over-blocked
+`gh pr close 7 --comment "(done)" --delete-branch` — which is why it was removed.
+Keep detection LITERAL and faithful-click-safe; do not re-introduce an
+adversarial parser or a fail-closed metachar/quote SUPPRESSOR. This is distinct from
+the KEPT additive flag-normalization arm (_flag_condition_danger_op), which only ADDS
+recognition of canonical flag spellings via a quote-aware tokenize and ABSTAINS on a
+parse failure — it can only OVER-block, never suppress, so do NOT strip it as
+"non-literal."
+
+What the guard DOES recognize (the honest-command surface only): the literal
+destructive patterns (DANGEROUS_PATTERNS); canonical flag SPELLINGS an honest
+agent actually types (close `-d`/`-cd`, branch `-Df`/`-fD`); the privileged-flag
+bind (set-equality of approved vs executed flags, so an honest re-run that ADDS a
+privilege re-prompts rather than silently escalating); and faithful-click region/
+quote handling so a quoted argument never truncates the approved command.
+
+rm-EXCEPTION (deliberate, documented so a future sweep does NOT "discover" a gap):
+the compound-destructive count (is_compound_destructive_command) treats a plain-`rm`
+head leg as destructive, so a recognized git/gh op chained with an `rm`
+(`gh pr merge 5 && rm -rf /`) is refused as a 2-destructive-leg mistake. This is
+rm-SPECIFIC by design — NOT a general filesystem-destroyer detector: `dd`, `mkfs`,
+`shred`, `truncate`, etc. are OUT OF SCOPE (do NOT add them — honest-mistake posture,
+no obfuscation-chasing: plain `rm` head only, not `/bin/rm`, `r''m`, `$(echo rm)`).
+And rm is deliberately ABSENT from is_dangerous_command, so a BARE `rm -rf /` and a
+PURE-rm chain (`rm -rf a && rm -rf b`) stay is_dangerous=False and are NEVER gated —
+the guard stays out of pure-filesystem commands.
+
+benign-CONTINUATION (the dual of the rm-EXCEPTION; documented so a future sweep does
+NOT "discover" the single-leg mint and "harden" it away): for EVERY recognized
+destructive op — gh pr merge, gh pr close, git force-push, AND git branch-delete — a
+SINGLE such op + ANY benign continuation mints a token AND the read side authorizes the
+continued command. "Benign" means the remainder is NOT a second destructive git/gh op —
+it need NOT be read-only (a `tee` or an output redirect WRITES a file and is still
+benign). A benign chain (`gh pr merge 5 && echo ok`, `gh pr merge 5 ; echo done`), a
+backgrounding (`gh pr merge 5 &`), a pipe to a pager/filter or `tee`
+(`gh pr merge 5 | tail`, `gh pr merge 5 | tee log`), or an output / fd redirect
+(`gh pr merge 5 > out.log`, `git push --force origin main 2>&1`,
+`git branch -D feature > log`) is a faithful single-command click:
+is_compound_destructive_command refuses ONLY on >=2 destructive legs (one destructive
+leg + benign continuation is NOT compound), and the read-side target is re-derived from
+the SINGLE destructive leg — the merge/close PR-NUMBER positional, the branch-delete
+name, OR the force-push ref — regardless of any trailing continuation / redirect tokens,
+so the approval still binds. (The positional extractors truncate at the first benign
+terminator on the quote-masked view; the read call site isolates the single destructive
+leg before deriving op/target/flags.) This is the GENERAL single-destructive-op-plus-
+benign-remainder pattern, NOT a recognition allow-list of viewers/filters — do NOT
+enumerate viewers in detection logic (an allow-list drifts and would re-block faithful
+clicks the count already mints).
+
+conservative-RECOGNITION (the design rule behind the accepted compound under-block;
+documented so a future sweep does NOT "discover" these forms and "harden" them into
+faithful-click over-blocks): recognition targets the SINGLE destructive command an honest
+agent runs (the destructive op plus the benign viewers/filters/redirects of benign-
+CONTINUATION above) and ERRS TOWARD LETTING THROUGH — over-blocking a faithful click is
+WRONG BY DEFINITION (the INVARIANT above), worse than missing a buried op. The ENTIRE
+flag-condition union arm (_flag_condition_danger_op) needs a positional, quote-aware
+parse — the close/branch-delete/force-push flag conditions AND the git-push
+remote-ref-delete (`:ref` / `--delete` / `-d`) / mass-delete (`--mirror` / `--prune` /
+multi-ref) extractors — so its recognition is ANCHORED to the FIRST executable leg (the
+_executable_prefix view): it does NOT chase those ops into NON-FIRST compound legs, and
+it derives FLAGS from that same leg (deriving flags from the WHOLE command while
+positionals came from the first leg let a force/delete flag in a benign continuation leg
+mislabel a benign first-leg op — the cross-leg flag leak). Chasing them needs a
+match-anywhere / per-leg scan that fires on a quoted `:ref` / `--mirror` mention in a
+benign leg — an over-block of a faithful click. The ACCEPTED price is that these forms
+run UNGATED when the destructive op is not the first leg:
+  - `cd /repo && git push origin --delete main`
+  - `git fetch && git push --mirror origin`
+  - `NOTE=x ; git push origin :main`
+  - `cd /repo && git branch -Df temp`   (cluster force-delete; idiomatic `-D` still caught per-leg, in any leg)
+  - `cd /repo && gh pr close 5 -d`      (short `-d` close; spelled `--delete-branch` still caught per-leg, in any leg)
+These are NOT bugs — do NOT "fix" them (the fix re-blocks faithful clicks). httpie
+(`http` / `https` CLI) is likewise WHOLLY ungated by design — ref-mutation, merge, AND
+protection-mutation — because the MINT classifier covers gh-api / curl / wget only; ANY
+httpie read-floor arm re-creates a gated-but-unmintable over-block. Ungated keeps read == mint.
+NB this first-leg anchoring is SPECIFIC to those parse-dependent forms: the LITERAL
+danger arms (the DANGEROUS_PATTERNS bank + the per-leg literal-arm tuples: force-push,
+branch-delete, close, API ref/protection) match in ANY leg position (per-leg for the
+tuple arms) and STILL gate in a non-first leg
+(`cd /repo && git push --force origin main` is caught). PUSH-TO-MAIN (and the `+refspec`
+force spelling) are ALSO gated in ANY leg (#1195 OBS-E/F-PL): the accurate refspec-DST
+predicate `_flag_condition_danger_op` is additionally invoked PER-LEG by its callers
+(detect_command_operation_type + _stripped_surface_danger), filtered to
+`_PER_LEG_PUSH_OPS` — so `cd /repo && git push origin main` is caught. (delete/mirror/:ref
+non-first-leg forms above STAY ungated — the per-leg push filter excludes them.) When an
+over-block of a faithful click is found, the fix WIDENS the mint, never narrows detection
+into a new under-block.
+=============================================================================
+
+Centralizes TOKEN_TTL, TOKEN_DIR, TOKEN_PREFIX, consumed-token cleanup,
+the regex-prefix constants (_GH_PREFIX, _GIT_PREFIX, etc.) and the
+canonical destructive-command operation-type classifier
+detect_command_operation_type. Both hooks call this classifier on the
+SAME input when the prose-embed convention holds, guaranteeing
+bidirectional write/read classification agreement (issue #720 Bug B).
+
+Token-lifecycle invariants (pinned by tests/test_merge_guard.py class
+TestTokenLifecycleInvariants):
+
+  I-1 (at most one unused token at any time):
+      cleanup_unused_tokens() is called from write_token() BEFORE
+      os.open(O_EXCL). Any prior unused token is atomically renamed to
+      .consumed before the new one exists on disk.
+
+  I-2 (successful operation immediately retires the token):
+      merge_guard_post.main() Bash branch detects successful
+      `gh pr merge` (dict-shape tool_response + interrupted=false +
+      op_type=merge + "Merged pull request" in stdout) and atomically
+      renames the consuming token to .consumed regardless of MAX_USES.
+
+  I-3 (TTL expiry retires the token):
+      merge_guard_pre.find_valid_token enforces `expires_at < now` and
+      removes expired tokens via _safe_remove. Audit-only invariant in
+      this module (no helper here; pinned by alias test).
+
+  I-4 (failed operation preserves token for retry within TTL up to MAX_USES):
+      merge_guard_pre._consume_token N-use slot semantics. .use-N
+      markers atomically claim slots via O_EXCL; final slot triggers
+      terminal .consumed rename. Audit-only invariant in this module.
+
+  I-5 (cross-session tokens never valid):
+      merge_guard_pre.find_valid_token enforces
+      current_session == token_session when both are present. Audit-
+      only invariant in this module.
+
+Cross-cutting cleanup: cleanup_orphan_tokens() reaps unconsumed tokens
+whose mtime exceeds ORPHAN_TOKEN_MAX_AGE_SECONDS (12x TOKEN_TTL).
+Triggered from merge_guard_pre.find_valid_token (primary, load-bearing
+on every dangerous-Bash precheck) and session_init.main (secondary,
+eager-cleanup at session start). Disk-hygiene defense — not a primary
+security check; the primary check is I-3 TTL expiry (bounded by TOKEN_TTL).
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import re
+import shlex
+import time
+from collections.abc import Sequence
+from pathlib import Path
+from typing import NamedTuple
+
+from .paths import get_claude_config_dir
+
+# Token TTL in seconds
+TOKEN_TTL = 900
+
+# Directory for token files. B2 (import-time binding): CLAUDE_CONFIG_DIR is
+# fixed per-process before this module is imported, so an eager SSOT-derived
+# read is production-correct here; the merge-guard tests patch THIS attribute
+# (not the env), so they stay valid and non-vacuous. Derive from the SSOT
+# resolver eagerly — do NOT re-hardcode Path.home()/".claude" (that breaks the
+# single-source-of-truth). Convert to a call-time accessor only if call-time
+# env-following is ever needed (TOKEN_DIR's write+read are both PACT-side, so it
+# never needs to follow a post-import env change).
+TOKEN_DIR = get_claude_config_dir()
+
+# Token file prefix
+TOKEN_PREFIX = "merge-authorized-"
+
+# Default max-use budget per authorization token. A token can authorize up
+# to MAX_USES identical-context retries within TOKEN_TTL before requiring
+# fresh AskUserQuestion approval. Set to 2 — the smallest N that resolves
+# the empirical retry-on-transient-failure case (single retry of an
+# identical command) without further eroding per-use-confirmation
+# discipline. A third identical retry still re-prompts via
+# AskUserQuestion, preserving the "stop and reconsider" checkpoint.
+# Audit: tightening this value is always safe (more re-prompting);
+# loosening (N>2) requires empirical justification — there is no current
+# case that needs >2 same-context retries.
+MAX_USES = 2
+
+# Suffix used by per-use marker files. Each marker file is created via
+# O_EXCL to atomically claim one use slot of an N-use token (#720 Bug C).
+USE_MARKER_SUFFIX = ".use-"
+
+# Orphan-token cleanup threshold, derived as a fixed multiple of TOKEN_TTL so the
+# two never drift. Tokens that survive past this window without being consumed or
+# used are reaped as disk hygiene — they cannot be legitimate (TOKEN_TTL already
+# expires them for authorization). 12x TOKEN_TTL gives strong margin against any
+# legitimate in-flight token while aggressively bounding accumulation. Disk-hygiene
+# defense — not a primary security check; the primary check is TOKEN_TTL expiry
+# (invariant I-3).
+ORPHAN_TOKEN_MAX_AGE_SECONDS = 12 * TOKEN_TTL
+
+# Layer 1 Block 3 (gh CLI / git semantic signal) per op_type — SEC-S2 cycle-2.
+# Each value is a substring that MUST appear in tool_response.stdout for the
+# op_type's successful invocation to retire the consuming token. A value of
+# None means "skip Block 3 for this op_type": the 3-block predicate degrades
+# to 2 blocks (Block 1 op_type match + Block 2 platform success signal).
+# force-push uses None because git push --force emits primarily to STDERR;
+# the empty-STDOUT case is fail-closed-on-no-signal (no retirement degrades
+# to TTL/MAX_USES safety net). New op_types: add 1 entry + tests; no other
+# changes required (lookup table is the SSOT, mirrors DANGEROUS_PATTERNS
+# convention).
+LAYER1_SUCCESS_STDOUT_PATTERNS: dict[str, str | None] = {
+    "merge": "Merged pull request",
+    "close": "Closed pull request",
+    "branch-delete": "Deleted branch",
+    "force-push": None,
+    # push-to-main (GAP3): a plain `git push` to main/master — emits to STDERR like
+    # force-push, so None (Block 3 skipped; Block 2 platform-success is load-bearing,
+    # fail-closed-on-no-signal → TTL/MAX_USES safety net, not bypass).
+    "push-to-main": None,
+}
+
+# -----------------------------------------------------------------------------
+# Regex prefix constants — shared between DANGEROUS_PATTERNS (read-side) and
+# detect_command_operation_type (both sides). Centralized here so the
+# write-side classifier can apply the SAME prefix semantics as the read-side
+# pattern bank without duplicating regex source.
+# -----------------------------------------------------------------------------
+
+# Upper bound on flag tokens in a CLI flag region. Governs BOTH the global-flag
+# prefix between a tool and its subcommand (e.g. `git -c k=v ... push`) AND the
+# push-dash-flag walk between `push` and its refspec (e.g. `git push -u -f main`).
+# The global-flag prefix bound eliminates the O(n^2) multi-anchor backtracking of
+# the unbounded `*` form (#1001); the push-dash-flag walk bound is defense-in-
+# depth structural-linearity (that walk was already linear once the prefix is
+# bounded — bounding the inner walk makes its linearity intrinsic rather than
+# contingent). Both preserve the "matches any token" semantics EXACTLY for any
+# command with <= _MAX_GLOBAL_FLAG_TOKENS flag tokens in that region — i.e. every
+# realistic command (the heaviest realistic git global-flag count, e.g.
+# `git -c a=1 -c b=2 -C /p --git-dir=/g --work-tree=/w push ...`, is ~10 tokens;
+# gh is ~2; push dash-flags ~2-3). 32 is ~3x that headroom, and is a fixed modest
+# constant so per-anchor work is O(32)=O(1) regardless of input length.
+#
+# ACCEPTED RESIDUAL (honest INV-D2 accounting): a command with >32 *valid* flag
+# tokens before its verb/refspec is NOT impossible — `git -c k=v` is a
+# legitimate, repeatable pair, so e.g. `git -c a=1 -c b=2 ...(17 pairs=34
+# tokens)... push --force` DOES execute yet exceeds the bound, so the bounded
+# form misses a real destructive op the unbounded form caught. This is a
+# NARROW residual under-block, accepted as a documented tradeoff against the
+# O(n^2) DoS, justified by the THREAT MODEL: #1001's input is operator/LLM-
+# authored command text (defense-in-depth, NOT adversarial network input), and
+# padding 17+ `-c` pairs to evade one's OWN merge guard is self-defeating (the
+# author would simply write the command directly). The push-dash-flag walk
+# carries the SAME residual class but is even less reachable (push dash-flags are
+# not meaningfully infinitely-repeatable; a flag with a non-dash value, e.g.
+# `-o <opt>`, already breaks the walk). It is a relaxation of INV-D2, not a
+# no-op — stated plainly rather than papered over.
+# DO NOT raise this constant casually: a larger cap scales the per-anchor work,
+# and on a pathological multi-anchor input the constant factor grows measurably
+# (a larger value carries a real, if modest, cost — it is not free). Keep it a
+# small fixed value so per-anchor work stays O(1)/linear.
+_MAX_GLOBAL_FLAG_TOKENS = 32
+
+# Optional global flags between CLI tool and subcommand — BOUNDED (was `*`).
+_GH_GLOBAL_FLAGS  = r"(?:\S+\s+){0,%d}" % _MAX_GLOBAL_FLAG_TOKENS
+# Tight variant for PR-number extraction — UNCHANGED (already linear; requires
+# a leading `-` per token so it fails fast; used only by _GH_PR_NUMBER_RE).
+_GH_FLAG_TOKENS   = r"(?:-\S*(?:\s+\S+)?\s+)*"
+_GIT_GLOBAL_FLAGS = r"(?:\S+\s+){0,%d}" % _MAX_GLOBAL_FLAG_TOKENS
+
+# Composed prefixes for DRY usage across all patterns.
+_GH_PREFIX = r"\bgh\s+" + _GH_GLOBAL_FLAGS
+_GIT_PREFIX = r"\bgit\s+" + _GIT_GLOBAL_FLAGS
+_GH_API_PREFIX = _GH_PREFIX + r"api\b"
+
+# The quote-BALANCED value token (#1118 re-model) — the single Q-SAFE primitive the
+# verb-message value strips consume via _strip_flag_values (arm 3, shared by carriers
+# 5/7/7b/7c/7d/8/9). A value token is a maximal run of bash quoted/escaped word pieces,
+# ending at unquoted whitespace. Because it consumes quoted spans ATOMICALLY it can never
+# bite a PARTIAL quoted span (a lone quote is not a complete `'…'`/`"…"`/`$'…'`), so it
+# structurally CANNOT emit a dangling quote into the `stripped` string that
+# _mask_shell_quotes / _slice_stripped_legs consume — the root-cause fix for the SEC-1/SEC-2
+# leg-merge regression. Its arm set mirrors _VERB_MSG_BODY below (bash's five quoting
+# mechanisms + backslash-escape), differing only in the plain-char class `[^\s'"$\\]` (a
+# value ends at unquoted whitespace) and the closing `+`. Inner quoted-span alternations are
+# first-char-disjoint (linear); the outer arms overlap only at the three `$`-initial arms, a
+# bounded per-unit ambiguity (both partitions reach the same offset) that cannot compound,
+# and the token matches only in trailing position so the greedy match never backtracks.
+# Linearity is verified empirically (the regex-perf suite + adversarial `$'…'`-repetition
+# timing).
+_VALUE_TOKEN = (
+    r"""(?:\\.|\$'(?:[^'\\]|\\.)*'|\$?"(?:[^"\\]|\\.)*"|'[^']*'|[^\s'"$\\]|\$)+"""
+)
+
+# Bash-faithful verb-message span BODY: a command's words from the verb to the first
+# UNQUOTED ;/&&/|/newline. Models ALL FIVE bash quoting mechanisms + backslash-escape so
+# it can NEVER desync quote-pairing and pair a `'` across a separator (the naive
+# `'[^']*'`-only body's leg-merge under-block). Arms in order:
+#   \\.                        backslash-escape OUTSIDE quotes (\'  \;  \&  \"  \\ …)
+#   \$'(?:[^'\\]|\\.)*'        ANSI-C  $'...'  (backslash honored inside)
+#   \$?"(?:[^"\\]|\\.)*"       double-quote "..." AND locale $"..." (backslash honored)
+#   '[^']*'                    single-quote '...'  (bash: NO escaping inside)
+#   [^&|;\n"'$\\]+             plain chars (excl. separators, quotes, $, backslash)
+#   \$                         a bare $ (e.g. $VAR)
+# Separators ;&|newline are excluded from EVERY arm, so the span stops at a real unquoted
+# separator. Shared SSOT for all verb-message carriers (5, 7/7b/7c/7d, curl) — replaces 7
+# former inline copies so they can never drift.
+_VERB_MSG_BODY = (
+    r"""(?:\\.|\$'(?:[^'\\]|\\.)*'|\$?"(?:[^"\\]|\\.)*"|'[^']*'|[^&|;\n"'$\\]+|\$)*"""
+)
+
+# Shared message-flag anchor (flag_sep group 1) for the sibling message-carrying git
+# verbs whose SOLE value-taking --m* option is --message — git merge, git stash
+# push/store, git notes add/append (verified via `git <verb> -h`, 2.50.1). The long
+# arm accepts any unambiguous abbreviation of --message (--m -> --message); the short
+# arm covers -m / bundled / attached. EXACTLY ONE capturing group (internals are all
+# non-capturing) so it satisfies the _strip_flag_values contract. This is byte-identical
+# to the git-commit anchor (carrier-5) but kept as a SEPARATE constant: the commit
+# carrier stays a self-contained literal, and git tag needs a DIFFERENT bounded variant
+# (its --merged/--no-merged collision), so the three are intentionally not unified.
+# The short cluster arm is TOKEN-START anchored `(?<!\S)` so it can only match a `-`
+# beginning a word: without it, `-[a-ln-zA-Z]*m` mis-matches MID-FLAG inside a longer
+# option (`-com` in `--committer`, `-adm` in `--admin`, `-am` in `--amend`), which lets
+# carrier-7e's git-merge span mangle a `git log --committer '…merge…'` surface and leave
+# the danger visible (an over-block). Genuine token-start clusters (`-m`, `-am`, `-cm`)
+# are whitespace-preceded so the anchor still admits them (no strip regression).
+_MSG_FLAG_ANCHOR = r"((?:--m(?:e(?:s(?:s(?:a(?:g(?:e)?)?)?)?)?)?|(?<!\S)-[a-ln-zA-Z]*m)\s*)"
+
+# Pre-compiled patterns for the operation-type classifier (consistent with
+# DANGEROUS_PATTERNS style).
+_GH_PR_MERGE_RE = re.compile(_GH_PREFIX + r"pr\s+merge\b")
+_GH_PR_CLOSE_RE = re.compile(_GH_PREFIX + r"pr\s+close\b")
+
+# Literal force-push arms — ONE arm-list SSOT consumed by BOTH the read floor
+# (is_dangerous_command) and the mint classifier (detect_command_operation_type),
+# so the two sides can never drift on a spelling. Matched PER-LEG over the shared
+# leg-boundary substrate (#1082): these arms' `.*` spans previously ran over the
+# WHOLE command, so a force-class flag in a benign continuation leg
+# (`git push origin feature && rm -f stale.txt`) gated the benign first-leg push —
+# one form (`git push && rm -f x.txt`) PERMANENTLY (no extractable target ->
+# unmintable). Semantics now: an arm fires iff push and the force-class flag
+# co-occur within ONE leg, in ANY leg position — `cd /repo && git push --force
+# origin main` still gates (deliberately DIFFERENT from the union arm's first-leg
+# anchoring; the literal floor keeps its match-anywhere purpose, per leg). Quoted
+# separators are handled by the substrate (a quoted `&&` is not a leg boundary) —
+# a tempered-regex span (`[^&|;]*`) would wrongly ungate that form.
+_FORCE_PUSH_LITERAL_ARMS = (
+    re.compile(_GIT_PREFIX + r"push\s+.*--force(?!-with-lease)\b"),
+    re.compile(_GIT_PREFIX + r"push\s+.*-f\b"),
+    re.compile(_GIT_PREFIX + r"push\s+-[a-zA-Z]*f"),
+)
+
+# leg-boundary substrate (#1087): these close arms' `.*`/lookahead previously ran
+# over the WHOLE stripped command, so a `--delete-branch` token in a benign
+# continuation leg fired the arm cross-leg. That over-reach ALSO laundered: the
+# ambiguous multi-close `gh pr close 42 && gh pr close 43 && echo --delete-branch`
+# was is_dangerous=True whole-command, so it minted a close token that AUTHORIZED an
+# escalated same-target single `gh pr close 42 --delete-branch`. Semantics now: an
+# arm fires iff `gh pr close` and `--delete-branch` co-occur within ONE leg, in ANY
+# leg position — so the ambiguous compound is is_dangerous=False per-leg (the mint
+# write-gate refuses -> no token -> laundering structurally dead) while a real
+# single-leg `gh pr close 42 --delete-branch` still gates. Quoted separators are
+# handled by the substrate (a quoted `&&` is not a leg boundary). Bodies are moved
+# VERBATIM from DANGEROUS_PATTERNS — the conversion changes WHERE they match
+# (per-leg vs whole-command), never WHAT they match.
+_CLOSE_LITERAL_ARMS = (
+    re.compile(_GH_PREFIX + r"pr\s+close\b(?=.*--delete-branch)"),   # forward
+    re.compile(r"--delete-branch.*" + _GH_PREFIX + r"pr\s+close\b"),  # reversed
+)
+
+# leg-boundary substrate (#1086): these 17 API danger arms' `.*` previously ran
+# over the WHOLE stripped command, so a mutating method / body-flag token in a
+# benign continuation leg (`gh api .../git/refs && echo -X DELETE`) over-blocked
+# the benign compound. Matched PER-LEG now: an arm fires iff the API client, the
+# mutating method (or implicit-POST body flag), and the target endpoint co-occur
+# within ONE leg. The negative-lookahead arms operate WITHIN a leg — a same-leg
+# explicit GET correctly excludes, and a body flag in a DIFFERENT leg no longer
+# wrongly includes. Bodies are moved VERBATIM from DANGEROUS_PATTERNS (flags —
+# re.IGNORECASE — lookaheads, and _GH_API_PREFIX/curl/wget prefixes unchanged);
+# the conversion changes WHERE they match, never WHAT they match. No-laundering
+# safety is preserved BY CONSTRUCTION, not by denylist-emptiness: an isolated API
+# leg is method-less hence detect-negative, so tier 2 abstains → symmetric
+# whole-command bind (the safe direction) — see TestEmergentDangerClassIsCloseOnly.
+_API_LITERAL_ARMS = (
+    # API-based merge bypasses (require mutating HTTP method to avoid blocking reads)
+    re.compile(_GH_API_PREFIX + r"(?=.*(?:-X|--method)\s+(?:PUT|PATCH|POST)\b).*merge", re.IGNORECASE),
+    re.compile(r"\bcurl\b(?=.*(?:-X|--request)\s+(?:PUT|PATCH|POST)\b).*api.*merge", re.IGNORECASE),
+    # API-based branch deletion via DELETE to git/refs endpoint.
+    # HOST-AGNOSTIC (#1061): the curl arms drop the literal `.*api.*` substring so a
+    # truly api-free Enterprise/proxy URL (e.g. https://git.example.com/repos/o/r/git/refs/...)
+    # no longer bypasses — bringing curl to parity with the already-host-agnostic
+    # gh-api/wget arms. The `api` key was an as-shipped heuristic (#268/#271), not a
+    # deliberated scope ruling; this WIDENS it. The over-block this widening would introduce
+    # on a quoted `-d` body mentioning git/refs is closed by carrier-8 (the HTTP-client
+    # data-body strip in _strip_non_executable_content) — the body value is stripped while
+    # the path-resident ref survives (PATH-vs-BODY invariant).
+    re.compile(_GH_API_PREFIX + r"(?=.*(?:-X|--method)\s+DELETE\b).*git/refs", re.IGNORECASE),
+    re.compile(r"\bcurl\b(?=.*(?:-X|--request)\s+DELETE\b).*git/refs", re.IGNORECASE),
+    # API-based ref mutation / force push via mutating method to git/refs endpoint
+    # (any mutating operation on git refs via API is inherently dangerous). Curl arm is
+    # host-agnostic (#1061) — see the DELETE arm note above.
+    re.compile(_GH_API_PREFIX + r"(?=.*(?:-X|--method)\s+(?:PATCH|POST|PUT)\b).*git/refs", re.IGNORECASE),
+    re.compile(r"\bcurl\b(?=.*(?:-X|--request)\s+(?:PATCH|POST|PUT)\b).*git/refs", re.IGNORECASE),
+    # Branch-protection API mutation (#1063): DELETE|PUT|PATCH on a
+    # `branches/<branch>/protection` endpoint WEAKENS protection (remove / replace /
+    # modify whole config). POST is EXCLUDED — it ENABLES protection sub-features
+    # (enforce_admins / required_signatures) = the STRENGTHENING direction, so gating it
+    # would over-block. HOST-AGNOSTIC (the #1061 lesson — no `.*api.*`). Explicit-method
+    # arms only (the protection endpoint has no implicit-POST danger like git/refs). The
+    # branch is PATH-resident, so carrier-8 never strips it (no preservation guard needed,
+    # unlike the body-resident contents arm). No httpie arm: the mint classifier's
+    # `_is_api_form` is gh-api/curl/wget only, so adding an httpie read arm would create a
+    # gated-but-unmintable over-block — omitted by design (httpie is WHOLLY out of charter;
+    # its ref-mutation/merge arms were removed with it).
+    re.compile(_GH_API_PREFIX + r"(?=.*(?:-X|--method)\s+(?:DELETE|PUT|PATCH)\b).*branches/.*/protection", re.IGNORECASE),
+    re.compile(r"\bcurl\b(?=.*(?:-X|--request)\s+(?:DELETE|PUT|PATCH)\b).*branches/.*/protection", re.IGNORECASE),
+    re.compile(r"\bwget\b(?=.*--method=(?:DELETE|PUT|PATCH)\b).*branches/.*/protection", re.IGNORECASE),
+    # gh api implicit POST: body param flags (-f, -F, --field, --raw-field, --input)
+    # cause gh api to default to POST. Dangerous when targeting git/refs or merge.
+    # Negative lookahead excludes explicit GET (which overrides implicit POST).
+    re.compile(_GH_API_PREFIX + r"(?!.*(?:-X|--method)\s+GET\b)(?=.*(?:-f|-F|--field|--raw-field|--input)\s).*git/refs", re.IGNORECASE),
+    re.compile(_GH_API_PREFIX + r"(?!.*(?:-X|--method)\s+GET\b)(?=.*(?:-f|-F|--field|--raw-field|--input)\s).*merge", re.IGNORECASE),
+    # curl implicit POST: --data/-d/--data-raw/--data-binary flags cause curl to
+    # default to POST. Dangerous when targeting git/refs or merge API endpoints.
+    # Negative lookahead excludes explicit GET (which overrides implicit POST).
+    re.compile(r"\bcurl\b(?!.*(?:-X|--request)\s+GET\b)(?=.*(?:--data(?:-(?:raw|binary))?|-d)\s).*git/refs", re.IGNORECASE),
+    re.compile(r"\bcurl\b(?!.*(?:-X|--request)\s+GET\b)(?=.*(?:--data(?:-(?:raw|binary))?|-d)\s).*api.*merge", re.IGNORECASE),
+    # Contents API: write operations (PUT/PATCH/POST) to /contents/ endpoint
+    # targeting main or master branch. Flags any mutating /contents/ call that
+    # mentions main or master anywhere in the command (acceptable false positive).
+    re.compile(_GH_API_PREFIX + r"(?=.*(?:-X|--method)\s+(?:PUT|PATCH|POST)\b).*contents/.*(?:main|master)", re.IGNORECASE),
+    re.compile(r"\bcurl\b(?=.*(?:-X|--request)\s+(?:PUT|PATCH|POST)\b).*api.*contents/.*(?:main|master)", re.IGNORECASE),
+    # Alternative HTTP clients: wget with --method flag
+    re.compile(r"\bwget\b(?=.*--method=(?:DELETE|PATCH|POST|PUT)\b).*git/refs", re.IGNORECASE),
+    re.compile(r"\bwget\b(?=.*--method=(?:DELETE|PATCH|POST|PUT)\b).*merge", re.IGNORECASE),
+    # Known API detection gaps (defense-in-depth, not a security boundary):
+    # - GraphQL mutations: gh api graphql -f query='mutation { ... }' bypasses REST-path matching
+    # - gh alias: aliases can hide API calls (tracked in #270)
+)
+
+# leg-boundary substrate (#1094): these three branch-delete arms' `.*` previously
+# ran over the WHOLE stripped command, so an idiomatic `-D` / `--delete --force`
+# token in a benign continuation leg (`git branch new-feature && echo -D`) gated
+# the benign compound — and, because the whole-command classifier ALSO returned
+# branch-delete for it, the ambiguous compound was MINTABLE from a click whose
+# branch leg was benign (the close-twin laundering shape). Matched PER-LEG now:
+# an arm fires iff `git branch` and the force-delete flag co-occur within ONE
+# leg, in ANY leg position (`cd /repo && git branch -D temp` still gates —
+# match-anywhere purpose preserved, per leg). Quoted separators are handled by
+# the substrate (a quoted `&&` is not a leg boundary). Bodies are moved VERBATIM
+# from DANGEROUS_PATTERNS — the conversion changes WHERE they match (per-leg vs
+# whole-command), never WHAT they match. Per-leg scoping also bounds the arms'
+# `\s+` runs: whole-command they DID span a raw newline — the one whitespace-class
+# leg separator — so `git branch --force<newline>--delete x` (two non-destructive
+# legs) previously gated; bounding `\s+` is the same over-block-cure direction. Clustered /
+# split spellings (`-Df` / `-fD` / `--delete -f`) are NOT these arms' job: they
+# are the union arm's (first-leg-anchored, by design).
+_BRANCH_DELETE_LITERAL_ARMS = (
+    re.compile(_GIT_PREFIX + r"branch\s+.*-D\b"),
+    re.compile(_GIT_PREFIX + r"branch\s+.*--delete\s+--force\b"),
+    re.compile(_GIT_PREFIX + r"branch\s+--force\s+--delete\b"),
+)
+
+
+def detect_command_operation_type(command: str) -> str | None:
+    """Detect the operation type of a destructive command.
+
+    Canonical classifier called from BOTH merge guard hooks. When the
+    AskUserQuestion text (post-hook) embeds a literal command in a quoted
+    region, the post-hook delegates to this function on the embedded
+    command — guaranteeing the post-hook's operation_type tag matches
+    what the pre-hook will compute for the same literal command, closing
+    the asymmetric-classifier bug class (#720 Bug B).
+
+    Returns:
+        "merge"         - gh pr merge
+        "close"         - gh pr close (any variant)
+        "force-push"    - git push --force / git push -f (excludes --force-with-lease);
+                          API PATCH/POST/PUT to git/refs (ref rewrite)
+        "push-to-main"  - git push <remote> main/master WITHOUT --force, incl.
+                          --force-with-lease pushes (review-bypass, distinct from
+                          force-push so neither token authorizes a force-push; plain
+                          and lease pushes mint DIFFERENT tokens via the
+                          --force-with-lease presence bind in PRIVILEGED_FLAGS)
+        "branch-delete" - git branch -D / git branch --delete --force / gh pr close --delete-branch;
+                          API DELETE to git/refs (ref removal)
+        "remote-ref-delete" - git push delete of a SINGLE remote ref (#1062a):
+                          push <remote> :ref / --delete ref / -d ref (incl. implicit
+                          remote). Union-arm-only; recognized IFF a single deletable
+                          ref is extractable (recognition⟺mintability by construction)
+        "remote-mass-delete" - git push MASS delete (#1062b): --mirror / --prune /
+                          multi-ref delete. Union-arm-only; recognized IFF a normalized
+                          mass-target tuple is extractable (single-ref defers to
+                          remote-ref-delete — the BOUNDARY discriminator, no double-classify)
+        "branch-protection" - API mutation WEAKENING branch protection (#1063):
+                          gh-api/curl/wget DELETE|PUT|PATCH on a branches/<b>/protection
+                          endpoint (host-agnostic; POST EXCLUDED = strengthening direction)
+        None            - destructive shape not in the recognized set
+                          (read-side caller treats None as "untyped command",
+                          which the tightened token-match semantic treats as
+                          a deny-on-typed-token signal rather than permissive)
+    """
+    # TWO-PASS (view-first, raw fallback): recognition's PRIMARY surface for the
+    # gh-pr PROSE arms is the executed-surface view — quoted data (a --comment/-m
+    # message) is masked, so an op keyword living in prose no longer classifies
+    # (the cross-auth cure: `gh pr close 5 --comment '…gh pr merge 5…'`
+    # classifies close, not merge, so mint and read bind the SAME faithful
+    # (op, target)). The raw fallback pass is arm-for-arm equivalent to the
+    # pre-view classifier, so every currently-recognized spelling keeps its
+    # non-None result BY CONSTRUCTION — load-bearing for the module INVARIANT:
+    # a wrapped faithful click (`bash -c 'gh pr merge 5'`) classifies None on
+    # the view (its payload is masked) and the read side REFUSES on a None op,
+    # so a view-only detect would permanently block it.
+    #
+    # ONLY the gh-pr merge/close arms consult the view. Every push/branch arm
+    # runs on RAW in BOTH passes: those are POSITIONAL / flag-presence
+    # classifiers, and masking a cosmetically-quoted EXECUTING token (a quoted
+    # remote name — `git push 'origin' --delete main`) turns it into a
+    # whitespace gap that a positional regex binds ACROSS, downgrading the op
+    # (remote-ref-delete → push-to-main) and laundering a benign push-to-main
+    # token into a delete authorization. The gh-pr prose arms are presence
+    # detectors with no positional mask-gap bind, so they carry no analogue.
+    view = _executed_surface_view(command)
+    legs = _split_into_legs(command)
+    op = (
+        _detect_op_pass(command, view, legs)      # view pass (gh-pr prose arms on view)
+        or _detect_op_pass(command, command, legs)  # raw fallback == pre-view classifier
+    )
+    if op is not None:
+        return op
+    # PER-LEG push arms (OBS-E/F-PL): restore the ANY-LEG push-to-main/force-push coverage
+    # the removed whole-string DANGEROUS_PATTERNS rows carried — the union arm is FIRST-LEG-
+    # anchored, so a push in a non-first leg (`cd /repo && git push origin main`) needs a
+    # per-leg call. CALLER-LEVEL (not inside _detect_op_pass): reached ONLY after BOTH passes
+    # return None, so every existing classification is byte-stable (the api-merge additive
+    # precedent), and the raw-fallback gh-pr arms still run before this (so
+    # `bash -c 'gh pr merge 5' && git push origin main` stays merge, not push-to-main).
+    for _leg in legs:
+        _lop = _flag_condition_danger_op(_leg)
+        if _lop in _PER_LEG_PUSH_OPS:
+            return _lop
+    return None
+
+
+def _detect_op_pass(
+    command: str,
+    surface: str,
+    raw_legs: "list[str]",
+) -> str | None:
+    """One precedence-ordered classification pass, parameterized by surface.
+
+    - `surface`: the string the gh-pr PROSE arms (merge/close) match. View pass:
+      the executed-surface view; fallback pass: the raw command. These are the
+      ONLY view-consulting arms (presence detectors — no positional mask-gap).
+    - `command` / `raw_legs` are ALWAYS the raw inputs — every other arm
+      consumes them in BOTH passes and MUST NOT move to the view:
+        * force-push / push-to-main (both arms) / branch-delete: positional or
+          flag-presence classifiers on git commands — masking a cosmetically-
+          quoted EXECUTING token (quoted remote) lets the positional arm bind
+          across the gap and DOWNGRADE the op (the quoted-remote-delete
+          laundering), or hides a quoted flag from a higher-precedence arm.
+          RAW == the certified base behavior for these classes.
+        * gh-api/curl/wget git-refs + branches/protection arms: a quoted
+          `gh api 'repos/o/r/git/refs/…' -X DELETE` is a faithful MINTING
+          spelling; the view blanks the quoted URL, so a view-side match would
+          make it gated-but-unmintable (a cardinal over-block).
+        * _api_merge_leg_endpoint: recognition⟺extractability coupling — the
+          leg classifies merge IFF its endpoint-position PR is extractable from
+          the SAME surface; masking would decouple them.
+        * _flag_condition_danger_op: already quote-aware via shlex and embeds
+          the remote-ref/mass-delete extractors (recognition⟺mintability); a
+          masked input would break quoted-refspec (`':main'`) extraction.
+    Precedence order is byte-identical to the pre-view classifier."""
+    # Order matters: gh pr close --delete-branch is BOTH a close and a
+    # branch-delete operation; the AskUserQuestion-side classifier
+    # (extract_context) tags it as "close" in priority order, so match
+    # the same precedence here for write/read symmetry.
+    if _GH_PR_MERGE_RE.search(surface):
+        return "merge"
+    if _GH_PR_CLOSE_RE.search(surface):
+        # gh pr close --delete-branch is a close-type operation per the
+        # write-side classifier. Branch-delete-via-pr-close is folded into
+        # the close class on both sides for symmetric authorization.
+        return "close"
+    # force-push: git push ... --force (excludes --force-with-lease — carved out
+    # of the force-push arms ONLY; the push-to-main arm still gates lease pushes
+    # to a default branch). Matched PER-LEG over the shared _FORCE_PUSH_LITERAL_ARMS
+    # SSOT (#1082) — the same arm list the read floor consumes, over the same leg
+    # substrate (_split_into_legs), so a force-class flag in a benign continuation
+    # leg no longer classifies the first-leg push as force-push and read==mint
+    # holds by construction on this class.
+    for _leg in raw_legs:
+        if any(arm.search(_leg) for arm in _FORCE_PUSH_LITERAL_ARMS):
+            return "force-push"
+    # Direct push to a default branch (main/master) — plain OR --force-with-lease —
+    # is a review-bypass, a DISTINCT op from force-push. It is now recognized by the
+    # UNIFIED refspec-DST predicate in the shared `_flag_condition_danger_op` push-to-main
+    # arm (#1195 OBS-E), reached via the union-arm fallback at the END of this function —
+    # so the former inline literals here (a `HEAD:(?:main|master)` arm + a bounded-flag-walk
+    # `(?:main|master)(?!:)` arm) were REMOVED. The unified predicate is accurate BOTH ways
+    # the literals were not (it excludes main-release/main.foo prefix over-blocks and
+    # catches feature:main / refs/heads/main under-blocks), and being the single shared arm
+    # both detect and the read floor call it is mint==read by construction. The --force/-f
+    # checks ABOVE still run first (a forced push to main returns force-push).
+    # API-based ref-mutation forms (gh api / curl / wget targeting
+    # /git/refs with mutating HTTP methods) classify by HTTP semantic:
+    # DELETE → branch-delete class (removes a ref)
+    # PATCH/POST/PUT → force-push class (rewrites a ref without PR review)
+    # Symmetric with how a force-push or branch-delete token from
+    # extract_context() would authorize the equivalent CLI form.
+    # gh-api recognition uses the TOLERANT `_GH_API_PREFIX` (same as the read floor)
+    # so a `gh -R o/r api ...` global-flag spelling MINTS instead of gating-on-read-
+    # but-not-minting (#1064 over-block). The METHOD checks below are IGNORECASE to
+    # match the IGNORECASE read floor, so a lowercase `-X delete` faithful form MINTS
+    # too. Both are mint-WIDENING (the read floor already gates these forms) — never a
+    # read-floor narrowing. Still gh-api/curl/wget only (NOT httpie), so no new
+    # gated-but-unmintable httpie state — and httpie now has NO read-floor arms at all
+    # (the read floor dropped them; httpie is wholly out of charter), so the invariant
+    # is two-sided.
+    _is_api_form = (
+        re.search(_GH_API_PREFIX, command, re.IGNORECASE)
+        or re.search(r"\b(?:curl|wget)\b", command, re.IGNORECASE)
+    )
+    if _is_api_form and "git/refs" in command:
+        if re.search(r"\bDELETE\b", command, re.IGNORECASE):
+            return "branch-delete"
+        if re.search(r"\b(?:PATCH|POST|PUT)\b", command, re.IGNORECASE):
+            return "force-push"
+    # branch-protection API mutation (#1063): DELETE|PUT|PATCH on a
+    # `branches/<b>/protection` endpoint WEAKENS protection (remove / replace /
+    # modify) — a DISTINCT op-class from branch-delete (it changes a config, not a
+    # ref). POST is EXCLUDED (it ENABLES protection sub-features = strengthening, so
+    # gating it would over-block). Path-disjoint from the git/refs arm above (a
+    # protection URL has no `git/refs`), so no shadowing. Method check is loose +
+    # IGNORECASE like the git/refs arm; the GAP1 write-gate (is_dangerous + the precise
+    # method-gated DANGEROUS_PATTERNS arms) ensures mint⊆read.
+    if _is_api_form and re.search(r"branches/.*/protection", command):
+        if re.search(r"\b(?:DELETE|PUT|PATCH)\b", command, re.IGNORECASE):
+            return "branch-protection"
+    # API-based PR merge (#1096, GH-API-ONLY per Option B): gh api with a mutating method
+    # (PUT/PATCH/POST) on a pulls/<N>/merge endpoint is a merge via API. curl/wget were
+    # DROPPED (sec #71: unsound value-flag denylist over an unbounded flag space) — they
+    # classify None and stay gated-but-unmintable. Recognized AND extracted by
+    # the ONE shared per-leg helper _api_merge_leg_endpoint, so recognition<->extractability
+    # read the SAME surface — a leg classifies merge IFF its ENDPOINT-position PR is
+    # extractable, which gives no gated-but-unmintable AND binds the URL-positional
+    # endpoint (never a flag-value / other-leg decoy — the #1096 target-confusion fix).
+    # ADDITIVE: this classifies inputs that were previously None (a genuine API merge)
+    # while leaving every EXISTING classification byte-identical. (It is NOT true that
+    # "every currently-None input stays None" — a genuine api-merge is correctly
+    # None->merge; that is the whole point of the arm. Only NON-merge inputs are
+    # unchanged.) Recognition predicate: tolerant IGNORECASE client (_GH_API_PREFIX, so a
+    # `gh -R o/r api` global-flag spelling also mints) + IGNORECASE PUT/PATCH/POST +
+    # case-SENSITIVE pulls/<N>/merge path. DELETE excluded; the implicit-POST (-f/--data,
+    # no method keyword) spelling is a deliberate residual, per the git/refs detect arm.
+    for _leg in raw_legs:
+        if _api_merge_leg_endpoint(_leg) is not None:
+            return "merge"
+    # branch-delete: git branch -D / --delete --force / --force --delete. Matched
+    # PER-LEG over the shared _BRANCH_DELETE_LITERAL_ARMS SSOT (#1094) — the same
+    # arm tuple the read floor consumes, over the same leg substrate
+    # (_split_into_legs), so a stray force-delete token in a benign continuation
+    # leg no longer classifies the compound as branch-delete, and read==mint
+    # holds by construction on this class (a command is gated via these arms iff
+    # some stripped leg matches iff detect classifies branch-delete here).
+    # Clustered spellings (-Df / -fD / --delete -f) fall through to the union-arm
+    # fallback below, same as the read floor.
+    for _leg in raw_legs:
+        if any(arm.search(_leg) for arm in _BRANCH_DELETE_LITERAL_ARMS):
+            return "branch-delete"
+    # Quote-aware normalized-flag FALLBACK (ADDITIVE, INV-AU): catches the
+    # clustered/split flag spellings the literal regexes above miss — chiefly
+    # `git branch -Df`/`-fD`/`--delete -f` (force-delete), which `-D\b` and the
+    # spelled-out `--delete --force` cannot see. Only reached when every literal
+    # check above has missed, so it can never override an established op-class
+    # precedence; it returns None when no flag-condition fires.
+    return _flag_condition_danger_op(command)
+
+
+# -----------------------------------------------------------------------------
+# Command-context extraction — the shared SSOT both hooks call on a COMMAND
+# STRING (never prose). The mint side (merge_guard_post) and the read side
+# (merge_guard_pre) both derive a command's (operation_type, target) from
+# extract_command_context, so the two arms can never classify the SAME command
+# differently again (the #720 / asymmetric-classifier bug class). A context key
+# is PRESENT only when positively extracted; ABSENT otherwise — absence, NOT a
+# None value, is the fail-closed signal a downstream gate keys on.
+# -----------------------------------------------------------------------------
+
+# PR-number positional extraction regex.
+#
+# Both flag-walks (between `gh` and `pr`, AND between the subcommand and the PR
+# number) use the tight `_GH_FLAG_TOKENS` form. A broad `_GH_GLOBAL_FLAGS` form
+# on the pre-subcommand walk would allow greedy consumption past a `gh pr
+# <subcmd> <PR>` substring inside `--body "..."` text, then re-anchor at a
+# SECOND `gh pr <subcmd>` occurrence embedded in the body — an authorization
+# bypass where the context check matched an embedded fake PR rather than the
+# real positional. Restricting both walks to flag-shaped tokens prevents walking
+# past the real positional into quoted body content.
+#
+# The trailing `(?![\w-])` rejects BOTH alphanumeric-suffix tokens (`7352abc`)
+# AND hyphen-suffix tokens (`7352-tests`). Python `\b` matches at a digit-to-
+# hyphen boundary (`-` is a non-word char), so a plain `\b` would incorrectly
+# capture `7352` from `7352-tests` (a branch-name argument). `(?![\w-])` is
+# strictly stronger: it rejects any continuation that is a word char OR a hyphen.
+_GH_PR_NUMBER_RE = re.compile(
+    r"\bgh\s+" + _GH_FLAG_TOKENS + r"pr\s+(?:merge|close)\s+"
+    + _GH_FLAG_TOKENS + r"(\d+)(?![\w-])"
+)
+
+# A quoted-command region inside prose: backticks (most common), then single
+# quotes, then double quotes; captures the content. When AskUserQuestion text
+# embeds the literal command in a quoted region (e.g. `gh pr merge 42`), the
+# SAME classifier the read side uses is applied to the embedded command,
+# guaranteeing bidirectional write/read agreement on the SAME input.
+_QUOTED_COMMAND_RE = re.compile(
+    r"`([^`]+)`"        # backticks
+    r"|'([^']+)'"       # single quotes
+    r'|"([^"]+)"'       # double quotes
+)
+
+# A bare (unquoted) `gh ...` / `git ...` command span: from the tool name up to
+# a shell separator (`;` `|` `&`), a quote, or end-of-line. The conservative
+# extractors below filter prose-polluted spans (a span that yields an op but no
+# target contributes no (op,target) pair), so over-capturing trailing prose is
+# harmless — it never invents a target.
+_BARE_COMMAND_RE = re.compile(r"\b(?:gh|git)\s+[^`'\";|&\n]+")
+
+# Allowlist of `gh pr merge|close` long-form flags KNOWN to take a value. The
+# defensive check in _extract_pr_number only rejects digits preceded by one of
+# these value-taking flags (avoiding false-positives on value-less flags like
+# `--admin`, `--auto`, `--squash` whose positional digit IS the PR). As of `gh`
+# v2 no real flag takes a digit value; this is a forward-compatible defense.
+# Extend this list when `gh` ships a flag that takes a numeric value.
+_GH_PR_VALUE_TAKING_FLAGS = frozenset({
+    "--body",
+    "--body-file",
+    "--subject",
+    "--author-email",
+    "--match-head-commit",
+    "--comment",
+    "--max-retries",
+    "--retry-count",
+    "--timeout",
+})
+
+
+def _strip_surrounding_quotes(token: str) -> str:
+    """Strip one layer of matching surrounding quotes from a captured CLI token.
+
+    ``'feat/x'`` -> ``feat/x``, ``"feat/x"`` -> ``feat/x``. Leaves an unquoted or
+    mismatched-quote token unchanged. Comparison-side normalization only — it
+    does NOT widen what a matcher regex captures, so it cannot introduce a
+    false-negative.
+    """
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in ("'", '"'):
+        return token[1:-1]
+    return token
+
+
+def _extract_pr_number(command: str) -> str | None:
+    """Extract the PR number positional from a `gh pr merge|close` command.
+
+    Wraps `_GH_PR_NUMBER_RE.search()` with a defensive post-extract check that
+    rejects digits which are actually the VALUE of an immediately-preceding
+    value-taking long-form flag (e.g. `--max-retries 5`). Value-less flags
+    (`--admin`, `--auto`, `--squash`) do NOT trigger the check — a digit after
+    one of them IS the PR positional. Returns None when no positional is found.
+    """
+    match = _GH_PR_NUMBER_RE.search(command)
+    if not match:
+        return None
+    pr_pos = match.start(1)
+    # Inspect the immediately-preceding token for a known value-taking
+    # long-form flag; if present, the captured digit is its value, not the PR.
+    preceding = command[:pr_pos].rstrip()
+    flag_match = re.search(r"(--[\w-]+)$", preceding)
+    if flag_match and flag_match.group(1) in _GH_PR_VALUE_TAKING_FLAGS:
+        return None
+    return match.group(1)
+
+
+def _extract_api_ref(command: str) -> str | None:
+    """Parse the ref from an API ref-mutation command's `git/refs/<ref>` path.
+
+    `detect_command_operation_type` classifies `gh api|curl|wget` calls on a
+    `git/refs/...` path by HTTP method (DELETE -> branch-delete, PATCH/POST/PUT
+    -> force-push). For both classes the affected ref is the path component, so
+    a single parser supplies the target. Returns the ref (a leading `heads/`
+    stripped), or None when the command is not a recognized API ref form.
+    """
+    if not (
+        re.search(r"\b(?:gh\s+api|curl|wget)\b", command, re.IGNORECASE)
+        and "git/refs/" in command
+    ):
+        return None
+    api_match = re.search(
+        r"git/refs/(?:heads/)?([A-Za-z0-9][A-Za-z0-9._/-]*)", command
+    )
+    return api_match.group(1) if api_match else None
+
+
+# Value-taking-flag skip set for the gh-api api-merge endpoint walk (#1096; GH-API-ONLY
+# per Option B). The api-merge mint arm is gh-api ONLY — curl/wget were DROPPED because
+# sec #71 proved a value-flag denylist over curl/wget's UNBOUNDED flag space is
+# structurally uncompletable (52 realistic-common decoy leaks), so a curl/wget mint arm
+# built on it is unsound. gh api's flags are FINITE + documented + first-positional-endpoint
+# = provably sound. Consequence: curl/wget api-merge classifies detect=None (mint=0),
+# staying in its PRE-EXISTING gated-but-unmintable state (the read arms still gate it) —
+# killing that laundering class BY CONSTRUCTION (can't mint -> can't launder). Tokens are
+# the shlex form. Includes the -R/--repo GLOBAL flag, which is decoy-capable (`gh -R
+# pulls/5/merge api …` would bind 5 if -R's value is not skipped). Booleans (-i/--include,
+# --paginate, --slurp, --silent, --verbose) are DELIBERATELY absent — skipping their next
+# token would swallow a positional.
+_API_MERGE_GH_VALUE_FLAGS = frozenset({
+    "-X", "--method", "-f", "--field", "-F", "--raw-field", "--input",
+    "-H", "--header", "--hostname", "-q", "--jq", "-t", "--template",
+    "--cache", "-R", "--repo",
+})
+
+_PULLS_MERGE_PR_RE = re.compile(r"pulls/(\d+)/merge\b")
+
+
+def _api_merge_leg_endpoint(leg: str) -> str | None:
+    """Return the ENDPOINT PR of a genuine per-leg API merge, or None (#1096).
+
+    ONE shared helper called by BOTH detect_command_operation_type's merge arm AND
+    _extract_api_merge_pr, so recognition and extraction read the SAME surface (kills
+    the reuse-across-two-domains root: detect recognizes a leg IFF its endpoint is
+    extractable -> no gated-but-unmintable BY CONSTRUCTION, and the bound PR is the URL
+    POSITIONAL endpoint, never a flag-value / other-leg decoy).
+
+    GH-API-ONLY (#1096 Option B; curl/wget dropped, sec #71). Recognition (gh-api client +
+    mutating method + pulls/<N>/merge path co-occur in this leg): tolerant IGNORECASE
+    _GH_API_PREFIX client + IGNORECASE PUT/PATCH/POST method + case-SENSITIVE pulls/<N>/merge
+    path. A curl/wget merge classifies None here -> gated-but-unmintable (read arms still gate).
+
+    Extraction binds the pulls/<N>/merge that is the URL POSITIONAL: strip body values
+    (carrier-8), shlex-tokenize, then walk skipping flags + the gh-api value-flag
+    values, and take the first surviving positional. On tokenizer failure NEVER returns
+    None for a recognized leg (falls back to the stripped/raw first-match) — a mis-parse
+    must not gate a faithful merge (over-block-safe).
+    """
+    client_gh = re.search(_GH_API_PREFIX, leg, re.IGNORECASE)
+    if not client_gh:
+        # GH-API-ONLY (#1096 Option B): curl/wget api-merge legs classify None here
+        # (mint=0), staying in their PRE-EXISTING gated-but-unmintable state (the
+        # curl/wget merge READ arms still gate them) — killing the 52 curl/wget
+        # laundering vectors BY CONSTRUCTION (sec #71: their value-flag denylist over an
+        # unbounded flag space is uncompletable). No new over-block (status quo ante).
+        return None
+    # Recognition uses the EXACT non-capturing literal `pulls/\d+/merge\b` via re.search
+    # (byte-identical to the prior detect arm), NOT the compiled capturing _PULLS_MERGE_PR_RE
+    # — so recognition stays byte-identical AND the non-vacuity arm-disable shim (which
+    # monkeypatches re.search of this exact literal) still surgically disables the arm.
+    # The capturing _PULLS_MERGE_PR_RE is used only for EXTRACTION (the walk + fallback).
+    if not re.search(r"pulls/\d+/merge\b", leg):
+        return None
+    if not re.search(r"\b(?:PUT|PATCH|POST)\b", leg, re.IGNORECASE):
+        return None
+    # Recognized. Extract the ENDPOINT-position PR.
+    stripped = _strip_non_executable_content(leg)
+    tokens = _shell_tokenize(stripped)
+    if tokens is None:
+        # Tokenizer failure (unbalanced quotes): NEVER None for a recognized leg
+        # (over-block-safe). Prefer the body-stripped surface (avoids body decoys);
+        # the raw leg is guaranteed to match (recognition required it).
+        m = _PULLS_MERGE_PR_RE.search(stripped) or _PULLS_MERGE_PR_RE.search(leg)
+        return m.group(1) if m else None
+    value_flags = _API_MERGE_GH_VALUE_FLAGS
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok.startswith("-"):
+            base = tok.split("=", 1)[0]
+            if "=" not in tok and base in value_flags:
+                i += 1  # bare space-separated value-flag: skip its value token too
+            # attached-value (`--method=PUT`, `-XPUT`) and booleans consume no extra token
+            i += 1
+            continue
+        # A positional: the endpoint is the FIRST pulls/<N>/merge positional (the URL
+        # argument; for gh api the endpoint is the first positional by REST convention).
+        mm = _PULLS_MERGE_PR_RE.search(tok)
+        if mm:
+            return mm.group(1)
+        i += 1
+    # Recognized (gh-api) but no endpoint positional survived (the only pulls/<N>/merge was
+    # a skipped flag VALUE, i.e. a body/decoy — the leg has no real merge endpoint). NOT a
+    # tokenizer failure, so this is a genuine "no extractable endpoint" -> None. Correct
+    # (no wrong-target mint); such an input never faithfully merges a PR. (#1096 is
+    # gh-api-only per Option B: curl/wget never reach this walk — they classify None at
+    # the client gate above — so there is no exotic-curl residual to accept.)
+    return None
+
+
+def _extract_api_merge_pr(command: str) -> str | None:
+    """Command-level api-merge PR: walk the legs and return the FIRST recognized leg's
+    ENDPOINT-position PR (#1096). Leg-scoping closes the cross-leg/echo decoy; the
+    per-leg helper closes the same-leg flag-value decoy. Consumed by extract_command_context
+    (mint + read whole-fallback + #1097 retirement cmd_target all heal at this one site)."""
+    for _leg in _split_into_legs(command):
+        pr = _api_merge_leg_endpoint(_leg)
+        if pr is not None:
+            return pr
+    return None
+
+
+def _extract_protection_branch(command: str) -> str | None:
+    """Parse the protected branch from a branch-protection API command's
+    `branches/<branch>/protection` path (#1063). The branch is PATH-resident (the
+    REST resource IS the URL), so carrier-8's body strip never removes it. The
+    non-greedy `(.+?)` correctly handles a slashed branch name (`feature/x`):
+    `branches/feature/x/protection` → `feature/x`. Returns the branch, or None when
+    the command is not a recognized protection form."""
+    m = re.search(r"branches/(.+?)/protection\b", command)
+    return _strip_surrounding_quotes(m.group(1)) if m else None
+
+
+def _extract_branch_name(command: str) -> str | None:
+    """Extract the SINGLE branch name targeted by a branch-delete command.
+
+    Owns the branch-delete target for extract_command_context. Handles the CLI
+    `git branch -D|--delete <name>` form (exactly ONE branch — a MULTI-target
+    delete like `git branch -D a b` is REFUSED, returning None) and the API
+    ref-DELETE form (the ref in a `git/refs/<ref>` path). Returns the
+    (quote-normalized) name, or None when no single branch target is positively
+    extractable.
+    """
+    api_ref = _extract_api_ref(command)
+    if api_ref is not None:
+        return api_ref
+    # CLI `git branch -D|--delete <name>`: isolate the tokens after `branch`,
+    # drop dash-flags, and require EXACTLY ONE positional branch name. A
+    # multi-target delete (`git branch -D a b`) has >1 positional -> REFUSE, so
+    # a token approved for ONE branch can never authorize deleting several (the
+    # #1032 multi-target under-block); 0 positionals -> REFUSE. Mirrors
+    # _extract_force_push_target_ref's multi-ref conservatism. The caller only
+    # reaches here when detect_command_operation_type already classified the
+    # command branch-delete, so a -D/--delete flag is present and is dropped
+    # with the other dash-flags.
+    # Truncate at the first benign continuation / redirect on the quote-masked
+    # view BEFORE counting positionals, so a faithful single branch-delete with a
+    # trailing continuation (`git branch -D feature | tail`, `... ; echo done`,
+    # `... > log`) re-derives its one branch name instead of miscounting the
+    # continuation tokens as extra positionals (-> None -> over-block). An
+    # ambiguous quote state makes _executable_prefix return None -> abstain -> the
+    # existing safe over-block (never a silently-authorized malformed command).
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        return None
+    branch_match = re.search(_GIT_PREFIX + r"branch\b(.*)$", prefix)
+    if not branch_match:
+        return None
+    positionals = [t for t in branch_match.group(1).split() if not t.startswith("-")]
+    if len(positionals) != 1:
+        return None
+    return _strip_surrounding_quotes(positionals[0])
+
+
+def _canonical_join(items: Sequence[str]) -> str:
+    """Netstring/length-prefix encode a sequence of strings into ONE canonical
+    identity STRING, injective by construction (a left-inverse decoder exists), so
+    distinct sequences never collide REGARDLESS of item content — incl. commas, '@',
+    '#', ':' and NUL. Pure + deterministic (no sort, no dedup — the caller supplies a
+    canonical ordered list). Stays a `str` (the token persists as JSON; compared by
+    str()-equality, never decoded). Shared SSOT for branch_set + mass_target (#1136)."""
+    return "".join(f"{len(i)}:{i}" for i in items)
+
+
+def _extract_branch_delete_set(command: str) -> str | None:
+    """Extract the canonical MULTI-branch identity of a force-delete command.
+
+    The MULTI-target sibling of _extract_branch_name (which owns the SINGLE
+    branch). Handles the CLI `git branch -D|--delete --force <a> <b> ...` form
+    with TWO OR MORE positional branch names, returning a canonical
+    sort+dedup+quote-strip identity STRING (the shared netstring `_canonical_join`
+    SSOT), or None
+    when fewer than two branch names are positively extractable (<2 -> defers to
+    the scalar _extract_branch_name path — the BOUNDARY discriminator, so a
+    command populates EXACTLY ONE of `branch` / `branch_set`).
+
+    Shares the _extract_mass_delete_target encoder (#1062b/#1136): an
+    ORDER-INDEPENDENT identity STRING (never a tuple/list — a token persists as
+    JSON, and the read side compares via `str()`, so a list<->tuple round-trip
+    must never enter the identity), built + canonicalized in this ONE shared SSOT
+    so mint and read derive byte-identical strings (D2 symmetry by construction).
+    Encoding is the netstring `_canonical_join` (`len:name` framing): the identity
+    is INJECTIVE by construction and CONTENT-AGNOSTIC, so distinct branch SETS never
+    collide regardless of name content — no separator has to be ref-illegal. (A bare
+    `,` join was NOT injective: a branch literally named `a,b` collided with the set
+    {a, b}, cross-authorizing distinct sets — the F1 review finding; framing closes
+    that class outright. The string is JSON/str()-safe: json round-trips it and str()
+    is stable, so the identity survives token persistence.)
+    Set-EQUALITY on this INJECTIVE string then closes the #1032 multi-target
+    under-block UNCONDITIONALLY: a `{a,b}` token cannot authorize `{a,b,c}`
+    (unequal strings) while a `{b,a}` reorder MATCHES (both canonicalize to the
+    same string).
+
+    Uses the SAME tokenization as _extract_branch_name (executable-prefix
+    truncation at a benign continuation/redirect via _executable_prefix, then drop
+    dash-flags), so the single/multi boundary is computed IDENTICALLY and no
+    command is double-counted or dropped. FORCE-only rides on op_type: the caller
+    reaches here only when detect_command_operation_type already classified
+    branch-delete (the FORCE `-D`/`-Df`/`-fD`/`--delete --force` spellings; #1094
+    per-leg cure), so a lowercase `-d`/`--delete` merged-branch delete (ungated at
+    HEAD) never reaches this and never populates `branch_set`.
+    """
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        return None
+    branch_match = re.search(_GIT_PREFIX + r"branch\b(.*)$", prefix)
+    if not branch_match:
+        return None
+    positionals = [t for t in branch_match.group(1).split() if not t.startswith("-")]
+    if len(positionals) < 2:
+        return None
+    names = sorted({_strip_surrounding_quotes(t) for t in positionals})
+    # Encode via the shared netstring SSOT (_canonical_join): each name is framed as
+    # `len:name`, so the identity is INJECTIVE by construction and CONTENT-AGNOSTIC —
+    # distinct sets never collide regardless of name content, without depending on any
+    # separator being ref-illegal (an earlier bare `,` join collided a branch named
+    # `a,b` with the set {a, b}). JSON/str()-safe, so mint==read symmetry and the JSON
+    # token round-trip both hold.
+    return _canonical_join(names) or None
+
+
+def _extract_force_push_target_ref(command: str) -> str | None:
+    """Conservative force-push destination-ref parse (KD-6) — refuse on ambiguity.
+
+    Returns the ref a force-push would rewrite, or None when the target is
+    implicit / multi-ref / unparseable (the caller treats None as ABSENT ->
+    REFUSE, the safe over-block direction). The accepted ref-form set is
+    SECURITY-RATIFICATION-PENDING (ratified at peer-review); this is the
+    architect's conservative default.
+
+    Recognized:
+        gh api|curl|wget .../git/refs/<ref>   -> <ref>    (API ref-mutation)
+        git push <remote> <src>:<dst>         -> <dst>
+        git push <remote> HEAD:<dst>          -> <dst>
+        git push <remote> <branch>            -> <branch> (incl. direct-to-main)
+    Refused (-> None):
+        git push --force            (implicit current-branch target)
+        git push <remote>           (remote-only, implicit branch)
+        any multi-ref / chained / value-flag-ambiguous / unparseable form
+    """
+    # API ref-mutation: the destination ref is in the git/refs/<ref> path.
+    api_ref = _extract_api_ref(command)
+    if api_ref is not None:
+        return api_ref
+
+    # CLI push: isolate the token sequence after `push` and require EXACTLY
+    # remote + refspec (2 positionals). 0 = implicit push; 1 = remote-only
+    # (implicit branch); >2 = multi-ref/chained -> all ambiguous, REFUSE.
+    # Positionals are counted via the SHARED _push_positionals helper (#1195
+    # OBS-C), which SKIPS the value token of a git-push value-taking option flag
+    # (`-o ci.skip`, `--push-option x`, `--repo url`) — the same helper the
+    # remote-ref-delete/mass-delete builders use. The prior naive
+    # `.split()`-drop-dash-flags miscounted `-o`'s NON-dash value (`ci.skip`) as
+    # a 3rd positional -> None -> a faithful force-push carrying a push-option
+    # was gated-but-unmintable (an over-block). Skipping the value token
+    # recovers the real refspec positional. Only MINT-ENABLING: is_dangerous and
+    # the op-class are unchanged; the target is the real refspec, never the -o
+    # value (mint==read, both via extract_command_context).
+    # Truncate at the first benign continuation / redirect on the quote-masked
+    # view BEFORE counting positionals, so a faithful single force-push with a
+    # trailing continuation (`git push --force origin main | tail`, `... 2>&1`,
+    # `... > log`, `... && echo done`) re-derives its target instead of
+    # miscounting the continuation tokens as extra positionals (-> None ->
+    # over-block). The redirect filename is structurally outside the positional
+    # window (`... feature > main` yields `feature`, never `main`). An ambiguous
+    # quote state makes _executable_prefix return None -> abstain -> the existing
+    # safe over-block (never a silently-authorized malformed command).
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        return None
+    push_match = re.search(_GIT_PREFIX + r"push\b(.*)$", prefix)
+    if not push_match:
+        return None
+    after_push = _shell_tokenize(push_match.group(1))
+    if after_push is None:                       # unbalanced quote -> abstain (safe over-block)
+        return None
+    positionals = _push_positionals(after_push)
+    if len(positionals) != 2:
+        return None
+    refspec = _strip_surrounding_quotes(positionals[1])
+    if ":" in refspec:
+        return refspec.rsplit(":", 1)[1] or None
+    return refspec or None
+
+
+def _extract_push_to_main_set(command: str) -> str | None:
+    """MULTI-ref sibling of the SCALAR push-to-main target (_extract_force_push_target_ref).
+
+    Returns the canonical injective identity of the pushed REFSPECS (>=2), or None
+    when fewer than two refspecs are extractable (<2 -> the scalar path owns the
+    single-ref form: the BOUNDARY discriminator, so a push-to-main command
+    populates EXACTLY ONE of `target_ref` / `push_set` — #1195 OBS-G, the
+    branch/branch_set (#1129) precedent transferred). Reuses the netstring
+    `_canonical_join` SSOT (#1136): injective by construction and CONTENT-AGNOSTIC
+    (colon / `+` / comma / `refs/heads/` content never collides), JSON/str()-safe,
+    so mint==read symmetry and the token round-trip both hold. The identity is
+    over the FULL refspec tokens (`feature:main` kept, never its dst alone) — the
+    tighter binding: src:dst pairs bind exactly, and a `+refspec` element stays
+    distinct from its plain spelling. The refspecs are `_push_positionals(...)[1:]`
+    — the remote positional is SKIPPED (a remote-AGNOSTIC identity, mirroring the
+    scalar target_ref, which binds the ref only; security-ratified). Tokenization
+    mirrors the push-to-main DETECTION arm in `_flag_condition_danger_op`
+    (`.split()` + the K flag bound + `push\\s` well-formedness), so the refspecs
+    bound here are the SAME tokens the detection predicate walked. Fail-safe:
+    unparseable / procsub (`_executable_prefix` None) or a flag-flood (>K) -> None
+    -> the command stays gated-but-unmintable (a residual over-block, never an
+    over-broad token).
+    """
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        return None                     # fail-safe (unparseable / procsub)
+    _pm = re.search(_GIT_PREFIX + r"push\s(.*)$", prefix)
+    if _pm is None:
+        return None                     # well-formed push only (excludes `push--force` glue)
+    _tail = _pm.group(1).split()
+    if sum(1 for t in _tail if t.startswith("-")) > _MAX_GLOBAL_FLAG_TOKENS:
+        return None                     # perf bound (mirrors the OBS-D/E flag walk)
+    refspecs = [_strip_surrounding_quotes(r) for r in _push_positionals(_tail)[1:]]
+    if len(refspecs) < 2:
+        return None                     # <2 -> the scalar target_ref path owns it (boundary)
+    return _canonical_join(sorted(set(refspecs)))   # sort+dedup+canonical (branch_set mirror)
+
+
+# #1195 OBS-I — the REF-SCOPE-NEUTRAL flag allowlist for force_push_set (the
+# ALLOWLIST-INVERSION guard; a SECURITY-OWNED membership surface like
+# PRIVILEGED_FLAGS — any future addition is a reviewed, deliberate act; the cert
+# pins the exact membership). force_push_set is populated ONLY when EVERY flag
+# token resolves into this set; ANYTHING else — the delete/mass op-triggers
+# (--delete/-d/--mirror/--prune), the scope expanders (--tags/--follow-tags/
+# --all/--branches), --recurse-submodules, -n/--dry-run, --force-with-lease on a
+# force-classified command, --no-force, the exotic --repo/--receive-pack/--exec,
+# the `--` end-of-options marker, and every unknown/FUTURE flag — fails SAFE to
+# None = gated-but-unmintable. Rationale: `_push_positionals` skips flags BY
+# DESIGN, so a positional set-identity is structurally BLIND to flag-borne
+# ref-scope semantics (`--force --delete origin main feature` classifies
+# force-push — force outranks delete — and would collide byte-identically with
+# the pure force set); such semantics can only be GUARDED (None), never encoded.
+# Allowlist incompleteness costs an exotic residual over-block, never a hole.
+_FORCE_PUSH_NEUTRAL_LONG = frozenset({
+    "--force",                     # the op itself + the forced-form trigger
+    "--no-verify",                 # bound via force-push PRIVILEGED_FLAGS (a2 discriminates)
+    "--verbose", "--quiet", "--progress", "--no-progress", "--porcelain",  # output-only
+    "--set-upstream",              # local tracking config
+    "--atomic",                    # transaction semantics, same ref set
+    "--ipv4", "--ipv6", "--thin", "--no-thin",                             # transport
+    "--signed", "--no-signed",     # transport signing
+    "--push-option",               # server-side message (value inert to ref scope)
+})
+_FORCE_PUSH_NEUTRAL_SHORT = frozenset("fvqu46")   # -f -v -q -u -4 -6 (cluster letters)
+
+
+def _resolve_neutral_force_tail(_tail: list) -> "tuple[list, bool] | None":
+    """ONE raw-token walk over the post-`push` tail (#1195 OBS-I): resolves git's
+    getopt-style value-taking `-o` in ANY cluster position, runs the
+    ref-scope-neutrality census, and detects the class-wide force flag —
+    returning (resolved_tail, force) or None when ANY flag token is non-neutral,
+    unknown, or malformed (fail-safe: gated-but-unmintable, never an over-broad
+    token).
+
+    WHY RAW TOKENS (load-bearing): `_normalized_flags` is CONDITION-SCOPED — it
+    reports only the flags the danger conditions test and is BLIND to
+    --tags/--all/-v/... — so a census built on it would silently pass a
+    scope-expansion smuggle. WHY the value resolution lives HERE: `-o` takes a
+    VALUE; getopt semantics make everything after `o` in a short cluster (or the
+    next token when `o` is last) that value, NOT flags — `-fvo msg` = -f -v
+    -o=msg; `-fov` = -f -o=v. The resolved tail (value tokens dropped, the
+    `o`+value consumed from clusters) is what the SHARED `_push_positionals`
+    then gathers, so the census and the positional gather agree on value tokens
+    BY CONSTRUCTION — while `_push_positionals` itself stays byte-untouched (its
+    other consumers keep today's behavior). The value-short set is
+    BOUNDED-COMPLETE = {-o}: every other git-push short is boolean.
+
+    O-FIRST GLUED-VALUE AMBIGUITY (lead+security ruling): a glued rest-of-token
+    value MINTS only when `f` is unambiguously present BEFORE the `o` in the
+    SAME cluster (`-fov`, `-fvoMSG` — force established either way you read the
+    tail). An o-first/no-f-before-o glued form (`-ofv`, `-vox`) is the shape
+    where git's parse (o consumes the rest as a VALUE — no force) diverges from
+    the pre-existing cluster-blind detection (which sees the letters as flags):
+    the OPERATION itself is parse-dependent, so minting ANY identity would be
+    wrong under one reading — fail SAFE to None (an exotic, low-good-faith
+    residual over-block; the detection mis-parse itself is out of scope here)."""
+    resolved: list = []
+    force = False
+    i, n = 0, len(_tail)
+    while i < n:
+        tok = _tail[i]
+        if not tok.startswith("-") or tok == "-":
+            resolved.append(tok)             # positional (or the bare '-' token)
+            i += 1
+            continue
+        if tok.startswith("--"):
+            name = tok.split("=", 1)[0]
+            if name not in _FORCE_PUSH_NEUTRAL_LONG:
+                return None                  # incl. bare `--` + unknown/future flags
+            if name == "--force":
+                force = True
+            if name == "--push-option" and "=" not in tok:
+                if i + 1 >= n:
+                    return None              # separate-value form missing its value
+                i += 2                       # skip the value token
+                continue
+            i += 1
+            continue
+        # Short cluster: boolean letters until a value-`o`; at `o` the rest of the
+        # token (or the next token when `o` is last) is its VALUE — never flags.
+        consumed_next = False
+        cluster_bad = False
+        cluster_force = False
+        for j in range(1, len(tok)):
+            ch = tok[j]
+            if ch == "o":
+                if j == len(tok) - 1:        # `-...o` last: next token is the value
+                    if i + 1 >= n:
+                        cluster_bad = True   # missing value (malformed) — fail-safe
+                    else:
+                        consumed_next = True
+                elif not cluster_force:
+                    # o-first / no-f-before-o GLUED value (`-ofv`, `-vox`): git's
+                    # parse and the cluster-blind detection diverge on WHAT THE
+                    # OPERATION IS — ambiguous, fail SAFE to None (lead ruling).
+                    cluster_bad = True
+                break                        # rest-of-token (if any) is the value
+            if ch not in _FORCE_PUSH_NEUTRAL_SHORT:
+                cluster_bad = True
+                break
+            if ch == "f":
+                force = True
+                cluster_force = True
+        if cluster_bad:
+            return None
+        i += 2 if consumed_next else 1
+    return resolved, force
+
+
+def _extract_force_push_set(command: str) -> str | None:
+    """MULTI-ref sibling of the SCALAR force-push target — the force-push analog
+    of _extract_push_to_main_set (#1195 OBS-I, reversing the OBS-G scope boundary
+    under its own ratified proof). Same skeleton (fail-safe prefix, single
+    guarded `push\\s` search, K flag bound, remote-agnostic positionals[1:],
+    `<2 -> None` scalar boundary, injective netstring `_canonical_join` identity)
+    PLUS the three OBS-I-specific layers:
+      (a) the ALLOWLIST-INVERSION census + the value-`-o` resolution + the force
+          trigger — ONE raw-token walk (_resolve_neutral_force_tail);
+      (b) FORCED-FORM NORMALIZATION: class-wide --force/-f upgrades every element
+          to its `+` form so the identity tracks WHICH REFS GET FORCED — the
+          mixed-set plain->forced collision cure (`+feature main` stays DISTINCT
+          from `--force +feature main`) while `--force feature main` ==
+          `+feature +main` (ratified: the same operation, one identity);
+      (c) the `:`-element DELETE GUARD (defense-in-depth for the refspec-syntax
+          channel when force wins classification): None on any ':'-leading
+          element after '+'-strip — a delete can never smuggle into a mintable
+          force set.
+    """
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        return None                     # fail-safe (unparseable / procsub)
+    _pm = re.search(_GIT_PREFIX + r"push\s(.*)$", prefix)
+    if _pm is None:
+        return None                     # well-formed push only (excludes glue)
+    _tail = _pm.group(1).split()
+    if sum(1 for t in _tail if t.startswith("-")) > _MAX_GLOBAL_FLAG_TOKENS:
+        return None                     # perf bound (mirrors the OBS-D/E flag walk)
+    _resolved = _resolve_neutral_force_tail(_tail)
+    if _resolved is None:
+        return None                     # non-neutral / unknown / malformed flag
+    _clean_tail, _force = _resolved
+    refspecs = [_strip_surrounding_quotes(r) for r in _push_positionals(_clean_tail)[1:]]
+    if len(refspecs) < 2:
+        return None                     # <2 -> the scalar target_ref path owns it
+    if _force:
+        refspecs = [r if r.startswith("+") else "+" + r for r in refspecs]
+    if any(r.lstrip("+").startswith(":") for r in refspecs):
+        return None                     # delete-refspec guard (fail-safe)
+    return _canonical_join(sorted(set(refspecs)))
+
+
+# git-push value-taking OPTION flags whose VALUE token must be skipped when
+# counting refspec positionals (else a contrived `-o ':weird'` push-option leaks
+# a fake delete refspec — the #1037 brittleness class). Their `--flag=value` form
+# carries the value INLINE (one token), so no next-token skip is needed. Used by
+# the remote-ref-delete + remote-mass-delete positional builder below; distinct
+# from the OP-TRIGGER flags (`--delete`/`-d`) which are NOT value-taking (the ref
+# is a separate positional).
+_GIT_PUSH_VALUE_FLAGS = frozenset(
+    {"-o", "--push-option", "--receive-pack", "--exec", "--repo"}
+)
+
+
+def _push_positionals(after_push: list[str]) -> list[str]:
+    """Positional (non-flag) tokens after the `push` subcommand, skipping the value
+    token consumed by a git-push value-taking option flag (`-o opt`, `--repo url`,
+    …). A `--flag=value` form carries its value inline (one token), so only the
+    separate-token form skips a follow-on token. Operates on a quote-aware
+    `_shell_tokenize` view (quotes already stripped), so a quoted `':oldref'` stays
+    ONE token bound to its flag and never leaks as a positional. Shared by both
+    push-delete extractors so they agree on positional boundaries."""
+    positionals: list[str] = []
+    i, n = 0, len(after_push)
+    while i < n:
+        tok = after_push[i]
+        if tok.startswith("-") and tok != "-":
+            flag = tok.split("=", 1)[0]
+            if flag in _GIT_PUSH_VALUE_FLAGS and "=" not in tok and i + 1 < n:
+                i += 2  # consume the option flag's separate value token
+                continue
+            i += 1  # a flag (boolean, op-trigger, or inline-value) — not a positional
+            continue
+        positionals.append(tok)
+        i += 1
+    return positionals
+
+
+def _tokens_after_push(command: str) -> list[str] | None:
+    """The quote-aware token list AFTER the first `push` token, on the executable
+    prefix of `command`, or None when the command is unparseable / has no `push`
+    token. Truncates at the first benign continuation / redirect (via
+    `_executable_prefix`) and abstains (None) on ambiguous quotes / procsub —
+    fail-OPEN to the literal floor, never fail-closed."""
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        return None
+    toks = _shell_tokenize(prefix)
+    if toks is None:
+        return None
+    for idx, tok in enumerate(toks):
+        if tok == "push":
+            return toks[idx + 1:]
+    return None
+
+
+def _extract_remote_ref_delete_target(command: str) -> str | None:
+    """Extract the SINGLE remote ref a `git push` delete would remove (#1062a), or
+    None when the form is implicit-current/multi-ref/ambiguous (→ the caller defers:
+    not recognized as remote-ref-delete; a mass form is picked up by
+    `_extract_mass_delete_target` instead). Reuses the force-push parser MACHINERY
+    (quote-mask + shlex view + value-flag skip) but adapts the positional rule for
+    delete semantics + the implicit-remote forms the force-push parser returns None
+    for (its conservative exactly-2-positional rule). Recognition⟺mintability by
+    construction: the `_flag_condition_danger_op` arm returns `remote-ref-delete`
+    IFF this yields a target, so the op can never reach a #1064 gated-but-unmintable
+    state.
+
+    Recognized (git grammar `git push [<repo>] <refspec>...`):
+        explicit remote, --delete/-d:  `origin --delete feature` → feature
+        implicit remote, --delete/-d:  `git push --delete feature` → feature
+        single-delete-with-repo:       `git push --delete a b` → b (repo=a, ref=b)
+        empty-source colon refspec:    `origin :feature` / `origin +:feature` → feature
+                                       `origin :refs/tags/v1` → refs/tags/v1
+    Deferred (→ None, picked up as remote-mass-delete or not destructive):
+        multi-ref delete (`origin --delete a b`, `origin :a :b`), --mirror/--prune,
+        plain push (`origin feature`), src:dst non-delete (`origin feat:feat`),
+        value-flag colon (`-o ':weird' main`), a delete literal inside a quoted arg.
+    """
+    after = _tokens_after_push(command)
+    if after is None:
+        return None
+    positionals = _push_positionals(after)
+    # CROSS-LEG FIX (review FINDING 1): compute the flag set from the SAME leg as the
+    # positionals — the post-`push` tokens of the executable prefix (`after`), NOT the
+    # whole command. Else a --delete/-d/--mirror/--prune token in a benign CONTINUATION
+    # leg (`git push origin feature && git branch -d old`) leaks in and mislabels the
+    # benign push as a delete (a fail-safe but common over-block). Every delete-relevant
+    # flag is a push SUBCOMMAND option (always after `push`), so the post-push tokens are
+    # the complete + correct scope; nothing real is missed (no read-floor narrowing).
+    gf = _normalized_flags(after, "git")  # git surface maps -d → --delete
+    if "--delete" in gf:
+        # git grammar: 1 positional = the refspec (implicit remote); 2 = <repo>
+        # <refspec>; 0 or ≥3 = ambiguous/multi → defer (mass handles ≥3).
+        if len(positionals) == 1:
+            return _strip_surrounding_quotes(positionals[0]) or None
+        if len(positionals) == 2:
+            return _strip_surrounding_quotes(positionals[1]) or None
+        return None
+    # No --delete flag: an empty-source colon refspec (`:dst` / `+:dst`) is a delete.
+    # EXACTLY ONE → its dst; ≠1 → defer (0 = not a delete; ≥2 = multi → mass).
+    colon_dsts = [p for p in positionals if re.match(r"^\+?:", p)]
+    if len(colon_dsts) == 1:
+        return _strip_surrounding_quotes(colon_dsts[0]).rsplit(":", 1)[1] or None
+    return None
+
+
+# Sentinel marking an IMPLICIT remote (a `git push --mirror` with no positional
+# remote) in a mass-delete target tuple — keeps the implicit-remote form MINTABLE
+# (a definite, deterministic target) rather than ambiguous. A NUL byte can never
+# appear in a real remote name, so it can never collide with one.
+_IMPLICIT_REMOTE_MARKER = "\x00implicit"
+
+
+def _extract_mass_delete_target(command: str) -> str | None:
+    """Extract a READABLE normalized per-invocation tuple binding the destructive
+    IDENTITY of a `git push` MASS-delete form (#1062b — `--mirror`/`--prune`/multi-ref
+    delete), or None when the command is not such a form. Binds the destructive
+    identity (mass-flags + remote + sorted refspecs), NOT the whole command line, so a
+    benign `-o ci.skip` does not over-bind; privileged flags ride the existing #1042
+    `bound_flags` axis. Derived identically on BOTH arms via this ONE SSOT → mint==read
+    parity by construction; recognition⟺mintability (the arm returns the op IFF this is
+    non-None) → #1064-impossible. Returns a READABLE netstring identity STRING
+    (`len:value`-framed field tuple; no `@`/`#`/`,` delimiters; #1136), never a hash:
+
+        _canonical_join([<sorted-mass-flags>, <remote-or-implicit-marker>, *<sorted-deduped-refspecs>])
+        git push --mirror origin               → 8:--mirror6:origin
+        git push --mirror                      → 8:--mirror9:\\x00implicit (implicit-remote MINTABLE)
+        git push --prune origin refs/heads/main → 7:--prune6:origin15:refs/heads/main
+        git push origin --delete a b           → 8:--delete6:origin1:a1:b (binds the EXACT deleted set)
+        git push origin :a :b                  → 8:--delete6:origin1:a1:b
+
+    BOUNDARY (lead-mandated, no double-classification): a SINGLE-ref delete is owned by
+    `_extract_remote_ref_delete_target` (tried FIRST in the recognition arm). This
+    extractor returns None for a single-ref form, so a command is classified by EXACTLY
+    ONE op-class. Per git grammar (first positional = repository), `git push --delete a b`
+    is repo=a/ref=b = SINGLE (→ remote-ref-delete), while `git push origin --delete a b`
+    is repo=origin/refs=a,b = MASS.
+    """
+    if not re.search(_GIT_PREFIX + r"push\b", command):
+        return None
+    # Single-ref delete is the OTHER op-class — defer to it (the boundary discriminator).
+    if _extract_remote_ref_delete_target(command) is not None:
+        return None
+    after = _tokens_after_push(command)
+    if after is None:
+        return None
+    # CROSS-LEG FIX (review FINDING 1): flag set from the SAME leg as the positionals
+    # (the post-`push` tokens), NOT the whole command — else a --mirror/--prune/--delete
+    # in a benign continuation leg (`git push origin feature && echo --mirror`) leaks in
+    # and mislabels the benign push as a mass-delete. All mass-relevant flags are push
+    # subcommand options, so post-push is the complete + correct scope.
+    gf = _normalized_flags(after, "git")  # needs --mirror/--prune in _FLAG_SPEC (added #1062b)
+    mass_flags = sorted(f for f in ("--mirror", "--prune") if f in gf)
+    positionals = _push_positionals(after)
+    colon_dsts = [p for p in positionals if re.match(r"^\+?:", p)]
+
+    if mass_flags:
+        # --mirror/--prune: remote = first positional (git grammar) or implicit;
+        # explicit refspecs (if any) are the remaining positionals.
+        remote = _strip_surrounding_quotes(positionals[0]) if positionals else _IMPLICIT_REMOTE_MARKER
+        refspecs = sorted(_strip_surrounding_quotes(p) for p in positionals[1:])
+        flags_part = ",".join(mass_flags)
+    elif "--delete" in gf:
+        # multi-ref --delete (the single-ref case already deferred above): git grammar
+        # repo = first positional, the rest are the deleted refs. Need >=2 refs to be mass.
+        if len(positionals) < 3:
+            return None
+        remote = _strip_surrounding_quotes(positionals[0])
+        refspecs = sorted(_strip_surrounding_quotes(p) for p in positionals[1:])
+        flags_part = "--delete"
+    elif len(colon_dsts) >= 2:
+        # multi empty-source colon delete (`origin :a :b`): remote = first non-colon
+        # positional (or implicit); refs = the colon dsts.
+        non_colon = [p for p in positionals if not re.match(r"^\+?:", p)]
+        remote = _strip_surrounding_quotes(non_colon[0]) if non_colon else _IMPLICIT_REMOTE_MARKER
+        refspecs = sorted(
+            _strip_surrounding_quotes(p).rsplit(":", 1)[1] for p in colon_dsts
+        )
+        flags_part = "--delete"
+    else:
+        return None
+
+    # Encode the destructive identity via the shared netstring SSOT (_canonical_join):
+    # framing subsumes the old `@`/`#`/`,` delimiters, so the identity is injective for
+    # ANY field content (closes the #1136 `#`/comma collision class). Dedup refspecs
+    # (a duplicate ref is the same target); empty refspecs frame uniformly (no `#`).
+    return _canonical_join([flags_part, remote, *sorted(set(refspecs))])
+
+
+# -----------------------------------------------------------------------------
+# Privileged-flag binding (#1042). The (operation_type, target) binding above
+# DROPS every dash-flag, so an approved `gh pr merge 5` and an executed
+# `gh pr merge 5 --admin` (branch-protection bypass) reduce to the SAME context
+# and authorize — the flag rides past the checkpoint undetected. The fix adds
+# ONE more binding dimension — `bound_flags` — computed by the SINGLE scanner
+# below, called from the SINGLE site in extract_command_context, so BOTH hook
+# arms inherit it and can never classify a command's flags differently (the same
+# anti-drift property that the shared (op,target) SSOT already guarantees).
+#
+# PRIVILEGED_FLAGS is the op-class-scoped denylist: { op_type -> { canonical_long
+# -> (aliases, value_taking) } }. Membership is PURE DATA — adding or removing a
+# flag is a one-line edit with ZERO scanner/predicate changes, so the security
+# review owns membership without touching logic. A flag's PRESENCE binds it; the
+# read-side set-equality gate then enforces never-escalate.
+#
+# EXCLUDES op-trigger flags that already change op_type (and are therefore
+# already bound through it): --force/-f (force-push), -D (branch-delete), and
+# gh pr close's --delete-branch (the close-danger trigger). Listing them here
+# would double-bind and needlessly over-block. NB the asymmetry: --delete-branch
+# /-d on gh pr MERGE is a post-merge SIDE-EFFECT (deletes the source branch), not
+# a merge op-trigger, so it IS bound on the `merge` class — and -d (merge
+# delete-branch) is a DIFFERENT op from -D (branch force-delete); op-class scoping
+# keeps them from being conflated.
+PRIVILEGED_FLAGS: dict[str, dict[str, tuple[tuple[str, ...], bool]]] = {
+    "merge": {
+        "--admin":         (("--admin",), False),               # bypass branch protection
+        "--delete-branch": (("-d", "--delete-branch"), False),  # side-effect: deletes source branch
+        "--repo":          (("-R", "--repo"), True),            # cross-repo redirect (value-carrying target)
+        # value-carrying SAFETY constraint (pins the merge to a head SHA); binding
+        # it closes the dropped-constraint case — approve with --match-head-commit,
+        # execute without it -> set-equality REFUSES (#1042).
+        "--match-head-commit": (("--match-head-commit",), True),
+    },
+    "close": {
+        "--repo":          (("-R", "--repo"), True),            # cross-repo redirect (value-carrying target)
+        # --delete-branch/-d: the IRREVERSIBLE branch-deleting variant of close. Bound
+        # here (symmetry with merge above) so a bare-close token's flag-set can never
+        # set-equal the --delete-branch variant → the bare→delete-variant escalation
+        # REFUSES. NB it is ALSO a close op-trigger, but op_type folds bare-close and
+        # close --delete-branch into the SAME 'close' op (close precedence), so the
+        # trigger alone does NOT distinguish the two commands at the bind layer — this
+        # flag binding is what separates them. No double-bind: op-trigger sets the OP
+        # dimension, this sets the orthogonal FLAG-SET dimension.
+        "--delete-branch": (("-d", "--delete-branch"), False),
+    },
+    "force-push": {
+        "--no-verify":     (("--no-verify",), False),           # bypass pre-push hook
+    },
+    "push-to-main": {
+        # --force-with-lease: the lease push CAN rewrite history (unlike a plain push),
+        # so its PRESENCE separates plain-push and lease-push token identities inside
+        # one op-class (the close/--delete-branch precedent above). Bound as a BOOLEAN:
+        # git's value is =-joined only (never space-separated), and a value-taking
+        # marking would (i) consume the next positional (`origin`) on the bare spelling
+        # and (ii) import mint-side adjacency-sensitivity from the wide flag_scan_text
+        # surface -> an over-block risk. All =<ref>:<expect> spellings therefore bind
+        # the same canonical bare token; intra-lease value variation is an accepted
+        # residual (never authorizes plain<->lease or lease<->force escalation).
+        "--force-with-lease": (("--force-with-lease",), False),
+    },
+    "branch-delete": {
+        # No bound flags today: branch-delete's privileged effect is its op-trigger
+        # (-D / --delete --force), already bound via op_type. Kept as an explicit
+        # extension point so a future bound flag is a one-line data edit here.
+    },
+    "remote-ref-delete": {
+        # No bound flags: remote-ref-delete's privileged effect (removing a remote
+        # ref) IS its op-trigger (--delete/-d/empty-source colon), already bound via
+        # op_type. Empty entry = explicit #1042 extension point (a future bound flag
+        # is a one-line data edit); it adds NO new bound flag, so the set-equality
+        # bind is untouched.
+    },
+    "remote-mass-delete": {
+        # No bound flags: remote-mass-delete's privileged effect (the mass destructive
+        # push) IS its op-trigger (--mirror/--prune/multi-ref-delete), bound via op_type
+        # AND folded into the mass_target identity tuple. The --mirror/--prune additions
+        # go to _FLAG_SPEC (danger-condition recognition) ONLY, NOT here, so the #1042
+        # set-equality bind is untouched. Empty entry = explicit extension point.
+    },
+    "branch-protection": {
+        # No bound flags: branch-protection's privileged effect (weakening protection)
+        # IS its op-trigger (the DELETE|PUT|PATCH method on the protection endpoint),
+        # bound via op_type. Empty entry = explicit #1042 extension point; adds NO new
+        # bound flag, so the set-equality bind is untouched.
+    },
+}
+
+
+def extract_privileged_flags(command: str, op_type: str | None) -> list[str]:
+    """Scan a command for the privileged dash-flags bound on its op-class (#1042).
+
+    Returns a SORTED list of canonical flag tokens (boolean flags as their
+    canonical long form, e.g. ``--admin``; value-taking flags as
+    ``--repo=<value>``). The read side compares these as SETS for exact equality,
+    so any added privilege OR dropped constraint mismatches and REFUSES.
+
+    The scan is a SINGLE linear ``str.split()`` token-walk against the op-class
+    denylist (``PRIVILEGED_FLAGS``) — constant per-token work, NO regex, no
+    backtracking — so it preserves the bounded/linear extraction invariant
+    (INV-D2) the rest of this module is careful about.
+
+    Normalizes every CLI form to one canonical token: exact long (``--admin``),
+    short alias (``-R`` -> ``--repo``), ``=``-joined (``--repo=x`` / ``-R=x``),
+    attached short value (``-Rx`` -> ``--repo=x``), and combined-short clusters
+    via a general per-character walk (``-sd`` -> ``--delete-branch``;
+    ``-dR owner/repo`` -> ``--delete-branch`` + ``--repo=owner/repo``) so NO bound
+    short is ever dropped regardless of cluster ordering. On the GIT surface
+    ONLY, an unambiguous long-prefix abbreviation is EXPANDED to its canonical
+    flag (``--no-verif`` -> ``--no-verify``) — this is SECURITY-LOAD-BEARING:
+    git's parser accepts abbreviation, so a missed match would be a silent
+    UNDER-block; gh rejects abbreviation, so its surface needs no expansion.
+
+    Args:
+        command: The command (read arm) or full approval surface (mint arm) to
+            scan. The caller decides which; the scanner treats it as one string.
+        op_type: The classified operation type, or None. Selects the denylist;
+            an op_type with no denylist entry (incl. None and the API/un-flagged
+            classes) yields ``[]``.
+
+    Returns:
+        Sorted list of canonical bound-flag tokens; ``[]`` when none are present.
+    """
+    denylist = PRIVILEGED_FLAGS.get(op_type) if op_type is not None else None
+    if not denylist:
+        # op_type is None, unknown, or carries no bound flags (e.g. branch-delete
+        # today). An empty result binds the empty set — over-block-safe and the
+        # correct outcome for the API/un-flagged classes.
+        return []
+
+    # Derive the lookup tables from the denylist ONCE per call. All small,
+    # constant-size structures (the denylist has <=3 entries per op-class), so
+    # the per-token work below stays O(1).
+    alias_to_canonical: dict[str, str] = {}
+    value_taking: set[str] = set()
+    canonical_long_names: list[str] = []
+    for canonical, (aliases, takes_value) in denylist.items():
+        canonical_long_names.append(canonical)
+        if takes_value:
+            value_taking.add(canonical)
+        for alias in aliases:
+            alias_to_canonical[alias] = canonical
+    # git's parse-options expands unambiguous long-prefix abbreviations; gh's
+    # pflag rejects them. Only the git surface needs abbreviation expansion.
+    # push-to-main is a git surface — DEFENSE-IN-DEPTH: no abbreviated lease
+    # spelling reaches this bind in the live flow today. Any prefix still
+    # containing `--force` (e.g. `--force-with-leas`) classifies FORCE-PUSH
+    # first (the force arms' lookahead excludes only the exact `-with-lease`
+    # suffix), and the shorter prefixes that DO classify push-to-main (`--forc`,
+    # `--fo`) are ambiguous to git itself — git rejects the command, so no live
+    # lease push runs unbound. The expansion keeps the bind correct if either
+    # neighbor ever shifts; a unique-in-OUR-denylist prefix binds conservatively
+    # (over-block-safe).
+    is_git_surface = op_type in ("force-push", "branch-delete", "push-to-main")
+
+    # P1 quote-aware tokenization (closes the quoted-flag bind bypass #3: a
+    # `"--admin"` is shlex-stripped to `--admin` → bound; the old `command.split()`
+    # kept the quotes → `startswith('-')` skipped it → the escalation rode along).
+    # BOTH arms call this shared function so the bind stays symmetric. On an
+    # unbalanced quote shlex returns None; fall back to `split()` so the bind never
+    # regresses below today's coverage. The bind is defense-in-depth on top of the
+    # literal floor (is_dangerous_command), which is the fail-closed default — there is
+    # no metachar suppressor in the honest-mistake model.
+    tokens = _shell_tokenize(command)
+    if tokens is None:
+        tokens = command.split()
+    found: set[str] = set()
+    i = 0
+    n = len(tokens)
+    while i < n:
+        token = tokens[i]
+        # Non-flag tokens, the bare `-` (stdin) and `--` (end-of-options) marker
+        # never bind. Skipping `--` is load-bearing: it must NOT prefix-match a
+        # sole long flag in the abbreviation branch below.
+        if not token.startswith("-") or token in ("-", "--"):
+            i += 1
+            continue
+
+        if token.startswith("--"):
+            # Long flag: exact denylist hit, or — git surface only — an
+            # unambiguous prefix abbreviation. An inline `=value` is split off.
+            flag_part, has_eq, inline_value = token.partition("=")
+            canonical = alias_to_canonical.get(flag_part)
+            if canonical is None and is_git_surface:
+                prefix_matches = [
+                    name for name in canonical_long_names if name.startswith(flag_part)
+                ]
+                # Exactly one match = unambiguous; >1 is ambiguous (git itself
+                # rejects it, so the command never runs) and binds nothing.
+                if len(prefix_matches) == 1:
+                    canonical = prefix_matches[0]
+            if canonical is None:
+                i += 1
+                continue
+            if canonical in value_taking:
+                if has_eq:                       # --repo=value
+                    found.add(f"{canonical}={inline_value}")
+                    i += 1
+                elif i + 1 < n:                  # --repo value
+                    found.add(f"{canonical}={tokens[i + 1]}")
+                    i += 2
+                else:                            # --repo (value missing; degenerate)
+                    found.add(canonical)
+                    i += 1
+            else:
+                # boolean: an explicit `=false`/`=0`/`=no` DISABLES the flag (the SAFE
+                # form), so it must NOT bind — else an approval of `--admin=false`
+                # would set-equal an execution of `--admin=true` (both → {--admin}) and
+                # AUTHORIZE the escalation. Any other (or no) value binds.
+                if not (has_eq and inline_value.lower() in _NEGATED_FLAG_VALUES):
+                    found.add(canonical)
+                i += 1
+            continue
+
+        # Short cluster (single dash): a general per-character walk that subsumes
+        # the lone short (`-R`), the combined boolean cluster (`-sd`), the
+        # attached short value (`-Rx`), and any mixed ordering (`-dR`, `-Rd`). A
+        # value-taking short consumes the REST of the cluster (or the next token)
+        # as its value and stops the walk — pflag semantics — so no bound short
+        # is ever dropped from a cluster.
+        cluster = token[1:]
+        consumed_next = False
+        j = 0
+        while j < len(cluster):
+            canonical = alias_to_canonical.get("-" + cluster[j])
+            if canonical is None:
+                j += 1
+                continue
+            if canonical in value_taking:
+                remainder = cluster[j + 1:]
+                if remainder.startswith("="):    # `-R=value`
+                    remainder = remainder[1:]
+                if remainder:                    # `-Rvalue`
+                    found.add(f"{canonical}={remainder}")
+                elif i + 1 < n:                  # `-R value`
+                    found.add(f"{canonical}={tokens[i + 1]}")
+                    consumed_next = True
+                else:                            # `-R` (value missing; degenerate)
+                    found.add(canonical)
+                break
+            found.add(canonical)                 # boolean short; keep walking
+            j += 1
+        i += 2 if consumed_next else 1
+
+    return sorted(found)
+
+
+def extract_command_context(command: str, flag_scan_text: str | None = None) -> dict:
+    """Extract operation context FROM A COMMAND STRING (never prose).
+
+    The shared SSOT both merge-guard hooks call. A key is PRESENT only when
+    positively extracted; ABSENT otherwise (absence — NOT a None value — is the
+    fail-closed signal). Possible keys:
+        operation_type: "merge" | "close" | "force-push" | "branch-delete"
+                        | "push-to-main" | "remote-ref-delete" | "remote-mass-delete"
+                        | "branch-protection"
+        pr_number:  str  (merge / close)
+        branch:     str  (branch-delete — SINGLE target, exactly 1 positional)
+        branch_set: str  (branch-delete — MULTI target #1129, >=2 positionals) —
+                     canonical sort+dedup+quote-strip names via the shared netstring _canonical_join (`len:name` framing,
+                     injective by construction, content-agnostic — no delimiter collision)
+        target_ref: str  (force-push / push-to-main, KD-6; remote-ref-delete #1062a)
+        push_set:   str  (push-to-main MULTI-ref #1195 OBS-G, >=2 refspecs) —
+                     canonical sort+dedup FULL-refspec identity via the shared
+                     netstring _canonical_join (remote-agnostic; the scalar
+                     target_ref owns the single-ref form — exactly one populated)
+        force_push_set: str (force-push MULTI-ref #1195 OBS-I, >=2 refspecs) —
+                     canonical FORCED-NORMALIZED identity (class-wide --force
+                     upgrades elements to '+'-form) gated by the ref-scope-neutral
+                     flag allowlist; exactly one of target_ref / push_set /
+                     force_push_set populated per command
+        mass_target: str (remote-mass-delete #1062b) — normalized identity STRING
+                     _canonical_join([<sorted-mass-flags>, <remote-or-implicit-marker>, *<sorted-deduped-refspecs>])
+        protected_branch: str (branch-protection #1063) — the branch from the
+                     branches/<b>/protection URL path
+        bound_flags: list[str]  (#1042) — sorted normalized privileged flags;
+                     ALWAYS present when operation_type is (empty list when none).
+
+    `flag_scan_text` (#1042) widens ONLY the privileged-flag scan to a fuller
+    surface than `command` — the mint arm passes the full selected-option text so
+    a flag positioned after a quoted argument is not lost to region truncation
+    (the read arm passes nothing, scanning the raw command). Op/target are ALWAYS
+    derived from `command` (region-anchored — preserves the anti-distractor
+    multiplicity gate); only the flag scan honors `flag_scan_text`.
+    """
+    context: dict = {}
+    # Line-continuation parity (mint==read by construction): join bash `\<newline>` on
+    # BOTH the op/target-anchoring `command` AND the wider `flag_scan_text` BEFORE
+    # detection, so the #1042 flag bind and the op/target derivation are continuation-
+    # INVARIANT and identical on both arms. Without this, a faithful
+    # `gh pr close 5 \<newline>--delete-branch` (whose region locate_command_regions now
+    # joins upstream) still bound NO flag on the MINT arm — its flag scan reads the raw
+    # option text whose `\<newline>` split `--delete-branch` off — while the READ arm,
+    # scanning the clean executed command, bound {--delete-branch}; the set-equality
+    # bind then REFUSED the faithful click (an over-block). Idempotent on already-
+    # normalized input, a strict no-op without a literal `\<newline>`, and join-only —
+    # it can only COMPLETE a split flag, never drop one.
+    command = _normalize_line_continuations(command)
+    if flag_scan_text is not None:
+        flag_scan_text = _normalize_line_continuations(flag_scan_text)
+    op_type = detect_command_operation_type(command)
+    if op_type is None:
+        return context
+    context["operation_type"] = op_type
+    # bound_flags is computed HERE (the single call site) so both arms inherit it
+    # un-driftably. It is an ATTRIBUTE of the (op,target) pair, never part of pair
+    # identity (_target_value / _collect_pairs ignore it), so flag variation can
+    # never inflate the distinct-pair count and trip the multiplicity refusal.
+    context["bound_flags"] = extract_privileged_flags(
+        flag_scan_text if flag_scan_text is not None else command, op_type
+    )
+    if op_type in ("merge", "close"):
+        pr_number = _extract_pr_number(command)
+        if pr_number is None and op_type == "merge":
+            pr_number = _extract_api_merge_pr(command)   # #1096 API pulls/<N>/merge
+        if pr_number is not None:
+            context["pr_number"] = pr_number
+    elif op_type == "branch-delete":
+        # Single-branch scalar path (BYTE-IDENTICAL): exactly ONE positional.
+        branch = _extract_branch_name(command)
+        if branch is not None:
+            context["branch"] = branch
+        else:
+            # Multi-branch (>=2 positionals) FORCE-delete: bind the canonical
+            # sorted+deduped branch-SET identity (#1129 R1, mirrors mass_target).
+            # _extract_branch_name returns non-None ONLY for exactly 1 positional
+            # and _extract_branch_delete_set ONLY for >=2, so they are MUTUALLY
+            # EXCLUSIVE -> a command populates EXACTLY ONE of `branch` /
+            # `branch_set` (the boundary discriminator). The distinct key plus the
+            # op-type-identity check in the read switch keep a scalar token from
+            # cross-authorizing a set command (and vice-versa).
+            branch_set = _extract_branch_delete_set(command)
+            if branch_set is not None:
+                context["branch_set"] = branch_set
+    elif op_type in ("force-push", "push-to-main"):
+        # push-to-main reuses the force-push target parser: its target IS the
+        # main/master ref that parser already returns for a plain push.
+        target_ref = _extract_force_push_target_ref(command)
+        if target_ref is not None:
+            context["target_ref"] = target_ref
+        elif op_type == "push-to-main":
+            # DISTINCT-set boundary (#1195 OBS-G): the MULTI-ref push-to-main
+            # identity, populated ONLY when the scalar refused (multi-ref ->
+            # target_ref None). Exactly ONE of `target_ref` / `push_set` /
+            # `force_push_set` is populated per command — the scalar's `!=2 ->
+            # None`, the sets' `<2 -> None`, and this op split are mutually
+            # exclusive by construction — so no scalar/set or cross-op
+            # cross-authorization window exists.
+            push_set = _extract_push_to_main_set(command)
+            if push_set is not None:
+                context["push_set"] = push_set
+        else:
+            # force-push (#1195 OBS-I, reversing the OBS-G scope boundary under
+            # its own ratified proof): the MULTI-ref FORCED-NORMALIZED set
+            # identity, gated by the ref-scope-neutral flag ALLOWLIST (see
+            # _extract_force_push_set) — a delete/mass/scope-expander/unknown
+            # flag on the execution or the approval derives force_push_set=None
+            # and fails SAFE to gated-but-unmintable / read-refused. The scalar
+            # _extract_force_push_target_ref above remains byte-untouched;
+            # multi-ref DELETE spellings still never mint (delete never gains a
+            # set — they classify remote-ref-delete/mass, not force-push, and a
+            # force-masked delete flag fails the allowlist).
+            force_push_set = _extract_force_push_set(command)
+            if force_push_set is not None:
+                context["force_push_set"] = force_push_set
+    elif op_type == "remote-ref-delete":
+        # #1062a: REUSE the `target_ref` key — the parser yields a ref, the key is
+        # semantically right, and the op-class identity (checked FIRST in the read
+        # switch) keeps a remote-ref-delete token from cross-authorizing a
+        # force-push/push-to-main with the same target_ref. Recognition⟺extractability:
+        # detect returned this op IFF the extractor yields a ref, so it is non-None here.
+        ref = _extract_remote_ref_delete_target(command)
+        if ref is not None:
+            context["target_ref"] = ref
+    elif op_type == "remote-mass-delete":
+        # #1062b: DISTINCT key `mass_target` (not target_ref — the value is a
+        # normalized identity tuple, a different shape from a ref). op-identity-first
+        # in the read switch already prevents cross-op match; a distinct key avoids any
+        # accidental equality with a ref-shaped target_ref. Recognition⟺extractability.
+        mass_target = _extract_mass_delete_target(command)
+        if mass_target is not None:
+            context["mass_target"] = mass_target
+    elif op_type == "branch-protection":
+        # #1063: the protected branch is PATH-resident (branches/<b>/protection).
+        # Distinct key `protected_branch`; op-identity-first in the read switch keeps
+        # it from cross-authorizing a branch-delete of the same branch name.
+        protected_branch = _extract_protection_branch(command)
+        if protected_branch is not None:
+            context["protected_branch"] = protected_branch
+    return context
+
+
+# Shell compound + FD-redirect regexes — the SSOT for BOTH the read side
+# (merge_guard_pre.is_compound_destructive_command re-imports these) AND the mint
+# side (which runs is_compound_destructive_command on each locate_command_regions
+# region). Centralized here so both sides scan on IDENTICAL separators (the #720
+# anti-drift class).
+#
+# `_COMPOUND_OPS_RE` matches the COMPLETE bash command-separator/backgrounding set
+# (P3): `&&`, `||`, `|&`, `;`, a bare `&` (background — the finding-#1 ride-along), a
+# bare `|` shell pipe, and newline. Multi-char ops precede their single-char prefixes
+# in the alternation so a match never mis-segments (`&&` before `&`; `||`/`|&` before
+# `|`). Scanned on the P2 QUOTE-MASKED view so an operator inside a quoted argument is
+# NOT a separator. FD-redirect / and-redirect / clobber tokens (`2>&1`, `1>&2`, `3<&0`,
+# `&>`, `&>>`, `>|`) are NEUTRALIZED by `_FD_REDIRECT_RE` BEFORE the scan so the new
+# bare-`&` arm does NOT false-positive on the bash redirect-both operator
+# (`gh pr merge 5 &>out.log` is NOT a compound) — NOT via lookaround on the bare-pipe
+# arm (an earlier lookbehind `(?<![0-9>])\|(?![<&])` had a spaceless-adjacency bypass:
+# `... 2>&1|gh pr merge 999` slipped past; the structural pre-strip eliminates that
+# class). `_FD_REDIRECT_RE`: `\d*[<>]&` (any `[<>]&` redirect prefix — fd-dup `2>&1`,
+# fd-close `0<&-`, csh `>&out.log`) | `>\|` (clobber) | `&>>?` (and-redirect `&>`/`&>>`;
+# the leading-`&` form). Audit: loosening
+# `_COMPOUND_OPS_RE` must preserve the seven shapes; the `&>`/`&>>` neutralization must
+# stay coupled to the bare-`&` arm; the pre-strip is the single source of truth.
+_COMPOUND_OPS_RE = re.compile(r"&&|\|\||\|&|;|&|\||\n")
+# `\d*[<>]&` neutralizes EVERY `[<>]&` redirect prefix — fd-dup (`2>&1`,`1>&2`),
+# fd-close (`0<&-`,`1>&-`), and csh and-redirect-to-file (`>&out.log`) — so the bare-`&`
+# arm cannot FP on any of them. A REAL background `&` is whitespace-preceded (` & `),
+# never `[<>]`-preceded, so it still detects. `&>>?` covers the leading-`&` and-redirect
+# (`&>`/`&>>`); `>\|` the clobber.
+_FD_REDIRECT_RE = re.compile(r"\d*[<>]&|>\||&>>?")
+
+
+
+def locate_command_regions(text: str) -> list[str]:
+    """Return ALL gh/git destructive-command regions in ONE string, in document
+    order.
+
+    A region is a candidate command substring — a quoted region (via
+    `_QUOTED_COMMAND_RE`) OR a bare `gh ...`/`git ...` span (via
+    `_BARE_COMMAND_RE`) — that `detect_command_operation_type` classifies
+    non-None.
+
+    Takes a SINGLE string, NEVER an options array (D3 structural invariant: the
+    function can never receive non-selected options, so it CANNOT over-scan —
+    'make illegal states unrepresentable' on a security boundary). The caller
+    passes ONE question's text or ONE selected option's text at a time.
+    """
+    # Mint==read parity: join bash line-continuations (`\<newline>` -> space) BEFORE
+    # the region scans, so the mint joins continuations IDENTICALLY to the read side
+    # (is_dangerous_command + is_compound_destructive_command both normalize first).
+    # Without this, `gh pr close 5 \<newline>--delete-branch` truncated at the newline
+    # to a non-dangerous region (`gh pr close 5 \`) -> mint withheld a token while the
+    # read side (normalized) DENIED the full command -> a faithful click was OVER-blocked.
+    # Offset/length note: the join SHORTENS text (2 chars -> 1), but every offset below
+    # (the `covered` quoted spans, the masked-view bare-span slices) indexes into THIS
+    # SAME normalized `text`, and the function returns region STRINGS (never offsets into
+    # the caller's original), so the length change is internally consistent and invisible
+    # to every caller. Join-only + no-op without a literal `\<newline>` -> detection can
+    # only INCREASE (never drop), so no new under-block.
+    text = _normalize_line_continuations(text)
+    regions: list[str] = []
+    covered: list[tuple[int, int]] = []
+    # Quoted regions first — an explicit command literal is the canonical form.
+    # COVER only quoted regions that ARE commands: a non-command quoted ARGUMENT
+    # (`--comment "x"`) must NOT be covered, else the masked-view bare span below
+    # (which now extends THROUGH it) would be wrongly skipped and drop #5's trailing
+    # flag. An embedded quoted COMMAND, by contrast, IS covered + captured separately
+    # so the multiplicity gate still refuses a distractor.
+    for match in _QUOTED_COMMAND_RE.finditer(text):
+        candidate = match.group(1) or match.group(2) or match.group(3)
+        if candidate and detect_command_operation_type(candidate) is not None:
+            covered.append((match.start(), match.end()))
+            regions.append(candidate)
+    # Bare gh/git spans located on the P2 QUOTE-MASKED view so a quoted ARGUMENT in
+    # the MIDDLE of a command (`--comment "x"`) no longer truncates the span and
+    # drops a trailing flag (#5). Single/double-quoted spans mask to spaces (the bare
+    # span extends through them); real separators (`;` `|` `&` newline) and backticks
+    # are NOT masked, so they still bound the span. Region text is sliced from the
+    # ORIGINAL so the real quoted value is preserved. The skip is CONTAINMENT (the
+    # bare span lies ENTIRELY within an already-captured quoted command, e.g. a
+    # backtick command) — NOT mere overlap: the outer command of a distractor
+    # `... "gh pr merge 999"` CONTAINS the covered inner region rather than being
+    # contained by it, so it is still added → two regions → multiplicity refuses.
+    masked = _mask_shell_quotes(text)
+    for match in _BARE_COMMAND_RE.finditer(masked):
+        if any(
+            c_start <= match.start() and match.end() <= c_end
+            for c_start, c_end in covered
+        ):
+            continue
+        span = text[match.start():match.end()].strip()
+        if detect_command_operation_type(span) is not None:
+            regions.append(span)
+    return regions
+
+
+def locate_command_region(text: str) -> str | None:
+    """Convenience: the first command region in `text`, else None. SINGLE
+    string arg (same D3 invariant as locate_command_regions)."""
+    regions = locate_command_regions(text)
+    return regions[0] if regions else None
+
+
+def cleanup_consumed_tokens(token_dir: Path) -> None:
+    """Remove stale .consumed token files and .use-N markers older than TOKEN_TTL.
+
+    Called from both hooks: during token scanning (pre-hook) and during
+    token creation (post-hook) to prevent accumulation. The .use-N markers
+    accompany N-use tokens (#720 Bug C) and persist on disk alongside the
+    .consumed terminal-rename until the TTL window elapses.
+
+    Args:
+        token_dir: Directory containing token files
+    """
+    now = time.time()
+    patterns = (
+        str(token_dir / f"{TOKEN_PREFIX}*.consumed"),
+        str(token_dir / f"{TOKEN_PREFIX}*{USE_MARKER_SUFFIX}*"),
+    )
+    for pattern in patterns:
+        for stale_path in glob.glob(pattern):
+            try:
+                # Use file modification time as a proxy for consumption time
+                mtime = os.path.getmtime(stale_path)
+                if now - mtime > TOKEN_TTL:
+                    try:
+                        os.unlink(stale_path)
+                    except OSError:
+                        pass
+            except OSError:
+                # File may have been cleaned up concurrently — ignore
+                pass
+
+
+def cleanup_unused_tokens(token_dir: Path) -> None:
+    """Atomically retire (rename to .consumed) any unused tokens in token_dir.
+
+    Maintains invariant I-1 (at most one unused token at any time). Called
+    from merge_guard_post.write_token() BEFORE the O_EXCL create of the new
+    token so that, at the instant O_EXCL succeeds, the directory holds zero
+    unused tokens (just cleaned) plus the new one — exactly one.
+
+    Concurrency model: POSIX rename(2) is atomic on the same filesystem.
+    When two writers race, exactly one rename of any given source path
+    succeeds; the loser raises FileNotFoundError which is swallowed. No
+    fs-lock required.
+
+    Args:
+        token_dir: Directory containing token files
+
+    Side effects:
+        Renames matching unused token files to <path>.consumed. Skips
+        already-.consumed paths and .use-N marker siblings (the latter
+        are auxiliary files for N-use slot claims; reaped by
+        cleanup_consumed_tokens at TOKEN_TTL boundary).
+    """
+    pattern = str(token_dir / f"{TOKEN_PREFIX}*")
+    for path in glob.glob(pattern):
+        # Already terminal — skip to avoid creating .consumed.consumed shape.
+        if path.endswith(".consumed"):
+            continue
+        # Per-use slot markers are NOT tokens; preserve them as audit trail
+        # alongside their parent token's retirement (cleanup_consumed_tokens
+        # reaps them at the TOKEN_TTL boundary).
+        if USE_MARKER_SUFFIX in os.path.basename(path):
+            continue
+        try:
+            os.rename(path, path + ".consumed")
+        except (FileNotFoundError, OSError):
+            # Concurrent retire (another writer's cleanup, or _consume_token
+            # claiming the same path) won the race — the invariant holds
+            # either way. Swallow.
+            pass
+
+
+def cleanup_orphan_tokens(
+    token_dir: Path,
+    max_age_seconds: int = ORPHAN_TOKEN_MAX_AGE_SECONDS,
+) -> None:
+    """Reap unconsumed tokens older than max_age_seconds (disk hygiene).
+
+    Targets tokens that escaped the normal lifecycle — e.g., when the
+    consuming dangerous-Bash command was never executed after authorization,
+    leaving a token to expire silently. TOKEN_TTL already expires
+    them for authorization purposes; this helper unlinks them from disk to
+    bound accumulation.
+
+    Idempotent. Fail-open on all OSError paths (file gone, permission
+    denied, dir missing) — disk hygiene must never block any caller.
+
+    Args:
+        token_dir: Directory containing token files
+        max_age_seconds: Reap threshold (default ORPHAN_TOKEN_MAX_AGE_SECONDS).
+
+    Side effects:
+        Unlinks matching token files. Skips .consumed and .use-N markers.
+    """
+    now = time.time()
+    pattern = str(token_dir / f"{TOKEN_PREFIX}*")
+    for path in glob.glob(pattern):
+        if path.endswith(".consumed"):
+            continue
+        if USE_MARKER_SUFFIX in os.path.basename(path):
+            continue
+        try:
+            mtime = os.path.getmtime(path)
+        except OSError:
+            # File gone between glob and stat — race-safe no-op.
+            continue
+        if now - mtime > max_age_seconds:
+            try:
+                os.unlink(path)
+            except OSError:
+                # Race vs concurrent cleanup or permission flake — swallow.
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Read-floor danger predicates (GAP1/GAP5) — PROMOTED from merge_guard_pre.py so
+# BOTH the read hook AND the mint hook (merge_guard_post) call the SAME predicate:
+# the mint gates its token-write on is_dangerous_command (mint⊆read by construction)
+# and refuses any compound via is_compound_destructive_command. pre.py re-imports
+# these. _COMPOUND_OPS_RE/_FD_REDIRECT_RE already live above (GAP5 elevation).
+# ---------------------------------------------------------------------------
+
+DANGEROUS_PATTERNS = [
+# PR merge via gh CLI
+re.compile(_GH_PREFIX + r"pr\s+merge\b"),
+# PR close with --delete-branch: the close+--delete-branch danger arms live in
+# _CLOSE_LITERAL_ARMS (defined with the classifier patterns above) — matched
+# PER-LEG by is_dangerous_command after this list misses (#1087 leg isolation),
+# NOT whole-string here (a whole-command match fired cross-leg and laundered an
+# ambiguous multi-close into an escalated-single token). Bare close is reversible.
+# Force push arms live in _FORCE_PUSH_LITERAL_ARMS (defined with the classifier
+# patterns above) — matched PER-LEG by is_dangerous_command after this list
+# misses (#1082 leg isolation), NOT whole-string here.
+# Force-branch-delete arms live in _BRANCH_DELETE_LITERAL_ARMS (defined with the
+# classifier patterns above) — matched PER-LEG by is_dangerous_command after this
+# list misses (#1094 leg isolation), NOT whole-string here (a whole-command match
+# fired cross-leg on a stray -D / --delete --force token in a benign leg).
+# API danger arms (merge / git-refs / branch-protection / contents / implicit-POST,
+# across gh api / curl / wget) live in _API_LITERAL_ARMS (defined with the classifier
+# patterns above) — matched PER-LEG by is_dangerous_command after this list misses
+# (#1086 leg isolation), NOT whole-string here (a whole-command match fired cross-leg
+# and over-blocked a benign compound carrying a method/body-flag token in a benign leg).
+# Direct push to a default branch (bypasses PR merge) — the former HEAD:main / HEAD:master
+# and bounded-flag-walk main / master literals were REMOVED (#1195 OBS-E): the read floor
+# recognizes push-to-main via `_flag_condition_danger_op` (its sole consumer here,
+# _stripped_surface_danger, calls it), using the UNIFIED _PUSH_MAIN_DST_RE refspec-DST
+# predicate — the SAME arm detect uses, so mint==read holds by construction with no second
+# copy to drift. The unified predicate fixes both the prefix over-block (main-release) and
+# the <src>:dst / full-ref under-block (feature:main / refs/heads/main) the literals had.
+]
+
+
+def _has_pipe_to_shell(command: str) -> bool:
+    """Check if command pipes output to a shell interpreter.
+
+    Detects patterns like ``echo "..." | bash``, ``printf "..." | sh``,
+    and ``echo "..." | xargs bash`` where echo/printf content would be
+    executed by the receiving shell.
+    """
+    return bool(
+        re.search(r"\|\s*(?:bash|sh|zsh)\b", command)
+        or re.search(r"\|\s*xargs\s+(?:.*\s+)?(?:bash|sh|zsh)\b", command)
+    )
+
+
+# Path-qualified shell token. Trailing (?![\w/]) anchors the shell name as a
+# whole PATH-LEAF token: excludes prefix-of-name (`>(basht)`/`>(teehee)`) AND
+# `>(bash/foo)` (bash is a DIRECTORY, foo the executable) while KEEPING
+# metachar-separated real vectors `>(bash;ls)`/`>(bash&&x)`/`>(bash|cat)`
+# (bash still executes).
+#
+# ReDoS — ReDoS-free AS USED, NOT standalone. Both arms anchor this token behind
+# `>\(`, so re.search only attempts it at the handful of `>(` offsets in a real
+# command. STANDALONE the nested `(?:[^\s)/]*/)*` is O(N^2): re.search retries at
+# EVERY start position (multi-offset retry) with an O(N) per-offset forward scan
+# — measured ~4x per input-doubling on pathological no-slash / all-slash input.
+# This is NOT within-match catastrophic backtracking (an anchored re.match is
+# linear, ~2x/double), so an atomic group `(?>...)` would NOT fix it (and atomic
+# groups are unavailable anyway — requires-python >=3.7). DO NOT reuse this token
+# UNGATED; if it is ever needed ungated, bound the path segments
+# `(?:[^\s)/]*/){0,K}` (the F1 mechanism), which caps the per-offset scan.
+_PROCSUB_SHELL = r"(?:[^\s)/]*/)*(?:bash|sh|zsh)(?![\w/])"
+
+
+def _has_process_substitution_to_shell(command: str) -> bool:
+    """Check if a command uses process substitution fed to a shell interpreter.
+
+    Detects:
+      - input-side  ``bash <(echo "...")``  — the shell consumes the substitution
+        as its input script (the original guard, UNCHANGED);
+      - output-side ``echo "..." > >(bash)`` — the command's stdout is routed into
+        a shell via process substitution. Caught in two forms (#1002):
+          * Arm A — ``>(shell)`` as a stdout-routing REDIRECT TARGET. The operator
+            set is stdout-only (``>``, ``>>``, ``1>``, ``1>>``, ``&>``, ``&>>``,
+            the csh ``>&`` excluding the fd-duplication ``>&N``, and the clobber
+            ``>|``); stderr-only routing (``2>``/``3>``) is excluded by omission.
+          * Arm B — ``>(shell)`` as a command ARGUMENT (tee-fanout & general, e.g.
+            ``... | tee >(bash)``). Keyed on a preceding NON-redirect token (word
+            char, quote, or close-bracket), so ``2> >(bash)`` (preceded by ``>``)
+            is NOT matched — the stderr exclusion holds on this arm too.
+    Both output-side arms accept an optional path prefix (``>(/bin/bash)``,
+    ``>(./sh)``) and require the shell name as a whole path-leaf token: non-shell
+    targets (``> >(tee ...)``, ``> >(cat ...)``), prefix-of-name (``>(teehee)``,
+    ``>(basht)``), and ``>(bash/foo)`` (bash a directory) are NOT matched.
+
+    The guard is consumed ONLY as a strip-SKIP condition: a True result PRESERVES
+    content for the dangerous-pattern scan, so widening it is monotonically
+    detection-increasing (INV-D2-safe; cannot create a false-negative).
+    """
+    return bool(
+        re.search(r"\b(?:bash|sh|zsh)\s+<\(", command)                       # input-side (unchanged)
+        # Arm A — redirect TARGET, stdout-routing operators only (stderr excluded by construction):
+        or re.search(r"(?:&>>?|>&(?![0-9])|>\||1>>?|(?<![0-9])>>?)\s*>\(\s*" + _PROCSUB_SHELL, command)
+        # Arm B — procsub as a command ARGUMENT (tee-fanout & general): preceded by a NON-redirect token:
+        or re.search(r"[\w\"')\]}]\s+>\(\s*" + _PROCSUB_SHELL, command)
+    )
+
+
+# Heredoc-BODY excision for the routing-flag view (#1129 R3). Reuses carrier-1's
+# marker grammar but replaces the BODY ONLY: the opener line (including a
+# genuinely-executing `| bash` / `> >(bash)` TAIL) and the closing marker stay
+# visible to the routing scan. Carrier-1's whole-match replacement would swallow
+# the opener tail and regress the pinned heredoc-pipe/procsub canaries
+# (under-block). Same input-side guard as carrier 1: a shell-fed body
+# (`bash <<EOF`) executes, so it is preserved. The REAL carrier-1 strip is
+# intentionally left untouched (this excision builds a view-only scan surface).
+_HEREDOC_BODY_RE = re.compile(
+    r"(<<-?\s*['\"]?(\w+)['\"]?[^\n]*\n)"   # 1: operator+marker+opener TAIL (kept)
+    r"(?:.*?\n)?"                            #    body (excised)
+    r"(\t*\2(?![\w]))",                      # 3: closing marker (kept)
+    re.DOTALL,
+)
+
+
+def _excise_heredoc_bodies_for_routing_scan(command: str) -> str:
+    if "<<" not in command:          # cheap short-circuit (perf: common case)
+        return command
+
+    def _repl(m: "re.Match") -> str:
+        preceding = command[: m.start()].rstrip()
+        if re.search(r"\b(?:bash|sh|zsh)\s*$", preceding):
+            return m.group(0)        # shell-fed heredoc: body executes — keep
+        return m.group(1) + "HEREDOC_BODY_EXCISED\n" + m.group(3)
+
+    return _HEREDOC_BODY_RE.sub(_repl, command)
+
+
+def _delimiter_is_unescaped(excised: str, d: int) -> bool:
+    """True iff the char at excised[d] is an UNescaped shell word-delimiter. Counts the
+    consecutive backslash run ending at d-1: EVEN (incl. 0) → the delimiter is real; ODD →
+    the delimiter is backslash-escaped (a literal char, part of the word) → NOT a delimiter.
+    Real-bash discriminant (the design intent): with `echo "x"\\ #y | sh`, the escaped space
+    is a literal argument char, the `#` is mid-word, and bash EXECUTES the pipe — so the
+    routing view must keep it; with `echo "x" #y | sh` (unescaped) bash treats `#`..EOL as a
+    comment and the pipe is SUPPRESSED — so excision is correct. `\\\\ #` (even run: literal
+    backslash then a real space) is a comment again, matching bash."""
+    b = d - 1
+    bs = 0
+    while b >= 0 and excised[b] == "\\":
+        bs += 1
+        b -= 1
+    return bs % 2 == 0
+
+
+def _excise_comments_view(excised: str, view: str) -> str:
+    """Step 3 of _excise_and_mask: view-only, SAME-LENGTH comment excision. A `#`
+    is a comment iff (a) it SURVIVES the quote mask (view[i] == "#": unquoted by
+    construction) AND (b) its predecessor ON THE PRE-MASK SURFACE (excised[i-1];
+    i == 0 counts as a comment start) is one of {start, space, tab, newline, ;,
+    &, |} AND (c) that delimiter is UNESCAPED (_delimiter_is_unescaped: even
+    backslash run immediately before it — `\\ #` / `\\<tab>#` / `\\;#` / `\\&#` /
+    `\\|#` make the `#` mid-word, NOT a comment, and bash EXECUTES what follows).
+    Testing the RAW predecessor is load-bearing: a masked closing quote
+    reads as a space on the view, so a view-side test would misclassify
+    `"x"#tail` as a comment (an executing tail eaten = under-block). The excision
+    replaces `#`..end-of-line (newline EXCLUDED) with spaces — same length, so
+    both consumers' 1:1 view/excised offset alignment holds (_procsub_anchor_view
+    indexes the pair pairwise). FAIL-TOWARD-NOT-COMMENT: any predecessor outside
+    the set leaves the text visible (worst case a residual over-block, never an
+    under-block). The pinned predecessor set is a strict SUBSET of bash's
+    comment-start contexts (bash also comments after `(`, backtick, …): fewer
+    excisions than bash = fail-toward-not-comment relative to ground truth — do
+    not widen without cert rows. Mask-BEFORE-excise gives quote-awareness for
+    free: a `#` inside a balanced quoted span is already spaces in `view`, so a
+    quoted `# … | sh` payload can never be excised through this step."""
+    if "#" not in view:                       # cheap short-circuit
+        return view
+    out = list(view)
+    i, n = 0, len(view)
+    while i < n:
+        if view[i] == "#" and (
+            i == 0
+            or (
+                excised[i - 1] in " \t\n;&|"
+                and _delimiter_is_unescaped(excised, i - 1)
+            )
+        ):
+            j = view.find("\n", i)
+            if j == -1:
+                j = n
+            for k in range(i, j):
+                out[k] = " "
+            i = j
+        else:
+            i += 1
+    return "".join(out)
+
+
+def _excise_and_mask(command: str) -> tuple[str, str]:
+    """Shared prefix for the two routing-flag views (#1129 R3): excise heredoc
+    bodies (opener line + closing marker kept; shell-fed bodies preserved), then
+    space-mask every balanced quoted span via _mask_shell_quotes, then excise
+    unquoted comments from the VIEW ONLY (a `#`-comment's `| sh` must not flip
+    piped_to_shell and disable every carrier — the comment text never executes).
+    Returns (excised, view). ORDER IS LOAD-BEARING: heredoc excision FIRST (stray
+    body quotes desync the quote mask — and a `#` inside a heredoc body is gone
+    before step 3 runs); mask BEFORE comment excision ("survives the mask" IS the
+    quote-awareness — a pre-mask excision on the raw string would eat executing
+    `' | sh'` tails through a quoted `#`). Steps 2 and 3 are both SAME-LENGTH, so
+    view and excised align 1:1 by offset."""
+    excised = _excise_heredoc_bodies_for_routing_scan(command)
+    view = _mask_shell_quotes(excised)
+    view = _excise_comments_view(excised, view)
+    return excised, view
+
+
+def _executed_surface_view(command: str) -> str:
+    """Routing-flag scan surface (#1129 R3): the command with non-executed
+    data removed — heredoc BODIES excised (opener line + closing marker kept;
+    shell-fed bodies preserved), then every balanced quoted span masked to
+    spaces via _mask_shell_quotes (defined later in this module; resolved at
+    call time). Fail direction: unbalanced/ambiguous quoting leaves text
+    UNMASKED -> the routing token stays visible -> detection preserved (at
+    worst a residual over-block on malformed input, never an under-block).
+    ORDER IS LOAD-BEARING: heredoc excision FIRST removes stray body quotes
+    that could desync the quote mask. Consumed ONLY by the hoisted
+    piped_to_shell / process_sub_to_shell computation; never fed to
+    DANGEROUS_PATTERNS and never returned as strip output."""
+    return _excise_and_mask(command)[1]
+
+
+def _procsub_anchor_view(command: str) -> str:
+    """OUTPUT-SIDE process-substitution routing view (#1129 R3-fix). The space-mask
+    executed-surface view, then arm B's preceding-token ANCHOR restored ONLY
+    immediately-left of a SURVIVING >(shell) whose writer token was a masked quoted
+    span. Everything from >( rightward is viewed EXACTLY as the space-mask (so the
+    incidental >("ba"sh)->>(    sh) catch is preserved). Re-catches the R3 arm-B
+    anchor regression WITHOUT a blanket fill (which breaks the shell-name region ->
+    a NEW under-block on >("ba"sh)) and WITHOUT computing arm B over raw (which
+    would re-flag a `>(shell)` sitting inside quoted carrier data). Relies on
+    _mask_shell_quotes being SAME-LENGTH: view and excised align 1:1 by offset.
+    Consumed ONLY by process_sub_to_shell."""
+    excised, view = _excise_and_mask(command)        # excise + space-mask; offsets aligned
+    if ">(" not in view:                             # cheap short-circuit (common case)
+        return view
+    out = list(view)
+    for m in re.finditer(r">\(", view):              # each SURVIVING >( on the view
+        i = m.start()
+        k = i - 1
+        # skip a genuine UNMASKED bash blank (space OR tab): view==excised at an unmasked position
+        while k >= 0 and view[k] == excised[k] and excised[k] in " \t":
+            k -= 1
+        # stop char masked to space in the view but a CLOSING QUOTE in raw ==
+        # a quoted writer token ended here -> reveal its closing quote (in arm B's
+        # class ['\w"')\]}]) so `<anchor>\s+>\(` matches. A redirect op (>, 2>) or a
+        # genuine separator is NOT a quote -> no restore -> arm A / stderr-exclusion
+        # and the absent-anchor case are all untouched.
+        if k >= 0 and view[k] == " " and excised[k] in "\"'":
+            out[k] = excised[k]
+    return "".join(out)
+
+
+def _has_eval_or_source(command: str) -> bool:
+    """Check if command contains eval or source that could execute variable values.
+
+    Detects patterns like ``CMD="..." && eval $CMD`` where a variable
+    assignment value would be executed via eval or source.
+    """
+    return bool(re.search(r"\b(?:eval|source)\b", command))
+
+
+def _var_is_expanded(var_name: str, command: str) -> bool:
+    """Check if a variable is expanded (used) elsewhere in the command.
+
+    Detects patterns like ``$VAR`` or ``${VAR}`` that would execute
+    the variable's value as a command when used bare (e.g., ``CMD="gh pr merge 42" && $CMD``).
+    """
+    # Match $VAR (word boundary) or ${VAR}
+    return bool(re.search(r"\$\{?" + re.escape(var_name) + r"\b", command))
+
+
+def _has_command_substitution(quoted_content: str) -> bool:
+    """Check if double-quoted content contains command substitution.
+
+    ``$(...)`` and backticks inside double quotes are executed by the shell,
+    so double-quoted strings containing them must not be stripped.
+    Single-quoted strings never have substitution (handled separately).
+    """
+    return "$(" in quoted_content or "`" in quoted_content
+
+
+# Span-scoped command-substitution preserve (#1140). The two scanners below let
+# _keep_carrier_value preserve ONLY the genuine `$(...)`/backtick SPANS of a value
+# (they execute -> stay caught) while stripping the surrounding INERT literal — the
+# cure for the over-block where a benign `$(date)` beside danger-looking prose caused
+# the WHOLE value to be preserved. Both are single-pass char walks (O(n), no regex
+# backtracking): each advances its cursor monotonically and visits every char O(1) times.
+def _extract_dollar_paren(c, i):
+    """Return the balanced ``$(...)`` span starting at c[i] (c[i]=='$', c[i+1]=='(')
+    and the index just past it, via a quote-aware + escape-aware depth counter: a ``)``
+    inside a NESTED ``$(...)`` or inside a quoted span does NOT close the outer span.
+    Returns (None, len(c)) when the span is unterminated."""
+    n = len(c); depth = 0; j = i
+    while j < n:
+        ch = c[j]
+        if ch == "\\": j += 2; continue
+        if ch in "\"'":
+            q = ch; j += 1
+            while j < n:
+                if c[j] == "\\" and q == '"': j += 2; continue
+                if c[j] == q: j += 1; break
+                j += 1
+            continue
+        if ch == "(": depth += 1; j += 1; continue
+        if ch == ")":
+            depth -= 1; j += 1
+            if depth == 0: return c[i:j], j
+            continue
+        j += 1
+    return None, n   # unterminated
+
+
+def _extract_backtick(c, i):
+    """Return the balanced backtick span starting at c[i] (c[i]=='`') and the index
+    just past it. Returns (None, len(c)) when the span is unterminated."""
+    n = len(c); j = i + 1
+    while j < n:
+        if c[j] == "\\": j += 2; continue
+        if c[j] == "`": return c[i:j+1], j+1
+        j += 1
+    return None, n
+
+
+def _preserve_substitution_spans(value):
+    """Replace literal (inert) text with 'STRIPPED'; preserve $(...)/`...` spans VERBATIM.
+    Escaped \\$( and \\` are inert. value is a dq "..." (arm 1) or an unquoted VALUE-TOKEN (arm 3).
+    QUOTE-CONTEXT-FAITHFUL: inside a dq value a ' is a LITERAL apostrophe (bash does not treat
+    it as structural), so dq-inner folds it into the stripped literal run (else ubiquitous
+    it's/don't over-block). A " in dq-inner cannot occur well-formed (arm 1 matched
+    "(?:[^"\\]|\\.)*") -> malformed -> fail-safe. In the UNQUOTED arm BOTH ' and " stay
+    structural -> fail-safe. Return None -> FAIL-SAFE (caller preserves whole value = today's
+    behavior) for: unterminated span, a preserved span carrying a quote, a " in dq-inner, or
+    either quote in the unquoted arm."""
+    def _scan(c, dq_inner):
+        out = []; lit = False; i = 0; n = len(c)
+        def flush():
+            nonlocal lit
+            if lit: out.append("STRIPPED"); lit = False
+        while i < n:
+            ch = c[i]
+            if ch == "\\": lit = True; i += 2 if i+1 < n else 1; continue
+            if ch == "$" and i+1 < n and c[i+1] == "(":
+                span, j = _extract_dollar_paren(c, i)
+                if span is None or '"' in span or "'" in span: return None
+                flush(); out.append(span); i = j; continue
+            if ch == "`":
+                span, j = _extract_backtick(c, i)
+                if span is None or '"' in span or "'" in span: return None
+                flush(); out.append(span); i = j; continue
+            if ch == '"': return None              # structural dq terminator -> fail-safe (malformed in dq-inner)
+            if ch == "'" and not dq_inner: return None   # unquoted: ' is structural -> fail-safe
+            lit = True; i += 1                     # dq-inner ' falls through -> LITERAL
+        flush()
+        return "".join(out)
+    if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
+        inner = _scan(value[1:-1], True)
+        return None if inner is None else '"' + inner + '"'
+    return _scan(value, False)                     # unquoted VALUE-TOKEN
+
+
+def _keep_carrier_value(m: "re.Match") -> str:
+    """Shared value replacer for the gh/git prose-carrier strips (#1129 R2): issue/pr
+    create|edit|comment, release create|edit, gist create|edit, git commit/tag -m, and
+    (new) merge/stash/notes. Passed as `keep_fn` to _strip_flag_values (arms 1 & 3 —
+    double-quoted + unquoted VALUE-TOKEN). Inert prose (no $()/backtick) -> the
+    flag(+separator) is kept and the value replaced with the inert `STRIPPED` bareword.
+    A value CONTAINING command substitution is SPAN-SCOPED (#1140): only the genuine
+    `$(...)`/backtick spans are preserved VERBATIM (they execute -> stay caught) while
+    the surrounding inert literal is stripped, so a benign `$(date)` beside
+    danger-looking prose no longer preserves the whole value (the over-block cure). On a
+    span the scanner cannot safely resolve (unterminated span, a preserved span carrying
+    a quote, or a structural quote in the value) it FAILS SAFE — the whole value is
+    preserved (today's behavior), never dropped. The single-quoted arm strips
+    unconditionally inside _strip_flag_values (untouched)."""
+    if not _has_command_substitution(m.group(0)):
+        return m.group(1) + "STRIPPED"          # inert prose -> strip (unchanged)
+    flag = m.group(1); value = m.group(0)[len(flag):]
+    transformed = _preserve_substitution_spans(value)
+    if transformed is None:
+        return m.group(0)                       # FAIL-SAFE: preserve whole value
+    return flag + transformed
+
+
+def _strip_inert_dq_value(m: "re.Match") -> str:
+    """Replace an inert double-quoted positional value with the bareword ``STRIPPED``;
+    span-scope a value that contains ``$()``/backtick (executing spans preserved VERBATIM
+    in the SAME dq context, surrounding inert literal stripped); FAIL-SAFE preserve-whole on
+    a span the scanner cannot resolve. Byte-identical to the echo/printf carrier's dq-arg
+    strip; used by the general inert-default positional strip (#1178, carrier 10) so a
+    non-flag-anchored quoted positional is stripped with the SAME $()-preserve + fail-safe
+    discipline as the flag-anchored carriers."""
+    if not _has_command_substitution(m.group(0)):
+        return "STRIPPED"
+    transformed = _preserve_substitution_spans(m.group(0))
+    return m.group(0) if transformed is None else transformed
+
+
+def _strip_flag_values(span: str, flag_sep_regex: str, keep_fn) -> str:
+    """Quote-safe value strip for a flag family within a single command span (#1118
+    re-model). KEEPS the flag(+separator) token; replaces the VALUE with a BALANCED
+    placeholder. Three arms by value-quoting (order load-bearing: quoted arms first, so
+    the unquoted VALUE-TOKEN arm never re-touches an already-stripped quoted value):
+      1. double-quoted value  -> keep_fn (preserves $()/backtick cmd-sub — it executes)
+      2. single-quoted value  -> unconditional 'STRIPPED' (single quotes never expand)
+      3. unquoted VALUE TOKEN  -> keep_fn (Q-SAFE: consumes a COMPLETE quote-balanced token
+                                  incl. embedded quoted spans, so it can NEVER emit a
+                                  dangling quote that would merge legs — the SEC-1/SEC-2
+                                  root-cause fix).
+    `flag_sep_regex` MUST be ONE capturing group (keep_fn uses m.group(1); the sq arm
+    backrefs `\\1`) and must introduce no OTHER capturing group. SHARED by carriers 8 & 9
+    so the two value strips can never drift again (the shared non-quote-aware matcher was
+    the #1118 root cause).
+    """
+    span = re.sub(flag_sep_regex + r'"(?:[^"\\]|\\.)*"', keep_fn, span)     # 1
+    span = re.sub(flag_sep_regex + r"'[^']*'", r"\1'STRIPPED'", span)       # 2
+    span = re.sub(flag_sep_regex + _VALUE_TOKEN, keep_fn, span)             # 3
+    return span
+
+
+def _strip_non_executable_content(command: str) -> str:
+    """Strip shell content that is clearly non-executable before pattern matching.
+
+    Removes text from contexts where dangerous-pattern text would not actually
+    execute as a command: heredocs, comments, echo/printf arguments, and
+    variable assignments. This prevents false positives without removing content
+    from genuinely dangerous contexts like ``bash -c '...'``.
+
+    Guards against execution-via-indirection: skips stripping when content
+    would actually execute (piped to shell, eval'd, command substitution,
+    heredoc fed to shell interpreter).
+
+    Conservative: when in doubt, preserves text (false positive > missed threat).
+
+    Args:
+        command: The raw bash command string
+
+    Returns:
+        The command with non-executable content replaced by placeholders
+    """
+    result = command
+
+    # Output-side execution-routing flags — computed ONCE for ALL stdout-
+    # producing content carriers (heredoc/echo/commit-msg/here-string/gh-
+    # creation). When the command pipes its output to a shell or feeds a shell
+    # via OUTPUT-side process substitution (`> >(bash)`), a stripped dangerous
+    # literal would still EXECUTE downstream, so those carriers must SKIP
+    # stripping (preserve content → detect). Hoisted above carrier 1 so the
+    # heredoc carrier can consult them too. MONOTONIC: a True flag only ADDS
+    # detection (skip strip → more content scanned); never removes it.
+    #
+    # The flags defend the EXECUTED surface, so they are computed over the
+    # executed-surface view (#1129 R3): quoted spans masked, heredoc bodies
+    # excised. Carrier DATA (a `| sh` or `>(bash)` inside a quoted value or
+    # heredoc body) can no longer disable the carriers; genuinely-executing
+    # routing (unquoted tails, opener-line tails) is unquoted shell structure
+    # and survives the view at identical offsets.
+    #
+    # The two flags read DIFFERENT views (#1129 R3-fix): piped_to_shell stays on
+    # the pure space-mask executed-surface view (the security 216-case pipe sweep
+    # stays byte-valid). process_sub_to_shell reads _procsub_anchor_view — the same
+    # space-mask with arm B's LEFT anchor restored immediately-left of a surviving
+    # >(shell) whose writer was a masked quoted token — re-catching the R3 arm-B
+    # regression (`echo "…" | "tee" >(bash)`) without a blanket fill (which would
+    # regress `>("ba"sh)`) and without computing arm B over raw (which would re-flag
+    # a `>(shell)` sitting inside quoted carrier data).
+    piped_to_shell = _has_pipe_to_shell(_executed_surface_view(command))
+    process_sub_to_shell = _has_process_substitution_to_shell(_procsub_anchor_view(command))
+
+    # 1. Strip heredoc bodies: << 'EOF' ... EOF, << EOF ... EOF, << "EOF" ... EOF
+    #    Match the heredoc marker, then everything up to and including the
+    #    closing marker on its own line.
+    #    GUARD (input-side): the inner check preserves the body if the heredoc
+    #    is fed to a shell interpreter (e.g. bash << EOF ... EOF — body executes).
+    #    GUARD (output-side): the outer piped/process-sub skip preserves the body
+    #    when it is routed to a shell via `| bash` / `> >(bash)`. The two COMPOSE.
+    if not piped_to_shell and not process_sub_to_shell:
+        def _strip_heredoc(match: re.Match) -> str:
+            # Check what command precedes the heredoc operator
+            start = match.start()
+            preceding = command[:start].rstrip()
+            # If the preceding command is a shell interpreter, preserve content
+            if re.search(r"\b(?:bash|sh|zsh)\s*$", preceding):
+                return match.group(0)  # Preserve — content executes
+            return "<<HEREDOC_STRIPPED"
+
+        result = re.sub(
+            r"<<-?\s*['\"]?(\w+)['\"]?.*?\n.*?\n\t*\1\b",
+            _strip_heredoc,
+            result,
+            flags=re.DOTALL,
+        )
+
+    # 2. Strip comments: # to end of line
+    #    Only strip when # appears at start of line or after whitespace/semicolon
+    #    (not inside words like issue#42 or URLs with #fragment).
+    result = re.sub(r"(?:^|(?<=\s)|(?<=;))\#.*$", "", result, flags=re.MULTILINE)
+
+    # 3. Strip echo/printf quoted arguments
+    #    Match echo/printf followed by flags then quoted strings.
+    #    Replace the quoted content but keep the echo command visible.
+    #    GUARD: Skip stripping if output is piped to a shell interpreter
+    #    (including via xargs), or fed via process substitution to a shell,
+    #    because the echo/printf content would be executed by the shell.
+    #    NOTE: ``bash -c 'dangerous'`` is NOT affected by this stripping —
+    #    the echo/printf regex only matches echo/printf commands, so
+    #    ``bash -c`` content is implicitly preserved and correctly detected.
+    #    (piped_to_shell / process_sub_to_shell are hoisted to the top.)
+    if not piped_to_shell and not process_sub_to_shell:
+        # echo/printf PRINT their args, they never execute them (#1140). Strip / span-scope
+        # EVERY positional quoted arg, not just the first: a danger literal in a 2nd+ arg is
+        # inert (printed) yet was over-blocking a faithful click. The ONLY execution path is
+        # output-routing to a shell (`| bash`, `> >(bash)`), already handled by the outer
+        # piped/process-sub skip this whole block sits inside — so widening to ALL args is
+        # under-block-safe.
+        def _strip_echo_dq_arg(m: re.Match) -> str:
+            # One double-quoted arg. Inert -> bareword STRIPPED; a value with $()/backtick is
+            # span-scoped (inert literal stripped, executing spans preserved in the SAME dq
+            # context as base so detection is identical); fail-safe preserves whole.
+            if not _has_command_substitution(m.group(0)):
+                return "STRIPPED"
+            transformed = _preserve_substitution_spans(m.group(0))
+            return m.group(0) if transformed is None else transformed
+
+        def _strip_echo_span(span_match: re.Match) -> str:
+            # Strip every quoted arg within the echo/printf span. dq FIRST, then sq, so a dq
+            # value's embedded `'` is consumed before the sq pass runs (no cross-contamination);
+            # sq -> bareword STRIPPED (sq $() is literal). The verb + flags sit OUTSIDE these
+            # inner subs and stay intact.
+            span = span_match.group(0)
+            span = re.sub(r'"(?:[^"\\]|\\.)*"', _strip_echo_dq_arg, span)
+            span = re.sub(r"'[^']*'", "STRIPPED", span)
+            return span
+
+        # Span = verb + the shared quote-aware body that STOPS at the first UNQUOTED
+        # ;/&&/|/newline, so an executing tail (`echo "x" && git branch -D y`) stays OUTSIDE the
+        # span and is caught (leg-locality). Keep the `\s+` so a bare `echo` token never matches.
+        result = re.sub(
+            r"\b(echo|printf)\s+" + _VERB_MSG_BODY,
+            _strip_echo_span,
+            result,
+        )
+
+    # 4. Strip variable assignment values: VAR="..." or VAR='...'
+    #    Only match simple assignments (NAME=VALUE), not command arguments.
+    #    GUARD: Skip stripping if eval/source appears in the command,
+    #    because the variable value could be executed.
+    #    GUARD: Skip stripping if $VAR or ${VAR} appears elsewhere in the
+    #    command, because bare expansion executes the value as a command
+    #    (e.g., CMD="gh pr merge 42" && $CMD).
+    has_eval = _has_eval_or_source(command)
+    if not has_eval:
+        # Double-quoted: guard against command substitution and bare expansion
+        def _strip_var_dq(match: re.Match) -> str:
+            var_name = match.group(1)
+            # ORDER LOAD-BEARING: a bare $VAR/${VAR} expansion word-splits and EXECUTES the
+            # WHOLE value (the inert literal INCLUDED, not just a substitution), so an expanded
+            # var preserves WHOLE — this MUST precede the substitution span-scope below.
+            if _var_is_expanded(var_name, command):
+                return match.group(0)  # Preserve — $VAR executes the whole value
+            if _has_command_substitution(match.group(0)):
+                # `git -c section.key=value` config injection is OUT OF SCOPE (#11): a git config
+                # value can be an EXECUTABLE config (core.pager / alias.* / core.editor), so its
+                # literal is not provably inert — preserve WHOLE to keep the -c surface at its
+                # exact status quo. Tell: a git config key ALWAYS has a `.`, so the matched key
+                # segment is preceded by `.`; a shell var / `--flag=` name never is. Use
+                # match.string (the post-carrier-1..3 result being sub'd), NOT `command` — the
+                # match offsets index into that result, not the raw command.
+                if match.start() > 0 and match.string[match.start() - 1] == ".":
+                    return match.group(0)  # config injection — status-quo preserve
+                # Non-expanded, non-config value WITH a substitution: strip the inert literal but
+                # preserve the genuine $()/backtick spans (they execute) via the same certified
+                # span scanner the message carriers use. A benign $(date) beside danger-looking
+                # prose no longer reverts the whole value (the equals-form over-block cure).
+                value = match.group(0)[len(var_name) + 1:]  # text after `NAME=`
+                transformed = _preserve_substitution_spans(value)
+                if transformed is None:
+                    return match.group(0)  # FAIL-SAFE: preserve whole (exotic span)
+                return var_name + "=" + transformed
+            return var_name + "=STRIPPED"
+
+        result = re.sub(
+            r'\b([A-Za-z_][A-Za-z0-9_]*)="(?:[^"\\]|\\.)*"',
+            _strip_var_dq,
+            result,
+        )
+
+        # Single-quoted: guard against bare expansion
+        def _strip_var_sq(match: re.Match) -> str:
+            var_name = match.group(1)
+            if _var_is_expanded(var_name, command):
+                return match.group(0)  # Preserve — $VAR executes
+            return var_name + "=STRIPPED"
+
+        result = re.sub(
+            r"\b([A-Za-z_][A-Za-z0-9_]*)='[^']*'",
+            _strip_var_sq,
+            result,
+        )
+
+    # 5. git commit MESSAGE carrier — SPAN-BOUNDED + FLAG-ANCHORED (migrated from the
+    #    former inline -m-only literal-quote arms to the shared quote-balanced machinery;
+    #    a structural clone of carrier-7d `git tag -m`). The -m/--message argument is a
+    #    commit message, never executed directly. FLAG-anchored to the -m/--message VALUE
+    #    only; BOUNDED to a git-commit span whose body (the SAME quote-aware body as
+    #    carriers 7/7b/7c/7d) STOPS at the first UNQUOTED ;/&&/|/newline so an executing
+    #    tail stays OUTSIDE the span and is caught. The prefix is a NON-gobbling
+    #    `git <bounded non-separator words> commit` (handles global flags like -C <path>)
+    #    whose word class EXCLUDES ;&| so it CANNOT cross an unquoted separator —
+    #    deliberately NOT _GIT_PREFIX, whose (?:\S+\s+){0,N} gobbler spans separators and
+    #    would let a later `git commit` pull an intermediate `;gh …;` into ONE span,
+    #    re-opening the #1129-class leg-merge under-block. Bounded {0,N} keeps it linear.
+    #    GUARD (output-side): a commit SUBJECT is echoed to git's stdout, so
+    #    `git commit -m "..." > >(bash)` (or `| bash`) routes it to a shell — the outer
+    #    piped/process-sub skip preserves it for detection (#1002).
+    #    GUARD (cmd-subst): $()/backtick in a double-quoted value preserves — rides on
+    #    _keep_carrier_value.
+    if not piped_to_shell and not process_sub_to_shell:
+        _git_commit_span = (
+            r"\bgit\s+(?:[^;&|\n\s]+\s+){0,%d}commit\b" % _MAX_GLOBAL_FLAG_TOKENS
+            + _VERB_MSG_BODY
+        )
+        result = re.sub(
+            _git_commit_span,
+            lambda mm: _strip_flag_values(
+                mm.group(0),
+                # Long arm accepts any unambiguous abbreviation of --message
+                # (--m -> --message): on `git commit` the ONLY --m* option IS
+                # --message, so a --m-prefix can never over-strip another option's
+                # value. Short arm (-m/bundled -am/attached -mMSG) unchanged.
+                # --trailer (#1178) carries a commit TRAILER (`Key: value` metadata
+                # appended to the message) — inert prose git never executes, so a
+                # danger-looking literal in a trailer value must not gate a faithful
+                # click. FLAG-anchored to the --trailer VALUE only (never a bare token),
+                # exactly like --message; disjoint from the --m* arm (t != m after --),
+                # so it can never over-strip another option's value. The `--trailer=VALUE`
+                # equals form is already stripped upstream by the variable-assignment
+                # carrier (which matches `trailer=...` as a NAME=VALUE), so only the SPACE
+                # form reaches here.
+                # Short cluster arm TOKEN-START anchored `(?<!\S)` (DEFENSIVE-CONSISTENCY
+                # mirror of _MSG_FLAG_ANCHOR): genuine `-m`/`-am`/attached `-mMSG` are
+                # whitespace-preceded so still strip; the anchor only blocks a MID-FLAG
+                # mis-match (`-com`/`-adm`/`-ame`) that a future strip-order shift could
+                # turn into an over-block. No census over-block runs through this carrier
+                # today; the anchor keeps carrier-5 identical to the merge anchor's fix.
+                r"((?:--m(?:e(?:s(?:s(?:a(?:g(?:e)?)?)?)?)?)?|--trailer|(?<!\S)-[a-ln-zA-Z]*m)\s*)",
+                _keep_carrier_value,
+            ),
+            result,
+        )
+
+    # 6. Strip here-string quoted arguments: <<< "..." or <<< '...'
+    #    Here-strings pass text as stdin, not as a command.
+    #    GUARD (input-side): the inner check preserves content if a shell
+    #    interpreter precedes the <<< (e.g. bash <<< "dangerous" — executes).
+    #    GUARD (cmd-subst): preserve double-quoted content containing $()/backtick.
+    #    GUARD (output-side): the outer piped/process-sub skip preserves content
+    #    routed to a shell via `| bash` / `> >(bash)`. The guards COMPOSE.
+    if not piped_to_shell and not process_sub_to_shell:
+        def _strip_herestring_dq(match: re.Match) -> str:
+            # Check what command precedes the <<< (shell-interpreter guard stays FIRST).
+            start = match.start()
+            preceding = command[:start].rstrip()
+            if re.search(r"\b(?:bash|sh|zsh)\s*$", preceding):
+                return match.group(0)  # Preserve — a shell reads the here-string as stdin
+            if not _has_command_substitution(match.group(0)):
+                return "<<<STRIPPED"                  # no-$() unchanged (bareword)
+            # has-$(): span-scope the value — strip the inert literal, preserve the executing
+            # spans (#1140). Emit the scanner's native dq output: it keeps each preserved span
+            # in the SAME executing dq context the coarse preserve used, so a real $(...) is
+            # detected IDENTICALLY to base (verified by the bidirectional cert). group(1) = dq value.
+            transformed = _preserve_substitution_spans(match.group(1))
+            if transformed is None:
+                return match.group(0)                 # fail-safe: preserve whole
+            return "<<<" + transformed
+
+        result = re.sub(
+            r'<<<\s*("(?:[^"\\]|\\.)*")',
+            _strip_herestring_dq,
+            result,
+        )
+
+        def _strip_herestring_sq(match: re.Match) -> str:
+            # Check what command precedes the <<<
+            start = match.start()
+            preceding = command[:start].rstrip()
+            if re.search(r"\b(?:bash|sh|zsh)\s*$", preceding):
+                return match.group(0)  # Preserve — content executes
+            return "<<<STRIPPED"
+
+        result = re.sub(
+            r"<<<\s*'[^']*'",
+            _strip_herestring_sq,
+            result,
+        )
+
+    # 6b. find -name/-path VALUE carrier: find's match-pattern values are inert
+    #     (find matches names; it never executes a -name/-path value), so a
+    #     danger-looking quoted pattern (`find . -name 'gh pr merge…'`) must not
+    #     gate a faithful search click. Span-bounded like carrier 5 (the
+    #     structural template): _VERB_MSG_BODY stops at the first unquoted
+    #     ;/&&/|/newline, so an executing tail stays OUTSIDE the span and is
+    #     caught. An executing find PRIMARY (-exec/-execdir/-ok/-okdir) anywhere
+    #     in the span disables the strip entirely (fail-toward-preserve: the
+    #     stripped value could be the -exec payload's evidence). Vocabulary is
+    #     the match-pattern primaries -name/-path/-iname/-ipath/-regex/-iregex
+    #     (#1195 OBS-A2 broadening — all inert: find MATCHES the pattern, never
+    #     shell-executes it). The ONE executing primary family
+    #     (-exec/-execdir/-ok/-okdir) stays whole-span-preserved (the deny below
+    #     fires first). find itself stays in _EXEC_WRAPPERS_COARSE, so carrier 10
+    #     still preserves find legs wholesale; the danger literal is simply gone
+    #     from the match-pattern value by the time the floor scans.
+    if not piped_to_shell and not process_sub_to_shell:
+        _find_exec_primary_re = re.compile(r"(?<!\S)-(?:exec|execdir|ok|okdir)(?!\S)")
+        _find_span = r"\bfind\s+" + _VERB_MSG_BODY
+
+        def _strip_find_span(m: "re.Match") -> str:
+            span = m.group(0)
+            if _find_exec_primary_re.search(span):
+                return span                   # -exec/-ok present => preserve whole span
+            return _strip_flag_values(
+                span,
+                r"((?<!\S)-(?:name|path|iname|ipath|regex|iregex)\s+)",
+                _keep_carrier_value,
+            )
+
+        result = re.sub(_find_span, _strip_find_span, result)
+
+    # 7. Strip gh issue/pr CREATION/COMMENT-carrier quoted arguments.
+    #    `gh issue create/edit/comment` and `gh pr create/comment` accept
+    #    --title/--body (and the -t/-b aliases) whose VALUE is prose sent to the
+    #    GitHub API — never executed by a shell. A dangerous-op literal named inside
+    #    that prose (e.g. `gh issue create --title "...git branch -D x..."`)
+    #    must not trip DANGEROUS_PATTERNS. Strip the quoted value; keep the
+    #    verb + flag tokens visible.
+    #
+    #    SCOPE (INV-D2) — exempts ONLY the non-executing ARGUMENT text of a
+    #    CREATION carrier. Does NOT match `gh pr close` (a real close-class
+    #    destructive verb; `--delete-branch` is the deny trigger) — `close`
+    #    is absent from the verb alternation by construction, so a
+    #    `gh pr close ... --delete-branch` command is NOT stripped and
+    #    DANGEROUS_PATTERNS still fires.
+    #
+    #    GUARD: same indirection guards as the echo/printf carrier — the
+    #    outer `piped_to_shell` / `process_sub_to_shell` skip (set at step 3)
+    #    covers pipe-to-shell / process-sub-to-shell; the double-quoted arm
+    #    additionally preserves a value containing command substitution
+    #    `$(`/backtick (it would execute). Single-quoted values never expand,
+    #    so they need only the outer skip (mirroring carriers 3 and 5).
+    #    `--body-file`/`-F` is NOT a carrier: it names a FILE whose content
+    #    is not on the command line, so there is nothing on the line to strip.
+    if not piped_to_shell and not process_sub_to_shell:
+        # Match the carrier COMMAND span first (verb + its arguments), then
+        # strip EVERY --title/--body/-t/-b value within that span. A single
+        # re.sub on the whole command would strip only the FIRST flag-value
+        # (the verb prefix is consumed by the first match and cannot re-anchor
+        # on a bare second flag), so the per-span inner-strip is required to
+        # strip both a `--title` and a `--body` on one command.
+        #
+        # The span body is QUOTE-AWARE: it consumes balanced quoted regions
+        # atomically (so `;`/`&`/`|`/newline INSIDE a quoted value are not
+        # separators) and stops at the first UNQUOTED `&`/`|`/`;`/newline; an
+        # unbalanced quote stops the span early (under-consume = over-block,
+        # never under-block). This is load-bearing for INV-D2: an unquoted
+        # executing op always terminates the span (none of the three body
+        # alternatives can begin at an unquoted separator), so a compound's
+        # executing tail (e.g. `... && git branch -D real`) falls OUTSIDE the
+        # span and is NEVER stripped — it stays caught. The three alternatives
+        # have DISJOINT first chars (non-sep-non-quote / `"` / `'`), so the
+        # nested `*` has no backtracking ambiguity (linear; no ReDoS). The
+        # double-quoted alternative honors `\"` escapes, matching bash's
+        # escaped-quote semantics so the regex cannot desync from the shell.
+        # Verb alternation: issue create|edit|comment, pr create|comment. NOT pr
+        # close — `close` is absent by construction so a close command never
+        # matches. `comment` is a non-executing carrier exactly like create/edit:
+        # its --body/-b value is API prose, and the SAME doubly-anchored strip
+        # (carrier verb + value DIRECTLY after --body/-t/-b) + quote-aware span +
+        # $()/backtick-preserve guard apply, so it inherits the create/edit
+        # safety — empirically verified: escaped-quote/escaped-dq/metachar bodies
+        # are handled correctly (op inside a dq/sq body is inert and stripped; an
+        # op OUTSIDE the body, after an unquoted separator OR a bare escaped quote
+        # not following a carrier flag, is NEVER stripped and stays caught).
+        _gh_carrier_span = (
+            r"gh\s+(?:issue\s+(?:create|edit|comment)|pr\s+(?:create|comment|edit))\b"
+            + _VERB_MSG_BODY
+        )
+
+        def _strip_gh_carrier_span(span_match: re.Match) -> str:
+            # Migrated (#1129 R2) to the SHARED quote-balanced _strip_flag_values (#1118
+            # machinery, same as carriers 8/9): its 3 arms
+            # (dq→keep_fn / sq→'STRIPPED' / unquoted VALUE-TOKEN→keep_fn) replace the
+            # former inline dq+sq re.sub. The unquoted VALUE-TOKEN arm ADDS coverage of
+            # ANSI-C `$'…'` + adjacent-concat `"a"'b'` body forms (consumed ATOMICALLY, so
+            # no dangling quote → no leg-merge). $()/backtick preserve rides on
+            # _keep_carrier_value. `edit` added to the pr alternation (OB1).
+            # --assignee/-a (create) + --add-assignee/--remove-assignee (edit) carry a
+            # GitHub LOGIN value (#1178) — inert API metadata never executed by a shell,
+            # so a danger-looking literal in an assignee value must not gate a faithful
+            # click. VALUE-taking on every carrier-7 verb (login arg), so they join the
+            # value-strip set; -a is admissible here because within these issue/pr verbs
+            # -a is unambiguously --assignee (contrast release -a=--attach, carrier 7b —
+            # a DIFFERENT span, never matched by this gh issue/pr anchor).
+            return _strip_flag_values(
+                span_match.group(0),
+                r"((?:--title|--body|--assignee|--add-assignee|--remove-assignee|-t|-b|-a)\s+)",
+                _keep_carrier_value,
+            )
+
+        result = re.sub(_gh_carrier_span, _strip_gh_carrier_span, result)
+
+        # 7b. gh release CREATE/EDIT carrier (#1129 R2). --notes/-n + --title/-t carry API
+        #     prose (never executed). EXCLUDE --notes-file/-F (a FILE, off-line) AND the
+        #     -d/--draft + -p/--prerelease BOOLEANS (arity verified vs gh 2.96.0) — a
+        #     boolean must never enter a value-strip set or the strip mis-consumes the
+        #     following token (PER-CARRIER flag sets, NEVER a union). Subcommand-specific
+        #     (create|edit, NEVER bare `gh release`) so `gh release delete` can never
+        #     start a carrier span. Shared quote-balanced _strip_flag_values + $()-preserve.
+        _gh_release_span = (
+            r"gh\s+release\s+(?:create|edit)\b"
+            + _VERB_MSG_BODY
+        )
+        result = re.sub(
+            _gh_release_span,
+            lambda m: _strip_flag_values(
+                m.group(0), r"((?:--notes|-n|--title|-t)\s+)", _keep_carrier_value
+            ),
+            result,
+        )
+
+        # 7c. gh gist CREATE/EDIT carrier (#1129 R2). --desc/-d is API prose. `-d` is
+        #     admissible ONLY here (gist -d=--desc VALUE; contrast release -d=--draft
+        #     BOOLEAN — the reason PER-CARRIER flag sets are mandatory). Subcommand-specific
+        #     (create|edit, NEVER bare `gh gist`) so `gh gist delete` never starts a carrier.
+        _gh_gist_span = (
+            r"gh\s+gist\s+(?:create|edit)\b"
+            + _VERB_MSG_BODY
+        )
+        result = re.sub(
+            _gh_gist_span,
+            lambda m: _strip_flag_values(
+                m.group(0), r"((?:--desc|-d)\s+)", _keep_carrier_value
+            ),
+            result,
+        )
+
+        # 7d. git tag MESSAGE carrier (#1129 R2; F1 leg-merge fix, HALT #64) — SPAN-BOUNDED
+        #     + FLAG-ANCHORED. `git tag -m/--message` (benign annotation prose) shares the
+        #     `tag` verb with the DESTRUCTIVE `git tag -d/--delete`, so the strip is
+        #     FLAG-anchored to the -m/--message VALUE only (never touches -d), and BOUNDED
+        #     to a git-tag span whose body (the SAME quote-aware body as 7/7b/7c) STOPS at
+        #     the first UNQUOTED ;/&&/|/newline. The span bound is LOAD-BEARING: the prior
+        #     WHOLE-COMMAND strip let _strip_flag_values arm 3 (unquoted VALUE-TOKEN, which
+        #     does NOT stop at ;&|) re-touch the arm-1 `STRIPPED` bareword and consume
+        #     `STRIPPED;gh` together — EATING the next leg's `gh` head
+        #     (`git tag -m "x";gh pr merge 5 --delete-branch` -> gh gone -> auto-ALLOW). The
+        #     span stops at the separator, so the executing tail stays OUTSIDE and caught.
+        #     The prefix is a NON-gobbling `git <bounded non-separator words> tag`
+        #     (handles global flags like `-C <path>`) whose word class EXCLUDES `;&|` so it
+        #     CANNOT cross an unquoted separator — deliberately NOT `_GIT_PREFIX`, whose
+        #     `(?:\S+\s+){0,N}` gobbler (its `\S+` spans separators) could cross a `;gh …;`
+        #     into a LATER `git tag`, re-opening the leg-merge on a command like
+        #     `git commit -m "x";gh pr merge 5;git tag v1`. Bounded `{0,N}` (same
+        #     _MAX_GLOBAL_FLAG_TOKENS as _GIT_PREFIX) keeps the match linear/sub-quadratic.
+        #     `-d` stays visible (only the -m value strips, within the span); a faithful
+        #     `git tag -m "…" v1` has no unquoted separator -> one span -> OB3 still strips.
+        #     $()/backtick preserve rides on _keep_carrier_value.
+        _git_tag_span = (
+            r"\bgit\s+(?:[^;&|\n\s]+\s+){0,%d}tag\b" % _MAX_GLOBAL_FLAG_TOKENS
+            + _VERB_MSG_BODY
+        )
+        result = re.sub(
+            _git_tag_span,
+            lambda mm: _strip_flag_values(
+                mm.group(0),
+                # Long arm is BOUNDED to --mes...--message — DELIBERATELY DIFFERENT
+                # from the commit anchor. `git tag` ALSO has the value-taking
+                # --merged/--no-merged options, which diverge from --message at char
+                # 3 (r != s), so starting the arm at --mes can never consume their
+                # values (--m/--me are ambiguous and git rejects them). Do NOT
+                # re-unify with the commit anchor. Short arm unchanged.
+                r"((?:--mes(?:s(?:a(?:g(?:e)?)?)?)?|-[a-ln-zA-Z]*m)\s*)",
+                _keep_carrier_value,
+            ),
+            result,
+        )
+
+        # 7e. Sibling message-carrying git verbs — SPAN-BOUNDED + FLAG-ANCHORED, the same
+        #     machinery as carriers 5/7d. `git merge`, `git stash push/store/save`, and
+        #     `git notes add/append` accept a -m/--message (or, for `stash save`, a
+        #     POSITIONAL) whose value is annotation prose, never executed. A destructive
+        #     literal named inside that prose (e.g. `git merge -m "...git branch -D x..."`)
+        #     must not trip DANGEROUS_PATTERNS. Each span is a NON-gobbling
+        #     `git <bounded non-separator words> <verb>` (word class EXCLUDES ;&| so it
+        #     CANNOT cross an unquoted separator — deliberately NOT _GIT_PREFIX, whose
+        #     gobbler would re-open the leg-merge under-block) + _VERB_MSG_BODY (STOPS at
+        #     the first UNQUOTED ;/&&/|/newline, so an executing tail stays OUTSIDE the span
+        #     and is caught). merge / stash push / stash store / notes are anchored on
+        #     _MSG_FLAG_ANCHOR (their SOLE value-taking --m* is --message, verified via
+        #     `git <verb> -h`). git cherry-pick / git revert are DELIBERATELY EXCLUDED:
+        #     their -m is --mainline <parent-number> (a NUMBER, not a message) — treating
+        #     them as message carriers would be wrong; a real destructive tail after them
+        #     stays caught via leg-locality. $()/backtick preserve rides on
+        #     _keep_carrier_value.
+        # LAZY prefix gobbler `{0,N}?` (#1195 OBS-A3g) — SCOPED TO git-merge ONLY. "merge"
+        # is uniquely BOTH a carrier verb AND a substring of the `gh pr merge` danger
+        # pattern, so a GREEDY `{0,N}` gobbler crosses into a `-m` message VALUE that
+        # contains "merge" (`git merge -m 'gh pr merge 5 --admin'`) and anchors the span on
+        # that INNER merge, stripping from the wrong offset -> the danger literal survives
+        # (over-block). Lazy matches the FIRST (VERB) merge, so _VERB_MSG_BODY spans the real
+        # -m value and it strips cleanly. Only WHERE `merge` is matched changes; the
+        # _VERB_MSG_BODY leg-locality terminator (stops at the first unquoted ;/&&/|/newline)
+        # is UNCHANGED, so a real destructive op in a SEPARATE leg is never swallowed.
+        # commit/tag/stash spans stay GREEDY — no danger pattern contains their verb word.
+        _git_merge_span = (
+            r"\bgit\s+(?:[^;&|\n\s]+\s+){0,%d}?merge\b" % _MAX_GLOBAL_FLAG_TOKENS
+            + _VERB_MSG_BODY
+        )
+        result = re.sub(
+            _git_merge_span,
+            lambda mm: _strip_flag_values(
+                mm.group(0), _MSG_FLAG_ANCHOR, _keep_carrier_value
+            ),
+            result,
+        )
+        # git stash push / store — both take -m/--message.
+        _git_stash_flag_span = (
+            r"\bgit\s+(?:[^;&|\n\s]+\s+){0,%d}stash\s+(?:push|store)\b" % _MAX_GLOBAL_FLAG_TOKENS
+            + _VERB_MSG_BODY
+        )
+        result = re.sub(
+            _git_stash_flag_span,
+            lambda mm: _strip_flag_values(
+                mm.group(0), _MSG_FLAG_ANCHOR, _keep_carrier_value
+            ),
+            result,
+        )
+        # git stash save <message> — the (deprecated) message is a POSITIONAL; save's
+        # non-message args are ALL boolean flags, so the anchor consumes `save` + any run
+        # of boolean flags + whitespace, and the dq/sq/VALUE-TOKEN arms strip the first
+        # value token (the positional message). Bare `git stash save` (no message) has no
+        # trailing value -> the anchor's trailing `\s+`+value never matches -> no misfire.
+        _git_stash_save_span = (
+            r"\bgit\s+(?:[^;&|\n\s]+\s+){0,%d}stash\s+save\b" % _MAX_GLOBAL_FLAG_TOKENS
+            + _VERB_MSG_BODY
+        )
+        result = re.sub(
+            _git_stash_save_span,
+            lambda mm: _strip_flag_values(
+                mm.group(0), r"(save(?:\s+-[-\w]+)*\s+)", _keep_carrier_value
+            ),
+            result,
+        )
+        # git notes add / append (-m/--message; an optional `--ref <ref>` global may
+        # precede the verb).
+        _git_notes_span = (
+            r"\bgit\s+(?:[^;&|\n\s]+\s+){0,%d}notes\s+(?:--ref(?:=|\s+)\S+\s+)?(?:add|append)\b"
+            % _MAX_GLOBAL_FLAG_TOKENS
+            + _VERB_MSG_BODY
+        )
+        result = re.sub(
+            _git_notes_span,
+            lambda mm: _strip_flag_values(
+                mm.group(0), _MSG_FLAG_ANCHOR, _keep_carrier_value
+            ),
+            result,
+        )
+
+    # 8. Strip HTTP-client request-body flag VALUES (curl / wget / gh api).
+    #    The #1061 widening (host-agnostic `.*git/refs`) and the #1063
+    #    `.*branches/.*/protection` arms would OTHERWISE fire on the destructive
+    #    path text when it merely appears inside a QUOTED data-body argument
+    #    (`curl -X POST .../log -d 'msg=touched git/refs/heads/x'`) — an over-block
+    #    of a faithful command (the #1037 hard-constraint). A faithful API ref /
+    #    protection mutation ALWAYS carries the destructive resource in the URL
+    #    PATH (REST convention — the resource IS the URL), NEVER the request body,
+    #    so stripping ONLY the data-body VALUE is zero-under-block: a path-resident
+    #    target can never be removed (the PATH-vs-BODY invariant).
+    #
+    #    Surface-scoped to a curl / wget / gh-api command SPAN so a `git push -d
+    #    <ref>` (git's `-d` = --delete, the ref is a positional we DO gate) is never
+    #    mis-stripped — the span anchors only on an HTTP-client head, and git is
+    #    absent from the anchor. TWO value-forms are handled:
+    #      (a) direct-value body flags — `FLAG <quoted-value>`: curl/wget
+    #          -d/--data[-raw|-binary|-ascii|-urlencode]/--body-data/--post-data.
+    #      (b) KEY=VALUE field flags — `FLAG <key>=<quoted-value>`: gh-api
+    #          --field/--raw-field/-f/-F (and curl -F form data). Strip the value
+    #          AFTER the `=`, keeping `flag key=`.
+    #    Surface-awareness falls out of the patterns: curl's bare boolean `-f`
+    #    (--fail) is followed by no `key=<quoted>` token, so form (b) never matches
+    #    it and a `curl -f -X DELETE .../git/refs/...` still gates.
+    #    EVERY flag token is KEPT (only the value is replaced) so the implicit-POST
+    #    lookaheads (`(?=.*(?:--data...|-f|--field|...)\s)`) still fire on a genuine
+    #    implicit-POST. Same execution-routing guards as carriers 3/5/7: skip when
+    #    piped/process-sub to a shell; the double-quoted arms preserve a value
+    #    containing command-substitution `$(`/backtick (it would execute).
+    #    (httpie body params are POSITIONALS, not flags, so they are out of scope —
+    #    non-key=value spellings (:= JSON literals, bare quoted items) survive, so a
+    #    quoted git literal can still FP via the match-anywhere git arms: rarer,
+    #    fails-safe (gates AND mints — no permanent block), pre-existing, un-fixed.)
+    if not piped_to_shell and not process_sub_to_shell:
+        # The HTTP-client command span: from a curl/wget/gh-api head up to the first
+        # UNQUOTED shell separator. Quote-aware body (balanced quotes consumed
+        # atomically; disjoint first chars → linear, no ReDoS) — identical shape to
+        # carrier 7's span. The URL positional and the method flag live in this span
+        # but are never matched by the body-flag patterns below (which require a body
+        # FLAG before the value), so they always survive. The gh-api head uses the
+        # TOLERANT `_GH_API_PREFIX` (same as the read floor) so a `gh -R o/r api ...`
+        # global-flag spelling's body IS stripped — else the #1037 body-mention
+        # over-block re-opens for that spelling (the strip would not run).
+        _http_client_span = (
+            r"(?:\bcurl\b|\bwget\b|" + _GH_API_PREFIX + r")"
+            + _VERB_MSG_BODY
+        )
+        # Direct-value body flags (form a).
+        _data_flag = r"(?:--data(?:-(?:raw|binary|ascii|urlencode))?|--body-data|--post-data|-d)"
+        # KEY=VALUE field flags (form b). The `<key>=` requirement is what makes the
+        # strip surface-aware (curl's boolean -f never has a key= after it).
+        _field_flag = r"(?:--field|--raw-field|-F|-f)"
+
+        def _strip_http_body_span(span_match: re.Match) -> str:
+            span = span_match.group(0)
+
+            # CONTENTS-API EXCEPTION (PATH-vs-BODY invariant boundary). The
+            # `.*contents/.*(?:main|master)` arm reads its destructive target — the
+            # branch being written — from the REQUEST BODY (`-d '{"branch":"master"}'`)
+            # or a `?branch=` query, NOT the URL path (the contents API path is
+            # `/contents/{filepath}`, branch-less). This is the ONE gated arm whose
+            # signal is body-resident; stripping its body would REMOVE the main/master
+            # gating signal → an UNDER-BLOCK. The contents arm must be left UNCHANGED
+            # (signal is body-resident), so preserve a contents-API span verbatim. Detected
+            # per-span (a compound's `/log` span is still stripped). git/refs and
+            # branches/protection targets are path-resident, so their bodies stay strippable.
+            # IGNORECASE to match the case-insensitive contents READ arm
+            # (`contents/.*(?:main|master)`, re.IGNORECASE): a `Contents/` (any case)
+            # span carries its main/master gating signal in the BODY, so it must be
+            # preserved from stripping in ANY case — else the #1096 unquoted body
+            # strip removes the signal for a capital-case spelling -> under-block.
+            if re.search(r"contents/", span, re.IGNORECASE):
+                return span
+
+            def _keep_flag_dq(m: re.Match) -> str:
+                # group(1) = the flag (+ key= for form b) up to the opening quote.
+                if not _has_command_substitution(m.group(0)):
+                    return m.group(1) + "'STRIPPED'"  # no-$() unchanged (single-quoted)
+                # has-$(): span-scope the value after the flag — strip the inert literal,
+                # preserve the executing $()/backtick spans (#1140). Emit the scanner's native
+                # dq output (NOT sq): it keeps each preserved span in the SAME executing dq
+                # context the coarse preserve used, so a real $(...) is detected IDENTICALLY to
+                # base (verified by the bidirectional cert).
+                flag = m.group(1)
+                transformed = _preserve_substitution_spans(m.group(0)[len(flag):])
+                if transformed is None:
+                    return m.group(0)                 # fail-safe: preserve whole
+                return flag + transformed
+
+            # Body flag VALUES via the SHARED quote-safe strip (#1118 re-model, FIX-A).
+            # Each call does 3 arms (dq / sq / unquoted VALUE-TOKEN); the unquoted arm now
+            # consumes a COMPLETE quote-balanced token, so an embedded-quote body value
+            # (`-f k=x"y z"`, a jq-ish `-d '...' ` payload) can no longer leave a dangling
+            # quote that mis-pairs in _mask_shell_quotes and MERGES legs — the pre-existing
+            # carrier-8 under-block (#1118 review). This closes the endpoint-decoy the
+            # quoted-only arms miss (`-f note=pulls/5/merge`, `-d body`) + the #1037
+            # unquoted-body read-floor over-block, over-block-safely: the arm is anchored on
+            # the body-flag(+key=) prefix, so the URL POSITIONAL endpoint (never preceded by
+            # such a prefix) is never matched. SPACE-form separator ONLY here — carrier-8's
+            # `=`-joined-flag completeness (`--field=k=v`) is a DIFFERENT, deferred issue
+            # (#1125); this commit fixes ONLY carrier-8's quote-safety.
+            # (a) direct-value body flags -d/--data*; (b) key=value field flags -f/-F/--field.
+            span = _strip_flag_values(span, r"(" + _data_flag + r"\s+)", _keep_flag_dq)
+            span = _strip_flag_values(
+                span, r"(" + _field_flag + r"\s+[\w.\-]+=)", _keep_flag_dq
+            )
+            return span
+
+        result = re.sub(_http_client_span, _strip_http_body_span, result)
+
+    # 9. Strip gh-api CLIENT-SIDE OUTPUT-SELECTOR + non-target flag VALUES (#1118), via
+    #    the SHARED quote-safe _strip_flag_values helper.
+    #    Carrier 8 removes the merge/git-refs FP substring from request-BODY values, but a
+    #    gh-api command's output selectors (--jq/-q jq filter, --template/-t Go template)
+    #    and other non-target value flags (-H/--header, --input body-file name, --hostname,
+    #    -p/--preview) still carry it, so a graphql/REST READ whose --jq names a response
+    #    field like `mergeStateStatus` is OVER-BLOCKED by the .*merge implicit-POST arm.
+    #    These VALUES can NEVER be the request ENDPOINT or METHOD (jq/template run on the
+    #    RESPONSE client-side; a header is request metadata; --input names a local file; a
+    #    hostname/preview name is not the resource — the endpoint is always the URL
+    #    positional), so stripping ONLY the value is zero-under-block (the CLIENT-vs-SERVER
+    #    analogue of carrier 8's PATH-vs-BODY invariant). gh-api's flag vocabulary is FINITE
+    #    + DOCUMENTED, so this surface is BOUNDED (unlike curl/wget's unbounded value-flag
+    #    vocabulary -> WON'T-FIX by construction, #1098). Scoped to a gh-api span ONLY (its
+    #    OWN _GH_API_PREFIX anchor, NARROWER than carrier 8's shared curl/wget/gh-api span),
+    #    and the FORM-AWARE `_selector_flagsep` is token-boundary anchored (`(?<!\S)`), so
+    #    -q/-t/-H/-p can never mis-strip curl -t (--telnet-option), wget -t (--tries),
+    #    gh pr create -t (--title, carrier 7), or a `-q` mid-token. Every flag token is KEPT
+    #    (only the value is replaced) so the implicit-POST lookaheads still fire on a genuine
+    #    write (a real mutation via --input to a path-resident endpoint keeps its --input
+    #    flag and stays HELD; its destructive target lives in the URL positional, never
+    #    stripped). CONTENTS-API early-return mirrors carrier 8: never touch a contents/ span
+    #    (its main/master gating signal is body/positional-resident). --cache is OUT (its
+    #    duration grammar provably cannot carry the substring).
+    #
+    #    QUOTE-SAFETY (#1118 re-model): the value strip goes through the SHARED
+    #    _strip_flag_values (quote-BALANCED _VALUE_TOKEN) + the FORM-AWARE separator (space /
+    #    =-long / =-short / attached-short). The PRIOR shipped carrier 9 used a
+    #    non-quote-aware unquoted arm (`[^\s'"]\S*`) + a `\s+`-only separator; its earlier
+    #    "additive-pure / cannot open a new under-block" claim was FALSIFIED by the #1118
+    #    review — on an embedded-quote value it emitted a DANGLING quote that mis-paired in
+    #    _mask_shell_quotes, MERGED legs, and regressed the guard in BOTH directions (SEC-1
+    #    over-block + SEC-2 under-block). This is NOT +N/-0; correctness is proven by
+    #    BIDIRECTIONAL base-vs-HEAD-vs-PATCH testing, never byte-diff. Same execution-routing
+    #    guards as carriers 3/5/7/8: skip when piped/process-sub to a shell; the double-
+    #    quoted arm preserves a value containing command substitution `$(`/backtick.
+    if not piped_to_shell and not process_sub_to_shell:
+        # The gh-api command span: from a gh-api head up to the first UNQUOTED shell
+        # separator. Quote-aware body (balanced quotes consumed atomically; disjoint
+        # first chars -> linear, no ReDoS) — identical shape to carriers 7/8, but
+        # anchored on gh-api ONLY (no curl/wget head), so -q/-t/-H/-p can never be
+        # mis-read as a curl/wget short flag. The URL positional and the -X/--method
+        # flag live in this span but are never matched by the selector-flag arms below
+        # (which require a selector FLAG directly before the value), so they survive.
+        _gh_api_selector_span = (
+            r"(?:" + _GH_API_PREFIX + r")"
+            + _VERB_MSG_BODY
+        )
+        # FORM-AWARE, token-anchored separator (#1118 re-model, FIX-B). gh (cobra/pflag)
+        # accepts a flag value four ways: space (`--jq x`), =-long (`--jq=x`), =-short
+        # (`-q=x`), attached-short (`-qx`). Long flags require a separator; short flags may
+        # attach. `(?<!\S)` anchors the flag at a token boundary, so `-q`/`-t`/`-H`/`-p`
+        # never match inside a positional (`some-q-endpoint`) or an already-stripped value.
+        # Long forms BEFORE short forms (so `--template` is not read as `-t` + `emplate`).
+        # Boolean flags (`--paginate`, `--slurp`, …) carry no value and are absent from the
+        # set. Wrapped in ONE capturing group at the call site (see _strip_flag_values).
+        _selector_flagsep = (
+            r"(?<!\S)(?:"
+            r"(?:--jq|--template|--header|--input|--hostname|--preview)(?:\s+|=)"
+            r"|(?:-q|-t|-H|-p)(?:\s+|=)?"
+            r")"
+        )
+
+        def _keep_selector_dq(m: re.Match) -> str:
+            # group(1) = the flag(+separator) captured by the wrapped _selector_flagsep.
+            # Same shape as carrier 8's _keep_flag_dq; both are keep_fn to _strip_flag_values.
+            if not _has_command_substitution(m.group(0)):
+                return m.group(1) + "'STRIPPED'"      # no-$() unchanged (single-quoted)
+            # has-$(): span-scope the value after the flag — strip the inert literal, preserve
+            # the executing $()/backtick spans (#1140). Emit the scanner's native dq output (NOT
+            # sq): it keeps each preserved span in the SAME executing dq context the coarse
+            # preserve used, so a real $(...) is detected IDENTICALLY to base (verified by cert).
+            flag = m.group(1)
+            transformed = _preserve_substitution_spans(m.group(0)[len(flag):])
+            if transformed is None:
+                return m.group(0)                     # fail-safe: preserve whole
+            return flag + transformed
+
+        def _strip_gh_api_selectors(span_match: re.Match) -> str:
+            span = span_match.group(0)
+            # CONTENTS-API exception (IGNORECASE, mirrors carrier 8): a contents span
+            # carries its main/master gating signal in the body/positional, so preserve
+            # the span verbatim (an output selector on a contents span is a rare, fail-
+            # safe pre-existing residual, not in #1118 scope).
+            if re.search(r"contents/", span, re.IGNORECASE):
+                return span
+            # Selector flag VALUES via the SHARED quote-safe strip (FIX-A + FIX-B). One call
+            # does all three arms (dq / sq / unquoted VALUE-TOKEN) across all four value-
+            # attachment forms. The unquoted arm consumes a COMPLETE quote-balanced token, so
+            # an embedded-quote selector value (a jq `.a+" "+.b`, a Go template
+            # `{{.n}}" "{{.t}}`, `-q x"y z"`) can no longer leave a dangling quote that merges
+            # legs (SEC-1/SEC-2). Anchored on the selector-flag(+separator) prefix, so the URL
+            # POSITIONAL endpoint (never preceded by such a prefix) is never matched -> a real
+            # destructive target in the path is never removed (over-block-safe).
+            span = _strip_flag_values(
+                span, r"(" + _selector_flagsep + r")", _keep_selector_dq
+            )
+            return span
+
+        result = re.sub(_gh_api_selector_span, _strip_gh_api_selectors, result)
+
+    # 10. GENERAL inert-default positional strip (#1178) — the strip-inert-by-default
+    #     inversion. For each shell-operator leg whose head is NEITHER a shell-string executor
+    #     / modeled wrapper (a) NOR an http-client (b), AND whose masked surface is NOT itself
+    #     dangerous (c), the quoted POSITIONAL values are INERT (POSIX argv of an unrecognized
+    #     command is never executed by the outer shell), so a danger-looking literal there must
+    #     not gate a faithful click — strip them (dq span-scopes $()/backtick; sq → bareword)
+    #     while PRESERVING executor / http-client / dangerous legs verbatim so every executing
+    #     arg stays caught and every destructive target survives for mint/read binding.
+    #     MONOTONIC toward False (only removes inert quoted content; never synthesizes a danger
+    #     token) so it can only CLOSE an over-block, never open one. Runs LAST (after the
+    #     flag-anchored carriers 1–9 have stripped their prose) under the SAME output-routing
+    #     skip. Leg slicing reuses the _slice_stripped_legs substrate on the in-progress result
+    #     (NOT _split_into_legs → re-strip recursion), rejoined with the ORIGINAL separators so
+    #     downstream leg boundaries are byte-unchanged.
+    if not piped_to_shell and not process_sub_to_shell:
+        result = _strip_inert_positional_legs(result)
+
+    return result
+
+
+def _has_eval_with_heredoc(command: str) -> bool:
+    """Detect eval (or backtick) command-substitution that wraps a heredoc.
+
+    The strip pipeline removes heredoc bodies BEFORE the regex-match phase.
+    An eval-wrapped destructive command inside a heredoc body is therefore
+    invisible to DANGEROUS_PATTERNS by the time matching runs:
+
+        eval $(cat <<HEREDOC
+        gh pr merge 999 --admin
+        HEREDOC
+        )
+
+    After ``_strip_non_executable_content``, the inner ``gh pr merge 999``
+    is gone. The outer eval invokes the heredoc body as a command, which
+    is exactly the destructive operation the merge guard is supposed to
+    intercept. Treat the eval+heredoc shape as categorically dangerous —
+    legitimate operator command flows do not use eval-wrapped heredoc as
+    a delivery mechanism, so the false-positive risk is low.
+
+    Detects both the modern ``$(...)`` substitution form and the legacy
+    backtick form.
+    """
+    # eval $(...) with a heredoc anywhere within the substitution
+    if re.search(r"\beval\s+\$\(", command) and "<<" in command:
+        return True
+    # eval `...` (backtick) wrapping a heredoc
+    if re.search(r"\beval\s+`[^`]*<<", command):
+        return True
+    return False
+
+
+def _shell_tokenize(command: str) -> list[str] | None:
+    """P1: quote-aware shell-word tokenizer (shlex.split posix=True, comments=False) —
+    strips single/double quotes, processes escapes, keeps a quoted-value span as ONE
+    token. Returns the token list on success, or None on ValueError (unbalanced /
+    unterminated quote). On None the callers ABSTAIN (extract_privileged_flags falls back
+    to `split()`; _flag_condition_danger_op returns None) and let the literal floor
+    (DANGEROUS_PATTERNS) decide — so an untokenizable command is dangerous only if the
+    floor matches, never dangerous merely because it failed to tokenize. shlex leaves
+    $ / $() / backtick LITERAL (no expansion); under the honest-mistake model that is
+    acceptable — runtime $-expansion is explicitly out of scope (the hook only ever sees
+    the pre-expansion literal an honest agent typed)."""
+    try:
+        return shlex.split(command, posix=True, comments=False)
+    except ValueError:
+        return None
+
+
+def _mask_shell_quotes(command: str) -> str:
+    """P2: bounded same-length quote-state scanner. Returns a copy with quoted spans
+    (delimiters + contents) — BOTH '...' and "..." — replaced by spaces, preserving
+    out-of-quote structure at identical offsets (P3 operator detection: a separator
+    inside EITHER quote is not a real separator). FAILS TOWARD UNMASKED: a `\\`-escaped
+    quote (outside quotes) never opens a span, and a mis-paired / unterminated quote
+    leaves the REST unmasked (visible) — so an operator/metachar can only OVER-block,
+    never under-block (the #1037-CLASS-1 closure: ambiguity never HIDES danger).
+    Identity on an unquoted command (constraint a)."""
+    out = list(command)
+    i, n = 0, len(command)
+    while i < n:
+        c = command[i]
+        if c == "\\":
+            i += 2  # escaped char (outside a quote) — next char is literal, not a delim
+            continue
+        if c == "'" or c == '"':
+            j = i + 1
+            closed = False
+            while j < n:
+                if c == '"' and command[j] == "\\":
+                    j += 2  # \\-escape is honored inside "..." (not inside '...')
+                    continue
+                if command[j] == c:
+                    closed = True
+                    break
+                j += 1
+            if not closed:
+                break  # unterminated quote → FAIL TOWARD UNMASKED (leave rest visible)
+            for k in range(i, min(j + 1, n)):
+                out[k] = " "
+            i = j + 1
+            continue
+        i += 1
+    return "".join(out)
+
+
+def _normalize_line_continuations(command: str) -> str:
+    """P0 (shell-semantic substrate SSOT): resolve bash line-continuations BEFORE
+    tokenization. Bash-faithful semantics: `\\<newline>` is SPLICED — REMOVED entirely,
+    gluing the surrounding text — NOT replaced with a space. A separating space
+    survives ONLY when one was already adjacent: `gh pr close 5 \\<newline>-d` splices
+    to `gh pr close 5 -d` (the space before the backslash survives, so `-d` stays a
+    clean separate token — the flag-scan under-block the split fix addresses), while
+    `merge\\<newline>5` glues to `merge5` (bash's printf-verified tokenization). This
+    empty-join (vs the former `→ space`) is what makes the comment predicate see the
+    REAL predecessor: `echo "…"\\<newline>#x` splices to `echo "…"#x`, so the `#` is
+    glued to the closing quote (a NON-delimiter) = NOT a comment, closing the #1148
+    line-continuation-splice comment under-block by construction. Routed through every
+    floor + mint call site, so mint and read resolve continuations IDENTICALLY
+    (mint==read by construction)."""
+    return command.replace("\\\n", "")
+
+
+# Benign continuation / redirect terminator for the positional target extractors
+# (_extract_force_push_target_ref / _extract_branch_name). Matches a compound
+# operator (`&&`, `||`, `|&`, `;`, `&`, `|`, newline — the _COMPOUND_OPS_RE set)
+# OR a redirect START. The redirect arm is `(?<!\S)\d+[<>]|[<>]`: a bare `<`/`>` is
+# ALWAYS a redirect (fd defaults), AND a leading fd-NUMBER (`2>`, `22>`) is a
+# redirect prefix ONLY when it is a standalone token — i.e. NOT preceded by a
+# non-whitespace char. This mirrors bash's IO_NUMBER rule: digits GLUED to the
+# preceding word are PART OF THE WORD, not an fd-number. So `git push origin
+# main2>log` is the bash WORD `main2` plus a `>log` redirect (the refspec is
+# `main2`, NOT `main`); only a whitespace-preceded `2>` (e.g. `main 2>&1`) is an
+# fd-redirect that truncates. The `(?<!\S)` lookbehind also keeps the scan LINEAR
+# on a long digit run — it prunes the redundant in-run start positions that a bare
+# `\d*` would re-scan (the O(n^2) catastrophic-backtracking a `\d*[<>]` exhibits).
+_BENIGN_TERMINATOR_RE = re.compile(r"&&|\|\||\|&|;|&|\||\n|(?<!\S)\d+[<>]|[<>]")
+
+# Process-substitution marker (`>(`/`<(`, allowing one optional space). An UNQUOTED
+# procsub is never an honest force-push/branch-delete form: bash treats
+# `git push --force origin main >(cmd)` as a MULTI-ref push (`>(cmd)` expands to an
+# extra `/dev/fd/N` positional), and `... > >(cmd)` redirects stdout into the
+# procsub FIFO. _executable_prefix ABSTAINS when this appears, rather than
+# truncating at the redirect and mis-deriving a single-ref target. Scanned on the
+# same _mask_shell_quotes view, so a quoted `"a>(b)"` is inert (never an over-block).
+_PROCSUB_MARKER_RE = re.compile(r"[<>] ?\(")
+
+
+def _executable_prefix(command: str) -> str | None:
+    """The command truncated at the first UNQUOTED compound-op-or-redirect.
+
+    Returns the leading executable span — everything before the first benign
+    continuation / redirect detected on the same-length `_mask_shell_quotes` view
+    — or the whole command when there is no such terminator. A quoted metachar
+    (`"weird>name"`) is masked to spaces on that view, so only an UNQUOTED
+    operator / redirect bounds the prefix. Returns None (the caller treats None as
+    an ABSENT target and REFUSES — fail-OPEN to the existing safe over-block) iff
+    EITHER the quote state is ambiguous (an unbalanced / unterminated quote makes
+    `_shell_tokenize` fail) OR an unquoted process-substitution marker (`>(`/`<(`)
+    is present (defense-in-depth — never an honest destructive form, and it makes a
+    single-ref target ambiguous). An adversarial quote-elided command is out of
+    scope and is never authorized, only ever over-blocked.
+    """
+    if _shell_tokenize(command) is None:  # unbalanced/unterminated quote -> abstain
+        return None
+    masked = _mask_shell_quotes(command)  # same-length; quoted metachars -> spaces
+    # Process-substitution defense-in-depth: an unquoted `>(`/`<(` is never an
+    # honest force-push/branch-delete form (bash makes a single-ref target ambiguous
+    # -> a multi-ref push, or redirects into a FIFO). Abstain rather than truncate
+    # at the redirect and mis-derive the target. Over-block direction only.
+    if _PROCSUB_MARKER_RE.search(masked):
+        return None
+    terminator = _BENIGN_TERMINATOR_RE.search(masked)
+    return command[: terminator.start()] if terminator else command
+
+
+# -----------------------------------------------------------------------------
+# P4 — op-agnostic quote-aware flag normalizer + per-op danger CONDITIONS.
+#
+# Generalizes the extract_privileged_flags cluster-walk into a SURFACE-keyed
+# normalizer fed by P1 tokens (quotes already stripped, so a quoted `"--admin"`
+# normalizes the same as a bare one). The SAME short differs by tool surface
+# (gh `-d` = --delete-branch; git `-d` = --delete), so the spec is keyed by
+# SURFACE. Danger is then a boolean CONDITION over the normalized set, ADDED to
+# the literal DANGEROUS_PATTERNS floor as a UNION arm (INV-AU: additive only — a
+# normalizer mis-parse can only fail-to-ADD a detection → over-block, never
+# under-block, because the literal floor still gates underneath).
+# -----------------------------------------------------------------------------
+
+# Per-surface flag spec: alias -> (canonical token, takes_value). A superset of
+# PRIVILEGED_FLAGS that ALSO carries the danger-relevant booleans the per-op
+# conditions test (-D / --delete / --force / --force-with-lease). The value-taking
+# entries (-R / --repo) are listed so a cluster like `-Rd val` parses correctly
+# (-R consumes the rest of the cluster as its value, so the trailing `d` is NOT
+# mis-read as --delete-branch). Aliases AGREE with PRIVILEGED_FLAGS so the danger
+# arm and the #1042 bind never disagree on a spelling. Unicode look-alike dashes
+# (U+2010 / U+2212) are deliberately ABSENT: an ASCII-only `startswith('-')`
+# leaves them unbound — gh/git reject them byte-exact, so they confer no privilege
+# and folding-to-ASCII would over-block a flag the tools simply ignore.
+_FLAG_SPEC: dict[str, dict[str, tuple[str, bool]]] = {
+    "gh": {
+        "--admin": ("--admin", False),
+        "-d": ("--delete-branch", False),
+        "--delete-branch": ("--delete-branch", False),
+        "-R": ("--repo", True),
+        "--repo": ("--repo", True),
+        "--match-head-commit": ("--match-head-commit", True),
+    },
+    "git": {
+        "-D": ("-D", False),
+        "-d": ("--delete", False),
+        "--delete": ("--delete", False),
+        "-f": ("--force", False),
+        "--force": ("--force", False),
+        "--force-with-lease": ("--force-with-lease", False),
+        "--no-verify": ("--no-verify", False),
+        # remote-mass-delete (#1062b) danger-condition booleans — present so
+        # `_normalized_flags` can SEE them for the mass-delete recognition arm. Like
+        # -D/--force, they are op-trigger booleans in _FLAG_SPEC but EXCLUDED from
+        # PRIVILEGED_FLAGS (the #1042 set-equality bind is untouched).
+        "--mirror": ("--mirror", False),
+        "--prune": ("--prune", False),
+    },
+}
+
+# Boolean-flag values that DISABLE the flag: `--admin=false` is the SAFE form, so
+# it does NOT confer the privilege / satisfy a danger condition. Any OTHER value
+# (or none) binds (fail-toward-binding on an unrecognized value = over-block-safe).
+_NEGATED_FLAG_VALUES = frozenset({"false", "0", "no"})
+
+
+def _normalized_flags(tokens: list[str], surface: str) -> set[str]:
+    """P4: canonicalize a P1 token list into the SET of flags PRESENT, across every
+    spelling (short / long / clustered / `=`-joined / attached-value), keyed by the
+    tool SURFACE ('gh' / 'git'). Booleans → bare canonical (`--delete-branch`);
+    value-takers → `--canonical=value`. An `=false`/`=0`/`=no` on a boolean NEGATES
+    it (omitted — the safe disable form). Mirrors the extract_privileged_flags
+    cluster-walk so the danger arm and the #1042 bind agree on every spelling.
+    Over-block-safe: an unrecognized token is skipped (never mis-bound)."""
+    spec = _FLAG_SPEC.get(surface, {})
+    if not spec:
+        return set()
+    found: set[str] = set()
+    i, n = 0, len(tokens)
+    while i < n:
+        token = tokens[i]
+        if not token.startswith("-") or token in ("-", "--"):
+            i += 1
+            continue
+        if token.startswith("--"):
+            flag_part, has_eq, value = token.partition("=")
+            entry = spec.get(flag_part)
+            if entry is None:
+                i += 1
+                continue
+            canonical, takes_value = entry
+            if takes_value:
+                if has_eq:                       # --repo=value
+                    found.add(f"{canonical}={value}")
+                    i += 1
+                elif i + 1 < n:                  # --repo value
+                    found.add(f"{canonical}={tokens[i + 1]}")
+                    i += 2
+                else:                            # --repo (value missing; degenerate)
+                    found.add(canonical)
+                    i += 1
+            else:
+                # boolean: an explicit `=false`/`=0`/`=no` DISABLES it → do not bind.
+                if not (has_eq and value.lower() in _NEGATED_FLAG_VALUES):
+                    found.add(canonical)
+                i += 1
+            continue
+        # short cluster (single dash): a per-character walk matching the privileged
+        # extractor's — a value-taking short consumes the REST of the cluster (or the
+        # next token) and stops, so no bound short is dropped regardless of ordering.
+        cluster = token[1:]
+        consumed_next = False
+        j = 0
+        while j < len(cluster):
+            entry = spec.get("-" + cluster[j])
+            if entry is None:
+                j += 1
+                continue
+            canonical, takes_value = entry
+            if takes_value:
+                remainder = cluster[j + 1:]
+                if remainder.startswith("="):    # `-R=value`
+                    remainder = remainder[1:]
+                if remainder:                    # `-Rvalue`
+                    found.add(f"{canonical}={remainder}")
+                elif i + 1 < n:                  # `-R value`
+                    found.add(f"{canonical}={tokens[i + 1]}")
+                    consumed_next = True
+                else:                            # `-R` (value missing; degenerate)
+                    found.add(canonical)
+                break
+            found.add(canonical)                 # boolean short; keep walking
+            j += 1
+        i += 2 if consumed_next else 1
+    return found
+
+
+# OBS-E (#1195) — the UNIFIED push-to-main destination-ref predicate. A push refspec whose
+# DESTINATION ref is EXACTLY main/master (optionally `<src>:`-prefixed, optionally
+# `refs/heads/`-prefixed), matched as a COMPLETE ref via .fullmatch on the refspec TOKEN.
+# Replaces the inaccurate `(?:main|master)(?!:)\b` predicate that was wrong BOTH ways
+# (prefix-matched main-release/main.foo/main@v1 = cardinal over-block; required main to
+# START the token so feature:main/refs/heads/main = under-block). The trailing negative-
+# lookahead forbids any ref-name continuation char (a COMPLETE ref); the `[^\s:+]` src
+# class excludes a leading `+` so `+main` is NOT a push-to-main dst (it FORCES → OBS-F).
+# SSOT: the ONE predicate the shared _flag_condition_danger_op push-to-main arm uses, which
+# BOTH detect (_detect_op_pass fallback) AND the read floor (_stripped_surface_danger) call
+# — mint==read by construction, no literal/DANGEROUS_PATTERNS copy left to drift.
+_PUSH_MAIN_DST_RE = re.compile(
+    r"(?:[^\s:+][^\s:]*:)?"   # optional <src>:  (src has no ':' and no leading '+')
+    r"(?:refs/heads/)?"      # optional full-ref dst prefix
+    r"(?:main|master)"       # the DESTINATION branch
+    r"(?![\w./@+-])"         # ... as a COMPLETE ref: no continuation char follows
+)
+
+# OBS-E/F-PL (#1195) — per-leg push-op filter. The push-to-main + force-push detection lives
+# in the whole-command `_flag_condition_danger_op`, which is FIRST-LEG-ANCHORED — so a push in
+# a NON-first leg (`cd /repo && git push origin main`) was lost when the whole-string
+# DANGEROUS_PATTERNS push-to-main rows were removed (unlike branch-delete/force-push, push-to-
+# main had no per-leg literal arm). The caller-level per-leg loops (in
+# detect_command_operation_type + _stripped_surface_danger) restore ANY-LEG coverage by calling
+# the SAME union arm per leg, filtered to these classes — a THIN caller, no second predicate.
+# Reached ONLY after the existing pipeline returns None/False, so every existing classification
+# is byte-stable. force-push is in the filter (not just push-to-main) so a non-first-leg
+# clustered/`+refspec` force spelling gates too (sibling consistency with `cd && push --force`).
+_PER_LEG_PUSH_OPS = ("push-to-main", "force-push")
+
+
+def _flag_condition_danger_op(command: str) -> str | None:
+    """P4 union arm: classify the FIRST EXECUTABLE LEG of `command` by a quote-aware
+    NORMALIZED-FLAG danger CONDITION across every flag spelling, returning the
+    op-class ("close" / "branch-delete" / "force-push" / "remote-ref-delete" /
+    "remote-mass-delete" / "push-to-main") iff a condition fires, else None.
+    FIRST-LEG-ANCHORED (extending the conservative-RECOGNITION posture to this arm).
+    NOTE (#1195 OBS-E/F-PL): callers ALSO invoke this per-leg for the push classes
+    (detect_command_operation_type + _stripped_surface_danger, filtered to
+    `_PER_LEG_PUSH_OPS`) to catch a push-to-main/force-push in a NON-first leg — this
+    function itself stays first-leg-anchored; the per-leg reach is the callers'.
+    Every surface consulted here — the token list, the coarse-shape prefixes,
+    and the extractor inputs — derives from `_executable_prefix(command)`, because
+    deriving FLAGS from the whole command while POSITIONALS came from the first
+    executable leg let a force/delete flag in a benign CONTINUATION leg mislabel a
+    benign first-leg op (the #1078 cross-leg flag leak). The coarse op-shape (which
+    subcommand) is matched with the SAME shared prefixes the literal floor uses; the
+    danger test is then a boolean condition over `_normalized_flags`. ADDITIVE over
+    the literal floor (INV-AU): an unparseable command / mis-parse can only FAIL to
+    return an op here (this arm ABSTAINS; the literal floor still decides), never
+    re-open an under-block. The coarse shape only SCOPES which condition runs — a
+    false coarse-match whose condition does not hold returns None (over-block-safe)."""
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        # Unbalanced quote OR process substitution → abstain; the literal floor
+        # decides. Procsub is never an honest destructive form (the helper's own
+        # rationale) — an exotic procsub+cluster combo is an accepted under-block.
+        return None
+    tokens = _shell_tokenize(prefix)
+    if tokens is None:
+        return None  # unparseable → this arm abstains; the literal floor decides (honest-mistake: no metachar catch-all)
+    # close --delete-branch — covers `-d`, clustered `-cd`, `--delete-branch`; the
+    # literal floor matches ONLY the spelled-out `--delete-branch` (the #2 gap).
+    if _GH_PR_CLOSE_RE.search(prefix):
+        if "--delete-branch" in _normalized_flags(tokens, "gh"):
+            return "close"
+    # git branch force-delete — covers `-D`, `-Df`, `-fD`, `--delete -f`/`--force`
+    # in any order; the literal floor matches ONLY `-D\b` / `--delete --force` /
+    # `--force --delete` (the #4 gap).
+    if re.search(_GIT_PREFIX + r"branch\b", prefix):
+        gf = _normalized_flags(tokens, "git")
+        if "-D" in gf or ("--delete" in gf and "--force" in gf):
+            return "branch-delete"
+    # git push --force — covers clustered short forms; `--force-with-lease` is the
+    # SAFE exclusion (a non-history-rewriting push). Redundant with the literal floor
+    # today (`-[a-zA-Z]*f` already catches the clusters) but kept for op-class parity.
+    if re.search(_GIT_PREFIX + r"push\b", prefix):
+        gf = _normalized_flags(tokens, "git")
+        if "--force" in gf and "--force-with-lease" not in gf:
+            return "force-push"
+        # remote-ref-delete (#1062a) — union-arm-only recognition (lead Q2: NO
+        # literal DANGEROUS_PATTERNS ref-delete arm). Recognize IFF a SINGLE
+        # deletable ref is extractable; recognition⟺mintability by construction
+        # (the SAME predicate feeds detect via the fallback AND the is_dangerous
+        # union), so this op can NEVER be #1064 gated-but-unmintable. A multi-ref /
+        # implicit-current / ambiguous form yields None here → not recognized → the
+        # mass arm below or the literal floor decides. Tried FIRST = the single-ref-
+        # extractability BOUNDARY discriminator: mass only runs when this returns None.
+        # Both extractors are fed `prefix` for single-surface coherence: each
+        # re-derives `_executable_prefix` internally (idempotent on a prefix), so
+        # this is behavior-identical — but the arm then has exactly ONE surface.
+        if _extract_remote_ref_delete_target(prefix) is not None:
+            return "remote-ref-delete"
+        # remote-mass-delete (#1062b) — mass forms (--mirror/--prune/multi-ref delete),
+        # recognized IFF a normalized mass-target tuple is extractable (the extractor
+        # itself defers to remote-ref-delete for a single ref, so no double-classify).
+        # Recognition⟺mintability by construction → #1064-impossible (implicit-remote
+        # included via the definite \x00implicit marker).
+        if _extract_mass_delete_target(prefix) is not None:
+            return "remote-mass-delete"
+        # push-to-main via the UNIFIED refspec-DST predicate (#1195 OBS-E, supersedes the
+        # OBS-D branch-token arm + the removed detect literals + DANGEROUS_PATTERNS copies).
+        # fullmatch _PUSH_MAIN_DST_RE on positionals[1:] — the REFSPECS. positionals[0] is
+        # the REMOTE and is DELIBERATELY SKIPPED: a remote literally NAMED 'main'
+        # (`git push main feature`) must NOT gate (it is a push of 'feature' to a remote
+        # called 'main', not a push to the main branch). _push_positionals skips interposed
+        # `-o` push-option values (OBS-C/D machinery); the K bound keeps the flag walk
+        # linear; the `push\s` reachability (single guarded match) keeps a glued
+        # `git push--force …` non-command out. LAST in the push branch (force/delete/mass
+        # classify above); SHARED arm ⇒ mint==read by construction.
+        _pm = re.search(_GIT_PREFIX + r"push\s(.*)$", prefix)         # well-formed push only
+        if _pm is not None:                                          #   (excludes push--force glue)
+            _tail = _pm.group(1).split()
+            if sum(1 for t in _tail if t.startswith("-")) <= _MAX_GLOBAL_FLAG_TOKENS:  # perf bound
+                _refspecs = [_strip_surrounding_quotes(r) for r in _push_positionals(_tail)[1:]]
+                # +<refspec> force-push (#1195 OBS-F): a leading '+' on ANY refspec is git's
+                # documented FORCE spelling — symmetric with `--force` → force-push for any
+                # target. Checked AFTER delete/mass (a `+:main` / `--delete +main` is a DELETE,
+                # claimed above) and BEFORE push-to-main (a `+main` FORCES → force-push, never
+                # push-to-main: a push-to-main token must NOT authorize a forced ref update;
+                # `git push origin +feature main` = force-push). `_PUSH_MAIN_DST_RE.fullmatch`
+                # is already False on a `+`-leading token (the src class excludes leading '+'),
+                # so no conflict. Over-block-safe by construction: force-push already gates any
+                # target; `+ref` is just another spelling. Bare `+` is not a refspec (len > 1).
+                if any(r.startswith("+") and len(r) > 1 for r in _refspecs):
+                    return "force-push"
+                for _r in _refspecs:                                  # REFSPECS only (skip remote)
+                    if _PUSH_MAIN_DST_RE.fullmatch(_r):
+                        return "push-to-main"
+    return None
+
+
+# =============================================================================
+# #1178 GENERAL inert-default positional strip — catalog, preserve-predicate,
+# wrapper recursion, and the carrier-10 leg strip.
+#
+# The strip-inert-by-DEFAULT inversion (design of record, SOUND-BOUNDED): a leg whose head
+# is an UNRECOGNIZED command has POSIX-argv-inert quoted positionals (the outer shell never
+# executes them), so a danger-looking literal there must not gate a faithful click — strip
+# it. A leg is PRESERVED (not stripped) iff its quoted content is load-bearing for a True
+# verdict: (a) its head hands a quoted string to a shell/interpreter (executor), or wraps a
+# command that does (modeled wrapper, RECURSED); (b) its head is an http-client whose
+# destructive target is a quoted URL that masking hides; or (c) its masked surface is itself
+# dangerous (a bare-token git/gh op whose quoted TARGET must survive mint/read binding). The
+# strip is MONOTONIC toward False: it only ever REPLACES an inert quoted value with STRIPPED
+# (or a $()-span-scoped value) — it never synthesizes a danger token — so it can only CLOSE
+# an over-block (True->False), never OPEN one; the whole safety burden reduces to preserve-
+# predicate completeness on the load-bearing legs.
+# =============================================================================
+
+# (a) Shell-string executors / interpreters. TOKEN-EQUALITY on the basename-normalized head
+# (C1 CARDINAL — NEVER substring/\b: a substring scan sees `bash` in `bash-completion` /
+# `python` in `python-config` and would wrongly PRESERVE an inert command's quoted arg,
+# re-opening the over-block). Bounded per-FAMILY patterns fold version/alias variants into
+# ONE member (python[0-9.]* / node|nodejs / ksh(93)?) so a real versioned interpreter is
+# caught while distinct tokens (python-config, node-gyp) are NOT (^…$ anchors the whole
+# token). busybox is a WRAPPER (its applet/executor is the 2nd token) → the wrapper set below.
+_SHELL_STRING_EXECUTORS = re.compile(
+    r"^(?:"
+    r"sh|bash|zsh|dash|ash|fish|csh|tcsh"                # POSIX + common shells
+    r"|ksh(?:93)?|rksh|mksh"                             # ksh family (ksh93 != ksh)
+    r"|hush|lash|msh"                                   # busybox exec-shell applets (run a -c string)
+    r"|eval|expect|watch"                               # string runners
+    r"|ssh|rsh|remsh|slogin|su"                         # remote / user-switch (-c / a command)
+    r"|python[0-9.]*|perl|ruby[0-9.]*|nodejs|node|php|awk|gawk"  # interpreters (-c/-e/-r)
+    r")$"
+)
+
+# (a) Modeled exec-WRAPPERS whose (possibly nested) executor's quoted arg executes. Split by
+# grammar tractability. RECURSE: the wrapper's own args are a bounded, well-known skip from
+# the head to the nested command, which _is_preserve_leg then RE-EVALUATES (nested executor →
+# preserve, case A caught; nested inert → strip, case B freed). sudo is RECURSE (≈ doas + a
+# bigger flag table; -i/-s/-e = shell/edit forms → preserve): sudo is ubiquitous and
+# `sudo logger "…"` / `sudo mycmd "…"` over-blocks are COMMON, not contrived, so coarse-
+# preserving it would retain a cardinal over-block. busybox + stdbuf are ALSO RECURSE: busybox's
+# applet is simply token[1] (empty own-flag grammar → nested command = token[1..]), and stdbuf's
+# only options are the -i/-o/-e buffering-mode VALUE-flags (attached `-oL` / separated `-o L` /
+# long `--output=L`) skippable by the phased walk — so their wrapped-inert over-block is CLOSEABLE
+# and MUST be closed. COARSE (still): grammars whose nested-command boundary is NOT reliably
+# skippable — find's `-exec CMD` is `;`/`+`-terminated with `{}` placeholders; flock has a leading
+# LOCKFILE positional + a `-c "STR"` string-exec arm (flock -c runs via sh -c) + FD forms —
+# preserved WHOLE (over-block-safe: `flock -c "STR"` stays CAUGHT; the `flock /lock mycmd "…"`
+# wrapped-inert over-block is a contrived, tracked residual). Enumerating EVERY wrapper is the
+# #1098 wall (D1): an unmodeled custom wrapper's under-block is a tolerated residual. NOTE:
+# recursing busybox requires its exec-capable shell applets (sh/ash/hush/lash/msh + awk) to be
+# recognized preserve-heads — hush/lash/msh were added to _SHELL_STRING_EXECUTORS so
+# `busybox hush -c "danger"` stays CAUGHT after the flip (else a fix-introduced under-block).
+_EXEC_WRAPPERS_RECURSE = frozenset({
+    "nohup", "setsid", "nice", "doas", "sudo", "timeout", "xargs", "env",
+    # Nameable exec-prefix family (#1178, user ruling = Option X + RECURSION). All 13 nameable
+    # exec-prefixes RECURSE (via _WRAPPER_GRAMMAR) so `<prefix> bash -c "danger"` stays CAUGHT
+    # AND the faithful inert `<prefix> mycmd "danger"` FREES — the over-block is CLOSEABLE, so
+    # it MUST be closed ("contrived" is not a valid exception under the user principle; only a
+    # by-construction-unclosable residual like curl/wget is acceptable). Per-prefix arg-skip
+    # grammar below, each BIDIRECTIONALLY certified (bash -c caught ∧ mycmd freed ∧ value-flag-
+    # before-executor caught). The ONLY tolerated under-block residual is the genuinely-CUSTOM
+    # (myrunner-style) exec-wrapper tail (ratified D1 — enumerating every wrapper = the #1098 wall).
+    "time", "exec", "command", "chrt", "taskset", "ionice", "unbuffer",
+    "proxychains", "torsocks", "catchsegv", "nocache", "eatmydata", "rlwrap",
+    # busybox + stdbuf RECURSE (F2 closure): busybox = empty own-flag grammar, applet = token[1]
+    # (its exec-capable shell applets sh/ash/hush/lash/msh + awk are recognized preserve-heads so
+    # `busybox sh -c "danger"` stays caught while `busybox mycmd "danger"` frees); stdbuf = -i/-o/-e
+    # buffering-mode VALUE-flags (attached `-oL` handled by the phased walk's short-value branch).
+    "busybox", "stdbuf",
+})
+_EXEC_WRAPPERS_COARSE = frozenset({
+    # Plan-ratified members whose nested-command boundary is NOT reliably skippable: find's -exec
+    # CMD is ;/+-terminated with {} placeholders; flock has a lockfile positional + a -c string-exec
+    # arm — both COARSE preserve-whole (their `<wrapper> bash -c "danger"` stays caught; the
+    # wrapped-inert over-block is a contrived, tracked residual). busybox/stdbuf moved to RECURSE
+    # (above, F2). The nameable exec-prefix family RECURSES, not here.
+    "find", "flock",
+})
+
+# (b) http-client heads whose destructive target is a quoted URL that _mask_shell_quotes
+# blanks (so the danger battery on the masked surface CANNOT see it) → preserving is the
+# load-bearing #1098-consistent exclusion (a strip would UNDER-block). curl/wget matched by
+# shlex basename head (catches a quoted "curl": base-True via \bcurl\b + a .* lookahead that
+# spans the closing quote). gh api is matched on the masked surface via _GH_API_PREFIX (an
+# unquoted `gh api`; a quoted "gh" api is base-FALSE — \bgh\s+ is broken by the closing quote
+# — so it needs no preserve).
+_HTTP_CLIENT_HEADS = frozenset({"curl", "wget"})
+
+# Recognized git/gh TOOL heads. Carrier 10 PRESERVES these legs wholesale and DEFERS to their
+# dedicated carriers (5 git commit / 7 gh issue-pr / 7b-e / 8 curl-body / 9 gh-api selector) +
+# the danger floor: re-stripping a value those carriers intentionally preserved is an
+# under-block (a git commit -m/tag $() fail-safe value, a `git -c` config dot-guard value, an
+# expanded var), and a DANGEROUS git/gh leg's target must survive for binding. Non-carrier
+# git/gh prose (e.g. `git log --grep "…git branch -D…"`) stays a benign over-block RESIDUAL —
+# never an under-block. (curl/wget/gh-api are the http-client heads above / the gh-api masked
+# clause, handled separately.)
+_TOOL_HEADS = frozenset({"git", "gh"})
+
+
+# =============================================================================
+# READ-VERB value-strip vocabulary — the carve-out from the d2 _TOOL_HEADS
+# preserve above. A git/gh READ verb (log/show/shortlog/grep, issue/pr list,
+# search) never executes its search/filter VALUES, so a danger-looking quoted
+# literal there (`git log --grep "gh pr merge 5 --admin"`) is an inert faithful
+# click that must not gate — _strip_read_verb_values (below, pre-d2 in
+# _maybe_strip_leg) strips exactly these values before the wholesale preserve
+# can fire.
+#
+# STRUCTURE RULES (each load-bearing):
+#   - Keys are the FULL verb path with EXACT token equality, never a shared
+#     short-flag set: `-e` is a value-taking pattern on git grep but the
+#     boolean `--email` on git shortlog — a shared table would mis-consume the
+#     next real token (the curl/wget-shaped fail-open). The verb set is CLOSED
+#     (design ruling): git diff and adjacents are OUT (git diff's harmless
+#     `-O <orderfile>` vs git grep's EXECUTING `-O<pager>` is exactly why
+#     per-verb keying is mandatory).
+#   - flag_arm is ONE capturing group (the _strip_flag_values flag_sep
+#     contract) whose alternatives are each anchored `(?<!\S)` (token start —
+#     a `--not-grep`-style superset can never match) and ordered LONGEST-FIRST
+#     (`--grep-reflog` before `--grep`; `--author-date` before `--author`).
+#     Long flags take `\s+` (space form ONLY: the `--flag="…"` form is
+#     carrier-4-pre-stripped upstream and MUST NOT be re-handled here); value
+#     shorts take `\s*` (attached `-Sfoo`/`-S'foo'` or spaced `-S foo` — the
+#     carrier-5 idiom). Bundled-cluster spellings (`-nS'x'`) are deliberately
+#     NOT matched → preserved → status-quo residual.
+#   - BOOLEANS ARE EXCLUDED BY OMISSION: with flag-anchored arms an unlisted
+#     boolean is simply never touched, so the only enumeration burden is
+#     "never list a boolean" (`--invert-grep`, `--all-match`, `-w/--web`,
+#     `--draft`, shortlog `-e/--email` MUST NOT appear — listing an arity-0
+#     flag would consume the next real token). Ambiguous arity → exclude
+#     (fail-toward-preserve). `--format`/`--pretty` (git) and
+#     `--json`/`--jq`/`--template` (gh) stay OUT of every flag_arm (smallest
+#     certified vocabulary; preserved = status quo).
+#   - deny_re: an EXECUTING flag anywhere in the leg's shlex tokens preserves
+#     the WHOLE leg (fail-toward-preserve). git grep `-O[<pager>]` /
+#     `--open-files-in-pager[=…]` EXECUTES its attached value (`-Ovim` runs
+#     vim; bare `-O` runs the default pager) — deny all spellings; the
+#     cluster-tolerant `-[a-zA-Z]*O` is deliberately over-wide (a false deny
+#     only preserves, never under-blocks).
+#   - strip_positionals (git grep / gh search only): after the guards in
+#     _strip_read_verb_values, every remaining quoted span in such a leg is
+#     data the verb never executes (patterns, pathspecs, query terms); gh
+#     search's `--` sentinel needs no special code (tokens after `--` are
+#     positionals and strip like any quoted span).
+#
+# Flag arities are doc-verified against git 2.50.1 (man git-log/git-grep/
+# git-shortlog) and gh 2.96.0 (`gh <verb> --help`), per-subcommand for
+# gh search (prs/issues/commits/repos/code differ; a prs-only flag like
+# `-B/--base` never enters a sibling subcommand's arm).
+# =============================================================================
+
+class _ReadVerbSpec(NamedTuple):
+    """Per-(tool, verb…) read-verb strip spec for _strip_read_verb_values."""
+    flag_arm: "re.Pattern | None"   # ONE capturing group: the flag(+separator) to keep;
+                                    # value consumed via _strip_flag_values' 3 arms
+    deny_re: "re.Pattern | None"    # executing-flag deny — ANY token match => whole-leg preserve
+    strip_positionals: bool         # grep/search only: strip remaining quoted spans
+
+
+# git grep's ONLY executing flag family: -O[<pager>] / --open-files-in-pager[=<pager>]
+# (attached-only optional value, EXECUTES it). Matched against quote-stripped shlex
+# tokens (shell semantics: a quoted '-O' still reaches git as the flag).
+_GIT_GREP_DENY_RE = re.compile(r"(?<!\S)-[a-zA-Z]*O|(?<!\S)--open-files-in-pager(?:=|\b)")
+
+_READ_VERB_SPECS: "dict[tuple[str, ...], _ReadVerbSpec]" = {
+    ("git", "log"): _ReadVerbSpec(
+        re.compile(
+            r"((?<!\S)(?:--grep-reflog|--grep|--author|--committer)\s+"
+            # bundled-cluster pickaxe short (#1195 OBS-A2): a dash cluster ENDING in the
+            # uppercase pickaxe flag S/G (`-nS'…'`, `-wG'…'`). [SG] uppercase-only so it
+            # never mis-binds `-s`/lowercase; the value is an inert pickaxe string.
+            r"|(?<!\S)-[a-zA-Z]*[SG]\s*)"
+        ),
+        None, False,
+    ),
+    ("git", "show"): _ReadVerbSpec(
+        re.compile(
+            r"((?<!\S)(?:--grep|--author|--committer)\s+"
+            r"|(?<!\S)-[a-zA-Z]*[SG]\s*)"
+        ),
+        None, False,
+    ),
+    # NO shorts on shortlog: its `-e` is the boolean `--email` (the cross-verb
+    # collision that mandates per-verb keying).
+    ("git", "shortlog"): _ReadVerbSpec(
+        re.compile(r"((?<!\S)(?:--grep|--author|--committer)\s+)"),
+        None, False,
+    ),
+    ("git", "grep"): _ReadVerbSpec(
+        re.compile(r"((?<!\S)-[ef]\s*)"),
+        _GIT_GREP_DENY_RE, True,
+    ),
+    ("gh", "issue", "list"): _ReadVerbSpec(
+        re.compile(
+            r"((?<!\S)(?:--search|--author|--app|--assignee|--label|--milestone"
+            r"|--mention|--type|--state|--limit|--repo)\s+"
+            r"|(?<!\S)-[SAalmsLR]\s*)"
+        ),
+        None, False,
+    ),
+    ("gh", "pr", "list"): _ReadVerbSpec(
+        re.compile(
+            r"((?<!\S)(?:--search|--author|--app|--assignee|--label|--base"
+            r"|--head|--state|--limit|--repo)\s+"
+            r"|(?<!\S)-[SAalBHsLR]\s*)"
+        ),
+        None, False,
+    ),
+    # gh search value-flag vocabularies are PER-SUBCOMMAND (gh 2.96.0 --help;
+    # issues/commits/repos/code are NOT the prs superset — a superset-applied
+    # flag that is boolean/absent on a sibling would mis-consume). Longest-first
+    # where one flag prefixes another (--review-requested/--reviewed-by before
+    # --review; --author-*/-committer-* before --author/--committer).
+    ("gh", "search", "prs"): _ReadVerbSpec(
+        re.compile(
+            r"((?<!\S)(?:--app|--assignee|--author|--base|--checks|--closed"
+            r"|--commenter|--comments|--created|--head|--interactions|--involves"
+            r"|--label|--language|--limit|--match|--mentions|--merged-at"
+            r"|--milestone|--order|--owner|--project|--reactions|--repo"
+            r"|--review-requested|--reviewed-by|--review|--sort|--state"
+            r"|--team-mentions|--updated|--visibility)\s+"
+            r"|(?<!\S)-[BHLR]\s*)"
+        ),
+        None, True,
+    ),
+    ("gh", "search", "issues"): _ReadVerbSpec(
+        re.compile(
+            r"((?<!\S)(?:--app|--assignee|--author|--closed|--commenter"
+            r"|--comments|--created|--interactions|--involves|--label"
+            r"|--language|--limit|--match|--mentions|--milestone|--order"
+            r"|--owner|--project|--reactions|--repo|--sort|--state"
+            r"|--team-mentions|--updated|--visibility)\s+"
+            r"|(?<!\S)-[LR]\s*)"
+        ),
+        None, True,
+    ),
+    ("gh", "search", "commits"): _ReadVerbSpec(
+        re.compile(
+            r"((?<!\S)(?:--author-date|--author-email|--author-name|--author"
+            r"|--committer-date|--committer-email|--committer-name|--committer"
+            r"|--hash|--limit|--order|--owner|--parent|--repo|--sort|--tree"
+            r"|--visibility)\s+"
+            r"|(?<!\S)-[LR]\s*)"
+        ),
+        None, True,
+    ),
+    ("gh", "search", "repos"): _ReadVerbSpec(
+        re.compile(
+            r"((?<!\S)(?:--created|--followers|--forks|--good-first-issues"
+            r"|--help-wanted-issues|--include-forks|--language|--license"
+            r"|--limit|--match|--number-topics|--order|--owner|--size|--sort"
+            r"|--stars|--topic|--updated|--visibility)\s+"
+            r"|(?<!\S)-L\s*)"
+        ),
+        None, True,
+    ),
+    ("gh", "search", "code"): _ReadVerbSpec(
+        re.compile(
+            r"((?<!\S)(?:--extension|--filename|--language|--limit|--match"
+            r"|--owner|--repo|--size)\s+"
+            r"|(?<!\S)-[LR]\s*)"
+        ),
+        None, True,
+    ),
+}
+
+
+# Bounded recursion depth for nested wrappers (`timeout nice bash -c …`). Beyond this →
+# fail-safe PRESERVE. 3 covers realistic nesting; the guard prevents pathological recursion.
+_MAX_WRAPPER_DEPTH = 3
+
+class _WrapperGrammar(NamedTuple):
+    """Per-wrapper own-arg grammar for the recursion walk. bool_flags = flags to skip (token
+    only); value_flags = flags whose NEXT token is a value to skip too; shell_flags = flags
+    that invoke a shell / make the arg the command → PRESERVE the whole leg; positionals =
+    count of leading NON-flag positional args to skip before the command (timeout's DURATION =
+    1). Long =forms (`--flag=x`) collapse to one token; env NAME=VALUE is handled generically.
+    An UNRECOGNIZED dash-flag (unknown arity) → PRESERVE — skipping the wrong number of tokens
+    could land PAST the executor = the under-block the fail-safe forbids."""
+    bool_flags: "frozenset[str]"
+    value_flags: "frozenset[str]"
+    shell_flags: "frozenset[str]"
+    positionals: int
+
+
+_WRAPPER_GRAMMAR: "dict[str, _WrapperGrammar]" = {
+    "nohup":   _WrapperGrammar(frozenset(), frozenset(), frozenset(), 0),
+    "setsid":  _WrapperGrammar(frozenset({"-c", "-f", "-w", "--ctty", "--fork", "--wait"}), frozenset(), frozenset(), 0),
+    "nice":    _WrapperGrammar(frozenset(), frozenset({"-n", "--adjustment"}), frozenset(), 0),
+    "doas":    _WrapperGrammar(frozenset({"-L", "-n"}), frozenset({"-C", "-u"}), frozenset({"-s"}), 0),
+    "timeout": _WrapperGrammar(frozenset({"--preserve-status", "--foreground", "-v", "--verbose"}), frozenset({"-s", "--signal", "-k", "--kill-after"}), frozenset(), 1),
+    "xargs":   _WrapperGrammar(frozenset({"-0", "--null", "-r", "--no-run-if-empty", "-t", "--verbose", "-p", "--interactive", "-x", "--exit", "-o", "--open-tty"}), frozenset({"-I", "-i", "-n", "--max-args", "-L", "--max-lines", "-P", "--max-procs", "-s", "--max-chars", "-d", "--delimiter", "-E", "-e", "-a", "--arg-file"}), frozenset(), 0),
+    "env":     _WrapperGrammar(frozenset({"-i", "--ignore-environment", "-0", "--null", "-v"}), frozenset({"-u", "--unset", "-C", "--chdir"}), frozenset({"-S", "--split-string"}), 0),
+    # sudo (≈ doas + a bigger table). shell/edit forms {-i,-s,-e} → preserve (no explicit CMD).
+    # -h OMITTED (ambiguous help-vs-host) → unrecognized → preserve (over-block-safe). Value
+    # flags (-u/-g/-C/-p/-R/-r/-T/-t/-U/-D) verified vs sudo(8). Arity errors here would
+    # under-block, so the value/bool split is cert-pinned per Q2 (value-flag-before-executor).
+    "sudo":    _WrapperGrammar(frozenset({"-A", "--askpass", "-B", "--bell", "-b", "--background", "-E", "--preserve-env", "-H", "--set-home", "-K", "--remove-timestamp", "-k", "--reset-timestamp", "-l", "--list", "-n", "--non-interactive", "-P", "--preserve-groups", "-S", "--stdin", "-V", "--version", "-v", "--validate"}), frozenset({"-C", "--close-from", "-D", "--chdir", "-g", "--group", "-p", "--prompt", "-R", "--chroot", "-r", "--role", "-T", "--command-timeout", "-t", "--type", "-U", "--other-user", "-u", "--user"}), frozenset({"-i", "--login", "-s", "--shell", "-e", "--edit"}), 0),
+    # Nameable exec-prefixes (#1178 Option X, RECURSION). Each bidirectionally certified (bash -c
+    # caught ∧ mycmd freed ∧ value-flag-before-executor caught). Unlisted flags → unrecognized →
+    # PRESERVE (fail-safe: an unmodeled option over-blocks rather than mis-skips past the
+    # executor). time = bash keyword (-p) + /usr/bin/time (-o/-f value). chrt/taskset carry a
+    # leading PRIORITY/MASK positional + a -p/--pid operate-on-existing-PID form (no CMD → shell/
+    # preserve). ionice: -c/-n class values. proxychains: -f config. torsocks: -d/-a/-p/-P/-u/-s
+    # values. rlwrap: large value set (-b/-C/-D/-e/-f/-g/-H/-l/-O/-P/-q/-s/-S/-t/-w/-z); -a/-m/-p
+    # are OPTIONAL-ATTACHED (bool unless attached). catchsegv/nocache/eatmydata take no options.
+    "time":        _WrapperGrammar(frozenset({"-a", "-p", "-q", "-v", "-V", "--append", "--portability", "--quiet", "--verbose", "--version", "--help"}), frozenset({"-o", "-f", "--output", "--format"}), frozenset(), 0),
+    "exec":        _WrapperGrammar(frozenset({"-c", "-l"}), frozenset({"-a"}), frozenset(), 0),
+    "command":     _WrapperGrammar(frozenset({"-p", "-V", "-v"}), frozenset(), frozenset(), 0),
+    "chrt":        _WrapperGrammar(frozenset({"-f", "-b", "-o", "-r", "-i", "-d", "-R", "-m", "-a", "-v", "--fifo", "--batch", "--other", "--rr", "--idle", "--deadline", "--reset-on-fork", "--all-tasks", "--verbose"}), frozenset(), frozenset({"-p", "--pid"}), 1),
+    "taskset":     _WrapperGrammar(frozenset({"-a", "--all-tasks", "-c", "--cpu-list"}), frozenset(), frozenset({"-p", "--pid"}), 1),
+    "ionice":      _WrapperGrammar(frozenset({"-t", "--ignore"}), frozenset({"-c", "--class", "-n", "--classdata"}), frozenset({"-p", "--pid"}), 0),
+    "unbuffer":    _WrapperGrammar(frozenset({"-p"}), frozenset(), frozenset(), 0),
+    "proxychains": _WrapperGrammar(frozenset({"-q", "--quiet"}), frozenset({"-f", "--config"}), frozenset(), 0),
+    "torsocks":    _WrapperGrammar(frozenset({"-h", "-q", "-i", "--isolate", "-H", "-V", "--version", "--help", "--shell"}), frozenset({"-d", "--debug", "-a", "--address", "-p", "--port", "-P", "--control-port", "-u", "--user", "-s", "--socks5"}), frozenset(), 0),
+    "catchsegv":   _WrapperGrammar(frozenset(), frozenset(), frozenset(), 0),
+    "nocache":     _WrapperGrammar(frozenset(), frozenset({"-n"}), frozenset(), 0),
+    "eatmydata":   _WrapperGrammar(frozenset(), frozenset(), frozenset(), 0),
+    "rlwrap":      _WrapperGrammar(frozenset({"-A", "-c", "-h", "-i", "-I", "-n", "-N", "-o", "-r", "-R", "-U", "-W", "-x", "-a", "-m", "-p", "--always-readline", "--complete-filenames", "--case-insensitive", "--no-children", "--one-shot", "--remember", "--quiet", "--help"}), frozenset({"-b", "-C", "-D", "-e", "-f", "-g", "-H", "-l", "-O", "-P", "-q", "-s", "-S", "-t", "-w", "-z", "--break-chars", "--command-name", "--history-no-dupes", "--forget-matching", "--file", "--history-filename", "--logfile", "--substitute-prompt", "--prompt", "--quote-characters", "--histsize", "--set-terminal-name", "--wait-before-prompt", "--filter"}), frozenset(), 0),
+    # busybox + stdbuf (#1178 F2). busybox: the wrapper-usage form is `busybox APPLET [args]` with NO
+    # own-flags before the applet — empty grammar, positionals=0, so the nested command is token[1]
+    # (the applet); its exec-capable shell applets (sh/ash/hush/lash/msh) + awk are recognized
+    # preserve-heads. stdbuf: the -i/-o/-e buffering-mode VALUE-flags (long --input/--output/--error);
+    # the MODE value attaches (`-oL`), separates (`-o L`), or long-equals (`--output=L`) — the
+    # attached-short form is consumed by _wrapper_nested_command's PHASE-1 short-value branch. no
+    # shell forms, positionals=0. --help/--version are unlisted → unrecognized → preserve (over-block-safe).
+    "busybox":     _WrapperGrammar(frozenset(), frozenset(), frozenset(), 0),
+    "stdbuf":      _WrapperGrammar(frozenset(), frozenset({"-i", "-o", "-e", "--input", "--output", "--error"}), frozenset(), 0),
+}
+
+
+def _stripped_surface_danger(stripped: str) -> bool:
+    """The literal danger battery over an ALREADY-STRIPPED (or MASKED) surface: the
+    DANGEROUS_PATTERNS scan + the four per-leg literal-arm families + the additive
+    whole-surface normalized-flag condition + the PER-LEG push-op loop (#1195 OBS-E/F-PL:
+    _flag_condition_danger_op per leg, filtered to _PER_LEG_PUSH_OPS, for a push-to-main /
+    force-push in a NON-first leg). Factored out of ``is_dangerous_command`` (behavior-identical)
+    so the #1178 preserve-predicate can consult the SAME danger predicate on a masked leg
+    WITHOUT re-entering ``_strip_non_executable_content`` (which would recurse — the predicate
+    runs INSIDE that strip). SURFACE-AGNOSTIC: it neither strips nor masks, only matches, so a
+    ``_mask_shell_quotes(leg)`` surface is safe (masking is idempotent for these regexes).
+    The SSOT for "is this surface dangerous" — the read floor and the preserve predicate can
+    never drift."""
+    for pattern in DANGEROUS_PATTERNS:
+        if pattern.search(stripped):
+            return True
+    # Literal arms matched PER-LEG over the SAME surface (identical provenance to the read
+    # floor). Legs computed ONCE and shared by all four arm loops.
+    legs = _slice_stripped_legs(stripped)
+    for _leg in legs:
+        if any(arm.search(_leg) for arm in _FORCE_PUSH_LITERAL_ARMS):
+            return True
+    for _leg in legs:
+        if any(arm.search(_leg) for arm in _CLOSE_LITERAL_ARMS):
+            return True
+    for _leg in legs:
+        if any(arm.search(_leg) for arm in _API_LITERAL_ARMS):
+            return True
+    for _leg in legs:
+        if any(arm.search(_leg) for arm in _BRANCH_DELETE_LITERAL_ARMS):
+            return True
+    if _flag_condition_danger_op(stripped) is not None:
+        return True
+    # PER-LEG push arms (OBS-E/F-PL): the whole-surface union call above is FIRST-LEG-
+    # anchored, so a push-to-main/force-push in a NON-first leg (`cd /repo && git push origin
+    # main`) needs a per-leg call — the SAME union arm per leg, filtered to the push classes
+    # (the shared _PER_LEG_PUSH_OPS constant → mint==read with the detect loop). leg[0] is
+    # harmlessly re-checked (the loop runs only after the whole-surface call returned None).
+    for _leg in legs:
+        if _flag_condition_danger_op(_leg) in _PER_LEG_PUSH_OPS:
+            return True
+    return False
+
+
+def _leg_token_spans(leg: str) -> "list[tuple[int, int]]":
+    """Quote-aware shell-token spans (start, end) into `leg`: a token is a maximal run with NO
+    UNQUOTED whitespace (a quoted or backslash-escaped whitespace stays INSIDE the token).
+    Mirrors the ``_mask_shell_quotes`` scanner exactly (backslash-escape outside quotes; `\\`
+    honored inside "…" but not '…'), so an embedded quoted span (`FOO=a"b c"d` = ONE token) never
+    SPLITS a token and a quoted head (`"timeout"`) stays token[0] — the two failure modes a
+    masked-`\\S+` tokenization has (an internal-quote span erases to spaces and either splits the
+    token or erases a quoted head, misaligning the walk). Callers reach here only on a balanced
+    leg (``_is_preserve_leg`` preserves an unbalanced one up front), so quotes always close."""
+    spans: list[tuple[int, int]] = []
+    i, n = 0, len(leg)
+    tok_start = -1
+    while i < n:
+        c = leg[i]
+        if c.isspace():
+            if tok_start >= 0:
+                spans.append((tok_start, i))
+                tok_start = -1
+            i += 1
+            continue
+        if tok_start < 0:
+            tok_start = i
+        if c == "\\":
+            i += 2
+            continue
+        if c == "'" or c == '"':
+            q = c
+            i += 1
+            while i < n:
+                if q == '"' and leg[i] == "\\":
+                    i += 2
+                    continue
+                if leg[i] == q:
+                    i += 1
+                    break
+                i += 1
+            continue
+        i += 1
+    if tok_start >= 0:
+        spans.append((tok_start, n))
+    return spans
+
+
+def _wrapper_nested_command(leg: str, head: str) -> "str | None":
+    """For a RECURSE-set wrapper leg, return the ORIGINAL-string substring of the nested
+    command (quotes intact) for ``_is_preserve_leg`` to recurse on, or None → FAIL-SAFE
+    PRESERVE. Tokens + offsets come from ``_leg_token_spans`` (quote-aware: an adjacent-concat
+    arg stays ONE token, a quoted head stays token[0]); flag recognition reads the RAW token
+    text (a NAME= prefix / a dash-flag is before any quote), and the returned slice indexes the
+    ORIGINAL leg so the nested command keeps its quotes. Returns None on ANY uncertainty: an
+    unrecognized dash-flag (unknown arity → can't safely skip its value = the mis-skip-past-
+    executor under-block), a shell-invocation flag (env -S / sudo -i,-s,-e / doas -s / …), a
+    value-flag at end-of-tokens, or no nested command."""
+    g = _WRAPPER_GRAMMAR[head]
+    spans = _leg_token_spans(leg)    # spans[0] is the wrapper head (quoted or not)
+    i, n = 1, len(spans)
+    # PHASE 1 — the wrapper's OWN flags (which PRECEDE any positional / the command). Stopping
+    # flag-consumption once a non-flag or `--` is seen is load-bearing: a wrapper flag that
+    # COLLIDES with a nested-command flag (taskset's `-c`=--cpu-list vs `bash -c`) must NOT be
+    # re-consumed AFTER the positional — else `taskset MASK bash -c "danger"`'s `-c` (bash's)
+    # would be eaten as taskset's, mis-locating the command → under-block.
+    while i < n:
+        start, end = spans[i]
+        tok = leg[start:end]
+        if tok == "--":
+            i += 1
+            break                                # end-of-options; rest is positionals + command
+        if tok.startswith("-") and tok != "-":
+            flagname = tok.split("=", 1)[0]
+            if flagname in g.shell_flags:
+                return None                      # shell-invocation form → preserve
+            if flagname in g.value_flags:
+                i += 1 if "=" in tok else 2      # --flag=value one token; --flag value two
+                continue
+            if flagname in g.bool_flags:
+                i += 1
+                continue
+            # ATTACHED-SHORT-VALUE getopt form (`-oL` = short value-flag `-o` + glued value `L`).
+            # A SHORT flag only (`-X`, single dash + one char), whose 2-char prefix is a DECLARED
+            # value_flag, with the value glued on (len > 2). The glued remainder is the value, so
+            # the whole token is consumed (i += 1). GENERAL across RECURSE wrappers (getopt-universal:
+            # `-Xvalue` always binds the value to -X), never bundled-boolean shorts (the prefix must be
+            # a value_flag). Cannot swallow the nested command: a command never starts with `-` (the
+            # PHASE-4 bare-dash guard), and PHASE-1 stops at the first non-flag, so an executor's own
+            # `-c` (which follows the non-flag command head) is never reached here. MONOTONIC: it only
+            # ADVANCES past a wrapper option, never synthesizes danger — so it can only CLOSE an
+            # over-block (recurse to an inert nested command), never open an under-block.
+            if len(tok) > 2 and tok[1] != "-" and tok[:2] in g.value_flags:
+                i += 1
+                continue
+            return None                          # unrecognized dash-flag → preserve
+        break                                    # first non-flag token → positionals / command
+    # PHASE 2 — the wrapper's leading POSITIONALS (timeout DURATION, chrt PRIORITY, taskset MASK).
+    for _ in range(g.positionals):
+        if i >= n:
+            return None                          # ran out (positional missing) → preserve
+        i += 1
+    # PHASE 3 — env NAME=VALUE assignments (env has positionals=0; they precede the command).
+    if head == "env":
+        while i < n and re.match(r"^[A-Za-z_]\w*=", leg[spans[i][0]:spans[i][1]]):
+            i += 1
+    # PHASE 4 — the nested command head.
+    if i >= n:
+        return None                              # no command → preserve
+    cmd_start, cmd_end = spans[i]
+    if leg[cmd_start:cmd_end].startswith("-"):
+        return None                              # a bare dash-flag is never a real command → preserve
+    return leg[cmd_start:]                        # nested command head (original, quotes intact)
+
+
+def _leg_command_word(leg: str) -> "str | None":
+    """Return the leg SUBSTRING starting at the TRUE command word — skipping any LEADING
+    env-assignment (`NAME=value`, quoted OR bare: `LC_ALL=C`, `FOO="a b"`) and redirection
+    (`>`, `2>`, `&>`, `2>/dev/null`, `2>&1`, `< in`…) tokens that PRECEDE the command. Returns
+    None when the leg is ONLY assignments/redirects (no command). SECURITY (#1178 head-
+    displacement): a leading assignment/redirect displaces tokens[0], so `_is_preserve_leg`
+    must compute the head on the TRUE command — else `LC_ALL=C bash -c "danger"` reads head
+    `LC_ALL=C`, no preserve clause fires, and the executor's danger arg is stripped = a
+    destructive UNDER-block. Mirrors the env WRAPPER's own NAME=VALUE skip (grammar PHASE 3)
+    at the leg top level for the BARE prefix form. Quote-aware via _leg_token_spans."""
+    spans = _leg_token_spans(leg)
+    k, n = 0, len(spans)
+    while k < n:
+        start, end = spans[k]
+        tok = leg[start:end]
+        # NAME=value / NAME+=value / NAME= (empty) assignment — the `\+?` covers the append
+        # form (`PATH+=/x`); the whole token is skipped so an embedded '='/'$'/quote in the value
+        # (`FOO=a=b`, `FOO=$HOME`, `FOO="a b"` → carrier-4-stripped to `FOO=STRIPPED`) stays inside
+        # the skipped token. (carrier 4 already stripped a non-expanded quoted RHS to NAME=STRIPPED
+        # BEFORE carrier 10, so quotes are not relied on surviving.)
+        if re.match(r"^[A-Za-z_]\w*\+?=", tok):
+            k += 1
+            continue
+        if re.match(r"^(?:[0-9]*(?:&?[<>]|<>)|&>>?)", tok):   # redirection operator
+            k += 1
+            # a BARE operator (`>`, `>>`, `2>`, `<`, `&>`, and SPACED-target `>&`/`<&`/`2>&`, `>|`)
+            # consumes the NEXT token as its target; a self-contained form (`2>&1`/`3>&2`/`>&2`
+            # fd-dup, `2>/dev/null`/`>file` attached target) does not. The `[<>]&` alt classifies a
+            # spaced redirect-both (`>& file`) as BARE (architect finding — else the walk lands on
+            # `file` and misses the real executor = under-block); `2>&1`/`>&2` stay self-contained
+            # (a trailing fd digit fails the fullmatch).
+            if re.fullmatch(r"[0-9]*(?:[<>]{1,2}|[<>]&|>\|)|&>>?", tok):
+                k += 1
+            continue
+        return leg[start:]                               # the true command word
+    return None                                          # only assignments/redirects → no command
+
+
+def _is_preserve_leg(leg: str, _depth: int = 0) -> bool:
+    """True iff this single leg's quoted-arg values must be PRESERVED (not stripped) by the
+    #1178 general inert-default strip — see the catalog block above for clauses (a)/(b)/(c).
+    FAIL-SAFE to PRESERVE (True) on any ambiguity (unparseable quotes, uncertain wrapper
+    boundary, recursion depth): preserving is the OVER-BLOCK-safe direction (it can only leave
+    an over-block unclosed, never open an under-block)."""
+    if _shell_tokenize(leg) is None:
+        return True                                      # unbalanced quote → fail-safe preserve
+    # (d1) a QUOTED variable-assignment RHS that survived the variable-assignment carrier (4)
+    # is an EXPANDED value: carrier 4 strips a non-expanded `NAME="…"` to `NAME=STRIPPED`, and
+    # when eval/source is present it skips entirely (preserving all) — either way, a `NAME="…"`
+    # / `NAME='…'` still QUOTED here is one carrier 4 kept because it executes via its expansion
+    # (`FOO="gh pr merge 5" && $FOO`, `export CMD="…" && eval $CMD`). Carrier 10 must NOT
+    # re-strip it (under-block). Covers leading (`FOO=`) and builder (`export/declare NAME=`)
+    # forms alike. NOTE: this un-anchored regex also matches a `--flag="v"` (the `flag="`
+    # inside) — but carrier 4 pre-strips flag-attached literals before carrier 10, so it is a
+    # no-op there; and either way the false-match direction is always PRESERVE (over-block-safe,
+    # never under-block).
+    if re.search(r"""[A-Za-z_]\w*=["']""", leg):
+        return True
+    # HEAD-DISPLACEMENT guard (#1178 SEC): compute the head clauses on the TRUE command word
+    # (skip leading env-assignment / redirection prefixes) — else a leading `LC_ALL=C` / bare
+    # `FOO=bar` / `2>/dev/null` displaces tokens[0] and the real executor is missed (under-block).
+    cmd_leg = _leg_command_word(leg)
+    if cmd_leg is not None:
+        tokens = _shell_tokenize(cmd_leg)
+        if tokens:
+            head = os.path.basename(tokens[0])
+            if head in _TOOL_HEADS:                      # (d2) git/gh → defer to carriers 5/7/8/9
+                return True
+            if _SHELL_STRING_EXECUTORS.match(head):      # (a) executor / interpreter
+                return True
+            if head in _HTTP_CLIENT_HEADS:               # (b) curl/wget (quoted head via shlex)
+                return True
+            if head in _EXEC_WRAPPERS_COARSE:            # (a) wrapper, boundary not skippable
+                return True
+            if head in _EXEC_WRAPPERS_RECURSE:           # (a) wrapper, recurse to nested command
+                if _depth >= _MAX_WRAPPER_DEPTH:
+                    return True                          # depth guard → fail-safe preserve
+                nested = _wrapper_nested_command(cmd_leg, head)
+                if nested is None:
+                    return True                          # uncertain boundary → fail-safe preserve
+                return _is_preserve_leg(nested, _depth + 1)
+    masked = _mask_shell_quotes(leg)                     # tail checks on the WHOLE leg (conservative)
+    # (d3) an unquoted process substitution `<(cmd)` / `>(cmd)` EXECUTES cmd, so its quoted args
+    # may execute — preserve. Masking blanks a quoted `"<("`, so only a REAL procsub triggers.
+    if _PROCSUB_MARKER_RE.search(masked):
+        return True
+    if re.search(_GH_API_PREFIX, masked):                # (b) gh api (unquoted `gh api`)
+        return True
+    return _stripped_surface_danger(masked)              # (c) bare-token danger (defense-in-depth)
+
+
+def _strip_quoted_positionals(leg: str) -> str:
+    """Strip a leg's quoted positional values: dq span-scopes $()/backtick (via
+    _strip_inert_dq_value); sq → bareword STRIPPED. Pure factor of the two inline
+    substitutions the carrier-10 inert-default strip has always applied — shared with the
+    read-verb carve-out's positional-strip verbs (git grep / gh search), where every
+    quoted span surviving the carve-out's guards is data the verb never executes
+    (patterns, pathspecs, query terms)."""
+    stripped = re.sub(r'"(?:[^"\\]|\\.)*"', _strip_inert_dq_value, leg)
+    return re.sub(r"'[^']*'", "STRIPPED", stripped)
+
+
+# git global options that PRECEDE the subcommand (for _resolve_git_subcommand, #1195 OBS-A1).
+# VALUE-taking (skip the flag AND its value token):
+_GIT_GLOBAL_VALUE_FLAGS = frozenset({
+    "-C", "-c", "--git-dir", "--work-tree", "--namespace", "--exec-path", "--config-env",
+})
+# Boolean (skip the flag token only):
+_GIT_GLOBAL_BOOL_FLAGS = frozenset({
+    "--no-pager", "--paginate", "-p", "--bare", "--no-replace-objects",
+    "--literal-pathspecs", "--glob-pathspecs", "--noglob-pathspecs",
+    "--icase-pathspecs", "--no-optional-locks",
+})
+
+
+def _resolve_git_subcommand(tokens: "list[str]") -> "int | None":
+    """tokens[0] == 'git'; skip leading git GLOBAL flags to return the SUBCOMMAND token
+    index, or None if none is reached. Skips ONLY dash-prefixed global flags (never a
+    positional word), so a DESTRUCTIVE subcommand always resolves to ITSELF —
+    `git push origin grep ':main'` -> 'push' (index 1, the first non-flag token), never
+    'grep'. This is the load-bearing invariant for destructive-still-gates: the resolver
+    can never gobble a positional into a read-verb key. An UNKNOWN global dash-flag returns
+    None (fail-safe: don't resolve -> the leg preserves = over-block-safe)."""
+    i, n = 1, len(tokens)
+    while i < n:
+        t = tokens[i]
+        if t in _GIT_GLOBAL_VALUE_FLAGS:
+            i += 2                                   # flag + its value token
+            continue
+        if "=" in t and t.split("=", 1)[0] in _GIT_GLOBAL_VALUE_FLAGS:
+            i += 1                                   # --flag=value (one token)
+            continue
+        if t in _GIT_GLOBAL_BOOL_FLAGS:
+            i += 1
+            continue
+        if t.startswith("-"):
+            return None                              # unknown global flag -> fail-safe preserve
+        return i                                     # first non-flag token = subcommand
+    return None
+
+
+def _strip_read_verb_values(leg: str, _depth: int = 0) -> "str | None":
+    """READ-VERB value carve-out (pre-d2): strip the inert search/filter VALUES of a
+    closed set of git/gh read verbs (_READ_VERB_SPECS) so a danger-looking quoted
+    literal there (`git log --grep "…"`, `git grep '…'`, `gh pr list --search '…'`)
+    no longer gates a faithful click via the d2 _TOOL_HEADS wholesale preserve.
+
+    CONTRACT: returns None = "not a read-verb leg / guarded — fall through to the
+    existing preserve/strip path"; returns a str = the final leg text (possibly
+    identical). NEVER returns a quote-unbalanced string (guard g7).
+
+    Runs INSIDE the per-leg walk: legs are sliced on the masked+FD-neutralized view
+    BEFORE any strip fires, so a destructive sibling leg is not present in this
+    function's input — separator-crossing (`git log --grep=foo&&gh pr merge 5`) is
+    impossible BY CONSTRUCTION. A whole-string variant of this strip would reopen
+    that under-block and is a forbidden alternative.
+
+    MONOTONICITY (same argument as the carrier-10 strip): only listed flag VALUES
+    and (for the positional-strip verbs) quoted spans are replaced with STRIPPED —
+    it never synthesizes a danger token and never touches unquoted structure beyond
+    a listed flag's own value, so it can only CLOSE an over-block (True→False),
+    never open one; the safety burden reduces to guards g2/g3/g4/g6 keeping every
+    load-bearing (executing) quoted value out of its reach. Each guard closes a
+    live under-block vector:
+      g2: with `eval` anywhere in the command, carrier 4 skips ALL assignments — a
+          `FOO="gh pr merge 5 --admin"` surviving inside this leg is executed by a
+          sibling `eval $FOO` leg; stripping positionals here would remove the
+          only evidence.
+      g3: `git grep $(sh -c '…')` — a bare $()/backtick span in the leg executes;
+          whole-leg guard is deliberately coarser than the carriers' dq
+          span-scoping (simplest sound bound; the cost is an unclosed over-block
+          on `--grep 'x' $(date)`-shaped legs — status-quo residual).
+      g4: `git grep -f <(sh -c '…')` — an unquoted process substitution executes.
+      g6: an executing flag (git grep -O family) anywhere in the shlex tokens.
+    Exact-token verb matching (tokens[1]/tokens[2]) is REQUIRED: a bounded
+    word-gobbler prefix would let `git push origin grep ':main'` bind the grep
+    spec and strip a deletable quoted refspec (an under-block). Global-flag
+    spellings (`git -C x log …`) therefore fall through to d2 preserve —
+    status-quo residual, tracked."""
+    # ---- guards: ANY hit => return None (fall through to _is_preserve_leg) ----
+    if _shell_tokenize(leg) is None:                 # g1 unbalanced quote (fail-safe)
+        return None
+    if re.search(r"""[A-Za-z_]\w*=["']""", leg):     # g2 d1-replica: a NAME="…" survivor
+        return None                                  #    is an expanded/eval'd value
+    if _has_command_substitution(leg):               # g3 $()/backtick anywhere in the leg
+        return None
+    cmd_leg = _leg_command_word(leg)                 # g5a env/redirect prefix skip
+    if cmd_leg is None:
+        return None
+    tokens = _shell_tokenize(cmd_leg)
+    if not tokens:
+        return None
+    head = os.path.basename(tokens[0])
+    if head == "git":
+        si = _resolve_git_subcommand(tokens)         # A1: skip git globals to the real verb
+        if si is None:                               #    (git -C x log …, git -c k=v log …)
+            return None
+        key = ("git", tokens[si])
+    elif head == "gh" and len(tokens) >= 3:
+        key = ("gh", tokens[1], tokens[2])
+    elif head in _EXEC_WRAPPERS_RECURSE and _depth < _MAX_WRAPPER_DEPTH:
+        # A1: a read-only WRAPPER prefix (timeout/nice/env/…) — resolve the nested command
+        # and RECURSE. _wrapper_nested_command returns preserve (None) for shell-invocation
+        # forms (env -S, sudo -s) and any wrapper whose boundary is uncertain, so a wrapper
+        # that CHANGES execution semantics never resolves to a strippable read verb (no
+        # under-block). A stripped nested maps back under the verbatim wrapper prefix:
+        # `nested` is a suffix of `leg`, so the prefix is byte-preserved by length.
+        nested = _wrapper_nested_command(cmd_leg, head)
+        if nested is None:
+            return None
+        rv = _strip_read_verb_values(nested, _depth + 1)
+        if rv is None:
+            return None
+        mapped = leg[: len(leg) - len(nested)] + rv
+        if _shell_tokenize(mapped) is None:          # g7 balance fail-safe on the mapped leg
+            return leg
+        return mapped
+    else:
+        return None
+    spec = _READ_VERB_SPECS.get(key)                 # g5b exact-verb miss => None
+    if spec is None:
+        return None
+    if _PROCSUB_MARKER_RE.search(_mask_shell_quotes(leg)):   # g4 procsub in leg (d3 replica)
+        return None
+    if spec.deny_re is not None and any(
+        spec.deny_re.match(t) for t in tokens
+    ):                                               # g6 executing-flag deny (shlex tokens —
+        return None                                  #    a quoted '-O' is still the flag)
+    # ---- strips (quote-balanced via the certified _strip_flag_values arms) ----
+    out = leg
+    if spec.flag_arm is not None:
+        out = _strip_flag_values(out, spec.flag_arm.pattern, _keep_carrier_value)
+    if spec.strip_positionals:
+        out = _strip_quoted_positionals(out)
+    if _shell_tokenize(out) is None:                 # g7 quote-balance fail-safe: NEVER
+        return leg                                   #    emit a dangling quote (leg-merge)
+    return out
+
+
+def _maybe_strip_leg(leg: str) -> str:
+    """Strip a leg's quoted positional VALUES iff it is inert (not preserved); else verbatim.
+    The read-verb carve-out (_strip_read_verb_values) runs FIRST — before the d2 _TOOL_HEADS
+    clause inside _is_preserve_leg can preserve a git/gh read-verb leg wholesale. dq
+    span-scopes $()/backtick (via _strip_inert_dq_value); sq → bareword STRIPPED. The verb +
+    unquoted structure stay intact; the leg carries NO shell-operator separator (those are
+    outside the leg), so this never re-slices."""
+    rv = _strip_read_verb_values(leg)
+    if rv is not None:
+        return rv                                    # already balance-checked inside
+    if _is_preserve_leg(leg):
+        return leg
+    stripped = _strip_quoted_positionals(leg)
+    # QUOTE-BALANCE fail-safe (#1118 leg-merge guard): the per-span dq regex is NOT
+    # $()-nesting-aware, so on an exotic nested-quote value (`"a $(b "c") d"`) it can mis-pair
+    # and emit an unbalanced leg. An unbalanced leg fed downstream could let _mask_shell_quotes
+    # pair a stray quote ACROSS a separator and MERGE legs (under-block). shlex is the oracle:
+    # we only reach here with a balanced ORIGINAL (an unbalanced one preserved at the top), so
+    # if the strip broke balance, preserve the ORIGINAL leg rather than emit a dangling quote.
+    if _shell_tokenize(stripped) is None:
+        return leg
+    return stripped
+
+
+def _strip_inert_positional_legs(result: str) -> str:
+    """Carrier-10 core (#1178): slice `result` into shell-operator legs — the SAME masked +
+    FD-neutralize substrate as ``_slice_stripped_legs``, but RETAINING the original separators
+    — and strip each INERT (non-preserved) leg's quoted positional values, emitting preserve
+    legs verbatim. Rejoined with the ORIGINAL separators so a downstream re-slice of this
+    result sees byte-unchanged leg boundaries. Slices via this in-line walk (NOT
+    ``_split_into_legs``, which re-strips → recursion)."""
+    view = _FD_REDIRECT_RE.sub(
+        lambda m: " " * len(m.group()), _mask_shell_quotes(result)
+    )
+    out, last = [], 0
+    for m in _COMPOUND_OPS_RE.finditer(view):
+        out.append(_maybe_strip_leg(result[last:m.start()]))
+        out.append(result[m.start():m.end()])            # ORIGINAL separator, verbatim
+        last = m.end()
+    out.append(_maybe_strip_leg(result[last:]))
+    return "".join(out)
+
+
+def is_dangerous_command(command: str) -> bool:
+    """Check if a bash command is a dangerous git operation.
+
+    Strips non-executable content (heredocs, comments, echo arguments, variable
+    assignments) before matching, to avoid false positives when dangerous-pattern
+    text appears in non-command contexts.
+
+    Args:
+        command: The bash command string
+
+    Returns:
+        True if the command matches a dangerous pattern
+    """
+    # Pre-strip detection: eval+heredoc shape obscures destructive ops via
+    # the heredoc-strip pipeline. Treat as dangerous before the strip runs.
+    if _has_eval_with_heredoc(command):
+        return True
+
+    # Normalize bash line continuations (\<newline>) via the shared P0 SSOT before
+    # any matching (so this floor + the substrate join lines identically).
+    command = _normalize_line_continuations(command)
+    stripped = _strip_non_executable_content(command)
+    # The literal danger battery (DANGEROUS_PATTERNS + the four per-leg literal-arm families +
+    # the additive normalized-flag condition) is the SSOT _stripped_surface_danger — factored
+    # out so the #1178 general-strip preserve-predicate can consult the SAME predicate on a
+    # masked leg without re-entering the strip (recursion). Behavior-identical to the prior
+    # inline battery.
+    return _stripped_surface_danger(stripped)
+
+
+# A plain `rm` head token at a compound leg's start. DELIBERATELY rm-SPECIFIC and used
+# ONLY by the compound-leg count below — NOT a general dangerous-op detector (dd/mkfs/
+# shred/etc. are out of scope under the honest-mistake model) and NOT part of
+# is_dangerous_command (so a bare `rm -rf /` and a pure-rm chain stay is_dangerous=False
+# and the guard never gates them — see the rm-exception note in the module THREAT MODEL).
+# Matches a literal `rm` at the leg head only; no obfuscation-chasing — not `/bin/rm`,
+# `r''m`, `$(echo rm)`, or aliases.
+_RM_HEAD_RE = re.compile(r"\s*rm(?=\s|$)")
+
+
+def _leg_is_destructive(leg: str) -> bool:
+    """Count a compound leg as destructive if it is a recognized git/gh-destructive op
+    (``is_dangerous_command``) OR its head command is a plain ``rm`` (the rm-exception).
+
+    The rm arm is the ONE deliberate non-git/gh case: an honest agent chaining a real
+    destructive git/gh op WITH a file-removing ``rm`` (``gh pr merge 5 && rm -rf /``) is
+    exactly the multi-destructive mistake the compound refuse exists to catch. It is
+    rm-specific by design; do NOT generalize it to other filesystem-destroying tools.
+    """
+    return is_dangerous_command(leg) or _RM_HEAD_RE.match(leg) is not None
+
+
+def _slice_stripped_legs(stripped: str) -> list[str]:
+    """Slice an ALREADY-STRIPPED command into its shell-operator-separated legs
+    (always >=1 leg). The mask + FD-neutralize + slice core of the leg-boundary
+    SSOT: `_split_into_legs` wraps this with normalize + strip, and callers that
+    already hold the stripped text can slice directly, so leg boundaries are
+    computed from ONE substrate without re-stripping.
+
+    Operators are detected on the P2-masked + FD-neutralized view so an operator
+    INSIDE a quoted arg (`--subject "a; b"`) or an FD / and-redirect (`2>&1`,
+    `&>`, `>|`) is NOT a separator. Each FD-redirect is replaced by an EQUAL-LENGTH
+    run of spaces (NOT a single space) so the masked view stays SAME-LENGTH as
+    `stripped` and each operator's offsets map 1:1 back to the ORIGINAL legs (which
+    carry the real flag spellings the callers classify). A single-space collapse
+    would shrink the view and mis-slice the legs after a multi-char redirect (e.g.
+    `2>&1 | rm -rf ~`). The leg slices are taken from `stripped`, never the masked
+    `view` — the view exists ONLY to locate the operator offsets.
+    """
+    view = _FD_REDIRECT_RE.sub(
+        lambda m: " " * len(m.group()), _mask_shell_quotes(stripped)
+    )
+    legs, last = [], 0
+    for m in _COMPOUND_OPS_RE.finditer(view):
+        legs.append(stripped[last : m.start()])
+        last = m.end()
+    legs.append(stripped[last:])
+    return legs
+
+
+def _split_into_legs(command: str) -> list[str]:
+    """Split a command into its shell-operator-separated legs (always >=1 leg).
+
+    The single SSOT for leg boundaries: both is_compound_destructive_command (the
+    >=2-destructive-leg refuse) AND _single_destructive_leg (the read-side
+    single-leg isolation) consume this, so the two can never see divergent leg
+    boundaries (the #720/#878 divergence class). A command with no shell operator
+    yields a one-element list (the whole stripped command). Operator-detection
+    mechanics (quote masking, equal-length FD neutralization, slicing from the
+    stripped text) live in `_slice_stripped_legs`, the shared slicing core.
+    """
+    normalized = _normalize_line_continuations(command)
+    stripped = _strip_non_executable_content(normalized)
+    return _slice_stripped_legs(stripped)
+
+
+def _single_destructive_leg(command: str) -> str | None:
+    """The UNIQUE is_dangerous_command leg of a command, or None.
+
+    Returns the single destructive gh/git leg when EXACTLY one leg is dangerous;
+    None when 0 legs are dangerous, or — at the read call site, unreachably — when
+    >=2 are (is_compound_destructive_command REFUSES that upstream, at
+    check_merge_authorization, BEFORE the read seam). The read seam consumes this
+    as TIER 1 of a two-tier bind-surface fallback: None here falls through to
+    `_single_detectable_leg` (tier 2 — the EMERGENT-danger case, where whole-
+    command danger comes from a cross-leg lookahead and no leg is dangerous in
+    isolation), and only then to the WHOLE command (the existing over-binding
+    scan = the safe over-block direction). The never-silently-narrow guard is
+    about AMBIGUITY and is preserved across both tiers: a fail-toward-unmasked
+    quote split, a parse failure, or a non-unique leg can only collapse WIDER
+    (to the whole-command context); narrowing happens ONLY on a positively
+    identified unique leg — dangerous here, or detect-positive in tier 2. Do
+    NOT "fix" the tier-2 fallback back to whole-command as a regression: the
+    two-tier basis is what keeps the read bind symmetric with the leg-bounded
+    mint window for emergent-danger compounds.
+
+    This is the substrate the read side uses to derive (op, target, bound_flags)
+    from the destructive op ALONE — so a privileged flag on a benign NEIGHBOR leg
+    cannot pollute bound_flags (the over-block) and a benign neighbor's PR number
+    cannot cross-contaminate the target via _extract_pr_number's first-match-
+    anywhere scan (the latent under-block). A privileged flag that modifies the
+    destructive op is a token of its OWN simple-command (leg), so it stays bound;
+    only a different statement's flag (past an operator boundary) is dropped.
+    """
+    dangerous = [
+        leg.strip()
+        for leg in _split_into_legs(command)
+        if is_dangerous_command(leg.strip())
+    ]
+    return dangerous[0] if len(dangerous) == 1 else None
+
+
+def _single_detectable_leg(command: str) -> str | None:
+    """#1083 emergent-danger bind fallback: the UNIQUE leg that
+    detect_command_operation_type classifies non-None, or None. Consulted ONLY
+    when _single_destructive_leg found no individually-dangerous leg (the
+    emergent case: whole-command danger from a cross-leg lookahead). Narrowing
+    happens ONLY on positive unique identification — 0 or >=2 detectable legs
+    fall through to the conservative whole-command context — so the abstain
+    basis of _single_destructive_leg (ambiguity can only collapse WIDER, never
+    narrower) is preserved: ambiguity still widens; only a positively unique
+    op leg narrows. Binding from that leg is shell-faithful: a flag that
+    modifies the executed op is a token of the op's OWN leg; a flag past an
+    operator boundary belongs to a different statement.
+    """
+    detectable = [
+        leg.strip()
+        for leg in _split_into_legs(command)
+        if detect_command_operation_type(leg.strip()) is not None
+    ]
+    return detectable[0] if len(detectable) == 1 else None
+
+
+def is_compound_destructive_command(command: str) -> bool:
+    """Detect an agent chaining MULTIPLE destructive operations into one command.
+
+    Returns True iff the command joins >=2 DESTRUCTIVE legs with a shell operator
+    (``&&``, ``||``, ``|&``, ``;``, ``&``, ``|``, newline), e.g.:
+
+        gh pr close 5 -d && git branch -Df victim
+        gh pr merge 100 && gh pr close 999 --delete-branch
+        gh pr merge 5 && rm -rf /          # git/gh op chained with a plain `rm`
+
+    This is the chaining analogue of the privileged-flag bind: both catch the agent
+    doing MORE than the operator clicked — here, an ADDED destructive op the single
+    approval did not cover. A leg counts as destructive if it is a recognized
+    git/gh-destructive op OR its head command is a plain ``rm`` (the rm-EXCEPTION — see
+    the module THREAT MODEL; rm is rm-specific by design and is NOT in
+    is_dangerous_command, so a bare or pure-rm command is never gated). Honest-mistake
+    model: a SINGLE destructive op plus a benign continuation / decoration /
+    backgrounding is a faithful single-command click and MUST mint + execute — so
+    `gh pr merge 5 && echo ok`, `gh pr merge 5 ; echo done`, `gh pr merge 5 &`,
+    `gh pr merge 5 | tee log`, `gh pr merge 5 > out.log` are NOT compound-destructive
+    (one destructive leg). Only >=2 destructive legs are refused (route to
+    one-op-at-a-time approval).
+    """
+    # Legs come from the shared _split_into_legs SSOT (masked + FD-neutralized split
+    # on _COMPOUND_OPS_RE, slices taken from `stripped`). A command with no operator
+    # yields ONE leg, so the >=2 count below is False — identical to the prior
+    # explicit no-operator short-circuit, without a separate code path that could
+    # drift from the read-side leg isolation.
+    legs = _split_into_legs(command)
+    # >=2 DESTRUCTIVE legs → refuse. A leg is destructive via _leg_is_destructive: a
+    # recognized git/gh-destructive op (so a non-canonical flag spelling like `-Df` in a
+    # leg still counts) OR a plain-`rm` head leg (the documented rm-exception). A single
+    # destructive leg + benign legs → NOT compound (the single op routes through its own
+    # one-op approval as usual). This count is only consulted once is_dangerous_command is
+    # already True (a git/gh op is present) at the read call site, so a bare `rm` or a
+    # pure-rm chain — is_dangerous=False — never reaches it (the guard stays out of
+    # pure-filesystem commands).
+    return sum(1 for leg in legs if _leg_is_destructive(leg)) >= 2

--- a/pact-plugin/tests/merge_guard_baseline_loader.py
+++ b/pact-plugin/tests/merge_guard_baseline_loader.py
@@ -1,20 +1,28 @@
 """
 Location: pact-plugin/tests/merge_guard_baseline_loader.py
-Summary: Loud-fail loader for the COMMITTED vendored merge-guard baseline fixture
-         (fixtures/merge_guard_baseline/merge_guard_common_b4041ccf.py). Every
-         base-vs-HEAD differential row in the over-block-cluster cert files loads the
-         pre-fix classifier through this ONE function so the bidirectional certs are
-         CI-EXECUTABLE: the fixture is committed bytes, not a `git show` of a SHA that a
-         shallow clone cannot resolve (9 of 14 existing baseline SHAs are CI-invisible
-         non-ancestors — the lesson this loader exists to close).
-Used by: test_merge_guard_1181_cert.py, test_merge_guard_1155_cert.py,
-         test_merge_guard_1148_cert.py (and future certs migrating off `git show`).
+Summary: Loud-fail loaders for the COMMITTED vendored merge-guard baseline fixtures.
+         TWO independent pre-fix baselines, each vendored as committed bytes (never a
+         `git show` of a SHA a shallow clone cannot resolve — 9 of 14 existing baseline
+         SHAs are CI-invisible non-ancestors, the lesson these loaders exist to close):
 
-CONTRACT (all failure modes are HARD pytest.fail, NEVER skip, no @requires_history):
+           load_baseline()          -> fixtures/merge_guard_baseline/merge_guard_common_b4041ccf.py
+                                       (pre OBS-A→I; the over-block-cluster certs' base)
+           load_baseline_172a77dd() -> fixtures/merge_guard_baseline/merge_guard_common_172a77dd.py
+                                       (post OBS-A→I / pre #1134; the three-dimension cert's base)
+
+         RETAIN both. b4041ccf has FIVE cert consumers and is NOT superseded by the
+         172a77dd baseline — they pin DIFFERENT pre-fix states (different bug sets).
+Used by: b4041ccf  -> test_merge_guard_1181_cert.py, test_merge_guard_1155_cert.py,
+                      test_merge_guard_1148_cert.py, test_merge_guard_obs_cert.py,
+                      test_merge_guard_overblock_cluster_monotonicity.py
+         172a77dd -> test_merge_guard_1134_cert.py
+
+CONTRACT (both loaders — all failure modes are HARD pytest.fail, NEVER skip, no
+@requires_history):
   1. Fixture file missing            -> pytest.fail (the cert cannot certify silently).
   2. sha256 mismatch with the pin    -> pytest.fail (fixture bytes drifted).
   3. Pre-fix discriminator rows fail -> pytest.fail (post-fix bytes were vendored:
-     the baseline MUST still exhibit all three over-block-cluster bugs).
+     the baseline MUST still exhibit the bug(s) its consuming cert fixes).
 """
 import hashlib
 import importlib.util
@@ -109,4 +117,93 @@ def load_baseline():
         )
 
     _cached_baseline = module
+    return module
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Second baseline: post OBS-A→I / pre #1134 (172a77dd), the base for the
+# three-dimension cert. A SEPARATE entry point rather than a parameter on
+# load_baseline(), so the five existing b4041ccf consumers are byte-untouched.
+# ─────────────────────────────────────────────────────────────────────────────
+_FIXTURE_PATH_172A77DD = (
+    Path(__file__).parent
+    / "fixtures"
+    / "merge_guard_baseline"
+    / "merge_guard_common_172a77dd.py"
+)
+# sha256 of merge_guard_common.py at 172a77dd (this arc's base, `git show`-vendored).
+_FIXTURE_SHA256_172A77DD = (
+    "1a3dc4a60bfe534133aea75a39915e78fb9d0617d69ff8278cfc6a6f26c2741b"
+)
+
+# Pre-fix discriminator inputs (danger literals assembled at runtime so this file
+# carries no raw destructive literal and stays inert to the live guard).
+_DISCRIMINATOR_1134_UNDERBLOCK = "cd /repo && " + "git " + "push " + "origin --delete feature"
+_DISCRIMINATOR_1134_CLOSE_ASYM = "cd /repo && " + "gh " + "pr " + "close 5 -d"
+
+_cached_baseline_172a77dd = None
+
+
+def load_baseline_172a77dd():
+    """Load the vendored post-OBS-A→I / pre-#1134 classifier module (cached),
+    loud-failing on any integrity problem. Same contract and calling convention as
+    load_baseline(); callers use it as `load_baseline_172a77dd().is_dangerous_command(cmd)`.
+
+    Pre-fix discriminators (the baseline MUST still exhibit the #1134 under-block, or
+    post-fix bytes were vendored and the cert would certify against itself):
+      1. `cd … && git push origin --delete feature` runs UNGATED (is_dangerous False) —
+         the good-faith-reachable non-first-leg under-block this arc closes.
+      2. `cd … && gh pr close 5 -d` is CLASSIFIED (detect == "close") yet UNGATED
+         (is_dangerous False) — the pre-fix mint==read asymmetry on the close family
+         (the raw-fallback detect arm sees it; the per-leg gate does not). Post-fix both
+         are True. This second discriminator also proves the fixture is not merely an
+         is_dangerous-False stub: it pins the exact detect/gate SPLIT the fix repairs.
+    """
+    global _cached_baseline_172a77dd
+    if _cached_baseline_172a77dd is not None:
+        return _cached_baseline_172a77dd
+
+    if not _FIXTURE_PATH_172A77DD.is_file():
+        pytest.fail(
+            "172a77dd baseline fixture missing (%s) — the three-dimension cert cannot run"
+            % _FIXTURE_PATH_172A77DD
+        )
+    data = _FIXTURE_PATH_172A77DD.read_bytes()
+    digest = hashlib.sha256(data).hexdigest()
+    if digest != _FIXTURE_SHA256_172A77DD:
+        pytest.fail(
+            "172a77dd baseline fixture sha256 mismatch: got %s, pinned %s — fixture "
+            "bytes drifted; re-vendor from `git show 172a77dd:…`"
+            % (digest, _FIXTURE_SHA256_172A77DD)
+        )
+
+    spec = importlib.util.spec_from_file_location(
+        "shared._merge_guard_baseline_172a77dd", _FIXTURE_PATH_172A77DD
+    )
+    if spec is None or spec.loader is None:
+        pytest.fail(
+            "172a77dd baseline fixture spec unloadable: %s — the cert cannot run"
+            % _FIXTURE_PATH_172A77DD
+        )
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = "shared"
+    spec.loader.exec_module(module)
+
+    if module.is_dangerous_command(_DISCRIMINATOR_1134_UNDERBLOCK) is not False:
+        pytest.fail(
+            "vendored 172a77dd baseline does not exhibit the #1134 non-first-leg "
+            "under-block (delete-in-leg-2 already gates) — post-fix bytes were vendored"
+        )
+    if module.detect_command_operation_type(_DISCRIMINATOR_1134_CLOSE_ASYM) != "close":
+        pytest.fail(
+            "vendored 172a77dd baseline does not classify the leg-2 close form — the "
+            "detect/gate asymmetry the cert pins is absent; wrong bytes were vendored"
+        )
+    if module.is_dangerous_command(_DISCRIMINATOR_1134_CLOSE_ASYM) is not False:
+        pytest.fail(
+            "vendored 172a77dd baseline already GATES the leg-2 close form — the pre-fix "
+            "mint==read asymmetry is absent; post-fix bytes were vendored"
+        )
+
+    _cached_baseline_172a77dd = module
     return module

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -12986,6 +12986,32 @@ class TestTokenLifecycleExtensions:
         # counter-test: change LAYER1_SUCCESS_STDOUT_PATTERNS["force-push"]
         #               from None to a fixed string → assertion fails.
         # expected RED cardinality: {1}
+
+        IF YOU ARE HERE BECAUSE YOU ADDED `remote-ref-delete` OR
+        `remote-mass-delete`, READ THIS BEFORE UPDATING THE PIN.
+
+        Adding either key is not a mistake — it is a live deferred proposal. But it
+        RE-OPENS A QUESTION THAT IS CURRENTLY CLOSED, and updating this pin to match
+        your edit would close it silently.
+
+        The question: the per-leg op-filter widening lets an EARLIER leg claim a
+        verdict a later leg used to win, which RE-LABELS 216 commands across 6
+        distinct transitions (e.g. `cd /repo && git branch -Df temp && git push
+        origin main` classifies branch-delete, not push-to-main). That was measured
+        BENIGN for retirement — 0 tokens survive that previously retired.
+
+        WHY it is benign is the part your change disturbs. These rows never retired
+        at base either: they passed Block 1 and then failed the IDENTITY match
+        (`cmd_target` is None on a two-dangerous-leg fallback, against a token target
+        of `main`). Post-widening they fail EARLIER, at Block 1, precisely because the
+        two remote-delete classes are ABSENT from this table. Different mechanism,
+        same outcome — so the benignity currently rests on the identity mismatch AND
+        on that absence.
+
+        Add either key and those transitions begin clearing Block 1 again, leaving
+        only the identity mismatch. That may well still hold. But it has not been
+        measured, so: REDO THE RE-LABEL RETIREMENT ANALYSIS (216 commands, 6
+        transitions) before shipping the addition, and record the result here.
         """
         from shared.merge_guard_common import LAYER1_SUCCESS_STDOUT_PATTERNS
 

--- a/pact-plugin/tests/test_merge_guard_1134_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1134_cert.py
@@ -839,6 +839,166 @@ class TestCloseRepoValueMisbindClosed:
         assert _execute(cmd, tmp_path) == _ALLOW, "faithful --repo close did not self-authorize: %r" % cmd
 
 
+# ── gh pr close URL HOST-CLASS WIDEN (over-block closure) ──────────────────────────
+# The close URL extractor's host char class was `[\w.-]+`, which REJECTED ':' (port)
+# and '@' (userinfo). A faithful GHE-on-a-custom-port URL
+# (`gh pr close https://ghe.corp:8443/o/r/pull/9 -d`) and a userinfo URL therefore
+# extracted target=None -> gated-but-unmintable OVER-BLOCK (gh RUNS both). The widen to
+# `[\w.@:-]+` (HOST SEGMENT ONLY — the owner/repo group and the `/pull/(\d+)(?![\w-])`
+# anchor are untouched) mints them. Identity encoding is KEEP-IN (lead-ratified): the
+# host is captured VERBATIM into `url:<host>/<owner>/<repo>#<N>`, so distinct spellings
+# (userinfo vs bare, port vs no-port, and the deceptive `github.com@evil.com` whose
+# verbatim id set-equals NEITHER `github.com` NOR `evil.com`) can never cross-authorize.
+# All identity strings measured against the committed host-widen, not computed.
+CLOSE_HOSTWIDEN_MINT = [
+    (_GH + "close https://ghe.corp:8443/o/r/pull/9 -d", "url:ghe.corp:8443/o/r#9"),
+    (_GH + "close https://user@github.com/o/r/pull/9 -d", "url:user@github.com/o/r#9"),
+    (_GH + "close https://u@ghe.corp:8443/o/r/pull/9 -d", "url:u@ghe.corp:8443/o/r#9"),
+]
+
+# KEEP-IN laundering: a widened-host token must REFUSE a DIFFERENT-host execution; each
+# faithful self-execution AUTHORIZES. The deceptive row is the load-bearing one — it pins
+# that the verbatim-host identity set-equals neither the apparent host nor the real host.
+# (name, approve, execute, expect_allow.)
+CLOSE_HOSTWIDEN_LAUNDERING = [
+    ("userinfo token -> bare host", _GH + "close https://user@github.com/o/r/pull/9 -d",
+     _GH + "close https://github.com/o/r/pull/9 -d", False),
+    ("port token -> no-port host", _GH + "close https://ghe.corp:8443/o/r/pull/9 -d",
+     _GH + "close https://ghe.corp/o/r/pull/9 -d", False),
+    ("deceptive userinfo-as-host -> apparent host", _GH + "close https://github.com@evil.com/o/r/pull/9 -d",
+     _GH + "close https://github.com/o/r/pull/9 -d", False),
+    ("deceptive userinfo-as-host -> real host", _GH + "close https://github.com@evil.com/o/r/pull/9 -d",
+     _GH + "close https://evil.com/o/r/pull/9 -d", False),
+    ("faithful port self", _GH + "close https://ghe.corp:8443/o/r/pull/9 -d",
+     _GH + "close https://ghe.corp:8443/o/r/pull/9 -d", True),
+    ("faithful userinfo self", _GH + "close https://user@github.com/o/r/pull/9 -d",
+     _GH + "close https://user@github.com/o/r/pull/9 -d", True),
+]
+
+# Anchor integrity under the widened host: the `/pull/(\d+)` anchor still resolves N with a
+# port/userinfo host, digits in the repo, and a trailing path/query/fragment.
+CLOSE_HOSTWIDEN_ANCHOR = [
+    (_GH + "close https://ghe.corp:8443/o/r-123/pull/9 -d", "url:ghe.corp:8443/o/r-123#9"),
+    (_GH + "close https://ghe.corp:8443/o/r/pull/9/files -d", "url:ghe.corp:8443/o/r#9"),
+    (_GH + "close https://ghe.corp:8443/o/r/pull/9?diff=split -d", "url:ghe.corp:8443/o/r#9"),
+    (_GH + "close https://ghe.corp:8443/o/r/pull/9#c-1 -d", "url:ghe.corp:8443/o/r#9"),
+]
+
+
+class TestCloseHostWidenGateAndMint:
+    """OVER-BLOCK CLOSURE: the close URL host class widened `[\\w.-]` -> `[\\w.@:-]` to admit
+    port (`:`) and userinfo (`@`). A faithful GHE-on-a-custom-port / userinfo close URL
+    previously extracted target=None -> gated-but-unmintable OVER-BLOCK. Each row now gates,
+    mints ONE token binding op=close and the VERBATIM KEEP-IN identity (read OFF the token),
+    and self-authorizes. The counter-test-by-revert known-bad narrows `_GH_PULL_URL_RE` back
+    to its pre-widen host class and asserts the forms mint None again, coupling the rows to
+    the host-widen commit."""
+
+    @pytest.mark.parametrize(
+        "cmd,value", CLOSE_HOSTWIDEN_MINT, ids=[r[0] for r in CLOSE_HOSTWIDEN_MINT]
+    )
+    def test_widened_host_gates_and_mints_keep_in(self, cmd, value, tmp_path):
+        assert D(cmd) is True, "widened-host faithful close not gated: %r" % cmd
+        minted, ctx = _mint(cmd, tmp_path)
+        assert minted == 1, (
+            "OVER-BLOCK persists — widened-host close gates but does NOT mint "
+            "(gated-but-unmintable): %r" % cmd
+        )
+        assert ctx.get("operation_type") == "close", (
+            "token bound the wrong op: %r for %r" % (ctx.get("operation_type"), cmd)
+        )
+        assert ctx.get("pr_number") == value, (
+            "wrong KEEP-IN close identity: got %r, expected the verbatim-host %r for %r"
+            % (ctx.get("pr_number"), value, cmd)
+        )
+        assert _execute(cmd, tmp_path) == _ALLOW, (
+            "the faithful widened-host close's own token did not self-authorize: %r" % cmd
+        )
+
+    def test_narrowing_the_host_class_reopens_the_over_block(self, monkeypatch):
+        import re as _re
+        # VACUITY GUARD: the live regex must currently mint on the widened form, else the
+        # narrow below is a no-op and this proves nothing.
+        assert mgc._extract_close_target(CLOSE_HOSTWIDEN_MINT[0][0]) is not None, (
+            "the widened-host form already mints None at head — the host-widen is absent, so "
+            "the narrow known-bad below would prove nothing"
+        )
+        # KNOWN-BAD: revert `_GH_PULL_URL_RE` to the pre-widen host class (`[\w.-]`, no :/@).
+        narrow = _re.compile(r"https?://([\w.-]+)/([\w.-]+/[\w.-]+)/pull/(\d+)(?![\w-])")
+        monkeypatch.setattr(mgc, "_GH_PULL_URL_RE", narrow)
+        reopened = [
+            cmd for cmd, _v in CLOSE_HOSTWIDEN_MINT
+            if mgc._extract_close_target(cmd) is not None
+        ]
+        assert reopened == [], (
+            "with the host class narrowed to its pre-widen shape, these widened-host forms "
+            "STILL extract a target — the host-widen is not the attributable cause, so the "
+            "gate+mint rows above prove nothing: %r" % reopened
+        )
+
+
+class TestCloseHostWidenLaundering:
+    """The KEEP-IN safety property, certified BEHAVIORALLY end-to-end: a widened-host token
+    must NOT authorize a DIFFERENT-host execution — including the deceptive userinfo-as-host
+    form (`github.com@evil.com`, whose VERBATIM identity `url:github.com@evil.com/o/r#9`
+    set-equals NEITHER `github.com` NOR `evil.com`). minted==1 asserted FIRST so a DENY is a
+    read decision. Each escalation is its own known-bad: the verbatim-host qualifier is what
+    makes it refuse, and an identity coarsening (normalizing the host, dropping userinfo/port)
+    would flip it to AUTHORIZE. Faithful self-executions AUTHORIZE (no over-block)."""
+
+    @pytest.mark.parametrize(
+        "name,approve,execute,expect_allow", CLOSE_HOSTWIDEN_LAUNDERING,
+        ids=[r[0] for r in CLOSE_HOSTWIDEN_LAUNDERING],
+    )
+    def test_keep_in_identity_refuses_cross_host(self, name, approve, execute, expect_allow, tmp_path):
+        minted, _ = _mint(approve, tmp_path)
+        assert minted == 1, "approve did not mint (%s): %r" % (name, approve)
+        rc = _execute(execute, tmp_path)
+        if expect_allow:
+            assert rc == _ALLOW, (
+                "OVER-BLOCK: a faithful widened-host close self-execution was REFUSED "
+                "(%s): %r" % (name, execute)
+            )
+        else:
+            assert rc == _DENY, (
+                "LAUNDERING: a widened-host close token authorized a DIFFERENT-host "
+                "execution (%s): approve=%r execute=%r" % (name, approve, execute)
+            )
+
+
+class TestCloseHostWidenAnchorAndResiduals:
+    """Anchor integrity under the widened host (the `/pull/(\\d+)` anchor still resolves N
+    with a port/userinfo host, repo digits, and a trailing path/query/fragment), the
+    empty-target guard (an empty positional binds None, not a degenerate `branch:`), and a
+    DOCUMENTED pre-existing residual: a bracketed-IPv6 host still mints None — a faithful-but-
+    rare gated-but-unmintable over-block that the host-widen does NOT close (the host class
+    never admitted `[`/`]`; None pre-widen too). It is pinned VISIBLE like the `--label 5`
+    residual, NOT asserted-closed; if it is ever closed, re-confirm the disposition rather
+    than silently updating this pin."""
+
+    @pytest.mark.parametrize(
+        "cmd,value", CLOSE_HOSTWIDEN_ANCHOR, ids=[r[0] for r in CLOSE_HOSTWIDEN_ANCHOR]
+    )
+    def test_anchor_resolves_under_widened_host(self, cmd, value):
+        got = mgc._extract_close_target(cmd)
+        assert got == value, (
+            "the widened host broke the /pull/N anchor: got %r, expected %r for %r"
+            % (got, value, cmd)
+        )
+
+    def test_empty_target_binds_none(self):
+        # An empty positional was minting a degenerate `branch:` identity; it now binds None.
+        got = mgc._extract_close_target(_GH + "close '' -d")
+        assert got is None, "empty close target no longer None (degenerate mint reopened): %r" % got
+
+    def test_bracketed_ipv6_host_is_a_documented_residual(self):
+        got = mgc._extract_close_target(_GH + "close https://[::1]/o/r/pull/9 -d")
+        assert got is None, (
+            "the bracketed-IPv6 residual changed shape — re-confirm the disposition rather "
+            "than silently updating this pin: %r" % got
+        )
+
+
 class TestMergeExtractorUnchangedByCloseFold:
     """The fold restructured CLOSE to derive from `_gh_close_positionals` and NOT call
     `_extract_pr_number`; the MERGE path STILL uses `_extract_pr_number`. This pins the
@@ -880,6 +1040,63 @@ class TestMergeExtractorUnchangedByCloseFold:
         assert minted == 1 and ctx.get("pr_number") == "42", (
             "merge no longer mints the positional PR through the real hook: minted=%s pr=%r"
             % (minted, ctx.get("pr_number") if ctx else None)
+        )
+
+
+class TestMergeShadowGuardIsLoadBearing:
+    """NON-VACUITY for the merge value-flag-shadow guard in `_extract_pr_number` (the
+    `--max-retries 5`-style rejection at the preceding-value-flag check). The
+    TestMergeExtractorUnchangedByCloseFold behavioral rows place the positional BEFORE the
+    value-flag (`gh pr merge 42 <flag> 99`), so `_GH_PR_NUMBER_RE` matches the positional 42
+    DIRECTLY and the shadow guard is never the deciding factor — disabling the guard entirely
+    trips ZERO of those rows. This closes that gap.
+
+    The guard fires ONLY when a value-flag's value is the SOLE positional-shaped digit
+    (`gh pr merge --max-retries 5`, NO PR positional — a FAITHFUL command; gh infers the
+    current-branch PR). At HEAD the guard makes the extractor ABSTAIN (None) rather than
+    mis-bind the flag value as PR `5` — a laundering vector (approve a current-branch merge,
+    reuse the token to merge PR #5).
+
+    THE KNOWN-BAD LEG IS LOAD-BEARING: a base==head `is None` assertion WITHOUT the monkeypatch
+    leg would itself be another untested-guard vacuity — the exact pattern this arc exists to
+    close. The monkeypatch (drop `--max-retries` from the value-flag set) demonstrates the
+    guard mis-binds `5` when killed, so the live `is None` assertion is a REAL guard-test rather
+    than a second dead check. Mirrors TestBenignWordBoundaryKnownBad."""
+
+    _SHADOW = _GH + "merge --max-retries 5"  # value-flag value is the ONLY positional-shaped digit
+
+    def test_shadow_form_abstains_live_base_and_head(self):
+        # The guard's correct behavior: the `--max-retries` value `5` is NOT mis-bound as
+        # the PR number — the extractor abstains so gh's current-branch inference stands.
+        assert mgc._extract_pr_number(self._SHADOW) is None, (
+            "merge shadow guard regressed at head — the --max-retries value was mis-bound "
+            "as the PR number: %r" % self._SHADOW
+        )
+        assert load_baseline_172a77dd()._extract_pr_number(self._SHADOW) is None, (
+            "baseline does not abstain on the shadow form — the merge extractor is not the "
+            "byte-identical pre-fix state, so the head==None pin certifies nothing: %r"
+            % self._SHADOW
+        )
+
+    def test_dropping_the_flag_reopens_the_mis_bind(self, monkeypatch):
+        # VACUITY GUARD: --max-retries must currently be in the value-flag set, else the drop
+        # below is a no-op and this proves nothing.
+        assert "--max-retries" in mgc._GH_PR_VALUE_TAKING_FLAGS, (
+            "--max-retries is not in _GH_PR_VALUE_TAKING_FLAGS — the drop below is a no-op; "
+            "the shadow guard's flag set changed shape"
+        )
+        # KNOWN-BAD: drop `--max-retries` from the value-flag set (kill the shadow guard for
+        # this flag). The extractor now mis-binds the flag value `5` as the PR — the exact
+        # laundering the guard prevents. This is what makes the live `is None` above coupled
+        # to the guard rather than an untested-guard vacuity.
+        reduced = frozenset(
+            f for f in mgc._GH_PR_VALUE_TAKING_FLAGS if f != "--max-retries"
+        )
+        monkeypatch.setattr(mgc, "_GH_PR_VALUE_TAKING_FLAGS", reduced)
+        assert mgc._extract_pr_number(self._SHADOW) == "5", (
+            "dropping --max-retries did NOT reopen the mis-bind — the shadow guard is not the "
+            "attributable cause of the abstain, so test_shadow_form_abstains_live_base_and_head "
+            "proves nothing: %r" % self._SHADOW
         )
 
 

--- a/pact-plugin/tests/test_merge_guard_1134_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1134_cert.py
@@ -1,0 +1,1130 @@
+"""
+Location: pact-plugin/tests/test_merge_guard_1134_cert.py
+Summary: The DURABLE three-dimension certification for the non-first-leg destructive
+         recognition fix (#1134) and the remote-delete PRIVILEGED_FLAGS split binding.
+         Certifies against the REAL classifier + REAL post/pre hooks, base (committed
+         vendored fixture at 172a77dd via merge_guard_baseline_loader — loud-fail,
+         CI-executable, never skip) vs live HEAD. NEVER a byte-diff / git-show-by-SHA.
+
+WHY THREE DIMENSIONS. is_dangerous_command is only ONE of the three surfaces this arc
+moves. A monotonicity sweep that watches is_dangerous alone would go green while seeing
+at most a third of the change — the same shape of error as the #1118 +N/-0 byte-diff
+"certificate", one abstraction level up. The three surfaces, each with its own oracle:
+
+  D1  is_dangerous_command       — leg-position parity (the gate)
+  D2  mintability                — minted==1 + which-key-won (OFF THE TOKEN) + a REAL
+                                   post_main -> pre_main round-trip (the gated-but-
+                                   unmintable guard, the cardinal over-block's subtler half)
+  D3  detect_command_operation_type — op-parity (mint==read: gate <=> detect non-None)
+
+GOVERNING MODEL — SACROSANCT, GOOD-FAITH. The merge-guard routes an HONEST destructive
+command through the user's approval click; a faithful single-command click always mints
+and self-authorizes. The ONLY cardinal sin is the OVER-BLOCK: blocking a faithful click,
+INCLUDING gating it but leaving it unmintable (gated-but-unmintable). Under-blocks are
+tolerated ONLY when they take deliberate/adversarial construction a good-faith user would
+never type; a good-faith DESTRUCTIVE command running ungated is STILL unacceptable (that
+is exactly what #1134 was — `cd /repo && git push origin --delete feature` ran completely
+ungated). MUST_HOLD is the over-block direction, the one with NO tolerance band.
+
+STATED RESIDUAL (security §1 — carried VERBATIM, load-bearing not decorative):
+    The by-construction subset argument bounds the CLASS of false positives, not the
+    COUNT. If an unfound first-leg false positive F exists, the widening MULTIPLIES its
+    reach across leg positions. Absence of F is precisely what a corpus cannot prove.
+    The benign parity rows are the live guard against this.
+Consequence for reading this file: a GREEN run is NOT a proof of the universal "no
+faithful click is ever over-blocked". The BENIGN parity sweep and MUST_STAY_OFF rows
+bound the CLASS of over-blocks we enumerated; they cannot bound the COUNT of first-leg
+false positives that were never enumerated. Do not let the green cert read as more.
+
+ADVERSARIAL-ONLY RESIDUALS (documented, NOT closed — do not re-file as over-blocks). Two
+non-faithful close forms are gated/minted with a wrong-but-harmless identity, tolerated
+under the good-faith model because gh itself REFUSES the command, so there is no faithful
+click to protect:
+  (1) NO-ARG close (`gh pr close -d`) — gh requires a positional, so it never runs (see the
+      note by MUST_STAY_OFF). Gated-but-non-faithful.
+  (2) UNKNOWN/misapplied value-flag with a numeric value and NO positional
+      (`gh pr close --label 5 -d`) — the positional-first close fold cannot close this (an
+      allow-list was rejected as a future over-block), so it still mints '5' BY DESIGN. It
+      is a confused-deputy laundering vector reachable ONLY by an adversary crafting a
+      non-runnable approval. The "still mints '5'" assertion is OWNED by the coder's
+      test_unknown_value_flag_on_nonfaithful_close_is_adversarial_only (the SSOT); this cert
+      REFERENCES it and does NOT duplicate it or assert abstention. FAITHFUL commands (a real
+      value-flag WITH a positional) all mint the CORRECT identity — see
+      TestCloseRepoValueMisbindClosed.
+
+CORPUS AND ITS AXES (a probe is only as complete as its corpus — state it):
+  * 53 differential rows: MUST_FLIP 22 / MUST_HOLD 29 / MUST_STAY_OFF 2, plus 8 BENIGN.
+  * MUST_HOLD is the UNION of two independent enumerations that diverged by 13 rows on
+    this exact class. It is NOT trimmed to the intersection — the over-block direction
+    gets the superset.
+  * Leg-position axis: 5 benign prefixes (`cd &&`, `cd ;`, `git status &&`, `echo &&`,
+    `false ||`). Each is a benign-CONTINUATION carrier that must not change a verdict.
+  * Close POSITIONAL-TYPE axis (number/url/branch x first-leg/non-first-leg): covered by
+    TestCloseUrlBranchNowGateAndMint + TestCloseMintLaundering. This axis was originally
+    MISSED — the corpus swept only the number positional, and a faithful gated-but-
+    unmintable over-block hid in the url/branch forms until a base-vs-fixed sweep across
+    the positional type surfaced it. The lesson (a probe is only as complete as its corpus)
+    is why the axis is now enumerated explicitly.
+  * NOT swept here (declared, deferred with analysis on the PR): >3 legs; quoted/nested
+    subshells; non-git/gh carriers (curl/wget/httpie). See the PR's deferred table.
+
+WHICH-KEY-WON IS READ OFF THE MINTED TOKEN, NEVER off extract_command_context(command).
+On the compound rows #1134 is ABOUT (`cd /repo && git push origin --delete feature`),
+the whole-command extractor binds ZERO identity keys, yet the faithful click still MINTS
+because the mint path selects the destructive leg via _extraction_surface. A which-key-won
+assertion read from the whole-command context would misreport on exactly those rows —
+false-fail, or vacuously green if weakened to tolerate the empty binding. The authoritative
+signal is the token's own `context` dict on disk.
+
+THE MINT+ALLOW ROUND-TRIP ALONE IS PIPELINE-BLIND TO THE #1134 GATE (documented so it is
+not "simplified" into a check that proves nothing). Measured: under an _PER_LEG_OPS revert
+the newly-gated row goes UNGATED yet mint+exec still returns (1, ALLOW) — the mint uses the
+fix-independent _extraction_surface, and the exec ALLOWs because the row is no longer gated,
+not because the token authorized it. The assertions COUPLED to the fix are (a) exec-WITHOUT-
+token -> DENY (proves the row is gated; base known-bad = ungated -> ALLOW) and (b) minted==1
+paired with is_dangerous==True (the gated-but-unmintable guard; known-bad = a mint-target
+neuter -> minted 0 -> DENY). See TestD2Mintability for both.
+
+KNOWN-BAD DISCIPLINE. Every assertion here is demonstrated FAILING on a known-bad, because
+this arc found FIVE checks that proved nothing and ONE invariant (the `-D\\b` word boundary)
+with NO check at all. Where two mechanisms both cover a row (the per-leg filter AND a
+literal arm, or the per-leg filter AND the raw-fallback detect arm), NEITHER endpoint
+(all-on / all-off) can detect a silently-dead one — so the mechanism neuters ISOLATE a
+single mechanism and carry a vacuity guard asserting the neuter is not a no-op.
+
+TOKEN-DIR ISOLATION RULE (a standing rule — this class bit twice). Any test that mints
+tokens in a LOOP over rows must give each iteration a FRESH token dir; a leaked token from
+an earlier row contaminates a later row's authorize/refuse outcome. It first hit a D2
+gated-but-unmintable known-bad, then RECURRED in the binding base-sim loop, where it flipped
+`--no-verify` to a false "stays closed" and produced a wrong "doubly-defended" attribution
+that a clean re-measurement overturned. Parametrized single-row tests are safe (pytest hands
+each a fresh tmp_path); the hazard is a for-loop over rows inside ONE test. Route such loops
+through `_isolated_roundtrip`, which OWNS its token dir and cannot share it by construction.
+
+SEQUENCING — code-commit-then-tests does NOT apply here, and the stale lesson must not be
+re-imported. That rule exists to avoid a red intermediate when tests assert against a HEAD
+that does not yet contain the fix. This cert is a base-vs-HEAD DIFFERENTIAL whose base is a
+COMMITTED VENDORED FIXTURE (172a77dd bytes), not a git checkout — it is CI-executable at any
+HEAD without the pre-fix commit being reachable, and it cannot go red from commit ordering
+because the pre-fix state is frozen in the fixture. (This file ABSORBS the scratchpad
+verify_postfix.py verifier: a cert test runs in CI on every future change, forever; a
+scratchpad script runs once, by whoever remembers.)
+
+Destructive verbs are assembled at runtime so this file stays inert to the live guard.
+"""
+import io
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+sys.path.insert(0, str(Path(__file__).parent))
+
+import merge_guard_post as mgpost  # noqa: E402
+import merge_guard_pre as mgpre  # noqa: E402
+import shared.merge_guard_common as mgc  # noqa: E402
+from merge_guard_baseline_loader import load_baseline_172a77dd  # noqa: E402
+from merge_guard_post import main as post_main  # noqa: E402
+from merge_guard_pre import main as pre_main  # noqa: E402
+
+# Runtime-assembled command stems (kept out of one literal so this file is inert).
+_PG = "git " + "push "
+_GH = "gh " + "pr "
+_GB = "git " + "branch "
+_PREFIX = "cd /repo && "
+
+D = mgc.is_dangerous_command
+DETECT = mgc.detect_command_operation_type
+
+
+def _base():
+    """The pre-#1134 classifier's is_dangerous_command (loud-fail vendored fixture)."""
+    return load_baseline_172a77dd().is_dangerous_command
+
+
+def _base_detect():
+    return load_baseline_172a77dd().detect_command_operation_type
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# CORPUS — module-level data, the cert IS the corpus.
+# MUST_FLIP rows carry (command, expected_op, expected_target_key) so D2/D3 can assert
+# which-key-won and op-parity, not merely a boolean.
+# ═════════════════════════════════════════════════════════════════════════════════
+MUST_FLIP = [
+    # branch-delete (6) — literal floor is only -D\b | --delete --force | --force --delete,
+    # so these cluster/separated spellings are LEFT BEHIND in a non-first leg at base.
+    (_GB + "-Df temp", "branch-delete", "branch"),
+    (_GB + "-fD temp", "branch-delete", "branch"),
+    (_GB + "--delete -f temp", "branch-delete", "branch"),
+    (_GB + "-df temp", "branch-delete", "branch"),
+    (_GB + "-fd temp", "branch-delete", "branch"),
+    (_GB + "-d -f temp", "branch-delete", "branch"),
+    # close (4)
+    (_GH + "close 5 -d", "close", "pr_number"),
+    (_GH + "close 5 -dR owner/repo", "close", "pr_number"),
+    (_GH + "close 5 -d -R owner/repo", "close", "pr_number"),
+    (_GH + "close 5 -R owner/repo -d", "close", "pr_number"),
+    # remote-ref-delete (7) — WHOLLY left behind (no literal arm at all).
+    (_PG + "origin :main", "remote-ref-delete", "target_ref"),
+    (_PG + "origin --delete main", "remote-ref-delete", "target_ref"),
+    (_PG + "-d origin main", "remote-ref-delete", "target_ref"),
+    (_PG + "--delete origin main", "remote-ref-delete", "target_ref"),
+    (_PG + "origin -d main", "remote-ref-delete", "target_ref"),
+    (_PG + "-du origin main", "remote-ref-delete", "target_ref"),
+    (_PG + "-ud origin main", "remote-ref-delete", "target_ref"),
+    # remote-mass-delete (5) — WHOLLY left behind.
+    (_PG + "--mirror origin", "remote-mass-delete", "mass_target"),
+    (_PG + "--prune origin --all", "remote-mass-delete", "mass_target"),
+    (_PG + "origin :a :b", "remote-mass-delete", "mass_target"),
+    (_PG + "origin --delete a b", "remote-mass-delete", "mass_target"),
+    (_PG + "-d origin a b", "remote-mass-delete", "mass_target"),
+]
+
+# The 4 close rows carry detect=close at BASE via the raw-fallback gh-pr arm (NOT the
+# per-leg filter), while is_dangerous is False — a pre-fix detect/gate ASYMMETRY the fix
+# closes. So on the DETECT side the per-leg filter SOLELY drives the 18 non-close rows;
+# the D3 filter-neuter isolates on those. (This is the two-mechanism blindness, in D3.)
+MUST_FLIP_FILTER_DRIVES_DETECT = [
+    r for r in MUST_FLIP if r[1] != "close"
+]
+assert len(MUST_FLIP_FILTER_DRIVES_DETECT) == 18
+
+# MUST_HOLD (29) — gated in BOTH positions at base AND head. They certify nothing on
+# their own (they pass pre-fix); their job is to catch a future change that BREAKS
+# working coverage. The over-block direction with no tolerance band; the UNION of two
+# independent enumerations (not the intersection).
+MUST_HOLD = [
+    _GB + "-D temp", _GB + "-D a b", _GB + "-D -f temp",
+    _GB + "-f -D temp", _GB + "--delete --force temp",
+    _GB + "--force --delete temp", _GB + "-D --force temp",
+    _GB + "--delete --force a b",
+    _GH + "close 5 --delete-branch",
+    _GH + "close 5 --delete-branch --repo owner/repo",
+    _GH + "merge 42", _GH + "merge 42 --admin", _GH + "merge 42 -d",
+    _GH + "merge 42 --admin -d", _GH + "merge 42 -dR owner/repo",
+    _GH + "merge 42 --admin --delete-branch",
+    _PG + "--force origin main", _PG + "-f origin main",
+    _PG + "-fu origin main", _PG + "-uf origin main",
+    _PG + "-f -u origin main", _PG + "--force -u origin main",
+    _PG + "origin main", _PG + "origin HEAD:main",
+    _PG + "origin main:main", _PG + "-u origin main",
+    _GH + "merge 42 --squash --admin",
+    _PG + "--force origin main feature",
+    # op=push-to-main, NOT force-push: --force-with-lease is the SAFE exclusion on the
+    # force arm, so this row's coverage comes from the push-to-main arm — a fix touching
+    # push-to-main is what it guards.
+    _PG + "--force-with-lease origin main",
+]
+
+# MUST_STAY_OFF (2) — NOT dangerous even bare, correctly. Gating these = OVER-BLOCK.
+# Both are NUMBERED (a runnable close) and correctly ungated.
+MUST_STAY_OFF = [
+    _GH + "close 5",                 # reversible close, no delete flag
+    _GH + "close 5 -Rd owner/repo",  # -R value-taking: -Rd == -R=d, no -d delete present
+]
+# NB the NO-ARG close forms (`gh pr close -d`, `gh pr close --delete-branch`, and their
+# non-first-leg carriers) ARE gated at HEAD, but that is NOT an over-block and they are
+# NEITHER MUST_FLIP NOR MUST_STAY_OFF: `gh pr close` REQUIRES an explicit target
+# (`{<number>|<url>|<branch>}` — braces = required; it is `gh pr view` that infers the
+# branch). A command the CLI refuses to run has no faithful click, so gating it costs no
+# honest user anything — gated-but-non-faithful, harmless. Do not "fix" it to ungate, and
+# do not add it as a MUST_STAY_OFF row: asserting it ungated would mandate loosening a
+# harmless gate toward a real under-block. (The numberless-close gate is by-construction
+# unmintable — no target — but that is moot precisely because no faithful click exists.)
+
+# BENIGN (8) — the first-leg false-positive guard (the over-block direction). Chosen to
+# stress the widening: benign pushes NOT to main, a filter-value that MENTIONS delete
+# tokens, and the exact `-o "note: use --mirror ..."` shape that literal per-leg arms
+# were measured to over-block (3 cardinal over-blocks vs the filter's 0).
+BENIGN = [
+    "git status",
+    "git log --committer 'note: --delete and -D mentioned'",
+    _PG + "origin feature",
+    _GB + "feature-Dashboard",       # branch CREATION; the `-D\b` word-boundary guard
+    _GH + "view 5",
+    _GH + "list",
+    _GB + "-a",
+    _PG + "origin feature -o \"note: use --mirror for backups\"",
+]
+
+# Benign branch CREATIONS whose `-D\b` guard the boundary removal would break (they
+# contain a mid-word `-D`: featur[e-D]ashboard). The dedicated \b known-bad set.
+BENIGN_BRANCH_CREATION = [
+    _GB + "feature-Dashboard",
+    _GB + "my-Diagram-branch",
+    _GB + "release-Docs",
+]
+
+# Benign-CONTINUATION leg carriers. is_dangerous(P + C) MUST equal is_dangerous(C).
+PREFIXES = [
+    ("cd &&", "cd /tmp/r && "),
+    ("cd ;", "cd /tmp/r ; "),
+    ("status &&", "git status && "),
+    ("echo &&", "echo hi && "),
+    ("||", "false || "),
+]
+
+# The 4 classes the #1134 widening ADDED to the per-leg filter (the fix itself).
+NEW_PER_LEG_CLASSES = ("branch-delete", "close", "remote-ref-delete", "remote-mass-delete")
+
+# The count pin: MUST_FLIP spellings x prefixes. Pinned so a corpus-size drift is loud.
+COUNT_PIN_SPELLINGS = 22
+COUNT_PIN_VIOLATIONS = COUNT_PIN_SPELLINGS * len(PREFIXES)  # 22 x 5 = 110
+
+# MINT-PIN gap-closure (security review). The shipped scratchpad probe (probe_1134_mintpath)
+# patched a FOUR-tuple that EXCLUDED `close` and `branch-delete`, so those two newly-reached
+# classes were GATE-pinned only — never MINT-pinned. A gate with no verified mint path is
+# the cardinal gated-but-unmintable over-block waiting to be introduced. These rows pin
+# minted==1 + identity-off-the-token for close and branch-delete in a NON-FIRST leg, across
+# TWO distinct benign carriers (so the pin is not an artifact of one prefix's parse), closing
+# the exclusion explicitly. (cmd, expected_op, expected_target_key.)
+MINT_PIN_CLOSE_AND_BRANCH_DELETE = [
+    ("cd /repo && " + _GH + "close 5 -d", "close", "pr_number"),
+    ("git fetch && " + _GH + "close 5 -dR owner/repo", "close", "pr_number"),
+    ("cd /repo && " + _GB + "-Df temp", "branch-delete", "branch"),
+    ("git fetch && " + _GB + "-D old-feature", "branch-delete", "branch"),
+]
+
+# ── Close POSITIONAL-TYPE axis (the axis the corpus originally MISSED) ─────────────
+# `gh pr close` accepts {<number>|<url>|<branch>}. The corpus covered only the NUMBER
+# positional, so a faithful gated-but-unmintable OVER-BLOCK hid in the url/branch forms:
+# commit 1 gated the NON-FIRST-LEG forms, and the FIRST-LEG url/branch forms were a
+# PRE-EXISTING gated-but-unmintable. The commit-5 extractor fix makes ALL faithful close
+# forms gate+MINT, binding `pr_number` with a positional-type-QUALIFIED value:
+#   number -> '5'  |  url -> 'url:<host>/<owner>/<repo>#<N>'  |  branch -> 'branch:<name>'
+# Measured base(172a77dd) -> fixed(commit 5):
+#   url/branch FL : base gated+mint0 (the over-block) -> fixed gate+mint   [D2 mint-flip]
+#   url/branch NFL: base UNGATED                      -> fixed gate+mint   [D1 gate + D2 mint]
+# (The number FL row is base gate+mint already — the control; number NFL is the #1134
+# leg-position flip, already in MUST_FLIP.)
+_URL = "https://github.com/o/r/pull/5"
+# (cmd, expected_pr_number_value, base_gated)  base_gated True => D2 mint-flip; False => D1.
+CLOSE_URL_BRANCH_FLIP = [
+    (_GH + "close " + _URL + " -d", "url:github.com/o/r#5", True),           # url FL  (D2)
+    (_PREFIX + _GH + "close " + _URL + " -d", "url:github.com/o/r#5", False),  # url NFL (D1+D2)
+    (_GH + "close feature -d", "branch:feature", True),                      # branch FL (D2)
+    (_PREFIX + _GH + "close feature -d", "branch:feature", False),            # branch NFL (D1+D2)
+]
+
+# Cross-spelling / cross-host / cross-repo LAUNDERING. The host-qualified close identity is
+# what makes a url/branch token refuse a DIFFERENT-looking-but-same-number execution. Each
+# escalation must REFUSE; each faithful self-execution must AUTHORIZE. minted==1 asserted
+# FIRST so a DENY is a read decision. (name, approve, execute, expect_allow.)
+_URL_ENT = "https://github.enterprise.com/o/r/pull/5"
+_URL_OTHER = "https://github.com/o/other/pull/5"
+CLOSE_LAUNDERING = [
+    ("url token -> bare number", _GH + "close " + _URL + " -d", _GH + "close 5 -d", False),
+    ("url token -> cross-host url", _GH + "close " + _URL + " -d", _GH + "close " + _URL_ENT + " -d", False),
+    ("url token -> different-repo url", _GH + "close " + _URL + " -d", _GH + "close " + _URL_OTHER + " -d", False),
+    ("branch token -> bare number", _GH + "close feature -d", _GH + "close 5 -d", False),
+    ("branch token -> different branch", _GH + "close feature -d", _GH + "close main -d", False),
+    ("number token -> url", _GH + "close 5 -d", _GH + "close " + _URL + " -d", False),
+    # commit-6 --repo mis-bind: the branch:feature token must NOT authorize a PR-5 close.
+    # This is the CI-permanent known-bad for the mis-bind fix: if the identity coarsened
+    # back to '5' (the mis-bind), this would AUTHORIZE instead of REFUSE.
+    ("--repo branch token -> number", _GH + "close --repo 5/6 feature -d", _GH + "close 5 --repo 5/6 -d", False),
+    ("faithful url == url", _GH + "close " + _URL + " -d", _GH + "close " + _URL + " -d", True),
+    ("faithful branch == branch", _GH + "close feature -d", _GH + "close feature -d", True),
+    ("faithful --repo branch == same", _GH + "close --repo 5/6 feature -d", _GH + "close --repo 5/6 feature -d", True),
+]
+
+# Case 1 (commit 6): the `--repo`/`-R` value mis-bind fix. `--repo` takes a repo value that
+# can start with a digit (`5/6`); at commit-6's PARENT (7bb6ac5c) `_extract_pr_number`'s
+# value-flag list OMITTED `--repo` while `_gh_close_positionals` INCLUDED it, so the repo
+# value's leading digit shadowed the branch positional and mis-bound '5'. The fold aligns
+# the lists (positional-first close derivation), so these FAITHFUL commands (real --repo flag
+# + real branch positional, gh runs them) now mint the branch. Counter-test-by-revert
+# (source -> 7bb6ac5c): these mint '5' (the mis-bind) — coupling them to commit 6.
+CLOSE_REPO_MISBIND = [
+    _GH + "close --repo 5/6 feature -d",
+    _GH + "close -R 5/6 feature -d",
+    _GH + "close --repo 55/66 feature -d",
+]
+
+# The value-taking gh pr flags `_extract_pr_number` must skip. The MERGE path still uses
+# `_extract_pr_number` (byte-untouched by the close fold), so this pins the fold's structural
+# claim that CLOSE AND MERGE DO NOT CROSS: merge minting is identical base(172a77dd) -> HEAD.
+_GH_MERGE_VALUE_FLAGS = [
+    "--body", "--body-file", "--subject", "--author-email", "--match-head-commit",
+    "--comment", "--max-retries", "--retry-count", "--timeout",
+]
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# REAL post_main -> pre_main drivers (the D2 backbone; sibling of the obs-cert harness).
+# _mint returns (count, token_context) — context read OFF the minted token on disk.
+# ═════════════════════════════════════════════════════════════════════════════════
+_ALLOW, _DENY = 0, 2
+
+# The identity keys a token may bind (the which-key-won read).
+_TARGET_KEYS = (
+    "pr_number", "branch", "target_ref", "mass_target",
+    "protected_branch", "branch_set", "push_set",
+)
+
+
+def _mint(cmd, tok):
+    """Drive the REAL post hook with an approval embedding `cmd`. Returns
+    (count_of_tokens_minted, context_dict_or_None) — the context is read from the token
+    FILE, which is authoritative for which-key-won even when the whole-command extractor
+    binds nothing (the compound-row artifact)."""
+    before = set(tok.glob("merge-authorized-*"))
+    env = json.dumps({
+        "tool_name": "AskUserQuestion",
+        "tool_input": {"questions": [{
+            "question": "Proceed?",
+            "options": [
+                {"label": "Yes", "description": "Run `%s`" % cmd},
+                {"label": "Cancel", "description": "Abort"},
+            ],
+        }]},
+        "tool_response": {"answers": {"Proceed?": "Yes"}},
+        "session_id": "cert-1134",
+    })
+    with patch.object(mgpost, "TOKEN_DIR", tok), \
+            patch("sys.stdin", io.StringIO(env)), \
+            patch("sys.stdout", io.StringIO()):
+        try:
+            post_main()
+        except SystemExit as e:
+            assert e.code == 0, "post hook exited nonzero: %r" % (e.code,)
+    new = set(tok.glob("merge-authorized-*")) - before
+    if len(new) != 1:
+        return len(new), None
+    ctx = json.loads(next(iter(new)).read_text()).get("context", {})
+    return 1, ctx
+
+
+def _execute(cmd, tok):
+    """Run `cmd` through the REAL pre hook; return exit code (0=ALLOW, 2=DENY)."""
+    env = json.dumps({
+        "tool_name": "Bash",
+        "tool_input": {"command": cmd},
+        "session_id": "cert-1134",
+    })
+    with patch.object(mgpre, "TOKEN_DIR", tok), \
+            patch("sys.stdin", io.StringIO(env)), \
+            patch("sys.stdout", io.StringIO()), \
+            patch("sys.stderr", io.StringIO()):
+        try:
+            pre_main()
+            return _ALLOW
+        except SystemExit as e:
+            return e.code if isinstance(e.code, int) else _ALLOW
+
+
+def _won_key(ctx):
+    """The single identity key bound in a token context (which-key-won)."""
+    keys = [k for k in _TARGET_KEYS if ctx.get(k)]
+    return keys[0] if len(keys) == 1 else keys
+
+
+def _isolated_roundtrip(approve, execute):
+    """Mint `approve`, then execute `execute`, in a token dir this call OWNS — allocated
+    internally and torn down on return, so it is STRUCTURALLY IMPOSSIBLE to share across
+    rows. Returns (minted, rc).
+
+    TOKEN-DIR ISOLATION RULE (bit twice, now closed): any test that mints tokens in a LOOP
+    must give each iteration a fresh token dir — a leaked token from an earlier row
+    contaminates a later row's authorize/refuse outcome. It first hit a D2 gated-but-
+    unmintable known-bad (shared tmp_path across a vacuity-mint and the neuter-exec), then
+    RECURRED in the binding base-sim loop (one tmp_path across three escalation iterations),
+    where the leak flipped --no-verify to a false "stays closed" and produced a wrong
+    "doubly-defended" attribution. Parametrized single-row tests are safe (pytest gives each
+    a fresh tmp_path); the hazard is a for-loop over rows inside ONE test. Route such loops
+    through THIS helper so the dir cannot be shared by construction."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        tok = Path(d)
+        minted, _ = _mint(approve, tok)
+        assert minted == 1, "the approval did not mint (round-trip is vacuous): %r" % approve
+        return minted, _execute(execute, tok)
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# CORPUS SHAPE — guards against silent corpus drift (a shrunk corpus is a wrong-mechanism
+# model masquerading as a passing cert; three re-label counts 0/5/216 were all "correct"
+# about their own corpus — the corpus is part of the claim).
+# ═════════════════════════════════════════════════════════════════════════════════
+class TestCorpusShape:
+    def test_row_counts_are_pinned(self):
+        assert len(MUST_FLIP) == 22, "MUST_FLIP drifted from 22"
+        assert len(MUST_HOLD) == 29, "MUST_HOLD drifted from 29 (do NOT trim the union)"
+        assert len(MUST_STAY_OFF) == 2, "MUST_STAY_OFF drifted from 2"
+        assert len(BENIGN) == 8, "BENIGN drifted from 8"
+
+    def test_count_pin_constant_matches_corpus(self):
+        # The {22, 110} figure is derived from the corpus, not hard-typed independently,
+        # so it cannot silently disagree with the rows it pins.
+        assert COUNT_PIN_SPELLINGS == len(MUST_FLIP)
+        assert COUNT_PIN_VIOLATIONS == len(MUST_FLIP) * len(PREFIXES) == 110
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# D1 — is_dangerous_command, leg-position parity.
+# ═════════════════════════════════════════════════════════════════════════════════
+class TestD1MustFlip:
+    """The under-block closure. bare is dangerous at base AND head; the NON-FIRST leg
+    was False at base (the #1134 under-block) and is True at head across every prefix.
+    The base fixture IS the demonstrated known-bad — the assertion cannot pass vacuously
+    because the same rows measurably fail leg-2 at base."""
+
+    @pytest.mark.parametrize(
+        "cmd,op,key", MUST_FLIP, ids=[r[0] for r in MUST_FLIP]
+    )
+    def test_flip(self, cmd, op, key):
+        # bare dangerous both sides (else it is not an under-block row at all).
+        assert _base()(cmd) is True, "row not dangerous bare at base — mislabeled: %r" % cmd
+        assert D(cmd) is True, "row lost bare coverage at head: %r" % cmd
+        for label, p in PREFIXES:
+            # KNOWN-BAD: leg-2 was UNGATED at base (the under-block the fix closes).
+            assert _base()(p + cmd) is False, (
+                "%s: leg-2 already gated at base — row does not demonstrate the #1134 "
+                "under-block: %r" % (label, p + cmd)
+            )
+            # HEAD: leg-2 now gates (no under-reach).
+            assert D(p + cmd) is True, (
+                "#1134 UNDER-BLOCK RE-OPENED — non-first-leg destructive form ungated at "
+                "head under %s: %r" % (label, p + cmd)
+            )
+
+
+class TestD1MustHold:
+    """Working coverage that must not regress. Gated in BOTH positions at base and head.
+    The base==True assertion is the VACUITY GUARD: a MUST_HOLD row that is False at base
+    is mislabeled (it belongs in MUST_FLIP) and its 'stays gated' claim would be
+    vacuous — so the row is required to stand on its own pre-fix coverage."""
+
+    @pytest.mark.parametrize("cmd", MUST_HOLD, ids=MUST_HOLD)
+    def test_hold(self, cmd):
+        assert _base()(cmd) is True, "MUST_HOLD row not gated bare at base (mislabeled): %r" % cmd
+        assert D(cmd) is True, "REGRESSION: MUST_HOLD bare coverage lost at head: %r" % cmd
+        for label, p in PREFIXES:
+            assert _base()(p + cmd) is True, (
+                "MUST_HOLD row not gated in leg-2 at base under %s (mislabeled — belongs "
+                "in MUST_FLIP): %r" % (label, p + cmd)
+            )
+            assert D(p + cmd) is True, (
+                "REGRESSION: MUST_HOLD working leg-2 coverage lost under %s: %r"
+                % (label, p + cmd)
+            )
+
+
+class TestD1MustStayOff:
+    """The over-block guard for the close/option parser. NOT dangerous even bare, and
+    still not dangerous in any leg position — at base AND head. A change that gates these
+    has introduced the cardinal over-block."""
+
+    @pytest.mark.parametrize("cmd", MUST_STAY_OFF, ids=MUST_STAY_OFF)
+    def test_stay_off(self, cmd):
+        assert _base()(cmd) is False, "MUST_STAY_OFF row already gated at base (mislabeled): %r" % cmd
+        assert D(cmd) is False, "OVER-BLOCK introduced (cardinal) — bare form gated: %r" % cmd
+        for label, p in PREFIXES:
+            assert D(p + cmd) is False, (
+                "OVER-BLOCK introduced (cardinal) — benign form gated in leg-2 under %s: %r"
+                % (label, p + cmd)
+            )
+
+
+class TestD1BenignParitySweep:
+    """THE LOAD-BEARING GATE (over-block direction): is_dangerous(P + C) == is_dangerous(C)
+    for every benign prefix P and benign command C, and all-False. Over-reach shows as a
+    benign parity violation; this is the live guard for the STATED RESIDUAL (an unfound
+    first-leg false positive whose reach the widening would multiply across legs). It
+    bounds the CLASS of over-blocks we enumerated — NOT the COUNT of first-leg false
+    positives never enumerated. Complementary to TestD1MustFlip's parity (under-reach) —
+    neither supersedes the other."""
+
+    @pytest.mark.parametrize("cmd", BENIGN, ids=BENIGN)
+    def test_benign_parity_and_all_false(self, cmd):
+        assert D(cmd) is False, "benign command gated bare (first-leg false positive): %r" % cmd
+        for label, p in PREFIXES:
+            assert D(p + cmd) == D(cmd), (
+                "LEG-POSITION PARITY VIOLATION (over-reach) — benign verdict changed by a "
+                "benign %s prefix: %r" % (label, p + cmd)
+            )
+            assert D(p + cmd) is False, (
+                "benign command gated in leg-2 under %s (over-block): %r" % (label, p + cmd)
+            )
+
+
+class TestBenignWordBoundaryKnownBad:
+    """Non-vacuity for the benign branch-creation rows: the `-D\\b` word boundary on the
+    branch-delete literal arm is the invariant this arc found with NO check at all —
+    removing it gates ordinary branch CREATIONS (`git branch feature-Dashboard`) with a
+    suite failure set otherwise identical to control. Here the benign guard is shown to
+    FAIL on that exact known-bad, then to hold once restored."""
+
+    def test_boundary_removal_overblocks_then_restore(self, monkeypatch):
+        import re
+        arms = mgc._BRANCH_DELETE_LITERAL_ARMS
+        # VACUITY GUARD: the -D arm must actually carry `-D\b`, else the neuter is a no-op.
+        d_arm = next((a for a in arms if r"-D\b" in a.pattern), None)
+        assert d_arm is not None, (
+            "no branch-delete literal arm carries `-D\\b` — the boundary neuter below "
+            "would prove nothing; the arm shape changed"
+        )
+        # Baseline: benign branch-creations stay off.
+        for cmd in BENIGN_BRANCH_CREATION:
+            assert D(cmd) is False, "benign branch-creation already gated pre-neuter: %r" % cmd
+        # KNOWN-BAD: strip the boundary off the -D arm.
+        neutered = tuple(
+            re.compile(a.pattern.replace(r"-D\b", "-D")) if a is d_arm else a
+            for a in arms
+        )
+        monkeypatch.setattr(mgc, "_BRANCH_DELETE_LITERAL_ARMS", neutered)
+        overblocked = [cmd for cmd in BENIGN_BRANCH_CREATION if D(cmd) is True]
+        assert overblocked, (
+            "removing `-D\\b` did NOT over-block any benign branch-creation — the guard "
+            "the benign rows provide is not attributable to the word boundary; "
+            "re-examine what actually keeps these ungated"
+        )
+
+
+class TestCountPin:
+    """{22 spellings, 110 violations} -> {0, 0}. The parity-violation cardinality over the
+    MUST_FLIP spellings: at base every spelling violates leg-position parity in all 5
+    prefixes (the under-block); at head none does. The base figure is the known-bad."""
+
+    def _violations(self, danger):
+        spellings, n = set(), 0
+        for cmd, _op, _key in MUST_FLIP:
+            for _label, p in PREFIXES:
+                if danger(p + cmd) != danger(cmd):
+                    spellings.add(cmd)
+                    n += 1
+        return len(spellings), n
+
+    def test_head_is_zero(self):
+        assert self._violations(D) == (0, 0), (
+            "leg-position parity violations remain at head — the #1134 under-block is "
+            "not fully closed"
+        )
+
+    def test_base_is_the_known_bad(self):
+        assert self._violations(_base()) == (COUNT_PIN_SPELLINGS, COUNT_PIN_VIOLATIONS), (
+            "base did not exhibit {22, 110} violations — the vendored fixture is not the "
+            "pre-#1134 state, so the head==0 pin certifies nothing"
+        )
+
+
+class TestD1PerSiteFilterNeuter:
+    """MECHANISM ISOLATION (is_dangerous): the per-leg _PER_LEG_OPS filter is the SOLE
+    thing gating every MUST_FLIP row in a non-first leg (no literal arm reaches them
+    there — that is why they were left behind). Reverting the filter to its pre-fix
+    2-tuple drops all 22. `_PER_LEG_OPS` is referenced as a CALL-TIME module attribute,
+    so a revert of the rename (AttributeError) or the widening (this test) fails loudly."""
+
+    def test_filter_is_load_bearing_for_gating(self, monkeypatch):
+        # VACUITY GUARD: the 4 new classes must currently be in the filter, else the
+        # neuter is a no-op and this proves nothing.
+        assert set(NEW_PER_LEG_CLASSES) <= set(mgc._PER_LEG_OPS), (
+            "the 4 #1134 classes are not in _PER_LEG_OPS — the neuter below is a no-op"
+        )
+        monkeypatch.setattr(mgc, "_PER_LEG_OPS", ("push-to-main", "force-push"))
+        survivors = [
+            cmd for cmd, _op, _key in MUST_FLIP if D(_PREFIX + cmd) is True
+        ]
+        assert survivors == [], (
+            "with the filter reverted to its pre-fix 2-tuple, these leg-2 rows STILL "
+            "gate — a second mechanism covers them, so the filter is not the attributable "
+            "cause and TestD1MustFlip cannot credit it: %r" % survivors
+        )
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# D2 — mintability. A gated form whose target cannot be bound is the cardinal
+# gated-but-unmintable over-block. minted==1 asserted FIRST; which-key-won read OFF the
+# token; exec-without-token DENY is the fix-coupled leg (base = ungated -> ALLOW).
+# ═════════════════════════════════════════════════════════════════════════════════
+class TestD2Mintability:
+    """For every newly-gated MUST_FLIP row: gated at head, DENIED without a token (proves
+    the gate — the fix; base known-bad = ungated), MINTS exactly one token that binds the
+    RIGHT op and the RIGHT identity key (read off the token, not the whole-command
+    context), and self-authorizes ALLOW. The exec-without-token DENY is what makes the
+    round-trip fix-coupled rather than pipeline-blind."""
+
+    @pytest.mark.parametrize(
+        "cmd,op,key", MUST_FLIP, ids=[r[0] for r in MUST_FLIP]
+    )
+    def test_gated_and_mintable(self, cmd, op, key, tmp_path):
+        row = _PREFIX + cmd  # certify the NON-FIRST-leg form (the fix's population)
+        assert D(row) is True, "row not gated at head (D1 precondition): %r" % row
+        # KNOWN-BAD leg: at base this ran ungated; at head, no token -> DENY (gated).
+        assert _base()(row) is False, "row already gated at base — not a #1134 flip: %r" % row
+        assert _execute(row, tmp_path) == _DENY, (
+            "gated row was ALLOWED with NO token — the gate is not live at exec time: %r" % row
+        )
+        # MINT (minted==1 FIRST — a mint-side miss must not masquerade as a read decision).
+        minted, ctx = _mint(row, tmp_path)
+        assert minted == 1, (
+            "gated row did NOT mint — the cardinal gated-but-unmintable OVER-BLOCK: %r" % row
+        )
+        # which-key-won, OFF THE TOKEN (whole-command extract binds nothing on compounds).
+        assert ctx.get("operation_type") == op, (
+            "token bound the wrong op: got %r, expected %r for %r"
+            % (ctx.get("operation_type"), op, row)
+        )
+        assert _won_key(ctx) == key, (
+            "token bound the wrong identity key: got %r, expected %r for %r"
+            % (_won_key(ctx), key, row)
+        )
+        # self-authorize: the faithful click's own token ALLOWs its own execution.
+        assert _execute(row, tmp_path) == _ALLOW, (
+            "the faithful click's own token did NOT authorize its execution: %r" % row
+        )
+
+
+class TestD2GatedButUnmintableKnownBad:
+    """Non-vacuity for minted==1: a mint-target neuter (the exact #1129 shape — a key
+    dropped from _target_value) turns a gated row gated-but-UNMINTABLE, so the faithful
+    click is refused with no way to authorize. Demonstrates the minted==1 assertions fail
+    on a known-bad. `_target_value` referenced call-time via the module."""
+
+    def test_dropping_target_ref_makes_a_gated_row_unmintable(self, tmp_path, monkeypatch):
+        row = _PREFIX + _PG + "origin --delete feature"  # remote-ref-delete -> target_ref
+        # VACUITY GUARD in its OWN dir (its token must not leak into the known-bad exec).
+        vac = tmp_path / "vac"
+        vac.mkdir()
+        minted, ctx = _mint(row, vac)
+        assert minted == 1 and _won_key(ctx) == "target_ref", (
+            "row does not mint on target_ref at head — pick a different witness"
+        )
+
+        def _tv_without_target_ref(cmd_ctx):
+            return (cmd_ctx.get("pr_number")
+                    or cmd_ctx.get("branch")
+                    or cmd_ctx.get("branch_set")
+                    or cmd_ctx.get("mass_target")
+                    or cmd_ctx.get("protected_branch"))  # target_ref DROPPED
+
+        monkeypatch.setattr(mgpost, "_target_value", _tv_without_target_ref)
+        # KNOWN-BAD in a FRESH dir: mint 0 -> the exec finds no token -> DENY. The faithful
+        # click is refused with no way to authorize = the gated-but-unmintable over-block.
+        kb = tmp_path / "kb"
+        kb.mkdir()
+        m2, _ = _mint(row, kb)
+        assert m2 == 0, "mint-target neuter did not stop the mint — the guard is inert"
+        assert _execute(row, kb) == _DENY, (
+            "gated-but-unmintable row was not denied — the round-trip cannot see the "
+            "over-block it exists to catch"
+        )
+
+
+class TestD2MintPinCloseAndBranchDelete:
+    """GAP-CLOSURE (security review): mint-pin `close` and `branch-delete` in a non-first
+    leg — the two classes the shipped mint-path probe's 4-tuple EXCLUDED, leaving them
+    gate-pinned only. Each row: gated at head, mints exactly one token binding the RIGHT
+    op and RIGHT identity key (read OFF the token), and self-authorizes. Two carriers so
+    the pin is not a single-prefix artifact."""
+
+    @pytest.mark.parametrize(
+        "cmd,op,key", MINT_PIN_CLOSE_AND_BRANCH_DELETE,
+        ids=[r[0] for r in MINT_PIN_CLOSE_AND_BRANCH_DELETE],
+    )
+    def test_close_and_branch_delete_mint_in_non_first_leg(self, cmd, op, key, tmp_path):
+        assert D(cmd) is True, "row not gated at head (mint-pin precondition): %r" % cmd
+        minted, ctx = _mint(cmd, tmp_path)
+        assert minted == 1, (
+            "GATE-PINNED BUT NOT MINT-PINNED — %s in a non-first leg gates but does not "
+            "mint (the exclusion the 4-tuple probe hid): %r" % (op, cmd)
+        )
+        assert ctx.get("operation_type") == op, (
+            "token bound wrong op: got %r expected %r for %r"
+            % (ctx.get("operation_type"), op, cmd)
+        )
+        assert _won_key(ctx) == key, (
+            "token bound wrong identity key: got %r expected %r for %r"
+            % (_won_key(ctx), key, cmd)
+        )
+        assert _execute(cmd, tmp_path) == _ALLOW, (
+            "the faithful click's own token did not authorize its execution: %r" % cmd
+        )
+
+
+class TestCloseUrlBranchNowGateAndMint:
+    """THE POSITIONAL-TYPE AXIS THE CORPUS MISSED. `gh pr close` accepts number|url|branch;
+    the corpus covered only number, so a faithful gated-but-unmintable OVER-BLOCK hid in the
+    url/branch forms (NFL commit-1-introduced; FL pre-existing). The commit-5 extractor fix
+    makes them gate+MINT with a positional-type-qualified `pr_number` value. Per row: the
+    base differential is measured via the 172a77dd fixture (NFL base-ungated = D1 gate-flip;
+    FL base-gated = D2 — its base mint0 is the over-block, documented in the HANDOFF via a
+    base worktree); at the fix the form gates, mints ONE token binding op=close and the RIGHT
+    qualified value (read OFF the token, since whole-command _target_value returns None on
+    the compound), and self-authorizes."""
+
+    @pytest.mark.parametrize(
+        "cmd,value,base_gated", CLOSE_URL_BRANCH_FLIP,
+        ids=[r[0] for r in CLOSE_URL_BRANCH_FLIP],
+    )
+    def test_url_branch_close_gate_and_mint(self, cmd, value, base_gated, tmp_path):
+        # Base differential (is_dangerous, via the fixture): D1 rows base-ungated, D2 rows
+        # base-gated. This is the known-bad axis: at base these forms either did not gate
+        # (D1) or gated-but-could-not-mint (D2) — either way the faithful click was blocked.
+        assert _base()(cmd) is base_gated, (
+            "base is_dangerous kind changed for %r (expected base_gated=%s)" % (cmd, base_gated)
+        )
+        # Fixed: gates, mints the qualified identity, self-authorizes.
+        assert D(cmd) is True, "the fix did not gate the faithful close form: %r" % cmd
+        minted, ctx = _mint(cmd, tmp_path)
+        assert minted == 1, (
+            "OVER-BLOCK persists — the faithful close form gates but does NOT mint "
+            "(gated-but-unmintable): %r" % cmd
+        )
+        assert ctx.get("operation_type") == "close", (
+            "token bound the wrong op: %r for %r" % (ctx.get("operation_type"), cmd)
+        )
+        assert ctx.get("pr_number") == value, (
+            "wrong close identity: got %r, expected the positional-type-qualified %r for %r"
+            % (ctx.get("pr_number"), value, cmd)
+        )
+        assert _execute(cmd, tmp_path) == _ALLOW, (
+            "the faithful close click's own token did not self-authorize: %r" % cmd
+        )
+
+
+class TestCloseMintLaundering:
+    """The mint-laundering guard for the positional-type-qualified close identity: a token
+    minted for one spelling (url / branch / number) must NOT authorize a DIFFERENT-identity
+    execution — including the cross-host and cross-repo cases the host-qualified value exists
+    to distinguish. Faithful self-executions must still AUTHORIZE (no over-block). Every
+    escalation row is its own known-bad: the identity qualification is what makes it refuse,
+    and a coarsening that dropped the host/repo/branch qualifier would flip it to AUTHORIZE."""
+
+    @pytest.mark.parametrize(
+        "name,approve,execute,expect_allow", CLOSE_LAUNDERING,
+        ids=[r[0] for r in CLOSE_LAUNDERING],
+    )
+    def test_close_identity_laundering(self, name, approve, execute, expect_allow, tmp_path):
+        minted, _ = _mint(approve, tmp_path)
+        assert minted == 1, "approve did not mint (%s): %r" % (name, approve)
+        rc = _execute(execute, tmp_path)
+        if expect_allow:
+            assert rc == _ALLOW, (
+                "OVER-BLOCK: a faithful close self-execution was REFUSED (%s): %r"
+                % (name, execute)
+            )
+        else:
+            assert rc == _DENY, (
+                "LAUNDERING: a close token authorized a DIFFERENT-identity execution "
+                "(%s): approve=%r execute=%r" % (name, approve, execute)
+            )
+
+
+class TestCloseRepoValueMisbindClosed:
+    """Commit 6: the `--repo`/`-R` value mis-bind. A repo value starting with a digit
+    (`--repo 5/6`) shadowed the branch positional and mis-bound '5' at commit-6's parent
+    (7bb6ac5c), because `_extract_pr_number`'s value-flag list omitted `--repo` while
+    `_gh_close_positionals` included it. The positional-first fold aligns them. These are
+    FAITHFUL commands (real flag + real positional). The CI-permanent known-bad is the
+    laundering row (`--repo branch token -> number` in CLOSE_LAUNDERING): if the identity
+    coarsened back to '5', that row would AUTHORIZE. Counter-test-by-revert to 7bb6ac5c
+    (mints '5') is documented in the HANDOFF."""
+
+    @pytest.mark.parametrize("cmd", CLOSE_REPO_MISBIND, ids=CLOSE_REPO_MISBIND)
+    def test_repo_value_does_not_shadow_branch_positional(self, cmd, tmp_path):
+        assert D(cmd) is True, "faithful --repo close form not gated: %r" % cmd
+        minted, ctx = _mint(cmd, tmp_path)
+        assert minted == 1, "faithful --repo close form did not mint: %r" % cmd
+        assert ctx.get("operation_type") == "close"
+        assert ctx.get("pr_number") == "branch:feature", (
+            "MIS-BIND: --repo value shadowed the branch positional — bound %r, expected "
+            "'branch:feature' (the repo value's leading digit was mistaken for the PR): %r"
+            % (ctx.get("pr_number"), cmd)
+        )
+        assert _execute(cmd, tmp_path) == _ALLOW, "faithful --repo close did not self-authorize: %r" % cmd
+
+
+class TestMergeExtractorUnchangedByCloseFold:
+    """The fold restructured CLOSE to derive from `_gh_close_positionals` and NOT call
+    `_extract_pr_number`; the MERGE path STILL uses `_extract_pr_number`. This pins the
+    structural claim that CLOSE AND MERGE DO NOT CROSS — merge value-flag minting is
+    IDENTICAL base(172a77dd) -> HEAD across the full 9-flag value-taking set. Known-bad: if
+    the fold had touched the shared extractor or its flag set, a merge command with a numeric
+    value-flag value would mint the flag's value instead of the positional PR."""
+
+    def test_value_flag_set_byte_identical_base_to_head(self):
+        base_set = getattr(load_baseline_172a77dd(), "_GH_PR_VALUE_TAKING_FLAGS", None)
+        assert base_set == mgc._GH_PR_VALUE_TAKING_FLAGS, (
+            "the gh pr value-taking flag set changed base->HEAD — the close fold touched the "
+            "merge-shared extractor's vocabulary: base=%r head=%r"
+            % (base_set, mgc._GH_PR_VALUE_TAKING_FLAGS)
+        )
+        assert len(mgc._GH_PR_VALUE_TAKING_FLAGS) == 9, (
+            "expected 9 value-taking flags; the set changed size: %r"
+            % (sorted(mgc._GH_PR_VALUE_TAKING_FLAGS),)
+        )
+
+    @pytest.mark.parametrize("flag", _GH_MERGE_VALUE_FLAGS, ids=_GH_MERGE_VALUE_FLAGS)
+    def test_merge_extractor_binds_positional_not_flag_value(self, flag):
+        # A merge command with a numeric value-flag value must bind the POSITIONAL PR (42),
+        # not the flag's value (99) — and identically at base and HEAD (the pure extractor,
+        # no post hook needed).
+        cmd = _GH + "merge 42 " + flag + " 99 --admin"
+        base = load_baseline_172a77dd()._extract_pr_number(cmd)
+        head = mgc._extract_pr_number(cmd)
+        assert base == head == "42", (
+            "merge extractor changed or mis-binds under %s: base=%r head=%r (expected '42' "
+            "both — the flag value 99 must not shadow the positional): %r"
+            % (flag, base, head, cmd)
+        )
+
+    def test_merge_mints_positional_end_to_end(self, tmp_path):
+        # Behavioral backstop through the REAL post hook: merge still mints the positional.
+        cmd = _GH + "merge 42 --comment 99 --admin"
+        minted, ctx = _mint(cmd, tmp_path)
+        assert minted == 1 and ctx.get("pr_number") == "42", (
+            "merge no longer mints the positional PR through the real hook: minted=%s pr=%r"
+            % (minted, ctx.get("pr_number") if ctx else None)
+        )
+
+
+class TestD2RoundTripIsPipelineBlindWithoutTheGate:
+    """DOCUMENTED TRAP — do NOT 'simplify' D2 to mint + self-authorize ALLOW. Under an
+    _PER_LEG_OPS revert the row goes UNGATED yet mint+exec still returns (1, ALLOW): the
+    mint uses the fix-independent _extraction_surface and the exec ALLOWs because the row
+    is no longer gated. This asserts that blindness EXPLICITLY, so the exec-without-token
+    DENY in TestD2Mintability is understood as the fix-coupled leg, not a redundant one."""
+
+    def test_mint_plus_allow_survives_the_fix_revert(self, tmp_path, monkeypatch):
+        row = _PREFIX + _PG + "origin --delete feature"
+        monkeypatch.setattr(mgc, "_PER_LEG_OPS", ("push-to-main", "force-push"))
+        assert D(row) is False, "expected the revert to ungate the row (vacuity guard)"
+        minted, _ = _mint(row, tmp_path)
+        assert minted == 1, "mint is fix-independent (uses _extraction_surface) — expected 1"
+        assert _execute(row, tmp_path) == _ALLOW, (
+            "expected ALLOW-because-ungated under the revert — this is the blindness the "
+            "exec-without-token DENY exists to close"
+        )
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# D3 — detect_command_operation_type, op-parity (mint==read: detect non-None <=> gated).
+# ═════════════════════════════════════════════════════════════════════════════════
+class TestD3OpParity:
+    """The mint==read symmetry, in the direction that is load-bearing: GATED ⟹ CLASSIFIED.
+    Every gated form MUST have a non-None op so the mint can bind a target — a gated form
+    detect cannot classify is the gated-but-unmintable over-block. The REVERSE (classified
+    ⟹ gated) is deliberately NOT asserted: `gh pr close 5` is op-classified `close` yet
+    correctly UNGATED (a reversible close is not dangerous), so full equivalence is false
+    by design. The over-broad-gating direction is guarded by TestD1MustStayOff /
+    TestD1BenignParitySweep (is_dangerous=False), not here."""
+
+    _GATED = (
+        [(c, op) for c, op, _k in MUST_FLIP]
+        + [(c, None) for c in MUST_HOLD]     # op unspecified: only gated⟹classified pinned
+    )
+
+    @pytest.mark.parametrize("cmd,op", _GATED, ids=[r[0] for r in _GATED])
+    def test_gated_implies_classified(self, cmd, op):
+        for _label, p in ([("bare", "")] + PREFIXES):
+            full = p + cmd
+            if D(full) is True:
+                assert DETECT(full) is not None, (
+                    "GATED-BUT-UNMINTABLE: gated form has op=None, the mint cannot bind a "
+                    "target -> the faithful click is refused with no way to authorize: %r"
+                    % full
+                )
+        if op is not None:
+            # the fix must classify the newly-gated form with the RIGHT op, in leg-2.
+            assert DETECT(_PREFIX + cmd) == op, (
+                "detect op-parity: got %r, expected %r for %r"
+                % (DETECT(_PREFIX + cmd), op, _PREFIX + cmd)
+            )
+
+    @pytest.mark.parametrize("cmd", BENIGN, ids=BENIGN)
+    def test_benign_is_unclassified(self, cmd):
+        # A benign command the op-classifier recognizes is a smell — the next widening
+        # that gates its op would over-block it. (MUST_STAY_OFF is exempt: a reversible
+        # close IS a recognized op, correctly ungated.)
+        for _label, p in ([("bare", "")] + PREFIXES):
+            assert DETECT(p + cmd) is None, (
+                "benign command classified as %r under %s — a widening of that op would "
+                "over-block it: %r" % (DETECT(p + cmd), _label, p + cmd)
+            )
+
+
+class TestD3PerSiteFilterNeuter:
+    """MECHANISM ISOLATION (detect): the per-leg filter drives detect for the 18 non-close
+    rows (None at base, classified at head). The 4 CLOSE rows are deliberately EXCLUDED —
+    they carry detect==close at base via the raw-fallback gh-pr arm, NOT the filter, so a
+    'filter reverted -> detect None' claim is FALSE for them (they keep detect==close).
+    Asserting on them would be the two-mechanism endpoint blindness. Reverting the filter
+    drops detect on the 18; the 4 close rows are pinned to KEEP detect==close as the
+    control that the exclusion is real."""
+
+    def test_filter_drives_detect_on_non_close_rows(self, monkeypatch):
+        assert set(NEW_PER_LEG_CLASSES) <= set(mgc._PER_LEG_OPS), "vacuity guard: filter no-op"
+        monkeypatch.setattr(mgc, "_PER_LEG_OPS", ("push-to-main", "force-push"))
+        survivors = [
+            cmd for cmd, _op, _key in MUST_FLIP_FILTER_DRIVES_DETECT
+            if DETECT(_PREFIX + cmd) is not None
+        ]
+        assert survivors == [], (
+            "with the filter reverted, these non-close leg-2 rows STILL classify — a "
+            "second detect mechanism covers them, so the filter is not attributable: %r"
+            % survivors
+        )
+
+    def test_close_rows_keep_detect_via_raw_fallback(self, monkeypatch):
+        # The isolation control: close detect is NOT the filter's, so it survives the
+        # revert. (If this ever fails, the close family's detect mechanism moved and the
+        # exclusion above must be re-derived.)
+        monkeypatch.setattr(mgc, "_PER_LEG_OPS", ("push-to-main", "force-push"))
+        for cmd, op, _key in MUST_FLIP:
+            if op == "close":
+                assert DETECT(_PREFIX + cmd) == "close", (
+                    "close leg-2 detect vanished under the filter revert — it was NOT "
+                    "carried by the raw-fallback arm after all: %r" % (_PREFIX + cmd)
+                )
+
+
+class TestConsumerSharedObjectInvariant:
+    """The mint==read symmetry is preserved BY CONSTRUCTION because both consumers
+    (detect_command_operation_type and _stripped_surface_danger) read the SAME shared
+    _PER_LEG_OPS object at call time. This guards the refactor that duplicates the
+    constant into two literals: mutating the module global must move BOTH surfaces
+    identically. If one consumer held a private copy, its verdict would not change and
+    the symmetry TestD3OpParity checks could later be weakened without notice."""
+
+    def test_both_consumers_track_the_same_module_global(self, monkeypatch):
+        probe = _PREFIX + _PG + "origin main"  # push-to-main leg-2, filter-carried
+        assert D(probe) is True and DETECT(probe) == "push-to-main", "baseline moved"
+        # Emptying the ONE global must drop BOTH the read floor (via _stripped_surface_
+        # danger, reached through is_dangerous) AND detect. A private copy in either
+        # consumer would keep that consumer's verdict unchanged — the known-bad.
+        monkeypatch.setattr(mgc, "_PER_LEG_OPS", ())
+        assert D(probe) is False, (
+            "is_dangerous still gated after emptying _PER_LEG_OPS — _stripped_surface_"
+            "danger is reading a private copy, not the shared global"
+        )
+        assert DETECT(probe) is None, (
+            "detect still classified after emptying _PER_LEG_OPS — detect is reading a "
+            "private copy, not the shared global"
+        )
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# BINDING — the remote-delete PRIVILEGED_FLAGS split, certified BEHAVIORALLY end-to-end.
+# The most severe finding of the arc: a single-branch-delete approval must NOT authorize
+# a wholesale --mirror remote wipe. The structural data-shape of the split is pinned in
+# test_merge_guard_privileged_flags.py::TestRemoteDeleteSplitBinding; here it is the
+# escalation OUTCOME, with its known-bad.
+# ═════════════════════════════════════════════════════════════════════════════════
+# The security-engineer's 7 split-binding rows, re-measured HERE via the REAL round-trip
+# (stronger than the probe's replicated identity comparison). 3 escalation-closure rows
+# (approve a single/mass delete; an execution ADDING a scope/privilege flag REFUSES) + 4
+# faithful-preserved rows (approve==execute AUTHORIZES, no over-block). Flags assembled at
+# runtime so the file stays inert. (name, approve_cmd, execute_cmd, expect_allow.)
+_DEL, _MIR, _PRU, _NOV = "--delete", "--mirror", "--prune", "--no-verify"
+SPLIT_BINDING_ROWS = [
+    ("esc :main -> --mirror :main", _PG + "origin :main", _PG + "origin " + _MIR + " :main", False),
+    ("esc :main -> --prune :main", _PG + "origin :main", _PG + "origin " + _PRU + " :main", False),
+    ("esc del -> del --no-verify", _PG + "origin " + _DEL + " feat",
+     _PG + "origin " + _DEL + " feat " + _NOV, False),
+    ("faithful --mirror", _PG + _MIR + " origin", _PG + _MIR + " origin", True),
+    ("faithful :main", _PG + "origin :main", _PG + "origin :main", True),
+    ("faithful del", _PG + "origin " + _DEL + " feat", _PG + "origin " + _DEL + " feat", True),
+    ("faithful del+no-verify", _PG + "origin " + _DEL + " feat " + _NOV,
+     _PG + "origin " + _DEL + " feat " + _NOV, True),
+]
+SPLIT_BINDING_ESCALATIONS = [r for r in SPLIT_BINDING_ROWS if r[3] is False]
+
+
+class TestBindingEscalationClosed:
+    """The remote-delete split PRIVILEGED_FLAGS binding, certified BEHAVIORALLY end-to-end.
+    The most severe finding of the arc: approving a single/mass delete must NOT authorize
+    an execution that ADDS a scope-widening (--mirror/--prune) or privilege (--no-verify)
+    flag. minted==1 asserted FIRST on every escalation so a DENY is a READ decision, never
+    a mint-side miss. The base-simulation and per-flag unbind are the demonstrated
+    known-bads: without the binding the escalations AUTHORIZE."""
+
+    def _roundtrip(self, approve, execute, tok):
+        # tok MUST be a fresh dir per call — a shared dir leaks tokens across rows and
+        # silently changes outcomes (a token-leak bug that once produced a false
+        # "--no-verify stays closed" reading in this very class).
+        minted, _ = _mint(approve, tok)
+        assert minted == 1, "the delete approval did not mint: %r" % approve
+        return _execute(execute, tok)
+
+    def test_single_branch_approval_denies_mirror_wipe(self, tmp_path):
+        rc = self._roundtrip(_PG + "origin :main", _PG + "--mirror origin :main", tmp_path)
+        assert rc == _DENY, (
+            "SEVERE: a single-branch-delete approval AUTHORIZED a wholesale --mirror "
+            "remote wipe — the identity-coarsening escalation is open"
+        )
+
+    @pytest.mark.parametrize(
+        "name,approve,execute,expect_allow", SPLIT_BINDING_ROWS,
+        ids=[r[0] for r in SPLIT_BINDING_ROWS],
+    )
+    def test_split_binding_rows(self, name, approve, execute, expect_allow, tmp_path):
+        rc = self._roundtrip(approve, execute, tmp_path)
+        if expect_allow:
+            assert rc == _ALLOW, (
+                "OVER-BLOCK: faithful approve==execute was REFUSED (%s): %r" % (name, execute)
+            )
+        else:
+            assert rc == _DENY, (
+                "ESCALATION OPEN: an execution adding a scope/privilege flag was "
+                "AUTHORIZED by a plainer approval (%s): approve=%r execute=%r"
+                % (name, approve, execute)
+            )
+
+    def test_stripping_binding_reopens_all_three_escalations(self, monkeypatch):
+        # KNOWN-BAD (base simulation): strip the commit-2 bindings from the remote-delete
+        # ops. ALL THREE escalations (--mirror, --prune, --no-verify) must REOPEN
+        # (AUTHORIZE) — the binding is the SOLE closer for every one, so every escalation
+        # row is non-vacuous. This STRENGTHENS commit 2 (the binding closes all three, not
+        # just the two scope-widening flags).
+        #
+        # Corroborated two ways beyond this in-process monkeypatch: (a) a TRUE-BASE
+        # detached worktree at 172a77dd — where remote-ref-delete's binding is natively
+        # absent — AUTHORIZES all three via the real round-trip; (b) the security review's
+        # independent measurement. --no-verify is pre-bound on the FORCE-PUSH op-class,
+        # but PRIVILEGED_FLAGS is indexed by op_type, so that entry is never consulted for
+        # a remote-ref-delete command — there is NO cross-op-class defense-in-depth here.
+        #
+        # METHOD NOTE (a bug this test previously had): each row MUST use a FRESH token dir.
+        # An earlier version looped all three through one shared dir; leaked tokens made
+        # --no-verify falsely read as "stays closed", which is where a wrong
+        # "doubly-defended" attribution came from. Per-row fresh dirs is the fix.
+        assert "--no-verify" in mgc.PRIVILEGED_FLAGS["remote-ref-delete"], (
+            "remote-ref-delete does not bind --no-verify — the strip below is a no-op"
+        )
+        monkeypatch.setitem(mgc.PRIVILEGED_FLAGS, "remote-ref-delete", {})
+        monkeypatch.setitem(mgc.PRIVILEGED_FLAGS, "remote-mass-delete", {})
+        # _isolated_roundtrip owns a fresh token dir per call — the loop CANNOT share one
+        # (the token-leak that produced the wrong "doubly-defended" reading is structurally
+        # closed here).
+        still_closed = [
+            name for name, approve, execute, _ in SPLIT_BINDING_ESCALATIONS
+            if _isolated_roundtrip(approve, execute)[1] != _ALLOW
+        ]
+        assert still_closed == [], (
+            "with the remote-delete bindings stripped, these escalations did NOT reopen: "
+            "%r — the binding is not their attributable closer, so their cert rows would "
+            "prove nothing (or the strip is not reaching the read gate)." % (still_closed,)
+        )
+
+    def test_unbinding_mirror_reopens_the_escalation(self, tmp_path, monkeypatch):
+        # Per-flag known-bad: --mirror specifically must be bound; removing just it must
+        # reopen the mirror wipe (ALLOW), proving that binding is the attributable cause.
+        assert "--mirror" in mgc.PRIVILEGED_FLAGS["remote-ref-delete"], (
+            "--mirror is not bound on remote-ref-delete — the closure is not attributable "
+            "to this binding; the escalation rows prove nothing"
+        )
+        stripped = {
+            k: v for k, v in mgc.PRIVILEGED_FLAGS["remote-ref-delete"].items()
+            if k != "--mirror"
+        }
+        monkeypatch.setitem(mgc.PRIVILEGED_FLAGS, "remote-ref-delete", stripped)
+        rc = self._roundtrip(_PG + "origin :main", _PG + "--mirror origin :main", tmp_path)
+        assert rc == _ALLOW, (
+            "unbinding --mirror did NOT reopen the wipe escalation — the binding is inert, "
+            "so its cert row proves nothing"
+        )

--- a/pact-plugin/tests/test_merge_guard_obs_cert.py
+++ b/pact-plugin/tests/test_merge_guard_obs_cert.py
@@ -446,7 +446,7 @@ class TestObsEPerLegPushToMain:
 
     def test_mint_read_symmetry_across_matrix(self):
         # gate <=> detect non-None on every matrix row (the mint==read symmetry the shared
-        # _PER_LEG_PUSH_OPS filter + one predicate guarantee by construction).
+        # _PER_LEG_OPS filter + one predicate guarantee by construction).
         rows = (OBS_E_PERLEG_FIX + OBS_E_NO_REGRESSION + OBS_E_UNDER_BLOCK_NOW_GATE
                 + OBS_E_OVER_BLOCK_STAYS_UNGATED + OBS_E_PERLEG_NOW_GATED)
         for _label, cmd in rows:

--- a/pact-plugin/tests/test_merge_guard_obs_cert.py
+++ b/pact-plugin/tests/test_merge_guard_obs_cert.py
@@ -376,14 +376,20 @@ OBS_E_OVER_BLOCK_STAYS_UNGATED = [
     ("commitmsg-main-then-push-feature", "git commit -m 'see main' && git push origin feature"),
     ("feature-colon-main-release", "git push origin feature:main-release"),
 ]
-# EXCLUDED per-leg residuals (delete/mass/branch-delete in a non-first leg) — the
-# {push-to-main, force-push} filter deliberately does NOT gate these (pre-existing, out of
-# scope; deleting main is rarely good-faith → acceptable under-block).
-OBS_E_PERLEG_RESIDUALS = [
+# Per-leg delete/mass/branch-delete forms. These were formerly EXCLUDED from the per-leg
+# filter and asserted to stay ungated, on the reasoning that "deleting main is rarely
+# good-faith → acceptable under-block". That reasoning does not survive the good-faith
+# model: `cd /repo && git push origin --delete feature` is an ordinary thing to type and
+# it ran COMPLETELY UNGATED, which is a breach of the one floor, not an acceptable
+# residual. The filter now carries all six union-arm classes, so these GATE.
+OBS_E_PERLEG_NOW_GATED = [
     ("cd-colon-main", "cd /repo && git push origin :main"),
     ("cd-delete-main", "cd /repo && git push origin --delete main"),
     ("fetch-mirror", "git fetch && git push --mirror origin"),
     ("cd-branch-Df", "cd /repo && git branch -Df temp"),
+    # the good-faith row that motivated the change (a feature branch, not main)
+    ("cd-delete-feature", "cd /repo && git push origin --delete feature"),
+    ("cd-close-short-d", "cd /repo && gh pr close 5 -d"),
 ]
 
 
@@ -413,10 +419,21 @@ class TestObsEPerLegPushToMain:
         assert DETECT(cmd) is None
 
     @pytest.mark.parametrize(
-        "label,cmd", OBS_E_PERLEG_RESIDUALS, ids=[r[0] for r in OBS_E_PERLEG_RESIDUALS]
+        "label,cmd", OBS_E_PERLEG_NOW_GATED, ids=[r[0] for r in OBS_E_PERLEG_NOW_GATED]
     )
-    def test_excluded_perleg_residuals_stay_ungated(self, label, cmd):
-        assert D(cmd) is False, "the {push-to-main,force-push} filter wrongly gated a delete/mass leg"
+    def test_non_first_leg_delete_and_mass_forms_gate(self, label, cmd):
+        """#1134: a delete/mass/close op in a NON-FIRST leg gates, and stays MINTABLE.
+        Gating alone would be half a fix — a gated form whose target cannot be bound is
+        the cardinal gated-but-unmintable over-block, so detect must also classify."""
+        assert load_baseline().is_dangerous_command(cmd) is False, (
+            "not an under-block at base — this row no longer demonstrates the #1134 "
+            "fix and should be moved to a no-regression set: %r" % cmd
+        )
+        assert D(cmd) is True, "non-first-leg delete/mass under-block re-opened: %r" % cmd
+        assert DETECT(cmd) is not None, (
+            "gated but unclassified — the mint cannot bind this form, which is the "
+            "cardinal gated-but-unmintable over-block: %r" % cmd
+        )
 
     def test_precedence_first_leg_unchanged(self):
         assert DETECT("git push origin --delete main") == "remote-ref-delete"
@@ -431,7 +448,7 @@ class TestObsEPerLegPushToMain:
         # gate <=> detect non-None on every matrix row (the mint==read symmetry the shared
         # _PER_LEG_PUSH_OPS filter + one predicate guarantee by construction).
         rows = (OBS_E_PERLEG_FIX + OBS_E_NO_REGRESSION + OBS_E_UNDER_BLOCK_NOW_GATE
-                + OBS_E_OVER_BLOCK_STAYS_UNGATED + OBS_E_PERLEG_RESIDUALS)
+                + OBS_E_OVER_BLOCK_STAYS_UNGATED + OBS_E_PERLEG_NOW_GATED)
         for _label, cmd in rows:
             assert (DETECT(cmd) is not None) == (D(cmd) is True), "mint!=read on %r" % cmd
 

--- a/pact-plugin/tests/test_merge_guard_op_recognition_completeness.py
+++ b/pact-plugin/tests/test_merge_guard_op_recognition_completeness.py
@@ -1972,6 +1972,56 @@ class TestCloseTargetBranchInertAndLegScoped:
         assert _close_target_or_none("gh pr close https://github.com/o/r/issues/5 -d") is None
         assert _close_target_or_none("gh pr close https://evil.example/o/r/tree/main -d") is None
 
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "gh pr close --repo 5/6 feature -d",    # numeric-leading repo, --repo BEFORE branch
+            "gh pr close -R 5/6 feature -d",        # short -R, the form a long-only guard misses
+            "gh pr close -dR 5/6 feature",          # clustered -dR
+            "gh pr close --repo 55/66 feature -d",  # multi-digit repo
+        ],
+    )
+    def test_numeric_leading_repo_value_does_not_shadow_the_branch(self, cmd):
+        """REGRESSION (security finding): a `--repo`/`-R` value whose owner starts
+        with digits (`5/6`) must NOT be mis-read as the PR number. The old close
+        path called `_extract_pr_number` FIRST, whose long-only value-flag guard
+        let the regex backtrack onto the repo's leading digit and shadow the branch
+        — laundering an approved branch-close into a different-PR close. The single
+        value-flag-complete positional walk closes it: the branch is bound, the
+        repo digits are stripped as a flag value."""
+        assert _close_target(cmd) == "branch:feature", (
+            f"a numeric-leading --repo/-R value shadowed the branch target: {cmd!r}"
+        )
+
+    def test_numeric_repo_launder_refuses(self):
+        """The security-confirmed launder MUST be caught: approving a branch-close
+        whose `--repo 5/6` shadowed the PR must NOT authorize closing PR #5."""
+        assert _authorizes(
+            "gh pr close --repo 5/6 feature -d",   # approve: closes branch `feature`
+            "gh pr close 5 --repo 5/6 -d",         # execute: closes PR #5 — different target
+        ) is False
+
+    @pytest.mark.parametrize("cmd", [
+        "gh pr close --label 5 -d",   # --label is NOT a gh pr close flag
+        "gh pr close --foo 5 -d",     # arbitrary unknown flag
+    ])
+    def test_unknown_value_flag_on_nonfaithful_close_is_adversarial_only(self, cmd):
+        """DOCUMENTED ADVERSARIAL-ONLY RESIDUAL (pinned so it stays visible, not
+        hidden behind a false 'never a mis-bind' claim). An UNKNOWN flag whose
+        value is the SOLE positional-shaped token (`gh pr close --label 5`) binds
+        that value ('5') as the target — the value-flag walk can't know `--label`
+        takes a value. BUT `gh pr close` has no `--label` flag and no valid
+        positional here, so gh ITSELF REJECTS the command: it is NON-FAITHFUL.
+        Exploiting the minted '5' is a confused-deputy that needs the user to
+        approve a command gh won't run, which a good-faith user never does. This
+        is TOLERATED under the good-faith model and deliberately NOT closed (the
+        FAITHFUL --repo mis-bind above IS closed). If this ever needs closing, the
+        route is a known-close-flag allow-list, not this test loosening."""
+        assert _close_target(cmd) == "5", (
+            "the documented adversarial-only residual changed shape — re-confirm "
+            f"the disposition rather than silently updating the pin: {cmd!r}"
+        )
+
     def test_branch_named_like_a_number_binds_the_number_namespace(self):
         """DOCUMENTED AMBIGUITY: gh resolves a bare digit as the PR NUMBER (number
         precedes branch in `{number|url|branch}`), so a branch literally named `5`

--- a/pact-plugin/tests/test_merge_guard_op_recognition_completeness.py
+++ b/pact-plugin/tests/test_merge_guard_op_recognition_completeness.py
@@ -1643,7 +1643,7 @@ class TestBranchDeleteLiteralArmCrossLegSweep:
         CONSTRUCTION rather than merely demonstrated passing."""
         cmd = "cd /repo && git branch -D temp"
         arms = mgc._BRANCH_DELETE_LITERAL_ARMS
-        per_leg = mgc._PER_LEG_PUSH_OPS
+        per_leg = mgc._PER_LEG_OPS
         filter_without_branch_delete = tuple(
             op for op in per_leg if op != "branch-delete"
         )
@@ -1658,7 +1658,7 @@ class TestBranchDeleteLiteralArmCrossLegSweep:
 
         # ROW 1 — neuter the LITERAL TUPLE only. The per-leg filter must carry it.
         monkeypatch.setattr(mgc, "_BRANCH_DELETE_LITERAL_ARMS", ())
-        monkeypatch.setattr(mgc, "_PER_LEG_PUSH_OPS", per_leg)
+        monkeypatch.setattr(mgc, "_PER_LEG_OPS", per_leg)
         assert mgc.is_dangerous_command(cmd) is True, (
             "FILTER SIDE IS DEAD: with the literal tuple neutered, the per-leg "
             "filter failed to gate a non-first-leg `-D`. The #1134 under-block is "
@@ -1670,7 +1670,7 @@ class TestBranchDeleteLiteralArmCrossLegSweep:
 
         # ROW 2 — neuter the PER-LEG FILTER only. The literal tuple must carry it.
         monkeypatch.setattr(mgc, "_BRANCH_DELETE_LITERAL_ARMS", arms)
-        monkeypatch.setattr(mgc, "_PER_LEG_PUSH_OPS", filter_without_branch_delete)
+        monkeypatch.setattr(mgc, "_PER_LEG_OPS", filter_without_branch_delete)
         assert mgc.is_dangerous_command(cmd) is True, (
             "TUPLE SIDE IS DEAD: with `branch-delete` dropped from the per-leg "
             "filter, the literal arms failed to gate a non-first-leg `-D`. The "
@@ -1683,7 +1683,7 @@ class TestBranchDeleteLiteralArmCrossLegSweep:
         # ROW 3 — neuter BOTH. Nothing else may cover the row. This is the
         # known-bad control that makes rows 1-2 non-vacuous.
         monkeypatch.setattr(mgc, "_BRANCH_DELETE_LITERAL_ARMS", ())
-        monkeypatch.setattr(mgc, "_PER_LEG_PUSH_OPS", filter_without_branch_delete)
+        monkeypatch.setattr(mgc, "_PER_LEG_OPS", filter_without_branch_delete)
         assert mgc.is_dangerous_command(cmd) is False, (
             "A THIRD mechanism covers this row. Rows 1-2 above are therefore "
             "vacuous — they cannot attribute coverage to the mechanism they name. "
@@ -2455,7 +2455,7 @@ class TestAcceptedRecognitionLimitationPins:
         CONSTRUCTION, not by an ordering accident.
 
         If this property is ever removed, per-leg invocation becomes actively unsafe
-        and the widened `_PER_LEG_PUSH_OPS` filter turns into an over-block engine —
+        and the widened `_PER_LEG_OPS` filter turns into an over-block engine —
         which is why this pin is stronger than pin #1 and why it must fail loudly."""
         # Positionals name a BENIGN op; the danger flag lives in a LATER leg.
         # If flags leaked from the whole command, leg 1 would be mislabeled.

--- a/pact-plugin/tests/test_merge_guard_op_recognition_completeness.py
+++ b/pact-plugin/tests/test_merge_guard_op_recognition_completeness.py
@@ -1768,6 +1768,250 @@ class TestBranchDeleteWordBoundaryMustStayOff:
         assert OP("git branch -D temp") == "branch-delete"
 
 
+def _close_target(cmd):
+    """The minted close-target identity for `cmd` via the REAL post path."""
+    res = mint(cmd)
+    assert res.context is not None, f"close did not mint (refusal={res.refusal_reason}): {cmd!r}"
+    return _target_value(res.context)
+
+
+def _authorizes(approve_cmd, execute_cmd):
+    """True iff a token minted from `approve_cmd` authorizes `execute_cmd`."""
+    res = mint(approve_cmd)
+    assert res.context is not None, f"approve did not mint: {approve_cmd!r}"
+    return MATCH(token_from_ctx(res.context), execute_cmd)
+
+
+_PULL5 = "https://github.com/o/r/pull/5"
+
+
+class TestCloseTargetMintsAllFaithfulForms:
+    """`gh pr close` accepts ``{<number> | <url> | <branch>}`` — all three are
+    faithful. The per-leg widening gated the url/branch forms in a non-first leg
+    but ``_extract_pr_number`` is number-only, so they gated WITHOUT a mint path
+    = a HEAD-introduced faithful GATED-BUT-UNMINTABLE over-block (and the same
+    shape pre-existed on the first leg). `_extract_close_target` closes it by
+    minting every faithful form. These rows are the MUST_FLIP cert for that.
+
+    The no-arg form (`gh pr close -d`) is NOT here: gh refuses a close with no
+    positional, so it has no faithful click and its gated-but-unmintable state is
+    not an over-block (measured separately)."""
+
+    @pytest.mark.parametrize(
+        "cmd,expected",
+        [
+            ("gh pr close 5 -d", "5"),
+            ("cd /repo && gh pr close 5 -d", "5"),
+            (f"gh pr close {_PULL5} -d", "url:github.com/o/r#5"),
+            (f"cd /repo && gh pr close {_PULL5} -d", "url:github.com/o/r#5"),
+            ("gh pr close feature -d", "branch:feature"),
+            ("cd /repo && gh pr close feature -d", "branch:feature"),
+        ],
+    )
+    def test_every_faithful_close_form_gates_and_mints(self, cmd, expected):
+        assert D(cmd) is True, f"faithful close stopped gating: {cmd!r}"
+        assert _close_target(cmd) == expected, (
+            f"close minted the wrong identity for {cmd!r} — recognition<=>mint "
+            f"coupling (#1064) requires the identity to be exactly the target"
+        )
+
+    def test_minted_identity_is_exactly_the_target_not_a_neighbor(self):
+        """#1064: the url mints the PR IN THAT url, the branch mints THAT branch —
+        never a different PR. The identity is parsed from the `/pull/<N>` segment
+        gh itself resolves, so it cannot name a PR the command does not close."""
+        assert _close_target(f"gh pr close {_PULL5} -d") == "url:github.com/o/r#5"
+        assert _close_target("gh pr close https://github.com/x/y/pull/9 -d") == "url:github.com/x/y#9"
+        assert _close_target("gh pr close release/2.0 -d") == "branch:release/2.0"
+
+    @pytest.mark.parametrize(
+        "cmd,expected",
+        [
+            # repo/owner containing digits — the /pull/ anchor is not fooled
+            ("gh pr close https://github.com/o/r-123/pull/5 -d", "url:github.com/o/r-123#5"),
+            ("gh pr close https://github.com/o123/r/pull/7 -d", "url:github.com/o123/r#7"),
+            # trailing path / query / fragment — (\d+)(?![\w-]) stops at the PR number
+            ("gh pr close https://github.com/o/r/pull/5/files -d", "url:github.com/o/r#5"),
+            ("gh pr close https://github.com/o/r/pull/5?diff=split -d", "url:github.com/o/r#5"),
+            ("gh pr close https://github.com/o/r/pull/5#issuecomment-9 -d", "url:github.com/o/r#5"),
+            # GitHub Enterprise host — must still mint (not an over-block)
+            ("gh pr close https://github.company.com/o/r/pull/42 -d", "url:github.company.com/o/r#42"),
+        ],
+    )
+    def test_url_number_parse_robust_against_decoy_digits(self, cmd, expected):
+        """The URL identity is anchored on the literal `/pull/<N>` segment, so a
+        digit in the owner/repo, a query string, a fragment, or a trailing path
+        component can never be mistaken for (or extend) the PR number."""
+        assert _close_target(cmd) == expected
+
+
+class TestCloseTargetLaunderingRefused:
+    """MINT-LAUNDERING known-bads (#1064) — each MUST be caught (REFUSE). Shown
+    FAILING-on-known-bad, not just the happy path passing. The four identity
+    namespaces (`5` / `url:host/o/r#N` / `branch:name`) are disjoint, and the URL
+    is HOST- and repo-QUALIFIED specifically so it can never set-equal a bare
+    number in a DIFFERENT repo."""
+
+    def test_cross_repo_url_to_bare_number_refuses(self):
+        """THE SHARP ONE. Approve closing PR #5 via an explicit-repo URL; execute
+        a bare `gh pr close 5` — which closes PR #5 of whatever repo it runs in.
+        If the url minted bare `5`, this would authorize closing PR #5 in a
+        DIFFERENT repo (cross-repo target confusion). Repo-qualification blocks it."""
+        assert _authorizes(f"gh pr close {_PULL5} -d", "gh pr close 5 -d") is False
+
+    def test_cross_host_url_refuses(self):
+        assert _authorizes(
+            "gh pr close https://github.com/o/r/pull/5 -d",
+            "gh pr close https://github.enterprise.com/o/r/pull/5 -d",
+        ) is False
+
+    def test_cross_repo_url_to_url_refuses(self):
+        assert _authorizes(
+            "gh pr close https://github.com/o/r/pull/5 -d",
+            "gh pr close https://github.com/evil/repo/pull/5 -d",
+        ) is False
+
+    def test_branch_to_different_branch_refuses(self):
+        assert _authorizes("gh pr close feature -d", "gh pr close other -d") is False
+
+    def test_branch_to_number_refuses(self):
+        assert _authorizes("gh pr close feature -d", "gh pr close 5 -d") is False
+
+    def test_number_to_different_number_refuses(self):
+        assert _authorizes("gh pr close 5 -d", "gh pr close 6 -d") is False
+
+    def test_faithful_self_authorizes_every_form(self):
+        """Non-vacuity for the REFUSE rows: the same command DOES authorize itself
+        on every form, so the refusals above are discrimination, not a blanket
+        deny."""
+        for cmd in ("gh pr close 5 -d", f"gh pr close {_PULL5} -d", "gh pr close feature -d",
+                    "cd /repo && gh pr close feature -d"):
+            assert _authorizes(cmd, cmd) is True, f"faithful re-execution refused: {cmd!r}"
+
+
+class TestCloseTargetBranchInertAndLegScoped:
+    """Constraint B — the branch identity binds the LITERAL positional token, and
+    that binding is (i) LEG-SCOPED (no cross-leg pickup) and (ii) FLAG-INERT (a
+    dash-token can never be bound as the target, a quoted token binds its literal
+    content and cannot inject)."""
+
+    def test_branch_identity_is_leg_scoped(self):
+        """A url/branch in a BENIGN continuation leg is never picked up as the
+        close target — the extractor reads only the first executable leg. If it
+        leaked, the first-leg numbered close would mis-bind the later leg's ref."""
+        # first leg is the real close (mints 5); a decoy branch/url follows benign
+        assert _close_target("gh pr close 5 -d && echo feature") == "5"
+        assert _close_target(f"gh pr close 5 -d ; echo {_PULL5}") == "5"
+
+    def test_dash_token_is_never_bound_as_the_target(self):
+        """A flag can never become the close identity — positionals starting with
+        `-` are dropped. `gh pr close --repo o/r -d` has NO positional target
+        (the repo is a flag value), so it abstains (mint None), never binds a flag."""
+        assert _close_target_or_none("gh pr close -d --repo o/r") is None
+        assert _close_target_or_none("gh pr close --repo o/r -d") is None
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "gh pr close feature --repo o/r -d",     # --repo VALUE after target
+            "gh pr close --repo o/r feature -d",     # --repo VALUE before target
+            "gh pr close feature -R o/r -d",         # short -R value
+            "gh pr close -dR o/r feature",           # clustered -dR, value is next token
+            'gh pr close -c "nice work" feature -d',  # -c comment value (quoted)
+            "gh pr close feature -cd",               # -c attached-cluster value
+            "gh pr close --comment hello feature -d",  # --comment value
+        ],
+    )
+    def test_value_flag_value_is_not_bound_as_the_target(self, cmd):
+        """CONSTRAINT B — a VALUE-taking flag's value (`-R/--repo o/r`,
+        `-c/--comment msg`) is stripped before the positional scan, so a faithful
+        branch-close WITH such a flag still binds the BRANCH (never over-blocks by
+        counting the value as a second positional, never mis-binds the value)."""
+        assert D(cmd) is True
+        assert _close_target(cmd) == "branch:feature", (
+            f"a value-taking flag's value was mis-read as the close target: {cmd!r}"
+        )
+
+    def test_comment_value_that_is_a_url_is_not_read_as_the_pr(self):
+        """The sharpest value-flag case: a PR URL passed as a `--comment` value
+        must NOT be extracted as the close target — the real target is the branch
+        positional. Value stripping happens BEFORE URL classification."""
+        cmd = "gh pr close feature --comment https://github.com/o/r/pull/999 -d"
+        assert _close_target(cmd) == "branch:feature", (
+            "a URL inside a --comment value was mis-bound as the PR — the value "
+            "strip must precede URL classification"
+        )
+
+    def test_quoted_branch_binds_its_literal_content(self):
+        """A quoted branch name binds the literal string (quotes stripped); it is
+        a target IDENTITY, never executed, so it cannot inject a flag or a second
+        command. Two distinct quoted names stay distinct identities."""
+        assert _close_target('gh pr close "feature/x" -d') == "branch:feature/x"
+        assert _authorizes('gh pr close "feature/x" -d', 'gh pr close "feature/y" -d') is False
+
+    def test_branch_shaped_like_a_flag_is_not_bound_and_does_not_inject(self):
+        """A positional that LOOKS like a flag (`--force`, `-D`) is dropped by the
+        dash-filter, so it is never bound as the target and cannot inject. A close
+        whose only positional-looking token is dash-prefixed has NO target ->
+        abstains (the command is not a faithful single-target close anyway)."""
+        assert _close_target_or_none("gh pr close --force -d") is None
+        assert _close_target_or_none("gh pr close -D -d") is None
+
+    def test_branch_with_shell_metachars_binds_literal_inert_identity(self):
+        """A branch name carrying shell metacharacters binds the LITERAL token as
+        an identity string — it is compared, never executed, so it cannot inject a
+        command. Two different such names stay distinct identities (no collision)."""
+        # _executable_prefix truncates at an unquoted metachar, so a bare $(...) is
+        # not a single clean positional -> abstain; a QUOTED odd name binds literal.
+        assert _close_target('gh pr close "weird;name" -d') == "branch:weird;name"
+        assert _authorizes('gh pr close "weird;name" -d', 'gh pr close "other;name" -d') is False
+
+    def test_branch_shaped_like_a_url_but_not_a_pull_url_abstains(self):
+        """A positional containing `://` that is NOT a github `/pull/<N>` URL is an
+        unrecognized URL form -> abstain (mint None), never a garbage `branch:`
+        identity. gh would reject such a target anyway."""
+        assert _close_target_or_none("gh pr close https://github.com/o/r/issues/5 -d") is None
+        assert _close_target_or_none("gh pr close https://evil.example/o/r/tree/main -d") is None
+
+    def test_branch_named_like_a_number_binds_the_number_namespace(self):
+        """DOCUMENTED AMBIGUITY: gh resolves a bare digit as the PR NUMBER (number
+        precedes branch in `{number|url|branch}`), so a branch literally named `5`
+        is indistinguishable from PR #5 to gh itself. The extractor matches that
+        precedence: `gh pr close 5` binds number `5`, never `branch:5`. Not a
+        collision — both spellings resolve to the same command for gh."""
+        assert _close_target("gh pr close 5 -d") == "5"
+        assert _close_target("gh pr close 5 -d") != "branch:5"
+
+
+def _close_target_or_none(cmd):
+    """Like _close_target but tolerates a non-minting (abstaining) close: returns
+    the identity or None, without asserting a mint occurred."""
+    res = mint(cmd)
+    return _target_value(res.context) if res.context is not None else None
+
+
+class TestCloseTargetExtensionNonVacuous:
+    """The extractor extension must be shown LIVE: neuter it back to the
+    number-only behavior and a url/branch MUST_FLIP row loses its mint. If it
+    keeps minting with the extension reverted, the extension is not what carries
+    these forms and every row above is vacuous."""
+
+    def test_url_and_branch_lose_mint_when_extractor_reverted(self, monkeypatch):
+        # sanity: with the extension live, url + branch mint
+        assert _close_target(f"gh pr close {_PULL5} -d") == "url:github.com/o/r#5"
+        assert _close_target("gh pr close feature -d") == "branch:feature"
+        # revert _extract_close_target to the pre-fix number-only behavior
+        monkeypatch.setattr(mgc, "_extract_close_target", mgc._extract_pr_number)
+        assert _close_target_or_none(f"gh pr close {_PULL5} -d") is None, (
+            "url still mints with the extractor reverted — the extension is not "
+            "carrying the url form, so the MUST_FLIP rows are vacuous"
+        )
+        assert _close_target_or_none("gh pr close feature -d") is None, (
+            "branch still mints with the extractor reverted — vacuous"
+        )
+        # and the NUMBER form is unaffected by the revert (it never needed the extension)
+        assert _close_target_or_none("gh pr close 5 -d") == "5"
+
+
 class TestApiMergeMintParity:
     """#1096 API-merge mint parity — the bidirectional cert for the additive
     per-leg detect arm (GH-API-ONLY per Option B + mutating PUT/PATCH/POST + a

--- a/pact-plugin/tests/test_merge_guard_op_recognition_completeness.py
+++ b/pact-plugin/tests/test_merge_guard_op_recognition_completeness.py
@@ -1615,26 +1615,82 @@ class TestBranchDeleteLiteralArmCrossLegSweep:
             "— detect is not consuming the shared leg seam"
         )
 
-    def test_literal_tuple_is_load_bearing_on_both_sides_via_golden_row(self, monkeypatch):
-        """Detect-side load-bearing discriminator, on the GOLDEN row
-        `cd /repo && git branch -D temp`: the union arm is first-leg-anchored
-        and abstains on it, so ONLY the literal tuple can catch it on either
-        side. Neutering the tuple ALONE (no identity slice) must drop BOTH the
-        gate (D False) and the classification (OP None) — proving the tuple, not
-        a neighboring family, carries this form. The single-leg `-D` /
-        `--delete --force` rows would NOT discriminate (the union arm also
-        recognizes their spellings in the first leg)."""
+    def test_golden_row_split_proof_each_mechanism_isolated(self, monkeypatch):
+        """SPLIT PROOF on the GOLDEN row `cd /repo && git branch -D temp`.
+
+        WHY THE PREVIOUS SHAPE HAD TO BE RE-DERIVED, not repaired. This test used to
+        neuter the literal tuple ALONE and assert the row went ungated, on the premise
+        that "the union arm is first-leg-anchored and abstains here, so ONLY the tuple
+        can catch it." That premise was falsified by design, not by drift: the per-leg
+        filter now carries `branch-delete`, so the union loop reaches this row too and
+        the tuple-only neuter no longer drops it. Loosening the old assertion would
+        have hidden a real change; the proof is re-derived instead.
+
+        WHY THE ENDPOINTS PROVE NOTHING NOW. After the widening there are TWO
+        independently sufficient covering mechanisms, so:
+          - `untouched -> gates` passes even if one mechanism is already silently dead
+            (the survivor covers the row);
+          - `both neutered -> ungated` ALSO passes if one is already dead.
+        Neither endpoint can detect a silently-dead mechanism. A bare either-covers
+        assertion is exactly the check that proves nothing.
+
+        THE DISCRIMINATING ASSERTION IS THE ONE THAT ISOLATES A SINGLE MECHANISM.
+        Rows 1 and 2 below each neuter ONE mechanism and require the OTHER to carry
+        the row alone; that is what makes this a SPLIT proof rather than a union
+        check. Row 3 neuters both and requires the row to drop — it proves nothing
+        else covers the form, and it doubles as the known-bad control for rows 1-2,
+        so each assertion is demonstrated failing on a known-bad input BY
+        CONSTRUCTION rather than merely demonstrated passing."""
         cmd = "cd /repo && git branch -D temp"
+        arms = mgc._BRANCH_DELETE_LITERAL_ARMS
+        per_leg = mgc._PER_LEG_PUSH_OPS
+        filter_without_branch_delete = tuple(
+            op for op in per_leg if op != "branch-delete"
+        )
+        assert filter_without_branch_delete != per_leg, (
+            "VACUITY GUARD: 'branch-delete' is not in the per-leg filter, so the "
+            "filter-side neuter below is a no-op and row 2 would prove nothing."
+        )
+
+        # Baseline: both mechanisms live.
         assert mgc.is_dangerous_command(cmd) is True
         assert mgc.detect_command_operation_type(cmd) == "branch-delete"
+
+        # ROW 1 — neuter the LITERAL TUPLE only. The per-leg filter must carry it.
         monkeypatch.setattr(mgc, "_BRANCH_DELETE_LITERAL_ARMS", ())
+        monkeypatch.setattr(mgc, "_PER_LEG_PUSH_OPS", per_leg)
+        assert mgc.is_dangerous_command(cmd) is True, (
+            "FILTER SIDE IS DEAD: with the literal tuple neutered, the per-leg "
+            "filter failed to gate a non-first-leg `-D`. The #1134 under-block is "
+            "re-opened for every form that has no literal arm."
+        )
+        assert mgc.detect_command_operation_type(cmd) == "branch-delete", (
+            "filter side is dead on the detect arm (read/mint would disagree)"
+        )
+
+        # ROW 2 — neuter the PER-LEG FILTER only. The literal tuple must carry it.
+        monkeypatch.setattr(mgc, "_BRANCH_DELETE_LITERAL_ARMS", arms)
+        monkeypatch.setattr(mgc, "_PER_LEG_PUSH_OPS", filter_without_branch_delete)
+        assert mgc.is_dangerous_command(cmd) is True, (
+            "TUPLE SIDE IS DEAD: with `branch-delete` dropped from the per-leg "
+            "filter, the literal arms failed to gate a non-first-leg `-D`. The "
+            "any-leg literal floor has silently stopped carrying this family."
+        )
+        assert mgc.detect_command_operation_type(cmd) == "branch-delete", (
+            "tuple side is dead on the detect arm"
+        )
+
+        # ROW 3 — neuter BOTH. Nothing else may cover the row. This is the
+        # known-bad control that makes rows 1-2 non-vacuous.
+        monkeypatch.setattr(mgc, "_BRANCH_DELETE_LITERAL_ARMS", ())
+        monkeypatch.setattr(mgc, "_PER_LEG_PUSH_OPS", filter_without_branch_delete)
         assert mgc.is_dangerous_command(cmd) is False, (
-            "non-first-leg -D still gates with the tuple neutered — a second "
-            "family covers it and the tuple is not load-bearing on the read floor"
+            "A THIRD mechanism covers this row. Rows 1-2 above are therefore "
+            "vacuous — they cannot attribute coverage to the mechanism they name. "
+            "Identify the third family before trusting this proof."
         )
         assert mgc.detect_command_operation_type(cmd) is None, (
-            "non-first-leg -D still classifies with the tuple neutered — a "
-            "second family covers it and the tuple is not load-bearing in detect"
+            "a third mechanism classifies this row on the detect arm"
         )
 
 
@@ -1656,6 +1712,60 @@ class _ApiMergeDetectArmDisabledRe:
 
     def __getattr__(self, name):
         return getattr(_real_re, name)
+
+
+class TestBranchDeleteWordBoundaryMustStayOff:
+    """MUST_STAY_OFF — the `\\b` on the `-D` literal arm, enforced.
+
+    The branch-delete arm is `git\\s+...branch\\s+.*-D\\b`. The trailing `\\b` is the
+    only thing stopping `-D` from matching INSIDE an ordinary branch name: any name
+    whose second hyphen-separated word starts with a capital D reads as `-D` to a
+    boundaryless pattern — `feature-Dashboard`, `release-December`, `*-Dev*`,
+    `new-Design`.
+
+    WHY THIS CLASS EXISTS AT ALL. "Do not touch the `\\b`" was a documented mandate
+    with NOTHING enforcing it. Removing the boundary from all three occurrences
+    produces a suite failure set IDENTICAL to control — zero new failures, zero
+    disappeared — while gating SIX ordinary good-faith commands, including
+    `git branch feature-Dashboard`, which CREATES a branch and would be classified
+    `branch-delete`. That is the cardinal over-block, invisible, with a green suite.
+
+    So this is not a check that proved nothing; it was an invariant with no check.
+    These rows convert it into a visible one. Every command below is benign and
+    must never gate."""
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "git branch feature-Dashboard",              # CREATES a branch
+            'git branch --list "release-Dec*"',          # list, glob
+            'git branch --list "*-Dev*"',                # list, leading glob
+            "git branch --contains feature-Dashboard",   # read: which branches contain
+            "git branch -m old new-Design",              # rename
+            "git branch --merged release-December",      # read: merged-into filter
+        ],
+    )
+    def test_capital_d_inside_a_branch_name_never_gates(self, cmd):
+        assert D(cmd) is False, (
+            "CARDINAL OVER-BLOCK: an ordinary branch name containing a hyphen "
+            "followed by a capital D gated. The `-D` literal arm has lost its "
+            "trailing word boundary, so `-D` is matching inside a NAME rather than "
+            f"as a flag. Restore the `\\b`: {cmd!r}"
+        )
+        assert OP(cmd) is None, (
+            f"same boundary regression, on the detect arm — note `git branch "
+            f"feature-Dashboard` CREATES a branch: {cmd!r}"
+        )
+
+    def test_the_boundary_rows_are_not_vacuous(self):
+        """Control: the arm this class guards still fires on a REAL `-D`. Without
+        this, every row above would stay green if the branch-delete arm were
+        deleted outright — passing for the wrong reason."""
+        assert D("git branch -D temp") is True, (
+            "the branch-delete arm no longer gates a genuine `-D`, so the "
+            "boundary rows above prove nothing"
+        )
+        assert OP("git branch -D temp") == "branch-delete"
 
 
 class TestApiMergeMintParity:
@@ -2176,39 +2286,112 @@ class TestApiMergeEndpointResidualBoundary:
 
 
 class TestAcceptedRecognitionLimitationPins:
-    """FORWARD-PROTECTION pins for the ACCEPTED conservative-recognition limitation
-    (the review-cycle-1 SECURITY-HALT disposition). These forms run UNGATED BY
-    DESIGN, and these tests assert that ON PURPOSE — they are the executable tripwire
-    so a future maintainer who 'hardens' recognition into a match-anywhere / per-leg
-    scan (which would re-block faithful clicks) sees these flip RED and STOPS.
+    """FORWARD-PROTECTION pins for the recognition posture.
 
-    THE PRINCIPLE (do NOT 'fix' these): the git-push remote-ref-delete (:ref /
-    --delete / -d) and mass-delete (--mirror / --prune / multi-ref) forms need a
-    positional, quote-aware parse, so their recognition is ANCHORED to the FIRST
-    executable leg and does NOT chase the op into NON-FIRST compound legs. Chasing it
-    requires a match-anywhere scan that fires on a quoted :ref / --mirror mention in a
-    benign leg = an over-block of a faithful click, which is WRONG BY DEFINITION
-    (worse than missing a buried op). The fix for any over-block WIDENS the mint,
-    never narrows detection into a new under-block.
+    THE PRINCIPLE these pins protect is unchanged and is the reason they exist:
+    over-blocking a faithful click is WRONG BY DEFINITION, worse than missing a
+    buried op, and the fix for any over-block WIDENS the mint rather than narrowing
+    detection into a new under-block.
+
+    WHAT CHANGED — read this before restoring anything from git history. These pins
+    were originally written to assert that non-first-leg push-delete / mass-delete /
+    cluster-flag forms run UNGATED, on the premise that reaching them REQUIRED a
+    match-anywhere scan (which would fire on a quoted `:ref` / `--mirror` mention in
+    a benign leg and over-block a faithful click). THAT PREMISE WAS FALSE. A quote-
+    aware PER-LEG predicate reaches those forms with no match-anywhere behavior: each
+    call sees ONE isolated leg and derives flags AND positionals from it, so a mention
+    inside a benign leg stays a mention. Leaving them ungated was therefore not a
+    principled limitation but a good-faith-reachable UNDER-BLOCK (`cd /repo && git
+    push origin --delete feature` ran completely ungated), and it was closed.
+
+    So the OUTCOME assertion those pins carried was a PROXY for the author's real
+    intent — protect faithful clicks — and the proxy broke when the mechanism it
+    stood on was replaced. The pins below now assert the intent directly: the
+    MECHANISM that would genuinely over-block is still absent / the property that
+    makes per-leg safe is still present, PLUS benign rows that must stay ungated.
+
+    STILL TRUE, and still the thing to guard: the LITERAL arms' word boundary must
+    not be loosened. That WOULD grant delete tokens match-anywhere coverage and IS
+    the over-block this class was created to prevent.
     """
+
+    def test_no_match_anywhere_literal_arm_for_delete_tokens(self):
+        """MECHANISM PIN #1 — asserts the ABSENCE of the one unsafe mechanism.
+
+        The over-block this class guards comes from ONE specific shape: a literal arm
+        that matches a delete token ANYWHERE in the command string, with no word
+        boundary and no leg isolation. Such an arm fires on a delete token sitting
+        inside a benign leg — a quoted `--mirror` in a push option, a `:main` inside a
+        commit message — and blocks a faithful click.
+
+        Non-first-leg reach is NOT that shape and must not be confused with it: it is
+        the SAME quote-aware predicate re-invoked on an ISOLATED leg. This pin
+        therefore constrains the literal arms only, and is deliberately silent about
+        per-leg coverage.
+
+        Worded as an ABSENCE claim (contrast mechanism pin #2, which asserts a
+        PRESENCE): the two failure modes differ, and one shared pin would paper over
+        that difference.
+
+        NOT a regex-shape assertion. Inspecting the arm patterns for word boundaries
+        proves nothing here — every arm carries `\\b` in its leading `\\bgit` anchor, so
+        a 'pattern contains \\b' check passes unconditionally. Match-anywhere is a
+        property of HOW the arms are APPLIED, not of what they contain, so this pin
+        measures the application.
+
+        The row is chosen so the arm regex ITSELF spans the leg separator: the
+        branch-delete arm is `git\\s+...branch\\s+.*-D\\b`, and its `.*` happily crosses
+        `&&`, so it MATCHES the whole compound below. The guard nonetheless returns
+        False — which is only possible if the arms are evaluated PER-LEG. That makes
+        the pin self-controlling: the first assertion establishes the arm would fire
+        whole-string (if it ever stops, the premise moved and you are told so rather
+        than passing silently), and the second establishes it does not."""
+        cmd = "git branch new-feature && echo -D"
+        assert any(arm.search(cmd) for arm in mgc._BRANCH_DELETE_LITERAL_ARMS), (
+            "PREMISE MOVED: no branch-delete arm matches this compound whole-string "
+            "any more, so this row no longer discriminates per-leg from "
+            "match-anywhere. Re-derive the row before trusting the pin below."
+        )
+        assert mgc.is_dangerous_command(cmd) is False, (
+            "MATCH-ANYWHERE REGRESSION: a branch-delete arm whose regex spans the leg "
+            "separator now gates a command whose only `-D` sits in a BENIGN `echo` "
+            "leg. The literal arms are being applied to the WHOLE command instead of "
+            "per-leg — this is the faithful-click over-block this class exists to "
+            "prevent."
+        )
+        assert mgc.detect_command_operation_type(cmd) is None, (
+            "same match-anywhere regression, on the detect side"
+        )
 
     @pytest.mark.parametrize(
         "cmd",
         [
-            "cd /repo && git push origin --delete main",   # ref-delete in a non-first leg
-            "git fetch && git push --mirror origin",        # mass-delete in a non-first leg
-            "NOTE=x ; git push origin :main",               # colon-delete after an assignment leg
+            # A delete token quoted inside a benign push OPTION — the canonical
+            # match-anywhere casualty.
+            'git push origin feature -o "note: use --mirror for backups"',
+            'git push origin feature -o "cleanup: replaces --delete flow"',
+            # A delete token inside a commit message on a benign leg.
+            'git commit -m "document --mirror and :main semantics"',
+            # A delete token echoed, never executed.
+            'echo "run git push origin :main to drop it"',
+            # Reads that merely NAME the destructive spellings.
+            "git help push | grep -- --mirror",
         ],
     )
-    def test_non_first_leg_push_delete_ungated_by_design(self, cmd):
-        """ACCEPTED LIMITATION — do NOT fix. A push-delete/mass-delete in a NON-FIRST
-        compound leg is ungated (first-leg anchoring). If this assertion FAILS, the
-        recognition was hardened into a match-anywhere scan that over-blocks faithful
-        clicks — that is the WRONG fix; re-read the conservative-recognition principle."""
+    def test_delete_token_in_benign_context_stays_ungated(self, cmd):
+        """OUTCOME ROWS for mechanism pin #1 — the faithful clicks the absent
+        mechanism would have blocked.
+
+        Mechanism-only is weaker than it looks: it can be fully satisfied while an
+        over-block returns by another route. These rows assert the INTENT (a faithful
+        click is never blocked) rather than a proxy for it, so they stay valid even if
+        the mechanism is later re-expressed some other way. Every row names a delete
+        token but executes nothing destructive."""
         assert D(cmd) is False, (
-            f"Recognition was hardened to chase a non-first-leg push-delete — this "
-            f"RE-INTRODUCES a faithful-click over-block. Do NOT 'fix' this form: {cmd!r}"
+            f"OVER-BLOCK: a delete token in a BENIGN context gated a faithful click. "
+            f"Something acquired match-anywhere reach over delete tokens: {cmd!r}"
         )
+        assert OP(cmd) is None, f"benign delete-token mention classified as an op: {cmd!r}"
 
     def test_httpie_protection_ungated_by_design(self):
         """ACCEPTED LIMITATION — do NOT fix by bolting on an httpie read arm. The mint
@@ -2253,24 +2436,71 @@ class TestAcceptedRecognitionLimitationPins:
         assert D(cmd) is True, f"UNDER-BLOCK: literal arm stopped gating in a non-first leg: {cmd!r}"
         assert OP(cmd) == expected_op
 
+    def test_leg_locality_invariant_flags_and_positionals_share_one_leg(self):
+        """MECHANISM PIN #2 — asserts the PRESENCE of the property that makes
+        per-leg coverage safe. This is the STRONGER of the two pins.
+
+        Deliberately worded as a PRESENCE claim, unlike pin #1's absence claim. The
+        failure modes are not the same and a single shared pin would hide the
+        difference: pin #1 guards against a mechanism being ADDED (match-anywhere
+        reach), this one guards against a property being REMOVED (leg locality).
+
+        THE INVARIANT: `_flag_condition_danger_op(leg)` sets
+        `prefix = _executable_prefix(leg)` and derives EVERYTHING from that one
+        prefix — the token list, the coarse op-shape, and the extractor inputs. So
+        flags AND positionals come from the SAME isolated leg. This is what makes it
+        safe for callers to re-invoke the arm per leg: the cross-leg flag leak
+        (positionals from leg 1, flags from the whole command, so a `--force` in a
+        benign continuation mislabels a benign first-leg op) is impossible BY
+        CONSTRUCTION, not by an ordering accident.
+
+        If this property is ever removed, per-leg invocation becomes actively unsafe
+        and the widened `_PER_LEG_PUSH_OPS` filter turns into an over-block engine —
+        which is why this pin is stronger than pin #1 and why it must fail loudly."""
+        # Positionals name a BENIGN op; the danger flag lives in a LATER leg.
+        # If flags leaked from the whole command, leg 1 would be mislabeled.
+        leaky = "git branch new-feature && echo --delete --force"
+        assert mgc._flag_condition_danger_op(leaky) is None, (
+            "CROSS-LEG FLAG LEAK: the union arm classified a benign first-leg "
+            "`git branch new-feature` as dangerous by picking up `--delete --force` "
+            "from a LATER leg. Flags are no longer derived from the same isolated "
+            "leg as the positionals — per-leg invocation is now unsafe."
+        )
+        # Control: the SAME flags, in the SAME leg as the positionals, DO fire.
+        # Without this, the assertion above passes even if the arm stopped
+        # recognizing the op entirely (verified presence, not function).
+        same_leg = "git branch --delete --force temp"
+        assert mgc._flag_condition_danger_op(same_leg) == "branch-delete", (
+            "VACUITY CONTROL FAILED: the union arm no longer recognizes "
+            "`--delete --force` even within ONE leg, so the leak assertion above "
+            "proves nothing. Re-derive both rows."
+        )
+        # And the invariant survives leg isolation: the danger leg, taken alone,
+        # still classifies — this is exactly what the per-leg callers rely on.
+        assert mgc._flag_condition_danger_op("git branch -Df temp") == "branch-delete"
+
     @pytest.mark.parametrize(
         "cmd",
         [
-            "cd /repo && git branch -Df temp",   # cluster force-delete in a non-first leg
-            "cd /repo && gh pr close 5 -d",      # short -d close in a non-first leg
+            # Benign first leg + a danger-flag SPELLING in a later, non-executing leg.
+            "git branch new-feature && echo --delete --force",
+            "git branch --list && echo -Df",
+            "gh pr view 5 && echo --delete-branch",
+            # Flag-shaped text as an argument VALUE on a benign command.
+            "git config --get alias.nuke",
+            "grep -Df pattern file.txt",
         ],
     )
-    def test_non_first_leg_cluster_flag_forms_ungated_by_design(self, cmd):
-        """ACCEPTED LIMITATION — do NOT fix. The flag-condition union arm is
-        FIRST-LEG-ANCHORED, so a clustered/short danger flag in a NON-FIRST leg
-        loses union coverage. Re-detecting these requires whole-command or per-leg
-        flag derivation — exactly the cross-leg flag leak the anchoring removed /
-        the pinned over-block reintroduction. The idiomatic spellings (`-D`,
-        `--delete-branch`) remain caught per-leg, in any leg, by the literal floor
-        (the contrast rows in this class)."""
+    def test_flags_in_a_benign_leg_never_label_a_benign_op(self, cmd):
+        """OUTCOME ROWS for mechanism pin #2 — the faithful clicks a leak would block.
+
+        Pairs with the mechanism assertion above for the same reason pin #1 carries
+        outcome rows: a mechanism pin can be fully satisfied while an over-block
+        returns by another route. Each row has a benign executable op and a danger
+        flag that must stay inert because it is not in that op's leg."""
         assert D(cmd) is False, (
-            f"Recognition was widened to chase a non-first-leg cluster flag — this "
-            f"RE-INTRODUCES a faithful-click over-block. Do NOT 'fix' this form: {cmd!r}"
+            f"OVER-BLOCK: a danger flag in a NON-EXECUTING leg labeled a benign op "
+            f"as dangerous — the cross-leg flag leak is back: {cmd!r}"
         )
 
 

--- a/pact-plugin/tests/test_merge_guard_over_block_batch.py
+++ b/pact-plugin/tests/test_merge_guard_over_block_batch.py
@@ -221,9 +221,12 @@ class TestCrossLegLeakSeparatorAndPlacementMatrix:
     def test_real_destructive_op_in_later_leg_still_gates(self, cmd, expected_op):
         """DISCRIMINATION CONTRAST — NOT an over-block. When the NON-first leg holds
         a GENUINELY destructive op (idiomatic `git branch -D` / `gh pr close
-        --delete-branch`), the LITERAL floor gates it match-anywhere BY DESIGN (SSOT
-        header NB), and it is authorizable via the read side's single-destructive-leg
-        isolation. This differs from BOTH the cured benign-leak rows above (where the
+        --delete-branch`), the LITERAL floor gates it in ANY leg position BY DESIGN
+        (SSOT header NB) — PER-LEG, not match-anywhere: the arms are evaluated against
+        each isolated leg, which is why a danger token sitting in a BENIGN leg (the
+        rows above) still runs free while a real op in a later leg gates. It is
+        authorizable via the read side's single-destructive-leg isolation. This
+        differs from BOTH the cured benign-leak rows above (where the
         later leg is a benign `rm`/`echo` whose flag leaked into the union arm) AND
         the #1082 over-block residual (a benign push mislabeled force-push by a later
         `rm -f`/`rm --force`) — here a real destructive op is present, so gating is

--- a/pact-plugin/tests/test_merge_guard_privileged_flags.py
+++ b/pact-plugin/tests/test_merge_guard_privileged_flags.py
@@ -578,3 +578,117 @@ class TestFlagVariationIsPairAttribute:
 
         pairs = _collect_pairs(["gh pr merge 5 --admin", "gh pr merge 6"])
         assert len(pairs) == 2
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# REMOTE-DELETE SPLIT BINDING — data shape + the coupling it depends on
+# ════════════════════════════════════════════════════════════════════════════
+
+
+class TestRemoteDeleteSplitBinding:
+    """The two remote-delete classes get DIFFERENT bindings, and the asymmetry is
+    deliberate:
+
+        remote-ref-delete   --mirror, --prune, --no-verify
+        remote-mass-delete  --no-verify only
+
+    WHY THESE ASSERTIONS ARE STRUCTURAL AND NOT BEHAVIORAL. A behavioral row here
+    would be decorative by construction. The correct SPLIT binding and a defective
+    SYMMETRIC one (all three flags on BOTH classes) produce ZERO observable
+    behavioral differences: every mass-class flag escalation ALREADY refuses at
+    base, because `_extract_mass_delete_target` embeds the flag in the identity
+    netstring. So an authorize-outcome test passes identically under both, and
+    someone who binds all three on both classes reports every cert row green,
+    truthfully. The check would prove nothing.
+
+    The reason the split still stands is AUDITABILITY, not behavior: a redundant
+    binding installs a guard that changes no outcome while reading as protection.
+    On a control whose dominant failure mode is checks that prove nothing, every
+    entry in the table must be load-bearing. So the shape itself is what gets
+    asserted."""
+
+    def test_ref_delete_binds_all_three_modifiers(self):
+        """--mirror/--prune are MODIFIERS on this class (the trigger is
+        --delete/-d/empty-source colon), so they must be bound. This is the half
+        that closes the escalation where approving a single-branch delete
+        authorized a wholesale remote wipe."""
+        from shared.merge_guard_common import PRIVILEGED_FLAGS
+
+        bound = set(PRIVILEGED_FLAGS["remote-ref-delete"])
+        assert bound == {"--mirror", "--prune", "--no-verify"}, (
+            "remote-ref-delete's binding changed. --mirror/--prune are LOAD-BEARING "
+            "here: without them a `git push origin :main` approval set-equals a "
+            "`git push origin --mirror :main` execution, which deletes every remote "
+            f"ref with no local counterpart. Found: {sorted(bound)}"
+        )
+
+    def test_mass_delete_binds_only_no_verify(self):
+        """--mirror/--prune TRIGGER this class and are already folded into the
+        mass_target identity, so binding them here would be inert. Asserted as an
+        exact set so an 'improvement' that symmetrizes the two entries turns RED
+        and has to justify itself against the pin below."""
+        from shared.merge_guard_common import PRIVILEGED_FLAGS
+
+        bound = set(PRIVILEGED_FLAGS["remote-mass-delete"])
+        assert bound == {"--no-verify"}, (
+            "remote-mass-delete's binding changed. --mirror/--prune are the "
+            "op-TRIGGER for this class and are already embedded in the mass_target "
+            "identity, so binding them here adds an entry that changes no outcome — "
+            "a guard that does nothing while reading as protection. If you are "
+            "symmetrizing the two remote-delete entries, read the coupling pin "
+            f"below first. Found: {sorted(bound)}"
+        )
+
+    def test_mass_target_embeds_the_scope_flag_in_its_identity(self):
+        """COUPLING PIN — LOAD-BEARING, NOT DOCUMENTARY. Do not treat this as a
+        note about `_extract_mass_delete_target`; it is the assertion that makes the
+        split binding above SAFE rather than merely tidy.
+
+        WHAT BREAKS IF THIS TEST IS REMOVED OR WEAKENED. The narrow
+        `remote-mass-delete` binding is sound ONLY while mass_target keeps the scope
+        flag inside the identity it returns. Measured, under a coarsened mass_target
+        that returns the remote only:
+
+            split binding      -> the --mirror/--prune escalation OPENS (authorizes)
+            symmetric binding  -> the escalation stays closed
+
+        So the redundancy that symmetric binding would carry is NOT inert — it is
+        defense-in-depth against exactly this coarsening. Split is chosen for
+        auditability, and split-plus-this-pin is safety-equivalent to symmetric.
+        Delete this pin and that equivalence is gone: the escalation reopens on the
+        mass class with nothing to catch it. `vacuous today` and `inert` are
+        different claims, and this one is only the first.
+
+        REMEDY — IF YOU COARSEN `mass_target`, YOU MUST BIND `--mirror` AND
+        `--prune` ON `remote-mass-delete` IN THE SAME COMMIT. That restores the
+        protection the embedding was providing. Do not simply update this test to
+        match a coarsened identity.
+
+        Why this is a plausible future edit rather than a hypothetical: it is this
+        codebase's own recurring coarsening shape — a scalar extractor normalizing
+        away a semantic distinction that its set sibling explicitly guards. It reads
+        like a cleanup."""
+        from shared.merge_guard_common import _extract_mass_delete_target
+
+        push = "git " + "push "
+        mirror = _extract_mass_delete_target(push + "--mirror origin")
+        prune = _extract_mass_delete_target(push + "--prune origin")
+
+        assert mirror is not None and prune is not None, (
+            "mass_target stopped binding the --mirror/--prune forms entirely; the "
+            "identity-layer defense this pin protects is gone"
+        )
+        assert mirror != prune, (
+            "COUPLING BROKEN: --mirror and --prune now produce the SAME identity, so "
+            "the identity layer no longer separates them. The remote-mass-delete "
+            "binding is deliberately narrow BECAUSE that separation existed — with "
+            "it gone, a --mirror<->--prune escalation on the mass class is "
+            "unguarded. Either restore the embedding, or bind --mirror/--prune on "
+            "remote-mass-delete as well."
+        )
+        assert "--mirror" in mirror and "--prune" in prune, (
+            "COUPLING BROKEN: mass_target no longer EMBEDS the scope flag in its "
+            f"identity (got {mirror!r} / {prune!r}). Same consequence as above: the "
+            "narrow mass-delete binding is only sound while the flag is part of the "
+            "identity."
+        )


### PR DESCRIPTION
## Summary

Consolidates the fixable pre-existing merge-guard over-block residuals left after the OBS-A→I arc (post-v4.6.9), plus a full closure of the `gh pr close` positional over-block class surfaced during review. The merge-guard's cardinal sin is the **over-block** — blocking (or gating-but-leaving-unmintable) a faithful single-command approval click — and every fix here closes one without opening a good-faith under-block.

Version bump: **4.6.10** (PATCH).

## What ships

**1. `#1134` — non-first-leg destructive recognition (under-block, floor breach).** `cd /repo && git push origin --delete feature` ran completely ungated. Root cause was *absence of reach*, not a missing arm: the per-leg union arm already computed the correct verdict; the caller-side filter discarded it. Fix widens `_PER_LEG_OPS` to a 6-tuple. Measured at 0 cardinal over-blocks vs the literal-arm alternative's 3.

**2. `PRIVILEGED_FLAGS` split binding — identity-coarsening escalation.** Approving `git push origin :main` (delete one branch) authorized `git push origin --mirror :main` (wholesale remote wipe). The split binding (`remote-ref-delete` ← `--mirror`/`--prune`/`--no-verify`; `remote-mass-delete` ← `--no-verify` only) closes it. Independently verified as the sole closer for all four remote-delete escalations.

**3. `gh pr close` positional over-block closure.** The `#1134` widening gated non-first-leg `gh pr close`, but the target extractor was number-only. `gh pr close` accepts `{<number>|<url>|<branch>}`, so the faithful branch and url forms gated with no mint path — a cardinal over-block. Extended the close target extractor to mint all three faithful positional forms with disjoint, **host-qualified** url identities (cross-host laundering blocked by construction). A follow-on fix closes a `--repo` value mis-bind by restructuring close to a positional-first walk, so `close` and `merge` use separate value-flag lists that cannot cross-diverge (merge byte-untouched, verified).

**4. Two falsified recognition-limitation tripwires narrowed** (not deleted) — re-pinned to their mechanism plus benign-outcome rows; the two mechanism pins are worded differently on purpose (one asserts the absence of an unsafe mechanism, one the presence of the leg-locality invariant). Eight stale-prose sites corrected in the same commits that falsify them.

**5. `_PER_LEG_PUSH_OPS` → `_PER_LEG_OPS`** rename (the filter now holds six op-classes, not two).

## Certification

Ships a durable three-dimension CI cert (`test_merge_guard_1134_cert.py`) — the corpus ships **as** the cert: D1 leg-position parity, D2 mintability (identity read off the minted token, via a real post→pre round-trip), D3 op-parity. Every assertion carries a demonstrated known-bad; a fresh vendored base fixture at the arc's base SHA with a loud-fail loader; per-site vacuity guards; token-dir isolation by construction; and a merge-unchanged pin that deliberately is NOT coupled to the close fold (it pins that close and merge don't cross).

Full suite: **12329 passed, 0 failed, 0 errors**. Independent adversarial security review: **PASS (0 critical / 0 high / 0 medium / 0 low)** across all code commits, both directions (no over-block introduced, no realistic laundering).

## Scope notes

One adversarial-only, non-faithful residual is **documented, not asserted-closed**: `gh pr close --<unknown-value-flag> <num>` with no positional still mints the flag's number — but `gh pr close` requires a positional, so gh rejects the command (non-faithful confused-deputy). An allow-list would close it at the cost of over-blocking any future gh close flag, so it is pinned as a documented residual with an honest fail-safe comment rather than a false "never a mis-bind" claim.

Pre-existing over-blocks outside this arc's scope (first-leg `gh pr close <branch>|<url> -d`, bare `git push --force`, `gh pr merge --help` gating) are tracked separately.
