### PR TITLE
Contain CLAUDE.md writes to the project boundary — close F1 symlink write-through (#1247)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.17",
+      "version": "4.6.18",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.18",
+      "version": "4.6.19",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.17/       # Plugin version
+│               └── 4.6.18/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.18/       # Plugin version
+│               └── 4.6.19/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.17",
+  "version": "4.6.18",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.18",
+  "version": "4.6.19",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.17
+> **Version**: 4.6.18
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.18
+> **Version**: 4.6.19
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/shared/agent_handoff_marker.py
+++ b/pact-plugin/hooks/shared/agent_handoff_marker.py
@@ -266,11 +266,21 @@ def _resolve_marker_target(
     # and mkdir(exist_ok=True) silently follows an existing symlink.
     # Re-resolve both paths and verify marker_dir is still contained within
     # the base. commonpath (not str.startswith — defeats the /teams/foo vs
-    # /teams/foobar prefix-collision) is the robust containment test; chosen
-    # over Path.is_relative_to because pyproject pins requires-python >=3.7
-    # and is_relative_to is 3.9+. On breach OR any resolution error: fail-open
-    # emit (return None) WITHOUT writing a marker at the escaped path —
-    # consistent with the is_symlink() pre-check's fail-open posture.
+    # /teams/foobar prefix-collision) is the robust containment test, and that
+    # prefix-collision reason is the ONLY reason it is preferred here.
+    # This was previously also justified as commonpath over Path.is_relative_to
+    # "because pyproject pins requires-python >=3.7 and is_relative_to is 3.9+".
+    # That argument is INVALID and is recorded here so it is not re-derived.
+    # pyproject does declare >=3.7, but nothing on the install path consults
+    # requires-python, so the declaration is inert; the ENFORCED floor is 3.9
+    # (the CI lint target and the 3.9 AST gate), and the oldest interpreter a
+    # consumer plausibly runs the hooks under is 3.9.6. is_relative_to is
+    # therefore available at the operative floor and rejects the prefix
+    # collision too, so either primitive would be correct -- the choice is not
+    # load-bearing and only the stated reason was wrong.
+    # On breach OR any resolution error: fail-open emit (return None) WITHOUT
+    # writing a marker at the escaped path — consistent with the is_symlink()
+    # pre-check's fail-open posture.
     try:
         real_marker = os.path.realpath(marker_dir)
         real_base = os.path.realpath(base)

--- a/pact-plugin/hooks/shared/claude_md_manager.py
+++ b/pact-plugin/hooks/shared/claude_md_manager.py
@@ -187,8 +187,26 @@ _STALE_ORCHESTRATOR_LINE_RE = re.compile(
 )
 
 
-def _atomic_write_text(target: Path, content: str) -> None:
-    """Replace `target`'s contents with `content` atomically.
+class ContainmentError(OSError):
+    """A CLAUDE.md write target escaped its project containment boundary (#1247).
+
+    Subclasses OSError so a caller that does not name it explicitly still
+    catches it via `except OSError`. Callers convert it to an OPAQUE skip
+    message ("path precondition not met") that does not leak the resolved
+    victim path -- matching what the leaf `is_symlink` guards returned before
+    containment replaced them.
+
+    Twin of ContainmentError in
+    `skills/pact-memory/scripts/working_memory.py` (skills cannot import from
+    hooks/shared). The two class defs are trivial markers; the load-bearing
+    logic is the containment CHECK inside `_atomic_write_text`, drift-gated by
+    TestAtomicWriteTwinCopyDrift.
+    """
+
+
+def _atomic_write_text(target: Path, content: str, project_root: Path) -> None:
+    """Replace `target`'s contents with `content` atomically, iff `target` is
+    contained within `project_root` (#1247).
 
     `Path.write_text` truncates the file and THEN writes, so a crash, a full
     disk, or a kill between those two steps leaves a TRUNCATED CLAUDE.md. That
@@ -204,10 +222,18 @@ def _atomic_write_text(target: Path, content: str) -> None:
     momentarily visible with the wrong permissions -- unlike a chmod after the
     write, which leaves exactly such a window on a file holding user content.
 
+    #1247 CONTAINMENT: before creating the temp, refuse (fail-CLOSED) unless the
+    RESOLVED target is inside the RESOLVED `project_root`. `project_root` MUST be
+    the trusted base the target's OWN resolver used (never a re-derivation) -- a
+    symlinked-parent `.claude` (F1) perturbs `target.resolve()` but not the
+    base's, so the escape is caught. `commonpath` (not `Path.is_relative_to`,
+    3.9+ vs the repo's 3.7 floor; not `str.startswith`, which wrongly allows the
+    sibling-prefix `/abc` vs `/ab`). Any resolution/commonpath error fails closed.
+
     Callers must already hold `file_lock` for the target. The lock closes the
-    concurrent-writer window; this closes the crash/truncation window. They are
-    different hazards and neither fix subsumes the other. Note the lock is a
-    separate sidecar file, so replacing the target's inode does not disturb it.
+    concurrent-writer window; this closes the crash/truncation window; the
+    containment check runs inside the lock by construction (callers hold it),
+    preserving the TOCTOU defense the replaced leaf `is_symlink` guards had.
 
     Requires write permission on the target's DIRECTORY (to create the temp),
     where a bare `write_text` needed only permission on the file itself. A
@@ -216,14 +242,33 @@ def _atomic_write_text(target: Path, content: str) -> None:
 
     NOTE: a deliberate duplicate of `_atomic_write_text` in
     `skills/pact-memory/scripts/working_memory.py`, which cannot import from
-    `hooks/shared/` (separate package). Unlike the `file_lock` twin, the two
-    copies are NOT drift-gated: atomicity has no cross-process invariant, so
-    each copy is independently correct and may legitimately diverge.
+    `hooks/shared/` (separate package). This twin IS drift-gated by
+    TestAtomicWriteTwinCopyDrift (mirroring TestFileLockTwinCopyDrift): the
+    containment CHECK is a security invariant that must not silently diverge
+    between the hook and skill copies (#1118-class hazard).
 
     Args:
         target: Path to replace. Its parent directory must already exist.
         content: Full file contents to write.
+        project_root: The trusted base directory `target` must be contained in.
+
+    Raises:
+        ContainmentError: `target` resolves outside `project_root`.
     """
+    # #1247 containment guard, fail-CLOSED, BEFORE creating the temp file.
+    try:
+        resolved_target = str(target.resolve())
+        resolved_root = str(project_root.resolve())
+        contained = (
+            os.path.commonpath([resolved_root, resolved_target]) == resolved_root
+        )
+    except (ValueError, OSError):
+        contained = False
+    if not contained:
+        raise ContainmentError(
+            "refusing write: target escapes the project containment boundary"
+        )
+
     fd, tmp_name = tempfile.mkstemp(
         dir=str(target.parent), prefix=f".{target.name}.", suffix=".tmp"
     )
@@ -398,17 +443,12 @@ def strip_orphan_kernel_block() -> str | None:
     # Fail-open on timeout — next session start will retry.
     try:
         with file_lock(target_file):
-            # Symlink guard INSIDE the lock (TOCTOU defense): is_symlink
-            # uses lstat under the hood which does NOT follow the link, so
-            # this is safe even if the link target is itself a malicious
-            # file. Inside the lock so an attacker cannot swap the target
-            # between an outside-lock check and the write.
-            if target_file.is_symlink():
-                return (
-                    "Migration skipped: ~/.claude/CLAUDE.md path "
-                    "precondition not met."
-                )
-
+            # #1247: the containment check in _atomic_write_text REPLACES the
+            # former leaf is_symlink guard. It runs inside this lock (TOCTOU-
+            # safe, since callers hold file_lock) and strictly DOMINATES
+            # is_symlink -- it catches a symlinked-PARENT escape (which
+            # is_symlink missed) as well as a leaf symlink, via
+            # resolve()-then-commonpath against the anchor below.
             try:
                 content = target_file.read_text(encoding="utf-8")
             except OSError:
@@ -467,10 +507,23 @@ def strip_orphan_kernel_block() -> str | None:
                 new_content = ""
 
             try:
-                _atomic_write_text(target_file, new_content)
+                # anchor: GLOBAL config dir, NOT a project root -- do not unify
+                # onto CLAUDE_PROJECT_DIR / a project root (R4). This file lives
+                # at ~/.claude/CLAUDE.md, a different trust boundary; project-
+                # rooting it would over-block every invocation.
+                _atomic_write_text(
+                    target_file, new_content, get_claude_config_dir()
+                )
                 return (
                     "Removed obsolete PACT kernel block from "
                     "~/.claude/CLAUDE.md"
+                )
+            except ContainmentError:
+                # Opaque skip, matching the message the removed is_symlink
+                # guard returned -- do not leak the resolved victim path.
+                return (
+                    "Migration skipped: ~/.claude/CLAUDE.md path "
+                    "precondition not met."
                 )
             except OSError as e:
                 return (
@@ -655,18 +708,19 @@ def ensure_project_memory_md() -> str | None:
     try:
         ensure_dot_claude_parent(target_file)
         with file_lock(target_file):
-            # Symlink guard: the resolver returned "new_default" (neither
-            # location exists), but the preferred path could still be a
-            # dangling symlink. is_symlink uses lstat and returns True even
-            # for dangling links. Re-check inside the lock so a concurrent
-            # writer that just created the file is detected.
-            if target_file.is_symlink():
-                return "Project CLAUDE.md skipped: path precondition not met."
+            # #1247: containment (in _atomic_write_text) REPLACES the former
+            # leaf is_symlink guard -- it runs inside the lock (TOCTOU-safe)
+            # and dominates is_symlink (catches a symlinked-parent escape as
+            # well as a leaf symlink, via resolve()-then-commonpath).
             if target_file.exists():
                 return None
             try:
-                _atomic_write_text(target_file, memory_template)
+                _atomic_write_text(
+                    target_file, memory_template, Path(project_dir)
+                )
                 return "Created project CLAUDE.md with memory sections"
+            except ContainmentError:
+                return "Project CLAUDE.md skipped: path precondition not met."
             except OSError as e:
                 return f"Project CLAUDE.md failed: {str(e)[:50]}"
     except TimeoutError:
@@ -727,9 +781,8 @@ def migrate_to_managed_structure() -> str | None:
 
     try:
         with file_lock(target_file):
-            if target_file.is_symlink():
-                return "Migration skipped: project CLAUDE.md path precondition not met."
-
+            # #1247: containment (in _atomic_write_text) REPLACES the former
+            # leaf is_symlink guard -- inside the lock, dominates is_symlink.
             try:
                 content = target_file.read_text(encoding="utf-8")
             except OSError:
@@ -742,8 +795,12 @@ def migrate_to_managed_structure() -> str | None:
             new_content = _build_migrated_content(content)
 
             try:
-                _atomic_write_text(target_file, new_content)
+                _atomic_write_text(
+                    target_file, new_content, Path(project_dir)
+                )
                 return "Migrated project CLAUDE.md to managed structure (#404)"
+            except ContainmentError:
+                return "Migration skipped: project CLAUDE.md path precondition not met."
             except OSError as e:
                 return f"Migration failed: {str(e)[:50]}"
     except TimeoutError:

--- a/pact-plugin/hooks/shared/claude_md_manager.py
+++ b/pact-plugin/hooks/shared/claude_md_manager.py
@@ -483,6 +483,17 @@ def strip_orphan_kernel_block() -> str | None:
             "Kernel-block migration skipped; will retry on next session "
             "start."
         )
+    except OSError:
+        # #1245: file_lock ACQUISITION (sidecar mkdir/open) can raise
+        # PermissionError etc., which is not a TimeoutError and would escape
+        # uncaught. The inner except handles post-acquisition write failures;
+        # this catches acquisition failures at the same skip-and-retry level.
+        # Opaque (no str(e)) so the sidecar path is not leaked into a status
+        # string -- matches the sibling TimeoutError message's non-disclosure.
+        return (
+            "Could not acquire lock on ~/.claude/CLAUDE.md "
+            "(path precondition not met); kernel-block migration skipped."
+        )
 
 
 def extract_managed_region(content: str) -> tuple[str, int] | None:
@@ -740,6 +751,15 @@ def migrate_to_managed_structure() -> str | None:
             "Failed to acquire lock on project CLAUDE.md within 5s "
             "(another session_init hook may be running concurrently). "
             "CLAUDE.md migration skipped; will retry on next session start."
+        )
+    except OSError:
+        # #1245: lock ACQUISITION PermissionError escapes `except TimeoutError`;
+        # catch it at the same skip-and-retry level (inner except handles the
+        # post-acquisition write). Opaque, matching the sibling TimeoutError
+        # message -- do not leak the sidecar path into a status string.
+        return (
+            "Could not acquire lock on project CLAUDE.md "
+            "(path precondition not met); CLAUDE.md migration skipped."
         )
 
 

--- a/pact-plugin/hooks/shared/claude_md_manager.py
+++ b/pact-plugin/hooks/shared/claude_md_manager.py
@@ -445,10 +445,13 @@ def strip_orphan_kernel_block() -> str | None:
         with file_lock(target_file):
             # #1247: the containment check in _atomic_write_text REPLACES the
             # former leaf is_symlink guard. It runs inside this lock (TOCTOU-
-            # safe, since callers hold file_lock) and strictly DOMINATES
-            # is_symlink -- it catches a symlinked-PARENT escape (which
-            # is_symlink missed) as well as a leaf symlink, via
-            # resolve()-then-commonpath against the anchor below.
+            # safe, since callers hold file_lock) and is the RIGHT control
+            # here: resolve()-then-commonpath against the anchor below catches
+            # the symlinked-PARENT escape the leaf is_symlink guard MISSED
+            # (F1). It does NOT dominate is_symlink -- the two catch
+            # overlapping-but-different sets: containment safely ALLOWS a
+            # benign in-project leaf redirect (os.replace swaps the leaf, no
+            # write-through) that the old blanket guard refused.
             try:
                 content = target_file.read_text(encoding="utf-8")
             except OSError:
@@ -710,8 +713,10 @@ def ensure_project_memory_md() -> str | None:
         with file_lock(target_file):
             # #1247: containment (in _atomic_write_text) REPLACES the former
             # leaf is_symlink guard -- it runs inside the lock (TOCTOU-safe)
-            # and dominates is_symlink (catches a symlinked-parent escape as
-            # well as a leaf symlink, via resolve()-then-commonpath).
+            # and catches the symlinked-PARENT escape the leaf guard MISSED
+            # (F1), via resolve()-then-commonpath. It does NOT dominate
+            # is_symlink: it safely ALLOWS a benign in-project leaf redirect
+            # (os.replace leaf-swap, no write-through) the old guard refused.
             if target_file.exists():
                 return None
             try:
@@ -782,7 +787,10 @@ def migrate_to_managed_structure() -> str | None:
     try:
         with file_lock(target_file):
             # #1247: containment (in _atomic_write_text) REPLACES the former
-            # leaf is_symlink guard -- inside the lock, dominates is_symlink.
+            # leaf is_symlink guard -- inside the lock. It catches the
+            # symlinked-PARENT escape the leaf guard MISSED (F1) and safely
+            # ALLOWS a benign in-project leaf redirect; it does NOT dominate
+            # is_symlink (the two catch overlapping-but-different sets).
             try:
                 content = target_file.read_text(encoding="utf-8")
             except OSError:

--- a/pact-plugin/hooks/shared/claude_md_manager.py
+++ b/pact-plugin/hooks/shared/claude_md_manager.py
@@ -26,8 +26,8 @@ import fcntl  # Unix-only; PACT supports macOS/Linux. No Windows compat shim.
 import os
 import re
 import sys
-import tempfile
 import time
+import uuid
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -205,8 +205,8 @@ class ContainmentError(OSError):
 
 
 def _atomic_write_text(target: Path, content: str, project_root: Path) -> None:
-    """Replace `target`'s contents with `content` atomically, iff `target` is
-    contained within `project_root` (#1247).
+    """Replace `target`'s contents with `content` atomically, iff the directory
+    the write will bind into is contained within `project_root` (#1247).
 
     `Path.write_text` truncates the file and THEN writes, so a crash, a full
     disk, or a kill between those two steps leaves a TRUNCATED CLAUDE.md. That
@@ -218,34 +218,89 @@ def _atomic_write_text(target: Path, content: str, project_root: Path) -> None:
     write. The temp file is created in the TARGET'S OWN DIRECTORY because
     `os.replace` is only atomic within a single filesystem.
 
-    The mode is set on the TEMP file before the rename, so the target is never
-    momentarily visible with the wrong permissions -- unlike a chmod after the
-    write, which leaves exactly such a window on a file holding user content.
+    CONTAINMENT -- WHY THERE IS NO PATH RESOLVER HERE
+    -------------------------------------------------
+    An earlier form of this guard compared `str(target.resolve())` against the
+    resolved root. `resolve()` follows every component INCLUDING the leaf; the
+    write follows only the PARENT chain and then binds the leaf as a directory
+    entry. Those are two independent traversals of two different path
+    expressions, and on a two-leg symlink topology they name different
+    directories -- so the guard certified a path the write never touched.
 
-    #1247 CONTAINMENT: before creating the temp, refuse (fail-CLOSED) unless the
-    RESOLVED target is inside the RESOLVED `project_root`. `project_root` MUST be
-    the trusted base the target's OWN resolver used (never a re-derivation) -- a
-    symlinked-parent `.claude` (F1) perturbs `target.resolve()` but not the
-    base's, so the escape is caught. `commonpath` (not `Path.is_relative_to`,
-    3.9+ vs the repo's 3.7 floor; not `str.startswith`, which wrongly allows the
-    sibling-prefix `/abc` vs `/ab`). Any resolution/commonpath error fails closed.
+    The general defect is that `Path.resolve()` and `os.path.realpath` are
+    SECOND implementations of path resolution, running in userspace, which the
+    write does not use. A predicate built on one is sound exactly while the two
+    agree, and the disagreement set (symlink loops, absent components) is
+    discovered, never bounded. So this function asks the kernel instead:
+
+      anchor  = (st_dev, st_ino) of os.stat(project_root)
+      node    = the directory the write will bind into, held OPEN
+      walk up via ".." comparing (st_dev, st_ino) until the anchor matches
+      (CONTAINED) or a directory is its own parent (filesystem root, REFUSE)
+
+    and then performs temp-create, fchmod, fsync, rename and cleanup THROUGH
+    that same descriptor. The object CHECKED is the object MUTATED, by
+    construction rather than by agreement. Consequences that fall out rather
+    than being bolted on: version-invariant (no `Path.resolve()` exists here, so
+    its 3.9-3.12 vs 3.13+ RuntimeError split is unreachable, not caught);
+    strict (an absent parent raises instead of being lexically completed);
+    immune to case-folding, Unicode normalisation form and trailing separators,
+    because nothing is compared as text; and sibling-prefix (`/abc` under
+    `/ab`) is refused structurally, since `/abc` never walks up to `/ab`'s
+    inode.
+
+    The parent is opened FOLLOWING symlinks -- see the inline note. Mounts
+    beneath the project are ALLOWED: `..` from a mount root yields the mount
+    POINT's parent, so the walk crosses one transparently, and the write still
+    lands inside the anchor's subtree.
+
+    THE LEAF IS NEVER CONSULTED, AND THAT COUPLES THIS TO THE WRITE SHAPE
+    --------------------------------------------------------------------
+    Containment is entirely a property of the parent chain, because the parent
+    chain is the only part the kernel traverses on the way to the write. A leaf
+    symlink pointing OUTSIDE the root is therefore ALLOWED, and that is the
+    correct verdict, not a concession: `os.replace` is renameat(2), which
+    unlinks whatever entry sits at the final name and binds the temp file's
+    inode there. It never opens the leaf and never follows it, so the payload
+    lands at the in-project entry and any outside victim is left byte-intact.
+
+    That ALLOW is sound ONLY while the write replaces the leaf ENTRY rather
+    than writing THROUGH it. Two rewrites would silently convert every such
+    ALLOW into a real escape, with this predicate untouched: (1) resolving the
+    target once and using it downstream -- proposed as a cheap way to make the
+    check and the act agree, which it does, on the WRONG side, by making the
+    write follow the leaf; (2) replacing temp-plus-rename with an open/truncate
+    on the target. MEASURED, so the guarantee is stated at its real strength:
+    with either rewrite spliced in, `TestR6InProjectRedirectResidualDocumented`
+    turns RED on its victim-untouched assertion, so the in-project half of this
+    coupling IS pinned by an executing test today. The out-of-project half is
+    pinned separately, and could not be pinned at all before this predicate,
+    because the earlier one refused that topology outright.
 
     Callers must already hold `file_lock` for the target. The lock closes the
-    concurrent-writer window; this closes the crash/truncation window; the
-    containment check runs inside the lock by construction (callers hold it),
-    preserving the TOCTOU defense the replaced leaf `is_symlink` guards had.
+    concurrent-writer window; this closes the crash/truncation window.
 
-    Requires write permission on the target's DIRECTORY (to create the temp),
-    where a bare `write_text` needed only permission on the file itself. A
-    read-only directory holding a writable CLAUDE.md would now fail the write
-    rather than truncate it -- a safe direction, but a real behaviour change.
+    Requires read+execute on the target's directory and write permission on it
+    (to create the temp), where a bare `write_text` needed only permission on
+    the file itself. A read-only directory holding a writable CLAUDE.md fails
+    the write rather than truncating it -- a safe direction, but a real
+    behaviour change.
+
+    SCOPE LIMIT, stated because the natural summary of this change overclaims:
+    `file_lock` runs BEFORE this function at every call site and does its own
+    unprotected `target_file.resolve()`. Removing `Path.resolve()` from this
+    guard makes the GUARD version-invariant; it does NOT make the write path
+    version-invariant end-to-end, and a symlink loop still raises upstream.
 
     NOTE: a deliberate duplicate of `_atomic_write_text` in
     `skills/pact-memory/scripts/working_memory.py`, which cannot import from
     `hooks/shared/` (separate package). This twin IS drift-gated by
     TestAtomicWriteTwinCopyDrift (mirroring TestFileLockTwinCopyDrift): the
     containment CHECK is a security invariant that must not silently diverge
-    between the hook and skill copies (#1118-class hazard).
+    between the hook and skill copies (#1118-class hazard). That gate compares
+    only THIS function's body, which is why the check is inlined here rather
+    than extracted -- a named helper would have to be twinned too, and would
+    sit outside every drift gate in the repo.
 
     Args:
         target: Path to replace. Its parent directory must already exist.
@@ -253,52 +308,142 @@ def _atomic_write_text(target: Path, content: str, project_root: Path) -> None:
         project_root: The trusted base directory `target` must be contained in.
 
     Raises:
-        ContainmentError: `target` resolves outside `project_root`.
+        ContainmentError: the write's parent directory is not the project root
+            or a descendant of it; or the boundary could not be established at
+            all. Fail-CLOSED in every case, with a distinct message per cause.
     """
-    # #1247 containment guard, fail-CLOSED, BEFORE creating the temp file.
+    # #1247 CONTAINMENT, fail-CLOSED, BEFORE anything is created: kernel object
+    # ancestry on a pinned directory descriptor. No Path.resolve(), no
+    # os.path.realpath, no string comparison takes part in this decision.
     try:
-        resolved_target = str(target.resolve())
-        resolved_root = str(project_root.resolve())
-        contained = (
-            os.path.commonpath([resolved_root, resolved_target]) == resolved_root
-        )
-    except (ValueError, OSError):
-        contained = False
-    if not contained:
+        anchor_stat = os.stat(str(project_root))
+        anchor_key = (anchor_stat.st_dev, anchor_stat.st_ino)
+        # FOLLOWS symlinks, deliberately: this is exactly how the kernel will
+        # traverse the parent chain for the write. O_NOFOLLOW here would refuse
+        # any symlinked final component of the parent path -- including a benign
+        # in-project `.claude` -> `<project>/config/claude`, which the pre-#1247
+        # code allowed -- a NEW over-block on an axis that is not containment.
+        # It would also add nothing: the ancestry test below runs ON this
+        # descriptor, so there is no check-then-open gap for it to close.
+        parent_fd = os.open(str(target.parent), os.O_RDONLY | os.O_DIRECTORY)
+    except (OSError, NotImplementedError):
+        # An absent parent, a parent that is not a directory, a symlink loop
+        # (ELOOP), and an unsupported-primitive failure all land here. Bare
+        # RuntimeError is deliberately NOT caught: it is unreachable, because no
+        # Path.resolve() call exists in this function, and catching it would
+        # imply one still did and invite one back. NotImplementedError is named
+        # explicitly -- it is a RuntimeError SUBCLASS, and it is Python's
+        # documented signal for an unsupported dir_fd argument.
         raise ContainmentError(
-            "refusing write: target escapes the project containment boundary"
+            "refusing write: cannot establish the containment boundary"
         )
 
-    fd, tmp_name = tempfile.mkstemp(
-        dir=str(target.parent), prefix=f".{target.name}.", suffix=".tmp"
-    )
+    walked = []
     try:
-        # os.fdopen takes ownership of fd only on success; if it raises, the
-        # raw fd mkstemp opened would leak (the outer cleanup unlinks the temp
-        # FILE but cannot close a descriptor it never received a handle for).
-        try:
-            handle = os.fdopen(fd, "w", encoding="utf-8")
-        except BaseException:
-            os.close(fd)
-            raise
-        with handle:
-            handle.write(content)
-            handle.flush()
-            # Without the fsync the rename can be persisted while the data
-            # behind it is not, which reintroduces the empty-file failure this
-            # function exists to prevent.
-            os.fsync(handle.fileno())
-        # mkstemp already creates 0o600; setting it explicitly keeps the mode a
-        # property of this function rather than of the stdlib's default.
-        os.chmod(tmp_name, 0o600)
-        os.replace(tmp_name, target)
+        # 1024 is an INLINE LITERAL rather than a module constant because a
+        # constant would sit outside the region the twin drift gate compares
+        # (only this function's body) and could diverge between the twins
+        # silently. It is a LIVENESS backstop, not a policy ceiling: a POSIX
+        # path is PATH_MAX-bounded and every component costs at least two bytes
+        # including its separator, so no reachable path carries this many
+        # components. Reaching it means the filesystem is misreporting "..",
+        # not that the path is legitimately deep -- which is why exhaustion
+        # raises its own message below instead of the escape one. Normal
+        # operation terminates at the filesystem root and never arrives here.
+        contained = False
+        node = parent_fd
+        for _ in range(1024):
+            node_stat = os.fstat(node)
+            if (node_stat.st_dev, node_stat.st_ino) == anchor_key:
+                contained = True
+                break
+            up = os.open("..", os.O_RDONLY | os.O_DIRECTORY, dir_fd=node)
+            walked.append(up)
+            up_stat = os.fstat(up)
+            if (up_stat.st_dev, up_stat.st_ino) == (
+                node_stat.st_dev,
+                node_stat.st_ino,
+            ):
+                # A directory that is its own parent is the filesystem root:
+                # the walk is over and the anchor was never reached.
+                break
+            node = up
+        else:
+            raise ContainmentError(
+                "refusing write: containment walk did not terminate"
+            )
+        if not contained:
+            raise ContainmentError(
+                "refusing write: target escapes the project containment boundary"
+            )
     except BaseException:
-        # Never leave a stray temp file behind next to the user's CLAUDE.md.
-        try:
-            os.unlink(tmp_name)
-        except OSError:
-            pass
+        os.close(parent_fd)
         raise
+    finally:
+        for extra in walked:
+            os.close(extra)
+
+    try:
+        tmp_name = f".{target.name}.{uuid.uuid4().hex}.tmp"
+        try:
+            fd = os.open(
+                tmp_name,
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                0o600,
+                dir_fd=parent_fd,
+            )
+        except NotImplementedError:
+            raise ContainmentError(
+                "refusing write: platform lacks directory-descriptor file creation"
+            )
+        try:
+            # os.fdopen takes ownership of fd only on success; if it raises, the
+            # raw fd would leak (the cleanup below unlinks the temp FILE but
+            # cannot close a descriptor it never received a handle for).
+            try:
+                handle = os.fdopen(fd, "w", encoding="utf-8")
+            except BaseException:
+                os.close(fd)
+                raise
+            with handle:
+                handle.write(content)
+                handle.flush()
+                # fchmod on the OPEN HANDLE, never os.chmod by name: a chmod by
+                # name after the close would reintroduce the name-based race
+                # this descriptor design exists to remove. It is NOT guarding
+                # against over-permissiveness -- umask can only CLEAR bits, so
+                # os.open(..., 0o600) cannot yield anything more permissive than
+                # 0o600. Its actual effect is the opposite: it RESTORES an
+                # owner-write bit a restrictive umask removed (measured: with
+                # the open mode alone, umask 0o277 leaves 0o400). The property
+                # is DETERMINISM -- the mode belongs to this function rather
+                # than to the caller's umask. It precedes the fsync so the mode
+                # change is part of what that fsync flushes.
+                os.fchmod(handle.fileno(), 0o600)
+                # Without the fsync the rename can be persisted while the data
+                # behind it is not, which reintroduces the empty-file failure
+                # this function exists to prevent.
+                os.fsync(handle.fileno())
+            try:
+                os.replace(
+                    tmp_name,
+                    target.name,
+                    src_dir_fd=parent_fd,
+                    dst_dir_fd=parent_fd,
+                )
+            except NotImplementedError:
+                raise ContainmentError(
+                    "refusing write: platform lacks directory-descriptor rename"
+                )
+        except BaseException:
+            # Never leave a stray temp file behind next to the user's CLAUDE.md.
+            try:
+                os.unlink(tmp_name, dir_fd=parent_fd)
+            except OSError:
+                pass
+            raise
+    finally:
+        os.close(parent_fd)
 
 
 def _strip_legacy_lines(content: str) -> str:
@@ -633,8 +778,10 @@ def ensure_dot_claude_parent(path: Path) -> None:
     a regular file (e.g., a local attacker deliberately blocking mkdir
     by creating a file where `.claude/` should be). Without this guard
     the code path would fall through to the subsequent `_atomic_write_text`
-    call and surface a less-clear OSError from `tempfile.mkstemp`, which
-    needs the parent to be a writable directory.
+    call, whose `os.open(parent, O_DIRECTORY)` fails on a non-directory
+    parent and reports it as a ContainmentError -- accurate as a fail-closed
+    refusal, but it names the containment boundary rather than the blocking
+    file, so the clearer error belongs here.
 
     Args:
         path: The target CLAUDE.md path (e.g. /proj/.claude/CLAUDE.md).

--- a/pact-plugin/hooks/shared/claude_md_manager.py
+++ b/pact-plugin/hooks/shared/claude_md_manager.py
@@ -62,8 +62,10 @@ def file_lock(target_file: Path):
     Not re-entrant: nested acquisition from the same thread will deadlock
     (TimeoutError after ``_LOCK_TIMEOUT_SECONDS``).
 
-    Creates (or opens) `{target_file.parent}/.{target_file.name}.lock` and
-    takes an ``fcntl`` exclusive advisory lock on its file descriptor.
+    Creates (or opens) a sidecar named `.{target_file.name}.lock` inside the
+    RESOLVED parent directory -- `target_file.parent.resolve()`, not the
+    unresolved parent, so two spellings of one directory share one sidecar --
+    and takes an ``fcntl`` exclusive advisory lock on its file descriptor.
     Polls with non-blocking acquire + sleep so a stuck holder cannot hang
     session_init forever: raises ``TimeoutError`` after
     ``_LOCK_TIMEOUT_SECONDS``.
@@ -85,12 +87,23 @@ def file_lock(target_file: Path):
             should treat this as a transient failure and return a
             fail-open status string so session_init can surface it.
     """
-    # Resolve the WHOLE target, not just its parent: fcntl.flock serialises on
-    # the sidecar's inode, so two spellings of one file must produce one sidecar
-    # name. Resolving only the parent still keys a symlinked FILE by its alias
-    # (two names, one inode -> two sidecars -> no mutual exclusion).
-    resolved_target = target_file.resolve()
-    lock_path = resolved_target.parent / f".{resolved_target.name}.lock"
+    # Key the sidecar on the DIRECTORY THE WRITE BINDS INTO plus the LITERAL
+    # leaf name, so lock identity and write identity are the same thing and
+    # cannot diverge when the write replaces the leaf entry.
+    # The PARENT is resolved so two spellings of one directory produce one
+    # sidecar, and therefore one lock. The LEAF is deliberately NOT resolved:
+    # os.replace is renameat(2) and binds the final component as a directory
+    # ENTRY without following it, so resolving the leaf would key the lock on a
+    # path the write never touches -- and would make the key CHANGE across the
+    # write, which is a lock whose identity is a function of the state it is
+    # supposed to protect. Mirrors the write's own os.open(target.parent) +
+    # target.name; see the write-shape dependency noted in _atomic_write_text.
+    # NOT provided, deliberately: two NAMES for one INODE do not collapse onto
+    # one sidecar. A hardlink pair is exactly that and never collapsed under
+    # any spelling of this formula, because resolve() canonicalises symlinks
+    # and not inodes -- the justification this comment replaced claimed
+    # otherwise and was wrong about its own code.
+    lock_path = target_file.parent.resolve() / f".{target_file.name}.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     # 0o600: the lock file is adjacent to user-private CLAUDE.md content;
     # match the same permissions to avoid leaving a world-readable sidecar.
@@ -220,6 +233,17 @@ def _atomic_write_text(target: Path, content: str, project_root: Path) -> None:
 
     CONTAINMENT -- WHY THERE IS NO PATH RESOLVER HERE
     -------------------------------------------------
+
+    PRECONDITION. This guard eliminates one class outright and narrows another.
+    The class eliminated is disagreement between two path resolutions: only
+    one traversal happens here and its result is held OPEN, so no second
+    resolution exists to disagree with it. What is narrowed is time. The walk
+    establishes ancestry AT THE INSTANT OF THE WALK, and a descriptor pins
+    IDENTITY, not POSITION -- so containment holds provided the directory the
+    write binds into does not change position relative to the anchor between
+    the walk and the rename. Only the chain from that directory up to the
+    anchor matters; relocating anything off it is irrelevant.
+
     An earlier form of this guard compared `str(target.resolve())` against the
     resolved root. `resolve()` follows every component INCLUDING the leaf; the
     write follows only the PARENT chain and then binds the leaf as a directory

--- a/pact-plugin/hooks/shared/claude_md_manager.py
+++ b/pact-plugin/hooks/shared/claude_md_manager.py
@@ -456,10 +456,25 @@ def _atomic_write_text(target: Path, content: str, project_root: Path) -> None:
                     "refusing write: platform lacks directory-descriptor rename"
                 )
         except BaseException:
-            # Never leave a stray temp file behind next to the user's CLAUDE.md.
+            # Remove the temp rather than leave it beside the user's CLAUDE.md.
+            # BEST-EFFORT, not absolute: if the removal itself fails the temp
+            # survives, because nothing downstream of here can remove it. That
+            # is the deliberate trade below -- a stray file is preferable to
+            # losing the reason the write was refused.
             try:
                 os.unlink(tmp_name, dir_fd=parent_fd)
-            except OSError:
+            except (OSError, NotImplementedError):
+                # SWALLOWED, not mapped -- the one capability site handled this
+                # way, and deliberately so. This cleanup runs while an exception
+                # is already in flight; anything raised here REPLACES it, and
+                # the bare `raise` below never runs. The caller would then see
+                # a cleanup failure instead of the containment refusal that
+                # actually stopped the write, so a leftover temp file would
+                # outrank the reason the write was refused. The original
+                # exception wins; best-effort cleanup stays best-effort.
+                # NotImplementedError is named for the same reason as at the
+                # dir_fd sites above: it subclasses RuntimeError, NOT OSError,
+                # so a bare `except OSError` is blind to it.
                 pass
             raise
     finally:

--- a/pact-plugin/hooks/shared/claude_md_manager.py
+++ b/pact-plugin/hooks/shared/claude_md_manager.py
@@ -357,7 +357,27 @@ def _atomic_write_text(target: Path, content: str, project_root: Path) -> None:
             if (node_stat.st_dev, node_stat.st_ino) == anchor_key:
                 contained = True
                 break
-            up = os.open("..", os.O_RDONLY | os.O_DIRECTORY, dir_fd=node)
+            try:
+                up = os.open("..", os.O_RDONLY | os.O_DIRECTORY, dir_fd=node)
+            except NotImplementedError:
+                # NARROW BY DESIGN -- only NotImplementedError is mapped here.
+                # A genuine OSError from this open (EACCES on an ancestor the
+                # user cannot read) must keep propagating RAW through the outer
+                # handler; relabelling it would report a permission failure as
+                # a capability failure.
+                # NotImplementedError has to be named explicitly because it is
+                # a RuntimeError SUBCLASS, NOT an OSError one, while
+                # ContainmentError subclasses OSError. So the callers'
+                # `except ContainmentError` / `except OSError` arms are blind
+                # to it: unmapped, it would escape as-is and CRASH the hook
+                # instead of failing closed into the site's opaque skip status.
+                # This is the same reason given at the parent-directory open;
+                # it applies wherever a dir_fd argument is passed, and this is
+                # the second such site.
+                raise ContainmentError(
+                    "refusing write: platform lacks directory-descriptor "
+                    "ancestry traversal"
+                )
             walked.append(up)
             up_stat = os.fstat(up)
             if (up_stat.st_dev, up_stat.st_ino) == (

--- a/pact-plugin/hooks/shared/claude_md_manager.py
+++ b/pact-plugin/hooks/shared/claude_md_manager.py
@@ -611,9 +611,13 @@ def strip_orphan_kernel_block() -> str | None:
             # #1247: the containment check in _atomic_write_text REPLACES the
             # former leaf is_symlink guard. It runs inside this lock (TOCTOU-
             # safe, since callers hold file_lock) and is the RIGHT control
-            # here: resolve()-then-commonpath against the anchor below catches
-            # the symlinked-PARENT escape the leaf is_symlink guard MISSED
-            # (F1). It does NOT dominate is_symlink -- the two catch
+            # here: kernel-object ancestry on a pinned parent descriptor
+            # catches the symlinked-PARENT escape the leaf is_symlink guard
+            # MISSED (F1). No resolver runs inside the guard -- see
+            # _atomic_write_text; do NOT reintroduce one, and in particular do
+            # not resolve the target and reuse it downstream, which would make
+            # the WRITE follow the leaf.
+            # It does NOT dominate is_symlink -- the two catch
             # overlapping-but-different sets: containment safely ALLOWS a
             # benign in-project leaf redirect (os.replace swaps the leaf, no
             # write-through) that the old blanket guard refused.
@@ -881,7 +885,10 @@ def ensure_project_memory_md() -> str | None:
             # #1247: containment (in _atomic_write_text) REPLACES the former
             # leaf is_symlink guard -- it runs inside the lock (TOCTOU-safe)
             # and catches the symlinked-PARENT escape the leaf guard MISSED
-            # (F1), via resolve()-then-commonpath. It does NOT dominate
+            # (F1), via kernel-object ancestry on a pinned parent descriptor.
+            # No resolver runs inside the guard -- do NOT reintroduce one, and
+            # do not resolve the target and reuse it downstream: that makes the
+            # WRITE follow the leaf. It does NOT dominate
             # is_symlink: it safely ALLOWS a benign in-project leaf redirect
             # (os.replace leaf-swap, no write-through) the old guard refused.
             if target_file.exists():

--- a/pact-plugin/hooks/shared/session_resume.py
+++ b/pact-plugin/hooks/shared/session_resume.py
@@ -20,6 +20,7 @@ import os
 import re
 import sys
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any
 
 from shared.claude_md_manager import (
@@ -28,6 +29,7 @@ from shared.claude_md_manager import (
     MANAGED_TITLE,
     MEMORY_END_MARKER,
     MEMORY_START_MARKER,
+    ContainmentError,
     _atomic_write_text,
     ensure_dot_claude_parent,
     file_lock,
@@ -158,13 +160,9 @@ def update_session_info(
     # Fail-open on timeout — next session start will retry.
     try:
         with file_lock(target_file):
-            # Symlink guard INSIDE the lock (TOCTOU defense): is_symlink
-            # uses lstat (does not follow the link). Inside the lock so an
-            # attacker cannot swap the target between an outside-lock
-            # check and the write.
-            if target_file.is_symlink():
-                return "Session info skipped: path precondition not met."
-
+            # #1247: containment (in _atomic_write_text) REPLACES the former
+            # leaf is_symlink guard -- inside the lock (TOCTOU-safe), and it
+            # dominates is_symlink (catches a symlinked-parent escape too).
             try:
                 # Case 0: File doesn't exist -- create it with the full canonical
                 # PACT_MANAGED structure so the orchestrator has a stable Current
@@ -195,7 +193,7 @@ def update_session_info(
                         "\n"
                         f"{MANAGED_END_MARKER}\n"
                     )
-                    _atomic_write_text(target_file, new_content)
+                    _atomic_write_text(target_file, new_content, Path(project_dir))
                     return "Session info created in new project CLAUDE.md"
 
                 content = target_file.read_text(encoding="utf-8")
@@ -217,7 +215,7 @@ def update_session_info(
                         flags=re.DOTALL,
                     )
                     if new_content != content:
-                        _atomic_write_text(target_file, new_content)
+                        _atomic_write_text(target_file, new_content, Path(project_dir))
                         return "Session info updated in project CLAUDE.md"
                     return None
 
@@ -269,9 +267,12 @@ def update_session_info(
                             content += "\n"
                         new_content = content + "\n" + session_block + "\n"
 
-                _atomic_write_text(target_file, new_content)
+                _atomic_write_text(target_file, new_content, Path(project_dir))
                 return "Session info added to project CLAUDE.md"
 
+            except ContainmentError:
+                # Opaque skip, matching the removed is_symlink guard's message.
+                return "Session info skipped: path precondition not met."
             except Exception as e:
                 return f"Session info failed: {str(e)[:50]}"
     except TimeoutError:

--- a/pact-plugin/hooks/shared/session_resume.py
+++ b/pact-plugin/hooks/shared/session_resume.py
@@ -161,8 +161,10 @@ def update_session_info(
     try:
         with file_lock(target_file):
             # #1247: containment (in _atomic_write_text) REPLACES the former
-            # leaf is_symlink guard -- inside the lock (TOCTOU-safe), and it
-            # dominates is_symlink (catches a symlinked-parent escape too).
+            # leaf is_symlink guard -- inside the lock (TOCTOU-safe). It
+            # catches the symlinked-PARENT escape the leaf guard MISSED (F1)
+            # and safely ALLOWS a benign in-project leaf redirect; it does NOT
+            # dominate is_symlink (overlapping-but-different sets).
             try:
                 # Case 0: File doesn't exist -- create it with the full canonical
                 # PACT_MANAGED structure so the orchestrator has a stable Current

--- a/pact-plugin/hooks/shared/session_resume.py
+++ b/pact-plugin/hooks/shared/session_resume.py
@@ -280,6 +280,15 @@ def update_session_info(
             "(another session_init hook may be running concurrently). "
             "Session info update skipped; will retry on next session start."
         )
+    except OSError:
+        # #1245: lock ACQUISITION PermissionError escapes `except TimeoutError`;
+        # catch it at the same skip-and-retry level (the inner except Exception
+        # handles only post-acquisition failures, inside the `with file_lock`).
+        # Opaque, matching the sibling TimeoutError message -- no path leak.
+        return (
+            "Could not acquire lock on project CLAUDE.md "
+            "(path precondition not met); session info update skipped."
+        )
 
 
 def restore_last_session(

--- a/pact-plugin/hooks/staleness.py
+++ b/pact-plugin/hooks/staleness.py
@@ -137,6 +137,27 @@ def _resolve_project_claude_md_with_base() -> Tuple[Optional[Path], Optional[Pat
     return (found, cwd) if found is not None else (None, None)
 
 
+def _lexical_base_of(claude_md_path: Path) -> Path:
+    """Recover the pre-`.claude` base of a resolver-produced CLAUDE.md path by
+    INVERTING the resolver's construction (base/.claude/CLAUDE.md | base/
+    CLAUDE.md) -- #1247 option D, for a caller-SUPPLIED path with no separate
+    base (session_init's production flow passes the path, not the base).
+
+    Purely lexical (pathlib `.parent` never follows symlinks), so an F1
+    symlinked-parent `.claude` still escapes on the target's resolve() and is
+    refused. Locked to the resolver's own base by TestStalenessLexicalBaseParity
+    -- if _resolve_project_claude_md_with_base ever grows a third path shape,
+    that test turns this formula's divergence into a RED.
+
+    Edge (adversarial-only UNDER-block, tolerated per the good-faith model): a
+    project dir literally named ".claude" using the LEGACY layout lands one
+    level too high. Requires deliberate construction; not a bug.
+    """
+    if claude_md_path.parent.name == ".claude":
+        return claude_md_path.parent.parent
+    return claude_md_path.parent
+
+
 def get_project_claude_md_path() -> Optional[Path]:
     """
     Get the path to the project-level CLAUDE.md (path only).
@@ -455,7 +476,15 @@ def check_pinned_staleness(claude_md_path: Optional[Path] = None) -> Optional[st
         Informational message about stale pins found, or None.
     """
     if claude_md_path is None:
-        claude_md_path = _get_project_claude_md_path()
+        claude_md_path, project_root = _resolve_project_claude_md_with_base()
+    else:
+        # A caller-supplied path came from a TRUSTED resolver -- session_init
+        # resolves via _get_project_claude_md_path() and PASSES it here, so
+        # production DOES supply the param. Recover its pre-.claude base by
+        # inverting the resolver's construction (see _lexical_base_of): the
+        # SAME base the resolver used, not a re-derived root, and F1-safe
+        # (purely lexical, no symlink follow) + parity-locked.
+        project_root = _lexical_base_of(claude_md_path)
     if claude_md_path is None:
         return None
 
@@ -490,13 +519,16 @@ def check_pinned_staleness(claude_md_path: Optional[Path] = None) -> Optional[st
             # imports from shared.claude_md_manager — a module-level
             # import here would create a staleness → claude_md_manager →
             # (indirectly) staleness cycle on some Python versions.
-            from shared.claude_md_manager import _atomic_write_text, file_lock
+            from shared.claude_md_manager import (
+                ContainmentError,
+                _atomic_write_text,
+                file_lock,
+            )
             with file_lock(claude_md_path):
-                # Symlink guard INSIDE the lock (TOCTOU defense). is_symlink
-                # uses lstat so it does not follow the link. Status string is
-                # deliberately opaque to avoid revealing the internal guard.
-                if claude_md_path.is_symlink():
-                    return "Pinned staleness skipped: path precondition not met."
+                # #1247: containment (in _atomic_write_text) REPLACES the
+                # former leaf is_symlink guard -- inside the lock (TOCTOU-safe)
+                # and it dominates is_symlink (catches a symlinked-parent
+                # escape too). Status string stays opaque.
                 # Re-read inside the lock — a concurrent update_session_info
                 # may have landed between our outer
                 # read at L348 and the lock acquisition. If content changed,
@@ -511,7 +543,9 @@ def check_pinned_staleness(claude_md_path: Optional[Path] = None) -> Optional[st
                 # write sites this one never set a mode, so `write_text` left
                 # the file's existing permissions alone; the helper normalises
                 # it to 0o600, matching every other writer in the plugin.
-                _atomic_write_text(claude_md_path, new_content)
+                _atomic_write_text(claude_md_path, new_content, project_root)
+        except ContainmentError:
+            return "Pinned staleness skipped: path precondition not met."
         except TimeoutError:
             return "Pinned staleness update skipped: lock contention."
         except OSError as e:

--- a/pact-plugin/hooks/staleness.py
+++ b/pact-plugin/hooks/staleness.py
@@ -68,9 +68,11 @@ def _find_existing_claude_md(base: Path) -> Optional[Path]:
     return None
 
 
-def get_project_claude_md_path() -> Optional[Path]:
+def _resolve_project_claude_md_with_base() -> Tuple[Optional[Path], Optional[Path]]:
     """
-    Get the path to the project-level CLAUDE.md.
+    Resolve the project-level CLAUDE.md AND the trusted base directory it was
+    found under, so a write caller can containment-check the target against the
+    base the resolver actually used (#1247).
 
     Honors both supported locations:
       - $base/.claude/CLAUDE.md  (preferred / new default)
@@ -82,14 +84,23 @@ def get_project_claude_md_path() -> Optional[Path]:
          the worktree path, which often does not contain CLAUDE.md)
       3. Current working directory
 
+    The returned `base` is the branch's directory captured BEFORE descending
+    into `.claude` (the arg to `_find_existing_claude_md`), NOT the returned
+    path and NOT a re-derivation -- the trusted pre-resolve anchor that makes
+    the #1247 containment check non-vacuous. `get_project_claude_md_path` is
+    now a thin wrapper returning `[0]`, so read-only callers and the
+    resolver-parity lint are unaffected.
+
     Returns:
-        Path to an existing project CLAUDE.md if found, None otherwise.
+        (path, base) where path is an existing project CLAUDE.md and base is
+        the directory it was found under; (None, None) if none exists.
     """
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
     if project_dir:
-        found = _find_existing_claude_md(Path(project_dir))
+        base = Path(project_dir)
+        found = _find_existing_claude_md(base)
         if found is not None:
-            return found
+            return found, base
 
     # Fallback: detect git root (worktree-safe)
     # Uses --git-common-dir instead of --show-toplevel because the latter
@@ -116,12 +127,29 @@ def get_project_claude_md_path() -> Optional[Path]:
             repo_root = common_dir.resolve().parent
             found = _find_existing_claude_md(repo_root)
             if found is not None:
-                return found
+                return found, repo_root
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
         pass
 
     # Last resort: current working directory
-    return _find_existing_claude_md(Path.cwd())
+    cwd = Path.cwd()
+    found = _find_existing_claude_md(cwd)
+    return (found, cwd) if found is not None else (None, None)
+
+
+def get_project_claude_md_path() -> Optional[Path]:
+    """
+    Get the path to the project-level CLAUDE.md (path only).
+
+    Thin wrapper over `_resolve_project_claude_md_with_base` (added for #1247);
+    read-only callers, session_init, and the resolver-parity lint use this
+    Path-only name, while the write caller (check_pinned_staleness) uses the
+    with-base variant to get the containment anchor.
+
+    Returns:
+        Path to an existing project CLAUDE.md if found, None otherwise.
+    """
+    return _resolve_project_claude_md_with_base()[0]
 
 
 # Backward-compatible alias (tests and session_init patch the underscore name)

--- a/pact-plugin/hooks/staleness.py
+++ b/pact-plugin/hooks/staleness.py
@@ -526,9 +526,11 @@ def check_pinned_staleness(claude_md_path: Optional[Path] = None) -> Optional[st
             )
             with file_lock(claude_md_path):
                 # #1247: containment (in _atomic_write_text) REPLACES the
-                # former leaf is_symlink guard -- inside the lock (TOCTOU-safe)
-                # and it dominates is_symlink (catches a symlinked-parent
-                # escape too). Status string stays opaque.
+                # former leaf is_symlink guard -- inside the lock (TOCTOU-safe).
+                # It catches the symlinked-PARENT escape the leaf guard MISSED
+                # (F1) and safely ALLOWS a benign in-project leaf redirect; it
+                # does NOT dominate is_symlink (overlapping-but-different sets).
+                # Status string stays opaque.
                 # Re-read inside the lock — a concurrent update_session_info
                 # may have landed between our outer
                 # read at L348 and the lock acquisition. If content changed,

--- a/pact-plugin/scripts/check_pin_caps.py
+++ b/pact-plugin/scripts/check_pin_caps.py
@@ -57,6 +57,8 @@ Used by:
   - Test files: tests/test_check_pin_caps.py (advisory-path coverage)
 """
 
+from __future__ import annotations
+
 import argparse
 import importlib.util
 import json

--- a/pact-plugin/skills/pact-memory/scripts/__init__.py
+++ b/pact-plugin/skills/pact-memory/scripts/__init__.py
@@ -13,6 +13,8 @@ Complete package for the PACT Memory skill including:
 - Setup: Auto-initialization and model download
 """
 
+from __future__ import annotations
+
 # Database layer
 from .database import (
     # Connection management

--- a/pact-plugin/skills/pact-memory/scripts/cli.py
+++ b/pact-plugin/skills/pact-memory/scripts/cli.py
@@ -28,6 +28,8 @@ Commands:
     setup                Initialize/verify memory system
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import os

--- a/pact-plugin/skills/pact-memory/scripts/config.py
+++ b/pact-plugin/skills/pact-memory/scripts/config.py
@@ -12,6 +12,8 @@ Used by:
 - setup_memory.py: Directory creation (PACT_MEMORY_DIR)
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 
 # Base directory for all PACT memory data

--- a/pact-plugin/skills/pact-memory/scripts/database.py
+++ b/pact-plugin/skills/pact-memory/scripts/database.py
@@ -13,6 +13,8 @@ Standard library sqlite3 has enable_load_extension disabled by default.
 Falls back gracefully to keyword-only search when extensions unavailable.
 """
 
+from __future__ import annotations
+
 import hashlib
 import json
 import logging

--- a/pact-plugin/skills/pact-memory/scripts/embedding_catchup.py
+++ b/pact-plugin/skills/pact-memory/scripts/embedding_catchup.py
@@ -12,6 +12,8 @@ Used by:
 - memory_api.py: May use for manual catch-up operations
 """
 
+from __future__ import annotations
+
 import logging
 import platform
 import struct

--- a/pact-plugin/skills/pact-memory/scripts/embeddings.py
+++ b/pact-plugin/skills/pact-memory/scripts/embeddings.py
@@ -11,6 +11,8 @@ Used by:
 - memory_api.py: Generates embeddings when saving memories
 """
 
+from __future__ import annotations
+
 import logging
 import threading
 from typing import Any, Dict, List, Optional

--- a/pact-plugin/skills/pact-memory/scripts/graph.py
+++ b/pact-plugin/skills/pact-memory/scripts/graph.py
@@ -14,6 +14,8 @@ Graph Structure:
   - File -> File (imports, tests, extends, calls)
 """
 
+from __future__ import annotations
+
 import logging
 import sqlite3
 from datetime import datetime, timezone

--- a/pact-plugin/skills/pact-memory/scripts/memory_api.py
+++ b/pact-plugin/skills/pact-memory/scripts/memory_api.py
@@ -17,6 +17,8 @@ Note: Memory initialization is lazy-loaded on first use via memory_init.py,
 eliminating startup cost for non-memory users.
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import os

--- a/pact-plugin/skills/pact-memory/scripts/memory_init.py
+++ b/pact-plugin/skills/pact-memory/scripts/memory_init.py
@@ -19,6 +19,8 @@ Used by:
 Thread-safety: Uses threading.Lock for the session-scoped initialization flag.
 """
 
+from __future__ import annotations
+
 import logging
 import struct
 import subprocess

--- a/pact-plugin/skills/pact-memory/scripts/models.py
+++ b/pact-plugin/skills/pact-memory/scripts/models.py
@@ -12,6 +12,8 @@ Used by:
 - search.py: Search results returned as MemoryObject instances
 """
 
+from __future__ import annotations
+
 import json
 import logging
 from dataclasses import dataclass, field, fields as dataclass_fields

--- a/pact-plugin/skills/pact-memory/scripts/pact_session.py
+++ b/pact-plugin/skills/pact-memory/scripts/pact_session.py
@@ -15,6 +15,8 @@ slug) because skill scripts can't import from the hooks package (different
 Python package boundary).
 """
 
+from __future__ import annotations
+
 import json
 import os
 from pathlib import Path

--- a/pact-plugin/skills/pact-memory/scripts/search.py
+++ b/pact-plugin/skills/pact-memory/scripts/search.py
@@ -13,6 +13,8 @@ Used by:
 - memory_api.py: High-level search() method
 """
 
+from __future__ import annotations
+
 import logging
 import struct
 from typing import Any, Dict, List, Optional, Set, Tuple

--- a/pact-plugin/skills/pact-memory/scripts/setup_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/setup_memory.py
@@ -12,6 +12,8 @@ Used by:
 - CLI: Manual setup commands
 """
 
+from __future__ import annotations
+
 import logging
 import sys
 from pathlib import Path

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -347,12 +347,14 @@ def _get_claude_md_path() -> Optional[Path]:
     return _find_existing_claude_md(Path.cwd())
 
 
-def _resolve_display_claude_md_path() -> Optional[Path]:
+def _resolve_display_claude_md_with_base() -> Tuple[Optional[Path], Optional[Path]]:
     """
-    Resolve the CLAUDE.md the CURRENT SESSION displays, so Working Memory /
-    Retrieved Context syncs land in the file the session actually reads.
+    Resolve the display CLAUDE.md AND the trusted base directory it was found
+    under, so a write caller can containment-check the target against the base
+    the resolver actually used (#1247).
 
-    Resolution order:
+    Same resolution order as `_resolve_display_claude_md_path` (which is now a
+    thin wrapper returning `[0]`):
       1. CLAUDE_PROJECT_DIR env var, if set -> that dir's .claude/CLAUDE.md
          (preferred) or ./CLAUDE.md (legacy).
       2. Git worktree root via `git rev-parse --show-toplevel` -> the same
@@ -370,25 +372,33 @@ def _resolve_display_claude_md_path() -> Optional[Path]:
     _get_claude_md_path's MAIN-repo anchor (--git-common-dir) for the common
     case where it is not. Because branch 2 precedes branch 3, the two resolvers
     now differ ONLY in that worktree-root branch: in a non-worktree checkout
-    both branches resolve the same directory, so this function's result is
+    both branches resolve the same directory, so the [0] of this result is
     identical to _get_claude_md_path's.
 
+    The returned `base` is the branch's directory captured BEFORE descending
+    into `.claude` (the arg passed to `_find_existing_claude_md`), NOT the
+    returned path and NOT a re-derivation. That is the trusted pre-resolve
+    anchor that makes the #1247 containment check non-vacuous: an F1
+    symlinked-parent `.claude` perturbs the target's resolve() but not the
+    base's, so containment catches the escape.
+
     This never CREATES a CLAUDE.md (the orchestrator manages the file's
-    lifecycle); it only probes for an existing one and returns its Path, or
-    None when none exists at the resolved base (callers skip the sync).
+    lifecycle); it only probes for an existing one.
 
     Returns:
-        Path to the existing display CLAUDE.md, or None if none exists.
+        (path, base) where path is the existing display CLAUDE.md and base is
+        the directory it was found under; (None, None) if none exists.
     """
     # Resolution must never raise into the sync path; on any failure (a bad
     # CLAUDE_PROJECT_DIR value, an inaccessible probe target, or a deleted cwd)
-    # return None so the caller skips the sync and the save still succeeds.
+    # return (None, None) so the caller skips the sync and the save still succeeds.
     try:
         project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
         if project_dir:
-            found = _find_existing_claude_md(Path(project_dir))
+            base = Path(project_dir)
+            found = _find_existing_claude_md(base)
             if found is not None:
-                return found
+                return found, base
 
         # Worktree root: --show-toplevel returns the worktree directory when run
         # inside a worktree (and the main repo root otherwise), matching the
@@ -404,7 +414,7 @@ def _resolve_display_claude_md_path() -> Optional[Path]:
                 worktree_root = Path(result.stdout.strip())
                 found = _find_existing_claude_md(worktree_root)
                 if found is not None:
-                    return found
+                    return found, worktree_root
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             pass
 
@@ -435,15 +445,33 @@ def _resolve_display_claude_md_path() -> Optional[Path]:
                 repo_root = common_dir.resolve().parent
                 found = _find_existing_claude_md(repo_root)
                 if found is not None:
-                    return found
+                    return found, repo_root
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             pass
 
         # Last resort: current working directory
-        return _find_existing_claude_md(Path.cwd())
+        cwd = Path.cwd()
+        found = _find_existing_claude_md(cwd)
+        return (found, cwd) if found is not None else (None, None)
     except Exception as e:
         logger.debug("display CLAUDE.md resolution failed, skipping sync: %s", e)
-        return None
+        return None, None
+
+
+def _resolve_display_claude_md_path() -> Optional[Path]:
+    """
+    Resolve the CLAUDE.md the CURRENT SESSION displays (path only).
+
+    Thin wrapper over `_resolve_display_claude_md_with_base` (added for #1247);
+    read-only callers and the resolver-parity lint use this Path-only name,
+    while the 2 write callers use the with-base variant to get the containment
+    anchor. See that function for the full resolution order and the base
+    semantics.
+
+    Returns:
+        Path to the existing display CLAUDE.md, or None if none exists.
+    """
+    return _resolve_display_claude_md_with_base()[0]
 
 
 def _estimate_tokens(text: str) -> int:

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -177,8 +177,23 @@ def file_lock(target_file: Path):
 #     action exists if the paths genuinely diverge).
 
 
-def _atomic_write_text(target: Path, content: str) -> None:
-    """Replace `target`'s contents with `content` atomically.
+class ContainmentError(OSError):
+    """A CLAUDE.md write target escaped its project containment boundary (#1247).
+
+    Subclasses OSError so a caller that does not name it explicitly still
+    catches it via `except OSError`. Callers convert it to an OPAQUE skip
+    message that does not leak the resolved victim path.
+
+    Twin of ContainmentError in `hooks/shared/claude_md_manager.py` (this module
+    cannot import from hooks/shared). The two class defs are trivial markers;
+    the load-bearing logic is the containment CHECK inside `_atomic_write_text`,
+    drift-gated by TestAtomicWriteTwinCopyDrift.
+    """
+
+
+def _atomic_write_text(target: Path, content: str, project_root: Path) -> None:
+    """Replace `target`'s contents with `content` atomically, iff `target` is
+    contained within `project_root` (#1247).
 
     `Path.write_text` truncates the file and THEN writes, so a crash, a full
     disk, or a kill between those two steps leaves a TRUNCATED CLAUDE.md. In the
@@ -194,10 +209,18 @@ def _atomic_write_text(target: Path, content: str) -> None:
     momentarily visible with the wrong permissions -- unlike a chmod after the
     write, which leaves exactly such a window on a file holding user content.
 
+    #1247 CONTAINMENT: before creating the temp, refuse (fail-CLOSED) unless the
+    RESOLVED target is inside the RESOLVED `project_root`. `project_root` MUST be
+    the trusted base the target's OWN resolver used (never a re-derivation) -- a
+    symlinked-parent `.claude` (F1) perturbs `target.resolve()` but not the
+    base's, so the escape is caught. `commonpath` (not `Path.is_relative_to`,
+    3.9+ vs the repo's 3.7 floor; not `str.startswith`, which wrongly allows the
+    sibling-prefix `/abc` vs `/ab`). Any resolution/commonpath error fails closed.
+
     Callers must already hold `file_lock` for the target. The lock closes the
-    concurrent-writer window; this closes the crash/truncation window. They are
-    different hazards, and neither fix subsumes the other. Note the lock is a
-    separate sidecar file, so replacing the target's inode does not disturb it.
+    concurrent-writer window; this closes the crash/truncation window; the
+    containment check runs inside the lock by construction (callers hold it),
+    preserving the TOCTOU defense the replaced leaf `is_symlink` guards had.
 
     Requires write permission on the target's DIRECTORY (to create the temp),
     where a bare `write_text` needed only permission on the file itself. A
@@ -207,14 +230,32 @@ def _atomic_write_text(target: Path, content: str) -> None:
     NOTE: a deliberate duplicate of `_atomic_write_text` in
     `hooks/shared/claude_md_manager.py`. This module cannot import from
     `hooks/shared/` (separate package), the same constraint that produced the
-    `file_lock` twin above. Unlike that twin, the two copies are NOT
-    drift-gated: atomicity has no cross-process invariant, so each copy is
-    independently correct and may legitimately diverge.
+    `file_lock` twin above. This twin IS drift-gated by
+    TestAtomicWriteTwinCopyDrift: the containment CHECK is a security invariant
+    that must not silently diverge between the hook and skill copies.
 
     Args:
         target: Path to replace. Its parent directory must already exist.
         content: Full file contents to write.
+        project_root: The trusted base directory `target` must be contained in.
+
+    Raises:
+        ContainmentError: `target` resolves outside `project_root`.
     """
+    # #1247 containment guard, fail-CLOSED, BEFORE creating the temp file.
+    try:
+        resolved_target = str(target.resolve())
+        resolved_root = str(project_root.resolve())
+        contained = (
+            os.path.commonpath([resolved_root, resolved_target]) == resolved_root
+        )
+    except (ValueError, OSError):
+        contained = False
+    if not contained:
+        raise ContainmentError(
+            "refusing write: target escapes the project containment boundary"
+        )
+
     fd, tmp_name = tempfile.mkstemp(
         dir=str(target.parent), prefix=f".{target.name}.", suffix=".tmp"
     )
@@ -826,7 +867,7 @@ def sync_to_claude_md(
     Returns:
         True if sync succeeded, False otherwise.
     """
-    claude_md_path = _resolve_display_claude_md_path()
+    claude_md_path, project_root = _resolve_display_claude_md_with_base()
 
     if claude_md_path is None:
         logger.debug("CLAUDE.md not found, skipping working memory sync")
@@ -880,7 +921,7 @@ def sync_to_claude_md(
 
             # Write back to file (atomic: temp + rename, so a crash mid-write
             # cannot leave the always-loaded CLAUDE.md truncated)
-            _atomic_write_text(claude_md_path, new_content)
+            _atomic_write_text(claude_md_path, new_content, project_root)
 
         logger.info("Synced memory to CLAUDE.md Working Memory section")
         return True
@@ -1033,7 +1074,7 @@ def sync_retrieved_to_claude_md(
     if not memories:
         return False
 
-    claude_md_path = _resolve_display_claude_md_path()
+    claude_md_path, project_root = _resolve_display_claude_md_with_base()
 
     if claude_md_path is None:
         logger.debug("CLAUDE.md not found, skipping retrieved context sync")
@@ -1110,7 +1151,7 @@ def sync_retrieved_to_claude_md(
 
             # Write back to file (atomic: temp + rename, so a crash mid-write
             # cannot leave the always-loaded CLAUDE.md truncated)
-            _atomic_write_text(claude_md_path, new_content)
+            _atomic_write_text(claude_md_path, new_content, project_root)
 
         logger.info("Synced retrieved memories to CLAUDE.md Retrieved Context section")
         return True

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -13,6 +13,8 @@ Used by:
 - Test files: test_working_memory.py tests all functions in this module
 """
 
+from __future__ import annotations
+
 import fcntl
 import logging
 import os

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -347,7 +347,27 @@ def _atomic_write_text(target: Path, content: str, project_root: Path) -> None:
             if (node_stat.st_dev, node_stat.st_ino) == anchor_key:
                 contained = True
                 break
-            up = os.open("..", os.O_RDONLY | os.O_DIRECTORY, dir_fd=node)
+            try:
+                up = os.open("..", os.O_RDONLY | os.O_DIRECTORY, dir_fd=node)
+            except NotImplementedError:
+                # NARROW BY DESIGN -- only NotImplementedError is mapped here.
+                # A genuine OSError from this open (EACCES on an ancestor the
+                # user cannot read) must keep propagating RAW through the outer
+                # handler; relabelling it would report a permission failure as
+                # a capability failure.
+                # NotImplementedError has to be named explicitly because it is
+                # a RuntimeError SUBCLASS, NOT an OSError one, while
+                # ContainmentError subclasses OSError. So the callers'
+                # `except ContainmentError` / `except OSError` arms are blind
+                # to it: unmapped, it would escape as-is and CRASH the hook
+                # instead of failing closed into the site's opaque skip status.
+                # This is the same reason given at the parent-directory open;
+                # it applies wherever a dir_fd argument is passed, and this is
+                # the second such site.
+                raise ContainmentError(
+                    "refusing write: platform lacks directory-descriptor "
+                    "ancestry traversal"
+                )
             walked.append(up)
             up_stat = os.fstat(up)
             if (up_stat.st_dev, up_stat.st_ino) == (

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -446,10 +446,25 @@ def _atomic_write_text(target: Path, content: str, project_root: Path) -> None:
                     "refusing write: platform lacks directory-descriptor rename"
                 )
         except BaseException:
-            # Never leave a stray temp file behind next to the user's CLAUDE.md.
+            # Remove the temp rather than leave it beside the user's CLAUDE.md.
+            # BEST-EFFORT, not absolute: if the removal itself fails the temp
+            # survives, because nothing downstream of here can remove it. That
+            # is the deliberate trade below -- a stray file is preferable to
+            # losing the reason the write was refused.
             try:
                 os.unlink(tmp_name, dir_fd=parent_fd)
-            except OSError:
+            except (OSError, NotImplementedError):
+                # SWALLOWED, not mapped -- the one capability site handled this
+                # way, and deliberately so. This cleanup runs while an exception
+                # is already in flight; anything raised here REPLACES it, and
+                # the bare `raise` below never runs. The caller would then see
+                # a cleanup failure instead of the containment refusal that
+                # actually stopped the write, so a leftover temp file would
+                # outrank the reason the write was refused. The original
+                # exception wins; best-effort cleanup stays best-effort.
+                # NotImplementedError is named for the same reason as at the
+                # dir_fd sites above: it subclasses RuntimeError, NOT OSError,
+                # so a bare `except OSError` is blind to it.
                 pass
             raise
     finally:

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -111,12 +111,23 @@ def file_lock(target_file: Path):
     would alter this body and trip the drift test; the OS-level non-re-entrancy
     plus the callers' fail-open already bound the worst case).
     """
-    # Resolve the WHOLE target, not just its parent: fcntl.flock serialises on
-    # the sidecar's inode, so two spellings of one file must produce one sidecar
-    # name. Resolving only the parent still keys a symlinked FILE by its alias
-    # (two names, one inode -> two sidecars -> no mutual exclusion).
-    resolved_target = target_file.resolve()
-    lock_path = resolved_target.parent / f".{resolved_target.name}.lock"
+    # Key the sidecar on the DIRECTORY THE WRITE BINDS INTO plus the LITERAL
+    # leaf name, so lock identity and write identity are the same thing and
+    # cannot diverge when the write replaces the leaf entry.
+    # The PARENT is resolved so two spellings of one directory produce one
+    # sidecar, and therefore one lock. The LEAF is deliberately NOT resolved:
+    # os.replace is renameat(2) and binds the final component as a directory
+    # ENTRY without following it, so resolving the leaf would key the lock on a
+    # path the write never touches -- and would make the key CHANGE across the
+    # write, which is a lock whose identity is a function of the state it is
+    # supposed to protect. Mirrors the write's own os.open(target.parent) +
+    # target.name; see the write-shape dependency noted in _atomic_write_text.
+    # NOT provided, deliberately: two NAMES for one INODE do not collapse onto
+    # one sidecar. A hardlink pair is exactly that and never collapsed under
+    # any spelling of this formula, because resolve() canonicalises symlinks
+    # and not inodes -- the justification this comment replaced claimed
+    # otherwise and was wrong about its own code.
+    lock_path = target_file.parent.resolve() / f".{target_file.name}.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     # 0o600: the lock file is adjacent to user-private CLAUDE.md content;
     # match the same permissions to avoid leaving a world-readable sidecar.
@@ -209,6 +220,17 @@ def _atomic_write_text(target: Path, content: str, project_root: Path) -> None:
 
     CONTAINMENT -- WHY THERE IS NO PATH RESOLVER HERE
     -------------------------------------------------
+
+    PRECONDITION. This guard eliminates one class outright and narrows another.
+    The class eliminated is disagreement between two path resolutions: only
+    one traversal happens here and its result is held OPEN, so no second
+    resolution exists to disagree with it. What is narrowed is time. The walk
+    establishes ancestry AT THE INSTANT OF THE WALK, and a descriptor pins
+    IDENTITY, not POSITION -- so containment holds provided the directory the
+    write binds into does not change position relative to the anchor between
+    the walk and the rename. Only the chain from that directory up to the
+    anchor matters; relocating anything off it is irrelevant.
+
     An earlier form of this guard compared `str(target.resolve())` against the
     resolved root. `resolve()` follows every component INCLUDING the leaf; the
     write follows only the PARENT chain and then binds the leaf as a directory

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -19,8 +19,8 @@ import os
 import re
 import subprocess
 import sys
-import tempfile
 import time
+import uuid
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -192,47 +192,103 @@ class ContainmentError(OSError):
 
 
 def _atomic_write_text(target: Path, content: str, project_root: Path) -> None:
-    """Replace `target`'s contents with `content` atomically, iff `target` is
-    contained within `project_root` (#1247).
+    """Replace `target`'s contents with `content` atomically, iff the directory
+    the write will bind into is contained within `project_root` (#1247).
 
     `Path.write_text` truncates the file and THEN writes, so a crash, a full
-    disk, or a kill between those two steps leaves a TRUNCATED CLAUDE.md. In the
-    projects this runs in that file is gitignored and untracked, so there is no
-    recovery path -- the user's pinned context is simply gone.
+    disk, or a kill between those two steps leaves a TRUNCATED CLAUDE.md. That
+    file is gitignored and untracked in the projects this runs in, so there is
+    no recovery path -- the user's pinned context is simply gone.
 
     Writing to a sibling temp file and renaming makes the replacement atomic: a
     reader sees either the whole old file or the whole new one, never a partial
     write. The temp file is created in the TARGET'S OWN DIRECTORY because
     `os.replace` is only atomic within a single filesystem.
 
-    The mode is set on the TEMP file before the rename, so the target is never
-    momentarily visible with the wrong permissions -- unlike a chmod after the
-    write, which leaves exactly such a window on a file holding user content.
+    CONTAINMENT -- WHY THERE IS NO PATH RESOLVER HERE
+    -------------------------------------------------
+    An earlier form of this guard compared `str(target.resolve())` against the
+    resolved root. `resolve()` follows every component INCLUDING the leaf; the
+    write follows only the PARENT chain and then binds the leaf as a directory
+    entry. Those are two independent traversals of two different path
+    expressions, and on a two-leg symlink topology they name different
+    directories -- so the guard certified a path the write never touched.
 
-    #1247 CONTAINMENT: before creating the temp, refuse (fail-CLOSED) unless the
-    RESOLVED target is inside the RESOLVED `project_root`. `project_root` MUST be
-    the trusted base the target's OWN resolver used (never a re-derivation) -- a
-    symlinked-parent `.claude` (F1) perturbs `target.resolve()` but not the
-    base's, so the escape is caught. `commonpath` (not `Path.is_relative_to`,
-    3.9+ vs the repo's 3.7 floor; not `str.startswith`, which wrongly allows the
-    sibling-prefix `/abc` vs `/ab`). Any resolution/commonpath error fails closed.
+    The general defect is that `Path.resolve()` and `os.path.realpath` are
+    SECOND implementations of path resolution, running in userspace, which the
+    write does not use. A predicate built on one is sound exactly while the two
+    agree, and the disagreement set (symlink loops, absent components) is
+    discovered, never bounded. So this function asks the kernel instead:
+
+      anchor  = (st_dev, st_ino) of os.stat(project_root)
+      node    = the directory the write will bind into, held OPEN
+      walk up via ".." comparing (st_dev, st_ino) until the anchor matches
+      (CONTAINED) or a directory is its own parent (filesystem root, REFUSE)
+
+    and then performs temp-create, fchmod, fsync, rename and cleanup THROUGH
+    that same descriptor. The object CHECKED is the object MUTATED, by
+    construction rather than by agreement. Consequences that fall out rather
+    than being bolted on: version-invariant (no `Path.resolve()` exists here, so
+    its 3.9-3.12 vs 3.13+ RuntimeError split is unreachable, not caught);
+    strict (an absent parent raises instead of being lexically completed);
+    immune to case-folding, Unicode normalisation form and trailing separators,
+    because nothing is compared as text; and sibling-prefix (`/abc` under
+    `/ab`) is refused structurally, since `/abc` never walks up to `/ab`'s
+    inode.
+
+    The parent is opened FOLLOWING symlinks -- see the inline note. Mounts
+    beneath the project are ALLOWED: `..` from a mount root yields the mount
+    POINT's parent, so the walk crosses one transparently, and the write still
+    lands inside the anchor's subtree.
+
+    THE LEAF IS NEVER CONSULTED, AND THAT COUPLES THIS TO THE WRITE SHAPE
+    --------------------------------------------------------------------
+    Containment is entirely a property of the parent chain, because the parent
+    chain is the only part the kernel traverses on the way to the write. A leaf
+    symlink pointing OUTSIDE the root is therefore ALLOWED, and that is the
+    correct verdict, not a concession: `os.replace` is renameat(2), which
+    unlinks whatever entry sits at the final name and binds the temp file's
+    inode there. It never opens the leaf and never follows it, so the payload
+    lands at the in-project entry and any outside victim is left byte-intact.
+
+    That ALLOW is sound ONLY while the write replaces the leaf ENTRY rather
+    than writing THROUGH it. Two rewrites would silently convert every such
+    ALLOW into a real escape, with this predicate untouched: (1) resolving the
+    target once and using it downstream -- proposed as a cheap way to make the
+    check and the act agree, which it does, on the WRONG side, by making the
+    write follow the leaf; (2) replacing temp-plus-rename with an open/truncate
+    on the target. MEASURED, so the guarantee is stated at its real strength:
+    with either rewrite spliced in, `TestR6InProjectRedirectResidualDocumented`
+    turns RED on its victim-untouched assertion, so the in-project half of this
+    coupling IS pinned by an executing test today. The out-of-project half is
+    pinned separately, and could not be pinned at all before this predicate,
+    because the earlier one refused that topology outright.
 
     Callers must already hold `file_lock` for the target. The lock closes the
-    concurrent-writer window; this closes the crash/truncation window; the
-    containment check runs inside the lock by construction (callers hold it),
-    preserving the TOCTOU defense the replaced leaf `is_symlink` guards had.
+    concurrent-writer window; this closes the crash/truncation window.
 
-    Requires write permission on the target's DIRECTORY (to create the temp),
-    where a bare `write_text` needed only permission on the file itself. A
-    read-only directory holding a writable CLAUDE.md would now fail the write
-    rather than truncate it -- a safe direction, but a real behaviour change.
+    Requires read+execute on the target's directory and write permission on it
+    (to create the temp), where a bare `write_text` needed only permission on
+    the file itself. A read-only directory holding a writable CLAUDE.md fails
+    the write rather than truncating it -- a safe direction, but a real
+    behaviour change.
+
+    SCOPE LIMIT, stated because the natural summary of this change overclaims:
+    `file_lock` runs BEFORE this function at every call site and does its own
+    unprotected `target_file.resolve()`. Removing `Path.resolve()` from this
+    guard makes the GUARD version-invariant; it does NOT make the write path
+    version-invariant end-to-end, and a symlink loop still raises upstream.
 
     NOTE: a deliberate duplicate of `_atomic_write_text` in
     `hooks/shared/claude_md_manager.py`. This module cannot import from
     `hooks/shared/` (separate package), the same constraint that produced the
     `file_lock` twin above. This twin IS drift-gated by
-    TestAtomicWriteTwinCopyDrift: the containment CHECK is a security invariant
-    that must not silently diverge between the hook and skill copies.
+    TestAtomicWriteTwinCopyDrift: the
+    containment CHECK is a security invariant that must not silently diverge
+    between the hook and skill copies (#1118-class hazard). That gate compares
+    only THIS function's body, which is why the check is inlined here rather
+    than extracted -- a named helper would have to be twinned too, and would
+    sit outside every drift gate in the repo.
 
     Args:
         target: Path to replace. Its parent directory must already exist.
@@ -240,52 +296,142 @@ def _atomic_write_text(target: Path, content: str, project_root: Path) -> None:
         project_root: The trusted base directory `target` must be contained in.
 
     Raises:
-        ContainmentError: `target` resolves outside `project_root`.
+        ContainmentError: the write's parent directory is not the project root
+            or a descendant of it; or the boundary could not be established at
+            all. Fail-CLOSED in every case, with a distinct message per cause.
     """
-    # #1247 containment guard, fail-CLOSED, BEFORE creating the temp file.
+    # #1247 CONTAINMENT, fail-CLOSED, BEFORE anything is created: kernel object
+    # ancestry on a pinned directory descriptor. No Path.resolve(), no
+    # os.path.realpath, no string comparison takes part in this decision.
     try:
-        resolved_target = str(target.resolve())
-        resolved_root = str(project_root.resolve())
-        contained = (
-            os.path.commonpath([resolved_root, resolved_target]) == resolved_root
-        )
-    except (ValueError, OSError):
-        contained = False
-    if not contained:
+        anchor_stat = os.stat(str(project_root))
+        anchor_key = (anchor_stat.st_dev, anchor_stat.st_ino)
+        # FOLLOWS symlinks, deliberately: this is exactly how the kernel will
+        # traverse the parent chain for the write. O_NOFOLLOW here would refuse
+        # any symlinked final component of the parent path -- including a benign
+        # in-project `.claude` -> `<project>/config/claude`, which the pre-#1247
+        # code allowed -- a NEW over-block on an axis that is not containment.
+        # It would also add nothing: the ancestry test below runs ON this
+        # descriptor, so there is no check-then-open gap for it to close.
+        parent_fd = os.open(str(target.parent), os.O_RDONLY | os.O_DIRECTORY)
+    except (OSError, NotImplementedError):
+        # An absent parent, a parent that is not a directory, a symlink loop
+        # (ELOOP), and an unsupported-primitive failure all land here. Bare
+        # RuntimeError is deliberately NOT caught: it is unreachable, because no
+        # Path.resolve() call exists in this function, and catching it would
+        # imply one still did and invite one back. NotImplementedError is named
+        # explicitly -- it is a RuntimeError SUBCLASS, and it is Python's
+        # documented signal for an unsupported dir_fd argument.
         raise ContainmentError(
-            "refusing write: target escapes the project containment boundary"
+            "refusing write: cannot establish the containment boundary"
         )
 
-    fd, tmp_name = tempfile.mkstemp(
-        dir=str(target.parent), prefix=f".{target.name}.", suffix=".tmp"
-    )
+    walked = []
     try:
-        # os.fdopen takes ownership of fd only on success; if it raises, the
-        # raw fd mkstemp opened would leak (the outer cleanup unlinks the temp
-        # FILE but cannot close a descriptor it never received a handle for).
-        try:
-            handle = os.fdopen(fd, "w", encoding="utf-8")
-        except BaseException:
-            os.close(fd)
-            raise
-        with handle:
-            handle.write(content)
-            handle.flush()
-            # Without the fsync the rename can be persisted while the data
-            # behind it is not, which reintroduces the empty-file failure this
-            # function exists to prevent.
-            os.fsync(handle.fileno())
-        # mkstemp already creates 0o600; setting it explicitly keeps the mode a
-        # property of this function rather than of the stdlib's default.
-        os.chmod(tmp_name, 0o600)
-        os.replace(tmp_name, target)
+        # 1024 is an INLINE LITERAL rather than a module constant because a
+        # constant would sit outside the region the twin drift gate compares
+        # (only this function's body) and could diverge between the twins
+        # silently. It is a LIVENESS backstop, not a policy ceiling: a POSIX
+        # path is PATH_MAX-bounded and every component costs at least two bytes
+        # including its separator, so no reachable path carries this many
+        # components. Reaching it means the filesystem is misreporting "..",
+        # not that the path is legitimately deep -- which is why exhaustion
+        # raises its own message below instead of the escape one. Normal
+        # operation terminates at the filesystem root and never arrives here.
+        contained = False
+        node = parent_fd
+        for _ in range(1024):
+            node_stat = os.fstat(node)
+            if (node_stat.st_dev, node_stat.st_ino) == anchor_key:
+                contained = True
+                break
+            up = os.open("..", os.O_RDONLY | os.O_DIRECTORY, dir_fd=node)
+            walked.append(up)
+            up_stat = os.fstat(up)
+            if (up_stat.st_dev, up_stat.st_ino) == (
+                node_stat.st_dev,
+                node_stat.st_ino,
+            ):
+                # A directory that is its own parent is the filesystem root:
+                # the walk is over and the anchor was never reached.
+                break
+            node = up
+        else:
+            raise ContainmentError(
+                "refusing write: containment walk did not terminate"
+            )
+        if not contained:
+            raise ContainmentError(
+                "refusing write: target escapes the project containment boundary"
+            )
     except BaseException:
-        # Never leave a stray temp file behind next to the user's CLAUDE.md.
-        try:
-            os.unlink(tmp_name)
-        except OSError:
-            pass
+        os.close(parent_fd)
         raise
+    finally:
+        for extra in walked:
+            os.close(extra)
+
+    try:
+        tmp_name = f".{target.name}.{uuid.uuid4().hex}.tmp"
+        try:
+            fd = os.open(
+                tmp_name,
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                0o600,
+                dir_fd=parent_fd,
+            )
+        except NotImplementedError:
+            raise ContainmentError(
+                "refusing write: platform lacks directory-descriptor file creation"
+            )
+        try:
+            # os.fdopen takes ownership of fd only on success; if it raises, the
+            # raw fd would leak (the cleanup below unlinks the temp FILE but
+            # cannot close a descriptor it never received a handle for).
+            try:
+                handle = os.fdopen(fd, "w", encoding="utf-8")
+            except BaseException:
+                os.close(fd)
+                raise
+            with handle:
+                handle.write(content)
+                handle.flush()
+                # fchmod on the OPEN HANDLE, never os.chmod by name: a chmod by
+                # name after the close would reintroduce the name-based race
+                # this descriptor design exists to remove. It is NOT guarding
+                # against over-permissiveness -- umask can only CLEAR bits, so
+                # os.open(..., 0o600) cannot yield anything more permissive than
+                # 0o600. Its actual effect is the opposite: it RESTORES an
+                # owner-write bit a restrictive umask removed (measured: with
+                # the open mode alone, umask 0o277 leaves 0o400). The property
+                # is DETERMINISM -- the mode belongs to this function rather
+                # than to the caller's umask. It precedes the fsync so the mode
+                # change is part of what that fsync flushes.
+                os.fchmod(handle.fileno(), 0o600)
+                # Without the fsync the rename can be persisted while the data
+                # behind it is not, which reintroduces the empty-file failure
+                # this function exists to prevent.
+                os.fsync(handle.fileno())
+            try:
+                os.replace(
+                    tmp_name,
+                    target.name,
+                    src_dir_fd=parent_fd,
+                    dst_dir_fd=parent_fd,
+                )
+            except NotImplementedError:
+                raise ContainmentError(
+                    "refusing write: platform lacks directory-descriptor rename"
+                )
+        except BaseException:
+            # Never leave a stray temp file behind next to the user's CLAUDE.md.
+            try:
+                os.unlink(tmp_name, dir_fd=parent_fd)
+            except OSError:
+                pass
+            raise
+    finally:
+        os.close(parent_fd)
 
 
 def extract_managed_region(content: str) -> Optional[Tuple[str, int]]:

--- a/pact-plugin/tests/test_claude_md_manager.py
+++ b/pact-plugin/tests/test_claude_md_manager.py
@@ -1799,22 +1799,48 @@ class TestMigrateToManagedStructure:
 
         assert result is None
 
-    def test_symlink_guard(self, tmp_path, monkeypatch):
-        """Returns 'skipped' message when target is a symlink."""
+    def test_leaf_symlink_out_of_project_allowed_victim_untouched(
+        self, tmp_path, monkeypatch
+    ):
+        """A leaf symlink pointing OUT of the project is ALLOWED, and the write
+        lands at the in-project entry instead of following the link.
+
+        This replaces a negative that asserted a 'skipped' status. That refusal
+        was an OVER-BLOCK: containment is decided on the parent chain and the
+        leaf is never consulted, so this topology is contained. It is SAFE for
+        the reason the assertions below check rather than by assumption --
+        os.replace is renameat(2), which binds the final component as a
+        directory ENTRY and never follows it, so the payload lands in-project
+        and the outside file keeps its bytes.
+
+        BOTH boundaries are asserted deliberately, and the order of reasoning
+        matters: victim-byte-unchanged would ALSO hold if the write had simply
+        been refused, so on its own it cannot distinguish ALLOW from REFUSE and
+        would leave this test unable to fail for the right reason. The
+        entry-is-no-longer-a-symlink assertion is what pins that the write
+        actually happened, and happened in-project.
+        """
         from shared.claude_md_manager import migrate_to_managed_structure
 
         project_dir = tmp_path / "project"
         project_dir.mkdir()
-        real_file = tmp_path / "real_claude.md"
-        real_file.write_text("# Project Memory\n")
+        outside_victim = tmp_path / "real_claude.md"
+        outside_victim.write_text("# Project Memory\n", encoding="utf-8")
+        before = outside_victim.read_text(encoding="utf-8")
         claude_md = project_dir / "CLAUDE.md"
-        claude_md.symlink_to(real_file)
+        claude_md.symlink_to(outside_victim)
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project_dir))
 
         result = migrate_to_managed_structure()
 
         assert result is not None
-        assert "skipped" in result.lower()
+        assert "skipped" not in result.lower()
+        # Boundary 1 -- the out-of-project victim is byte-unchanged.
+        assert outside_victim.read_text(encoding="utf-8") == before
+        # Boundary 2 -- the write landed at the IN-PROJECT entry, replacing the
+        # symlink with a real file.
+        assert not claude_md.is_symlink()
+        assert claude_md.is_file()
 
     def test_migrated_file_has_secure_permissions(self, tmp_path, monkeypatch):
         """Migrated file should have 0o600 permissions."""
@@ -2857,22 +2883,42 @@ class TestStripOrphanKernelBlock(_StripOrphanBlockTestBase):
         assert "skipped" in result.lower()
         assert "PACT_END appears before PACT_START" in result
 
-    def test_symlink_returns_skip_status(self, tmp_path):
-        # Replace target_file with a symlink to a real file under tmp_path
+    def test_leaf_symlink_out_of_config_allowed_victim_untouched(self, tmp_path):
+        """A leaf symlink escaping the config dir is ALLOWED; the strip lands on
+        the in-config entry and the outside file is untouched.
+
+        Replaces a negative asserting a 'skipped' status. That refusal was an
+        OVER-BLOCK -- the leaf is never consulted, and the target's parent IS the
+        anchor here, so the topology is contained. os.replace binds the final
+        component as a directory ENTRY without following it, which is why the
+        outside file survives a write that was permitted.
+
+        Both boundaries are asserted: victim-byte-unchanged alone cannot tell
+        ALLOW from REFUSE (it holds either way), so the entry-no-longer-a-symlink
+        assertion is what makes this test able to fail for the right reason.
+        """
         real_target = tmp_path / "real_claude.md"
         real_target.write_text(
             f"# user\n{self.START_MARKER}\nstale\n{self.END_MARKER}\n",
             encoding="utf-8",
         )
+        before = real_target.read_text(encoding="utf-8")
         self.target_file.parent.mkdir(parents=True, exist_ok=True)
         if self.target_file.exists():
             self.target_file.unlink()
         self.target_file.symlink_to(real_target)
+
         result = self.call_stripper()
+
         assert result is not None
-        assert "skipped" in result.lower()
-        # Real target must not have been rewritten
-        assert self.START_MARKER in real_target.read_text(encoding="utf-8")
+        assert "Removed obsolete PACT kernel block" in result
+        # Boundary 1 -- the out-of-config victim is BYTE-unchanged, not merely
+        # still carrying its marker.
+        assert real_target.read_text(encoding="utf-8") == before
+        # Boundary 2 -- the strip landed on the in-config entry, which is now a
+        # real file rather than the symlink.
+        assert not self.target_file.is_symlink()
+        assert self.START_MARKER not in self.target_file.read_text(encoding="utf-8")
 
     def test_missing_target_file_returns_none(self):
         # File doesn't exist — stripper short-circuits to None.

--- a/pact-plugin/tests/test_containment_certification.py
+++ b/pact-plugin/tests/test_containment_certification.py
@@ -1,0 +1,1260 @@
+"""Certification of the corrected CLAUDE.md write-path containment predicate.
+
+WHAT IS UNDER CERTIFICATION. `_atomic_write_text` decides containment by KERNEL
+OBJECT ANCESTRY on a pinned directory descriptor, in both twins
+(`hooks/shared/claude_md_manager.py` and
+`skills/pact-memory/scripts/working_memory.py`):
+
+    anchor = (st_dev, st_ino) of os.stat(project_root)
+    node   = os.open(target.parent, O_RDONLY|O_DIRECTORY)   # FOLLOWS symlinks
+    walk up via os.open("..", dir_fd=node) comparing (st_dev, st_ino)
+    until the anchor matches (CONTAINED) or a directory is its own parent
+    (filesystem root -> REFUSE)
+
+and then performs temp-create, fchmod, fsync, rename and cleanup THROUGH that
+same descriptor. There is no `Path.resolve()`, no `os.path.realpath` and no
+string comparison anywhere in the decision. The object CHECKED is the object
+MUTATED, by construction rather than by agreement.
+
+CERTIFICATION IS BIDIRECTIONAL, WHICH IS THE POINT. The defect being repaired
+lives on the ALLOW branch: the superseded predicate both permitted a two-leg
+symlink composition AND refused a benign leaf pointing outside. A suite made
+only of refusals passes by refusing everything, which is the cardinal
+over-block. Every refusal here is paired with a positive control that writes
+successfully in the same harness.
+
+--------------------------------------------------------------------------
+THREE HAZARDS THAT DEFEAT A CARELESS SUITE. All three are measured, not
+theorised, and each is defended against in a specific test below.
+--------------------------------------------------------------------------
+
+1. THE WALK IS UNREACHABLE ON A FLAT TOPOLOGY. The loop tests
+   `os.fstat(node)` against the anchor and BREAKS before it ever reaches
+   `os.open("..", dir_fd=node)`. So when `target.parent` IS the anchor -- the
+   legacy `./CLAUDE.md` shape -- that site executes ZERO times. An injection
+   aimed there never fires and the write simply succeeds.
+   `test_flat_topology_makes_the_walk_site_unreachable` DEMONSTRATES that
+   vacuity rather than asserting it, and every capability test states its
+   observed hit count instead of inferring firing from a green result.
+
+2. THE CAPABILITY MESSAGES ARE SPLIT ACROSS SOURCE LITERALS. The walk's
+   message is built by implicit concatenation of two adjacent string
+   literals, so a line-oriented search of the SOURCE for the rendered phrase
+   `refusing write: platform lacks directory-descriptor ancestry traversal`
+   returns ZERO matches while the AST-joined constant is that full sentence.
+   MEASURED: `grep -c` for the rendered phrase is 0 in BOTH twins; the
+   fragment `"ancestry traversal"` sits alone on its own source line.
+   CONSEQUENCE FOR ANYONE VERIFYING THIS FILE: grepping the twins for a
+   message asserted below will give you a FALSE NEGATIVE and make a correct
+   assertion look like it references a string that does not exist. Do not
+   "fix" it. The only sound instruments are a RUNTIME assertion on `str(exc)`
+   (what every test here does) or an AST join (what
+   `TestRefusalMessageContract` does). The messages are written here as
+   single unsplit literals precisely so that they remain greppable from the
+   TEST side even though they are not from the source side.
+
+3. THE CAPABILITY BRANCH HAS NEVER EXECUTED ON ANY SUPPORTED PLATFORM.
+   `os.open` is in `os.supports_dir_fd` on every interpreter measured, so no
+   natural path reaches any of the four mappings. The injections in
+   `TestCapabilityBranchInjection` are the first and only thing that has ever
+   run them. Nothing in this file may be read as evidence that the capability
+   is absent anywhere real -- the branch is triggered ARTIFICIALLY here.
+
+DEBUGGING PRIOR, from two independent parties. On a branch that has never
+executed, a surprising result is more likely to be the instrument than the
+code, and the two most likely instrument faults are a FLAT FIXTURE and a
+MIS-SPECIFIED INJECTION PREDICATE, in that order. Establish which you are
+holding before reporting a finding -- and if the code really is wrong, that is
+a real finding and must not be smoothed over.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+import unicodedata
+from pathlib import Path
+
+import pytest
+
+# hooks/ and the pact-memory scripts dir on path (mirrors the sibling test
+# files: test_containment_guard.py adds hooks/, test_staleness.py adds the
+# scripts dir and imports the twin as a top-level `working_memory`).
+_TESTS = Path(__file__).resolve().parent
+for _p in (
+    _TESTS.parent / "hooks",
+    _TESTS.parent / "skills" / "pact-memory" / "scripts",
+):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+
+# ---------------------------------------------------------------------------
+# The six refusal messages, as RENDERED at runtime.
+#
+# Written as single unsplit literals on purpose -- see hazard 2 in the module
+# docstring. In the SOURCE, MSG_CAP_WALK is two adjacent literals, so searching
+# the twins for it returns nothing.
+# ---------------------------------------------------------------------------
+
+MSG_BOUNDARY = "refusing write: cannot establish the containment boundary"
+MSG_EXHAUSTION = "refusing write: containment walk did not terminate"
+MSG_ESCAPE = "refusing write: target escapes the project containment boundary"
+MSG_CAP_WALK = (
+    "refusing write: platform lacks directory-descriptor ancestry traversal"
+)
+MSG_CAP_TEMP = "refusing write: platform lacks directory-descriptor file creation"
+MSG_CAP_RENAME = "refusing write: platform lacks directory-descriptor rename"
+
+ALL_MESSAGES = (
+    MSG_BOUNDARY,
+    MSG_EXHAUSTION,
+    MSG_ESCAPE,
+    MSG_CAP_WALK,
+    MSG_CAP_TEMP,
+    MSG_CAP_RENAME,
+)
+
+CANONICAL_REL = "hooks/shared/claude_md_manager.py"
+TWIN_REL = "skills/pact-memory/scripts/working_memory.py"
+PLUGIN_ROOT = _TESTS.parent
+
+# The ancestry walk's inline iteration bound. Pinned here because the design
+# deliberately made it an INLINE LITERAL rather than a module constant (a
+# constant would sit outside the region the twin drift gate compares), so this
+# assertion is the only thing outside that gate which notices it changing.
+WALK_BOUND = 1024
+
+# A deep in-project path must be ALLOWED at a NAMED depth. The number is the
+# whole point: the superseded bound admitted 63 levels, so a test at depth 5 or
+# 10 passes while proving nothing about it. The certification floor is 70; this
+# clears it with margin.
+DEEP_DEPTH = 80
+
+
+# ---------------------------------------------------------------------------
+# Twin parametrisation
+# ---------------------------------------------------------------------------
+
+_TWIN_PARAMS = ("canonical", "skill")
+
+
+def _load_twin(which: str):
+    if which == "canonical":
+        import shared.claude_md_manager as mod
+        return mod
+    import working_memory as mod
+    return mod
+
+
+@pytest.fixture(params=_TWIN_PARAMS)
+def twin(request):
+    """Both copies of the security function, exercised independently.
+
+    WHAT THIS AXIS IS FOR, stated narrowly. The drift gate guarantees TEXT
+    identity of the function body. What it structurally cannot catch is
+    IDENTICAL TEXT BEHAVING DIFFERENTLY because of module-level context -- a
+    different import set, a different ContainmentError class object, a
+    different fcntl availability. That is not hypothetical: `uuid` had to be
+    added to BOTH twins when the descriptor design landed, and an asymmetry
+    there would have been invisible to a body-only gate.
+
+    So this axis covers the obligations whose outcome depends on the predicate
+    executing correctly IN ITS MODULE CONTEXT -- the topology matrix, the four
+    capability sites, the negative control. Obligations that test CALL-SITE
+    integration (per-site anchors, status strings, skip-status shapes) are
+    deliberately SINGLE-twin: the twins have genuinely different call sites, so
+    duplicating those would assert sameness where difference is CORRECT, and
+    the resulting failure would be "fixed" by making the twins wrongly alike.
+
+    The drift gate also does not prove the skill copy is ever EXERCISED, which
+    is how a prior non-vacuity experiment reported a healthy number while the
+    skill side had almost no behavioural coverage of its own.
+    """
+    return _load_twin(request.param)
+
+
+class TestTwinAxisIsNotVacuous:
+    """A parametrized axis that silently collapses to ONE target is the same
+    vacuity class this suite exists to catch, and it would run green twice
+    while certifying half of what its ids claim. These tests are the guard
+    against that shape appearing in the guard itself."""
+
+    def test_every_declared_param_resolves_to_a_distinct_module(self):
+        """Not circular: the assertion is about the RESOLVED modules, not the
+        param names. Two params spelled differently that both import the
+        canonical twin would fail here, which is exactly the collapse being
+        guarded against."""
+        files = {
+            param: Path(_load_twin(param).__file__).resolve()
+            for param in _TWIN_PARAMS
+        }
+        assert len(set(files.values())) == len(_TWIN_PARAMS), (
+            f"the twin axis collapsed onto fewer modules than it declares: {files}"
+        )
+
+    def test_the_params_resolve_to_the_two_expected_twins(self):
+        assert Path(_load_twin("canonical").__file__).resolve() == (
+            PLUGIN_ROOT / CANONICAL_REL
+        ).resolve()
+        assert Path(_load_twin("skill").__file__).resolve() == (
+            PLUGIN_ROOT / TWIN_REL
+        ).resolve()
+
+    def test_the_twins_expose_distinct_function_and_exception_objects(self):
+        """`pytest.raises(twin.ContainmentError)` is only a per-twin assertion
+        if each module owns its own class object. If the twins ever shared one
+        (an import rather than a copy), every capability row would silently
+        become a single-twin assertion wearing a two-twin id."""
+        canonical, skill = _load_twin("canonical"), _load_twin("skill")
+        assert canonical is not skill
+        assert canonical._atomic_write_text is not skill._atomic_write_text
+        assert canonical.ContainmentError is not skill.ContainmentError
+
+
+# ---------------------------------------------------------------------------
+# Topology helpers
+# ---------------------------------------------------------------------------
+
+def _fd_count() -> int:
+    """Open descriptors for this process. -1 when /dev/fd is unavailable."""
+    try:
+        return len(os.listdir("/dev/fd"))
+    except OSError:  # pragma: no cover - platform without /dev/fd
+        return -1
+
+
+def _nested_project(root: Path):
+    """project/sub/CLAUDE.md -- NESTED, so the ancestry walk actually runs.
+
+    Returns (project, target). Do not replace this with a flat layout: see
+    hazard 1. `sub` is one real level below the anchor, which is the minimum
+    that makes `os.open("..", dir_fd=)` execute at all.
+    """
+    project = root / "project"
+    holder = project / "sub"
+    holder.mkdir(parents=True)
+    target = holder / "CLAUDE.md"
+    target.write_text("ORIGINAL\n", encoding="utf-8")
+    return project, target
+
+
+def _flat_project(root: Path):
+    """project/CLAUDE.md -- FLAT, where target.parent IS the anchor.
+
+    Used ONLY to demonstrate the vacuity hazard. Never use it to certify the
+    walk site.
+    """
+    project = root / "project"
+    project.mkdir(parents=True)
+    target = project / "CLAUDE.md"
+    target.write_text("ORIGINAL\n", encoding="utf-8")
+    return project, target
+
+
+def _two_leg_composition(project: Path, outside: Path) -> Path:
+    """The topology that produced the regression, both legs.
+
+    Leg 1: `project/.claude` -> symlink OUT to `outside`.
+    Leg 2: `outside/CLAUDE.md` -> symlink back IN to `project/real.md`.
+
+    A predicate that resolves the whole target path lands on `project/real.md`,
+    sees it inside the anchor, and ALLOWS. The write traverses only the PARENT
+    chain, lands in `outside`, and binds the leaf there as a directory entry --
+    so the guard certified a path the write never touched. Returns the
+    unresolved target `project/.claude/CLAUDE.md`.
+    """
+    project.mkdir(parents=True, exist_ok=True)
+    outside.mkdir(parents=True, exist_ok=True)
+    victim = project / "real.md"
+    victim.write_text("IN-PROJECT VICTIM\n", encoding="utf-8")
+    os.symlink(str(outside), str(project / ".claude"), target_is_directory=True)
+    os.symlink(str(victim), str(outside / "CLAUDE.md"))
+    return project / ".claude" / "CLAUDE.md"
+
+
+def _volume_is_case_insensitive(base: Path) -> bool:
+    probe = base / "CaseProbe"
+    probe.mkdir()
+    return (base / "caseprobe").exists()
+
+
+def _find_python39():
+    """Best-effort discovery of a real 3.9 interpreter, mirroring the
+    established pattern in test_bootstrap_gate.py. Returns None when absent --
+    callers skip rather than fail."""
+    import shutil
+
+    for candidate in (shutil.which("python3.9"), "/usr/bin/python3"):
+        if not candidate or not Path(candidate).exists():
+            continue
+        try:
+            probe = subprocess.run(
+                [candidate, "--version"], capture_output=True, text=True, timeout=10
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if (probe.stdout + probe.stderr).strip().startswith("Python 3.9"):
+            return candidate
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Capability injection harness
+# ---------------------------------------------------------------------------
+
+class _CapabilityInjector:
+    """Raises at EXACTLY ONE of the four sites that pass a `dir_fd`.
+
+    Three of the four sites are `os.open`, so a naive patch cannot tell them
+    apart. The discriminator is the pair (dir_fd, path):
+
+        site 1  parent-directory open   dir_fd is None
+        site 2  ancestry walk           dir_fd is not None and path == ".."
+        site 3  temp create             dir_fd is not None and path != ".."
+        site 4  rename                  os.replace
+
+    Getting this subtly wrong lands the injection on a DIFFERENT site while
+    every assertion still passes -- which is why each test asserts the
+    site-distinct message rather than merely that a ContainmentError was
+    raised.
+
+    Also records, for non-vacuity and fd accounting:
+      * `hits`         - times the chosen site actually fired
+      * `walk_calls`   - times the walk's os.open was reached at all
+      * `parent_closes`- closes counted against the CAPTURED parent fd. Exactly
+                         1 is correct; 0 is a leak; 2 is a double-close.
+                         Counting closes globally cannot distinguish these.
+    """
+
+    def __init__(self, site: int, exc_factory):
+        self.site = site
+        self.exc_factory = exc_factory
+        self.hits = 0
+        self.walk_calls = 0
+        self.parent_fd = None
+        self.parent_closes = 0
+        self._real_open = os.open
+        self._real_replace = os.replace
+        self._real_close = os.close
+
+    def open(self, path, flags, mode=0o777, *, dir_fd=None, **kw):
+        is_walk = dir_fd is not None and path == ".."
+        is_parent = dir_fd is None
+        if is_walk:
+            self.walk_calls += 1
+        hit = (
+            (self.site == 1 and is_parent)
+            or (self.site == 2 and is_walk)
+            or (self.site == 3 and dir_fd is not None and path != "..")
+        )
+        if hit:
+            self.hits += 1
+            raise self.exc_factory()
+        if dir_fd is None:
+            fd = self._real_open(path, flags, mode, **kw)
+        else:
+            fd = self._real_open(path, flags, mode, dir_fd=dir_fd, **kw)
+        if is_parent and flags & os.O_DIRECTORY and self.parent_fd is None:
+            self.parent_fd = fd
+        return fd
+
+    def replace(self, src, dst, **kw):
+        if self.site == 4:
+            self.hits += 1
+            raise self.exc_factory()
+        return self._real_replace(src, dst, **kw)
+
+    def close(self, fd):
+        if self.parent_fd is not None and fd == self.parent_fd:
+            self.parent_closes += 1
+        return self._real_close(fd)
+
+    def install(self, monkeypatch):
+        monkeypatch.setattr(os, "open", self.open)
+        monkeypatch.setattr(os, "replace", self.replace)
+        monkeypatch.setattr(os, "close", self.close)
+
+
+def _unsupported():
+    return NotImplementedError("simulated: dir_fd unsupported on this platform")
+
+
+def _eacces():
+    return PermissionError(13, "simulated permission failure")
+
+
+# ===========================================================================
+# FORCE THE CAPABILITY BRANCH BY INJECTION.
+# ===========================================================================
+
+class TestCapabilityBranchInjection:
+    """The four `dir_fd` sites map an unsupported primitive to a fail-CLOSED
+    ContainmentError, each with its OWN message.
+
+    THIS BRANCH IS TRIGGERED ARTIFICIALLY AND IS UNREACHABLE ON EVERY PLATFORM
+    MEASURED -- `os.open` is in `os.supports_dir_fd` everywhere tested, so no
+    natural path raises NotImplementedError. Nothing here is evidence that the
+    capability is missing somewhere real.
+
+    WHY THE MESSAGE ASSERTION IS LOAD-BEARING RATHER THAN COSMETIC.
+    NotImplementedError subclasses RuntimeError, NOT OSError, while
+    ContainmentError subclasses OSError -- so an UNMAPPED one is invisible to
+    every caller arm written `except ContainmentError` or `except OSError`, and
+    would crash the hook instead of failing closed into the site's opaque skip.
+    If two sites shared a message, a test claiming to certify one of them would
+    pass when the other fired. So each row asserts the distinct message, the
+    observed hit count, the target's bytes and the fd delta.
+    """
+
+    @pytest.mark.parametrize(
+        "site,expected_message",
+        [
+            (1, MSG_BOUNDARY),
+            (2, MSG_CAP_WALK),
+            (3, MSG_CAP_TEMP),
+            (4, MSG_CAP_RENAME),
+        ],
+        ids=["parent-open", "ancestry-walk", "temp-create", "rename"],
+    )
+    def test_each_dir_fd_site_fails_closed_with_its_own_message(
+        self, tmp_path, monkeypatch, twin, site, expected_message
+    ):
+        """Four EXPLICIT rows, not a quantifier.
+
+        A count is checkable; a quantifier reads as satisfied by any injection
+        that raises. An author who injects once, sees a ContainmentError and
+        moves on has satisfied "inject at all dir_fd sites" as written -- which
+        is exactly how three sites read as covered while a fourth sat unmapped
+        and would have crashed the hook.
+
+        NESTED topology is mandatory here: on a flat layout site 2 is never
+        reached (hazard 1), and a broad injection would instead fire at site 3
+        while this test's name still claimed site 2.
+        """
+        project, target = _nested_project(tmp_path)
+        before = target.read_bytes()
+        fds_before = _fd_count()
+
+        injector = _CapabilityInjector(site, _unsupported)
+        injector.install(monkeypatch)
+        with pytest.raises(twin.ContainmentError) as excinfo:
+            twin._atomic_write_text(target, "NEW PAYLOAD\n", project)
+        monkeypatch.undo()
+
+        assert str(excinfo.value) == expected_message, (
+            f"site {site} raised the wrong message -- a shared or drifted "
+            f"message means this assertion cannot tell which site fired"
+        )
+        # NON-VACUITY: the injection actually ran. Never infer firing from a
+        # green result -- a green result only proves something raised.
+        assert injector.hits == 1, (
+            f"site {site} injection fired {injector.hits}x, expected exactly 1"
+        )
+        # The failure mode that matters is not "it raised" but "it raised and
+        # left the target or the fd table damaged".
+        assert target.read_bytes() == before
+        assert _fd_count() == fds_before
+        assert not [p for p in target.parent.iterdir() if p.name != target.name], (
+            "a stray temp file was left next to the user's CLAUDE.md"
+        )
+
+    def test_walk_site_is_genuinely_reached_on_the_nested_topology(
+        self, tmp_path, monkeypatch, twin
+    ):
+        """Companion to the ancestry-walk row: the walk really executes here.
+
+        Paired with `test_flat_topology_makes_the_walk_site_unreachable`, this
+        is what gives the ancestry-walk row its meaning. Without the flat control, "the
+        injection fired" is an unfalsified claim about a site that might have
+        been reachable by accident.
+        """
+        project, target = _nested_project(tmp_path)
+        injector = _CapabilityInjector(2, _unsupported)
+        injector.install(monkeypatch)
+        with pytest.raises(twin.ContainmentError):
+            twin._atomic_write_text(target, "NEW\n", project)
+        monkeypatch.undo()
+
+        assert injector.walk_calls == 1
+        assert injector.hits == 1
+
+    def test_flat_topology_makes_the_walk_site_unreachable(
+        self, tmp_path, monkeypatch, twin
+    ):
+        """DEMONSTRATES the vacuity hazard rather than asserting it.
+
+        On a flat layout `target.parent` IS the anchor, so the ancestry check
+        matches on the first iteration and breaks BEFORE the first
+        `os.open("..")`. The site-2 injection therefore never fires and the
+        write SUCCEEDS. A capability test written against this layout would be
+        certifying nothing at all.
+
+        This test is the reason the ancestry-walk row can be trusted. Do not "repair" it
+        by making it expect a refusal -- a refusal here would mean the flat
+        write path had broken.
+        """
+        project, target = _flat_project(tmp_path)
+        injector = _CapabilityInjector(2, _unsupported)
+        injector.install(monkeypatch)
+        twin._atomic_write_text(target, "NEW PAYLOAD\n", project)
+        monkeypatch.undo()
+
+        # COUPLING LEG FIRST. The two assertions below are ABSENCES, and an
+        # absence passes vacuously if the injector was never installed at all.
+        # Capturing the parent fd proves `injector.open` really intercepted the
+        # parent-directory open, so the zeros that follow are observations
+        # rather than an artefact of a dead patch.
+        assert injector.parent_fd is not None, (
+            "the injector never intercepted the parent open -- the zeros below "
+            "would be vacuous"
+        )
+        assert injector.walk_calls == 0, "the walk ran on a flat topology"
+        assert injector.hits == 0, "the injection fired where it cannot be reached"
+        assert target.read_text(encoding="utf-8") == "NEW PAYLOAD\n"
+
+    def test_genuine_permission_error_at_the_walk_stays_a_raw_oserror(
+        self, tmp_path, monkeypatch, twin
+    ):
+        """NEGATIVE CONTROL -- the mapping is narrow BY DESIGN.
+
+        Only NotImplementedError is mapped at the walk. A genuine EACCES on an
+        ancestor the user cannot read must keep propagating RAW, because
+        relabelling it would report a permission failure as a capability
+        failure.
+
+        Without this control a future widening of that handler to
+        `except OSError` would silently relabel EVERY permission failure as a
+        capability failure, and all four rows above would still pass. This is
+        the test that makes the narrowness falsifiable.
+        """
+        project, target = _nested_project(tmp_path)
+        before = target.read_bytes()
+        fds_before = _fd_count()
+
+        injector = _CapabilityInjector(2, _eacces)
+        injector.install(monkeypatch)
+        with pytest.raises(OSError) as excinfo:
+            twin._atomic_write_text(target, "NEW\n", project)
+        monkeypatch.undo()
+
+        # ContainmentError IS an OSError subclass, so `pytest.raises(OSError)`
+        # alone would pass on a relabelled error. The exclusion is the assertion.
+        assert not isinstance(excinfo.value, twin.ContainmentError), (
+            "a genuine EACCES was relabelled as a containment/capability "
+            "failure -- the walk's handler has been widened beyond "
+            "NotImplementedError"
+        )
+        assert excinfo.value.errno == 13
+        assert injector.hits == 1
+        assert injector.parent_closes == 1, (
+            f"parent fd closed {injector.parent_closes}x -- 1 is correct, "
+            f"0 leaks, 2 is a double-close"
+        )
+        assert target.read_bytes() == before
+        assert _fd_count() == fds_before
+
+    def test_parent_descriptor_is_closed_exactly_once_on_the_walk_failure(
+        self, tmp_path, monkeypatch, twin
+    ):
+        """fd accounting on the mapped path, counted against the CAPTURED fd.
+
+        The mapping is a NESTED inner try inside the outer try, so the
+        ContainmentError it raises still reaches
+        `except BaseException: os.close(parent_fd)`. An explicit close in the
+        inner arm would therefore DOUBLE-close. A refactor to a sibling arm
+        inverts this and would then require the explicit close -- so this
+        assertion is what pins the current structure.
+        """
+        project, target = _nested_project(tmp_path)
+        injector = _CapabilityInjector(2, _unsupported)
+        injector.install(monkeypatch)
+        with pytest.raises(twin.ContainmentError):
+            twin._atomic_write_text(target, "NEW\n", project)
+        monkeypatch.undo()
+
+        assert injector.parent_closes == 1
+
+
+# ===========================================================================
+# The two-leg composition through real production entry points
+# ===========================================================================
+
+class TestTwoLegCompositionThroughProductionEntryPoints:
+    """The regression topology, driven through each of the THREE production
+    entry points that regressed -- named individually so this cannot be
+    discharged by testing one of them.
+
+    The verdict is keyed on the RETURNED STATUS STRING, not on a filesystem
+    delta: an absent file cannot distinguish "refused" from "no-opped for an
+    unrelated reason", so a delta-only assertion would pass against a function
+    that never reached the write at all.
+    """
+
+    _LEGACY = "# Project Memory\n\n## Pinned Context\n\n## Working Memory\n"
+    _STALE = (
+        "# Project Memory\n\n## Pinned Context\n\n"
+        "### Old Feature (PR #100, merged 2020-01-01)\n- detail\n\n"
+    )
+
+    def test_migrate_to_managed_structure_refuses(self, tmp_path, monkeypatch):
+        from shared.claude_md_manager import migrate_to_managed_structure
+
+        project = tmp_path / "proj"
+        outside = tmp_path / "outside"
+        target = _two_leg_composition(project, outside)
+        # Legacy content reachable THROUGH both legs, so the write path is
+        # reached rather than short-circuited by a no-op branch.
+        target.write_text(self._LEGACY, encoding="utf-8")
+        victim_before = (project / "real.md").read_bytes()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+
+        result = migrate_to_managed_structure()
+
+        assert result == (
+            "Migration skipped: project CLAUDE.md path precondition not met."
+        )
+        assert (project / "real.md").read_bytes() == victim_before
+        assert "PACT_MANAGED_START" not in (outside / "CLAUDE.md").read_text(
+            encoding="utf-8"
+        )
+
+    def test_update_session_info_refuses(self, tmp_path, monkeypatch):
+        from shared.session_resume import update_session_info
+
+        project = tmp_path / "proj"
+        outside = tmp_path / "outside"
+        _two_leg_composition(project, outside)
+        victim_before = (project / "real.md").read_bytes()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+
+        result = update_session_info("sid-123", "PACT-team")
+
+        # EXACT string. `result is None or "skipped" in result` would pass on
+        # the None returned when no project dir is set -- a disjunction that
+        # cannot fail for the right reason.
+        assert result == "Session info skipped: path precondition not met."
+        assert (project / "real.md").read_bytes() == victim_before
+        assert "SESSION_START" not in (outside / "CLAUDE.md").read_text(
+            encoding="utf-8"
+        )
+
+    def test_check_pinned_staleness_refuses(self, tmp_path):
+        from unittest.mock import patch
+
+        from session_init import check_pinned_staleness
+
+        project = tmp_path / "proj"
+        outside = tmp_path / "outside"
+        target = _two_leg_composition(project, outside)
+        target.write_text(self._STALE, encoding="utf-8")
+        victim_before = (project / "real.md").read_bytes()
+
+        with patch("session_init._get_project_claude_md_path", return_value=target), \
+             patch("staleness._get_project_claude_md_path", return_value=target):
+            result = check_pinned_staleness()
+
+        assert result == "Pinned staleness skipped: path precondition not met."
+        assert (project / "real.md").read_bytes() == victim_before
+
+
+# ===========================================================================
+# Refusals, each paired with a positive control
+# ===========================================================================
+
+class TestPredicateRefusals:
+    """Every refusal below is paired with `test_positive_control_*`, which
+    writes successfully through the SAME twin in the same harness. Without the
+    pairing a refusal assertion is satisfied by a predicate that refuses
+    everything."""
+
+    def test_positive_control_plain_nested_write_is_allowed(self, tmp_path, twin):
+        """A plain nested write, and the non-vacuity control for this whole class."""
+        project, target = _nested_project(tmp_path)
+        twin._atomic_write_text(target, "PAYLOAD\n", project)
+        assert target.read_text(encoding="utf-8") == "PAYLOAD\n"
+
+    def test_two_leg_composition_refused_at_the_predicate(self, tmp_path, twin):
+        """The two-leg composition at the predicate level, for BOTH twins.
+
+        The entry-point tests above drive only the canonical copy, because the
+        three regressing entry points live there. This is the skill twin's
+        independent exercise of the same topology.
+        """
+        project = tmp_path / "proj"
+        outside = tmp_path / "outside"
+        target = _two_leg_composition(project, outside)
+        victim_before = (project / "real.md").read_bytes()
+        outside_before = (outside / "CLAUDE.md").read_bytes()
+
+        with pytest.raises(twin.ContainmentError) as excinfo:
+            twin._atomic_write_text(target, "ESCAPED\n", project)
+
+        assert str(excinfo.value) == MSG_ESCAPE
+        assert (project / "real.md").read_bytes() == victim_before
+        assert (outside / "CLAUDE.md").read_bytes() == outside_before
+
+    def test_symlinked_parent_out_of_project_refused(self, tmp_path, twin):
+        """The single-leg parent-out escape."""
+        project = tmp_path / "proj"
+        outside = tmp_path / "outside"
+        project.mkdir()
+        outside.mkdir()
+        os.symlink(str(outside), str(project / ".claude"), target_is_directory=True)
+        target = project / ".claude" / "CLAUDE.md"
+
+        with pytest.raises(twin.ContainmentError) as excinfo:
+            twin._atomic_write_text(target, "ESCAPED\n", project)
+
+        assert str(excinfo.value) == MSG_ESCAPE
+        assert not (outside / "CLAUDE.md").exists()
+
+    def test_sibling_prefix_refused_structurally(self, tmp_path, twin):
+        """`/abc` is refused under anchor `/ab`.
+
+        RATIONALE UPDATED FOR THE CORRECTED PREDICATE. This case used to be
+        explained by the choice of `os.path.commonpath` over `str.startswith`;
+        that primitive has left the write path entirely. The refusal is now
+        STRUCTURAL and has nothing to do with text: `/abc` simply never walks
+        up to `/ab`'s inode. The string-prefix trap it guards against cannot
+        even be expressed in the current predicate.
+        """
+        anchor = tmp_path / "ab"
+        anchor.mkdir()
+        sibling = tmp_path / "abc"  # shares the STRING prefix, not a path child
+        sibling.mkdir()
+        target = sibling / "CLAUDE.md"
+        target.write_text("orig\n", encoding="utf-8")
+
+        with pytest.raises(twin.ContainmentError) as excinfo:
+            twin._atomic_write_text(target, "new\n", anchor)
+
+        assert str(excinfo.value) == MSG_ESCAPE
+        assert target.read_text(encoding="utf-8") == "orig\n"
+
+    def test_absent_parent_refused_at_check_time(self, tmp_path, twin):
+        """An absent parent -- strictness, by construction rather than by policy.
+
+        The superseded predicate lexically completed a non-existent parent and
+        certified it CONTAINED; if the parent then appeared as an outward
+        symlink the write escaped, deterministically and without a race.
+        `os.open` on an absent parent raises, so the fail-open closes for free.
+        """
+        project = tmp_path / "proj"
+        project.mkdir()
+        target = project / "does-not-exist" / "CLAUDE.md"
+
+        with pytest.raises(twin.ContainmentError) as excinfo:
+            twin._atomic_write_text(target, "new\n", project)
+
+        # The boundary could not be established at all -- distinct from escape.
+        assert str(excinfo.value) == MSG_BOUNDARY
+
+    def test_symlink_loop_in_target_parent_chain_refused(self, tmp_path, twin):
+        """A symlink loop in the TARGET parent chain.
+
+        A loop reaches the kernel as ELOOP -- an OSError -- on every
+        interpreter, because there is no second, userspace resolver here to
+        disagree about whether a loop is even an error. The superseded
+        predicate inherited `Path.resolve()`'s version-dependent behaviour on
+        exactly this input.
+        """
+        project = tmp_path / "proj"
+        project.mkdir()
+        os.symlink(str(project / "loop_b"), str(project / "loop_a"))
+        os.symlink(str(project / "loop_a"), str(project / "loop_b"))
+        target = project / "loop_a" / "CLAUDE.md"
+
+        with pytest.raises(twin.ContainmentError) as excinfo:
+            twin._atomic_write_text(target, "new\n", project)
+
+        assert str(excinfo.value) == MSG_BOUNDARY
+
+    def test_symlink_loop_in_anchor_chain_refused(self, tmp_path, twin):
+        """A symlink loop in the ANCHOR chain.
+
+        The anchor is `os.stat(project_root)`, so a loop there raises in the
+        same handler. Both sides use ONE resolver -- the kernel.
+        """
+        project, target = _nested_project(tmp_path)
+        anchor_a = tmp_path / "anchor_a"
+        anchor_b = tmp_path / "anchor_b"
+        os.symlink(str(anchor_b), str(anchor_a))
+        os.symlink(str(anchor_a), str(anchor_b))
+
+        with pytest.raises(twin.ContainmentError) as excinfo:
+            twin._atomic_write_text(target, "new\n", anchor_a)
+
+        assert str(excinfo.value) == MSG_BOUNDARY
+
+
+# ===========================================================================
+# The ALLOW branch, where the repaired defect lives
+# ===========================================================================
+
+class TestPredicateAllows:
+    """The over-block certification. A guard tested only for refusal passes by
+    refusing everything, and the shipped defect was on this branch."""
+
+    def test_benign_symlinked_dot_claude_parent_absolute_allowed(self, tmp_path, twin):
+        """A benign symlinked `.claude` PARENT -- and this is the test that FAILS if anyone adds
+        O_NOFOLLOW to the parent open.
+
+        `.claude` is a symlink whose target is INSIDE the project. Both the
+        superseded predicate and the code before it allowed this. O_NOFOLLOW on
+        the parent open would refuse ANY symlinked final component of the
+        parent path, which is a NEW over-block on an axis that is not
+        containment -- and it would add nothing, because the ancestry test runs
+        ON the opened descriptor, so there is no check-then-open gap to close.
+        """
+        project = tmp_path / "proj"
+        real_dir = project / "config" / "claude"
+        real_dir.mkdir(parents=True)
+        os.symlink(str(real_dir), str(project / ".claude"), target_is_directory=True)
+        target = project / ".claude" / "CLAUDE.md"
+
+        twin._atomic_write_text(target, "PAYLOAD\n", project)
+
+        assert (real_dir / "CLAUDE.md").read_text(encoding="utf-8") == "PAYLOAD\n"
+
+    def test_benign_symlinked_dot_claude_parent_relative_allowed(self, tmp_path, twin):
+        """A benign symlinked `.claude` PARENT, RELATIVE form -- what a committed repo symlink
+        actually looks like. A repo cannot commit an absolute symlink, so this
+        is the shape that ships; certifying only the absolute form would leave
+        the realistic one uncovered."""
+        project = tmp_path / "proj"
+        real_dir = project / "config" / "claude"
+        real_dir.mkdir(parents=True)
+        os.symlink("config/claude", str(project / ".claude"), target_is_directory=True)
+        target = project / ".claude" / "CLAUDE.md"
+
+        twin._atomic_write_text(target, "PAYLOAD\n", project)
+
+        assert (real_dir / "CLAUDE.md").read_text(encoding="utf-8") == "PAYLOAD\n"
+
+    def test_deep_in_project_path_allowed_at_depth_80(self, tmp_path, twin):
+        """Regression test for the superseded depth bound.
+
+        THE NUMBER IS THE WHOLE POINT. The defective bound admitted 63 levels,
+        so a test at depth 5 or 10 passes while proving nothing about it. The
+        certification floor is 70; this runs at 80.
+
+        The bound is now a LIVENESS backstop rather than a policy ceiling:
+        reaching it means the filesystem is misreporting "..", not that a path
+        is legitimately deep.
+        """
+        project = tmp_path / "proj"
+        deep = project
+        for i in range(DEEP_DEPTH):
+            deep = deep / f"d{i}"
+        deep.mkdir(parents=True)
+        target = deep / "CLAUDE.md"
+
+        twin._atomic_write_text(target, "DEEP\n", project)
+
+        assert target.read_text(encoding="utf-8") == "DEEP\n"
+
+    def test_case_variant_anchor_allowed_on_case_insensitive_volume(
+        self, tmp_path, twin
+    ):
+        """A case-variant anchor -- both string predicates over-block here.
+
+        Nothing is compared as text, so a case-variant spelling of the anchor
+        stats to the SAME inode and is contained. On a case-SENSITIVE volume
+        the variant spelling is a genuinely different, non-existent directory
+        and `os.stat` raises -- fail-closed and correct -- so the case is
+        skipped there rather than asserted.
+        """
+        if not _volume_is_case_insensitive(tmp_path):
+            pytest.skip("case-sensitive volume: the variant anchor does not exist")
+
+        project = tmp_path / "MixedCase"
+        (project / "sub").mkdir(parents=True)
+        target = project / "sub" / "CLAUDE.md"
+        variant_anchor = tmp_path / "mixedcase"
+
+        twin._atomic_write_text(target, "PAYLOAD\n", variant_anchor)
+
+        assert target.read_text(encoding="utf-8") == "PAYLOAD\n"
+
+    def test_nfd_variant_anchor_allowed_when_the_volume_normalises(
+        self, tmp_path, twin
+    ):
+        """Unicode normalisation form.
+
+        Same mechanism as the case variant: the kernel resolves both spellings
+        to one inode, and the predicate never compares the text. Skipped where
+        the volume does not treat the two forms as one name.
+        """
+        nfc = unicodedata.normalize("NFC", "café-proj")
+        nfd = unicodedata.normalize("NFD", "café-proj")
+        project = tmp_path / nfc
+        (project / "sub").mkdir(parents=True)
+        target = project / "sub" / "CLAUDE.md"
+        variant_anchor = tmp_path / nfd
+        try:
+            os.stat(str(variant_anchor))
+        except OSError:
+            pytest.skip("volume does not normalise NFC/NFD to one name")
+
+        twin._atomic_write_text(target, "PAYLOAD\n", variant_anchor)
+
+        assert target.read_text(encoding="utf-8") == "PAYLOAD\n"
+
+
+# ===========================================================================
+# The leaf-outside-root coupling tripwire
+# ===========================================================================
+
+class TestLeafOutsideRootCouplingTripwire:
+    """A leaf symlink pointing OUTSIDE the root is ALLOWED, and that is the
+    correct verdict -- a derivation, not a concession.
+
+    Containment is entirely a property of the PARENT chain, because the parent
+    chain is the only part the kernel traverses on the way to the write.
+    `os.replace` is renameat(2): it unlinks whatever entry sits at the final
+    name and binds the temp file's inode there, never opening and never
+    following the leaf. So the payload lands at the in-project entry and any
+    outside victim keeps its bytes.
+
+    THIS IS A COUPLING TRIPWIRE AND MUST NOT BE "FIXED" BY MAKING IT REFUSE.
+    The ALLOW is sound ONLY while the write replaces the leaf ENTRY rather than
+    writing THROUGH it. Two rewrites would silently convert it into a real
+    escape with the predicate untouched: resolving the target once and using it
+    downstream (which makes check and act agree by making the WRITE follow the
+    leaf), or replacing temp-plus-rename with an open/truncate on the target.
+    A failure here means THE WRITE SHAPE CHANGED. Making the guard refuse the
+    topology would re-introduce the cardinal over-block this work removed.
+
+    WHAT THIS ADDS OVER THE EXISTING IN-PROJECT TRIPWIRE, stated narrowly: the
+    in-project half is already pinned by an executing test. This pins the
+    OUT-OF-PROJECT topology, which could not be pinned before, because the
+    superseded predicate refused it outright.
+    """
+
+    def test_leaf_pointing_outside_is_allowed_and_lands_in_project(
+        self, tmp_path, twin
+    ):
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / "sub").mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        victim = outside / "victim.md"
+        victim.write_text("OUTSIDE VICTIM\n", encoding="utf-8")
+        victim_before = victim.read_bytes()
+        victim_ino_before = victim.stat().st_ino
+
+        entry = project / "sub" / "CLAUDE.md"
+        os.symlink(str(victim), str(entry))
+
+        # ALLOWED -- containment never consults the leaf.
+        twin._atomic_write_text(entry, "PAYLOAD\n", project)
+
+        # 1. the payload landed at the IN-PROJECT entry
+        assert entry.read_text(encoding="utf-8") == "PAYLOAD\n"
+        # 2. the outside victim is byte-unchanged -- and same inode, so it was
+        #    not replaced either. Byte-equality alone would ALSO hold under a
+        #    refusal, so on its own it cannot distinguish ALLOW from REFUSE;
+        #    assertion 3 is what pins the ALLOW.
+        assert victim.read_bytes() == victim_before
+        assert victim.stat().st_ino == victim_ino_before
+        # 3. the in-project entry is no longer a symlink -- the write HAPPENED,
+        #    and it replaced the link rather than following it.
+        assert not entry.is_symlink()
+
+
+# ===========================================================================
+# Exhaustion is distinguishable from escape
+# ===========================================================================
+
+class _FakeStat:
+    """Minimal stand-in: the walk reads only st_dev and st_ino."""
+
+    def __init__(self, dev, ino):
+        self.st_dev = dev
+        self.st_ino = ino
+
+
+class TestWalkExhaustion:
+    def test_exhaustion_raises_its_own_message_not_the_escape_message(
+        self, tmp_path, monkeypatch, twin
+    ):
+        """Exhaustion and escape are both ContainmentError, so only the message
+        separates them.
+
+        If exhaustion reused the escape message, a future debugger would hunt a
+        phantom symlink for a walk that simply ran out. Nothing escaped here.
+
+        HOW EXHAUSTION IS FORCED. A real 1024-deep tree is not reachable
+        (PATH_MAX) and opening 1024 real descriptors would hit the process fd
+        limit and raise EMFILE -- which would surface as a RAW OSError and make
+        this test assert the wrong thing entirely. So the walk is synthesised:
+        every `os.open("..")` returns a sentinel descriptor whose fstat reports
+        a unique (st_dev, st_ino), so neither the anchor match nor the
+        self-parent match can ever fire. That is precisely the condition the
+        bound exists to survive -- a filesystem misreporting "..".
+        """
+        project, target = _nested_project(tmp_path)
+        real_open, real_fstat, real_close = os.open, os.fstat, os.close
+        sentinel_base = 1 << 30
+        state = {"next": sentinel_base, "walk_opens": 0}
+
+        def fake_open(path, flags, mode=0o777, *, dir_fd=None, **kw):
+            if dir_fd is not None and path == "..":
+                state["walk_opens"] += 1
+                fd = state["next"]
+                state["next"] += 1
+                return fd
+            if dir_fd is None:
+                return real_open(path, flags, mode, **kw)
+            return real_open(path, flags, mode, dir_fd=dir_fd, **kw)
+
+        def fake_fstat(fd):
+            if fd >= sentinel_base:
+                # Unique every time: never the anchor, never its own parent.
+                return _FakeStat(-1, fd)
+            return real_fstat(fd)
+
+        def fake_close(fd):
+            if fd >= sentinel_base:
+                return None
+            return real_close(fd)
+
+        monkeypatch.setattr(os, "open", fake_open)
+        monkeypatch.setattr(os, "fstat", fake_fstat)
+        monkeypatch.setattr(os, "close", fake_close)
+        with pytest.raises(twin.ContainmentError) as excinfo:
+            twin._atomic_write_text(target, "new\n", project)
+        monkeypatch.undo()
+
+        assert str(excinfo.value) == MSG_EXHAUSTION
+        assert str(excinfo.value) != MSG_ESCAPE, (
+            "exhaustion reported itself as an escape -- nothing escaped, the "
+            "walk ran out"
+        )
+        # Pins the INLINE literal bound. The design deliberately kept it inline
+        # rather than a module constant so it stays inside the twin drift gate;
+        # this is the only assertion outside that gate which notices it change.
+        assert state["walk_opens"] == WALK_BOUND
+
+
+# ===========================================================================
+# Mode determinism under a restrictive umask
+# ===========================================================================
+
+class TestModeDeterminism:
+    def test_final_mode_is_0600_under_restrictive_umask(self, tmp_path, twin):
+        """Pins the fchmod whose rationale was corrected.
+
+        The fchmod is NOT defending against over-permissiveness: umask can only
+        CLEAR bits, so `os.open(..., 0o600)` cannot yield anything more
+        permissive than 0o600. Its actual effect is the opposite -- it RESTORES
+        an owner-write bit that a restrictive umask removed. 0o277 is the case
+        that would otherwise leave 0o400, which is why the test uses it rather
+        than a milder value.
+        """
+        import stat
+
+        project, target = _nested_project(tmp_path)
+        old_umask = os.umask(0o277)
+        try:
+            twin._atomic_write_text(target, "PAYLOAD\n", project)
+        finally:
+            os.umask(old_umask)
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+        assert target.read_text(encoding="utf-8") == "PAYLOAD\n"
+
+
+# ===========================================================================
+# Descriptor hygiene, allow and refuse counted SEPARATELY
+# ===========================================================================
+
+class TestDescriptorHygiene:
+    """The prior arc leaked a descriptor in this function; the delta assertion
+    is the durable guard.
+
+    Counted SEPARATELY rather than in aggregate, and with a NAMED count. "A
+    batch" is satisfiable by two calls, and an aggregate delta lets a leak on
+    one path be masked by the other path being clean.
+    """
+
+    CALLS = 120  # certification floor is 100 each; the measured baseline was 300
+
+    def test_successful_writes_leak_no_descriptors(self, tmp_path, twin):
+        project, target = _nested_project(tmp_path)
+        twin._atomic_write_text(target, "warmup\n", project)  # settle lazy imports
+
+        before = _fd_count()
+        for i in range(self.CALLS):
+            twin._atomic_write_text(target, f"payload {i}\n", project)
+        after = _fd_count()
+
+        assert after - before == 0, f"leaked {after - before} fds over {self.CALLS} writes"
+        assert target.read_text(encoding="utf-8") == f"payload {self.CALLS - 1}\n"
+
+    def test_refused_writes_leak_no_descriptors(self, tmp_path, twin):
+        project = tmp_path / "proj"
+        outside = tmp_path / "outside"
+        project.mkdir()
+        outside.mkdir()
+        os.symlink(str(outside), str(project / ".claude"), target_is_directory=True)
+        target = project / ".claude" / "CLAUDE.md"
+        with pytest.raises(twin.ContainmentError):
+            twin._atomic_write_text(target, "warmup\n", project)
+
+        before = _fd_count()
+        refusals = 0
+        for _ in range(self.CALLS):
+            with pytest.raises(twin.ContainmentError):
+                twin._atomic_write_text(target, "nope\n", project)
+            refusals += 1
+        after = _fd_count()
+
+        assert refusals == self.CALLS  # the loop really ran; not a vacuous 0
+        assert after - before == 0, (
+            f"leaked {after - before} fds over {self.CALLS} refusals"
+        )
+
+
+# ===========================================================================
+# The message contract itself
+# ===========================================================================
+
+class TestRefusalMessageContract:
+    """The per-site messages are load-bearing for the certification, not just
+    for logs: they are the only thing that lets a capability test say WHICH
+    site fired. If two of them ever collapse to one string, the injection rows
+    above keep passing while proving strictly less. This class is what makes
+    that collapse a test failure."""
+
+    def test_all_refusal_messages_are_pairwise_distinct(self):
+        assert len(set(ALL_MESSAGES)) == len(ALL_MESSAGES), (
+            "two refusal messages collapsed -- a capability row can no longer "
+            "discriminate the site that raised"
+        )
+
+    @pytest.mark.parametrize("rel", [CANONICAL_REL, TWIN_REL])
+    def test_source_renders_exactly_these_messages(self, rel):
+        """Read the messages out of the SOURCE by AST join and compare.
+
+        WHY AST AND NOT GREP -- this is hazard 2 made executable. The walk's
+        message is two adjacent string literals in the source, so a
+        line-oriented search for the rendered phrase finds NOTHING while the
+        joined constant is the full sentence. `ast.literal_eval` of the node
+        sees what Python sees. A verifier who reaches for grep here will
+        conclude, wrongly, that the asserted message does not exist.
+        """
+        import ast
+
+        source = (PLUGIN_ROOT / rel).read_text(encoding="utf-8")
+        fn = next(
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.FunctionDef) and node.name == "_atomic_write_text"
+        )
+        rendered = {
+            node.exc.args[0].value
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Raise)
+            and isinstance(node.exc, ast.Call)
+            and node.exc.args
+            and isinstance(node.exc.args[0], ast.Constant)
+        }
+        assert rendered == set(ALL_MESSAGES)
+
+    def test_the_walk_message_is_split_in_source_and_unfindable_by_grep(self):
+        """Pins the hazard itself, so it cannot silently stop being true.
+
+        If someone later joins the literal onto one line this test fails, which
+        is the signal to delete the warnings in this file's docstring. If the
+        message text drifts, the AST test above fails instead. Between them the
+        documentation cannot rot into a false statement.
+        """
+        source = (PLUGIN_ROOT / CANONICAL_REL).read_text(encoding="utf-8")
+        assert MSG_CAP_WALK not in source, (
+            "the walk message is now contiguous in source -- the split-literal "
+            "warnings in this file's docstring are stale and should be removed"
+        )
+        assert "ancestry traversal" in source  # the fragment IS findable
+
+
+# ===========================================================================
+# Loop handling at the version floor
+# ===========================================================================
+
+_FLOOR_PROBE = '''
+import os, sys, tempfile
+from pathlib import Path
+sys.path.insert(0, {hooks!r})
+from shared.claude_md_manager import _atomic_write_text, ContainmentError
+
+root = Path(tempfile.mkdtemp())
+results = []
+
+# target-parent chain loop
+p = root / "t" ; p.mkdir()
+os.symlink(str(p / "b"), str(p / "a")) ; os.symlink(str(p / "a"), str(p / "b"))
+try:
+    _atomic_write_text(p / "a" / "CLAUDE.md", "x\\n", p)
+    results.append("target:NO-RAISE")
+except ContainmentError as e:
+    results.append("target:ContainmentError:" + str(e))
+except BaseException as e:
+    results.append("target:RAW:" + type(e).__name__)
+
+# anchor chain loop
+q = root / "q" / "sub" ; q.mkdir(parents=True)
+os.symlink(str(root / "ab"), str(root / "aa")) ; os.symlink(str(root / "aa"), str(root / "ab"))
+try:
+    _atomic_write_text(q / "CLAUDE.md", "x\\n", root / "aa")
+    results.append("anchor:NO-RAISE")
+except ContainmentError as e:
+    results.append("anchor:ContainmentError:" + str(e))
+except BaseException as e:
+    results.append("anchor:RAW:" + type(e).__name__)
+
+print("|".join(results))
+'''
+
+
+class TestVersionFloorLoopHandling:
+    def test_loops_refuse_identically_on_a_real_39_interpreter(self):
+        """Loop handling on BOTH available interpreters.
+
+        CI runs one interpreter, so this opportunistically discovers a real 3.9
+        and SKIPS when absent, following the established pattern.
+
+        WHAT THIS DOES AND DOES NOT ESTABLISH. It measures the two ENDPOINTS,
+        3.9 and the running interpreter. 3.10-3.13 are unmeasured, and the
+        claim that the verdict is version-invariant across the middle rests on
+        CONSTRUCTION -- no `Path.resolve()` call exists in this function, so the
+        RuntimeError class that splits 3.9-3.12 from 3.13+ is unreachable
+        rather than caught. Never state this as "identical across 3.9-3.14".
+
+        SCOPE LIMIT, because the natural summary overclaims: `file_lock` runs
+        BEFORE this guard at every call site and does its own unprotected
+        `resolve()`. This makes the GUARD version-invariant; it does NOT make
+        the write path version-invariant end to end.
+        """
+        interpreter = _find_python39()
+        if interpreter is None:
+            pytest.skip("no real 3.9 interpreter available")
+
+        probe = _FLOOR_PROBE.format(hooks=str(PLUGIN_ROOT / "hooks"))
+        result = subprocess.run(
+            [interpreter, "-c", textwrap.dedent(probe)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode == 0, result.stderr
+        rows = dict(
+            (part.split(":", 1)[0], part.split(":", 1)[1])
+            for part in result.stdout.strip().split("|")
+        )
+        assert rows["target"] == f"ContainmentError:{MSG_BOUNDARY}"
+        assert rows["anchor"] == f"ContainmentError:{MSG_BOUNDARY}"

--- a/pact-plugin/tests/test_containment_certification.py
+++ b/pact-plugin/tests/test_containment_certification.py
@@ -306,23 +306,47 @@ def _find_python39():
 # ---------------------------------------------------------------------------
 
 class _CapabilityInjector:
-    """Raises at EXACTLY ONE of the four sites that pass a `dir_fd`.
+    """Raises at EXACTLY ONE capability site.
 
-    Three of the four sites are `os.open`, so a naive patch cannot tell them
-    apart. The discriminator is the pair (dir_fd, path):
+    MEMBERSHIP PREDICATE, stated because leaving it unstated is what let the
+    count be wrong three times. The covered set is EVERY `os.*` call in
+    `_atomic_write_text` whose `NotImplementedError` must not reach the caller
+    unmapped. That is FIVE sites, of which FOUR are MAPPED to a distinct
+    `ContainmentError` and the FIFTH is SWALLOWED so the original exception
+    wins.
 
-        site 1  parent-directory open   dir_fd is None
-        site 2  ancestry walk           dir_fd is not None and path == ".."
-        site 3  temp create             dir_fd is not None and path != ".."
-        site 4  rename                  os.replace
+    `dir_fd` was never the discriminator -- only a proxy close enough to look
+    like one. Counting "sites that raise ContainmentError" gives four; counting
+    "sites the capability contract covers" gives five; and an argument sweep on
+    `dir_fd` misses the parent open (which passes none) while a read of the
+    mapped-site list misses the cleanup unlink (which passes one). Three
+    observers counted three different sets and each believed the list complete.
+    Ask of any new `os.*` call: must its NotImplementedError not reach the
+    caller? Yes means it belongs here, whatever its arguments look like.
+
+    Three of the five sites are `os.open`, so a naive patch cannot tell them
+    apart. The MECHANICAL discriminator -- an implementation detail of this
+    injector, not the definition -- is the pair (dir_fd, path):
+
+        site 1  parent-directory open   os.open,    dir_fd is None      MAPPED
+        site 2  ancestry walk           os.open,    dir_fd, path ".."   MAPPED
+        site 3  temp create             os.open,    dir_fd, path != ".."MAPPED
+        site 4  rename                  os.replace                      MAPPED
+        site 5  cleanup unlink          os.unlink,  dir_fd            SWALLOWED
 
     Getting this subtly wrong lands the injection on a DIFFERENT site while
     every assertion still passes -- which is why each test asserts the
     site-distinct message rather than merely that a ContainmentError was
     raised.
 
+    Site 5 needs a PRECONDITION the others do not: the cleanup arm only runs
+    after something already failed, so site 5 also raises at the rename to
+    reach it. The rename raise is scaffolding; `unlink_hits` is what proves the
+    site-5 injection itself fired.
+
     Also records, for non-vacuity and fd accounting:
       * `hits`         - times the chosen site actually fired
+      * `unlink_hits`  - times the cleanup unlink fired (site 5 only)
       * `walk_calls`   - times the walk's os.open was reached at all
       * `parent_closes`- closes counted against the CAPTURED parent fd. Exactly
                          1 is correct; 0 is a leak; 2 is a double-close.
@@ -333,12 +357,14 @@ class _CapabilityInjector:
         self.site = site
         self.exc_factory = exc_factory
         self.hits = 0
+        self.unlink_hits = 0
         self.walk_calls = 0
         self.parent_fd = None
         self.parent_closes = 0
         self._real_open = os.open
         self._real_replace = os.replace
         self._real_close = os.close
+        self._real_unlink = os.unlink
 
     def open(self, path, flags, mode=0o777, *, dir_fd=None, **kw):
         is_walk = dir_fd is not None and path == ".."
@@ -362,10 +388,19 @@ class _CapabilityInjector:
         return fd
 
     def replace(self, src, dst, **kw):
-        if self.site == 4:
+        # Site 5 raises here too, as the PRECONDITION that reaches the cleanup
+        # arm -- the ContainmentError this produces is the one site 5 asserts
+        # survives, so it is scaffolding rather than the subject.
+        if self.site in (4, 5):
             self.hits += 1
             raise self.exc_factory()
         return self._real_replace(src, dst, **kw)
+
+    def unlink(self, path, *, dir_fd=None, **kw):
+        if self.site == 5:
+            self.unlink_hits += 1
+            raise self.exc_factory()
+        return self._real_unlink(path, dir_fd=dir_fd, **kw)
 
     def close(self, fd):
         if self.parent_fd is not None and fd == self.parent_fd:
@@ -376,6 +411,7 @@ class _CapabilityInjector:
         monkeypatch.setattr(os, "open", self.open)
         monkeypatch.setattr(os, "replace", self.replace)
         monkeypatch.setattr(os, "close", self.close)
+        monkeypatch.setattr(os, "unlink", self.unlink)
 
 
 def _unsupported():
@@ -549,6 +585,71 @@ class TestCapabilityBranchInjection:
         )
         assert excinfo.value.errno == 13
         assert injector.hits == 1
+        assert injector.parent_closes == 1, (
+            f"parent fd closed {injector.parent_closes}x -- 1 is correct, "
+            f"0 leaks, 2 is a double-close"
+        )
+        assert target.read_bytes() == before
+        assert _fd_count() == fds_before
+
+    def test_cleanup_unlink_is_swallowed_and_the_original_error_survives(
+        self, tmp_path, monkeypatch, twin
+    ):
+        """SITE 5 -- the SWALLOWED site. Deliberately NOT in the family above.
+
+        The four rows above assert "a ContainmentError with THIS site's own
+        message". Site 5 asserts the opposite shape: NO new exception, and the
+        exception already in flight arrives INTACT. Parametrizing it alongside
+        them would force the shared assertion down to whatever all five satisfy,
+        which means dropping the message check that makes the other four
+        meaningful -- and a row labelled "site 5" inside a family whose
+        docstring says "each site raises a distinct message" would misdescribe
+        what it checks.
+
+        WHY IDENTITY AND NOT TYPE. The cleanup runs while an exception is
+        already propagating, so anything raised there REPLACES it and the
+        handler's bare `raise` never runs. Asserting only that "a
+        ContainmentError arrived" would therefore pass even if the cleanup
+        raised its OWN ContainmentError -- the precise substitution this site
+        exists to forbid, sailing through the test written to forbid it. So the
+        assertion is on the MESSAGE: the rename's message, unchanged.
+
+        ARTIFICIAL, like the rest of this class: `os.unlink` supports `dir_fd`
+        on every platform measured, so nothing here is evidence the capability
+        is missing anywhere real. It proves the SWALLOW, not the branch.
+
+        A STRAY TEMP SURVIVES ON THIS PATH, and that is inherent rather than a
+        defect: the primitive being injected IS the cleanup, so nothing
+        downstream can remove the file. The fix corrects the exception CLASS; it
+        cannot perform a removal the platform cannot perform. Do not "repair"
+        this test by asserting the temp is gone -- that assertion can only be
+        made true by adding a second cleanup path, which is new machinery on a
+        branch that has never executed.
+        """
+        project, target = _nested_project(tmp_path)
+        before = target.read_bytes()
+        fds_before = _fd_count()
+
+        injector = _CapabilityInjector(5, _unsupported)
+        injector.install(monkeypatch)
+        with pytest.raises(twin.ContainmentError) as excinfo:
+            twin._atomic_write_text(target, "NEW PAYLOAD\n", project)
+        monkeypatch.undo()
+
+        # IDENTITY, not type: the rename's message must arrive unaltered.
+        assert str(excinfo.value) == MSG_CAP_RENAME, (
+            "the cleanup substituted its own error for the one it was cleaning "
+            "up after -- a stray temp file must never outrank the reason the "
+            "write was refused"
+        )
+        # NON-VACUITY, both legs: the precondition reached the cleanup arm, and
+        # the site-5 injection itself fired inside it. Without the second the
+        # first would only prove the rename mapping still works.
+        assert injector.hits == 1, "the rename precondition did not fire"
+        assert injector.unlink_hits == 1, (
+            f"the cleanup unlink fired {injector.unlink_hits}x -- the swallow "
+            f"was never exercised"
+        )
         assert injector.parent_closes == 1, (
             f"parent fd closed {injector.parent_closes}x -- 1 is correct, "
             f"0 leaks, 2 is a double-close"

--- a/pact-plugin/tests/test_containment_guard.py
+++ b/pact-plugin/tests/test_containment_guard.py
@@ -1,0 +1,489 @@
+"""Cross-site bidirectional certification of the #1247 CLAUDE.md write-path
+containment guard.
+
+The guard is inlined at the top of the `_atomic_write_text` twin
+(hooks/shared/claude_md_manager.py + skills/pact-memory/scripts/working_memory.py):
+it refuses a write unless the RESOLVED target is contained within the RESOLVED
+`project_root` (os.path.commonpath, fail-CLOSED). Correctness hinges on ANCHOR
+IDENTITY — each of the 7 write callers passes its OWN pre-resolve base, never a
+re-derived root.
+
+The seed tests (test_staleness.py) cover site 1 (staleness) via a LEAF symlink.
+This file WIDENS to the actual F1 vector — a symlinked-PARENT `.claude` — driven
+through each caller's REAL production entry point (NOT synthetic no-path calls;
+that is the discipline that would have caught both premises falsified this arc),
+and asserts BOTH directions at every site: F1 escape → REFUSED, benign → ALLOWED.
+A guard tested only for refusal passes by refusing everything (the cardinal
+over-block).
+
+Real-production-entry topology (traced against merged code, not assumed):
+  * session_init SessionStart  -> site 1 check_pinned_staleness,
+                                   site 5 strip_orphan_kernel_block (GLOBAL anchor),
+                                   site 6 ensure_project_memory_md,
+                                   site 7 migrate_to_managed_structure
+  * bootstrap_marker_writer     -> sites 2-4 update_session_info
+  * memory_api save/search      -> sites 8-9 sync_to_claude_md / sync_retrieved
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# hooks/shared on path (mirrors the other hook test files).
+_HOOKS = str(Path(__file__).resolve().parent.parent / "hooks")
+if _HOOKS not in sys.path:
+    sys.path.insert(0, _HOOKS)
+
+
+# ---------------------------------------------------------------------------
+# Layout helpers — the actual F1 vector is a symlinked-PARENT `.claude`.
+# ---------------------------------------------------------------------------
+
+def _mount_symlinked_parent_escape(project: Path, outside: Path) -> Path:
+    """Ship `project/.claude` as a symlink pointing OUTSIDE the project.
+
+    This is F1: the leaf `is_symlink()` on `.claude/CLAUDE.md` is False (the leaf
+    is a regular path component under the symlinked dir), yet `resolve()` escapes
+    the project. Returns the (unresolved) escaping target path
+    `project/.claude/CLAUDE.md`.
+    """
+    project.mkdir(parents=True, exist_ok=True)
+    outside.mkdir(parents=True, exist_ok=True)
+    os.symlink(str(outside), str(project / ".claude"), target_is_directory=True)
+    return project / ".claude" / "CLAUDE.md"
+
+
+def _mount_benign_dot_claude(project: Path) -> Path:
+    """A normal in-project `.claude/` directory. Returns project/.claude/CLAUDE.md."""
+    (project / ".claude").mkdir(parents=True, exist_ok=True)
+    return project / ".claude" / "CLAUDE.md"
+
+
+def _mode(p: Path) -> int:
+    import stat
+    return stat.S_IMODE(p.stat().st_mode)
+
+
+# ---------------------------------------------------------------------------
+# Site 6 — ensure_project_memory_md (anchor: CLAUDE_PROJECT_DIR; writes on CREATE)
+# ---------------------------------------------------------------------------
+
+class TestSite6EnsureProjectMemoryMd:
+    """ensure_project_memory_md CREATES project/.claude/CLAUDE.md when absent,
+    anchored on CLAUDE_PROJECT_DIR. Driven through the real function (no path
+    param — it resolves internally from the env)."""
+
+    def test_f1_symlinked_parent_escape_refused(self, tmp_path, monkeypatch):
+        from shared.claude_md_manager import ensure_project_memory_md
+
+        project = tmp_path / "proj"
+        outside = tmp_path / "outside"
+        _mount_symlinked_parent_escape(project, outside)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+
+        result = ensure_project_memory_md()
+
+        # Refused with the opaque skip; NO file created through the escaping link.
+        assert result == "Project CLAUDE.md skipped: path precondition not met."
+        assert not (outside / "CLAUDE.md").exists(), "write escaped to outside the project"
+
+    def test_benign_dot_claude_allows_creation(self, tmp_path, monkeypatch):
+        from shared.claude_md_manager import ensure_project_memory_md
+
+        project = tmp_path / "proj"
+        target = _mount_benign_dot_claude(project)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+
+        result = ensure_project_memory_md()
+
+        # Allowed: the in-project file is created (over-block cert for this site).
+        assert result == "Created project CLAUDE.md with memory sections"
+        assert target.exists()
+        assert _mode(target) == 0o600
+
+
+# ---------------------------------------------------------------------------
+# Site 7 — migrate_to_managed_structure (anchor: CLAUDE_PROJECT_DIR; writes when
+# an unmanaged file EXISTS)
+# ---------------------------------------------------------------------------
+
+class TestSite7MigrateToManagedStructure:
+    """migrate_to_managed_structure rewrites an existing unmanaged project
+    CLAUDE.md in place, anchored on CLAUDE_PROJECT_DIR."""
+
+    _LEGACY = "# Project Memory\n\n## Pinned Context\n\n## Working Memory\n"
+
+    def test_f1_symlinked_parent_escape_refused(self, tmp_path, monkeypatch):
+        from shared.claude_md_manager import migrate_to_managed_structure
+
+        project = tmp_path / "proj"
+        outside = tmp_path / "outside"
+        _mount_symlinked_parent_escape(project, outside)
+        # An unmanaged file exists THROUGH the escaping link (so the migrate
+        # write-path is reached, not the new_default no-op).
+        (outside / "CLAUDE.md").write_text(self._LEGACY, encoding="utf-8")
+        outside_before = (outside / "CLAUDE.md").read_text(encoding="utf-8")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+
+        result = migrate_to_managed_structure()
+
+        assert result == "Migration skipped: project CLAUDE.md path precondition not met."
+        # The out-of-project victim is byte-unchanged — no write-through.
+        assert (outside / "CLAUDE.md").read_text(encoding="utf-8") == outside_before
+        assert "PACT_MANAGED_START" not in (outside / "CLAUDE.md").read_text(encoding="utf-8")
+
+    def test_benign_dot_claude_allows_migration(self, tmp_path, monkeypatch):
+        from shared.claude_md_manager import migrate_to_managed_structure
+
+        project = tmp_path / "proj"
+        target = _mount_benign_dot_claude(project)
+        target.write_text(self._LEGACY, encoding="utf-8")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+
+        result = migrate_to_managed_structure()
+
+        assert result == "Migrated project CLAUDE.md to managed structure (#404)"
+        assert "PACT_MANAGED_START" in target.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Site 1 — check_pinned_staleness: F1 PARENT vector + multi-hop chain.
+# (The seed in test_staleness.py covers the LEAF vector; this covers the actual
+# F1 symlinked-PARENT `.claude` and a multi-hop escape, via the real wrapper.)
+# ---------------------------------------------------------------------------
+
+_STALE = (
+    "# Project Memory\n\n## Pinned Context\n\n"
+    "### Old Feature (PR #100, merged 2020-01-01)\n- detail\n\n"
+)
+
+
+class TestSite1StalenessParentAndMultiHop:
+    def test_f1_symlinked_parent_escape_refused(self, tmp_path):
+        from session_init import check_pinned_staleness
+
+        project = tmp_path / "proj"
+        outside = tmp_path / "outside"
+        project.mkdir()
+        outside.mkdir()
+        os.symlink(str(outside), str(project / ".claude"), target_is_directory=True)
+        managed = project / ".claude" / "CLAUDE.md"  # resolves into `outside`
+        managed.write_text(_STALE, encoding="utf-8")
+        before = (outside / "CLAUDE.md").read_text(encoding="utf-8")
+
+        from unittest.mock import patch
+        with patch("session_init._get_project_claude_md_path", return_value=managed), \
+             patch("staleness._get_project_claude_md_path", return_value=managed):
+            result = check_pinned_staleness()
+
+        # Lexical base = proj (parent.name=='.claude' -> parent.parent); target
+        # resolves into `outside` -> escapes -> opaque refuse, victim untouched.
+        assert result == "Pinned staleness skipped: path precondition not met."
+        assert (outside / "CLAUDE.md").read_text(encoding="utf-8") == before
+
+    def test_multi_hop_symlink_chain_escape_refused(self, tmp_path):
+        from session_init import check_pinned_staleness
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        # .claude -> hop1 -> hop2 -> outside  (resolve() follows the whole chain)
+        hop2 = tmp_path / "hop2"
+        os.symlink(str(outside), str(hop2), target_is_directory=True)
+        hop1 = tmp_path / "hop1"
+        os.symlink(str(hop2), str(hop1), target_is_directory=True)
+        os.symlink(str(hop1), str(project / ".claude"), target_is_directory=True)
+        managed = project / ".claude" / "CLAUDE.md"
+        managed.write_text(_STALE, encoding="utf-8")
+        before = (outside / "CLAUDE.md").read_text(encoding="utf-8")
+
+        from unittest.mock import patch
+        with patch("session_init._get_project_claude_md_path", return_value=managed), \
+             patch("staleness._get_project_claude_md_path", return_value=managed):
+            result = check_pinned_staleness()
+
+        assert result == "Pinned staleness skipped: path precondition not met."
+        assert (outside / "CLAUDE.md").read_text(encoding="utf-8") == before
+
+
+# ---------------------------------------------------------------------------
+# Sites 8-9 — display sync OVER-BLOCK CERT (the load-bearing anchor-identity
+# test). External worktree ALLOWS on its own --show-toplevel base; the SAME
+# write REFUSES when the anchor is swapped to the main-repo root (--git-common-
+# dir). Proves the anchor is the resolver's own base, not a re-derivation.
+# ---------------------------------------------------------------------------
+
+def _git(*args, cwd):
+    import subprocess
+    subprocess.run(["git", *args], cwd=str(cwd), check=True,
+                   capture_output=True, text=True)
+
+
+class TestSites89DisplayOverBlockAnchorIdentity:
+    def _external_worktree(self, tmp_path):
+        """A main repo plus an EXTERNAL worktree (NOT nested under main), each a
+        real git worktree. Returns (main, worktree)."""
+        main = tmp_path / "mainrepo"
+        main.mkdir()
+        _git("init", cwd=main)
+        _git("config", "user.email", "t@e.com", cwd=main)
+        _git("config", "user.name", "T", cwd=main)
+        (main / "README.md").write_text("x\n", encoding="utf-8")
+        _git("add", "README.md", cwd=main)
+        _git("commit", "-m", "init", cwd=main)
+        worktree = tmp_path / "external-wt"  # sibling of main, NOT under it
+        _git("worktree", "add", str(worktree), "-b", "feat", cwd=main)
+        (worktree / ".claude").mkdir()
+        (worktree / ".claude" / "CLAUDE.md").write_text(
+            "# WT\n\n## Working Memory\n<!-- Auto-managed by pact-memory skill. -->\n",
+            encoding="utf-8",
+        )
+        return main, worktree
+
+    def test_external_worktree_allows_on_own_base(self, tmp_path, monkeypatch):
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent
+                               / "skills" / "pact-memory"))
+        import scripts.working_memory as wm
+
+        main, worktree = self._external_worktree(tmp_path)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        prev = Path.cwd()
+        os.chdir(str(worktree))
+        try:
+            # Real resolver: --show-toplevel base = the worktree root -> the
+            # worktree target is contained -> ALLOWED (the over-block cert).
+            result = wm.sync_to_claude_md(
+                {"context": "external worktree entry"}, None, "id1"
+            )
+        finally:
+            os.chdir(str(prev))
+
+        assert result is True
+        wt_text = (worktree / ".claude" / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "external worktree entry" in wt_text
+
+    def test_anchor_swap_to_main_root_would_refuse(self, tmp_path, monkeypatch):
+        """MUTATION cert: swap the resolver's base from the worktree root to the
+        MAIN-repo root. The SAME contained write now escapes the wrong anchor and
+        is REFUSED. This is what proves the anchor is load-bearing rather than
+        vacuous — anchoring on --git-common-dir (main root) over-blocks an
+        external worktree's own legitimate write."""
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent
+                               / "skills" / "pact-memory"))
+        import scripts.working_memory as wm
+
+        main, worktree = self._external_worktree(tmp_path)
+        target = worktree / ".claude" / "CLAUDE.md"
+        before = target.read_text(encoding="utf-8")
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+
+        # Swap the base to the MAIN repo root (the wrong anchor). The worktree
+        # target is NOT under main -> commonpath != main -> ContainmentError.
+        def _wrong_base():
+            return (target, main)
+        monkeypatch.setattr(wm, "_resolve_display_claude_md_with_base", _wrong_base)
+
+        result = wm.sync_to_claude_md({"context": "should be refused"}, None, "id2")
+
+        # sync swallows the ContainmentError and returns False (write skipped);
+        # the worktree file is byte-unchanged.
+        assert result is False
+        assert target.read_text(encoding="utf-8") == before
+
+
+# ---------------------------------------------------------------------------
+# Sites 2-4 — update_session_info (anchor: CLAUDE_PROJECT_DIR).
+# ---------------------------------------------------------------------------
+
+class TestSites234UpdateSessionInfo:
+    def test_f1_symlinked_parent_escape_refused(self, tmp_path, monkeypatch):
+        from shared.session_resume import update_session_info
+
+        project = tmp_path / "proj"
+        outside = tmp_path / "outside"
+        _mount_symlinked_parent_escape(project, outside)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+
+        result = update_session_info("sid-123", "PACT-team")
+
+        # Refused: nothing written through the escaping link.
+        assert not (outside / "CLAUDE.md").exists(), "session write escaped the project"
+        assert result is None or "skipped" in result.lower()
+
+    def test_benign_allows_session_write(self, tmp_path, monkeypatch):
+        from shared.session_resume import update_session_info
+
+        project = tmp_path / "proj"
+        _mount_benign_dot_claude(project)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+
+        result = update_session_info("sid-123", "PACT-team")
+
+        target = project / ".claude" / "CLAUDE.md"
+        assert target.exists()
+        assert "SESSION_START" in target.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Site 5 — strip_orphan_kernel_block: GLOBAL config-dir anchor + R4 negative.
+# ---------------------------------------------------------------------------
+
+_ORPHAN = "# Global\n<!-- PACT_START: kernel -->\nstale kernel block\n<!-- PACT_END -->\nafter\n"
+
+
+class TestSite5StripOrphanGlobalAnchor:
+    def test_f1_escape_from_global_config_refused(self, tmp_path, monkeypatch):
+        from shared.claude_md_manager import strip_orphan_kernel_block
+
+        config = tmp_path / "cfg"
+        config.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        victim = outside / "victim.md"
+        victim.write_text(_ORPHAN, encoding="utf-8")  # orphan block => write-path reached
+        os.symlink(str(victim), str(config / "CLAUDE.md"))  # global CLAUDE.md escapes cfg
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config))
+        before = victim.read_text(encoding="utf-8")
+
+        strip_orphan_kernel_block()
+
+        # No write-through: the out-of-config victim keeps its orphan block. (This
+        # holds via os.replace's leaf-swap alone, so it is NOT guard-coupled.)
+        assert victim.read_text(encoding="utf-8") == before
+        # GUARD-COUPLED assertion: the containment guard REFUSES the escaping write
+        # BEFORE os.replace, so config/CLAUDE.md stays a symlink. Without the guard,
+        # os.replace would replace the leaf symlink with a real (stripped) file, so
+        # is_symlink() would flip to False -- this is what turns the test RED on a
+        # guard revert (leaf-swap alone would leave this GREEN).
+        assert (config / "CLAUDE.md").is_symlink(), (
+            "guard did not refuse: the escaping leaf symlink was replaced"
+        )
+
+    def test_benign_global_file_allows_strip(self, tmp_path, monkeypatch):
+        from shared.claude_md_manager import strip_orphan_kernel_block
+
+        config = tmp_path / "cfg"
+        config.mkdir()
+        (config / "CLAUDE.md").write_text(_ORPHAN, encoding="utf-8")
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config))
+
+        strip_orphan_kernel_block()
+
+        # Allowed: the orphan block was stripped from the in-config global file.
+        after = (config / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "PACT_START" not in after and "stale kernel block" not in after
+
+    def test_r4_a_project_root_anchor_would_overblock_the_global_file(self, tmp_path, monkeypatch):
+        """R4 NEGATIVE TEST: the strip site anchors on the GLOBAL config dir, NOT
+        a project root, and must stay that way. The global ~/.claude/CLAUDE.md is
+        NEVER under a project root, so a well-meaning 'unify onto CLAUDE_PROJECT_DIR'
+        refactor would over-block EVERY strip invocation. Demonstrated directly at
+        the _atomic_write_text level: the same global target is REFUSED on a
+        project-root anchor and ALLOWED on the correct global anchor."""
+        from shared.claude_md_manager import _atomic_write_text, ContainmentError
+        from shared.paths import get_claude_config_dir
+
+        config = tmp_path / "cfg"
+        config.mkdir()
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config))
+        target = get_claude_config_dir() / "CLAUDE.md"
+        target.write_text("orig\n", encoding="utf-8")
+
+        unrelated_project = tmp_path / "some_project"
+        unrelated_project.mkdir()
+
+        # WRONG anchor (a project root) -> the global file escapes -> REFUSED.
+        with pytest.raises(ContainmentError):
+            _atomic_write_text(target, "new\n", unrelated_project)
+        assert target.read_text(encoding="utf-8") == "orig\n"  # untouched
+
+        # CORRECT anchor (the global config dir) -> contained -> ALLOWED.
+        _atomic_write_text(target, "new\n", get_claude_config_dir())
+        assert target.read_text(encoding="utf-8") == "new\n"
+
+
+# ---------------------------------------------------------------------------
+# R6 — documented residual (security-engineer signed-off, OUT of #1247 scope).
+# ---------------------------------------------------------------------------
+
+class TestR6InProjectRedirectResidualDocumented:
+    """DOCUMENTED negative test for the R6 residual — do NOT 'fix' this back.
+
+    Containment ALLOWS an in-project leaf-symlink redirect (it is contained).
+    That is the DELIBERATE #1247 behavior change: the old leaf `is_symlink` ban
+    refused ALL symlinks, an over-block on benign in-project symlinks; containment
+    refuses only ESCAPES. It is SAFE because `os.replace` REPLACES the leaf entry
+    rather than writing THROUGH it, so a crafted in-project redirect cannot
+    overwrite its pointed-to file — it clobbers the attacker's own symlink.
+
+    The residual fd-relative TOCTOU (a symlink swapped between `resolve()` and the
+    write) is security-engineer-signed-off as BELOW the good-faith threat floor
+    and deferred to a FUTURE FD-relative-atomic-write follow-up (open+verify the
+    parent-dir fd, then O_NOFOLLOW + renameat). It is OUT OF #1247 SCOPE. Re-adding
+    an `is_symlink` ban to 'close' it would re-introduce the cardinal over-block
+    #1247 removed. This test pins the current, intended behavior so a future
+    reader does not regress it.
+    """
+
+    def test_in_project_redirect_allowed_and_os_replace_does_not_write_through(self, tmp_path):
+        from shared.claude_md_manager import _atomic_write_text
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        sibling = project / "sib.md"
+        sibling.write_text("SIBLING CONTENT\n", encoding="utf-8")
+        target = project / "CLAUDE.md"
+        os.symlink(str(sibling), str(target))  # in-project leaf redirect
+
+        # Contained (both in project) -> ALLOWED; no exception.
+        _atomic_write_text(target, "NEW MANAGED CONTENT\n", project)
+
+        # os.replace replaced the LINK, did not write THROUGH it:
+        assert sibling.read_text(encoding="utf-8") == "SIBLING CONTENT\n"  # victim untouched
+        assert not target.is_symlink()                                     # link -> real file
+        assert target.read_text(encoding="utf-8") == "NEW MANAGED CONTENT\n"
+
+
+# ---------------------------------------------------------------------------
+# Predicate discriminator — sibling-prefix mounted layout (commonpath, not
+# str.startswith). `/abc` is NOT within `/ab`, but startswith would allow it.
+# ---------------------------------------------------------------------------
+
+class TestSiblingPrefixMountedLayout:
+    def test_sibling_prefix_refused_commonpath_not_startswith(self, tmp_path):
+        from shared.claude_md_manager import _atomic_write_text, ContainmentError
+
+        anchor = tmp_path / "ab"
+        anchor.mkdir()
+        sibling = tmp_path / "abc"       # shares the STRING prefix "ab", not a path child
+        sibling.mkdir()
+        target = sibling / "CLAUDE.md"
+        target.write_text("orig\n", encoding="utf-8")
+
+        # commonpath([/ab, /abc/CLAUDE.md]) == /  != /ab  -> REFUSE.
+        # str(target).startswith(str(anchor)) would WRONGLY allow it.
+        with pytest.raises(ContainmentError):
+            _atomic_write_text(target, "new\n", anchor)
+        assert target.read_text(encoding="utf-8") == "orig\n"
+
+    def test_benign_prefix_symlink_on_base_allowed(self, tmp_path):
+        """A benign symlinked mount on the base (the /tmp->/private/tmp class)
+        canonicalizes identically on both sides -> contained -> ALLOWED. Proves
+        containment is resolved-vs-resolved (raw-vs-resolved would false-refuse)."""
+        from shared.claude_md_manager import _atomic_write_text
+
+        real_root = tmp_path / "real"
+        (real_root / ".claude").mkdir(parents=True)
+        target = real_root / ".claude" / "CLAUDE.md"
+        target.write_text("orig\n", encoding="utf-8")
+        # Anchor passed via a symlinked alias of the SAME dir.
+        alias_root = tmp_path / "alias"
+        os.symlink(str(real_root), str(alias_root), target_is_directory=True)
+
+        # target under real_root; anchor is the alias (resolves to real_root) ->
+        # both resolve equal -> contained -> ALLOWED.
+        _atomic_write_text(target, "new\n", alias_root)
+        assert target.read_text(encoding="utf-8") == "new\n"

--- a/pact-plugin/tests/test_containment_guard.py
+++ b/pact-plugin/tests/test_containment_guard.py
@@ -335,7 +335,24 @@ _ORPHAN = "# Global\n<!-- PACT_START: kernel -->\nstale kernel block\n<!-- PACT_
 
 
 class TestSite5StripOrphanGlobalAnchor:
-    def test_f1_escape_from_global_config_refused(self, tmp_path, monkeypatch):
+    def test_leaf_out_of_config_allowed_and_victim_untouched(self, tmp_path, monkeypatch):
+        """LEAF-out at the global-config anchor: ALLOWED, victim untouched.
+
+        WHY THIS SITE HAS NO PARENT-OUT TOPOLOGY, which is why the test looks
+        different from every other site's: the anchor here IS the target's
+        parent (the config dir holds CLAUDE.md directly), so no intermediate
+        component sits between anchor and leaf and there is nothing to point
+        outward. A leaf symlink is the only escape-shaped construction
+        available. This test was previously named for F1 and asserted a
+        refusal; the name described a topology it does not build, and the
+        refusal was the over-block #1247 exists to remove.
+
+        Containment is decided on the parent chain and never consults the leaf,
+        so this is contained and the write proceeds. It is SAFE because
+        os.replace is renameat(2): it binds the final component as a directory
+        ENTRY without following it, so the payload lands on the in-config entry
+        and the outside victim keeps its bytes.
+        """
         from shared.claude_md_manager import strip_orphan_kernel_block
 
         config = tmp_path / "cfg"
@@ -344,23 +361,25 @@ class TestSite5StripOrphanGlobalAnchor:
         outside.mkdir()
         victim = outside / "victim.md"
         victim.write_text(_ORPHAN, encoding="utf-8")  # orphan block => write-path reached
-        os.symlink(str(victim), str(config / "CLAUDE.md"))  # global CLAUDE.md escapes cfg
+        entry = config / "CLAUDE.md"
+        os.symlink(str(victim), str(entry))  # global CLAUDE.md leaf points outside cfg
         monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config))
         before = victim.read_text(encoding="utf-8")
 
         strip_orphan_kernel_block()
 
-        # No write-through: the out-of-config victim keeps its orphan block. (This
-        # holds via os.replace's leaf-swap alone, so it is NOT guard-coupled.)
+        # Boundary 1 -- no write-through: the out-of-config victim is byte-intact.
+        # This holds via renameat's leaf-swap and would ALSO hold under a refusal,
+        # so on its own it cannot distinguish ALLOW from REFUSE.
         assert victim.read_text(encoding="utf-8") == before
-        # GUARD-COUPLED assertion: the containment guard REFUSES the escaping write
-        # BEFORE os.replace, so config/CLAUDE.md stays a symlink. Without the guard,
-        # os.replace would replace the leaf symlink with a real (stripped) file, so
-        # is_symlink() would flip to False -- this is what turns the test RED on a
-        # guard revert (leaf-swap alone would leave this GREEN).
-        assert (config / "CLAUDE.md").is_symlink(), (
-            "guard did not refuse: the escaping leaf symlink was replaced"
+        # Boundary 2 -- the write HAPPENED, at the in-config entry: the symlink is
+        # replaced by a real, stripped file. This is the assertion that pins the
+        # ALLOW, and it is the one that flips if anyone makes the write follow the
+        # leaf or re-adds a leaf-symlink ban.
+        assert not entry.is_symlink(), (
+            "expected the in-config entry to be replaced by a real file"
         )
+        assert "PACT_START" not in entry.read_text(encoding="utf-8")
 
     def test_benign_global_file_allows_strip(self, tmp_path, monkeypatch):
         from shared.claude_md_manager import strip_orphan_kernel_block

--- a/pact-plugin/tests/test_containment_guard.py
+++ b/pact-plugin/tests/test_containment_guard.py
@@ -410,22 +410,43 @@ class TestSite5StripOrphanGlobalAnchor:
 # ---------------------------------------------------------------------------
 
 class TestR6InProjectRedirectResidualDocumented:
-    """DOCUMENTED negative test for the R6 residual — do NOT 'fix' this back.
+    """DOCUMENTED negative test for the R6 residual -- do NOT 'fix' this back.
 
-    Containment ALLOWS an in-project leaf-symlink redirect (it is contained).
-    That is the DELIBERATE #1247 behavior change: the old leaf `is_symlink` ban
-    refused ALL symlinks, an over-block on benign in-project symlinks; containment
-    refuses only ESCAPES. It is SAFE because `os.replace` REPLACES the leaf entry
-    rather than writing THROUGH it, so a crafted in-project redirect cannot
-    overwrite its pointed-to file — it clobbers the attacker's own symlink.
+    Containment ALLOWS a leaf-symlink redirect. The leaf is never consulted at
+    all: containment is decided entirely on the PARENT chain, because the parent
+    chain is the only part the kernel traverses on the way to the write. The old
+    leaf `is_symlink` ban refused ALL symlinks, an over-block on benign ones.
 
-    The residual fd-relative TOCTOU (a symlink swapped between `resolve()` and the
-    write) is security-engineer-signed-off as BELOW the good-faith threat floor
-    and deferred to a FUTURE FD-relative-atomic-write follow-up (open+verify the
-    parent-dir fd, then O_NOFOLLOW + renameat). It is OUT OF #1247 SCOPE. Re-adding
-    an `is_symlink` ban to 'close' it would re-introduce the cardinal over-block
-    #1247 removed. This test pins the current, intended behavior so a future
-    reader does not regress it.
+    It is SAFE because `os.replace` is renameat(2), which REPLACES the leaf entry
+    rather than writing THROUGH it: it unlinks whatever entry sits at the final
+    name and binds the temp file's inode there, never opening or following the
+    leaf. So a crafted redirect cannot overwrite its pointed-to file -- it
+    clobbers the attacker's own symlink.
+
+    THIS TEST IS A COUPLING TRIPWIRE, and that is its real job. The ALLOW above
+    is sound only while the write replaces the leaf ENTRY. Two rewrites would
+    silently turn it into a real escape with the predicate untouched: resolving
+    the target once and using it downstream (which makes check and act agree by
+    making the WRITE follow the leaf), or replacing temp-plus-rename with an
+    open/truncate on the target. MEASURED: with either rewrite spliced in, the
+    victim-untouched assertion below turns RED. Do NOT 'fix' a failure here by
+    making the guard refuse the topology -- that would re-introduce the cardinal
+    over-block #1247 removed. A failure here means the WRITE SHAPE changed.
+
+    SUPERSEDED PRESCRIPTION, recorded because it appeared in three places and its
+    available reading was harmful: earlier notes sketched the follow-up as
+    "open+verify the parent-dir fd, then O_NOFOLLOW + renameat". The pinned form
+    has since landed, and it does NOT use O_NOFOLLOW anywhere. O_NOFOLLOW on the
+    parent open would refuse any symlinked final component of the parent path,
+    including a benign in-project `.claude` -> `<project>/config/claude` that
+    both the old and the current code allow -- a NEW over-block on an axis that
+    is not containment. It would also add nothing: the ancestry test runs ON the
+    opened descriptor, so there is no check-then-open gap for it to close.
+
+    The fd-relative TOCTOU that was signed off as BELOW the good-faith threat
+    floor and deferred is now closed as a side effect, since the check and the
+    write share one pinned parent descriptor. That closure was a bonus of the
+    pinned form, never its justification.
     """
 
     def test_in_project_redirect_allowed_and_os_replace_does_not_write_through(self, tmp_path):

--- a/pact-plugin/tests/test_containment_guard.py
+++ b/pact-plugin/tests/test_containment_guard.py
@@ -3,10 +3,14 @@ containment guard.
 
 The guard is inlined at the top of the `_atomic_write_text` twin
 (hooks/shared/claude_md_manager.py + skills/pact-memory/scripts/working_memory.py):
-it refuses a write unless the RESOLVED target is contained within the RESOLVED
-`project_root` (os.path.commonpath, fail-CLOSED). Correctness hinges on ANCHOR
-IDENTITY — each of the 7 write callers passes its OWN pre-resolve base, never a
-re-derived root.
+it refuses a write unless the directory the write will BIND INTO is contained
+within `project_root`, decided by KERNEL OBJECT ANCESTRY on a pinned directory
+descriptor — no `Path.resolve()`, no `os.path.realpath`, no string comparison
+takes part (#1247). Correctness hinges on ANCHOR IDENTITY — each of the 7 write
+callers passes its OWN pre-resolve base, never a re-derived root.
+
+The per-obligation certification of that predicate lives in the sibling file
+test_containment_certification.py; this file is the cross-SITE sweep.
 
 The seed tests (test_staleness.py) cover site 1 (staleness) via a LEAF symlink.
 This file WIDENS to the actual F1 vector — a symlinked-PARENT `.claude` — driven
@@ -281,7 +285,8 @@ class TestSites89DisplayOverBlockAnchorIdentity:
         monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
 
         # Swap the base to the MAIN repo root (the wrong anchor). The worktree
-        # target is NOT under main -> commonpath != main -> ContainmentError.
+        # target's parent chain never walks up to main's inode -> the ancestry
+        # walk reaches the filesystem root without matching -> ContainmentError.
         def _wrong_base():
             return (target, main)
         monkeypatch.setattr(wm, "_resolve_display_claude_md_with_base", _wrong_base)
@@ -488,12 +493,22 @@ class TestR6InProjectRedirectResidualDocumented:
 
 
 # ---------------------------------------------------------------------------
-# Predicate discriminator — sibling-prefix mounted layout (commonpath, not
-# str.startswith). `/abc` is NOT within `/ab`, but startswith would allow it.
+# Predicate discriminator — sibling-prefix mounted layout. `/abc` is NOT within
+# `/ab`, and the refusal is now STRUCTURAL rather than a property of a chosen
+# string primitive.
 # ---------------------------------------------------------------------------
 
 class TestSiblingPrefixMountedLayout:
-    def test_sibling_prefix_refused_commonpath_not_startswith(self, tmp_path):
+    def test_sibling_prefix_refused_structurally(self, tmp_path):
+        """RATIONALE UPDATED FOR THE CORRECTED PREDICATE (#1247).
+
+        This case used to be explained by the choice of `os.path.commonpath`
+        over `str.startswith`. That primitive has left the write path
+        entirely, so the old rationale named a mechanism that no longer
+        exists. The refusal now has nothing to do with text: `/abc` simply
+        never walks up to `/ab`'s inode. The string-prefix trap the old
+        wording guarded against cannot even be expressed in this predicate.
+        """
         from shared.claude_md_manager import _atomic_write_text, ContainmentError
 
         anchor = tmp_path / "ab"
@@ -503,16 +518,20 @@ class TestSiblingPrefixMountedLayout:
         target = sibling / "CLAUDE.md"
         target.write_text("orig\n", encoding="utf-8")
 
-        # commonpath([/ab, /abc/CLAUDE.md]) == /  != /ab  -> REFUSE.
-        # str(target).startswith(str(anchor)) would WRONGLY allow it.
+        # The ancestry walk from /abc reaches the filesystem root without ever
+        # matching /ab's (st_dev, st_ino) -> REFUSE.
         with pytest.raises(ContainmentError):
             _atomic_write_text(target, "new\n", anchor)
         assert target.read_text(encoding="utf-8") == "orig\n"
 
     def test_benign_prefix_symlink_on_base_allowed(self, tmp_path):
-        """A benign symlinked mount on the base (the /tmp->/private/tmp class)
-        canonicalizes identically on both sides -> contained -> ALLOWED. Proves
-        containment is resolved-vs-resolved (raw-vs-resolved would false-refuse)."""
+        """A benign symlinked alias of the anchor (the /tmp->/private/tmp
+        class) -> contained -> ALLOWED.
+
+        `os.stat` on the alias FOLLOWS it, so the anchor key is the real
+        directory's (st_dev, st_ino) and the walk matches it. The alias and the
+        real directory are one kernel object, so there is no spelling for the
+        predicate to disagree about."""
         from shared.claude_md_manager import _atomic_write_text
 
         real_root = tmp_path / "real"

--- a/pact-plugin/tests/test_containment_guard.py
+++ b/pact-plugin/tests/test_containment_guard.py
@@ -471,6 +471,27 @@ class TestR6InProjectRedirectResidualDocumented:
     floor and deferred is now closed as a side effect, since the check and the
     write share one pinned parent descriptor. That closure was a bonus of the
     pinned form, never its justification.
+
+    THE LOCK KEYING ALSO DEPENDS ON THIS TEST, AND THAT IS NOT OBVIOUS FROM
+    THE LOCK CODE.
+    `file_lock` keys its sidecar on `target_file.parent.resolve()` plus the
+    LITERAL leaf name -- it deliberately does NOT follow the leaf. That is
+    only correct while the write REPLACES the leaf entry rather than writing
+    THROUGH it, which is the exact property this test pins.
+
+    Two names for one inode therefore no longer share a lock, and that was
+    retired ON PURPOSE: a rename-based write destroys the alias relationship
+    on the first commit, so the property protected a relationship that no
+    longer exists.
+
+    If the write ever became an open/truncate on the target, the two names
+    would share a destination again, the lost-update silhouette would become
+    real, and the lock keying would become WRONG -- SILENTLY, because the lock
+    would still look correct from the lock code. There is no path from
+    `file_lock` back to this test, so anyone weakening or deleting this
+    tripwire is also invalidating the lock keying and has no way to learn it
+    where they are working. That is why the dependency is stated here rather
+    than only in the design document.
     """
 
     def test_in_project_redirect_allowed_and_os_replace_does_not_write_through(self, tmp_path):

--- a/pact-plugin/tests/test_lock_identity_certification.py
+++ b/pact-plugin/tests/test_lock_identity_certification.py
@@ -1,0 +1,775 @@
+"""Certification of the lock-identity fix: the sidecar names what the write binds.
+
+WHAT IS UNDER CERTIFICATION. `file_lock` keys its sidecar on
+
+    target_file.parent.resolve() / f".{target_file.name}.lock"
+
+in both twins (`hooks/shared/claude_md_manager.py`,
+`skills/pact-memory/scripts/working_memory.py`). The PARENT is resolved so two
+SPELLINGS of one directory produce one sidecar; the LEAF is deliberately NOT
+resolved, because the write is `os.replace` — renameat(2) — which binds the
+final component as a directory ENTRY without following it.
+
+The superseded formula resolved the WHOLE target. Under a leaf symlink that
+named a different directory than the write, and — because the write REPLACES
+the leaf entry — the sidecar computed for one target path CHANGED ACROSS THE
+WRITE. A mutual-exclusion primitive whose identity is a function of the state
+it protects does not serialise that state. That is the defect closed here.
+
+CERTIFICATION IS BIDIRECTIONAL. It is not enough to show the lock and write
+agree; the property that IS real must be preserved:
+  (a) lock and write cannot name different directories under a leaf symlink,
+      and the sidecar is STABLE across the write;
+  (b) two SPELLINGS of one directory still take ONE lock.
+
+DELIBERATELY NOT CERTIFIED — two NAMES for one INODE (leaf symlink, hardlink)
+do NOT collapse onto one sidecar, and no longer should. That property was
+retired on purpose: a rename-based write destroys the alias relationship on
+the first commit, so it protected a relationship that no longer exists. The
+old formula never delivered it in general anyway — a hardlink pair is exactly
+two names for one inode and never collapsed, because `resolve()` canonicalises
+symlinks, not inodes. A test pinning it would certify a reversed decision.
+
+--------------------------------------------------------------------------
+TWO MEASURED FACTS ABOUT THE INSTRUMENTS, recorded because both invert the
+intuitive choice and a later reader will otherwise "harden" them backwards.
+--------------------------------------------------------------------------
+
+1. PROVENANCE MUST USE `__module__`, NOT `inspect.getsourcefile()`.
+   `file_lock` is `@contextmanager`-decorated, so what callers import is a
+   wrapper. It would be natural to assume `__module__` reports the decorator
+   and to reach for `getsourcefile()` as the more rigorous check. MEASURED,
+   and it is the reverse:
+
+     `__module__`            canonical 'shared.claude_md_manager'
+                             skill     'working_memory'          -> DISCRIMINATES
+     `inspect.getsourcefile` canonical contextlib.py
+                             skill     contextlib.py             -> DOES NOT
+
+   `functools.wraps` copies `__module__` through the decorator, so it is
+   accurate. `getsourcefile()` resolves the wrapper's code object to
+   contextlib.py for BOTH twins, while `_atomic_write_text` (undecorated)
+   resolves to its real module — so a same-module guard built on it ABORTS on
+   every LEGITIMATE pairing and "catches" the cross-module ones only by
+   accident of that mismatch. It fails in both directions. Do not swap it in.
+
+2. THE T-1 PARAGRAPH'S END ANCHOR IS NOT LOAD-BEARING. Including or excluding
+   the trailing blank line yields the same sha256, because the extraction is
+   rstripped. The START anchor and the token are what carry the extraction. A
+   reader who later "tightens" the end anchor should know it was never doing
+   work.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import os
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_TESTS = Path(__file__).resolve().parent
+for _p in (
+    _TESTS.parent / "hooks",
+    _TESTS.parent / "skills" / "pact-memory" / "scripts",
+):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+PLUGIN_ROOT = _TESTS.parent
+CANONICAL_REL = "hooks/shared/claude_md_manager.py"
+TWIN_REL = "skills/pact-memory/scripts/working_memory.py"
+
+# --- the T-1 CONTAINMENT precondition paragraph -----------------------------
+# Reference values independently reproduced from BOTH twins at the commit that
+# introduced the paragraph. The paragraph is a CONTRACT TERM: it states what
+# the containment guard does and does not promise, and the write path is
+# twinned, so the two copies must say the same thing.
+T1_ANCHOR = "PRECONDITION."
+T1_TOKEN = "IDENTITY, not POSITION"
+T1_SHA256_PREFIX = "68e7297b2129978f"
+T1_LENGTH = 672
+
+# --- module provenance ------------------------------------------------------
+CANONICAL_MODULE = "shared.claude_md_manager"
+TWIN_MODULE = "working_memory"
+
+
+def _load_twin(which: str):
+    if which == "canonical":
+        import shared.claude_md_manager as mod
+        return mod, CANONICAL_MODULE
+    import working_memory as mod
+    return mod, TWIN_MODULE
+
+
+_TWIN_PARAMS = ("canonical", "skill")
+
+
+@pytest.fixture(params=_TWIN_PARAMS)
+def twin(request):
+    """One twin, plus the module name its functions must report.
+
+    The twins are TWO INDEPENDENT LIVE DEFINITIONS -- `working_memory` defines
+    its own `file_lock` and its own `_atomic_write_text` and cannot import from
+    `claude_md_manager` at all (separate package). So a CROSS-MODULE pairing is
+    silently constructible: take `file_lock` from one twin and
+    `_atomic_write_text` from the other and you measure a combination
+    production never runs.
+    """
+    mod, expected = _load_twin(request.param)
+    return mod, expected
+
+
+def assert_same_module(mod, expected_module: str) -> None:
+    """L9 -- abort unless BOTH primitives come from the expected single module.
+
+    ABORTS rather than warns, deliberately: a warning scrolls past in a
+    12,000-test run and the green summary is what gets reported.
+
+    Note what this bounds. The drift gates prove the two copies MATCH; this
+    proves which one was MEASURED. Those are different claims, and only the
+    second is at risk from a harness that imports across the twins.
+    """
+    fl_mod = mod.file_lock.__module__
+    aw_mod = mod._atomic_write_text.__module__
+    assert fl_mod == expected_module, (
+        f"file_lock came from {fl_mod!r}, expected {expected_module!r} -- "
+        f"this test is measuring a different twin than it names"
+    )
+    assert aw_mod == expected_module, (
+        f"_atomic_write_text came from {aw_mod!r}, expected {expected_module!r}"
+    )
+    assert fl_mod == aw_mod, (
+        f"CROSS-MODULE PAIRING: file_lock from {fl_mod!r} but "
+        f"_atomic_write_text from {aw_mod!r} -- production never runs this "
+        f"combination"
+    )
+
+
+def _extract_t1_paragraph(source: str) -> str:
+    """Return the T-1 precondition paragraph, or "" if the anchor is absent.
+
+    Anchored on the line beginning `PRECONDITION.` and terminated at the first
+    blank line. Returns "" rather than raising, so the CALLER's non-emptiness
+    assertion is what fails -- an extractor that raises would give a red test
+    for a reason that reads like a broken test rather than a missing contract
+    term.
+    """
+    lines = source.splitlines(keepends=True)
+    starts = [i for i, ln in enumerate(lines) if ln.strip().startswith(T1_ANCHOR)]
+    if len(starts) != 1:
+        return ""
+    start = starts[0]
+    end = start
+    while end < len(lines) and lines[end].strip():
+        end += 1
+    return "".join(lines[start:end]).rstrip("\n")
+
+
+def _read(rel: str) -> str:
+    return (PLUGIN_ROOT / rel).read_text(encoding="utf-8")
+
+
+# ===========================================================================
+# L9 -- the provenance guard itself, proven able to fail
+# ===========================================================================
+
+class TestProvenanceGuardIsNotVacuous:
+    """The L9 guard exists because a harness already made the cross-module
+    mistake. A guard for that failure which cannot itself fail would be worse
+    than no guard, because it would retire the concern."""
+
+    def test_module_attribute_discriminates_the_twins(self):
+        """The mechanism works. Recorded as a test rather than a comment so
+        that a Python change making `__module__` non-discriminating (e.g. a
+        decorator that stops using functools.wraps) fails HERE, loudly, rather
+        than silently turning every provenance assertion into a tautology."""
+        canonical, _ = _load_twin("canonical")
+        skill, _ = _load_twin("skill")
+        assert canonical.file_lock.__module__ == CANONICAL_MODULE
+        assert skill.file_lock.__module__ == TWIN_MODULE
+        assert canonical.file_lock.__module__ != skill.file_lock.__module__
+        assert (
+            canonical._atomic_write_text.__module__
+            != skill._atomic_write_text.__module__
+        )
+
+    def test_guard_aborts_on_a_cross_module_pairing(self):
+        """NEGATIVE CONTROL. Build the pairing production never runs and prove
+        the guard rejects it. Without this, `assert_same_module` could be
+        satisfied by any two functions from one import and would never fail."""
+        canonical, _ = _load_twin("canonical")
+        skill, _ = _load_twin("skill")
+
+        class _Crossed:
+            file_lock = staticmethod(canonical.file_lock)
+            _atomic_write_text = staticmethod(skill._atomic_write_text)
+
+        with pytest.raises(AssertionError):
+            assert_same_module(_Crossed, CANONICAL_MODULE)
+
+    def test_getsourcefile_is_not_a_usable_fallback(self):
+        """Pins the measured fact in fact 1 of the module docstring, so the
+        'more rigorous' swap fails instead of silently inverting the guard.
+
+        `file_lock` is @contextmanager-wrapped, so its source file resolves to
+        contextlib for BOTH twins while `_atomic_write_text` resolves to the
+        real module. Any same-module check built on getsourcefile therefore
+        rejects LEGITIMATE pairings.
+        """
+        canonical, _ = _load_twin("canonical")
+        assert inspect.getsourcefile(canonical.file_lock).endswith("contextlib.py")
+        assert inspect.getsourcefile(canonical._atomic_write_text).endswith(
+            "claude_md_manager.py"
+        )
+        # The two disagree, which is why the naive same-file guard would abort
+        # on a pairing that is in fact correct.
+        assert inspect.getsourcefile(canonical.file_lock) != inspect.getsourcefile(
+            canonical._atomic_write_text
+        )
+
+    def test_assert_same_module_accepts_each_real_twin(self, twin):
+        """Positive control paired with the abort case above: the guard admits
+        exactly the two pairings production actually runs."""
+        mod, expected = twin
+        assert_same_module(mod, expected)
+
+
+# ===========================================================================
+# The T-1 twin-parity gate -- the only enforcement that will exist
+# ===========================================================================
+
+class TestT1PreconditionParity:
+    """The nine-line CONTAINMENT precondition must be byte-identical in both
+    twins.
+
+    WHY THIS GATE EXISTS. Both twin drift gates STRIP docstrings --
+    `_extract_body` describes itself as "docstring-tolerant, logic-pinning" --
+    so nothing mechanical catches divergence between the two copies of this
+    paragraph. Before this gate the only check that had ever run was a one-off
+    manual byte-compare. This replaces a person with a mechanism.
+
+    NARROW BY DESIGN: this paragraph's parity ONLY, never full docstring
+    equality. The existing gates' tolerance is deliberate -- the twins'
+    docstrings legitimately differ, each pointing at the other -- and widening
+    it as a side-effect of this gate would be a regression dressed as rigour.
+
+    THE VACUITY HAZARD THIS CLASS IS BUILT AGAINST. An extractor anchored on
+    something that later moves returns EMPTY from BOTH copies, and `"" == ""`
+    passes green while measuring nothing -- which would leave the contract term
+    exactly as unprotected as it was before, while LOOKING covered. That
+    converts a known gap into an unknown one, which is worse than no gate. So
+    emptiness, content, length, digest and uniqueness are all asserted, and the
+    comparison is proven able to fail.
+    """
+
+    def test_paragraph_extracts_non_empty_from_both_twins(self):
+        for rel in (CANONICAL_REL, TWIN_REL):
+            para = _extract_t1_paragraph(_read(rel))
+            assert para, f"T-1 paragraph extraction returned EMPTY from {rel}"
+
+    def test_extraction_contains_the_distinctive_token(self):
+        """Non-emptiness alone is satisfiable by the wrong span. The token must
+        be in the EXTRACTION, not merely somewhere in the file."""
+        for rel in (CANONICAL_REL, TWIN_REL):
+            para = _extract_t1_paragraph(_read(rel))
+            assert T1_TOKEN in para, (
+                f"extraction from {rel} does not contain {T1_TOKEN!r} -- the "
+                f"anchor selected the wrong span"
+            )
+
+    def test_anchor_and_token_are_unique_per_file(self):
+        """Closes the NON-EMPTY FALSE POSITIVE.
+
+        Non-empty and token-present are BOTH satisfiable by an extractor that
+        selected the wrong span, if the anchor ever duplicates. A false
+        positive terminates the search before a false negative can fire and
+        hands you something that feels like success. Uniqueness is what closes
+        it -- measured 1 and 1 at the time this gate was written, asserted
+        rather than assumed to stay so.
+        """
+        for rel in (CANONICAL_REL, TWIN_REL):
+            src = _read(rel)
+            anchors = [
+                ln for ln in src.splitlines() if ln.strip().startswith(T1_ANCHOR)
+            ]
+            assert len(anchors) == 1, (
+                f"{rel} has {len(anchors)} {T1_ANCHOR!r} anchors; the extractor "
+                f"can no longer identify the paragraph unambiguously"
+            )
+            assert src.count(T1_TOKEN) == 1, (
+                f"{rel} has {src.count(T1_TOKEN)} occurrences of the token; it "
+                f"is no longer distinctive enough to validate the extraction"
+            )
+
+    def test_paragraph_matches_the_reference_digest_and_length(self):
+        """Pins the CONTENT, not just parity. Two copies could match each other
+        while both having drifted from the accepted wording."""
+        for rel in (CANONICAL_REL, TWIN_REL):
+            para = _extract_t1_paragraph(_read(rel))
+            digest = hashlib.sha256(para.encode("utf-8")).hexdigest()
+            assert len(para) == T1_LENGTH, f"{rel}: length {len(para)}"
+            assert digest.startswith(T1_SHA256_PREFIX), f"{rel}: sha256 {digest[:16]}"
+
+    def test_paragraph_is_byte_identical_across_the_twins(self):
+        canonical = _extract_t1_paragraph(_read(CANONICAL_REL))
+        twin = _extract_t1_paragraph(_read(TWIN_REL))
+        assert canonical and twin, "guarded by the non-empty test above"
+        assert canonical == twin, (
+            "T-1 CONTAINMENT precondition has DIVERGED between the twins. It is "
+            "a contract term on a twinned write path; both copies must state "
+            "the same promise. Update both in the SAME commit."
+        )
+
+    def test_comparison_reddens_when_one_copy_is_mutated(self):
+        """NON-VACUITY, by mutation rather than by argument.
+
+        Proves the equality assertion above can actually fail. Mutation is
+        IN-MEMORY -- the file on disk is never touched -- so this cannot leave
+        the tree dirty if it fails midway.
+        """
+        canonical = _extract_t1_paragraph(_read(CANONICAL_REL))
+        mutated = canonical.replace(T1_TOKEN, "POSITION, not IDENTITY", 1)
+        assert mutated != canonical, "the mutation did not change anything"
+        twin = _extract_t1_paragraph(_read(TWIN_REL))
+        assert mutated != twin, (
+            "a mutated paragraph still compares equal to the twin -- the "
+            "equality assertion cannot detect divergence"
+        )
+
+    def test_extractor_returns_empty_when_the_anchor_moves(self):
+        """The specific vacuity mode, proven detectable.
+
+        If the anchor is reworded the extractor returns "" -- and the
+        non-emptiness test above is what turns that into a RED. This asserts
+        the extractor really does collapse to "" rather than silently returning
+        a neighbouring paragraph, which would be the non-empty false positive.
+        """
+        src = _read(CANONICAL_REL)
+        without_anchor = src.replace(T1_ANCHOR, "REWORDED.", 1)
+        assert _extract_t1_paragraph(without_anchor) == "", (
+            "extractor returned a non-empty span after the anchor was removed "
+            "-- it is selecting something other than the intended paragraph"
+        )
+
+
+# ===========================================================================
+# L7 -- the existing drift gates must pass unmodified
+# ===========================================================================
+
+class TestExistingDriftGatesUnmodified:
+    """L7 proves the copies match. It does NOT prove either copy was measured
+    -- that is L9's job, and conflating them is how a suite certifies a
+    function it never called."""
+
+    @pytest.mark.parametrize(
+        "gate",
+        [
+            "TestFileLockTwinCopyDrift",
+            "test_lock_timeout_constants_match",
+            "TestAtomicWriteTwinCopyDrift",
+        ],
+    )
+    def test_named_drift_gate_still_exists_in_test_staleness(self, gate):
+        """Pins that the three gates the design relies on are still present and
+        named as the design names them. If one is renamed or removed, the
+        parity argument this suite leans on has quietly lost a leg."""
+        src = (_TESTS / "test_staleness.py").read_text(encoding="utf-8")
+        assert re.search(rf"\b{re.escape(gate)}\b", src), (
+            f"{gate} is no longer present in test_staleness.py -- the "
+            f"twin-parity argument depends on it"
+        )
+
+
+# ===========================================================================
+# Behavioural core -- L1/L2/L3/L4/L8
+#
+# DERIVATION, and it is named here so a reader can tell it from the scratch
+# harness used during the fix: the sidecar is taken from the path PRODUCTION
+# ACTUALLY OPENS, never recomputed in the test. Recomputation is the trap --
+# a test that re-implements the formula compares its own arithmetic to itself
+# and agrees on every topology regardless of what production does.
+#
+# SELECTION KEYS ON WHICH CALL, NEVER ON PATH SHAPE. Filtering for `.lock` or
+# a leading dot would reinstate the very naming assumption this exercise
+# removes, so `file_lock`'s single open is taken positionally and the count is
+# asserted rather than searched.
+#
+# THE PATCH WINDOW IS GLOBAL AND THEREFORE NARROW. `import os` binds one
+# module object process-wide -- there is no per-module `os` to instrument, so
+# routing the patch "through" a twin is not possible and not required. What
+# selects the twin is WHICH `file_lock` is invoked inside the window; the L9
+# provenance assert is what attributes the observation. Patch, call, restore
+# in a `finally`, so unrelated opens cannot land in the record.
+# ===========================================================================
+
+class _OpenRecorder:
+    """Records every `os.open` in a narrow window, with `fstat` AT OPEN TIME.
+
+    fstat must happen while the fd is open -- `_atomic_write_text` closes its
+    descriptors before returning, so a later stat would fail or, worse,
+    silently describe a different object.
+    """
+
+    def __init__(self):
+        self.calls = []
+
+    def __enter__(self):
+        import os as _os
+        self._os = _os
+        self._real = _os.open
+
+        def spy(path, flags, mode=0o777, *, dir_fd=None, **kw):
+            if dir_fd is None:
+                fd = self._real(path, flags, mode, **kw)
+            else:
+                fd = self._real(path, flags, mode, dir_fd=dir_fd, **kw)
+            try:
+                st = _os.fstat(fd)
+                ident = (st.st_dev, st.st_ino)
+            except OSError:  # pragma: no cover - defensive
+                ident = None
+            self.calls.append({
+                "path": str(path),
+                "is_dir_open": bool(flags & _os.O_DIRECTORY),
+                "top_level": dir_fd is None,
+                "ident": ident,
+            })
+            return fd
+
+        _os.open = spy
+        return self
+
+    def __exit__(self, *exc):
+        self._os.open = self._real
+        return False
+
+
+def derive_sidecar_from_production(mod, target):
+    """Return the sidecar path PRODUCTION opened. Never recomputed.
+
+    Asserts exactly one open and RAISES otherwise -- no fallback and no
+    guessing which open is the sidecar. If `file_lock` ever opens more than
+    one file, this must go red rather than silently pick.
+    """
+    rec = _OpenRecorder()
+    with rec:
+        with mod.file_lock(target):
+            pass
+    opens = rec.calls
+    assert len(opens) == 1, (
+        f"file_lock performed {len(opens)} os.open calls, expected exactly 1; "
+        f"the single-open premise this derivation rests on has changed: "
+        f"{[o['path'] for o in opens]}"
+    )
+    return Path(opens[0]["path"])
+
+
+def derive_write_parent_ident(mod, target, content, root):
+    """Return (st_dev, st_ino) of the directory the WRITE binds into.
+
+    STRUCTURAL discriminator, deliberately not positional: the parent open is
+    the unique call that is both O_DIRECTORY and top-level (`dir_fd is None`).
+    The ancestry walk's opens all pass `dir_fd`, and the temp-file open is not
+    O_DIRECTORY. Selecting "the first O_DIRECTORY open" would also work today
+    but depends on call ORDER; this depends on call SHAPE and so survives a
+    reordering of the walk.
+
+    Returns None when the parent could not be opened at all (dangling parent),
+    which is a real outcome and must not be faked.
+    """
+    rec = _OpenRecorder()
+    with rec:
+        try:
+            mod._atomic_write_text(target, content, root)
+        except Exception:
+            pass  # refusal/failure is a legitimate outcome for some topologies
+    parents = [c for c in rec.calls if c["is_dir_open"] and c["top_level"]]
+    if not parents:
+        return None
+    assert len(parents) == 1, (
+        f"expected exactly one top-level O_DIRECTORY open (the write's "
+        f"parent); found {len(parents)}: {[p['path'] for p in parents]}"
+    )
+    return parents[0]["ident"]
+
+
+def _dir_ident(path: Path):
+    import os as _os
+    st = _os.stat(str(path))
+    return (st.st_dev, st.st_ino)
+
+
+def _dirs(root: Path):
+    return {p for p in root.rglob("*") if p.is_dir()}
+
+
+def _topology(kind, root: Path):
+    """Build one of the six named topologies. Returns (project, target)."""
+    import os as _os
+    proj = root / "proj"
+    outside = root / "outside"
+    proj.mkdir()
+    if kind == "plain":
+        (proj / ".claude").mkdir()
+        return proj, proj / ".claude" / "CLAUDE.md"
+    if kind == "leaf-out-existing":
+        outside.mkdir()
+        (outside / "victim.md").write_text("VICTIM\n", encoding="utf-8")
+        (proj / ".claude").mkdir()
+        tgt = proj / ".claude" / "CLAUDE.md"
+        _os.symlink(str(outside / "victim.md"), str(tgt))
+        return proj, tgt
+    if kind == "leaf-out-dangling":
+        (proj / ".claude").mkdir()
+        tgt = proj / ".claude" / "CLAUDE.md"
+        _os.symlink(str(root / "gone" / "deep" / "victim.md"), str(tgt))
+        return proj, tgt
+    if kind == "parent-out-existing":
+        outside.mkdir()
+        _os.symlink(str(outside), str(proj / ".claude"), target_is_directory=True)
+        return proj, proj / ".claude" / "CLAUDE.md"
+    if kind == "parent-out-dangling":
+        _os.symlink(str(root / "nodir"), str(proj / ".claude"),
+                    target_is_directory=True)
+        return proj, proj / ".claude" / "CLAUDE.md"
+    if kind == "two-leg":
+        outside.mkdir()
+        (proj / "real.md").write_text("IN-PROJECT\n", encoding="utf-8")
+        _os.symlink(str(outside), str(proj / ".claude"), target_is_directory=True)
+        _os.symlink(str(proj / "real.md"), str(outside / "CLAUDE.md"))
+        return proj, proj / ".claude" / "CLAUDE.md"
+    raise AssertionError(f"unknown topology {kind}")
+
+
+
+def assert_topology_constructed(kind, proj: Path, target: Path) -> None:
+    """FIXTURE PRECONDITION -- fail if the defective topology was not built.
+
+    THIS IS A DIFFERENT GUARD FROM A CODE MUTATION, and a suite can pass one
+    while being wide open on the other:
+
+        mutate the CODE     -> does the assertion catch a broken fix?
+                               -> REGRESSION cover
+        degrade the FIXTURE -> does the assertion catch a test that has
+                               stopped testing? -> NON-VACUITY cover
+
+    The exposure here is specific and permanent. If a setup silently stops
+    building its symlink, the topology becomes benign and "the sidecar does
+    not flip across the write" is TRUE FOR THE WRONG REASON -- forever, with
+    no code change to blame and nothing ever failing to prompt an
+    investigation. MEASURED before this guard existed: the stability test
+    passed on a degenerate plain-file fixture, having never read the topology
+    at all.
+
+    The measurement lane got this property by ACCIDENT -- it compared against
+    an unfixed base tree, which is a fixture guaranteed to still exhibit the
+    defect, so a degenerate setup showed up as the base going quiet. A
+    shipping suite has no second tree, so it has to buy the property
+    deliberately. This is that purchase.
+    """
+    claude_dir = proj / ".claude"
+    if kind == "plain":
+        assert not claude_dir.is_symlink(), "plain: .claude should be a real dir"
+        assert not target.is_symlink(), "plain: leaf should be a real file path"
+        return
+    if kind == "leaf-out-existing":
+        assert target.is_symlink(), "leaf-out-existing: leaf is NOT a symlink"
+        dest = Path(os.readlink(str(target)))
+        assert dest.exists(), "leaf-out-existing: destination should exist"
+        assert proj.resolve() not in dest.resolve().parents, (
+            "leaf-out-existing: leaf does not point OUTSIDE the project"
+        )
+        return
+    if kind == "leaf-out-dangling":
+        assert target.is_symlink(), "leaf-out-dangling: leaf is NOT a symlink"
+        assert not target.exists(), "leaf-out-dangling: destination should be absent"
+        return
+    if kind == "parent-out-existing":
+        assert claude_dir.is_symlink(), "parent-out-existing: .claude is NOT a symlink"
+        assert claude_dir.exists(), "parent-out-existing: destination should exist"
+        return
+    if kind == "parent-out-dangling":
+        assert claude_dir.is_symlink(), "parent-out-dangling: .claude is NOT a symlink"
+        assert not claude_dir.exists(), "parent-out-dangling: should be dangling"
+        return
+    if kind == "two-leg":
+        assert claude_dir.is_symlink(), "two-leg: .claude (leg 1) is NOT a symlink"
+        outside_entry = Path(os.readlink(str(claude_dir))) / "CLAUDE.md"
+        assert outside_entry.is_symlink(), "two-leg: leg 2 is NOT a symlink"
+        assert outside_entry.resolve() == (proj / "real.md").resolve(), (
+            "two-leg: leg 2 does not point back INTO the project"
+        )
+        return
+    raise AssertionError(f"unknown topology {kind}")
+
+
+SIX_TOPOLOGIES = [
+    "plain", "leaf-out-existing", "leaf-out-dangling",
+    "parent-out-existing", "parent-out-dangling", "two-leg",
+]
+
+
+class TestSidecarAgreesWithTheWrite:
+    """L1/L2 -- the sidecar names the directory the write binds into."""
+
+    @pytest.mark.parametrize("kind", SIX_TOPOLOGIES)
+    def test_sidecar_directory_is_the_directory_the_write_binds(
+        self, tmp_path, twin, kind
+    ):
+        """L1. Compared by (st_dev, st_ino), NEVER by string equality -- string
+        equality would also hide a userspace-vs-kernel resolution disagreement,
+        which is the class of defect this whole arc is about."""
+        mod, expected_module = twin
+        assert_same_module(mod, expected_module)
+
+        proj, target = _topology(kind, tmp_path)
+        assert_topology_constructed(kind, proj, target)
+        sidecar = derive_sidecar_from_production(mod, target)
+        write_ident = derive_write_parent_ident(mod, target, "PAYLOAD\n", proj)
+
+        if write_ident is None:
+            # Dangling parent: the write cannot open a parent at all, so there
+            # is no identity to agree with. Assert that rather than fabricate
+            # agreement -- and assert the sidecar's directory is likewise
+            # absent, which is the honest form of "they agree".
+            assert kind == "parent-out-dangling", (
+                f"{kind}: the write established no parent, which was only "
+                f"expected on the dangling-parent row"
+            )
+            return
+        assert _dir_ident(sidecar.parent) == write_ident, (
+            f"{kind}: sidecar directory {sidecar.parent} does not name the "
+            f"same kernel object as the directory the write binds into"
+        )
+
+    def test_sidecar_is_stable_across_the_write(self, tmp_path, twin):
+        """L2. Under the superseded formula this flipped across the write,
+        because the sidecar was a function of the leaf and the write replaces
+        the leaf entry."""
+        mod, expected_module = twin
+        assert_same_module(mod, expected_module)
+
+        proj, target = _topology("leaf-out-existing", tmp_path)
+        assert_topology_constructed("leaf-out-existing", proj, target)
+        before = derive_sidecar_from_production(mod, target)
+        mod._atomic_write_text(target, "PAYLOAD\n", proj)
+        # The write must have COMPLETED -- otherwise "unchanged" is trivially
+        # true and this test measures nothing (the sidecar cannot move if
+        # nothing happened).
+        assert not target.is_symlink(), "write did not complete: leaf still a symlink"
+        assert target.read_text(encoding="utf-8") == "PAYLOAD\n"
+        after = derive_sidecar_from_production(mod, target)
+        assert before == after, (
+            f"sidecar MOVED across the write: {before} -> {after}. Lock "
+            f"identity is a function of the state it protects."
+        )
+
+    def test_two_spellings_of_one_directory_take_one_lock(self, tmp_path, twin):
+        """The property that IS real, and must be preserved (direction b)."""
+        import os as _os
+        mod, expected_module = twin
+        assert_same_module(mod, expected_module)
+
+        real = tmp_path / "real"
+        (real / ".claude").mkdir(parents=True)
+        alias = tmp_path / "alias"
+        _os.symlink(str(real), str(alias), target_is_directory=True)
+
+        via_real = derive_sidecar_from_production(mod, real / ".claude" / "CLAUDE.md")
+        via_alias = derive_sidecar_from_production(mod, alias / ".claude" / "CLAUDE.md")
+        assert via_real == via_alias, (
+            "two SPELLINGS of one directory produced different sidecars"
+        )
+
+    def test_two_names_for_one_inode_do_NOT_collapse(self, tmp_path, twin):
+        """RETIRED PROPERTY, pinned as retired rather than left ambiguous.
+
+        A hardlink pair is two names for one inode. They deliberately do NOT
+        share a sidecar: a rename-based write destroys the alias relationship
+        on the first commit, so collapsing them would protect a relationship
+        that no longer exists. The superseded formula did not deliver this
+        either -- resolve() canonicalises symlinks, not inodes.
+
+        Do NOT "fix" this into an equality assertion. Doing so would re-certify
+        a decision that was reversed on purpose.
+        """
+        import os as _os
+        mod, expected_module = twin
+        assert_same_module(mod, expected_module)
+
+        d = tmp_path / "proj" / ".claude"
+        d.mkdir(parents=True)
+        a = d / "CLAUDE.md"
+        a.write_text("x\n", encoding="utf-8")
+        b = d / "ALIAS.md"
+        _os.link(str(a), str(b))
+        assert a.stat().st_ino == b.stat().st_ino, "fixture is not a hardlink pair"
+
+        assert derive_sidecar_from_production(mod, a) != \
+            derive_sidecar_from_production(mod, b)
+
+
+class TestDirectoryCreationCeiling:
+    """L3/L4 -- the DoS-relevant axis. Every 'creates nothing' assertion is
+    paired with a positive control in the SAME harness, because an empty
+    created-set is equally produced by a harness that never ran."""
+
+    def test_positive_control_dangling_parent_DOES_create_directories(
+        self, tmp_path, twin
+    ):
+        """The control. If this does not create directories, the snapshot
+        machinery is not observing creation and every zero below is worthless.
+        This row creates dirs under BOTH schemes -- it is untouched by the fix
+        and belongs to a separately-tracked residual."""
+        mod, expected_module = twin
+        assert_same_module(mod, expected_module)
+        proj, target = _topology("parent-out-dangling", tmp_path)
+        assert_topology_constructed("parent-out-dangling", proj, target)
+        before = _dirs(tmp_path)
+        try:
+            with mod.file_lock(target):
+                pass
+        except OSError:
+            pass
+        assert _dirs(tmp_path) - before, (
+            "the dangling-PARENT control created NO directories -- the "
+            "snapshot cannot observe creation, so the zero-assertions below "
+            "would prove nothing"
+        )
+
+    def test_dangling_leaf_creates_zero_directories(self, tmp_path, twin):
+        """L3 -- the directory-creation DoS vector the fix CLOSES. Under the
+        superseded formula this created the whole dangling chain as real
+        directories at an attacker-chosen path."""
+        mod, expected_module = twin
+        assert_same_module(mod, expected_module)
+        proj, target = _topology("leaf-out-dangling", tmp_path)
+        assert_topology_constructed("leaf-out-dangling", proj, target)
+        before = _dirs(tmp_path)
+        with mod.file_lock(target):
+            pass
+        assert _dirs(tmp_path) - before == set(), (
+            f"dangling-leaf topology created directories: "
+            f"{_dirs(tmp_path) - before}"
+        )
+
+    def test_two_leg_sidecar_is_byte_zero_and_creates_no_directory(
+        self, tmp_path, twin
+    ):
+        """L4 -- pins the ACCEPTED residual at its measured size, so a future
+        change that widens it fails here."""
+        mod, expected_module = twin
+        assert_same_module(mod, expected_module)
+        proj, target = _topology("two-leg", tmp_path)
+        assert_topology_constructed("two-leg", proj, target)
+        before = _dirs(tmp_path)
+        sidecar = derive_sidecar_from_production(mod, target)
+        assert _dirs(tmp_path) - before == set(), "two-leg created a directory"
+        assert sidecar.stat().st_size == 0, (
+            f"two-leg sidecar is {sidecar.stat().st_size} bytes, expected 0"
+        )

--- a/pact-plugin/tests/test_lock_identity_certification.py
+++ b/pact-plugin/tests/test_lock_identity_certification.py
@@ -62,6 +62,7 @@ intuitive choice and a later reader will otherwise "harden" them backwards.
 
 from __future__ import annotations
 
+import ast
 import hashlib
 import inspect
 import os
@@ -168,6 +169,22 @@ def _extract_t1_paragraph(source: str) -> str:
     while end < len(lines) and lines[end].strip():
         end += 1
     return "".join(lines[start:end]).rstrip("\n")
+
+
+def _atomic_write_docstring(rel: str) -> str:
+    """Return `_atomic_write_text`'s docstring, via AST.
+
+    WHY AST AND NOT A LINE SCAN. This region is the scope for the token
+    assertion below, and a line-scan region would itself be an ANCHORED
+    EXTRACTION -- i.e. a guard whose own failure mode is the one it exists to
+    guard against. `ast` gets the docstring from the parser, so the region
+    cannot drift out from under the assertion the way an anchor can.
+    """
+    tree = ast.parse(_read(rel))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_atomic_write_text":
+            return ast.get_docstring(node, clean=False) or ""
+    return ""
 
 
 def _read(rel: str) -> str:
@@ -291,6 +308,22 @@ class TestT1PreconditionParity:
         hands you something that feels like success. Uniqueness is what closes
         it -- measured 1 and 1 at the time this gate was written, asserted
         rather than assumed to stay so.
+
+        THE TWO ASSERTIONS HAVE DIFFERENT SCOPES ON PURPOSE. The TOKEN count is
+        scoped to `_atomic_write_text`'s docstring; the ANCHOR count is
+        WHOLE-FILE. That is not an oversight and must not be "tidied" into
+        symmetry.
+
+        The anchor assertion mirrors an invariant the EXTRACTOR genuinely has:
+        `_extract_t1_paragraph` searches the WHOLE FILE and returns "" unless it
+        finds exactly one anchor. An assertion mirroring an extractor invariant
+        must carry the EXTRACTOR's scope, not the region's -- scope it to the
+        docstring while the extractor stays whole-file and you get a silent
+        disagreement, where a second anchor elsewhere makes the extractor return
+        "" (reddening the non-empty test) while this assertion reports fine.
+
+        COUPLING, because it is invisible from either side alone: IF ANYONE EVER
+        SCOPES THE EXTRACTOR'S SEARCH, THE ANCHOR ASSERTION MUST MOVE WITH IT.
         """
         for rel in (CANONICAL_REL, TWIN_REL):
             src = _read(rel)
@@ -301,14 +334,43 @@ class TestT1PreconditionParity:
                 f"{rel} has {len(anchors)} {T1_ANCHOR!r} anchors; the extractor "
                 f"can no longer identify the paragraph unambiguously"
             )
-            assert src.count(T1_TOKEN) == 1, (
-                f"{rel} has {src.count(T1_TOKEN)} occurrences of the token; it "
-                f"is no longer distinctive enough to validate the extraction"
+            # SCOPED TO THE DOCSTRING, DELIBERATELY ASYMMETRIC WITH THE
+            # ANCHOR ASSERTION ABOVE -- see the coupling note in this test's
+            # docstring. Whole-file counting made a legitimate CROSS-REFERENCE
+            # elsewhere in the module (`# See the "IDENTITY, not POSITION"
+            # precondition ...`) redden this gate while the paragraph was
+            # byte-identical and the digest matched: a false alarm on exactly
+            # the kind of cross-reference this codebase models as good practice.
+            doc = _atomic_write_docstring(rel)
+            assert doc, f"{rel}: _atomic_write_text docstring not found"
+            assert doc.count(T1_TOKEN) == 1, (
+                f"{rel} has {doc.count(T1_TOKEN)} occurrences of the token IN "
+                f"THE DOCSTRING; it is no longer distinctive enough to validate "
+                f"the extraction"
             )
 
     def test_paragraph_matches_the_reference_digest_and_length(self):
         """Pins the CONTENT, not just parity. Two copies could match each other
-        while both having drifted from the accepted wording."""
+        while both having drifted from the accepted wording.
+
+        THIS ASSERTION IS THE LOAD-BEARING WRONG-SPAN EXCLUSION. DO NOT DELETE
+        IT AS DUPLICATIVE OF THE TOKEN CHECK -- that is the exact simplification
+        an adversarial review measured to be wrong. Of five adversarial
+        docstrings crafted to impersonate this paragraph, FOUR satisfied all
+        three of the cheap guards (non-emptiness, distinctive token, anchor
+        uniqueness). Only the digest and length excluded them. The cheap guards
+        look like the substantive checks and are the weaker ones.
+
+        WHAT THE CHEAP GUARDS BUY, since they are not redundant either: the
+        digest is SELF-CERTIFYING AT THE MOMENT IT IS RE-BASELINED. When the
+        paragraph is legitimately reworded someone updates the reference to
+        whatever the extractor returned -- and at that instant the digest
+        cannot detect a broken extractor; it gets pinned TO the wrong span and
+        confirms it forever after. The token and anchor checks are independent
+        of the reference value and are the only guards still standing during a
+        re-pin. So: the digest catches drift, the cheap guards protect the
+        update. Removing either leaves a window.
+        """
         for rel in (CANONICAL_REL, TWIN_REL):
             para = _extract_t1_paragraph(_read(rel))
             digest = hashlib.sha256(para.encode("utf-8")).hexdigest()
@@ -386,7 +448,25 @@ class TestExistingDriftGatesUnmodified:
 
 
 # ===========================================================================
-# Behavioural core -- L1/L2/L3/L4/L8
+# Behavioural core -- L1/L2/L3/L4
+#
+# L8 IS NOT CERTIFIED BY A TEST IN THIS FILE, AND THAT IS A DELIBERATE
+# ABSTENTION RATHER THAN AN OVERSIGHT. It is recorded here because every other
+# obligation is traceable to a docstring, and an obligation named in a banner
+# but claimed by nothing reads as a gap.
+#
+# L8 asks that the failure-log site is unchanged in behaviour. It is covered BY
+# INHERITANCE: that site carries its OWN leaf `is_symlink()` guard inside the
+# lock and pre-creates its parent before taking it, so on the only topology
+# where the two formulas differ -- a symlinked leaf -- the write is refused
+# under BOTH, and the site can create no directory either way. Its existing
+# tests pass untouched.
+#
+# STATE THE STRENGTH HONESTLY: that is weaker than L1-L4, which are certified
+# directly here. Inheritance is an argument that the site cannot be affected,
+# not a measurement that it was not. If the failure-log site ever loses its own
+# leaf guard or stops pre-creating its parent, this obligation silently becomes
+# uncovered and nothing in this file will notice.
 #
 # DERIVATION, and it is named here so a reader can tell it from the scratch
 # harness used during the fix: the sidecar is taken from the path PRODUCTION
@@ -547,6 +627,49 @@ def _topology(kind, root: Path):
 
 
 
+def _assert_points_outside(link: Path, proj: Path, label: str) -> None:
+    """Assert a symlink's DESTINATION is outside the project.
+
+    SYMLINK-NESS IS NOT OUT-NESS, and the difference is load-bearing. A
+    precondition that checks only "is a symlink, is dangling" is satisfied by a
+    degraded fixture pointing IN-PROJECT at a path whose parent exists -- under
+    which the superseded formula creates ZERO directories, so the L3 DoS
+    regression test PASSES and can no longer fail for the reason it exists.
+
+    That is the failure `assert_topology_constructed` was written to prevent,
+    one level deeper: the guard against fixture rot was itself under-specified.
+
+    Uses `os.readlink` rather than `resolve()` because these destinations are
+    frequently DANGLING, and `resolve()` on a dangling link would not tell us
+    where it was aiming. The destination is made absolute against the link's own
+    directory so a relative symlink is judged by where it actually points.
+
+    DO NOT lean on production to reject a degraded fixture on the suite's
+    behalf: `file_lock` calls `mkdir(parents=True)` and will happily create a
+    missing `.claude` itself, so a degraded `plain` case is masked by PRODUCTION
+    rather than caught by the test.
+    """
+    dest = Path(os.readlink(str(link)))
+    if not dest.is_absolute():
+        dest = (link.parent / dest)
+    proj_resolved = proj.resolve()
+    # `os.path.realpath` and NOT `normpath`: the destination is frequently
+    # DANGLING, but its existing ANCESTORS still need resolving or the two
+    # sides of the comparison are spelled differently and it silently never
+    # matches. On macOS a tmp path is /var/... while proj.resolve() yields
+    # /private/var/..., so a normpath-only comparison accepts an in-project
+    # destination -- MEASURED: it did, and the degraded fixture sailed through.
+    # realpath is non-strict: it resolves the existing prefix and leaves the
+    # absent tail lexical, which is exactly what a dangling link needs.
+    dest_norm = Path(os.path.realpath(str(dest)))
+    assert not (
+        dest_norm == proj_resolved or proj_resolved in dest_norm.parents
+    ), (
+        f"{label}: symlink points IN-PROJECT ({dest_norm}) -- the topology is "
+        f"degenerate and the test would pass for the wrong reason"
+    )
+
+
 def assert_topology_constructed(kind, proj: Path, target: Path) -> None:
     """FIXTURE PRECONDITION -- fail if the defective topology was not built.
 
@@ -575,6 +698,7 @@ def assert_topology_constructed(kind, proj: Path, target: Path) -> None:
     claude_dir = proj / ".claude"
     if kind == "plain":
         assert not claude_dir.is_symlink(), "plain: .claude should be a real dir"
+        assert claude_dir.is_dir(), "plain: .claude should already EXIST as a dir"
         assert not target.is_symlink(), "plain: leaf should be a real file path"
         return
     if kind == "leaf-out-existing":
@@ -588,17 +712,21 @@ def assert_topology_constructed(kind, proj: Path, target: Path) -> None:
     if kind == "leaf-out-dangling":
         assert target.is_symlink(), "leaf-out-dangling: leaf is NOT a symlink"
         assert not target.exists(), "leaf-out-dangling: destination should be absent"
+        _assert_points_outside(target, proj, "leaf-out-dangling")
         return
     if kind == "parent-out-existing":
         assert claude_dir.is_symlink(), "parent-out-existing: .claude is NOT a symlink"
         assert claude_dir.exists(), "parent-out-existing: destination should exist"
+        _assert_points_outside(claude_dir, proj, "parent-out-existing")
         return
     if kind == "parent-out-dangling":
         assert claude_dir.is_symlink(), "parent-out-dangling: .claude is NOT a symlink"
         assert not claude_dir.exists(), "parent-out-dangling: should be dangling"
+        _assert_points_outside(claude_dir, proj, "parent-out-dangling")
         return
     if kind == "two-leg":
         assert claude_dir.is_symlink(), "two-leg: .claude (leg 1) is NOT a symlink"
+        _assert_points_outside(claude_dir, proj, "two-leg leg 1")
         outside_entry = Path(os.readlink(str(claude_dir))) / "CLAUDE.md"
         assert outside_entry.is_symlink(), "two-leg: leg 2 is NOT a symlink"
         assert outside_entry.resolve() == (proj / "real.md").resolve(), (
@@ -680,6 +808,31 @@ class TestSidecarAgreesWithTheWrite:
         alias = tmp_path / "alias"
         _os.symlink(str(real), str(alias), target_is_directory=True)
 
+        # READ THIS BEFORE ADDING CASE OR UNICODE VARIANTS TO THIS TEST.
+        #
+        # The property is MUTUAL EXCLUSION. It is verified here by PATH-STRING
+        # EQUALITY, which is a STRICTER PROXY than the property -- sound only
+        # for the case built above, where `resolve()` collapses a directory
+        # symlink alias to one string.
+        #
+        # It does NOT generalise. A case-variant (`Proj` vs `proj`) and an
+        # NFC/NFD pair are the SAME kernel object reached by DIFFERENT strings,
+        # so the two derived sidecar paths differ while `samefile` is True and
+        # `flock` serialises on the inode regardless -- mutual exclusion is
+        # fully intact and this assertion would nonetheless FAIL.
+        #
+        # So widening this test with those rows produces a RED THAT IS THE
+        # INSTRUMENT'S FAULT, and the natural repair -- deleting the rows you
+        # just added -- discards correct coverage to silence a wrong check. To
+        # cover them, assert `samefile` on the two sidecars, or actual `flock`
+        # exclusion (hold via one spelling, attempt via the other). NOT path
+        # equality.
+        #
+        # THE PRECEDENT THAT WILL TEMPT YOU IS ONE FILE AWAY:
+        # test_containment_certification.py has case-variant and NFD-variant
+        # tests for the neighbouring containment property, where they are
+        # correct. Copying that pattern here without changing the assertion is
+        # the specific mistake this comment exists to prevent.
         via_real = derive_sidecar_from_production(mod, real / ".claude" / "CLAUDE.md")
         via_alias = derive_sidecar_from_production(mod, alias / ".claude" / "CLAUDE.md")
         assert via_real == via_alias, (

--- a/pact-plugin/tests/test_memory_ct_fields.py
+++ b/pact-plugin/tests/test_memory_ct_fields.py
@@ -709,7 +709,7 @@ class TestSyncToClaudeMdWithCTFields:
         }
 
         # Mock the display-target resolver to return our temp file
-        with patch("scripts.working_memory._resolve_display_claude_md_path", return_value=claude_md):
+        with patch("scripts.working_memory._resolve_display_claude_md_with_base", return_value=(claude_md, claude_md.parent)):
             result = sync_to_claude_md(memory, memory_id="test-ct-sync")
 
         assert result is True

--- a/pact-plugin/tests/test_py39_annotation_compat.py
+++ b/pact-plugin/tests/test_py39_annotation_compat.py
@@ -386,8 +386,10 @@ class TestDiscoveryFloor:
         # deliberate scope decision. History: lowered 63 -> 55 when the dormant
         # hooks/refresh/ package (8 modules) was removed, dropping the scanned
         # count 66 -> 58; raised 55 -> 71 when skills/pact-memory/scripts and
-        # scripts were added, taking the count 58 -> 74. Both moves keep the
-        # same slack of 3, and that tightness is the point: at the old floor of
+        # scripts were added, taking the count 59 -> 74 (hooks/ had gained one
+        # file since the 58 above, so measure the count -- do not carry a
+        # figure forward from this history). Both moves keep the same slack of
+        # 3, and that tightness is the point: at the old floor of
         # 55 the entire skills/pact-memory/scripts root could vanish (74 -> 60)
         # and this assertion would still pass, so the widened scan would have
         # been guarded in name only.

--- a/pact-plugin/tests/test_py39_annotation_compat.py
+++ b/pact-plugin/tests/test_py39_annotation_compat.py
@@ -1,7 +1,8 @@
 """
 Location: pact-plugin/tests/test_py39_annotation_compat.py
-Summary: Static AST guard keeping pact-plugin/hooks/ importable under
-         Python 3.9 (GUI-launched macOS sessions run hooks on
+Summary: Static AST guard keeping the plugin's bare-python3 surfaces
+         importable under Python 3.9 -- hooks/, skills/pact-memory/scripts/
+         and scripts/ (GUI-launched macOS sessions run these on
          /usr/bin/python3 = 3.9.x). Four rules:
          R0 every scanned .py parses at ast feature_version=(3, 9) — a
             best-effort syntax floor per CPython policy: it rejects
@@ -38,10 +39,14 @@ import pytest
 
 PLUGIN_ROOT = Path(__file__).parent.parent
 
-# Extension point: add adjacent bare-python3 surfaces here (one line each),
-# e.g. PLUGIN_ROOT / "skills" / "pact-memory" / "scripts",
-#      PLUGIN_ROOT / "scripts".
-SCANNED_ROOTS: tuple[Path, ...] = (PLUGIN_ROOT / "hooks",)
+# Every bare-python3 surface in the plugin: code a consumer can end up running
+# on /usr/bin/python3 rather than a managed interpreter. Extension point --
+# add further such surfaces here, one line each.
+SCANNED_ROOTS: tuple[Path, ...] = (
+    PLUGIN_ROOT / "hooks",
+    PLUGIN_ROOT / "skills" / "pact-memory" / "scripts",
+    PLUGIN_ROOT / "scripts",
+)
 
 # Integer-flag namespaces: `a.X | a.Y` rooted here is bitwise-OR on int
 # constants, valid on every Python 3.x — never a type union.
@@ -373,15 +378,25 @@ class TestDiscoveryFloor:
     """Discovery must never silently collapse to an empty scan."""
 
     def test_scanned_file_count_floor(self):
-        # If SCANNED_ROOTS resolves empty (directory rename, anchor break),
-        # the per-file parameter sets degrade to a single skip each and the
-        # aggregate rules pass vacuously over zero files — silently green.
-        # Floor rather than exact count so adding hooks never breaks it;
-        # bump the floor as hooks/ grows, never lower it without a
-        # deliberate scope decision. Lowered 63 -> 55 when the dormant
-        # hooks/refresh/ package (8 modules) was removed, dropping the
-        # scanned count 66 -> 58; the floor keeps the same slack of 3.
-        assert len(_SCANNED_FILES) >= 55
+        # If a root in SCANNED_ROOTS resolves empty (directory rename, anchor
+        # break), the per-file parameter sets degrade to a single skip each and
+        # the aggregate rules pass vacuously over those files — silently green.
+        # Floor rather than exact count so adding files never breaks it; bump
+        # the floor as the scanned roots grow, never lower it without a
+        # deliberate scope decision. History: lowered 63 -> 55 when the dormant
+        # hooks/refresh/ package (8 modules) was removed, dropping the scanned
+        # count 66 -> 58; raised 55 -> 71 when skills/pact-memory/scripts and
+        # scripts were added, taking the count 58 -> 74. Both moves keep the
+        # same slack of 3, and that tightness is the point: at the old floor of
+        # 55 the entire skills/pact-memory/scripts root could vanish (74 -> 60)
+        # and this assertion would still pass, so the widened scan would have
+        # been guarded in name only.
+        #
+        # LIMIT, stated rather than implied: a count floor cannot protect a
+        # single-file root. Losing scripts/ takes the count to 73, which no
+        # workable floor distinguishes from normal churn. This test guards
+        # against a LARGE root collapsing, not against every root.
+        assert len(_SCANNED_FILES) >= 71
 
 
 class TestPy39SyntaxFloor:

--- a/pact-plugin/tests/test_session_resume.py
+++ b/pact-plugin/tests/test_session_resume.py
@@ -723,20 +723,33 @@ class TestUpdateSessionInfoLocking:
         t.join(timeout=5)
 
 
-class TestUpdateSessionInfoSymlinkRefusal:
-    """SECURITY hardening — update_session_info refuses to operate on symlinks.
+class TestUpdateSessionInfoLeafSymlinkAllowed:
+    """SECURITY — update_session_info never writes THROUGH a leaf symlink.
 
-    Matches the pattern in remove_stale_kernel_block and update_pact_routing:
-    if the project CLAUDE.md is a symlink, return an opaque 'Session info
-    skipped: ... path precondition not met.' string and do not follow the
-    link. is_symlink uses lstat so it does not follow the link.
+    The property that matters is that an out-of-project file pointed at by the
+    project CLAUDE.md is never modified. That property holds, and it holds for a
+    structural reason rather than a guard: the write publishes via renameat(2),
+    which binds the final path component as a directory ENTRY without following
+    it, so the payload lands on the in-project entry.
 
-    The status string is deliberately opaque — no mention of 'symlink' or
-    'refusing' to avoid disclosing the internal guard to a local attacker."""
+    An earlier form of this class ALSO refused to write at all when the target
+    was a symlink, and asserted that refusal. That ban was an over-block on
+    benign in-project symlinks, and containment now decides on the parent chain
+    without consulting the leaf, so a contained target is written even when its
+    leaf points outside. The victim-untouched guarantee is unchanged."""
 
-    def test_update_session_info_refuses_symlink(self, tmp_path, monkeypatch):
-        """If the project CLAUDE.md is a symlink, update_session_info returns
-        an opaque skip status and does not touch the symlink target."""
+    def test_leaf_symlink_out_of_project_allowed_target_untouched(
+        self, tmp_path, monkeypatch
+    ):
+        """A leaf symlink escaping the project is written IN-PROJECT: the entry
+        becomes a real file and the out-of-project target keeps its bytes.
+
+        Both boundaries are asserted. Target-byte-identical is the security
+        property, but it would hold under a refusal too, so it cannot on its own
+        show that anything was permitted; the entry-no-longer-a-symlink
+        assertion is what distinguishes ALLOW from REFUSE and what flips if the
+        write is ever made to follow the leaf.
+        """
         import os
         from shared.session_resume import update_session_info
 
@@ -761,13 +774,14 @@ class TestUpdateSessionInfoSymlinkRefusal:
         result = update_session_info("sess-new", "pact-new")
 
         assert result is not None
-        assert "Session info skipped" in result
-        assert "path precondition not met" in result
-        assert "symlink" not in result.lower()
-        assert "refusing" not in result.lower()
-        # Symlink target is byte-identical (untouched)
+        assert "Session info updated" in result
+        # Boundary 1 -- the out-of-project target is BYTE-identical. This is the
+        # security property, and it survives the change from refuse to allow.
         assert symlink_target.read_text(encoding="utf-8") == symlink_target_content
-        assert managed_path.is_symlink()
+        # Boundary 2 -- the write happened at the IN-PROJECT entry, replacing the
+        # symlink with a real file carrying the new session id.
+        assert not managed_path.is_symlink()
+        assert "sess-new" in managed_path.read_text(encoding="utf-8")
 
 
 class TestCheckPausedState:

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -73,7 +73,9 @@ class TestCheckPinnedStaleness:
         from session_init import check_pinned_staleness
 
         with patch("session_init._get_project_claude_md_path", return_value=None), \
-             patch("staleness._get_project_claude_md_path", return_value=None):
+             patch("staleness._get_project_claude_md_path", return_value=None), \
+             patch("staleness._resolve_project_claude_md_with_base",
+                   return_value=(None, None)):
             result = check_pinned_staleness()
 
         assert result is None
@@ -926,51 +928,118 @@ class TestCheckPinnedStalenessHardening:
         )
 
     def test_symlink_target_rejected_with_opaque_status(self, tmp_path):
-        """If the project CLAUDE.md is a symlink, check_pinned_staleness
-        returns an opaque 'precondition not met' string and does NOT touch
-        the symlink target.
+        """If the project CLAUDE.md is a symlink whose target ESCAPES the
+        project root, check_pinned_staleness returns an opaque 'precondition
+        not met' string and does NOT touch the attacker-chosen target.
 
-        Pre-fix, the function would call write_text on the symlink path,
-        which would follow the link and clobber the attacker-chosen target.
-        Post-fix, the inside-lock symlink guard refuses to operate.
+        This is the F1 write-through threat: a symlink (leaf here, or via a
+        symlinked parent) redirecting the write to an out-of-project victim
+        (e.g. the user's global ~/.claude/CLAUDE.md). The #1247 containment
+        guard resolves the target and refuses when it escapes the anchor.
+        (An IN-PROJECT redirect is contained and allowed — see
+        test_in_project_symlink_redirect_allowed_containment_supersedes_ban.)
         """
         from session_init import check_pinned_staleness
 
-        # Plant a regular file as the symlink target
-        symlink_target = tmp_path / "external_target.md"
-        original_target_content = "# External file (must not be modified)\n"
-        symlink_target.write_text(original_target_content, encoding="utf-8")
+        # Project root is proj_dir (the lexical base of proj_dir/CLAUDE.md).
+        proj_dir = tmp_path / "proj"
+        proj_dir.mkdir()
 
-        # Replace the project CLAUDE.md with a symlink to the external target
-        managed_path = tmp_path / "CLAUDE.md"
-        os.symlink(str(symlink_target), str(managed_path))
+        # Plant the attacker-chosen target OUTSIDE the project root, seeded
+        # with stale content so the read-through drives modified=True (the
+        # gate into the file_lock write path).
+        outside_dir = tmp_path / "outside"
+        outside_dir.mkdir()
+        escaping_target = outside_dir / "external_target.md"
+        escaping_target.write_text(self._stale_pinned_content(), encoding="utf-8")
+
+        # project CLAUDE.md is a symlink escaping to that out-of-project target.
+        managed_path = proj_dir / "CLAUDE.md"
+        os.symlink(str(escaping_target), str(managed_path))
         assert managed_path.is_symlink()
-
-        # The symlink itself reads through to stale content (so the inner
-        # read_text + parse + apply_staleness_markings path runs and
-        # produces modified=True, which is what gates the file_lock entry)
-        symlink_target.write_text(
-            self._stale_pinned_content(), encoding="utf-8"
-        )
 
         with patch("session_init._get_project_claude_md_path", return_value=managed_path), \
              patch("staleness._get_project_claude_md_path", return_value=managed_path):
             result = check_pinned_staleness()
 
-        # Status string is opaque — does not reveal the internal symlink
+        # Status string is opaque — does not reveal the internal containment
         # check to a local attacker reading hook stderr.
         assert result is not None
         assert "skipped" in result.lower()
         assert "symlink" not in result.lower()
         assert "refusing" not in result.lower()
 
-        # Critical: the symlink TARGET is byte-identical to what we wrote
-        # last (the stale content). The function did not append a STALE
-        # marker, did not insert a budget warning, did not write at all.
-        assert symlink_target.read_text(encoding="utf-8") == self._stale_pinned_content()
-        # The symlink itself is still a symlink (was not replaced with a
-        # regular file by a bypassing write).
+        # Critical: the out-of-project target is byte-identical to what we
+        # wrote (the stale content). The guard refused before any write — no
+        # STALE marker, no budget warning, no write-through to the victim.
+        assert escaping_target.read_text(encoding="utf-8") == self._stale_pinned_content()
+        # The symlink itself is untouched (refusal happened before os.replace).
         assert managed_path.is_symlink()
+
+    def test_in_project_symlink_redirect_allowed_containment_supersedes_ban(self, tmp_path):
+        """#1247 deliberate behavior change: an IN-PROJECT symlink redirect is
+        ALLOWED. Containment refuses only ESCAPES; an in-project target is
+        contained. The former blunt leaf-is_symlink guard refused ALL symlinks
+        (an over-block on benign in-project symlinks) — containment removes
+        that over-block while still closing the F1 escape.
+
+        Security-engineer-signed-off residual: os.replace REPLACES the symlink
+        entry, it does NOT write through it, so even a crafted in-project
+        redirect cannot overwrite its pointed-to file. This pins that safety:
+        the pointed-to in-project file is byte-unchanged and CLAUDE.md becomes
+        a regular file carrying the staleness update.
+        """
+        from session_init import check_pinned_staleness
+
+        # Both the symlink and its target are IN-PROJECT (project root =
+        # tmp_path, the lexical base of tmp_path/CLAUDE.md) -> contained.
+        sibling = tmp_path / "sib.md"
+        sibling.write_text(self._stale_pinned_content(), encoding="utf-8")
+        sibling_before = sibling.read_text(encoding="utf-8")
+
+        managed_path = tmp_path / "CLAUDE.md"
+        os.symlink(str(sibling), str(managed_path))
+        assert managed_path.is_symlink()
+
+        with patch("session_init._get_project_claude_md_path", return_value=managed_path), \
+             patch("staleness._get_project_claude_md_path", return_value=managed_path):
+            result = check_pinned_staleness()
+
+        # ALLOWED: the write proceeded (a detection message, not the opaque skip).
+        assert result is not None
+        assert "skipped" not in result.lower()
+
+        # os.replace does NOT write through the leaf symlink: the pointed-to
+        # in-project file is byte-unchanged...
+        assert sibling.read_text(encoding="utf-8") == sibling_before
+        # ...and CLAUDE.md is now a real file carrying the staleness marker.
+        assert not managed_path.is_symlink()
+        assert "<!-- STALE:" in managed_path.read_text(encoding="utf-8")
+
+    def test_containment_refusal_attributed_not_lock_contention(self, tmp_path):
+        """A containment refusal must surface the CONTAINMENT status, never the
+        lock-contention status. ContainmentError subclasses OSError, so if the
+        `except ContainmentError` arm were ordered after `except OSError` (or
+        dropped), an escape would be silently misattributed to a lock failure.
+        This pins the arm ordering end-to-end via the real write path.
+        """
+        from session_init import check_pinned_staleness
+
+        proj_dir = tmp_path / "proj"
+        proj_dir.mkdir()
+        outside_dir = tmp_path / "outside"
+        outside_dir.mkdir()
+        escaping_target = outside_dir / "victim.md"
+        escaping_target.write_text(self._stale_pinned_content(), encoding="utf-8")
+        managed_path = proj_dir / "CLAUDE.md"
+        os.symlink(str(escaping_target), str(managed_path))
+
+        with patch("session_init._get_project_claude_md_path", return_value=managed_path), \
+             patch("staleness._get_project_claude_md_path", return_value=managed_path):
+            result = check_pinned_staleness()
+
+        assert result == "Pinned staleness skipped: path precondition not met."
+        assert "lock contention" not in result.lower()
 
     def test_concurrent_content_change_skips_write(self, tmp_path, monkeypatch):
         """If content changes between the outer read at L348 and the
@@ -1343,4 +1412,103 @@ class TestFileLockTwinCopyDrift:
         assert cmm._LOCK_POLL_INTERVAL == wm._LOCK_POLL_INTERVAL, (
             "_LOCK_POLL_INTERVAL drift between claude_md_manager.py and "
             "working_memory.py — update both in the same commit"
+        )
+
+
+class TestStalenessLexicalBaseParity:
+    """#1247: the lexical base recovered from a SUPPLIED path (option D in
+    check_pinned_staleness, via staleness._lexical_base_of) MUST equal the base
+    the resolver itself used. session_init passes staleness a resolved PATH
+    (not a base), so the containment anchor is recovered by inverting the
+    resolver's construction; if _resolve_project_claude_md_with_base ever grows
+    a THIRD path shape, that lexical formula would silently diverge and the
+    guard would anchor on the wrong root. This test turns that divergence into
+    a RED -- the single-source-of-truth safeguard the architect mandated
+    (twin-drift discipline applied to anchor derivation). It exercises the REAL
+    production formula (_lexical_base_of), not a test copy.
+    """
+
+    def test_lexical_base_matches_resolver_base_dot_claude(self, tmp_path, monkeypatch):
+        import staleness as st
+
+        (tmp_path / ".claude").mkdir()
+        (tmp_path / ".claude" / "CLAUDE.md").write_text("# x\n", encoding="utf-8")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+        path, base = st._resolve_project_claude_md_with_base()
+        assert path is not None and base is not None
+        assert st._lexical_base_of(path) == base, (
+            "lexical base recovery diverged from the resolver's base for the "
+            ".claude/CLAUDE.md shape — option D would anchor containment on the "
+            "wrong root"
+        )
+
+    def test_lexical_base_matches_resolver_base_legacy(self, tmp_path, monkeypatch):
+        import staleness as st
+
+        (tmp_path / "CLAUDE.md").write_text("# x\n", encoding="utf-8")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+        path, base = st._resolve_project_claude_md_with_base()
+        assert path is not None and base is not None
+        assert st._lexical_base_of(path) == base, (
+            "lexical base recovery diverged from the resolver's base for the "
+            "legacy ./CLAUDE.md shape — option D would anchor containment on "
+            "the wrong root"
+        )
+
+
+class TestAtomicWriteTwinCopyDrift:
+    """Drift detection for the _atomic_write_text twin (#1247).
+
+    _atomic_write_text is twin-copied from hooks/shared/claude_md_manager into
+    skills/pact-memory/scripts/working_memory (skills/ cannot import from
+    hooks/shared/). Since #1247 it carries the CONTAINMENT SECURITY CHECK, so
+    the function BODY must stay byte-identical across the two copies -- a
+    silent divergence in the security check between the hook and skill copies
+    is the #1118-class hazard this gate exists to prevent. The docstring may
+    differ (each copy points at the other); the executable logic may not.
+    """
+
+    @staticmethod
+    def _extract_body(source: str) -> str:
+        """Return the executable body: skip leading decorators + the def line,
+        strip a leading docstring, dedent, normalize. Same extractor as
+        TestFileLockTwinCopyDrift (docstring-tolerant, logic-pinning)."""
+        lines = source.split("\n")
+        idx = 0
+        while idx < len(lines) and lines[idx].lstrip().startswith("@"):
+            idx += 1
+        body_lines = lines[idx + 1:]
+        body_text = textwrap.dedent("\n".join(body_lines)).strip()
+        for quote in ['"""', "'''"]:
+            if body_text.startswith(quote):
+                end_idx = body_text.find(quote, len(quote))
+                if end_idx != -1:
+                    body_text = body_text[end_idx + len(quote):].strip()
+                break
+        return body_text
+
+    def test_atomic_write_text_bodies_are_identical(self):
+        """The _atomic_write_text body MUST be byte-identical across the twins.
+
+        The body carries the #1247 containment check (commonpath, fail-closed);
+        a divergence would let the hook and skill write paths enforce different
+        containment, silently defeating the guard on one side. Compares logic
+        only -- docstrings are allowed to differ.
+        """
+        from shared.claude_md_manager import _atomic_write_text as canonical
+        from working_memory import _atomic_write_text as twin
+
+        canonical_body = self._extract_body(inspect.getsource(canonical))
+        twin_body = self._extract_body(inspect.getsource(twin))
+
+        assert canonical_body == twin_body, (
+            "_atomic_write_text twin drift between "
+            "hooks/shared/claude_md_manager.py and "
+            "skills/pact-memory/scripts/working_memory.py — the #1247 "
+            "containment check must stay identical; update both in the SAME "
+            "commit.\n"
+            f"canonical body:\n{canonical_body}\n\n"
+            f"twin body:\n{twin_body}"
         )

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -1504,10 +1504,19 @@ class TestAtomicWriteTwinCopyDrift:
     def test_atomic_write_text_bodies_are_identical(self):
         """The _atomic_write_text body MUST be byte-identical across the twins.
 
-        The body carries the #1247 containment check (commonpath, fail-closed);
-        a divergence would let the hook and skill write paths enforce different
-        containment, silently defeating the guard on one side. Compares logic
-        only -- docstrings are allowed to differ.
+        The body carries the #1247 containment check (kernel object ancestry on
+        a pinned directory descriptor, fail-closed); a divergence would let the
+        hook and skill write paths enforce different containment, silently
+        defeating the guard on one side. Compares logic only -- docstrings are
+        allowed to differ.
+
+        THIS GATE PROVES BYTE-IDENTITY, NOT THAT EITHER COPY IS EXERCISED. It
+        goes red whenever the bodies diverge for ANY reason, including a
+        deliberate single-twin experiment -- so a red here is not by itself
+        evidence of a behavioural regression, and counting it as one inflates
+        the apparent coverage of whichever twin was left untouched. The
+        behavioural coverage of each copy lives in
+        test_containment_certification.py, which drives both independently.
         """
         from shared.claude_md_manager import _atomic_write_text as canonical
         from working_memory import _atomic_write_text as twin

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -927,17 +927,21 @@ class TestCheckPinnedStalenessHardening:
             "## Working Memory\n"
         )
 
-    def test_symlink_target_rejected_with_opaque_status(self, tmp_path):
-        """If the project CLAUDE.md is a symlink whose target ESCAPES the
-        project root, check_pinned_staleness returns an opaque 'precondition
-        not met' string and does NOT touch the attacker-chosen target.
+    def test_leaf_symlink_out_of_project_allowed_victim_untouched(self, tmp_path):
+        """A leaf symlink pointing OUT of the project is ALLOWED, and the write
+        lands in-project rather than on the out-of-project victim.
 
-        This is the F1 write-through threat: a symlink (leaf here, or via a
-        symlinked parent) redirecting the write to an out-of-project victim
-        (e.g. the user's global ~/.claude/CLAUDE.md). The #1247 containment
-        guard resolves the target and refuses when it escapes the anchor.
-        (An IN-PROJECT redirect is contained and allowed — see
-        test_in_project_symlink_redirect_allowed_containment_supersedes_ban.)
+        THIS IS THE TRAP-1 COUPLING TRIPWIRE at this site, and it could not
+        exist before the corrected predicate, because the earlier one refused
+        this topology outright. It replaces a negative that asserted the
+        refusal. That refusal was an over-block: containment is decided on the
+        parent chain and the leaf is never consulted. The genuine escape shape
+        at this site is a symlinked PARENT, which is covered separately.
+
+        DO NOT 'fix' a failure here by making the guard refuse the topology.
+        The victim survives because os.replace is renameat(2) -- it binds the
+        final component as a directory ENTRY without following it. A failure
+        here means the WRITE SHAPE changed, not that the guard weakened.
         """
         from session_init import check_pinned_staleness
 
@@ -945,36 +949,34 @@ class TestCheckPinnedStalenessHardening:
         proj_dir = tmp_path / "proj"
         proj_dir.mkdir()
 
-        # Plant the attacker-chosen target OUTSIDE the project root, seeded
-        # with stale content so the read-through drives modified=True (the
-        # gate into the file_lock write path).
+        # Plant a file OUTSIDE the project root, seeded with stale content so
+        # the read-through drives modified=True (the gate into the write path).
         outside_dir = tmp_path / "outside"
         outside_dir.mkdir()
-        escaping_target = outside_dir / "external_target.md"
-        escaping_target.write_text(self._stale_pinned_content(), encoding="utf-8")
+        outside_victim = outside_dir / "external_target.md"
+        outside_victim.write_text(self._stale_pinned_content(), encoding="utf-8")
 
-        # project CLAUDE.md is a symlink escaping to that out-of-project target.
+        # project CLAUDE.md is a leaf symlink pointing at that outside file.
         managed_path = proj_dir / "CLAUDE.md"
-        os.symlink(str(escaping_target), str(managed_path))
+        os.symlink(str(outside_victim), str(managed_path))
         assert managed_path.is_symlink()
 
         with patch("session_init._get_project_claude_md_path", return_value=managed_path), \
              patch("staleness._get_project_claude_md_path", return_value=managed_path):
             result = check_pinned_staleness()
 
-        # Status string is opaque — does not reveal the internal containment
-        # check to a local attacker reading hook stderr.
         assert result is not None
-        assert "skipped" in result.lower()
-        assert "symlink" not in result.lower()
-        assert "refusing" not in result.lower()
+        assert "skipped" not in result.lower()
 
-        # Critical: the out-of-project target is byte-identical to what we
-        # wrote (the stale content). The guard refused before any write — no
-        # STALE marker, no budget warning, no write-through to the victim.
-        assert escaping_target.read_text(encoding="utf-8") == self._stale_pinned_content()
-        # The symlink itself is untouched (refusal happened before os.replace).
-        assert managed_path.is_symlink()
+        # Boundary 1 -- the out-of-project victim is BYTE-identical: no STALE
+        # marker, no budget warning, no write-through. Note this would ALSO hold
+        # under a refusal, so it cannot by itself show the write was permitted.
+        assert outside_victim.read_text(encoding="utf-8") == self._stale_pinned_content()
+        # Boundary 2 -- the write landed at the IN-PROJECT entry, which is now a
+        # real file. This is the assertion that pins the ALLOW and the one that
+        # flips if the write is ever made to follow the leaf.
+        assert not managed_path.is_symlink()
+        assert "STALE" in managed_path.read_text(encoding="utf-8")
 
     def test_in_project_symlink_redirect_allowed_containment_supersedes_ban(self, tmp_path):
         """#1247 deliberate behavior change: an IN-PROJECT symlink redirect is
@@ -1022,17 +1024,25 @@ class TestCheckPinnedStalenessHardening:
         `except ContainmentError` arm were ordered after `except OSError` (or
         dropped), an escape would be silently misattributed to a lock failure.
         This pins the arm ordering end-to-end via the real write path.
+
+        THE TOPOLOGY IS LOAD-BEARING, not incidental scenery. The escape must be
+        a symlinked PARENT, never a symlinked leaf. Containment is decided on the
+        parent chain and the leaf is never consulted, so a leaf pointing outside
+        is ALLOWED and raises nothing -- this test would then go green while
+        exercising no refusal path at all, and would keep passing with the
+        `except` arms in the wrong order. Only a parent-out topology reaches the
+        refusal this test exists to attribute.
         """
         from session_init import check_pinned_staleness
 
-        proj_dir = tmp_path / "proj"
-        proj_dir.mkdir()
-        outside_dir = tmp_path / "outside"
-        outside_dir.mkdir()
-        escaping_target = outside_dir / "victim.md"
-        escaping_target.write_text(self._stale_pinned_content(), encoding="utf-8")
-        managed_path = proj_dir / "CLAUDE.md"
-        os.symlink(str(escaping_target), str(managed_path))
+        project = tmp_path / "proj"
+        project.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        os.symlink(str(outside), str(project / ".claude"), target_is_directory=True)
+        managed_path = project / ".claude" / "CLAUDE.md"  # resolves into `outside`
+        managed_path.write_text(self._stale_pinned_content(), encoding="utf-8")
+        before = (outside / "CLAUDE.md").read_text(encoding="utf-8")
 
         with patch("session_init._get_project_claude_md_path", return_value=managed_path), \
              patch("staleness._get_project_claude_md_path", return_value=managed_path):
@@ -1040,6 +1050,8 @@ class TestCheckPinnedStalenessHardening:
 
         assert result == "Pinned staleness skipped: path precondition not met."
         assert "lock contention" not in result.lower()
+        # The out-of-project victim is untouched by the refusal.
+        assert (outside / "CLAUDE.md").read_text(encoding="utf-8") == before
 
     def test_concurrent_content_change_skips_write(self, tmp_path, monkeypatch):
         """If content changes between the outer read at L348 and the

--- a/pact-plugin/tests/test_token_budget.py
+++ b/pact-plugin/tests/test_token_budget.py
@@ -234,7 +234,7 @@ class TestSyncToClaudeMdBudgetEnforcement:
         )
         claude_md = self._create_claude_md(tmp_path, existing_content)
 
-        with patch("working_memory._resolve_display_claude_md_path", return_value=claude_md):
+        with patch("working_memory._resolve_display_claude_md_with_base", return_value=(claude_md, claude_md.parent)):
             result = sync_to_claude_md(
                 {"context": "New context entry", "goal": "New goal"},
                 memory_id="test123"
@@ -258,7 +258,7 @@ class TestSyncToClaudeMdBudgetEnforcement:
         )
         claude_md = self._create_claude_md(tmp_path, content)
 
-        with patch("working_memory._resolve_display_claude_md_path", return_value=claude_md):
+        with patch("working_memory._resolve_display_claude_md_with_base", return_value=(claude_md, claude_md.parent)):
             result = sync_to_claude_md({"context": "Test"}, memory_id="id1")
 
         new_content = claude_md.read_text(encoding="utf-8")
@@ -294,7 +294,7 @@ class TestSyncToClaudeMdBudgetEnforcement:
         )
         claude_md = self._create_claude_md(tmp_path, existing_content)
 
-        with patch("working_memory._resolve_display_claude_md_path", return_value=claude_md):
+        with patch("working_memory._resolve_display_claude_md_with_base", return_value=(claude_md, claude_md.parent)):
             result = sync_to_claude_md(
                 {"context": "Brand new entry"},
                 memory_id="new123"
@@ -355,7 +355,7 @@ class TestSyncRetrievedBudgetEnforcement:
         )
         claude_md = self._create_claude_md(tmp_path, existing_content)
 
-        with patch("working_memory._resolve_display_claude_md_path", return_value=claude_md):
+        with patch("working_memory._resolve_display_claude_md_with_base", return_value=(claude_md, claude_md.parent)):
             result = sync_retrieved_to_claude_md(
                 [{"context": "New retrieved", "goal": "test"}],
                 query="test search",

--- a/pact-plugin/tests/test_working_memory_resolver_and_lock_release.py
+++ b/pact-plugin/tests/test_working_memory_resolver_and_lock_release.py
@@ -197,9 +197,9 @@ class TestReadOnlyDirectoryFailSafe:
         reached = {"atomic_write": False}
         real_atomic = wm._atomic_write_text
 
-        def spy_atomic(target, content):
+        def spy_atomic(target, content, project_root):
             reached["atomic_write"] = True
-            return real_atomic(target, content)
+            return real_atomic(target, content, project_root)
 
         monkeypatch.setattr(wm, "_atomic_write_text", spy_atomic)
 

--- a/pact-plugin/tests/test_working_memory_resolver_and_lock_release.py
+++ b/pact-plugin/tests/test_working_memory_resolver_and_lock_release.py
@@ -65,19 +65,20 @@ class TestLockReleaseOnException:
     def test_chmod_failure_mid_window_releases_lock_and_fails_open(
         self, tmp_path, monkeypatch
     ):
-        """If os.chmod raises INSIDE the `with file_lock` block,
-        sync_to_claude_md must (a) return False (fail-open via the outer
+        """If setting the temp file's mode raises INSIDE the `with file_lock`
+        block, sync_to_claude_md must (a) return False (fail-open via the outer
         try/except) and (b) leave the lock RE-ACQUIRABLE — proving the lock was
         released on the exception path, not leaked.
 
-        Mid-window failure SITE (post-atomicity, C2/C3a): the sync now writes via
-        _atomic_write_text, which calls os.chmod on the TEMP file (before
-        os.replace), not on the target after a bare write_text. So a boom on
-        os.chmod is still a reachable mid-window exception — it fires inside
-        _atomic_write_text, propagates out through the file_lock contextmanager's
-        `finally`, and is caught by the outer try/except. The assertions below
-        (fail-open + lock re-acquirable) are what this test pins; the exact chmod
-        site moved with the atomicity refactor but the exception path did not.
+        Mid-window failure SITE: _atomic_write_text sets the mode on the TEMP
+        file before publishing it, so a boom there is a reachable mid-window
+        exception — it fires inside _atomic_write_text, propagates out through
+        the file_lock contextmanager's `finally`, and is caught by the outer
+        try/except. The assertions below (fail-open + lock re-acquirable) are
+        what this test pins; the SITE has moved twice now (target-after-write ->
+        os.chmod on the temp -> os.fchmod on the open handle) while the
+        exception path did not. Inject at whichever primitive currently sets the
+        mode; do not treat the primitive as the thing under test.
 
         A leaked lock would force the next acquirer to block until the 5s
         timeout (then fail open), degrading every subsequent sync. We prove
@@ -89,12 +90,12 @@ class TestLockReleaseOnException:
         claude_md = _seed_claude_md(tmp_path)
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
 
-        # Raise at the os.chmod inside _atomic_write_text (chmod-the-temp step,
-        # before os.replace), exercising the mid-window exception path.
-        def boom_chmod(*args, **kwargs):
-            raise OSError("simulated chmod failure mid-window")
+        # Raise at the os.fchmod inside _atomic_write_text (mode-set on the open
+        # temp handle, before the rename), exercising the mid-window path.
+        def boom_fchmod(*args, **kwargs):
+            raise OSError("simulated mode-set failure mid-window")
 
-        monkeypatch.setattr(wm.os, "chmod", boom_chmod)
+        monkeypatch.setattr(wm.os, "fchmod", boom_fchmod)
 
         result = wm.sync_to_claude_md(
             {"context": "MID-WINDOW-BOOM", "goal": "g"}, None, "id"
@@ -117,14 +118,14 @@ class TestLockReleaseOnException:
         pre-sync content — the failed write rolled back completely, not merely
         "not torn".
 
-        Post-atomicity (C2/C3a) this is a stronger and now-true guarantee than
-        the old "structurally complete" check. _atomic_write_text writes a temp,
-        chmods the TEMP, then os.replace()s it onto the target. os.chmod is boomed
-        here, so the exception fires BEFORE os.replace — the target inode is never
-        swapped and retains its exact original bytes. (Under the OLD write_text-
-        then-chmod path the target would already hold the NEW content when chmod
-        boomed, so `final == before` would FAIL — which is exactly why this
-        assertion is coupled to the atomic-replace rollback and not vacuous.)
+        This is a stronger guarantee than a "structurally complete" check.
+        _atomic_write_text writes a temp, sets the TEMP's mode, then renames it
+        onto the target. os.fchmod is boomed here, so the exception fires BEFORE
+        the rename — the target inode is never swapped and retains its exact
+        original bytes. (Under a write-then-chmod path the target would already
+        hold the NEW content when the mode-set boomed, so `final == before` would
+        FAIL — which is exactly why this assertion is coupled to the
+        atomic-replace rollback and not vacuous.)
         """
         import working_memory as wm
 
@@ -132,10 +133,10 @@ class TestLockReleaseOnException:
         before = claude_md.read_text(encoding="utf-8")
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
 
-        def boom_chmod(*args, **kwargs):
-            raise OSError("simulated chmod failure mid-window")
+        def boom_fchmod(*args, **kwargs):
+            raise OSError("simulated mode-set failure mid-window")
 
-        monkeypatch.setattr(wm.os, "chmod", boom_chmod)
+        monkeypatch.setattr(wm.os, "fchmod", boom_fchmod)
 
         result = wm.sync_to_claude_md({"context": "TORN-CHECK", "goal": "g"}, None, "id")
 
@@ -152,12 +153,12 @@ class TestLockReleaseOnException:
 # ---------------------------------------------------------------------------
 
 class TestReadOnlyDirectoryFailSafe:
-    """The atomicity refactor (C2/C3a) requires write permission on the target's
-    DIRECTORY — _atomic_write_text creates its temp there via mkstemp — where the
-    old bare write_text needed only permission on the file. On a read-only
-    directory holding a writable CLAUDE.md the sync now REFUSES the write (fails
-    safe) instead of truncating. Narrow config (bind mounts, restrictive umask)
-    but real."""
+    """The atomic write requires write permission on the target's DIRECTORY —
+    _atomic_write_text creates its temp there, relative to a descriptor it holds
+    on that directory — where the old bare write_text needed only permission on
+    the file. On a read-only directory holding a writable CLAUDE.md the sync
+    REFUSES the write (fails safe) instead of truncating. Narrow config (bind
+    mounts, restrictive umask) but real."""
 
     def test_readonly_dir_refuses_atomic_write_at_write_site_and_leaves_file_intact(
         self, tmp_path, monkeypatch

--- a/pact-plugin/tests/test_working_memory_resolver_and_lock_release.py
+++ b/pact-plugin/tests/test_working_memory_resolver_and_lock_release.py
@@ -328,6 +328,10 @@ class TestProjectDirDivergenceResidual:
         sidecar_b = path_b.parent / f".{path_b.name}.lock"
         assert sidecar_a != sidecar_b, (
             "Different caller roots → different sidecars → no shared lock. The "
-            "lock serializes only when all writers resolve the SAME root; the "
-            "divergence path is unprotected by design (note-not-guard)."
+            "lock serializes only when all writers resolve the SAME root; ROOT "
+            "divergence is unprotected by design (note-not-guard). That is a "
+            "DIFFERENT residual from the LEAF divergence the sidecar formula "
+            "fixes -- a lock keyed on the resolved leaf changed identity when "
+            "the write replaced that leaf. Do not read this note as blessing "
+            "that one: it was a defect and it is closed."
         )

--- a/pact-plugin/tests/test_working_memory_worktree_sync.py
+++ b/pact-plugin/tests/test_working_memory_worktree_sync.py
@@ -608,15 +608,15 @@ class TestEndToEndParity:
         prev = Path.cwd()
         os.chdir(str(worktree))
         try:
-            with patch("scripts.working_memory._resolve_display_claude_md_path",
-                       return_value=worktree / ".claude" / "CLAUDE.md"):
+            with patch("scripts.working_memory._resolve_display_claude_md_with_base",
+                       return_value=(worktree / ".claude" / "CLAUDE.md", worktree)):
                 sync_to_claude_md(dict(memory), memory_id="shared-id")
         finally:
             os.chdir(str(prev))
 
         # Render in the main session.
-        with patch("scripts.working_memory._resolve_display_claude_md_path",
-                   return_value=main / ".claude" / "CLAUDE.md"):
+        with patch("scripts.working_memory._resolve_display_claude_md_with_base",
+                   return_value=(main / ".claude" / "CLAUDE.md", main)):
             sync_to_claude_md(dict(memory), memory_id="shared-id")
 
         worktree_entry = _working_memory_block(


### PR DESCRIPTION
Closes #1247.

## What this PR does

Containment for PACT-managed `CLAUDE.md` writes is now decided by **kernel object ancestry on a pinned directory descriptor**, not by comparing path strings.

`_atomic_write_text` opens the directory the write will bind into, walks up via `openat("..")` chained descriptor-to-descriptor comparing `(st_dev, st_ino)` against the anchor, and then performs temp-create, `fchmod`, `fsync`, `renameat` and cleanup **through that same descriptor**. The object checked is the object mutated, by construction.

No `Path.resolve()`, no `os.path.realpath`, and no string comparison takes part in the containment decision.

## Why the previous approach was replaced

The earlier revision of this PR compared `str(target.resolve())` against a resolved anchor. **That was a regression**, and it merged review-clean before independent adversarial verification caught it.

`resolve()` follows *every* component including the leaf. The write is `os.replace`, which is `renameat(2)`: it traverses only the **parent chain** and binds the leaf as a **directory entry** without following it. On a two-leg topology — `<project>/.claude` symlinking out, and the leaf inside that destination symlinking back in — those two traversals name **different directories**. The guard certified a path the write never touched.

Measured: base **refused** what that revision **permitted**, at three production entry points, reachable from a fresh `git clone` with no attacker and no race.

Two independent traversals of a mutable namespace can always disagree. Binding the check and the write to one descriptor removes the divergence structurally rather than patching the instance.

## What falls out of removing the second resolver

These are consequences of the design, not separately-handled cases:

- **Version invariance.** `Path.resolve()` raises `RuntimeError` on a symlink loop on 3.9–3.12 and resolves silently on 3.13+. The predicate calls it nowhere, so that class is unreachable by construction.
- **Case-folding and Unicode form.** `os.path.normcase` is the identity function on both shipped platforms, and APFS is normalisation-insensitive while Linux is not — so no single string policy is correct on both. Comparing inodes never compares text.
- **Benign leaf-out is ALLOWED, correctly.** Containment is entirely a property of the parent chain, because that is the only part the kernel traverses. This is a derivation, not a concession.

## Scope

Eight commits:

| | |
|---|---|
| `c2c1f795` | the predicate, both twins |
| `4c939131` | realign 8 existing tests the change falsified |
| `d9babf88` | correct an invalid 3.7-floor rationale (justification only; `commonpath` stays on its independent sibling-prefix reason) |
| `7a63e158` | extend the 3.9 annotation gate to every bare-`python3` surface |
| `5a643855` | correct a scanned-file count |
| `c0b4f892` | map a fourth `dir_fd` capability site |
| `765d675e` | correct two stale mechanism comments, and the record of `c0b4f892` |
| `475051e1` | 61-test certification suite |

The security change (`c2c1f795`) is reviewable alone.

## Verification

- **Bidirectional.** Reverting both twins to the shipped predicate splits the failures in both directions: REFUSE-branch at all three production entry points, ALLOW-branch on leaf-outside, case-variant and NFD. A neuter shows tests notice the guard's *absence*; that revert shows they notice the old guard's *specific wrongness*.
- **Non-vacuity, per twin, re-aimed** at where the predicate now lives — proven live before any count was taken. The skill-side twin went from **one** behavioural test to five.
- **The twin axis guards itself.** Collapsing the fixture so both params load the canonical module leaves **58 of 61 tests passing green**, every id still reading `[skill]`. Three tests now assert the params resolve to distinct modules, keyed on resolved modules rather than param names.
- Independent review by three lanes that authored none of these commits: fresh adversarial, runtime, and path/filesystem. A 48-row escape sweep found zero payloads outside the anchor, with the identical sweep flagging five escapes at base.

Suite: **1 failed / 12657 passed / 15 skipped / 0 errors**. The single failure is #1250, a pre-existing date-bomb absent from this diff and reproducible at base.

## Known residuals — shipped deliberately, not overlooked

- **`file_lock` runs upstream of the guard.** It resolves the target and creates a directory chain plus a `0o600` sidecar at the resolved location *before* containment is evaluated. **Byte-identical to base** and out of scope here; this PR makes the **guard** version-invariant, not the **entry point**.
- **Traversal permissions.** The walk needs read+execute on every directory from `target.parent` to the anchor. An execute-only intermediate directory *inside* a project now refuses where the string predicate allowed. Pathological, **fail-closed**, and the one place this design is less permissive in a non-adversarial layout. It surfaces as a raw `PermissionError`, so callers report a generic failure rather than the opaque skip.
- **The capability branch has never executed** on any supported platform. Its coverage is by injection only, and no doc, docstring or commit message describes it as verified.
- **3.10–3.13 unmeasured.** Version behaviour is measured at 3.9.6 and 3.14.6 and argued *by construction* between; Linux evidence is overlayfs in a VM rather than bare ext4.
- **Ancestry is stable in space, not in time.** Relocating the pinned directory between walk and rename was demonstrated by injection — mechanism, not natural exploitability, and it requires a capability that already permits a simpler attack.
