### PR TITLE
Working Memory hardening (Track A): atomic writes, lock identity, worktree resolution — v4.6.17

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.16",
+      "version": "4.6.17",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.16/       # Plugin version
+│               └── 4.6.17/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.16",
+  "version": "4.6.17",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.16
+> **Version**: 4.6.17
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/agents/pact-secretary.md
+++ b/pact-plugin/agents/pact-secretary.md
@@ -72,10 +72,12 @@ You are the team's go-to source for historical context. The team-lead and specia
 
 You are **exempted from the standard teachback** at spawn — your bootstrap task `secretary: deliver session briefing` is a discrete deliverable dispatched single-task (the `pact-secretary` agentType is teachback-exempt), so there is no Task A to teach back about. Find that task via `TaskList` (it is owned by you) and claim it (`TaskUpdate(taskId, status="in_progress")`), then immediately:
 
-1. **Clean stale Working Memory entries**: Read the Working Memory section of the project's CLAUDE.md. The file may be at `$CLAUDE_PROJECT_DIR/.claude/CLAUDE.md` (preferred) or `$CLAUDE_PROJECT_DIR/CLAUDE.md` (legacy) — use whichever exists, matching the detection logic in `resolve_project_claude_md_path()`. Evaluate each entry against these stale criteria (any one triggers removal):
+1. **Clean stale Working Memory entries**: Read the Working Memory section of the project's CLAUDE.md. The file may be at `$CLAUDE_PROJECT_DIR/.claude/CLAUDE.md` (preferred) or `$CLAUDE_PROJECT_DIR/CLAUDE.md` (legacy) — use whichever exists, matching the detection logic in `resolve_project_claude_md_path()`. Evaluate each entry against these stale criteria (any one FAIL triggers removal; a criterion that cannot be evaluated never does):
    - **Age**: Entry older than 7 days (using the `YYYY-MM-DD` date in the Working Memory header)
    - **Content**: Entry contains test artifacts, debugging notes, or temporary context markers (patterns like `test_`, `debug_`, `temp_`, `WIP:`)
-   - **Orphaned references**: Entry references a memory ID that no longer exists in pact-memory (verify via `get` CLI command)
+   - **Orphaned references**: Entry cites a Memory ID that no longer exists in pact-memory (verify via `get` CLI command). This criterion has **three** outcomes, not two: it **FAILS** when the cited ID is absent from the database, **PASSES** when the ID resolves, and **CANNOT BE EVALUATED** when the entry carries no Memory ID at all. A missing ID is **not** an orphaned reference — compressed entries have no ID by construction, so scoring absence as a FAIL deletes entries this criterion never actually judged.
+
+   The unevaluable entries are not a random slice. Compression strips Memory IDs oldest-first, so the entries you cannot check for orphaned references are the same entries most likely to be stale on **Age** — judge them on Age and Content deliberately rather than letting them fall through unexamined.
 
    Remove stale entries by rewriting the Working Memory section. Report cleanup in your session briefing.
 
@@ -197,14 +199,17 @@ If no patterns found: "No calibration data or known patterns for this domain."
 
 # WORKING MEMORY SYNC
 
-**AUTOMATIC**: When you save a memory using the CLI `save` command, it automatically:
-- Syncs to the Working Memory section in CLAUDE.md
-- Maintains a rolling window of the last 3 entries
-- Includes the Memory ID for reference back to the database
+**AUTOMATIC**: When you save a memory using the CLI `save` command, it syncs that memory into the Working Memory section of CLAUDE.md. You do NOT need to manually edit CLAUDE.md for a save to appear there.
 
-You do NOT need to manually edit CLAUDE.md. The sync happens automatically on every save.
+**What the section actually holds.** The entry list is capped at 3, and then a token budget is applied to the section as a whole. Those two rules interact, so the number of entries you see is not fixed:
 
-**Relationship to auto-memory**: The platform's auto-memory (MEMORY.md) captures free-form session learnings automatically. Working Memory provides a complementary structured view -- PACT-specific context (goals, decisions, lessons) sourced from the SQLite database. Both are loaded into the system prompt independently. The reduced entry count (3 instead of 5) limits token overlap while retaining the structured format that auto-memory does not provide.
+- The **newest entry is always kept in full**, and it is the only entry guaranteed to carry its **Memory ID**. It is never compressed and never dropped.
+- **Older entries are compressed** to a date line plus a one-sentence summary. Compression **drops the Memory ID**, so a compressed entry cannot be looked up with the `get` command.
+- When the newest entry **on its own** exceeds the section's token budget — which a typical full entry does — the older entries are dropped entirely and the section shows a **single** entry.
+
+So do not assume three entries are present, and do not assume an entry you can see is addressable by ID. Read the section before reasoning about what it contains. The full history stays searchable via the `search` command regardless of how much the section displays.
+
+**Relationship to auto-memory**: The platform's auto-memory (MEMORY.md) captures free-form session learnings automatically. Working Memory provides a complementary structured view -- PACT-specific context (goals, decisions, lessons) sourced from the SQLite database. Both are loaded into the system prompt independently. The small, token-budgeted entry count limits token overlap while retaining the structured format that auto-memory does not provide.
 
 # SESSION CONSOLIDATION (Pass 2)
 

--- a/pact-plugin/hooks/shared/claude_md_manager.py
+++ b/pact-plugin/hooks/shared/claude_md_manager.py
@@ -204,7 +204,7 @@ def _atomic_write_text(target: Path, content: str) -> None:
     momentarily visible with the wrong permissions -- unlike a chmod after the
     write, which leaves exactly such a window on a file holding user content.
 
-    Callers should already hold `file_lock` for the target. The lock closes the
+    Callers must already hold `file_lock` for the target. The lock closes the
     concurrent-writer window; this closes the crash/truncation window. They are
     different hazards and neither fix subsumes the other. Note the lock is a
     separate sidecar file, so replacing the target's inode does not disturb it.
@@ -228,7 +228,15 @@ def _atomic_write_text(target: Path, content: str) -> None:
         dir=str(target.parent), prefix=f".{target.name}.", suffix=".tmp"
     )
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        # os.fdopen takes ownership of fd only on success; if it raises, the
+        # raw fd mkstemp opened would leak (the outer cleanup unlinks the temp
+        # FILE but cannot close a descriptor it never received a handle for).
+        try:
+            handle = os.fdopen(fd, "w", encoding="utf-8")
+        except BaseException:
+            os.close(fd)
+            raise
+        with handle:
             handle.write(content)
             handle.flush()
             # Without the fsync the rename can be persisted while the data

