### PR TITLE
fix: add required since field to teachback intentional_wait templates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.14",
+      "version": "4.6.15",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.14/       # Plugin version
+│               └── 4.6.15/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.14",
+  "version": "4.6.15",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.14
+> **Version**: 4.6.15
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/commands/comPACT.md
+++ b/pact-plugin/commands/comPACT.md
@@ -185,7 +185,7 @@ A_id = TaskCreate(
     subject="{specialist}: TEACHBACK for {sub-task}",
     description="DOGFOOD TEACHBACK GATE for {sub-task}.\n\n"
                 "Submit TEACHBACK by writing metadata.teachback_submit using the CANONICAL field schema (do NOT improvise key names): understanding, most_likely_wrong, least_confident_item, first_action, variety_acknowledgment (an OBJECT). See the pact-teachback skill for field semantics. "
-                "SET intentional_wait{reason=awaiting_lead_completion, expected_resolver=team-lead}. Idle. "
+                "SET intentional_wait{reason=awaiting_lead_completion, expected_resolver=team-lead, since=<canonical_since() output>}. Idle. "
                 "DO NOT mark this task completed — team-lead-only completion. Lead will mark completed "
                 "after teachback acceptance, then send a wake-SendMessage confirming Task B is claimable.\n\n"
                 "When Task B unblocks, claim it (TaskUpdate status=in_progress) BEFORE any implementation tool-use — it is pre-assigned to you but still pending; you flip it, not the lead.\n\n"

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -75,7 +75,7 @@ A_id = TaskCreate(
     subject="{role}: TEACHBACK for {feature}",
     description="DOGFOOD TEACHBACK GATE for {feature}.\n\n"
                 "Submit TEACHBACK by writing metadata.teachback_submit using the CANONICAL field schema (do NOT improvise key names): understanding, most_likely_wrong, least_confident_item, first_action, variety_acknowledgment (an OBJECT). See the pact-teachback skill for field semantics. "
-                "SET intentional_wait{reason=awaiting_lead_completion, expected_resolver=team-lead}. Idle. "
+                "SET intentional_wait{reason=awaiting_lead_completion, expected_resolver=team-lead, since=<canonical_since() output>}. Idle. "
                 "DO NOT mark this task completed — team-lead-only completion. Lead will mark completed "
                 "after teachback acceptance, then send a wake-SendMessage confirming Task B is claimable. "
                 "If TEACHBACK is rejected, team-lead writes metadata.teachback_rejection and sends a "


### PR DESCRIPTION
## What

Adds the required `since` field to the `intentional_wait` templates in `orchestrate.md` and `comPACT.md`.

## Why

Both command files instructed teammates to `SET intentional_wait{...}` without the `since` field, which `validate_wait` requires. A teammate following the template literally emitted a wait that **fails validation**, silently suppressing its own missed-wake alarm via the `find_stale_missed_wakes` pre-gate — so the alarm that should catch a stalled teammate never fired.

## What this deliberately does NOT change

The `expected_resolver` value stays `team-lead`. It is off the `KNOWN_RESOLVERS` vocabulary hint, but `validate_wait` accepts any non-empty resolver string, so it is inert. The spelling is left for a separate plugin-wide member-vocabulary standardization rather than being decided piecemeal on this one field.

## Testing

`rtk proxy python -m pytest pact-plugin/tests -q` -> 12534 passed, 15 skipped, 0 failed, 0 errors (errors token scanned explicitly).

PATCH bump 4.6.14 -> 4.6.15.