### PR TITLE
Freeze the clock in session-resume date-sensitive fixtures (#1250)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.17",
+      "version": "4.6.18",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.17/       # Plugin version
+│               └── 4.6.18/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.17",
+  "version": "4.6.18",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.17
+> **Version**: 4.6.18
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/tests/test_session_resume.py
+++ b/pact-plugin/tests/test_session_resume.py
@@ -45,6 +45,7 @@ _build_journal_resume() -- truncation boundary:
        81 (truncated to 77+"..."), 120 (well over, truncated)
 """
 
+import datetime as _dt
 import sys
 from pathlib import Path
 
@@ -934,6 +935,65 @@ def _write_journal_events(session_dir, events):
             f.write(_json.dumps(event) + "\n")
 
 
+# ---------------------------------------------------------------------------
+# Frozen clock — for tests whose fixtures carry ABSOLUTE timestamps that
+# production compares against `now`.
+#
+# WHY THIS EXISTS. `check_paused_state` applies a 14-day TTL by computing
+# `(datetime.now(utc) - paused_at).days`, so a fixture pinning an absolute
+# instant tests a DIFFERENT branch every day and eventually crosses the
+# threshold. That is not hypothetical: it fired, and it reddened CI on every
+# PR in the repo until this fixture landed.
+#
+# WHY FREEZE RATHER THAN COMPUTE THE TIMESTAMPS RELATIVE TO NOW. Three
+# reasons, in order of weight:
+#   1. Several of these tests assert on OUTPUT TEXT THAT EMBEDS THE DATE
+#      ("A stale refreshed claim from 2026-07-09 also exists."). Relativising
+#      the fixture would force the expected string to be computed too, so the
+#      test would no longer state what it expects.
+#   2. The fixtures encode INTERLOCKING instants — a paused event, a refresh
+#      event and a consumption record — read against TWO different thresholds
+#      (the 14-day paused TTL and the 48-hour refresh horizon). Re-deriving
+#      them all is arithmetic that, if wrong, leaves the test PASSING on a
+#      different branch than the one it names.
+#   3. Freezing keeps every constant meaning exactly what its author meant. A
+#      future reader cannot tell a re-derived timestamp from a deliberately
+#      chosen one.
+#
+# WHY A SUBCLASS AND NOT A Mock. `session_resume` binds the CLASS via
+# `from datetime import datetime`, so patching that name replaces it for EVERY
+# use in the module — including `datetime.fromisoformat`, which parses each of
+# these timestamps. A Mock would break parsing rather than freeze the clock,
+# and would fail in a way that looks like a production bug.
+# ---------------------------------------------------------------------------
+
+# Chosen so every absolute paused fixture in this module sits 8-9 days old:
+# comfortably INSIDE the 14-day window, but far enough from 0 that lowering
+# the threshold actually flips the branch (a frozen `now` a few hours after
+# the fixtures would keep them fresh under almost any threshold, making the
+# tests insensitive to the very cutoff they exist to pin).
+_FROZEN_NOW = _dt.datetime(2026, 7, 18, 12, 0, 0, tzinfo=_dt.timezone.utc)
+
+
+class _FrozenDatetime(_dt.datetime):
+    """A real `datetime` in every respect except that `now()` is fixed."""
+
+    @classmethod
+    def now(cls, tz=None):
+        return _FROZEN_NOW if tz is not None else _FROZEN_NOW.replace(tzinfo=None)
+
+
+@pytest.fixture
+def frozen_clock(monkeypatch):
+    """Freeze `shared.session_resume`'s clock at `_FROZEN_NOW`.
+
+    Returns the frozen instant so a test can derive an age from it explicitly
+    rather than restating a date.
+    """
+    monkeypatch.setattr("shared.session_resume.datetime", _FrozenDatetime)
+    return _FROZEN_NOW
+
+
 def _refresh_event(ts="2026-07-10T12:00:00Z", **fields):
     """Minimal valid session_refreshed event with optional overrides."""
     event = {
@@ -1182,7 +1242,9 @@ class TestResumeArbitration:
         assert "A stale paused claim from 2026-07-09 also exists." in result
         assert "Paused work detected" not in result
 
-    def test_paused_newer_wins_and_mentions_stale_refreshed(self, tmp_path):
+    def test_paused_newer_wins_and_mentions_stale_refreshed(
+        self, tmp_path, frozen_clock
+    ):
         sd = tmp_path / "s2"
         sd.mkdir()
         _write_journal_events(sd, [
@@ -1460,7 +1522,9 @@ class TestArbitrationHaltSurvival:
         ):
             return check_resume_state(prev_session_dir=str(sd))
 
-    def test_newer_pause_beats_halt_refresh_halt_line_survives(self, tmp_path):
+    def test_newer_pause_beats_halt_refresh_halt_line_survives(
+        self, tmp_path, frozen_clock
+    ):
         sd = tmp_path / "h1"
         sd.mkdir()
         _write_journal_events(sd, [
@@ -1591,9 +1655,62 @@ class TestCheckResumeState:
         assert "refresh_ts=2026-07-10T12:00:00Z" in result
         assert "Do NOT message any pre-refresh teammate name" in result
 
-    def test_paused_only_delegation_intact(self, tmp_path):
+    def test_stale_paused_state_surfaces_stale_branch(self, tmp_path, frozen_clock):
+        """The STALE side of the 14-day TTL, pinned explicitly.
+
+        WHY THIS EXISTS AS A SEPARATE TEST. The threshold previously had
+        coverage on ONE SIDE ONLY at this level: a single test asserted the
+        fresh branch, so when its fixture drifted past the cutoff the suite
+        reported a failure rather than a silent branch change — and nothing
+        anywhere asserted that the stale branch still produced the stale
+        message. One-sided coverage cannot distinguish "the cutoff moved"
+        from "my fixture aged".
+
+        Paired with `test_spent_refresh_falls_back_to_paused`, this straddles
+        the cutoff. The pair is only meaningful if the two sit on OPPOSITE
+        sides, so the check that matters is not that both go red when the
+        threshold is perturbed — two tests on the same side would do that —
+        but that they fail in OPPOSITE DIRECTIONS: inverting the comparison
+        makes this one report the FRESH message and its sibling report the
+        STALE one.
+        """
+        from unittest.mock import patch as mock_patch
+        from shared.session_resume import check_resume_state
+
+        sd = tmp_path / "stale-paused"
+        sd.mkdir()
+        # 17 days before the frozen now — past the 14-day cutoff, and derived
+        # from it rather than restated, so the margin cannot drift apart from
+        # the clock it is measured against.
+        paused_at = frozen_clock - _dt.timedelta(days=17)
+        _write_journal_events(sd, [{
+            "v": 1, "type": "session_paused", "pr_number": 55,
+            "pr_url": "https://github.com/o/r/pull/55", "branch": "feat/old",
+            "worktree_path": "/tmp/wt-old", "consolidation_completed": True,
+            "ts": paused_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }])
+
+        with mock_patch(
+            "shared.session_resume._check_pr_state", return_value="OPEN"
+        ):
+            result = check_resume_state(prev_session_dir=str(sd))
+
+        assert result == (
+            f"Stale paused state from {paused_at.strftime('%Y-%m-%d')} "
+            f"(older than 14 days). PR #55 on feat/old."
+        )
+        # The fresh branch must NOT be taken — this is the assertion that
+        # inverts against the sibling's.
+        assert not result.startswith("Paused work detected")
+
+    def test_paused_only_delegation_intact(self, tmp_path, frozen_clock):
         """The paused leg through the entry point behaves exactly like
-        check_paused_state: same prompt, same PR-gated logic."""
+        check_paused_state: same prompt, same PR-gated logic.
+
+        `frozen_clock` because the fixture pins an absolute instant against
+        the 14-day TTL; unfrozen, this asserts the fresh branch only until
+        the fixture ages out.
+        """
         from unittest.mock import patch as mock_patch
         from shared.session_resume import check_paused_state, check_resume_state
 
@@ -1613,7 +1730,17 @@ class TestCheckResumeState:
         assert via_entry == via_legacy
         assert via_entry.startswith("Paused work detected: PR #88")
 
-    def test_spent_refresh_falls_back_to_paused(self, tmp_path):
+    def test_spent_refresh_falls_back_to_paused(self, tmp_path, frozen_clock):
+        """A spent (consumed) refresh falls back to the FRESH-paused branch.
+
+        Uses `frozen_clock` because the fixture below pins absolute instants
+        against production's 14-day TTL; without it this test silently
+        migrates to the stale branch once the fixture ages past the cutoff.
+        Its stale-branch counterpart is
+        `TestCheckResumeState::test_stale_paused_state_surfaces_stale_branch`
+        — the two straddle the threshold and must fail in OPPOSITE
+        directions, which is what stops the pair from drifting to one side.
+        """
         from unittest.mock import patch as mock_patch
         from shared.session_resume import check_resume_state
 


### PR DESCRIPTION
Closes #1250.

## The defect

`test_spent_refresh_falls_back_to_paused` seeded a `session_paused` journal event at the absolute instant `2026-07-09T11:00:00Z` and asserted the **fresh**-paused branch. Production applies a 14-day staleness window computed relative to `now`, so from 2026-07-23 onward `check_resume_state` correctly returned the stale branch and the assertion failed.

**Production is correct.** The test encoded an absolute instant to exercise a predicate that is relative to now. The intent was right; the encoding expired.

This reddened CI on **every PR in the repo**, not just one — which trains reviewers to ignore red CI, the expensive failure mode this fix exists to prevent.

## The sweep found three more, all firing the next day

A census would have been the wrong instrument: `tests/` holds 500+ absolute date literals and nearly all are inert. A date is only a bomb if it feeds a production **age comparison**, so the sweep worked backwards from those seams and then *measured* rather than reasoned — a scratch pytest plugin shifted the clock at exactly those seams and the failure set was diffed against baseline.

| Test | Seeded | Age at 2026-07-24 | Status |
|---|---|---|---|
| `test_spent_refresh_falls_back_to_paused` | 07-09 | 15d | already firing |
| `test_paused_newer_wins_and_mentions_stale_refreshed` | 07-10 | 14d | fires next day |
| `test_newer_pause_beats_halt_refresh_halt_line_survives` | 07-10 | 14d | fires next day |
| `test_paused_only_delegation_intact` | 07-10 | 14d | fires next day |

The threshold is a strict `> 14`, so 14 days exactly still passes — that is the one-day gap. Fixing only the reported test would have looked correct for about eighteen hours.

The raw probe reported 13 failures at +30d against a baseline of 1. It was **not** reported as 12 bombs: the probe has a false-positive class by construction (it skews production's clock but not the test's, so tests already using relative timestamps fail as artifacts). Mechanical classification split it 4 real / 8 artifacts.

## The fix

Freeze the clock via a `datetime` **subclass** overriding only `now()` — not a `Mock`. `session_resume.py` binds the class with `from datetime import datetime` and calls `datetime.fromisoformat` on that same name to parse every fixture timestamp, so a broad mock would break parsing and fail in a way that looks like a production bug.

The frozen instant is `2026-07-18T12:00:00Z`, placing the fixtures 8–9 days old. This is deliberate: freezing `now` just *after* the fixtures would pass under almost any threshold value, leaving the tests insensitive to the very cutoff they exist to pin — green forever, measuring nothing.

Three of the four bombs also assert on output text that **embeds the date**, so relativising the fixtures would have forced the expected string to be computed too, and the tests would no longer state what they expect.

## Coverage

Adds a stale-branch sibling at `check_resume_state`, which had coverage on the fresh side only. Its age derives from the frozen instant rather than restating a date, so the margin cannot drift apart from the clock it is measured against.

(The stale side was already pinned one level down at `_check_journal_paused_state` by `test_ttl_boundary_is_strict_greater_than_14_days`; the gap was specifically at the `check_resume_state` entry point.)

## Verification

- Full suite, unfiltered `rtk proxy python -m pytest` with the errors token read explicitly: **12547 passed / 15 skipped / 0 failed / 0 errors**.
- **Non-vacuity, opposite directions from a single perturbation.** Inverting the operator (`>` → `<=`): the fresh test failed by *receiving the stale message*, and the stale test failed by *receiving the fresh message* — each took the other's branch. Corroborated per-side: threshold→30 reddens only the stale test; threshold→5 reddens only the fresh test. Two tests on the same side of a threshold cannot produce that.
- Post-fix re-probe at +30d, +365d and +3650d: all four defused; only the two known harness artifacts remain, constant across shifts — which is itself the signature of an artifact rather than a fuse.
- Production restored byte-identical after every mutation. Test-only change; `git diff --quiet -- hooks/ skills/ scripts/` clean.
- Import hygiene: PASS.

## Follow-ups (not in this PR)

- The clock-shift probe is session-local. It answers "what expires next" rather than "what is broken now" and found three bombs nobody knew about — worth a scheduled CI early-warning gate.
- `_refresh_event`'s default ts is the absolute literal `2026-07-10T12:00:00Z`, shared by every caller that does not override it. Already fired-and-stuck rather than armed (the 48h horizon makes it permanently stale, so those tests are stably green), but a trap for the next author writing a test that expects a *fresh* refresh.