--- a/pact-plugin/hooks/shared/claude_md_manager.py
+++ b/pact-plugin/hooks/shared/claude_md_manager.py
@@ -85,7 +85,12 @@ def file_lock(target_file: Path):
             should treat this as a transient failure and return a
             fail-open status string so session_init can surface it.
     """
-    lock_path = target_file.parent / f".{target_file.name}.lock"
+    # Resolve the WHOLE target, not just its parent: fcntl.flock serialises on
+    # the sidecar's inode, so two spellings of one file must produce one sidecar
+    # name. Resolving only the parent still keys a symlinked FILE by its alias
+    # (two names, one inode -> two sidecars -> no mutual exclusion).
+    resolved_target = target_file.resolve()
+    lock_path = resolved_target.parent / f".{resolved_target.name}.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     # 0o600: the lock file is adjacent to user-private CLAUDE.md content;
     # match the same permissions to avoid leaving a world-readable sidecar.

--- a/pact-plugin/hooks/shared/claude_md_manager.py
+++ b/pact-plugin/hooks/shared/claude_md_manager.py
@@ -26,6 +26,7 @@ import fcntl  # Unix-only; PACT supports macOS/Linux. No Windows compat shim.
 import os
 import re
 import sys
+import tempfile
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -179,6 +180,67 @@ _BOUNDARY_ALT = "|".join(PACT_BOUNDARY_PREFIXES)
 _STALE_ORCHESTRATOR_LINE_RE = re.compile(
     r"^The global PACT Orchestrator is loaded from `~/\.claude/CLAUDE\.md`\.?\s*$",
 )
+
+
+def _atomic_write_text(target: Path, content: str) -> None:
+    """Replace `target`'s contents with `content` atomically.
+
+    `Path.write_text` truncates the file and THEN writes, so a crash, a full
+    disk, or a kill between those two steps leaves a TRUNCATED CLAUDE.md. That
+    file is gitignored and untracked in the projects this runs in, so there is
+    no recovery path -- the user's pinned context is simply gone.
+
+    Writing to a sibling temp file and renaming makes the replacement atomic: a
+    reader sees either the whole old file or the whole new one, never a partial
+    write. The temp file is created in the TARGET'S OWN DIRECTORY because
+    `os.replace` is only atomic within a single filesystem.
+
+    The mode is set on the TEMP file before the rename, so the target is never
+    momentarily visible with the wrong permissions -- unlike a chmod after the
+    write, which leaves exactly such a window on a file holding user content.
+
+    Callers should already hold `file_lock` for the target. The lock closes the
+    concurrent-writer window; this closes the crash/truncation window. They are
+    different hazards and neither fix subsumes the other. Note the lock is a
+    separate sidecar file, so replacing the target's inode does not disturb it.
+
+    Requires write permission on the target's DIRECTORY (to create the temp),
+    where a bare `write_text` needed only permission on the file itself. A
+    read-only directory holding a writable CLAUDE.md would now fail the write
+    rather than truncate it -- a safe direction, but a real behaviour change.
+
+    NOTE: a deliberate duplicate of `_atomic_write_text` in
+    `skills/pact-memory/scripts/working_memory.py`, which cannot import from
+    `hooks/shared/` (separate package). Unlike the `file_lock` twin, the two
+    copies are NOT drift-gated: atomicity has no cross-process invariant, so
+    each copy is independently correct and may legitimately diverge.
+
+    Args:
+        target: Path to replace. Its parent directory must already exist.
+        content: Full file contents to write.
+    """
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(target.parent), prefix=f".{target.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            # Without the fsync the rename can be persisted while the data
+            # behind it is not, which reintroduces the empty-file failure this
+            # function exists to prevent.
+            os.fsync(handle.fileno())
+        # mkstemp already creates 0o600; setting it explicitly keeps the mode a
+        # property of this function rather than of the stdlib's default.
+        os.chmod(tmp_name, 0o600)
+        os.replace(tmp_name, target)
+    except BaseException:
+        # Never leave a stray temp file behind next to the user's CLAUDE.md.
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
 
 
 def _strip_legacy_lines(content: str) -> str:
@@ -392,8 +454,7 @@ def strip_orphan_kernel_block() -> str | None:
                 new_content = ""
 
             try:
-                target_file.write_text(new_content, encoding="utf-8")
-                os.chmod(str(target_file), 0o600)
+                _atomic_write_text(target_file, new_content)
                 return (
                     "Removed obsolete PACT kernel block from "
                     "~/.claude/CLAUDE.md"
@@ -491,8 +552,9 @@ def ensure_dot_claude_parent(path: Path) -> None:
     Raises early with a clear message when the parent path exists but is
     a regular file (e.g., a local attacker deliberately blocking mkdir
     by creating a file where `.claude/` should be). Without this guard
-    the code path would fall through to the subsequent write_text call
-    and surface a less-clear late-stage OSError.
+    the code path would fall through to the subsequent `_atomic_write_text`
+    call and surface a less-clear OSError from `tempfile.mkstemp`, which
+    needs the parent to be a writable directory.
 
     Args:
         path: The target CLAUDE.md path (e.g. /proj/.claude/CLAUDE.md).
@@ -579,8 +641,7 @@ def ensure_project_memory_md() -> str | None:
             if target_file.exists():
                 return None
             try:
-                target_file.write_text(memory_template, encoding="utf-8")
-                os.chmod(str(target_file), 0o600)
+                _atomic_write_text(target_file, memory_template)
                 return "Created project CLAUDE.md with memory sections"
             except OSError as e:
                 return f"Project CLAUDE.md failed: {str(e)[:50]}"
@@ -657,8 +718,7 @@ def migrate_to_managed_structure() -> str | None:
             new_content = _build_migrated_content(content)
 
             try:
-                target_file.write_text(new_content, encoding="utf-8")
-                os.chmod(str(target_file), 0o600)
+                _atomic_write_text(target_file, new_content)
                 return "Migrated project CLAUDE.md to managed structure (#404)"
             except OSError as e:
                 return f"Migration failed: {str(e)[:50]}"

--- a/pact-plugin/hooks/shared/session_resume.py
+++ b/pact-plugin/hooks/shared/session_resume.py
@@ -28,6 +28,7 @@ from shared.claude_md_manager import (
     MANAGED_TITLE,
     MEMORY_END_MARKER,
     MEMORY_START_MARKER,
+    _atomic_write_text,
     ensure_dot_claude_parent,
     file_lock,
     resolve_project_claude_md_path,
@@ -194,8 +195,7 @@ def update_session_info(
                         "\n"
                         f"{MANAGED_END_MARKER}\n"
                     )
-                    target_file.write_text(new_content, encoding="utf-8")
-                    os.chmod(str(target_file), 0o600)
+                    _atomic_write_text(target_file, new_content)
                     return "Session info created in new project CLAUDE.md"
 
                 content = target_file.read_text(encoding="utf-8")
@@ -217,8 +217,7 @@ def update_session_info(
                         flags=re.DOTALL,
                     )
                     if new_content != content:
-                        target_file.write_text(new_content, encoding="utf-8")
-                        os.chmod(str(target_file), 0o600)
+                        _atomic_write_text(target_file, new_content)
                         return "Session info updated in project CLAUDE.md"
                     return None
 
@@ -270,8 +269,7 @@ def update_session_info(
                             content += "\n"
                         new_content = content + "\n" + session_block + "\n"
 
-                target_file.write_text(new_content, encoding="utf-8")
-                os.chmod(str(target_file), 0o600)
+                _atomic_write_text(target_file, new_content)
                 return "Session info added to project CLAUDE.md"
 
             except Exception as e:

--- a/pact-plugin/hooks/staleness.py
+++ b/pact-plugin/hooks/staleness.py
@@ -487,7 +487,10 @@ def check_pinned_staleness(claude_md_path: Optional[Path] = None) -> Optional[st
         except TimeoutError:
             return "Pinned staleness update skipped: lock contention."
         except OSError as e:
-            logger_msg = f"Failed to update pinned staleness: {e}"
+            # Truncate like the sibling write sites (session_resume, cli): the
+            # raw exception embeds the absolute CLAUDE.md path, which should not
+            # leak into a status string.
+            logger_msg = f"Failed to update pinned staleness: {str(e)[:50]}"
             return logger_msg
 
     if stale_count > 0:

--- a/pact-plugin/hooks/staleness.py
+++ b/pact-plugin/hooks/staleness.py
@@ -462,7 +462,7 @@ def check_pinned_staleness(claude_md_path: Optional[Path] = None) -> Optional[st
             # imports from shared.claude_md_manager — a module-level
             # import here would create a staleness → claude_md_manager →
             # (indirectly) staleness cycle on some Python versions.
-            from shared.claude_md_manager import file_lock
+            from shared.claude_md_manager import _atomic_write_text, file_lock
             with file_lock(claude_md_path):
                 # Symlink guard INSIDE the lock (TOCTOU defense). is_symlink
                 # uses lstat so it does not follow the link. Status string is
@@ -478,7 +478,12 @@ def check_pinned_staleness(claude_md_path: Optional[Path] = None) -> Optional[st
                 current = claude_md_path.read_text(encoding="utf-8")
                 if current != content:
                     return None
-                claude_md_path.write_text(new_content, encoding="utf-8")
+                # Atomic (temp + rename) so a crash mid-write cannot truncate
+                # the always-loaded CLAUDE.md. NOTE: unlike the other CLAUDE.md
+                # write sites this one never set a mode, so `write_text` left
+                # the file's existing permissions alone; the helper normalises
+                # it to 0o600, matching every other writer in the plugin.
+                _atomic_write_text(claude_md_path, new_content)
         except TimeoutError:
             return "Pinned staleness update skipped: lock contention."
         except OSError as e:

--- a/pact-plugin/skills/pact-handoff-harvest/SKILL.md
+++ b/pact-plugin/skills/pact-handoff-harvest/SKILL.md
@@ -268,9 +268,13 @@ Review all memories saved during this session by listing recent pact-memory entr
 - Prune superseded memories (update or delete entries replaced by newer information)
 - **Prune stale `## team=` sections** in `~/.claude/agent-memory/pact-secretary/session_processed_tasks.md`: drop any `## team=` section older than ~30 days (judge by the section's `Last processed` timestamp) or whose team is known-complete (the session has wrapped/paused and will not resume). This is safe — the session journal's `agent_handoff` events are the authoritative dedup source, so a pruned-then-resurrected team re-derives its processed set from its own journal. Prune only stale/complete sections; never touch an active team's section. (Pruning happens only in this deep-clean Consolidation pass — the Standard/Incremental hot paths leave the file untouched apart from your own section.)
 
-### Step 4: Sync Working Memory
+### Step 4: Reconcile Working Memory
 
-Sync Working Memory to CLAUDE.md. The auto-sync mechanism handles individual saves, but consolidation may have merged/pruned entries that require a refresh.
+**No command syncs Working Memory, and consolidation does not refresh it.** The section is written only as a side effect of `save`; `update` and `delete` do not touch CLAUDE.md at all. So the merges and prunes you performed in Step 3 are **not** reflected in the Working Memory section — it still shows the pre-consolidation entries, and it will keep showing them until the next `save` rewrites it.
+
+Do not look for a sync or reconcile command; the CLI has none, and attempting one wastes a turn. If consolidation superseded or deleted a memory that the section still displays, the only way to correct it now is to **rewrite the Working Memory section directly**, exactly as the spawn-time stale-entry cleanup does.
+
+**But a hand rewrite is not durable, so do not record it as the fix.** The next `save` prepends its own entry and re-applies the token budget to whatever text is already in the section, so anything you rewrote is compressed or dropped by the same rules as any other older entry — and because a typical full entry alone exceeds the budget, the next `save` usually erases the rewrite entirely. The section also never re-reads the store, so correcting a record with `update` or `delete` fixes the record but never propagates into the display on its own. **The durable correction lives in the store; the rewrite is a stopgap for the current session only.** Report both in Step 6 — what you rewrote, and that the section will not hold it — so the team-lead reads the display as transient rather than repaired.
 
 ### Step 5: Save Orchestration Retrospective
 

--- a/pact-plugin/skills/pact-memory/SKILL.md
+++ b/pact-plugin/skills/pact-memory/SKILL.md
@@ -352,7 +352,7 @@ right purpose.
 | Layer | Storage | Content | Who Writes | Auto-Loaded |
 |-------|---------|---------|------------|-------------|
 | **Auto-memory** (MEMORY.md) | `~/.claude/projects/{hash}/memory/` | Free-form session learnings, user preferences, general patterns | Platform (automatic) | Yes (first 200 lines) |
-| **pact-memory** (SQLite) | `~/.claude/pact-memory/memory.db` | Structured institutional knowledge: context, goals, decisions, lessons, entities | Agents via this skill | Via Working Memory sync to CLAUDE.md |
+| **pact-memory** (SQLite) | `~/.claude/pact-memory/memory.db` | Structured institutional knowledge: context, goals, decisions, lessons, entities | Agents via this skill | Partially — newest entries only, via Working Memory sync to CLAUDE.md |
 | **Agent persistent memory** | `~/.claude/agent-memory/<name>/` | Per-agent domain expertise accumulated across sessions | Individual agents (automatic) | Yes (first 200 lines, per agent) |
 
 **pact-memory's unique value**: Structured fields (context, goal, decisions,
@@ -362,9 +362,13 @@ markdown does not provide.
 
 **Coexistence model**: Auto-memory captures broad session context automatically.
 pact-memory captures deliberate, structured knowledge at PACT phase boundaries.
-The Working Memory section in CLAUDE.md shows the 3 most recent pact-memory
-entries, providing structured context that complements auto-memory's general
-learnings.
+The Working Memory section in CLAUDE.md shows the most recent pact-memory
+entries — capped at 3, then reduced further by a token budget, so it commonly
+shows fewer and often only one. The newest entry is kept in full and is the only
+one guaranteed to carry its Memory ID; older entries are compressed to a one-line
+summary and lose theirs. What survives provides structured context that
+complements auto-memory's general learnings, and the full history stays
+searchable via the `search` command.
 
 ## Integration with PACT
 

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -19,6 +19,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -169,6 +170,52 @@ def file_lock(target_file: Path):
 #     fallbacks diverged between processes, the sidecars would differ and the
 #     lock would not serialize — accepted as out-of-contract (no safe fallback
 #     action exists if the paths genuinely diverge).
+
+
+def _atomic_write_text(target: Path, content: str) -> None:
+    """Replace `target`'s contents with `content` atomically.
+
+    `Path.write_text` truncates the file and THEN writes, so a crash, a full
+    disk, or a kill between those two steps leaves a TRUNCATED CLAUDE.md. In the
+    projects this runs in that file is gitignored and untracked, so there is no
+    recovery path -- the user's pinned context is simply gone.
+
+    Writing to a sibling temp file and renaming makes the replacement atomic: a
+    reader sees either the whole old file or the whole new one, never a partial
+    write. The temp file is created in the TARGET'S OWN DIRECTORY because
+    `os.replace` is only atomic within a single filesystem.
+
+    Callers must already hold `file_lock` for the target. The lock closes the
+    concurrent-writer window; this closes the crash/truncation window. They are
+    different hazards, and neither fix subsumes the other. Note the lock is a
+    separate sidecar file, so replacing the target's inode does not disturb it.
+
+    Args:
+        target: Path to replace. Its parent directory must already exist.
+        content: Full file contents to write.
+    """
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(target.parent), prefix=f".{target.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            # Without the fsync the rename can be persisted while the data
+            # behind it is not, which reintroduces the empty-file failure this
+            # function exists to prevent.
+            os.fsync(handle.fileno())
+        # mkstemp already creates 0o600; setting it explicitly keeps the mode a
+        # property of this function rather than of the stdlib's default.
+        os.chmod(tmp_name, 0o600)
+        os.replace(tmp_name, target)
+    except BaseException:
+        # Never leave a stray temp file behind next to the user's CLAUDE.md.
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
 
 
 def extract_managed_region(content: str) -> Optional[Tuple[str, int]]:
@@ -736,9 +783,9 @@ def sync_to_claude_md(
                     content += "\n"
                 new_content = content + "\n" + section_text
 
-            # Write back to file
-            claude_md_path.write_text(new_content, encoding="utf-8")
-            os.chmod(str(claude_md_path), 0o600)
+            # Write back to file (atomic: temp + rename, so a crash mid-write
+            # cannot leave the always-loaded CLAUDE.md truncated)
+            _atomic_write_text(claude_md_path, new_content)
 
         logger.info("Synced memory to CLAUDE.md Working Memory section")
         return True
@@ -966,9 +1013,9 @@ def sync_retrieved_to_claude_md(
                         content += "\n"
                     new_content = content + "\n" + section_text
 
-            # Write back to file
-            claude_md_path.write_text(new_content, encoding="utf-8")
-            os.chmod(str(claude_md_path), 0o600)
+            # Write back to file (atomic: temp + rename, so a crash mid-write
+            # cannot leave the always-loaded CLAUDE.md truncated)
+            _atomic_write_text(claude_md_path, new_content)
 
         logger.info("Synced retrieved memories to CLAUDE.md Retrieved Context section")
         return True

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -109,7 +109,12 @@ def file_lock(target_file: Path):
     would alter this body and trip the drift test; the OS-level non-re-entrancy
     plus the callers' fail-open already bound the worst case).
     """
