### PR TITLE
Enumerate the causes behind a no-task-assigned denial, and document the setting that restores the tools

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.12",
+      "version": "4.6.13",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.12/       # Plugin version
+│               └── 4.6.13/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ PACT turns one AI into a coordinated dev team. Instead of a single Claude guessi
 ## Quick Start
 
 > **Prerequisite:** PACT requires [Agent Teams](#enabling-agent-teams), which is experimental and disabled by default. Add `"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"` to the `"env"` section of your `~/.claude/settings.json` before installing.
+>
+> **Conditional prerequisite:** if specialist agents refuse to spawn once PACT is installed, one further setting may be required — see [If specialist agents will not spawn](#if-specialist-agents-will-not-spawn). Check before you set it. It carries a real cost, and most installs never need it.
 
 **1. Install the plugin**
 
@@ -385,9 +387,44 @@ The `env` setting enables Agent Teams. The `permissions.additionalDirectories` e
 
 > **Note:** Bash allow rules are intentionally omitted — they are [fragile](https://docs.anthropic.com/en/docs/claude-code/settings#permission-settings) for commands with arguments. When agents run `mkdir` or `rm` in `~/.claude/` paths, select **"Yes, and always allow from this project"** to add the rule automatically.
 
-Without the `env` setting, PACT commands like `/PACT:orchestrate` and `/PACT:comPACT` will fail to spawn specialist agents.
+Without the `env` setting, PACT commands like `/PACT:orchestrate` and `/PACT:comPACT` will fail to spawn specialist agents. If they still fail *with* the setting in place, see [If specialist agents will not spawn](#if-specialist-agents-will-not-spawn) below.
 
 > **Note:** Agent Teams have [known limitations](https://code.claude.com/docs/en/agent-teams#limitations) around session resumption, task coordination, and shutdown behavior. See the Claude Code docs for details.
+
+#### If specialist agents will not spawn
+
+**Symptom.** Every attempt to start a specialist is refused, and the refusal blames a missing task assignment. Creating that task is itself impossible, because the tools that create tasks are absent from the session. Claude Code decides server-side, based on the model a session is running, whether to withhold them. The session cannot recover on its own — the bootstrap step never completes, so file edits and further spawns stay blocked as well.
+
+**First, confirm this is what you are hitting.** In the stuck session, ask Claude:
+
+```
+Can you see all four of these tools right now: TaskCreate, TaskUpdate, TaskList,
+TaskGet? If your tools load on demand, run ToolSearch with the query
+select:TaskCreate,TaskUpdate,TaskList,TaskGet and tell me which of the four
+are present.
+```
+
+- **Any of the four missing** — this is the problem, and the setting below fixes it.
+- **All four present** — this is *not* the problem, and the setting below will not help. Something else is refusing the spawn; this check rules out one cause, not the rest.
+
+**The setting.** Add `DISABLE_GROWTHBOOK` to the `env` block of your `~/.claude/settings.json`, alongside the Agent Teams setting, then start a new session. A session that has already been denied the tools does not pick them up again, so the stuck one cannot be rescued:
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "DISABLE_GROWTHBOOK": "1"
+  }
+}
+```
+
+**What it costs you.** The setting is blunt: it turns off Claude Code's remote configuration channel entirely. Every remotely-controlled option reverts to its built-in default, and Remote Control stops working. That channel is also the vendor's fastest lever for responding to an incident, so leaving this in place permanently opts you out of server-side mitigations that would otherwise reach you between releases.
+
+**The other side of the same trade.** Turning the channel off also means a vendor-controlled switch can no longer change how your already-installed client behaves. A reader who treats that capability as attack surface will see this setting as a hardening measure rather than a concession. Both readings are correct; which one governs depends on whether you are more exposed to a mitigation that never arrives or to a behavior change you never reviewed.
+
+**Taking it back out.** This is a workaround for current platform behavior, not a standing recommendation — the gate is server-controlled and can change without notice, so expect to remove this setting eventually.
+
+To find out whether you still need it, delete the entry, **start a new shell, and start a new session from that shell**, then run the check above. All three steps matter, because environment values propagate asymmetrically: a value added to `settings.json` reaches processes that are already running, but removing it does not retract it from them; a value set in a shell profile only affects shells started afterwards; and a value exported by hand in a live shell survives both. Deleting the line and re-testing in place tells you nothing.
 
 ### Optional dependencies
 

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.12",
+  "version": "4.6.13",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.12
+> **Version**: 4.6.13
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/bootstrap_gate.py
+++ b/pact-plugin/hooks/bootstrap_gate.py
@@ -379,10 +379,28 @@ _SECRETARY_AGENT_TYPE = "pact-secretary"
 # shared/marker_schema.py — the SSOT shared by producer
 # (bootstrap_marker_writer.py) and this verifier. Imported above.
 
+# The trailing clause is a POINTER, not a diagnosis. This gate reads no task
+# store and carries no rule identifier, so it cannot tell WHY bootstrap has not
+# completed — and the overwhelmingly common answer is the benign one: the
+# ritual simply has not been run yet. The clause is therefore CONDITIONED on a
+# symptom the reader can observe for themselves, never phrased as advice to go
+# change a setting. Routing a user who has merely not bootstrapped toward a
+# high-blast-radius configuration change would be actively harmful, which is
+# why the condition comes first and the pointer second.
+#
+# "State-independent" here means TRUE in every state, not RECOMMENDING THE SAME
+# ACTION in every state: when the condition does not hold the clause asks
+# nothing of the reader.
+#
+# Any change to this text must be mirrored into
+# ``_CANONICAL_DENY_REASON_LITERAL`` in tests/test_bootstrap_gate.py. That
+# two-site edit is the deny-reason drift detector's intended review path.
 _DENY_REASON = (
     "PACT bootstrap required. Invoke Skill(\"PACT:bootstrap\") first. "
     "Code-editing tools (Edit, Write) and agent dispatch (Agent) are blocked "
-    "until bootstrap completes. Bash, Read, Glob, Grep are available."
+    "until bootstrap completes. Bash, Read, Glob, Grep are available. "
+    "If bootstrap cannot complete because the task-management tools are "
+    "unavailable, see \"Enabling Agent Teams\" in the PACT README."
 )
 
 

--- a/pact-plugin/hooks/bootstrap_gate.py
+++ b/pact-plugin/hooks/bootstrap_gate.py
@@ -392,6 +392,15 @@ _SECRETARY_AGENT_TYPE = "pact-secretary"
 # ACTION in every state: when the condition does not hold the clause asks
 # nothing of the reader.
 #
+# The pointer is an ABSOLUTE URL rather than a section name, and that is not a
+# style choice. The README shipped INSIDE the plugin package does not contain
+# that section — it lives in the repository README — so a reader who searches
+# their local copy for a quoted section title finds nothing, which is worse
+# than no pointer at all. This URL is already the established convention in
+# the shipped README, which links it twice. It also lands on the section
+# together with its cost paragraph, which a terse local restatement would
+# drop. Do NOT "simplify" this back to a section name.
+#
 # Any change to this text must be mirrored into
 # ``_CANONICAL_DENY_REASON_LITERAL`` in tests/test_bootstrap_gate.py. That
 # two-site edit is the deny-reason drift detector's intended review path.
@@ -400,7 +409,8 @@ _DENY_REASON = (
     "Code-editing tools (Edit, Write) and agent dispatch (Agent) are blocked "
     "until bootstrap completes. Bash, Read, Glob, Grep are available. "
     "If bootstrap cannot complete because the task-management tools are "
-    "unavailable, see \"Enabling Agent Teams\" in the PACT README."
+    "unavailable, see "
+    "https://github.com/Synaptic-Labs-AI/PACT-Plugin#enabling-agent-teams"
 )
 
 

--- a/pact-plugin/hooks/dispatch_gate.py
+++ b/pact-plugin/hooks/dispatch_gate.py
@@ -556,8 +556,16 @@ def _augment_deny_with_stale_diagnosis(
         for the STALE team, so a marker-gated check would miss exactly the case
         this diagnoses.
       * When the shared detector returns None (no mismatch — the healthy case,
-        or CLAUDE.md absent as in worktrees), the ORIGINAL message is preserved
-        verbatim. The augmentation is purely additive on a detected mismatch.
+        or CLAUDE.md absent as in worktrees), THIS FUNCTION returns the
+        ORIGINAL message unchanged. The augmentation is purely additive on a
+        detected mismatch.
+
+    SCOPE OF THAT LAST CLAIM: it describes THIS FUNCTION's return value, NOT
+    the text the gate finally emits. ``_compose_deny_diagnosis`` reads an
+    unchanged return as "the incumbent did not fire" and may then append the
+    rule-⑧ cause enumeration. So on ``no_task_assigned`` the emitted deny can
+    carry appended text even though this function preserved the message
+    verbatim. The contract here is unchanged; only its consumer is new.
     """
     try:
         if rule not in _STALE_DIAGNOSABLE_RULES:
@@ -573,6 +581,167 @@ def _augment_deny_with_stale_diagnosis(
         # The deny itself is unaffected; only the optional self-diagnosis is
         # dropped. NEVER re-raise out of the dispatch path.
         return message
+
+
+# Appended to the rule-⑧ deny when no stale-team mismatch was detected.
+#
+# Rule ⑧ fires whenever no task with this owner is OBSERVED, and that is
+# already a conflated signal: an unreadable store, a symlink escape, an unsafe
+# team name and an I/O error all look identical to an empty store from inside
+# this gate. So the text ENUMERATES the known causes and hands the reader a
+# check they can run themselves, rather than asserting a cause this gate has no
+# way to determine. The framing is deliberately OBSERVATION, not existence.
+#
+# ACTION-FIRST ordering: the check and the pointer come before the cause list,
+# so anything downstream that truncates leaves the actionable part intact.
+#
+# The branch arms NARROW, they do not CLOSE. "All four present" eliminates
+# cause (3) and claims nothing further, because the four causes below are the
+# KNOWN ones rather than a proven-exhaustive set. Naming the complement ("you
+# are in case (1), (2) or (4)") would send a reader outside that set to chase
+# three wrong causes, which is the very defect this text exists to fix.
+#
+# Cause (1) is worded to COVER the store-clearing case rather than leaving it
+# uncovered, and the earlier "creation was genuinely skipped" is exactly what
+# it must not say. The task store is periodically cleared, so a task can be
+# created and then vanish before the spawn is evaluated — leaving a readable,
+# correctly-resolved, genuinely-empty store, which reads as none of (1)-(4).
+# The remedy for that reader is already (1)'s remedy, so the fix is to widen
+# (1)'s DESCRIPTION, not to add a fifth entry. Wording it as an assertion that
+# creation never happened would invite the one reader who KNOWS they created
+# the task to dismiss the only cause whose action would have helped them.
+#
+# Stated as the OBSERVABLE ("created and since cleared") rather than by naming
+# the clearing mechanism: that mechanism is undocumented and its trigger is
+# unknown, so naming it here would present an internal as a stable interface.
+#
+# The self-check is POSITIVE-ONLY, and that is load-bearing. A permissions
+# error PROVES cause (4); listing the store successfully proves NOTHING —
+# ``ls`` follows symlinks and validates no containment, while this gate's
+# iterator refuses a symlink escape, so a team dir symlinked outside the tasks
+# root makes this gate deny while ``ls`` lists fine. A negative arm would
+# therefore report "not case (4)" in precisely the case that IS (4). A cue that
+# NARROWS is admissible; an assertion that ELIMINATES is not.
+#
+# The remedy for cause (3) is a pointer, never an inlined setting: it is a
+# conditional prerequisite with real blast radius, and a deny message cannot
+# carry the cost statement that has to accompany it.
+_CAUSE_ENUMERATION = (
+    "\n\n"
+    "DIAGNOSIS — this gate did not OBSERVE a task assigned to this owner.\n"
+    "That is not the same as one not existing.\n"
+    "\n"
+    "TO NARROW IT DOWN, confirm all four task tools are available to you:\n"
+    "    ToolSearch \"select:TaskCreate,TaskUpdate,TaskList,TaskGet\"\n"
+    "  Any missing      -> case (3) below. See \"Enabling Agent Teams\" in the\n"
+    "                      PACT README for the setting that restores them,\n"
+    "                      and its trade-offs.\n"
+    "  All four present -> not case (3). That rules out one cause, not the rest.\n"
+    "If listing the task store reports a PERMISSIONS ERROR, you are in case (4).\n"
+    "\n"
+    "KNOWN CAUSES:\n"
+    " (1) No task exists for this owner — never created, or created and since\n"
+    "     cleared. Create the teachback task + the work task, then re-dispatch.\n"
+    " (2) This session's recorded team no longer matches the live one, so this\n"
+    "     gate reads a different task store than the one the task tools write.\n"
+    "     Completing the bootstrap ritual rewrites those records.\n"
+    " (3) The task-management tools are not available in this session at all.\n"
+    "     They can be withheld by a server-controlled feature gate keyed on the\n"
+    "     session's model — in which case (1) cannot be satisfied, because the\n"
+    "     tool needed to create the task is itself absent.\n"
+    " (4) The task store could not be READ — a permissions error, a relocated\n"
+    "     or unreadable store directory, or an I/O fault. This gate cannot\n"
+    "     distinguish an unreadable store from an empty one.\n"
+)
+
+
+# Fail-closed fallback for a violated precondition. Every DENY path in
+# ``evaluate_dispatch`` supplies a real message (11 of 11, verified by
+# enumeration), so this is UNREACHABLE today. It exists because the failure
+# DIRECTION of the alternative is wrong, not because the case is expected.
+#
+# Without it, a non-str ``message`` makes the concatenation below raise
+# TypeError — and the composer runs OUTSIDE the ``try`` that guards
+# ``evaluate_dispatch``, so nothing catches it. The hook would exit 1, and a
+# nonzero-non-2 exit is NON-BLOCKING: the tool call proceeds. A gate whose
+# entire job is to refuse would silently become a pass-through, which is the
+# one direction it must never fail in.
+#
+# Returning a string instead keeps the deny intact: ``main()`` derives exit 2
+# from the DECISION, never from this text. The text is deliberately a real
+# sentence rather than an empty string — ``reason or ""`` would trade a crash
+# for a blank denial, which fails closed but tells the operator nothing.
+_MISSING_DENY_REASON = (
+    "PACT dispatch_gate: dispatch DENIED, but the gate produced no reason "
+    "text. That is an internal defect in the gate itself, not a problem with "
+    "the dispatch. The denial stands."
+)
+
+
+def _compose_deny_diagnosis(
+    rule: str | None, message: str | None, input_data: dict,
+) -> str:
+    """Return the user-facing deny text: the incumbent stale-team diagnosis if
+    it fired, ELSE the cause enumeration on rule ⑧, ELSE ``message`` unchanged.
+
+    A-xor-B BY CONSTRUCTION — the two blocks are mutually exclusive, and the
+    precedence lives HERE, in one dispatcher, rather than as a call-order
+    agreement between two sites in ``main()``. An ordering convention has no
+    mechanism to survive the next edit of ``main()``; this does.
+
+    The incumbent wins because SPECIFIC EVIDENCE BEATS A GENERIC LIST: once the
+    detector has actually identified the mismatch, appending a four-cause "it
+    could be any of these" block would degrade a precise diagnosis into a vague
+    one.
+
+    NEVER RAISES. Its OWN BODY does no I/O and is a pure function of its
+    arguments — one string comparison and one concatenation.
+
+    IT IS NOT I/O-FREE OVERALL, and the distinction is load-bearing. It
+    delegates to ``_augment_deny_with_stale_diagnosis``, which calls
+    ``detect_stale_session_block``, which reads ``CLAUDE_PROJECT_DIR`` and
+    performs ``Path.exists()`` + ``Path.read_text()`` against the project
+    CLAUDE.md. The return value therefore depends on disk contents, not on the
+    arguments alone.
+
+    The true and load-bearing claim is ZERO **NEW** I/O: that read is
+    PRE-EXISTING on exactly this path, so this change adds no filesystem work
+    and cannot introduce the fail-open hang that a new unbounded read would.
+    Writing "no I/O" instead would be false, and would invite a future author
+    to relocate this call somewhere the read WOULD be new — which is precisely
+    the safety case this gate rests on.
+
+    It is called strictly AFTER ``_journal_decision`` has recorded the
+    canonical reason, so the journal keeps the un-augmented text regardless of
+    what this returns.
+
+    GRACEFUL DEGRADATION: the incumbent is itself never-raises and returns
+    ``message`` unchanged on any internal failure, which is indistinguishable
+    here from "no mismatch detected". A detector failure therefore falls
+    through to the enumeration — A's failure degrades INTO B, never into
+    silence.
+
+    Note the ``augmented != message`` test infers "the incumbent fired" from a
+    VALUE DIFFERENCE rather than from a flag the incumbent sets. That is sound
+    only because the incumbent's fire path is append-only with a non-empty
+    suffix, so a fired call is always strictly longer. If that ever stops
+    holding, this must become an explicit fired-signal rather than a smarter
+    comparison.
+
+    TOTAL over its argument types: a non-str ``message`` returns the fail-closed
+    fallback rather than raising. See ``_MISSING_DENY_REASON`` for why the
+    annotation alone is not sufficient here — an unenforced precondition on
+    this particular function fails OPEN.
+    """
+    if not isinstance(message, str):
+        return _MISSING_DENY_REASON
+
+    augmented = _augment_deny_with_stale_diagnosis(rule, message, input_data)
+    if augmented != message:
+        return augmented
+    if rule == "no_task_assigned":
+        return message + _CAUSE_ENUMERATION
+    return message
 
 
 def main() -> None:
@@ -613,12 +782,13 @@ def main() -> None:
         print(_SUPPRESS_OUTPUT)
         sys.exit(0)
     if decision == "DENY":
-        # MESSAGE-ONLY self-diagnosis: on a restart-symptom deny rule, append a
-        # stale-team/store mismatch explanation + re-align steps when detected.
+        # MESSAGE-ONLY self-diagnosis: either the stale-team/store mismatch
+        # explanation (when detected) or, on rule ⑧, the cause enumeration —
+        # never both, per the A-xor-B precedence inside the composer.
         # Journaling above recorded the canonical (un-augmented) reason; this
         # augments ONLY the user-facing message and never the decision. The
-        # helper is never-raises — on any error the original reason stands.
-        deny_message = _augment_deny_with_stale_diagnosis(rule, reason, input_data)
+        # composer is never-raises — on any error the original reason stands.
+        deny_message = _compose_deny_diagnosis(rule, reason, input_data)
         print(json.dumps({
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",

--- a/pact-plugin/hooks/dispatch_gate.py
+++ b/pact-plugin/hooks/dispatch_gate.py
@@ -626,16 +626,42 @@ def _augment_deny_with_stale_diagnosis(
 # The remedy for cause (3) is a pointer, never an inlined setting: it is a
 # conditional prerequisite with real blast radius, and a deny message cannot
 # carry the cost statement that has to accompany it.
+#
+# That pointer is an ABSOLUTE URL rather than a section name. The README
+# shipped INSIDE the plugin package does not contain that section — it lives
+# in the repository README — so a reader searching their local copy for a
+# quoted section title finds nothing, which is worse than no pointer at all.
+# The shipped README already links this exact URL twice, so this follows an
+# established convention rather than inventing one. The URL also lands on the
+# section TOGETHER WITH its cost paragraph, which is the entire reason the
+# remedy is a pointer; a terse local restatement would drop it. Do NOT
+# "simplify" this back to a section name.
+#
+# THE OPENING QUALIFIER IS LOAD-BEARING, not throat-clearing. The rule-⑧ base
+# message ends with an unhedged imperative — create the teachback task and the
+# work task — and that instruction is CORRECT only under cause (1). Under (2)
+# the tasks land in a store this gate does not read, under (3) they cannot be
+# created at all, and under (4) they cannot be read back; in every one of
+# those an operator who acts on the first sentence burns a cycle and gets a
+# byte-identical denial. The base message CANNOT be edited (the journalled
+# reason is pinned byte-identical to base), so the qualification has to live
+# here — and it has to REACH BACK and name that instruction explicitly. A
+# general hedge about observation-versus-existence does not do that, because
+# by the time it registers the reader has already acted on the imperative.
 _CAUSE_ENUMERATION = (
     "\n\n"
     "DIAGNOSIS — this gate did not OBSERVE a task assigned to this owner.\n"
     "That is not the same as one not existing.\n"
     "\n"
+    "The instruction above resolves cause (1) ONLY. Under (2), (3) and (4)\n"
+    "creating the tasks changes nothing and this denial repeats unchanged,\n"
+    "so identify the cause before acting on that instruction.\n"
+    "\n"
     "TO NARROW IT DOWN, confirm all four task tools are available to you:\n"
     "    ToolSearch \"select:TaskCreate,TaskUpdate,TaskList,TaskGet\"\n"
-    "  Any missing      -> case (3) below. See \"Enabling Agent Teams\" in the\n"
-    "                      PACT README for the setting that restores them,\n"
-    "                      and its trade-offs.\n"
+    "  Any missing      -> case (3) below. For the setting that restores\n"
+    "                      them, and its trade-offs, see\n"
+    "                      https://github.com/Synaptic-Labs-AI/PACT-Plugin#enabling-agent-teams\n"
     "  All four present -> not case (3). That rules out one cause, not the rest.\n"
     "If listing the task store reports a PERMISSIONS ERROR, you are in case (4).\n"
     "\n"
@@ -715,11 +741,17 @@ def _compose_deny_diagnosis(
     canonical reason, so the journal keeps the un-augmented text regardless of
     what this returns.
 
-    GRACEFUL DEGRADATION: the incumbent is itself never-raises and returns
-    ``message`` unchanged on any internal failure, which is indistinguishable
-    here from "no mismatch detected". A detector failure therefore falls
-    through to the enumeration — A's failure degrades INTO B, never into
-    silence.
+    GRACEFUL DEGRADATION, and note it is RULE-SCOPED. The incumbent is itself
+    never-raises and returns ``message`` unchanged on any internal failure,
+    which is indistinguishable here from "no mismatch detected". On
+    ``no_task_assigned`` a detector failure therefore falls through to the
+    enumeration — A's failure degrades INTO B rather than into silence.
+
+    On ``team_name_unavailable`` — the OTHER member of
+    ``_STALE_DIAGNOSABLE_RULES`` — there is no B, so the same failure degrades
+    into silence, and that is CORRECT: the un-augmented deny is the right
+    output there. Do not read this as a general property of the composer and
+    do not extend the enumeration to that rule to make it one.
 
     Note the ``augmented != message`` test infers "the incumbent fired" from a
     VALUE DIFFERENCE rather than from a flag the incumbent sets. That is sound

--- a/pact-plugin/tests/test_bootstrap_gate.py
+++ b/pact-plugin/tests/test_bootstrap_gate.py
@@ -97,7 +97,9 @@ _SLUG = "project"
 _CANONICAL_DENY_REASON_LITERAL = (
     "PACT bootstrap required. Invoke Skill(\"PACT:bootstrap\") first. "
     "Code-editing tools (Edit, Write) and agent dispatch (Agent) are blocked "
-    "until bootstrap completes. Bash, Read, Glob, Grep are available."
+    "until bootstrap completes. Bash, Read, Glob, Grep are available. "
+    "If bootstrap cannot complete because the task-management tools are "
+    "unavailable, see \"Enabling Agent Teams\" in the PACT README."
 )
 
 

--- a/pact-plugin/tests/test_bootstrap_gate.py
+++ b/pact-plugin/tests/test_bootstrap_gate.py
@@ -99,7 +99,8 @@ _CANONICAL_DENY_REASON_LITERAL = (
     "Code-editing tools (Edit, Write) and agent dispatch (Agent) are blocked "
     "until bootstrap completes. Bash, Read, Glob, Grep are available. "
     "If bootstrap cannot complete because the task-management tools are "
-    "unavailable, see \"Enabling Agent Teams\" in the PACT README."
+    "unavailable, see "
+    "https://github.com/Synaptic-Labs-AI/PACT-Plugin#enabling-agent-teams"
 )
 
 

--- a/pact-plugin/tests/test_dispatch_gate_cause_enumeration.py
+++ b/pact-plugin/tests/test_dispatch_gate_cause_enumeration.py
@@ -1178,3 +1178,163 @@ def test_readme_pointer_has_a_referent():
         "were not updated, or the pointer shipped ahead of its referent. The "
         "shipped README's own links to this anchor break too."
     )
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# No silent "just set this" — the setting never appears without its cost
+# ══════════════════════════════════════════════════════════════════════════
+
+# The setting has exactly ONE spelling and no synonym set. That is what makes
+# the TRIGGER side of this pin complete — see the disclaimer below for the side
+# that is not.
+_SETTING = "DISABLE_GROWTHBOOK"
+
+# Derived from the acceptance criteria, not composed fresh: the blast-radius
+# statement, the verification step, and the retirement note. The remaining
+# criteria (the prerequisite/env-block pairing, and project-agnostic wording)
+# are not co-occurrence properties and are deliberately out of scope here.
+#
+# Matched on SUBSTANTIVE CONTENT rather than on the bold label that introduces
+# each one, so relabelling a paragraph does not red while DELETING it does. A
+# label is presentation; these strings are the claim the criterion asks for.
+_DISCLOSURE_ELEMENTS = {
+    "blast-radius statement": "remote configuration channel",
+    "verification step": "select:TaskCreate,TaskUpdate,TaskList,TaskGet",
+    "retirement note": "not a standing recommendation",
+}
+
+_DOC_SURFACES = ("README.md", "pact-plugin/README.md")
+
+
+def _sections(text):
+    """Split markdown into (heading, body) at every ATX heading, FENCE-AWARE.
+
+    Lines inside ``` fences are never treated as headings. This matters
+    concretely rather than theoretically: the root README has a fenced shell
+    block whose comment lines begin with '#', and a naive splitter segments on
+    them, silently moving the section boundary and letting the co-occurrence
+    check straddle a heading it should have stopped at.
+    """
+    sections, heading, body, fenced = [], "<preamble>", [], False
+    for line in text.splitlines():
+        if line.lstrip().startswith("```"):
+            fenced = not fenced
+        if not fenced and line.startswith("#"):
+            sections.append((heading, "\n".join(body)))
+            heading, body = line.strip(), []
+        else:
+            body.append(line)
+    sections.append((heading, "\n".join(body)))
+    return sections
+
+
+def test_setting_is_never_named_without_its_cost():
+    """Wherever the setting is NAMED, its cost is disclosed in the SAME section.
+
+    WHAT THIS PROVES. The setting cannot be mentioned in an operator-facing
+    markdown surface without the blast-radius statement, the verification step
+    and the retirement note appearing in the same section. On the TRIGGER side
+    this is COMPLETE, and that is unusual enough to be worth stating plainly:
+    ``DISABLE_GROWTHBOOK`` is an environment variable with exactly one spelling
+    and no synonyms, so a mention cannot be reworded out of detection the way a
+    prose concept could. Nobody can add the setting to these files and evade
+    this check except by not adding it.
+
+    WHAT THIS DOES NOT PROVE, and it must not be cited for any of it. The
+    SATISFACTION side is incomplete in three separate ways. (1) It cannot judge
+    ADEQUACY — that a blast-radius paragraph exists says nothing about whether
+    it describes the actual blast radius, or describes it correctly. (2) It
+    cannot judge ADJACENCY IN RENDERED OUTPUT — section containment is not
+    reading order, and an element can satisfy this check while sitting far
+    enough from the setting that a scrolling reader never connects them.
+    (3) It cannot judge SUFFICIENCY OF THE SET — these three elements come from
+    the acceptance criteria, and criteria can be incomplete. So a green result
+    here means "the setting is not named silently"; it does NOT mean "the
+    trade-off is adequately disclosed". Do not cite it for the latter.
+
+    WHICH REVIEW STEP OWNS THE REST. Human review of this subsection's CONTENT
+    at PR time, on the same two-site path the deny-reason literal forces: a
+    change that touches the setting's documentation must re-read the cost
+    paragraph rather than confirm a green. That includes the ordering invariant
+    named in ``test_readme_pointer_has_a_referent`` — verification before
+    remedy — which no artifact can enforce and which this test does not attempt
+    to. If the sole evidence offered for adequate disclosure is that this test
+    passed, the review step has been skipped, not satisfied.
+
+    COUPLED against the absence trap. The co-occurrence rule is an implication,
+    and an implication with no true antecedent is free: delete the whole
+    subsection and every co-occurrence check below passes trivially. So the
+    premise is asserted FIRST — the setting must actually be documented
+    somewhere — which is the same coupling discipline the enumeration pins use.
+    """
+    for name, marker in _DISCLOSURE_ELEMENTS.items():
+        assert marker.isascii(), (
+            f"{name} marker is not ASCII-only: {marker!r}. A marker spanning a "
+            "non-ASCII character invites a transcription that substitutes a "
+            "hyphen for U+2014, after which it silently stops matching."
+        )
+
+    surfaces = {}
+    for rel in _DOC_SURFACES:
+        path = _REPO_ROOT / rel
+        assert path.exists(), f"operator-facing surface missing: {path}"
+        surfaces[rel] = path.read_text(encoding="utf-8")
+
+    # PREMISE — without this the implication below is vacuous.
+    documenting = [rel for rel, text in surfaces.items() if _SETTING in text]
+    assert documenting, (
+        f"{_SETTING} is documented in NONE of {list(_DOC_SURFACES)}, so every "
+        "co-occurrence assertion below passes by absence and this test proves "
+        "nothing. If the setting was removed on purpose, delete this test in "
+        "the same change rather than leaving it green and hollow."
+    )
+
+    for rel in documenting:
+        naming = [
+            (h, b) for h, b in _sections(surfaces[rel]) if _SETTING in b or _SETTING in h
+        ]
+        assert naming, f"{_SETTING} present in {rel} but in no section"
+        for heading, body in naming:
+            missing = {
+                name: marker
+                for name, marker in _DISCLOSURE_ELEMENTS.items()
+                if marker not in body
+            }
+            assert not missing, (
+                f"{rel} names {_SETTING} under {heading!r} without, in the same "
+                f"section: {sorted(missing)}. A reader who applies the setting "
+                "from this section alone does so without being told what it "
+                "costs, how to confirm they need it, or when to take it back "
+                "out. Add the element to THIS section — moving it elsewhere in "
+                "the file satisfies a grep but not the reader."
+            )
+
+
+def test_gate_texts_point_at_the_setting_and_never_inline_it():
+    """The gates carry a POINTER; they must never inline the setting itself.
+
+    A deny message cannot carry the cost statement, the verification step and
+    the retirement note — so a gate that names the setting has necessarily
+    named it silently, which is the one form of disclosure the criteria
+    forbid outright. The pointer exists precisely so the setting is only ever
+    encountered next to its trade-off.
+
+    COUPLED, because a bare absence assertion here would pass if the gate texts
+    were emptied, deleted or renamed out of existence: the positive half
+    asserts each gate still carries its pointer URL. Absence of the setting is
+    only meaningful while the pointer is present to replace it.
+    """
+    for source_name in _GATE_SOURCES:
+        source = (Path(__file__).parent.parent / "hooks" / source_name).read_text(
+            encoding="utf-8"
+        )
+        assert _pointer_urls(source_name), (
+            f"{source_name} carries no pointer URL, so the absence check below "
+            "is vacuous — it would pass on an empty file."
+        )
+        assert _SETTING not in source, (
+            f"{source_name} inlines {_SETTING} into gate text. A deny message "
+            "cannot carry the blast radius, the verification step and the "
+            "retirement note, so naming the setting here discloses it "
+            "silently. Point at the documented section instead."
+        )

--- a/pact-plugin/tests/test_dispatch_gate_cause_enumeration.py
+++ b/pact-plugin/tests/test_dispatch_gate_cause_enumeration.py
@@ -884,6 +884,14 @@ def test_unreadable_store_denies_while_the_owner_matching_task_survives(
     original_mode = stat.S_IMODE(tasks_dir.stat().st_mode)
     os.chmod(tasks_dir, 0o000)
     try:
+        # The state the diagnosis's positive arm describes, established as an
+        # OBSERVATION before the gate runs. Without this the assertion further
+        # down would only show that the sentence is PRESENT, not that it is
+        # TRUE here — which is the whole difference between pinning the text
+        # and pinning the advice.
+        with pytest.raises(PermissionError):
+            os.listdir(tasks_dir)
+
         _reset_context_caches(monkeypatch)
         code_unreadable, out_unreadable = _run_main(_make_input(), capsys)
     finally:
@@ -908,6 +916,81 @@ def test_unreadable_store_denies_while_the_owner_matching_task_survives(
     )
     assert stat.S_IMODE(tasks_dir.stat().st_mode) == original_mode, (
         "the store's mode must be restored"
+    )
+
+    # THE ADVICE, NOT MERELY THE TEXT. The self-check has exactly one arm that
+    # makes a proof-strength claim: a permissions error on the store PROVES
+    # cause (4). Every other test in this file can only show that sentence is
+    # PRESENT. This is the one scenario that is actually IN the state the
+    # sentence describes — the listing above genuinely raised PermissionError —
+    # so here the claim is verified rather than quoted.
+    assert _CAUSE4_POSITIVE_PROOF in reason, (
+        "the sound positive arm is missing from a deny emitted in exactly the "
+        "state it describes: the store raised a permissions error and the "
+        "reader is not told that this proves cause (4)"
+    )
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# The value property the A-xor-B inference rests on
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def test_fired_incumbent_produces_a_strictly_longer_message(
+    tmp_path, monkeypatch, capsys
+):
+    """When the incumbent fires it must return STRICTLY MORE than it was given.
+
+    The composer infers "the incumbent fired" from a value difference rather
+    than from a flag. That inference is sound only while the fire path is
+    append-only with a NON-EMPTY suffix — and nothing was pinning the non-empty
+    part. The concrete regression it admits: shrink the appended text to
+    nothing and a fired incumbent returns the message unchanged, the composer
+    reads that as "did not fire", and the enumeration appends on top of a case
+    the design deliberately suppresses. Silent, and in the wrong direction.
+
+    THE HALF THIS DOES NOT COVER, so it is not mistaken for the whole: "no
+    second path can ever change the message without the incumbent firing" is a
+    universal claim over future code and no test expresses it. That half stays
+    a declared residual with an escalation trigger in the composer docstring.
+    Only the VALUE property is testable today, and it is testable cheaply.
+
+    Coupled against one run: the stale marker present (the incumbent really
+    fired), the emitted text strictly longer than the journaled reason, and the
+    enumeration absent. Length alone would be satisfied by the enumeration
+    appending, which is the very case this must distinguish.
+    """
+    journal = _capture_journal(monkeypatch)
+
+    _full_setup(monkeypatch, tmp_path, tasks=(("someone-else", "pending"),))
+    _write_project_claude_md(monkeypatch, tmp_path, _STALE_SESSION_ID)
+    _reset_context_caches(monkeypatch)
+
+    code, out = _run_main(_make_input(), capsys)
+    emitted = out["hookSpecificOutput"]["permissionDecisionReason"]
+    rule, journaled = _journaled(journal, 0)
+
+    assert code == 2, "the deny must fire"
+    assert rule == "no_task_assigned", f"expected the no-task rule, got {rule!r}"
+
+    # Guards the derived marker itself: _STALE_MARKER is a slice of a
+    # production constant, and an empty constant would make every
+    # "_STALE_MARKER in reason" assertion in this file vacuously true and every
+    # "not in" assertion fail — so pin non-emptiness rather than assume it.
+    assert _STALE_MARKER, (
+        "the derived stale marker is empty — every assertion using it is now "
+        "either vacuous or inverted"
+    )
+    assert _STALE_MARKER in emitted, "the incumbent must actually have fired"
+
+    assert len(emitted) > len(journaled), (
+        "a fired incumbent must return strictly more than it was given; an "
+        "empty suffix makes the composer's fired-vs-not inference undecidable"
+    )
+    assert emitted.startswith(journaled), "the fire path must be append-only"
+    assert _ENUM_MARKER not in emitted, (
+        "the enumeration must stay suppressed when the incumbent fired — if it "
+        "appended here, the length check above passed for the wrong reason"
     )
 
 

--- a/pact-plugin/tests/test_dispatch_gate_cause_enumeration.py
+++ b/pact-plugin/tests/test_dispatch_gate_cause_enumeration.py
@@ -81,6 +81,7 @@ NON-VACUITY DISCIPLINE — the reasons, so a later editor does not undo them:
 
 import json
 import os
+import re
 import stat
 import sys
 from pathlib import Path
@@ -998,64 +999,182 @@ def test_fired_incumbent_produces_a_strictly_longer_message(
 # The pointer has a referent — and that is ALL this section pins
 # ══════════════════════════════════════════════════════════════════════════
 
-# Repo root, per the convention already used by the version-bump suite.
+# Repo root, per the convention already used by the version-bump suite. Used
+# ONLY for the anchor-referent leg below — see the shipped-vs-dev note there.
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
-# The README section both gate texts send the reader to.
-_POINTER_PHRASE = "Enabling Agent Teams"
-_POINTER_HEADING = f"### {_POINTER_PHRASE}"
+# THE SHIPPED ARTIFACT. marketplace.json packages `./pact-plugin` only, so this
+# README is what a consumer actually receives; the repo-root one is NOT
+# packaged. Any pin aimed solely at the repo root tests the DEV surface.
+_SHIPPED_README = Path(__file__).resolve().parent.parent / "README.md"
 
 # Read as SOURCE rather than imported: the dispatch-gate pointer lives inside a
 # post-fix constant, and importing it would make this an import artifact under
 # a revert. Reading the file also keeps one assertion covering both gates.
 _GATE_SOURCES = ("dispatch_gate.py", "bootstrap_gate.py")
 
+# DERIVED from the gate sources, never hand-typed. A hand-typed expected URL is
+# the failure mode this whole test exists to catch, one level up: it would go
+# stale silently the moment the gates changed, and its greenness would then
+# certify agreement with a string nobody emits.
+_POINTER_URL_RE = re.compile(r"https://github\.com/[^\s\"'\\]+#[^\s\"'\\]+")
+
+# THE VERIFIED PAIR — anchor as GitHub actually serves it, and the heading that
+# produces it. Measured, not derived; see the anchor-referent leg for the exact
+# command and why a computed slug would be unsound here. Both halves are pinned
+# so an edit to EITHER side reds, which is what makes this a correspondence
+# check rather than a restatement of one side.
+_VERIFIED_ANCHOR = "enabling-agent-teams"
+_VERIFIED_HEADING = "### Enabling Agent Teams"
+
+
+def _pointer_urls(source_name):
+    """Every anchored GitHub URL emitted by one gate's source."""
+    source = (Path(__file__).parent.parent / "hooks" / source_name).read_text(
+        encoding="utf-8"
+    )
+    return set(_POINTER_URL_RE.findall(source))
+
 
 def test_readme_pointer_has_a_referent():
-    """Both gates name a README section; that section must exist.
+    """Both gates emit a pointer URL; it must resolve from what a consumer has.
 
-    A deny message that sends an operator to a heading which is not there is
-    worse than one that says nothing — it spends the reader's remaining
-    patience on a search that cannot succeed. The two artifacts are edited by
-    different people at different times, and nothing else couples them.
+    A deny message that sends an operator somewhere that is not there is worse
+    than one that says nothing — it spends the reader's remaining patience on a
+    search that cannot succeed. The artifacts are edited by different people at
+    different times, and nothing else couples them.
 
-    COUPLED so it cannot pass by absence: the pointer must be PRESENT in both
-    gate texts AND the heading must exist. Testing only the implication
-    ("if the pointer is present then the heading exists") would pass trivially
-    the moment someone removed the pointer, which is exactly the state this is
-    meant to notice. Removing a pointer legitimately is still allowed — it just
-    has to come here and say so, the same two-site review path the canonical
-    deny-reason literal forces.
+    WHAT THIS PIN DEFENDS, STATED NARROWLY. A full URL in a deny message is
+    SELF-RESOLVING: the reader can follow it holding no README at all. So the
+    pointer's reachability is the URL's doing, not this test's. What this test
+    defends is that the URL is CORRECT — that its anchor has a real referent and
+    that the two gates have not drifted apart. Do not cite it as "consumers can
+    reach the docs"; that claim belongs to the URL and would over-read a green.
+
+    RESOLVE THE SUBJECT THE WAY THE READER DOES — the rule that fixes the aim.
+    An earlier version asserted a heading in the repo-root README while the
+    pointer named a SECTION BY TITLE, so the pin resolved a file the pointer did
+    not name; it stayed green while the pointer dangled. The lesson is NOT
+    "always aim at the packaged path" — under a URL pointer the packaged README
+    is the wrong target and such an assertion could not pass, because the
+    heading legitimately is not there. The aim follows the POINTER: under a URL,
+    the file that URL serves. Whenever the pointer's FORM changes, re-derive
+    this aim rather than carrying it over.
+
+    THE URL IS DERIVED FROM THE GATE SOURCES, never hand-typed. A hand-typed
+    expected URL is the same failure one level up — it goes stale silently the
+    moment the gates change, and then agrees with a string nobody emits.
+
+    COUPLED so it cannot pass by absence. Testing only the implication ("if a
+    pointer is present then it resolves") would pass trivially the moment
+    someone removed the pointer, which is exactly the state this is meant to
+    notice. Removing a pointer legitimately is still allowed — it just has to
+    come here and say so, the same two-site review path the canonical
+    deny-reason literal forces. The four legs, in order of what they carry:
+
+      ESSENTIAL — the anchor corresponds to a real heading in the ROOT README,
+        the file the URL serves. Under a URL pointer this is the correctness
+        case; the shipped README's own links to this anchor depend on it too.
+      ANTI-REGRESSION — both gates carry a URL rather than a bare section name,
+        catching the future author who "simplifies" the pointer back to a
+        readable title. That simplification is what produced the original
+        defect, so this leg is the one guarding against its return.
+      ANTI-DRIFT — the two gates carry the IDENTICAL URL, so they cannot half-
+        answer a reader the other sent somewhere else.
+      CROSS-CHECK — the URL also appears in the shipped README. Corroborating
+        rather than primary under a URL pointer, but it is the leg whose
+        non-vacuity was demonstrated by mutation (the predecessor pin stayed
+        GREEN under the same mutation that reds this one), so it is the one
+        with direct evidence behind it. Do not drop it as redundant.
 
     WHAT THIS DOES NOT PIN, and must not be read as pinning. The clause in the
-    bootstrap gate is safe to over-point partly because its referent OPENS with
-    a falsifiable check — the reader is told how to confirm they have this
-    problem before being shown a high-blast-radius setting. That protection is
-    a property of the PAIR, not of either file: reorder the README section to
-    lead with the remedy and the protection is gone while this test stays
-    green. Verification-before-remedy ordering is a review-time invariant with
-    no artifact that can enforce it. This test pins referent EXISTENCE only.
+    bootstrap gate is safe to over-point partly because the reader is told how
+    to confirm they have this problem before being shown a high-blast-radius
+    setting.
+
+    BE PRECISE ABOUT WHERE THAT PROTECTION LIVES — an earlier draft of this
+    docstring said the referent "opens with a falsifiable check", and it does
+    not. The pointed-at section opens with the Agent Teams settings block. The
+    check lives further down, inside its "If specialist agents will not spawn"
+    SUBSECTION, which opens with "First, confirm this is what you are hitting"
+    and only then reaches "The setting". So the ordering invariant is
+    check-before-remedy WITHIN THAT SUBSECTION, not at the top of the section
+    the gates name. The distinction matters because this paragraph exists for a
+    future auditor re-checking the ordering: one who reads "opens with" lands at
+    the section heading, finds a settings block and no check, and concludes the
+    protection has already been lost when it has not.
+
+    That protection is a property of the PAIR, not of either file: reorder the
+    subsection to lead with the remedy and the protection is gone while this
+    test stays green. Verification-before-remedy ordering is a review-time
+    invariant with no artifact that can enforce it. This test pins referent
+    EXISTENCE only.
     """
-    readme = _REPO_ROOT / "README.md"
-    assert readme.exists(), f"repo README not found at {readme}"
-    readme_text = readme.read_text(encoding="utf-8")
+    per_gate = {name: _pointer_urls(name) for name in _GATE_SOURCES}
 
-    pointing = []
-    for source_name in _GATE_SOURCES:
-        source = (Path(__file__).parent.parent / "hooks" / source_name).read_text(
-            encoding="utf-8"
-        )
-        if _POINTER_PHRASE in source:
-            pointing.append(source_name)
-
-    assert sorted(pointing) == sorted(_GATE_SOURCES), (
-        f"expected both gates to point at {_POINTER_PHRASE!r}; only {pointing} "
+    pointing = sorted(name for name, urls in per_gate.items() if urls)
+    assert pointing == sorted(_GATE_SOURCES), (
+        f"expected both gates to carry an anchored pointer URL; only {pointing} "
         "do. If a pointer was removed on purpose, update this test in the same "
         "change — silently dropping it is what this assertion exists to catch."
     )
 
-    assert _POINTER_HEADING in readme_text, (
-        f"the gates point at a README section {_POINTER_HEADING!r} that does "
-        "not exist. Either the heading was renamed and the gate texts were not "
-        "updated, or the pointer shipped ahead of its referent."
+    emitted = set().union(*per_gate.values())
+    assert len(emitted) == 1, (
+        f"the gates point at {len(emitted)} different URLs: {sorted(emitted)}. "
+        "One referent, or the two gates drift apart and each half-answers a "
+        "reader the other sent somewhere else."
+    )
+    url = emitted.pop()
+
+    # THE SHIPPED-SURFACE LEG. This is the one that must not be aimed at the
+    # repo root: that README is not packaged, so a pin against it stays green
+    # under BOTH the broken and the fixed state, and its greenness then reads as
+    # confirmation of a property it never checked.
+    assert _SHIPPED_README.exists(), (
+        f"shipped README not found at {_SHIPPED_README} — this leg cannot mean "
+        "anything until it points at a file that exists"
+    )
+    shipped_text = _SHIPPED_README.read_text(encoding="utf-8")
+    assert url in shipped_text, (
+        f"the gates emit {url!r}, which does not appear in the SHIPPED README "
+        f"({_SHIPPED_README.name}). marketplace.json packages ./pact-plugin "
+        "only, so that file is the artifact a consumer receives. A URL the "
+        "shipped docs never mention is one nobody can cross-check against the "
+        "artifact they actually have."
+    )
+
+    # ANCHOR-REFERENT LEG — THE ESSENTIAL ONE under a URL pointer. The URL names
+    # the REPO-ROOT README, so that file is the artifact the pointer actually
+    # resolves to; this leg is about GitHub's rendering target, NOT about what
+    # ships, and the two are different files ON PURPOSE.
+    #
+    # THE PAIR BELOW IS A MEASUREMENT, NOT A COMPUTATION, and that distinction
+    # is the whole reason it is written this way. Deriving the slug from the
+    # heading with an assumed lowercase-and-hyphenate rule would pass against a
+    # slug GitHub does not actually serve — this repo has a pinned precedent of
+    # a heading containing an em-dash, which strips to EMPTY and yields a
+    # DOUBLED hyphen where the obvious rule predicts a single one. A computed
+    # slug would then certify the transform rather than the correspondence.
+    #
+    # Verified empirically against GitHub's own renderer rather than assumed:
+    #     gh api repos/<owner>/<repo>/readme -H "Accept: application/vnd.github.html"
+    # which returned id="user-content-enabling-agent-teams" for this heading.
+    # Re-run that command if either side of the pair below changes; do NOT
+    # "simplify" this into a slugger.
+    anchor = url.split("#", 1)[1]
+    assert anchor == _VERIFIED_ANCHOR, (
+        f"the gates now point at anchor {anchor!r}, but the verified pair pins "
+        f"{_VERIFIED_ANCHOR!r}. Re-verify the anchor against GitHub's rendered "
+        "HTML and update BOTH halves of the pair — do not compute the new slug."
+    )
+
+    root_readme = _REPO_ROOT / "README.md"
+    assert root_readme.exists(), f"repo README not found at {root_readme}"
+    assert _VERIFIED_HEADING in root_readme.read_text(encoding="utf-8"), (
+        f"the gates point at anchor {anchor!r}, whose verified referent "
+        f"{_VERIFIED_HEADING!r} is not in the repo-root README that GitHub "
+        "renders at that URL. Either the heading was renamed and the gate texts "
+        "were not updated, or the pointer shipped ahead of its referent. The "
+        "shipped README's own links to this anchor break too."
     )

--- a/pact-plugin/tests/test_dispatch_gate_cause_enumeration.py
+++ b/pact-plugin/tests/test_dispatch_gate_cause_enumeration.py
@@ -7,11 +7,29 @@ team name and an I/O error. ``_compose_deny_diagnosis`` therefore appends a
 four-cause enumeration plus a self-check the reader can run — but only when the
 incumbent stale-team detector did NOT fire, and only on rule ⑧.
 
-SCOPE OF THIS FILE — deliberately partial. It covers the A-xor-B precedence,
-the graceful-degradation path, rule isolation, and the journal-purity property.
-It is NOT the full matrix: the T1-T9 integration matrix and the coupled
-verbatim-equality pin are authored separately and extend THIS file. Do not read
-a green run here as comprehensive coverage of the enumeration.
+SCOPE OF THIS FILE. It covers the A-xor-B precedence on BOTH stale-diagnosable
+rules, the graceful-degradation path, rule isolation, the healthy ALLOW path,
+journal purity, branch completeness across all four causes, advice soundness,
+the emitted-versus-journaled boundary, and cause (4) as a real runtime state.
+
+WHAT A GREEN RUN HERE STILL DOES NOT ESTABLISH — three named residuals, none
+of them a gap that more coverage closes:
+
+  * Whether the text HELPS. Every assertion below is about presence, absence
+    and structure. None of them can tell whether an operator reading this deny
+    cold reaches a correct next action, which is the primary risk of a change
+    that is almost entirely text. That is a review question with a human owner.
+
+  * Advice soundness in NOVEL wording. Two tests here guard known-bad phrasings
+    with denylists, and a phrase denylist over free prose cannot be complete.
+    Each declares the bound in its own docstring; neither is evidence that the
+    text contains no unsound claim.
+
+  * Verification-before-remedy ordering in the README section the gates point
+    at. ``test_readme_pointer_has_a_referent`` pins that the referent EXISTS,
+    and deliberately not that it still leads with a falsifiable check before
+    showing the reader a high-blast-radius setting. That protection is a
+    property of the gate/README pair which no single artifact can enforce.
 
 NON-VACUITY DISCIPLINE — the reasons, so a later editor does not undo them:
 
@@ -51,11 +69,23 @@ NON-VACUITY DISCIPLINE — the reasons, so a later editor does not undo them:
     code, and there is no pre-fix behaviour to compare against. Every test
     that DOES carry revert-cardinality drives ``main()`` end-to-end and
     asserts only on observable deny text.
+
+    EXACTLY TWO, VERIFIED BY MEASUREMENT rather than by reading the names.
+    Under a source-only revert of the gate every failing test's traceback was
+    inspected: 9 fail on assertions, and only the 2 named above fail on the
+    import. Any test added here that imports from ``dispatch_gate`` inside its
+    body joins that list and must be named in it — the check is not "does it
+    look like a unit test", it is "does the symbol it reaches for exist at
+    base".
 """
 
 import json
+import os
+import stat
 import sys
 from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
@@ -63,7 +93,9 @@ from test_dispatch_gate import (  # noqa: E402 — sibling harness reuse
     _make_input,
     _run_main,
     _full_setup,
+    _capture_journal,
     _TEAM,
+    _NAME,
 )
 
 # Pre-existing production symbol — deriving the stale-diagnosis literal from it
@@ -447,4 +479,500 @@ def test_journaled_reason_excludes_the_enumeration(tmp_path, monkeypatch, capsys
     assert journaled == reason[: len(journaled)], (
         "the emitted text must be the journaled reason plus appended diagnosis, "
         "not a rewritten message"
+    )
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# Branch completeness — every KNOWN CAUSE is pinned by its own marker
+# ══════════════════════════════════════════════════════════════════════════
+
+# One ASCII marker per cause. POST-FIX text, so hardcoded rather than derived:
+# importing the constant would raise ImportError under a revert, which is an
+# import artifact rather than a behavioural failure and would disqualify this
+# from the non-vacuity set. Cause (4) reuses the shared discriminator marker
+# rather than typing a second literal for the same span.
+#
+# WHY EACH CAUSE NEEDS ITS OWN MARKER. Prose deletes silently. Measured before
+# this test existed, independently by two parties against the same tree:
+# deleting cause (1), (2) or (3) from the enumeration left the entire suite
+# green at 114 passed. Only cause (4) failed anything, and only INCIDENTALLY —
+# ``could not be READ`` was chosen to discriminate a four-cause enumeration
+# from a three-cause one, never as a completeness pin, and nothing about that
+# choice generalised to the other three.
+#
+# Each marker was confirmed against the live constant (not merely proposed):
+# ASCII-only, occurring exactly once, and landing inside its own cause block.
+_CAUSE_MARKERS = {
+    1: "No task exists for this owner",
+    2: "recorded team no longer matches",
+    3: "not available in this session at all",
+    4: _CAUSE4_MARKER,
+}
+
+
+def test_every_known_cause_carries_its_own_marker(tmp_path, monkeypatch, capsys):
+    """COMPLETENESS PIN — each of the four causes must survive independently.
+
+    Written against observable deny text only, importing no post-fix symbol, so
+    it carries revert-cardinality rather than producing an import artifact.
+
+    All four are checked in ONE body deliberately. Split into four tests, each
+    would still fail on its own deletion — but the coupling is what makes the
+    *set* the unit under test: a future edit that drops a cause AND its test
+    together has to delete a named entry from the mapping above, which is a
+    visible act, rather than quietly shrinking prose.
+
+    The count is asserted as EXACTLY ONE rather than merely present: a marker
+    appearing twice means the span it identifies is no longer unique, so the
+    pin would no longer distinguish which cause survived.
+
+    THIS TEST PASSING IS NOT WHAT MAKES IT SOUND. An absence-shaped property
+    ("no cause can be deleted silently") is only established by deleting each
+    cause and watching this fail — which is how the gap it closes was found in
+    the first place, and which was re-run against this test after writing it.
+    """
+    _full_setup(monkeypatch, tmp_path, tasks=(("someone-else", "pending"),))
+    _write_project_claude_md(monkeypatch, tmp_path, _LIVE_SESSION_ID)
+    _reset_context_caches(monkeypatch)
+
+    code, out = _run_main(_make_input(), capsys)
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+
+    # Without this the enumeration never appended and every check below would
+    # be reporting on a string that was never produced.
+    assert code == 2, "rule 8 must actually DENY, else this test is vacuous"
+    assert _ENUM_MARKER in reason, "enumeration absent — nothing to check"
+
+    for cause, marker in _CAUSE_MARKERS.items():
+        assert marker.isascii(), (
+            f"cause ({cause}) marker is not ASCII-only: {marker!r}. A marker "
+            "that spans a non-ASCII character invites a transcription that "
+            "substitutes a hyphen for U+2014, after which it can never fail."
+        )
+
+    missing = {
+        cause: reason.count(marker)
+        for cause, marker in _CAUSE_MARKERS.items()
+        if reason.count(marker) != 1
+    }
+    assert not missing, (
+        "every KNOWN CAUSE must appear exactly once in the emitted deny; "
+        f"occurrence counts off for {missing}. A cause whose marker is gone "
+        "has been deleted or reworded out of the enumeration, and the reader "
+        "who is in that state is now given a list that does not contain them."
+    )
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# Advice soundness — the branch arms NARROW, they do not CLOSE
+# ══════════════════════════════════════════════════════════════════════════
+
+# The disclaimer that makes the "all four present" arm honest. This is the
+# POSITIVE half and it is the half that generalises: any reintroduction of a
+# closed-set claim has to remove or contradict this sentence, whereas the
+# denylist below only catches wordings already seen.
+_NARROWING_DISCLAIMER = "rules out one cause, not the rest"
+
+# Wordings that would restore the FALSE-EXHAUSTIVENESS claim: naming the
+# complement of case (3) as a closed set. Unsound because the four causes are
+# the KNOWN ones, not a proven-exhaustive set — a task created and then cleared
+# from the store before the spawn is evaluated leaves this gate denying against
+# a store that is readable, correctly resolved and genuinely empty, and the
+# clearing trigger is not understood well enough to exclude it.
+#
+# SCOPED TO THE COMPLEMENT CLAIM. "you are in case (4)" is deliberately absent
+# from this set: it is the SOUND positive proof already in the text (a
+# permissions error PROVES cause (4)), and a guard that forbade the shipped
+# sound construction would be deleted by the first author who hit it. Each
+# entry below was checked against the live constant for false positives.
+_FORBIDDEN_EXHAUSTIVENESS_CLAIMS = (
+    "you are in case (1)",
+    "you are in case (2)",
+    "must be case",
+    "must be one of",
+    "one of cases",
+    "leaves only case",
+)
+
+
+def test_branch_arm_narrows_and_makes_no_closed_set_claim(
+    tmp_path, monkeypatch, capsys
+):
+    """The self-check may eliminate case (3) and must claim nothing further.
+
+    COUPLED: the positive disclaimer and the forbidden complement wordings are
+    asserted against the SAME emitted text. Absence-only would pass trivially
+    on an empty string, and on a revert where no enumeration exists at all.
+
+    KNOWN BOUND, stated so a green result is not over-read. The negative half
+    is a phrase denylist over free prose and CANNOT be complete — a complement
+    claim in novel wording passes it. That limitation is real and is the same
+    one the cause-(4) tripwire declares about itself. What carries the weight
+    here is the POSITIVE half: the disclaimer must be present, and restoring a
+    closed-set claim while leaving "rules out one cause, not the rest" in place
+    produces text that contradicts itself in adjacent sentences. Do not cite
+    this test as proof that the text makes no closed-set claim.
+    """
+    _full_setup(monkeypatch, tmp_path, tasks=(("someone-else", "pending"),))
+    _write_project_claude_md(monkeypatch, tmp_path, _LIVE_SESSION_ID)
+    _reset_context_caches(monkeypatch)
+
+    code, out = _run_main(_make_input(), capsys)
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+
+    assert code == 2, "rule 8 must actually DENY, else this test is vacuous"
+
+    # POSITIVE half — without this the absence checks below prove nothing.
+    assert _NARROWING_DISCLAIMER in reason, (
+        "the narrowing disclaimer is gone. The self-check discriminates case "
+        "(3) from not-(3) and nothing else; without this sentence the arm "
+        "reads as though it had identified the cause."
+    )
+
+    lowered = reason.lower()
+    for phrase in _FORBIDDEN_EXHAUSTIVENESS_CLAIMS:
+        assert phrase.lower() not in lowered, (
+            f"closed-set claim reintroduced: {phrase!r}. Ruling out case (3) "
+            "does not place the reader in the remaining listed causes — the "
+            "enumeration is the KNOWN set, not a proven-exhaustive one, and "
+            "naming the complement sends a reader outside it to chase causes "
+            "that are not theirs."
+        )
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# Degraded-detection input still reaches the enumeration
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def test_claude_md_absent_still_appends_the_enumeration(
+    tmp_path, monkeypatch, capsys
+):
+    """With NO project CLAUDE.md the detector cannot compare recorded-vs-live
+    and returns None, so the enumeration must append.
+
+    Distinct from the healthy leg, which writes a CLAUDE.md recording the LIVE
+    id and exercises the recorded==actual branch; here no file exists on either
+    lookup path and the ``content is None`` branch runs instead.
+
+    The sibling file covers this input for the stale-marker-ABSENCE cell and
+    says so in its own docstring. Nothing there asserts the enumeration is
+    PRESENT, so a composer that silently stopped appending on this path would
+    not have been caught. This is the ADDED cell, not a tightened one.
+    """
+    _full_setup(monkeypatch, tmp_path, tasks=(("someone-else", "pending"),))
+
+    empty_project = tmp_path / "no_claude_md_project"
+    empty_project.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(empty_project))
+    assert not (empty_project / "CLAUDE.md").exists()
+    assert not (empty_project / ".claude" / "CLAUDE.md").exists()
+    _reset_context_caches(monkeypatch)
+
+    code, out = _run_main(_make_input(), capsys)
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+
+    assert code == 2, "decision unchanged (DENY) when CLAUDE.md is absent"
+    _assert_deny_text(reason, rule_text="no Task assigned", enumeration=True)
+    assert _STALE_MARKER not in reason, "no stale diagnosis without a CLAUDE.md"
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# A-xor-B on the OTHER stale-diagnosable rule
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def _setup_rule_six(monkeypatch, root):
+    """Force rule ⑥ (team_name_unavailable) by writing an EMPTY context team
+    name. Local to this file rather than shared with the sibling: importing it
+    would execute that module at import time for no other benefit.
+
+    The cache resets are load-bearing — ``_full_setup`` has already warmed
+    pact_context with a VALID team, so rewriting the file alone leaves the gate
+    reading the cached good value and rule ⑥ never fires.
+    """
+    import shared.pact_context as ctx_module
+
+    plugin_root = _full_setup(monkeypatch, root)
+    ctx_path = root / "pact-session-context.json"
+    ctx_path.write_text(
+        json.dumps(
+            {
+                "team_name": "",
+                "session_id": _LIVE_SESSION_ID,
+                "project_dir": str(root / "project"),
+                "plugin_root": str(plugin_root),
+                "started_at": "2026-01-01T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ctx_module, "_context_path", ctx_path)
+    _reset_context_caches(monkeypatch)
+    return plugin_root
+
+
+def test_rule_six_under_stale_mismatch_gets_incumbent_without_enumeration(
+    tmp_path, monkeypatch, capsys
+):
+    """Rule ⑥ WITH a stale mismatch: the incumbent fires and the enumeration
+    must stay away.
+
+    The sibling file asserts the stale marker PRESENT on this input but never
+    asserts the enumeration ABSENT, so an A-xor-B break on rule ⑥ — the other
+    member of the stale-diagnosable set — was silent. Coupled here: the
+    incumbent's marker present AND the enumeration's markers absent, against
+    the same emitted text, so neither half can pass by absence.
+    """
+    _setup_rule_six(monkeypatch, tmp_path)
+    _write_project_claude_md(monkeypatch, tmp_path, _STALE_SESSION_ID)
+    _reset_context_caches(monkeypatch)
+
+    code, out = _run_main(_make_input(), capsys)
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+
+    assert code == 2, "rule 6 must actually fire, else this test is vacuous"
+    assert _STALE_MARKER in reason, "incumbent stale diagnosis must fire"
+    _assert_deny_text(reason, rule_text="team_name is unavailable",
+                      enumeration=False)
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# The surviving AC-2 invariant: no output change where neither block applies
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def _journaled(journal, index):
+    """Return (rule, reason) for the index-th dispatch_decision event.
+
+    Asserting on the journaled RULE — not merely on the exit code — is what
+    stops a leg certifying nothing. Exit 2 is reachable by every deny rule in
+    the gate, so a leg that meant to exercise one rule and actually fired
+    another looks identical from the outside.
+    """
+    events = [e for e in journal if e.get("type") == "dispatch_decision"]
+    assert len(events) > index, (
+        f"expected at least {index + 1} dispatch_decision events, "
+        f"got {len(events)}"
+    )
+    return events[index].get("rule"), events[index].get("reason")
+
+
+def test_emitted_equals_journaled_except_where_a_block_applies(
+    tmp_path, monkeypatch, capsys
+):
+    """AC-2, SATISFIED AS AMENDED — the invariant that survived the design.
+
+    AC-2 as written ("no output change for the ordinary 'lead skipped task
+    creation' case") rests on a discriminator that no longer exists, and the
+    case it names is cause (1), whose output changes BY CONSTRUCTION — that is
+    the feature. The surviving, testable invariant is this: where NEITHER
+    diagnosis block applies, the emitted deny is byte-identical to the
+    canonical reason; where one does, the emitted text EXTENDS that reason and
+    never rewrites it.
+
+    The journal is legitimate ground truth for "canonical", because journalling
+    provably precedes augmentation. That also keeps both legs free of post-fix
+    symbols, so each survives a revert as a behavioural failure.
+
+    COUPLED IN ONE BODY. Leg 1 alone is an equality that a composer doing
+    nothing at all would satisfy; leg 2 alone cannot tell "extended" from
+    "rewritten and coincidentally longer". Together they pin the boundary.
+    """
+    journal = _capture_journal(monkeypatch)
+
+    # ── Leg 1 — rule ⑥, no mismatch: neither block applies ──
+    leg_1 = tmp_path / "leg_untouched"
+    leg_1.mkdir()
+    _setup_rule_six(monkeypatch, leg_1)
+    _write_project_claude_md(monkeypatch, leg_1, _LIVE_SESSION_ID)
+    _reset_context_caches(monkeypatch)
+
+    code_1, out_1 = _run_main(_make_input(), capsys)
+    emitted_1 = out_1["hookSpecificOutput"]["permissionDecisionReason"]
+    rule_1, journaled_1 = _journaled(journal, 0)
+
+    assert code_1 == 2, "leg 1 must DENY"
+    assert rule_1 == "team_name_unavailable", (
+        f"leg 1 fired {rule_1!r}, not the rule it was built to exercise — "
+        "the row certifies nothing about its intent"
+    )
+    assert emitted_1 == journaled_1, (
+        "where neither block applies the user-facing text must be the "
+        "canonical reason, byte for byte"
+    )
+
+    # ── Leg 2 — rule ⑧, no mismatch: the enumeration appends ──
+    leg_2 = tmp_path / "leg_extended"
+    leg_2.mkdir()
+    _full_setup(monkeypatch, leg_2, tasks=(("someone-else", "pending"),))
+    _write_project_claude_md(monkeypatch, leg_2, _LIVE_SESSION_ID)
+    _reset_context_caches(monkeypatch)
+
+    code_2, out_2 = _run_main(_make_input(), capsys)
+    emitted_2 = out_2["hookSpecificOutput"]["permissionDecisionReason"]
+    rule_2, journaled_2 = _journaled(journal, 1)
+
+    assert code_2 == 2, "leg 2 must DENY"
+    assert rule_2 == "no_task_assigned", (
+        f"leg 2 fired {rule_2!r}, not the rule it was built to exercise"
+    )
+    assert emitted_2 != journaled_2, (
+        "leg 2 must actually be augmented, else leg 1's equality proves only "
+        "that nothing anywhere appends"
+    )
+    assert emitted_2.startswith(journaled_2), (
+        "the emitted text must EXTEND the canonical reason, not rewrite it"
+    )
+    assert _ENUM_MARKER not in journaled_2, (
+        "the journal must keep the un-augmented reason"
+    )
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# Cause (4) as a RUNTIME STATE — an unreadable store, not just wording
+# ══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.skipif(
+    os.geteuid() == 0,
+    reason="mode 0o000 does not deny root, so the unreadable-store leg cannot "
+           "be constructed; the test would pass or fail for the wrong reason",
+)
+def test_unreadable_store_denies_while_the_owner_matching_task_survives(
+    tmp_path, monkeypatch, capsys
+):
+    """THE OWNER-MATCH LEVER — cause (4) reached as real state, no mock.
+
+    The gate cannot distinguish an unreadable store from an empty one, which
+    is why cause (4) is in the enumeration at all. This pins that claim as
+    BEHAVIOUR rather than as text: the store holds a task owned by the very
+    name being dispatched, so the ONLY thing standing between ALLOW and DENY
+    is whether the directory can be read.
+
+    Non-mocked seam by construction — a real directory, a real mode change,
+    the unstubbed ``iter_team_task_jsons`` read. Mocking the iterator would
+    replace exactly the seam under test.
+
+    THREE GUARDS AGAINST CERTIFYING NOTHING, because two states produce a
+    rule-⑧ deny and this test asserts a claim about which one it is:
+      * the readable leg must ALLOW — establishing the task is genuinely
+        there and matching, so the deny cannot be blamed on a missing task;
+      * the journaled RULE must be no_task_assigned — exit 2 alone is
+        reachable by every deny rule, and by the load-failure emitter;
+      * after the mode is restored the task file is re-read and asserted
+        unchanged — so "only the readability moved" is asserted, not argued.
+    """
+    _full_setup(monkeypatch, tmp_path)  # default task owner == the dispatch name
+    tasks_dir = tmp_path / ".claude" / "tasks" / _TEAM
+    task_files = sorted(tasks_dir.glob("*.json"))
+    assert task_files, "fixture must seed at least one task file"
+    before = task_files[0].read_text(encoding="utf-8")
+    assert json.loads(before)["owner"] == _NAME, (
+        "the lever requires a task owned by the dispatched name"
+    )
+
+    journal = _capture_journal(monkeypatch)
+
+    # ── Readable: the task is found, the dispatch is allowed ──
+    _reset_context_caches(monkeypatch)
+    code_readable, out_readable = _run_main(_make_input(), capsys)
+    assert code_readable == 0, "a matching task in a readable store must ALLOW"
+    assert out_readable.get("suppressOutput") is True
+
+    # ── Unreadable: same store, same task, same input ──
+    original_mode = stat.S_IMODE(tasks_dir.stat().st_mode)
+    os.chmod(tasks_dir, 0o000)
+    try:
+        _reset_context_caches(monkeypatch)
+        code_unreadable, out_unreadable = _run_main(_make_input(), capsys)
+    finally:
+        # Restored before any assertion can fail out of the block: a 0o000
+        # directory left behind outlives this test and breaks unrelated ones.
+        os.chmod(tasks_dir, original_mode)
+
+    reason = out_unreadable["hookSpecificOutput"]["permissionDecisionReason"]
+    rule, _journaled_reason = _journaled(journal, 1)
+
+    assert code_unreadable == 2, "an unreadable store must DENY"
+    assert rule == "no_task_assigned", (
+        f"expected the no-task rule, got {rule!r} — an unreadable store must "
+        "reach the same conflated rule a genuinely empty one does, which is "
+        "the whole reason cause (4) is enumerated"
+    )
+    _assert_deny_text(reason, rule_text="no Task assigned", enumeration=True)
+
+    assert task_files[0].read_text(encoding="utf-8") == before, (
+        "the task file must be untouched — if the contents moved, the deny is "
+        "not evidence about readability"
+    )
+    assert stat.S_IMODE(tasks_dir.stat().st_mode) == original_mode, (
+        "the store's mode must be restored"
+    )
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# The pointer has a referent — and that is ALL this section pins
+# ══════════════════════════════════════════════════════════════════════════
+
+# Repo root, per the convention already used by the version-bump suite.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# The README section both gate texts send the reader to.
+_POINTER_PHRASE = "Enabling Agent Teams"
+_POINTER_HEADING = f"### {_POINTER_PHRASE}"
+
+# Read as SOURCE rather than imported: the dispatch-gate pointer lives inside a
+# post-fix constant, and importing it would make this an import artifact under
+# a revert. Reading the file also keeps one assertion covering both gates.
+_GATE_SOURCES = ("dispatch_gate.py", "bootstrap_gate.py")
+
+
+def test_readme_pointer_has_a_referent():
+    """Both gates name a README section; that section must exist.
+
+    A deny message that sends an operator to a heading which is not there is
+    worse than one that says nothing — it spends the reader's remaining
+    patience on a search that cannot succeed. The two artifacts are edited by
+    different people at different times, and nothing else couples them.
+
+    COUPLED so it cannot pass by absence: the pointer must be PRESENT in both
+    gate texts AND the heading must exist. Testing only the implication
+    ("if the pointer is present then the heading exists") would pass trivially
+    the moment someone removed the pointer, which is exactly the state this is
+    meant to notice. Removing a pointer legitimately is still allowed — it just
+    has to come here and say so, the same two-site review path the canonical
+    deny-reason literal forces.
+
+    WHAT THIS DOES NOT PIN, and must not be read as pinning. The clause in the
+    bootstrap gate is safe to over-point partly because its referent OPENS with
+    a falsifiable check — the reader is told how to confirm they have this
+    problem before being shown a high-blast-radius setting. That protection is
+    a property of the PAIR, not of either file: reorder the README section to
+    lead with the remedy and the protection is gone while this test stays
+    green. Verification-before-remedy ordering is a review-time invariant with
+    no artifact that can enforce it. This test pins referent EXISTENCE only.
+    """
+    readme = _REPO_ROOT / "README.md"
+    assert readme.exists(), f"repo README not found at {readme}"
+    readme_text = readme.read_text(encoding="utf-8")
+
+    pointing = []
+    for source_name in _GATE_SOURCES:
+        source = (Path(__file__).parent.parent / "hooks" / source_name).read_text(
+            encoding="utf-8"
+        )
+        if _POINTER_PHRASE in source:
+            pointing.append(source_name)
+
+    assert sorted(pointing) == sorted(_GATE_SOURCES), (
+        f"expected both gates to point at {_POINTER_PHRASE!r}; only {pointing} "
+        "do. If a pointer was removed on purpose, update this test in the same "
+        "change — silently dropping it is what this assertion exists to catch."
+    )
+
+    assert _POINTER_HEADING in readme_text, (
+        f"the gates point at a README section {_POINTER_HEADING!r} that does "
+        "not exist. Either the heading was renamed and the gate texts were not "
+        "updated, or the pointer shipped ahead of its referent."
     )

--- a/pact-plugin/tests/test_dispatch_gate_cause_enumeration.py
+++ b/pact-plugin/tests/test_dispatch_gate_cause_enumeration.py
@@ -1,0 +1,450 @@
+"""
+Cause enumeration appended to the rule-⑧ (``no_task_assigned``) deny.
+
+Rule ⑧ fires whenever no task for this owner is OBSERVED, which conflates a
+genuinely-missing task with an unreadable store, a symlink escape, an unsafe
+team name and an I/O error. ``_compose_deny_diagnosis`` therefore appends a
+four-cause enumeration plus a self-check the reader can run — but only when the
+incumbent stale-team detector did NOT fire, and only on rule ⑧.
+
+SCOPE OF THIS FILE — deliberately partial. It covers the A-xor-B precedence,
+the graceful-degradation path, rule isolation, and the journal-purity property.
+It is NOT the full matrix: the T1-T9 integration matrix and the coupled
+verbatim-equality pin are authored separately and extend THIS file. Do not read
+a green run here as comprehensive coverage of the enumeration.
+
+NON-VACUITY DISCIPLINE — the reasons, so a later editor does not undo them:
+
+  * Markers are module-level SHARED CONSTANTS and the assertion helper reads
+    them from there. ``_assert_deny_text`` takes a BOOL for which side of the
+    pair it is checking, never a marker string. If the signature ever accepts
+    a marker from the caller, the first caller that types a hyphen for U+2014
+    makes the negative arm vacuous forever — the exact defect the helper
+    exists to prevent, reintroduced at its own call site.
+
+  * Every marker is ASCII-only and none SPANS a non-ASCII character. The
+    enumeration prose does contain em-dashes; the markers are chosen to sit
+    clear of them. ``blocking for safety`` is used rather than the full
+    ``failure — blocking for safety``, which contains U+2014.
+
+  * The positive and negative legs are COUPLED IN ONE TEST BODY. Split across
+    two tests they would yield revert-cardinality {1}: the negative leg passes
+    by absence and contributes nothing on its own.
+
+  * Absence assertions on PRE-EXISTING text derive their literal from a
+    pre-existing symbol (``_STALE_REALIGN_HINT``) so they survive a revert.
+    Markers for POST-FIX text are hardcoded, since importing a post-fix symbol
+    would yield an ImportError artifact under revert rather than a behavioural
+    failure.
+
+  * Exit 2 is NOT asserted as proof that no exception escaped. ``main()``
+    catches runtime exceptions and routes them through the load-failure
+    emitter, which also denies and also exits 2. The load-failure marker is
+    asserted ABSENT instead, which only the intended path satisfies.
+
+  * TWO TESTS SIT DELIBERATELY OUTSIDE THE REVERT-NON-VACUITY SET and must not
+    be counted in it: ``test_composer_is_total_over_message_type`` and
+    ``test_enumeration_has_no_negative_arm_on_cause_four`` import POST-FIX
+    symbols directly, so under a revert they raise ImportError — an import
+    artifact, not a behavioural failure, which the plan disqualifies. That is
+    unavoidable and correct for these two: both assert properties OF the new
+    code, and there is no pre-fix behaviour to compare against. Every test
+    that DOES carry revert-cardinality drives ``main()`` end-to-end and
+    asserts only on observable deny text.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+from test_dispatch_gate import (  # noqa: E402 — sibling harness reuse
+    _make_input,
+    _run_main,
+    _full_setup,
+    _TEAM,
+)
+
+# Pre-existing production symbol — deriving the stale-diagnosis literal from it
+# keeps the absence assertions valid under a revert of this change.
+from dispatch_gate import _STALE_REALIGN_HINT  # noqa: E402
+
+# ── Shared markers ────────────────────────────────────────────────────────
+# ASCII-only, and each verified to sit clear of the prose's em-dashes.
+# POST-FIX text → hardcoded on purpose (see module docstring).
+_ENUM_MARKER = "did not OBSERVE"           # opening line, most stable
+_ENUM_ACTION_MARKER = "TO NARROW IT DOWN"  # action-first block
+_CAUSE4_MARKER = "could not be READ"       # discriminates 4-cause from 3-cause
+
+# PRE-EXISTING text → derived, not typed.
+_STALE_MARKER = _STALE_REALIGN_HINT[:40]
+
+# PRE-EXISTING load-failure text. Hardcoded as an ASCII-only substring because
+# it lives inside an f-string rather than a named constant; its liveness is
+# pinned by test_load_failure_marker_is_live below, so this absence assertion
+# cannot silently go vacuous.
+_LOAD_FAILURE_MARKER = "blocking for safety"
+
+_LIVE_SESSION_ID = "test-session"
+_STALE_SESSION_ID = "0000dead-beef-4000-8000-000000000000"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _write_project_claude_md(monkeypatch, root, recorded_session_id):
+    """Point CLAUDE_PROJECT_DIR at a CLAUDE.md recording ``recorded_session_id``.
+
+    Inlined rather than imported from test_dispatch_gate_stale_diagnosis: a
+    sibling-module import executes that module at import time, and this file
+    needs none of the rest of it.
+    """
+    proj = root / "project_md"
+    proj.mkdir(parents=True, exist_ok=True)
+    (proj / "CLAUDE.md").write_text(
+        "# Project\n\n## Current Session\n"
+        f"- Resume: `claude --resume {recorded_session_id}`\n"
+        f"- Team: `{_TEAM}`\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(proj))
+
+
+def _reset_context_caches(monkeypatch):
+    """Drop pact_context's memoised reads so a second leg in the same test body
+    re-resolves against the state that leg just wrote."""
+    import shared.pact_context as ctx_module
+
+    monkeypatch.setattr(ctx_module, "_cache", None, raising=False)
+    monkeypatch.setattr(ctx_module, "_aligned_cache", None, raising=False)
+
+
+def _assert_deny_text(reason, *, rule_text, enumeration):
+    """Assert the deny text against the shared markers.
+
+    ``enumeration`` is a BOOL — which SIDE of the coupled pair to check — not a
+    marker string. Callers supply only ``rule_text``, the rule's own wording.
+    Letting a caller pass the marker is what makes a negative arm vacuous.
+    """
+    assert rule_text in reason, f"base deny text missing: {rule_text!r}"
+
+    if enumeration:
+        assert _ENUM_MARKER in reason, "enumeration expected but absent"
+        assert _ENUM_ACTION_MARKER in reason, "action block expected but absent"
+        assert _CAUSE4_MARKER in reason, "cause (4) expected but absent"
+    else:
+        assert _ENUM_MARKER not in reason, "enumeration present but not expected"
+        assert _ENUM_ACTION_MARKER not in reason, "action block leaked"
+        assert _CAUSE4_MARKER not in reason, "cause (4) leaked"
+
+    # Only the intended path satisfies this; exit 2 alone would not, since the
+    # load-failure emitter also denies and also exits 2.
+    assert _LOAD_FAILURE_MARKER not in reason, "routed through load-failure path"
+
+
+# ── Marker liveness ───────────────────────────────────────────────────────
+
+
+def test_load_failure_marker_is_live():
+    """The load-failure marker asserted ABSENT elsewhere must be a real
+    substring of the gate's load-failure text, else every such assertion is
+    vacuous. Read from source rather than imported so this still means
+    something if the constant is restructured."""
+    src = (Path(__file__).parent.parent / "hooks" / "dispatch_gate.py").read_text(
+        encoding="utf-8"
+    )
+    assert _LOAD_FAILURE_MARKER in src, (
+        "load-failure marker no longer appears in dispatch_gate.py — every "
+        "absence assertion using it is now vacuous"
+    )
+
+
+def test_markers_are_ascii_and_span_no_multibyte():
+    """Each hardcoded marker must be ASCII-only. A marker that spans a
+    non-ASCII character invites an eyeball transcription that substitutes a
+    hyphen for U+2014, after which the assertion can never fail."""
+    for marker in (
+        _ENUM_MARKER,
+        _ENUM_ACTION_MARKER,
+        _CAUSE4_MARKER,
+        _LOAD_FAILURE_MARKER,
+    ):
+        assert marker.isascii(), f"marker is not ASCII-only: {marker!r}"
+
+
+# ── A-xor-B precedence: the coupled non-vacuity pair ──────────────────────
+
+
+def test_enumeration_appends_exactly_when_incumbent_does_not_fire(
+    tmp_path, monkeypatch, capsys
+):
+    """COUPLED PAIR IN ONE BODY — both legs, one test, revert-cardinality {2}.
+
+    Leg A (healthy, no stale mismatch): the incumbent finds nothing, so the
+    enumeration appends and no stale diagnosis appears.
+    Leg B (stale mismatch): the incumbent fires, so its specific diagnosis is
+    returned and the generic enumeration is suppressed.
+
+    Together these pin A-xor-B. Either leg alone would pass by absence.
+    """
+    # ── Leg A — healthy: enumeration present, stale diagnosis absent ──
+    leg_a = tmp_path / "leg_a"
+    leg_a.mkdir()
+    _full_setup(monkeypatch, leg_a, tasks=(("someone-else", "pending"),))
+    _write_project_claude_md(monkeypatch, leg_a, _LIVE_SESSION_ID)
+    _reset_context_caches(monkeypatch)
+
+    code_a, out_a = _run_main(_make_input(), capsys)
+    reason_a = out_a["hookSpecificOutput"]["permissionDecisionReason"]
+
+    assert code_a == 2, "decision must still be DENY"
+    _assert_deny_text(reason_a, rule_text="no Task assigned", enumeration=True)
+    assert _STALE_MARKER not in reason_a, "stale diagnosis must not fire when healthy"
+
+    # ── Leg B — stale mismatch: incumbent wins, enumeration suppressed ──
+    leg_b = tmp_path / "leg_b"
+    leg_b.mkdir()
+    _full_setup(monkeypatch, leg_b, tasks=(("someone-else", "pending"),))
+    _write_project_claude_md(monkeypatch, leg_b, _STALE_SESSION_ID)
+    _reset_context_caches(monkeypatch)
+
+    code_b, out_b = _run_main(_make_input(), capsys)
+    reason_b = out_b["hookSpecificOutput"]["permissionDecisionReason"]
+
+    assert code_b == 2, "decision must still be DENY"
+    assert _STALE_MARKER in reason_b, "incumbent stale diagnosis must fire"
+    _assert_deny_text(reason_b, rule_text="no Task assigned", enumeration=False)
+
+
+# ── Graceful degradation: A's failure degrades INTO B ─────────────────────
+
+
+def test_detector_raise_degrades_into_enumeration_not_silence(
+    tmp_path, monkeypatch, capsys
+):
+    """When the stale detector RAISES, the incumbent's never-raises wrap returns
+    the message unchanged. The composer cannot distinguish that from 'no
+    mismatch', so the enumeration appends: A's failure degrades INTO B rather
+    than into silence.
+
+    The input is a stale-mismatch input, so without the raise leg B above would
+    have suppressed the enumeration — that is what makes this non-vacuous.
+    """
+    import dispatch_gate
+
+    _full_setup(monkeypatch, tmp_path, tasks=(("someone-else", "pending"),))
+    _write_project_claude_md(monkeypatch, tmp_path, _STALE_SESSION_ID)
+    _reset_context_caches(monkeypatch)
+
+    def _boom(_input_data):
+        raise RuntimeError("detector blew up")
+
+    monkeypatch.setattr(dispatch_gate, "detect_stale_session_block", _boom)
+
+    code, out = _run_main(_make_input(), capsys)
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+
+    assert code == 2, "deny still fires despite the detector raising"
+    _assert_deny_text(reason, rule_text="no Task assigned", enumeration=True)
+    assert _STALE_MARKER not in reason, "no partial stale diagnosis"
+
+
+# ── Rule isolation ────────────────────────────────────────────────────────
+
+
+def test_rule_six_deny_never_receives_the_enumeration(
+    tmp_path, monkeypatch, capsys
+):
+    """Rule ⑥ (team_name_unavailable) is the OTHER member of the
+    stale-diagnosable set, so it is the rule most likely to be caught by a
+    frozenset-based gate instead of the rule-equality gate the composer uses.
+    It must never carry the enumeration: an empty session team says nothing
+    about whether the task store was observable."""
+    import shared.pact_context as ctx_module
+
+    plugin_root = _full_setup(monkeypatch, tmp_path)
+    ctx_path = tmp_path / "pact-session-context.json"
+    ctx_path.write_text(
+        json.dumps(
+            {
+                "team_name": "",
+                "session_id": _LIVE_SESSION_ID,
+                "project_dir": str(tmp_path / "project"),
+                "plugin_root": str(plugin_root),
+                "started_at": "2026-01-01T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ctx_module, "_context_path", ctx_path)
+    _reset_context_caches(monkeypatch)
+    _write_project_claude_md(monkeypatch, tmp_path, _LIVE_SESSION_ID)
+
+    code, out = _run_main(_make_input(), capsys)
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+
+    assert code == 2, "rule 6 must actually fire, else this test is vacuous"
+    _assert_deny_text(reason, rule_text="team_name is unavailable",
+                      enumeration=False)
+
+
+def test_non_symptom_deny_receives_neither_diagnosis(
+    tmp_path, monkeypatch, capsys
+):
+    """A deny rule outside the stale-diagnosable set gets neither block, even
+    with a stale-recorded CLAUDE.md present. A name-validation failure is not a
+    restart symptom and not a store-observability symptom."""
+    _full_setup(monkeypatch, tmp_path)
+    _write_project_claude_md(monkeypatch, tmp_path, _STALE_SESSION_ID)
+    _reset_context_caches(monkeypatch)
+
+    code, out = _run_main(_make_input(name=""), capsys)
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+
+    assert code == 2, "name_required must still DENY"
+    _assert_deny_text(reason, rule_text="name=", enumeration=False)
+    assert _STALE_MARKER not in reason, "stale diagnosis must not reach this rule"
+
+
+# ── Healthy ALLOW is untouched ────────────────────────────────────────────
+
+
+def test_healthy_allow_path_is_untouched(tmp_path, monkeypatch, capsys):
+    """The composer runs only on the DENY branch. A healthy dispatch must still
+    exit 0 and emit the suppress-output payload with no diagnosis text
+    anywhere."""
+    _full_setup(monkeypatch, tmp_path)
+    _reset_context_caches(monkeypatch)
+
+    code, out = _run_main(_make_input(), capsys)
+
+    assert code == 0, "healthy dispatch must ALLOW"
+    assert out.get("suppressOutput") is True, "suppressOutput payload preserved"
+    assert _ENUM_MARKER not in json.dumps(out), "no diagnosis on the ALLOW path"
+
+
+# ── Advice soundness: no negative arm on cause (4) ────────────────────────
+
+# Phrasings that would ELIMINATE cause (4) on a successful listing. Each is
+# unsound for the same reason: `ls` follows symlinks and validates no
+# containment, while the gate's iterator refuses a symlink escape, so a team
+# dir symlinked outside the tasks root lists fine AND denies. Any of these
+# would tell that operator "not case (4)" in precisely the case that IS (4).
+#
+# SCOPED TO CAUSE (4) ON PURPOSE. Bare "rules out" is NOT here: it is a SOUND
+# construction ("rules out case (3)" is correct, and the README ships "rules
+# out one cause, not the rest"). A guard that forbade the phrasing our own
+# peer artifact uses would be deleted by the first author who hit it.
+_FORBIDDEN_CAUSE4_ELIMINATIONS = (
+    "not in case (4)",
+    "not case (4)",
+    "rules out case (4)",
+    "rules out cause (4)",
+    "excludes case (4)",
+    "eliminates case (4)",
+    "cannot be case (4)",
+)
+
+# The SOUND positive arm this pairs with: a permissions error PROVES (4).
+_CAUSE4_POSITIVE_PROOF = "PERMISSIONS ERROR"
+
+
+def test_enumeration_has_no_negative_arm_on_cause_four():
+    """TRIPWIRE FOR A KNOWN REGRESSION — NOT A PROOF OF ADVICE SOUNDNESS.
+
+    Read this limitation before trusting a green result. A phrase denylist over
+    free prose CANNOT be complete: the next author who reintroduces a negative
+    arm in different words passes this test. Its actual job is narrower and
+    still worth having — when the known-bad construction returns, a human is
+    forced to look, exactly like the `_CANONICAL_DENY_REASON_LITERAL` byte-pin.
+
+    What a green result here means: "the specific unsound phrasings we have
+    seen are absent." What it does NOT mean: "the text contains no negative
+    arm." Do not cite this test for the latter.
+
+    Coupled with the POSITIVE arm so the pair cannot both pass vacuously: if
+    the whole self-check block were deleted, the positive assertion fails.
+    Checking only for absence would pass trivially on an empty string.
+    """
+    from dispatch_gate import _CAUSE_ENUMERATION
+
+    lowered = _CAUSE_ENUMERATION.lower()
+    for phrase in _FORBIDDEN_CAUSE4_ELIMINATIONS:
+        assert phrase.lower() not in lowered, (
+            f"unsound negative arm reintroduced: {phrase!r}. A successful "
+            "listing does NOT rule out cause (4) — ls follows symlinks and "
+            "does no containment validation, while the gate's iterator "
+            "refuses a symlink escape."
+        )
+
+    assert _CAUSE4_POSITIVE_PROOF in _CAUSE_ENUMERATION, (
+        "the sound positive arm (a permissions error PROVES cause 4) is gone; "
+        "without it the absence assertions above pass vacuously"
+    )
+
+
+# ── Precondition totality: the failure DIRECTION ──────────────────────────
+
+
+def test_composer_is_total_over_message_type():
+    """A non-str message must return the fail-closed fallback, never raise.
+
+    WHY THIS IS NOT DEFENSIVE CLUTTER. Every DENY path in evaluate_dispatch
+    supplies a real message (11 of 11, verified by enumeration), so this is
+    unreachable today. It is pinned because the failure DIRECTION of the
+    alternative is wrong: the composer runs OUTSIDE main()'s runtime try, so a
+    TypeError here escapes uncaught and exits 1 — and a nonzero-non-2 exit is
+    NON-BLOCKING, meaning the tool call proceeds. A gate whose job is to refuse
+    would silently become a pass-through.
+
+    Asserted on the returned VALUE, not merely on "did not raise": the fallback
+    must be a real non-empty sentence. An empty string would also avoid the
+    crash while telling the operator nothing, which is the degraded outcome
+    this fallback exists to rule out.
+    """
+    from dispatch_gate import _compose_deny_diagnosis, _MISSING_DENY_REASON
+
+    for bad_message in (None, 0, [], {}, object()):
+        out = _compose_deny_diagnosis("no_task_assigned", bad_message, {})
+        assert out == _MISSING_DENY_REASON, f"not fail-closed for {type(bad_message)}"
+        assert isinstance(out, str) and out.strip(), "fallback must be non-empty"
+        assert _ENUM_MARKER not in out, "must not claim to have diagnosed a cause"
+
+    # The guard must not have cost the normal path anything.
+    assert _compose_deny_diagnosis("some_other_rule", "plain deny", {}) == "plain deny"
+
+
+# ── Journal purity ────────────────────────────────────────────────────────
+
+
+def test_journaled_reason_excludes_the_enumeration(tmp_path, monkeypatch, capsys):
+    """The composer runs strictly AFTER _journal_decision, so the journal keeps
+    the canonical un-augmented reason even on the rule whose emitted text grew.
+
+    Asserted as a COUPLED pair against the same run: the enumeration is present
+    in the emitted text and absent from the journaled reason. Checking only the
+    journal would pass trivially if the enumeration never appended at all.
+    """
+    from test_dispatch_gate import _capture_journal
+
+    _full_setup(monkeypatch, tmp_path, tasks=(("someone-else", "pending"),))
+    _write_project_claude_md(monkeypatch, tmp_path, _LIVE_SESSION_ID)
+    _reset_context_caches(monkeypatch)
+    journal = _capture_journal(monkeypatch)
+
+    code, out = _run_main(_make_input(), capsys)
+    reason = out["hookSpecificOutput"]["permissionDecisionReason"]
+
+    assert code == 2
+    assert _ENUM_MARKER in reason, "positive conjunct: the emitted text grew"
+
+    events = [e for e in journal if e.get("type") == "dispatch_decision"]
+    assert len(events) == 1, f"expected one dispatch_decision, got {len(events)}"
+    journaled = events[0].get("reason")
+    assert journaled, "journal must carry a reason on a DENY"
+    assert _ENUM_MARKER not in journaled, "journal must keep the canonical reason"
+    assert journaled == reason[: len(journaled)], (
+        "the emitted text must be the journaled reason plus appended diagnosis, "
+        "not a rewritten message"
+    )

--- a/pact-plugin/tests/test_dispatch_gate_stale_diagnosis.py
+++ b/pact-plugin/tests/test_dispatch_gate_stale_diagnosis.py
@@ -10,19 +10,34 @@ the EXISTING shared.stale_session.detect_stale_session_block detection at the
 two restart-symptom deny sites (rule ⑥ team_name_unavailable, rule ⑧
 no_task_assigned), MESSAGE-ONLY.
 
+SCOPE NOTE — what "unaugmented" means in this file. These tests assert the
+absence of the STALE-DIAGNOSIS markers, and nothing more. They do NOT assert
+that the emitted deny equals the rule's base message: on rule ⑧ the composer
+appends a cause enumeration whenever the stale detector does not fire, so the
+"no mismatch" legs below emit MORE than the base text while still correctly
+carrying no stale-diagnosis. Coverage of the enumeration itself lives in
+test_dispatch_gate_cause_enumeration.py.
+
+Worth stating plainly because the suite cannot catch it: every "falls back to
+the original message" test here asserts marker-ABSENCE, never message-equality,
+so all of them stayed green when the composer started appending. A fully green
+run proves nothing about whether these docstrings are accurate.
+
 What this file pins:
   - BOTH-MODES MATRIX (in-process session_id==leadSessionId AND tmux
     session_id!=leadSessionId): on a stale-team mismatch the augmented
-    self-diagnosis appears at BOTH deny sites; on no mismatch the ORIGINAL
-    message is preserved verbatim. The augmentation is mode-agnostic, so the
+    self-diagnosis appears at BOTH deny sites; on no mismatch NO stale
+    diagnosis is added. The augmentation is mode-agnostic, so the
     matrix is an INVARIANCE proof (same outcome both modes).
   - NON-VACUITY via PAIRED ENABLE/DISABLE (mismatch-present vs mismatch-absent
     inputs), not git-revert: the augmentation marker is present iff a mismatch
     is detected. A test would FAIL if the augmentation were removed.
   - DECISION UNCHANGED: the gate still DENYs (exit 2) on exactly the same
     inputs; only the message text changes.
-  - DEFENSIVE never-raises: if the detector raises, the deny still returns the
-    ORIGINAL message and no exception escapes.
+  - DEFENSIVE never-raises: if the detector raises, the deny still fires with
+    no stale diagnosis attached and no exception escapes. (On rule ⑧ the
+    composer then appends the cause enumeration — a detector failure degrades
+    INTO the generic diagnosis, not into silence.)
 
 Reuses the in-process harness from test_dispatch_gate.py (_run_main / _full_setup
 / _seed_team) so the both-modes setup matches the rest of the gate's suite.
@@ -126,9 +141,14 @@ def test_no_task_assigned_deny_augmented_on_stale_mismatch(
 def test_no_task_assigned_deny_unaugmented_when_no_mismatch(
     mode_label, lead_id, tmp_path, monkeypatch, capsys
 ):
-    """DISABLE leg: when recorded==live (healthy), the rule-⑧ deny keeps its
-    ORIGINAL message verbatim — no augmentation. Paired with the ENABLE test
-    above this is the non-vacuity proof (marker present IFF mismatch)."""
+    """DISABLE leg: when recorded==live (healthy), the rule-⑧ deny carries NO
+    stale diagnosis. Paired with the ENABLE test above this is the non-vacuity
+    proof (stale marker present IFF mismatch).
+
+    The deny is NOT byte-identical to the base message here — the composer
+    appends the cause enumeration precisely because the stale detector did not
+    fire. That is asserted in test_dispatch_gate_cause_enumeration.py; this leg
+    owns only the stale-marker-absence cell."""
     _full_setup(monkeypatch, tmp_path, tasks=(("someone-else", "pending"),))
     _seed_team_with_lead(
         tmp_path, _TEAM, lead_id, tasks=(("someone-else", "pending"),)
@@ -240,8 +260,11 @@ def test_non_symptom_deny_not_augmented_even_under_mismatch(
 def test_detector_exception_falls_back_to_original_message(
     mode_label, lead_id, tmp_path, monkeypatch, capsys
 ):
-    """If detect_stale_session_block raises, the deny still returns the ORIGINAL
-    message and the gate still exits 2 — no exception escapes dispatch."""
+    """If detect_stale_session_block raises, the deny still fires with no stale
+    diagnosis attached and the gate still exits 2 — no exception escapes
+    dispatch. On this rule-⑧ input the composer then appends the cause
+    enumeration, so the raise degrades INTO the generic diagnosis rather than
+    into silence; this leg owns the stale-marker-absence cell only."""
     _full_setup(monkeypatch, tmp_path, tasks=(("someone-else", "pending"),))
     _seed_team_with_lead(
         tmp_path, _TEAM, lead_id, tasks=(("someone-else", "pending"),)
@@ -382,8 +405,10 @@ def test_gate_site_claude_md_absent_falls_back_to_original_message(
     tmp_path, monkeypatch, capsys
 ):
     """M2: when the project CLAUDE.md is ABSENT (the worktree/gitignored case
-    the PR leans on), the detector returns None → the rule-⑧ deny keeps its
-    ORIGINAL message verbatim, end-to-end through dispatch_gate.main().
+    the PR leans on), the detector returns None → the rule-⑧ deny carries NO
+    stale diagnosis, end-to-end through dispatch_gate.main(). (The composer
+    appends the cause enumeration on this path; that cell is owned by
+    test_dispatch_gate_cause_enumeration.py.)
 
     Distinct from the healthy-recorded==live disable leg: there NO file is
     written at all, and CLAUDE_PROJECT_DIR points at a dir with no CLAUDE.md
@@ -414,7 +439,8 @@ def test_gate_site_unset_project_dir_falls_back_to_original_message(
     tmp_path, monkeypatch, capsys
 ):
     """M2 sibling: CLAUDE_PROJECT_DIR UNSET → detector returns None (cannot
-    locate CLAUDE.md) → original deny message, end-to-end."""
+    locate CLAUDE.md) → rule-⑧ deny with NO stale diagnosis, end-to-end. (The
+    composer appends the cause enumeration on this path.)"""
     _full_setup(monkeypatch, tmp_path, tasks=(("someone-else", "pending"),))
     _seed_team_with_lead(
         tmp_path, _TEAM, _LIVE_SESSION_ID, tasks=(("someone-else", "pending"),)
@@ -439,8 +465,9 @@ def test_gate_site_bad_session_id_falls_back_to_original_message(
 ):
     """M3: an invalid/sentinel/control-char stdin session_id makes the detector
     return None (per _is_unknown_or_missing_session — an unvalidated id must
-    never be interpolated into the warning) → the rule-⑧ deny keeps its
-    ORIGINAL message, even though a stale-recorded CLAUDE.md is present.
+    never be interpolated into the warning) → the rule-⑧ deny carries NO stale
+    diagnosis, even though a stale-recorded CLAUDE.md is present. (The composer
+    appends the cause enumeration on this path.)
 
     The CLAUDE.md records a DIFFERENT id, so were the bad id naively compared
     it would 'mismatch' and wrongly augment; the predicate gate must suppress

--- a/pact-plugin/tests/test_dispatch_gate_stale_diagnosis.py
+++ b/pact-plugin/tests/test_dispatch_gate_stale_diagnosis.py
@@ -59,10 +59,65 @@ from test_dispatch_gate import (  # noqa: E402 — sibling harness reuse
     _TEAM,
 )
 
+# Pre-existing production symbol. Imported so the liveness pin below checks the
+# LIVE constant rather than a copy of it, and so this file keeps working under a
+# revert of any change that only touches the cause enumeration.
+from dispatch_gate import _STALE_REALIGN_HINT  # noqa: E402
+
 # A marker substring unique to the augmentation — asserting on it proves the
 # net-new self-diagnosis text is present without coupling to exact wording.
 _AUGMENT_MARKER = "STALE-TEAM/STORE MISMATCH"
 _REALIGN_MARKER = "pact-session-context.json"
+
+
+def test_stale_markers_are_live_and_ascii():
+    """Both markers are asserted ABSENT in ~10 places in this file; an absence
+    assertion on a literal that cannot match is vacuous forever, silently.
+
+    Today those absence assertions are safe only INCIDENTALLY: both markers are
+    also used in POSITIVE assertions here, and a green baseline on an ``in``
+    check is itself proof the literal matches. That protection lasts exactly as
+    long as the last positive assertion does — delete those and all ~10 absence
+    assertions go vacuous with nothing to notice. This converts the incidental
+    safety into designed safety, sibling to
+    ``test_load_failure_marker_is_live`` in test_dispatch_gate_cause_enumeration.
+
+    Checked against the LIVE ``_STALE_REALIGN_HINT`` rather than a source-text
+    scan: a substring can survive in the file (a comment, a docstring, a dead
+    branch) after it has stopped being part of the emitted text, and it is the
+    EMITTED text these markers are asserted against.
+
+    The ASCII conjunct guards the transcription slip specifically: a marker
+    spanning a non-ASCII character invites an eyeball copy that substitutes a
+    hyphen for U+2014, after which the ``not in`` check can never fail.
+
+    HONEST LIMIT ON THAT CONJUNCT — it is a FORWARD guard, not an independently
+    proven one. ``_STALE_REALIGN_HINT`` is currently pure ASCII, so any marker
+    that fails the ASCII check also fails the substring check below it: the two
+    cannot be falsified separately today, and a non-vacuity run will show them
+    co-firing. It is kept because the constant is PROSE and the prose in this
+    codebase routinely carries em-dashes — ``_CAUSE_ENUMERATION`` already does,
+    which is exactly why the sibling meta-test there IS independently
+    meaningful. The day this constant gains one mid-marker, this conjunct is the
+    only thing between a ``not in`` assertion and permanent silent vacuity.
+    Do not delete it for being redundant; it is redundant only while the
+    constant stays ASCII, and nothing enforces that.
+    """
+    for name, marker in (
+        ("_AUGMENT_MARKER", _AUGMENT_MARKER),
+        ("_REALIGN_MARKER", _REALIGN_MARKER),
+    ):
+        assert marker.isascii(), (
+            f"{name} is not ASCII-only: {marker!r}. A marker that spans a "
+            "non-ASCII character invites a transcription that substitutes a "
+            "hyphen for U+2014, after which it can never fail."
+        )
+        assert marker in _STALE_REALIGN_HINT, (
+            f"{name} ({marker!r}) is no longer a substring of the live "
+            "_STALE_REALIGN_HINT — every absence assertion using it in this "
+            "file is now vacuous. Re-derive the marker from the production "
+            "constant; do not re-type it."
+        )
 
 # session_id values for the both-modes matrix.
 _LIVE_SESSION_ID = "test-session"          # the stdin session_id _make_input uses


### PR DESCRIPTION
Makes the task-tools-unavailable failure **avoidable** (README) and **diagnosable** (gate message).

## The problem

Claude Code can withhold the four task-management tools from a session, decided server-side by the model the session runs. PACT then cannot spawn any specialist — the spawn is refused for a missing task assignment that *cannot be created*, bootstrap never completes, and file edits stay blocked. The session cannot recover on its own, and the denial names the one action the user is unable to perform.

## What shipped

**Diagnosable.** The rule-⑧ denial now carries a cause enumeration and a self-check the reader can run. Framed as *observation* rather than existence — the gate did not OBSERVE a task; that is not the same as one not existing.

**Avoidable.** A conditional-prerequisite subsection under `Enabling Agent Teams`: symptom, a check the reader can actually perform, the setting, its blast radius in both directions, and removal instructions carrying the asymmetric env-propagation caveat.

## The design was overturned during consultation

The issue proposed detecting which cause applies, keyed on `.highwatermark`. Measured, that marker is written on store **drain**, not on first task creation — `hw == min(live id) − 1`, 6/6 stores. Absence means *nothing has drained yet*, a window every healthy session passes through.

Deeper: the task store **provably cannot** separate the causes. A candidate signal correlated 328/328 and was then broken twice, including one session with an empty store that was *receiving* task-tool attachments.

So the recommended design **deletes the predicate**. No `hooks/shared/` module, no cross-team scan, no filesystem read — a constant string and a pure dispatcher. **Zero new subprocesses in any consumer session.**

Four of the issue's five acceptance criteria assumed that discriminator. They are amended in the issue body, with the originals preserved verbatim in a comment alongside the measurement that falsified each.

## Review notes

**Certification is behavioural, not additive-purity.** Base-vs-patch across an input corpus driven end-to-end through `main()`: journal divergences 0, exit-code divergences 0, emitted deltas append-only with base as an exact prefix. Two independent corpora, built separately by the implementer and the auditor, agree. No byte-diff argument is used anywhere — this repo has a pinned precedent of that argument shipping a falsified certificate.

**Every enumerated cause is pinned by a test verified capable of failing** — deleted and observed to fail, not observed to pass. That mattered: measured on the first implementation, three of the four causes could be deleted with the suite fully green, and the fourth was held only incidentally by a marker chosen for a different assertion.

**Three residuals no test can reach**, called out rather than papered over:
- Whether the text actually helps a cold operator. With the discriminator gone this PR is entirely a text change, so this is effectively the whole acceptance surface.
- Advice soundness in *novel* wording — the guard is a phrase tripwire for a known regression, and its docstring says so; a denylist over free prose cannot be complete.
- The README's verification-before-remedy **ordering**. The bootstrap-gate clause is safe partly because its referent opens with a falsifiable check, so a reader who is not in this failure state is turned back before the blunt setting. That guarantee spans two files no single test imports together — reordering that section would remove it with nothing failing.

## Gate

`12574 passed, 15 skipped, 0 errors`, full suite. Version bumped to 4.6.13 across the four canonical locations.
