### PR TITLE
merge-guard: close force-push / pr-merge mint-gap + inert-help over-blocks (#1203)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.10",
+      "version": "4.6.11",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.10/       # Plugin version
+│               └── 4.6.11/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.10",
+  "version": "4.6.11",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.10
+> **Version**: 4.6.11
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/merge_guard_post.py
+++ b/pact-plugin/hooks/merge_guard_post.py
@@ -177,10 +177,13 @@ def _target_value(cmd_ctx: dict) -> str | None:
     multi-ref push-to-main (#1195 OBS-G) uses the distinct `push_set` and multi-ref
     force-push (#1195 OBS-I) the distinct `force_push_set` (their scalar single-ref
     sibling `target_ref` is already listed); the IMPLICIT current-branch force-push
-    (#1203) uses the distinct target-blind `force_push_implicit` sentinel — each added
-    here so that op MINTS, not just gates."""
+    (#1203) uses the distinct target-blind `force_push_implicit` sentinel and the bare
+    `gh pr merge` (#1203) the distinct target-blind `merge_implicit` sentinel (its
+    scalar sibling `pr_number` is already listed) — each added here so that op MINTS,
+    not just gates."""
     return (
         cmd_ctx.get("pr_number")
+        or cmd_ctx.get("merge_implicit")
         or cmd_ctx.get("branch")
         or cmd_ctx.get("branch_set")
         or cmd_ctx.get("target_ref")

--- a/pact-plugin/hooks/merge_guard_post.py
+++ b/pact-plugin/hooks/merge_guard_post.py
@@ -176,8 +176,9 @@ def _target_value(cmd_ctx: dict) -> str | None:
     `branch_set` (its scalar single-branch sibling `branch` is already listed);
     multi-ref push-to-main (#1195 OBS-G) uses the distinct `push_set` and multi-ref
     force-push (#1195 OBS-I) the distinct `force_push_set` (their scalar single-ref
-    sibling `target_ref` is already listed) — each added here so that op MINTS, not
-    just gates."""
+    sibling `target_ref` is already listed); the IMPLICIT current-branch force-push
+    (#1203) uses the distinct target-blind `force_push_implicit` sentinel — each added
+    here so that op MINTS, not just gates."""
     return (
         cmd_ctx.get("pr_number")
         or cmd_ctx.get("branch")
@@ -185,6 +186,7 @@ def _target_value(cmd_ctx: dict) -> str | None:
         or cmd_ctx.get("target_ref")
         or cmd_ctx.get("push_set")
         or cmd_ctx.get("force_push_set")
+        or cmd_ctx.get("force_push_implicit")
         or cmd_ctx.get("mass_target")
         or cmd_ctx.get("protected_branch")
     )

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -598,11 +598,23 @@ def _token_matches_command(token: dict, command: str) -> bool:
         # force_push_set=None and is REFUSED here via the absent-side rule
         # (mint and read are the same guarded extractor — the escalation closes
         # in both directions by construction). Exactly one of target_ref /
-        # force_push_set is present per command; the a2 bound_flags equality
-        # above still discriminates --no-verify.
+        # force_push_set / force_push_implicit is present per command; the a2
+        # bound_flags equality above still discriminates --no-verify.
+        #
+        # #1203 — the IMPLICIT current-branch force-push binds on the distinct
+        # target-blind `force_push_implicit` sentinel. op-type-first (checked above)
+        # already guarantees token_op == cmd_op == "force-push", and the sentinel is a
+        # DISTINCT key populated ONLY when target_ref/force_push_set are absent, so this
+        # clause can only match implicit↔implicit: an explicit-ref command has
+        # target_ref/force_push_set (not force_push_implicit) → the sentinel side is
+        # absent → _both_present_equal REFUSES, and vice-versa (no cross-authorization
+        # between an implicit-form token and an explicit `--force origin main`).
         return (
             _both_present_equal(context.get("target_ref"), cmd.get("target_ref"))
             or _both_present_equal(context.get("force_push_set"), cmd.get("force_push_set"))
+            or _both_present_equal(
+                context.get("force_push_implicit"), cmd.get("force_push_implicit")
+            )
         )
     if token_op == "remote-ref-delete":
         # KD-6 (SECURITY-RATIFICATION-PENDING): the destination ref must match

--- a/pact-plugin/hooks/merge_guard_pre.py
+++ b/pact-plugin/hooks/merge_guard_pre.py
@@ -549,7 +549,24 @@ def _token_matches_command(token: dict, command: str) -> bool:
     # match. Unextractable or mismatched target -> REFUSE (over-block is the safe
     # #1031 direction; the read side never under-blocks #1032).
     if token_op in ("merge", "close"):
-        return _both_present_equal(context.get("pr_number"), cmd.get("pr_number"))
+        # #1203 — the faithful bare `gh pr merge` binds on the distinct target-blind
+        # `merge_implicit` sentinel, MERGE-ONLY. The `token_op == "merge"` guard keeps a
+        # close on the pr_number-only path (#1134: close was dissolved, and its
+        # populate-site never mints the sentinel, so this is defense-in-depth belt-and-
+        # suspenders on top of that). op-type-first (above) already fixed
+        # token_op == cmd_op; the DISTINCT key means an implicit-merge token (carries
+        # merge_implicit, not pr_number) can NOT authorize an explicit `gh pr merge 42`
+        # (carries pr_number, not merge_implicit) — the absent side fails
+        # _both_present_equal in BOTH directions — and never a close.
+        return (
+            _both_present_equal(context.get("pr_number"), cmd.get("pr_number"))
+            or (
+                token_op == "merge"
+                and _both_present_equal(
+                    context.get("merge_implicit"), cmd.get("merge_implicit")
+                )
+            )
+        )
     if token_op == "branch-delete":
         # #1129 R1: SINGLE-branch scalar OR MULTI-branch canonical SET (D1/D2
         # set-EQUALITY). Exactly one key is present per command (1 positional ->

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -1695,41 +1695,47 @@ _MERGE_IMPLICIT_SENTINEL = "\x00implicit-merge"
 
 def _implicit_force_push_identity(command: str) -> str | None:
     """The `force_push_implicit` mint identity for a CLEAN implicit-current-branch
-    force-push (SET A), or None (SET B / unparseable). #1203 cycle-3 (findings #1+#2)
-    REMOTE-QUALIFIES the identity so `--force origin` ⊥ `--force upstream` — the remote
-    is STATICALLY present in the command (unlike the runtime branch), so binding it
-    closes the remote-blind cross-auth WITHOUT any over-block (a faithful `--force
-    origin` still round-trips to authorize itself):
+    force-push (SET A), or None (multi-ref / unparseable). #1203 cycle-3 REMOTE-QUALIFIED
+    the identity (so `--force origin` ⊥ `--force upstream`); cycle-4 reframes the
+    separator to the NETSTRING SSOT so a URL-remote (which contains `:`) ALSO mints —
+    closing the pre-existing URL-remote over-block — while KEEPING injectivity and
+    WITHOUT any un-gate:
 
       - 0 positionals (bare `git push --force`/`-f`) → the PLAIN
         `_FORCE_PUSH_IMPLICIT_SENTINEL`: the remote is ALSO runtime-unknowable
         (push.default / @{upstream}), so the identity stays fully target-blind.
-      - exactly 1 PLAIN-remote positional (`git push --force origin`,
-        `git push origin --force`) → `_FORCE_PUSH_IMPLICIT_SENTINEL + ":" + <remote>`:
-        REMOTE-qualified, BRANCH-still-blind (the accepted KD-3 target-precision
-        residual — one click authorizes the current branch to THAT remote for the TTL).
+      - exactly 1 positional — ANY <repository>: a named remote (`origin`), a URL
+        (`git@github.com:o/r.git` / `ssh://…` / `https://…`), or even a refspec-SHAPED
+        token → `_FORCE_PUSH_IMPLICIT_SENTINEL + _canonical_join([<remote>])`:
+        REMOTE-qualified, BRANCH-still-blind (KD-3 residual). git parses a LONE push
+        positional as the <repository> regardless of shape, so ALL 1-positionals are
+        remotes; a refspec-shaped one is a NON-RUNNABLE repository spelling that binds
+        HARMLESSLY (self-authorizing-only — its token round-trips ONLY to itself).
+
+    The NETSTRING (`_canonical_join`, the branch_set/mass_target SSOT — `len:content`
+    framing) is content-agnostic + INJECTIVE by construction for ANY remote string incl.
+    `:`/`@`/NUL, which is why cycle-4 can DROP cycle-3's `:`/`refs/`/`HEAD`/`+`
+    single-positional refusal: injectivity no longer needs the remote to be `:`-free.
+    Distinct remotes → distinct frames; a qualified value (…`<len>:<remote>`) can never
+    set-equal the bare `_FORCE_PUSH_IMPLICIT_SENTINEL`.
 
     Consulted by extract_command_context's force-push branch ONLY after
     _extract_force_push_target_ref (scalar) AND _extract_force_push_set (multi-ref) both
     returned None (KD-4 mutual-exclusivity), so an explicit-ref/multi-ref command never
-    reaches here — a non-None identity mints the sentinel for a form that would
-    otherwise be gated-but-unmintable (the cardinal over-block).
+    reaches here — a non-None identity mints the sentinel for a form that would otherwise
+    be gated-but-unmintable (the cardinal over-block). is_dangerous is computed SEPARATELY
+    (unchanged) — this is a MINT-only change, never an un-gate.
 
-    SET B → None (fail-safe, stays gated-but-unmintable, UNCHANGED): a single positional
-    that is a REFSPEC/REF not a plain remote (`:`-bearing `HEAD:main`, an scp-URL remote
-    `git@github.com:o/r.git`, `refs/…`, a bare `HEAD`, a `+`-forced ref), or any multi-
-    positional / unparseable form. git parses a lone positional as the <repository>, so
-    those ref-looking single-positional forms are non-runnable (fatal 128) and need no
-    mint. The `:` EXCLUSION is ALSO what keeps the `<SENTINEL>:<remote>` separator
-    INJECTIVE — a qualified remote is always `:`-free, so distinct remotes → distinct
-    identities and no scp-URL colon can collide two commands. Positionals are counted via
-    the SHARED _push_positionals (value-flag skip), so a `-o ci.skip` push-option never
-    inflates the count NOR leaks as the remote. Unbalanced-quote / no-push → None.
+    None (fail-safe, gated-but-unmintable) for: MULTI-positional (>=2 — the explicit-ref
+    path owns target_ref, UNCHANGED); a degenerate empty/whitespace-only positional; and
+    any unparseable / unbalanced-quote / procsub form. Positionals are counted via the
+    SHARED _push_positionals (value-flag skip), so a `-o ci.skip` push-option never
+    inflates the count NOR leaks as the remote.
 
     mint==read BY CONSTRUCTION: both hook arms derive via extract_command_context and
     consume `force_push_implicit` generically (read `_both_present_equal`, mint
     `_target_value`); the value is a pure function of the command string (no runtime
-    resolution), so a more-specific remote-qualified value needs NO read/mint edit."""
+    resolution), so the netstring value needs NO read/mint edit."""
     after = _tokens_after_push(command)
     if after is None:
         return None                               # no push token / unbalanced → abstain
@@ -1738,18 +1744,17 @@ def _implicit_force_push_identity(command: str) -> str | None:
         return _FORCE_PUSH_IMPLICIT_SENTINEL      # bare — remote ALSO runtime-unknowable
     if len(positionals) == 1:
         remote = _strip_surrounding_quotes(positionals[0])
-        # A PLAIN remote (git treats a lone positional as the <repository>, so `origin`
-        # → push current branch to origin). A `:` / `refs/` / `HEAD` / `+` token is a
-        # refspec/ref (SET B, non-runnable) → refuse; the `:` refusal also guarantees
-        # the `<SENTINEL>:<remote>` separator stays injective.
-        if (
-            ":" not in remote
-            and not remote.startswith("refs/")
-            and remote != "HEAD"
-            and not remote.startswith("+")
-        ):
-            return _FORCE_PUSH_IMPLICIT_SENTINEL + ":" + remote
-    return None
+        if not remote.strip():
+            return None                           # degenerate empty/whitespace → abstain
+        # ANY 1-positional is the <repository> by git grammar — a named remote, a URL
+        # (`git@github.com:o/r.git` / `ssh://…` / `https://…`), OR a non-runnable
+        # refspec-SHAPED token; the NETSTRING _canonical_join binds it INJECTIVELY (incl.
+        # a `:`-bearing URL), so cycle-4 DROPS cycle-3's `:`/`refs/`/`HEAD`/`+` refusal —
+        # injectivity no longer needs the remote to be `:`-free, and a refspec-shaped
+        # bind is self-authorizing-only (non-runnable; its token round-trips ONLY to
+        # itself). This is the URL-remote over-block close (#1203 cycle-4).
+        return _FORCE_PUSH_IMPLICIT_SENTINEL + _canonical_join([remote])
+    return None                                   # >=2 positional → explicit-ref path owns it
 
 
 def _extract_remote_ref_delete_target(command: str) -> str | None:

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -1538,6 +1538,62 @@ def _tokens_after_push(command: str) -> list[str] | None:
     return None
 
 
+# #1203 — target-blind sentinel identities for the IMPLICIT destructive forms whose
+# real target is RUNTIME state absent from the command string (a bare force-push
+# rewrites f(push.default, @{upstream}); a bare `gh pr merge` merges the current-branch
+# PR). NUL-framed so the value is REF-ILLEGAL — no git ref/branch or gh PR identity can
+# contain a NUL, so a sentinel can NEVER collide with a real target_ref/pr_number
+# (defense-in-depth on top of the distinct typed key). Each is its OWN context key
+# (KD-2), never a value in target_ref/pr_number, so op-type-first + distinct-key keeps
+# an implicit-form token from cross-authorizing an explicit `--force origin main` /
+# `gh pr merge 42` and vice-versa. The KD-4 mutual-exclusivity holds by construction:
+# a sentinel populates ONLY when the explicit target key for that op is absent.
+_FORCE_PUSH_IMPLICIT_SENTINEL = "\x00implicit-force-push"
+_MERGE_IMPLICIT_SENTINEL = "\x00implicit-merge"
+
+
+def _is_implicit_current_branch_force_push(command: str) -> bool:
+    """True iff `command` is a CLEAN implicit-current-branch force-push (SET A) — a
+    faithful form whose target is the current branch (runtime state, unknowable from
+    the string): 0 positionals (`git push --force`, `git push -f`) OR exactly 1
+    PLAIN-REMOTE positional (`git push --force origin`, `git push origin --force`).
+
+    Consulted by extract_command_context's force-push branch ONLY after
+    _extract_force_push_target_ref (scalar) AND _extract_force_push_set (multi-ref)
+    both returned None — an explicit-ref/multi-ref command already populated
+    target_ref/force_push_set and never reaches here (KD-4 mutual-exclusivity), so a
+    True here mints the target-blind `force_push_implicit` sentinel for a form that
+    would otherwise be gated-but-unmintable (the cardinal over-block).
+
+    SET B → False (fail-safe, stays gated-but-unmintable): a single positional that is
+    a REFSPEC/REF, not a plain remote (`:`-bearing `HEAD:main`, `refs/…`, a bare
+    `HEAD`, a `+`-forced ref), or any multi-positional / unparseable form. git parses a
+    lone positional as the <repository>, so those ref-looking single-positional forms
+    are non-runnable (fatal 128) and need no mint; refusing them keeps the sentinel
+    surface tight WITHOUT opening a faithful-click over-block. Positionals are counted
+    via the SHARED _push_positionals (value-flag skip), so a `-o ci.skip` push-option
+    never inflates the count. An unbalanced-quote / no-push form abstains → False."""
+    after = _tokens_after_push(command)
+    if after is None:
+        return False                              # no push token / unbalanced → abstain
+    positionals = _push_positionals(after)
+    if len(positionals) == 0:
+        return True                               # bare implicit current-branch force-push
+    if len(positionals) == 1:
+        remote = _strip_surrounding_quotes(positionals[0])
+        # A PLAIN remote (git treats a lone positional as the <repository>, so `origin`
+        # → push current branch to origin). A `:` / `refs/` / `HEAD` / `+` token is a
+        # refspec/ref (SET B, non-runnable) → refuse.
+        if (
+            ":" not in remote
+            and not remote.startswith("refs/")
+            and remote != "HEAD"
+            and not remote.startswith("+")
+        ):
+            return True
+    return False
+
+
 def _extract_remote_ref_delete_target(command: str) -> str | None:
     """Extract the SINGLE remote ref a `git push` delete would remove (#1062a), or
     None when the form is implicit-current/multi-ref/ambiguous (→ the caller defers:
@@ -1988,6 +2044,12 @@ def extract_command_context(command: str, flag_scan_text: str | None = None) -> 
                      upgrades elements to '+'-form) gated by the ref-scope-neutral
                      flag allowlist; exactly one of target_ref / push_set /
                      force_push_set populated per command
+        force_push_implicit: str (force-push IMPLICIT current-branch #1203) — a
+                     target-blind NUL-framed sentinel (_FORCE_PUSH_IMPLICIT_SENTINEL),
+                     populated ONLY on op_type=='force-push' when target_ref AND
+                     force_push_set are both absent (the clean 0/1-plain-remote-
+                     positional forms whose target is runtime state); distinct key so
+                     it never cross-authorizes an explicit target_ref/force_push_set
         mass_target: str (remote-mass-delete #1062b) — normalized identity STRING
                      _canonical_join([<sorted-mass-flags>, <remote-or-implicit-marker>, *<sorted-deduped-refspecs>])
         protected_branch: str (branch-protection #1063) — the branch from the
@@ -2088,6 +2150,21 @@ def extract_command_context(command: str, flag_scan_text: str | None = None) -> 
             force_push_set = _extract_force_push_set(command)
             if force_push_set is not None:
                 context["force_push_set"] = force_push_set
+            elif _is_implicit_current_branch_force_push(command):
+                # #1203 KD-2/KD-4 — TARGET-BLIND sentinel for the implicit current-
+                # branch force-push (`git push --force`, `-f`, `--force origin`, …),
+                # whose real target is runtime state absent from the string. Reached
+                # ONLY when target_ref (scalar) AND force_push_set (multi-ref) are BOTH
+                # absent, on op_type=='force-push' (never the push-to-main path above),
+                # so an explicit-ref/multi-ref command never carries this sentinel —
+                # the mutual-exclusivity is structural. Distinct typed key (not a
+                # target_ref value) so op-type-first + distinct-key keeps this token
+                # from cross-authorizing an explicit `--force origin main`. The scalar
+                # (_extract_force_push_target_ref) and set (_extract_force_push_set)
+                # extractors above stay BYTE-UNTOUCHED — this is a pure additive elif
+                # on their shared None. is_dangerous is unchanged (still True): this is
+                # target-PRECISION (mint the over-blocked form), never un-gating.
+                context["force_push_implicit"] = _FORCE_PUSH_IMPLICIT_SENTINEL
     elif op_type == "remote-ref-delete":
         # #1062a: REUSE the `target_ref` key — the parser yields a ref, the key is
         # semantically right, and the op-class identity (checked FIRST in the read

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -1693,46 +1693,63 @@ _FORCE_PUSH_IMPLICIT_SENTINEL = "\x00implicit-force-push"
 _MERGE_IMPLICIT_SENTINEL = "\x00implicit-merge"
 
 
-def _is_implicit_current_branch_force_push(command: str) -> bool:
-    """True iff `command` is a CLEAN implicit-current-branch force-push (SET A) — a
-    faithful form whose target is the current branch (runtime state, unknowable from
-    the string): 0 positionals (`git push --force`, `git push -f`) OR exactly 1
-    PLAIN-REMOTE positional (`git push --force origin`, `git push origin --force`).
+def _implicit_force_push_identity(command: str) -> str | None:
+    """The `force_push_implicit` mint identity for a CLEAN implicit-current-branch
+    force-push (SET A), or None (SET B / unparseable). #1203 cycle-3 (findings #1+#2)
+    REMOTE-QUALIFIES the identity so `--force origin` ⊥ `--force upstream` — the remote
+    is STATICALLY present in the command (unlike the runtime branch), so binding it
+    closes the remote-blind cross-auth WITHOUT any over-block (a faithful `--force
+    origin` still round-trips to authorize itself):
+
+      - 0 positionals (bare `git push --force`/`-f`) → the PLAIN
+        `_FORCE_PUSH_IMPLICIT_SENTINEL`: the remote is ALSO runtime-unknowable
+        (push.default / @{upstream}), so the identity stays fully target-blind.
+      - exactly 1 PLAIN-remote positional (`git push --force origin`,
+        `git push origin --force`) → `_FORCE_PUSH_IMPLICIT_SENTINEL + ":" + <remote>`:
+        REMOTE-qualified, BRANCH-still-blind (the accepted KD-3 target-precision
+        residual — one click authorizes the current branch to THAT remote for the TTL).
 
     Consulted by extract_command_context's force-push branch ONLY after
-    _extract_force_push_target_ref (scalar) AND _extract_force_push_set (multi-ref)
-    both returned None — an explicit-ref/multi-ref command already populated
-    target_ref/force_push_set and never reaches here (KD-4 mutual-exclusivity), so a
-    True here mints the target-blind `force_push_implicit` sentinel for a form that
-    would otherwise be gated-but-unmintable (the cardinal over-block).
+    _extract_force_push_target_ref (scalar) AND _extract_force_push_set (multi-ref) both
+    returned None (KD-4 mutual-exclusivity), so an explicit-ref/multi-ref command never
+    reaches here — a non-None identity mints the sentinel for a form that would
+    otherwise be gated-but-unmintable (the cardinal over-block).
 
-    SET B → False (fail-safe, stays gated-but-unmintable): a single positional that is
-    a REFSPEC/REF, not a plain remote (`:`-bearing `HEAD:main`, `refs/…`, a bare
-    `HEAD`, a `+`-forced ref), or any multi-positional / unparseable form. git parses a
-    lone positional as the <repository>, so those ref-looking single-positional forms
-    are non-runnable (fatal 128) and need no mint; refusing them keeps the sentinel
-    surface tight WITHOUT opening a faithful-click over-block. Positionals are counted
-    via the SHARED _push_positionals (value-flag skip), so a `-o ci.skip` push-option
-    never inflates the count. An unbalanced-quote / no-push form abstains → False."""
+    SET B → None (fail-safe, stays gated-but-unmintable, UNCHANGED): a single positional
+    that is a REFSPEC/REF not a plain remote (`:`-bearing `HEAD:main`, an scp-URL remote
+    `git@github.com:o/r.git`, `refs/…`, a bare `HEAD`, a `+`-forced ref), or any multi-
+    positional / unparseable form. git parses a lone positional as the <repository>, so
+    those ref-looking single-positional forms are non-runnable (fatal 128) and need no
+    mint. The `:` EXCLUSION is ALSO what keeps the `<SENTINEL>:<remote>` separator
+    INJECTIVE — a qualified remote is always `:`-free, so distinct remotes → distinct
+    identities and no scp-URL colon can collide two commands. Positionals are counted via
+    the SHARED _push_positionals (value-flag skip), so a `-o ci.skip` push-option never
+    inflates the count NOR leaks as the remote. Unbalanced-quote / no-push → None.
+
+    mint==read BY CONSTRUCTION: both hook arms derive via extract_command_context and
+    consume `force_push_implicit` generically (read `_both_present_equal`, mint
+    `_target_value`); the value is a pure function of the command string (no runtime
+    resolution), so a more-specific remote-qualified value needs NO read/mint edit."""
     after = _tokens_after_push(command)
     if after is None:
-        return False                              # no push token / unbalanced → abstain
+        return None                               # no push token / unbalanced → abstain
     positionals = _push_positionals(after)
     if len(positionals) == 0:
-        return True                               # bare implicit current-branch force-push
+        return _FORCE_PUSH_IMPLICIT_SENTINEL      # bare — remote ALSO runtime-unknowable
     if len(positionals) == 1:
         remote = _strip_surrounding_quotes(positionals[0])
         # A PLAIN remote (git treats a lone positional as the <repository>, so `origin`
         # → push current branch to origin). A `:` / `refs/` / `HEAD` / `+` token is a
-        # refspec/ref (SET B, non-runnable) → refuse.
+        # refspec/ref (SET B, non-runnable) → refuse; the `:` refusal also guarantees
+        # the `<SENTINEL>:<remote>` separator stays injective.
         if (
             ":" not in remote
             and not remote.startswith("refs/")
             and remote != "HEAD"
             and not remote.startswith("+")
         ):
-            return True
-    return False
+            return _FORCE_PUSH_IMPLICIT_SENTINEL + ":" + remote
+    return None
 
 
 def _extract_remote_ref_delete_target(command: str) -> str | None:
@@ -2196,11 +2213,14 @@ def extract_command_context(command: str, flag_scan_text: str | None = None) -> 
                      flag allowlist; exactly one of target_ref / push_set /
                      force_push_set populated per command
         force_push_implicit: str (force-push IMPLICIT current-branch #1203) — a
-                     target-blind NUL-framed sentinel (_FORCE_PUSH_IMPLICIT_SENTINEL),
-                     populated ONLY on op_type=='force-push' when target_ref AND
-                     force_push_set are both absent (the clean 0/1-plain-remote-
-                     positional forms whose target is runtime state); distinct key so
-                     it never cross-authorizes an explicit target_ref/force_push_set
+                     branch-blind NUL-framed sentinel, REMOTE-QUALIFIED (cycle-3 #1+#2):
+                     bare form = `_FORCE_PUSH_IMPLICIT_SENTINEL` (remote also runtime-
+                     unknowable); 1-plain-remote form = `<SENTINEL>:<remote>` so
+                     `--force origin` ⊥ `--force upstream`. Populated ONLY on
+                     op_type=='force-push' when target_ref AND force_push_set are both
+                     absent (the clean 0/1-plain-remote forms; SET B → None → absent);
+                     distinct key so it never cross-authorizes an explicit
+                     target_ref/force_push_set (via _implicit_force_push_identity)
         mass_target: str (remote-mass-delete #1062b) — normalized identity STRING
                      _canonical_join([<sorted-mass-flags>, <remote-or-implicit-marker>, *<sorted-deduped-refspecs>])
         protected_branch: str (branch-protection #1063) — the branch from the
@@ -2331,21 +2351,26 @@ def extract_command_context(command: str, flag_scan_text: str | None = None) -> 
             force_push_set = _extract_force_push_set(command)
             if force_push_set is not None:
                 context["force_push_set"] = force_push_set
-            elif _is_implicit_current_branch_force_push(command):
-                # #1203 KD-2/KD-4 — TARGET-BLIND sentinel for the implicit current-
-                # branch force-push (`git push --force`, `-f`, `--force origin`, …),
-                # whose real target is runtime state absent from the string. Reached
-                # ONLY when target_ref (scalar) AND force_push_set (multi-ref) are BOTH
-                # absent, on op_type=='force-push' (never the push-to-main path above),
-                # so an explicit-ref/multi-ref command never carries this sentinel —
-                # the mutual-exclusivity is structural. Distinct typed key (not a
-                # target_ref value) so op-type-first + distinct-key keeps this token
-                # from cross-authorizing an explicit `--force origin main`. The scalar
-                # (_extract_force_push_target_ref) and set (_extract_force_push_set)
-                # extractors above stay BYTE-UNTOUCHED — this is a pure additive elif
-                # on their shared None. is_dangerous is unchanged (still True): this is
-                # target-PRECISION (mint the over-blocked form), never un-gating.
-                context["force_push_implicit"] = _FORCE_PUSH_IMPLICIT_SENTINEL
+            else:
+                # #1203 KD-2/KD-4 + cycle-3 — REMOTE-QUALIFIED target-blind sentinel for
+                # the implicit current-branch force-push (`git push --force`, `-f`,
+                # `--force origin`, …), whose BRANCH target is runtime state absent from
+                # the string. Reached ONLY when target_ref (scalar) AND force_push_set
+                # (multi-ref) are BOTH absent, on op_type=='force-push' (never the
+                # push-to-main path above), so an explicit-ref/multi-ref command never
+                # carries this sentinel — the mutual-exclusivity is structural. Distinct
+                # typed key (not a target_ref value) so op-type-first + distinct-key keeps
+                # this token from cross-authorizing an explicit `--force origin main`.
+                # cycle-3 (#1+#2): the identity now binds the EXPLICIT remote (`…:origin`)
+                # for a 1-positional form so `--force origin` ⊥ `--force upstream`; the
+                # bare form stays fully blind (remote runtime-unknowable). SET B →
+                # identity None → key absent → gated-but-unmintable (UNCHANGED). The
+                # scalar/set extractors above stay BYTE-UNTOUCHED. is_dangerous is
+                # unchanged (still True): target-PRECISION (mint the over-blocked form),
+                # never un-gating.
+                fpi = _implicit_force_push_identity(command)
+                if fpi is not None:
+                    context["force_push_implicit"] = fpi
     elif op_type == "remote-ref-delete":
         # #1062a: REUSE the `target_ref` key — the parser yields a ref, the key is
         # semantically right, and the op-class identity (checked FIRST in the read

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -4742,6 +4742,79 @@ def _strip_inert_positional_legs(result: str) -> str:
     return "".join(out)
 
 
+def _is_inert_help_leg(leg: str) -> bool:
+    """True iff `leg` is an INERT help invocation that mutates nothing — a `--help`
+    / `-h` help request, or a `gh|git help <sub>` head form. Such a leg contributes
+    NO danger: `gh pr merge --help`, `git push --force --help`, `gh help pr merge`
+    all print help and exit without merging/pushing, so gating them is pure friction
+    (a cardinal over-block under the good-faith model).
+
+    QUOTE-AWARE + VALUE-FLAG-AWARE (fail-TOWARD-gating on any ambiguity):
+      - Tokens come from the quote-aware `_leg_token_spans`, so a `--help` living
+        INSIDE a quoted value (`gh pr merge 5 --comment "…--help…"`) is one value
+        token, never a bare flag — it stays gated.
+      - A `-h` that is the VALUE of a gh-pr value-taking flag (`--subject -h`) is
+        SKIPPED with its flag, so the decoy is not read as help — it stays gated.
+      - Only an EXACT `--help` / `-h` flag token counts; a bundled short cluster
+        (`-fh`) is NOT `-h`, so it does not match and the command stays gated
+        (fail-toward-gating). An unbalanced-quote leg abstains (→ not inert → gated).
+
+    The `gh|git help <sub>` head form is matched on the command HEAD (first token
+    past any `NAME=value` env-assignments), so a quoted `"gh help"` decoy in a value
+    never triggers it. `git help …` is a no-op here (a `git help` leg is already
+    non-dangerous), included only so the recognizer is uniform across gh/git."""
+    if _shell_tokenize(leg) is None:
+        return False                              # unbalanced quotes → abstain (gate)
+    tokens = [leg[s:e] for s, e in _leg_token_spans(leg)]
+    # gh|git help <sub> head form — the command head past leading env-assignments.
+    positionals = [_strip_surrounding_quotes(t) for t in tokens if not t.startswith("-")]
+    head = 0
+    while head < len(positionals) and re.fullmatch(
+        r"[A-Za-z_][A-Za-z0-9_]*=.*", positionals[head]
+    ):
+        head += 1
+    if (
+        head + 1 < len(positionals)
+        and positionals[head] in ("gh", "git")
+        and positionals[head + 1] == "help"
+    ):
+        return True
+    # Exact --help/-h flag token, skipping any gh-pr value-taking flag's value token
+    # (so a value `-h` is never misread as a help request).
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok.split("=", 1)[0] in _GH_PR_VALUE_TAKING_FLAGS and "=" not in tok:
+            i += 2                                # skip the flag AND its separate value token
+            continue
+        if tok in ("--help", "-h"):
+            return True
+        i += 1
+    return False
+
+
+def _neutralize_inert_help_legs(stripped: str) -> str:
+    """Blank every INERT help leg (`_is_inert_help_leg`) in an already-stripped
+    surface with an EQUAL-LENGTH run of spaces, leaving separators + non-inert legs
+    byte-untouched. Applied by `is_dangerous_command` BEFORE the danger battery, so
+    a leg whose only danger is a help-suppressed op stops gating while every REAL
+    destructive leg keeps its exact bytes and still gates (per-leg, NOT a whole-
+    command prefilter: `--help && gh pr merge 6` blanks leg 1 only → leg 2 gates).
+
+    Equal-length blanking preserves ALL offsets, so the battery's whole-surface
+    scans (`DANGEROUS_PATTERNS`, `_flag_condition_danger_op`) and its per-leg re-slice
+    map 1:1 back to the original — the same offset-preserving discipline the
+    `_FD_REDIRECT_RE` neutralize uses in `_slice_stripped_leg_spans`. Idempotent, and
+    a strict no-op on a surface with no inert leg."""
+    spans = _slice_stripped_leg_spans(stripped)
+    result = list(stripped)
+    for start, end in spans:
+        if _is_inert_help_leg(stripped[start:end]):
+            for i in range(start, end):
+                result[i] = " "
+    return "".join(result)
+
+
 def is_dangerous_command(command: str) -> bool:
     """Check if a bash command is a dangerous git operation.
 
@@ -4764,6 +4837,15 @@ def is_dangerous_command(command: str) -> bool:
     # any matching (so this floor + the substrate join lines identically).
     command = _normalize_line_continuations(command)
     stripped = _strip_non_executable_content(command)
+    # C1 (#1203) — inert-help suppression: blank any leg that is an inert `--help`/
+    # `-h` / `gh help` invocation BEFORE the danger battery, so a faithful help
+    # request stops gating (a cardinal over-block). Per-leg + offset-preserving, so
+    # every REAL destructive leg keeps its bytes and still gates. This is the SINGLE
+    # load-bearing layer: the gate (check_merge_authorization), the compound counter
+    # (is_compound_destructive_command → _leg_is_destructive), and the read/mint leg
+    # selection (_single_destructive_leg) ALL route through is_dangerous_command, so
+    # suppressing here makes every consumer agree the inert leg is non-gating.
+    stripped = _neutralize_inert_help_legs(stripped)
     # The literal danger battery (DANGEROUS_PATTERNS + the four per-leg literal-arm families +
     # the additive normalized-flag condition) is the SSOT _stripped_surface_danger — factored
     # out so the #1178 general-strip preserve-predicate can consult the SAME predicate on a
@@ -4811,15 +4893,26 @@ def _slice_stripped_legs(stripped: str) -> list[str]:
     `2>&1 | rm -rf ~`). The leg slices are taken from `stripped`, never the masked
     `view` — the view exists ONLY to locate the operator offsets.
     """
+    return [stripped[s:e] for s, e in _slice_stripped_leg_spans(stripped)]
+
+
+def _slice_stripped_leg_spans(stripped: str) -> "list[tuple[int, int]]":
+    """The (start, end) offset spans of each leg within `stripped` — the span form
+    of `_slice_stripped_legs` (which is `[stripped[s:e] for s, e in ...]`, byte-
+    identical output by construction). Factored out so an OFFSET-preserving consumer
+    (the C1 inert-help neutralizer) can blank a leg IN PLACE with an equal-length
+    run without re-deriving the leg boundaries — one leg-boundary substrate, no
+    drift. Same masked + FD-neutralized view + `_COMPOUND_OPS_RE` scan as the slice
+    form; the view exists ONLY to locate operator offsets, spans index `stripped`."""
     view = _FD_REDIRECT_RE.sub(
         lambda m: " " * len(m.group()), _mask_shell_quotes(stripped)
     )
-    legs, last = [], 0
+    spans, last = [], 0
     for m in _COMPOUND_OPS_RE.finditer(view):
-        legs.append(stripped[last : m.start()])
+        spans.append((last, m.start()))
         last = m.end()
-    legs.append(stripped[last:])
-    return legs
+    spans.append((last, len(stripped)))
+    return spans
 
 
 def _split_into_legs(command: str) -> list[str]:

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -779,6 +779,28 @@ _GH_PR_VALUE_TAKING_FLAGS = frozenset({
     "--timeout",
 })
 
+# #1203 C1b — value-taking gh pr merge/close flags the inert-help recognizer must skip
+# BEYOND the shared _GH_PR_VALUE_TAKING_FLAGS long-form SSOT, so a `-h`/`--help` sitting
+# in one of their VALUE positions (separate form `-t -h`, `-R -h`, `--repo -h`) is not
+# misread as a help request and does not un-gate a REAL merge/close (the auditor's
+# confirmed under-block). Two groups:
+#   • SHORT aliases of the shared long value flags: -t(--subject) -b(--body)
+#     -F(--body-file) -A(--author-email) -c(--comment).
+#   • --repo AND its short -R — a value-taking flag on merge AND close (test-engineer
+#     #68, live-verified) that is ABSENT from the shared long SSOT.
+# KEPT SEPARATE from _GH_PR_VALUE_TAKING_FLAGS ON PURPOSE: that SSOT is also consumed by
+# _extract_pr_number + the merge shadow-guard, so widening it would change target
+# extraction (the SEPARATE short/-repo pr_number MISBIND is escalated on its own, not
+# folded here). This set touches ONLY the inert recognizer.
+# ONLY genuinely value-taking flags belong here — a BOOLEAN (e.g. -d/--delete-branch,
+# -s/--squash, -r/--rebase, -m/--merge) would skip a real following `-h` and RE-INTRODUCE
+# an over-block; those are correctly EXCLUDED. The GLUED form (`-tVALUE` / `-t-h` /
+# `--repo=-h` / `-R=-h`) needs no entry — one token, not literally `-h`/`--help`, so it
+# neither skips nor matches (stays gated).
+_INERT_HELP_EXTRA_VALUE_FLAGS = frozenset(
+    {"-t", "-b", "-F", "-A", "-c", "-R", "--repo"}
+)
+
 
 def _strip_surrounding_quotes(token: str) -> str:
     """Strip one layer of matching surrounding quotes from a captured CLI token.
@@ -4858,8 +4880,11 @@ def _is_inert_help_leg(leg: str) -> bool:
       - Tokens come from the quote-aware `_leg_token_spans`, so a `--help` living
         INSIDE a quoted value (`gh pr merge 5 --comment "…--help…"`) is one value
         token, never a bare flag — it stays gated.
-      - A `-h` that is the VALUE of a gh-pr value-taking flag (`--subject -h`) is
-        SKIPPED with its flag, so the decoy is not read as help — it stays gated.
+      - A `-h` (or `--help`) that is the VALUE of a gh-pr value-taking flag is SKIPPED
+        with its flag, so the decoy is not read as help — it stays gated. Both the
+        shared LONG-form SSOT (`--subject -h`) AND the inert-recognizer supplement
+        `_INERT_HELP_EXTRA_VALUE_FLAGS` — the short aliases `-t`/`-b`/`-F`/`-A`/`-c` plus
+        `--repo`/`-R` (#1203 C1b) — are covered, across gh pr merge AND close.
       - Only an EXACT `--help` / `-h` flag token counts; a bundled short cluster
         (`-fh`) is NOT `-h`, so it does not match and the command stays gated
         (fail-toward-gating). An unbalanced-quote leg abstains (→ not inert → gated).
@@ -4885,12 +4910,26 @@ def _is_inert_help_leg(leg: str) -> bool:
     ):
         return True
     # Exact --help/-h flag token, skipping any gh-pr value-taking flag's value token
-    # (so a value `-h` is never misread as a help request).
+    # (so a value `-h` — or a value `--help` — is never misread as a help request).
+    # BOTH the LONG forms (--subject/--body/… incl. the `--flag=value` inline form) and
+    # their SHORT aliases (-t/-b/-F/-A/-c in the separate `-t <value>` form) are skipped
+    # (#1203 C1b), closing the short-form value-decoy under-block. `i += 2` skips the
+    # flag AND whatever its next token is, so `-t -h` AND `-t --help` both stay gated.
     i = 0
     while i < len(tokens):
         tok = tokens[i]
-        if tok.split("=", 1)[0] in _GH_PR_VALUE_TAKING_FLAGS and "=" not in tok:
-            i += 2                                # skip the flag AND its separate value token
+        flagname = tok.split("=", 1)[0]
+        # Skip a value-taking flag AND its separate value token: the shared long-form
+        # SSOT, PLUS the inert-recognizer's short aliases + --repo/-R (#1203 C1b). The
+        # `"=" not in tok` guard leaves the inline `--flag=value` / `-R=value` form as
+        # one token (already safe — not literally `-h`). `i += 2` skips whatever the
+        # value is, so both `-t -h` AND `-t --help` stay gated.
+        is_value_flag = (
+            flagname in _GH_PR_VALUE_TAKING_FLAGS
+            or flagname in _INERT_HELP_EXTRA_VALUE_FLAGS
+        ) and "=" not in tok
+        if is_value_flag:
+            i += 2
             continue
         if tok in ("--help", "-h"):
             return True

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -1037,16 +1037,20 @@ def _extract_close_target(command: str) -> str | None:
     return _classify_pr_target(target)
 
 
-# #1203 M1 — MERGE positional-walk value-flags: the merge value-taking flags whose value
-# token must be stripped so the branch/url TARGET positional is isolated — the SAME set
-# C1b established (the long value SSOT + --repo + the short aliases), NOT close's
-# {--repo,--comment}. DERIVED from the C1b sets so there is ONE value-flag SSOT: a merge
-# value-flag added for inert-help recognition is automatically honored by the target walk
-# too (the divergent-copies bug class this arc kept hitting cannot recur).
-_GH_MERGE_VALUE_LONG = _GH_PR_VALUE_TAKING_FLAGS | {"--repo"}
-_GH_MERGE_VALUE_SHORT = frozenset(
-    f[1] for f in _INERT_HELP_EXTRA_VALUE_FLAGS if len(f) == 2 and f[0] == "-"
+# #1203 M1 — MERGE positional-walk value-flags: the MERGE-SPECIFIC value-taking flags
+# whose value token must be stripped so the branch/url TARGET positional is isolated.
+# EXACTLY the 5 `gh pr merge` value flags (gh 2.96.0 `gh pr merge --help` census,
+# test-engineer #68) — deliberately NOT the gh-pr-WIDE _GH_PR_VALUE_TAKING_FLAGS union
+# (which carries close/review-only flags ABSENT from merge: --comment, --match-head-commit,
+# --max-retries, --retry-count, --timeout) and NOT close's {--repo,--comment}. Merge-
+# SPECIFIC for the SAME reason _gh_close_positionals is close-specific: a wider set could
+# mis-parse a NON-runnable merge's positional (symmetry with the close walk). Booleans
+# (--admin/--auto/-s/-r/-m/-d) are EXCLUDED — they take no value, so they never consume
+# the target positional.
+_GH_MERGE_VALUE_LONG = frozenset(
+    {"--author-email", "--body", "--body-file", "--subject", "--repo"}
 )
+_GH_MERGE_VALUE_SHORT = frozenset("AbFtR")   # -A/-b/-F/-t/-R (no -c: merge has no --comment)
 
 
 def _gh_merge_positionals(tokens: "list[str]") -> "list[str] | None":

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -5020,41 +5020,65 @@ def _is_inert_help_leg(leg: str) -> bool:
         (`-fh`) is NOT `-h`, so it does not match and the command stays gated
         (fail-toward-gating). An unbalanced-quote leg abstains (→ not inert → gated).
 
-    The `gh|git help <sub>` head form is matched on the command HEAD (first token
-    past any `NAME=value` env-assignments), so a quoted `"gh help"` decoy in a value
-    never triggers it. `git help …` is a no-op here (a `git help` leg is already
-    non-dangerous), included only so the recognizer is uniform across gh/git."""
+    The `gh|git help <sub>` head form is ADJACENCY-strict (#1203 finding-#4): it fires
+    only when `help` is the IMMEDIATE raw token after the git/gh head (past NAME=value
+    env-assignments), and a `-h`/`--help` flag counts only AT/AFTER the subcommand
+    position (the first non-dash raw token after the head). A git GLOBAL value-option
+    whose VALUE is literally `help`/`-h`/`--help` (`git -C help push --force`,
+    `git -C -h push --force`) therefore stays GATED — its value sits in the leading
+    global-option region, not the subcommand slot. Both checks read the FULL raw token
+    stream, so an intervening dash-option is visible; a quoted `"gh help"` decoy in a
+    value never triggers it. Enumeration-free (no git global-value-option list) and
+    fail-safe toward gating."""
     if _shell_tokenize(leg) is None:
         return False                              # unbalanced quotes → abstain (gate)
     tokens = [leg[s:e] for s, e in _leg_token_spans(leg)]
-    # gh|git help <sub> head form — the command head past leading env-assignments.
-    positionals = [_strip_surrounding_quotes(t) for t in tokens if not t.startswith("-")]
+    # RAW quote-stripped token stream (#1203 finding-#4): BOTH the head-form adjacency
+    # AND the flag-loop subcommand-anchor are computed on the FULL stream — NEVER a
+    # dash-filtered positional list — so a git GLOBAL value-option positioned between the
+    # git/gh head and its target (`git -C help …`, `git -C -h …`) stays VISIBLE. The old
+    # dash-filtered list dropped it, misreading the option's VALUE as the `help`
+    # subcommand (head-form) or as a `-h` help flag (flag-loop) and UN-GATING a real
+    # destructive leg — the two siblings of the value-decoy gap C1b closed. ENUMERATION-
+    # FREE: neither arm needs to know which git global options take values; both key on
+    # token ADJACENCY / POSITION, failing TOWARD gating (avoids the --match-head-commit
+    # enumeration-drift trap).
+    raw = [_strip_surrounding_quotes(t) for t in tokens]
+    # Command head past leading NAME=value env-assignments (`FOO=bar git help push`
+    # still resolves git as the head).
     head = 0
-    while head < len(positionals) and re.fullmatch(
-        r"[A-Za-z_][A-Za-z0-9_]*=.*", positionals[head]
-    ):
+    while head < len(raw) and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", raw[head]):
         head += 1
-    if (
-        head + 1 < len(positionals)
-        and positionals[head] in ("gh", "git")
-        and positionals[head + 1] == "help"
-    ):
+    is_git_gh_head = head < len(raw) and raw[head] in ("gh", "git")
+    # ARM 1 — head-form ADJACENCY: `gh|git help <sub>` is inert ONLY when `help` is the
+    # IMMEDIATE next raw token after the git/gh head. An intervening dash-token (a global
+    # value-option like `-C`, whose value happens to be literally `help`) breaks the
+    # adjacency → the head-form does NOT fire → the danger battery gates the real
+    # destructive leg (`git -C help push --force` gates).
+    if is_git_gh_head and head + 1 < len(raw) and raw[head + 1] == "help":
         return True
-    # Exact --help/-h flag token, skipping any gh-pr value-taking flag's value token
-    # (so a value `-h` — or a value `--help` — is never misread as a help request).
-    # BOTH the LONG forms (--subject/--body/… incl. the `--flag=value` inline form) and
-    # their SHORT aliases (-t/-b/-F/-A/-c in the separate `-t <value>` form) are skipped
-    # (#1203 C1b), closing the short-form value-decoy under-block. `i += 2` skips the
-    # flag AND whatever its next token is, so `-t -h` AND `-t --help` both stay gated.
+    # ARM 2 — flag-loop SUBCOMMAND-ANCHOR: a `-h`/`--help` is a help flag ONLY at/after
+    # the SUBCOMMAND position — the FIRST NON-DASH raw token after the git/gh head. A
+    # `-h`/`--help` in the LEADING global-option region (before that token) is a git
+    # global value-option's VALUE (`git -C -h …`, `git --git-dir --help …`), NOT help. A
+    # non-git/gh head has no global-option region to protect → anchor 0 (any help flag is
+    # help). Structural — no git global-value-option enumeration.
+    anchor = 0
+    if is_git_gh_head:
+        anchor = head + 1
+        while anchor < len(raw) and raw[anchor].startswith("-") and raw[anchor] != "-":
+            anchor += 1
+    # Exact --help/-h flag token (at/after the ARM-2 anchor), skipping any gh-pr
+    # value-taking flag's value token (#1203 C1b: --subject/--body/… + short aliases
+    # -t/-b/-F/-A/-c + --repo/-R), so a value `-h`/`--help` is never misread as help.
+    # The C1b enumerated skip (gh-pr SUBCOMMAND value flags) and the ARM-2 structural
+    # anchor (git LEADING global value-options) are COMPLEMENTARY — different option
+    # classes. `i += 2` skips the flag AND its value; `"=" not in tok` leaves the inline
+    # `--flag=value` form as one already-safe token.
     i = 0
     while i < len(tokens):
         tok = tokens[i]
         flagname = tok.split("=", 1)[0]
-        # Skip a value-taking flag AND its separate value token: the shared long-form
-        # SSOT, PLUS the inert-recognizer's short aliases + --repo/-R (#1203 C1b). The
-        # `"=" not in tok` guard leaves the inline `--flag=value` / `-R=value` form as
-        # one token (already safe — not literally `-h`). `i += 2` skips whatever the
-        # value is, so both `-t -h` AND `-t --help` stay gated.
         is_value_flag = (
             flagname in _GH_PR_VALUE_TAKING_FLAGS
             or flagname in _INERT_HELP_EXTRA_VALUE_FLAGS
@@ -5062,7 +5086,7 @@ def _is_inert_help_leg(leg: str) -> bool:
         if is_value_flag:
             i += 2
             continue
-        if tok in ("--help", "-h"):
+        if tok in ("--help", "-h") and i >= anchor:
             return True
         i += 1
     return False

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -2030,6 +2030,11 @@ def extract_command_context(command: str, flag_scan_text: str | None = None) -> 
                         | "push-to-main" | "remote-ref-delete" | "remote-mass-delete"
                         | "branch-protection"
         pr_number:  str  (merge / close)
+        merge_implicit: str (merge IMPLICIT bare `gh pr merge` #1203) — a target-blind
+                     NUL-framed sentinel (_MERGE_IMPLICIT_SENTINEL), populated ONLY on
+                     op_type=='merge' when pr_number is absent (never close — the
+                     merge-only populate-site); distinct key so it never
+                     cross-authorizes an explicit pr_number
         branch:     str  (branch-delete — SINGLE target, exactly 1 positional)
         branch_set: str  (branch-delete — MULTI target #1129, >=2 positionals) —
                      canonical sort+dedup+quote-strip names via the shared netstring _canonical_join (`len:name` framing,
@@ -2102,6 +2107,29 @@ def extract_command_context(command: str, flag_scan_text: str | None = None) -> 
                 pr_number = _extract_api_merge_pr(command)   # #1096 API pulls/<N>/merge
         if pr_number is not None:
             context["pr_number"] = pr_number
+        elif op_type == "merge" and _GH_PR_MERGE_RE.search(
+            _executed_surface_view(command)
+        ):
+            # #1203 KD-8 — TARGET-BLIND sentinel for the faithful bare CLI `gh pr merge`
+            # (and `--admin`/`--squash` with no number), whose target is the current-
+            # branch PR = runtime state resolvable only by a network gh-API call at mint
+            # time (infeasible in-hook) → the same target-blind treatment as the force-
+            # push sentinel. Reached ONLY when pr_number is absent. Guarded THREE ways:
+            #   (1) MERGE-ONLY (op_type=="merge"): #1134 dissolved the bare `gh pr close`
+            #       (a close REQUIRES a target / is non-runnable), so a close must NEVER
+            #       mint this — the populate-site guarantees a close can't carry the key.
+            #   (2) CLI-SHAPE-ONLY (_GH_PR_MERGE_RE on the quote-masked view — the SAME
+            #       surface the detect CLI-merge arm uses): an API merge
+            #       (`gh api … /pulls/N/merge`) ALWAYS carries an explicit endpoint PR,
+            #       never a current-branch target, so it must NOT get the target-blind
+            #       sentinel; when its pr extractor yields nothing (malformed / neutered)
+            #       the command stays gated-but-unmintable, not sentinel-minted. Masking
+            #       the view keeps a quoted `gh pr merge` decoy in a flag value from
+            #       tripping the CLI shape.
+            # Distinct typed key (not pr_number) so an implicit-merge token cannot
+            # cross-authorize an explicit `gh pr merge 42` and vice-versa. is_dangerous
+            # is unchanged (still True): target-PRECISION mint, never un-gating.
+            context["merge_implicit"] = _MERGE_IMPLICIT_SENTINEL
     elif op_type == "branch-delete":
         # Single-branch scalar path (BYTE-IDENTICAL): exactly ONE positional.
         branch = _extract_branch_name(command)

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -1037,20 +1037,16 @@ def _extract_close_target(command: str) -> str | None:
     return _classify_pr_target(target)
 
 
-# #1203 M1 — MERGE positional-walk value-flags: the MERGE-SPECIFIC value-taking flags
-# whose value token must be stripped so the branch/url TARGET positional is isolated.
-# EXACTLY the 5 `gh pr merge` value flags (gh 2.96.0 `gh pr merge --help` census,
-# test-engineer #68) — deliberately NOT the gh-pr-WIDE _GH_PR_VALUE_TAKING_FLAGS union
-# (which carries close/review-only flags ABSENT from merge: --comment, --match-head-commit,
-# --max-retries, --retry-count, --timeout) and NOT close's {--repo,--comment}. Merge-
-# SPECIFIC for the SAME reason _gh_close_positionals is close-specific: a wider set could
-# mis-parse a NON-runnable merge's positional (symmetry with the close walk). Booleans
-# (--admin/--auto/-s/-r/-m/-d) are EXCLUDED — they take no value, so they never consume
-# the target positional.
-_GH_MERGE_VALUE_LONG = frozenset(
-    {"--author-email", "--body", "--body-file", "--subject", "--repo"}
+# #1203 M1 — MERGE positional-walk value-flags: the merge value-taking flags whose value
+# token must be stripped so the branch/url TARGET positional is isolated — the SAME set
+# C1b established (the long value SSOT + --repo + the short aliases), NOT close's
+# {--repo,--comment}. DERIVED from the C1b sets so there is ONE value-flag SSOT: a merge
+# value-flag added for inert-help recognition is automatically honored by the target walk
+# too (the divergent-copies bug class this arc kept hitting cannot recur).
+_GH_MERGE_VALUE_LONG = _GH_PR_VALUE_TAKING_FLAGS | {"--repo"}
+_GH_MERGE_VALUE_SHORT = frozenset(
+    f[1] for f in _INERT_HELP_EXTRA_VALUE_FLAGS if len(f) == 2 and f[0] == "-"
 )
-_GH_MERGE_VALUE_SHORT = frozenset("AbFtR")   # -A/-b/-F/-t/-R (no -c: merge has no --comment)
 
 
 def _gh_merge_positionals(tokens: "list[str]") -> "list[str] | None":

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -934,6 +934,42 @@ def _gh_close_positionals(tokens: "list[str]") -> "list[str] | None":
     return positionals
 
 
+def _classify_pr_target(target: str) -> str | None:
+    """Classify a single ALREADY-QUOTE-STRIPPED gh-pr positional into one of FOUR
+    disjoint identity namespaces — the SHARED SSOT (#1203 M1) for BOTH the close and
+    the merge target identity, so the two can never diverge:
+
+    - empty / degenerate         -> None (abstain, never a garbage id)
+    - bare digits                -> the digits (repo-IMPLICIT PR number, gh's number
+                                    precedence)
+    - a github/enterprise PR URL -> ``url:<host>/<owner>/<repo>#<N>`` (HOST- and
+                                    repo-QUALIFIED, so a cross-host/cross-repo url can
+                                    never set-equal a bare number or a same-number url
+                                    in a different repo)
+    - a ``://``-bearing token that is NOT a recognized PR URL -> None (abstain, never a
+                                    garbage ``branch:`` id)
+    - anything else              -> ``branch:<name>`` (repo-IMPLICIT name-only;
+                                    cross-repo distinction is carried SEPARATELY by
+                                    ``--repo`` in bound_flags, the a2 axis)
+
+    Extracted VERBATIM from _extract_close_target's classification tail so close's
+    output stays byte-identical; _extract_merge_target feeds it a MERGE-value-flag-aware
+    positional (its own walk) — the CLASSIFICATION is shared, the positional walk is
+    op-specific. A branch literally named ``url:x`` classifies ``branch:url:x`` (no
+    ``://`` -> the branch namespace), never colliding with a real ``url:`` identity —
+    the namespaces are injective by construction."""
+    if not target:
+        return None  # empty/degenerate positional -> abstain, never a garbage id
+    if target.isdigit():
+        return target  # bare PR number — gh's number precedence, repo-implicit
+    url = _GH_PULL_URL_RE.search(target)
+    if url is not None:
+        return "url:" + url.group(1) + "/" + url.group(2) + "#" + url.group(3)
+    if "://" in target:
+        return None  # unrecognized URL form -> abstain, never a garbage branch id
+    return "branch:" + target
+
+
 def _extract_close_target(command: str) -> str | None:
     """The close-target identity for a faithful ``gh pr close`` command, across
     all three positional forms gh accepts (``{<number> | <url> | <branch>}``).
@@ -993,18 +1029,101 @@ def _extract_close_target(command: str) -> str | None:
     if positionals is None or len(positionals) != 1:
         return None
     target = _strip_surrounding_quotes(positionals[0])
-    if not target:
-        return None  # empty/degenerate positional -> abstain, never a garbage id
-    # Classify the SINGLE positional (value-flag values already stripped, so a
-    # digit/url/branch here IS the target, never a --repo/--comment value).
-    if target.isdigit():
-        return target  # bare PR number — gh's number precedence, repo-implicit
-    url = _GH_PULL_URL_RE.search(target)
-    if url is not None:
-        return "url:" + url.group(1) + "/" + url.group(2) + "#" + url.group(3)
-    if "://" in target:
-        return None  # unrecognized URL form -> abstain, never a garbage branch id
-    return "branch:" + target
+    # #1203 M1 — classify via the SHARED _classify_pr_target SSOT (extracted VERBATIM
+    # from here, so close's output is byte-identical; merge reuses the SAME classifier
+    # over its OWN merge-value-flag-aware positional walk). Value-flag values are
+    # already stripped by _gh_close_positionals, so the digit/url/branch here IS the
+    # target, never a --repo/--comment value.
+    return _classify_pr_target(target)
+
+
+# #1203 M1 — MERGE positional-walk value-flags: the merge value-taking flags whose value
+# token must be stripped so the branch/url TARGET positional is isolated — the SAME set
+# C1b established (the long value SSOT + --repo + the short aliases), NOT close's
+# {--repo,--comment}. DERIVED from the C1b sets so there is ONE value-flag SSOT: a merge
+# value-flag added for inert-help recognition is automatically honored by the target walk
+# too (the divergent-copies bug class this arc kept hitting cannot recur).
+_GH_MERGE_VALUE_LONG = _GH_PR_VALUE_TAKING_FLAGS | {"--repo"}
+_GH_MERGE_VALUE_SHORT = frozenset(
+    f[1] for f in _INERT_HELP_EXTRA_VALUE_FLAGS if len(f) == 2 and f[0] == "-"
+)
+
+
+def _gh_merge_positionals(tokens: "list[str]") -> "list[str] | None":
+    """The positional args of a ``gh pr merge`` token list, with MERGE value-taking flags
+    AND their values removed (mirrors _gh_close_positionals's cobra walk, but over the
+    MERGE value-flag set — NOT close's {--repo,--comment}: a merge form carries
+    --subject/--body/-t/… so close's walk would mis-read a value as the target, reviving
+    M1 one layer down). Returns the positionals after ``merge``, or None if ``merge`` is
+    absent. A value-flag VALUE can never survive as a positional, so it can never be
+    mis-bound as the {number|url|branch} target."""
+    try:
+        i = tokens.index("merge") + 1
+    except ValueError:
+        return None
+    positionals: "list[str]" = []
+    n = len(tokens)
+    while i < n:
+        tok = tokens[i]
+        if tok.startswith("--"):
+            flag, has_eq, _v = tok.partition("=")
+            i += 2 if (flag in _GH_MERGE_VALUE_LONG and not has_eq) else 1
+            continue
+        if tok.startswith("-") and tok != "-":
+            body = tok[1:]
+            consumes_next = False
+            for j, ch in enumerate(body):
+                if ch in _GH_MERGE_VALUE_SHORT:
+                    consumes_next = j == len(body) - 1   # `-R value`; else `-Rvalue`
+                    break
+            i += 2 if consumes_next else 1
+            continue
+        positionals.append(tok)
+        i += 1
+    return positionals
+
+
+def _extract_merge_target(command: str) -> str | None:
+    """The EXPLICIT merge-target identity for a faithful ``gh pr merge <branch>`` /
+    ``<url>`` (or ``<number>``, though _extract_pr_number owns that first), or None
+    (#1203 M1). Closes the cross-auth where every NON-numeric merge collapsed into the
+    target-blind merge_implicit sentinel: it isolates the target positional via the
+    MERGE-value-flag-aware _gh_merge_positionals (so ``--subject foo`` is NOT read as the
+    target), requires EXACTLY ONE positional (0 = truly-bare -> the caller mints
+    merge_implicit; >=2 = ambiguous -> abstain, gated-but-unmintable, the cross-auth-SAFE
+    direction), then classifies it via the SHARED _classify_pr_target (namespaces
+    IDENTICAL to close: number / url:<host>/<owner>/<repo>#N / branch:<name>). Abstains on
+    unbalanced quote / procsub / no merge token — the existing safe posture; mint==read
+    holds because BOTH hook arms derive via extract_command_context."""
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        return None
+    tokens = _shell_tokenize(prefix)
+    if tokens is None:
+        return None
+    positionals = _gh_merge_positionals(tokens)
+    if positionals is None or len(positionals) != 1:
+        return None
+    return _classify_pr_target(_strip_surrounding_quotes(positionals[0]))
+
+
+def _is_bare_cli_merge(command: str) -> bool:
+    """True iff ``command`` is a TRULY-BARE CLI ``gh pr merge`` — the CLI merge shape
+    (_GH_PR_MERGE_RE on the quote-masked view, which excludes an API merge that always
+    carries an explicit endpoint PR) with ZERO real positional target (flags-only). This
+    is the ONLY form that mints the target-blind merge_implicit sentinel (#1203 M1: a
+    branch/url positional binds an explicit target via _extract_merge_target instead; a
+    >=2 ambiguous count abstains). The 0-positional test uses the SAME _gh_merge_positionals
+    walk _extract_merge_target uses, so bare-vs-explicit is ONE boundary (no double-count)."""
+    if not _GH_PR_MERGE_RE.search(_executed_surface_view(command)):
+        return False
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        return False
+    tokens = _shell_tokenize(prefix)
+    if tokens is None:
+        return False
+    return _gh_merge_positionals(tokens) == []
 
 
 def _extract_api_ref(command: str) -> str | None:
@@ -2051,12 +2170,17 @@ def extract_command_context(command: str, flag_scan_text: str | None = None) -> 
         operation_type: "merge" | "close" | "force-push" | "branch-delete"
                         | "push-to-main" | "remote-ref-delete" | "remote-mass-delete"
                         | "branch-protection"
-        pr_number:  str  (merge / close)
-        merge_implicit: str (merge IMPLICIT bare `gh pr merge` #1203) — a target-blind
-                     NUL-framed sentinel (_MERGE_IMPLICIT_SENTINEL), populated ONLY on
-                     op_type=='merge' when pr_number is absent (never close — the
-                     merge-only populate-site); distinct key so it never
-                     cross-authorizes an explicit pr_number
+        pr_number:  str  (merge / close) — the EXPLICIT PR/target identity: a bare
+                     number, OR (close + merge #1203 M1) a `url:<host>/<owner>/<repo>#N`
+                     / `branch:<name>` namespaced identity via the shared
+                     _classify_pr_target; op-type-first keeps merge⊥close
+        merge_implicit: str (merge IMPLICIT truly-bare `gh pr merge` #1203) — a
+                     target-blind NUL-framed sentinel (_MERGE_IMPLICIT_SENTINEL),
+                     populated ONLY on op_type=='merge' when pr_number is absent AND the
+                     command is truly-bare (_is_bare_cli_merge: CLI shape + ZERO real
+                     positional target; an explicit branch/url binds pr_number above, a
+                     >=2-positional form abstains; never close); distinct key so it never
+                     cross-authorizes an explicit pr_number (number/branch/url)
         branch:     str  (branch-delete — SINGLE target, exactly 1 positional)
         branch_set: str  (branch-delete — MULTI target #1129, >=2 positionals) —
                      canonical sort+dedup+quote-strip names via the shared netstring _canonical_join (`len:name` framing,
@@ -2127,29 +2251,36 @@ def extract_command_context(command: str, flag_scan_text: str | None = None) -> 
             pr_number = _extract_pr_number(command)
             if pr_number is None:
                 pr_number = _extract_api_merge_pr(command)   # #1096 API pulls/<N>/merge
+            if pr_number is None:
+                # #1203 M1 — the EXPLICIT `gh pr merge <branch>`/`<url>` target. Mirrors
+                # close's {number|url|branch} bind via the SHARED _classify_pr_target, so
+                # a branch/url merge binds a DISTINCT explicit identity (branch:<name> /
+                # url:<host>/<owner>/<repo>#N) instead of the target-blind sentinel —
+                # closing the M1 cross-auth (every non-numeric merge previously collapsed
+                # to one identity). The positional is isolated by the MERGE-value-flag
+                # walk (_extract_merge_target), NOT close's, so a value like
+                # `--subject foo` is not mis-read as the branch. Reuses close's hardened
+                # host-qualified/injective identity logic; bound to pr_number (already a
+                # four-site mint key) so op-type-first keeps merge⊥close.
+                pr_number = _extract_merge_target(command)
         if pr_number is not None:
             context["pr_number"] = pr_number
-        elif op_type == "merge" and _GH_PR_MERGE_RE.search(
-            _executed_surface_view(command)
-        ):
-            # #1203 KD-8 — TARGET-BLIND sentinel for the faithful bare CLI `gh pr merge`
-            # (and `--admin`/`--squash` with no number), whose target is the current-
-            # branch PR = runtime state resolvable only by a network gh-API call at mint
-            # time (infeasible in-hook) → the same target-blind treatment as the force-
-            # push sentinel. Reached ONLY when pr_number is absent. Guarded THREE ways:
-            #   (1) MERGE-ONLY (op_type=="merge"): #1134 dissolved the bare `gh pr close`
-            #       (a close REQUIRES a target / is non-runnable), so a close must NEVER
-            #       mint this — the populate-site guarantees a close can't carry the key.
-            #   (2) CLI-SHAPE-ONLY (_GH_PR_MERGE_RE on the quote-masked view — the SAME
-            #       surface the detect CLI-merge arm uses): an API merge
-            #       (`gh api … /pulls/N/merge`) ALWAYS carries an explicit endpoint PR,
-            #       never a current-branch target, so it must NOT get the target-blind
-            #       sentinel; when its pr extractor yields nothing (malformed / neutered)
-            #       the command stays gated-but-unmintable, not sentinel-minted. Masking
-            #       the view keeps a quoted `gh pr merge` decoy in a flag value from
-            #       tripping the CLI shape.
-            # Distinct typed key (not pr_number) so an implicit-merge token cannot
-            # cross-authorize an explicit `gh pr merge 42` and vice-versa. is_dangerous
+        elif op_type == "merge" and _is_bare_cli_merge(command):
+            # #1203 KD-8 + M1 — TARGET-BLIND sentinel for ONLY the TRULY-BARE CLI
+            # `gh pr merge` (and `--admin`/`--squash` — flags-only, ZERO positional
+            # target), whose target is the current-branch PR = runtime state resolvable
+            # only by a network gh-API call at mint time (infeasible in-hook). Guarded:
+            #   (1) MERGE-ONLY (op_type=="merge"): #1134 dissolved bare `gh pr close`, so
+            #       a close must NEVER mint this — the populate-site can't carry the key.
+            #   (2) TRULY-BARE ONLY (_is_bare_cli_merge — CLI shape AND 0 real positionals
+            #       via the merge value-flag walk): an EXPLICIT branch/url target already
+            #       bound pr_number above (the M1 cross-auth fix), and a >=2 ambiguous
+            #       count abstains (gated-but-unmintable, cross-auth-safe) — never the
+            #       sentinel. The CLI-shape check also excludes an API merge (which always
+            #       carries an explicit endpoint PR).
+            # DISTINCT typed key (not pr_number) so an implicit-merge token cannot cross-
+            # authorize an EXPLICIT merge — now TRUE for number AND branch AND url (every
+            # explicit form binds pr_number; op-type-first keeps merge⊥close). is_dangerous
             # is unchanged (still True): target-PRECISION mint, never un-gating.
             context["merge_implicit"] = _MERGE_IMPLICIT_SENTINEL
     elif op_type == "branch-delete":

--- a/pact-plugin/tests/fixtures/merge_guard_baseline/merge_guard_common_5017d1f2.py
+++ b/pact-plugin/tests/fixtures/merge_guard_baseline/merge_guard_common_5017d1f2.py
@@ -1,0 +1,4935 @@
+"""
+Location: pact-plugin/hooks/shared/merge_guard_common.py
+Summary: Shared constants and utilities for the merge guard hook pair.
+Used by: merge_guard_pre.py (PreToolUse) and merge_guard_post.py (PostToolUse)
+
+================================ THREAT MODEL ================================
+HONEST-MISTAKE PREVENTION — read this BEFORE "hardening" the guard.
+
+The merge guard exists to route an HONEST destructive command through the
+operator's AskUserQuestion approval click: it catches an agent about to run a
+real destructive git/gh operation BY MISTAKE and asks the operator to confirm.
+It is NOT an adversarial sandbox and makes NO attempt to stop a determined
+evader.
+
+INVARIANT (supersedes everything): a faithful single-command click ALWAYS mints
+a token and executes. A faithful operator clicks the option carrying the command
+(`gh pr merge 5`, `gh pr close 5 --delete-branch`, even `gh pr merge 5 --admin`)
+→ it mints → the command runs. ANYTHING that can block a faithful single-command
+click is WRONG BY DEFINITION — over-blocking a faithful click is a worse failure
+than not catching an obfuscated one.
+
+EXPLICITLY OUT OF SCOPE (these are NOT bugs; do NOT "fix" them — a blind
+adversarial sweep that "finds" them must NOT re-trigger hardening, because the
+hardening that catches them also blocks faithful clicks):
+  - quote-concat / quote-elision in the op keyword: `gh pr ''merge`,
+    `gh pr "merge"`, `g'h' pr merge`, `gh pr m'erge'` — an honest agent does not
+    obfuscate the command it intends to run.
+  - command-as-data via an interpreter pipe / substitution / eval:
+    `echo '...' | sh`, `$(echo '...')`, `eval "$CMD"` — deliberate evasion, not a
+    mistake.
+  - runtime $-expansion hiding the op or a flag: `gh pr $VERB 5`,
+    `gh pr merge 5 $FLAGS` — the hook only sees the pre-expansion literal an
+    honest agent typed.
+  - attached / equals API flag-spelling evading the literal pattern:
+    `gh api -XDELETE`, `--method=DELETE`.
+A metachar/quote SUPPRESSOR for the above (the removed shell-semantic over-block
+layer) re-blocks faithful clicks — e.g. it over-blocked
+`gh pr close 7 --comment "(done)" --delete-branch` — which is why it was removed.
+Keep detection LITERAL and faithful-click-safe; do not re-introduce an
+adversarial parser or a fail-closed metachar/quote SUPPRESSOR. This is distinct from
+the KEPT additive flag-normalization arm (_flag_condition_danger_op), which only ADDS
+recognition of canonical flag spellings via a quote-aware tokenize and ABSTAINS on a
+parse failure — it can only OVER-block, never suppress, so do NOT strip it as
+"non-literal."
+
+What the guard DOES recognize (the honest-command surface only): the literal
+destructive patterns (DANGEROUS_PATTERNS); canonical flag SPELLINGS an honest
+agent actually types (close `-d`/`-cd`, branch `-Df`/`-fD`); the privileged-flag
+bind (set-equality of approved vs executed flags, so an honest re-run that ADDS a
+privilege re-prompts rather than silently escalating); and faithful-click region/
+quote handling so a quoted argument never truncates the approved command.
+
+rm-EXCEPTION (deliberate, documented so a future sweep does NOT "discover" a gap):
+the compound-destructive count (is_compound_destructive_command) treats a plain-`rm`
+head leg as destructive, so a recognized git/gh op chained with an `rm`
+(`gh pr merge 5 && rm -rf /`) is refused as a 2-destructive-leg mistake. This is
+rm-SPECIFIC by design — NOT a general filesystem-destroyer detector: `dd`, `mkfs`,
+`shred`, `truncate`, etc. are OUT OF SCOPE (do NOT add them — honest-mistake posture,
+no obfuscation-chasing: plain `rm` head only, not `/bin/rm`, `r''m`, `$(echo rm)`).
+And rm is deliberately ABSENT from is_dangerous_command, so a BARE `rm -rf /` and a
+PURE-rm chain (`rm -rf a && rm -rf b`) stay is_dangerous=False and are NEVER gated —
+the guard stays out of pure-filesystem commands.
+
+benign-CONTINUATION (the dual of the rm-EXCEPTION; documented so a future sweep does
+NOT "discover" the single-leg mint and "harden" it away): for EVERY recognized
+destructive op — gh pr merge, gh pr close, git force-push, AND git branch-delete — a
+SINGLE such op + ANY benign continuation mints a token AND the read side authorizes the
+continued command. "Benign" means the remainder is NOT a second destructive git/gh op —
+it need NOT be read-only (a `tee` or an output redirect WRITES a file and is still
+benign). A benign chain (`gh pr merge 5 && echo ok`, `gh pr merge 5 ; echo done`), a
+backgrounding (`gh pr merge 5 &`), a pipe to a pager/filter or `tee`
+(`gh pr merge 5 | tail`, `gh pr merge 5 | tee log`), or an output / fd redirect
+(`gh pr merge 5 > out.log`, `git push --force origin main 2>&1`,
+`git branch -D feature > log`) is a faithful single-command click:
+is_compound_destructive_command refuses ONLY on >=2 destructive legs (one destructive
+leg + benign continuation is NOT compound), and the read-side target is re-derived from
+the SINGLE destructive leg — the merge/close PR-NUMBER positional, the branch-delete
+name, OR the force-push ref — regardless of any trailing continuation / redirect tokens,
+so the approval still binds. (The positional extractors truncate at the first benign
+terminator on the quote-masked view; the read call site isolates the single destructive
+leg before deriving op/target/flags.) This is the GENERAL single-destructive-op-plus-
+benign-remainder pattern, NOT a recognition allow-list of viewers/filters — do NOT
+enumerate viewers in detection logic (an allow-list drifts and would re-block faithful
+clicks the count already mints).
+
+conservative-RECOGNITION (the design rule; documented so a future sweep does NOT
+"discover" these forms and "harden" them into faithful-click over-blocks): recognition
+targets the SINGLE destructive command an honest agent runs (the destructive op plus the
+benign viewers/filters/redirects of benign-CONTINUATION above) and ERRS TOWARD LETTING
+THROUGH — over-blocking a faithful click is WRONG BY DEFINITION (the INVARIANT above),
+worse than missing a buried op. The ENTIRE flag-condition union arm
+(_flag_condition_danger_op) needs a positional, quote-aware parse — the
+close/branch-delete/force-push flag conditions AND the git-push remote-ref-delete
+(`:ref` / `--delete` / `-d`) / mass-delete (`--mirror` / `--prune` / multi-ref)
+extractors — so THIS FUNCTION is ANCHORED to the FIRST executable leg (the
+_executable_prefix view), deriving both POSITIONALS and FLAGS from that ONE leg
+(deriving flags from the WHOLE command while positionals came from the first leg let a
+force/delete flag in a benign continuation leg mislabel a benign first-leg op — the
+cross-leg flag leak).
+
+ANY-LEG reach is the CALLERS' (`_PER_LEG_OPS`, below): they re-invoke this same arm on
+each ISOLATED leg. That is NOT a match-anywhere scan — the distinction is the whole
+point. A match-anywhere scan fires on a quoted `:ref` / `--mirror` mention in a benign
+leg (a faithful-click over-block); a per-leg re-invocation runs the SAME positional,
+quote-aware parse on a leg that is its own first leg, so a mention inside a benign leg
+is a mention, not an op. Leg-locality is preserved BY CONSTRUCTION: the derivation is
+per-leg on both axes, so the cross-leg flag leak cannot reappear through this route.
+Consequently these forms DO gate in any leg position:
+  - `cd /repo && git push origin --delete main`
+  - `git fetch && git push --mirror origin`
+  - `NOTE=x ; git push origin :main`
+  - `cd /repo && git branch -Df temp`   (cluster force-delete)
+  - `cd /repo && gh pr close 5 -d`      (short `-d` close)
+The earlier design accepted these as UNGATED, on the premise that reaching them required
+a match-anywhere scan. That premise was false — the per-leg predicate reaches them with
+no match-anywhere behavior — and leaving them ungated was a good-faith-reachable
+under-block, so they were closed. What must NOT be "fixed" is the literal arms' word
+boundary: granting delete tokens match-anywhere coverage IS the over-block this design
+rule guards, and it remains guarded. httpie
+(`http` / `https` CLI) is likewise WHOLLY ungated by design — ref-mutation, merge, AND
+protection-mutation — because the MINT classifier covers gh-api / curl / wget only; ANY
+httpie read-floor arm re-creates a gated-but-unmintable over-block. Ungated keeps read == mint.
+NB the first-leg anchoring is a property of `_flag_condition_danger_op` ITSELF, not of the
+guard's leg coverage. TWO independent mechanisms deliver ANY-LEG reach, and both are
+per-leg rather than match-anywhere: the LITERAL danger arms (the DANGEROUS_PATTERNS bank
++ the per-leg literal-arm tuples: force-push, branch-delete, close, API ref/protection)
+match in ANY leg position (`cd /repo && git push --force origin main` is caught); and the
+accurate refspec-DST predicate `_flag_condition_danger_op` is additionally invoked PER-LEG
+by its callers (detect_command_operation_type + _stripped_surface_danger), filtered to
+`_PER_LEG_OPS` — so `cd /repo && git push origin main` is caught. That filter carries ALL
+SIX union-arm classes, so the delete/mirror/:ref forms gate in any leg too. The two
+mechanisms OVERLAP on some forms (e.g. `cd /repo && git branch -D temp` is covered by
+both); when proving either one is load-bearing, isolate it — an assertion that exercises
+the whole pipeline passes while one mechanism is silently dead. When an over-block of a
+faithful click is found, the fix WIDENS the mint, never narrows detection into a new
+under-block.
+=============================================================================
+
+Centralizes TOKEN_TTL, TOKEN_DIR, TOKEN_PREFIX, consumed-token cleanup,
+the regex-prefix constants (_GH_PREFIX, _GIT_PREFIX, etc.) and the
+canonical destructive-command operation-type classifier
+detect_command_operation_type. Both hooks call this classifier on the
+SAME input when the prose-embed convention holds, guaranteeing
+bidirectional write/read classification agreement (issue #720 Bug B).
+
+Token-lifecycle invariants (pinned by tests/test_merge_guard.py class
+TestTokenLifecycleInvariants):
+
+  I-1 (at most one unused token at any time):
+      cleanup_unused_tokens() is called from write_token() BEFORE
+      os.open(O_EXCL). Any prior unused token is atomically renamed to
+      .consumed before the new one exists on disk.
+
+  I-2 (successful operation immediately retires the token):
+      merge_guard_post.main() Bash branch detects successful
+      `gh pr merge` (dict-shape tool_response + interrupted=false +
+      op_type=merge + "Merged pull request" in stdout) and atomically
+      renames the consuming token to .consumed regardless of MAX_USES.
+
+  I-3 (TTL expiry retires the token):
+      merge_guard_pre.find_valid_token enforces `expires_at < now` and
+      removes expired tokens via _safe_remove. Audit-only invariant in
+      this module (no helper here; pinned by alias test).
+
+  I-4 (failed operation preserves token for retry within TTL up to MAX_USES):
+      merge_guard_pre._consume_token N-use slot semantics. .use-N
+      markers atomically claim slots via O_EXCL; final slot triggers
+      terminal .consumed rename. Audit-only invariant in this module.
+
+  I-5 (cross-session tokens never valid):
+      merge_guard_pre.find_valid_token enforces
+      current_session == token_session when both are present. Audit-
+      only invariant in this module.
+
+Cross-cutting cleanup: cleanup_orphan_tokens() reaps unconsumed tokens
+whose mtime exceeds ORPHAN_TOKEN_MAX_AGE_SECONDS (12x TOKEN_TTL).
+Triggered from merge_guard_pre.find_valid_token (primary, load-bearing
+on every dangerous-Bash precheck) and session_init.main (secondary,
+eager-cleanup at session start). Disk-hygiene defense — not a primary
+security check; the primary check is I-3 TTL expiry (bounded by TOKEN_TTL).
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import re
+import shlex
+import time
+from collections.abc import Sequence
+from pathlib import Path
+from typing import NamedTuple
+
+from .paths import get_claude_config_dir
+
+# Token TTL in seconds
+TOKEN_TTL = 900
+
+# Directory for token files. B2 (import-time binding): CLAUDE_CONFIG_DIR is
+# fixed per-process before this module is imported, so an eager SSOT-derived
+# read is production-correct here; the merge-guard tests patch THIS attribute
+# (not the env), so they stay valid and non-vacuous. Derive from the SSOT
+# resolver eagerly — do NOT re-hardcode Path.home()/".claude" (that breaks the
+# single-source-of-truth). Convert to a call-time accessor only if call-time
+# env-following is ever needed (TOKEN_DIR's write+read are both PACT-side, so it
+# never needs to follow a post-import env change).
+TOKEN_DIR = get_claude_config_dir()
+
+# Token file prefix
+TOKEN_PREFIX = "merge-authorized-"
+
+# Default max-use budget per authorization token. A token can authorize up
+# to MAX_USES identical-context retries within TOKEN_TTL before requiring
+# fresh AskUserQuestion approval. Set to 2 — the smallest N that resolves
+# the empirical retry-on-transient-failure case (single retry of an
+# identical command) without further eroding per-use-confirmation
+# discipline. A third identical retry still re-prompts via
+# AskUserQuestion, preserving the "stop and reconsider" checkpoint.
+# Audit: tightening this value is always safe (more re-prompting);
+# loosening (N>2) requires empirical justification — there is no current
+# case that needs >2 same-context retries.
+MAX_USES = 2
+
+# Suffix used by per-use marker files. Each marker file is created via
+# O_EXCL to atomically claim one use slot of an N-use token (#720 Bug C).
+USE_MARKER_SUFFIX = ".use-"
+
+# Orphan-token cleanup threshold, derived as a fixed multiple of TOKEN_TTL so the
+# two never drift. Tokens that survive past this window without being consumed or
+# used are reaped as disk hygiene — they cannot be legitimate (TOKEN_TTL already
+# expires them for authorization). 12x TOKEN_TTL gives strong margin against any
+# legitimate in-flight token while aggressively bounding accumulation. Disk-hygiene
+# defense — not a primary security check; the primary check is TOKEN_TTL expiry
+# (invariant I-3).
+ORPHAN_TOKEN_MAX_AGE_SECONDS = 12 * TOKEN_TTL
+
+# Layer 1 Block 3 (gh CLI / git semantic signal) per op_type — SEC-S2 cycle-2.
+# Each value is a substring that MUST appear in tool_response.stdout for the
+# op_type's successful invocation to retire the consuming token. A value of
+# None means "skip Block 3 for this op_type": the 3-block predicate degrades
+# to 2 blocks (Block 1 op_type match + Block 2 platform success signal).
+# force-push uses None because git push --force emits primarily to STDERR;
+# the empty-STDOUT case is fail-closed-on-no-signal (no retirement degrades
+# to TTL/MAX_USES safety net). New op_types: add 1 entry + tests; no other
+# changes required (lookup table is the SSOT, mirrors DANGEROUS_PATTERNS
+# convention).
+LAYER1_SUCCESS_STDOUT_PATTERNS: dict[str, str | None] = {
+    "merge": "Merged pull request",
+    "close": "Closed pull request",
+    "branch-delete": "Deleted branch",
+    "force-push": None,
+    # push-to-main (GAP3): a plain `git push` to main/master — emits to STDERR like
+    # force-push, so None (Block 3 skipped; Block 2 platform-success is load-bearing,
+    # fail-closed-on-no-signal → TTL/MAX_USES safety net, not bypass).
+    "push-to-main": None,
+}
+
+# -----------------------------------------------------------------------------
+# Regex prefix constants — shared between DANGEROUS_PATTERNS (read-side) and
+# detect_command_operation_type (both sides). Centralized here so the
+# write-side classifier can apply the SAME prefix semantics as the read-side
+# pattern bank without duplicating regex source.
+# -----------------------------------------------------------------------------
+
+# Upper bound on flag tokens in a CLI flag region. Governs BOTH the global-flag
+# prefix between a tool and its subcommand (e.g. `git -c k=v ... push`) AND the
+# push-dash-flag walk between `push` and its refspec (e.g. `git push -u -f main`).
+# The global-flag prefix bound eliminates the O(n^2) multi-anchor backtracking of
+# the unbounded `*` form (#1001); the push-dash-flag walk bound is defense-in-
+# depth structural-linearity (that walk was already linear once the prefix is
+# bounded — bounding the inner walk makes its linearity intrinsic rather than
+# contingent). Both preserve the "matches any token" semantics EXACTLY for any
+# command with <= _MAX_GLOBAL_FLAG_TOKENS flag tokens in that region — i.e. every
+# realistic command (the heaviest realistic git global-flag count, e.g.
+# `git -c a=1 -c b=2 -C /p --git-dir=/g --work-tree=/w push ...`, is ~10 tokens;
+# gh is ~2; push dash-flags ~2-3). 32 is ~3x that headroom, and is a fixed modest
+# constant so per-anchor work is O(32)=O(1) regardless of input length.
+#
+# ACCEPTED RESIDUAL (honest INV-D2 accounting): a command with >32 *valid* flag
+# tokens before its verb/refspec is NOT impossible — `git -c k=v` is a
+# legitimate, repeatable pair, so e.g. `git -c a=1 -c b=2 ...(17 pairs=34
+# tokens)... push --force` DOES execute yet exceeds the bound, so the bounded
+# form misses a real destructive op the unbounded form caught. This is a
+# NARROW residual under-block, accepted as a documented tradeoff against the
+# O(n^2) DoS, justified by the THREAT MODEL: #1001's input is operator/LLM-
+# authored command text (defense-in-depth, NOT adversarial network input), and
+# padding 17+ `-c` pairs to evade one's OWN merge guard is self-defeating (the
+# author would simply write the command directly). The push-dash-flag walk
+# carries the SAME residual class but is even less reachable (push dash-flags are
+# not meaningfully infinitely-repeatable; a flag with a non-dash value, e.g.
+# `-o <opt>`, already breaks the walk). It is a relaxation of INV-D2, not a
+# no-op — stated plainly rather than papered over.
+# DO NOT raise this constant casually: a larger cap scales the per-anchor work,
+# and on a pathological multi-anchor input the constant factor grows measurably
+# (a larger value carries a real, if modest, cost — it is not free). Keep it a
+# small fixed value so per-anchor work stays O(1)/linear.
+_MAX_GLOBAL_FLAG_TOKENS = 32
+
+# Optional global flags between CLI tool and subcommand — BOUNDED (was `*`).
+_GH_GLOBAL_FLAGS  = r"(?:\S+\s+){0,%d}" % _MAX_GLOBAL_FLAG_TOKENS
+# Tight variant for PR-number extraction — UNCHANGED (already linear; requires
+# a leading `-` per token so it fails fast; used only by _GH_PR_NUMBER_RE).
+_GH_FLAG_TOKENS   = r"(?:-\S*(?:\s+\S+)?\s+)*"
+_GIT_GLOBAL_FLAGS = r"(?:\S+\s+){0,%d}" % _MAX_GLOBAL_FLAG_TOKENS
+
+# Composed prefixes for DRY usage across all patterns.
+_GH_PREFIX = r"\bgh\s+" + _GH_GLOBAL_FLAGS
+_GIT_PREFIX = r"\bgit\s+" + _GIT_GLOBAL_FLAGS
+_GH_API_PREFIX = _GH_PREFIX + r"api\b"
+
+# The quote-BALANCED value token (#1118 re-model) — the single Q-SAFE primitive the
+# verb-message value strips consume via _strip_flag_values (arm 3, shared by carriers
+# 5/7/7b/7c/7d/8/9). A value token is a maximal run of bash quoted/escaped word pieces,
+# ending at unquoted whitespace. Because it consumes quoted spans ATOMICALLY it can never
+# bite a PARTIAL quoted span (a lone quote is not a complete `'…'`/`"…"`/`$'…'`), so it
+# structurally CANNOT emit a dangling quote into the `stripped` string that
+# _mask_shell_quotes / _slice_stripped_legs consume — the root-cause fix for the SEC-1/SEC-2
+# leg-merge regression. Its arm set mirrors _VERB_MSG_BODY below (bash's five quoting
+# mechanisms + backslash-escape), differing only in the plain-char class `[^\s'"$\\]` (a
+# value ends at unquoted whitespace) and the closing `+`. Inner quoted-span alternations are
+# first-char-disjoint (linear); the outer arms overlap only at the three `$`-initial arms, a
+# bounded per-unit ambiguity (both partitions reach the same offset) that cannot compound,
+# and the token matches only in trailing position so the greedy match never backtracks.
+# Linearity is verified empirically (the regex-perf suite + adversarial `$'…'`-repetition
+# timing).
+_VALUE_TOKEN = (
+    r"""(?:\\.|\$'(?:[^'\\]|\\.)*'|\$?"(?:[^"\\]|\\.)*"|'[^']*'|[^\s'"$\\]|\$)+"""
+)
+
+# Bash-faithful verb-message span BODY: a command's words from the verb to the first
+# UNQUOTED ;/&&/|/newline. Models ALL FIVE bash quoting mechanisms + backslash-escape so
+# it can NEVER desync quote-pairing and pair a `'` across a separator (the naive
+# `'[^']*'`-only body's leg-merge under-block). Arms in order:
+#   \\.                        backslash-escape OUTSIDE quotes (\'  \;  \&  \"  \\ …)
+#   \$'(?:[^'\\]|\\.)*'        ANSI-C  $'...'  (backslash honored inside)
+#   \$?"(?:[^"\\]|\\.)*"       double-quote "..." AND locale $"..." (backslash honored)
+#   '[^']*'                    single-quote '...'  (bash: NO escaping inside)
+#   [^&|;\n"'$\\]+             plain chars (excl. separators, quotes, $, backslash)
+#   \$                         a bare $ (e.g. $VAR)
+# Separators ;&|newline are excluded from EVERY arm, so the span stops at a real unquoted
+# separator. Shared SSOT for all verb-message carriers (5, 7/7b/7c/7d, curl) — replaces 7
+# former inline copies so they can never drift.
+_VERB_MSG_BODY = (
+    r"""(?:\\.|\$'(?:[^'\\]|\\.)*'|\$?"(?:[^"\\]|\\.)*"|'[^']*'|[^&|;\n"'$\\]+|\$)*"""
+)
+
+# Shared message-flag anchor (flag_sep group 1) for the sibling message-carrying git
+# verbs whose SOLE value-taking --m* option is --message — git merge, git stash
+# push/store, git notes add/append (verified via `git <verb> -h`, 2.50.1). The long
+# arm accepts any unambiguous abbreviation of --message (--m -> --message); the short
+# arm covers -m / bundled / attached. EXACTLY ONE capturing group (internals are all
+# non-capturing) so it satisfies the _strip_flag_values contract. This is byte-identical
+# to the git-commit anchor (carrier-5) but kept as a SEPARATE constant: the commit
+# carrier stays a self-contained literal, and git tag needs a DIFFERENT bounded variant
+# (its --merged/--no-merged collision), so the three are intentionally not unified.
+# The short cluster arm is TOKEN-START anchored `(?<!\S)` so it can only match a `-`
+# beginning a word: without it, `-[a-ln-zA-Z]*m` mis-matches MID-FLAG inside a longer
+# option (`-com` in `--committer`, `-adm` in `--admin`, `-am` in `--amend`), which lets
+# carrier-7e's git-merge span mangle a `git log --committer '…merge…'` surface and leave
+# the danger visible (an over-block). Genuine token-start clusters (`-m`, `-am`, `-cm`)
+# are whitespace-preceded so the anchor still admits them (no strip regression).
+_MSG_FLAG_ANCHOR = r"((?:--m(?:e(?:s(?:s(?:a(?:g(?:e)?)?)?)?)?)?|(?<!\S)-[a-ln-zA-Z]*m)\s*)"
+
+# Pre-compiled patterns for the operation-type classifier (consistent with
+# DANGEROUS_PATTERNS style).
+_GH_PR_MERGE_RE = re.compile(_GH_PREFIX + r"pr\s+merge\b")
+_GH_PR_CLOSE_RE = re.compile(_GH_PREFIX + r"pr\s+close\b")
+
+# Literal force-push arms — ONE arm-list SSOT consumed by BOTH the read floor
+# (is_dangerous_command) and the mint classifier (detect_command_operation_type),
+# so the two sides can never drift on a spelling. Matched PER-LEG over the shared
+# leg-boundary substrate (#1082): these arms' `.*` spans previously ran over the
+# WHOLE command, so a force-class flag in a benign continuation leg
+# (`git push origin feature && rm -f stale.txt`) gated the benign first-leg push —
+# one form (`git push && rm -f x.txt`) PERMANENTLY (no extractable target ->
+# unmintable). Semantics now: an arm fires iff push and the force-class flag
+# co-occur within ONE leg, in ANY leg position — `cd /repo && git push --force
+# origin main` still gates (deliberately DIFFERENT from the union arm's first-leg
+# anchoring; the literal floor keeps its match-anywhere purpose, per leg). Quoted
+# separators are handled by the substrate (a quoted `&&` is not a leg boundary) —
+# a tempered-regex span (`[^&|;]*`) would wrongly ungate that form.
+_FORCE_PUSH_LITERAL_ARMS = (
+    re.compile(_GIT_PREFIX + r"push\s+.*--force(?!-with-lease)\b"),
+    re.compile(_GIT_PREFIX + r"push\s+.*-f\b"),
+    re.compile(_GIT_PREFIX + r"push\s+-[a-zA-Z]*f"),
+)
+
+# leg-boundary substrate (#1087): these close arms' `.*`/lookahead previously ran
+# over the WHOLE stripped command, so a `--delete-branch` token in a benign
+# continuation leg fired the arm cross-leg. That over-reach ALSO laundered: the
+# ambiguous multi-close `gh pr close 42 && gh pr close 43 && echo --delete-branch`
+# was is_dangerous=True whole-command, so it minted a close token that AUTHORIZED an
+# escalated same-target single `gh pr close 42 --delete-branch`. Semantics now: an
+# arm fires iff `gh pr close` and `--delete-branch` co-occur within ONE leg, in ANY
+# leg position — so the ambiguous compound is is_dangerous=False per-leg (the mint
+# write-gate refuses -> no token -> laundering structurally dead) while a real
+# single-leg `gh pr close 42 --delete-branch` still gates. Quoted separators are
+# handled by the substrate (a quoted `&&` is not a leg boundary). Bodies are moved
+# VERBATIM from DANGEROUS_PATTERNS — the conversion changes WHERE they match
+# (per-leg vs whole-command), never WHAT they match.
+_CLOSE_LITERAL_ARMS = (
+    re.compile(_GH_PREFIX + r"pr\s+close\b(?=.*--delete-branch)"),   # forward
+    re.compile(r"--delete-branch.*" + _GH_PREFIX + r"pr\s+close\b"),  # reversed
+)
+
+# leg-boundary substrate (#1086): these 17 API danger arms' `.*` previously ran
+# over the WHOLE stripped command, so a mutating method / body-flag token in a
+# benign continuation leg (`gh api .../git/refs && echo -X DELETE`) over-blocked
+# the benign compound. Matched PER-LEG now: an arm fires iff the API client, the
+# mutating method (or implicit-POST body flag), and the target endpoint co-occur
+# within ONE leg. The negative-lookahead arms operate WITHIN a leg — a same-leg
+# explicit GET correctly excludes, and a body flag in a DIFFERENT leg no longer
+# wrongly includes. Bodies are moved VERBATIM from DANGEROUS_PATTERNS (flags —
+# re.IGNORECASE — lookaheads, and _GH_API_PREFIX/curl/wget prefixes unchanged);
+# the conversion changes WHERE they match, never WHAT they match. No-laundering
+# safety is preserved BY CONSTRUCTION, not by denylist-emptiness: an isolated API
+# leg is method-less hence detect-negative, so tier 2 abstains → symmetric
+# whole-command bind (the safe direction) — see TestEmergentDangerClassIsCloseOnly.
+_API_LITERAL_ARMS = (
+    # API-based merge bypasses (require mutating HTTP method to avoid blocking reads)
+    re.compile(_GH_API_PREFIX + r"(?=.*(?:-X|--method)\s+(?:PUT|PATCH|POST)\b).*merge", re.IGNORECASE),
+    re.compile(r"\bcurl\b(?=.*(?:-X|--request)\s+(?:PUT|PATCH|POST)\b).*api.*merge", re.IGNORECASE),
+    # API-based branch deletion via DELETE to git/refs endpoint.
+    # HOST-AGNOSTIC (#1061): the curl arms drop the literal `.*api.*` substring so a
+    # truly api-free Enterprise/proxy URL (e.g. https://git.example.com/repos/o/r/git/refs/...)
+    # no longer bypasses — bringing curl to parity with the already-host-agnostic
+    # gh-api/wget arms. The `api` key was an as-shipped heuristic (#268/#271), not a
+    # deliberated scope ruling; this WIDENS it. The over-block this widening would introduce
+    # on a quoted `-d` body mentioning git/refs is closed by carrier-8 (the HTTP-client
+    # data-body strip in _strip_non_executable_content) — the body value is stripped while
+    # the path-resident ref survives (PATH-vs-BODY invariant).
+    re.compile(_GH_API_PREFIX + r"(?=.*(?:-X|--method)\s+DELETE\b).*git/refs", re.IGNORECASE),
+    re.compile(r"\bcurl\b(?=.*(?:-X|--request)\s+DELETE\b).*git/refs", re.IGNORECASE),
+    # API-based ref mutation / force push via mutating method to git/refs endpoint
+    # (any mutating operation on git refs via API is inherently dangerous). Curl arm is
+    # host-agnostic (#1061) — see the DELETE arm note above.
+    re.compile(_GH_API_PREFIX + r"(?=.*(?:-X|--method)\s+(?:PATCH|POST|PUT)\b).*git/refs", re.IGNORECASE),
+    re.compile(r"\bcurl\b(?=.*(?:-X|--request)\s+(?:PATCH|POST|PUT)\b).*git/refs", re.IGNORECASE),
+    # Branch-protection API mutation (#1063): DELETE|PUT|PATCH on a
+    # `branches/<branch>/protection` endpoint WEAKENS protection (remove / replace /
+    # modify whole config). POST is EXCLUDED — it ENABLES protection sub-features
+    # (enforce_admins / required_signatures) = the STRENGTHENING direction, so gating it
+    # would over-block. HOST-AGNOSTIC (the #1061 lesson — no `.*api.*`). Explicit-method
+    # arms only (the protection endpoint has no implicit-POST danger like git/refs). The
+    # branch is PATH-resident, so carrier-8 never strips it (no preservation guard needed,
+    # unlike the body-resident contents arm). No httpie arm: the mint classifier's
+    # `_is_api_form` is gh-api/curl/wget only, so adding an httpie read arm would create a
+    # gated-but-unmintable over-block — omitted by design (httpie is WHOLLY out of charter;
+    # its ref-mutation/merge arms were removed with it).
+    re.compile(_GH_API_PREFIX + r"(?=.*(?:-X|--method)\s+(?:DELETE|PUT|PATCH)\b).*branches/.*/protection", re.IGNORECASE),
+    re.compile(r"\bcurl\b(?=.*(?:-X|--request)\s+(?:DELETE|PUT|PATCH)\b).*branches/.*/protection", re.IGNORECASE),
+    re.compile(r"\bwget\b(?=.*--method=(?:DELETE|PUT|PATCH)\b).*branches/.*/protection", re.IGNORECASE),
+    # gh api implicit POST: body param flags (-f, -F, --field, --raw-field, --input)
+    # cause gh api to default to POST. Dangerous when targeting git/refs or merge.
+    # Negative lookahead excludes explicit GET (which overrides implicit POST).
+    re.compile(_GH_API_PREFIX + r"(?!.*(?:-X|--method)\s+GET\b)(?=.*(?:-f|-F|--field|--raw-field|--input)\s).*git/refs", re.IGNORECASE),
+    re.compile(_GH_API_PREFIX + r"(?!.*(?:-X|--method)\s+GET\b)(?=.*(?:-f|-F|--field|--raw-field|--input)\s).*merge", re.IGNORECASE),
+    # curl implicit POST: --data/-d/--data-raw/--data-binary flags cause curl to
+    # default to POST. Dangerous when targeting git/refs or merge API endpoints.
+    # Negative lookahead excludes explicit GET (which overrides implicit POST).
+    re.compile(r"\bcurl\b(?!.*(?:-X|--request)\s+GET\b)(?=.*(?:--data(?:-(?:raw|binary))?|-d)\s).*git/refs", re.IGNORECASE),
+    re.compile(r"\bcurl\b(?!.*(?:-X|--request)\s+GET\b)(?=.*(?:--data(?:-(?:raw|binary))?|-d)\s).*api.*merge", re.IGNORECASE),
+    # Contents API: write operations (PUT/PATCH/POST) to /contents/ endpoint
+    # targeting main or master branch. Flags any mutating /contents/ call that
+    # mentions main or master anywhere in the command (acceptable false positive).
+    re.compile(_GH_API_PREFIX + r"(?=.*(?:-X|--method)\s+(?:PUT|PATCH|POST)\b).*contents/.*(?:main|master)", re.IGNORECASE),
+    re.compile(r"\bcurl\b(?=.*(?:-X|--request)\s+(?:PUT|PATCH|POST)\b).*api.*contents/.*(?:main|master)", re.IGNORECASE),
+    # Alternative HTTP clients: wget with --method flag
+    re.compile(r"\bwget\b(?=.*--method=(?:DELETE|PATCH|POST|PUT)\b).*git/refs", re.IGNORECASE),
+    re.compile(r"\bwget\b(?=.*--method=(?:DELETE|PATCH|POST|PUT)\b).*merge", re.IGNORECASE),
+    # Known API detection gaps (defense-in-depth, not a security boundary):
+    # - GraphQL mutations: gh api graphql -f query='mutation { ... }' bypasses REST-path matching
+    # - gh alias: aliases can hide API calls (tracked in #270)
+)
+
+# leg-boundary substrate (#1094): these three branch-delete arms' `.*` previously
+# ran over the WHOLE stripped command, so an idiomatic `-D` / `--delete --force`
+# token in a benign continuation leg (`git branch new-feature && echo -D`) gated
+# the benign compound — and, because the whole-command classifier ALSO returned
+# branch-delete for it, the ambiguous compound was MINTABLE from a click whose
+# branch leg was benign (the close-twin laundering shape). Matched PER-LEG now:
+# an arm fires iff `git branch` and the force-delete flag co-occur within ONE
+# leg, in ANY leg position (`cd /repo && git branch -D temp` still gates —
+# match-anywhere purpose preserved, per leg). Quoted separators are handled by
+# the substrate (a quoted `&&` is not a leg boundary). Bodies are moved VERBATIM
+# from DANGEROUS_PATTERNS — the conversion changes WHERE they match (per-leg vs
+# whole-command), never WHAT they match. Per-leg scoping also bounds the arms'
+# `\s+` runs: whole-command they DID span a raw newline — the one whitespace-class
+# leg separator — so `git branch --force<newline>--delete x` (two non-destructive
+# legs) previously gated; bounding `\s+` is the same over-block-cure direction. Clustered /
+# split spellings (`-Df` / `-fD` / `--delete -f`) are NOT these arms' job: they
+# are the union arm's (first-leg-anchored, by design).
+_BRANCH_DELETE_LITERAL_ARMS = (
+    re.compile(_GIT_PREFIX + r"branch\s+.*-D\b"),
+    re.compile(_GIT_PREFIX + r"branch\s+.*--delete\s+--force\b"),
+    re.compile(_GIT_PREFIX + r"branch\s+--force\s+--delete\b"),
+)
+
+
+def detect_command_operation_type(command: str) -> str | None:
+    """Detect the operation type of a destructive command.
+
+    Canonical classifier called from BOTH merge guard hooks. When the
+    AskUserQuestion text (post-hook) embeds a literal command in a quoted
+    region, the post-hook delegates to this function on the embedded
+    command — guaranteeing the post-hook's operation_type tag matches
+    what the pre-hook will compute for the same literal command, closing
+    the asymmetric-classifier bug class (#720 Bug B).
+
+    Returns:
+        "merge"         - gh pr merge
+        "close"         - gh pr close (any variant)
+        "force-push"    - git push --force / git push -f (excludes --force-with-lease);
+                          API PATCH/POST/PUT to git/refs (ref rewrite)
+        "push-to-main"  - git push <remote> main/master WITHOUT --force, incl.
+                          --force-with-lease pushes (review-bypass, distinct from
+                          force-push so neither token authorizes a force-push; plain
+                          and lease pushes mint DIFFERENT tokens via the
+                          --force-with-lease presence bind in PRIVILEGED_FLAGS)
+        "branch-delete" - git branch -D / git branch --delete --force / gh pr close --delete-branch;
+                          API DELETE to git/refs (ref removal)
+        "remote-ref-delete" - git push delete of a SINGLE remote ref (#1062a):
+                          push <remote> :ref / --delete ref / -d ref (incl. implicit
+                          remote). Union-arm-only; recognized IFF a single deletable
+                          ref is extractable (recognition⟺mintability by construction)
+        "remote-mass-delete" - git push MASS delete (#1062b): --mirror / --prune /
+                          multi-ref delete. Union-arm-only; recognized IFF a normalized
+                          mass-target tuple is extractable (single-ref defers to
+                          remote-ref-delete — the BOUNDARY discriminator, no double-classify)
+        "branch-protection" - API mutation WEAKENING branch protection (#1063):
+                          gh-api/curl/wget DELETE|PUT|PATCH on a branches/<b>/protection
+                          endpoint (host-agnostic; POST EXCLUDED = strengthening direction)
+        None            - destructive shape not in the recognized set
+                          (read-side caller treats None as "untyped command",
+                          which the tightened token-match semantic treats as
+                          a deny-on-typed-token signal rather than permissive)
+    """
+    # TWO-PASS (view-first, raw fallback): recognition's PRIMARY surface for the
+    # gh-pr PROSE arms is the executed-surface view — quoted data (a --comment/-m
+    # message) is masked, so an op keyword living in prose no longer classifies
+    # (the cross-auth cure: `gh pr close 5 --comment '…gh pr merge 5…'`
+    # classifies close, not merge, so mint and read bind the SAME faithful
+    # (op, target)). The raw fallback pass is arm-for-arm equivalent to the
+    # pre-view classifier, so every currently-recognized spelling keeps its
+    # non-None result BY CONSTRUCTION — load-bearing for the module INVARIANT:
+    # a wrapped faithful click (`bash -c 'gh pr merge 5'`) classifies None on
+    # the view (its payload is masked) and the read side REFUSES on a None op,
+    # so a view-only detect would permanently block it.
+    #
+    # ONLY the gh-pr merge/close arms consult the view. Every push/branch arm
+    # runs on RAW in BOTH passes: those are POSITIONAL / flag-presence
+    # classifiers, and masking a cosmetically-quoted EXECUTING token (a quoted
+    # remote name — `git push 'origin' --delete main`) turns it into a
+    # whitespace gap that a positional regex binds ACROSS, downgrading the op
+    # (remote-ref-delete → push-to-main) and laundering a benign push-to-main
+    # token into a delete authorization. The gh-pr prose arms are presence
+    # detectors with no positional mask-gap bind, so they carry no analogue.
+    view = _executed_surface_view(command)
+    legs = _split_into_legs(command)
+    op = (
+        _detect_op_pass(command, view, legs)      # view pass (gh-pr prose arms on view)
+        or _detect_op_pass(command, command, legs)  # raw fallback == pre-view classifier
+    )
+    if op is not None:
+        return op
+    # PER-LEG arms: the union arm is FIRST-LEG-anchored, so any op it recognizes in a
+    # non-first leg (`cd /repo && git push origin main`, `cd /repo && git push origin
+    # --delete feature`) needs a per-leg call. CALLER-LEVEL (not inside _detect_op_pass):
+    # reached ONLY after BOTH passes return None, so no command that already classifies
+    # changes verdict (the api-merge additive precedent), and the raw-fallback gh-pr arms
+    # still run before this (so
+    # `bash -c 'gh pr merge 5' && git push origin main` stays merge, not push-to-main).
+    for _leg in legs:
+        _lop = _flag_condition_danger_op(_leg)
+        if _lop in _PER_LEG_OPS:
+            return _lop
+    return None
+
+
+def _detect_op_pass(
+    command: str,
+    surface: str,
+    raw_legs: "list[str]",
+) -> str | None:
+    """One precedence-ordered classification pass, parameterized by surface.
+
+    - `surface`: the string the gh-pr PROSE arms (merge/close) match. View pass:
+      the executed-surface view; fallback pass: the raw command. These are the
+      ONLY view-consulting arms (presence detectors — no positional mask-gap).
+    - `command` / `raw_legs` are ALWAYS the raw inputs — every other arm
+      consumes them in BOTH passes and MUST NOT move to the view:
+        * force-push / push-to-main (both arms) / branch-delete: positional or
+          flag-presence classifiers on git commands — masking a cosmetically-
+          quoted EXECUTING token (quoted remote) lets the positional arm bind
+          across the gap and DOWNGRADE the op (the quoted-remote-delete
+          laundering), or hides a quoted flag from a higher-precedence arm.
+          RAW == the certified base behavior for these classes.
+        * gh-api/curl/wget git-refs + branches/protection arms: a quoted
+          `gh api 'repos/o/r/git/refs/…' -X DELETE` is a faithful MINTING
+          spelling; the view blanks the quoted URL, so a view-side match would
+          make it gated-but-unmintable (a cardinal over-block).
+        * _api_merge_leg_endpoint: recognition⟺extractability coupling — the
+          leg classifies merge IFF its endpoint-position PR is extractable from
+          the SAME surface; masking would decouple them.
+        * _flag_condition_danger_op: already quote-aware via shlex and embeds
+          the remote-ref/mass-delete extractors (recognition⟺mintability); a
+          masked input would break quoted-refspec (`':main'`) extraction.
+    Precedence order is byte-identical to the pre-view classifier."""
+    # Order matters: gh pr close --delete-branch is BOTH a close and a
+    # branch-delete operation; the AskUserQuestion-side classifier
+    # (extract_context) tags it as "close" in priority order, so match
+    # the same precedence here for write/read symmetry.
+    if _GH_PR_MERGE_RE.search(surface):
+        return "merge"
+    if _GH_PR_CLOSE_RE.search(surface):
+        # gh pr close --delete-branch is a close-type operation per the
+        # write-side classifier. Branch-delete-via-pr-close is folded into
+        # the close class on both sides for symmetric authorization.
+        return "close"
+    # force-push: git push ... --force (excludes --force-with-lease — carved out
+    # of the force-push arms ONLY; the push-to-main arm still gates lease pushes
+    # to a default branch). Matched PER-LEG over the shared _FORCE_PUSH_LITERAL_ARMS
+    # SSOT (#1082) — the same arm list the read floor consumes, over the same leg
+    # substrate (_split_into_legs), so a force-class flag in a benign continuation
+    # leg no longer classifies the first-leg push as force-push and read==mint
+    # holds by construction on this class.
+    for _leg in raw_legs:
+        if any(arm.search(_leg) for arm in _FORCE_PUSH_LITERAL_ARMS):
+            return "force-push"
+    # Direct push to a default branch (main/master) — plain OR --force-with-lease —
+    # is a review-bypass, a DISTINCT op from force-push. It is now recognized by the
+    # UNIFIED refspec-DST predicate in the shared `_flag_condition_danger_op` push-to-main
+    # arm (#1195 OBS-E), reached via the union-arm fallback at the END of this function —
+    # so the former inline literals here (a `HEAD:(?:main|master)` arm + a bounded-flag-walk
+    # `(?:main|master)(?!:)` arm) were REMOVED. The unified predicate is accurate BOTH ways
+    # the literals were not (it excludes main-release/main.foo prefix over-blocks and
+    # catches feature:main / refs/heads/main under-blocks), and being the single shared arm
+    # both detect and the read floor call it is mint==read by construction. The --force/-f
+    # checks ABOVE still run first (a forced push to main returns force-push).
+    # API-based ref-mutation forms (gh api / curl / wget targeting
+    # /git/refs with mutating HTTP methods) classify by HTTP semantic:
+    # DELETE → branch-delete class (removes a ref)
+    # PATCH/POST/PUT → force-push class (rewrites a ref without PR review)
+    # Symmetric with how a force-push or branch-delete token from
+    # extract_context() would authorize the equivalent CLI form.
+    # gh-api recognition uses the TOLERANT `_GH_API_PREFIX` (same as the read floor)
+    # so a `gh -R o/r api ...` global-flag spelling MINTS instead of gating-on-read-
+    # but-not-minting (#1064 over-block). The METHOD checks below are IGNORECASE to
+    # match the IGNORECASE read floor, so a lowercase `-X delete` faithful form MINTS
+    # too. Both are mint-WIDENING (the read floor already gates these forms) — never a
+    # read-floor narrowing. Still gh-api/curl/wget only (NOT httpie), so no new
+    # gated-but-unmintable httpie state — and httpie now has NO read-floor arms at all
+    # (the read floor dropped them; httpie is wholly out of charter), so the invariant
+    # is two-sided.
+    _is_api_form = (
+        re.search(_GH_API_PREFIX, command, re.IGNORECASE)
+        or re.search(r"\b(?:curl|wget)\b", command, re.IGNORECASE)
+    )
+    if _is_api_form and "git/refs" in command:
+        if re.search(r"\bDELETE\b", command, re.IGNORECASE):
+            return "branch-delete"
+        if re.search(r"\b(?:PATCH|POST|PUT)\b", command, re.IGNORECASE):
+            return "force-push"
+    # branch-protection API mutation (#1063): DELETE|PUT|PATCH on a
+    # `branches/<b>/protection` endpoint WEAKENS protection (remove / replace /
+    # modify) — a DISTINCT op-class from branch-delete (it changes a config, not a
+    # ref). POST is EXCLUDED (it ENABLES protection sub-features = strengthening, so
+    # gating it would over-block). Path-disjoint from the git/refs arm above (a
+    # protection URL has no `git/refs`), so no shadowing. Method check is loose +
+    # IGNORECASE like the git/refs arm; the GAP1 write-gate (is_dangerous + the precise
+    # method-gated DANGEROUS_PATTERNS arms) ensures mint⊆read.
+    if _is_api_form and re.search(r"branches/.*/protection", command):
+        if re.search(r"\b(?:DELETE|PUT|PATCH)\b", command, re.IGNORECASE):
+            return "branch-protection"
+    # API-based PR merge (#1096, GH-API-ONLY per Option B): gh api with a mutating method
+    # (PUT/PATCH/POST) on a pulls/<N>/merge endpoint is a merge via API. curl/wget were
+    # DROPPED (sec #71: unsound value-flag denylist over an unbounded flag space) — they
+    # classify None and stay gated-but-unmintable. Recognized AND extracted by
+    # the ONE shared per-leg helper _api_merge_leg_endpoint, so recognition<->extractability
+    # read the SAME surface — a leg classifies merge IFF its ENDPOINT-position PR is
+    # extractable, which gives no gated-but-unmintable AND binds the URL-positional
+    # endpoint (never a flag-value / other-leg decoy — the #1096 target-confusion fix).
+    # ADDITIVE: this classifies inputs that were previously None (a genuine API merge)
+    # while leaving every EXISTING classification byte-identical. (It is NOT true that
+    # "every currently-None input stays None" — a genuine api-merge is correctly
+    # None->merge; that is the whole point of the arm. Only NON-merge inputs are
+    # unchanged.) Recognition predicate: tolerant IGNORECASE client (_GH_API_PREFIX, so a
+    # `gh -R o/r api` global-flag spelling also mints) + IGNORECASE PUT/PATCH/POST +
+    # case-SENSITIVE pulls/<N>/merge path. DELETE excluded; the implicit-POST (-f/--data,
+    # no method keyword) spelling is a deliberate residual, per the git/refs detect arm.
+    for _leg in raw_legs:
+        if _api_merge_leg_endpoint(_leg) is not None:
+            return "merge"
+    # branch-delete: git branch -D / --delete --force / --force --delete. Matched
+    # PER-LEG over the shared _BRANCH_DELETE_LITERAL_ARMS SSOT (#1094) — the same
+    # arm tuple the read floor consumes, over the same leg substrate
+    # (_split_into_legs), so a stray force-delete token in a benign continuation
+    # leg no longer classifies the compound as branch-delete, and read==mint
+    # holds by construction on this class (a command is gated via these arms iff
+    # some stripped leg matches iff detect classifies branch-delete here).
+    # Clustered spellings (-Df / -fD / --delete -f) fall through to the union-arm
+    # fallback below, same as the read floor.
+    for _leg in raw_legs:
+        if any(arm.search(_leg) for arm in _BRANCH_DELETE_LITERAL_ARMS):
+            return "branch-delete"
+    # Quote-aware normalized-flag FALLBACK (ADDITIVE, INV-AU): catches the
+    # clustered/split flag spellings the literal regexes above miss — chiefly
+    # `git branch -Df`/`-fD`/`--delete -f` (force-delete), which `-D\b` and the
+    # spelled-out `--delete --force` cannot see. Only reached when every literal
+    # check above has missed, so it can never override an established op-class
+    # precedence; it returns None when no flag-condition fires.
+    return _flag_condition_danger_op(command)
+
+
+# -----------------------------------------------------------------------------
+# Command-context extraction — the shared SSOT both hooks call on a COMMAND
+# STRING (never prose). The mint side (merge_guard_post) and the read side
+# (merge_guard_pre) both derive a command's (operation_type, target) from
+# extract_command_context, so the two arms can never classify the SAME command
+# differently again (the #720 / asymmetric-classifier bug class). A context key
+# is PRESENT only when positively extracted; ABSENT otherwise — absence, NOT a
+# None value, is the fail-closed signal a downstream gate keys on.
+# -----------------------------------------------------------------------------
+
+# PR-number positional extraction regex.
+#
+# Both flag-walks (between `gh` and `pr`, AND between the subcommand and the PR
+# number) use the tight `_GH_FLAG_TOKENS` form. A broad `_GH_GLOBAL_FLAGS` form
+# on the pre-subcommand walk would allow greedy consumption past a `gh pr
+# <subcmd> <PR>` substring inside `--body "..."` text, then re-anchor at a
+# SECOND `gh pr <subcmd>` occurrence embedded in the body — an authorization
+# bypass where the context check matched an embedded fake PR rather than the
+# real positional. Restricting both walks to flag-shaped tokens prevents walking
+# past the real positional into quoted body content.
+#
+# The trailing `(?![\w-])` rejects BOTH alphanumeric-suffix tokens (`7352abc`)
+# AND hyphen-suffix tokens (`7352-tests`). Python `\b` matches at a digit-to-
+# hyphen boundary (`-` is a non-word char), so a plain `\b` would incorrectly
+# capture `7352` from `7352-tests` (a branch-name argument). `(?![\w-])` is
+# strictly stronger: it rejects any continuation that is a word char OR a hyphen.
+_GH_PR_NUMBER_RE = re.compile(
+    r"\bgh\s+" + _GH_FLAG_TOKENS + r"pr\s+(?:merge|close)\s+"
+    + _GH_FLAG_TOKENS + r"(\d+)(?![\w-])"
+)
+
+# A quoted-command region inside prose: backticks (most common), then single
+# quotes, then double quotes; captures the content. When AskUserQuestion text
+# embeds the literal command in a quoted region (e.g. `gh pr merge 42`), the
+# SAME classifier the read side uses is applied to the embedded command,
+# guaranteeing bidirectional write/read agreement on the SAME input.
+_QUOTED_COMMAND_RE = re.compile(
+    r"`([^`]+)`"        # backticks
+    r"|'([^']+)'"       # single quotes
+    r'|"([^"]+)"'       # double quotes
+)
+
+# A bare (unquoted) `gh ...` / `git ...` command span: from the tool name up to
+# a shell separator (`;` `|` `&`), a quote, or end-of-line. The conservative
+# extractors below filter prose-polluted spans (a span that yields an op but no
+# target contributes no (op,target) pair), so over-capturing trailing prose is
+# harmless — it never invents a target.
+_BARE_COMMAND_RE = re.compile(r"\b(?:gh|git)\s+[^`'\";|&\n]+")
+
+# Allowlist of `gh pr merge|close` long-form flags KNOWN to take a value. The
+# defensive check in _extract_pr_number only rejects digits preceded by one of
+# these value-taking flags (avoiding false-positives on value-less flags like
+# `--admin`, `--auto`, `--squash` whose positional digit IS the PR). As of `gh`
+# v2 no real flag takes a digit value; this is a forward-compatible defense.
+# Extend this list when `gh` ships a flag that takes a numeric value.
+_GH_PR_VALUE_TAKING_FLAGS = frozenset({
+    "--body",
+    "--body-file",
+    "--subject",
+    "--author-email",
+    "--match-head-commit",
+    "--comment",
+    "--max-retries",
+    "--retry-count",
+    "--timeout",
+})
+
+
+def _strip_surrounding_quotes(token: str) -> str:
+    """Strip one layer of matching surrounding quotes from a captured CLI token.
+
+    ``'feat/x'`` -> ``feat/x``, ``"feat/x"`` -> ``feat/x``. Leaves an unquoted or
+    mismatched-quote token unchanged. Comparison-side normalization only — it
+    does NOT widen what a matcher regex captures, so it cannot introduce a
+    false-negative.
+    """
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in ("'", '"'):
+        return token[1:-1]
+    return token
+
+
+def _extract_pr_number(command: str) -> str | None:
+    """Extract the PR number positional from a `gh pr merge|close` command.
+
+    Wraps `_GH_PR_NUMBER_RE.search()` with a defensive post-extract check that
+    rejects digits which are actually the VALUE of an immediately-preceding
+    value-taking long-form flag (e.g. `--max-retries 5`). Value-less flags
+    (`--admin`, `--auto`, `--squash`) do NOT trigger the check — a digit after
+    one of them IS the PR positional. Returns None when no positional is found.
+    """
+    match = _GH_PR_NUMBER_RE.search(command)
+    if not match:
+        return None
+    pr_pos = match.start(1)
+    # Inspect the immediately-preceding token for a known value-taking
+    # long-form flag; if present, the captured digit is its value, not the PR.
+    preceding = command[:pr_pos].rstrip()
+    flag_match = re.search(r"(--[\w-]+)$", preceding)
+    if flag_match and flag_match.group(1) in _GH_PR_VALUE_TAKING_FLAGS:
+        return None
+    return match.group(1)
+
+
+# A `gh pr close` PR URL: host + owner/repo + the /pull/<N> segment. Anchored on
+# the LITERAL `/pull/` path element, so digits inside owner/repo (`o/r-123`) are
+# never mistaken for the PR number; `(\d+)(?![\w-])` stops exactly at the PR
+# number, so a trailing path (`/pull/5/files`), query (`?diff=split`), or
+# fragment (`#c-9`) cannot extend or replace it. The host char class accepts a
+# PORT (`ghe.corp:8443`) and USERINFO (`user@github.com`) so a faithful GHE-with-
+# port or userinfo url MINTS — gh RUNS both (empirically confirmed), so leaving
+# them target=None was a gated-but-unmintable over-block. The widen is HOST-
+# SEGMENT ONLY: the owner/repo group and the `/pull/(\d+)(?![\w-])` anchor are
+# unchanged, so the PR number still resolves exactly (no anchor drift). The host
+# is captured VERBATIM into the minted identity (NOT normalized): distinct
+# spellings mint distinct identities (`user@github.com` != `github.com`,
+# `ghe.corp:8443` != `ghe.corp`), so a token binds ONLY its own exact command and
+# can NEVER cross-authorize a different host/PR (mint==read by construction; over-
+# block-safe, never a launder — a deceptive `github.com@evil.com` mints its own
+# verbatim id and authorizes only that exact typed command). STILL UNMATCHED: a
+# BRACKETED IPv6-literal host (`https://[::1]/o/r/pull/9`) — `[`/`]` are outside
+# the class — a non-realistic faithful form that stays a safe-direction over-
+# block; widen to include `[]` only if a real gh IPv6 form ever appears.
+_GH_PULL_URL_RE = re.compile(
+    r"https?://([\w.@:-]+)/([\w.-]+/[\w.-]+)/pull/(\d+)(?![\w-])"
+)
+
+# The COMPLETE set of value-taking flags on `gh pr close` (verified against
+# `gh pr close --help`): `-R/--repo` and `-c/--comment`. `-d/--delete-branch` is
+# boolean. This set is used to strip a flag's VALUE from the positional scan so a
+# repo (`--repo o/r`) or comment (`-c "msg"`) value is never mistaken for the
+# {number|url|branch} target.
+#
+# WHY gh IS SOLVABLE WHERE curl/wget IS NOT (the #1098 WON'T-FIX contrast): gh's
+# value-flag vocabulary for a given subcommand is BOUNDED and documented (two
+# flags here), so this set can be COMPLETE for current gh — every faithful form
+# is handled, zero over-block today. curl/wget's value-flag vocabulary is
+# unbounded and version-growing, which is why a sound extractor there is
+# impossible and #1098 closed WON'T-FIX. Bounded => completable is the whole
+# reason gh-close has a real fix.
+#
+# BEHAVIOR ON AN UNLISTED VALUE-FLAG — two sub-cases, stated honestly (NOT
+# "never a mis-bind"):
+#  (a) the flag's value is an EXTRA token alongside a real target
+#      (`gh pr close feature --newflag x`) -> TWO positionals -> ABSTAIN
+#      (over-block, the SAFE/VISIBLE direction; fixable by listing the flag).
+#  (b) the flag's value is the SOLE positional-shaped token
+#      (`gh pr close --newflag 5`, NO real target) -> that value is bound as the
+#      target. BUT such a command has no valid {number|url|branch} positional, so
+#      gh ITSELF REJECTS it -> it is NON-FAITHFUL. Minting from it is a
+#      confused-deputy: an adversary must get the user to APPROVE a command gh
+#      won't run, then reuse the token on a real one. ADVERSARIAL-ONLY, tolerated
+#      under the good-faith model (a good-faith user never approves a command that
+#      cannot execute). This is a DOCUMENTED RESIDUAL, not closed here — see
+#      test_unknown_value_flag_on_nonfaithful_close_is_adversarial_only.
+# `--repo`/`-c/--comment` are LISTED, so the security-reported FAITHFUL mis-bind
+# (`gh pr close --repo 5/6 feature` shadowing the branch with the repo digit) is
+# fully closed. curl/wget contrast (#1098): gh's per-subcommand value-flag set is
+# bounded/documented so the FAITHFUL forms are completely covered; curl/wget's is
+# unbounded, so no sound extractor exists there.
+_GH_CLOSE_VALUE_LONG = frozenset({"--repo", "--comment"})
+_GH_CLOSE_VALUE_SHORT = frozenset("Rc")
+
+
+def _gh_close_positionals(tokens: "list[str]") -> "list[str] | None":
+    """The positional args of a ``gh pr close`` token list, with value-taking
+    flags AND their values removed (cobra semantics: clustered shorts, ``=``-joined
+    and attached values all handled). Returns the positionals after ``close``, or
+    None if ``close`` is absent. A repo/comment VALUE can never survive as a
+    positional, so it can never be mis-bound as the {number|url|branch} target."""
+    try:
+        i = tokens.index("close") + 1
+    except ValueError:
+        return None
+    positionals: "list[str]" = []
+    n = len(tokens)
+    while i < n:
+        tok = tokens[i]
+        if tok.startswith("--"):
+            flag, has_eq, _v = tok.partition("=")
+            # `--repo value` / `--comment value` consume the NEXT token; the
+            # `=`-joined and boolean/unknown long forms are self-contained.
+            i += 2 if (flag in _GH_CLOSE_VALUE_LONG and not has_eq) else 1
+            continue
+        if tok.startswith("-") and tok != "-":
+            # Short cluster (cobra): a value-taking short consumes the REST of the
+            # cluster as its attached value, or — if it is the last char — the NEXT
+            # token. Booleans before it (`-dR value` = -d + -R value) don't matter.
+            body = tok[1:]
+            consumes_next = False
+            for j, ch in enumerate(body):
+                if ch in _GH_CLOSE_VALUE_SHORT:
+                    consumes_next = j == len(body) - 1   # `-R value`; else `-Rvalue`
+                    break
+            i += 2 if consumes_next else 1
+            continue
+        positionals.append(tok)
+        i += 1
+    return positionals
+
+
+def _extract_close_target(command: str) -> str | None:
+    """The close-target identity for a faithful ``gh pr close`` command, across
+    all three positional forms gh accepts (``{<number> | <url> | <branch>}``).
+
+    Returns one of FOUR disjoint identity namespaces (so no spelling can ever
+    set-equal another):
+
+    - bare PR number -> the digits (``"5"``). Repo-IMPLICIT, exactly as the
+      pre-existing number-close identity already is.
+    - github/enterprise PR URL -> ``"url:<host>/<owner>/<repo>#<N>"``. HOST- and
+      repo-QUALIFIED on purpose: a URL names an explicit repo, so binding only
+      the number would let it set-equal a bare ``"5"`` and authorize closing PR
+      #5 in a DIFFERENT repo (cross-repo target confusion). The number is parsed
+      from the ``/pull/<N>`` segment gh itself resolves, so the identity IS the
+      PR the command closes.
+    - single branch positional -> ``"branch:<name>"``. Name-only (repo-implicit
+      like the number form — a bare branch carries no repo). Branch names may
+      contain ``/`` (``feature/foo``), so slashes are allowed; a token carrying
+      ``://`` is an UNRECOGNIZED url form (not a github ``/pull/`` URL) -> abstain
+      rather than mint a garbage ``branch:`` identity.
+    - none of the above (incl. the NO-positional form ``gh pr close -d``, which
+      gh itself refuses) -> ``None`` (abstain; the read floor still gates, but a
+      command gh will not run has no faithful click to over-block).
+
+    LEG-LOCAL: everything is derived from ``_executable_prefix(command)`` (the
+    first executable leg), so a URL/branch mentioned in a benign continuation leg
+    is never picked up (no cross-leg identity injection). Dash-prefixed tokens
+    are dropped from the positional scan, so a flag can never be bound as the
+    target. Numeric precedence matches gh's own: a bare digit is always the PR
+    number, so a branch literally named ``5`` is indistinguishable from PR #5 to
+    BOTH gh and this guard (documented, not a collision — the two resolve to the
+    same command).
+
+    SINGLE VALUE-FLAG SSOT (structural — do NOT reintroduce a second list): ALL
+    three forms (number, url, branch) are classified from the ONE positional that
+    ``_gh_close_positionals`` returns, which strips value-flag values via the
+    single ``_GH_CLOSE_VALUE_*`` set. The number path deliberately does NOT call
+    ``_extract_pr_number`` — that function's value-flag handling is (a) long-form
+    only (blind to ``-R``) and (b) a DIFFERENT, incomplete flag list, so routing
+    close numbers through it re-created the two-lists-diverge mis-bind: on
+    ``gh pr close --repo 5/6 feature`` / ``-R 5/6 feature`` its regex backtracks
+    to grab the repo's leading digit as the PR (shadowing the branch), which
+    LAUNDERED an approved branch-close into a different-PR close. Deriving every
+    close form from the one value-flag-complete positional walk makes that
+    divergence impossible by construction. (merge still uses ``_extract_pr_number``
+    — its value-flags differ; this SSOT is close-scoped.)"""
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        return None  # unbalanced quote / procsub -> abstain (existing safe posture)
+    tokens = _shell_tokenize(prefix)
+    if tokens is None:
+        return None  # unparseable -> abstain
+    positionals = _gh_close_positionals(tokens)
+    # Exactly ONE positional is a single-target close. 0 (the no-arg form gh
+    # refuses) or >=2 (ambiguous / an unlisted value-flag's value survived) ->
+    # abstain; the >=2 case is the over-block-safe fail direction.
+    if positionals is None or len(positionals) != 1:
+        return None
+    target = _strip_surrounding_quotes(positionals[0])
+    if not target:
+        return None  # empty/degenerate positional -> abstain, never a garbage id
+    # Classify the SINGLE positional (value-flag values already stripped, so a
+    # digit/url/branch here IS the target, never a --repo/--comment value).
+    if target.isdigit():
+        return target  # bare PR number — gh's number precedence, repo-implicit
+    url = _GH_PULL_URL_RE.search(target)
+    if url is not None:
+        return "url:" + url.group(1) + "/" + url.group(2) + "#" + url.group(3)
+    if "://" in target:
+        return None  # unrecognized URL form -> abstain, never a garbage branch id
+    return "branch:" + target
+
+
+def _extract_api_ref(command: str) -> str | None:
+    """Parse the ref from an API ref-mutation command's `git/refs/<ref>` path.
+
+    `detect_command_operation_type` classifies `gh api|curl|wget` calls on a
+    `git/refs/...` path by HTTP method (DELETE -> branch-delete, PATCH/POST/PUT
+    -> force-push). For both classes the affected ref is the path component, so
+    a single parser supplies the target. Returns the ref (a leading `heads/`
+    stripped), or None when the command is not a recognized API ref form.
+    """
+    if not (
+        re.search(r"\b(?:gh\s+api|curl|wget)\b", command, re.IGNORECASE)
+        and "git/refs/" in command
+    ):
+        return None
+    api_match = re.search(
+        r"git/refs/(?:heads/)?([A-Za-z0-9][A-Za-z0-9._/-]*)", command
+    )
+    return api_match.group(1) if api_match else None
+
+
+# Value-taking-flag skip set for the gh-api api-merge endpoint walk (#1096; GH-API-ONLY
+# per Option B). The api-merge mint arm is gh-api ONLY — curl/wget were DROPPED because
+# sec #71 proved a value-flag denylist over curl/wget's UNBOUNDED flag space is
+# structurally uncompletable (52 realistic-common decoy leaks), so a curl/wget mint arm
+# built on it is unsound. gh api's flags are FINITE + documented + first-positional-endpoint
+# = provably sound. Consequence: curl/wget api-merge classifies detect=None (mint=0),
+# staying in its PRE-EXISTING gated-but-unmintable state (the read arms still gate it) —
+# killing that laundering class BY CONSTRUCTION (can't mint -> can't launder). Tokens are
+# the shlex form. Includes the -R/--repo GLOBAL flag, which is decoy-capable (`gh -R
+# pulls/5/merge api …` would bind 5 if -R's value is not skipped). Booleans (-i/--include,
+# --paginate, --slurp, --silent, --verbose) are DELIBERATELY absent — skipping their next
+# token would swallow a positional.
+_API_MERGE_GH_VALUE_FLAGS = frozenset({
+    "-X", "--method", "-f", "--field", "-F", "--raw-field", "--input",
+    "-H", "--header", "--hostname", "-q", "--jq", "-t", "--template",
+    "--cache", "-R", "--repo",
+})
+
+_PULLS_MERGE_PR_RE = re.compile(r"pulls/(\d+)/merge\b")
+
+
+def _api_merge_leg_endpoint(leg: str) -> str | None:
+    """Return the ENDPOINT PR of a genuine per-leg API merge, or None (#1096).
+
+    ONE shared helper called by BOTH detect_command_operation_type's merge arm AND
+    _extract_api_merge_pr, so recognition and extraction read the SAME surface (kills
+    the reuse-across-two-domains root: detect recognizes a leg IFF its endpoint is
+    extractable -> no gated-but-unmintable BY CONSTRUCTION, and the bound PR is the URL
+    POSITIONAL endpoint, never a flag-value / other-leg decoy).
+
+    GH-API-ONLY (#1096 Option B; curl/wget dropped, sec #71). Recognition (gh-api client +
+    mutating method + pulls/<N>/merge path co-occur in this leg): tolerant IGNORECASE
+    _GH_API_PREFIX client + IGNORECASE PUT/PATCH/POST method + case-SENSITIVE pulls/<N>/merge
+    path. A curl/wget merge classifies None here -> gated-but-unmintable (read arms still gate).
+
+    Extraction binds the pulls/<N>/merge that is the URL POSITIONAL: strip body values
+    (carrier-8), shlex-tokenize, then walk skipping flags + the gh-api value-flag
+    values, and take the first surviving positional. On tokenizer failure NEVER returns
+    None for a recognized leg (falls back to the stripped/raw first-match) — a mis-parse
+    must not gate a faithful merge (over-block-safe).
+    """
+    client_gh = re.search(_GH_API_PREFIX, leg, re.IGNORECASE)
+    if not client_gh:
+        # GH-API-ONLY (#1096 Option B): curl/wget api-merge legs classify None here
+        # (mint=0), staying in their PRE-EXISTING gated-but-unmintable state (the
+        # curl/wget merge READ arms still gate them) — killing the 52 curl/wget
+        # laundering vectors BY CONSTRUCTION (sec #71: their value-flag denylist over an
+        # unbounded flag space is uncompletable). No new over-block (status quo ante).
+        return None
+    # Recognition uses the EXACT non-capturing literal `pulls/\d+/merge\b` via re.search
+    # (byte-identical to the prior detect arm), NOT the compiled capturing _PULLS_MERGE_PR_RE
+    # — so recognition stays byte-identical AND the non-vacuity arm-disable shim (which
+    # monkeypatches re.search of this exact literal) still surgically disables the arm.
+    # The capturing _PULLS_MERGE_PR_RE is used only for EXTRACTION (the walk + fallback).
+    if not re.search(r"pulls/\d+/merge\b", leg):
+        return None
+    if not re.search(r"\b(?:PUT|PATCH|POST)\b", leg, re.IGNORECASE):
+        return None
+    # Recognized. Extract the ENDPOINT-position PR.
+    stripped = _strip_non_executable_content(leg)
+    tokens = _shell_tokenize(stripped)
+    if tokens is None:
+        # Tokenizer failure (unbalanced quotes): NEVER None for a recognized leg
+        # (over-block-safe). Prefer the body-stripped surface (avoids body decoys);
+        # the raw leg is guaranteed to match (recognition required it).
+        m = _PULLS_MERGE_PR_RE.search(stripped) or _PULLS_MERGE_PR_RE.search(leg)
+        return m.group(1) if m else None
+    value_flags = _API_MERGE_GH_VALUE_FLAGS
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok.startswith("-"):
+            base = tok.split("=", 1)[0]
+            if "=" not in tok and base in value_flags:
+                i += 1  # bare space-separated value-flag: skip its value token too
+            # attached-value (`--method=PUT`, `-XPUT`) and booleans consume no extra token
+            i += 1
+            continue
+        # A positional: the endpoint is the FIRST pulls/<N>/merge positional (the URL
+        # argument; for gh api the endpoint is the first positional by REST convention).
+        mm = _PULLS_MERGE_PR_RE.search(tok)
+        if mm:
+            return mm.group(1)
+        i += 1
+    # Recognized (gh-api) but no endpoint positional survived (the only pulls/<N>/merge was
+    # a skipped flag VALUE, i.e. a body/decoy — the leg has no real merge endpoint). NOT a
+    # tokenizer failure, so this is a genuine "no extractable endpoint" -> None. Correct
+    # (no wrong-target mint); such an input never faithfully merges a PR. (#1096 is
+    # gh-api-only per Option B: curl/wget never reach this walk — they classify None at
+    # the client gate above — so there is no exotic-curl residual to accept.)
+    return None
+
+
+def _extract_api_merge_pr(command: str) -> str | None:
+    """Command-level api-merge PR: walk the legs and return the FIRST recognized leg's
+    ENDPOINT-position PR (#1096). Leg-scoping closes the cross-leg/echo decoy; the
+    per-leg helper closes the same-leg flag-value decoy. Consumed by extract_command_context
+    (mint + read whole-fallback + #1097 retirement cmd_target all heal at this one site)."""
+    for _leg in _split_into_legs(command):
+        pr = _api_merge_leg_endpoint(_leg)
+        if pr is not None:
+            return pr
+    return None
+
+
+def _extract_protection_branch(command: str) -> str | None:
+    """Parse the protected branch from a branch-protection API command's
+    `branches/<branch>/protection` path (#1063). The branch is PATH-resident (the
+    REST resource IS the URL), so carrier-8's body strip never removes it. The
+    non-greedy `(.+?)` correctly handles a slashed branch name (`feature/x`):
+    `branches/feature/x/protection` → `feature/x`. Returns the branch, or None when
+    the command is not a recognized protection form."""
+    m = re.search(r"branches/(.+?)/protection\b", command)
+    return _strip_surrounding_quotes(m.group(1)) if m else None
+
+
+def _extract_branch_name(command: str) -> str | None:
+    """Extract the SINGLE branch name targeted by a branch-delete command.
+
+    Owns the branch-delete target for extract_command_context. Handles the CLI
+    `git branch -D|--delete <name>` form (exactly ONE branch — a MULTI-target
+    delete like `git branch -D a b` is REFUSED, returning None) and the API
+    ref-DELETE form (the ref in a `git/refs/<ref>` path). Returns the
+    (quote-normalized) name, or None when no single branch target is positively
+    extractable.
+    """
+    api_ref = _extract_api_ref(command)
+    if api_ref is not None:
+        return api_ref
+    # CLI `git branch -D|--delete <name>`: isolate the tokens after `branch`,
+    # drop dash-flags, and require EXACTLY ONE positional branch name. A
+    # multi-target delete (`git branch -D a b`) has >1 positional -> REFUSE, so
+    # a token approved for ONE branch can never authorize deleting several (the
+    # #1032 multi-target under-block); 0 positionals -> REFUSE. Mirrors
+    # _extract_force_push_target_ref's multi-ref conservatism. The caller only
+    # reaches here when detect_command_operation_type already classified the
+    # command branch-delete, so a -D/--delete flag is present and is dropped
+    # with the other dash-flags.
+    # Truncate at the first benign continuation / redirect on the quote-masked
+    # view BEFORE counting positionals, so a faithful single branch-delete with a
+    # trailing continuation (`git branch -D feature | tail`, `... ; echo done`,
+    # `... > log`) re-derives its one branch name instead of miscounting the
+    # continuation tokens as extra positionals (-> None -> over-block). An
+    # ambiguous quote state makes _executable_prefix return None -> abstain -> the
+    # existing safe over-block (never a silently-authorized malformed command).
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        return None
+    branch_match = re.search(_GIT_PREFIX + r"branch\b(.*)$", prefix)
+    if not branch_match:
+        return None
+    positionals = [t for t in branch_match.group(1).split() if not t.startswith("-")]
+    if len(positionals) != 1:
+        return None
+    return _strip_surrounding_quotes(positionals[0])
+
+
+def _canonical_join(items: Sequence[str]) -> str:
+    """Netstring/length-prefix encode a sequence of strings into ONE canonical
+    identity STRING, injective by construction (a left-inverse decoder exists), so
+    distinct sequences never collide REGARDLESS of item content — incl. commas, '@',
+    '#', ':' and NUL. Pure + deterministic (no sort, no dedup — the caller supplies a
+    canonical ordered list). Stays a `str` (the token persists as JSON; compared by
+    str()-equality, never decoded). Shared SSOT for branch_set + mass_target (#1136)."""
+    return "".join(f"{len(i)}:{i}" for i in items)
+
+
+def _extract_branch_delete_set(command: str) -> str | None:
+    """Extract the canonical MULTI-branch identity of a force-delete command.
+
+    The MULTI-target sibling of _extract_branch_name (which owns the SINGLE
+    branch). Handles the CLI `git branch -D|--delete --force <a> <b> ...` form
+    with TWO OR MORE positional branch names, returning a canonical
+    sort+dedup+quote-strip identity STRING (the shared netstring `_canonical_join`
+    SSOT), or None
+    when fewer than two branch names are positively extractable (<2 -> defers to
+    the scalar _extract_branch_name path — the BOUNDARY discriminator, so a
+    command populates EXACTLY ONE of `branch` / `branch_set`).
+
+    Shares the _extract_mass_delete_target encoder (#1062b/#1136): an
+    ORDER-INDEPENDENT identity STRING (never a tuple/list — a token persists as
+    JSON, and the read side compares via `str()`, so a list<->tuple round-trip
+    must never enter the identity), built + canonicalized in this ONE shared SSOT
+    so mint and read derive byte-identical strings (D2 symmetry by construction).
+    Encoding is the netstring `_canonical_join` (`len:name` framing): the identity
+    is INJECTIVE by construction and CONTENT-AGNOSTIC, so distinct branch SETS never
+    collide regardless of name content — no separator has to be ref-illegal. (A bare
+    `,` join was NOT injective: a branch literally named `a,b` collided with the set
+    {a, b}, cross-authorizing distinct sets — the F1 review finding; framing closes
+    that class outright. The string is JSON/str()-safe: json round-trips it and str()
+    is stable, so the identity survives token persistence.)
+    Set-EQUALITY on this INJECTIVE string then closes the #1032 multi-target
+    under-block UNCONDITIONALLY: a `{a,b}` token cannot authorize `{a,b,c}`
+    (unequal strings) while a `{b,a}` reorder MATCHES (both canonicalize to the
+    same string).
+
+    Uses the SAME tokenization as _extract_branch_name (executable-prefix
+    truncation at a benign continuation/redirect via _executable_prefix, then drop
+    dash-flags), so the single/multi boundary is computed IDENTICALLY and no
+    command is double-counted or dropped. FORCE-only rides on op_type: the caller
+    reaches here only when detect_command_operation_type already classified
+    branch-delete (the FORCE `-D`/`-Df`/`-fD`/`--delete --force` spellings; #1094
+    per-leg cure), so a lowercase `-d`/`--delete` merged-branch delete (ungated at
+    HEAD) never reaches this and never populates `branch_set`.
+    """
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        return None
+    branch_match = re.search(_GIT_PREFIX + r"branch\b(.*)$", prefix)
+    if not branch_match:
+        return None
+    positionals = [t for t in branch_match.group(1).split() if not t.startswith("-")]
+    if len(positionals) < 2:
+        return None
+    names = sorted({_strip_surrounding_quotes(t) for t in positionals})
+    # Encode via the shared netstring SSOT (_canonical_join): each name is framed as
+    # `len:name`, so the identity is INJECTIVE by construction and CONTENT-AGNOSTIC —
+    # distinct sets never collide regardless of name content, without depending on any
+    # separator being ref-illegal (an earlier bare `,` join collided a branch named
+    # `a,b` with the set {a, b}). JSON/str()-safe, so mint==read symmetry and the JSON
+    # token round-trip both hold.
+    return _canonical_join(names) or None
+
+
+def _extract_force_push_target_ref(command: str) -> str | None:
+    """Conservative force-push destination-ref parse (KD-6) — refuse on ambiguity.
+
+    Returns the ref a force-push would rewrite, or None when the target is
+    implicit / multi-ref / unparseable (the caller treats None as ABSENT ->
+    REFUSE, the safe over-block direction). The accepted ref-form set is
+    SECURITY-RATIFICATION-PENDING (ratified at peer-review); this is the
+    architect's conservative default.
+
+    Recognized:
+        gh api|curl|wget .../git/refs/<ref>   -> <ref>    (API ref-mutation)
+        git push <remote> <src>:<dst>         -> <dst>
+        git push <remote> HEAD:<dst>          -> <dst>
+        git push <remote> <branch>            -> <branch> (incl. direct-to-main)
+    Refused (-> None):
+        git push --force            (implicit current-branch target)
+        git push <remote>           (remote-only, implicit branch)
+        any multi-ref / chained / value-flag-ambiguous / unparseable form
+    """
+    # API ref-mutation: the destination ref is in the git/refs/<ref> path.
+    api_ref = _extract_api_ref(command)
+    if api_ref is not None:
+        return api_ref
+
+    # CLI push: isolate the token sequence after `push` and require EXACTLY
+    # remote + refspec (2 positionals). 0 = implicit push; 1 = remote-only
+    # (implicit branch); >2 = multi-ref/chained -> all ambiguous, REFUSE.
+    # Positionals are counted via the SHARED _push_positionals helper (#1195
+    # OBS-C), which SKIPS the value token of a git-push value-taking option flag
+    # (`-o ci.skip`, `--push-option x`, `--repo url`) — the same helper the
+    # remote-ref-delete/mass-delete builders use. The prior naive
+    # `.split()`-drop-dash-flags miscounted `-o`'s NON-dash value (`ci.skip`) as
+    # a 3rd positional -> None -> a faithful force-push carrying a push-option
+    # was gated-but-unmintable (an over-block). Skipping the value token
+    # recovers the real refspec positional. Only MINT-ENABLING: is_dangerous and
+    # the op-class are unchanged; the target is the real refspec, never the -o
+    # value (mint==read, both via extract_command_context).
+    # Truncate at the first benign continuation / redirect on the quote-masked
+    # view BEFORE counting positionals, so a faithful single force-push with a
+    # trailing continuation (`git push --force origin main | tail`, `... 2>&1`,
+    # `... > log`, `... && echo done`) re-derives its target instead of
+    # miscounting the continuation tokens as extra positionals (-> None ->
+    # over-block). The redirect filename is structurally outside the positional
+    # window (`... feature > main` yields `feature`, never `main`). An ambiguous
+    # quote state makes _executable_prefix return None -> abstain -> the existing
+    # safe over-block (never a silently-authorized malformed command).
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        return None
+    push_match = re.search(_GIT_PREFIX + r"push\b(.*)$", prefix)
+    if not push_match:
+        return None
+    after_push = _shell_tokenize(push_match.group(1))
+    if after_push is None:                       # unbalanced quote -> abstain (safe over-block)
+        return None
+    positionals = _push_positionals(after_push)
+    if len(positionals) != 2:
+        return None
+    refspec = _strip_surrounding_quotes(positionals[1])
+    if ":" in refspec:
+        return refspec.rsplit(":", 1)[1] or None
+    return refspec or None
+
+
+def _extract_push_to_main_set(command: str) -> str | None:
+    """MULTI-ref sibling of the SCALAR push-to-main target (_extract_force_push_target_ref).
+
+    Returns the canonical injective identity of the pushed REFSPECS (>=2), or None
+    when fewer than two refspecs are extractable (<2 -> the scalar path owns the
+    single-ref form: the BOUNDARY discriminator, so a push-to-main command
+    populates EXACTLY ONE of `target_ref` / `push_set` — #1195 OBS-G, the
+    branch/branch_set (#1129) precedent transferred). Reuses the netstring
+    `_canonical_join` SSOT (#1136): injective by construction and CONTENT-AGNOSTIC
+    (colon / `+` / comma / `refs/heads/` content never collides), JSON/str()-safe,
+    so mint==read symmetry and the token round-trip both hold. The identity is
+    over the FULL refspec tokens (`feature:main` kept, never its dst alone) — the
+    tighter binding: src:dst pairs bind exactly, and a `+refspec` element stays
+    distinct from its plain spelling. The refspecs are `_push_positionals(...)[1:]`
+    — the remote positional is SKIPPED (a remote-AGNOSTIC identity, mirroring the
+    scalar target_ref, which binds the ref only; security-ratified). Tokenization
+    mirrors the push-to-main DETECTION arm in `_flag_condition_danger_op`
+    (`.split()` + the K flag bound + `push\\s` well-formedness), so the refspecs
+    bound here are the SAME tokens the detection predicate walked. Fail-safe:
+    unparseable / procsub (`_executable_prefix` None) or a flag-flood (>K) -> None
+    -> the command stays gated-but-unmintable (a residual over-block, never an
+    over-broad token).
+    """
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        return None                     # fail-safe (unparseable / procsub)
+    _pm = re.search(_GIT_PREFIX + r"push\s(.*)$", prefix)
+    if _pm is None:
+        return None                     # well-formed push only (excludes `push--force` glue)
+    _tail = _pm.group(1).split()
+    if sum(1 for t in _tail if t.startswith("-")) > _MAX_GLOBAL_FLAG_TOKENS:
+        return None                     # perf bound (mirrors the OBS-D/E flag walk)
+    refspecs = [_strip_surrounding_quotes(r) for r in _push_positionals(_tail)[1:]]
+    if len(refspecs) < 2:
+        return None                     # <2 -> the scalar target_ref path owns it (boundary)
+    return _canonical_join(sorted(set(refspecs)))   # sort+dedup+canonical (branch_set mirror)
+
+
+# #1195 OBS-I — the REF-SCOPE-NEUTRAL flag allowlist for force_push_set (the
+# ALLOWLIST-INVERSION guard; a SECURITY-OWNED membership surface like
+# PRIVILEGED_FLAGS — any future addition is a reviewed, deliberate act; the cert
+# pins the exact membership). force_push_set is populated ONLY when EVERY flag
+# token resolves into this set; ANYTHING else — the delete/mass op-triggers
+# (--delete/-d/--mirror/--prune), the scope expanders (--tags/--follow-tags/
+# --all/--branches), --recurse-submodules, -n/--dry-run, --force-with-lease on a
+# force-classified command, --no-force, the exotic --repo/--receive-pack/--exec,
+# the `--` end-of-options marker, and every unknown/FUTURE flag — fails SAFE to
+# None = gated-but-unmintable. Rationale: `_push_positionals` skips flags BY
+# DESIGN, so a positional set-identity is structurally BLIND to flag-borne
+# ref-scope semantics (`--force --delete origin main feature` classifies
+# force-push — force outranks delete — and would collide byte-identically with
+# the pure force set); such semantics can only be GUARDED (None), never encoded.
+# Allowlist incompleteness costs an exotic residual over-block, never a hole.
+_FORCE_PUSH_NEUTRAL_LONG = frozenset({
+    "--force",                     # the op itself + the forced-form trigger
+    "--no-verify",                 # bound via force-push PRIVILEGED_FLAGS (a2 discriminates)
+    "--verbose", "--quiet", "--progress", "--no-progress", "--porcelain",  # output-only
+    "--set-upstream",              # local tracking config
+    "--atomic",                    # transaction semantics, same ref set
+    "--ipv4", "--ipv6", "--thin", "--no-thin",                             # transport
+    "--signed", "--no-signed",     # transport signing
+    "--push-option",               # server-side message (value inert to ref scope)
+})
+_FORCE_PUSH_NEUTRAL_SHORT = frozenset("fvqu46")   # -f -v -q -u -4 -6 (cluster letters)
+
+
+def _resolve_neutral_force_tail(_tail: list) -> "tuple[list, bool] | None":
+    """ONE raw-token walk over the post-`push` tail (#1195 OBS-I): resolves git's
+    getopt-style value-taking `-o` in ANY cluster position, runs the
+    ref-scope-neutrality census, and detects the class-wide force flag —
+    returning (resolved_tail, force) or None when ANY flag token is non-neutral,
+    unknown, or malformed (fail-safe: gated-but-unmintable, never an over-broad
+    token).
+
+    WHY RAW TOKENS (load-bearing): `_normalized_flags` is CONDITION-SCOPED — it
+    reports only the flags the danger conditions test and is BLIND to
+    --tags/--all/-v/... — so a census built on it would silently pass a
+    scope-expansion smuggle. WHY the value resolution lives HERE: `-o` takes a
+    VALUE; getopt semantics make everything after `o` in a short cluster (or the
+    next token when `o` is last) that value, NOT flags — `-fvo msg` = -f -v
+    -o=msg; `-fov` = -f -o=v. The resolved tail (value tokens dropped, the
+    `o`+value consumed from clusters) is what the SHARED `_push_positionals`
+    then gathers, so the census and the positional gather agree on value tokens
+    BY CONSTRUCTION — while `_push_positionals` itself stays byte-untouched (its
+    other consumers keep today's behavior). The value-short set is
+    BOUNDED-COMPLETE = {-o}: every other git-push short is boolean.
+
+    O-FIRST GLUED-VALUE AMBIGUITY (lead+security ruling): a glued rest-of-token
+    value MINTS only when `f` is unambiguously present BEFORE the `o` in the
+    SAME cluster (`-fov`, `-fvoMSG` — force established either way you read the
+    tail). An o-first/no-f-before-o glued form (`-ofv`, `-vox`) is the shape
+    where git's parse (o consumes the rest as a VALUE — no force) diverges from
+    the pre-existing cluster-blind detection (which sees the letters as flags):
+    the OPERATION itself is parse-dependent, so minting ANY identity would be
+    wrong under one reading — fail SAFE to None (an exotic, low-good-faith
+    residual over-block; the detection mis-parse itself is out of scope here)."""
+    resolved: list = []
+    force = False
+    i, n = 0, len(_tail)
+    while i < n:
+        tok = _tail[i]
+        if not tok.startswith("-") or tok == "-":
+            resolved.append(tok)             # positional (or the bare '-' token)
+            i += 1
+            continue
+        if tok.startswith("--"):
+            name = tok.split("=", 1)[0]
+            if name not in _FORCE_PUSH_NEUTRAL_LONG:
+                return None                  # incl. bare `--` + unknown/future flags
+            if name == "--force":
+                force = True
+            if name == "--push-option" and "=" not in tok:
+                if i + 1 >= n:
+                    return None              # separate-value form missing its value
+                i += 2                       # skip the value token
+                continue
+            i += 1
+            continue
+        # Short cluster: boolean letters until a value-`o`; at `o` the rest of the
+        # token (or the next token when `o` is last) is its VALUE — never flags.
+        consumed_next = False
+        cluster_bad = False
+        cluster_force = False
+        for j in range(1, len(tok)):
+            ch = tok[j]
+            if ch == "o":
+                if j == len(tok) - 1:        # `-...o` last: next token is the value
+                    if i + 1 >= n:
+                        cluster_bad = True   # missing value (malformed) — fail-safe
+                    else:
+                        consumed_next = True
+                elif not cluster_force:
+                    # o-first / no-f-before-o GLUED value (`-ofv`, `-vox`): git's
+                    # parse and the cluster-blind detection diverge on WHAT THE
+                    # OPERATION IS — ambiguous, fail SAFE to None (lead ruling).
+                    cluster_bad = True
+                break                        # rest-of-token (if any) is the value
+            if ch not in _FORCE_PUSH_NEUTRAL_SHORT:
+                cluster_bad = True
+                break
+            if ch == "f":
+                force = True
+                cluster_force = True
+        if cluster_bad:
+            return None
+        i += 2 if consumed_next else 1
+    return resolved, force
+
+
+def _extract_force_push_set(command: str) -> str | None:
+    """MULTI-ref sibling of the SCALAR force-push target — the force-push analog
+    of _extract_push_to_main_set (#1195 OBS-I, reversing the OBS-G scope boundary
+    under its own ratified proof). Same skeleton (fail-safe prefix, single
+    guarded `push\\s` search, K flag bound, remote-agnostic positionals[1:],
+    `<2 -> None` scalar boundary, injective netstring `_canonical_join` identity)
+    PLUS the three OBS-I-specific layers:
+      (a) the ALLOWLIST-INVERSION census + the value-`-o` resolution + the force
+          trigger — ONE raw-token walk (_resolve_neutral_force_tail);
+      (b) FORCED-FORM NORMALIZATION: class-wide --force/-f upgrades every element
+          to its `+` form so the identity tracks WHICH REFS GET FORCED — the
+          mixed-set plain->forced collision cure (`+feature main` stays DISTINCT
+          from `--force +feature main`) while `--force feature main` ==
+          `+feature +main` (ratified: the same operation, one identity);
+      (c) the `:`-element DELETE GUARD (defense-in-depth for the refspec-syntax
+          channel when force wins classification): None on any ':'-leading
+          element after '+'-strip — a delete can never smuggle into a mintable
+          force set.
+    """
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        return None                     # fail-safe (unparseable / procsub)
+    _pm = re.search(_GIT_PREFIX + r"push\s(.*)$", prefix)
+    if _pm is None:
+        return None                     # well-formed push only (excludes glue)
+    _tail = _pm.group(1).split()
+    if sum(1 for t in _tail if t.startswith("-")) > _MAX_GLOBAL_FLAG_TOKENS:
+        return None                     # perf bound (mirrors the OBS-D/E flag walk)
+    _resolved = _resolve_neutral_force_tail(_tail)
+    if _resolved is None:
+        return None                     # non-neutral / unknown / malformed flag
+    _clean_tail, _force = _resolved
+    refspecs = [_strip_surrounding_quotes(r) for r in _push_positionals(_clean_tail)[1:]]
+    if len(refspecs) < 2:
+        return None                     # <2 -> the scalar target_ref path owns it
+    if _force:
+        refspecs = [r if r.startswith("+") else "+" + r for r in refspecs]
+    if any(r.lstrip("+").startswith(":") for r in refspecs):
+        return None                     # delete-refspec guard (fail-safe)
+    return _canonical_join(sorted(set(refspecs)))
+
+
+# git-push value-taking OPTION flags whose VALUE token must be skipped when
+# counting refspec positionals (else a contrived `-o ':weird'` push-option leaks
+# a fake delete refspec — the #1037 brittleness class). Their `--flag=value` form
+# carries the value INLINE (one token), so no next-token skip is needed. Used by
+# the remote-ref-delete + remote-mass-delete positional builder below; distinct
+# from the OP-TRIGGER flags (`--delete`/`-d`) which are NOT value-taking (the ref
+# is a separate positional).
+_GIT_PUSH_VALUE_FLAGS = frozenset(
+    {"-o", "--push-option", "--receive-pack", "--exec", "--repo"}
+)
+
+
+def _push_positionals(after_push: list[str]) -> list[str]:
+    """Positional (non-flag) tokens after the `push` subcommand, skipping the value
+    token consumed by a git-push value-taking option flag (`-o opt`, `--repo url`,
+    …). A `--flag=value` form carries its value inline (one token), so only the
+    separate-token form skips a follow-on token. Operates on a quote-aware
+    `_shell_tokenize` view (quotes already stripped), so a quoted `':oldref'` stays
+    ONE token bound to its flag and never leaks as a positional. Shared by both
+    push-delete extractors so they agree on positional boundaries."""
+    positionals: list[str] = []
+    i, n = 0, len(after_push)
+    while i < n:
+        tok = after_push[i]
+        if tok.startswith("-") and tok != "-":
+            flag = tok.split("=", 1)[0]
+            if flag in _GIT_PUSH_VALUE_FLAGS and "=" not in tok and i + 1 < n:
+                i += 2  # consume the option flag's separate value token
+                continue
+            i += 1  # a flag (boolean, op-trigger, or inline-value) — not a positional
+            continue
+        positionals.append(tok)
+        i += 1
+    return positionals
+
+
+def _tokens_after_push(command: str) -> list[str] | None:
+    """The quote-aware token list AFTER the first `push` token, on the executable
+    prefix of `command`, or None when the command is unparseable / has no `push`
+    token. Truncates at the first benign continuation / redirect (via
+    `_executable_prefix`) and abstains (None) on ambiguous quotes / procsub —
+    fail-OPEN to the literal floor, never fail-closed."""
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        return None
+    toks = _shell_tokenize(prefix)
+    if toks is None:
+        return None
+    for idx, tok in enumerate(toks):
+        if tok == "push":
+            return toks[idx + 1:]
+    return None
+
+
+def _extract_remote_ref_delete_target(command: str) -> str | None:
+    """Extract the SINGLE remote ref a `git push` delete would remove (#1062a), or
+    None when the form is implicit-current/multi-ref/ambiguous (→ the caller defers:
+    not recognized as remote-ref-delete; a mass form is picked up by
+    `_extract_mass_delete_target` instead). Reuses the force-push parser MACHINERY
+    (quote-mask + shlex view + value-flag skip) but adapts the positional rule for
+    delete semantics + the implicit-remote forms the force-push parser returns None
+    for (its conservative exactly-2-positional rule). Recognition⟺mintability by
+    construction: the `_flag_condition_danger_op` arm returns `remote-ref-delete`
+    IFF this yields a target, so the op can never reach a #1064 gated-but-unmintable
+    state.
+
+    Recognized (git grammar `git push [<repo>] <refspec>...`):
+        explicit remote, --delete/-d:  `origin --delete feature` → feature
+        implicit remote, --delete/-d:  `git push --delete feature` → feature
+        single-delete-with-repo:       `git push --delete a b` → b (repo=a, ref=b)
+        empty-source colon refspec:    `origin :feature` / `origin +:feature` → feature
+                                       `origin :refs/tags/v1` → refs/tags/v1
+    Deferred (→ None, picked up as remote-mass-delete or not destructive):
+        multi-ref delete (`origin --delete a b`, `origin :a :b`), --mirror/--prune,
+        plain push (`origin feature`), src:dst non-delete (`origin feat:feat`),
+        value-flag colon (`-o ':weird' main`), a delete literal inside a quoted arg.
+    """
+    after = _tokens_after_push(command)
+    if after is None:
+        return None
+    positionals = _push_positionals(after)
+    # CROSS-LEG FIX (review FINDING 1): compute the flag set from the SAME leg as the
+    # positionals — the post-`push` tokens of the executable prefix (`after`), NOT the
+    # whole command. Else a --delete/-d/--mirror/--prune token in a benign CONTINUATION
+    # leg (`git push origin feature && git branch -d old`) leaks in and mislabels the
+    # benign push as a delete (a fail-safe but common over-block). Every delete-relevant
+    # flag is a push SUBCOMMAND option (always after `push`), so the post-push tokens are
+    # the complete + correct scope; nothing real is missed (no read-floor narrowing).
+    gf = _normalized_flags(after, "git")  # git surface maps -d → --delete
+    if "--delete" in gf:
+        # git grammar: 1 positional = the refspec (implicit remote); 2 = <repo>
+        # <refspec>; 0 or ≥3 = ambiguous/multi → defer (mass handles ≥3).
+        if len(positionals) == 1:
+            return _strip_surrounding_quotes(positionals[0]) or None
+        if len(positionals) == 2:
+            return _strip_surrounding_quotes(positionals[1]) or None
+        return None
+    # No --delete flag: an empty-source colon refspec (`:dst` / `+:dst`) is a delete.
+    # EXACTLY ONE → its dst; ≠1 → defer (0 = not a delete; ≥2 = multi → mass).
+    colon_dsts = [p for p in positionals if re.match(r"^\+?:", p)]
+    if len(colon_dsts) == 1:
+        return _strip_surrounding_quotes(colon_dsts[0]).rsplit(":", 1)[1] or None
+    return None
+
+
+# Sentinel marking an IMPLICIT remote (a `git push --mirror` with no positional
+# remote) in a mass-delete target tuple — keeps the implicit-remote form MINTABLE
+# (a definite, deterministic target) rather than ambiguous. A NUL byte can never
+# appear in a real remote name, so it can never collide with one.
+_IMPLICIT_REMOTE_MARKER = "\x00implicit"
+
+
+def _extract_mass_delete_target(command: str) -> str | None:
+    """Extract a READABLE normalized per-invocation tuple binding the destructive
+    IDENTITY of a `git push` MASS-delete form (#1062b — `--mirror`/`--prune`/multi-ref
+    delete), or None when the command is not such a form. Binds the destructive
+    identity (mass-flags + remote + sorted refspecs), NOT the whole command line, so a
+    benign `-o ci.skip` does not over-bind; privileged flags ride the existing #1042
+    `bound_flags` axis. Derived identically on BOTH arms via this ONE SSOT → mint==read
+    parity by construction; recognition⟺mintability (the arm returns the op IFF this is
+    non-None) → #1064-impossible. Returns a READABLE netstring identity STRING
+    (`len:value`-framed field tuple; no `@`/`#`/`,` delimiters; #1136), never a hash:
+
+        _canonical_join([<sorted-mass-flags>, <remote-or-implicit-marker>, *<sorted-deduped-refspecs>])
+        git push --mirror origin               → 8:--mirror6:origin
+        git push --mirror                      → 8:--mirror9:\\x00implicit (implicit-remote MINTABLE)
+        git push --prune origin refs/heads/main → 7:--prune6:origin15:refs/heads/main
+        git push origin --delete a b           → 8:--delete6:origin1:a1:b (binds the EXACT deleted set)
+        git push origin :a :b                  → 8:--delete6:origin1:a1:b
+
+    BOUNDARY (lead-mandated, no double-classification): a SINGLE-ref delete is owned by
+    `_extract_remote_ref_delete_target` (tried FIRST in the recognition arm). This
+    extractor returns None for a single-ref form, so a command is classified by EXACTLY
+    ONE op-class. Per git grammar (first positional = repository), `git push --delete a b`
+    is repo=a/ref=b = SINGLE (→ remote-ref-delete), while `git push origin --delete a b`
+    is repo=origin/refs=a,b = MASS.
+    """
+    if not re.search(_GIT_PREFIX + r"push\b", command):
+        return None
+    # Single-ref delete is the OTHER op-class — defer to it (the boundary discriminator).
+    if _extract_remote_ref_delete_target(command) is not None:
+        return None
+    after = _tokens_after_push(command)
+    if after is None:
+        return None
+    # CROSS-LEG FIX (review FINDING 1): flag set from the SAME leg as the positionals
+    # (the post-`push` tokens), NOT the whole command — else a --mirror/--prune/--delete
+    # in a benign continuation leg (`git push origin feature && echo --mirror`) leaks in
+    # and mislabels the benign push as a mass-delete. All mass-relevant flags are push
+    # subcommand options, so post-push is the complete + correct scope.
+    gf = _normalized_flags(after, "git")  # needs --mirror/--prune in _FLAG_SPEC (added #1062b)
+    mass_flags = sorted(f for f in ("--mirror", "--prune") if f in gf)
+    positionals = _push_positionals(after)
+    colon_dsts = [p for p in positionals if re.match(r"^\+?:", p)]
+
+    if mass_flags:
+        # --mirror/--prune: remote = first positional (git grammar) or implicit;
+        # explicit refspecs (if any) are the remaining positionals.
+        remote = _strip_surrounding_quotes(positionals[0]) if positionals else _IMPLICIT_REMOTE_MARKER
+        refspecs = sorted(_strip_surrounding_quotes(p) for p in positionals[1:])
+        flags_part = ",".join(mass_flags)
+    elif "--delete" in gf:
+        # multi-ref --delete (the single-ref case already deferred above): git grammar
+        # repo = first positional, the rest are the deleted refs. Need >=2 refs to be mass.
+        if len(positionals) < 3:
+            return None
+        remote = _strip_surrounding_quotes(positionals[0])
+        refspecs = sorted(_strip_surrounding_quotes(p) for p in positionals[1:])
+        flags_part = "--delete"
+    elif len(colon_dsts) >= 2:
+        # multi empty-source colon delete (`origin :a :b`): remote = first non-colon
+        # positional (or implicit); refs = the colon dsts.
+        non_colon = [p for p in positionals if not re.match(r"^\+?:", p)]
+        remote = _strip_surrounding_quotes(non_colon[0]) if non_colon else _IMPLICIT_REMOTE_MARKER
+        refspecs = sorted(
+            _strip_surrounding_quotes(p).rsplit(":", 1)[1] for p in colon_dsts
+        )
+        flags_part = "--delete"
+    else:
+        return None
+
+    # Encode the destructive identity via the shared netstring SSOT (_canonical_join):
+    # framing subsumes the old `@`/`#`/`,` delimiters, so the identity is injective for
+    # ANY field content (closes the #1136 `#`/comma collision class). Dedup refspecs
+    # (a duplicate ref is the same target); empty refspecs frame uniformly (no `#`).
+    return _canonical_join([flags_part, remote, *sorted(set(refspecs))])
+
+
+# -----------------------------------------------------------------------------
+# Privileged-flag binding (#1042). The (operation_type, target) binding above
+# DROPS every dash-flag, so an approved `gh pr merge 5` and an executed
+# `gh pr merge 5 --admin` (branch-protection bypass) reduce to the SAME context
+# and authorize — the flag rides past the checkpoint undetected. The fix adds
+# ONE more binding dimension — `bound_flags` — computed by the SINGLE scanner
+# below, called from the SINGLE site in extract_command_context, so BOTH hook
+# arms inherit it and can never classify a command's flags differently (the same
+# anti-drift property that the shared (op,target) SSOT already guarantees).
+#
+# PRIVILEGED_FLAGS is the op-class-scoped denylist: { op_type -> { canonical_long
+# -> (aliases, value_taking) } }. Membership is PURE DATA — adding or removing a
+# flag is a one-line edit with ZERO scanner/predicate changes, so the security
+# review owns membership without touching logic. A flag's PRESENCE binds it; the
+# read-side set-equality gate then enforces never-escalate.
+#
+# EXCLUDES op-trigger flags that already change op_type (and are therefore
+# already bound through it): --force/-f (force-push), -D (branch-delete), and
+# gh pr close's --delete-branch (the close-danger trigger). Listing them here
+# would double-bind and needlessly over-block.
+#
+# THE EXCLUSION IS PER-CLASS, NOT GLOBAL — it is the flag's ROLE ON THAT CLASS
+# that decides, and the same flag can have different roles on different classes.
+# The rule: EXCLUDE A TRIGGER FROM THE CLASS IT TRIGGERS; BIND IT WHERE IT IS A
+# MODIFIER. Worked instances, all three of which look like exceptions until the
+# rule is stated this way:
+#   - --delete-branch/-d TRIGGERS `close`, but on gh pr MERGE it is a post-merge
+#     SIDE-EFFECT (deletes the source branch), so it IS bound on `merge`. (And -d
+#     on merge is a DIFFERENT op from -D branch force-delete; op-class scoping
+#     keeps them from being conflated.) It is ALSO bound on `close` itself, for
+#     the narrower reason spelled out at that entry: op_type folds bare-close and
+#     close --delete-branch into ONE op, so there the trigger does not
+#     discriminate and the flag binding is what separates them.
+#   - --mirror/--prune TRIGGER `remote-mass-delete`, but on `remote-ref-delete`
+#     they are scope-widening MODIFIERS, so they ARE bound there — that binding
+#     is what stops a single-branch-delete approval from authorizing a wholesale
+#     remote wipe.
+# So "is this flag an op-trigger?" is the WRONG question at this table. The right
+# one is "is it a trigger OF THIS CLASS?"
+PRIVILEGED_FLAGS: dict[str, dict[str, tuple[tuple[str, ...], bool]]] = {
+    "merge": {
+        "--admin":         (("--admin",), False),               # bypass branch protection
+        "--delete-branch": (("-d", "--delete-branch"), False),  # side-effect: deletes source branch
+        "--repo":          (("-R", "--repo"), True),            # cross-repo redirect (value-carrying target)
+        # value-carrying SAFETY constraint (pins the merge to a head SHA); binding
+        # it closes the dropped-constraint case — approve with --match-head-commit,
+        # execute without it -> set-equality REFUSES (#1042).
+        "--match-head-commit": (("--match-head-commit",), True),
+    },
+    "close": {
+        "--repo":          (("-R", "--repo"), True),            # cross-repo redirect (value-carrying target)
+        # --delete-branch/-d: the IRREVERSIBLE branch-deleting variant of close. Bound
+        # here (symmetry with merge above) so a bare-close token's flag-set can never
+        # set-equal the --delete-branch variant → the bare→delete-variant escalation
+        # REFUSES. NB it is ALSO a close op-trigger, but op_type folds bare-close and
+        # close --delete-branch into the SAME 'close' op (close precedence), so the
+        # trigger alone does NOT distinguish the two commands at the bind layer — this
+        # flag binding is what separates them. No double-bind: op-trigger sets the OP
+        # dimension, this sets the orthogonal FLAG-SET dimension.
+        "--delete-branch": (("-d", "--delete-branch"), False),
+    },
+    "force-push": {
+        "--no-verify":     (("--no-verify",), False),           # bypass pre-push hook
+    },
+    "push-to-main": {
+        # --force-with-lease: the lease push CAN rewrite history (unlike a plain push),
+        # so its PRESENCE separates plain-push and lease-push token identities inside
+        # one op-class (the close/--delete-branch precedent above). Bound as a BOOLEAN:
+        # git's value is =-joined only (never space-separated), and a value-taking
+        # marking would (i) consume the next positional (`origin`) on the bare spelling
+        # and (ii) import mint-side adjacency-sensitivity from the wide flag_scan_text
+        # surface -> an over-block risk. All =<ref>:<expect> spellings therefore bind
+        # the same canonical bare token; intra-lease value variation is an accepted
+        # residual (never authorizes plain<->lease or lease<->force escalation).
+        "--force-with-lease": (("--force-with-lease",), False),
+    },
+    "branch-delete": {
+        # No bound flags today: branch-delete's privileged effect is its op-trigger
+        # (-D / --delete --force), already bound via op_type. Kept as an explicit
+        # extension point so a future bound flag is a one-line data edit here.
+    },
+    "remote-ref-delete": {
+        # The op-TRIGGER here is --delete/-d/empty-source colon, already bound via
+        # op_type. These three are MODIFIERS on top of that trigger, so binding them
+        # adds a dimension the identity did not previously capture.
+        #
+        # --mirror/--prune are LOAD-BEARING on this class. A single-ref delete's
+        # identity is otherwise the bare ref (`main`), so an approval for
+        # `git push origin :main` (delete ONE branch) set-equaled an execution of
+        # `git push origin --mirror :main` — which deletes EVERY remote ref with no
+        # local counterpart. Single-branch approval, wholesale remote wipe. The
+        # single-ref extractor wins the boundary discriminator, so the scope-changing
+        # flag rode an identity that did not capture it. Binding closes it.
+        "--mirror":    (("--mirror",), False),
+        "--prune":     (("--prune",), False),
+        # bypasses the pre-push hook — a privilege, not a target change
+        "--no-verify": (("--no-verify",), False),
+    },
+    "remote-mass-delete": {
+        # DELIBERATELY NARROWER THAN ITS SIBLING, and the asymmetry is not cosmetic:
+        # exclude a trigger from the class it triggers; bind it where it is a modifier.
+        # --mirror/--prune are the op-TRIGGER for this class, and _extract_mass_delete_target
+        # EMBEDS them in the identity netstring (`git push --mirror origin` binds
+        # '8:--mirror6:origin', `--prune` binds '7:--prune6:origin'). So a --mirror/--prune
+        # escalation on this class ALREADY refuses at the identity layer, and binding them
+        # here changes no outcome TODAY — a cert row for it would be vacuous, and on a
+        # control whose dominant failure mode is checks that prove nothing, an entry that
+        # reads as protection while proving nothing is a real cost.
+        #
+        # VACUOUS TODAY IS NOT THE SAME CLAIM AS INERT, and the difference decides the
+        # design. Binding them here WOULD matter if the identity ever coarsened (see the
+        # COUPLING note below) — so the choice is not "redundant vs useful", it is
+        # "auditable now, with the coupling pinned" vs "silently defended, unverifiably".
+        # We take the first: narrow entry + a load-bearing pin on what it depends on.
+        #
+        # COUPLING — LOAD-BEARING, pinned by test, not left implicit. This narrowness
+        # DEPENDS on mass_target continuing to EMBED the flag. Measured under a coarsened
+        # mass_target (remote only): the split binding lets the --mirror/--prune escalation
+        # OPEN, while a symmetric binding would keep it closed. So the redundancy is NOT
+        # inert — split is chosen for auditability and is safety-equivalent to symmetric
+        # ONLY while that embedding holds.
+        # REMEDY: if you coarsen mass_target, you MUST bind --mirror and --prune HERE in
+        # the same commit. See test_mass_target_embeds_the_scope_flag_in_its_identity.
+        "--no-verify": (("--no-verify",), False),
+    },
+    "branch-protection": {
+        # No bound flags: branch-protection's privileged effect (weakening protection)
+        # IS its op-trigger (the DELETE|PUT|PATCH method on the protection endpoint),
+        # bound via op_type. Empty entry = explicit #1042 extension point; adds NO new
+        # bound flag, so the set-equality bind is untouched.
+    },
+}
+
+
+def extract_privileged_flags(command: str, op_type: str | None) -> list[str]:
+    """Scan a command for the privileged dash-flags bound on its op-class (#1042).
+
+    Returns a SORTED list of canonical flag tokens (boolean flags as their
+    canonical long form, e.g. ``--admin``; value-taking flags as
+    ``--repo=<value>``). The read side compares these as SETS for exact equality,
+    so any added privilege OR dropped constraint mismatches and REFUSES.
+
+    The scan is a SINGLE linear ``str.split()`` token-walk against the op-class
+    denylist (``PRIVILEGED_FLAGS``) — constant per-token work, NO regex, no
+    backtracking — so it preserves the bounded/linear extraction invariant
+    (INV-D2) the rest of this module is careful about.
+
+    Normalizes every CLI form to one canonical token: exact long (``--admin``),
+    short alias (``-R`` -> ``--repo``), ``=``-joined (``--repo=x`` / ``-R=x``),
+    attached short value (``-Rx`` -> ``--repo=x``), and combined-short clusters
+    via a general per-character walk (``-sd`` -> ``--delete-branch``;
+    ``-dR owner/repo`` -> ``--delete-branch`` + ``--repo=owner/repo``) so NO bound
+    short is ever dropped regardless of cluster ordering. On the GIT surface
+    ONLY, an unambiguous long-prefix abbreviation is EXPANDED to its canonical
+    flag (``--no-verif`` -> ``--no-verify``) — this is SECURITY-LOAD-BEARING:
+    git's parser accepts abbreviation, so a missed match would be a silent
+    UNDER-block; gh rejects abbreviation, so its surface needs no expansion.
+
+    Args:
+        command: The command (read arm) or full approval surface (mint arm) to
+            scan. The caller decides which; the scanner treats it as one string.
+        op_type: The classified operation type, or None. Selects the denylist;
+            an op_type with no denylist entry (incl. None and the API/un-flagged
+            classes) yields ``[]``.
+
+    Returns:
+        Sorted list of canonical bound-flag tokens; ``[]`` when none are present.
+    """
+    denylist = PRIVILEGED_FLAGS.get(op_type) if op_type is not None else None
+    if not denylist:
+        # op_type is None, unknown, or carries no bound flags (e.g. branch-delete
+        # today). An empty result binds the empty set — over-block-safe and the
+        # correct outcome for the API/un-flagged classes.
+        return []
+
+    # Derive the lookup tables from the denylist ONCE per call. All small,
+    # constant-size structures (the denylist has <=3 entries per op-class), so
+    # the per-token work below stays O(1).
+    alias_to_canonical: dict[str, str] = {}
+    value_taking: set[str] = set()
+    canonical_long_names: list[str] = []
+    for canonical, (aliases, takes_value) in denylist.items():
+        canonical_long_names.append(canonical)
+        if takes_value:
+            value_taking.add(canonical)
+        for alias in aliases:
+            alias_to_canonical[alias] = canonical
+    # git's parse-options expands unambiguous long-prefix abbreviations; gh's
+    # pflag rejects them. Only the git surface needs abbreviation expansion.
+    # push-to-main is a git surface — DEFENSE-IN-DEPTH: no abbreviated lease
+    # spelling reaches this bind in the live flow today. Any prefix still
+    # containing `--force` (e.g. `--force-with-leas`) classifies FORCE-PUSH
+    # first (the force arms' lookahead excludes only the exact `-with-lease`
+    # suffix), and the shorter prefixes that DO classify push-to-main (`--forc`,
+    # `--fo`) are ambiguous to git itself — git rejects the command, so no live
+    # lease push runs unbound. The expansion keeps the bind correct if either
+    # neighbor ever shifts; a unique-in-OUR-denylist prefix binds conservatively
+    # (over-block-safe).
+    is_git_surface = op_type in ("force-push", "branch-delete", "push-to-main")
+
+    # P1 quote-aware tokenization (closes the quoted-flag bind bypass #3: a
+    # `"--admin"` is shlex-stripped to `--admin` → bound; the old `command.split()`
+    # kept the quotes → `startswith('-')` skipped it → the escalation rode along).
+    # BOTH arms call this shared function so the bind stays symmetric. On an
+    # unbalanced quote shlex returns None; fall back to `split()` so the bind never
+    # regresses below today's coverage. The bind is defense-in-depth on top of the
+    # literal floor (is_dangerous_command), which is the fail-closed default — there is
+    # no metachar suppressor in the honest-mistake model.
+    tokens = _shell_tokenize(command)
+    if tokens is None:
+        tokens = command.split()
+    found: set[str] = set()
+    i = 0
+    n = len(tokens)
+    while i < n:
+        token = tokens[i]
+        # Non-flag tokens, the bare `-` (stdin) and `--` (end-of-options) marker
+        # never bind. Skipping `--` is load-bearing: it must NOT prefix-match a
+        # sole long flag in the abbreviation branch below.
+        if not token.startswith("-") or token in ("-", "--"):
+            i += 1
+            continue
+
+        if token.startswith("--"):
+            # Long flag: exact denylist hit, or — git surface only — an
+            # unambiguous prefix abbreviation. An inline `=value` is split off.
+            flag_part, has_eq, inline_value = token.partition("=")
+            canonical = alias_to_canonical.get(flag_part)
+            if canonical is None and is_git_surface:
+                prefix_matches = [
+                    name for name in canonical_long_names if name.startswith(flag_part)
+                ]
+                # Exactly one match = unambiguous; >1 is ambiguous (git itself
+                # rejects it, so the command never runs) and binds nothing.
+                if len(prefix_matches) == 1:
+                    canonical = prefix_matches[0]
+            if canonical is None:
+                i += 1
+                continue
+            if canonical in value_taking:
+                if has_eq:                       # --repo=value
+                    found.add(f"{canonical}={inline_value}")
+                    i += 1
+                elif i + 1 < n:                  # --repo value
+                    found.add(f"{canonical}={tokens[i + 1]}")
+                    i += 2
+                else:                            # --repo (value missing; degenerate)
+                    found.add(canonical)
+                    i += 1
+            else:
+                # boolean: an explicit `=false`/`=0`/`=no` DISABLES the flag (the SAFE
+                # form), so it must NOT bind — else an approval of `--admin=false`
+                # would set-equal an execution of `--admin=true` (both → {--admin}) and
+                # AUTHORIZE the escalation. Any other (or no) value binds.
+                if not (has_eq and inline_value.lower() in _NEGATED_FLAG_VALUES):
+                    found.add(canonical)
+                i += 1
+            continue
+
+        # Short cluster (single dash): a general per-character walk that subsumes
+        # the lone short (`-R`), the combined boolean cluster (`-sd`), the
+        # attached short value (`-Rx`), and any mixed ordering (`-dR`, `-Rd`). A
+        # value-taking short consumes the REST of the cluster (or the next token)
+        # as its value and stops the walk — pflag semantics — so no bound short
+        # is ever dropped from a cluster.
+        cluster = token[1:]
+        consumed_next = False
+        j = 0
+        while j < len(cluster):
+            canonical = alias_to_canonical.get("-" + cluster[j])
+            if canonical is None:
+                j += 1
+                continue
+            if canonical in value_taking:
+                remainder = cluster[j + 1:]
+                if remainder.startswith("="):    # `-R=value`
+                    remainder = remainder[1:]
+                if remainder:                    # `-Rvalue`
+                    found.add(f"{canonical}={remainder}")
+                elif i + 1 < n:                  # `-R value`
+                    found.add(f"{canonical}={tokens[i + 1]}")
+                    consumed_next = True
+                else:                            # `-R` (value missing; degenerate)
+                    found.add(canonical)
+                break
+            found.add(canonical)                 # boolean short; keep walking
+            j += 1
+        i += 2 if consumed_next else 1
+
+    return sorted(found)
+
+
+def extract_command_context(command: str, flag_scan_text: str | None = None) -> dict:
+    """Extract operation context FROM A COMMAND STRING (never prose).
+
+    The shared SSOT both merge-guard hooks call. A key is PRESENT only when
+    positively extracted; ABSENT otherwise (absence — NOT a None value — is the
+    fail-closed signal). Possible keys:
+        operation_type: "merge" | "close" | "force-push" | "branch-delete"
+                        | "push-to-main" | "remote-ref-delete" | "remote-mass-delete"
+                        | "branch-protection"
+        pr_number:  str  (merge / close)
+        branch:     str  (branch-delete — SINGLE target, exactly 1 positional)
+        branch_set: str  (branch-delete — MULTI target #1129, >=2 positionals) —
+                     canonical sort+dedup+quote-strip names via the shared netstring _canonical_join (`len:name` framing,
+                     injective by construction, content-agnostic — no delimiter collision)
+        target_ref: str  (force-push / push-to-main, KD-6; remote-ref-delete #1062a)
+        push_set:   str  (push-to-main MULTI-ref #1195 OBS-G, >=2 refspecs) —
+                     canonical sort+dedup FULL-refspec identity via the shared
+                     netstring _canonical_join (remote-agnostic; the scalar
+                     target_ref owns the single-ref form — exactly one populated)
+        force_push_set: str (force-push MULTI-ref #1195 OBS-I, >=2 refspecs) —
+                     canonical FORCED-NORMALIZED identity (class-wide --force
+                     upgrades elements to '+'-form) gated by the ref-scope-neutral
+                     flag allowlist; exactly one of target_ref / push_set /
+                     force_push_set populated per command
+        mass_target: str (remote-mass-delete #1062b) — normalized identity STRING
+                     _canonical_join([<sorted-mass-flags>, <remote-or-implicit-marker>, *<sorted-deduped-refspecs>])
+        protected_branch: str (branch-protection #1063) — the branch from the
+                     branches/<b>/protection URL path
+        bound_flags: list[str]  (#1042) — sorted normalized privileged flags;
+                     ALWAYS present when operation_type is (empty list when none).
+
+    `flag_scan_text` (#1042) widens ONLY the privileged-flag scan to a fuller
+    surface than `command` — the mint arm passes the full selected-option text so
+    a flag positioned after a quoted argument is not lost to region truncation
+    (the read arm passes nothing, scanning the raw command). Op/target are ALWAYS
+    derived from `command` (region-anchored — preserves the anti-distractor
+    multiplicity gate); only the flag scan honors `flag_scan_text`.
+    """
+    context: dict = {}
+    # Line-continuation parity (mint==read by construction): join bash `\<newline>` on
+    # BOTH the op/target-anchoring `command` AND the wider `flag_scan_text` BEFORE
+    # detection, so the #1042 flag bind and the op/target derivation are continuation-
+    # INVARIANT and identical on both arms. Without this, a faithful
+    # `gh pr close 5 \<newline>--delete-branch` (whose region locate_command_regions now
+    # joins upstream) still bound NO flag on the MINT arm — its flag scan reads the raw
+    # option text whose `\<newline>` split `--delete-branch` off — while the READ arm,
+    # scanning the clean executed command, bound {--delete-branch}; the set-equality
+    # bind then REFUSED the faithful click (an over-block). Idempotent on already-
+    # normalized input, a strict no-op without a literal `\<newline>`, and join-only —
+    # it can only COMPLETE a split flag, never drop one.
+    command = _normalize_line_continuations(command)
+    if flag_scan_text is not None:
+        flag_scan_text = _normalize_line_continuations(flag_scan_text)
+    op_type = detect_command_operation_type(command)
+    if op_type is None:
+        return context
+    context["operation_type"] = op_type
+    # bound_flags is computed HERE (the single call site) so both arms inherit it
+    # un-driftably. It is an ATTRIBUTE of the (op,target) pair, never part of pair
+    # identity (_target_value / _collect_pairs ignore it), so flag variation can
+    # never inflate the distinct-pair count and trip the multiplicity refusal.
+    context["bound_flags"] = extract_privileged_flags(
+        flag_scan_text if flag_scan_text is not None else command, op_type
+    )
+    if op_type in ("merge", "close"):
+        # close accepts {<number>|<url>|<branch>} — bind whichever the command
+        # carries so EVERY faithful close form MINTS (not just the number form).
+        # merge keeps the number-only extractor (+ the #1096 API pulls/<N> path).
+        if op_type == "close":
+            pr_number = _extract_close_target(command)
+        else:
+            pr_number = _extract_pr_number(command)
+            if pr_number is None:
+                pr_number = _extract_api_merge_pr(command)   # #1096 API pulls/<N>/merge
+        if pr_number is not None:
+            context["pr_number"] = pr_number
+    elif op_type == "branch-delete":
+        # Single-branch scalar path (BYTE-IDENTICAL): exactly ONE positional.
+        branch = _extract_branch_name(command)
+        if branch is not None:
+            context["branch"] = branch
+        else:
+            # Multi-branch (>=2 positionals) FORCE-delete: bind the canonical
+            # sorted+deduped branch-SET identity (#1129 R1, mirrors mass_target).
+            # _extract_branch_name returns non-None ONLY for exactly 1 positional
+            # and _extract_branch_delete_set ONLY for >=2, so they are MUTUALLY
+            # EXCLUSIVE -> a command populates EXACTLY ONE of `branch` /
+            # `branch_set` (the boundary discriminator). The distinct key plus the
+            # op-type-identity check in the read switch keep a scalar token from
+            # cross-authorizing a set command (and vice-versa).
+            branch_set = _extract_branch_delete_set(command)
+            if branch_set is not None:
+                context["branch_set"] = branch_set
+    elif op_type in ("force-push", "push-to-main"):
+        # push-to-main reuses the force-push target parser: its target IS the
+        # main/master ref that parser already returns for a plain push.
+        target_ref = _extract_force_push_target_ref(command)
+        if target_ref is not None:
+            context["target_ref"] = target_ref
+        elif op_type == "push-to-main":
+            # DISTINCT-set boundary (#1195 OBS-G): the MULTI-ref push-to-main
+            # identity, populated ONLY when the scalar refused (multi-ref ->
+            # target_ref None). Exactly ONE of `target_ref` / `push_set` /
+            # `force_push_set` is populated per command — the scalar's `!=2 ->
+            # None`, the sets' `<2 -> None`, and this op split are mutually
+            # exclusive by construction — so no scalar/set or cross-op
+            # cross-authorization window exists.
+            push_set = _extract_push_to_main_set(command)
+            if push_set is not None:
+                context["push_set"] = push_set
+        else:
+            # force-push (#1195 OBS-I, reversing the OBS-G scope boundary under
+            # its own ratified proof): the MULTI-ref FORCED-NORMALIZED set
+            # identity, gated by the ref-scope-neutral flag ALLOWLIST (see
+            # _extract_force_push_set) — a delete/mass/scope-expander/unknown
+            # flag on the execution or the approval derives force_push_set=None
+            # and fails SAFE to gated-but-unmintable / read-refused. The scalar
+            # _extract_force_push_target_ref above remains byte-untouched;
+            # multi-ref DELETE spellings still never mint (delete never gains a
+            # set — they classify remote-ref-delete/mass, not force-push, and a
+            # force-masked delete flag fails the allowlist).
+            force_push_set = _extract_force_push_set(command)
+            if force_push_set is not None:
+                context["force_push_set"] = force_push_set
+    elif op_type == "remote-ref-delete":
+        # #1062a: REUSE the `target_ref` key — the parser yields a ref, the key is
+        # semantically right, and the op-class identity (checked FIRST in the read
+        # switch) keeps a remote-ref-delete token from cross-authorizing a
+        # force-push/push-to-main with the same target_ref. Recognition⟺extractability:
+        # detect returned this op IFF the extractor yields a ref, so it is non-None here.
+        ref = _extract_remote_ref_delete_target(command)
+        if ref is not None:
+            context["target_ref"] = ref
+    elif op_type == "remote-mass-delete":
+        # #1062b: DISTINCT key `mass_target` (not target_ref — the value is a
+        # normalized identity tuple, a different shape from a ref). op-identity-first
+        # in the read switch already prevents cross-op match; a distinct key avoids any
+        # accidental equality with a ref-shaped target_ref. Recognition⟺extractability.
+        mass_target = _extract_mass_delete_target(command)
+        if mass_target is not None:
+            context["mass_target"] = mass_target
+    elif op_type == "branch-protection":
+        # #1063: the protected branch is PATH-resident (branches/<b>/protection).
+        # Distinct key `protected_branch`; op-identity-first in the read switch keeps
+        # it from cross-authorizing a branch-delete of the same branch name.
+        protected_branch = _extract_protection_branch(command)
+        if protected_branch is not None:
+            context["protected_branch"] = protected_branch
+    return context
+
+
+# Shell compound + FD-redirect regexes — the SSOT for BOTH the read side
+# (merge_guard_pre.is_compound_destructive_command re-imports these) AND the mint
+# side (which runs is_compound_destructive_command on each locate_command_regions
+# region). Centralized here so both sides scan on IDENTICAL separators (the #720
+# anti-drift class).
+#
+# `_COMPOUND_OPS_RE` matches the COMPLETE bash command-separator/backgrounding set
+# (P3): `&&`, `||`, `|&`, `;`, a bare `&` (background — the finding-#1 ride-along), a
+# bare `|` shell pipe, and newline. Multi-char ops precede their single-char prefixes
+# in the alternation so a match never mis-segments (`&&` before `&`; `||`/`|&` before
+# `|`). Scanned on the P2 QUOTE-MASKED view so an operator inside a quoted argument is
+# NOT a separator. FD-redirect / and-redirect / clobber tokens (`2>&1`, `1>&2`, `3<&0`,
+# `&>`, `&>>`, `>|`) are NEUTRALIZED by `_FD_REDIRECT_RE` BEFORE the scan so the new
+# bare-`&` arm does NOT false-positive on the bash redirect-both operator
+# (`gh pr merge 5 &>out.log` is NOT a compound) — NOT via lookaround on the bare-pipe
+# arm (an earlier lookbehind `(?<![0-9>])\|(?![<&])` had a spaceless-adjacency bypass:
+# `... 2>&1|gh pr merge 999` slipped past; the structural pre-strip eliminates that
+# class). `_FD_REDIRECT_RE`: `\d*[<>]&` (any `[<>]&` redirect prefix — fd-dup `2>&1`,
+# fd-close `0<&-`, csh `>&out.log`) | `>\|` (clobber) | `&>>?` (and-redirect `&>`/`&>>`;
+# the leading-`&` form). Audit: loosening
+# `_COMPOUND_OPS_RE` must preserve the seven shapes; the `&>`/`&>>` neutralization must
+# stay coupled to the bare-`&` arm; the pre-strip is the single source of truth.
+_COMPOUND_OPS_RE = re.compile(r"&&|\|\||\|&|;|&|\||\n")
+# `\d*[<>]&` neutralizes EVERY `[<>]&` redirect prefix — fd-dup (`2>&1`,`1>&2`),
+# fd-close (`0<&-`,`1>&-`), and csh and-redirect-to-file (`>&out.log`) — so the bare-`&`
+# arm cannot FP on any of them. A REAL background `&` is whitespace-preceded (` & `),
+# never `[<>]`-preceded, so it still detects. `&>>?` covers the leading-`&` and-redirect
+# (`&>`/`&>>`); `>\|` the clobber.
+_FD_REDIRECT_RE = re.compile(r"\d*[<>]&|>\||&>>?")
+
+
+
+def locate_command_regions(text: str) -> list[str]:
+    """Return ALL gh/git destructive-command regions in ONE string, in document
+    order.
+
+    A region is a candidate command substring — a quoted region (via
+    `_QUOTED_COMMAND_RE`) OR a bare `gh ...`/`git ...` span (via
+    `_BARE_COMMAND_RE`) — that `detect_command_operation_type` classifies
+    non-None.
+
+    Takes a SINGLE string, NEVER an options array (D3 structural invariant: the
+    function can never receive non-selected options, so it CANNOT over-scan —
+    'make illegal states unrepresentable' on a security boundary). The caller
+    passes ONE question's text or ONE selected option's text at a time.
+    """
+    # Mint==read parity: join bash line-continuations (`\<newline>` -> space) BEFORE
+    # the region scans, so the mint joins continuations IDENTICALLY to the read side
+    # (is_dangerous_command + is_compound_destructive_command both normalize first).
+    # Without this, `gh pr close 5 \<newline>--delete-branch` truncated at the newline
+    # to a non-dangerous region (`gh pr close 5 \`) -> mint withheld a token while the
+    # read side (normalized) DENIED the full command -> a faithful click was OVER-blocked.
+    # Offset/length note: the join SHORTENS text (2 chars -> 1), but every offset below
+    # (the `covered` quoted spans, the masked-view bare-span slices) indexes into THIS
+    # SAME normalized `text`, and the function returns region STRINGS (never offsets into
+    # the caller's original), so the length change is internally consistent and invisible
+    # to every caller. Join-only + no-op without a literal `\<newline>` -> detection can
+    # only INCREASE (never drop), so no new under-block.
+    text = _normalize_line_continuations(text)
+    regions: list[str] = []
+    covered: list[tuple[int, int]] = []
+    # Quoted regions first — an explicit command literal is the canonical form.
+    # COVER only quoted regions that ARE commands: a non-command quoted ARGUMENT
+    # (`--comment "x"`) must NOT be covered, else the masked-view bare span below
+    # (which now extends THROUGH it) would be wrongly skipped and drop #5's trailing
+    # flag. An embedded quoted COMMAND, by contrast, IS covered + captured separately
+    # so the multiplicity gate still refuses a distractor.
+    for match in _QUOTED_COMMAND_RE.finditer(text):
+        candidate = match.group(1) or match.group(2) or match.group(3)
+        if candidate and detect_command_operation_type(candidate) is not None:
+            covered.append((match.start(), match.end()))
+            regions.append(candidate)
+    # Bare gh/git spans located on the P2 QUOTE-MASKED view so a quoted ARGUMENT in
+    # the MIDDLE of a command (`--comment "x"`) no longer truncates the span and
+    # drops a trailing flag (#5). Single/double-quoted spans mask to spaces (the bare
+    # span extends through them); real separators (`;` `|` `&` newline) and backticks
+    # are NOT masked, so they still bound the span. Region text is sliced from the
+    # ORIGINAL so the real quoted value is preserved. The skip is CONTAINMENT (the
+    # bare span lies ENTIRELY within an already-captured quoted command, e.g. a
+    # backtick command) — NOT mere overlap: the outer command of a distractor
+    # `... "gh pr merge 999"` CONTAINS the covered inner region rather than being
+    # contained by it, so it is still added → two regions → multiplicity refuses.
+    masked = _mask_shell_quotes(text)
+    for match in _BARE_COMMAND_RE.finditer(masked):
+        if any(
+            c_start <= match.start() and match.end() <= c_end
+            for c_start, c_end in covered
+        ):
+            continue
+        span = text[match.start():match.end()].strip()
+        if detect_command_operation_type(span) is not None:
+            regions.append(span)
+    return regions
+
+
+def locate_command_region(text: str) -> str | None:
+    """Convenience: the first command region in `text`, else None. SINGLE
+    string arg (same D3 invariant as locate_command_regions)."""
+    regions = locate_command_regions(text)
+    return regions[0] if regions else None
+
+
+def cleanup_consumed_tokens(token_dir: Path) -> None:
+    """Remove stale .consumed token files and .use-N markers older than TOKEN_TTL.
+
+    Called from both hooks: during token scanning (pre-hook) and during
+    token creation (post-hook) to prevent accumulation. The .use-N markers
+    accompany N-use tokens (#720 Bug C) and persist on disk alongside the
+    .consumed terminal-rename until the TTL window elapses.
+
+    Args:
+        token_dir: Directory containing token files
+    """
+    now = time.time()
+    patterns = (
+        str(token_dir / f"{TOKEN_PREFIX}*.consumed"),
+        str(token_dir / f"{TOKEN_PREFIX}*{USE_MARKER_SUFFIX}*"),
+    )
+    for pattern in patterns:
+        for stale_path in glob.glob(pattern):
+            try:
+                # Use file modification time as a proxy for consumption time
+                mtime = os.path.getmtime(stale_path)
+                if now - mtime > TOKEN_TTL:
+                    try:
+                        os.unlink(stale_path)
+                    except OSError:
+                        pass
+            except OSError:
+                # File may have been cleaned up concurrently — ignore
+                pass
+
+
+def cleanup_unused_tokens(token_dir: Path) -> None:
+    """Atomically retire (rename to .consumed) any unused tokens in token_dir.
+
+    Maintains invariant I-1 (at most one unused token at any time). Called
+    from merge_guard_post.write_token() BEFORE the O_EXCL create of the new
+    token so that, at the instant O_EXCL succeeds, the directory holds zero
+    unused tokens (just cleaned) plus the new one — exactly one.
+
+    Concurrency model: POSIX rename(2) is atomic on the same filesystem.
+    When two writers race, exactly one rename of any given source path
+    succeeds; the loser raises FileNotFoundError which is swallowed. No
+    fs-lock required.
+
+    Args:
+        token_dir: Directory containing token files
+
+    Side effects:
+        Renames matching unused token files to <path>.consumed. Skips
+        already-.consumed paths and .use-N marker siblings (the latter
+        are auxiliary files for N-use slot claims; reaped by
+        cleanup_consumed_tokens at TOKEN_TTL boundary).
+    """
+    pattern = str(token_dir / f"{TOKEN_PREFIX}*")
+    for path in glob.glob(pattern):
+        # Already terminal — skip to avoid creating .consumed.consumed shape.
+        if path.endswith(".consumed"):
+            continue
+        # Per-use slot markers are NOT tokens; preserve them as audit trail
+        # alongside their parent token's retirement (cleanup_consumed_tokens
+        # reaps them at the TOKEN_TTL boundary).
+        if USE_MARKER_SUFFIX in os.path.basename(path):
+            continue
+        try:
+            os.rename(path, path + ".consumed")
+        except (FileNotFoundError, OSError):
+            # Concurrent retire (another writer's cleanup, or _consume_token
+            # claiming the same path) won the race — the invariant holds
+            # either way. Swallow.
+            pass
+
+
+def cleanup_orphan_tokens(
+    token_dir: Path,
+    max_age_seconds: int = ORPHAN_TOKEN_MAX_AGE_SECONDS,
+) -> None:
+    """Reap unconsumed tokens older than max_age_seconds (disk hygiene).
+
+    Targets tokens that escaped the normal lifecycle — e.g., when the
+    consuming dangerous-Bash command was never executed after authorization,
+    leaving a token to expire silently. TOKEN_TTL already expires
+    them for authorization purposes; this helper unlinks them from disk to
+    bound accumulation.
+
+    Idempotent. Fail-open on all OSError paths (file gone, permission
+    denied, dir missing) — disk hygiene must never block any caller.
+
+    Args:
+        token_dir: Directory containing token files
+        max_age_seconds: Reap threshold (default ORPHAN_TOKEN_MAX_AGE_SECONDS).
+
+    Side effects:
+        Unlinks matching token files. Skips .consumed and .use-N markers.
+    """
+    now = time.time()
+    pattern = str(token_dir / f"{TOKEN_PREFIX}*")
+    for path in glob.glob(pattern):
+        if path.endswith(".consumed"):
+            continue
+        if USE_MARKER_SUFFIX in os.path.basename(path):
+            continue
+        try:
+            mtime = os.path.getmtime(path)
+        except OSError:
+            # File gone between glob and stat — race-safe no-op.
+            continue
+        if now - mtime > max_age_seconds:
+            try:
+                os.unlink(path)
+            except OSError:
+                # Race vs concurrent cleanup or permission flake — swallow.
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Read-floor danger predicates (GAP1/GAP5) — PROMOTED from merge_guard_pre.py so
+# BOTH the read hook AND the mint hook (merge_guard_post) call the SAME predicate:
+# the mint gates its token-write on is_dangerous_command (mint⊆read by construction)
+# and refuses any compound via is_compound_destructive_command. pre.py re-imports
+# these. _COMPOUND_OPS_RE/_FD_REDIRECT_RE already live above (GAP5 elevation).
+# ---------------------------------------------------------------------------
+
+DANGEROUS_PATTERNS = [
+# PR merge via gh CLI
+re.compile(_GH_PREFIX + r"pr\s+merge\b"),
+# PR close with --delete-branch: the close+--delete-branch danger arms live in
+# _CLOSE_LITERAL_ARMS (defined with the classifier patterns above) — matched
+# PER-LEG by is_dangerous_command after this list misses (#1087 leg isolation),
+# NOT whole-string here (a whole-command match fired cross-leg and laundered an
+# ambiguous multi-close into an escalated-single token). Bare close is reversible.
+# Force push arms live in _FORCE_PUSH_LITERAL_ARMS (defined with the classifier
+# patterns above) — matched PER-LEG by is_dangerous_command after this list
+# misses (#1082 leg isolation), NOT whole-string here.
+# Force-branch-delete arms live in _BRANCH_DELETE_LITERAL_ARMS (defined with the
+# classifier patterns above) — matched PER-LEG by is_dangerous_command after this
+# list misses (#1094 leg isolation), NOT whole-string here (a whole-command match
+# fired cross-leg on a stray -D / --delete --force token in a benign leg).
+# API danger arms (merge / git-refs / branch-protection / contents / implicit-POST,
+# across gh api / curl / wget) live in _API_LITERAL_ARMS (defined with the classifier
+# patterns above) — matched PER-LEG by is_dangerous_command after this list misses
+# (#1086 leg isolation), NOT whole-string here (a whole-command match fired cross-leg
+# and over-blocked a benign compound carrying a method/body-flag token in a benign leg).
+# Direct push to a default branch (bypasses PR merge) — the former HEAD:main / HEAD:master
+# and bounded-flag-walk main / master literals were REMOVED (#1195 OBS-E): the read floor
+# recognizes push-to-main via `_flag_condition_danger_op` (its sole consumer here,
+# _stripped_surface_danger, calls it), using the UNIFIED _PUSH_MAIN_DST_RE refspec-DST
+# predicate — the SAME arm detect uses, so mint==read holds by construction with no second
+# copy to drift. The unified predicate fixes both the prefix over-block (main-release) and
+# the <src>:dst / full-ref under-block (feature:main / refs/heads/main) the literals had.
+]
+
+
+def _has_pipe_to_shell(command: str) -> bool:
+    """Check if command pipes output to a shell interpreter.
+
+    Detects patterns like ``echo "..." | bash``, ``printf "..." | sh``,
+    and ``echo "..." | xargs bash`` where echo/printf content would be
+    executed by the receiving shell.
+    """
+    return bool(
+        re.search(r"\|\s*(?:bash|sh|zsh)\b", command)
+        or re.search(r"\|\s*xargs\s+(?:.*\s+)?(?:bash|sh|zsh)\b", command)
+    )
+
+
+# Path-qualified shell token. Trailing (?![\w/]) anchors the shell name as a
+# whole PATH-LEAF token: excludes prefix-of-name (`>(basht)`/`>(teehee)`) AND
+# `>(bash/foo)` (bash is a DIRECTORY, foo the executable) while KEEPING
+# metachar-separated real vectors `>(bash;ls)`/`>(bash&&x)`/`>(bash|cat)`
+# (bash still executes).
+#
+# ReDoS — ReDoS-free AS USED, NOT standalone. Both arms anchor this token behind
+# `>\(`, so re.search only attempts it at the handful of `>(` offsets in a real
+# command. STANDALONE the nested `(?:[^\s)/]*/)*` is O(N^2): re.search retries at
+# EVERY start position (multi-offset retry) with an O(N) per-offset forward scan
+# — measured ~4x per input-doubling on pathological no-slash / all-slash input.
+# This is NOT within-match catastrophic backtracking (an anchored re.match is
+# linear, ~2x/double), so an atomic group `(?>...)` would NOT fix it (and atomic
+# groups are unavailable anyway — requires-python >=3.7). DO NOT reuse this token
+# UNGATED; if it is ever needed ungated, bound the path segments
+# `(?:[^\s)/]*/){0,K}` (the F1 mechanism), which caps the per-offset scan.
+_PROCSUB_SHELL = r"(?:[^\s)/]*/)*(?:bash|sh|zsh)(?![\w/])"
+
+
+def _has_process_substitution_to_shell(command: str) -> bool:
+    """Check if a command uses process substitution fed to a shell interpreter.
+
+    Detects:
+      - input-side  ``bash <(echo "...")``  — the shell consumes the substitution
+        as its input script (the original guard, UNCHANGED);
+      - output-side ``echo "..." > >(bash)`` — the command's stdout is routed into
+        a shell via process substitution. Caught in two forms (#1002):
+          * Arm A — ``>(shell)`` as a stdout-routing REDIRECT TARGET. The operator
+            set is stdout-only (``>``, ``>>``, ``1>``, ``1>>``, ``&>``, ``&>>``,
+            the csh ``>&`` excluding the fd-duplication ``>&N``, and the clobber
+            ``>|``); stderr-only routing (``2>``/``3>``) is excluded by omission.
+          * Arm B — ``>(shell)`` as a command ARGUMENT (tee-fanout & general, e.g.
+            ``... | tee >(bash)``). Keyed on a preceding NON-redirect token (word
+            char, quote, or close-bracket), so ``2> >(bash)`` (preceded by ``>``)
+            is NOT matched — the stderr exclusion holds on this arm too.
+    Both output-side arms accept an optional path prefix (``>(/bin/bash)``,
+    ``>(./sh)``) and require the shell name as a whole path-leaf token: non-shell
+    targets (``> >(tee ...)``, ``> >(cat ...)``), prefix-of-name (``>(teehee)``,
+    ``>(basht)``), and ``>(bash/foo)`` (bash a directory) are NOT matched.
+
+    The guard is consumed ONLY as a strip-SKIP condition: a True result PRESERVES
+    content for the dangerous-pattern scan, so widening it is monotonically
+    detection-increasing (INV-D2-safe; cannot create a false-negative).
+    """
+    return bool(
+        re.search(r"\b(?:bash|sh|zsh)\s+<\(", command)                       # input-side (unchanged)
+        # Arm A — redirect TARGET, stdout-routing operators only (stderr excluded by construction):
+        or re.search(r"(?:&>>?|>&(?![0-9])|>\||1>>?|(?<![0-9])>>?)\s*>\(\s*" + _PROCSUB_SHELL, command)
+        # Arm B — procsub as a command ARGUMENT (tee-fanout & general): preceded by a NON-redirect token:
+        or re.search(r"[\w\"')\]}]\s+>\(\s*" + _PROCSUB_SHELL, command)
+    )
+
+
+# Heredoc-BODY excision for the routing-flag view (#1129 R3). Reuses carrier-1's
+# marker grammar but replaces the BODY ONLY: the opener line (including a
+# genuinely-executing `| bash` / `> >(bash)` TAIL) and the closing marker stay
+# visible to the routing scan. Carrier-1's whole-match replacement would swallow
+# the opener tail and regress the pinned heredoc-pipe/procsub canaries
+# (under-block). Same input-side guard as carrier 1: a shell-fed body
+# (`bash <<EOF`) executes, so it is preserved. The REAL carrier-1 strip is
+# intentionally left untouched (this excision builds a view-only scan surface).
+_HEREDOC_BODY_RE = re.compile(
+    r"(<<-?\s*['\"]?(\w+)['\"]?[^\n]*\n)"   # 1: operator+marker+opener TAIL (kept)
+    r"(?:.*?\n)?"                            #    body (excised)
+    r"(\t*\2(?![\w]))",                      # 3: closing marker (kept)
+    re.DOTALL,
+)
+
+
+def _excise_heredoc_bodies_for_routing_scan(command: str) -> str:
+    if "<<" not in command:          # cheap short-circuit (perf: common case)
+        return command
+
+    def _repl(m: "re.Match") -> str:
+        preceding = command[: m.start()].rstrip()
+        if re.search(r"\b(?:bash|sh|zsh)\s*$", preceding):
+            return m.group(0)        # shell-fed heredoc: body executes — keep
+        return m.group(1) + "HEREDOC_BODY_EXCISED\n" + m.group(3)
+
+    return _HEREDOC_BODY_RE.sub(_repl, command)
+
+
+def _delimiter_is_unescaped(excised: str, d: int) -> bool:
+    """True iff the char at excised[d] is an UNescaped shell word-delimiter. Counts the
+    consecutive backslash run ending at d-1: EVEN (incl. 0) → the delimiter is real; ODD →
+    the delimiter is backslash-escaped (a literal char, part of the word) → NOT a delimiter.
+    Real-bash discriminant (the design intent): with `echo "x"\\ #y | sh`, the escaped space
+    is a literal argument char, the `#` is mid-word, and bash EXECUTES the pipe — so the
+    routing view must keep it; with `echo "x" #y | sh` (unescaped) bash treats `#`..EOL as a
+    comment and the pipe is SUPPRESSED — so excision is correct. `\\\\ #` (even run: literal
+    backslash then a real space) is a comment again, matching bash."""
+    b = d - 1
+    bs = 0
+    while b >= 0 and excised[b] == "\\":
+        bs += 1
+        b -= 1
+    return bs % 2 == 0
+
+
+def _excise_comments_view(excised: str, view: str) -> str:
+    """Step 3 of _excise_and_mask: view-only, SAME-LENGTH comment excision. A `#`
+    is a comment iff (a) it SURVIVES the quote mask (view[i] == "#": unquoted by
+    construction) AND (b) its predecessor ON THE PRE-MASK SURFACE (excised[i-1];
+    i == 0 counts as a comment start) is one of {start, space, tab, newline, ;,
+    &, |} AND (c) that delimiter is UNESCAPED (_delimiter_is_unescaped: even
+    backslash run immediately before it — `\\ #` / `\\<tab>#` / `\\;#` / `\\&#` /
+    `\\|#` make the `#` mid-word, NOT a comment, and bash EXECUTES what follows).
+    Testing the RAW predecessor is load-bearing: a masked closing quote
+    reads as a space on the view, so a view-side test would misclassify
+    `"x"#tail` as a comment (an executing tail eaten = under-block). The excision
+    replaces `#`..end-of-line (newline EXCLUDED) with spaces — same length, so
+    both consumers' 1:1 view/excised offset alignment holds (_procsub_anchor_view
+    indexes the pair pairwise). FAIL-TOWARD-NOT-COMMENT: any predecessor outside
+    the set leaves the text visible (worst case a residual over-block, never an
+    under-block). The pinned predecessor set is a strict SUBSET of bash's
+    comment-start contexts (bash also comments after `(`, backtick, …): fewer
+    excisions than bash = fail-toward-not-comment relative to ground truth — do
+    not widen without cert rows. Mask-BEFORE-excise gives quote-awareness for
+    free: a `#` inside a balanced quoted span is already spaces in `view`, so a
+    quoted `# … | sh` payload can never be excised through this step."""
+    if "#" not in view:                       # cheap short-circuit
+        return view
+    out = list(view)
+    i, n = 0, len(view)
+    while i < n:
+        if view[i] == "#" and (
+            i == 0
+            or (
+                excised[i - 1] in " \t\n;&|"
+                and _delimiter_is_unescaped(excised, i - 1)
+            )
+        ):
+            j = view.find("\n", i)
+            if j == -1:
+                j = n
+            for k in range(i, j):
+                out[k] = " "
+            i = j
+        else:
+            i += 1
+    return "".join(out)
+
+
+def _excise_and_mask(command: str) -> tuple[str, str]:
+    """Shared prefix for the two routing-flag views (#1129 R3): excise heredoc
+    bodies (opener line + closing marker kept; shell-fed bodies preserved), then
+    space-mask every balanced quoted span via _mask_shell_quotes, then excise
+    unquoted comments from the VIEW ONLY (a `#`-comment's `| sh` must not flip
+    piped_to_shell and disable every carrier — the comment text never executes).
+    Returns (excised, view). ORDER IS LOAD-BEARING: heredoc excision FIRST (stray
+    body quotes desync the quote mask — and a `#` inside a heredoc body is gone
+    before step 3 runs); mask BEFORE comment excision ("survives the mask" IS the
+    quote-awareness — a pre-mask excision on the raw string would eat executing
+    `' | sh'` tails through a quoted `#`). Steps 2 and 3 are both SAME-LENGTH, so
+    view and excised align 1:1 by offset."""
+    excised = _excise_heredoc_bodies_for_routing_scan(command)
+    view = _mask_shell_quotes(excised)
+    view = _excise_comments_view(excised, view)
+    return excised, view
+
+
+def _executed_surface_view(command: str) -> str:
+    """Routing-flag scan surface (#1129 R3): the command with non-executed
+    data removed — heredoc BODIES excised (opener line + closing marker kept;
+    shell-fed bodies preserved), then every balanced quoted span masked to
+    spaces via _mask_shell_quotes (defined later in this module; resolved at
+    call time). Fail direction: unbalanced/ambiguous quoting leaves text
+    UNMASKED -> the routing token stays visible -> detection preserved (at
+    worst a residual over-block on malformed input, never an under-block).
+    ORDER IS LOAD-BEARING: heredoc excision FIRST removes stray body quotes
+    that could desync the quote mask. Consumed ONLY by the hoisted
+    piped_to_shell / process_sub_to_shell computation; never fed to
+    DANGEROUS_PATTERNS and never returned as strip output."""
+    return _excise_and_mask(command)[1]
+
+
+def _procsub_anchor_view(command: str) -> str:
+    """OUTPUT-SIDE process-substitution routing view (#1129 R3-fix). The space-mask
+    executed-surface view, then arm B's preceding-token ANCHOR restored ONLY
+    immediately-left of a SURVIVING >(shell) whose writer token was a masked quoted
+    span. Everything from >( rightward is viewed EXACTLY as the space-mask (so the
+    incidental >("ba"sh)->>(    sh) catch is preserved). Re-catches the R3 arm-B
+    anchor regression WITHOUT a blanket fill (which breaks the shell-name region ->
+    a NEW under-block on >("ba"sh)) and WITHOUT computing arm B over raw (which
+    would re-flag a `>(shell)` sitting inside quoted carrier data). Relies on
+    _mask_shell_quotes being SAME-LENGTH: view and excised align 1:1 by offset.
+    Consumed ONLY by process_sub_to_shell."""
+    excised, view = _excise_and_mask(command)        # excise + space-mask; offsets aligned
+    if ">(" not in view:                             # cheap short-circuit (common case)
+        return view
+    out = list(view)
+    for m in re.finditer(r">\(", view):              # each SURVIVING >( on the view
+        i = m.start()
+        k = i - 1
+        # skip a genuine UNMASKED bash blank (space OR tab): view==excised at an unmasked position
+        while k >= 0 and view[k] == excised[k] and excised[k] in " \t":
+            k -= 1
+        # stop char masked to space in the view but a CLOSING QUOTE in raw ==
+        # a quoted writer token ended here -> reveal its closing quote (in arm B's
+        # class ['\w"')\]}]) so `<anchor>\s+>\(` matches. A redirect op (>, 2>) or a
+        # genuine separator is NOT a quote -> no restore -> arm A / stderr-exclusion
+        # and the absent-anchor case are all untouched.
+        if k >= 0 and view[k] == " " and excised[k] in "\"'":
+            out[k] = excised[k]
+    return "".join(out)
+
+
+def _has_eval_or_source(command: str) -> bool:
+    """Check if command contains eval or source that could execute variable values.
+
+    Detects patterns like ``CMD="..." && eval $CMD`` where a variable
+    assignment value would be executed via eval or source.
+    """
+    return bool(re.search(r"\b(?:eval|source)\b", command))
+
+
+def _var_is_expanded(var_name: str, command: str) -> bool:
+    """Check if a variable is expanded (used) elsewhere in the command.
+
+    Detects patterns like ``$VAR`` or ``${VAR}`` that would execute
+    the variable's value as a command when used bare (e.g., ``CMD="gh pr merge 42" && $CMD``).
+    """
+    # Match $VAR (word boundary) or ${VAR}
+    return bool(re.search(r"\$\{?" + re.escape(var_name) + r"\b", command))
+
+
+def _has_command_substitution(quoted_content: str) -> bool:
+    """Check if double-quoted content contains command substitution.
+
+    ``$(...)`` and backticks inside double quotes are executed by the shell,
+    so double-quoted strings containing them must not be stripped.
+    Single-quoted strings never have substitution (handled separately).
+    """
+    return "$(" in quoted_content or "`" in quoted_content
+
+
+# Span-scoped command-substitution preserve (#1140). The two scanners below let
+# _keep_carrier_value preserve ONLY the genuine `$(...)`/backtick SPANS of a value
+# (they execute -> stay caught) while stripping the surrounding INERT literal — the
+# cure for the over-block where a benign `$(date)` beside danger-looking prose caused
+# the WHOLE value to be preserved. Both are single-pass char walks (O(n), no regex
+# backtracking): each advances its cursor monotonically and visits every char O(1) times.
+def _extract_dollar_paren(c, i):
+    """Return the balanced ``$(...)`` span starting at c[i] (c[i]=='$', c[i+1]=='(')
+    and the index just past it, via a quote-aware + escape-aware depth counter: a ``)``
+    inside a NESTED ``$(...)`` or inside a quoted span does NOT close the outer span.
+    Returns (None, len(c)) when the span is unterminated."""
+    n = len(c); depth = 0; j = i
+    while j < n:
+        ch = c[j]
+        if ch == "\\": j += 2; continue
+        if ch in "\"'":
+            q = ch; j += 1
+            while j < n:
+                if c[j] == "\\" and q == '"': j += 2; continue
+                if c[j] == q: j += 1; break
+                j += 1
+            continue
+        if ch == "(": depth += 1; j += 1; continue
+        if ch == ")":
+            depth -= 1; j += 1
+            if depth == 0: return c[i:j], j
+            continue
+        j += 1
+    return None, n   # unterminated
+
+
+def _extract_backtick(c, i):
+    """Return the balanced backtick span starting at c[i] (c[i]=='`') and the index
+    just past it. Returns (None, len(c)) when the span is unterminated."""
+    n = len(c); j = i + 1
+    while j < n:
+        if c[j] == "\\": j += 2; continue
+        if c[j] == "`": return c[i:j+1], j+1
+        j += 1
+    return None, n
+
+
+def _preserve_substitution_spans(value):
+    """Replace literal (inert) text with 'STRIPPED'; preserve $(...)/`...` spans VERBATIM.
+    Escaped \\$( and \\` are inert. value is a dq "..." (arm 1) or an unquoted VALUE-TOKEN (arm 3).
+    QUOTE-CONTEXT-FAITHFUL: inside a dq value a ' is a LITERAL apostrophe (bash does not treat
+    it as structural), so dq-inner folds it into the stripped literal run (else ubiquitous
+    it's/don't over-block). A " in dq-inner cannot occur well-formed (arm 1 matched
+    "(?:[^"\\]|\\.)*") -> malformed -> fail-safe. In the UNQUOTED arm BOTH ' and " stay
+    structural -> fail-safe. Return None -> FAIL-SAFE (caller preserves whole value = today's
+    behavior) for: unterminated span, a preserved span carrying a quote, a " in dq-inner, or
+    either quote in the unquoted arm."""
+    def _scan(c, dq_inner):
+        out = []; lit = False; i = 0; n = len(c)
+        def flush():
+            nonlocal lit
+            if lit: out.append("STRIPPED"); lit = False
+        while i < n:
+            ch = c[i]
+            if ch == "\\": lit = True; i += 2 if i+1 < n else 1; continue
+            if ch == "$" and i+1 < n and c[i+1] == "(":
+                span, j = _extract_dollar_paren(c, i)
+                if span is None or '"' in span or "'" in span: return None
+                flush(); out.append(span); i = j; continue
+            if ch == "`":
+                span, j = _extract_backtick(c, i)
+                if span is None or '"' in span or "'" in span: return None
+                flush(); out.append(span); i = j; continue
+            if ch == '"': return None              # structural dq terminator -> fail-safe (malformed in dq-inner)
+            if ch == "'" and not dq_inner: return None   # unquoted: ' is structural -> fail-safe
+            lit = True; i += 1                     # dq-inner ' falls through -> LITERAL
+        flush()
+        return "".join(out)
+    if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
+        inner = _scan(value[1:-1], True)
+        return None if inner is None else '"' + inner + '"'
+    return _scan(value, False)                     # unquoted VALUE-TOKEN
+
+
+def _keep_carrier_value(m: "re.Match") -> str:
+    """Shared value replacer for the gh/git prose-carrier strips (#1129 R2): issue/pr
+    create|edit|comment, release create|edit, gist create|edit, git commit/tag -m, and
+    (new) merge/stash/notes. Passed as `keep_fn` to _strip_flag_values (arms 1 & 3 —
+    double-quoted + unquoted VALUE-TOKEN). Inert prose (no $()/backtick) -> the
+    flag(+separator) is kept and the value replaced with the inert `STRIPPED` bareword.
+    A value CONTAINING command substitution is SPAN-SCOPED (#1140): only the genuine
+    `$(...)`/backtick spans are preserved VERBATIM (they execute -> stay caught) while
+    the surrounding inert literal is stripped, so a benign `$(date)` beside
+    danger-looking prose no longer preserves the whole value (the over-block cure). On a
+    span the scanner cannot safely resolve (unterminated span, a preserved span carrying
+    a quote, or a structural quote in the value) it FAILS SAFE — the whole value is
+    preserved (today's behavior), never dropped. The single-quoted arm strips
+    unconditionally inside _strip_flag_values (untouched)."""
+    if not _has_command_substitution(m.group(0)):
+        return m.group(1) + "STRIPPED"          # inert prose -> strip (unchanged)
+    flag = m.group(1); value = m.group(0)[len(flag):]
+    transformed = _preserve_substitution_spans(value)
+    if transformed is None:
+        return m.group(0)                       # FAIL-SAFE: preserve whole value
+    return flag + transformed
+
+
+def _strip_inert_dq_value(m: "re.Match") -> str:
+    """Replace an inert double-quoted positional value with the bareword ``STRIPPED``;
+    span-scope a value that contains ``$()``/backtick (executing spans preserved VERBATIM
+    in the SAME dq context, surrounding inert literal stripped); FAIL-SAFE preserve-whole on
+    a span the scanner cannot resolve. Byte-identical to the echo/printf carrier's dq-arg
+    strip; used by the general inert-default positional strip (#1178, carrier 10) so a
+    non-flag-anchored quoted positional is stripped with the SAME $()-preserve + fail-safe
+    discipline as the flag-anchored carriers."""
+    if not _has_command_substitution(m.group(0)):
+        return "STRIPPED"
+    transformed = _preserve_substitution_spans(m.group(0))
+    return m.group(0) if transformed is None else transformed
+
+
+def _strip_flag_values(span: str, flag_sep_regex: str, keep_fn) -> str:
+    """Quote-safe value strip for a flag family within a single command span (#1118
+    re-model). KEEPS the flag(+separator) token; replaces the VALUE with a BALANCED
+    placeholder. Three arms by value-quoting (order load-bearing: quoted arms first, so
+    the unquoted VALUE-TOKEN arm never re-touches an already-stripped quoted value):
+      1. double-quoted value  -> keep_fn (preserves $()/backtick cmd-sub — it executes)
+      2. single-quoted value  -> unconditional 'STRIPPED' (single quotes never expand)
+      3. unquoted VALUE TOKEN  -> keep_fn (Q-SAFE: consumes a COMPLETE quote-balanced token
+                                  incl. embedded quoted spans, so it can NEVER emit a
+                                  dangling quote that would merge legs — the SEC-1/SEC-2
+                                  root-cause fix).
+    `flag_sep_regex` MUST be ONE capturing group (keep_fn uses m.group(1); the sq arm
+    backrefs `\\1`) and must introduce no OTHER capturing group. SHARED by carriers 8 & 9
+    so the two value strips can never drift again (the shared non-quote-aware matcher was
+    the #1118 root cause).
+    """
+    span = re.sub(flag_sep_regex + r'"(?:[^"\\]|\\.)*"', keep_fn, span)     # 1
+    span = re.sub(flag_sep_regex + r"'[^']*'", r"\1'STRIPPED'", span)       # 2
+    span = re.sub(flag_sep_regex + _VALUE_TOKEN, keep_fn, span)             # 3
+    return span
+
+
+def _strip_non_executable_content(command: str) -> str:
+    """Strip shell content that is clearly non-executable before pattern matching.
+
+    Removes text from contexts where dangerous-pattern text would not actually
+    execute as a command: heredocs, comments, echo/printf arguments, and
+    variable assignments. This prevents false positives without removing content
+    from genuinely dangerous contexts like ``bash -c '...'``.
+
+    Guards against execution-via-indirection: skips stripping when content
+    would actually execute (piped to shell, eval'd, command substitution,
+    heredoc fed to shell interpreter).
+
+    Conservative: when in doubt, preserves text (false positive > missed threat).
+
+    Args:
+        command: The raw bash command string
+
+    Returns:
+        The command with non-executable content replaced by placeholders
+    """
+    result = command
+
+    # Output-side execution-routing flags — computed ONCE for ALL stdout-
+    # producing content carriers (heredoc/echo/commit-msg/here-string/gh-
+    # creation). When the command pipes its output to a shell or feeds a shell
+    # via OUTPUT-side process substitution (`> >(bash)`), a stripped dangerous
+    # literal would still EXECUTE downstream, so those carriers must SKIP
+    # stripping (preserve content → detect). Hoisted above carrier 1 so the
+    # heredoc carrier can consult them too. MONOTONIC: a True flag only ADDS
+    # detection (skip strip → more content scanned); never removes it.
+    #
+    # The flags defend the EXECUTED surface, so they are computed over the
+    # executed-surface view (#1129 R3): quoted spans masked, heredoc bodies
+    # excised. Carrier DATA (a `| sh` or `>(bash)` inside a quoted value or
+    # heredoc body) can no longer disable the carriers; genuinely-executing
+    # routing (unquoted tails, opener-line tails) is unquoted shell structure
+    # and survives the view at identical offsets.
+    #
+    # The two flags read DIFFERENT views (#1129 R3-fix): piped_to_shell stays on
+    # the pure space-mask executed-surface view (the security 216-case pipe sweep
+    # stays byte-valid). process_sub_to_shell reads _procsub_anchor_view — the same
+    # space-mask with arm B's LEFT anchor restored immediately-left of a surviving
+    # >(shell) whose writer was a masked quoted token — re-catching the R3 arm-B
+    # regression (`echo "…" | "tee" >(bash)`) without a blanket fill (which would
+    # regress `>("ba"sh)`) and without computing arm B over raw (which would re-flag
+    # a `>(shell)` sitting inside quoted carrier data).
+    piped_to_shell = _has_pipe_to_shell(_executed_surface_view(command))
+    process_sub_to_shell = _has_process_substitution_to_shell(_procsub_anchor_view(command))
+
+    # 1. Strip heredoc bodies: << 'EOF' ... EOF, << EOF ... EOF, << "EOF" ... EOF
+    #    Match the heredoc marker, then everything up to and including the
+    #    closing marker on its own line.
+    #    GUARD (input-side): the inner check preserves the body if the heredoc
+    #    is fed to a shell interpreter (e.g. bash << EOF ... EOF — body executes).
+    #    GUARD (output-side): the outer piped/process-sub skip preserves the body
+    #    when it is routed to a shell via `| bash` / `> >(bash)`. The two COMPOSE.
+    if not piped_to_shell and not process_sub_to_shell:
+        def _strip_heredoc(match: re.Match) -> str:
+            # Check what command precedes the heredoc operator
+            start = match.start()
+            preceding = command[:start].rstrip()
+            # If the preceding command is a shell interpreter, preserve content
+            if re.search(r"\b(?:bash|sh|zsh)\s*$", preceding):
+                return match.group(0)  # Preserve — content executes
+            return "<<HEREDOC_STRIPPED"
+
+        result = re.sub(
+            r"<<-?\s*['\"]?(\w+)['\"]?.*?\n.*?\n\t*\1\b",
+            _strip_heredoc,
+            result,
+            flags=re.DOTALL,
+        )
+
+    # 2. Strip comments: # to end of line
+    #    Only strip when # appears at start of line or after whitespace/semicolon
+    #    (not inside words like issue#42 or URLs with #fragment).
+    result = re.sub(r"(?:^|(?<=\s)|(?<=;))\#.*$", "", result, flags=re.MULTILINE)
+
+    # 3. Strip echo/printf quoted arguments
+    #    Match echo/printf followed by flags then quoted strings.
+    #    Replace the quoted content but keep the echo command visible.
+    #    GUARD: Skip stripping if output is piped to a shell interpreter
+    #    (including via xargs), or fed via process substitution to a shell,
+    #    because the echo/printf content would be executed by the shell.
+    #    NOTE: ``bash -c 'dangerous'`` is NOT affected by this stripping —
+    #    the echo/printf regex only matches echo/printf commands, so
+    #    ``bash -c`` content is implicitly preserved and correctly detected.
+    #    (piped_to_shell / process_sub_to_shell are hoisted to the top.)
+    if not piped_to_shell and not process_sub_to_shell:
+        # echo/printf PRINT their args, they never execute them (#1140). Strip / span-scope
+        # EVERY positional quoted arg, not just the first: a danger literal in a 2nd+ arg is
+        # inert (printed) yet was over-blocking a faithful click. The ONLY execution path is
+        # output-routing to a shell (`| bash`, `> >(bash)`), already handled by the outer
+        # piped/process-sub skip this whole block sits inside — so widening to ALL args is
+        # under-block-safe.
+        def _strip_echo_dq_arg(m: re.Match) -> str:
+            # One double-quoted arg. Inert -> bareword STRIPPED; a value with $()/backtick is
+            # span-scoped (inert literal stripped, executing spans preserved in the SAME dq
+            # context as base so detection is identical); fail-safe preserves whole.
+            if not _has_command_substitution(m.group(0)):
+                return "STRIPPED"
+            transformed = _preserve_substitution_spans(m.group(0))
+            return m.group(0) if transformed is None else transformed
+
+        def _strip_echo_span(span_match: re.Match) -> str:
+            # Strip every quoted arg within the echo/printf span. dq FIRST, then sq, so a dq
+            # value's embedded `'` is consumed before the sq pass runs (no cross-contamination);
+            # sq -> bareword STRIPPED (sq $() is literal). The verb + flags sit OUTSIDE these
+            # inner subs and stay intact.
+            span = span_match.group(0)
+            span = re.sub(r'"(?:[^"\\]|\\.)*"', _strip_echo_dq_arg, span)
+            span = re.sub(r"'[^']*'", "STRIPPED", span)
+            return span
+
+        # Span = verb + the shared quote-aware body that STOPS at the first UNQUOTED
+        # ;/&&/|/newline, so an executing tail (`echo "x" && git branch -D y`) stays OUTSIDE the
+        # span and is caught (leg-locality). Keep the `\s+` so a bare `echo` token never matches.
+        result = re.sub(
+            r"\b(echo|printf)\s+" + _VERB_MSG_BODY,
+            _strip_echo_span,
+            result,
+        )
+
+    # 4. Strip variable assignment values: VAR="..." or VAR='...'
+    #    Only match simple assignments (NAME=VALUE), not command arguments.
+    #    GUARD: Skip stripping if eval/source appears in the command,
+    #    because the variable value could be executed.
+    #    GUARD: Skip stripping if $VAR or ${VAR} appears elsewhere in the
+    #    command, because bare expansion executes the value as a command
+    #    (e.g., CMD="gh pr merge 42" && $CMD).
+    has_eval = _has_eval_or_source(command)
+    if not has_eval:
+        # Double-quoted: guard against command substitution and bare expansion
+        def _strip_var_dq(match: re.Match) -> str:
+            var_name = match.group(1)
+            # ORDER LOAD-BEARING: a bare $VAR/${VAR} expansion word-splits and EXECUTES the
+            # WHOLE value (the inert literal INCLUDED, not just a substitution), so an expanded
+            # var preserves WHOLE — this MUST precede the substitution span-scope below.
+            if _var_is_expanded(var_name, command):
+                return match.group(0)  # Preserve — $VAR executes the whole value
+            if _has_command_substitution(match.group(0)):
+                # `git -c section.key=value` config injection is OUT OF SCOPE (#11): a git config
+                # value can be an EXECUTABLE config (core.pager / alias.* / core.editor), so its
+                # literal is not provably inert — preserve WHOLE to keep the -c surface at its
+                # exact status quo. Tell: a git config key ALWAYS has a `.`, so the matched key
+                # segment is preceded by `.`; a shell var / `--flag=` name never is. Use
+                # match.string (the post-carrier-1..3 result being sub'd), NOT `command` — the
+                # match offsets index into that result, not the raw command.
+                if match.start() > 0 and match.string[match.start() - 1] == ".":
+                    return match.group(0)  # config injection — status-quo preserve
+                # Non-expanded, non-config value WITH a substitution: strip the inert literal but
+                # preserve the genuine $()/backtick spans (they execute) via the same certified
+                # span scanner the message carriers use. A benign $(date) beside danger-looking
+                # prose no longer reverts the whole value (the equals-form over-block cure).
+                value = match.group(0)[len(var_name) + 1:]  # text after `NAME=`
+                transformed = _preserve_substitution_spans(value)
+                if transformed is None:
+                    return match.group(0)  # FAIL-SAFE: preserve whole (exotic span)
+                return var_name + "=" + transformed
+            return var_name + "=STRIPPED"
+
+        result = re.sub(
+            r'\b([A-Za-z_][A-Za-z0-9_]*)="(?:[^"\\]|\\.)*"',
+            _strip_var_dq,
+            result,
+        )
+
+        # Single-quoted: guard against bare expansion
+        def _strip_var_sq(match: re.Match) -> str:
+            var_name = match.group(1)
+            if _var_is_expanded(var_name, command):
+                return match.group(0)  # Preserve — $VAR executes
+            return var_name + "=STRIPPED"
+
+        result = re.sub(
+            r"\b([A-Za-z_][A-Za-z0-9_]*)='[^']*'",
+            _strip_var_sq,
+            result,
+        )
+
+    # 5. git commit MESSAGE carrier — SPAN-BOUNDED + FLAG-ANCHORED (migrated from the
+    #    former inline -m-only literal-quote arms to the shared quote-balanced machinery;
+    #    a structural clone of carrier-7d `git tag -m`). The -m/--message argument is a
+    #    commit message, never executed directly. FLAG-anchored to the -m/--message VALUE
+    #    only; BOUNDED to a git-commit span whose body (the SAME quote-aware body as
+    #    carriers 7/7b/7c/7d) STOPS at the first UNQUOTED ;/&&/|/newline so an executing
+    #    tail stays OUTSIDE the span and is caught. The prefix is a NON-gobbling
+    #    `git <bounded non-separator words> commit` (handles global flags like -C <path>)
+    #    whose word class EXCLUDES ;&| so it CANNOT cross an unquoted separator —
+    #    deliberately NOT _GIT_PREFIX, whose (?:\S+\s+){0,N} gobbler spans separators and
+    #    would let a later `git commit` pull an intermediate `;gh …;` into ONE span,
+    #    re-opening the #1129-class leg-merge under-block. Bounded {0,N} keeps it linear.
+    #    GUARD (output-side): a commit SUBJECT is echoed to git's stdout, so
+    #    `git commit -m "..." > >(bash)` (or `| bash`) routes it to a shell — the outer
+    #    piped/process-sub skip preserves it for detection (#1002).
+    #    GUARD (cmd-subst): $()/backtick in a double-quoted value preserves — rides on
+    #    _keep_carrier_value.
+    if not piped_to_shell and not process_sub_to_shell:
+        _git_commit_span = (
+            r"\bgit\s+(?:[^;&|\n\s]+\s+){0,%d}commit\b" % _MAX_GLOBAL_FLAG_TOKENS
+            + _VERB_MSG_BODY
+        )
+        result = re.sub(
+            _git_commit_span,
+            lambda mm: _strip_flag_values(
+                mm.group(0),
+                # Long arm accepts any unambiguous abbreviation of --message
+                # (--m -> --message): on `git commit` the ONLY --m* option IS
+                # --message, so a --m-prefix can never over-strip another option's
+                # value. Short arm (-m/bundled -am/attached -mMSG) unchanged.
+                # --trailer (#1178) carries a commit TRAILER (`Key: value` metadata
+                # appended to the message) — inert prose git never executes, so a
+                # danger-looking literal in a trailer value must not gate a faithful
+                # click. FLAG-anchored to the --trailer VALUE only (never a bare token),
+                # exactly like --message; disjoint from the --m* arm (t != m after --),
+                # so it can never over-strip another option's value. The `--trailer=VALUE`
+                # equals form is already stripped upstream by the variable-assignment
+                # carrier (which matches `trailer=...` as a NAME=VALUE), so only the SPACE
+                # form reaches here.
+                # Short cluster arm TOKEN-START anchored `(?<!\S)` (DEFENSIVE-CONSISTENCY
+                # mirror of _MSG_FLAG_ANCHOR): genuine `-m`/`-am`/attached `-mMSG` are
+                # whitespace-preceded so still strip; the anchor only blocks a MID-FLAG
+                # mis-match (`-com`/`-adm`/`-ame`) that a future strip-order shift could
+                # turn into an over-block. No census over-block runs through this carrier
+                # today; the anchor keeps carrier-5 identical to the merge anchor's fix.
+                r"((?:--m(?:e(?:s(?:s(?:a(?:g(?:e)?)?)?)?)?)?|--trailer|(?<!\S)-[a-ln-zA-Z]*m)\s*)",
+                _keep_carrier_value,
+            ),
+            result,
+        )
+
+    # 6. Strip here-string quoted arguments: <<< "..." or <<< '...'
+    #    Here-strings pass text as stdin, not as a command.
+    #    GUARD (input-side): the inner check preserves content if a shell
+    #    interpreter precedes the <<< (e.g. bash <<< "dangerous" — executes).
+    #    GUARD (cmd-subst): preserve double-quoted content containing $()/backtick.
+    #    GUARD (output-side): the outer piped/process-sub skip preserves content
+    #    routed to a shell via `| bash` / `> >(bash)`. The guards COMPOSE.
+    if not piped_to_shell and not process_sub_to_shell:
+        def _strip_herestring_dq(match: re.Match) -> str:
+            # Check what command precedes the <<< (shell-interpreter guard stays FIRST).
+            start = match.start()
+            preceding = command[:start].rstrip()
+            if re.search(r"\b(?:bash|sh|zsh)\s*$", preceding):
+                return match.group(0)  # Preserve — a shell reads the here-string as stdin
+            if not _has_command_substitution(match.group(0)):
+                return "<<<STRIPPED"                  # no-$() unchanged (bareword)
+            # has-$(): span-scope the value — strip the inert literal, preserve the executing
+            # spans (#1140). Emit the scanner's native dq output: it keeps each preserved span
+            # in the SAME executing dq context the coarse preserve used, so a real $(...) is
+            # detected IDENTICALLY to base (verified by the bidirectional cert). group(1) = dq value.
+            transformed = _preserve_substitution_spans(match.group(1))
+            if transformed is None:
+                return match.group(0)                 # fail-safe: preserve whole
+            return "<<<" + transformed
+
+        result = re.sub(
+            r'<<<\s*("(?:[^"\\]|\\.)*")',
+            _strip_herestring_dq,
+            result,
+        )
+
+        def _strip_herestring_sq(match: re.Match) -> str:
+            # Check what command precedes the <<<
+            start = match.start()
+            preceding = command[:start].rstrip()
+            if re.search(r"\b(?:bash|sh|zsh)\s*$", preceding):
+                return match.group(0)  # Preserve — content executes
+            return "<<<STRIPPED"
+
+        result = re.sub(
+            r"<<<\s*'[^']*'",
+            _strip_herestring_sq,
+            result,
+        )
+
+    # 6b. find -name/-path VALUE carrier: find's match-pattern values are inert
+    #     (find matches names; it never executes a -name/-path value), so a
+    #     danger-looking quoted pattern (`find . -name 'gh pr merge…'`) must not
+    #     gate a faithful search click. Span-bounded like carrier 5 (the
+    #     structural template): _VERB_MSG_BODY stops at the first unquoted
+    #     ;/&&/|/newline, so an executing tail stays OUTSIDE the span and is
+    #     caught. An executing find PRIMARY (-exec/-execdir/-ok/-okdir) anywhere
+    #     in the span disables the strip entirely (fail-toward-preserve: the
+    #     stripped value could be the -exec payload's evidence). Vocabulary is
+    #     the match-pattern primaries -name/-path/-iname/-ipath/-regex/-iregex
+    #     (#1195 OBS-A2 broadening — all inert: find MATCHES the pattern, never
+    #     shell-executes it). The ONE executing primary family
+    #     (-exec/-execdir/-ok/-okdir) stays whole-span-preserved (the deny below
+    #     fires first). find itself stays in _EXEC_WRAPPERS_COARSE, so carrier 10
+    #     still preserves find legs wholesale; the danger literal is simply gone
+    #     from the match-pattern value by the time the floor scans.
+    if not piped_to_shell and not process_sub_to_shell:
+        _find_exec_primary_re = re.compile(r"(?<!\S)-(?:exec|execdir|ok|okdir)(?!\S)")
+        _find_span = r"\bfind\s+" + _VERB_MSG_BODY
+
+        def _strip_find_span(m: "re.Match") -> str:
+            span = m.group(0)
+            if _find_exec_primary_re.search(span):
+                return span                   # -exec/-ok present => preserve whole span
+            return _strip_flag_values(
+                span,
+                r"((?<!\S)-(?:name|path|iname|ipath|regex|iregex)\s+)",
+                _keep_carrier_value,
+            )
+
+        result = re.sub(_find_span, _strip_find_span, result)
+
+    # 7. Strip gh issue/pr CREATION/COMMENT-carrier quoted arguments.
+    #    `gh issue create/edit/comment` and `gh pr create/comment` accept
+    #    --title/--body (and the -t/-b aliases) whose VALUE is prose sent to the
+    #    GitHub API — never executed by a shell. A dangerous-op literal named inside
+    #    that prose (e.g. `gh issue create --title "...git branch -D x..."`)
+    #    must not trip DANGEROUS_PATTERNS. Strip the quoted value; keep the
+    #    verb + flag tokens visible.
+    #
+    #    SCOPE (INV-D2) — exempts ONLY the non-executing ARGUMENT text of a
+    #    CREATION carrier. Does NOT match `gh pr close` (a real close-class
+    #    destructive verb; `--delete-branch` is the deny trigger) — `close`
+    #    is absent from the verb alternation by construction, so a
+    #    `gh pr close ... --delete-branch` command is NOT stripped and
+    #    DANGEROUS_PATTERNS still fires.
+    #
+    #    GUARD: same indirection guards as the echo/printf carrier — the
+    #    outer `piped_to_shell` / `process_sub_to_shell` skip (set at step 3)
+    #    covers pipe-to-shell / process-sub-to-shell; the double-quoted arm
+    #    additionally preserves a value containing command substitution
+    #    `$(`/backtick (it would execute). Single-quoted values never expand,
+    #    so they need only the outer skip (mirroring carriers 3 and 5).
+    #    `--body-file`/`-F` is NOT a carrier: it names a FILE whose content
+    #    is not on the command line, so there is nothing on the line to strip.
+    if not piped_to_shell and not process_sub_to_shell:
+        # Match the carrier COMMAND span first (verb + its arguments), then
+        # strip EVERY --title/--body/-t/-b value within that span. A single
+        # re.sub on the whole command would strip only the FIRST flag-value
+        # (the verb prefix is consumed by the first match and cannot re-anchor
+        # on a bare second flag), so the per-span inner-strip is required to
+        # strip both a `--title` and a `--body` on one command.
+        #
+        # The span body is QUOTE-AWARE: it consumes balanced quoted regions
+        # atomically (so `;`/`&`/`|`/newline INSIDE a quoted value are not
+        # separators) and stops at the first UNQUOTED `&`/`|`/`;`/newline; an
+        # unbalanced quote stops the span early (under-consume = over-block,
+        # never under-block). This is load-bearing for INV-D2: an unquoted
+        # executing op always terminates the span (none of the three body
+        # alternatives can begin at an unquoted separator), so a compound's
+        # executing tail (e.g. `... && git branch -D real`) falls OUTSIDE the
+        # span and is NEVER stripped — it stays caught. The three alternatives
+        # have DISJOINT first chars (non-sep-non-quote / `"` / `'`), so the
+        # nested `*` has no backtracking ambiguity (linear; no ReDoS). The
+        # double-quoted alternative honors `\"` escapes, matching bash's
+        # escaped-quote semantics so the regex cannot desync from the shell.
+        # Verb alternation: issue create|edit|comment, pr create|comment. NOT pr
+        # close — `close` is absent by construction so a close command never
+        # matches. `comment` is a non-executing carrier exactly like create/edit:
+        # its --body/-b value is API prose, and the SAME doubly-anchored strip
+        # (carrier verb + value DIRECTLY after --body/-t/-b) + quote-aware span +
+        # $()/backtick-preserve guard apply, so it inherits the create/edit
+        # safety — empirically verified: escaped-quote/escaped-dq/metachar bodies
+        # are handled correctly (op inside a dq/sq body is inert and stripped; an
+        # op OUTSIDE the body, after an unquoted separator OR a bare escaped quote
+        # not following a carrier flag, is NEVER stripped and stays caught).
+        _gh_carrier_span = (
+            r"gh\s+(?:issue\s+(?:create|edit|comment)|pr\s+(?:create|comment|edit))\b"
+            + _VERB_MSG_BODY
+        )
+
+        def _strip_gh_carrier_span(span_match: re.Match) -> str:
+            # Migrated (#1129 R2) to the SHARED quote-balanced _strip_flag_values (#1118
+            # machinery, same as carriers 8/9): its 3 arms
+            # (dq→keep_fn / sq→'STRIPPED' / unquoted VALUE-TOKEN→keep_fn) replace the
+            # former inline dq+sq re.sub. The unquoted VALUE-TOKEN arm ADDS coverage of
+            # ANSI-C `$'…'` + adjacent-concat `"a"'b'` body forms (consumed ATOMICALLY, so
+            # no dangling quote → no leg-merge). $()/backtick preserve rides on
+            # _keep_carrier_value. `edit` added to the pr alternation (OB1).
+            # --assignee/-a (create) + --add-assignee/--remove-assignee (edit) carry a
+            # GitHub LOGIN value (#1178) — inert API metadata never executed by a shell,
+            # so a danger-looking literal in an assignee value must not gate a faithful
+            # click. VALUE-taking on every carrier-7 verb (login arg), so they join the
+            # value-strip set; -a is admissible here because within these issue/pr verbs
+            # -a is unambiguously --assignee (contrast release -a=--attach, carrier 7b —
+            # a DIFFERENT span, never matched by this gh issue/pr anchor).
+            return _strip_flag_values(
+                span_match.group(0),
+                r"((?:--title|--body|--assignee|--add-assignee|--remove-assignee|-t|-b|-a)\s+)",
+                _keep_carrier_value,
+            )
+
+        result = re.sub(_gh_carrier_span, _strip_gh_carrier_span, result)
+
+        # 7b. gh release CREATE/EDIT carrier (#1129 R2). --notes/-n + --title/-t carry API
+        #     prose (never executed). EXCLUDE --notes-file/-F (a FILE, off-line) AND the
+        #     -d/--draft + -p/--prerelease BOOLEANS (arity verified vs gh 2.96.0) — a
+        #     boolean must never enter a value-strip set or the strip mis-consumes the
+        #     following token (PER-CARRIER flag sets, NEVER a union). Subcommand-specific
+        #     (create|edit, NEVER bare `gh release`) so `gh release delete` can never
+        #     start a carrier span. Shared quote-balanced _strip_flag_values + $()-preserve.
+        _gh_release_span = (
+            r"gh\s+release\s+(?:create|edit)\b"
+            + _VERB_MSG_BODY
+        )
+        result = re.sub(
+            _gh_release_span,
+            lambda m: _strip_flag_values(
+                m.group(0), r"((?:--notes|-n|--title|-t)\s+)", _keep_carrier_value
+            ),
+            result,
+        )
+
+        # 7c. gh gist CREATE/EDIT carrier (#1129 R2). --desc/-d is API prose. `-d` is
+        #     admissible ONLY here (gist -d=--desc VALUE; contrast release -d=--draft
+        #     BOOLEAN — the reason PER-CARRIER flag sets are mandatory). Subcommand-specific
+        #     (create|edit, NEVER bare `gh gist`) so `gh gist delete` never starts a carrier.
+        _gh_gist_span = (
+            r"gh\s+gist\s+(?:create|edit)\b"
+            + _VERB_MSG_BODY
+        )
+        result = re.sub(
+            _gh_gist_span,
+            lambda m: _strip_flag_values(
+                m.group(0), r"((?:--desc|-d)\s+)", _keep_carrier_value
+            ),
+            result,
+        )
+
+        # 7d. git tag MESSAGE carrier (#1129 R2; F1 leg-merge fix, HALT #64) — SPAN-BOUNDED
+        #     + FLAG-ANCHORED. `git tag -m/--message` (benign annotation prose) shares the
+        #     `tag` verb with the DESTRUCTIVE `git tag -d/--delete`, so the strip is
+        #     FLAG-anchored to the -m/--message VALUE only (never touches -d), and BOUNDED
+        #     to a git-tag span whose body (the SAME quote-aware body as 7/7b/7c) STOPS at
+        #     the first UNQUOTED ;/&&/|/newline. The span bound is LOAD-BEARING: the prior
+        #     WHOLE-COMMAND strip let _strip_flag_values arm 3 (unquoted VALUE-TOKEN, which
+        #     does NOT stop at ;&|) re-touch the arm-1 `STRIPPED` bareword and consume
+        #     `STRIPPED;gh` together — EATING the next leg's `gh` head
+        #     (`git tag -m "x";gh pr merge 5 --delete-branch` -> gh gone -> auto-ALLOW). The
+        #     span stops at the separator, so the executing tail stays OUTSIDE and caught.
+        #     The prefix is a NON-gobbling `git <bounded non-separator words> tag`
+        #     (handles global flags like `-C <path>`) whose word class EXCLUDES `;&|` so it
+        #     CANNOT cross an unquoted separator — deliberately NOT `_GIT_PREFIX`, whose
+        #     `(?:\S+\s+){0,N}` gobbler (its `\S+` spans separators) could cross a `;gh …;`
+        #     into a LATER `git tag`, re-opening the leg-merge on a command like
+        #     `git commit -m "x";gh pr merge 5;git tag v1`. Bounded `{0,N}` (same
+        #     _MAX_GLOBAL_FLAG_TOKENS as _GIT_PREFIX) keeps the match linear/sub-quadratic.
+        #     `-d` stays visible (only the -m value strips, within the span); a faithful
+        #     `git tag -m "…" v1` has no unquoted separator -> one span -> OB3 still strips.
+        #     $()/backtick preserve rides on _keep_carrier_value.
+        _git_tag_span = (
+            r"\bgit\s+(?:[^;&|\n\s]+\s+){0,%d}tag\b" % _MAX_GLOBAL_FLAG_TOKENS
+            + _VERB_MSG_BODY
+        )
+        result = re.sub(
+            _git_tag_span,
+            lambda mm: _strip_flag_values(
+                mm.group(0),
+                # Long arm is BOUNDED to --mes...--message — DELIBERATELY DIFFERENT
+                # from the commit anchor. `git tag` ALSO has the value-taking
+                # --merged/--no-merged options, which diverge from --message at char
+                # 3 (r != s), so starting the arm at --mes can never consume their
+                # values (--m/--me are ambiguous and git rejects them). Do NOT
+                # re-unify with the commit anchor. Short arm unchanged.
+                r"((?:--mes(?:s(?:a(?:g(?:e)?)?)?)?|-[a-ln-zA-Z]*m)\s*)",
+                _keep_carrier_value,
+            ),
+            result,
+        )
+
+        # 7e. Sibling message-carrying git verbs — SPAN-BOUNDED + FLAG-ANCHORED, the same
+        #     machinery as carriers 5/7d. `git merge`, `git stash push/store/save`, and
+        #     `git notes add/append` accept a -m/--message (or, for `stash save`, a
+        #     POSITIONAL) whose value is annotation prose, never executed. A destructive
+        #     literal named inside that prose (e.g. `git merge -m "...git branch -D x..."`)
+        #     must not trip DANGEROUS_PATTERNS. Each span is a NON-gobbling
+        #     `git <bounded non-separator words> <verb>` (word class EXCLUDES ;&| so it
+        #     CANNOT cross an unquoted separator — deliberately NOT _GIT_PREFIX, whose
+        #     gobbler would re-open the leg-merge under-block) + _VERB_MSG_BODY (STOPS at
+        #     the first UNQUOTED ;/&&/|/newline, so an executing tail stays OUTSIDE the span
+        #     and is caught). merge / stash push / stash store / notes are anchored on
+        #     _MSG_FLAG_ANCHOR (their SOLE value-taking --m* is --message, verified via
+        #     `git <verb> -h`). git cherry-pick / git revert are DELIBERATELY EXCLUDED:
+        #     their -m is --mainline <parent-number> (a NUMBER, not a message) — treating
+        #     them as message carriers would be wrong; a real destructive tail after them
+        #     stays caught via leg-locality. $()/backtick preserve rides on
+        #     _keep_carrier_value.
+        # LAZY prefix gobbler `{0,N}?` (#1195 OBS-A3g) — SCOPED TO git-merge ONLY. "merge"
+        # is uniquely BOTH a carrier verb AND a substring of the `gh pr merge` danger
+        # pattern, so a GREEDY `{0,N}` gobbler crosses into a `-m` message VALUE that
+        # contains "merge" (`git merge -m 'gh pr merge 5 --admin'`) and anchors the span on
+        # that INNER merge, stripping from the wrong offset -> the danger literal survives
+        # (over-block). Lazy matches the FIRST (VERB) merge, so _VERB_MSG_BODY spans the real
+        # -m value and it strips cleanly. Only WHERE `merge` is matched changes; the
+        # _VERB_MSG_BODY leg-locality terminator (stops at the first unquoted ;/&&/|/newline)
+        # is UNCHANGED, so a real destructive op in a SEPARATE leg is never swallowed.
+        # commit/tag/stash spans stay GREEDY — no danger pattern contains their verb word.
+        _git_merge_span = (
+            r"\bgit\s+(?:[^;&|\n\s]+\s+){0,%d}?merge\b" % _MAX_GLOBAL_FLAG_TOKENS
+            + _VERB_MSG_BODY
+        )
+        result = re.sub(
+            _git_merge_span,
+            lambda mm: _strip_flag_values(
+                mm.group(0), _MSG_FLAG_ANCHOR, _keep_carrier_value
+            ),
+            result,
+        )
+        # git stash push / store — both take -m/--message.
+        _git_stash_flag_span = (
+            r"\bgit\s+(?:[^;&|\n\s]+\s+){0,%d}stash\s+(?:push|store)\b" % _MAX_GLOBAL_FLAG_TOKENS
+            + _VERB_MSG_BODY
+        )
+        result = re.sub(
+            _git_stash_flag_span,
+            lambda mm: _strip_flag_values(
+                mm.group(0), _MSG_FLAG_ANCHOR, _keep_carrier_value
+            ),
+            result,
+        )
+        # git stash save <message> — the (deprecated) message is a POSITIONAL; save's
+        # non-message args are ALL boolean flags, so the anchor consumes `save` + any run
+        # of boolean flags + whitespace, and the dq/sq/VALUE-TOKEN arms strip the first
+        # value token (the positional message). Bare `git stash save` (no message) has no
+        # trailing value -> the anchor's trailing `\s+`+value never matches -> no misfire.
+        _git_stash_save_span = (
+            r"\bgit\s+(?:[^;&|\n\s]+\s+){0,%d}stash\s+save\b" % _MAX_GLOBAL_FLAG_TOKENS
+            + _VERB_MSG_BODY
+        )
+        result = re.sub(
+            _git_stash_save_span,
+            lambda mm: _strip_flag_values(
+                mm.group(0), r"(save(?:\s+-[-\w]+)*\s+)", _keep_carrier_value
+            ),
+            result,
+        )
+        # git notes add / append (-m/--message; an optional `--ref <ref>` global may
+        # precede the verb).
+        _git_notes_span = (
+            r"\bgit\s+(?:[^;&|\n\s]+\s+){0,%d}notes\s+(?:--ref(?:=|\s+)\S+\s+)?(?:add|append)\b"
+            % _MAX_GLOBAL_FLAG_TOKENS
+            + _VERB_MSG_BODY
+        )
+        result = re.sub(
+            _git_notes_span,
+            lambda mm: _strip_flag_values(
+                mm.group(0), _MSG_FLAG_ANCHOR, _keep_carrier_value
+            ),
+            result,
+        )
+
+    # 8. Strip HTTP-client request-body flag VALUES (curl / wget / gh api).
+    #    The #1061 widening (host-agnostic `.*git/refs`) and the #1063
+    #    `.*branches/.*/protection` arms would OTHERWISE fire on the destructive
+    #    path text when it merely appears inside a QUOTED data-body argument
+    #    (`curl -X POST .../log -d 'msg=touched git/refs/heads/x'`) — an over-block
+    #    of a faithful command (the #1037 hard-constraint). A faithful API ref /
+    #    protection mutation ALWAYS carries the destructive resource in the URL
+    #    PATH (REST convention — the resource IS the URL), NEVER the request body,
+    #    so stripping ONLY the data-body VALUE is zero-under-block: a path-resident
+    #    target can never be removed (the PATH-vs-BODY invariant).
+    #
+    #    Surface-scoped to a curl / wget / gh-api command SPAN so a `git push -d
+    #    <ref>` (git's `-d` = --delete, the ref is a positional we DO gate) is never
+    #    mis-stripped — the span anchors only on an HTTP-client head, and git is
+    #    absent from the anchor. TWO value-forms are handled:
+    #      (a) direct-value body flags — `FLAG <quoted-value>`: curl/wget
+    #          -d/--data[-raw|-binary|-ascii|-urlencode]/--body-data/--post-data.
+    #      (b) KEY=VALUE field flags — `FLAG <key>=<quoted-value>`: gh-api
+    #          --field/--raw-field/-f/-F (and curl -F form data). Strip the value
+    #          AFTER the `=`, keeping `flag key=`.
+    #    Surface-awareness falls out of the patterns: curl's bare boolean `-f`
+    #    (--fail) is followed by no `key=<quoted>` token, so form (b) never matches
+    #    it and a `curl -f -X DELETE .../git/refs/...` still gates.
+    #    EVERY flag token is KEPT (only the value is replaced) so the implicit-POST
+    #    lookaheads (`(?=.*(?:--data...|-f|--field|...)\s)`) still fire on a genuine
+    #    implicit-POST. Same execution-routing guards as carriers 3/5/7: skip when
+    #    piped/process-sub to a shell; the double-quoted arms preserve a value
+    #    containing command-substitution `$(`/backtick (it would execute).
+    #    (httpie body params are POSITIONALS, not flags, so they are out of scope —
+    #    non-key=value spellings (:= JSON literals, bare quoted items) survive, so a
+    #    quoted git literal can still FP via the match-anywhere git arms: rarer,
+    #    fails-safe (gates AND mints — no permanent block), pre-existing, un-fixed.)
+    if not piped_to_shell and not process_sub_to_shell:
+        # The HTTP-client command span: from a curl/wget/gh-api head up to the first
+        # UNQUOTED shell separator. Quote-aware body (balanced quotes consumed
+        # atomically; disjoint first chars → linear, no ReDoS) — identical shape to
+        # carrier 7's span. The URL positional and the method flag live in this span
+        # but are never matched by the body-flag patterns below (which require a body
+        # FLAG before the value), so they always survive. The gh-api head uses the
+        # TOLERANT `_GH_API_PREFIX` (same as the read floor) so a `gh -R o/r api ...`
+        # global-flag spelling's body IS stripped — else the #1037 body-mention
+        # over-block re-opens for that spelling (the strip would not run).
+        _http_client_span = (
+            r"(?:\bcurl\b|\bwget\b|" + _GH_API_PREFIX + r")"
+            + _VERB_MSG_BODY
+        )
+        # Direct-value body flags (form a).
+        _data_flag = r"(?:--data(?:-(?:raw|binary|ascii|urlencode))?|--body-data|--post-data|-d)"
+        # KEY=VALUE field flags (form b). The `<key>=` requirement is what makes the
+        # strip surface-aware (curl's boolean -f never has a key= after it).
+        _field_flag = r"(?:--field|--raw-field|-F|-f)"
+
+        def _strip_http_body_span(span_match: re.Match) -> str:
+            span = span_match.group(0)
+
+            # CONTENTS-API EXCEPTION (PATH-vs-BODY invariant boundary). The
+            # `.*contents/.*(?:main|master)` arm reads its destructive target — the
+            # branch being written — from the REQUEST BODY (`-d '{"branch":"master"}'`)
+            # or a `?branch=` query, NOT the URL path (the contents API path is
+            # `/contents/{filepath}`, branch-less). This is the ONE gated arm whose
+            # signal is body-resident; stripping its body would REMOVE the main/master
+            # gating signal → an UNDER-BLOCK. The contents arm must be left UNCHANGED
+            # (signal is body-resident), so preserve a contents-API span verbatim. Detected
+            # per-span (a compound's `/log` span is still stripped). git/refs and
+            # branches/protection targets are path-resident, so their bodies stay strippable.
+            # IGNORECASE to match the case-insensitive contents READ arm
+            # (`contents/.*(?:main|master)`, re.IGNORECASE): a `Contents/` (any case)
+            # span carries its main/master gating signal in the BODY, so it must be
+            # preserved from stripping in ANY case — else the #1096 unquoted body
+            # strip removes the signal for a capital-case spelling -> under-block.
+            if re.search(r"contents/", span, re.IGNORECASE):
+                return span
+
+            def _keep_flag_dq(m: re.Match) -> str:
+                # group(1) = the flag (+ key= for form b) up to the opening quote.
+                if not _has_command_substitution(m.group(0)):
+                    return m.group(1) + "'STRIPPED'"  # no-$() unchanged (single-quoted)
+                # has-$(): span-scope the value after the flag — strip the inert literal,
+                # preserve the executing $()/backtick spans (#1140). Emit the scanner's native
+                # dq output (NOT sq): it keeps each preserved span in the SAME executing dq
+                # context the coarse preserve used, so a real $(...) is detected IDENTICALLY to
+                # base (verified by the bidirectional cert).
+                flag = m.group(1)
+                transformed = _preserve_substitution_spans(m.group(0)[len(flag):])
+                if transformed is None:
+                    return m.group(0)                 # fail-safe: preserve whole
+                return flag + transformed
+
+            # Body flag VALUES via the SHARED quote-safe strip (#1118 re-model, FIX-A).
+            # Each call does 3 arms (dq / sq / unquoted VALUE-TOKEN); the unquoted arm now
+            # consumes a COMPLETE quote-balanced token, so an embedded-quote body value
+            # (`-f k=x"y z"`, a jq-ish `-d '...' ` payload) can no longer leave a dangling
+            # quote that mis-pairs in _mask_shell_quotes and MERGES legs — the pre-existing
+            # carrier-8 under-block (#1118 review). This closes the endpoint-decoy the
+            # quoted-only arms miss (`-f note=pulls/5/merge`, `-d body`) + the #1037
+            # unquoted-body read-floor over-block, over-block-safely: the arm is anchored on
+            # the body-flag(+key=) prefix, so the URL POSITIONAL endpoint (never preceded by
+            # such a prefix) is never matched. SPACE-form separator ONLY here — carrier-8's
+            # `=`-joined-flag completeness (`--field=k=v`) is a DIFFERENT, deferred issue
+            # (#1125); this commit fixes ONLY carrier-8's quote-safety.
+            # (a) direct-value body flags -d/--data*; (b) key=value field flags -f/-F/--field.
+            span = _strip_flag_values(span, r"(" + _data_flag + r"\s+)", _keep_flag_dq)
+            span = _strip_flag_values(
+                span, r"(" + _field_flag + r"\s+[\w.\-]+=)", _keep_flag_dq
+            )
+            return span
+
+        result = re.sub(_http_client_span, _strip_http_body_span, result)
+
+    # 9. Strip gh-api CLIENT-SIDE OUTPUT-SELECTOR + non-target flag VALUES (#1118), via
+    #    the SHARED quote-safe _strip_flag_values helper.
+    #    Carrier 8 removes the merge/git-refs FP substring from request-BODY values, but a
+    #    gh-api command's output selectors (--jq/-q jq filter, --template/-t Go template)
+    #    and other non-target value flags (-H/--header, --input body-file name, --hostname,
+    #    -p/--preview) still carry it, so a graphql/REST READ whose --jq names a response
+    #    field like `mergeStateStatus` is OVER-BLOCKED by the .*merge implicit-POST arm.
+    #    These VALUES can NEVER be the request ENDPOINT or METHOD (jq/template run on the
+    #    RESPONSE client-side; a header is request metadata; --input names a local file; a
+    #    hostname/preview name is not the resource — the endpoint is always the URL
+    #    positional), so stripping ONLY the value is zero-under-block (the CLIENT-vs-SERVER
+    #    analogue of carrier 8's PATH-vs-BODY invariant). gh-api's flag vocabulary is FINITE
+    #    + DOCUMENTED, so this surface is BOUNDED (unlike curl/wget's unbounded value-flag
+    #    vocabulary -> WON'T-FIX by construction, #1098). Scoped to a gh-api span ONLY (its
+    #    OWN _GH_API_PREFIX anchor, NARROWER than carrier 8's shared curl/wget/gh-api span),
+    #    and the FORM-AWARE `_selector_flagsep` is token-boundary anchored (`(?<!\S)`), so
+    #    -q/-t/-H/-p can never mis-strip curl -t (--telnet-option), wget -t (--tries),
+    #    gh pr create -t (--title, carrier 7), or a `-q` mid-token. Every flag token is KEPT
+    #    (only the value is replaced) so the implicit-POST lookaheads still fire on a genuine
+    #    write (a real mutation via --input to a path-resident endpoint keeps its --input
+    #    flag and stays HELD; its destructive target lives in the URL positional, never
+    #    stripped). CONTENTS-API early-return mirrors carrier 8: never touch a contents/ span
+    #    (its main/master gating signal is body/positional-resident). --cache is OUT (its
+    #    duration grammar provably cannot carry the substring).
+    #
+    #    QUOTE-SAFETY (#1118 re-model): the value strip goes through the SHARED
+    #    _strip_flag_values (quote-BALANCED _VALUE_TOKEN) + the FORM-AWARE separator (space /
+    #    =-long / =-short / attached-short). The PRIOR shipped carrier 9 used a
+    #    non-quote-aware unquoted arm (`[^\s'"]\S*`) + a `\s+`-only separator; its earlier
+    #    "additive-pure / cannot open a new under-block" claim was FALSIFIED by the #1118
+    #    review — on an embedded-quote value it emitted a DANGLING quote that mis-paired in
+    #    _mask_shell_quotes, MERGED legs, and regressed the guard in BOTH directions (SEC-1
+    #    over-block + SEC-2 under-block). This is NOT +N/-0; correctness is proven by
+    #    BIDIRECTIONAL base-vs-HEAD-vs-PATCH testing, never byte-diff. Same execution-routing
+    #    guards as carriers 3/5/7/8: skip when piped/process-sub to a shell; the double-
+    #    quoted arm preserves a value containing command substitution `$(`/backtick.
+    if not piped_to_shell and not process_sub_to_shell:
+        # The gh-api command span: from a gh-api head up to the first UNQUOTED shell
+        # separator. Quote-aware body (balanced quotes consumed atomically; disjoint
+        # first chars -> linear, no ReDoS) — identical shape to carriers 7/8, but
+        # anchored on gh-api ONLY (no curl/wget head), so -q/-t/-H/-p can never be
+        # mis-read as a curl/wget short flag. The URL positional and the -X/--method
+        # flag live in this span but are never matched by the selector-flag arms below
+        # (which require a selector FLAG directly before the value), so they survive.
+        _gh_api_selector_span = (
+            r"(?:" + _GH_API_PREFIX + r")"
+            + _VERB_MSG_BODY
+        )
+        # FORM-AWARE, token-anchored separator (#1118 re-model, FIX-B). gh (cobra/pflag)
+        # accepts a flag value four ways: space (`--jq x`), =-long (`--jq=x`), =-short
+        # (`-q=x`), attached-short (`-qx`). Long flags require a separator; short flags may
+        # attach. `(?<!\S)` anchors the flag at a token boundary, so `-q`/`-t`/`-H`/`-p`
+        # never match inside a positional (`some-q-endpoint`) or an already-stripped value.
+        # Long forms BEFORE short forms (so `--template` is not read as `-t` + `emplate`).
+        # Boolean flags (`--paginate`, `--slurp`, …) carry no value and are absent from the
+        # set. Wrapped in ONE capturing group at the call site (see _strip_flag_values).
+        _selector_flagsep = (
+            r"(?<!\S)(?:"
+            r"(?:--jq|--template|--header|--input|--hostname|--preview)(?:\s+|=)"
+            r"|(?:-q|-t|-H|-p)(?:\s+|=)?"
+            r")"
+        )
+
+        def _keep_selector_dq(m: re.Match) -> str:
+            # group(1) = the flag(+separator) captured by the wrapped _selector_flagsep.
+            # Same shape as carrier 8's _keep_flag_dq; both are keep_fn to _strip_flag_values.
+            if not _has_command_substitution(m.group(0)):
+                return m.group(1) + "'STRIPPED'"      # no-$() unchanged (single-quoted)
+            # has-$(): span-scope the value after the flag — strip the inert literal, preserve
+            # the executing $()/backtick spans (#1140). Emit the scanner's native dq output (NOT
+            # sq): it keeps each preserved span in the SAME executing dq context the coarse
+            # preserve used, so a real $(...) is detected IDENTICALLY to base (verified by cert).
+            flag = m.group(1)
+            transformed = _preserve_substitution_spans(m.group(0)[len(flag):])
+            if transformed is None:
+                return m.group(0)                     # fail-safe: preserve whole
+            return flag + transformed
+
+        def _strip_gh_api_selectors(span_match: re.Match) -> str:
+            span = span_match.group(0)
+            # CONTENTS-API exception (IGNORECASE, mirrors carrier 8): a contents span
+            # carries its main/master gating signal in the body/positional, so preserve
+            # the span verbatim (an output selector on a contents span is a rare, fail-
+            # safe pre-existing residual, not in #1118 scope).
+            if re.search(r"contents/", span, re.IGNORECASE):
+                return span
+            # Selector flag VALUES via the SHARED quote-safe strip (FIX-A + FIX-B). One call
+            # does all three arms (dq / sq / unquoted VALUE-TOKEN) across all four value-
+            # attachment forms. The unquoted arm consumes a COMPLETE quote-balanced token, so
+            # an embedded-quote selector value (a jq `.a+" "+.b`, a Go template
+            # `{{.n}}" "{{.t}}`, `-q x"y z"`) can no longer leave a dangling quote that merges
+            # legs (SEC-1/SEC-2). Anchored on the selector-flag(+separator) prefix, so the URL
+            # POSITIONAL endpoint (never preceded by such a prefix) is never matched -> a real
+            # destructive target in the path is never removed (over-block-safe).
+            span = _strip_flag_values(
+                span, r"(" + _selector_flagsep + r")", _keep_selector_dq
+            )
+            return span
+
+        result = re.sub(_gh_api_selector_span, _strip_gh_api_selectors, result)
+
+    # 10. GENERAL inert-default positional strip (#1178) — the strip-inert-by-default
+    #     inversion. For each shell-operator leg whose head is NEITHER a shell-string executor
+    #     / modeled wrapper (a) NOR an http-client (b), AND whose masked surface is NOT itself
+    #     dangerous (c), the quoted POSITIONAL values are INERT (POSIX argv of an unrecognized
+    #     command is never executed by the outer shell), so a danger-looking literal there must
+    #     not gate a faithful click — strip them (dq span-scopes $()/backtick; sq → bareword)
+    #     while PRESERVING executor / http-client / dangerous legs verbatim so every executing
+    #     arg stays caught and every destructive target survives for mint/read binding.
+    #     MONOTONIC toward False (only removes inert quoted content; never synthesizes a danger
+    #     token) so it can only CLOSE an over-block, never open one. Runs LAST (after the
+    #     flag-anchored carriers 1–9 have stripped their prose) under the SAME output-routing
+    #     skip. Leg slicing reuses the _slice_stripped_legs substrate on the in-progress result
+    #     (NOT _split_into_legs → re-strip recursion), rejoined with the ORIGINAL separators so
+    #     downstream leg boundaries are byte-unchanged.
+    if not piped_to_shell and not process_sub_to_shell:
+        result = _strip_inert_positional_legs(result)
+
+    return result
+
+
+def _has_eval_with_heredoc(command: str) -> bool:
+    """Detect eval (or backtick) command-substitution that wraps a heredoc.
+
+    The strip pipeline removes heredoc bodies BEFORE the regex-match phase.
+    An eval-wrapped destructive command inside a heredoc body is therefore
+    invisible to DANGEROUS_PATTERNS by the time matching runs:
+
+        eval $(cat <<HEREDOC
+        gh pr merge 999 --admin
+        HEREDOC
+        )
+
+    After ``_strip_non_executable_content``, the inner ``gh pr merge 999``
+    is gone. The outer eval invokes the heredoc body as a command, which
+    is exactly the destructive operation the merge guard is supposed to
+    intercept. Treat the eval+heredoc shape as categorically dangerous —
+    legitimate operator command flows do not use eval-wrapped heredoc as
+    a delivery mechanism, so the false-positive risk is low.
+
+    Detects both the modern ``$(...)`` substitution form and the legacy
+    backtick form.
+    """
+    # eval $(...) with a heredoc anywhere within the substitution
+    if re.search(r"\beval\s+\$\(", command) and "<<" in command:
+        return True
+    # eval `...` (backtick) wrapping a heredoc
+    if re.search(r"\beval\s+`[^`]*<<", command):
+        return True
+    return False
+
+
+def _shell_tokenize(command: str) -> list[str] | None:
+    """P1: quote-aware shell-word tokenizer (shlex.split posix=True, comments=False) —
+    strips single/double quotes, processes escapes, keeps a quoted-value span as ONE
+    token. Returns the token list on success, or None on ValueError (unbalanced /
+    unterminated quote). On None the callers ABSTAIN (extract_privileged_flags falls back
+    to `split()`; _flag_condition_danger_op returns None) and let the literal floor
+    (DANGEROUS_PATTERNS) decide — so an untokenizable command is dangerous only if the
+    floor matches, never dangerous merely because it failed to tokenize. shlex leaves
+    $ / $() / backtick LITERAL (no expansion); under the honest-mistake model that is
+    acceptable — runtime $-expansion is explicitly out of scope (the hook only ever sees
+    the pre-expansion literal an honest agent typed)."""
+    try:
+        return shlex.split(command, posix=True, comments=False)
+    except ValueError:
+        return None
+
+
+def _mask_shell_quotes(command: str) -> str:
+    """P2: bounded same-length quote-state scanner. Returns a copy with quoted spans
+    (delimiters + contents) — BOTH '...' and "..." — replaced by spaces, preserving
+    out-of-quote structure at identical offsets (P3 operator detection: a separator
+    inside EITHER quote is not a real separator). FAILS TOWARD UNMASKED: a `\\`-escaped
+    quote (outside quotes) never opens a span, and a mis-paired / unterminated quote
+    leaves the REST unmasked (visible) — so an operator/metachar can only OVER-block,
+    never under-block (the #1037-CLASS-1 closure: ambiguity never HIDES danger).
+    Identity on an unquoted command (constraint a)."""
+    out = list(command)
+    i, n = 0, len(command)
+    while i < n:
+        c = command[i]
+        if c == "\\":
+            i += 2  # escaped char (outside a quote) — next char is literal, not a delim
+            continue
+        if c == "'" or c == '"':
+            j = i + 1
+            closed = False
+            while j < n:
+                if c == '"' and command[j] == "\\":
+                    j += 2  # \\-escape is honored inside "..." (not inside '...')
+                    continue
+                if command[j] == c:
+                    closed = True
+                    break
+                j += 1
+            if not closed:
+                break  # unterminated quote → FAIL TOWARD UNMASKED (leave rest visible)
+            for k in range(i, min(j + 1, n)):
+                out[k] = " "
+            i = j + 1
+            continue
+        i += 1
+    return "".join(out)
+
+
+def _normalize_line_continuations(command: str) -> str:
+    """P0 (shell-semantic substrate SSOT): resolve bash line-continuations BEFORE
+    tokenization. Bash-faithful semantics: `\\<newline>` is SPLICED — REMOVED entirely,
+    gluing the surrounding text — NOT replaced with a space. A separating space
+    survives ONLY when one was already adjacent: `gh pr close 5 \\<newline>-d` splices
+    to `gh pr close 5 -d` (the space before the backslash survives, so `-d` stays a
+    clean separate token — the flag-scan under-block the split fix addresses), while
+    `merge\\<newline>5` glues to `merge5` (bash's printf-verified tokenization). This
+    empty-join (vs the former `→ space`) is what makes the comment predicate see the
+    REAL predecessor: `echo "…"\\<newline>#x` splices to `echo "…"#x`, so the `#` is
+    glued to the closing quote (a NON-delimiter) = NOT a comment, closing the #1148
+    line-continuation-splice comment under-block by construction. Routed through every
+    floor + mint call site, so mint and read resolve continuations IDENTICALLY
+    (mint==read by construction)."""
+    return command.replace("\\\n", "")
+
+
+# Benign continuation / redirect terminator for the positional target extractors
+# (_extract_force_push_target_ref / _extract_branch_name). Matches a compound
+# operator (`&&`, `||`, `|&`, `;`, `&`, `|`, newline — the _COMPOUND_OPS_RE set)
+# OR a redirect START. The redirect arm is `(?<!\S)\d+[<>]|[<>]`: a bare `<`/`>` is
+# ALWAYS a redirect (fd defaults), AND a leading fd-NUMBER (`2>`, `22>`) is a
+# redirect prefix ONLY when it is a standalone token — i.e. NOT preceded by a
+# non-whitespace char. This mirrors bash's IO_NUMBER rule: digits GLUED to the
+# preceding word are PART OF THE WORD, not an fd-number. So `git push origin
+# main2>log` is the bash WORD `main2` plus a `>log` redirect (the refspec is
+# `main2`, NOT `main`); only a whitespace-preceded `2>` (e.g. `main 2>&1`) is an
+# fd-redirect that truncates. The `(?<!\S)` lookbehind also keeps the scan LINEAR
+# on a long digit run — it prunes the redundant in-run start positions that a bare
+# `\d*` would re-scan (the O(n^2) catastrophic-backtracking a `\d*[<>]` exhibits).
+_BENIGN_TERMINATOR_RE = re.compile(r"&&|\|\||\|&|;|&|\||\n|(?<!\S)\d+[<>]|[<>]")
+
+# Process-substitution marker (`>(`/`<(`, allowing one optional space). An UNQUOTED
+# procsub is never an honest force-push/branch-delete form: bash treats
+# `git push --force origin main >(cmd)` as a MULTI-ref push (`>(cmd)` expands to an
+# extra `/dev/fd/N` positional), and `... > >(cmd)` redirects stdout into the
+# procsub FIFO. _executable_prefix ABSTAINS when this appears, rather than
+# truncating at the redirect and mis-deriving a single-ref target. Scanned on the
+# same _mask_shell_quotes view, so a quoted `"a>(b)"` is inert (never an over-block).
+_PROCSUB_MARKER_RE = re.compile(r"[<>] ?\(")
+
+
+def _executable_prefix(command: str) -> str | None:
+    """The command truncated at the first UNQUOTED compound-op-or-redirect.
+
+    Returns the leading executable span — everything before the first benign
+    continuation / redirect detected on the same-length `_mask_shell_quotes` view
+    — or the whole command when there is no such terminator. A quoted metachar
+    (`"weird>name"`) is masked to spaces on that view, so only an UNQUOTED
+    operator / redirect bounds the prefix. Returns None (the caller treats None as
+    an ABSENT target and REFUSES — fail-OPEN to the existing safe over-block) iff
+    EITHER the quote state is ambiguous (an unbalanced / unterminated quote makes
+    `_shell_tokenize` fail) OR an unquoted process-substitution marker (`>(`/`<(`)
+    is present (defense-in-depth — never an honest destructive form, and it makes a
+    single-ref target ambiguous). An adversarial quote-elided command is out of
+    scope and is never authorized, only ever over-blocked.
+    """
+    if _shell_tokenize(command) is None:  # unbalanced/unterminated quote -> abstain
+        return None
+    masked = _mask_shell_quotes(command)  # same-length; quoted metachars -> spaces
+    # Process-substitution defense-in-depth: an unquoted `>(`/`<(` is never an
+    # honest force-push/branch-delete form (bash makes a single-ref target ambiguous
+    # -> a multi-ref push, or redirects into a FIFO). Abstain rather than truncate
+    # at the redirect and mis-derive the target. Over-block direction only.
+    if _PROCSUB_MARKER_RE.search(masked):
+        return None
+    terminator = _BENIGN_TERMINATOR_RE.search(masked)
+    return command[: terminator.start()] if terminator else command
+
+
+# -----------------------------------------------------------------------------
+# P4 — op-agnostic quote-aware flag normalizer + per-op danger CONDITIONS.
+#
+# Generalizes the extract_privileged_flags cluster-walk into a SURFACE-keyed
+# normalizer fed by P1 tokens (quotes already stripped, so a quoted `"--admin"`
+# normalizes the same as a bare one). The SAME short differs by tool surface
+# (gh `-d` = --delete-branch; git `-d` = --delete), so the spec is keyed by
+# SURFACE. Danger is then a boolean CONDITION over the normalized set, ADDED to
+# the literal DANGEROUS_PATTERNS floor as a UNION arm (INV-AU: additive only — a
+# normalizer mis-parse can only fail-to-ADD a detection → over-block, never
+# under-block, because the literal floor still gates underneath).
+# -----------------------------------------------------------------------------
+
+# Per-surface flag spec: alias -> (canonical token, takes_value). A superset of
+# PRIVILEGED_FLAGS that ALSO carries the danger-relevant booleans the per-op
+# conditions test (-D / --delete / --force / --force-with-lease). The value-taking
+# entries (-R / --repo) are listed so a cluster like `-Rd val` parses correctly
+# (-R consumes the rest of the cluster as its value, so the trailing `d` is NOT
+# mis-read as --delete-branch). Aliases AGREE with PRIVILEGED_FLAGS so the danger
+# arm and the #1042 bind never disagree on a spelling. Unicode look-alike dashes
+# (U+2010 / U+2212) are deliberately ABSENT: an ASCII-only `startswith('-')`
+# leaves them unbound — gh/git reject them byte-exact, so they confer no privilege
+# and folding-to-ASCII would over-block a flag the tools simply ignore.
+_FLAG_SPEC: dict[str, dict[str, tuple[str, bool]]] = {
+    "gh": {
+        "--admin": ("--admin", False),
+        "-d": ("--delete-branch", False),
+        "--delete-branch": ("--delete-branch", False),
+        "-R": ("--repo", True),
+        "--repo": ("--repo", True),
+        "--match-head-commit": ("--match-head-commit", True),
+    },
+    "git": {
+        "-D": ("-D", False),
+        "-d": ("--delete", False),
+        "--delete": ("--delete", False),
+        "-f": ("--force", False),
+        "--force": ("--force", False),
+        "--force-with-lease": ("--force-with-lease", False),
+        "--no-verify": ("--no-verify", False),
+        # remote-mass-delete (#1062b) danger-condition booleans — present so
+        # `_normalized_flags` can SEE them for the mass-delete recognition arm. Like
+        # -D/--force, they are op-trigger booleans in _FLAG_SPEC but EXCLUDED from
+        # PRIVILEGED_FLAGS (the #1042 set-equality bind is untouched).
+        "--mirror": ("--mirror", False),
+        "--prune": ("--prune", False),
+    },
+}
+
+# Boolean-flag values that DISABLE the flag: `--admin=false` is the SAFE form, so
+# it does NOT confer the privilege / satisfy a danger condition. Any OTHER value
+# (or none) binds (fail-toward-binding on an unrecognized value = over-block-safe).
+_NEGATED_FLAG_VALUES = frozenset({"false", "0", "no"})
+
+
+def _normalized_flags(tokens: list[str], surface: str) -> set[str]:
+    """P4: canonicalize a P1 token list into the SET of flags PRESENT, across every
+    spelling (short / long / clustered / `=`-joined / attached-value), keyed by the
+    tool SURFACE ('gh' / 'git'). Booleans → bare canonical (`--delete-branch`);
+    value-takers → `--canonical=value`. An `=false`/`=0`/`=no` on a boolean NEGATES
+    it (omitted — the safe disable form). Mirrors the extract_privileged_flags
+    cluster-walk so the danger arm and the #1042 bind agree on every spelling.
+    Over-block-safe: an unrecognized token is skipped (never mis-bound)."""
+    spec = _FLAG_SPEC.get(surface, {})
+    if not spec:
+        return set()
+    found: set[str] = set()
+    i, n = 0, len(tokens)
+    while i < n:
+        token = tokens[i]
+        if not token.startswith("-") or token in ("-", "--"):
+            i += 1
+            continue
+        if token.startswith("--"):
+            flag_part, has_eq, value = token.partition("=")
+            entry = spec.get(flag_part)
+            if entry is None:
+                i += 1
+                continue
+            canonical, takes_value = entry
+            if takes_value:
+                if has_eq:                       # --repo=value
+                    found.add(f"{canonical}={value}")
+                    i += 1
+                elif i + 1 < n:                  # --repo value
+                    found.add(f"{canonical}={tokens[i + 1]}")
+                    i += 2
+                else:                            # --repo (value missing; degenerate)
+                    found.add(canonical)
+                    i += 1
+            else:
+                # boolean: an explicit `=false`/`=0`/`=no` DISABLES it → do not bind.
+                if not (has_eq and value.lower() in _NEGATED_FLAG_VALUES):
+                    found.add(canonical)
+                i += 1
+            continue
+        # short cluster (single dash): a per-character walk matching the privileged
+        # extractor's — a value-taking short consumes the REST of the cluster (or the
+        # next token) and stops, so no bound short is dropped regardless of ordering.
+        cluster = token[1:]
+        consumed_next = False
+        j = 0
+        while j < len(cluster):
+            entry = spec.get("-" + cluster[j])
+            if entry is None:
+                j += 1
+                continue
+            canonical, takes_value = entry
+            if takes_value:
+                remainder = cluster[j + 1:]
+                if remainder.startswith("="):    # `-R=value`
+                    remainder = remainder[1:]
+                if remainder:                    # `-Rvalue`
+                    found.add(f"{canonical}={remainder}")
+                elif i + 1 < n:                  # `-R value`
+                    found.add(f"{canonical}={tokens[i + 1]}")
+                    consumed_next = True
+                else:                            # `-R` (value missing; degenerate)
+                    found.add(canonical)
+                break
+            found.add(canonical)                 # boolean short; keep walking
+            j += 1
+        i += 2 if consumed_next else 1
+    return found
+
+
+# OBS-E (#1195) — the UNIFIED push-to-main destination-ref predicate. A push refspec whose
+# DESTINATION ref is EXACTLY main/master (optionally `<src>:`-prefixed, optionally
+# `refs/heads/`-prefixed), matched as a COMPLETE ref via .fullmatch on the refspec TOKEN.
+# Replaces the inaccurate `(?:main|master)(?!:)\b` predicate that was wrong BOTH ways
+# (prefix-matched main-release/main.foo/main@v1 = cardinal over-block; required main to
+# START the token so feature:main/refs/heads/main = under-block). The trailing negative-
+# lookahead forbids any ref-name continuation char (a COMPLETE ref); the `[^\s:+]` src
+# class excludes a leading `+` so `+main` is NOT a push-to-main dst (it FORCES → OBS-F).
+# SSOT: the ONE predicate the shared _flag_condition_danger_op push-to-main arm uses, which
+# BOTH detect (_detect_op_pass fallback) AND the read floor (_stripped_surface_danger) call
+# — mint==read by construction, no literal/DANGEROUS_PATTERNS copy left to drift.
+_PUSH_MAIN_DST_RE = re.compile(
+    r"(?:[^\s:+][^\s:]*:)?"   # optional <src>:  (src has no ':' and no leading '+')
+    r"(?:refs/heads/)?"      # optional full-ref dst prefix
+    r"(?:main|master)"       # the DESTINATION branch
+    r"(?![\w./@+-])"         # ... as a COMPLETE ref: no continuation char follows
+)
+
+# Per-leg op filter. `_flag_condition_danger_op` is FIRST-LEG-ANCHORED, so any op it
+# recognizes is LOST when the destructive command is not the first leg
+# (`cd /repo && git push origin main`). The caller-level per-leg loops (in
+# detect_command_operation_type + _stripped_surface_danger) restore ANY-LEG coverage by calling
+# the SAME union arm per leg, filtered to these classes — a THIN caller, no second predicate.
+# Reached ONLY after the existing pipeline returns None/False, so no command that ALREADY
+# gates changes its verdict.
+#
+# ALL SIX union-arm classes are listed. The four delete/close classes were added to close a
+# good-faith-reachable UNDER-BLOCK: `cd /repo && git push origin --delete feature` ran
+# COMPLETELY UNGATED. Widening this FILTER — rather than adding per-leg LITERAL arms — is
+# what keeps that fix over-block-free: literal arms were measured at 3 cardinal over-blocks
+# (e.g. `git push origin feature -o "note: use --mirror for backups"`) versus 0 here, because
+# the delete families need a positional, value-aware parse a regex cannot do. The filter reuses
+# the parse the union arm already performs on an ISOLATED leg, so a quoted `--mirror` mention
+# in a benign leg is never a match.
+#
+# Filtering both consumers on this ONE constant is what makes mint == read by construction:
+# a class added here reaches detect and the read floor in the same edit, so they cannot drift.
+#
+# CAVEAT (leg precedence): both loops return on the FIRST leg whose op is in this tuple. On a
+# compound carrying TWO ops from this set, an EARLIER leg now wins where a later one used to
+# — e.g. `cd /repo && git branch -Df temp && git push origin main` classifies branch-delete,
+# not push-to-main. Every such command has >=2 independently-dangerous legs (per-leg danger is
+# evaluated on an ISOLATED leg, which is its own first leg, so the dangerous-leg count is
+# unchanged by this filter), and a >=2-dangerous-leg compound is refused at the pair level
+# regardless of which label it carries — so this re-labels a verdict that never authorizes.
+_PER_LEG_OPS = (
+    "push-to-main",
+    "force-push",
+    "branch-delete",
+    "close",
+    "remote-ref-delete",
+    "remote-mass-delete",
+)
+
+
+def _flag_condition_danger_op(command: str) -> str | None:
+    """P4 union arm: classify the FIRST EXECUTABLE LEG of `command` by a quote-aware
+    NORMALIZED-FLAG danger CONDITION across every flag spelling, returning the
+    op-class ("close" / "branch-delete" / "force-push" / "remote-ref-delete" /
+    "remote-mass-delete" / "push-to-main") iff a condition fires, else None.
+    FIRST-LEG-ANCHORED (extending the conservative-RECOGNITION posture to this arm).
+    NOTE: callers ALSO invoke this per-leg for every class in `_PER_LEG_OPS`
+    (detect_command_operation_type + _stripped_surface_danger) to catch a recognized op
+    in a NON-first leg — this function itself stays first-leg-anchored; the per-leg reach
+    is the callers'. That split is what makes per-leg coverage safe: each call still sees
+    ONE isolated leg and derives flags AND positionals from it, so widening the caller's
+    filter can never introduce the cross-leg flag leak.
+    Every surface consulted here — the token list, the coarse-shape prefixes,
+    and the extractor inputs — derives from `_executable_prefix(command)`, because
+    deriving FLAGS from the whole command while POSITIONALS came from the first
+    executable leg let a force/delete flag in a benign CONTINUATION leg mislabel a
+    benign first-leg op (the #1078 cross-leg flag leak). The coarse op-shape (which
+    subcommand) is matched with the SAME shared prefixes the literal floor uses; the
+    danger test is then a boolean condition over `_normalized_flags`. ADDITIVE over
+    the literal floor (INV-AU): an unparseable command / mis-parse can only FAIL to
+    return an op here (this arm ABSTAINS; the literal floor still decides), never
+    re-open an under-block. The coarse shape only SCOPES which condition runs — a
+    false coarse-match whose condition does not hold returns None (over-block-safe)."""
+    prefix = _executable_prefix(command)
+    if prefix is None:
+        # Unbalanced quote OR process substitution → abstain; the literal floor
+        # decides. Procsub is never an honest destructive form (the helper's own
+        # rationale) — an exotic procsub+cluster combo is an accepted under-block.
+        return None
+    tokens = _shell_tokenize(prefix)
+    if tokens is None:
+        return None  # unparseable → this arm abstains; the literal floor decides (honest-mistake: no metachar catch-all)
+    # close --delete-branch — covers `-d`, clustered `-cd`, `--delete-branch`; the
+    # literal floor matches ONLY the spelled-out `--delete-branch` (the #2 gap).
+    if _GH_PR_CLOSE_RE.search(prefix):
+        if "--delete-branch" in _normalized_flags(tokens, "gh"):
+            return "close"
+    # git branch force-delete — covers `-D`, `-Df`, `-fD`, `--delete -f`/`--force`
+    # in any order; the literal floor matches ONLY `-D\b` / `--delete --force` /
+    # `--force --delete` (the #4 gap).
+    if re.search(_GIT_PREFIX + r"branch\b", prefix):
+        gf = _normalized_flags(tokens, "git")
+        if "-D" in gf or ("--delete" in gf and "--force" in gf):
+            return "branch-delete"
+    # git push --force — covers clustered short forms; `--force-with-lease` is the
+    # SAFE exclusion (a non-history-rewriting push). Redundant with the literal floor
+    # today (`-[a-zA-Z]*f` already catches the clusters) but kept for op-class parity.
+    if re.search(_GIT_PREFIX + r"push\b", prefix):
+        gf = _normalized_flags(tokens, "git")
+        if "--force" in gf and "--force-with-lease" not in gf:
+            return "force-push"
+        # remote-ref-delete (#1062a) — union-arm-only recognition (lead Q2: NO
+        # literal DANGEROUS_PATTERNS ref-delete arm). Recognize IFF a SINGLE
+        # deletable ref is extractable; recognition⟺mintability by construction
+        # (the SAME predicate feeds detect via the fallback AND the is_dangerous
+        # union), so this op can NEVER be #1064 gated-but-unmintable. A multi-ref /
+        # implicit-current / ambiguous form yields None here → not recognized → the
+        # mass arm below or the literal floor decides. Tried FIRST = the single-ref-
+        # extractability BOUNDARY discriminator: mass only runs when this returns None.
+        # Both extractors are fed `prefix` for single-surface coherence: each
+        # re-derives `_executable_prefix` internally (idempotent on a prefix), so
+        # this is behavior-identical — but the arm then has exactly ONE surface.
+        if _extract_remote_ref_delete_target(prefix) is not None:
+            return "remote-ref-delete"
+        # remote-mass-delete (#1062b) — mass forms (--mirror/--prune/multi-ref delete),
+        # recognized IFF a normalized mass-target tuple is extractable (the extractor
+        # itself defers to remote-ref-delete for a single ref, so no double-classify).
+        # Recognition⟺mintability by construction → #1064-impossible (implicit-remote
+        # included via the definite \x00implicit marker).
+        if _extract_mass_delete_target(prefix) is not None:
+            return "remote-mass-delete"
+        # push-to-main via the UNIFIED refspec-DST predicate (#1195 OBS-E, supersedes the
+        # OBS-D branch-token arm + the removed detect literals + DANGEROUS_PATTERNS copies).
+        # fullmatch _PUSH_MAIN_DST_RE on positionals[1:] — the REFSPECS. positionals[0] is
+        # the REMOTE and is DELIBERATELY SKIPPED: a remote literally NAMED 'main'
+        # (`git push main feature`) must NOT gate (it is a push of 'feature' to a remote
+        # called 'main', not a push to the main branch). _push_positionals skips interposed
+        # `-o` push-option values (OBS-C/D machinery); the K bound keeps the flag walk
+        # linear; the `push\s` reachability (single guarded match) keeps a glued
+        # `git push--force …` non-command out. LAST in the push branch (force/delete/mass
+        # classify above); SHARED arm ⇒ mint==read by construction.
+        _pm = re.search(_GIT_PREFIX + r"push\s(.*)$", prefix)         # well-formed push only
+        if _pm is not None:                                          #   (excludes push--force glue)
+            _tail = _pm.group(1).split()
+            if sum(1 for t in _tail if t.startswith("-")) <= _MAX_GLOBAL_FLAG_TOKENS:  # perf bound
+                _refspecs = [_strip_surrounding_quotes(r) for r in _push_positionals(_tail)[1:]]
+                # +<refspec> force-push (#1195 OBS-F): a leading '+' on ANY refspec is git's
+                # documented FORCE spelling — symmetric with `--force` → force-push for any
+                # target. Checked AFTER delete/mass (a `+:main` / `--delete +main` is a DELETE,
+                # claimed above) and BEFORE push-to-main (a `+main` FORCES → force-push, never
+                # push-to-main: a push-to-main token must NOT authorize a forced ref update;
+                # `git push origin +feature main` = force-push). `_PUSH_MAIN_DST_RE.fullmatch`
+                # is already False on a `+`-leading token (the src class excludes leading '+'),
+                # so no conflict. Over-block-safe by construction: force-push already gates any
+                # target; `+ref` is just another spelling. Bare `+` is not a refspec (len > 1).
+                if any(r.startswith("+") and len(r) > 1 for r in _refspecs):
+                    return "force-push"
+                for _r in _refspecs:                                  # REFSPECS only (skip remote)
+                    if _PUSH_MAIN_DST_RE.fullmatch(_r):
+                        return "push-to-main"
+    return None
+
+
+# =============================================================================
+# #1178 GENERAL inert-default positional strip — catalog, preserve-predicate,
+# wrapper recursion, and the carrier-10 leg strip.
+#
+# The strip-inert-by-DEFAULT inversion (design of record, SOUND-BOUNDED): a leg whose head
+# is an UNRECOGNIZED command has POSIX-argv-inert quoted positionals (the outer shell never
+# executes them), so a danger-looking literal there must not gate a faithful click — strip
+# it. A leg is PRESERVED (not stripped) iff its quoted content is load-bearing for a True
+# verdict: (a) its head hands a quoted string to a shell/interpreter (executor), or wraps a
+# command that does (modeled wrapper, RECURSED); (b) its head is an http-client whose
+# destructive target is a quoted URL that masking hides; or (c) its masked surface is itself
+# dangerous (a bare-token git/gh op whose quoted TARGET must survive mint/read binding). The
+# strip is MONOTONIC toward False: it only ever REPLACES an inert quoted value with STRIPPED
+# (or a $()-span-scoped value) — it never synthesizes a danger token — so it can only CLOSE
+# an over-block (True->False), never OPEN one; the whole safety burden reduces to preserve-
+# predicate completeness on the load-bearing legs.
+# =============================================================================
+
+# (a) Shell-string executors / interpreters. TOKEN-EQUALITY on the basename-normalized head
+# (C1 CARDINAL — NEVER substring/\b: a substring scan sees `bash` in `bash-completion` /
+# `python` in `python-config` and would wrongly PRESERVE an inert command's quoted arg,
+# re-opening the over-block). Bounded per-FAMILY patterns fold version/alias variants into
+# ONE member (python[0-9.]* / node|nodejs / ksh(93)?) so a real versioned interpreter is
+# caught while distinct tokens (python-config, node-gyp) are NOT (^…$ anchors the whole
+# token). busybox is a WRAPPER (its applet/executor is the 2nd token) → the wrapper set below.
+_SHELL_STRING_EXECUTORS = re.compile(
+    r"^(?:"
+    r"sh|bash|zsh|dash|ash|fish|csh|tcsh"                # POSIX + common shells
+    r"|ksh(?:93)?|rksh|mksh"                             # ksh family (ksh93 != ksh)
+    r"|hush|lash|msh"                                   # busybox exec-shell applets (run a -c string)
+    r"|eval|expect|watch"                               # string runners
+    r"|ssh|rsh|remsh|slogin|su"                         # remote / user-switch (-c / a command)
+    r"|python[0-9.]*|perl|ruby[0-9.]*|nodejs|node|php|awk|gawk"  # interpreters (-c/-e/-r)
+    r")$"
+)
+
+# (a) Modeled exec-WRAPPERS whose (possibly nested) executor's quoted arg executes. Split by
+# grammar tractability. RECURSE: the wrapper's own args are a bounded, well-known skip from
+# the head to the nested command, which _is_preserve_leg then RE-EVALUATES (nested executor →
+# preserve, case A caught; nested inert → strip, case B freed). sudo is RECURSE (≈ doas + a
+# bigger flag table; -i/-s/-e = shell/edit forms → preserve): sudo is ubiquitous and
+# `sudo logger "…"` / `sudo mycmd "…"` over-blocks are COMMON, not contrived, so coarse-
+# preserving it would retain a cardinal over-block. busybox + stdbuf are ALSO RECURSE: busybox's
+# applet is simply token[1] (empty own-flag grammar → nested command = token[1..]), and stdbuf's
+# only options are the -i/-o/-e buffering-mode VALUE-flags (attached `-oL` / separated `-o L` /
+# long `--output=L`) skippable by the phased walk — so their wrapped-inert over-block is CLOSEABLE
+# and MUST be closed. COARSE (still): grammars whose nested-command boundary is NOT reliably
+# skippable — find's `-exec CMD` is `;`/`+`-terminated with `{}` placeholders; flock has a leading
+# LOCKFILE positional + a `-c "STR"` string-exec arm (flock -c runs via sh -c) + FD forms —
+# preserved WHOLE (over-block-safe: `flock -c "STR"` stays CAUGHT; the `flock /lock mycmd "…"`
+# wrapped-inert over-block is a contrived, tracked residual). Enumerating EVERY wrapper is the
+# #1098 wall (D1): an unmodeled custom wrapper's under-block is a tolerated residual. NOTE:
+# recursing busybox requires its exec-capable shell applets (sh/ash/hush/lash/msh + awk) to be
+# recognized preserve-heads — hush/lash/msh were added to _SHELL_STRING_EXECUTORS so
+# `busybox hush -c "danger"` stays CAUGHT after the flip (else a fix-introduced under-block).
+_EXEC_WRAPPERS_RECURSE = frozenset({
+    "nohup", "setsid", "nice", "doas", "sudo", "timeout", "xargs", "env",
+    # Nameable exec-prefix family (#1178, user ruling = Option X + RECURSION). All 13 nameable
+    # exec-prefixes RECURSE (via _WRAPPER_GRAMMAR) so `<prefix> bash -c "danger"` stays CAUGHT
+    # AND the faithful inert `<prefix> mycmd "danger"` FREES — the over-block is CLOSEABLE, so
+    # it MUST be closed ("contrived" is not a valid exception under the user principle; only a
+    # by-construction-unclosable residual like curl/wget is acceptable). Per-prefix arg-skip
+    # grammar below, each BIDIRECTIONALLY certified (bash -c caught ∧ mycmd freed ∧ value-flag-
+    # before-executor caught). The ONLY tolerated under-block residual is the genuinely-CUSTOM
+    # (myrunner-style) exec-wrapper tail (ratified D1 — enumerating every wrapper = the #1098 wall).
+    "time", "exec", "command", "chrt", "taskset", "ionice", "unbuffer",
+    "proxychains", "torsocks", "catchsegv", "nocache", "eatmydata", "rlwrap",
+    # busybox + stdbuf RECURSE (F2 closure): busybox = empty own-flag grammar, applet = token[1]
+    # (its exec-capable shell applets sh/ash/hush/lash/msh + awk are recognized preserve-heads so
+    # `busybox sh -c "danger"` stays caught while `busybox mycmd "danger"` frees); stdbuf = -i/-o/-e
+    # buffering-mode VALUE-flags (attached `-oL` handled by the phased walk's short-value branch).
+    "busybox", "stdbuf",
+})
+_EXEC_WRAPPERS_COARSE = frozenset({
+    # Plan-ratified members whose nested-command boundary is NOT reliably skippable: find's -exec
+    # CMD is ;/+-terminated with {} placeholders; flock has a lockfile positional + a -c string-exec
+    # arm — both COARSE preserve-whole (their `<wrapper> bash -c "danger"` stays caught; the
+    # wrapped-inert over-block is a contrived, tracked residual). busybox/stdbuf moved to RECURSE
+    # (above, F2). The nameable exec-prefix family RECURSES, not here.
+    "find", "flock",
+})
+
+# (b) http-client heads whose destructive target is a quoted URL that _mask_shell_quotes
+# blanks (so the danger battery on the masked surface CANNOT see it) → preserving is the
+# load-bearing #1098-consistent exclusion (a strip would UNDER-block). curl/wget matched by
+# shlex basename head (catches a quoted "curl": base-True via \bcurl\b + a .* lookahead that
+# spans the closing quote). gh api is matched on the masked surface via _GH_API_PREFIX (an
+# unquoted `gh api`; a quoted "gh" api is base-FALSE — \bgh\s+ is broken by the closing quote
+# — so it needs no preserve).
+_HTTP_CLIENT_HEADS = frozenset({"curl", "wget"})
+
+# Recognized git/gh TOOL heads. Carrier 10 PRESERVES these legs wholesale and DEFERS to their
+# dedicated carriers (5 git commit / 7 gh issue-pr / 7b-e / 8 curl-body / 9 gh-api selector) +
+# the danger floor: re-stripping a value those carriers intentionally preserved is an
+# under-block (a git commit -m/tag $() fail-safe value, a `git -c` config dot-guard value, an
+# expanded var), and a DANGEROUS git/gh leg's target must survive for binding. Non-carrier
+# git/gh prose (e.g. `git log --grep "…git branch -D…"`) stays a benign over-block RESIDUAL —
+# never an under-block. (curl/wget/gh-api are the http-client heads above / the gh-api masked
+# clause, handled separately.)
+_TOOL_HEADS = frozenset({"git", "gh"})
+
+
+# =============================================================================
+# READ-VERB value-strip vocabulary — the carve-out from the d2 _TOOL_HEADS
+# preserve above. A git/gh READ verb (log/show/shortlog/grep, issue/pr list,
+# search) never executes its search/filter VALUES, so a danger-looking quoted
+# literal there (`git log --grep "gh pr merge 5 --admin"`) is an inert faithful
+# click that must not gate — _strip_read_verb_values (below, pre-d2 in
+# _maybe_strip_leg) strips exactly these values before the wholesale preserve
+# can fire.
+#
+# STRUCTURE RULES (each load-bearing):
+#   - Keys are the FULL verb path with EXACT token equality, never a shared
+#     short-flag set: `-e` is a value-taking pattern on git grep but the
+#     boolean `--email` on git shortlog — a shared table would mis-consume the
+#     next real token (the curl/wget-shaped fail-open). The verb set is CLOSED
+#     (design ruling): git diff and adjacents are OUT (git diff's harmless
+#     `-O <orderfile>` vs git grep's EXECUTING `-O<pager>` is exactly why
+#     per-verb keying is mandatory).
+#   - flag_arm is ONE capturing group (the _strip_flag_values flag_sep
+#     contract) whose alternatives are each anchored `(?<!\S)` (token start —
+#     a `--not-grep`-style superset can never match) and ordered LONGEST-FIRST
+#     (`--grep-reflog` before `--grep`; `--author-date` before `--author`).
+#     Long flags take `\s+` (space form ONLY: the `--flag="…"` form is
+#     carrier-4-pre-stripped upstream and MUST NOT be re-handled here); value
+#     shorts take `\s*` (attached `-Sfoo`/`-S'foo'` or spaced `-S foo` — the
+#     carrier-5 idiom). Bundled-cluster spellings (`-nS'x'`) are deliberately
+#     NOT matched → preserved → status-quo residual.
+#   - BOOLEANS ARE EXCLUDED BY OMISSION: with flag-anchored arms an unlisted
+#     boolean is simply never touched, so the only enumeration burden is
+#     "never list a boolean" (`--invert-grep`, `--all-match`, `-w/--web`,
+#     `--draft`, shortlog `-e/--email` MUST NOT appear — listing an arity-0
+#     flag would consume the next real token). Ambiguous arity → exclude
+#     (fail-toward-preserve). `--format`/`--pretty` (git) and
+#     `--json`/`--jq`/`--template` (gh) stay OUT of every flag_arm (smallest
+#     certified vocabulary; preserved = status quo).
+#   - deny_re: an EXECUTING flag anywhere in the leg's shlex tokens preserves
+#     the WHOLE leg (fail-toward-preserve). git grep `-O[<pager>]` /
+#     `--open-files-in-pager[=…]` EXECUTES its attached value (`-Ovim` runs
+#     vim; bare `-O` runs the default pager) — deny all spellings; the
+#     cluster-tolerant `-[a-zA-Z]*O` is deliberately over-wide (a false deny
+#     only preserves, never under-blocks).
+#   - strip_positionals (git grep / gh search only): after the guards in
+#     _strip_read_verb_values, every remaining quoted span in such a leg is
+#     data the verb never executes (patterns, pathspecs, query terms); gh
+#     search's `--` sentinel needs no special code (tokens after `--` are
+#     positionals and strip like any quoted span).
+#
+# Flag arities are doc-verified against git 2.50.1 (man git-log/git-grep/
+# git-shortlog) and gh 2.96.0 (`gh <verb> --help`), per-subcommand for
+# gh search (prs/issues/commits/repos/code differ; a prs-only flag like
+# `-B/--base` never enters a sibling subcommand's arm).
+# =============================================================================
+
+class _ReadVerbSpec(NamedTuple):
+    """Per-(tool, verb…) read-verb strip spec for _strip_read_verb_values."""
+    flag_arm: "re.Pattern | None"   # ONE capturing group: the flag(+separator) to keep;
+                                    # value consumed via _strip_flag_values' 3 arms
+    deny_re: "re.Pattern | None"    # executing-flag deny — ANY token match => whole-leg preserve
+    strip_positionals: bool         # grep/search only: strip remaining quoted spans
+
+
+# git grep's ONLY executing flag family: -O[<pager>] / --open-files-in-pager[=<pager>]
+# (attached-only optional value, EXECUTES it). Matched against quote-stripped shlex
+# tokens (shell semantics: a quoted '-O' still reaches git as the flag).
+_GIT_GREP_DENY_RE = re.compile(r"(?<!\S)-[a-zA-Z]*O|(?<!\S)--open-files-in-pager(?:=|\b)")
+
+_READ_VERB_SPECS: "dict[tuple[str, ...], _ReadVerbSpec]" = {
+    ("git", "log"): _ReadVerbSpec(
+        re.compile(
+            r"((?<!\S)(?:--grep-reflog|--grep|--author|--committer)\s+"
+            # bundled-cluster pickaxe short (#1195 OBS-A2): a dash cluster ENDING in the
+            # uppercase pickaxe flag S/G (`-nS'…'`, `-wG'…'`). [SG] uppercase-only so it
+            # never mis-binds `-s`/lowercase; the value is an inert pickaxe string.
+            r"|(?<!\S)-[a-zA-Z]*[SG]\s*)"
+        ),
+        None, False,
+    ),
+    ("git", "show"): _ReadVerbSpec(
+        re.compile(
+            r"((?<!\S)(?:--grep|--author|--committer)\s+"
+            r"|(?<!\S)-[a-zA-Z]*[SG]\s*)"
+        ),
+        None, False,
+    ),
+    # NO shorts on shortlog: its `-e` is the boolean `--email` (the cross-verb
+    # collision that mandates per-verb keying).
+    ("git", "shortlog"): _ReadVerbSpec(
+        re.compile(r"((?<!\S)(?:--grep|--author|--committer)\s+)"),
+        None, False,
+    ),
+    ("git", "grep"): _ReadVerbSpec(
+        re.compile(r"((?<!\S)-[ef]\s*)"),
+        _GIT_GREP_DENY_RE, True,
+    ),
+    ("gh", "issue", "list"): _ReadVerbSpec(
+        re.compile(
+            r"((?<!\S)(?:--search|--author|--app|--assignee|--label|--milestone"
+            r"|--mention|--type|--state|--limit|--repo)\s+"
+            r"|(?<!\S)-[SAalmsLR]\s*)"
+        ),
+        None, False,
+    ),
+    ("gh", "pr", "list"): _ReadVerbSpec(
+        re.compile(
+            r"((?<!\S)(?:--search|--author|--app|--assignee|--label|--base"
+            r"|--head|--state|--limit|--repo)\s+"
+            r"|(?<!\S)-[SAalBHsLR]\s*)"
+        ),
+        None, False,
+    ),
+    # gh search value-flag vocabularies are PER-SUBCOMMAND (gh 2.96.0 --help;
+    # issues/commits/repos/code are NOT the prs superset — a superset-applied
+    # flag that is boolean/absent on a sibling would mis-consume). Longest-first
+    # where one flag prefixes another (--review-requested/--reviewed-by before
+    # --review; --author-*/-committer-* before --author/--committer).
+    ("gh", "search", "prs"): _ReadVerbSpec(
+        re.compile(
+            r"((?<!\S)(?:--app|--assignee|--author|--base|--checks|--closed"
+            r"|--commenter|--comments|--created|--head|--interactions|--involves"
+            r"|--label|--language|--limit|--match|--mentions|--merged-at"
+            r"|--milestone|--order|--owner|--project|--reactions|--repo"
+            r"|--review-requested|--reviewed-by|--review|--sort|--state"
+            r"|--team-mentions|--updated|--visibility)\s+"
+            r"|(?<!\S)-[BHLR]\s*)"
+        ),
+        None, True,
+    ),
+    ("gh", "search", "issues"): _ReadVerbSpec(
+        re.compile(
+            r"((?<!\S)(?:--app|--assignee|--author|--closed|--commenter"
+            r"|--comments|--created|--interactions|--involves|--label"
+            r"|--language|--limit|--match|--mentions|--milestone|--order"
+            r"|--owner|--project|--reactions|--repo|--sort|--state"
+            r"|--team-mentions|--updated|--visibility)\s+"
+            r"|(?<!\S)-[LR]\s*)"
+        ),
+        None, True,
+    ),
+    ("gh", "search", "commits"): _ReadVerbSpec(
+        re.compile(
+            r"((?<!\S)(?:--author-date|--author-email|--author-name|--author"
+            r"|--committer-date|--committer-email|--committer-name|--committer"
+            r"|--hash|--limit|--order|--owner|--parent|--repo|--sort|--tree"
+            r"|--visibility)\s+"
+            r"|(?<!\S)-[LR]\s*)"
+        ),
+        None, True,
+    ),
+    ("gh", "search", "repos"): _ReadVerbSpec(
+        re.compile(
+            r"((?<!\S)(?:--created|--followers|--forks|--good-first-issues"
+            r"|--help-wanted-issues|--include-forks|--language|--license"
+            r"|--limit|--match|--number-topics|--order|--owner|--size|--sort"
+            r"|--stars|--topic|--updated|--visibility)\s+"
+            r"|(?<!\S)-L\s*)"
+        ),
+        None, True,
+    ),
+    ("gh", "search", "code"): _ReadVerbSpec(
+        re.compile(
+            r"((?<!\S)(?:--extension|--filename|--language|--limit|--match"
+            r"|--owner|--repo|--size)\s+"
+            r"|(?<!\S)-[LR]\s*)"
+        ),
+        None, True,
+    ),
+}
+
+
+# Bounded recursion depth for nested wrappers (`timeout nice bash -c …`). Beyond this →
+# fail-safe PRESERVE. 3 covers realistic nesting; the guard prevents pathological recursion.
+_MAX_WRAPPER_DEPTH = 3
+
+class _WrapperGrammar(NamedTuple):
+    """Per-wrapper own-arg grammar for the recursion walk. bool_flags = flags to skip (token
+    only); value_flags = flags whose NEXT token is a value to skip too; shell_flags = flags
+    that invoke a shell / make the arg the command → PRESERVE the whole leg; positionals =
+    count of leading NON-flag positional args to skip before the command (timeout's DURATION =
+    1). Long =forms (`--flag=x`) collapse to one token; env NAME=VALUE is handled generically.
+    An UNRECOGNIZED dash-flag (unknown arity) → PRESERVE — skipping the wrong number of tokens
+    could land PAST the executor = the under-block the fail-safe forbids."""
+    bool_flags: "frozenset[str]"
+    value_flags: "frozenset[str]"
+    shell_flags: "frozenset[str]"
+    positionals: int
+
+
+_WRAPPER_GRAMMAR: "dict[str, _WrapperGrammar]" = {
+    "nohup":   _WrapperGrammar(frozenset(), frozenset(), frozenset(), 0),
+    "setsid":  _WrapperGrammar(frozenset({"-c", "-f", "-w", "--ctty", "--fork", "--wait"}), frozenset(), frozenset(), 0),
+    "nice":    _WrapperGrammar(frozenset(), frozenset({"-n", "--adjustment"}), frozenset(), 0),
+    "doas":    _WrapperGrammar(frozenset({"-L", "-n"}), frozenset({"-C", "-u"}), frozenset({"-s"}), 0),
+    "timeout": _WrapperGrammar(frozenset({"--preserve-status", "--foreground", "-v", "--verbose"}), frozenset({"-s", "--signal", "-k", "--kill-after"}), frozenset(), 1),
+    "xargs":   _WrapperGrammar(frozenset({"-0", "--null", "-r", "--no-run-if-empty", "-t", "--verbose", "-p", "--interactive", "-x", "--exit", "-o", "--open-tty"}), frozenset({"-I", "-i", "-n", "--max-args", "-L", "--max-lines", "-P", "--max-procs", "-s", "--max-chars", "-d", "--delimiter", "-E", "-e", "-a", "--arg-file"}), frozenset(), 0),
+    "env":     _WrapperGrammar(frozenset({"-i", "--ignore-environment", "-0", "--null", "-v"}), frozenset({"-u", "--unset", "-C", "--chdir"}), frozenset({"-S", "--split-string"}), 0),
+    # sudo (≈ doas + a bigger table). shell/edit forms {-i,-s,-e} → preserve (no explicit CMD).
+    # -h OMITTED (ambiguous help-vs-host) → unrecognized → preserve (over-block-safe). Value
+    # flags (-u/-g/-C/-p/-R/-r/-T/-t/-U/-D) verified vs sudo(8). Arity errors here would
+    # under-block, so the value/bool split is cert-pinned per Q2 (value-flag-before-executor).
+    "sudo":    _WrapperGrammar(frozenset({"-A", "--askpass", "-B", "--bell", "-b", "--background", "-E", "--preserve-env", "-H", "--set-home", "-K", "--remove-timestamp", "-k", "--reset-timestamp", "-l", "--list", "-n", "--non-interactive", "-P", "--preserve-groups", "-S", "--stdin", "-V", "--version", "-v", "--validate"}), frozenset({"-C", "--close-from", "-D", "--chdir", "-g", "--group", "-p", "--prompt", "-R", "--chroot", "-r", "--role", "-T", "--command-timeout", "-t", "--type", "-U", "--other-user", "-u", "--user"}), frozenset({"-i", "--login", "-s", "--shell", "-e", "--edit"}), 0),
+    # Nameable exec-prefixes (#1178 Option X, RECURSION). Each bidirectionally certified (bash -c
+    # caught ∧ mycmd freed ∧ value-flag-before-executor caught). Unlisted flags → unrecognized →
+    # PRESERVE (fail-safe: an unmodeled option over-blocks rather than mis-skips past the
+    # executor). time = bash keyword (-p) + /usr/bin/time (-o/-f value). chrt/taskset carry a
+    # leading PRIORITY/MASK positional + a -p/--pid operate-on-existing-PID form (no CMD → shell/
+    # preserve). ionice: -c/-n class values. proxychains: -f config. torsocks: -d/-a/-p/-P/-u/-s
+    # values. rlwrap: large value set (-b/-C/-D/-e/-f/-g/-H/-l/-O/-P/-q/-s/-S/-t/-w/-z); -a/-m/-p
+    # are OPTIONAL-ATTACHED (bool unless attached). catchsegv/nocache/eatmydata take no options.
+    "time":        _WrapperGrammar(frozenset({"-a", "-p", "-q", "-v", "-V", "--append", "--portability", "--quiet", "--verbose", "--version", "--help"}), frozenset({"-o", "-f", "--output", "--format"}), frozenset(), 0),
+    "exec":        _WrapperGrammar(frozenset({"-c", "-l"}), frozenset({"-a"}), frozenset(), 0),
+    "command":     _WrapperGrammar(frozenset({"-p", "-V", "-v"}), frozenset(), frozenset(), 0),
+    "chrt":        _WrapperGrammar(frozenset({"-f", "-b", "-o", "-r", "-i", "-d", "-R", "-m", "-a", "-v", "--fifo", "--batch", "--other", "--rr", "--idle", "--deadline", "--reset-on-fork", "--all-tasks", "--verbose"}), frozenset(), frozenset({"-p", "--pid"}), 1),
+    "taskset":     _WrapperGrammar(frozenset({"-a", "--all-tasks", "-c", "--cpu-list"}), frozenset(), frozenset({"-p", "--pid"}), 1),
+    "ionice":      _WrapperGrammar(frozenset({"-t", "--ignore"}), frozenset({"-c", "--class", "-n", "--classdata"}), frozenset({"-p", "--pid"}), 0),
+    "unbuffer":    _WrapperGrammar(frozenset({"-p"}), frozenset(), frozenset(), 0),
+    "proxychains": _WrapperGrammar(frozenset({"-q", "--quiet"}), frozenset({"-f", "--config"}), frozenset(), 0),
+    "torsocks":    _WrapperGrammar(frozenset({"-h", "-q", "-i", "--isolate", "-H", "-V", "--version", "--help", "--shell"}), frozenset({"-d", "--debug", "-a", "--address", "-p", "--port", "-P", "--control-port", "-u", "--user", "-s", "--socks5"}), frozenset(), 0),
+    "catchsegv":   _WrapperGrammar(frozenset(), frozenset(), frozenset(), 0),
+    "nocache":     _WrapperGrammar(frozenset(), frozenset({"-n"}), frozenset(), 0),
+    "eatmydata":   _WrapperGrammar(frozenset(), frozenset(), frozenset(), 0),
+    "rlwrap":      _WrapperGrammar(frozenset({"-A", "-c", "-h", "-i", "-I", "-n", "-N", "-o", "-r", "-R", "-U", "-W", "-x", "-a", "-m", "-p", "--always-readline", "--complete-filenames", "--case-insensitive", "--no-children", "--one-shot", "--remember", "--quiet", "--help"}), frozenset({"-b", "-C", "-D", "-e", "-f", "-g", "-H", "-l", "-O", "-P", "-q", "-s", "-S", "-t", "-w", "-z", "--break-chars", "--command-name", "--history-no-dupes", "--forget-matching", "--file", "--history-filename", "--logfile", "--substitute-prompt", "--prompt", "--quote-characters", "--histsize", "--set-terminal-name", "--wait-before-prompt", "--filter"}), frozenset(), 0),
+    # busybox + stdbuf (#1178 F2). busybox: the wrapper-usage form is `busybox APPLET [args]` with NO
+    # own-flags before the applet — empty grammar, positionals=0, so the nested command is token[1]
+    # (the applet); its exec-capable shell applets (sh/ash/hush/lash/msh) + awk are recognized
+    # preserve-heads. stdbuf: the -i/-o/-e buffering-mode VALUE-flags (long --input/--output/--error);
+    # the MODE value attaches (`-oL`), separates (`-o L`), or long-equals (`--output=L`) — the
+    # attached-short form is consumed by _wrapper_nested_command's PHASE-1 short-value branch. no
+    # shell forms, positionals=0. --help/--version are unlisted → unrecognized → preserve (over-block-safe).
+    "busybox":     _WrapperGrammar(frozenset(), frozenset(), frozenset(), 0),
+    "stdbuf":      _WrapperGrammar(frozenset(), frozenset({"-i", "-o", "-e", "--input", "--output", "--error"}), frozenset(), 0),
+}
+
+
+def _stripped_surface_danger(stripped: str) -> bool:
+    """The literal danger battery over an ALREADY-STRIPPED (or MASKED) surface: the
+    DANGEROUS_PATTERNS scan + the four per-leg literal-arm families + the additive
+    whole-surface normalized-flag condition + the PER-LEG op loop
+    (_flag_condition_danger_op per leg, filtered to _PER_LEG_OPS, for any recognized op in
+    a NON-first leg). Factored out of ``is_dangerous_command`` (behavior-identical)
+    so the #1178 preserve-predicate can consult the SAME danger predicate on a masked leg
+    WITHOUT re-entering ``_strip_non_executable_content`` (which would recurse — the predicate
+    runs INSIDE that strip). SURFACE-AGNOSTIC: it neither strips nor masks, only matches, so a
+    ``_mask_shell_quotes(leg)`` surface is safe (masking is idempotent for these regexes).
+    The SSOT for "is this surface dangerous" — the read floor and the preserve predicate can
+    never drift."""
+    for pattern in DANGEROUS_PATTERNS:
+        if pattern.search(stripped):
+            return True
+    # Literal arms matched PER-LEG over the SAME surface (identical provenance to the read
+    # floor). Legs computed ONCE and shared by all four arm loops.
+    legs = _slice_stripped_legs(stripped)
+    for _leg in legs:
+        if any(arm.search(_leg) for arm in _FORCE_PUSH_LITERAL_ARMS):
+            return True
+    for _leg in legs:
+        if any(arm.search(_leg) for arm in _CLOSE_LITERAL_ARMS):
+            return True
+    for _leg in legs:
+        if any(arm.search(_leg) for arm in _API_LITERAL_ARMS):
+            return True
+    for _leg in legs:
+        if any(arm.search(_leg) for arm in _BRANCH_DELETE_LITERAL_ARMS):
+            return True
+    if _flag_condition_danger_op(stripped) is not None:
+        return True
+    # PER-LEG arms: the whole-surface union call above is FIRST-LEG-anchored, so a recognized
+    # op in a NON-first leg (`cd /repo && git push origin main`, `cd /repo && git push origin
+    # --delete feature`) needs a per-leg call — the SAME union arm per leg, filtered by the
+    # SAME shared _PER_LEG_OPS constant the detect loop uses (→ mint==read by construction).
+    # leg[0] is harmlessly re-checked (the loop runs only after the whole-surface call
+    # returned None).
+    for _leg in legs:
+        if _flag_condition_danger_op(_leg) in _PER_LEG_OPS:
+            return True
+    return False
+
+
+def _leg_token_spans(leg: str) -> "list[tuple[int, int]]":
+    """Quote-aware shell-token spans (start, end) into `leg`: a token is a maximal run with NO
+    UNQUOTED whitespace (a quoted or backslash-escaped whitespace stays INSIDE the token).
+    Mirrors the ``_mask_shell_quotes`` scanner exactly (backslash-escape outside quotes; `\\`
+    honored inside "…" but not '…'), so an embedded quoted span (`FOO=a"b c"d` = ONE token) never
+    SPLITS a token and a quoted head (`"timeout"`) stays token[0] — the two failure modes a
+    masked-`\\S+` tokenization has (an internal-quote span erases to spaces and either splits the
+    token or erases a quoted head, misaligning the walk). Callers reach here only on a balanced
+    leg (``_is_preserve_leg`` preserves an unbalanced one up front), so quotes always close."""
+    spans: list[tuple[int, int]] = []
+    i, n = 0, len(leg)
+    tok_start = -1
+    while i < n:
+        c = leg[i]
+        if c.isspace():
+            if tok_start >= 0:
+                spans.append((tok_start, i))
+                tok_start = -1
+            i += 1
+            continue
+        if tok_start < 0:
+            tok_start = i
+        if c == "\\":
+            i += 2
+            continue
+        if c == "'" or c == '"':
+            q = c
+            i += 1
+            while i < n:
+                if q == '"' and leg[i] == "\\":
+                    i += 2
+                    continue
+                if leg[i] == q:
+                    i += 1
+                    break
+                i += 1
+            continue
+        i += 1
+    if tok_start >= 0:
+        spans.append((tok_start, n))
+    return spans
+
+
+def _wrapper_nested_command(leg: str, head: str) -> "str | None":
+    """For a RECURSE-set wrapper leg, return the ORIGINAL-string substring of the nested
+    command (quotes intact) for ``_is_preserve_leg`` to recurse on, or None → FAIL-SAFE
+    PRESERVE. Tokens + offsets come from ``_leg_token_spans`` (quote-aware: an adjacent-concat
+    arg stays ONE token, a quoted head stays token[0]); flag recognition reads the RAW token
+    text (a NAME= prefix / a dash-flag is before any quote), and the returned slice indexes the
+    ORIGINAL leg so the nested command keeps its quotes. Returns None on ANY uncertainty: an
+    unrecognized dash-flag (unknown arity → can't safely skip its value = the mis-skip-past-
+    executor under-block), a shell-invocation flag (env -S / sudo -i,-s,-e / doas -s / …), a
+    value-flag at end-of-tokens, or no nested command."""
+    g = _WRAPPER_GRAMMAR[head]
+    spans = _leg_token_spans(leg)    # spans[0] is the wrapper head (quoted or not)
+    i, n = 1, len(spans)
+    # PHASE 1 — the wrapper's OWN flags (which PRECEDE any positional / the command). Stopping
+    # flag-consumption once a non-flag or `--` is seen is load-bearing: a wrapper flag that
+    # COLLIDES with a nested-command flag (taskset's `-c`=--cpu-list vs `bash -c`) must NOT be
+    # re-consumed AFTER the positional — else `taskset MASK bash -c "danger"`'s `-c` (bash's)
+    # would be eaten as taskset's, mis-locating the command → under-block.
+    while i < n:
+        start, end = spans[i]
+        tok = leg[start:end]
+        if tok == "--":
+            i += 1
+            break                                # end-of-options; rest is positionals + command
+        if tok.startswith("-") and tok != "-":
+            flagname = tok.split("=", 1)[0]
+            if flagname in g.shell_flags:
+                return None                      # shell-invocation form → preserve
+            if flagname in g.value_flags:
+                i += 1 if "=" in tok else 2      # --flag=value one token; --flag value two
+                continue
+            if flagname in g.bool_flags:
+                i += 1
+                continue
+            # ATTACHED-SHORT-VALUE getopt form (`-oL` = short value-flag `-o` + glued value `L`).
+            # A SHORT flag only (`-X`, single dash + one char), whose 2-char prefix is a DECLARED
+            # value_flag, with the value glued on (len > 2). The glued remainder is the value, so
+            # the whole token is consumed (i += 1). GENERAL across RECURSE wrappers (getopt-universal:
+            # `-Xvalue` always binds the value to -X), never bundled-boolean shorts (the prefix must be
+            # a value_flag). Cannot swallow the nested command: a command never starts with `-` (the
+            # PHASE-4 bare-dash guard), and PHASE-1 stops at the first non-flag, so an executor's own
+            # `-c` (which follows the non-flag command head) is never reached here. MONOTONIC: it only
+            # ADVANCES past a wrapper option, never synthesizes danger — so it can only CLOSE an
+            # over-block (recurse to an inert nested command), never open an under-block.
+            if len(tok) > 2 and tok[1] != "-" and tok[:2] in g.value_flags:
+                i += 1
+                continue
+            return None                          # unrecognized dash-flag → preserve
+        break                                    # first non-flag token → positionals / command
+    # PHASE 2 — the wrapper's leading POSITIONALS (timeout DURATION, chrt PRIORITY, taskset MASK).
+    for _ in range(g.positionals):
+        if i >= n:
+            return None                          # ran out (positional missing) → preserve
+        i += 1
+    # PHASE 3 — env NAME=VALUE assignments (env has positionals=0; they precede the command).
+    if head == "env":
+        while i < n and re.match(r"^[A-Za-z_]\w*=", leg[spans[i][0]:spans[i][1]]):
+            i += 1
+    # PHASE 4 — the nested command head.
+    if i >= n:
+        return None                              # no command → preserve
+    cmd_start, cmd_end = spans[i]
+    if leg[cmd_start:cmd_end].startswith("-"):
+        return None                              # a bare dash-flag is never a real command → preserve
+    return leg[cmd_start:]                        # nested command head (original, quotes intact)
+
+
+def _leg_command_word(leg: str) -> "str | None":
+    """Return the leg SUBSTRING starting at the TRUE command word — skipping any LEADING
+    env-assignment (`NAME=value`, quoted OR bare: `LC_ALL=C`, `FOO="a b"`) and redirection
+    (`>`, `2>`, `&>`, `2>/dev/null`, `2>&1`, `< in`…) tokens that PRECEDE the command. Returns
+    None when the leg is ONLY assignments/redirects (no command). SECURITY (#1178 head-
+    displacement): a leading assignment/redirect displaces tokens[0], so `_is_preserve_leg`
+    must compute the head on the TRUE command — else `LC_ALL=C bash -c "danger"` reads head
+    `LC_ALL=C`, no preserve clause fires, and the executor's danger arg is stripped = a
+    destructive UNDER-block. Mirrors the env WRAPPER's own NAME=VALUE skip (grammar PHASE 3)
+    at the leg top level for the BARE prefix form. Quote-aware via _leg_token_spans."""
+    spans = _leg_token_spans(leg)
+    k, n = 0, len(spans)
+    while k < n:
+        start, end = spans[k]
+        tok = leg[start:end]
+        # NAME=value / NAME+=value / NAME= (empty) assignment — the `\+?` covers the append
+        # form (`PATH+=/x`); the whole token is skipped so an embedded '='/'$'/quote in the value
+        # (`FOO=a=b`, `FOO=$HOME`, `FOO="a b"` → carrier-4-stripped to `FOO=STRIPPED`) stays inside
+        # the skipped token. (carrier 4 already stripped a non-expanded quoted RHS to NAME=STRIPPED
+        # BEFORE carrier 10, so quotes are not relied on surviving.)
+        if re.match(r"^[A-Za-z_]\w*\+?=", tok):
+            k += 1
+            continue
+        if re.match(r"^(?:[0-9]*(?:&?[<>]|<>)|&>>?)", tok):   # redirection operator
+            k += 1
+            # a BARE operator (`>`, `>>`, `2>`, `<`, `&>`, and SPACED-target `>&`/`<&`/`2>&`, `>|`)
+            # consumes the NEXT token as its target; a self-contained form (`2>&1`/`3>&2`/`>&2`
+            # fd-dup, `2>/dev/null`/`>file` attached target) does not. The `[<>]&` alt classifies a
+            # spaced redirect-both (`>& file`) as BARE (architect finding — else the walk lands on
+            # `file` and misses the real executor = under-block); `2>&1`/`>&2` stay self-contained
+            # (a trailing fd digit fails the fullmatch).
+            if re.fullmatch(r"[0-9]*(?:[<>]{1,2}|[<>]&|>\|)|&>>?", tok):
+                k += 1
+            continue
+        return leg[start:]                               # the true command word
+    return None                                          # only assignments/redirects → no command
+
+
+def _is_preserve_leg(leg: str, _depth: int = 0) -> bool:
+    """True iff this single leg's quoted-arg values must be PRESERVED (not stripped) by the
+    #1178 general inert-default strip — see the catalog block above for clauses (a)/(b)/(c).
+    FAIL-SAFE to PRESERVE (True) on any ambiguity (unparseable quotes, uncertain wrapper
+    boundary, recursion depth): preserving is the OVER-BLOCK-safe direction (it can only leave
+    an over-block unclosed, never open an under-block)."""
+    if _shell_tokenize(leg) is None:
+        return True                                      # unbalanced quote → fail-safe preserve
+    # (d1) a QUOTED variable-assignment RHS that survived the variable-assignment carrier (4)
+    # is an EXPANDED value: carrier 4 strips a non-expanded `NAME="…"` to `NAME=STRIPPED`, and
+    # when eval/source is present it skips entirely (preserving all) — either way, a `NAME="…"`
+    # / `NAME='…'` still QUOTED here is one carrier 4 kept because it executes via its expansion
+    # (`FOO="gh pr merge 5" && $FOO`, `export CMD="…" && eval $CMD`). Carrier 10 must NOT
+    # re-strip it (under-block). Covers leading (`FOO=`) and builder (`export/declare NAME=`)
+    # forms alike. NOTE: this un-anchored regex also matches a `--flag="v"` (the `flag="`
+    # inside) — but carrier 4 pre-strips flag-attached literals before carrier 10, so it is a
+    # no-op there; and either way the false-match direction is always PRESERVE (over-block-safe,
+    # never under-block).
+    if re.search(r"""[A-Za-z_]\w*=["']""", leg):
+        return True
+    # HEAD-DISPLACEMENT guard (#1178 SEC): compute the head clauses on the TRUE command word
+    # (skip leading env-assignment / redirection prefixes) — else a leading `LC_ALL=C` / bare
+    # `FOO=bar` / `2>/dev/null` displaces tokens[0] and the real executor is missed (under-block).
+    cmd_leg = _leg_command_word(leg)
+    if cmd_leg is not None:
+        tokens = _shell_tokenize(cmd_leg)
+        if tokens:
+            head = os.path.basename(tokens[0])
+            if head in _TOOL_HEADS:                      # (d2) git/gh → defer to carriers 5/7/8/9
+                return True
+            if _SHELL_STRING_EXECUTORS.match(head):      # (a) executor / interpreter
+                return True
+            if head in _HTTP_CLIENT_HEADS:               # (b) curl/wget (quoted head via shlex)
+                return True
+            if head in _EXEC_WRAPPERS_COARSE:            # (a) wrapper, boundary not skippable
+                return True
+            if head in _EXEC_WRAPPERS_RECURSE:           # (a) wrapper, recurse to nested command
+                if _depth >= _MAX_WRAPPER_DEPTH:
+                    return True                          # depth guard → fail-safe preserve
+                nested = _wrapper_nested_command(cmd_leg, head)
+                if nested is None:
+                    return True                          # uncertain boundary → fail-safe preserve
+                return _is_preserve_leg(nested, _depth + 1)
+    masked = _mask_shell_quotes(leg)                     # tail checks on the WHOLE leg (conservative)
+    # (d3) an unquoted process substitution `<(cmd)` / `>(cmd)` EXECUTES cmd, so its quoted args
+    # may execute — preserve. Masking blanks a quoted `"<("`, so only a REAL procsub triggers.
+    if _PROCSUB_MARKER_RE.search(masked):
+        return True
+    if re.search(_GH_API_PREFIX, masked):                # (b) gh api (unquoted `gh api`)
+        return True
+    return _stripped_surface_danger(masked)              # (c) bare-token danger (defense-in-depth)
+
+
+def _strip_quoted_positionals(leg: str) -> str:
+    """Strip a leg's quoted positional values: dq span-scopes $()/backtick (via
+    _strip_inert_dq_value); sq → bareword STRIPPED. Pure factor of the two inline
+    substitutions the carrier-10 inert-default strip has always applied — shared with the
+    read-verb carve-out's positional-strip verbs (git grep / gh search), where every
+    quoted span surviving the carve-out's guards is data the verb never executes
+    (patterns, pathspecs, query terms)."""
+    stripped = re.sub(r'"(?:[^"\\]|\\.)*"', _strip_inert_dq_value, leg)
+    return re.sub(r"'[^']*'", "STRIPPED", stripped)
+
+
+# git global options that PRECEDE the subcommand (for _resolve_git_subcommand, #1195 OBS-A1).
+# VALUE-taking (skip the flag AND its value token):
+_GIT_GLOBAL_VALUE_FLAGS = frozenset({
+    "-C", "-c", "--git-dir", "--work-tree", "--namespace", "--exec-path", "--config-env",
+})
+# Boolean (skip the flag token only):
+_GIT_GLOBAL_BOOL_FLAGS = frozenset({
+    "--no-pager", "--paginate", "-p", "--bare", "--no-replace-objects",
+    "--literal-pathspecs", "--glob-pathspecs", "--noglob-pathspecs",
+    "--icase-pathspecs", "--no-optional-locks",
+})
+
+
+def _resolve_git_subcommand(tokens: "list[str]") -> "int | None":
+    """tokens[0] == 'git'; skip leading git GLOBAL flags to return the SUBCOMMAND token
+    index, or None if none is reached. Skips ONLY dash-prefixed global flags (never a
+    positional word), so a DESTRUCTIVE subcommand always resolves to ITSELF —
+    `git push origin grep ':main'` -> 'push' (index 1, the first non-flag token), never
+    'grep'. This is the load-bearing invariant for destructive-still-gates: the resolver
+    can never gobble a positional into a read-verb key. An UNKNOWN global dash-flag returns
+    None (fail-safe: don't resolve -> the leg preserves = over-block-safe)."""
+    i, n = 1, len(tokens)
+    while i < n:
+        t = tokens[i]
+        if t in _GIT_GLOBAL_VALUE_FLAGS:
+            i += 2                                   # flag + its value token
+            continue
+        if "=" in t and t.split("=", 1)[0] in _GIT_GLOBAL_VALUE_FLAGS:
+            i += 1                                   # --flag=value (one token)
+            continue
+        if t in _GIT_GLOBAL_BOOL_FLAGS:
+            i += 1
+            continue
+        if t.startswith("-"):
+            return None                              # unknown global flag -> fail-safe preserve
+        return i                                     # first non-flag token = subcommand
+    return None
+
+
+def _strip_read_verb_values(leg: str, _depth: int = 0) -> "str | None":
+    """READ-VERB value carve-out (pre-d2): strip the inert search/filter VALUES of a
+    closed set of git/gh read verbs (_READ_VERB_SPECS) so a danger-looking quoted
+    literal there (`git log --grep "…"`, `git grep '…'`, `gh pr list --search '…'`)
+    no longer gates a faithful click via the d2 _TOOL_HEADS wholesale preserve.
+
+    CONTRACT: returns None = "not a read-verb leg / guarded — fall through to the
+    existing preserve/strip path"; returns a str = the final leg text (possibly
+    identical). NEVER returns a quote-unbalanced string (guard g7).
+
+    Runs INSIDE the per-leg walk: legs are sliced on the masked+FD-neutralized view
+    BEFORE any strip fires, so a destructive sibling leg is not present in this
+    function's input — separator-crossing (`git log --grep=foo&&gh pr merge 5`) is
+    impossible BY CONSTRUCTION. A whole-string variant of this strip would reopen
+    that under-block and is a forbidden alternative.
+
+    MONOTONICITY (same argument as the carrier-10 strip): only listed flag VALUES
+    and (for the positional-strip verbs) quoted spans are replaced with STRIPPED —
+    it never synthesizes a danger token and never touches unquoted structure beyond
+    a listed flag's own value, so it can only CLOSE an over-block (True→False),
+    never open one; the safety burden reduces to guards g2/g3/g4/g6 keeping every
+    load-bearing (executing) quoted value out of its reach. Each guard closes a
+    live under-block vector:
+      g2: with `eval` anywhere in the command, carrier 4 skips ALL assignments — a
+          `FOO="gh pr merge 5 --admin"` surviving inside this leg is executed by a
+          sibling `eval $FOO` leg; stripping positionals here would remove the
+          only evidence.
+      g3: `git grep $(sh -c '…')` — a bare $()/backtick span in the leg executes;
+          whole-leg guard is deliberately coarser than the carriers' dq
+          span-scoping (simplest sound bound; the cost is an unclosed over-block
+          on `--grep 'x' $(date)`-shaped legs — status-quo residual).
+      g4: `git grep -f <(sh -c '…')` — an unquoted process substitution executes.
+      g6: an executing flag (git grep -O family) anywhere in the shlex tokens.
+    Exact-token verb matching (tokens[1]/tokens[2]) is REQUIRED: a bounded
+    word-gobbler prefix would let `git push origin grep ':main'` bind the grep
+    spec and strip a deletable quoted refspec (an under-block). Global-flag
+    spellings (`git -C x log …`) therefore fall through to d2 preserve —
+    status-quo residual, tracked."""
+    # ---- guards: ANY hit => return None (fall through to _is_preserve_leg) ----
+    if _shell_tokenize(leg) is None:                 # g1 unbalanced quote (fail-safe)
+        return None
+    if re.search(r"""[A-Za-z_]\w*=["']""", leg):     # g2 d1-replica: a NAME="…" survivor
+        return None                                  #    is an expanded/eval'd value
+    if _has_command_substitution(leg):               # g3 $()/backtick anywhere in the leg
+        return None
+    cmd_leg = _leg_command_word(leg)                 # g5a env/redirect prefix skip
+    if cmd_leg is None:
+        return None
+    tokens = _shell_tokenize(cmd_leg)
+    if not tokens:
+        return None
+    head = os.path.basename(tokens[0])
+    if head == "git":
+        si = _resolve_git_subcommand(tokens)         # A1: skip git globals to the real verb
+        if si is None:                               #    (git -C x log …, git -c k=v log …)
+            return None
+        key = ("git", tokens[si])
+    elif head == "gh" and len(tokens) >= 3:
+        key = ("gh", tokens[1], tokens[2])
+    elif head in _EXEC_WRAPPERS_RECURSE and _depth < _MAX_WRAPPER_DEPTH:
+        # A1: a read-only WRAPPER prefix (timeout/nice/env/…) — resolve the nested command
+        # and RECURSE. _wrapper_nested_command returns preserve (None) for shell-invocation
+        # forms (env -S, sudo -s) and any wrapper whose boundary is uncertain, so a wrapper
+        # that CHANGES execution semantics never resolves to a strippable read verb (no
+        # under-block). A stripped nested maps back under the verbatim wrapper prefix:
+        # `nested` is a suffix of `leg`, so the prefix is byte-preserved by length.
+        nested = _wrapper_nested_command(cmd_leg, head)
+        if nested is None:
+            return None
+        rv = _strip_read_verb_values(nested, _depth + 1)
+        if rv is None:
+            return None
+        mapped = leg[: len(leg) - len(nested)] + rv
+        if _shell_tokenize(mapped) is None:          # g7 balance fail-safe on the mapped leg
+            return leg
+        return mapped
+    else:
+        return None
+    spec = _READ_VERB_SPECS.get(key)                 # g5b exact-verb miss => None
+    if spec is None:
+        return None
+    if _PROCSUB_MARKER_RE.search(_mask_shell_quotes(leg)):   # g4 procsub in leg (d3 replica)
+        return None
+    if spec.deny_re is not None and any(
+        spec.deny_re.match(t) for t in tokens
+    ):                                               # g6 executing-flag deny (shlex tokens —
+        return None                                  #    a quoted '-O' is still the flag)
+    # ---- strips (quote-balanced via the certified _strip_flag_values arms) ----
+    out = leg
+    if spec.flag_arm is not None:
+        out = _strip_flag_values(out, spec.flag_arm.pattern, _keep_carrier_value)
+    if spec.strip_positionals:
+        out = _strip_quoted_positionals(out)
+    if _shell_tokenize(out) is None:                 # g7 quote-balance fail-safe: NEVER
+        return leg                                   #    emit a dangling quote (leg-merge)
+    return out
+
+
+def _maybe_strip_leg(leg: str) -> str:
+    """Strip a leg's quoted positional VALUES iff it is inert (not preserved); else verbatim.
+    The read-verb carve-out (_strip_read_verb_values) runs FIRST — before the d2 _TOOL_HEADS
+    clause inside _is_preserve_leg can preserve a git/gh read-verb leg wholesale. dq
+    span-scopes $()/backtick (via _strip_inert_dq_value); sq → bareword STRIPPED. The verb +
+    unquoted structure stay intact; the leg carries NO shell-operator separator (those are
+    outside the leg), so this never re-slices."""
+    rv = _strip_read_verb_values(leg)
+    if rv is not None:
+        return rv                                    # already balance-checked inside
+    if _is_preserve_leg(leg):
+        return leg
+    stripped = _strip_quoted_positionals(leg)
+    # QUOTE-BALANCE fail-safe (#1118 leg-merge guard): the per-span dq regex is NOT
+    # $()-nesting-aware, so on an exotic nested-quote value (`"a $(b "c") d"`) it can mis-pair
+    # and emit an unbalanced leg. An unbalanced leg fed downstream could let _mask_shell_quotes
+    # pair a stray quote ACROSS a separator and MERGE legs (under-block). shlex is the oracle:
+    # we only reach here with a balanced ORIGINAL (an unbalanced one preserved at the top), so
+    # if the strip broke balance, preserve the ORIGINAL leg rather than emit a dangling quote.
+    if _shell_tokenize(stripped) is None:
+        return leg
+    return stripped
+
+
+def _strip_inert_positional_legs(result: str) -> str:
+    """Carrier-10 core (#1178): slice `result` into shell-operator legs — the SAME masked +
+    FD-neutralize substrate as ``_slice_stripped_legs``, but RETAINING the original separators
+    — and strip each INERT (non-preserved) leg's quoted positional values, emitting preserve
+    legs verbatim. Rejoined with the ORIGINAL separators so a downstream re-slice of this
+    result sees byte-unchanged leg boundaries. Slices via this in-line walk (NOT
+    ``_split_into_legs``, which re-strips → recursion)."""
+    view = _FD_REDIRECT_RE.sub(
+        lambda m: " " * len(m.group()), _mask_shell_quotes(result)
+    )
+    out, last = [], 0
+    for m in _COMPOUND_OPS_RE.finditer(view):
+        out.append(_maybe_strip_leg(result[last:m.start()]))
+        out.append(result[m.start():m.end()])            # ORIGINAL separator, verbatim
+        last = m.end()
+    out.append(_maybe_strip_leg(result[last:]))
+    return "".join(out)
+
+
+def is_dangerous_command(command: str) -> bool:
+    """Check if a bash command is a dangerous git operation.
+
+    Strips non-executable content (heredocs, comments, echo arguments, variable
+    assignments) before matching, to avoid false positives when dangerous-pattern
+    text appears in non-command contexts.
+
+    Args:
+        command: The bash command string
+
+    Returns:
+        True if the command matches a dangerous pattern
+    """
+    # Pre-strip detection: eval+heredoc shape obscures destructive ops via
+    # the heredoc-strip pipeline. Treat as dangerous before the strip runs.
+    if _has_eval_with_heredoc(command):
+        return True
+
+    # Normalize bash line continuations (\<newline>) via the shared P0 SSOT before
+    # any matching (so this floor + the substrate join lines identically).
+    command = _normalize_line_continuations(command)
+    stripped = _strip_non_executable_content(command)
+    # The literal danger battery (DANGEROUS_PATTERNS + the four per-leg literal-arm families +
+    # the additive normalized-flag condition) is the SSOT _stripped_surface_danger — factored
+    # out so the #1178 general-strip preserve-predicate can consult the SAME predicate on a
+    # masked leg without re-entering the strip (recursion). Behavior-identical to the prior
+    # inline battery.
+    return _stripped_surface_danger(stripped)
+
+
+# A plain `rm` head token at a compound leg's start. DELIBERATELY rm-SPECIFIC and used
+# ONLY by the compound-leg count below — NOT a general dangerous-op detector (dd/mkfs/
+# shred/etc. are out of scope under the honest-mistake model) and NOT part of
+# is_dangerous_command (so a bare `rm -rf /` and a pure-rm chain stay is_dangerous=False
+# and the guard never gates them — see the rm-exception note in the module THREAT MODEL).
+# Matches a literal `rm` at the leg head only; no obfuscation-chasing — not `/bin/rm`,
+# `r''m`, `$(echo rm)`, or aliases.
+_RM_HEAD_RE = re.compile(r"\s*rm(?=\s|$)")
+
+
+def _leg_is_destructive(leg: str) -> bool:
+    """Count a compound leg as destructive if it is a recognized git/gh-destructive op
+    (``is_dangerous_command``) OR its head command is a plain ``rm`` (the rm-exception).
+
+    The rm arm is the ONE deliberate non-git/gh case: an honest agent chaining a real
+    destructive git/gh op WITH a file-removing ``rm`` (``gh pr merge 5 && rm -rf /``) is
+    exactly the multi-destructive mistake the compound refuse exists to catch. It is
+    rm-specific by design; do NOT generalize it to other filesystem-destroying tools.
+    """
+    return is_dangerous_command(leg) or _RM_HEAD_RE.match(leg) is not None
+
+
+def _slice_stripped_legs(stripped: str) -> list[str]:
+    """Slice an ALREADY-STRIPPED command into its shell-operator-separated legs
+    (always >=1 leg). The mask + FD-neutralize + slice core of the leg-boundary
+    SSOT: `_split_into_legs` wraps this with normalize + strip, and callers that
+    already hold the stripped text can slice directly, so leg boundaries are
+    computed from ONE substrate without re-stripping.
+
+    Operators are detected on the P2-masked + FD-neutralized view so an operator
+    INSIDE a quoted arg (`--subject "a; b"`) or an FD / and-redirect (`2>&1`,
+    `&>`, `>|`) is NOT a separator. Each FD-redirect is replaced by an EQUAL-LENGTH
+    run of spaces (NOT a single space) so the masked view stays SAME-LENGTH as
+    `stripped` and each operator's offsets map 1:1 back to the ORIGINAL legs (which
+    carry the real flag spellings the callers classify). A single-space collapse
+    would shrink the view and mis-slice the legs after a multi-char redirect (e.g.
+    `2>&1 | rm -rf ~`). The leg slices are taken from `stripped`, never the masked
+    `view` — the view exists ONLY to locate the operator offsets.
+    """
+    view = _FD_REDIRECT_RE.sub(
+        lambda m: " " * len(m.group()), _mask_shell_quotes(stripped)
+    )
+    legs, last = [], 0
+    for m in _COMPOUND_OPS_RE.finditer(view):
+        legs.append(stripped[last : m.start()])
+        last = m.end()
+    legs.append(stripped[last:])
+    return legs
+
+
+def _split_into_legs(command: str) -> list[str]:
+    """Split a command into its shell-operator-separated legs (always >=1 leg).
+
+    The single SSOT for leg boundaries: both is_compound_destructive_command (the
+    >=2-destructive-leg refuse) AND _single_destructive_leg (the read-side
+    single-leg isolation) consume this, so the two can never see divergent leg
+    boundaries (the #720/#878 divergence class). A command with no shell operator
+    yields a one-element list (the whole stripped command). Operator-detection
+    mechanics (quote masking, equal-length FD neutralization, slicing from the
+    stripped text) live in `_slice_stripped_legs`, the shared slicing core.
+    """
+    normalized = _normalize_line_continuations(command)
+    stripped = _strip_non_executable_content(normalized)
+    return _slice_stripped_legs(stripped)
+
+
+def _single_destructive_leg(command: str) -> str | None:
+    """The UNIQUE is_dangerous_command leg of a command, or None.
+
+    Returns the single destructive gh/git leg when EXACTLY one leg is dangerous;
+    None when 0 legs are dangerous, or — at the read call site, unreachably — when
+    >=2 are (is_compound_destructive_command REFUSES that upstream, at
+    check_merge_authorization, BEFORE the read seam). The read seam consumes this
+    as TIER 1 of a two-tier bind-surface fallback: None here falls through to
+    `_single_detectable_leg` (tier 2 — the EMERGENT-danger case, where whole-
+    command danger comes from a cross-leg lookahead and no leg is dangerous in
+    isolation), and only then to the WHOLE command (the existing over-binding
+    scan = the safe over-block direction). The never-silently-narrow guard is
+    about AMBIGUITY and is preserved across both tiers: a fail-toward-unmasked
+    quote split, a parse failure, or a non-unique leg can only collapse WIDER
+    (to the whole-command context); narrowing happens ONLY on a positively
+    identified unique leg — dangerous here, or detect-positive in tier 2. Do
+    NOT "fix" the tier-2 fallback back to whole-command as a regression: the
+    two-tier basis is what keeps the read bind symmetric with the leg-bounded
+    mint window for emergent-danger compounds.
+
+    This is the substrate the read side uses to derive (op, target, bound_flags)
+    from the destructive op ALONE — so a privileged flag on a benign NEIGHBOR leg
+    cannot pollute bound_flags (the over-block) and a benign neighbor's PR number
+    cannot cross-contaminate the target via _extract_pr_number's first-match-
+    anywhere scan (the latent under-block). A privileged flag that modifies the
+    destructive op is a token of its OWN simple-command (leg), so it stays bound;
+    only a different statement's flag (past an operator boundary) is dropped.
+    """
+    dangerous = [
+        leg.strip()
+        for leg in _split_into_legs(command)
+        if is_dangerous_command(leg.strip())
+    ]
+    return dangerous[0] if len(dangerous) == 1 else None
+
+
+def _single_detectable_leg(command: str) -> str | None:
+    """#1083 emergent-danger bind fallback: the UNIQUE leg that
+    detect_command_operation_type classifies non-None, or None. Consulted ONLY
+    when _single_destructive_leg found no individually-dangerous leg (the
+    emergent case: whole-command danger from a cross-leg lookahead). Narrowing
+    happens ONLY on positive unique identification — 0 or >=2 detectable legs
+    fall through to the conservative whole-command context — so the abstain
+    basis of _single_destructive_leg (ambiguity can only collapse WIDER, never
+    narrower) is preserved: ambiguity still widens; only a positively unique
+    op leg narrows. Binding from that leg is shell-faithful: a flag that
+    modifies the executed op is a token of the op's OWN leg; a flag past an
+    operator boundary belongs to a different statement.
+    """
+    detectable = [
+        leg.strip()
+        for leg in _split_into_legs(command)
+        if detect_command_operation_type(leg.strip()) is not None
+    ]
+    return detectable[0] if len(detectable) == 1 else None
+
+
+def is_compound_destructive_command(command: str) -> bool:
+    """Detect an agent chaining MULTIPLE destructive operations into one command.
+
+    Returns True iff the command joins >=2 DESTRUCTIVE legs with a shell operator
+    (``&&``, ``||``, ``|&``, ``;``, ``&``, ``|``, newline), e.g.:
+
+        gh pr close 5 -d && git branch -Df victim
+        gh pr merge 100 && gh pr close 999 --delete-branch
+        gh pr merge 5 && rm -rf /          # git/gh op chained with a plain `rm`
+
+    This is the chaining analogue of the privileged-flag bind: both catch the agent
+    doing MORE than the operator clicked — here, an ADDED destructive op the single
+    approval did not cover. A leg counts as destructive if it is a recognized
+    git/gh-destructive op OR its head command is a plain ``rm`` (the rm-EXCEPTION — see
+    the module THREAT MODEL; rm is rm-specific by design and is NOT in
+    is_dangerous_command, so a bare or pure-rm command is never gated). Honest-mistake
+    model: a SINGLE destructive op plus a benign continuation / decoration /
+    backgrounding is a faithful single-command click and MUST mint + execute — so
+    `gh pr merge 5 && echo ok`, `gh pr merge 5 ; echo done`, `gh pr merge 5 &`,
+    `gh pr merge 5 | tee log`, `gh pr merge 5 > out.log` are NOT compound-destructive
+    (one destructive leg). Only >=2 destructive legs are refused (route to
+    one-op-at-a-time approval).
+    """
+    # Legs come from the shared _split_into_legs SSOT (masked + FD-neutralized split
+    # on _COMPOUND_OPS_RE, slices taken from `stripped`). A command with no operator
+    # yields ONE leg, so the >=2 count below is False — identical to the prior
+    # explicit no-operator short-circuit, without a separate code path that could
+    # drift from the read-side leg isolation.
+    legs = _split_into_legs(command)
+    # >=2 DESTRUCTIVE legs → refuse. A leg is destructive via _leg_is_destructive: a
+    # recognized git/gh-destructive op (so a non-canonical flag spelling like `-Df` in a
+    # leg still counts) OR a plain-`rm` head leg (the documented rm-exception). A single
+    # destructive leg + benign legs → NOT compound (the single op routes through its own
+    # one-op approval as usual). This count is only consulted once is_dangerous_command is
+    # already True (a git/gh op is present) at the read call site, so a bare `rm` or a
+    # pure-rm chain — is_dangerous=False — never reaches it (the guard stays out of
+    # pure-filesystem commands).
+    return sum(1 for leg in legs if _leg_is_destructive(leg)) >= 2

--- a/pact-plugin/tests/merge_guard_baseline_loader.py
+++ b/pact-plugin/tests/merge_guard_baseline_loader.py
@@ -207,3 +207,117 @@ def load_baseline_172a77dd():
 
     _cached_baseline_172a77dd = module
     return module
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Third baseline: v4.6.10 (5017d1f2), the PARENT of the #1203 commits (C1/C3/C3b/
+# C1b). The base for test_merge_guard_1203_cert.py. A SEPARATE entry point rather
+# than a parameter, so the two existing consumers are byte-untouched. Vendored via
+# `git show 5017d1f2:…` (the parent is committed, so the SHA resolves; commit-code-
+# first satisfied). At this base every #1203 over-block is PRESENT: the implicit
+# force-push and bare `gh pr merge` are gated-but-UNMINTABLE (no sentinel key
+# exists yet), and the inert `gh pr merge --help` is gated (no inert recognizer).
+# ─────────────────────────────────────────────────────────────────────────────
+_FIXTURE_PATH_5017D1F2 = (
+    Path(__file__).parent
+    / "fixtures"
+    / "merge_guard_baseline"
+    / "merge_guard_common_5017d1f2.py"
+)
+# sha256 of merge_guard_common.py at 5017d1f2 (the #1203 parent, `git show`-vendored).
+_FIXTURE_SHA256_5017D1F2 = (
+    "e6bcca04e22bff115bb6d6be62cd5d397364a64934f5b74a74d4b545e71fab1a"
+)
+
+# The identity keys a mintable context may bind (the gated-but-unmintable check:
+# a #1203 implicit form is gated at base with NONE of these present).
+_MINT_KEYS_1203 = (
+    "pr_number", "branch", "branch_set", "target_ref", "push_set",
+    "force_push_set", "force_push_implicit", "merge_implicit",
+    "mass_target", "protected_branch",
+)
+
+# Pre-fix discriminator inputs (danger literals assembled at runtime so this file
+# carries no raw destructive literal and stays inert to the live guard).
+_DISCRIMINATOR_1203_FP = "git " + "push " + "--force"           # SET A implicit force-push
+_DISCRIMINATOR_1203_MERGE = "gh " + "pr " + "merge"             # bare gh pr merge
+_DISCRIMINATOR_1203_INERT = "gh " + "pr " + "merge --help"      # inert help over-block
+
+_cached_baseline_5017d1f2 = None
+
+
+def load_baseline_5017d1f2():
+    """Load the vendored v4.6.10 (5017d1f2) classifier module — the PARENT of the
+    #1203 commits — cached, loud-failing on any integrity problem. Same contract and
+    calling convention as load_baseline(); callers use it as
+    `load_baseline_5017d1f2().is_dangerous_command(cmd)`.
+
+    Pre-fix discriminators (the baseline MUST still exhibit the #1203 over-blocks, or
+    post-fix bytes were vendored and the cert would certify against itself):
+      1. `git push --force` is DANGEROUS (is_dangerous True) yet binds NONE of the mint
+         keys — the gated-but-UNMINTABLE implicit force-push over-block C3 closes.
+      2. bare `gh pr merge` is DANGEROUS yet binds no mint key — the gated-but-unmintable
+         bare-merge over-block C3b closes.
+      3. `gh pr merge --help` is DANGEROUS (no inert-help recognizer exists yet) — the
+         inert over-block C1 closes. Post-fix all three are fixed (sentinels mint / inert
+         un-gates), so a post-fix module fails these discriminators loudly.
+    """
+    global _cached_baseline_5017d1f2
+    if _cached_baseline_5017d1f2 is not None:
+        return _cached_baseline_5017d1f2
+
+    if not _FIXTURE_PATH_5017D1F2.is_file():
+        pytest.fail(
+            "5017d1f2 baseline fixture missing (%s) — the #1203 cert cannot run"
+            % _FIXTURE_PATH_5017D1F2
+        )
+    data = _FIXTURE_PATH_5017D1F2.read_bytes()
+    digest = hashlib.sha256(data).hexdigest()
+    if digest != _FIXTURE_SHA256_5017D1F2:
+        pytest.fail(
+            "5017d1f2 baseline fixture sha256 mismatch: got %s, pinned %s — fixture "
+            "bytes drifted; re-vendor from `git show 5017d1f2:…`"
+            % (digest, _FIXTURE_SHA256_5017D1F2)
+        )
+
+    spec = importlib.util.spec_from_file_location(
+        "shared._merge_guard_baseline_5017d1f2", _FIXTURE_PATH_5017D1F2
+    )
+    if spec is None or spec.loader is None:
+        pytest.fail(
+            "5017d1f2 baseline fixture spec unloadable: %s — the cert cannot run"
+            % _FIXTURE_PATH_5017D1F2
+        )
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = "shared"
+    spec.loader.exec_module(module)
+
+    def _binds_no_mint_key(cmd):
+        ctx = module.extract_command_context(cmd)
+        return not any(ctx.get(k) for k in _MINT_KEYS_1203)
+
+    if not (
+        module.is_dangerous_command(_DISCRIMINATOR_1203_FP) is True
+        and _binds_no_mint_key(_DISCRIMINATOR_1203_FP)
+    ):
+        pytest.fail(
+            "vendored 5017d1f2 baseline does not exhibit the implicit force-push "
+            "gated-but-unmintable over-block — post-fix bytes were vendored"
+        )
+    if not (
+        module.is_dangerous_command(_DISCRIMINATOR_1203_MERGE) is True
+        and _binds_no_mint_key(_DISCRIMINATOR_1203_MERGE)
+    ):
+        pytest.fail(
+            "vendored 5017d1f2 baseline does not exhibit the bare-merge "
+            "gated-but-unmintable over-block — post-fix bytes were vendored"
+        )
+    if module.is_dangerous_command(_DISCRIMINATOR_1203_INERT) is not True:
+        pytest.fail(
+            "vendored 5017d1f2 baseline does not gate the inert `gh pr merge --help` "
+            "form — the inert-help recognizer is already present; post-fix bytes were "
+            "vendored"
+        )
+
+    _cached_baseline_5017d1f2 = module
+    return module

--- a/pact-plugin/tests/test_merge_guard.py
+++ b/pact-plugin/tests/test_merge_guard.py
@@ -8519,11 +8519,18 @@ class TestGhGlobalFlagBypassEdgeCases:
     # --- Many flags chained ---
 
     def test_three_global_flags(self):
-        """Three global flags before subcommand is detected."""
+        """Three global flags before subcommand is detected.
+
+        Uses --verbose (like the sibling test_five_flag_tokens), NOT --help: a
+        --help leg is an INERT help request (gh short-circuits to help and exits,
+        merging nothing), so it is correctly NOT gated. This test targets
+        flag-chaining robustness (many global flags must not bypass detection of
+        the real merge), not help suppression.
+        """
         from merge_guard_pre import is_dangerous_command
 
         assert is_dangerous_command(
-            "gh --repo owner/repo --hostname host.com --help pr merge 42"
+            "gh --repo owner/repo --hostname host.com --verbose pr merge 42"
         )
 
     def test_five_flag_tokens(self):

--- a/pact-plugin/tests/test_merge_guard_1203_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1203_cert.py
@@ -1,0 +1,623 @@
+"""
+Location: pact-plugin/tests/test_merge_guard_1203_cert.py
+Summary: The DURABLE five-dimension certification for the #1203 over-block fix — the
+         TARGET-BLIND SENTINEL mint for the implicit current-branch force-push (C3) and
+         the bare `gh pr merge` (C3b), plus the generalized inert-help recognizer (C1)
+         and its short-alias value-flag skip (C1b). Certifies against the REAL classifier
+         + REAL post/pre hooks, base (committed vendored fixture at 5017d1f2 — the #1203
+         PARENT — via merge_guard_baseline_loader.load_baseline_5017d1f2; loud-fail,
+         CI-executable, never skip) vs live HEAD. NEVER a byte-diff / git-show-by-SHA at
+         assertion time.
+
+GOVERNING MODEL — SACROSANCT, GOOD-FAITH. The merge-guard routes an HONEST destructive
+command through the user's approval click; a faithful single-command click always mints
+and self-authorizes. The ONLY cardinal sin is the OVER-BLOCK: blocking a faithful click,
+INCLUDING gating it but leaving it unmintable (gated-but-unmintable). The #1203 arc closes
+FOUR over-blocks: (1) the implicit current-branch force-push (`git push --force`), gated-
+but-unmintable at 5017d1f2 because its destination is runtime state absent from the command
+string; (2) the bare `gh pr merge`, same shape (current-branch PR unresolvable in-hook);
+(3) the inert `gh pr merge --help` / `git push --force --help`, gated though it merges/pushes
+NOTHING; (4) the C1b short-alias value-decoy (`gh pr merge 5 -t -h`), an under-block C1
+briefly INTRODUCED and C1b closed WITHIN the arc.
+
+WHY TARGET-BLIND SENTINEL (KD-1/KD-2). An implicit force-push target is config-dependent
+(push.default + upstream can rename the ref or make it multi-ref), so a runtime-resolve to a
+concrete branch would MINT THE WRONG TARGET and LAUNDER — a `git push --force` token resolved
+to `main` would cross-authorize an explicit `git push --force origin main`. The fix mints a
+DISTINCT, NUL-framed, target-blind key (`force_push_implicit` / `merge_implicit`, each a
+NUL-prefixed constant that TestCorpusShape pins distinct) in a mutually-exclusive populate-site (KD-4: reached ONLY when the explicit target keys target_ref
+AND force_push_set are BOTH absent, on op_type=='force-push', 0/1-positional only). The NUL byte
+can NEVER appear in a real target_ref/pr_number, and the distinct KEY is never compared against
+target_ref/pr_number — so an implicit-form token can NOT cross-authorize an explicit
+`--force origin main` / a numbered `gh pr merge 42`, and force-push ⊥ merge (distinct keys +
+op-type-first). is_dangerous stays True for every minted form — this is target-PRECISION, NOT
+un-gating (the floor).
+
+THE FIVE DIMENSIONS, each with a demonstrated known-bad:
+  (a) MINT              — every MUST_MINT form MINTS a token AND is_dangerous stays True.
+                          Base known-bad: gated-but-unmintable (dang True, no mint key).
+  (b) OFF-TOKEN ROUND-  — identity read OFF the minted token via a REAL post_main -> pre_main
+      TRIP               round-trip (never off extract_command_context(command)); compound
+                          `cd && …` rows included. Known-bad: the pipeline-blindness trap —
+                          the exec-WITHOUT-token DENY is the fix-coupled leg.
+  (c) NO-CROSS-AUTH     — force_push_implicit ⊥ explicit-ref, merge_implicit ⊥ number,
+                          force_push_implicit ⊥ merge_implicit, ⊥ cross-op. Discriminating
+                          known-bad: simulate the REJECTED runtime-resolve (bind target_ref=
+                          'main' for the implicit form) -> the implicit token cross-authorizes
+                          `--force origin main` (proves the target-blind distinct key is load-
+                          bearing). ACCEPTED residual (KD-3): the target-blind sentinel + the
+                          existing max_uses=2 lifecycle means a 2nd use rides to a DIFFERENT
+                          current branch — ALLOWED and documented, NOT a re-prompt.
+  (d) INERT-NOT-GATED   — MUST_STAY_INERT un-gates (base known-bad = gated at 5017d1f2) + the
+                          C1b short-alias matrix (long-gates / short-gates / bare-`-h`-un-gates
+                          for {-t,-b,-F,-A,-c,-R,--repo}, -h AND --help, merge AND close).
+                          C1b known-bad = SUPPLEMENT-REVERT (neuter _INERT_HELP_EXTRA_VALUE_
+                          FLAGS -> `-t -h` un-gates) — the C1b under-block was born+closed
+                          WITHIN the arc, so it does NOT show against the 5017d1f2 base.
+  (e) CONTROL-UNCHANGED — explicit ref'd forms + `gh pr merge 42` byte-identical base->HEAD;
+                          the scalar/set extractors are untouched. Known-bad: a control whose
+                          identity changed base->HEAD would mean the fix perturbed the explicit
+                          path.
+
+NON-VACUITY DISCIPLINE (carried first-hand from test_merge_guard_1134_cert.py + the close-arc):
+every assertion is demonstrated FAILING on a known-bad; identity is read OFF the token, never
+off the whole-command extract; token-dir isolation for any mint LOOP via an owned-dir helper
+(the leak bit twice historically); base-vs-frozen-fixture differential, NEVER a byte-diff.
+Known-bads are verified to ACTUALLY flip the row (a "does-not-cross-authorize" pin is vacuous
+if the neuter never reaches the guarded branch).
+
+ACCEPTED RESIDUALS (documented, NOT defects — do not "fix" to green):
+  * SET B non-runnable ref-positional force-push (`git push --force HEAD` / `main` / `:main` /
+    `HEAD:main` / `refs/heads/main` / `+main`): git parses the sole positional as <repository>
+    -> fatal 128, so there is NO faithful click; they stay gated-but-unmintable. A mint-on-no-
+    target fix would ALSO harmlessly over-mint them (error before push) — BOTH dispositions are
+    acceptable; we pin the actual (still gated-but-unmintable) and document the other.
+  * max_uses=2 cross-branch 2nd-use ride (KD-3): asserted ALLOWED + documented below.
+
+Destructive verbs are assembled at runtime so this file stays inert to the live guard.
+"""
+import io
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+sys.path.insert(0, str(Path(__file__).parent))
+
+import merge_guard_post as mgpost  # noqa: E402
+import merge_guard_pre as mgpre  # noqa: E402
+import shared.merge_guard_common as mgc  # noqa: E402
+from merge_guard_baseline_loader import load_baseline_5017d1f2  # noqa: E402
+from merge_guard_post import main as post_main  # noqa: E402
+from merge_guard_pre import main as pre_main  # noqa: E402
+
+# Runtime-assembled command stems (kept out of one literal so this file is inert).
+_PG = "git " + "push "
+_GH = "gh " + "pr "
+_PREFIX = "cd /repo && "
+
+D = mgc.is_dangerous_command
+DETECT = mgc.detect_command_operation_type
+FP_SENTINEL = mgc._FORCE_PUSH_IMPLICIT_SENTINEL
+MERGE_SENTINEL = mgc._MERGE_IMPLICIT_SENTINEL
+
+
+def _base():
+    """The pre-#1203 (5017d1f2) classifier's is_dangerous_command."""
+    return load_baseline_5017d1f2().is_dangerous_command
+
+
+def _base_ctx():
+    return load_baseline_5017d1f2().extract_command_context
+
+
+# The identity keys a token may bind (the which-key-won read).
+_TARGET_KEYS = (
+    "pr_number", "branch", "branch_set", "target_ref", "push_set",
+    "force_push_set", "force_push_implicit", "merge_implicit",
+    "mass_target", "protected_branch",
+)
+
+
+def _mint_keys(ctx):
+    return [k for k in _TARGET_KEYS if ctx.get(k)]
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# CORPUS — module-level data, the cert IS the corpus. Row-count pinned below.
+# ═════════════════════════════════════════════════════════════════════════════════
+# MUST_MINT force-push (6 RUNNABLE implicit forms) — each mints force_push_implicit.
+MUST_MINT_FORCE_PUSH = [
+    _PG + "--force",
+    _PG + "-f",
+    _PG + "-f origin",
+    _PG + "--force origin",
+    "git -c user.name=x push --force",
+    _PREFIX + _PG + "--force",
+]
+
+# MUST_MINT bare merge (faithful, gh infers the current-branch PR) — merge_implicit.
+MUST_MINT_MERGE = [
+    _GH + "merge",
+    _GH + "merge --admin",
+    _GH + "merge --squash",
+]
+
+# MUST_STAY_INERT — un-gated at HEAD (help short-circuits, mutates nothing); GATED at base.
+MUST_STAY_INERT = [
+    _GH + "merge --help",
+    _GH + "merge -h",
+    "gh " + "help " + "pr " + "merge",
+    _PG + "--force --help",
+    _GH + "close -d --help",   # close WITH delete-branch (dangerous at base) -> inert at head
+]
+
+# DONT_CARE_RESIDUAL — SET B non-runnable ref-positional force-push (fatal 128). Pinned as
+# gated-but-unmintable (the accepted disposition); harmless-over-mint would also be acceptable.
+DONT_CARE_RESIDUAL = [
+    _PG + "--force HEAD",
+    _PG + "--force main",
+    _PG + "--force :main",
+    _PG + "--force HEAD:main",
+    _PG + "--force refs/heads/main",
+    _PG + "--force +main",
+]
+
+# CONTROL_UNCHANGED — explicit ref'd forms + numbered merge. (cmd, expected_key, expected_value)
+CONTROL_UNCHANGED = [
+    (_PG + "--force origin main", "target_ref", "main"),
+    (_PG + "-f origin main", "target_ref", "main"),
+    (_PG + "--force origin HEAD:main", "target_ref", "main"),
+    (_PG + "--force origin +main", "target_ref", "+main"),
+    (_GH + "merge 42", "pr_number", "42"),
+]
+
+# ── C1b short-alias value-decoy matrix ─────────────────────────────────────────
+# The gh pr merge/close value-taking flags whose short aliases C1b skips. Each
+# `<flag> -h` / `<flag> --help` binds the -h/--help as the flag's VALUE => a REAL
+# destructive command that MUST gate; only a BARE -h/--help is a help short-circuit.
+_C1B_MERGE_VALUE_SHORTS = ["-t", "-b", "-F", "-A", "-R"]
+_C1B_MERGE_VALUE_LONGS = ["--subject", "--body", "--body-file", "--author-email", "--repo"]
+# close is destructive only with -d; its value-shorts are -c(--comment) and -R(--repo).
+_C1B_CLOSE_VALUE_SHORTS = ["-c", "-R"]
+
+# Boolean shorts whose following -h is a REAL bare help (must STAY inert — a skip here
+# would re-introduce an over-block).
+_C1B_MERGE_BOOL_SHORTS = ["-d", "-s", "-r", "-m"]
+
+
+def _c1b_must_gate_rows():
+    """(cmd, label) for every short/long value-flag decoy that MUST gate at HEAD."""
+    rows = []
+    for dv in ("-h", "--help"):
+        for f in _C1B_MERGE_VALUE_SHORTS + _C1B_MERGE_VALUE_LONGS:
+            rows.append((_GH + "merge 5 " + f + " " + dv, "merge %s %s" % (f, dv)))
+        for f in _C1B_CLOSE_VALUE_SHORTS:
+            rows.append((_GH + "close 5 -d " + f + " " + dv, "close -d %s %s" % (f, dv)))
+    return rows
+
+
+C1B_MUST_GATE = _c1b_must_gate_rows()
+C1B_MUST_STAY_INERT = [_GH + "merge 5 " + b + " -h" for b in _C1B_MERGE_BOOL_SHORTS]
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# REAL post_main -> pre_main drivers (copied from the 1134 cert harness pattern).
+# _mint returns (count, token_context) — context read OFF the minted token on disk.
+# ═════════════════════════════════════════════════════════════════════════════════
+_ALLOW, _DENY = 0, 2
+
+
+def _mint(cmd, tok):
+    """Drive the REAL post hook with an approval embedding `cmd`. Returns
+    (count_of_tokens_minted, context_dict_or_None) read from the token FILE."""
+    before = set(tok.glob("merge-authorized-*"))
+    env = json.dumps({
+        "tool_name": "AskUserQuestion",
+        "tool_input": {"questions": [{
+            "question": "Proceed?",
+            "options": [
+                {"label": "Yes", "description": "Run `%s`" % cmd},
+                {"label": "Cancel", "description": "Abort"},
+            ],
+        }]},
+        "tool_response": {"answers": {"Proceed?": "Yes"}},
+        "session_id": "cert-1203",
+    })
+    with patch.object(mgpost, "TOKEN_DIR", tok), \
+            patch("sys.stdin", io.StringIO(env)), \
+            patch("sys.stdout", io.StringIO()):
+        try:
+            post_main()
+        except SystemExit as e:
+            assert e.code == 0, "post hook exited nonzero: %r" % (e.code,)
+    new = set(tok.glob("merge-authorized-*")) - before
+    if len(new) != 1:
+        return len(new), None
+    ctx = json.loads(next(iter(new)).read_text()).get("context", {})
+    return 1, ctx
+
+
+def _execute(cmd, tok):
+    """Run `cmd` through the REAL pre hook; return exit code (0=ALLOW, 2=DENY)."""
+    env = json.dumps({
+        "tool_name": "Bash",
+        "tool_input": {"command": cmd},
+        "session_id": "cert-1203",
+    })
+    with patch.object(mgpre, "TOKEN_DIR", tok), \
+            patch("sys.stdin", io.StringIO(env)), \
+            patch("sys.stdout", io.StringIO()), \
+            patch("sys.stderr", io.StringIO()):
+        try:
+            pre_main()
+            return _ALLOW
+        except SystemExit as e:
+            return e.code if isinstance(e.code, int) else _ALLOW
+
+
+def _won_key(ctx):
+    keys = _mint_keys(ctx)
+    return keys[0] if len(keys) == 1 else keys
+
+
+def _isolated_roundtrip(approve, execute):
+    """Mint `approve`, then execute `execute`, in a token dir this call OWNS — so it is
+    STRUCTURALLY IMPOSSIBLE to share across rows (the token-leak that bit the 1134 cert
+    twice cannot recur). Returns (minted, rc)."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        tok = Path(d)
+        minted, _ = _mint(approve, tok)
+        assert minted == 1, "the approval did not mint (round-trip is vacuous): %r" % approve
+        return minted, _execute(execute, tok)
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# CORPUS SHAPE — silent-drift guard.
+# ═════════════════════════════════════════════════════════════════════════════════
+class TestCorpusShape:
+    def test_row_counts_are_pinned(self):
+        assert len(MUST_MINT_FORCE_PUSH) == 6, "MUST_MINT_FORCE_PUSH drifted from 6"
+        assert len(MUST_MINT_MERGE) == 3, "MUST_MINT_MERGE drifted from 3"
+        assert len(MUST_STAY_INERT) == 5, "MUST_STAY_INERT drifted from 5"
+        assert len(DONT_CARE_RESIDUAL) == 6, "DONT_CARE_RESIDUAL (SET B) drifted from 6"
+        assert len(CONTROL_UNCHANGED) == 5, "CONTROL_UNCHANGED drifted from 5"
+        # C1b matrix: (5 short + 5 long merge + 2 close) x 2 decoy spellings = 24.
+        assert len(C1B_MUST_GATE) == 24, "C1b matrix drifted from 24"
+        assert len(C1B_MUST_STAY_INERT) == 4, "C1b boolean-inert drifted from 4"
+
+    def test_sentinels_are_nul_framed_and_distinct(self):
+        assert FP_SENTINEL != MERGE_SENTINEL, "the two sentinels must be DISTINCT"
+        assert "\x00" in FP_SENTINEL and "\x00" in MERGE_SENTINEL, (
+            "sentinels must be NUL-framed (a NUL can never appear in a real ref/pr_number)"
+        )
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# (a) MINT — every MUST_MINT form mints + is_dangerous stays True (target-precision).
+# ═════════════════════════════════════════════════════════════════════════════════
+class TestDimAMintForcePush:
+    """Every runnable implicit force-push: gated at head AND base (is_dangerous True — NOT
+    un-gated), UNMINTABLE at base (the over-block: dang True but no mint key), and at head
+    mints exactly one token binding op=force-push on the target-blind sentinel, self-authorizing."""
+
+    @pytest.mark.parametrize("cmd", MUST_MINT_FORCE_PUSH, ids=MUST_MINT_FORCE_PUSH)
+    def test_mints_force_push_implicit(self, cmd, tmp_path):
+        assert D(cmd) is True, "implicit force-push not gated at head (floor lost): %r" % cmd
+        assert _base()(cmd) is True, "row not dangerous at base — not a gated-but-unmintable row: %r" % cmd
+        # KNOWN-BAD (base): gated but binds NO mint key -> the over-block.
+        assert _mint_keys(_base_ctx()(cmd)) == [], (
+            "base already binds a mint key — not the #1203 gated-but-unmintable over-block: %r" % cmd
+        )
+        assert _execute(cmd, tmp_path) == _DENY, "gated row ALLOWED with no token: %r" % cmd
+        minted, ctx = _mint(cmd, tmp_path)
+        assert minted == 1, "OVER-BLOCK persists — implicit force-push gates but does NOT mint: %r" % cmd
+        assert ctx.get("operation_type") == "force-push", "wrong op: %r" % ctx.get("operation_type")
+        assert _won_key(ctx) == "force_push_implicit", (
+            "implicit force-push bound the wrong key: %r (expected force_push_implicit): %r"
+            % (_won_key(ctx), cmd)
+        )
+        assert ctx.get("force_push_implicit") == FP_SENTINEL, "wrong sentinel value: %r" % ctx.get("force_push_implicit")
+        assert _execute(cmd, tmp_path) == _ALLOW, "faithful click's own token did not self-authorize: %r" % cmd
+
+
+class TestDimAMintMerge:
+    """Bare `gh pr merge` / `--admin` / `--squash`: same shape on merge_implicit."""
+
+    @pytest.mark.parametrize("cmd", MUST_MINT_MERGE, ids=MUST_MINT_MERGE)
+    def test_mints_merge_implicit(self, cmd, tmp_path):
+        assert D(cmd) is True, "bare merge not gated at head: %r" % cmd
+        assert _base()(cmd) is True, "bare merge not dangerous at base: %r" % cmd
+        assert _mint_keys(_base_ctx()(cmd)) == [], "base already mintable — not the over-block: %r" % cmd
+        assert _execute(cmd, tmp_path) == _DENY, "gated bare merge ALLOWED with no token: %r" % cmd
+        minted, ctx = _mint(cmd, tmp_path)
+        assert minted == 1, "OVER-BLOCK persists — bare merge gates but does NOT mint: %r" % cmd
+        assert ctx.get("operation_type") == "merge", "wrong op: %r" % ctx.get("operation_type")
+        assert _won_key(ctx) == "merge_implicit", (
+            "bare merge bound the wrong key: %r (expected merge_implicit): %r" % (_won_key(ctx), cmd)
+        )
+        assert ctx.get("merge_implicit") == MERGE_SENTINEL, "wrong sentinel value: %r" % ctx.get("merge_implicit")
+        assert _execute(cmd, tmp_path) == _ALLOW, "faithful bare-merge token did not self-authorize: %r" % cmd
+
+
+class TestDimAMintTargetNeuterKnownBad:
+    """NON-VACUITY for minted==1: dropping force_push_implicit from _target_value (the exact
+    #1064 four-site-omission shape) turns the gated implicit force-push gated-but-UNMINTABLE,
+    so the faithful click is refused with no way to authorize. Demonstrates the minted==1
+    assertions fail on a known-bad. `_target_value` referenced call-time via the module."""
+
+    def test_dropping_sentinel_from_target_value_makes_it_unmintable(self, tmp_path, monkeypatch):
+        row = _PG + "--force"
+        vac = tmp_path / "vac"; vac.mkdir()
+        minted, ctx = _mint(row, vac)
+        assert minted == 1 and _won_key(ctx) == "force_push_implicit", "row does not mint the sentinel at head"
+
+        def _tv_without_sentinel(cmd_ctx):
+            return (cmd_ctx.get("pr_number") or cmd_ctx.get("branch")
+                    or cmd_ctx.get("branch_set") or cmd_ctx.get("target_ref")
+                    or cmd_ctx.get("push_set") or cmd_ctx.get("force_push_set")
+                    or cmd_ctx.get("merge_implicit") or cmd_ctx.get("mass_target")
+                    or cmd_ctx.get("protected_branch"))  # force_push_implicit DROPPED
+
+        monkeypatch.setattr(mgpost, "_target_value", _tv_without_sentinel)
+        kb = tmp_path / "kb"; kb.mkdir()
+        m2, _ = _mint(row, kb)
+        assert m2 == 0, "the sentinel-drop did not stop the mint — the four-site enumeration is inert"
+        assert _execute(row, kb) == _DENY, (
+            "gated-but-unmintable row was not denied — the mint pin cannot see the over-block it exists to catch"
+        )
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# (b) OFF-TOKEN ROUND-TRIP — identity read off the token; the exec-without-token DENY is
+# the fix-coupled leg (the mint alone is pipeline-blind).
+# ═════════════════════════════════════════════════════════════════════════════════
+class TestDimBOffTokenRoundTrip:
+    """The sentinel identity is read OFF the token (compound `cd && …` rows bind nothing on
+    the whole-command extract, so the token file is authoritative). exec-without-token DENY
+    proves the gate; mint+self-authorize ALLOW proves the round-trip."""
+
+    @pytest.mark.parametrize("cmd", MUST_MINT_FORCE_PUSH + MUST_MINT_MERGE,
+                             ids=MUST_MINT_FORCE_PUSH + MUST_MINT_MERGE)
+    def test_identity_off_the_token(self, cmd, tmp_path):
+        assert _execute(cmd, tmp_path) == _DENY, "gate not live at exec time (no token): %r" % cmd
+        minted, ctx = _mint(cmd, tmp_path)
+        assert minted == 1, "did not mint: %r" % cmd
+        sentinel = ctx.get("force_push_implicit") or ctx.get("merge_implicit")
+        assert sentinel in (FP_SENTINEL, MERGE_SENTINEL), (
+            "token did not carry a target-blind sentinel off the token file: %r" % cmd
+        )
+        assert _execute(cmd, tmp_path) == _ALLOW, "own token did not authorize: %r" % cmd
+
+    def test_mint_plus_allow_is_pipeline_blind_without_the_gate(self, tmp_path, monkeypatch):
+        # DOCUMENTED TRAP: under a sentinel-populate revert the row goes UNMINTABLE, but a
+        # naive "mint + self-authorize" check that skipped the exec-WITHOUT-token DENY could
+        # be fooled by a fix-independent mint path. Here we show the exec-without-token DENY
+        # is the load-bearing leg: with the sentinel dropped, the row cannot mint AND cannot
+        # authorize -> DENY. (Mirrors the 1134 cert's pipeline-blindness note.)
+        row = _PG + "--force"
+        monkeypatch.setattr(mgc, "_is_implicit_current_branch_force_push", lambda c: False)
+        assert _mint_keys(mgc.extract_command_context(row)) == [], "revert did not un-mint the row (vacuity guard)"
+        minted, _ = _mint(row, tmp_path)
+        assert minted == 0, "row still minted after the populate revert"
+        assert _execute(row, tmp_path) == _DENY, "unmintable row was not denied at exec"
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# (c) NO-CROSS-AUTH — the sentinel is target-blind but STRUCTURALLY walled off explicit
+# and cross-op forms (distinct NUL key + op-type-first + mutual-exclusive populate).
+# ═════════════════════════════════════════════════════════════════════════════════
+# (name, approve, execute, expect_allow)
+CROSS_AUTH_ROWS = [
+    ("fp-implicit -> explicit --force origin main", _PG + "--force", _PG + "--force origin main", False),
+    ("fp-implicit -> explicit -f origin main", _PG + "--force", _PG + "-f origin main", False),
+    ("explicit --force origin main -> fp-implicit", _PG + "--force origin main", _PG + "--force", False),
+    ("merge-implicit -> explicit merge 42", _GH + "merge", _GH + "merge 42", False),
+    ("explicit merge 42 -> merge-implicit", _GH + "merge 42", _GH + "merge", False),
+    ("fp-implicit -> bare merge (cross-op)", _PG + "--force", _GH + "merge", False),
+    ("merge-implicit -> fp-implicit (cross-op)", _GH + "merge", _PG + "--force", False),
+    # faithful self-authorize (no over-block)
+    ("fp-implicit self", _PG + "--force", _PG + "--force", True),
+    ("merge-implicit self", _GH + "merge", _GH + "merge", True),
+]
+
+
+class TestDimCNoCrossAuth:
+    """Every escalation REFUSES; every faithful self-execution AUTHORIZES. minted==1 asserted
+    FIRST (via the owned-dir helper) so a DENY is a READ decision, never a mint-side miss."""
+
+    @pytest.mark.parametrize("name,approve,execute,expect_allow", CROSS_AUTH_ROWS,
+                             ids=[r[0] for r in CROSS_AUTH_ROWS])
+    def test_cross_auth(self, name, approve, execute, expect_allow):
+        _, rc = _isolated_roundtrip(approve, execute)
+        if expect_allow:
+            assert rc == _ALLOW, "OVER-BLOCK: a faithful self-execution was REFUSED (%s)" % name
+        else:
+            assert rc == _DENY, (
+                "CROSS-AUTH OPEN: an implicit-form token authorized a DIFFERENT-identity "
+                "execution (%s): approve=%r execute=%r" % (name, approve, execute)
+            )
+
+    def test_runtime_resolve_would_open_the_launder_known_bad(self, tmp_path, monkeypatch):
+        # THE DISCRIMINATING KNOWN-BAD. Simulate the REJECTED runtime-resolve design (KD-1
+        # option b): make the implicit force-push resolve to a CONCRETE target_ref='main'
+        # (as `push.default=current` on branch main would) INSTEAD of the target-blind
+        # sentinel. Now the implicit token carries target_ref='main' and cross-authorizes an
+        # explicit `--force origin main` (target_ref='main') — the exact launder the target-
+        # blind distinct-key design prevents. Patched on the POST hook's own binding (mint side).
+        orig = mgpost.extract_command_context
+
+        def _resolved(cmd, *a, **k):
+            ctx = dict(orig(cmd, *a, **k))
+            if ctx.get("force_push_implicit"):
+                ctx.pop("force_push_implicit")
+                ctx["target_ref"] = "main"    # runtime-resolve to the current branch
+            return ctx
+
+        monkeypatch.setattr(mgpost, "extract_command_context", _resolved)
+        minted, ctx = _mint(_PG + "--force", tmp_path)
+        assert minted == 1 and ctx.get("target_ref") == "main", (
+            "the runtime-resolve simulation did not bind target_ref='main' (known-bad inert)"
+        )
+        # The implicit token now AUTHORIZES the explicit push to main — cross-auth OPENED.
+        assert _execute(_PG + "--force origin main", tmp_path) == _ALLOW, (
+            "the runtime-resolve known-bad did NOT open the cross-auth — the distinct target-"
+            "blind key is not the attributable closer, so the DENY rows above prove nothing"
+        )
+
+
+class TestDimCMaxUsesResidual:
+    """ACCEPTED RESIDUAL (KD-3): the target-blind sentinel + the existing max_uses=2 lifecycle
+    means an implicit force-push token can be used a SECOND time — and because the sentinel is
+    target-blind, that 2nd use may be a DIFFERENT current branch (another implicit form). This
+    is ALLOWED and documented (target-precision under-block accepted per the over-block-priority
+    directive), NOT a re-prompt. If MAX_USES were tightened to 1, the 2nd use would DENY — so
+    this row also pins the current max_uses=2 lifecycle."""
+
+    def test_max_uses_is_two(self):
+        assert mgc.MAX_USES == 2, "MAX_USES changed — the KD-3 accepted-residual reasoning shifts"
+
+    def test_second_use_rides_to_a_different_implicit_force_push(self, tmp_path):
+        minted, _ = _mint(_PG + "--force", tmp_path)
+        assert minted == 1
+        assert _execute(_PG + "--force", tmp_path) == _ALLOW, "1st use denied (unexpected)"
+        # 2nd use — a DIFFERENT implicit force-push spelling (target-blind => same sentinel).
+        assert _execute(_PG + "-f", tmp_path) == _ALLOW, (
+            "the max_uses=2 cross-branch 2nd-use ride is CLOSED — if this is intended (max_uses "
+            "tightened), update the KD-3 accepted-residual documentation rather than this pin"
+        )
+        # 3rd use exhausts the 2 slots.
+        assert _execute(_PG + "--force", tmp_path) == _DENY, "token outlived its max_uses=2 budget"
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# (d) INERT-NOT-GATED — MUST_STAY_INERT + the C1b short-alias matrix.
+# ═════════════════════════════════════════════════════════════════════════════════
+class TestDimDInert:
+    """Inert help forms un-gate at HEAD (merge/push nothing); GATED at 5017d1f2 base (no inert
+    recognizer) — the base is the demonstrated known-bad."""
+
+    @pytest.mark.parametrize("cmd", MUST_STAY_INERT, ids=MUST_STAY_INERT)
+    def test_inert_ungated_at_head_gated_at_base(self, cmd):
+        assert D(cmd) is False, "inert help form GATED at head (over-block): %r" % cmd
+        assert DETECT(cmd) is None or D(cmd) is False  # help form contributes no live danger
+        assert _base()(cmd) is True, (
+            "inert form was NOT gated at 5017d1f2 base — the C1 inert-recognition differential "
+            "is vacuous for this row (base==head): %r" % cmd
+        )
+
+
+class TestDimDC1bShortAlias:
+    """The C1b short-alias value-decoy matrix: every `<value-flag> -h`/`--help` GATES at head
+    (the -h/--help is the flag's VALUE => a real destructive command), for both short and long
+    forms, merge AND close. Boolean `-h` stays inert. The C1b under-block was introduced by C1
+    and closed by C1b WITHIN the arc, so it does NOT show against the 5017d1f2 base — its
+    non-vacuity is the SUPPLEMENT-REVERT known-bad below, not a base differential."""
+
+    @pytest.mark.parametrize("cmd,label", C1B_MUST_GATE, ids=[r[1] for r in C1B_MUST_GATE])
+    def test_value_decoy_gates(self, cmd, label):
+        assert D(cmd) is True, "C1b value-decoy did NOT gate (under-block): %s -> %r" % (label, cmd)
+
+    @pytest.mark.parametrize("cmd", C1B_MUST_STAY_INERT, ids=C1B_MUST_STAY_INERT)
+    def test_boolean_short_h_stays_inert(self, cmd):
+        assert D(cmd) is False, (
+            "a boolean short's following -h was treated as a VALUE and gated (over-block) — the "
+            "boolean must NOT be in the skip set: %r" % cmd
+        )
+
+    def test_supplement_revert_reopens_the_short_alias_under_block(self, monkeypatch):
+        # NON-VACUITY: neuter the C1b supplement (empty _INERT_HELP_EXTRA_VALUE_FLAGS). The
+        # short-form value-decoys must UN-GATE again (the C1b under-block reopens), while the
+        # LONG forms stay gated (they use the shared _GH_PR_VALUE_TAKING_FLAGS, untouched). This
+        # is what couples the short-alias rows above to C1b rather than being a dead assertion.
+        assert set(_C1B_MERGE_VALUE_SHORTS + _C1B_CLOSE_VALUE_SHORTS) <= set(mgc._INERT_HELP_EXTRA_VALUE_FLAGS), (
+            "the short aliases are not in _INERT_HELP_EXTRA_VALUE_FLAGS — the revert below is a no-op"
+        )
+        monkeypatch.setattr(mgc, "_INERT_HELP_EXTRA_VALUE_FLAGS", frozenset())
+        reopened = [cmd for cmd in (_GH + "merge 5 -t -h", _GH + "merge 5 -R -h",
+                                    _GH + "close 5 -d -c -h") if D(cmd) is False]
+        assert len(reopened) == 3, (
+            "emptying the C1b supplement did NOT reopen the short-alias under-block on all 3 "
+            "witnesses — the supplement is not the attributable closer: still-gated=%r"
+            % [c for c in (_GH + "merge 5 -t -h", _GH + "merge 5 -R -h", _GH + "close 5 -d -c -h")
+               if D(c) is True]
+        )
+        # LONG forms are NOT affected by the supplement (shared long set) — they still gate.
+        assert D(_GH + "merge 5 --subject -h") is True, (
+            "the long-form value skip regressed under the supplement revert — the two skip sets "
+            "are not independent as documented"
+        )
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# (e) CONTROL-UNCHANGED — explicit ref'd forms + numbered merge byte-identical base->HEAD.
+# ═════════════════════════════════════════════════════════════════════════════════
+class TestDimEControlUnchanged:
+    """The fix is a pure additive elif on the shared-None of the scalar/set extractors; the
+    explicit ref'd forms and the numbered merge must be IDENTICAL base->HEAD (same gate, same
+    op, same bound identity). A control whose identity changed would mean the fix perturbed the
+    explicit path — a regression the additive design forbids."""
+
+    @pytest.mark.parametrize("cmd,key,value", CONTROL_UNCHANGED, ids=[r[0] for r in CONTROL_UNCHANGED])
+    def test_explicit_forms_identical_base_to_head(self, cmd, key, value):
+        assert _base()(cmd) is True and D(cmd) is True, "control lost its gate base/head: %r" % cmd
+        head_ctx = mgc.extract_command_context(cmd)
+        base_ctx = _base_ctx()(cmd)
+        assert head_ctx.get(key) == value, "head control identity changed: %r -> %r" % (cmd, head_ctx.get(key))
+        assert base_ctx.get(key) == value, "base control identity differs: %r -> %r" % (cmd, base_ctx.get(key))
+        # No sentinel ever leaks onto an explicit form (KD-4 mutual-exclusivity).
+        assert not head_ctx.get("force_push_implicit") and not head_ctx.get("merge_implicit"), (
+            "an EXPLICIT form carries a sentinel at head — the mutual-exclusive populate broke: %r" % cmd
+        )
+
+    def test_scalar_and_set_extractors_byte_untouched(self):
+        # The scalar/set force-push extractors are byte-identical base->HEAD (the fix is a pure
+        # additive elif on their shared None).
+        base = load_baseline_5017d1f2()
+        for cmd, key, value in CONTROL_UNCHANGED:
+            if key == "target_ref":
+                assert base._extract_force_push_target_ref(cmd) == mgc._extract_force_push_target_ref(cmd) == value, (
+                    "scalar force-push extractor changed base->HEAD for %r" % cmd
+                )
+
+    def test_api_endpoint_merge_binds_pr_number_not_the_sentinel(self):
+        # The #1096 API merge (`gh api -X PUT …/pulls/<N>/merge`) carries a concrete PR number,
+        # so pr_number is bound and merge_implicit is NEVER populated (KD-4 mutual-exclusivity:
+        # the bare-merge sentinel is reached ONLY when pr_number is absent). Byte-identical
+        # base->HEAD — the fix did not touch the API-merge path.
+        cmd = "gh " + "api -X PUT repos/o/r/pulls/5/merge"
+        base = load_baseline_5017d1f2()
+        head_ctx = mgc.extract_command_context(cmd)
+        assert D(cmd) is True and head_ctx.get("operation_type") == "merge"
+        assert head_ctx.get("pr_number") == "5", "API merge did not bind pr_number: %r" % head_ctx.get("pr_number")
+        assert not head_ctx.get("merge_implicit"), (
+            "the merge_implicit sentinel LEAKED onto a numbered API merge — KD-4 mutual-"
+            "exclusivity broke (a bare-merge token could then authorize a numbered merge)"
+        )
+        assert base.extract_command_context(cmd).get("pr_number") == "5", "API merge pr_number changed base->HEAD"
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# ACCEPTED RESIDUAL — SET B non-runnable ref-positional force-push: gated-but-unmintable,
+# documented (NOT a defect). A "mint-on-no-target" fix would harmlessly over-mint them too;
+# we pin the actual disposition and document the alternative as acceptable.
+# ═════════════════════════════════════════════════════════════════════════════════
+class TestSetBNonRunnableResidual:
+    @pytest.mark.parametrize("cmd", DONT_CARE_RESIDUAL, ids=DONT_CARE_RESIDUAL)
+    def test_set_b_gated_but_unmintable(self, cmd, tmp_path):
+        # Gated (is_dangerous True) but binds no sentinel (SET B is excluded from the implicit
+        # predicate — non-runnable, fatal 128, no faithful click to protect). Either "still
+        # gated-but-unmintable" (pinned here) OR "harmlessly over-minted" is acceptable; a
+        # regression that makes it MINT a force_push_implicit is fine, but one that UN-GATES it
+        # would be an under-block — so we pin the gate stays True and the key stays a sentinel
+        # (or absent), never an explicit target_ref.
+        assert D(cmd) is True, "SET B non-runnable form UN-GATED (under-block): %r" % cmd
+        ctx = mgc.extract_command_context(cmd)
+        assert not ctx.get("target_ref") and not ctx.get("force_push_set"), (
+            "SET B bound an EXPLICIT target — a non-runnable form must never resolve a concrete "
+            "ref (that would be the launder the SET A/SET B split exists to avoid): %r" % cmd
+        )

--- a/pact-plugin/tests/test_merge_guard_1203_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1203_cert.py
@@ -105,6 +105,14 @@ FP_SENTINEL = mgc._FORCE_PUSH_IMPLICIT_SENTINEL
 MERGE_SENTINEL = mgc._MERGE_IMPLICIT_SENTINEL
 
 
+def _fpq(*positionals):
+    """The cycle-4 NETSTRING-qualified force_push_implicit identity for a 1-positional implicit
+    force-push: `SENTINEL + _canonical_join([<remote-or-url-or-refspec>])` (len-prefixed, e.g.
+    `SENTINEL + '6:origin'`). Derived through the REAL _canonical_join SSOT (not a hardcoded
+    `:remote`), so a netstring-format change is reflected here and the identity stays injective."""
+    return FP_SENTINEL + mgc._canonical_join(list(positionals))
+
+
 def _base():
     """The pre-#1203 (5017d1f2) classifier's is_dangerous_command."""
     return load_baseline_5017d1f2().is_dangerous_command
@@ -147,8 +155,8 @@ MUST_MINT_FORCE_PUSH = [
 FP_IMPLICIT_VALUE = {
     _PG + "--force": FP_SENTINEL,
     _PG + "-f": FP_SENTINEL,
-    _PG + "-f origin": FP_SENTINEL + ":origin",
-    _PG + "--force origin": FP_SENTINEL + ":origin",
+    _PG + "-f origin": _fpq("origin"),                # cycle-4: netstring-qualified
+    _PG + "--force origin": _fpq("origin"),           # cycle-4: netstring-qualified
     "git -c user.name=x push --force": FP_SENTINEL,
     _PREFIX + _PG + "--force": FP_SENTINEL,
 }
@@ -419,11 +427,12 @@ class TestDimBOffTokenRoundTrip:
         minted, ctx = _mint(cmd, tmp_path)
         assert minted == 1, "did not mint: %r" % cmd
         sentinel = ctx.get("force_push_implicit") or ctx.get("merge_implicit")
-        # cycle-3: force_push_implicit may be the plain sentinel (truly-implicit) OR a
-        # remote-qualified `SENTINEL:<remote>` (1-positional). merge_implicit is the plain merge
-        # sentinel. Either way the identity must be read OFF the token as a NUL-framed sentinel.
+        # force_push_implicit may be the plain sentinel (truly-implicit 0-positional) OR a
+        # cycle-4 netstring-qualified `SENTINEL + <_canonical_join([positional])>` (1-positional).
+        # merge_implicit is the plain merge sentinel. Either way the identity is read OFF the
+        # token as a NUL-framed sentinel (every force-push value begins with FP_SENTINEL).
         assert sentinel is not None and (
-            sentinel == MERGE_SENTINEL or sentinel == FP_SENTINEL or sentinel.startswith(FP_SENTINEL + ":")
+            sentinel == MERGE_SENTINEL or sentinel.startswith(FP_SENTINEL)
         ), "token did not carry a target-blind sentinel off the token file: %r (%r)" % (cmd, sentinel)
         assert _execute(cmd, tmp_path) == _ALLOW, "own token did not authorize: %r" % cmd
 
@@ -978,12 +987,12 @@ class TestFinding4ValueOptionInertBlindness:
 # ═════════════════════════════════════════════════════════════════════════════════
 # (cmd_tail, expected force_push_implicit identity)
 CYCLE3_IDENTITY = [
-    ("--force origin", FP_SENTINEL + ":origin"),
-    ("-f origin", FP_SENTINEL + ":origin"),
-    ("origin --force", FP_SENTINEL + ":origin"),          # ordering-agnostic (same identity)
-    ("--force upstream", FP_SENTINEL + ":upstream"),
-    ("--force -o ci.skip origin", FP_SENTINEL + ":origin"),  # -o value-skip preserved
-    ("--force", FP_SENTINEL),                             # bare 0-positional keeps plain sentinel
+    ("--force origin", _fpq("origin")),
+    ("-f origin", _fpq("origin")),
+    ("origin --force", _fpq("origin")),                  # ordering-agnostic (same identity)
+    ("--force upstream", _fpq("upstream")),
+    ("--force -o ci.skip origin", _fpq("origin")),       # -o value-skip preserved
+    ("--force", FP_SENTINEL),                            # bare 0-positional keeps plain sentinel
 ]
 # (name, approve, execute, expect_allow) — the cross-remote closure + the ordering-agnostic ALLOW.
 CYCLE3_CROSS_AUTH = [
@@ -995,8 +1004,13 @@ CYCLE3_CROSS_AUTH = [
 
 
 class TestCycle3RemoteQualifiedIdentity:
-    """The 1-positional force-push mints a REMOTE-QUALIFIED identity so distinct remotes cannot
-    cross-authorize; token order is agnostic; the bare form keeps the plain sentinel."""
+    """The 1-positional force-push mints a positional-QUALIFIED identity so distinct positionals
+    cannot cross-authorize; token order is agnostic; the bare 0-positional keeps the plain
+    sentinel. cycle-3 introduced `SENTINEL:<remote>`; cycle-4 (#90-93) generalized it to the
+    injective NETSTRING `SENTINEL + _canonical_join([positional])` AND dropped the refspec-shape
+    refusal, so ALL 1-positionals (named remotes, URL-remotes, refspec-shapes) now mint — closing
+    the URL-remote FAITHFUL over-block (a URL is a valid runnable remote). The `_fpq()` helper
+    derives the expected value through the REAL _canonical_join SSOT."""
 
     @pytest.mark.parametrize("tail,value", CYCLE3_IDENTITY, ids=[r[0] for r in CYCLE3_IDENTITY])
     def test_identity_value(self, tail, value):
@@ -1015,15 +1029,22 @@ class TestCycle3RemoteQualifiedIdentity:
                 "did not distinguish the identities" % (name, approve, execute)
             )
 
-    def test_mutual_exclusivity_and_setb_preserved(self):
-        # explicit target_ref still WINS (no implicit sentinel leak); SET B stays fpi-None + gated.
+    def test_mutual_exclusivity_and_multiref_preserved(self):
+        # explicit target_ref still WINS for a remote+ref pair (no implicit sentinel leak).
         ex = mgc.extract_command_context(_PG + "--force origin main")
         assert ex.get("target_ref") == "main" and not ex.get("force_push_implicit"), (
-            "cycle-3 leaked a remote-qualified sentinel onto an EXPLICIT-ref force-push: %r" % ex
+            "leaked an implicit sentinel onto an EXPLICIT remote+ref force-push: %r" % ex
         )
-        setb = mgc.extract_command_context(_PG + "--force HEAD")
-        assert not setb.get("force_push_implicit") and D(_PG + "--force HEAD") is True, (
-            "cycle-3 changed SET B: it must stay gated-but-unmintable (fpi None), not resolve a remote"
+        # cycle-4: a 1-positional refspec-shape (`--force HEAD`) now MINTS the netstring identity
+        # (the URL-remote closure binds ALL 1-positionals), NOT SET-B-None.
+        hd = mgc.extract_command_context(_PG + "--force HEAD")
+        assert hd.get("force_push_implicit") == _fpq("HEAD") and D(_PG + "--force HEAD") is True, (
+            "cycle-4: `--force HEAD` must mint the netstring identity (1-positional), not stay SET-B None: %r" % hd
+        )
+        # multi-ref (>=2 refspecs) still owns force_push_set — the set path, never the implicit sentinel.
+        mr = mgc.extract_command_context(_PG + "--force origin main next")
+        assert mr.get("force_push_set") and not mr.get("force_push_implicit"), (
+            "multi-ref force-push leaked the implicit sentinel — the set path must own >=2 refspecs: %r" % mr
         )
 
     def test_dropping_remote_qualifier_reopens_cross_remote(self, monkeypatch):
@@ -1034,7 +1055,7 @@ class TestCycle3RemoteQualifiedIdentity:
         # remote qualification.
         orig = mgc._implicit_force_push_identity
         # sanity: the live fn currently qualifies (else the coarsen below is a no-op).
-        assert orig(_PG + "--force origin") == FP_SENTINEL + ":origin", "vacuity guard: identity not remote-qualified"
+        assert orig(_PG + "--force origin") == _fpq("origin"), "vacuity guard: identity not remote-qualified"
         monkeypatch.setattr(mgc, "_implicit_force_push_identity", lambda c: (FP_SENTINEL if orig(c) else None))
         _, rc = _isolated_roundtrip(_PG + "--force origin", _PG + "--force upstream")
         assert rc == _ALLOW, (
@@ -1042,25 +1063,85 @@ class TestCycle3RemoteQualifiedIdentity:
             "auth — the remote qualifier is not the attributable closer, so the DENY rows prove nothing"
         )
 
+    # cycle-4: URL-remote + refspec-shape 1-positionals now MINT (the netstring closure of the
+    # URL-remote over-block). Identity is SENTINEL + _canonical_join([positional]), URL-verbatim.
+    _URL_A = "git@github.com" + ":o/r.git"
+    _URL_B = "git@github.com" + ":o/other.git"
+
     @pytest.mark.parametrize("url_remote", [
         "git@github.com" + ":o/r.git",           # scp-style
         "ssh://git@host" + "/o/r.git",           # ssh URL
         "https://github.com" + "/o/r.git",       # https URL
     ], ids=["scp", "ssh", "https"])
-    def test_url_remote_stays_set_b_pre_existing_over_block(self, url_remote):
-        # DOCUMENTED PRE-EXISTING RESIDUAL (security #89, OUT OF SCOPE for #1203): a URL-remote
-        # force-push (`git push --force git@host:repo`) is NOT recognized as a remote for the
-        # cycle-3 qualification, so it stays gated-but-UNMINTABLE (SET B) — a pre-existing
-        # OVER-BLOCK that predates this PR and needs a netstring-separator redesign to close
-        # (tracked separately). This is a PINNED-CURRENT-BEHAVIOR row (like the SET B + double-
-        # value-option residuals), NOT a should-mint assertion: it stays gated True (never
-        # un-gated) and binds NO identity (never a spurious remote-qualified mint). If it ever
-        # CHANGES, this reds and forces a re-confirm rather than a silent shift.
+    def test_url_remote_mints_netstring_identity(self, url_remote):
+        # BEHAVIOR FLIP (cycle-4, #90/#91/#92/#93): a URL-remote force-push (`git push --force
+        # git@host:repo`) IS a FAITHFUL runnable command — a URL is a valid git remote — so its
+        # former gated-but-UNMINTABLE state (the SET-B pin committed at b49af7ea) was a CARDINAL
+        # over-block. The netstring redesign now MINTS it: force_push_implicit == SENTINEL +
+        # _canonical_join([url]) (injective, URL captured VERBATIM), gated + self-authorizing.
         cmd = _PG + "--force " + url_remote
         c = mgc.extract_command_context(cmd)
         assert D(cmd) is True, "URL-remote force-push UN-GATED (would be an under-block): %r" % cmd
-        assert not c.get("force_push_implicit") and not c.get("target_ref") and not c.get("force_push_set"), (
-            "URL-remote force-push now binds an identity %r — the pre-existing SET-B over-block "
-            "changed; re-confirm the separate tracker's disposition, do NOT silently update: %r"
-            % (c, cmd)
+        assert c.get("force_push_implicit") == _fpq(url_remote), (
+            "URL-remote did not mint the netstring identity: got %r expected %r for %r"
+            % (c.get("force_push_implicit"), _fpq(url_remote), cmd)
+        )
+        _, rc = _isolated_roundtrip(cmd, cmd)
+        assert rc == _ALLOW, "faithful URL-remote force-push did not self-authorize (over-block): %r" % cmd
+
+    def test_url_and_refspec_injectivity_self_authorizing_only(self):
+        # INJECTIVITY (the point of the netstring): every newly-minting 1-positional authorizes
+        # ONLY itself. A URL token ⊥ a different URL / a named remote / the bare form; a refspec-
+        # shape ⊥ every other form. (name, approve, execute, expect_allow.)
+        rows = [
+            ("URL-A != URL-B", _PG + "--force " + self._URL_A, _PG + "--force " + self._URL_B, False),
+            ("bare != URL-A", _PG + "--force", _PG + "--force " + self._URL_A, False),
+            ("named origin != URL-A", _PG + "--force origin", _PG + "--force " + self._URL_A, False),
+            ("HEAD:main != +main", _PG + "--force HEAD:main", _PG + "--force +main", False),
+            ("HEAD:main != origin", _PG + "--force HEAD:main", _PG + "--force origin", False),
+            ("URL-A self", _PG + "--force " + self._URL_A, _PG + "--force " + self._URL_A, True),
+            ("HEAD:main self", _PG + "--force HEAD:main", _PG + "--force HEAD:main", True),
+        ]
+        for name, approve, execute, expect_allow in rows:
+            _, rc = _isolated_roundtrip(approve, execute)
+            if expect_allow:
+                assert rc == _ALLOW, "OVER-BLOCK: a faithful 1-positional self-execution REFUSED (%s)" % name
+            else:
+                assert rc == _DENY, (
+                    "CROSS-AUTH OPEN (%s): a netstring 1-positional token authorized a DIFFERENT "
+                    "1-positional — the netstring identity is not injective" % name
+                )
+
+    def test_reverting_url_refspec_binding_reopens_the_over_block(self, monkeypatch):
+        # NON-VACUITY (cycle-4 revert-of-the-fix known-bad): cycle-4 DROPPED cycle-3's
+        # `:`/`refs/`/`HEAD`/`+` single-positional REFUSAL (binding ALL 1-positionals via the
+        # injective netstring) — that drop is what CLOSED the URL-remote over-block. Re-apply the
+        # pre-cycle-4 refusal (refuse a `:`-bearing / refspec-shaped positional) → the URL +
+        # refspec-shape forms mint None again = gated-but-UNMINTABLE = the over-block REOPENS.
+        # Couples the URL/refspec mint rows to the cycle-4 drop-refusal; a plain named remote is
+        # UNAFFECTED (the attributable closer is specifically the drop-refusal, not the netstring
+        # reframe alone).
+        orig = mgc._implicit_force_push_identity
+        assert orig(_PG + "--force " + self._URL_A) is not None, (
+            "vacuity guard: the live fn does not currently bind a URL — cycle-4 absent, neuter is a no-op"
+        )
+
+        def _pre_cycle4(cmd):
+            ident = orig(cmd)
+            if ident and ident != FP_SENTINEL:
+                pos = ident[len(FP_SENTINEL):].split(":", 1)[1]   # netstring `<len>:<positional>`
+                if ":" in pos or pos.startswith("refs/") or pos.startswith("+") or pos == "HEAD":
+                    return None                                   # pre-cycle-4 refusal
+            return ident
+
+        monkeypatch.setattr(mgc, "_implicit_force_push_identity", _pre_cycle4)
+        for pos in [self._URL_A, "HEAD:main", "+main", "HEAD"]:
+            c = mgc.extract_command_context(_PG + "--force " + pos)
+            assert not c.get("force_push_implicit"), (
+                "reverting the URL/refspec binding did NOT reopen the over-block for %r — the "
+                "cycle-4 drop-refusal is not the attributable closer, so the URL/refspec mint rows "
+                "prove nothing" % pos
+            )
+        assert mgc.extract_command_context(_PG + "--force origin").get("force_push_implicit") == _fpq("origin"), (
+            "the revert wrongly un-bound a plain named remote — the pre-cycle-4 neuter over-reached"
         )

--- a/pact-plugin/tests/test_merge_guard_1203_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1203_cert.py
@@ -139,6 +139,20 @@ MUST_MINT_FORCE_PUSH = [
     _PREFIX + _PG + "--force",
 ]
 
+# cycle-3 (findings #1+#2 tighten): the force_push_implicit identity is REMOTE-QUALIFIED for
+# the 1-positional remote-only form (`--force origin` -> SENTINEL:origin), so a `--force origin`
+# approval no longer authorizes a `--force upstream` (cross-remote). The 0-positional truly-
+# implicit forms (bare `--force`/`-f`, global-flag, non-first-leg) keep the PLAIN sentinel. This
+# maps each MUST_MINT_FORCE_PUSH row to its expected identity value (pinned, not inferred).
+FP_IMPLICIT_VALUE = {
+    _PG + "--force": FP_SENTINEL,
+    _PG + "-f": FP_SENTINEL,
+    _PG + "-f origin": FP_SENTINEL + ":origin",
+    _PG + "--force origin": FP_SENTINEL + ":origin",
+    "git -c user.name=x push --force": FP_SENTINEL,
+    _PREFIX + _PG + "--force": FP_SENTINEL,
+}
+
 # MUST_MINT bare merge (faithful, gh infers the current-branch PR) — merge_implicit.
 MUST_MINT_MERGE = [
     _GH + "merge",
@@ -306,6 +320,9 @@ class TestCorpusShape:
         # Finding #4 (both arms): 6 head-form + 4 flag-loop = 10 GIT gate forms.
         assert len(F4_HEAD_FORM) == 6 and len(F4_FLAG_LOOP) == 4 and len(F4_GATE) == 10, "F4 gate corpus drifted"
         assert len(F4_INERT) == 6 and len(F4_DECOY_GATED) == 3, "F4 control corpus drifted"
+        # cycle-3 (remote-qualified force-push identity).
+        assert len(CYCLE3_IDENTITY) == 6 and len(CYCLE3_CROSS_AUTH) == 4, "cycle-3 corpus drifted"
+        assert len(FP_IMPLICIT_VALUE) == len(MUST_MINT_FORCE_PUSH) == 6, "FP_IMPLICIT_VALUE map drifted from the corpus"
 
 
 # ═════════════════════════════════════════════════════════════════════════════════
@@ -332,7 +349,10 @@ class TestDimAMintForcePush:
             "implicit force-push bound the wrong key: %r (expected force_push_implicit): %r"
             % (_won_key(ctx), cmd)
         )
-        assert ctx.get("force_push_implicit") == FP_SENTINEL, "wrong sentinel value: %r" % ctx.get("force_push_implicit")
+        assert ctx.get("force_push_implicit") == FP_IMPLICIT_VALUE[cmd], (
+            "wrong force_push_implicit identity: got %r, expected %r (cycle-3 remote-qualification) for %r"
+            % (ctx.get("force_push_implicit"), FP_IMPLICIT_VALUE[cmd], cmd)
+        )
         assert _execute(cmd, tmp_path) == _ALLOW, "faithful click's own token did not self-authorize: %r" % cmd
 
 
@@ -399,9 +419,12 @@ class TestDimBOffTokenRoundTrip:
         minted, ctx = _mint(cmd, tmp_path)
         assert minted == 1, "did not mint: %r" % cmd
         sentinel = ctx.get("force_push_implicit") or ctx.get("merge_implicit")
-        assert sentinel in (FP_SENTINEL, MERGE_SENTINEL), (
-            "token did not carry a target-blind sentinel off the token file: %r" % cmd
-        )
+        # cycle-3: force_push_implicit may be the plain sentinel (truly-implicit) OR a
+        # remote-qualified `SENTINEL:<remote>` (1-positional). merge_implicit is the plain merge
+        # sentinel. Either way the identity must be read OFF the token as a NUL-framed sentinel.
+        assert sentinel is not None and (
+            sentinel == MERGE_SENTINEL or sentinel == FP_SENTINEL or sentinel.startswith(FP_SENTINEL + ":")
+        ), "token did not carry a target-blind sentinel off the token file: %r (%r)" % (cmd, sentinel)
         assert _execute(cmd, tmp_path) == _ALLOW, "own token did not authorize: %r" % cmd
 
     def test_mint_plus_allow_is_pipeline_blind_without_the_gate(self, tmp_path, monkeypatch):
@@ -411,7 +434,10 @@ class TestDimBOffTokenRoundTrip:
         # is the load-bearing leg: with the sentinel dropped, the row cannot mint AND cannot
         # authorize -> DENY. (Mirrors the 1134 cert's pipeline-blindness note.)
         row = _PG + "--force"
-        monkeypatch.setattr(mgc, "_is_implicit_current_branch_force_push", lambda c: False)
+        # cycle-3 renamed the implicit-force-push predicate to the identity function
+        # `_implicit_force_push_identity` (str|None). Neuter it to None (no identity) → the row
+        # binds no force_push_implicit → gated-but-unmintable.
+        monkeypatch.setattr(mgc, "_implicit_force_push_identity", lambda c: None)
         assert _mint_keys(mgc.extract_command_context(row)) == [], "revert did not un-mint the row (vacuity guard)"
         minted, _ = _mint(row, tmp_path)
         assert minted == 0, "row still minted after the populate revert"
@@ -936,4 +962,105 @@ class TestFinding4ValueOptionInertBlindness:
         assert D(F4_GH_R_CONTROL) is True, (
             "gh -R -h un-gated under the finding-#4 revert — the revert touched C1b's orthogonal "
             "-R arm, not just the git-global-option anchors"
+        )
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# CYCLE-3 (findings #1+#2 TIGHTEN) — the force_push_implicit identity is now REMOTE-QUALIFIED
+# for the 1-positional remote-only form. Before cycle-3, `git push --force origin` and
+# `git push --force upstream` both minted the PLAIN sentinel, so a `--force origin` approval
+# cross-authorized a `--force upstream` (a different remote) — a coarse-identity cross-auth.
+# Cycle-3 binds `SENTINEL:<remote>` (via _implicit_force_push_identity, str|None), so the two
+# are DISTINCT identities and cannot cross-authorize; the bare 0-positional forms keep the
+# plain sentinel. The identity is remote-AGNOSTIC only in TOKEN ORDER (`--force origin` ==
+# `origin --force`), never across DIFFERENT remotes. Mutual-exclusivity with explicit
+# target_ref (`--force origin main`) and SET B (fpi None + gated) is preserved (no over-block).
+# ═════════════════════════════════════════════════════════════════════════════════
+# (cmd_tail, expected force_push_implicit identity)
+CYCLE3_IDENTITY = [
+    ("--force origin", FP_SENTINEL + ":origin"),
+    ("-f origin", FP_SENTINEL + ":origin"),
+    ("origin --force", FP_SENTINEL + ":origin"),          # ordering-agnostic (same identity)
+    ("--force upstream", FP_SENTINEL + ":upstream"),
+    ("--force -o ci.skip origin", FP_SENTINEL + ":origin"),  # -o value-skip preserved
+    ("--force", FP_SENTINEL),                             # bare 0-positional keeps plain sentinel
+]
+# (name, approve, execute, expect_allow) — the cross-remote closure + the ordering-agnostic ALLOW.
+CYCLE3_CROSS_AUTH = [
+    ("--force origin != --force upstream (cross-remote CLOSED)", _PG + "--force origin", _PG + "--force upstream", False),
+    ("bare --force != --force origin", _PG + "--force", _PG + "--force origin", False),
+    ("--force origin == origin --force (ordering-agnostic)", _PG + "--force origin", _PG + "origin --force", True),
+    ("--force origin self", _PG + "--force origin", _PG + "--force origin", True),
+]
+
+
+class TestCycle3RemoteQualifiedIdentity:
+    """The 1-positional force-push mints a REMOTE-QUALIFIED identity so distinct remotes cannot
+    cross-authorize; token order is agnostic; the bare form keeps the plain sentinel."""
+
+    @pytest.mark.parametrize("tail,value", CYCLE3_IDENTITY, ids=[r[0] for r in CYCLE3_IDENTITY])
+    def test_identity_value(self, tail, value):
+        got = mgc.extract_command_context(_PG + tail).get("force_push_implicit")
+        assert got == value, "cycle-3 identity mis-bound: got %r expected %r for %r" % (got, value, _PG + tail)
+
+    @pytest.mark.parametrize("name,approve,execute,expect_allow", CYCLE3_CROSS_AUTH,
+                             ids=[r[0] for r in CYCLE3_CROSS_AUTH])
+    def test_cross_remote(self, name, approve, execute, expect_allow):
+        _, rc = _isolated_roundtrip(approve, execute)
+        if expect_allow:
+            assert rc == _ALLOW, "OVER-BLOCK: a faithful same-identity force-push was REFUSED (%s)" % name
+        else:
+            assert rc == _DENY, (
+                "CROSS-REMOTE CROSS-AUTH OPEN (%s): approve=%r execute=%r — the remote qualifier "
+                "did not distinguish the identities" % (name, approve, execute)
+            )
+
+    def test_mutual_exclusivity_and_setb_preserved(self):
+        # explicit target_ref still WINS (no implicit sentinel leak); SET B stays fpi-None + gated.
+        ex = mgc.extract_command_context(_PG + "--force origin main")
+        assert ex.get("target_ref") == "main" and not ex.get("force_push_implicit"), (
+            "cycle-3 leaked a remote-qualified sentinel onto an EXPLICIT-ref force-push: %r" % ex
+        )
+        setb = mgc.extract_command_context(_PG + "--force HEAD")
+        assert not setb.get("force_push_implicit") and D(_PG + "--force HEAD") is True, (
+            "cycle-3 changed SET B: it must stay gated-but-unmintable (fpi None), not resolve a remote"
+        )
+
+    def test_dropping_remote_qualifier_reopens_cross_remote(self, monkeypatch):
+        # NON-VACUITY: coarsen the identity back to the PLAIN sentinel (the pre-cycle-3 shape) —
+        # `_implicit_force_push_identity` returns SENTINEL for ANY implicit form, dropping the
+        # `:<remote>` qualifier. Then `--force origin` and `--force upstream` share ONE identity
+        # and cross-authorize (the cross-remote reopens). Couples the cross_remote rows to the
+        # remote qualification.
+        orig = mgc._implicit_force_push_identity
+        # sanity: the live fn currently qualifies (else the coarsen below is a no-op).
+        assert orig(_PG + "--force origin") == FP_SENTINEL + ":origin", "vacuity guard: identity not remote-qualified"
+        monkeypatch.setattr(mgc, "_implicit_force_push_identity", lambda c: (FP_SENTINEL if orig(c) else None))
+        _, rc = _isolated_roundtrip(_PG + "--force origin", _PG + "--force upstream")
+        assert rc == _ALLOW, (
+            "coarsening the identity to the plain sentinel did NOT reopen the cross-remote cross-"
+            "auth — the remote qualifier is not the attributable closer, so the DENY rows prove nothing"
+        )
+
+    @pytest.mark.parametrize("url_remote", [
+        "git@github.com" + ":o/r.git",           # scp-style
+        "ssh://git@host" + "/o/r.git",           # ssh URL
+        "https://github.com" + "/o/r.git",       # https URL
+    ], ids=["scp", "ssh", "https"])
+    def test_url_remote_stays_set_b_pre_existing_over_block(self, url_remote):
+        # DOCUMENTED PRE-EXISTING RESIDUAL (security #89, OUT OF SCOPE for #1203): a URL-remote
+        # force-push (`git push --force git@host:repo`) is NOT recognized as a remote for the
+        # cycle-3 qualification, so it stays gated-but-UNMINTABLE (SET B) — a pre-existing
+        # OVER-BLOCK that predates this PR and needs a netstring-separator redesign to close
+        # (tracked separately). This is a PINNED-CURRENT-BEHAVIOR row (like the SET B + double-
+        # value-option residuals), NOT a should-mint assertion: it stays gated True (never
+        # un-gated) and binds NO identity (never a spurious remote-qualified mint). If it ever
+        # CHANGES, this reds and forces a re-confirm rather than a silent shift.
+        cmd = _PG + "--force " + url_remote
+        c = mgc.extract_command_context(cmd)
+        assert D(cmd) is True, "URL-remote force-push UN-GATED (would be an under-block): %r" % cmd
+        assert not c.get("force_push_implicit") and not c.get("target_ref") and not c.get("force_push_set"), (
+            "URL-remote force-push now binds an identity %r — the pre-existing SET-B over-block "
+            "changed; re-confirm the separate tracker's disposition, do NOT silently update: %r"
+            % (c, cmd)
         )

--- a/pact-plugin/tests/test_merge_guard_1203_cert.py
+++ b/pact-plugin/tests/test_merge_guard_1203_cert.py
@@ -296,6 +296,17 @@ class TestCorpusShape:
             "sentinels must be NUL-framed (a NUL can never appear in a real ref/pr_number)"
         )
 
+    def test_review_update_corpus_counts_pinned(self):
+        # M1 + F1 + close-output corpora (added in the peer-review cert-update).
+        assert len(MERGE_TARGET) == 5, "MERGE_TARGET drifted from 5"
+        assert len(MERGE_BARE) == 5, "MERGE_BARE drifted from 5"
+        assert len(MERGE_CROSS_AUTH) == 7, "MERGE_CROSS_AUTH drifted from 7"
+        assert len(F1_CROSS_AUTH) == 4, "F1_CROSS_AUTH drifted from 4"
+        assert len(CLOSE_OUTPUT_CORPUS) == 4, "CLOSE_OUTPUT_CORPUS drifted from 4"
+        # Finding #4 (both arms): 6 head-form + 4 flag-loop = 10 GIT gate forms.
+        assert len(F4_HEAD_FORM) == 6 and len(F4_FLAG_LOOP) == 4 and len(F4_GATE) == 10, "F4 gate corpus drifted"
+        assert len(F4_INERT) == 6 and len(F4_DECOY_GATED) == 3, "F4 control corpus drifted"
+
 
 # ═════════════════════════════════════════════════════════════════════════════════
 # (a) MINT — every MUST_MINT form mints + is_dangerous stays True (target-precision).
@@ -620,4 +631,309 @@ class TestSetBNonRunnableResidual:
         assert not ctx.get("target_ref") and not ctx.get("force_push_set"), (
             "SET B bound an EXPLICIT target — a non-runnable form must never resolve a concrete "
             "ref (that would be the launder the SET A/SET B split exists to avoid): %r" % cmd
+        )
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# M1 (peer-review TIGHTEN) — pr merge <branch>/<url> bind DISTINCT qualified targets;
+# merge_implicit fires ONLY truly-bare. C3b's sentinel OVER-fired on a branch/url
+# positional (an over-mint the INDEPENDENT security lane caught — the #70 cert missed
+# this positional-type axis, mirroring the close url/branch axis the 1134 cert originally
+# missed). The merge target binds under pr_number with a `_classify_pr_target`-qualified
+# value (branch:<name> | url:<host>/<owner>/<repo>#<N> | <N>), the SAME shared SSOT close
+# uses. --match-head-commit is a REAL gh pr merge value flag (derived-SSOT set): its value
+# MUST be stripped so it never abstains (over-block) nor mis-binds a numeric value
+# (laundering) — the security-gap regression guard against RE-NARROWING the merge walk (a
+# hand-narrowed "merge-specific" subset dropped it once; the derived-SSOT superset is safe).
+# ═════════════════════════════════════════════════════════════════════════════════
+_URL5 = "https://github.com/o/r/pull/5"
+# (cmd_tail, expected pr_number qualified value) — positional-bearing forms.
+MERGE_TARGET = [
+    ("feature", "branch:feature"),
+    (_URL5, "url:github.com/o/r#5"),
+    ("42", "42"),
+    ("--subject foo bar", "branch:bar"),                     # value `foo` stripped -> `bar`
+    ("--match-head-commit abc123 feature", "branch:feature"),  # SECURITY: value stripped
+]
+# truly-bare forms (0 positionals after the value-flag walk) -> merge_implicit sentinel.
+MERGE_BARE = ["", "--admin", "--squash", "--subject foo", "--match-head-commit 123"]
+
+# M1 injectivity / cross-auth (the qualified identity keeps distinct targets from cross-
+# authorizing). (name, approve, execute, expect_allow).
+MERGE_CROSS_AUTH = [
+    ("branch-a != branch-b", _GH + "merge feature", _GH + "merge other", False),
+    ("branch != number", _GH + "merge feature", _GH + "merge 42", False),
+    ("merge_implicit != branch", _GH + "merge", _GH + "merge feature", False),
+    ("url cross-repo", _GH + "merge " + _URL5, _GH + "merge https://github.com/o/other/pull/5", False),
+    ("url cross-host", _GH + "merge " + _URL5, _GH + "merge https://ghe.evil.com/o/r/pull/5", False),
+    ("merge branch != close branch (cross-op)", _GH + "merge feature", _GH + "close feature -d", False),
+    ("faithful branch self", _GH + "merge feature", _GH + "merge feature", True),
+]
+
+
+class TestDimM1MergeTargetDistinct:
+    """Every faithful pr-merge with a positional binds its DISTINCT qualified target under
+    pr_number (never the bare sentinel); merge_implicit fires ONLY truly-bare. Closes the
+    C3b over-mint (merge_implicit on a branch/url positional)."""
+
+    @pytest.mark.parametrize("tail,value", MERGE_TARGET, ids=[r[0] for r in MERGE_TARGET])
+    def test_positional_binds_qualified_not_sentinel(self, tail, value):
+        cmd = (_GH + "merge " + tail).rstrip()
+        c = mgc.extract_command_context(cmd)
+        assert D(cmd) is True and c.get("operation_type") == "merge", "merge not gated: %r" % cmd
+        assert c.get("pr_number") == value, (
+            "merge target mis-bound: got %r expected %r for %r" % (c.get("pr_number"), value, cmd)
+        )
+        assert not c.get("merge_implicit"), (
+            "merge_implicit OVER-fired on a positional target (the C3b over-mint M1 closed): %r" % cmd
+        )
+
+    @pytest.mark.parametrize("tail", MERGE_BARE, ids=[t or "(bare)" for t in MERGE_BARE])
+    def test_truly_bare_binds_merge_implicit(self, tail):
+        cmd = (_GH + "merge " + tail).rstrip()
+        c = mgc.extract_command_context(cmd)
+        assert c.get("merge_implicit") == MERGE_SENTINEL, "truly-bare merge did not mint merge_implicit: %r" % cmd
+        assert not c.get("pr_number"), "truly-bare merge mis-bound a pr_number %r: %r" % (c.get("pr_number"), cmd)
+
+    def test_match_head_commit_in_derived_value_flag_set(self):
+        # SECURITY-GAP REGRESSION GUARD (against the #68 re-narrowing error): --match-head-commit
+        # MUST be a recognized merge value flag or its value leaks as a positional -> over-block
+        # AND numeric-value laundering. The derived-SSOT superset must be retained.
+        assert "--match-head-commit" in mgc._GH_MERGE_VALUE_LONG, (
+            "--match-head-commit dropped from the merge value-flag set — re-narrowing reopens the "
+            "over-block (`--match-head-commit <sha> feature` abstains) + laundering "
+            "(`--match-head-commit 123` mis-binds pr_number=123)"
+        )
+
+    def test_dropping_match_head_commit_reopens_overblock_and_launder(self, monkeypatch):
+        # NON-VACUITY for the regression guard: exclude --match-head-commit from the merge walk
+        # (the #68 error). The flag's value then leaks as a positional -> (a) over-block: `<sha>
+        # feature` = 2 positionals -> abstain (no target, no sentinel); (b) laundering: `123` mis-
+        # bound as pr_number. Demonstrates the guard fails on the known-bad.
+        assert "--match-head-commit" in mgc._GH_MERGE_VALUE_LONG, "vacuity guard: flag not in set"
+        narrowed = frozenset(mgc._GH_MERGE_VALUE_LONG) - {"--match-head-commit"}
+        monkeypatch.setattr(mgc, "_GH_MERGE_VALUE_LONG", narrowed)
+        over = mgc.extract_command_context(_GH + "merge --match-head-commit abc123 feature")
+        assert not over.get("pr_number") and not over.get("merge_implicit"), (
+            "dropping --match-head-commit did NOT reopen the over-block abstain — the guard proves nothing"
+        )
+        laund = mgc.extract_command_context(_GH + "merge --match-head-commit 123")
+        assert laund.get("pr_number") == "123", (
+            "dropping --match-head-commit did NOT reopen the numeric-value laundering mis-bind"
+        )
+
+    @pytest.mark.parametrize("name,approve,execute,expect_allow", MERGE_CROSS_AUTH,
+                             ids=[r[0] for r in MERGE_CROSS_AUTH])
+    def test_merge_target_cross_auth(self, name, approve, execute, expect_allow):
+        _, rc = _isolated_roundtrip(approve, execute)
+        if expect_allow:
+            assert rc == _ALLOW, "OVER-BLOCK: faithful merge self-execution REFUSED (%s)" % name
+        else:
+            assert rc == _DENY, (
+                "CROSS-AUTH OPEN: a merge token authorized a DIFFERENT-target execution (%s): "
+                "approve=%r execute=%r" % (name, approve, execute)
+            )
+
+    def test_neuter_positional_walk_reopens_the_over_mint(self, monkeypatch):
+        # NON-VACUITY (intra-arc-born tighten -> in-cert neuter, NOT a 5017 base differential): the
+        # M1 tighten IS the `_gh_merge_positionals` walk, SHARED by _extract_merge_target AND
+        # _is_bare_cli_merge (one boundary). Neuter it to the C3b behavior (0 positionals always) ->
+        # `merge feature` binds merge_implicit again (the over-mint), so a bare-merge token
+        # authorizes it cross-target. At HEAD the branch:feature identity REFUSES it.
+        monkeypatch.setattr(mgc, "_gh_merge_positionals", lambda tokens: [])
+        c = mgc.extract_command_context(_GH + "merge feature")
+        assert c.get("merge_implicit") == MERGE_SENTINEL and not c.get("pr_number"), (
+            "the positional-walk neuter did not revert `merge feature` to the over-mint sentinel — "
+            "vacuity guard (the walk is not the shared boundary the cross-auth rows depend on)"
+        )
+        _, rc = _isolated_roundtrip(_GH + "merge", _GH + "merge feature")
+        assert rc == _ALLOW, (
+            "with the merge positional walk neutered, a bare-merge token did NOT authorize `merge "
+            "feature` — the walk is not the attributable closer of the C3b over-mint, so the merge "
+            "cross-auth rows above prove nothing"
+        )
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# F1 (from the #77 cert review) — DRIFT-PROOFING the force-push cross-auth boundary that
+# is closed-by-construction (op-type-first + distinct NUL key) but was UNPINNED: the
+# multi-ref force_push_set / push_set interaction and the max_uses=2 second-use × cross-op
+# refusal. All verified refuse-by-construction; pinned so a future change to the
+# force_push_set/push_set arms (#1195) or the max_uses logic cannot silently reopen a
+# cross-auth without a red cert.
+# ═════════════════════════════════════════════════════════════════════════════════
+F1_CROSS_AUTH = [
+    ("fp-implicit -> multi-ref force_push_set", _PG + "--force", _PG + "--force origin main next", False),
+    ("multi-ref force_push_set -> fp-implicit", _PG + "--force origin main next", _PG + "--force", False),
+    ("fp-implicit -> push-to-main (cross-op)", _PG + "--force", _PG + "origin main", False),
+    ("push-to-main -> fp-implicit (cross-op)", _PG + "origin main", _PG + "--force", False),
+]
+
+
+class TestF1ForcePushCrossAuthDriftProof:
+    """The force_push_implicit sentinel cannot cross-authorize a MULTI-ref force_push_set /
+    push_set command, nor a cross-op push-to-main — closed by op-type-first + the distinct NUL
+    key. Pinned here (unpinned in #70) to catch a future set-arm or op-type change."""
+
+    @pytest.mark.parametrize("name,approve,execute,expect_allow", F1_CROSS_AUTH,
+                             ids=[r[0] for r in F1_CROSS_AUTH])
+    def test_boundary_refuses(self, name, approve, execute, expect_allow):
+        _, rc = _isolated_roundtrip(approve, execute)
+        assert rc == _DENY, (
+            "F1 CROSS-AUTH OPEN (%s): approve=%r execute=%r — the force_push_implicit sentinel "
+            "reached a multi-ref/cross-op command" % (name, approve, execute)
+        )
+
+    def test_max_uses_second_use_refuses_cross_op(self, tmp_path):
+        # The accepted max_uses=2 cross-branch ride is SAME-OP only. A SECOND use on a CROSS-OP
+        # command must still DENY (op-type-first applies per use).
+        minted, _ = _mint(_PG + "--force", tmp_path)
+        assert minted == 1
+        assert _execute(_PG + "--force", tmp_path) == _ALLOW, "slot-1 same-op self denied (unexpected)"
+        assert _execute(_GH + "merge 42", tmp_path) == _DENY, (
+            "the max_uses=2 SECOND use authorized a CROSS-OP execution — op-type-first is not "
+            "applied per-use"
+        )
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# CLOSE-OUTPUT-BEHAVIOR pin (per the lead's ruling on the _classify_pr_target refactor):
+# _extract_close_target's classification tail moved into the shared `_classify_pr_target`
+# SSOT (now shared by close AND merge). Close OUTPUT must be BYTE-IDENTICAL base(5017)->HEAD
+# — an OUTPUT-behavior pin (there is no body-hash pin to evolve; this deliberately pins
+# behavior, not source shape, so future close/merge classifier evolution stays output-safe).
+# ═════════════════════════════════════════════════════════════════════════════════
+CLOSE_OUTPUT_CORPUS = [
+    _GH + "close 5 -d",
+    _GH + "close feature -d",
+    _GH + "close https://github.com/o/r/pull/9 -d",
+    _GH + "close --repo o/r feature -d",
+]
+
+
+class TestCloseOutputBehaviorUnchanged:
+    @pytest.mark.parametrize("cmd", CLOSE_OUTPUT_CORPUS, ids=CLOSE_OUTPUT_CORPUS)
+    def test_close_target_byte_identical_base_to_head(self, cmd):
+        base = load_baseline_5017d1f2()
+        assert base._extract_close_target(cmd) == mgc._extract_close_target(cmd), (
+            "close target OUTPUT changed base->HEAD under the _classify_pr_target refactor: %r" % cmd
+        )
+        # And the classification tail IS the shared SSOT now (merge reuses it).
+        assert mgc._extract_close_target(_GH + "close feature -d") == "branch:feature"
+
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# FINDING #4 (Workflow-sweep, HIGH — inert-help VALUE-OPTION blindness, both arms). The
+# `git help <sub>` head-form recognizer AND the `-h`/`--help` flag-loop in _is_inert_help_leg
+# derived their subcommand/help position from a token stream that did NOT account for git's
+# LEADING global VALUE-options (-C / --work-tree / --git-dir / --namespace). So a value
+# literally "help" (head-form arm) or literally "-h"/"--help" (flag-loop arm) was mis-read as
+# the help subcommand / a help flag, and a REAL destructive leg was blanked as inert. A CLEAN
+# C1 regression (base 5017 gated True; the C1-introduced recognizer un-gated it). Fix @4e3b5235
+# (both arms): is_git_gh_head + immediate-adjacency `raw[head+1]=="help"` (head-form), and a
+# subcommand ANCHOR (first non-dash raw token after the head) guarding the -h/--help flag-loop
+# (`… and i >= anchor`). Enumeration-FREE (structural anchor, NOT a git-option list). gh's -R
+# is already covered by C1b's _INERT_HELP_EXTRA_VALUE_FLAGS — an ORTHOGONAL arm, untouched.
+# ═════════════════════════════════════════════════════════════════════════════════
+_GITX = "git "
+_PUSHF = "push " + "--force origin main"           # -> "push --force origin main" (assembled, inert source)
+_PUSHDEL = "push " + "origin --delete feature"     # -> "push origin --delete feature"
+_BRDEL = "branch " + "-D feature"                  # -> "branch -D feature"
+
+# 6 head-form + 4 flag-loop GIT forms — each a REAL destructive leg whose git-global-value-
+# option's value ("help" or "-h"/"--help") was mis-read as inert. ALL MUST GATE at the fix.
+F4_HEAD_FORM = [
+    _GITX + "-C help " + _PUSHF,
+    _GITX + "-C help " + _PUSHDEL,
+    _GITX + "-C help " + _BRDEL,
+    _GITX + "--work-tree help " + _PUSHF,
+    _GITX + "--namespace help " + _PUSHF,
+    _GITX + "--git-dir help " + _PUSHF,
+]
+F4_FLAG_LOOP = [
+    _GITX + "-C -h " + _PUSHF,
+    _GITX + "--work-tree -h " + _PUSHF,
+    _GITX + "--git-dir --help " + _PUSHF,
+    _GITX + "--namespace -h " + _BRDEL,
+]
+F4_GATE = F4_HEAD_FORM + F4_FLAG_LOOP
+# gh -R -h pr merge — ALREADY gated via C1b's -R value-skip (the orthogonal arm); a stays-gated
+# double-coverage control (NOT closed by the finding-#4 git-option fix).
+F4_GH_R_CONTROL = "gh " + "-R -h " + "pr " + "merge"
+# genuine inert help forms that MUST stay inert (no reopened over-block from the fix).
+F4_INERT = [
+    _GITX + "help " + "push",                        # genuine git help
+    "gh " + "help " + "pr " + "merge",               # gh help head-form
+    _GH + "merge --help", _PG + "--force --help",    # subcommand help
+    _GITX + "push " + "-h",                          # genuine post-subcommand help
+    _GITX + "-C /repo " + "push " + "-h",            # -C value /repo then post-subcommand -h
+]
+# C1b value-decoys (gh short/long value-flag value == -h) stay gated (orthogonal arm).
+F4_DECOY_GATED = [_GH + "merge 5 --subject -h", _GH + "merge 5 -t -h", _GH + 'merge 5 --subject "x --help y"']
+# ACCEPTED adversarial-only structurally-inherent residual (architect #84 + security #85 ruled
+# ACCEPT): -C's non-dash value /repo stops the anchor early, so --work-tree's -h reads as help.
+F4_RESIDUAL = _GITX + "-C /repo --work-tree -h " + _PUSHF
+
+
+class TestFinding4ValueOptionInertBlindness:
+    """The 10 GIT value-option forms RE-GATE at the fix (the durable positive regression-guard);
+    gh -R orthogonal-stays-gated; genuine inert forms + C1b decoys unchanged; the double-value-
+    option residual pinned as an ACCEPTED structurally-inherent adversarial-only residual."""
+
+    @pytest.mark.parametrize("cmd", F4_GATE, ids=F4_GATE)
+    def test_git_value_option_form_gates(self, cmd):
+        # DURABLE REGRESSION GUARD: any future re-un-gating of these reds directly. base 5017
+        # ALSO gates (True) — the C1-introduced recognizer regressed it; the fix RE-gates.
+        assert D(cmd) is True, "FINDING #4 REGRESSION: a real destructive git value-option leg was blanked as inert: %r" % cmd
+        assert _base()(cmd) is True, "base 5017 does not gate this form (mislabeled): %r" % cmd
+
+    def test_gh_dash_r_stays_gated_c1b_orthogonal(self):
+        assert D(F4_GH_R_CONTROL) is True, "gh -R -h pr merge un-gated — C1b's orthogonal -R skip regressed"
+
+    @pytest.mark.parametrize("cmd", F4_INERT, ids=F4_INERT)
+    def test_inert_controls_stay_inert(self, cmd):
+        assert D(cmd) is False, "FINDING #4 fix OVER-BLOCKED a genuine inert help form (cardinal): %r" % cmd
+
+    @pytest.mark.parametrize("cmd", F4_DECOY_GATED, ids=F4_DECOY_GATED)
+    def test_c1b_value_decoys_stay_gated(self, cmd):
+        assert D(cmd) is True, "a C1b value-decoy un-gated under the finding-#4 fix: %r" % cmd
+
+    def test_accepted_adversarial_residual_pinned(self):
+        # PINNED-CURRENT-BEHAVIOR (NOT should-gate), modeled on the curl/wget WON'T-FIX +
+        # force_push_implicit KD-3 accepted residuals. Architect #84 empirically proved closing
+        # it (option b) breaks `git --no-pager push -h` (a cardinal over-block) or needs a
+        # rot-prone git-global-option arity enumeration; both lanes ruled ACCEPT. If this form
+        # ever CHANGES (gates, or the anchor shifts), this reds and forces a re-confirm of the
+        # disposition rather than a silent shift.
+        assert D(F4_RESIDUAL) is False, (
+            "the ACCEPTED double-value-option residual changed behavior — re-confirm the "
+            "architect(#84)/security(#85) disposition, do NOT silently update this pin: %r" % F4_RESIDUAL
+        )
+
+    def test_reverted_fix_reopens_all_10_git_forms(self, monkeypatch):
+        # NON-VACUITY (mechanism a; intra-arc-born so a 5017 differential is vacuous —
+        # base==PATCH==True). PROGRAMMATIC SOURCE-REVERT of BOTH fix symbols: take the LIVE
+        # _is_inert_help_leg source, string-replace ONLY the two fix anchors, exec, monkeypatch.
+        # The rev!=src + both-symbols-gone VACUITY GUARD means a future fix-shape change trips
+        # this LOUDLY instead of going silently vacuous.
+        import inspect
+        src = inspect.getsource(mgc._is_inert_help_leg)
+        rev = src.replace('tok in ("--help", "-h") and i >= anchor', 'tok in ("--help", "-h")')   # ARM 2
+        rev = rev.replace('raw[head + 1] == "help"', '"help" in raw[head + 1:]')                    # ARM 1
+        assert rev != src and "and i >= anchor" not in rev and 'raw[head + 1] == "help"' not in rev, (
+            "the finding-#4 fix symbols were not found in _is_inert_help_leg's live source — the "
+            "reverted-body neuter is INERT (the fix shape changed); re-derive the revert"
+        )
+        ns = dict(mgc.__dict__)
+        exec(rev, ns)
+        monkeypatch.setattr(mgc, "_is_inert_help_leg", ns["_is_inert_help_leg"])
+        reopened = [c for c in F4_GATE if D(c) is False]
+        assert len(reopened) == len(F4_GATE), (
+            "reverting both fix symbols did NOT reopen all 10 GIT forms — the fix is not the "
+            "attributable closer, so the gate rows prove nothing: still-gated=%r"
+            % [c for c in F4_GATE if D(c) is True]
+        )
+        assert D(F4_GH_R_CONTROL) is True, (
+            "gh -R -h un-gated under the finding-#4 revert — the revert touched C1b's orthogonal "
+            "-R arm, not just the git-global-option anchors"
         )


### PR DESCRIPTION
## Summary

Closes the fixable merge-guard **over-blocks** on force-push and inert-help command surfaces (#1203). Through peer review and an independent adversarial sweep, the arc also remediated the regressions and target-precision gaps those reviews surfaced. `is_dangerous` is unchanged for every faithful destructive command — the guard still routes them through approval; nothing is un-gated. What changed is that faithful destructive commands whose approval click previously could not mint an authorizing identity now can.

## Over-blocks closed

1. **Implicit force-push** (`git push --force`, `-f`, remote-only) — target-blind `force_push_implicit` sentinel, populated only when no explicit target key is present, matched op-type-first.
2. **Bare `gh pr merge`** (and `--admin`/`--squash` with no PR) — target-blind `merge_implicit`, merge-only with a CLI-shape gate so an API-endpoint merge (explicit PR) is excluded.
3. **Inert `--help`** — a `--help`/`-h` flag or `help` subcommand executes nothing; generalized per-leg recognition (a real destructive leg in a compound still gates), across both the head-form and the flag-loop (a git global value-option whose value was literally `help`/`-h`/`--help` was misread — closed by two enumeration-free structural predicates on the raw token stream).
4. **Force-push remote cross-auth** — the target-blind identity discarded the explicit remote, so `git push --force origin` cross-authorized `git push --force upstream` within the token window. Closed by a **remote-qualified identity** for the forms that carry an explicit remote; the bare form (runtime-unknowable remote) stays target-blind and the explicit-ref path is untouched.
5. **URL-remote force-push** — a faithful force-push to a URL remote (`git@host:repo`, `ssh://…`, `https://…`) was gated-but-unmintable (the colon separator excluded colon-bearing remotes). Closed by reframing the identity separator to a **content-agnostic length-prefixed encoding** (the existing netstring helper), injective for any remote string, and dropping the exclusion — every single-positional form now binds a distinct, self-authorizing-only identity. Also closes the collateral `git push --force HEAD` (a remote literally named `HEAD`) over-block.

## Remediations (peer review + adversarial sweep)

- **Merge target-distinctness (M1)** — `gh pr merge <branch>` / `<url>` collapsed into the target-blind sentinel (cross-repo cross-auth). Fixed by a shared, injective, host-qualified target classifier; the merge value-flag set is **derived** from the SSOT (a hand-narrowed set that dropped `--match-head-commit` was caught in review and reverted).

## Accepted residual (WON'T-FIX by construction)

- **Double-value-option inert-help** — `git -C /repo --work-tree -h push --force` stays un-gated (a leading non-dash-valued global option satisfies the subcommand anchor early). Adversarial-only (a work-tree literally named `-h` plus double-option stacking); closing it would require flag-arity enumeration that itself introduces a **cardinal over-block** on `git --no-pager push -h` (empirically proven).

## Deferred (separate trackers)

- **Explicit-ref force-push remote-blindness** — `git push --force origin main` vs `… upstream main` still cross-authorize (both bind `target_ref=main`). Pre-existing; the explicit-ref sibling of the implicit cross-auth closed here.
- **#1204** — `_extract_pr_number` short value-flag mint-target misbind (adversarial-only).
- **#1205** — bare `git push --force-with-lease` ungated (a good-faith under-block, opposite direction from this PR's over-block remit).

## Certification & review

`test_merge_guard_1203_cert.py` — per-remediation regression rows: positive `is_dangerous` / identity assertions (the durable guard) + programmatic reverted-predicate known-bads with vacuity guards + accepted-residual pins + a self-authorizing-only injectivity guard. Frozen fixtures + vendored parent baseline byte-untouched. **Full suite: 12493 passed, 15 skipped, 0 failed, 0 errors.**

Verified across independent lanes: architect coherence (×4), security adversarial review (×4, each with a post-commit byte-identity confirmation), test-engineer certification, and an independent multi-agent adversarial sweep of the shipped bytes.

## Version

PATCH → **v4.6.11** (over-block fixes + in-review regression/target-precision remediations; no new command/agent surface).