-    lock_path = target_file.parent / f".{target_file.name}.lock"
+    # Resolve the WHOLE target, not just its parent: fcntl.flock serialises on
+    # the sidecar's inode, so two spellings of one file must produce one sidecar
+    # name. Resolving only the parent still keys a symlinked FILE by its alias
+    # (two names, one inode -> two sidecars -> no mutual exclusion).
+    resolved_target = target_file.resolve()
+    lock_path = resolved_target.parent / f".{resolved_target.name}.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     # 0o600: the lock file is adjacent to user-private CLAUDE.md content;
     # match the same permissions to avoid leaving a world-readable sidecar.

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -185,10 +185,26 @@ def _atomic_write_text(target: Path, content: str) -> None:
     write. The temp file is created in the TARGET'S OWN DIRECTORY because
     `os.replace` is only atomic within a single filesystem.
 
+    The mode is set on the TEMP file before the rename, so the target is never
+    momentarily visible with the wrong permissions -- unlike a chmod after the
+    write, which leaves exactly such a window on a file holding user content.
+
     Callers must already hold `file_lock` for the target. The lock closes the
     concurrent-writer window; this closes the crash/truncation window. They are
     different hazards, and neither fix subsumes the other. Note the lock is a
     separate sidecar file, so replacing the target's inode does not disturb it.
+
+    Requires write permission on the target's DIRECTORY (to create the temp),
+    where a bare `write_text` needed only permission on the file itself. A
+    read-only directory holding a writable CLAUDE.md would now fail the write
+    rather than truncate it -- a safe direction, but a real behaviour change.
+
+    NOTE: a deliberate duplicate of `_atomic_write_text` in
+    `hooks/shared/claude_md_manager.py`. This module cannot import from
+    `hooks/shared/` (separate package), the same constraint that produced the
+    `file_lock` twin above. Unlike that twin, the two copies are NOT
+    drift-gated: atomicity has no cross-process invariant, so each copy is
+    independently correct and may legitimately diverge.
 
     Args:
         target: Path to replace. Its parent directory must already exist.

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -349,14 +349,21 @@ def _resolve_display_claude_md_path() -> Optional[Path]:
          (preferred) or ./CLAUDE.md (legacy).
       2. Git worktree root via `git rev-parse --show-toplevel` -> the same
          .claude/-then-legacy probe under the worktree root.
-      3. Current working directory -> the same probe.
+      3. Main repo root via `git rev-parse --git-common-dir`.parent -> the
+         same probe. Reached only when the worktree is NOT a session root
+         (branch 2 found nothing): under the PACT `.worktrees/` convention no
+         session is rooted in the worktree, so the file the session reads is
+         the main repo's. Without this branch that write is lost (returns
+         None); with it the write lands where the session reads.
+      4. Current working directory -> the same probe.
 
-    Unlike _get_claude_md_path (which anchors to the MAIN repo via
-    --git-common-dir so it can find a single shared CLAUDE.md), this anchors
-    to the WORKTREE root via --show-toplevel so a worktree-rooted session
-    updates its OWN display file — the same file session_init/session_resume
-    create and read. In a non-worktree checkout the two anchors coincide, so
-    the resolved path is identical to _get_claude_md_path's.
+    Branch 2 anchors the WORKTREE root (--show-toplevel) so a worktree that IS
+    a session root updates its OWN display file; branch 3 falls back to
+    _get_claude_md_path's MAIN-repo anchor (--git-common-dir) for the common
+    case where it is not. Because branch 2 precedes branch 3, the two resolvers
+    now differ ONLY in that worktree-root branch: in a non-worktree checkout
+    both branches resolve the same directory, so this function's result is
+    identical to _get_claude_md_path's.
 
     This never CREATES a CLAUDE.md (the orchestrator manages the file's
     lifecycle); it only probes for an existing one and returns its Path, or
