### PR TITLE
docs: reconcile teachback documentation to the GEN-3 blocking model (Phase 1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.15",
+      "version": "4.6.16",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.15/       # Plugin version
+│               └── 4.6.16/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.15",
+  "version": "4.6.16",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.15
+> **Version**: 4.6.16
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/agents/pact-orchestrator.md
+++ b/pact-plugin/agents/pact-orchestrator.md
@@ -492,7 +492,7 @@ Each specialist dispatch is a Task A (TEACHBACK) + Task B (work) pair with `bloc
 
 #### Validating Incoming Teachbacks
 
-When an agent sends a TEACHBACK, **compare it against the task as you dispatched it — check for both misstatements AND omissions of the objective, constraints, or success criteria**. If you spot a misunderstanding, reply with a correction via `SendMessage` before any other action — the agent is already working, so the correction window is short. Prevents **misunderstanding disguised as agreement** from going undetected until TEST phase.
+When an agent sends a TEACHBACK, **compare it against the task as you dispatched it — check for both misstatements AND omissions of the objective, constraints, or success criteria**. If you spot a misunderstanding, do NOT accept: write `metadata.teachback_rejection` with the correction and send a correction `SendMessage`. The agent is idling on `awaiting_lead_completion` (blocked, not yet working), so the block holds until you accept — there is no proceed-race; reject and let the agent revise on Task A. Prevents **misunderstanding disguised as agreement** from going undetected until TEST phase.
 
 **Then validate `variety_acknowledgment`** (5th canonical field per [pact-variety §variety_acknowledgment](../protocols/pact-variety.md#variety_acknowledgment--teammate-verification-workflow)). The teammate has judged your per-dimension variety rationales on Task B against THIS dispatch's actual work. Read `metadata.teachback_submit.variety_acknowledgment.rationale_articulates_this_dispatch`:
 

--- a/pact-plugin/commands/peer-review.md
+++ b/pact-plugin/commands/peer-review.md
@@ -250,10 +250,7 @@ This is the **primary memory trigger** — fires unconditionally at reviewer dis
 
 Each reviewer should state their understanding of the PR's intent before diving into review. This catches cases where a reviewer misunderstands the purpose and produces irrelevant findings.
 
-**Mechanism**: Include in each reviewer's task description:
-> "Before reviewing, send a teachback message to the team-lead stating your understanding of what this PR is trying to accomplish and what you'll focus on in your domain. Format: `[{sender}→team-lead] Teachback: I understand this PR is [intent]. Reviewing with focus on [domain focus]. Proceeding unless corrected.` Non-blocking — proceed with review after sending."
-
-This uses the same teachback mechanism as agent HANDOFFs. Background: [pact-ct-teachback.md](../protocols/pact-ct-teachback.md).
+**Mechanism**: The reviewer's understanding of the PR intent is captured by the **Teachback-Gated Dispatch** above — the reviewer's Task A teachback states the review angle and understanding of intent, is submitted as `metadata.teachback_submit`, and the reviewer idles on `awaiting_lead_completion` until the team-lead accepts (blocking). See [pact-ct-teachback.md](../protocols/pact-ct-teachback.md) for the mechanism.
 
 ---
 

--- a/pact-plugin/protocols/pact-completion-authority.md
+++ b/pact-plugin/protocols/pact-completion-authority.md
@@ -155,7 +155,7 @@ The status flip is the load-bearing approval action; the SendMessage is the load
 
 ### Validating Incoming Teachbacks
 
-When an agent sends a TEACHBACK, **compare it against the task as you dispatched it — check for both misstatements AND omissions of the objective, constraints, or success criteria**. If you spot a misunderstanding, reply with a correction via `SendMessage` before any other action — the agent is already working, so the correction window is short. Prevents **misunderstanding disguised as agreement** from going undetected until TEST phase. Once decided, follow the [Acceptance or Rejection two-call atomic pair](#completion-authority).
+When an agent sends a TEACHBACK, **compare it against the task as you dispatched it — check for both misstatements AND omissions of the objective, constraints, or success criteria**. If you spot a misunderstanding, do NOT accept: write `metadata.teachback_rejection` with the correction and send a correction `SendMessage`. The agent is idling on `awaiting_lead_completion` (blocked, not yet working), so the block holds until you accept — there is no proceed-race; reject and let the agent revise on Task A. Prevents **misunderstanding disguised as agreement** from going undetected until TEST phase. Once decided, follow the [Acceptance or Rejection two-call atomic pair](#completion-authority).
 
 ### Directive-Reflection Check
 

--- a/pact-plugin/protocols/pact-ct-teachback.md
+++ b/pact-plugin/protocols/pact-ct-teachback.md
@@ -28,17 +28,22 @@ When a downstream agent receives an upstream handoff (via `TaskGet`), their firs
 #### Flow
 
 ```
-1. Agent dispatched with upstream task reference (e.g., "Architect task: #5")
-2. Agent reads upstream handoff via `TaskGet(#5)`
-3. Agent sends teachback to team-lead via `SendMessage`:
-   "[{sender}→team-lead] Teachback: My understanding is... [key decisions restated]. Proceeding unless corrected."
-4. Agent proceeds with work (non-blocking)
-5. If orchestrator spots misunderstanding, they must `SendMessage` to agent to correct it
+1. Agent dispatched as a Task A (TEACHBACK gate) + Task B (primary work, blockedBy=[A]) pair
+2. Agent claims Task A, reads the upstream handoff/mission via `TaskGet`
+3. Agent writes its teachback to Task A metadata (`metadata.teachback_submit`, 5 canonical
+   fields) and sends a wake-signal `SendMessage` to team-lead:
+   "[{sender}→team-lead] Teachback submitted on Task #A. Idling on awaiting_lead_completion."
+4. Agent SETs `intentional_wait{reason=awaiting_lead_completion}` and idles — it does NOT
+   begin Task B (blocking)
+5. Team-lead reviews the teachback. On acceptance: wake-`SendMessage` FIRST, then
+   `TaskUpdate(A, status="completed")`, which unblocks Task B. On misunderstanding: write
+   `metadata.teachback_rejection` + a correction `SendMessage`; the agent revises on Task A.
+   The block holds until acceptance.
 ```
 
-#### Why Non-Blocking
+#### Why Blocking
 
-Blocking teachback (wait for confirmation before working) would serialize everything. Non-blocking gives the orchestrator a window to catch misunderstandings while the agent starts work. Most teachbacks will be correct — we're catching exceptions, not gatekeeping the norm.
+Blocking teachback — the teammate idles on `awaiting_lead_completion` until the lead accepts — catches a misunderstanding BEFORE the teammate burns context on a wrong implementation. The task graph makes this structural: Task B is `blockedBy=[A]`, so work cannot begin until the lead completes the teachback gate. This trades a short serialization delay for elimination of the most dangerous failure mode: misunderstanding disguised as agreement, otherwise undetected until TEST. Enforcement is blocking-by-protocol (the `blockedBy` edge) with advisory runtime hooks.
 
 #### Teachback Format
 
@@ -52,7 +57,7 @@ Blocking teachback (wait for confirmation before working) would serialize everyt
     - Decision attribution: "I understand {upstream agent} chose {decision} because {their stated reason}"
     - Assumption trace: "This reasoning depends on {assumption A}, {assumption B}, ..."
     - Contingency clause: "If {assumption A or B} changes, the decision should change to {alternative}"
-Proceeding unless corrected.
+Idling on awaiting_lead_completion until accepted.
 ```
 
 Keep teachbacks concise — 3-6 bullet points (or 4-7 when method reconstruction is included). The goal is to surface misunderstandings, not to restate the entire handoff. The method-reconstruction bullet is **optional below variety 11** and **required at variety ≥ 11**; see [When to Method-Reconstruct](#when-to-method-reconstruct) for the variety-band gate.

--- a/pact-plugin/protocols/pact-ct-teachback.md
+++ b/pact-plugin/protocols/pact-ct-teachback.md
@@ -43,7 +43,7 @@ When a downstream agent receives an upstream handoff (via `TaskGet`), their firs
 
 #### Why Blocking
 
-Blocking teachback — the teammate idles on `awaiting_lead_completion` until the lead accepts — catches a misunderstanding BEFORE the teammate burns context on a wrong implementation. The task graph makes this structural: Task B is `blockedBy=[A]`, so work cannot begin until the lead completes the teachback gate. This trades a short serialization delay for elimination of the most dangerous failure mode: misunderstanding disguised as agreement, otherwise undetected until TEST. Enforcement is blocking-by-protocol (the `blockedBy` edge) with advisory runtime hooks.
+Blocking teachback — the teammate idles on `awaiting_lead_completion` until the lead accepts — catches a misunderstanding BEFORE the teammate burns context on a wrong implementation. The task graph makes this structural: Task B is `blockedBy=[A]`, so it is not claimable until the lead completes the teachback gate. This trades a short serialization delay for elimination of the most dangerous failure mode: misunderstanding disguised as agreement, otherwise undetected until TEST. Enforcement is blocking-by-protocol (the `blockedBy` edge) with advisory runtime hooks.
 
 #### Teachback Format
 

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -405,17 +405,22 @@ When a downstream agent receives an upstream handoff (via `TaskGet`), their firs
 #### Flow
 
 ```
-1. Agent dispatched with upstream task reference (e.g., "Architect task: #5")
-2. Agent reads upstream handoff via `TaskGet(#5)`
-3. Agent sends teachback to team-lead via `SendMessage`:
-   "[{sender}→team-lead] Teachback: My understanding is... [key decisions restated]. Proceeding unless corrected."
-4. Agent proceeds with work (non-blocking)
-5. If orchestrator spots misunderstanding, they must `SendMessage` to agent to correct it
+1. Agent dispatched as a Task A (TEACHBACK gate) + Task B (primary work, blockedBy=[A]) pair
+2. Agent claims Task A, reads the upstream handoff/mission via `TaskGet`
+3. Agent writes its teachback to Task A metadata (`metadata.teachback_submit`, 5 canonical
+   fields) and sends a wake-signal `SendMessage` to team-lead:
+   "[{sender}→team-lead] Teachback submitted on Task #A. Idling on awaiting_lead_completion."
+4. Agent SETs `intentional_wait{reason=awaiting_lead_completion}` and idles — it does NOT
+   begin Task B (blocking)
+5. Team-lead reviews the teachback. On acceptance: wake-`SendMessage` FIRST, then
+   `TaskUpdate(A, status="completed")`, which unblocks Task B. On misunderstanding: write
+   `metadata.teachback_rejection` + a correction `SendMessage`; the agent revises on Task A.
+   The block holds until acceptance.
 ```
 
-#### Why Non-Blocking
+#### Why Blocking
 
-Blocking teachback (wait for confirmation before working) would serialize everything. Non-blocking gives the orchestrator a window to catch misunderstandings while the agent starts work. Most teachbacks will be correct — we're catching exceptions, not gatekeeping the norm.
+Blocking teachback — the teammate idles on `awaiting_lead_completion` until the lead accepts — catches a misunderstanding BEFORE the teammate burns context on a wrong implementation. The task graph makes this structural: Task B is `blockedBy=[A]`, so work cannot begin until the lead completes the teachback gate. This trades a short serialization delay for elimination of the most dangerous failure mode: misunderstanding disguised as agreement, otherwise undetected until TEST. Enforcement is blocking-by-protocol (the `blockedBy` edge) with advisory runtime hooks.
 
 #### Teachback Format
 
@@ -429,7 +434,7 @@ Blocking teachback (wait for confirmation before working) would serialize everyt
     - Decision attribution: "I understand {upstream agent} chose {decision} because {their stated reason}"
     - Assumption trace: "This reasoning depends on {assumption A}, {assumption B}, ..."
     - Contingency clause: "If {assumption A or B} changes, the decision should change to {alternative}"
-Proceeding unless corrected.
+Idling on awaiting_lead_completion until accepted.
 ```
 
 Keep teachbacks concise — 3-6 bullet points (or 4-7 when method reconstruction is included). The goal is to surface misunderstandings, not to restate the entire handoff. The method-reconstruction bullet is **optional below variety 11** and **required at variety ≥ 11**; see [When to Method-Reconstruct](#when-to-method-reconstruct) for the variety-band gate.
@@ -2227,7 +2232,7 @@ The status flip is the load-bearing approval action; the SendMessage is the load
 
 ### Validating Incoming Teachbacks
 
-When an agent sends a TEACHBACK, **compare it against the task as you dispatched it — check for both misstatements AND omissions of the objective, constraints, or success criteria**. If you spot a misunderstanding, reply with a correction via `SendMessage` before any other action — the agent is already working, so the correction window is short. Prevents **misunderstanding disguised as agreement** from going undetected until TEST phase. Once decided, follow the [Acceptance or Rejection two-call atomic pair](#completion-authority).
+When an agent sends a TEACHBACK, **compare it against the task as you dispatched it — check for both misstatements AND omissions of the objective, constraints, or success criteria**. If you spot a misunderstanding, do NOT accept: write `metadata.teachback_rejection` with the correction and send a correction `SendMessage`. The agent is idling on `awaiting_lead_completion` (blocked, not yet working), so the block holds until you accept — there is no proceed-race; reject and let the agent revise on Task A. Prevents **misunderstanding disguised as agreement** from going undetected until TEST phase. Once decided, follow the [Acceptance or Rejection two-call atomic pair](#completion-authority).
 
 ### Directive-Reflection Check
 

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -420,7 +420,7 @@ When a downstream agent receives an upstream handoff (via `TaskGet`), their firs
 
 #### Why Blocking
 
-Blocking teachback — the teammate idles on `awaiting_lead_completion` until the lead accepts — catches a misunderstanding BEFORE the teammate burns context on a wrong implementation. The task graph makes this structural: Task B is `blockedBy=[A]`, so work cannot begin until the lead completes the teachback gate. This trades a short serialization delay for elimination of the most dangerous failure mode: misunderstanding disguised as agreement, otherwise undetected until TEST. Enforcement is blocking-by-protocol (the `blockedBy` edge) with advisory runtime hooks.
+Blocking teachback — the teammate idles on `awaiting_lead_completion` until the lead accepts — catches a misunderstanding BEFORE the teammate burns context on a wrong implementation. The task graph makes this structural: Task B is `blockedBy=[A]`, so it is not claimable until the lead completes the teachback gate. This trades a short serialization delay for elimination of the most dangerous failure mode: misunderstanding disguised as agreement, otherwise undetected until TEST. Enforcement is blocking-by-protocol (the `blockedBy` edge) with advisory runtime hooks.
 
 #### Teachback Format
 

--- a/pact-plugin/skills/pact-teachback/SKILL.md
+++ b/pact-plugin/skills/pact-teachback/SKILL.md
@@ -60,9 +60,11 @@ team-lead can catch misunderstandings early, before you burn context on a
 wrong implementation.
 
 Under the Task A + Task B dispatch shape, your teachback is the deliverable
-of Task A. Task B (the primary work) is `blockedBy=[A]` and stays hidden
-in your TaskList until the team-lead accepts your teachback by transitioning
-Task A to `completed`.
+of Task A. Task B (the primary work) is `blockedBy=[A]`: it remains VISIBLE and
+readable in your TaskList (annotated as blocked) but is not claimable — the
+`blockedBy` edge filters it from the claimable set, it does not hide or lock it —
+until the team-lead accepts your teachback by transitioning Task A to `completed`,
+which makes Task B claimable.
 
 The 5 canonical fields (Step 1) are the L1 (procedure-level) gate; the optional `reasoning_reconstruction` nested field enables the L1.5 (method-level) gate at high-variety dispatches — see [pact-ct-teachback.md §When to Method-Reconstruct](../../protocols/pact-ct-teachback.md#when-to-method-reconstruct). Variety-band thresholds live at the SSOT in `hooks/shared/variety_scorer.py` (`COMPACT_MAX` / `ORCHESTRATE_MAX` / `PLAN_MODE_MAX` + `route_workflow`); do not hard-code the 6 / 10 / 14 thresholds.
 

--- a/pact-plugin/skills/pact-teachback/SKILL.md
+++ b/pact-plugin/skills/pact-teachback/SKILL.md
@@ -187,7 +187,7 @@ If you are dispatched as an owner in `TEACHBACK_EXEMPT_AGENT_TYPES` (currently `
 
 You must store your teachback (`metadata.teachback_submit` write) before any Edit/Write/Bash call used for implementation work. Reading files to understand the task (Read, Glob, Grep) is permitted before teachback; those are understanding actions, not implementation actions.
 
-Under the Task A + Task B dispatch shape, this ordering is structurally reinforced: Task B is hidden behind `blockedBy=[A]` until Task A's status transitions to `completed`. The `metadata.teachback_submit` write IS your teachback delivery; the team-lead's `TaskUpdate(A, status="completed")` paired with a wake-signal SendMessage IS approval.
+Under the Task A + Task B dispatch shape, this ordering is structurally reinforced: Task B is gated behind `blockedBy=[A]` (visible but not claimable) until Task A's status transitions to `completed`. The `metadata.teachback_submit` write IS your teachback delivery; the team-lead's `TaskUpdate(A, status="completed")` paired with a wake-signal SendMessage IS approval.
 
 ## Post-store behavior
 

--- a/pact-plugin/tests/test_agents_structure.py
+++ b/pact-plugin/tests/test_agents_structure.py
@@ -570,12 +570,24 @@ class TestTeachbackMicroSkillExtraction:
         'TaskUpdate(taskId, metadata={"teachback_submit":',  # Storage literal
     ]
 
-    # Lines that indicate full protocol content (not a stub).
-    # If pact-agent-teams contains these, the extraction is incomplete.
+    # Teachback MESSAGE-FORMAT / content-writing phrases the full teachback
+    # protocol carries but a pointer-stub never would. If pact-agent-teams
+    # contains any of these, the full protocol has leaked back into the stub
+    # (the extraction is incomplete). These deliberately avoid the
+    # intentional_wait / lifecycle vocabulary that pact-agent-teams
+    # legitimately owns as a stub (awaiting_lead_completion, the acceptance
+    # ordering TaskUpdate(A, status="completed")) — that territory is a muddy
+    # discriminator; teachback message-authoring guidance is not.
     FULL_PROTOCOL_MARKERS = [
         "Send as your **first message**",
         "Keep concise: 3-6 bullet points",
-        "Non-blocking: proceed with work after sending",
+        # Live teachback-template bullet from the current (blocking-era) full
+        # protocol: protocols/pact-ct-teachback.md "Teachback Format" plus its
+        # pact-protocols.md SSOT mirror. Replaces a dead non-blocking-era fossil
+        # ("Non-blocking: proceed with work after sending") that, after the
+        # reconciliation to the blocking model, appears nowhere and so could no
+        # longer catch a full-protocol dump.
+        "Building: {what I understand I'm building}",
     ]
 
     @pytest.fixture

--- a/pact-plugin/tests/test_agents_structure.py
+++ b/pact-plugin/tests/test_agents_structure.py
@@ -578,17 +578,40 @@ class TestTeachbackMicroSkillExtraction:
     # legitimately owns as a stub (awaiting_lead_completion, the acceptance
     # ordering TaskUpdate(A, status="completed")) — that territory is a muddy
     # discriminator; teachback message-authoring guidance is not.
-    FULL_PROTOCOL_MARKERS = [
+    #
+    # The markers are PARTITIONED into LIVE (present in the current protocol
+    # source) and HISTORICAL (pre-extraction fossils that appear nowhere in the
+    # current source). LIVE markers get BOTH guards — absent-from-stub AND
+    # present-in-source (drift-rot: if a live marker's source phrasing drifts it
+    # silently rots to a dead fossil and stops guarding, the exact failure the
+    # canary refresh in this PR fixed). HISTORICAL markers get ONLY the absent-
+    # from-stub guard — asserting their presence would fail, since they are
+    # intentionally dead in the source and retained purely to detect a re-dump
+    # of the OLD (pre-extraction) full protocol into the stub.
+
+    # marker -> the full-protocol source file (relative to the plugin root) that
+    # must contain it. pact-agent-teams stubs this source, so a full-protocol
+    # re-dump into the stub would carry the marker. The "Building:" bullet is the
+    # teachback-template line from pact-ct-teachback.md "Teachback Format" (also
+    # byte-mirrored into pact-protocols.md); it replaced a dead non-blocking-era
+    # fossil that appeared nowhere after the reconciliation to the blocking model.
+    LIVE_PROTOCOL_MARKERS = {
+        "Building: {what I understand I'm building}": "protocols/pact-ct-teachback.md",
+    }
+
+    # Pre-extraction phrasings that appear NOWHERE in the current source
+    # (verified 0-hit). Retained purely as leak-detectors for a re-dump of the
+    # OLD full protocol into the stub, so they are exempt from present-in-source.
+    HISTORICAL_PROTOCOL_MARKERS = [
         "Send as your **first message**",
         "Keep concise: 3-6 bullet points",
-        # Live teachback-template bullet from the current (blocking-era) full
-        # protocol: protocols/pact-ct-teachback.md "Teachback Format" plus its
-        # pact-protocols.md SSOT mirror. Replaces a dead non-blocking-era fossil
-        # ("Non-blocking: proceed with work after sending") that, after the
-        # reconciliation to the blocking model, appears nowhere and so could no
-        # longer catch a full-protocol dump.
-        "Building: {what I understand I'm building}",
     ]
+
+    # Canonical union consumed by the absent-from-stub canary (behavior
+    # unchanged). Deriving it from LIVE + HISTORICAL construction-enforces that
+    # every marker is classified — a new marker cannot enter FULL without a
+    # conscious live-vs-fossil decision (see test_protocol_markers_partition).
+    FULL_PROTOCOL_MARKERS = list(LIVE_PROTOCOL_MARKERS) + HISTORICAL_PROTOCOL_MARKERS
 
     @pytest.fixture
     def teachback_skill(self):
@@ -748,6 +771,47 @@ class TestTeachbackMicroSkillExtraction:
         assert "pact-teachback" in text, (
             "pact-agent-teams should reference pact-teachback skill "
             "as a pointer so agents know where the protocol lives."
+        )
+
+    def test_live_protocol_markers_present_in_source(self):
+        """T7 (drift-rot guard): each LIVE marker must still appear in its
+        full-protocol source. A marker only asserted `not in stub` (the T5
+        canary) silently rots to a dead fossil if the source phrasing drifts —
+        it keeps passing while guarding nothing. That is exactly the failure the
+        canary refresh in this PR corrected (the prior GEN-1 marker had rotted to
+        a phrase present nowhere after the blocking reconciliation). Asserting
+        present-in-source turns that silent rot into a red test.
+        """
+        plugin_root = Path(__file__).parent.parent
+        for marker, rel_source in self.LIVE_PROTOCOL_MARKERS.items():
+            source = plugin_root / rel_source
+            assert source.is_file(), f"live-marker source missing: {rel_source}"
+            text = source.read_text(encoding="utf-8")
+            assert marker in text, (
+                f"LIVE protocol marker {marker!r} no longer appears in its "
+                f"source {rel_source} — it has rotted to a dead fossil and no "
+                f"longer guards against a full-protocol dump. Refresh it to a "
+                f"live phrase from the current protocol, or reclassify it as "
+                f"HISTORICAL if the phrasing was intentionally removed."
+            )
+
+    def test_protocol_markers_partition(self):
+        """T8 (classification guard): every FULL_PROTOCOL_MARKERS entry is
+        classified as exactly one of LIVE (present-in-source, drift-rot-guarded)
+        or HISTORICAL (fossil, absent-from-stub only). Forces a future marker
+        addition to make the live-vs-fossil decision consciously; an unclassified
+        live marker would silently skip the present-in-source guard.
+        """
+        live = set(self.LIVE_PROTOCOL_MARKERS)
+        historical = set(self.HISTORICAL_PROTOCOL_MARKERS)
+        assert live.isdisjoint(historical), (
+            f"markers classified as BOTH live and historical: "
+            f"{sorted(live & historical)}"
+        )
+        assert set(self.FULL_PROTOCOL_MARKERS) == live | historical, (
+            "FULL_PROTOCOL_MARKERS must equal LIVE union HISTORICAL so every "
+            "marker is classified; an unclassified marker would skip the "
+            "present-in-source drift-rot guard"
         )
 
 

--- a/pact-plugin/tests/test_audit_protocol.py
+++ b/pact-plugin/tests/test_audit_protocol.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 PROTOCOLS_DIR = Path(__file__).parent.parent / "protocols"
 COMMANDS_DIR = Path(__file__).parent.parent / "commands"
 AGENTS_DIR = Path(__file__).parent.parent / "agents"
+SKILLS_DIR = Path(__file__).parent.parent / "skills"
 
 AUDIT_PROTOCOL = PROTOCOLS_DIR / "pact-audit.md"
 ORCHESTRATE_CMD = COMMANDS_DIR / "orchestrate.md"
@@ -508,3 +509,72 @@ class TestStructuralVerificationDiscipline:
             "extracts sync gate would silently no-op (skip) without it, "
             "leaving SSOT/extract drift undetected."
         )
+
+
+class TestTeachbackBlockingSemanticGuard:
+    """Semantic-regression guard for the teachback-doc reconciliation to ONE
+    blocking model.
+
+    The byte-mirror gate (test_verify_protocol_extracts_* above) guards
+    extract<->SSOT BYTE-IDENTITY: it catches a DESYNC of a mirrored pair but is
+    BLIND to the blocking-vs-non-blocking SEMANTIC. A future edit that
+    re-introduces GEN-1 non-blocking phrasing IDENTICALLY on both the extract and
+    its SSOT mirror stays byte-identical and passes the byte-gate. This guard
+    asserts the reconciled teachback surface does not re-introduce the specific
+    GEN-1 phrases the reconciliation removed.
+
+    False-positive safety: this is a DENYLIST of high-specificity phrases
+    distinctive to the removed GEN-1 teachback prose (each verified to appear
+    NOWHERE in the current sources). It deliberately does NOT denylist the
+    generic word "non-blocking", which legitimately occurs in these files (e.g.
+    pact-protocols.md: "The auditor is **non-blocking**", plus hook fail-open /
+    HANDOFF-processing contexts) and would false-positive. Phrase-specificity is
+    what lets this assert file-wide without region-bounding the multi-topic SSOT.
+
+    Bounded-completeness residual (intentional): a phrase denylist catches a
+    copy-paste REVERT to the old GEN-1 wording (the likely regression) but NOT a
+    re-worded non-blocking model expressed in fresh prose. Guarding the latter
+    would require the generic word + region-bounding + context exclusions, which
+    is fragile and false-positive-prone; that completeness is out of scope by
+    design (copy-paste-revert is the valuable, false-positive-safe coverage).
+    """
+
+    # The reconciled teachback surface (the reconciliation's edited file set).
+    RECONCILED_FILES = [
+        PROTOCOLS_DIR / "pact-ct-teachback.md",
+        PROTOCOLS_DIR / "pact-protocols.md",
+        PROTOCOLS_DIR / "pact-completion-authority.md",
+        SKILLS_DIR / "pact-teachback" / "SKILL.md",
+        AGENTS_DIR / "pact-orchestrator.md",
+        COMMANDS_DIR / "peer-review.md",
+    ]
+
+    # High-specificity GEN-1 (non-blocking) phrases the reconciliation removed.
+    # Distinctive enough that legitimate current prose never contains them, so a
+    # match means a GEN-1 regression re-entered the teachback surface. Matched
+    # case-insensitively so a re-cased revert is still caught. Note: "stays
+    # hidden" is the least-specific entry (it guards the corrected false
+    # blockedBy-visibility claim); the other three are unmistakably GEN-1
+    # teachback prose. The generic word "non-blocking" is intentionally EXCLUDED
+    # (it occurs legitimately, e.g. the auditor description in pact-protocols.md).
+    GEN1_REGRESSION_PHRASES = [
+        "Why Non-Blocking",                 # removed section heading
+        "Proceeding unless corrected",      # removed proceed-optimistically clause
+        "proceed with work after sending",  # removed non-blocking flow line
+        "stays hidden",                     # corrected false blockedBy claim
+    ]
+
+    def test_no_gen1_nonblocking_phrase_in_reconciled_surface(self):
+        for path in self.RECONCILED_FILES:
+            assert path.is_file(), f"reconciled surface file missing: {path}"
+            text = path.read_text(encoding="utf-8").lower()
+            for phrase in self.GEN1_REGRESSION_PHRASES:
+                assert phrase.lower() not in text, (
+                    f"GEN-1 non-blocking phrase {phrase!r} re-introduced into "
+                    f"{path.name} — the teachback surface reconciliation moved it "
+                    f"to ONE blocking model. The byte-mirror gate cannot catch "
+                    f"this (it guards byte-identity, not blocking-vs-non-blocking "
+                    f"semantics). If this phrasing is intentionally returning, the "
+                    f"reconciliation is being reverted; update this guard "
+                    f"deliberately."
+                )


### PR DESCRIPTION
## Summary

Phase 1 of #852: reconcile the teachback documentation surface to the GEN-3 (task-graph blocking) model. Six specialist consultations found the real defect was **documentation contradicting documentation** — the teachback surface shipped three generations of an unfinished migration, two of which survived and contradicted each other. With GEN-3 (blocking) ruled canonical, this PR makes the docs state one model.

Doc-only, no behavior change. Phase 2 (an optional, staged mechanical `PreToolUse` deny) remains deferred.

## Changes

- **Correct two false statements**: the "stays hidden" claim in the pact-teachback skill (a `blockedBy` work task is visible/readable in the task list, just not claimable — `blockedBy` filters it from the claimable set, it does not hide or lock it) and the persona "already working" self-contradiction in the Teachback Review region.
- **Supersede the stale GEN-1 non-blocking form to blocking** in `pact-ct-teachback.md` + its `pact-protocols.md` SSOT mirror (same-commit byte-gate), plus the matching `pact-completion-authority.md` clause + mirror.
- **Repoint** the peer-review reviewer-teachback mechanism to the blocking dispatch gate (its operative dispatch was already blocking), keeping the reviewer-teachback rationale.
- **Refresh a stale test canary**: `FULL_PROTOCOL_MARKERS` carried a dead phrase that could no longer catch a full-protocol re-dump into the agent-teams stub; replaced with a live message-format discriminator, plus a non-vacuity check confirming it flips red on a real dump.
- **PATCH version bump** 4.6.15 → 4.6.16.

## Verification

- Byte-gate (`verify-protocol-extracts.sh`): 19/0, both extract↔SSOT pairs MATCH.
- Full suite: 12582 passed, 0 failed, 0 errors.
- Concurrent auditor: GREEN on byte-mirror integrity + edit completeness.

Phase 1 of #852 — Phase 2 (mechanical deny) deferred; do not close #852 on merge.
