### PR TITLE
Bind each branch of the marketplace tripwire to one action

### DIFF
--- a/pact-plugin/tests/test_packaging_boundary.py
+++ b/pact-plugin/tests/test_packaging_boundary.py
@@ -526,8 +526,14 @@ def test_premise_marketplace_maps_only_the_pact_plugin_subtree():
         "here they are not — so an exclusion-shaped NAME in a marketplace entry "
         "is not evidence of exclusion BEHAVIOUR. That asymmetry is exactly why "
         "this check does not filter by key shape.\n\n"
-        "WHAT TO DO: establish the key's real semantics, then either relax this "
-        "assertion or move it to the exclusion tripwire in the sibling test."
+        "WHAT TO DO — establish the key's real semantics, then act on the "
+        "branch that resolves. These are not a menu; each branch above has ONE "
+        "correct action. If the key CAN name paths outside the declared source, "
+        "this check stops being precautionary: KEEP it here and rewrite this "
+        "message as a demonstrated mechanism. If it only REMOVES paths, MOVE it "
+        "to the exclusion tripwire in the sibling test — do NOT simply delete "
+        "it, or marketplace entries lose the model-changed tripwire that "
+        "plugin.json keeps, and the two manifests fall out of parity again."
     )
 
 


### PR DESCRIPTION
Follow-up to #1231, which merged before this fix was staged.

The marketplace precautionary tripwire added in #1231 closes with:

> WHAT TO DO: establish the key's real semantics, then **either relax this assertion or move it** to the exclusion tripwire in the sibling test.

That is a two-option menu with no mapping onto the two branches stated directly above it — and **relax is wrong in one of them.**

Deleting the assertion in the exclusion-only branch would leave `marketplace.json` entries with no model-changed tripwire while `plugin.json` keeps one in the sibling test. The two manifests fall back out of parity, which is the asymmetry the check exists to close. Exclusion being inert for the shim boundary is exactly why the sibling *kept* its tripwire rather than deleting it.

Each branch now maps to exactly one action, and the text forecloses the menu reading ("These are not a menu; each branch above has ONE correct action") rather than merely discouraging it.

## Provenance

Caught by a reviewer reading the revised text rather than accepting the author's summary of it — the author had stated the message said move-not-relax, which was true of the draft and false of the revision after a reordering compressed the conditional into a disjunction. **Structural editing advice can drop a binding the old prose carried implicitly, and neither the adviser nor the implementer is watching for it.**

## Verification

Full suite on this branch: `12534 passed, 15 skipped, 0 failed, 0 errors`. Assertion-message text only — no code path or trigger set changed.

Note for reviewers: phrases in this module span adjacent string literals, so a line-oriented grep for a human-readable phrase will false-clean. Read the rendered message or search a fragment short enough to sit inside one literal.