@@ -388,6 +395,37 @@ def _resolve_display_claude_md_path() -> Optional[Path]:
             if result.returncode == 0 and result.stdout.strip():
                 worktree_root = Path(result.stdout.strip())
                 found = _find_existing_claude_md(worktree_root)
+                if found is not None:
+                    return found
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            pass
+
+        # Main-repo root via --git-common-dir. Under the PACT `.worktrees/`
+        # convention no session is ever rooted in the worktree, so branch 2
+        # found nothing and the file the session actually reads is the MAIN
+        # repo's. --git-common-dir points at the shared .git dir whether run
+        # from the main repo or a linked worktree, so its parent is the main
+        # repo root in both. This is _get_claude_md_path's exact anchor.
+        #
+        # The is_absolute() guard is load-bearing, not decoration: git returns
+        # a RELATIVE path (".git", "../.git") when run at a repo root or subdir,
+        # and _find_existing_claude_md does a bare `base / "CLAUDE.md"` with no
+        # normalisation, so a relative base would yield a cwd-relative Path and
+        # a cwd-relative lock sidecar (the exact divergence D2 just closed).
+        # Reused verbatim from _get_claude_md_path.
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--git-common-dir"],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                common_dir = Path(result.stdout.strip())
+                if not common_dir.is_absolute():
+                    common_dir = Path.cwd() / common_dir
+                repo_root = common_dir.resolve().parent
+                found = _find_existing_claude_md(repo_root)
                 if found is not None:
                     return found
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -219,7 +219,15 @@ def _atomic_write_text(target: Path, content: str) -> None:
         dir=str(target.parent), prefix=f".{target.name}.", suffix=".tmp"
     )
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        # os.fdopen takes ownership of fd only on success; if it raises, the
+        # raw fd mkstemp opened would leak (the outer cleanup unlinks the temp
+        # FILE but cannot close a descriptor it never received a handle for).
+        try:
+            handle = os.fdopen(fd, "w", encoding="utf-8")
+        except BaseException:
+            os.close(fd)
+            raise
+        with handle:
             handle.write(content)
             handle.flush()
             # Without the fsync the rename can be persisted while the data

--- a/pact-plugin/tests/test_claude_md_manager.py
+++ b/pact-plugin/tests/test_claude_md_manager.py
@@ -198,14 +198,23 @@ class TestEnsureProjectMemoryMdErrorPaths:
         """Should return truncated error message when write fails."""
         from shared.claude_md_manager import ensure_project_memory_md
 
-        # Point to a directory where we can't write
-        read_only = tmp_path / "readonly"
-        read_only.mkdir()
+        # A WRITABLE project dir: the failure is injected, not environmental.
+        # An unwritable directory cannot be used to reach this code path --
+        # file_lock creates its sidecar in the same directory the write needs,
+        # so the lock raises first and the write is never attempted. The
+        # mocked failure is unreachable in production; only injection gets here.
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
 
-        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(read_only))
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project_dir))
 
+        # Patch the write helper, not Path.write_text -- the code writes via
+        # _atomic_write_text (temp + rename), so patching write_text would
+        # no-op silently and the test would pass without exercising anything.
         from unittest.mock import patch
-        with patch.object(Path, "write_text", side_effect=OSError("No space left")):
+
+        import shared.claude_md_manager as cmm
+        with patch.object(cmm, "_atomic_write_text", side_effect=OSError("No space left")):
             result = ensure_project_memory_md()
 
         assert result is not None
@@ -1870,8 +1879,11 @@ class TestMigrateToManagedStructure:
         claude_md.write_text("# Project Memory\n\n## Working Memory\n")
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project_dir))
 
+        # The migration writes via _atomic_write_text (temp + rename), not
+        # Path.write_text -- patching write_text here would no-op silently.
+        import shared.claude_md_manager as cmm
         with mock_patch.object(
-            type(claude_md), "write_text", side_effect=OSError("disk full")
+            cmm, "_atomic_write_text", side_effect=OSError("disk full")
         ):
             result = migrate_to_managed_structure()
 

--- a/pact-plugin/tests/test_claude_md_resolver_parity.py
+++ b/pact-plugin/tests/test_claude_md_resolver_parity.py
@@ -16,6 +16,7 @@ Resolvers under test:
 5. worktree_guard inline probe                                -- hooks/ (inline)
 """
 
+import os
 import sys
 from pathlib import Path
 from typing import Optional
@@ -227,3 +228,183 @@ class TestClaudeMdResolverParity:
             f"  All:        {classifications}\n"
             f"  Mismatches: {mismatches}"
         )
+
+
+# --- Display-resolver parity invariant ---------------------------------------
+#
+# The lint above drives every resolver through the CLAUDE_PROJECT_DIR branch,
+# so it never exercises the git-topology branches -- and it covers
+# _get_claude_md_path, which has NO production callers, while omitting
+# _resolve_display_claude_md_path, which determines every real sync write
+# target. This class pins the specific invariant _resolve_display_claude_md_path's
+# docstring asserts: it and _get_claude_md_path differ ONLY in the
+# worktree-root branch, so in a non-worktree checkout they resolve identically.
+#
+# It must run with CLAUDE_PROJECT_DIR UNSET -- the env branch short-circuits
+# before the git branches and would make the equivalence hold trivially,
+# testing nothing. Re-pointing the 5-way lint at the live resolver and deleting
+# the dead sibling is a separate follow-up, not this pin.
+
+
+def _pgit(cwd: Path, *args: str) -> None:
+    """Run git in `cwd` with a hermetic config (no user/global interference)."""
+    import subprocess
+
+    subprocess.run(
+        ["git", "-c", "init.defaultBranch=main", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        env={
+            **os.environ,
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_SYSTEM": os.devnull,
+        },
+        check=False,
+    )
+
+
+def _init_repo_with_claude_md(root: Path) -> Path:
+    """A committed git repo whose CLAUDE.md is gitignored + untracked (as in prod)."""
+    root.mkdir(parents=True, exist_ok=True)
+    _pgit(root, "init")
+    _pgit(root, "config", "user.email", "t@e")
+    _pgit(root, "config", "user.name", "T")
+    (root / ".gitignore").write_text("CLAUDE.md\n.claude/\n", encoding="utf-8")
+    (root / "README.md").write_text("seed", encoding="utf-8")
+    _pgit(root, "add", ".gitignore", "README.md")
+    _pgit(root, "commit", "-m", "seed")
+    dot = root / ".claude"
+    dot.mkdir()
+    claude_md = dot / "CLAUDE.md"
+    claude_md.write_text("# main\n", encoding="utf-8")
+    return claude_md
+
+
+class TestDisplayResolverParityInvariant:
+    """Pin the docstring claim Option C revised (working_memory:_resolve_display_...).
+
+    _resolve_display_claude_md_path anchors branch 2 on the WORKTREE root
+    (--show-toplevel) and falls back on the MAIN repo root (--git-common-dir)
+    in branch 3; _get_claude_md_path uses only the main-repo anchor. The claim:
+    they differ ONLY in that worktree-root branch.
+
+    Three cases together demonstrate the "only". Two of them predate Option C
+    and pin the CONTEXT that gives "only" its meaning; one is the actual
+    Option-C regression guard:
+
+      - coincide_in_non_worktree  -- CONTEXT (branch-3-independent): both
+        resolvers already coincided outside a worktree before Option C.
+      - diverge_when_worktree_owns_a_file -- CONTEXT (branch-3-independent):
+        the single legitimate divergence, in the worktree-root branch.
+      - coincide_in_pact_worktree_without_own_file -- LOAD-BEARING: this case
+        DIVERGED before Option C (display -> None, main -> the main file) and
+        COINCIDES after, purely because branch 3 was added. Deleting branch 3
+        flips only this case red; the other two stay green. It is the sole
+        member of this class that guards the Option-C change.
+
+    A sibling BEHAVIOURAL guard for the same case lives in
+    test_working_memory_worktree_sync.py: that one asserts the concrete main
+    file comes out AND that branch 3 fired. This class asserts the two
+    resolvers AGREE -- the resolver-relationship axis this parity file owns.
+    Different axis, different file, both fail on a branch-3 regression:
+    defence in depth, not duplication.
+    """
+
+    def test_non_worktree_checkout_resolvers_coincide(self, tmp_path, monkeypatch):
+        """In a plain (non-worktree) checkout the two resolvers return the SAME
+        existing path -- the equivalence the docstring promises."""
+        from working_memory import (
+            _get_claude_md_path,
+            _resolve_display_claude_md_path,
+        )
+
+        repo = tmp_path / "plainrepo"
+        expected = _init_repo_with_claude_md(repo)
+
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.chdir(repo)
+
+        display = _resolve_display_claude_md_path()
+        main = _get_claude_md_path()
+
+        # Both must resolve to the real file (a shared None would be vacuously
+        # "equal" while proving nothing), and to the SAME file.
+        assert display is not None and main is not None
+        assert os.path.realpath(display) == os.path.realpath(expected)
+        assert os.path.realpath(display) == os.path.realpath(main)
+
+    def test_worktree_divergence_is_confined_to_the_worktree_root_branch(
+        self, tmp_path, monkeypatch
+    ):
+        """Non-vacuity guard for the test above: the two resolvers CAN diverge,
+        and do so only in the worktree-root branch. A worktree that owns a
+        CLAUDE.md resolves the display path to its OWN file (branch 2) while the
+        main-repo resolver still points at the main file -- so the coincidence
+        above is a real property of the non-worktree case, not a constant."""
+        from working_memory import (
+            _get_claude_md_path,
+            _resolve_display_claude_md_path,
+        )
+
+        repo = tmp_path / "mainrepo"
+        main_file = _init_repo_with_claude_md(repo)
+        worktree = tmp_path / "wt"
+        _pgit(repo, "worktree", "add", str(worktree), "-b", "feature")
+        wt_dot = worktree / ".claude"
+        wt_dot.mkdir(parents=True)
+        wt_file = wt_dot / "CLAUDE.md"
+        wt_file.write_text("# worktree-own\n", encoding="utf-8")
+
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.chdir(worktree)
+
+        display = _resolve_display_claude_md_path()
+        main = _get_claude_md_path()
+
+        assert display is not None and main is not None
+        # Display follows the worktree's OWN file (branch 2, --show-toplevel);
+        # the main-repo resolver stays on the main file (--git-common-dir).
+        assert os.path.realpath(display) == os.path.realpath(wt_file)
+        assert os.path.realpath(main) == os.path.realpath(main_file)
+        assert os.path.realpath(display) != os.path.realpath(main)
+
+    def test_coincide_in_pact_worktree_without_own_file(self, tmp_path, monkeypatch):
+        """LOAD-BEARING: the one case Option C changed, and the only test in this
+        class that a branch-3 regression turns red.
+
+        A PACT-convention worktree has no CLAUDE.md of its own, so branch 2
+        (--show-toplevel) finds nothing. BEFORE Option C the display resolver
+        then fell through to cwd and returned None, while _get_claude_md_path
+        returned the main-repo file -- they DIVERGED. Option C's branch 3
+        (--git-common-dir) now sends the display resolver to that same main file,
+        so the two AGREE. Delete branch 3 and this assertion fails (display -> None
+        != main); the other two cases in this class stay green. That is the
+        proof this pin actually guards the change, not merely the docstring's
+        wording.
+
+        The sibling BEHAVIOURAL guard (concrete file + branch-3-fired) lives in
+        test_working_memory_worktree_sync.py; this asserts only that the two
+        resolvers converge, which is the invariant this parity file exists for.
+        """
+        from working_memory import (
+            _get_claude_md_path,
+            _resolve_display_claude_md_path,
+        )
+
+        repo = tmp_path / "mainrepo"
+        main_file = _init_repo_with_claude_md(repo)
+        worktree = tmp_path / "wt-no-own"
+        _pgit(repo, "worktree", "add", str(worktree), "-b", "feature")
+        # Deliberately NO .claude/CLAUDE.md in the worktree -- the PACT convention.
+
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.chdir(worktree)
+
+        display = _resolve_display_claude_md_path()
+        main = _get_claude_md_path()
+
+        assert display is not None and main is not None
+        assert os.path.realpath(display) == os.path.realpath(main)
+        # ...and specifically at the MAIN repo file, so a future change that made
+        # both resolvers agree on the WRONG file would still be caught.
+        assert os.path.realpath(display) == os.path.realpath(main_file)

--- a/pact-plugin/tests/test_memory_cli.py
+++ b/pact-plugin/tests/test_memory_cli.py
@@ -28,6 +28,11 @@ import pytest
 
 from helpers import create_test_schema, make_cli_memory_dict
 
+# Reused rather than re-implemented: the canonical minimal-CLAUDE.md seeder.
+# The isolation fixture below needs a real file at the env-var root, because
+# the display resolver treats "no CLAUDE.md here" as "keep looking".
+from test_working_memory_concurrency_comprehensive import _seed_claude_md
+
 # Add pact-memory skill root to path so `from scripts.cli import ...` works
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
 
@@ -94,6 +99,70 @@ def cli_script_path():
         Path(__file__).resolve().parent.parent
         / "skills" / "pact-memory" / "scripts" / "cli.py"
     )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_claude_md_target(tmp_path, monkeypatch):
+    """Redirect every CLAUDE.md resolution in this module to a per-test tmp tree.
+
+    The subprocess sites in this file pass neither ``env=`` nor ``cwd=``, so each
+    child inherits this process's ``os.environ`` and cwd. Without this fixture the
+    display resolver walks git from the inherited cwd and lands on the DEVELOPER'S
+    REAL project CLAUDE.md, and the ``save`` and ``search`` sites then write
+    Working Memory entries into it. That file is gitignored and untracked, so the
+    damage is invisible to ``git status`` and has no git recovery path.
+
+    BOTH halves are required, and this is the part that makes the obvious fix a
+    silent no-op: setting ``CLAUDE_PROJECT_DIR`` alone does NOT isolate, because
+    ``_resolve_display_claude_md_path`` probes the env dir and CONTINUES when no
+    CLAUDE.md is found there, falling through to the git walk and back onto the
+    live file. Seeding a CLAUDE.md at the env dir is what makes the first probe
+    succeed and terminate resolution before the walk.
+
+    Autouse rather than opt-in: a test that simply does not request the fixture
+    would be unprotected with nothing to see in review, and invisible non-coverage
+    is the exact failure mode this fixture exists to prevent. Scoped to this module
+    by placement -- a global autouse would break files that legitimately exercise
+    the resolver's fallback branches.
+    """
+    _seed_claude_md(tmp_path)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+
+class TestSubprocessClaudeMdIsolation:
+    """Proof that the autouse isolation reaches a SPAWNED CHILD, not just this process."""
+
+    def test_spawned_subprocess_resolves_claude_md_under_tmp(self, tmp_path):
+        """A child spawned the way every E2E site spawns one must resolve the
+        display CLAUDE.md inside the per-test tmp tree.
+
+        Asserts the resolved path REPORTED BY THE CHILD rather than that the
+        fixture ran. The chain under test is monkeypatch.setenv -> os.environ ->
+        subprocess inheritance -> resolver, and only a child process can witness
+        all four links; asserting on the parent's environ would prove none of them.
+        Spawned with no ``env=`` and no ``cwd=`` so it inherits exactly what the
+        other subprocess sites in this module inherit.
+        """
+        scripts_dir = (
+            Path(__file__).resolve().parent.parent
+            / "skills" / "pact-memory" / "scripts"
+        )
+        code = (
+            "import sys; sys.path.insert(0, {!r});"
+            "import working_memory as wm;"
+            "print(wm._resolve_display_claude_md_path())".format(str(scripts_dir))
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+
+        resolved = Path(result.stdout.strip())
+        assert resolved.resolve() == (tmp_path / ".claude" / "CLAUDE.md").resolve()
+        # Containment is the property that matters: anything under tmp_path is
+        # disposable, anything outside it is somebody's real file.
+        resolved.resolve().relative_to(tmp_path.resolve())
 
 
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -517,6 +517,57 @@ class TestStalenessErrorPaths:
         assert result is not None
         assert "Failed to update pinned staleness" in result
 
+    def test_successful_update_normalizes_file_mode_to_0o600(self, tmp_path):
+        """A successful staleness update clamps the file mode to 0o600.
+
+        staleness.py's write site calls _atomic_write_text, which chmods the temp
+        to 0o600 before os.replace, so a pre-existing 0o644 file is clamped to
+        0o600 on update. This pins the SITE behaviour (that check_pinned_staleness
+        actually invokes the clamp) — distinct from the helper's clamp (covered by
+        test_claude_md_manager.py's migration test) and the create path
+        (test_created_file_has_secure_permissions). Before this site switched from
+        bare write_text to _atomic_write_text it left the existing mode alone, so
+        the site normalization was asserted only in a commit message.
+
+        The explicit chmod 0o644 (NOT an ambient-umask default) is load-bearing:
+        it proves the update CHANGES 0o644 -> 0o600. A test relying on the umask
+        to make the pre-file non-0o600 would pass trivially under umask 077 —
+        itself a latent phantom-green.
+
+        Revert-coupled: reverting the write site to bare write_text leaves the
+        0o644 mode untouched and turns this test RED.
+        """
+        import stat
+        from staleness import check_pinned_staleness, PINNED_STALENESS_DAYS
+        from datetime import datetime, timedelta
+
+        old_date = (datetime.now() - timedelta(days=PINNED_STALENESS_DAYS + 10)).strftime("%Y-%m-%d")
+
+        claude_md = self._create_claude_md(tmp_path, (
+            "# Project Memory\n\n"
+            "## Pinned Context\n\n"
+            f"### Old Feature (PR #50, merged {old_date})\n"
+            "- Details\n\n"
+        ))
+        # Explicit non-0o600 starting mode so the post-update assertion proves a
+        # CLAMP, not an ambient-umask coincidence.
+        claude_md.chmod(0o644)
+        assert stat.S_IMODE(claude_md.stat().st_mode) == 0o644, (
+            "precondition: the seeded file must start at 0o644"
+        )
+
+        result = check_pinned_staleness(claude_md_path=claude_md)
+
+        # The stale pin triggered a real update (the write path ran), not a
+        # no-op skip — so the mode assertion below observes a write, not the seed.
+        assert result is not None
+        # SITE behaviour: the successful update landed the file at 0o600, clamping
+        # the 0o644 it started with.
+        final_mode = stat.S_IMODE(claude_md.stat().st_mode)
+        assert final_mode == 0o600, (
+            f"staleness update must clamp the file mode to 0o600, got {oct(final_mode)}"
+        )
+
 
 class TestStalenessModuleDirect:
     """Tests for staleness.py called directly (not via session_init wrapper)."""

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -484,8 +484,11 @@ class TestStalenessErrorPaths:
             "- Details\n\n"
         ))
 
-        # Let read_text work normally, but make write_text fail
-        with patch.object(type(claude_md), "write_text", side_effect=IOError("read-only fs")):
+        # Let read_text work normally, but make the write fail. staleness.py
+        # writes via claude_md_manager._atomic_write_text (temp + rename), not
+        # Path.write_text -- patching write_text here would no-op silently.
+        import shared.claude_md_manager as cmm
+        with patch.object(cmm, "_atomic_write_text", side_effect=IOError("read-only fs")):
             result = check_pinned_staleness(claude_md_path=claude_md)
 
         # Should return an error message string (not None)
@@ -507,7 +510,8 @@ class TestStalenessErrorPaths:
             "- Details\n\n"
         ))
 
-        with patch.object(type(claude_md), "write_text", side_effect=OSError("permission denied")):
+        import shared.claude_md_manager as cmm
+        with patch.object(cmm, "_atomic_write_text", side_effect=OSError("permission denied")):
             result = check_pinned_staleness(claude_md_path=claude_md)
 
         assert result is not None

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -972,17 +972,24 @@ class TestCheckPinnedStalenessHardening:
                 return concurrent_content
             return original_read_text(self, *args, **kwargs)
 
-        # Track writes so we can assert no write occurred
+        # Track writes so we can assert no write occurred. The managed-path write
+        # goes through _atomic_write_text (temp + rename), NOT Path.write_text, so
+        # tracking Path.write_text would never fire and the "no write" assertion
+        # would pass vacuously whether or not the write was skipped. Track the REAL
+        # write seam. staleness.check_pinned_staleness imports _atomic_write_text
+        # from shared.claude_md_manager at call time, so patching the module
+        # attribute is what its local `from ... import` binds to.
+        import shared.claude_md_manager as cmm
         write_calls = []
-        original_write_text = Path.write_text
+        real_atomic = cmm._atomic_write_text
 
-        def tracking_write_text(self, content, *args, **kwargs):
-            if str(self) == str(claude_md):
+        def tracking_atomic(target, content, *args, **kwargs):
+            if str(target) == str(claude_md):
                 write_calls.append(content)
-            return original_write_text(self, content, *args, **kwargs)
+            return real_atomic(target, content, *args, **kwargs)
 
         monkeypatch.setattr(Path, "read_text", fake_read_text)
-        monkeypatch.setattr(Path, "write_text", tracking_write_text)
+        monkeypatch.setattr(cmm, "_atomic_write_text", tracking_atomic)
 
         with patch("session_init._get_project_claude_md_path", return_value=claude_md), \
              patch("staleness._get_project_claude_md_path", return_value=claude_md):
@@ -995,8 +1002,7 @@ class TestCheckPinnedStalenessHardening:
         assert write_calls == [], (
             f"Expected zero writes when content changed under the writer, "
             f"but {len(write_calls)} write(s) occurred. The inside-lock "
-            f"re-read guard at staleness.py L386-388 is not protecting the "
-            f"concurrent writer's content."
+            f"re-read guard is not protecting the concurrent writer's content."
         )
         # Both reads happened (outer + inner re-read), confirming the lock
         # path was actually entered.

--- a/pact-plugin/tests/test_working_memory_resolver_and_lock_release.py
+++ b/pact-plugin/tests/test_working_memory_resolver_and_lock_release.py
@@ -29,6 +29,7 @@ the file-size advisory threshold):
 Used by: pytest (the working_memory edge-path gate).
 """
 
+import os
 import sys
 from pathlib import Path
 
@@ -64,10 +65,19 @@ class TestLockReleaseOnException:
     def test_chmod_failure_mid_window_releases_lock_and_fails_open(
         self, tmp_path, monkeypatch
     ):
-        """If os.chmod raises AFTER write_text but INSIDE the `with file_lock`
-        block, sync_to_claude_md must (a) return False (fail-open via the outer
+        """If os.chmod raises INSIDE the `with file_lock` block,
+        sync_to_claude_md must (a) return False (fail-open via the outer
         try/except) and (b) leave the lock RE-ACQUIRABLE — proving the lock was
         released on the exception path, not leaked.
+
+        Mid-window failure SITE (post-atomicity, C2/C3a): the sync now writes via
+        _atomic_write_text, which calls os.chmod on the TEMP file (before
+        os.replace), not on the target after a bare write_text. So a boom on
+        os.chmod is still a reachable mid-window exception — it fires inside
+        _atomic_write_text, propagates out through the file_lock contextmanager's
+        `finally`, and is caught by the outer try/except. The assertions below
+        (fail-open + lock re-acquirable) are what this test pins; the exact chmod
+        site moved with the atomicity refactor but the exception path did not.
 
         A leaked lock would force the next acquirer to block until the 5s
         timeout (then fail open), degrading every subsequent sync. We prove
@@ -79,7 +89,8 @@ class TestLockReleaseOnException:
         claude_md = _seed_claude_md(tmp_path)
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
 
-        # Raise inside the with-block, after write_text, at os.chmod.
+        # Raise at the os.chmod inside _atomic_write_text (chmod-the-temp step,
+        # before os.replace), exercising the mid-window exception path.
         def boom_chmod(*args, **kwargs):
             raise OSError("simulated chmod failure mid-window")
 
@@ -101,16 +112,24 @@ class TestLockReleaseOnException:
         with wm.file_lock(target):
             pass  # acquisition must succeed — if the lock had leaked this raises
 
-    def test_mid_window_exception_leaves_no_torn_write(self, tmp_path, monkeypatch):
-        """The file must remain well-formed (no partial/torn content) after a
-        mid-window exception. os.chmod runs AFTER write_text, so write_text may
-        have already replaced the file — assert it is still a complete,
-        parseable document with its Working Memory section intact, not a
-        truncated fragment.
+    def test_mid_window_exception_leaves_target_byte_identical(self, tmp_path, monkeypatch):
+        """After a mid-window exception the target must be BYTE-IDENTICAL to its
+        pre-sync content — the failed write rolled back completely, not merely
+        "not torn".
+
+        Post-atomicity (C2/C3a) this is a stronger and now-true guarantee than
+        the old "structurally complete" check. _atomic_write_text writes a temp,
+        chmods the TEMP, then os.replace()s it onto the target. os.chmod is boomed
+        here, so the exception fires BEFORE os.replace — the target inode is never
+        swapped and retains its exact original bytes. (Under the OLD write_text-
+        then-chmod path the target would already hold the NEW content when chmod
+        boomed, so `final == before` would FAIL — which is exactly why this
+        assertion is coupled to the atomic-replace rollback and not vacuous.)
         """
         import working_memory as wm
 
         claude_md = _seed_claude_md(tmp_path)
+        before = claude_md.read_text(encoding="utf-8")
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
 
         def boom_chmod(*args, **kwargs):
@@ -118,17 +137,92 @@ class TestLockReleaseOnException:
 
         monkeypatch.setattr(wm.os, "chmod", boom_chmod)
 
-        wm.sync_to_claude_md({"context": "TORN-CHECK", "goal": "g"}, None, "id")
+        result = wm.sync_to_claude_md({"context": "TORN-CHECK", "goal": "g"}, None, "id")
 
+        assert result is False, "a mid-window failure must fail open"
         final = claude_md.read_text(encoding="utf-8")
-        # write_text is atomic at the Python level (single write of the full
-        # new content), so the file is either the old or the new full document
-        # — never a fragment. Assert structural completeness.
-        assert final.startswith("# Project"), "file head was truncated"
-        assert "## Working Memory" in final, "section was lost"
-        # No dangling half-entry: every entry header has a body marker. (The
-        # write either fully landed the new entry or did not; both are whole.)
-        assert final.count("## Working Memory") == 1
+        # Rollback is total: the atomic replace never ran, so not one byte of the
+        # attempted new content reached the always-loaded file.
+        assert final == before, "target was mutated despite a pre-replace failure"
+        assert "TORN-CHECK" not in final, "partial/new content leaked into the target"
+
+
+# ---------------------------------------------------------------------------
+# 1b. Read-only target directory — atomic-write dir-permission fail-safe.
+# ---------------------------------------------------------------------------
+
+class TestReadOnlyDirectoryFailSafe:
+    """The atomicity refactor (C2/C3a) requires write permission on the target's
+    DIRECTORY — _atomic_write_text creates its temp there via mkstemp — where the
+    old bare write_text needed only permission on the file. On a read-only
+    directory holding a writable CLAUDE.md the sync now REFUSES the write (fails
+    safe) instead of truncating. Narrow config (bind mounts, restrictive umask)
+    but real."""
+
+    def test_readonly_dir_refuses_atomic_write_at_write_site_and_leaves_file_intact(
+        self, tmp_path, monkeypatch
+    ):
+        """A 0o500 directory holding a writable CLAUDE.md makes the atomic write
+        fail; sync returns False and the file is byte-unchanged.
+
+        The FAILURE SITE is asserted, not just the outcome — because two distinct
+        steps create a file in the target directory and they fail at DIFFERENT
+        sites: file_lock creates its `.CLAUDE.md.lock` sidecar (os.open O_CREAT),
+        and _atomic_write_text creates its temp (mkstemp). On a read-only dir with
+        NO sidecar the LOCK fails first and the atomic write is never reached — a
+        test that stopped at "returns False" would certify the lock's permission
+        check, not the atomic-write behaviour change it names. So this test
+        PRE-CREATES the sidecar, making the lock acquirable (opening an existing
+        file RDWR needs file-write + dir-search, not dir-create), so the failure
+        lands at mkstemp inside _atomic_write_text. Empirically verified: without
+        the pre-created sidecar the PermissionError comes from file_lock; with it,
+        from mkstemp.
+        """
+        import working_memory as wm
+
+        claude_md = _seed_claude_md(tmp_path)
+        before = claude_md.read_text(encoding="utf-8")
+        claude_dir = claude_md.parent
+
+        # Pre-create the lock sidecar so file_lock acquires without needing to
+        # CREATE a file in the soon-to-be read-only directory.
+        sidecar = claude_dir / f".{claude_md.name}.lock"
+        sidecar.write_text("", encoding="utf-8")
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+        # Instrument the SITE: record that _atomic_write_text was reached (proving
+        # the lock was passed) and let the REAL read-only dir make its mkstemp
+        # raise. The failure is a genuine filesystem PermissionError, not a stub.
+        reached = {"atomic_write": False}
+        real_atomic = wm._atomic_write_text
+
+        def spy_atomic(target, content):
+            reached["atomic_write"] = True
+            return real_atomic(target, content)
+
+        monkeypatch.setattr(wm, "_atomic_write_text", spy_atomic)
+
+        os.chmod(str(claude_dir), 0o500)
+        try:
+            result = wm.sync_to_claude_md(
+                {"context": "READONLY-DIR", "goal": "g"}, None, "id"
+            )
+        finally:
+            os.chmod(str(claude_dir), 0o700)  # restore so tmp cleanup can run
+
+        # Fail-safe: the sync declined and the always-loaded file is untouched.
+        assert result is False, "read-only dir must make the sync fail open"
+        assert claude_md.read_text(encoding="utf-8") == before, (
+            "target was mutated on a read-only dir — the write did not fail safe"
+        )
+        # SITE: execution reached _atomic_write_text (past the lock), so the
+        # failure is the atomic-write dir-write requirement, not the lock's.
+        assert reached["atomic_write"], (
+            "sync failed before reaching _atomic_write_text — the sidecar "
+            "precondition is not holding, so this exercises the lock's permission "
+            "check, not the dir-write behaviour change it exists to pin"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/pact-plugin/tests/test_working_memory_worktree_sync.py
+++ b/pact-plugin/tests/test_working_memory_worktree_sync.py
@@ -131,6 +131,34 @@ def clean_env(monkeypatch):
     return monkeypatch
 
 
+def _install_find_spy(monkeypatch):
+    """Spy scripts.working_memory._find_existing_claude_md, recording each call's
+    (base, result) so a test can assert WHICH resolver branch produced the answer.
+
+    _resolve_display_claude_md_path carries no branch tag, log line, or return
+    enum: it distinguishes branches only by which _find_existing_claude_md(base)
+    call first returns non-None. So the call sequence IS the branch trace — branch
+    2 passes the `--show-toplevel` worktree root, branch 3 passes the
+    `--git-common-dir` main-repo root. Spying the function itself (not a durable
+    side effect like the lock sidecar, which outlives the call and would measure
+    its own residue) is the seam the backend-coder used for the same distinction.
+
+    Returns a list of (Path(base), result) tuples in call order; monkeypatch tears
+    the spy down at test teardown so it never leaks into a sibling test.
+    """
+    import scripts.working_memory as wm
+    calls = []
+    real = wm._find_existing_claude_md
+
+    def spy(base):
+        result = real(base)
+        calls.append((Path(base), result))
+        return result
+
+    monkeypatch.setattr(wm, "_find_existing_claude_md", spy)
+    return calls
+
+
 # ---------------------------------------------------------------------------
 # Display-target resolver — _resolve_display_claude_md_path
 # ---------------------------------------------------------------------------
@@ -145,6 +173,86 @@ class TestDisplayTargetResolver:
         _main, worktree = worktree_repo
         resolved = _resolve_display_claude_md_path()
         assert resolved == worktree / ".claude" / "CLAUDE.md"
+
+    def test_worktree_without_own_file_resolves_main_via_branch_3(
+        self, tmp_path, clean_env
+    ):
+        """Option C branch 3: a PACT-convention worktree with NO own CLAUDE.md
+        whose MAIN repo HAS one resolves to the MAIN file.
+
+        Pre-Option-C this returned None and the write was silently lost — the
+        worktree had no file and no branch could see the main one. Branch 3
+        (`--git-common-dir`.parent) closes that gap. This is the SOLE behavioral
+        guard for branch 3: reverting that branch makes this test fail, because the
+        worktree cwd has no CLAUDE.md so the resolver falls through to None
+        (verified by revert-and-fail, not merely watched pass).
+
+        A path-only assertion cannot prove branch 3 fired rather than branch 2
+        landing on the same file, so the call SEQUENCE is asserted: branch 2
+        (worktree root) was attempted and returned None BEFORE branch 3 (main root)
+        returned the file. Order matters — a change that made branch 2 wrongly
+        succeed must not read as a branch-3 hit.
+        """
+        main = tmp_path / "mainproj"
+        worktree = tmp_path / "wt-feature"
+        _init_main_repo(main)                                 # main HAS .claude/CLAUDE.md
+        _add_worktree(main, worktree, with_dot_claude=False)  # worktree has NONE
+        calls = _install_find_spy(clean_env)
+
+        prev = Path.cwd()
+        os.chdir(str(worktree))
+        try:
+            resolved = _resolve_display_claude_md_path()
+        finally:
+            os.chdir(str(prev))
+
+        # VALUE: the concrete MAIN file. Compare resolved forms — branch 3 calls
+        # Path.resolve(), so on a symlinked tmp (/var -> /private/var) a bare ==
+        # against the unresolved main path would false-fail.
+        assert resolved is not None
+        assert resolved.resolve() == (main / ".claude" / "CLAUDE.md").resolve()
+
+        # MECHANISM: branch 2 (worktree root) probed and MISSED, THEN branch 3
+        # (main root) returned the file. The sequence, not mere membership.
+        assert len(calls) == 2, f"expected branch-2-then-branch-3, got {calls}"
+        (b2_base, b2_res), (b3_base, b3_res) = calls
+        assert b2_base.resolve() == worktree.resolve() and b2_res is None
+        assert b3_base.resolve() == main.resolve() and b3_res is not None
+
+    def test_worktree_with_own_file_resolves_via_branch_2_not_shadowed_by_branch_3(
+        self, tmp_path, clean_env
+    ):
+        """#935 non-regression: a worktree that IS a session root (has its OWN
+        CLAUDE.md) still resolves to its own file via branch 2 — branch 3 must not
+        shadow it.
+
+        Both main and worktree carry a CLAUDE.md here, so a resolver that consulted
+        the main repo first would return the wrong file. Certified by revert-and-
+        fail on branch 2: with branch 2 removed the resolver falls to branch 3 and
+        returns the MAIN file, failing this test — so it is coupled to branch 2, not
+        merely to the worktree path.
+        """
+        main = tmp_path / "mainproj"
+        worktree = tmp_path / "wt-feature"
+        _init_main_repo(main)                                # main HAS a file
+        _add_worktree(main, worktree, with_dot_claude=True)  # worktree ALSO has one
+        calls = _install_find_spy(clean_env)
+
+        prev = Path.cwd()
+        os.chdir(str(worktree))
+        try:
+            resolved = _resolve_display_claude_md_path()
+        finally:
+            os.chdir(str(prev))
+
+        assert resolved is not None
+        assert resolved.resolve() == (worktree / ".claude" / "CLAUDE.md").resolve()
+
+        # MECHANISM: branch 2 returned the file on the FIRST probe; branch 3 (main
+        # root) was never reached, proving it does not shadow branch 2.
+        assert len(calls) == 1, f"branch 3 should not be reached; calls={calls}"
+        (b2_base, b2_res), = calls
+        assert b2_base.resolve() == worktree.resolve() and b2_res is not None
 
     def test_worktree_session_resolves_worktree_file_when_env_is_worktree(
         self, worktree_repo, monkeypatch
@@ -552,29 +660,99 @@ class TestEndToEndParity:
         worktree_text = (dot / "CLAUDE.md").read_text(encoding="utf-8")
         assert "Recalled worktree note" in _retrieved_context_block(worktree_text)
 
-    def test_save_succeeds_when_display_file_missing(self, tmp_path, clean_env):
-        """A missing display file must never fail the save.
+    def test_worktree_save_with_no_own_file_lands_in_main_via_branch_3(
+        self, tmp_path, clean_env
+    ):
+        """A worktree-rooted save() with NO own CLAUDE.md, whose MAIN repo HAS
+        one, lands the Working Memory entry in the MAIN file via Option C
+        branch 3 — and the save still succeeds and persists the row.
 
-        The resolver returns None when no CLAUDE.md exists; save() still returns
-        a memory_id and persists the database row.
+        Renamed + strengthened from a former test that claimed "the resolver
+        returns None when no CLAUDE.md exists" while its fixture created
+        main/.claude/CLAUDE.md via _init_main_repo's with_dot_claude=True default.
+        That is the branch-3 scenario mislabeled as the None scenario; the old
+        `assert memory_id is not None` was insensitive to WHERE the sync landed,
+        so it passed without pinning resolution at all. The genuine no-file-
+        anywhere None case is the separate test below.
+
+        END-TO-END companion to the resolver-unit branch-3 guard
+        (test_worktree_without_own_file_resolves_main_via_branch_3): that pins the
+        resolver in isolation; this pins that save() actually routes its sync
+        through the resolver and writes the resolved file. Both fail on a branch-3
+        revert, at different levels — defense in depth.
         """
         main = tmp_path / "mainproj"
-        worktree = tmp_path / "wt-no-display"
-        _init_main_repo(main)
-        _add_worktree(main, worktree, with_dot_claude=False)
+        worktree = tmp_path / "wt-no-own-file"
+        _init_main_repo(main)                                 # main HAS .claude/CLAUDE.md
+        _add_worktree(main, worktree, with_dot_claude=False)  # worktree has NONE
         prev = Path.cwd()
         os.chdir(str(worktree))
         try:
             db_path = tmp_path / "memory.db"
             mem = PACTMemory(db_path=db_path)
-            memory_id = mem.save({"context": "No display file present"})
+            # Install the spy AFTER init so only the save()-time resolution is
+            # captured (empirically 2 calls: branch-2 miss then branch-3 hit).
+            calls = _install_find_spy(clean_env)
+            memory_id = mem.save({"context": "Branch-3 e2e entry"})
         finally:
             os.chdir(str(prev))
 
+        # Save succeeded and the row persisted — the original valid guarantee.
         assert memory_id is not None
         stored = mem.get(memory_id)
         assert stored is not None
-        assert stored.context == "No display file present"
+        assert stored.context == "Branch-3 e2e entry"
+
+        # VALUE: the entry physically landed in the MAIN file (branch 3); the
+        # worktree has no file at all, so the sync could not have gone elsewhere.
+        main_text = (main / ".claude" / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "Branch-3 e2e entry" in _working_memory_block(main_text)
+        assert not (worktree / ".claude" / "CLAUDE.md").exists()
+        assert not (worktree / "CLAUDE.md").exists()
+
+        # MECHANISM: save()'s sync resolved via branch 2 (worktree, None) THEN
+        # branch 3 (main, file) — confirms save() routes through the Option C
+        # branch, not merely that some file was written.
+        assert len(calls) == 2, f"expected branch-2-then-branch-3, got {calls}"
+        (b2_base, b2_res), (b3_base, b3_res) = calls
+        assert b2_base.resolve() == worktree.resolve() and b2_res is None
+        assert b3_base.resolve() == main.resolve() and b3_res is not None
+
+    def test_save_succeeds_when_no_display_file_anywhere(self, tmp_path, clean_env):
+        """The genuine no-file case: NEITHER the worktree NOR the main repo has a
+        CLAUDE.md, so the resolver returns None, save() skips the sync, and still
+        returns a memory_id and persists the row — creating NO file anywhere.
+
+        This is what the former test_save_succeeds_when_display_file_missing
+        docstring described but never built (its _init_main_repo default seeded
+        main). Constructed explicitly with with_dot_claude=False so the None path
+        is actually exercised. Branch-3-INDEPENDENT: unaffected by a branch-3
+        revert (main has no file either way), so it is not an Option-C guard.
+        """
+        main = tmp_path / "mainproj"
+        worktree = tmp_path / "wt-bare"
+        _init_main_repo(main, with_dot_claude=False, with_legacy=False)  # main: NO file
+        _add_worktree(main, worktree, with_dot_claude=False)             # worktree: NONE
+        prev = Path.cwd()
+        os.chdir(str(worktree))
+        try:
+            db_path = tmp_path / "memory.db"
+            mem = PACTMemory(db_path=db_path)
+            memory_id = mem.save({"context": "No display file anywhere"})
+        finally:
+            os.chdir(str(prev))
+
+        # Save still succeeds and persists.
+        assert memory_id is not None
+        stored = mem.get(memory_id)
+        assert stored is not None
+        assert stored.context == "No display file anywhere"
+
+        # Resolver returned None → sync skipped → NO CLAUDE.md created anywhere.
+        assert not (main / ".claude" / "CLAUDE.md").exists()
+        assert not (main / "CLAUDE.md").exists()
+        assert not (worktree / ".claude" / "CLAUDE.md").exists()
+        assert not (worktree / "CLAUDE.md").exists()
 
     def test_save_succeeds_when_sync_raises(self, worktree_repo, clean_env):
         """An exception inside the sync must be swallowed and never fail save()."""

--- a/pact-plugin/tests/test_working_memory_worktree_sync.py
+++ b/pact-plugin/tests/test_working_memory_worktree_sync.py
@@ -188,9 +188,17 @@ class TestDisplayTargetResolver:
     def test_returns_none_when_no_display_file_exists(self, tmp_path, clean_env):
         """When neither display location exists, the resolver returns None so the
         caller skips the sync rather than creating a file."""
+        # The main repo must have NO CLAUDE.md either, or the scenario in the
+        # title does not hold. Before Option C added the --git-common-dir
+        # fallback (branch 3), _init_main_repo's default with_dot_claude=True
+        # created main/.claude/CLAUDE.md, yet this test still passed asserting
+        # None -- because the old resolver had no branch that could SEE that
+        # file from a worktree cwd. It was green for a reason unrelated to its
+        # assertion (a pre-Option-C phantom-green); branch 3 now finds that
+        # file, so the fixture must actually construct the empty case.
         main = tmp_path / "mainproj"
         worktree = tmp_path / "wt-bare"
-        _init_main_repo(main)
+        _init_main_repo(main, with_dot_claude=False, with_legacy=False)
         _add_worktree(main, worktree, with_dot_claude=False)
         prev = Path.cwd()
         os.chdir(str(worktree))


### PR DESCRIPTION
## Summary

Track A of the Working Memory cluster remediation — retirement-independent hardening of the `CLAUDE.md` Working Memory subsystem. Every commit pays off regardless of the deferred KEEP/RETIRE decision (#160). **9 commits, full suite 12545 passed / 15 skipped / 0 failed / 0 errors.**

The arc began from a stale-context bug and a plan-mode consultation that **falsified the premise the tracker described**: the Working Memory section is not a materialized view over SQLite — it is a self-referential append-log that never queries the database. That reframing drove the whole remediation.

## What landed

| Commit | Change |
|---|---|
| `61055d82` | **Test isolation** — the CLI suite (53 subprocess sites, 15 mutating) was writing the developer's live gitignored `CLAUDE.md` on every run. Autouse fixture that seeds a file AND sets the env var (env-var-alone is a silent no-op). |
| `d27c2927` | **Doc corrections** — three LLM-loaded files described a Working Memory behaviour the runtime does not have (a 3-entry window that is actually conditional; a Memory-ID that compression strips; a sync command that does not exist). |
| `1fe36109` + `96ff3610` | **#375 atomicity** — `write_text` truncated-then-wrote, so a crash left a zero-byte `CLAUDE.md` with no git recovery. Now temp + fsync + `os.replace` at all **9** write sites (skill + hooks). Closes a wrong-closure: fixing one path while another could still truncate. |
| `19136644` | **D2 lock identity** — the lock sidecar was keyed by path *spelling*, so two names for one file (symlink, `/tmp`→`/private/tmp`, un-normalised `..`) produced two sidecars and `flock` gave no mutual exclusion. Now `.resolve()`s the whole target. Byte-identity-gated twin. |
| `69ffe910` | **D1 Option C** — a PACT-convention worktree session resolved to nothing and silently produced zero Working Memory while reporting success. A `--git-common-dir` branch (guarded, creates nothing) resolves to the main repo; a worktree that owns its own file is untouched (#935 preserved). |
| `31e3e059` + `b358879d` | **Regression guards** — parity pin for the resolver convergence Option C changed, plus behavioral Option-C guards and repair of **six phantom-greens** surfaced across the arc. |
| `977866f6` | Version bump 4.6.16 → 4.6.17 (PATCH — bug/test/doc). |

## Verification discipline

Every guard is certified by **revert-and-fail** — delete the feature, watch the test go red, restore — not by watching it pass. Six phantom-greens were caught (tests green for reasons unrelated to their assertions: mocks of unreachable failures, fixtures named for scenarios they never built, a pin passing without guarding the feature it named). An independent concurrent auditor verified ordering, gate integrity, and both D1 hard gates end-to-end.

## Scope boundaries

- **Deferred (not gaps)**: the #160 KEEP/RETIRE fork (this branch is retirement-independent by construction); Track C projection-semantics fixes (#410/#1221, #572/#573); the 800-token-budget question (#780).
- **Follow-ups filed / to file**: parity-lint re-point off the production-dead `_get_claude_md_path`; the pre-existing `migrate_to_managed_structure` PermissionError-from-`file_lock` leak (#1245). Related out-of-tracker findings filed during the arc: #1240–#1243.

`CLAUDE.md` sha unchanged across the entire chain — the file this work protects was never touched by the work that protects it.