### PR TITLE
Archive pins before eviction; repair three guards that read stronger than they were

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.19",
+      "version": "4.6.20",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.19/       # Plugin version
+│               └── 4.6.20/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.19",
+  "version": "4.6.20",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.19
+> **Version**: 4.6.20
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/commands/pin-memory.md
+++ b/pact-plugin/commands/pin-memory.md
@@ -43,20 +43,20 @@ Cap violations are denied by `hooks/pin_caps_gate.py` when the Edit/Write tool c
    ### Entry Title
    Content here (~5-10 lines max)
    ```
-4. Commit.
+4. **Commit — then confirm `CLAUDE.md` is actually in the resulting commit.** Where a project git-ignores `CLAUDE.md` (a bare `CLAUDE.md` line in `.gitignore` matches at any depth), the failure is loud in the obvious cases and silent in the one that matters. An explicit `git add CLAUDE.md` errors, and a commit whose only change is `CLAUDE.md` reports "nothing to commit" — both non-zero, both visible. But a blanket `git commit -a` / `-am` that also picks up other changed files **succeeds, exits 0, and simply omits `CLAUDE.md`**. Checking the commit's exit status instead of its contents is what turns that into a pin reported as durable while it has no git backing at all. So verify the file is in the commit, not that the commit succeeded. If it is not, report the pin as **applied to the working file but not version-controlled**, so the curator knows it lives only on this machine. NEVER use `git add -f` to force it past the ignore rule — the rule is the project's decision, not an obstacle.
 
 ### Without arguments — session review
 
 1. Read existing CLAUDE.md.
 2. Review the session for pin-worthy context. Apply the "When to Pin" criteria above.
 3. For each pin-worthy entry, add it as in "Adding a pin." If nothing is pin-worthy, report "No new context to pin."
-4. Commit changes if any were made.
+4. Commit any changes — and apply the same check as **Adding a pin** step 4: confirm `CLAUDE.md` is in the resulting commit rather than trusting the commit's exit status, and report any pin that did not make it in as applied to the working file but not version-controlled.
 
 ## Refusal flow (hook-denied edits)
 
 If the pin_caps_gate hook denies the Edit/Write, the deny reason tells you which cap fired. You MUST NOT bypass.
 
-- **Pin count cap reached (12/12)**: Run `/PACT:prune-memory` to evict an existing pin, then retry the add.
+- **Pin count cap reached (12/12)**: Run `/PACT:prune-memory` to demote an existing pin to long-term memory, then retry the add. Demotion archives the pin to pact-memory before removing it, so the content is preserved rather than lost.
 - **New pin body is N chars (cap: 1500)**: Compress the body, or add a `pin-size-override` rationale if the content is verbatim load-bearing.
 - **Embedded pin structure in body**: Your new pin body contains a `### ` heading, which would be counted as an additional pin on reload. Use `#### ` or bold for in-body structure instead.
 - **Override rationale malformed**: The rationale is empty, exceeds 120 chars, or contains a line terminator (`\n`, `\r`, or a Unicode line separator). Fix the rationale and retry.

--- a/pact-plugin/commands/prune-memory.md
+++ b/pact-plugin/commands/prune-memory.md
@@ -43,7 +43,7 @@ The CLI emits a JSON payload with `evictable_pins`:
     {"index": 0, "heading": "First Pin", "chars": 40, "stale": false, "override": false,
      "age_days": 60, "overdue": true},
     {"index": 1, "heading": "Second Pin", "chars": 30, "stale": true, "override": false,
-     "age_days": null, "overdue": false},
+     "age_days": null, "overdue": null},
     ...
   ]
 }

--- a/pact-plugin/commands/prune-memory.md
+++ b/pact-plugin/commands/prune-memory.md
@@ -153,10 +153,15 @@ writes the pin block to pact-memory, re-fetches it by the returned `memory_id`,
 and confirms the block is present byte-for-byte:
 
 ```json
-{"outcome": "ARCHIVED", "memory_id": "<32-hex>", "heading": "...", "chars": 412, "contained": true}
-{"outcome": "NOT_ARCHIVED", "memory_id": "<32-hex>|null", "reason": "<why>", "heading": "..."}
-{"outcome": "UNEVALUABLE", "reason": "<why>", "heading": "...|null"}
+{"outcome": "ARCHIVED", "memory_id": "<32-hex>", "heading": "...", "claude_md_path": "/abs/path/CLAUDE.md", "chars": 412, "contained": true}
+{"outcome": "NOT_ARCHIVED", "memory_id": "<32-hex>|null", "reason": "<why>", "heading": "...", "claude_md_path": "/abs/path/CLAUDE.md"}
+{"outcome": "UNEVALUABLE", "reason": "<why>", "heading": "...|null", "claude_md_path": "/abs/path/CLAUDE.md|null"}
 ```
+
+`outcome`, `heading` and `claude_md_path` are present in **every** verdict.
+`claude_md_path` names the file this run actually read and is null only when
+resolution itself failed — which is also the case where there is nothing to
+edit, so a null path is a refusal, never a prompt to guess.
 
 **Check the returned `heading` against the pin the curator chose in Step 2.**
 `--index N` is a position in `evictable_pins`, and the script re-resolves that
@@ -213,13 +218,58 @@ the `UNEVALUABLE` escape hatch was explicitly acknowledged.** If neither holds,
 this step does not run — go back and report the refusal. Do not remove a pin
 you cannot show is somewhere else.
 
-Read the current CLAUDE.md. Locate the pin block for the selected
-`{heading}`:
+Read the CLAUDE.md at **`claude_md_path`, the absolute path the Step 3 verdict
+reports** — not "the project's CLAUDE.md". That field names the file the
+archival run actually read, and editing anything else breaks the one link that
+makes the verdict mean something about the file you are about to change.
 
-- The date comment immediately preceding `### {heading}` (if any).
-- The `### {heading}` line itself.
-- The body up to (but not including) the next `### ` heading OR the
-  end of the `## Pinned Context` section.
+The two are not reliably the same file. Resolution falls back through
+`CLAUDE_PROJECT_DIR`, then the git common dir's parent, then the working
+directory, so the file that gets read is not always the one the invocation
+seems to name. **If `claude_md_path` is not the project you expected, STOP and
+report it; do not edit.**
+
+The script refuses one case for you and cannot refuse the other. A fall-through
+that lands **outside** the starting directory's repository is refused outright —
+that verdict arrives as `UNEVALUABLE` with a reason naming both the directory
+and the file it would otherwise have used. A fall-through **within the same
+repository is allowed**, deliberately: PACT's own worktrees have no CLAUDE.md
+of their own, so every normal invocation depends on reaching the main
+checkout's file. That residual is the one you have to catch by reading
+`claude_md_path` — which is the whole reason this step names it.
+
+Step 3's heading cross-check cannot save you here. Step 1 uses the *same*
+resolver, so both agree on the same wrong file and the headings match — it
+detects an index shift *within* one file and is structurally blind to a
+wrong-*file* resolution. A cross-check only catches disagreement between two
+things that can disagree, and these two cannot.
+
+Locate the pin block for the selected `{heading}`. **The block runs from this
+pin's own span start to the NEXT pin's span start** — where a span starts at
+its date-comment line if it has one, and at its `### ` heading otherwise:
+
+- Start: the date comment immediately preceding `### {heading}` (if any),
+  from that line's first character; otherwise the `### {heading}` line.
+- End: the **next pin's date comment line** — NOT the next `### ` heading —
+  or the end of the `## Pinned Context` section for the last pin.
+
+**Ending at the next `### ` heading is wrong and destroys content.** A span
+begins at the date comment, which sits *above* the heading, so a block that
+runs to the next heading swallows the following pin's entire date comment —
+including any `pin-size-override` rationale, which this command elsewhere
+calls load-bearing verbatim content. Measured on a three-pin fixture: the
+correct rule removes 50 characters, the next-heading rule removes 153, and
+the extra 103 are the surviving neighbour's date comment. That neighbour
+silently loses its override flag and its pinned date. **Those bytes belong to
+a pin that was never selected and were never archived, so nothing holds a
+copy** — the precise loss this command exists to prevent, on the default path,
+since every pin carries a date comment.
+
+Computing both edges by the same span rule makes the blocks partition the
+section instead of overlapping. This is the identical boundary
+`archive_pin.py` uses to build the block it archives, and the two must agree:
+if the destroy rule is wider than the archive rule, the difference is by
+definition content that was destroyed without being stored.
 
 Use the `Edit` tool to remove the full block, preserving surrounding
 blank lines (one blank line between remaining pins). The `pin_caps_gate`
@@ -306,6 +356,25 @@ inside it — a curator's reason containing an apostrophe or a backtick passes
 through verbatim instead of closing the quote and aborting the write under
 `set -e`. Construct JSON-valid string content (escape `\"`, `\\`, and control
 characters).
+
+The success event is emitted at Step 5, once the removal Edit has landed:
+
+```bash
+set -e
+trap 'rc=$?; echo "[JOURNAL WRITE FAILED] prune-memory.md (bash line $LINENO): \"${BASH_COMMAND%%$'\''\n'\''*}\" exit=$rc" >&2; exit $rc' ERR
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/shared/session_journal.py" write \
+  --type pin_pruned --session-dir '{session_dir}' --stdin <<'JSON'
+{"heading": "First Pin", "memory_id": "0f3a9c1d7e2b48f6a5c04d8e1b7f2a93", "pin_count": 12}
+JSON
+```
+
+Two things in that payload are deliberate and are the ones most likely to be
+"corrected" by a later editor. There is **no `outcome` field** — only required
+fields are validated, so an extra one would land in the audit trail looking
+authoritative while guaranteed by nothing. And `pin_count` is **12, the count
+BEFORE the removal**, matching the skip event above so both carry the same
+referent; the post-eviction count is derivable, since this command never evicts
+more than one pin per invocation.
 
 ## Notes
 

--- a/pact-plugin/commands/prune-memory.md
+++ b/pact-plugin/commands/prune-memory.md
@@ -228,13 +228,17 @@ A curator at the cap with a broken memory CLI must not be trapped between a
 command that will not add and a command that will not remove. So on
 `UNEVALUABLE` — and never on `NOT_ARCHIVED`, where the failure is definite:
 
-1. Read the pin block from CLAUDE.md and **print it verbatim into the
-   conversation**, under a heading stating it is the only remaining copy.
-   (If CLAUDE.md cannot be read, there is nothing to print and nothing to
-   evict — refuse outright and stop.)
+1. **Print `delete_string` verbatim into the conversation**, under a heading
+   stating it is the only remaining copy. The verdict carries it whenever the
+   pin was located, so this path needs no separate reading of the file — the
+   hatch consumes the same checked handle as Step 4 rather than working out
+   its own boundary. (If the verdict carries no handle, the pin was never
+   located: there is nothing to print and nothing to evict — refuse outright
+   and stop.)
 2. Ask the curator to confirm they have captured it elsewhere. This is an
    explicit acknowledgement — never a default, never inferred from silence.
-3. Only on that acknowledgement, proceed to Step 4.
+3. Only on that acknowledgement, proceed to Step 4, which removes that same
+   string.
 4. Emit the skip event with outcome `unverified_eviction`, so the unverified
    eviction is auditable.
 
@@ -273,37 +277,30 @@ detects an index shift *within* one file and is structurally blind to a
 wrong-*file* resolution. A cross-check only catches disagreement between two
 things that can disagree, and these two cannot.
 
-Locate the pin block for the selected `{heading}`. **The block runs from this
-pin's own span start to the NEXT pin's span start** — where a span starts at
-its date-comment line if it has one, and at its `### ` heading otherwise:
+**Remove exactly the string the Step 3 verdict emitted as `delete_string`, at
+`claude_md_path`:**
 
-- Start: the date comment immediately preceding `### {heading}` (if any),
-  from that line's first character; otherwise the `### {heading}` line.
-- End: the **next pin's date comment line** — NOT the next `### ` heading —
-  or the end of the `## Pinned Context` section for the last pin.
+    Edit(file_path=<claude_md_path>, old_string=<delete_string>, new_string="")
 
-**Ending at the next `### ` heading is wrong and destroys content.** A span
-begins at the date comment, which sits *above* the heading, so a block that
-runs to the next heading swallows the following pin's entire date comment —
-including any `pin-size-override` rationale, which this command elsewhere
-calls load-bearing verbatim content. Measured on a three-pin fixture: the
-correct rule removes 50 characters, the next-heading rule removes 153, and
-the extra 103 are the surviving neighbour's date comment. That neighbour
-silently loses its override flag and its pinned date. **Those bytes belong to
-a pin that was never selected and were never archived, so nothing holds a
-copy** — the precise loss this command exists to prevent, on the default path,
-since every pin carries a date comment.
+**Use the emitted string exactly as given. Do not trim, pad, reformat or tidy
+it, and do not add, remove or adjust blank lines around the Edit** — the string
+spans exactly what must be removed. A curator who "cleans up" the value breaks
+the match, and the Edit then fails rather than removing the wrong bytes. That
+failure is the safe direction, but it is a confusing dead end, so do not walk
+into it: if the Edit does not match, something changed the file after the
+verdict was produced. **Stop and re-run from Step 1 — do not search for a
+near-match and do not hand-edit.**
 
-Computing both edges by the same span rule makes the blocks partition the
-section instead of overlapping. This is the identical boundary
-`archive_pin.py` uses to build the block it archives, and the two must agree:
-if the destroy rule is wider than the archive rule, the difference is by
-definition content that was destroyed without being stored.
+`delete_string` is a **checked handle, not simply the pin's text.** The script
+emits it only once it has established the string can be used — that it is
+present and occurs exactly once. Where that could not be established the field
+is absent, and the verdict says so through its outcome rather than handing you
+something unusable. **A field is present exactly when the fact it names was
+established**, which is why a missing handle is a refusal and never an
+invitation to reconstruct one.
 
-Use the `Edit` tool to remove the full block, preserving surrounding
-blank lines (one blank line between remaining pins). The `pin_caps_gate`
-hook ALLOWS the edit because `len(post_pins) < len(pre_pins)` — strictly
-better, not worse.
+The `pin_caps_gate` hook ALLOWS the edit because `len(post_pins) <
+len(pre_pins)` — strictly better, not worse.
 
 ### Step 5 — Report
 

--- a/pact-plugin/commands/prune-memory.md
+++ b/pact-plugin/commands/prune-memory.md
@@ -153,7 +153,8 @@ writes the pin block to pact-memory, re-fetches it by the returned `memory_id`,
 and confirms the block is present byte-for-byte:
 
 ```json
-{"outcome": "ARCHIVED", "memory_id": "<32-hex>", "heading": "...", "claude_md_path": "/abs/path/CLAUDE.md", "chars": 412, "contained": true}
+{"outcome": "ARCHIVED", "memory_id": "<32-hex>", "heading": "...", "claude_md_path": "/abs/path/CLAUDE.md", "chars": 412, "contained": true, "occurrences": 1}
+{"outcome": "ARCHIVED_DELETE_UNSAFE", "memory_id": "<32-hex>", "heading": "...", "claude_md_path": "/abs/path/CLAUDE.md", "occurrences": 2, "locations": [1043, 2871], "reason": "<why>"}
 {"outcome": "NOT_ARCHIVED", "memory_id": "<32-hex>|null", "reason": "<why>", "heading": "...", "claude_md_path": "/abs/path/CLAUDE.md"}
 {"outcome": "UNEVALUABLE", "reason": "<why>", "heading": "...|null", "claude_md_path": "/abs/path/CLAUDE.md|null"}
 ```
@@ -178,13 +179,41 @@ index against itself and pass unconditionally. It is `null` only on
 pinned section, index out of range). **Read `null` as unresolvable and take the
 escape hatch below — never as a mismatch**; there is no heading to disagree with.
 
-Then act on the verdict — only one of the three permits removal:
+Then act on the verdict. **Only `ARCHIVED` permits the removal Edit** — the
+name determines the disposition, so no row needs a footnote to be actionable:
 
 | Verdict | Meaning | Action |
 |---|---|---|
 | `ARCHIVED` | the pin's bytes are provably in long-term memory | proceed to Step 4 |
+| `ARCHIVED_DELETE_UNSAFE` | the archive **succeeded**; only the automatic removal is unsafe | do NOT Edit; hand the curator `memory_id`, `occurrences` and `locations` for manual removal; emit `delete_unsafe`; stop |
 | `NOT_ARCHIVED` | the archive definitively failed | **refuse**; report `reason`; emit `archive_refused`; stop |
 | `UNEVALUABLE` | could not tell — CLI absent, crash, timeout, unreadable file | **refuse**; report `reason`; offer the escape hatch below |
+
+#### `ARCHIVED_DELETE_UNSAFE` — a redirect, not a refusal
+
+**The archive worked.** The pin's content is in long-term memory and the
+verdict carries the `memory_id` that proves it. What failed is only the
+automatic removal: the emitted handle did not occur exactly once in the file,
+so an `Edit` keyed on it would match the wrong text or none at all.
+
+So the command does not remove the pin, and tells the curator plainly: *your
+content is safe under this `memory_id`; the block was found `occurrences`
+times; remove the pin by hand.* **The curator is not stuck at the cap** — the
+eviction can still be completed manually, and the safety guarantee this command
+exists to provide already held. Say that explicitly; a curator meeting an
+unfamiliar refusal at 12/12 will otherwise read it as a dead end and start
+hand-editing without the memory_id in view.
+
+`locations` are character offsets and are **diagnostic — where to look, never
+what to delete.** An offset computed at verdict time is silently wrong if the
+file changed afterwards, which is the whole reason the removal is keyed on
+content rather than position.
+
+There is **no escape hatch** on this verdict, and that is deliberate rather
+than an omission. The hatch exists for *cannot tell*; this is a known-bad
+precondition for the delete. Offering proceed-anyway would hand the curator an
+ambiguous target to remove by hand, which is worse than declining to remove it
+automatically.
 
 **Do NOT warn-and-proceed on a failed archive.** Elsewhere in PACT a failed
 journal write degrades to a warning because the journal survives independently
@@ -307,13 +336,26 @@ trail is what makes a skipped archive visible at all.
 | `evictable_pins` empty | `pin_prune_skipped` | `no_candidates` |
 | `slot_status` unknown | `pin_prune_skipped` | `unknown_state` |
 | Archive refused (Step 3) | `pin_prune_skipped` | `archive_refused` |
+| Archived but removal unsafe (Step 3) | `pin_prune_skipped` | `delete_unsafe` |
 | Escape-hatch eviction | `pin_prune_skipped` | `unverified_eviction` |
 | Pin archived and removed | `pin_pruned` | — (no `outcome` field) |
 
+`delete_unsafe` is a **distinct value and must not be folded into
+`archive_refused`.** That value means the archive definitively failed, and a run
+of them is the signal that the archival mechanism itself is broken. On this exit
+the archive SUCCEEDED, so reusing it would make a run of successful archives
+read as a failing archiver — poisoning the one diagnostic that row exists for.
+
 `pin_prune_skipped` carries `outcome`, `pin_count` at the time of the skip, and
 `age_distribution` (oldest / newest / median `age_days`, over pins whose age is
-known). `reason` is optional — a bare Cancel does not elicit one, and emitting a
-field with nothing behind it is a report with no measurement in it.
+known). An **empty `age_distribution` means the measured set was empty** — no
+pins with a known age existed at that moment. It is never a placeholder and
+never means not-applicable: the field is computed identically on every exit and
+is not conditional on the outcome. In particular `no_candidates` means
+`evictable_pins` is empty, which is NOT the same as no pins existing, so where
+dated pins are present the real distribution goes in even though none are
+evictable. `reason` is optional — a bare Cancel does not elicit one, and
+emitting a field with nothing behind it is a report with no measurement in it.
 
 `pin_pruned` carries `heading`, the `memory_id` of the archive, and `pin_count`
 — the count BEFORE the removal, matching `pin_prune_skipped`'s "count at the
@@ -356,6 +398,59 @@ inside it — a curator's reason containing an apostrophe or a backtick passes
 through verbatim instead of closing the quote and aborting the write under
 `set -e`. Construct JSON-valid string content (escape `\"`, `\\`, and control
 characters).
+
+The remaining skip outcomes take the same form; the `set -e` and `trap` lines
+above apply to each and are not repeated. **One emit per fence** — do not
+combine them.
+
+`no_candidates`, where the empty `age_distribution` records that the measured
+set was empty rather than standing in for a value:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/shared/session_journal.py" write \
+  --type pin_prune_skipped --session-dir '{session_dir}' --stdin <<'JSON'
+{"outcome": "no_candidates", "pin_count": 0, "age_distribution": {}}
+JSON
+```
+
+`unknown_state`, where the CLI could not parse CLAUDE.md, so no age is known:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/shared/session_journal.py" write \
+  --type pin_prune_skipped --session-dir '{session_dir}' --stdin <<'JSON'
+{"outcome": "unknown_state", "pin_count": 12, "age_distribution": {}, "reason": "Pin slots: unknown (CLAUDE.md unparseable)"}
+JSON
+```
+
+`archive_refused`, where the archive definitively failed and the pin survives:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/shared/session_journal.py" write \
+  --type pin_prune_skipped --session-dir '{session_dir}' --stdin <<'JSON'
+{"outcome": "archive_refused", "pin_count": 12, "age_distribution": {"oldest": 60, "newest": 3, "median": 33}, "reason": "memory CLI timed out"}
+JSON
+```
+
+`delete_unsafe`, where the archive SUCCEEDED and only the automatic removal was
+declined — note it still carries a `reason`, because unlike a bare Cancel this
+exit always has one:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/shared/session_journal.py" write \
+  --type pin_prune_skipped --session-dir '{session_dir}' --stdin <<'JSON'
+{"outcome": "delete_unsafe", "pin_count": 12, "age_distribution": {"oldest": 60, "newest": 3, "median": 33}, "reason": "block occurs 2 times; removal would be ambiguous"}
+JSON
+```
+
+`unverified_eviction` is emitted on the escape-hatch path, where the pin was
+removed without a verified archive:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/shared/session_journal.py" write \
+  --type pin_prune_skipped --session-dir '{session_dir}' --stdin <<'JSON'
+{"outcome": "unverified_eviction", "pin_count": 12, "age_distribution": {"oldest": 60, "newest": 3, "median": 33}, "reason": "curator acknowledged the pin block was captured elsewhere"}
+JSON
+```
 
 The success event is emitted at Step 5, once the removal Edit has landed:
 

--- a/pact-plugin/commands/prune-memory.md
+++ b/pact-plugin/commands/prune-memory.md
@@ -4,14 +4,23 @@ description: Interactively prune pins from CLAUDE.md via paginated AskUserQuesti
 
 ## What this command does
 
-Presents the curator with the current evictable-pin list and asks which
-one (or none) to remove. Useful after `/PACT:pin-memory` is denied by
-the count cap: use `/PACT:prune-memory` to evict an existing pin, then
+Presents the curator with the current evictable-pin list, asks which
+one (or none) to remove, **archives the selected pin to long-term memory
+and verifies the archive before removing anything**, then removes it.
+Useful after `/PACT:pin-memory` is denied by the count cap: use
+`/PACT:prune-memory` to demote an existing pin to long-term memory, then
 retry the add.
+
+Demotion is not deletion. A pin leaves `## Pinned Context` only once its
+content is provably somewhere else — see [Step 3](#step-3--archive-the-selected-pin).
 
 The `pin_caps_gate` PreToolUse hook ALLOWS the resulting Edit because
 the pin count strictly decreases (net-worse predicate: pre has ≥N
-pins, post has N-1 — not worse, so allow).
+pins, post has N-1 — not worse, so allow). **The hook cannot enforce the
+archive**: it sees a count decrease and allows it, whether or not Step 3
+ran. Step 3 is enforced by this file and by nothing else, which is why
+every exit below emits a journal event — an invocation that evicts a pin
+while emitting nothing is the one state that should never occur.
 
 ## Process
 
@@ -31,31 +40,50 @@ The CLI emits a JSON payload with `evictable_pins`:
   "violation": null,
   "slot_status": "Pin slots: N/12 used, ...",
   "evictable_pins": [
-    {"index": 0, "heading": "First Pin", "chars": 40, "stale": false, "override": false},
-    {"index": 1, "heading": "Second Pin", "chars": 30, "stale": true, "override": false},
+    {"index": 0, "heading": "First Pin", "chars": 40, "stale": false, "override": false,
+     "age_days": 60, "overdue": true},
+    {"index": 1, "heading": "Second Pin", "chars": 30, "stale": true, "override": false,
+     "age_days": null, "overdue": false},
     ...
   ]
 }
 ```
 
-If `slot_status` starts with `Pin slots: unknown (...)`, the CLI could
-not parse CLAUDE.md. Report the reason and stop — do NOT attempt to
-evict from an unknown state.
+`age_days` is computed from the pin's `<!-- pinned: ... -->` date comment;
+`overdue` is true once that age reaches the staleness threshold. Both are
+distinct from `stale`, which reports only that a `<!-- STALE: ... -->` marker
+has been written into the body. A pin can be `overdue` without being `stale`.
 
-If `evictable_pins` is empty, report "No pins to prune." and stop.
+**`age_days: null` is a third state and is NOT `overdue: false`.** It means the
+pin carries no parseable date and its age is unknown. Surface it to the curator
+as unknown rather than silently treating it as fresh — an undated pin is the one
+most likely to have been sitting there longest.
+
+If `slot_status` starts with `Pin slots: unknown (...)`, the CLI could
+not parse CLAUDE.md. Report the reason, emit the skip event with outcome
+`unknown_state`, and stop — do NOT attempt to evict from an unknown state.
+
+If `evictable_pins` is empty, report "No pins to prune.", emit the skip
+event with outcome `no_candidates`, and stop.
 
 ### Step 2 — Ask the curator which pin to prune
 
 Present up to 3 candidate pins per `AskUserQuestion` call (plus a 4th
-"Show more" or "Cancel" option). Prefer STALE pins first — they are
-the safest to evict. Label shape:
+"Show more" or "Cancel" option). `AskUserQuestion` accepts at most 4
+options per question and at most 4 questions per call, so 3 candidates
+plus one navigation slot sits exactly at the option cap — this pagination
+cannot be widened, only paged.
+
+**Order `overdue` pins first** — they have outlived the horizon they were
+pinned for and are the default prune candidates. Within the same overdue
+bucket, Prefer STALE pins over fresh ones. Label shape:
 
 ```
 AskUserQuestion(questions=[{
   header: "Pin prune",
-  question: "Which pin to evict? (page N of M)",
+  question: "Which pin to demote to long-term memory? (page N of M)",
   options: [
-    {label: "Pin {index} — {heading}", description: "{chars} chars{, STALE if stale}{, OVERRIDE if override}"},
+    {label: "Pin {index} — {heading}", description: "{chars} chars{, OVERDUE {age_days}d if overdue}{, age unknown if age_days is null}{, STALE if stale}{, OVERRIDE if override}"},
     ...
     {label: "Show more",                description: "Next page of candidates"}
        | {label: "Cancel",              description: "Do not prune any pin"}
@@ -68,9 +96,122 @@ Pagination rules:
 - **> 3 evictable pins**: present 3 pins + "Show more" per page. The last page shows remaining pins + "Cancel".
 - Label format: `Pin {index} — {heading}` (the index is the position in `evictable_pins`, not the line in CLAUDE.md).
 
-If the curator picks "Cancel", report "Prune cancelled; CLAUDE.md unchanged." and stop.
+If the curator picks "Cancel", report "Prune cancelled; CLAUDE.md unchanged.",
+emit the skip event with outcome `cancelled`, and stop.
 
-### Step 3 — Remove the selected pin
+#### Justify the eviction
+
+Once a pin is selected, ask the curator — as a plain question, not an
+`AskUserQuestion` call, because a rationale cannot be enumerated as options
+in advance — **what concrete next-session question this pin resolves**.
+
+A justification MUST name a concrete question ("how do parsers scope their
+reads in CLAUDE.md?") and cite the pin's answer ("use `_extract_managed_region()`").
+It MUST NOT fall back to "load-bearing", "accurate", "important", or similar
+non-discriminating generalities. If the answer is one of those, say so and ask
+again — a pin nobody can frame a question for is a pin that has stopped earning
+its slot, and that is the finding, not an obstacle.
+
+This is a discipline rule you apply by reading the answer. It is deliberately
+NOT a banned-word check: a word list is satisfied by any synonym, and a
+mechanical-looking gate suppresses the scrutiny a prose rule invites.
+
+#### Re-confirm the other overdue pins
+
+For pins that are `overdue` but were NOT selected, batch re-confirmation into
+`AskUserQuestion` calls of up to 4 questions each (with 6 overdue pins that is
+2 calls, not 6). Ask whether each is still worth its slot. For each pin the
+curator keeps, collect a one-line reason and extend its date comment in place:
+
+```markdown
+<!-- pinned: 2026-05-26, reconfirmed: 2026-07-25 because {concrete reason} -->
+```
+
+The reason MUST be single-line and MUST NOT contain `>` — the parser reads the
+comment as `<!--\s*pinned:\s*[^>]+?-->`, so a `>` truncates it. Re-confirming
+resets the clock: age computes from the `reconfirmed:` date once present. The
+reason is free text and is subject to the same concreteness rule above.
+
+Scope note: justification is asked for the pin being evicted and for
+age-flagged borderline pins only — **not for every retained pin**. At 12 pins
+the exhaustive form serialises into roughly 20 prompts to evict one pin, and a
+curator facing 20 prompts answers with exactly the generalities this step
+exists to forbid.
+
+### Step 3 — Archive the selected pin
+
+Demote the pin into long-term memory and **verify it arrived** before anything
+is removed:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/archive_pin.py" --index N
+```
+
+The script always exits 0 and reports its verdict inside the JSON payload — a
+non-zero exit is a crash, not a verdict, and is treated as `UNEVALUABLE`. It
+writes the pin block to pact-memory, re-fetches it by the returned `memory_id`,
+and confirms the block is present byte-for-byte:
+
+```json
+{"outcome": "ARCHIVED", "memory_id": "<32-hex>", "heading": "...", "chars": 412, "contained": true}
+{"outcome": "NOT_ARCHIVED", "memory_id": "<32-hex>|null", "reason": "<why>", "heading": "..."}
+{"outcome": "UNEVALUABLE", "reason": "<why>", "heading": "...|null"}
+```
+
+**Check the returned `heading` against the pin the curator chose in Step 2.**
+`--index N` is a position in `evictable_pins`, and the script re-resolves that
+index against CLAUDE.md as it reads the file. If anything changed the pinned
+section in between, the index now denotes a different pin — and the archive
+would succeed, and its containment check would pass, for the wrong pin. On any
+mismatch, stop and re-run from Step 1. A verification that measures the right
+property on the wrong object reports success and proves nothing.
+
+`heading` is always present as a key. It is the pin's real parsed heading, never
+an echo of the index you passed — an echo would make this check compare the
+index against itself and pass unconditionally. It is `null` only on
+`UNEVALUABLE` where no pin could be resolved at all (unreadable CLAUDE.md, no
+pinned section, index out of range). **Read `null` as unresolvable and take the
+escape hatch below — never as a mismatch**; there is no heading to disagree with.
+
+Then act on the verdict — only one of the three permits removal:
+
+| Verdict | Meaning | Action |
+|---|---|---|
+| `ARCHIVED` | the pin's bytes are provably in long-term memory | proceed to Step 4 |
+| `NOT_ARCHIVED` | the archive definitively failed | **refuse**; report `reason`; emit `archive_refused`; stop |
+| `UNEVALUABLE` | could not tell — CLI absent, crash, timeout, unreadable file | **refuse**; report `reason`; offer the escape hatch below |
+
+**Do NOT warn-and-proceed on a failed archive.** Elsewhere in PACT a failed
+journal write degrades to a warning because the journal survives independently
+of the thing being written about. Here nothing survives: proceeding past a
+failed archive destroys the only copy of the pin, and CLAUDE.md is frequently
+git-ignored, so there may be no commit to recover it from. The degradation is
+to keep the pin, not to keep going.
+
+#### Escape hatch — `UNEVALUABLE` only
+
+A curator at the cap with a broken memory CLI must not be trapped between a
+command that will not add and a command that will not remove. So on
+`UNEVALUABLE` — and never on `NOT_ARCHIVED`, where the failure is definite:
+
+1. Read the pin block from CLAUDE.md and **print it verbatim into the
+   conversation**, under a heading stating it is the only remaining copy.
+   (If CLAUDE.md cannot be read, there is nothing to print and nothing to
+   evict — refuse outright and stop.)
+2. Ask the curator to confirm they have captured it elsewhere. This is an
+   explicit acknowledgement — never a default, never inferred from silence.
+3. Only on that acknowledgement, proceed to Step 4.
+4. Emit the skip event with outcome `unverified_eviction`, so the unverified
+   eviction is auditable.
+
+The hatch exists to make **the pin survive**, not to make the eviction proceed.
+
+### Step 4 — Remove the selected pin
+
+**Proceed only if Step 3 returned `ARCHIVED` with a matching `heading`, or if
+the `UNEVALUABLE` escape hatch was explicitly acknowledged.** If neither holds,
+this step does not run — go back and report the refusal. Do not remove a pin
+you cannot show is somewhere else.
 
 Read the current CLAUDE.md. Locate the pin block for the selected
 `{heading}`:
@@ -85,10 +226,86 @@ blank lines (one blank line between remaining pins). The `pin_caps_gate`
 hook ALLOWS the edit because `len(post_pins) < len(pre_pins)` — strictly
 better, not worse.
 
-### Step 4 — Report + commit
+### Step 5 — Report
 
-- Report: "Pruned pin {index}: {heading}".
-- Commit the change with a concise message, e.g. `chore: prune pin "{heading}"`.
+- Report: "Pruned pin {index}: {heading} — archived as {memory_id}." Name the
+  `memory_id` so the curator can retrieve the demoted content later.
+- Emit `pin_pruned` carrying that `memory_id`, the pin's `heading`, and
+  `pin_count`. It has no `outcome` field — the event's existence IS the
+  outcome. An escape-hatch eviction never reaches this event; it already
+  emitted `pin_prune_skipped` with `unverified_eviction` back at Step 3.
+- Commit the change — then **confirm `CLAUDE.md` is actually in the resulting
+  commit.** Where a project git-ignores `CLAUDE.md` (a bare `CLAUDE.md` line in
+  `.gitignore` matches at any depth), an explicit `git add CLAUDE.md` errors and
+  a commit whose only change is `CLAUDE.md` reports "nothing to commit" — both
+  loud. The silent case is a blanket `git commit -a` / `-am` that also picks up
+  other changed files: it succeeds, exits 0, and omits `CLAUDE.md`. Verify the
+  file is in the commit rather than trusting the commit's exit status, and if it
+  is not, report the prune as applied to the working file but not
+  version-controlled. NEVER use `git add -f`.
+
+## Telemetry
+
+Every exit emits exactly one journal event, so that an invocation which removed
+a pin while emitting nothing is detectable after the fact. That is the only
+check on Step 3 there is — the hook cannot enforce the archive, so the audit
+trail is what makes a skipped archive visible at all.
+
+| Exit | Event | `outcome` |
+|---|---|---|
+| Curator picks Cancel | `pin_prune_skipped` | `cancelled` |
+| `evictable_pins` empty | `pin_prune_skipped` | `no_candidates` |
+| `slot_status` unknown | `pin_prune_skipped` | `unknown_state` |
+| Archive refused (Step 3) | `pin_prune_skipped` | `archive_refused` |
+| Escape-hatch eviction | `pin_prune_skipped` | `unverified_eviction` |
+| Pin archived and removed | `pin_pruned` | — (no `outcome` field) |
+
+`pin_prune_skipped` carries `outcome`, `pin_count` at the time of the skip, and
+`age_distribution` (oldest / newest / median `age_days`, over pins whose age is
+known). `reason` is optional — a bare Cancel does not elicit one, and emitting a
+field with nothing behind it is a report with no measurement in it.
+
+`pin_pruned` carries `heading`, the `memory_id` of the archive, and `pin_count`
+— the count BEFORE the removal, matching `pin_prune_skipped`'s "count at the
+time of the decision" so the two events share one referent and stay directly
+comparable. The post-eviction count is derivable, since this command never
+evicts more than one pin per invocation. It carries no `outcome` field: only
+required fields are validated, so an extra one would be written into the audit
+trail looking authoritative while guaranteed by nothing. The `memory_id` is the
+point of the event — it makes the claim checkable by fetching it, rather than
+merely asserted.
+
+**Reading the trail: an eviction is a UNION, not a single event.** An
+escape-hatch eviction removed a pin but is filed under the skip event, because
+it has no `memory_id` to carry and `pin_pruned` requires one:
+
+    evictions = pin_pruned  UNION  (pin_prune_skipped WHERE outcome = "unverified_eviction")
+
+The second arm is exactly the set of evictions with no archive record. An audit
+that queries only `pin_pruned` under-counts evictions and, worse, misses the
+ones that went unverified — the population it most needs to see.
+
+Substitute `{session_dir}` from the `- Session dir:` line in CLAUDE.md's
+`## Current Session` block, falling back to `pact-session-context.json` for that
+one field. **If neither resolves, skip the emit, note it in the report, and
+carry on** — telemetry never blocks a prune. A failed audit write that refused a
+legitimate eviction would be a data-loss bug arriving from the observability
+layer, which is the one place nobody is watching for it.
+
+```bash
+set -e
+trap 'rc=$?; echo "[JOURNAL WRITE FAILED] prune-memory.md (bash line $LINENO): \"${BASH_COMMAND%%$'\''\n'\''*}\" exit=$rc" >&2; exit $rc' ERR
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/shared/session_journal.py" write \
+  --type pin_prune_skipped --session-dir '{session_dir}' --stdin <<'JSON'
+{"outcome": "cancelled", "pin_count": 12, "age_distribution": {"oldest": 60, "newest": 3, "median": 33}}
+JSON
+```
+
+The heredoc delimiter is quoted (`<<'JSON'`) so bash performs no expansion
+inside it — a curator's reason containing an apostrophe or a backtick passes
+through verbatim instead of closing the quote and aborting the write under
+`set -e`. Construct JSON-valid string content (escape `\"`, `\\`, and control
+characters).
 
 ## Notes
 
@@ -98,6 +315,9 @@ better, not worse.
 - Stale pins (marked with `<!-- STALE: Last relevant YYYY-MM-DD -->`)
   are surfaced with a `STALE` tag in the option description. Prefer
   pruning stale pins before non-stale.
+- Overdue pins (`age_days` past the threshold) are surfaced with an
+  `OVERDUE` tag and sorted first. `stale` and `overdue` are independent
+  signals — a pin can be either, both, or neither.
 - Override-carrying pins (with `pin-size-override` rationale) are
   surfaced with an `OVERRIDE` tag. These are load-bearing verbatim
   content; prune only with deliberate intent.

--- a/pact-plugin/hooks/pin_caps.py
+++ b/pact-plugin/hooks/pin_caps.py
@@ -368,9 +368,18 @@ def check_stale_block(
 # Shared deny-reason templates. Plain instructional text aimed at the curator
 # (the LLM driving Edit/Write). Rendered verbatim into permissionDecisionReason
 # so the curator sees the next-step action.
+# DEMOTE-NOT-DELETE framing. The curator meeting this deny is at the cap and
+# is being told to remove something they previously judged worth keeping, so
+# the wording has to answer "what happens to it?" before they decide. Naming
+# the destination (long-term memory) rather than the act (evict) is the whole
+# point: /PACT:prune-memory archives the pin's content to pact-memory and
+# verifies it arrived BEFORE removing it, so the content survives the removal.
+# "Evict" described only the deletion half and read as loss.
 DENY_REASON_COUNT = (
     "Pin count cap reached ({count}/{cap}). "
-    "Run /PACT:prune-memory to evict an existing pin before adding."
+    "Run /PACT:prune-memory to demote a pin to long-term memory before "
+    "adding — demotion archives the pin to pact-memory first, so the "
+    "content is preserved rather than lost."
 )
 
 DENY_REASON_SIZE = (

--- a/pact-plugin/hooks/shared/session_journal.py
+++ b/pact-plugin/hooks/shared/session_journal.py
@@ -256,7 +256,16 @@ _REQUIRED_FIELDS_BY_TYPE: dict[str, dict[str, type]] = {
     "artifact_paths": {"workflow": str, "feature": str, "paths": list},
     # commands/prune-memory.md writes pin_prune_skipped on EVERY no-eviction
     # exit, not only on Cancel: cancelled / no_candidates / unknown_state /
-    # archive_refused / unverified_eviction. `archive_refused` is the
+    # archive_refused / unverified_eviction / delete_unsafe.
+    #
+    # `delete_unsafe` is DISTINCT from `archive_refused` and must not be
+    # folded into it. It means the archive SUCCEEDED but the removal was
+    # unsafe (the block was not unique, so an Edit keyed on it would be
+    # ambiguous). Reusing `archive_refused` there would record a falsehood --
+    # and worse, it would POISON the diagnostic below: a run of them would
+    # read as a broken archiver while every archive in fact succeeded.
+    #
+    # `archive_refused` is the
     # highest-value row — a run of refusals is the signal that the archival
     # mechanism itself is broken, and emitting only on Cancel would make that
     # failure mode invisible to the audit this event exists for.
@@ -423,7 +432,8 @@ _OPTIONAL_FIELDS_BY_TYPE: dict[str, dict[str, type]] = {
     # commands/prune-memory.md writes pin_prune_skipped with an optional
     # `reason`, present ONLY where the flow genuinely elicited one: a
     # curator-supplied cancel reason, or the machine reason on
-    # archive_refused / unknown_state. A bare Cancel collects nothing, which
+    # archive_refused / unknown_state / delete_unsafe. A bare Cancel
+    # collects nothing, which
     # is exactly why this is optional rather than required — see the
     # required-fields registration above. The required-fields entry is what
     # ACTIVATES this optional check (same activation pattern as session_end /

--- a/pact-plugin/hooks/shared/session_journal.py
+++ b/pact-plugin/hooks/shared/session_journal.py
@@ -254,6 +254,63 @@ _REQUIRED_FIELDS_BY_TYPE: dict[str, dict[str, type]] = {
     # passes isinstance but is meaningless — that "missing artifact" case is the
     # task_lifecycle_gate backstop's job, NOT a zero-length event).
     "artifact_paths": {"workflow": str, "feature": str, "paths": list},
+    # commands/prune-memory.md writes pin_prune_skipped on EVERY no-eviction
+    # exit, not only on Cancel: cancelled / no_candidates / unknown_state /
+    # archive_refused / unverified_eviction. `archive_refused` is the
+    # highest-value row — a run of refusals is the signal that the archival
+    # mechanism itself is broken, and emitting only on Cancel would make that
+    # failure mode invisible to the audit this event exists for.
+    # `pin_count` is the count at the time of the skip; `age_distribution` is
+    # the oldest/newest/median summary, computable only because
+    # check_pin_caps --status now carries per-pin age_days.
+    #
+    # `reason` is deliberately NOT required (it is declared optional below).
+    # It is not obtainable on a bare Cancel without adding a prompt to every
+    # cancellation, and registering it as required would force either that
+    # extra prompt or a fabricated value — emitting a field we cannot
+    # populate is a success report with no measurement behind it, which is
+    # the exact defect class this work exists to remove.
+    "pin_prune_skipped": {
+        "outcome": str,
+        "pin_count": int,
+        "age_distribution": dict,
+    },
+    # commands/prune-memory.md writes pin_pruned on the SUCCESS path, after
+    # the removal Edit lands, carrying the memory_id the archival returned.
+    #
+    # Why a success event exists at all: pin_caps_gate ALLOWS the eviction
+    # Edit by construction (a deny-on-improvement predicate would trap a
+    # curator at 12/12 on the only cap-relief path), so nothing MECHANICALLY
+    # enforces that the archive ran. Detectability is therefore the entire
+    # remaining control. With skip-only telemetry a curator who bypassed the
+    # archive and went straight to the removal Edit would emit NOTHING and be
+    # indistinguishable from a correctly-archived eviction — the audit trail
+    # would be blind to precisely the failure mode it exists to catch.
+    # `memory_id` is what makes the claim CHECKABLE rather than asserted: an
+    # auditor can fetch it.
+    #
+    # `pin_count` is the count BEFORE the removal, matching
+    # pin_prune_skipped's "count at the time of the decision" so the two
+    # events share one referent and stay directly comparable.
+    #
+    # NO `outcome` FIELD, deliberately: only required fields are validated,
+    # so an unvalidated extra would sit in the audit trail looking
+    # authoritative while guaranteed by nothing.
+    #
+    # READING THE TRAIL — an eviction is a UNION, not a single event. An
+    # escape-hatch eviction removed a pin but is filed under
+    # pin_prune_skipped (outcome "unverified_eviction"), because it has no
+    # memory_id and this type requires one:
+    #     evictions = pin_pruned
+    #                 UNION (pin_prune_skipped WHERE outcome = unverified_eviction)
+    # The second arm IS the set of evictions with no archive record. Querying
+    # only pin_pruned under-counts, and misses the unverified population an
+    # audit most needs to see.
+    "pin_pruned": {
+        "heading": str,
+        "memory_id": str,
+        "pin_count": int,
+    },
 }
 
 
@@ -362,6 +419,17 @@ _OPTIONAL_FIELDS_BY_TYPE: dict[str, dict[str, type]] = {
     # missed_wake).
     "teachback_ack": {
         "concern": str,
+    },
+    # commands/prune-memory.md writes pin_prune_skipped with an optional
+    # `reason`, present ONLY where the flow genuinely elicited one: a
+    # curator-supplied cancel reason, or the machine reason on
+    # archive_refused / unknown_state. A bare Cancel collects nothing, which
+    # is exactly why this is optional rather than required — see the
+    # required-fields registration above. The required-fields entry is what
+    # ACTIVATES this optional check (same activation pattern as session_end /
+    # missed_wake / teachback_ack).
+    "pin_prune_skipped": {
+        "reason": str,
     },
     # hooks/shared/task_metadata_snapshot.emit_task_metadata_snapshot writes
     # task_metadata_snapshot with these optionals. subject is sentinel-

--- a/pact-plugin/scripts/archive_pin.py
+++ b/pact-plugin/scripts/archive_pin.py
@@ -32,12 +32,34 @@ Output (stdout, JSON, ALWAYS exit 0). `outcome`, `heading` and
 pin could not be resolved at all and is NEVER derived from the requested
 index; `claude_md_path` is null only when resolution itself failed:
 
-  {"outcome": "ARCHIVED",     "heading": str, "claude_md_path": str,
-   "memory_id": str, "chars": int, "contained": true}
-  {"outcome": "NOT_ARCHIVED", "heading": str, "claude_md_path": str,
-   "memory_id": str|null, "reason": str}
-  {"outcome": "UNEVALUABLE",  "heading": str|null,
-   "claude_md_path": str|null, "reason": str}
+  {"outcome": "ARCHIVED",               "heading": str, "claude_md_path": str,
+   "delete_string": str, "memory_id": str, "chars": int, "contained": true,
+   "occurrences": 1}
+  {"outcome": "ARCHIVED_DELETE_UNSAFE", "heading": str, "claude_md_path": str,
+   "delete_string": str, "memory_id": str, "occurrences": int,
+   "locations": [int], "reason": str}
+  {"outcome": "NOT_ARCHIVED",           "heading": str, "claude_md_path": str,
+   "delete_string": str, "memory_id": str|null, "reason": str}
+  {"outcome": "UNEVALUABLE",            "heading": str|null,
+   "claude_md_path": str|null, "delete_string": str|null, "reason": str}
+
+FOUR outcomes. Only ARCHIVED permits the removal Edit to proceed.
+
+`delete_string` is the verbatim block, a CONTENT handle: the removal is
+`Edit(old_string=delete_string, new_string="")`, which matches on content, so
+a file that moved under the caller makes the Edit FAIL LOUDLY rather than
+delete the wrong bytes. It is emitted whenever the pin RESOLVES -- including
+NOT_ARCHIVED and a located-pin UNEVALUABLE -- because it is a property of
+WHICH PIN, not of whether the archive worked; null only when the pin does not
+resolve. Uniqueness is verified after the save.
+
+ARCHIVED_DELETE_UNSAFE means the archive SUCCEEDED and the removal is unsafe:
+the block is not unique, so an Edit keyed on it would be ambiguous. It is a
+distinct outcome rather than a reason on another one because THE OUTCOME NAME
+MUST DETERMINE THE DISPOSITION -- one outcome with two dispositions forces a
+reason table, which is how a permission gets inherited by a condition it was
+never designed for. It offers no escape hatch, and does not trap the curator
+at the cap: the content is archived, so manual removal is a redirect.
 
 `claude_md_path` names the file THIS RUN ACTUALLY READ. It exists because
 resolution can succeed on the WRONG file: the order is CLAUDE_PROJECT_DIR ->
@@ -174,10 +196,16 @@ class _Unevaluable(Exception):
     """
 
     def __init__(self, reason: str, heading: str | None = None,
-                 claude_md_path: str | None = None):
+                 claude_md_path: str | None = None,
+                 delete_string: str | None = None):
         super().__init__(reason)
         self.reason = reason
         self.heading = heading
+        # The block to remove, when the pin RESOLVED before the failure. It is
+        # a property of WHICH PIN, not of whether the archive worked, so the
+        # escape-hatch path gets a mechanical boundary too and no consumer has
+        # to re-derive one.
+        self.delete_string = delete_string
         # The file this run read, when one was resolved before the failure.
         # None only when resolution itself failed -- there is genuinely no
         # path to name, and inventing one would be worse than null.
@@ -491,6 +519,60 @@ def _classify_cli_error(stderr: str) -> str:
     return text.splitlines()[-1][:300]
 
 
+def _unsafe_reason(occurrences: int, claude_md_path: str, memory_id: str) -> str:
+    """Explain WHY the removal is unsafe -- the two causes are different.
+
+    `occurrences != 1` catches both directions, but they are not the same
+    condition and a curator acts differently on each:
+
+      > 1   the block appears more than once, so an Edit keyed on it cannot be
+            targeted. DUPLICATION.
+      0     the block is not there at all. It was present when this run read
+            the file and is gone from the post-save re-read, which means
+            something modified CLAUDE.md concurrently -- a live hazard on a
+            file the curator may have open in an editor. ABSENCE, not ambiguity.
+
+    Telling a curator "ambiguous" when the block has VANISHED sends them
+    hunting for a second copy that does not exist. The disposition must be
+    readable from what the verdict says rather than reconstructed, and a
+    reason string that misdescribes its own condition is that failure in
+    miniature.
+    """
+    archived = (
+        f"The archive SUCCEEDED (memory_id {memory_id}) -- the content is "
+        f"safe. Remove the pin manually."
+    )
+    if occurrences == 0:
+        return (
+            f"the pin block is NO LONGER PRESENT in {claude_md_path}. It was "
+            f"read from that file moments ago, so something modified the file "
+            f"concurrently -- check for an editor or another process holding "
+            f"it. This is absence, not ambiguity: there is no second copy to "
+            f"find. {archived}"
+        )
+    return (
+        f"the pin block occurs {occurrences} times in {claude_md_path}; a "
+        f"removal Edit keyed on it would be ambiguous. {archived}"
+    )
+
+
+def _occurrence_offsets(text: str, needle: str) -> list:
+    """Character offsets of every occurrence of `needle`, for the unsafe verdict.
+
+    Offsets are DIAGNOSTIC only -- they tell a curator where the copies are.
+    They are deliberately NOT the delete handle: a positional handle computed
+    now and consumed later is silently wrong if anything touches the file in
+    between, whereas the content handle makes a stale Edit fail loudly.
+    """
+    offsets, start = [], 0
+    while True:
+        at = text.find(needle, start)
+        if at == -1:
+            return offsets
+        offsets.append(at)
+        start = at + 1
+
+
 def _build_record(block: str, heading: str) -> dict:
     """Build the pact-memory record for an archived pin.
 
@@ -609,9 +691,15 @@ def archive_pin(index: int, db_path=None) -> dict:
     # STANDALONE: always `save` (create), never `update` (fold). See
     # _build_record -- a fold runs no marker code and is invisible to an
     # archive scan.
+    # --no-sync: the Working Memory projection would write the record's
+    # `context` -- the block, verbatim -- back into the same CLAUDE.md this
+    # archive exists to remove it from. The pin SLOT would be freed while the
+    # file was not, and the duplicate would make the curator's removal Edit
+    # ambiguous. Measured: without it the block occurs twice and the file
+    # grows; with it CLAUDE.md is byte-identical across the save.
     _, stdout, stderr = _run_memory_cli(
-        [_ARCHIVE_SUBCOMMAND, "--stdin"], db_path=db_path, stdin_data=payload,
-        cwd=project_dir,
+        [_ARCHIVE_SUBCOMMAND, "--stdin", "--no-sync"], db_path=db_path,
+        stdin_data=payload, cwd=project_dir,
     )
     result = _parse_envelope(stdout)
     memory_id = result.get("memory_id") if isinstance(result, dict) else None
@@ -622,6 +710,7 @@ def archive_pin(index: int, db_path=None) -> dict:
             "outcome": "NOT_ARCHIVED",
             "heading": heading,
             "claude_md_path": claude_md_path,
+            "delete_string": block,
             "memory_id": None,
             "reason": f"save returned no memory_id -- {_classify_cli_error(stderr)}",
         }
@@ -639,6 +728,7 @@ def archive_pin(index: int, db_path=None) -> dict:
             f"saved as {memory_id} but re-fetch failed -- "
             f"{_classify_cli_error(stderr)}",
             heading=heading, claude_md_path=claude_md_path,
+            delete_string=block,
         )
 
     # --- conjunct 3: the pin block is present AT THE DESTINATION -----------
@@ -657,6 +747,7 @@ def archive_pin(index: int, db_path=None) -> dict:
             "outcome": "NOT_ARCHIVED",
             "heading": heading,
             "claude_md_path": claude_md_path,
+            "delete_string": block,
             "memory_id": memory_id,
             "reason": (
                 "saved record does not contain the pin block verbatim "
@@ -664,13 +755,57 @@ def archive_pin(index: int, db_path=None) -> dict:
             ),
         }
 
+    # --- delete_string uniqueness, checked AFTER the save --------------
+    # AFTER, because that is the state the curator's destructive Edit will
+    # actually meet -- checking before would validate a precondition on a file
+    # something may since have written to, which is the assumption under test.
+    # The before == after assertion turns that judgement call into a
+    # measurement: with the sync suppressed the two must agree, and a
+    # divergence surfaces loudly instead of being absorbed by whichever side
+    # was picked.
+    try:
+        post = claude_md.read_text(encoding="utf-8")
+    except (IOError, OSError, UnicodeDecodeError) as exc:
+        raise _Unevaluable(
+            f"CLAUDE.md unreadable after save ({type(exc).__name__})",
+            heading=heading, claude_md_path=claude_md_path,
+            delete_string=block,
+        )
+
+    occurrences = post.count(block)
+    if occurrences != 1:
+        # ARCHIVE SUCCEEDED, REMOVAL IS UNSAFE -- a distinct outcome, not a
+        # variant of another. Not UNEVALUABLE: that means "cannot tell", and
+        # this is a KNOWN-BAD precondition for the delete. Not NOT_ARCHIVED:
+        # that asserts the archive failed, which is false here and would put a
+        # falsehood in the one report whose job is truthful measurement.
+        # No escape hatch -- the curator removes the pin manually WITH the
+        # content already safely archived, so this redirects rather than traps
+        # them at the cap. The outcome NAME determines the disposition; a
+        # reason string would not, and a reason table is how a permission gets
+        # inherited by a condition it was never designed for.
+        return {
+            "outcome": "ARCHIVED_DELETE_UNSAFE",
+            "heading": heading,
+            "claude_md_path": claude_md_path,
+            "delete_string": block,
+            "memory_id": memory_id,
+            "chars": len(block),
+            "contained": True,
+            "occurrences": occurrences,
+            "locations": _occurrence_offsets(post, block),
+            "reason": _unsafe_reason(occurrences, claude_md_path, memory_id),
+        }
+
     return {
         "outcome": "ARCHIVED",
         "heading": heading,
         "claude_md_path": claude_md_path,
+        "delete_string": block,
         "memory_id": memory_id,
         "chars": len(block),
         "contained": True,
+        "occurrences": 1,
     }
 
 
@@ -689,6 +824,7 @@ def build_verdict(index: int, db_path=None) -> dict:
             "outcome": "UNEVALUABLE",
             "heading": exc.heading,
             "claude_md_path": exc.claude_md_path,
+            "delete_string": exc.delete_string,
             "reason": exc.reason,
         }
     except Exception as exc:  # noqa: BLE001 -- never crash the curator's flow
@@ -696,6 +832,7 @@ def build_verdict(index: int, db_path=None) -> dict:
             "outcome": "UNEVALUABLE",
             "heading": None,
             "claude_md_path": None,
+            "delete_string": None,
             "reason": f"internal error: {type(exc).__name__}",
         }
 

--- a/pact-plugin/scripts/archive_pin.py
+++ b/pact-plugin/scripts/archive_pin.py
@@ -27,10 +27,10 @@ Usage:
   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/archive_pin.py" --index N
   python3 archive_pin.py --index 0 --db-path /tmp/test.db   # tests only
 
-Output (stdout, JSON, ALWAYS exit 0). `outcome`, `heading` and
-`claude_md_path` are present in EVERY verdict. `heading` is null only when the
-pin could not be resolved at all and is NEVER derived from the requested
-index; `claude_md_path` is null only when resolution itself failed:
+Output (stdout, JSON, ALWAYS exit 0). `outcome`, `heading`, `claude_md_path`
+and `delete_string` are present as KEYS in every verdict; when a value is null
+that is governed by the invariant below, not by a per-failure enumeration.
+`heading` is NEVER derived from the requested index:
 
   {"outcome": "ARCHIVED",               "heading": str, "claude_md_path": str,
    "delete_string": str, "memory_id": str, "chars": int, "contained": true,
@@ -48,10 +48,10 @@ FOUR outcomes. Only ARCHIVED permits the removal Edit to proceed.
 `delete_string` is the verbatim block, a CONTENT handle: the removal is
 `Edit(old_string=delete_string, new_string="")`, which matches on content, so
 a file that moved under the caller makes the Edit FAIL LOUDLY rather than
-delete the wrong bytes. It is emitted whenever the pin RESOLVES -- including
-NOT_ARCHIVED and a located-pin UNEVALUABLE -- because it is a property of
-WHICH PIN, not of whether the archive worked; null only when the pin does not
-resolve. Uniqueness is verified after the save.
+delete the wrong bytes. It is a property of WHICH PIN, not of whether the
+archive worked, so it is present on NOT_ARCHIVED and on a located-pin
+UNEVALUABLE too. Uniqueness is verified after the save. Presence is governed
+by the invariant below.
 
 ARCHIVED_DELETE_UNSAFE means the archive SUCCEEDED and the removal is unsafe:
 the block is not unique, so an Edit keyed on it would be ambiguous. It is a
@@ -61,19 +61,41 @@ reason table, which is how a permission gets inherited by a condition it was
 never designed for. It offers no escape hatch, and does not trap the curator
 at the cap: the content is archived, so manual removal is a redirect.
 
-`claude_md_path` names the file THIS RUN ACTUALLY READ. It exists because
-resolution can succeed on the WRONG file: the order is CLAUDE_PROJECT_DIR ->
-git common-dir parent -> CWD, and a miss at any step falls through silently,
-so a CLAUDE_PROJECT_DIR naming a directory with no CLAUDE.md resolves to some
-other project's file and reports a confident success. The command's heading
-cross-check cannot catch it -- check_pin_caps.py uses the SAME resolver, so
-the listing and the archival agree on the same wrong file. Emitting the path
-is what makes a wrong file visible; `resolve_claude_md` additionally REFUSES
-the cross-project case outright.
+THE CONTRACT, stated as the INVARIANT THE CODE ENFORCES rather than as a
+list of which failures null which fields:
 
-Anything but ARCHIVED means the command REFUSES the eviction. NOT_ARCHIVED
-and UNEVALUABLE are kept distinct because collapsing "cannot tell" into
-"definitely bad" is how a two-valued validator destroys by construction.
+    EACH FIELD IS PRESENT IFF THE FACT IT NAMES WAS ACTUALLY ESTABLISHED.
+
+  `claude_md_path`  the file this run read.  Established once resolution
+                    succeeds -- so it survives EVERY later failure.
+  `heading`         which pin.  Established once the pin is located.
+  `delete_string`   a USABLE handle for the removal Edit.  Established once
+                    the block is sliced AND is non-empty AND is verbatim in
+                    the source.
+
+An enumeration ("null only when X") is a claim about observed data and is
+falsified by the first path nobody thought of -- which is exactly how the
+previous version of this contract came to be false the day it was written.
+The invariant above cannot be falsified by adding a fourth failure path,
+because it says what the code guarantees rather than what it was seen doing.
+
+TWO CONSEQUENCES a reader is likely to misread as bugs, so they are stated:
+
+1. A LATER failure never reports LESS than an earlier one.  Context is
+   attached at the boundary where it becomes known and is never dropped
+   afterwards, so a verdict's context grows monotonically with how far the
+   run got.  A post-resolution CLI failure therefore reports MORE than a
+   pre-resolution bad index, not less.  (It once reported less; that was the
+   bug this contract now pins.)
+
+2. Two post-resolution paths DELIBERATELY omit `delete_string`, and adding
+   it there would be a regression rather than a consistency fix.  An empty
+   block and a block that fails the source-side verbatim tripwire are both
+   cases where a handle was computed but is NOT USABLE -- an Edit keyed on
+   either would fail to match.  Emitting a handle known to be bad is worse
+   than emitting none, because the caller's whole reason to trust it is that
+   it was checked.  `heading` and `claude_md_path` are still present on both,
+   because those facts WERE established.
 
 Used by:
   - commands/prune-memory.md: invoked before the removal Edit; the verdict
@@ -682,6 +704,35 @@ def archive_pin(index: int, db_path=None) -> dict:
             heading=heading, claude_md_path=claude_md_path,
         )
 
+    def _cli(args, **kwargs):
+        """Invoke the memory CLI, enriching any UNEVALUABLE with pin context.
+
+        `_run_memory_cli` raises bare -- correctly, since it is a generic
+        helper with no idea which pin is being archived. But EVERY failure it
+        can raise happens AFTER the pin was resolved: CLAUDE.md read, pins
+        parsed, block already sliced. So the verdict can and must still name
+        the file, the heading and the delete handle.
+
+        Without this the LATER a failure occurs the LESS context survives,
+        which is backwards and is not something anyone would choose: a
+        pre-resolution bad index reported `claude_md_path` while a
+        post-resolution CLI timeout reported nothing at all.
+
+        It bit hardest exactly where it mattered most. A CLI timeout and a
+        missing CLI are the canonical CANNOT-TELL cases -- they are when the
+        escape hatch runs -- so the hatch would have had no mechanical
+        delete boundary in its own primary use case.
+        """
+        try:
+            return _run_memory_cli(args, **kwargs)
+        except _Unevaluable as exc:
+            raise _Unevaluable(
+                exc.reason,
+                heading=heading,
+                claude_md_path=claude_md_path,
+                delete_string=block,
+            ) from exc
+
     # --- conjunct 1: save returned a memory_id -----------------------------
     # Passed on STDIN rather than argv: the record embeds arbitrary curator
     # text, and an argv-borne payload would be bounded by ARG_MAX and would
@@ -697,7 +748,7 @@ def archive_pin(index: int, db_path=None) -> dict:
     # file was not, and the duplicate would make the curator's removal Edit
     # ambiguous. Measured: without it the block occurs twice and the file
     # grows; with it CLAUDE.md is byte-identical across the save.
-    _, stdout, stderr = _run_memory_cli(
+    _, stdout, stderr = _cli(
         [_ARCHIVE_SUBCOMMAND, "--stdin", "--no-sync"], db_path=db_path,
         stdin_data=payload, cwd=project_dir,
     )
@@ -716,7 +767,7 @@ def archive_pin(index: int, db_path=None) -> dict:
         }
 
     # --- conjunct 2: the record is retrievable by that id ------------------
-    _, stdout, stderr = _run_memory_cli(
+    _, stdout, stderr = _cli(
         ["get", memory_id], db_path=db_path, cwd=project_dir
     )
     fetched = _parse_envelope(stdout)

--- a/pact-plugin/scripts/archive_pin.py
+++ b/pact-plugin/scripts/archive_pin.py
@@ -1,0 +1,591 @@
+#!/usr/bin/env python3
+"""
+Archive a CLAUDE.md pin to pact-memory and report whether its bytes arrived.
+
+Location: pact-plugin/scripts/archive_pin.py
+
+Summary: Single-responsibility archival step for /PACT:prune-memory. Given
+the index of a pin in the `evictable_pins` list that `check_pin_caps.py
+--status` emits, this script extracts that pin's block VERBATIM from
+CLAUDE.md, saves it to pact-memory via the memory CLI, re-fetches the saved
+record by the returned `memory_id`, and asserts that the pin block is
+present in the fetched record. It emits a three-outcome verdict as JSON on
+stdout and ALWAYS exits 0.
+
+**It never deletes anything.** The eviction Edit stays with the command, so
+the destructive act remains visible to the curator and to the pin_caps_gate
+PreToolUse hook. This script measures; it does not decide.
+
+    The SCRIPT never refuses -- it measures and reports.
+    The COMMAND refuses, in prose, on the reported verdict.
+
+That split is why a fail-open here does not become a fail-open DECISION. A
+hook fail-open would allow the destructive Edit; a script fail-open only
+produces an UNEVALUABLE that the command must handle.
+
+Usage:
+  python3 "${CLAUDE_PLUGIN_ROOT}/scripts/archive_pin.py" --index N
+  python3 archive_pin.py --index 0 --db-path /tmp/test.db   # tests only
+
+Output (stdout, JSON, ALWAYS exit 0). `outcome` and `heading` are present
+in every verdict; `heading` is null only when the pin could not be resolved
+at all, and is NEVER derived from the requested index:
+
+  {"outcome": "ARCHIVED",     "heading": str, "memory_id": str,
+   "chars": int, "contained": true}
+  {"outcome": "NOT_ARCHIVED", "heading": str, "memory_id": str|null,
+   "reason": str}
+  {"outcome": "UNEVALUABLE",  "heading": str|null, "reason": str}
+
+Anything but ARCHIVED means the command REFUSES the eviction. NOT_ARCHIVED
+and UNEVALUABLE are kept distinct because collapsing "cannot tell" into
+"definitely bad" is how a two-valued validator destroys by construction.
+
+Used by:
+  - commands/prune-memory.md: invoked before the removal Edit; the verdict
+    gates whether the eviction proceeds
+  - tests/test_archive_pin.py
+
+Related:
+  - scripts/check_pin_caps.py -- supplies the `--index` coordinate system
+  - hooks/pin_caps.py -- parse_pins / Pin, the parser this reuses
+  - skills/pact-memory/scripts/cli.py -- the save/get surface, reached by
+    SUBPROCESS rather than import (keeps the process boundary the rest of
+    the codebase keeps, and the CLI is the tested public surface)
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Load pin_caps and staleness from hooks/ by explicit file path. Identical
+# rationale to check_pin_caps.py: `sys.path.insert(0, hooks_dir)` would
+# PREPEND, so a future hooks/types.py or hooks/json.py would shadow the
+# stdlib. Spec-loading binds by path, not by name resolution; hooks_dir is
+# APPENDED (not prepended) only so staleness's `from shared.claude_md_manager`
+# resolves, with the stdlib retaining priority on any name collision.
+_HOOKS_DIR = Path(__file__).resolve().parent.parent / "hooks"
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.append(str(_HOOKS_DIR))
+
+# The memory CLI. Reached by subprocess, never imported: skills/ is a
+# separate surface from scripts/, and cli.py is the tested public contract.
+_MEMORY_CLI = (
+    Path(__file__).resolve().parent.parent
+    / "skills" / "pact-memory" / "scripts" / "cli.py"
+)
+
+# Wall-clock ceiling for a single memory-CLI call. `save` spins the embedding
+# backend; a hang must surface as UNEVALUABLE (refuse, pin survives) rather
+# than blocking the curator's session indefinitely.
+_CLI_TIMEOUT_SECONDS = 120
+
+# Structured archive marker, written into `entities[].type`.
+#
+# THIS IS A NAMED CONSTANT ON PURPOSE, and any code that SCANS for archives
+# must read THIS constant rather than re-typing the literal. `entities[].type`
+# is unconstrained free text -- thousands of distinct values across the store,
+# with nothing validating any of them -- so the field is structured by POSITION,
+# not by SCHEMA. A typo or a second copy that drifts therefore ships SILENTLY:
+# the scanner returns a smaller set and raises no error. A confident undercount
+# is worse than a loud failure, which is why the value is pinned by a test.
+#
+# The value matches the one prior archive in the store that carries a type at
+# all. Adopting it rather than inventing a second value avoids forking the
+# convention -- which is the whole problem this marker exists to end, and
+# forking it inside the fix would be the same defect one level up.
+#
+# SCOPE OF WHAT THIS BUYS -- discoverability GOING FORWARD, never enumeration.
+# Archives written before this ships carry no marker at all, including ones
+# that were folded into an existing record rather than saved standalone. Any
+# count derived by scanning for archives is a FLOOR, not a total. Do not let a
+# docstring, test name, or comment claim this marker identifies pin archives
+# generally; it identifies the ones written after it ships.
+ARCHIVE_ENTITY_TYPE = "pact_memory_archive"
+
+# The memory CLI subcommand archival is permitted to use. See the STANDALONE
+# invariant on `_build_record` / `archive_pin`: an `update` would create no new
+# record and run no marker code, silently voiding the audit property.
+_ARCHIVE_SUBCOMMAND = "save"
+
+
+def _load_hook_module(name: str):
+    """Load a module from hooks/ by explicit file path.
+
+    Registers the loaded module in sys.modules under `name` before executing
+    so modules loaded via this same helper resolve `from {name} import ...`
+    against the already-loaded object (staleness does `from pin_caps import`).
+    """
+    module_path = _HOOKS_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, str(module_path))
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {name} from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_pin_caps = _load_hook_module("pin_caps")
+_staleness = _load_hook_module("staleness")
+
+parse_pins = _pin_caps.parse_pins
+_PIN_HEADING_RE = _pin_caps._PIN_HEADING_RE
+_parse_pinned_section = _staleness._parse_pinned_section
+get_project_claude_md_path = _staleness.get_project_claude_md_path
+
+
+class _Unevaluable(Exception):
+    """Raised when the pin's state cannot be established at all.
+
+    Distinct from a definite archival failure. Carries an optional heading
+    for the cases where the pin WAS resolved before the failure occurred.
+    """
+
+    def __init__(self, reason: str, heading: str | None = None):
+        super().__init__(reason)
+        self.reason = reason
+        self.heading = heading
+
+
+def _span_start(pinned_content: str, heading_start: int, date_comment) -> int:
+    """Offset where a pin's span begins: its date-comment LINE, else its heading.
+
+    Extracted so the START of pin N and the END of pin N-1 are computed by the
+    SAME rule. Deriving the end from the next HEADING instead would make the
+    two asymmetric and let each block swallow the following pin's date comment.
+    """
+    if not date_comment:
+        return heading_start
+    preceding = pinned_content[:heading_start]
+    # rfind takes the NEAREST preceding occurrence, so an identical comment
+    # string inside an earlier pin's body cannot capture the span.
+    comment_at = preceding.rfind(date_comment)
+    if comment_at == -1:
+        return heading_start
+    # Back up to that LINE's first character, so indentation is inside the span.
+    return preceding.rfind("\n", 0, comment_at) + 1
+
+
+def extract_pin_block(pinned_content: str, index: int, pins) -> str:
+    """Return the pin's block as a VERBATIM SLICE of `pinned_content`.
+
+    THIS IS A SLICE, NOT A RECONSTRUCTION, and the distinction is the whole
+    point. Rebuilding the block as `date_comment + "\\n" + heading + "\\n" +
+    body` looks equivalent but is not: `parse_pins` walks BACKWARD over blank
+    lines to find the date comment and stores it `.strip()`ed, so a rebuilt
+    block silently drops any blank line between comment and heading and any
+    trailing whitespace on the comment line. Measured across five plausible
+    hand-written pin formats, a rebuild is verbatim in only 2 of 5.
+
+    That matters because the archival success criterion asserts containment
+    of THIS string in the re-fetched record. If this string is already a
+    lossy rendering of the pin, all three conjuncts still hold and the
+    verdict certifies a variant -- a check reporting success while measuring
+    nothing, which is the exact defect this subsystem exists to remove. A
+    slice makes the criterion meaningful by making the block verbatim BY
+    CONSTRUCTION, so the containment test measures the only thing it ever
+    could: whether the storage round-trip preserved the bytes.
+
+    Span rule, per the spec:
+      - `end`   = the next `### ` heading start, or end of section for the last pin.
+      - `start` = walk backward from the heading start over blank lines; if the
+                  first non-blank preceding line matches the date-comment
+                  pattern, `start` is the offset of THAT LINE'S FIRST CHARACTER
+                  (so leading indentation is inside the slice); otherwise
+                  `start` is the heading start.
+      - Take `source[start:end]` EXACTLY. Do not strip, rejoin, or normalize.
+
+    The no-strip rule means the block carries the blank line(s) separating it
+    from the next pin. That is safe and was measured rather than assumed:
+    `context` is a scalar, so it escapes the string-list normalization, and a
+    value with one trailing newline, two trailing newlines, or a trailing
+    newline plus spaces all round-trip BYTE-EXACT through the real CLI. Had
+    any of those been stripped in transit, containment would have returned
+    false for every archive -- an over-block on the whole feature.
+
+    THE END BOUNDARY IS THE NEXT PIN'S SPAN START, NOT THE NEXT HEADING.
+    Running to the next `### ` would put the FOLLOWING pin's date comment
+    inside this pin's block, because a span starts at the comment line, which
+    sits BEFORE the heading. The archived record would then carry another
+    pin's pinned-date -- still a verbatim substring, so the containment check
+    could never notice, and still "correct" by every conjunct in the criterion.
+    Computing both edges with `_span_start` makes the spans partition the
+    section instead of overlapping.
+
+    Args:
+        pinned_content: The Pinned Context section body (what parse_pins ate).
+        index: Position of the pin within that section.
+        pins: The full parsed Pin list -- the NEXT pin's date_comment is needed
+            to place this pin's end boundary.
+
+    Raises:
+        _Unevaluable: if the section's headings no longer agree with `index`.
+    """
+    starts = [m.start() for m in _PIN_HEADING_RE.finditer(pinned_content)]
+    if index < 0 or index >= len(starts) or index >= len(pins):
+        raise _Unevaluable(
+            f"pin index {index} out of range (section has {len(starts)} pins)"
+        )
+
+    block_start = _span_start(pinned_content, starts[index], pins[index].date_comment)
+    if index + 1 < len(starts) and index + 1 < len(pins):
+        block_end = _span_start(
+            pinned_content, starts[index + 1], pins[index + 1].date_comment
+        )
+    else:
+        block_end = len(pinned_content)
+
+    return pinned_content[block_start:block_end]
+
+
+def project_dir_for(claude_md: Path) -> Path:
+    """Return the project directory that owns `claude_md`.
+
+    CLAUDE.md lives at either `<project>/.claude/CLAUDE.md` (preferred) or
+    `<project>/CLAUDE.md` (legacy), so the project root is one or two levels
+    up depending on which form resolved.
+
+    This is the INVERSE of `shared.claude_md_manager.resolve_project_claude_md_path`
+    (project dir -> CLAUDE.md); no existing helper goes this direction, which
+    is why it is defined here rather than reused. The two-layout knowledge is
+    owned by that module's `_DOT_CLAUDE_RELATIVE` / `_LEGACY_RELATIVE`; if a
+    THIRD location is ever supported, this function must be swept too. It is
+    deliberately NOT a sixth CLAUDE.md resolver -- it never probes the
+    filesystem for CLAUDE.md, it only maps a path already resolved by one of
+    the five, so `test_claude_md_resolver_parity.py` does not cover it.
+
+    This is load-bearing for WHERE the archived pin is filed. The memory
+    layer detects `project_id` from CLAUDE_PROJECT_DIR, else from git, else
+    by walking UP from the CWD to the nearest project marker -- and `.claude`
+    IS such a marker. So running the memory CLI from the plugin's own
+    directory files a consumer's archived pin under project `.claude`
+    (measured), because the installed plugin lives beneath `~/.claude/`.
+    Deriving the CWD from the CLAUDE.md we actually read keeps the pin and
+    its archive agreeing on the project by construction.
+    """
+    parent = claude_md.resolve().parent
+    return parent.parent if parent.name == ".claude" else parent
+
+
+def _run_memory_cli(args, db_path=None, stdin_data=None, cwd=None):
+    """Invoke the memory CLI and return (returncode, stdout, stderr).
+
+    STREAMS ARE KEPT SEPARATE AND MUST STAY THAT WAY. `save` writes an
+    embedding progress bar (`Fetching 10 files: ...`) to STDERR on SUCCESS
+    -- measured at ~130 bytes -- so merging the streams would splice that
+    bar into the JSON envelope and corrupt every parse. Never `2>&1` here.
+
+    Errors also go to stderr (cli.py's `_error`), which is why a failed call
+    presents as EMPTY STDOUT: NOT_FOUND, PREFIX_TOO_SHORT and an outright
+    crash are indistinguishable on stdout alone. The caller must classify
+    from the stderr envelope, whose key is `error` (NOT `error_type`).
+
+    Raises:
+        _Unevaluable: if the CLI is missing, hangs, or cannot be launched.
+    """
+    if not _MEMORY_CLI.exists():
+        raise _Unevaluable(f"memory CLI not found at {_MEMORY_CLI}")
+
+    argv = [sys.executable, str(_MEMORY_CLI), *args]
+    if db_path:
+        argv += ["--db-path", db_path]
+
+    # Pin the project for the child process. CLAUDE_PROJECT_DIR is the memory
+    # layer's PRIMARY detection strategy and is deterministic, unlike the git
+    # and CWD-walk fallbacks. An existing value is the platform's own
+    # statement of the project and is left alone; we only fill the gap.
+    env = None
+    if cwd is not None:
+        env = dict(os.environ)
+        env.setdefault("CLAUDE_PROJECT_DIR", str(cwd))
+
+    try:
+        proc = subprocess.run(
+            argv,
+            input=stdin_data,
+            capture_output=True,   # separate pipes -- NOT merged
+            text=True,
+            timeout=_CLI_TIMEOUT_SECONDS,
+            # CWD is the PROJECT that owns the pin, never the plugin's own
+            # directory -- see project_dir_for(). #935 residual: an unpinned
+            # CWD silently files the archive under the wrong project.
+            cwd=str(cwd) if cwd is not None else None,
+            env=env,
+        )
+    except subprocess.TimeoutExpired:
+        raise _Unevaluable(
+            f"memory CLI timed out after {_CLI_TIMEOUT_SECONDS}s"
+        )
+    except OSError as exc:
+        raise _Unevaluable(f"could not launch memory CLI: {type(exc).__name__}")
+
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _parse_envelope(stdout: str):
+    """Parse a success envelope from stdout, or return None.
+
+    Returns the `result` payload on a well-formed `{"ok": true, ...}`
+    envelope. Returns None for empty stdout, malformed JSON, or ok=false --
+    all of which the caller must treat as "the call did not succeed",
+    classifying the reason from stderr rather than from this absence.
+    """
+    if not stdout.strip():
+        return None
+    try:
+        envelope = json.loads(stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(envelope, dict) or not envelope.get("ok"):
+        return None
+    return envelope.get("result")
+
+
+def _classify_cli_error(stderr: str) -> str:
+    """Render a short reason from the memory CLI's stderr error envelope.
+
+    The envelope key is `error` (NOT `error_type`). Falls back to a trimmed
+    raw stderr when the payload is not a parseable envelope -- a crash
+    traceback still tells the curator more than a bare "failed" would.
+    """
+    text = stderr.strip()
+    if not text:
+        return "memory CLI failed with no diagnostic output"
+    try:
+        payload = json.loads(text)
+        if isinstance(payload, dict) and payload.get("error"):
+            message = payload.get("message", "")
+            return f"{payload['error']}: {message}".strip().rstrip(":")
+    except json.JSONDecodeError:
+        pass
+    return text.splitlines()[-1][:300]
+
+
+def _build_record(block: str, heading: str) -> dict:
+    """Build the pact-memory record for an archived pin.
+
+    THE PIN BODY GOES IN `context`, AND NEVER IN A LIST FIELD. This is a
+    prohibition, not a preference. String-list fields (lessons_learned,
+    reasoning_chains, ...) `.strip()` and NFC-normalize their items, so a
+    pin stored there comes back ALTERED and the containment check returns
+    FALSE for a perfectly good archive -- an OVER-BLOCK that refuses a
+    legitimate eviction, which is the cardinal error direction here.
+    Scalars escape that normalization and round-trip byte-exact.
+
+    This is not hypothetical: the one pin-archive record already in the
+    store asserts "Content preserved verbatim" while holding its content in
+    `lessons_learned`, a field that cannot deliver that guarantee.
+
+    `entities` carries the curation tags; `goal` carries the orienting
+    label. Curation and verbatim occupy DIFFERENT columns, so a queryable
+    archive and byte-exact preservation coexist with no trade-off.
+
+    STANDALONE ONLY. This record is always CREATED, never merged into an
+    existing one. The invariant is load-bearing rather than incidental: an
+    additive `update` creates no new record and runs no marker code, so a
+    folded archive is invisible to a marker scan -- which has already happened
+    to prior demotions. A future maintainer adding a fold path for a good
+    reason (dedup, retrieval quality) would void the audit property WITHOUT
+    TOUCHING THIS FUNCTION, and nothing would fail at runtime; the symptom is a
+    missing record in somebody's later audit. If a fold path is ever genuinely
+    wanted, write the marker on the update path too, or withdraw the
+    auditability claim in the same change.
+    """
+    archived_on = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return {
+        "context": block,
+        "goal": f"Archived pin: {heading}",
+        "entities": [{
+            "name": heading,
+            "type": ARCHIVE_ENTITY_TYPE,
+            "notes": (
+                f"demoted from CLAUDE.md Pinned Context on {archived_on}"
+            ),
+        }],
+    }
+
+
+def archive_pin(index: int, db_path=None) -> dict:
+    """Archive the pin at `index` and return a verdict dict.
+
+    Sequence: resolve CLAUDE.md -> parse pins -> slice the block verbatim ->
+    save -> re-fetch by the returned memory_id -> assert containment.
+
+    Raises:
+        _Unevaluable: whenever the pin's state cannot be established.
+    """
+    claude_md = get_project_claude_md_path()
+    if claude_md is None:
+        raise _Unevaluable("CLAUDE.md not found")
+
+    try:
+        content = claude_md.read_text(encoding="utf-8")
+    except (IOError, OSError, UnicodeDecodeError) as exc:
+        raise _Unevaluable(f"CLAUDE.md unreadable ({type(exc).__name__})")
+
+    parsed = _parse_pinned_section(content)
+    if parsed is None:
+        raise _Unevaluable("no Pinned Context section")
+
+    _, _, pinned_content = parsed
+    try:
+        pins = parse_pins(pinned_content)
+    except Exception as exc:  # noqa: BLE001 -- parse fault is unevaluable
+        raise _Unevaluable(f"pin parse failed ({type(exc).__name__})")
+
+    if index < 0 or index >= len(pins):
+        raise _Unevaluable(
+            f"pin index {index} out of range ({len(pins)} pins parsed)"
+        )
+
+    pin = pins[index]
+    # The pin's ACTUAL heading, read from the parse. Never echoed back from
+    # the requested index: the caller cross-checks this value against the
+    # curator's selection to catch an index shift between listing and
+    # archival, and an echo would make that check compare the index against
+    # itself and pass unconditionally.
+    heading = pin.heading[4:] if pin.heading.startswith("### ") else pin.heading
+
+    block = extract_pin_block(pinned_content, index, pins)
+    if not block.strip():
+        raise _Unevaluable("pin block is empty", heading=heading)
+
+    # Source-side tripwire. The slice makes this true BY CONSTRUCTION, so it
+    # costs nothing in the normal case -- it exists to fail loudly if the
+    # extractor ever regresses into a lossy rebuild. Checked BEFORE the save,
+    # so a broken extractor writes nothing.
+    if block not in content:
+        raise _Unevaluable(
+            "extracted block is not verbatim in CLAUDE.md (extractor bug)",
+            heading=heading,
+        )
+
+    # --- conjunct 1: save returned a memory_id -----------------------------
+    # Passed on STDIN rather than argv: the record embeds arbitrary curator
+    # text, and an argv-borne payload would be bounded by ARG_MAX and would
+    # surface the pin body in the process table.
+    project_dir = project_dir_for(claude_md)
+    payload = json.dumps(_build_record(block, heading))
+    # STANDALONE: always `save` (create), never `update` (fold). See
+    # _build_record -- a fold runs no marker code and is invisible to an
+    # archive scan.
+    _, stdout, stderr = _run_memory_cli(
+        [_ARCHIVE_SUBCOMMAND, "--stdin"], db_path=db_path, stdin_data=payload,
+        cwd=project_dir,
+    )
+    result = _parse_envelope(stdout)
+    memory_id = result.get("memory_id") if isinstance(result, dict) else None
+    if not memory_id:
+        # A definite failure of the save itself: the store was reachable and
+        # said no. NOT_ARCHIVED, not UNEVALUABLE.
+        return {
+            "outcome": "NOT_ARCHIVED",
+            "heading": heading,
+            "memory_id": None,
+            "reason": f"save returned no memory_id -- {_classify_cli_error(stderr)}",
+        }
+
+    # --- conjunct 2: the record is retrievable by that id ------------------
+    _, stdout, stderr = _run_memory_cli(
+        ["get", memory_id], db_path=db_path, cwd=project_dir
+    )
+    fetched = _parse_envelope(stdout)
+    if not isinstance(fetched, dict):
+        # The id came back but the record will not re-read. We cannot tell
+        # whether the bytes are safe, so we must not claim they are -- and we
+        # must not claim they are lost either.
+        raise _Unevaluable(
+            f"saved as {memory_id} but re-fetch failed -- "
+            f"{_classify_cli_error(stderr)}",
+            heading=heading,
+        )
+
+    # --- conjunct 3: the pin block is present AT THE DESTINATION -----------
+    # SUBSTRING, never equality. `context` may legitimately carry more than
+    # the block (a provenance preamble, say), and an equality assertion would
+    # return false for a correct archive -- an over-block in the one control
+    # whose entire purpose is not destroying content.
+    #
+    # This is the conjunct the old criterion lacked. A returned memory_id
+    # proves a record EXISTS (persistence); only this proves the record
+    # carries the PIN (fidelity). The founding data loss satisfied the former
+    # at the moment it occurred.
+    context = fetched.get("context")
+    if not isinstance(context, str) or block not in context:
+        return {
+            "outcome": "NOT_ARCHIVED",
+            "heading": heading,
+            "memory_id": memory_id,
+            "reason": (
+                "saved record does not contain the pin block verbatim "
+                "(fidelity check failed)"
+            ),
+        }
+
+    return {
+        "outcome": "ARCHIVED",
+        "heading": heading,
+        "memory_id": memory_id,
+        "chars": len(block),
+        "contained": True,
+    }
+
+
+def build_verdict(index: int, db_path=None) -> dict:
+    """Run the archival and return a verdict dict — never raises.
+
+    The single place where an unevaluable state becomes an UNEVALUABLE
+    verdict, so `main` only has to serialize. Keeping the mapping here
+    (rather than inline in `main`) is what lets tests exercise the
+    degradation paths without going through argv and stdout.
+    """
+    try:
+        return archive_pin(index, db_path=db_path)
+    except _Unevaluable as exc:
+        return {
+            "outcome": "UNEVALUABLE",
+            "heading": exc.heading,
+            "reason": exc.reason,
+        }
+    except Exception as exc:  # noqa: BLE001 -- never crash the curator's flow
+        return {
+            "outcome": "UNEVALUABLE",
+            "heading": None,
+            "reason": f"internal error: {type(exc).__name__}",
+        }
+
+
+def main(argv=None) -> int:
+    """Entry point. ALWAYS returns 0; the verdict is carried in-band."""
+    parser = argparse.ArgumentParser(
+        prog="archive_pin",
+        description=(
+            "Archive one CLAUDE.md pin to pact-memory and report, "
+            "mechanically, whether its bytes arrived."
+        ),
+    )
+    parser.add_argument(
+        "--index",
+        type=int,
+        required=True,
+        help="Position of the pin in check_pin_caps --status evictable_pins",
+    )
+    parser.add_argument("--db-path", help=argparse.SUPPRESS)
+    args = parser.parse_args(argv)
+
+    verdict = build_verdict(args.index, db_path=args.db_path)
+    sys.stdout.write(json.dumps(verdict) + "\n")
+    sys.stdout.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pact-plugin/scripts/archive_pin.py
+++ b/pact-plugin/scripts/archive_pin.py
@@ -27,15 +27,27 @@ Usage:
   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/archive_pin.py" --index N
   python3 archive_pin.py --index 0 --db-path /tmp/test.db   # tests only
 
-Output (stdout, JSON, ALWAYS exit 0). `outcome` and `heading` are present
-in every verdict; `heading` is null only when the pin could not be resolved
-at all, and is NEVER derived from the requested index:
+Output (stdout, JSON, ALWAYS exit 0). `outcome`, `heading` and
+`claude_md_path` are present in EVERY verdict. `heading` is null only when the
+pin could not be resolved at all and is NEVER derived from the requested
+index; `claude_md_path` is null only when resolution itself failed:
 
-  {"outcome": "ARCHIVED",     "heading": str, "memory_id": str,
-   "chars": int, "contained": true}
-  {"outcome": "NOT_ARCHIVED", "heading": str, "memory_id": str|null,
-   "reason": str}
-  {"outcome": "UNEVALUABLE",  "heading": str|null, "reason": str}
+  {"outcome": "ARCHIVED",     "heading": str, "claude_md_path": str,
+   "memory_id": str, "chars": int, "contained": true}
+  {"outcome": "NOT_ARCHIVED", "heading": str, "claude_md_path": str,
+   "memory_id": str|null, "reason": str}
+  {"outcome": "UNEVALUABLE",  "heading": str|null,
+   "claude_md_path": str|null, "reason": str}
+
+`claude_md_path` names the file THIS RUN ACTUALLY READ. It exists because
+resolution can succeed on the WRONG file: the order is CLAUDE_PROJECT_DIR ->
+git common-dir parent -> CWD, and a miss at any step falls through silently,
+so a CLAUDE_PROJECT_DIR naming a directory with no CLAUDE.md resolves to some
+other project's file and reports a confident success. The command's heading
+cross-check cannot catch it -- check_pin_caps.py uses the SAME resolver, so
+the listing and the archival agree on the same wrong file. Emitting the path
+is what makes a wrong file visible; `resolve_claude_md` additionally REFUSES
+the cross-project case outright.
 
 Anything but ARCHIVED means the command REFUSES the eviction. NOT_ARCHIVED
 and UNEVALUABLE are kept distinct because collapsing "cannot tell" into
@@ -140,6 +152,18 @@ parse_pins = _pin_caps.parse_pins
 _PIN_HEADING_RE = _pin_caps._PIN_HEADING_RE
 _parse_pinned_section = _staleness._parse_pinned_section
 get_project_claude_md_path = _staleness.get_project_claude_md_path
+# The (path, base) form. `base` is the directory the resolver ACTUALLY found
+# the file under, captured before descending into `.claude` -- a trusted
+# pre-resolve anchor rather than a re-derivation from the returned path.
+_resolve_project_claude_md_with_base = (
+    _staleness._resolve_project_claude_md_with_base
+)
+_find_existing_claude_md = _staleness._find_existing_claude_md
+# Lexical inverse of the resolver's base/CLAUDE.md construction. Purely
+# lexical (pathlib .parent never follows symlinks), and already locked to
+# the resolver's own shape by TestStalenessLexicalBaseParity -- so it is
+# the right primitive for project attribution, not a second derivation.
+_lexical_base_of = _staleness._lexical_base_of
 
 
 class _Unevaluable(Exception):
@@ -149,10 +173,15 @@ class _Unevaluable(Exception):
     for the cases where the pin WAS resolved before the failure occurred.
     """
 
-    def __init__(self, reason: str, heading: str | None = None):
+    def __init__(self, reason: str, heading: str | None = None,
+                 claude_md_path: str | None = None):
         super().__init__(reason)
         self.reason = reason
         self.heading = heading
+        # The file this run read, when one was resolved before the failure.
+        # None only when resolution itself failed -- there is genuinely no
+        # path to name, and inventing one would be worse than null.
+        self.claude_md_path = claude_md_path
 
 
 def _span_start(pinned_content: str, heading_start: int, date_comment) -> int:
@@ -194,8 +223,12 @@ def extract_pin_block(pinned_content: str, index: int, pins) -> str:
     CONSTRUCTION, so the containment test measures the only thing it ever
     could: whether the storage round-trip preserved the bytes.
 
-    Span rule, per the spec:
-      - `end`   = the next `### ` heading start, or end of section for the last pin.
+    Span rule:
+      - `end`   = the NEXT PIN'S SPAN START (its date-comment line, else its
+                  heading), or end of section for the last pin. NOT the next
+                  `### ` heading -- see the boundary note below; an earlier
+                  revision of this docstring said heading-start and a reader
+                  acted on it, which is why the rule is stated once, here.
       - `start` = walk backward from the heading start over blank lines; if the
                   first non-blank preceding line matches the date-comment
                   pattern, `start` is the offset of THAT LINE'S FIRST CHARACTER
@@ -244,6 +277,95 @@ def extract_pin_block(pinned_content: str, index: int, pins) -> str:
         block_end = len(pinned_content)
 
     return pinned_content[block_start:block_end]
+
+
+def _same_repository(env_dir: Path, base: Path) -> bool:
+    """True when `base` is the main repo of the git checkout at `env_dir`.
+
+    The discriminator between a LEGITIMATE fall-through and a wrong-project
+    one. PACT's own primary workflow sets CLAUDE_PROJECT_DIR to a WORKTREE,
+    where CLAUDE.md is gitignored and therefore absent; the resolver's
+    git-common-dir step then finds the MAIN repo's file, which is the correct
+    and intended answer. A blanket "env dir has no CLAUDE.md -> refuse" rule
+    would break that flow on every invocation -- a cardinal over-block.
+    Measured: this worktree has no CLAUDE.md and the main checkout does.
+
+    So the question is not "did we fall through" but "did we fall through to
+    somewhere that is still the same project". `--git-common-dir` answers it:
+    every worktree of a repo shares one common dir, so its parent is the main
+    root for both the worktree and the main checkout.
+
+    Fail-safe: any git error, timeout, or non-repo directory returns False,
+    which routes to a REFUSAL. On a destructive path declining to guess is the
+    safe direction -- refusing costs a recoverable UNEVALUABLE, while guessing
+    wrong archives and evicts from a project nobody named.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(env_dir), "rev-parse", "--git-common-dir"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+    if result.returncode != 0 or not result.stdout.strip():
+        return False
+    common_dir = Path(result.stdout.strip())
+    if not common_dir.is_absolute():
+        common_dir = Path(env_dir) / common_dir
+    try:
+        return common_dir.resolve().parent == Path(base).resolve()
+    except OSError:
+        return False
+
+
+def resolve_claude_md():
+    """Resolve the CLAUDE.md to operate on, refusing a cross-project fallback.
+
+    Returns (path, base). RAISES `_Unevaluable` rather than silently operating
+    on a file the invocation never named.
+
+    THE DEFECT THIS CLOSES. Resolution order is CLAUDE_PROJECT_DIR -> git
+    common-dir parent -> CWD, and a miss at any step falls through SILENTLY.
+    So CLAUDE_PROJECT_DIR naming a directory with no CLAUDE.md does not fail --
+    it resolves to a DIFFERENT project's file and reports a confident success.
+    Reproduced deliberately: with the env var naming project_b and the CWD in
+    project_a, the resolver returns project_a's CLAUDE.md.
+
+    Step 3's heading cross-check cannot see this. `check_pin_caps.py` uses the
+    SAME resolver, so the listing step and the archival step agree on the same
+    wrong file and every heading matches. That check catches an index shift
+    WITHIN a file; nothing catches a wrong FILE.
+
+    THE REFUSAL IS NARROW BY CONSTRUCTION. It fires only when
+    CLAUDE_PROJECT_DIR is explicitly set, names a directory with no CLAUDE.md,
+    AND the resolver landed outside that directory's own repository. The
+    worktree fall-through -- the case PACT itself depends on -- stays inside
+    the same repository and is allowed through.
+    """
+    # Resolve through `get_project_claude_md_path` -- the seam the rest of the
+    # suite already patches -- and derive the base LEXICALLY from the result,
+    # rather than taking the with-base form directly. Same answer in
+    # production (the with-base call is what this wraps), but it keeps one
+    # resolution seam for the whole codebase instead of introducing a second
+    # that fixtures would have to know about separately.
+    env_dir = os.environ.get("CLAUDE_PROJECT_DIR")
+    path = get_project_claude_md_path()
+    if path is None:
+        raise _Unevaluable("CLAUDE.md not found")
+    base = _lexical_base_of(path)
+
+    if env_dir:
+        env_path = Path(env_dir)
+        if (_find_existing_claude_md(env_path) is None
+                and not _same_repository(env_path, base)):
+            raise _Unevaluable(
+                f"CLAUDE_PROJECT_DIR={env_dir} contains no CLAUDE.md, and "
+                f"resolution fell through to {path} in a different project. "
+                f"Refusing rather than archiving a pin the invocation never "
+                f"named. Set CLAUDE_PROJECT_DIR to the project that owns the "
+                f"pin, or unset it to resolve from the working directory."
+            )
+    return path, base
 
 
 def project_dir_for(claude_md: Path) -> Path:
@@ -422,28 +544,37 @@ def archive_pin(index: int, db_path=None) -> dict:
     Raises:
         _Unevaluable: whenever the pin's state cannot be established.
     """
-    claude_md = get_project_claude_md_path()
-    if claude_md is None:
-        raise _Unevaluable("CLAUDE.md not found")
+    # Refuses a cross-project fall-through rather than silently operating on
+    # a file the invocation never named. `resolved_base` is the resolver's own
+    # trusted anchor, used for the archive's project attribution instead of
+    # re-deriving it from the leaf path (which followed symlinks).
+    claude_md, resolved_base = resolve_claude_md()
+    # Every verdict from here on names the file actually read, so a wrong-file
+    # resolution is visible rather than silent.
+    claude_md_path = str(claude_md)
 
     try:
         content = claude_md.read_text(encoding="utf-8")
     except (IOError, OSError, UnicodeDecodeError) as exc:
-        raise _Unevaluable(f"CLAUDE.md unreadable ({type(exc).__name__})")
+        raise _Unevaluable(f"CLAUDE.md unreadable ({type(exc).__name__})",
+                           claude_md_path=claude_md_path)
 
     parsed = _parse_pinned_section(content)
     if parsed is None:
-        raise _Unevaluable("no Pinned Context section")
+        raise _Unevaluable("no Pinned Context section",
+                           claude_md_path=claude_md_path)
 
     _, _, pinned_content = parsed
     try:
         pins = parse_pins(pinned_content)
     except Exception as exc:  # noqa: BLE001 -- parse fault is unevaluable
-        raise _Unevaluable(f"pin parse failed ({type(exc).__name__})")
+        raise _Unevaluable(f"pin parse failed ({type(exc).__name__})",
+                           claude_md_path=claude_md_path)
 
     if index < 0 or index >= len(pins):
         raise _Unevaluable(
-            f"pin index {index} out of range ({len(pins)} pins parsed)"
+            f"pin index {index} out of range ({len(pins)} pins parsed)",
+            claude_md_path=claude_md_path,
         )
 
     pin = pins[index]
@@ -456,7 +587,8 @@ def archive_pin(index: int, db_path=None) -> dict:
 
     block = extract_pin_block(pinned_content, index, pins)
     if not block.strip():
-        raise _Unevaluable("pin block is empty", heading=heading)
+        raise _Unevaluable("pin block is empty", heading=heading,
+                           claude_md_path=claude_md_path)
 
     # Source-side tripwire. The slice makes this true BY CONSTRUCTION, so it
     # costs nothing in the normal case -- it exists to fail loudly if the
@@ -465,14 +597,14 @@ def archive_pin(index: int, db_path=None) -> dict:
     if block not in content:
         raise _Unevaluable(
             "extracted block is not verbatim in CLAUDE.md (extractor bug)",
-            heading=heading,
+            heading=heading, claude_md_path=claude_md_path,
         )
 
     # --- conjunct 1: save returned a memory_id -----------------------------
     # Passed on STDIN rather than argv: the record embeds arbitrary curator
     # text, and an argv-borne payload would be bounded by ARG_MAX and would
     # surface the pin body in the process table.
-    project_dir = project_dir_for(claude_md)
+    project_dir = resolved_base
     payload = json.dumps(_build_record(block, heading))
     # STANDALONE: always `save` (create), never `update` (fold). See
     # _build_record -- a fold runs no marker code and is invisible to an
@@ -489,6 +621,7 @@ def archive_pin(index: int, db_path=None) -> dict:
         return {
             "outcome": "NOT_ARCHIVED",
             "heading": heading,
+            "claude_md_path": claude_md_path,
             "memory_id": None,
             "reason": f"save returned no memory_id -- {_classify_cli_error(stderr)}",
         }
@@ -505,7 +638,7 @@ def archive_pin(index: int, db_path=None) -> dict:
         raise _Unevaluable(
             f"saved as {memory_id} but re-fetch failed -- "
             f"{_classify_cli_error(stderr)}",
-            heading=heading,
+            heading=heading, claude_md_path=claude_md_path,
         )
 
     # --- conjunct 3: the pin block is present AT THE DESTINATION -----------
@@ -523,6 +656,7 @@ def archive_pin(index: int, db_path=None) -> dict:
         return {
             "outcome": "NOT_ARCHIVED",
             "heading": heading,
+            "claude_md_path": claude_md_path,
             "memory_id": memory_id,
             "reason": (
                 "saved record does not contain the pin block verbatim "
@@ -533,6 +667,7 @@ def archive_pin(index: int, db_path=None) -> dict:
     return {
         "outcome": "ARCHIVED",
         "heading": heading,
+        "claude_md_path": claude_md_path,
         "memory_id": memory_id,
         "chars": len(block),
         "contained": True,
@@ -553,12 +688,14 @@ def build_verdict(index: int, db_path=None) -> dict:
         return {
             "outcome": "UNEVALUABLE",
             "heading": exc.heading,
+            "claude_md_path": exc.claude_md_path,
             "reason": exc.reason,
         }
     except Exception as exc:  # noqa: BLE001 -- never crash the curator's flow
         return {
             "outcome": "UNEVALUABLE",
             "heading": None,
+            "claude_md_path": None,
             "reason": f"internal error: {type(exc).__name__}",
         }
 

--- a/pact-plugin/scripts/check_pin_caps.py
+++ b/pact-plugin/scripts/check_pin_caps.py
@@ -28,9 +28,22 @@ JSON output contract (stdout):
     "slot_status": "Pin slots: N/12 used, <N> chars remaining on largest pin",
     "evictable_pins": [
       {"index": int, "heading": str, "chars": int,
-       "stale": bool, "override": bool}, ...
+       "stale": bool, "override": bool,
+       "age_days": int|null, "overdue": bool|null}, ...
     ]
   }
+
+`age_days` / `overdue` are an ADDITIVE age signal. They are deliberately
+NOT named `stale` and do NOT replace it: `stale` means "a STALE marker has
+been written into the body" (marker-based, set by staleness.py), whereas
+`overdue` means "this pin is old". Two distinct facts under one name is
+what made the existing signal confusing, so they stay separate columns.
+
+Both are THREE-STATE, not two. A pin whose date comment is absent or
+unparseable reports `age_days: null` AND `overdue: null` — "unknown", never
+`overdue: false`. Rendering unknown as not-overdue would silently exempt
+exactly the pins whose provenance we cannot establish, which is the
+unevaluable-collapsed-into-valid failure this subsystem exists to avoid.
 
 Exit codes:
   0 — normal (status query or fail-open degradation)
@@ -62,7 +75,9 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 # Load pin_caps and staleness from hooks/ via importlib spec-loading.
@@ -110,24 +125,114 @@ parse_pins = _pin_caps.parse_pins
 _parse_pinned_section = _staleness._parse_pinned_section
 get_project_claude_md_path = _staleness.get_project_claude_md_path
 
+# Age-threshold source. staleness.py owns PINNED_STALENESS_DAYS; this module
+# reads it rather than declaring its own, so "overdue" and the SessionStart
+# stale-block directive can never drift to different thresholds. Do NOT
+# introduce a second constant here.
+PINNED_STALENESS_DAYS = _staleness.PINNED_STALENESS_DAYS
 
-def _build_evictable_pins(pins):
+# Date extraction from a parsed Pin.date_comment. The comment's own shape is
+# already validated upstream by pin_caps._DATE_COMMENT_RE / OVERRIDE_COMMENT_RE
+# (`<!-- pinned: ... -->`, optionally carrying a trailing clause); these two
+# patterns only pull the dates back out of a comment that already matched.
+#
+# Both are `search`, not `fullmatch`, because the comment legitimately carries
+# trailing content after the date — a size-override rationale
+# (`, pin-size-override: ...`) or a re-confirmation clause
+# (`, reconfirmed: YYYY-MM-DD because ...`). The upstream pattern is `[^>]+?`,
+# so that trailing content parses with no regex change anywhere.
+_PINNED_DATE_RE = re.compile(r"pinned:\s*(\d{4}-\d{2}-\d{2})", re.IGNORECASE)
+_RECONFIRMED_DATE_RE = re.compile(
+    r"reconfirmed:\s*(\d{4}-\d{2}-\d{2})", re.IGNORECASE
+)
+
+
+def _parse_iso_date(value):
+    """Parse a YYYY-MM-DD string to a UTC-midnight datetime, or None.
+
+    None on any unparseable value (a structurally well-formed but invalid
+    date such as 2026-13-45 raises ValueError and lands here too). Mirrors
+    staleness.detect_stale_entries' UTC-midnight convention so the two age
+    computations cannot disagree about what a calendar date means.
+    """
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return None
+
+
+def _pin_age_days(date_comment, now=None):
+    """Return the pin's age in whole days, or None when it cannot be known.
+
+    Reads the `<!-- pinned: ... -->` comment that parse_pins already captured
+    on the Pin. RE-CONFIRMATION RESETS THE CLOCK: when a `reconfirmed:` date
+    is present the age computes from THAT date, because the curator has
+    re-attested the pin more recently than they first wrote it. That is the
+    entire behavioural point of the re-confirmation grammar — without the
+    reset, re-confirming a pin would change nothing observable.
+
+    Returns None (not 0, and not a negative sentinel) when there is no date
+    comment or no parseable date in it. None is a genuine third state meaning
+    "unknown", and callers MUST NOT collapse it into "not overdue".
+
+    A future-dated pin yields a NEGATIVE age. That is reported as-is rather
+    than clamped to 0: a negative value is a visible data anomaly, whereas
+    clamping would render a malformed date as a freshly-pinned one.
+
+    Args:
+        date_comment: Pin.date_comment, or None.
+        now: Injectable clock for tests. Defaults to the current UTC time.
+    """
+    if not date_comment:
+        return None
+
+    # Re-confirmation wins over the original pinned date when present.
+    match = _RECONFIRMED_DATE_RE.search(date_comment)
+    if match is None:
+        match = _PINNED_DATE_RE.search(date_comment)
+    if match is None:
+        return None
+
+    pinned_at = _parse_iso_date(match.group(1))
+    if pinned_at is None:
+        return None
+
+    if now is None:
+        now = datetime.now(timezone.utc)
+    return (now - pinned_at).days
+
+
+def _build_evictable_pins(pins, now=None):
     """Transform parsed pins into the evictable_pins JSON shape.
 
     Order is presentation order (top-to-bottom in CLAUDE.md). Caller
-    (prune-memory.md) paginates 4-at-a-time into AskUserQuestion options.
+    (prune-memory.md) paginates 3 candidate pins per AskUserQuestion call,
+    plus a 4th navigation option ("Show more" / "Cancel"). The 4-option
+    ceiling is an AskUserQuestion schema cap, so the page size is 3 rather
+    than 4 -- the nav slot is not free.
+
+    `age_days` / `overdue` are additive (D7) and carry a third state: both
+    are null when the pin's date cannot be established. `overdue` is NEVER
+    false-by-default — a pin we cannot date is unknown, not fresh.
+
+    Args:
+        pins: Parsed Pin list.
+        now: Injectable clock, threaded to _pin_age_days for tests.
     """
     evictable = []
     for idx, pin in enumerate(pins):
         heading_text = pin.heading
         if heading_text.startswith("### "):
             heading_text = heading_text[4:]
+        age_days = _pin_age_days(pin.date_comment, now=now)
         evictable.append({
             "index": idx,
             "heading": heading_text,
             "chars": pin.body_chars,
             "stale": pin.is_stale,
             "override": pin.override_rationale is not None,
+            "age_days": age_days,
+            "overdue": None if age_days is None else age_days >= PINNED_STALENESS_DAYS,
         })
     return evictable
 

--- a/pact-plugin/skills/pact-memory/scripts/cli.py
+++ b/pact-plugin/skills/pact-memory/scripts/cli.py
@@ -116,7 +116,16 @@ def cmd_save(args, db_path=None):
 
     memory = PACTMemory(db_path=db_path)
     try:
-        memory_id = memory.save(memory_dict)
+        # Pass the kwarg ONLY when suppressing, so the default call site
+        # stays literally `memory.save(memory_dict)`. That is a stronger form
+        # of "existing callers are unaffected" than relying on the parameter
+        # default: the call is byte-identical, not merely equivalent. The
+        # suite's existing exact-call assertions pin this, and they were
+        # right to -- they caught the weaker version.
+        save_kwargs = {}
+        if getattr(args, "no_sync", False):
+            save_kwargs["sync_to_claude"] = False
+        memory_id = memory.save(memory_dict, **save_kwargs)
     except ValueError as exc:
         _error(
             "ValueError",
@@ -327,6 +336,15 @@ def build_parser():
     save_parser.add_argument("json_data", nargs="?", help="JSON memory object")
     save_parser.add_argument(
         "--stdin", action="store_true", help="Read JSON from stdin"
+    )
+    save_parser.add_argument(
+        "--no-sync",
+        action="store_true",
+        help=(
+            "Do not project this memory into CLAUDE.md's Working Memory. "
+            "Use when the projection would undo the caller's purpose, e.g. "
+            "archiving a pin that is about to be removed from CLAUDE.md."
+        ),
     )
 
     # search

--- a/pact-plugin/skills/pact-memory/scripts/memory_api.py
+++ b/pact-plugin/skills/pact-memory/scripts/memory_api.py
@@ -349,7 +349,8 @@ class PACTMemory:
         self,
         memory: Dict[str, Any],
         files: Optional[List[str]] = None,
-        include_tracked: bool = True
+        include_tracked: bool = True,
+        sync_to_claude: bool = True
     ) -> str:
         """
         Save a memory to the database.
@@ -364,6 +365,13 @@ class PACTMemory:
                     lessons_learned, decisions, entities, active_tasks.
             files: Optional explicit file list to link.
             include_tracked: Include automatically tracked session files.
+            sync_to_claude: Whether to project this memory into CLAUDE.md's
+                Working Memory section. Default True — existing callers are
+                unaffected. Pass False when the projection would defeat the
+                caller's purpose: the pin-archival path removes a block from
+                CLAUDE.md, and syncing writes the same bytes back, so the pin
+                SLOT is freed while the file is not. Mirrors `search`'s
+                parameter of the same name.
 
         Returns:
             The ID of the saved memory.
@@ -413,11 +421,14 @@ class PACTMemory:
             )
 
         # Sync to CLAUDE.md working memory (outside db connection context)
-        # This is non-critical - failures are logged but don't fail the save
-        try:
-            sync_to_claude_md(memory, files_to_link if files_to_link else None, memory_id)
-        except Exception as e:
-            logger.warning(f"Failed to sync to CLAUDE.md: {e}")
+        # This is non-critical - failures are logged but don't fail the save.
+        # Gated on sync_to_claude (default True): callers that omit the
+        # parameter reach this call exactly as before.
+        if sync_to_claude:
+            try:
+                sync_to_claude_md(memory, files_to_link if files_to_link else None, memory_id)
+            except Exception as e:
+                logger.warning(f"Failed to sync to CLAUDE.md: {e}")
 
         return memory_id
 

--- a/pact-plugin/tests/conftest.py
+++ b/pact-plugin/tests/conftest.py
@@ -27,6 +27,32 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 # Add pact-memory scripts to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
 
+
+def pytest_configure(config):
+    """Register markers that DECLARE an external dependency.
+
+    A test whose pass depends on something outside the repo must say so.
+    An undeclared dependency does not fail as a named condition — it fails
+    as flakiness, in an environment nobody was watching, which is the same
+    "reports success while measuring nothing" defect read backwards.
+
+    These markers deliberately do NOT skip. The tests run everywhere by
+    default; the marker exists so a constrained environment can DESELECT
+    them explicitly (`-m 'not requires_embedding_backend'`) and so the
+    deselection appears in the pytest header rather than as an anonymous
+    skip. Skipping by default would hide the dependency inside the skip
+    count, where a reviewer reading "N skipped" cannot tell an intentional
+    environmental exclusion from a test quietly disabled to buy a green.
+    """
+    config.addinivalue_line(
+        "markers",
+        "requires_embedding_backend: exercises the real pact-memory CLI "
+        "save path, which spins the embedding backend and reads its model "
+        "from a local cache. On a COLD cache that read is a network "
+        "download — deselect in a sandboxed or offline environment.",
+    )
+
+
 @pytest.fixture
 def pact_context(tmp_path, monkeypatch):
     """

--- a/pact-plugin/tests/test_archive_pin.py
+++ b/pact-plugin/tests/test_archive_pin.py
@@ -243,6 +243,86 @@ class TestExtractPinBlock_Verbatim:
             "contains its OWN pin's comment and not its successor's."
         )
 
+    @pytest.mark.parametrize("decoy_placement", ["mid_body", "adjacent"])
+    def test_span_start_takes_the_NEAREST_preceding_date_comment(
+        self, decoy_placement
+    ):
+        """`_span_start` must resolve a pin's date comment by NEAREST
+        preceding occurrence, not first.
+
+        THE PROPERTY, stated so it survives a rewrite: pin 1's span begins
+        at the comment ADJACENT TO ITS OWN HEADING. When an identical
+        comment string also appears earlier — inside pin 0's body — the
+        earlier one must not capture the span.
+
+        WHY THIS TEST EXISTS AND NO OTHER COVERS IT. Every other fixture in
+        this file has distinct date comments, so `rfind` and `find` return
+        the same offset and the whole suite passes under either. Measured:
+        swapping `preceding.rfind(date_comment)` for `.find(...)` leaves the
+        suite at 55 passed. Under `find`, pin 1's span starts at the decoy
+        and swallows the tail of pin 0's body, while pin 0's block truncates
+        at the decoy — and the archived record still satisfies every
+        containment conjunct, because a wrong span is still a verbatim
+        substring. Boundaries are exactly what containment cannot see.
+
+        `adjacent` is the sharper case: the decoy sits immediately before
+        the real comment, so anything weaker than nearest-occurrence picks
+        the wrong one by a single line.
+
+        NOTE WHAT IS DELIBERATELY *NOT* ASSERTED. Pin 0's block here
+        legitimately contains TWO date comments — the decoy is part of its
+        body. `count("<!-- pinned:") == 1` is a property of the live file's
+        current CONTENT, never an extractor invariant, and this fixture is
+        the counterexample. Asserting it would manufacture a false RED.
+        """
+        decoy = "<!-- pinned: 2026-02-02 -->"
+        # Text BETWEEN the decoy and the real comment. This is what a
+        # first-occurrence resolver drags into pin 1's block, so it must sit
+        # AFTER the decoy to discriminate — a marker placed before it is
+        # invisible to the bug.
+        between = (
+            "\n" if decoy_placement == "adjacent"
+            else "DRAGGED_IN_UNDER_FIND — still alpha's body.\n\n"
+        )
+        pinned = (
+            "<!-- pinned: 2026-01-01 -->\n"
+            "### Alpha\n"
+            "Alpha's body documents the pin format:\n"
+            f"{decoy}\n"
+            f"{between}"
+            f"{decoy}\n"
+            "### Beta\n"
+            "Beta's body.\n"
+        )
+        pins = pin_caps.parse_pins(pinned)
+        assert len(pins) == 2, f"fixture must parse as 2 pins, got {len(pins)}"
+        assert pinned.count(decoy) == 2, "fixture must contain the decoy twice"
+
+        alpha = archive_pin.extract_pin_block(pinned, 0, pins)
+        beta = archive_pin.extract_pin_block(pinned, 1, pins)
+
+        # THE load-bearing assertions, and they are ABSOLUTE OFFSETS rather
+        # than content checks. Pin 1 is last, so its span runs from the
+        # NEAREST (last) decoy occurrence to the end of the section.
+        #
+        # Content checks alone are too weak in the `adjacent` case, and
+        # PARTITION CANNOT CATCH THIS AT ALL: pin 0's end and pin 1's start
+        # are computed by the SAME `_span_start` call, so they move together
+        # and `alpha + beta == pinned` holds under both resolvers. Only an
+        # assertion pinned to the expected OFFSET discriminates.
+        nearest = pinned.rfind(decoy)
+        assert beta == pinned[nearest:], (
+            "pin 1's span did not begin at the NEAREST preceding date "
+            "comment. `_span_start` resolved the FIRST matching occurrence "
+            "instead, so an identical comment inside pin 0's body captured "
+            f"the span.\n  expected: {pinned[nearest:]!r}\n  actual:   {beta!r}"
+        )
+        assert alpha == pinned[:nearest], (
+            "pin 0's block did not end at pin 1's real span start — its END "
+            "boundary resolved to the decoy inside its own body.\n"
+            f"  expected: {pinned[:nearest]!r}\n  actual:   {alpha!r}"
+        )
+
     def test_spans_partition_the_section_without_overlap(self):
         """Stronger than the pairwise checks: every pin's span is disjoint
         from every other's, and concatenating them in order reproduces a

--- a/pact-plugin/tests/test_archive_pin.py
+++ b/pact-plugin/tests/test_archive_pin.py
@@ -323,6 +323,69 @@ class TestExtractPinBlock_Verbatim:
             f"  expected: {pinned[:nearest]!r}\n  actual:   {alpha!r}"
         )
 
+    def test_delete_to_next_heading_would_destroy_a_RETAINED_pins_date(self):
+        """The archive rule and the next-`### `-heading rule are NOT
+        interchangeable, and the difference is another pin's content.
+
+        WHAT THIS PINS. `extract_pin_block` ends a pin at the NEXT PIN'S
+        SPAN START (its date-comment line). A removal step that instead
+        ran to the next `### ` HEADING would delete a strict SUPERSET —
+        and the excess is the date comment belonging to the pin being
+        RETAINED. Stripping it makes that pin undatable, so `age_days`
+        becomes null, and by the three-state rule it drops out of the
+        overdue ordering permanently. The prune corrupts a pin nobody
+        chose to prune.
+
+        WHY IT IS WORTH A TEST WHEN NO PYTHON RUNS THE REMOVAL. The
+        removal is an LLM-executed Edit driven by prose, so what actually
+        gets deleted is not observable here. This does not attempt to
+        observe it. It pins the thing that IS observable and that makes
+        the prose's wording load-bearing rather than stylistic: that the
+        two candidate boundary rules diverge, and by exactly what. A
+        reader who changes the removal wording meets a measured statement
+        of what the other rule costs.
+
+        HONEST BOUND, so this is not mistaken for coextensivity: this
+        cannot catch the prose stating the wrong rule — that needs a
+        prose-contract guard — and neither can observe the actual delete.
+        Full span equality is only reachable by removing the SECOND
+        DERIVATION: emit the block or its offsets in the verdict so the
+        command has no boundaries to re-derive.
+        """
+        pinned = (
+            "<!-- pinned: 2026-01-01 -->\n"
+            "### Alpha\n"
+            "Alpha's body.\n\n"
+            "<!-- pinned: 2026-02-02 -->\n"
+            "### Beta\n"
+            "Beta's body.\n"
+        )
+        pins = pin_caps.parse_pins(pinned)
+        assert len(pins) == 2, f"fixture must parse as 2 pins, got {len(pins)}"
+        assert pins[1].date_comment, "the RETAINED pin must carry a date comment"
+
+        heading_starts = [
+            m.start() for m in pin_caps._PIN_HEADING_RE.finditer(pinned)
+        ]
+        archived = archive_pin.extract_pin_block(pinned, 0, pins)
+        # The rule a removal step must NOT use.
+        to_next_heading = pinned[pinned.index(archived):heading_starts[1]]
+
+        excess = to_next_heading[len(archived):]
+        assert excess, (
+            "the two boundary rules produced identical spans — this fixture "
+            "no longer discriminates them, so the test is measuring nothing. "
+            "Re-aim it rather than deleting it."
+        )
+        assert pins[1].date_comment in excess, (
+            "expected the excess to be the RETAINED pin's date comment; the "
+            f"rules still differ but not in the way documented. excess={excess!r}"
+        )
+        assert pins[1].date_comment not in archived, (
+            "the archived block already contains the next pin's date comment "
+            "— the span END regressed to the next-heading rule"
+        )
+
     def test_spans_partition_the_section_without_overlap(self):
         """Stronger than the pairwise checks: every pin's span is disjoint
         from every other's, and concatenating them in order reproduces a

--- a/pact-plugin/tests/test_archive_pin.py
+++ b/pact-plugin/tests/test_archive_pin.py
@@ -1,0 +1,826 @@
+"""
+Tests for scripts/archive_pin.py — the archive-on-evict verification step.
+
+Risk tier: CRITICAL. This script's verdict is what /PACT:prune-memory keys
+its refuse-or-proceed decision on, and the pin being archived may be the
+only remaining copy of the content (CLAUDE.md is gitignored, so there is no
+git fallback). A FALSE `ARCHIVED` is the one error that destroys data: the
+command acts on it by evicting. The inverse error (falsely refusing) costs
+an over-block and loses nothing, so the two directions are NOT symmetric
+and the tests here weight the false-positive direction accordingly.
+
+Test strategy, stated because it is load-bearing:
+
+  * At least one test drives the REAL memory CLI end-to-end against a temp
+    `--db-path` database. A suite that stubs every subprocess would verify
+    the stub, not the archive — the vacuous-verification defect this whole
+    feature exists to remove, reproduced one layer down.
+  * The failure matrix stubs `_run_memory_cli`, because a real store cannot
+    be made to fail on demand in the specific ways that matter.
+  * Temp DBs throughout — no test touches the shared store.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+sys.path.insert(0, str(Path(__file__).parent))
+
+from helpers import make_claude_md_with_pins, make_pin_entry  # noqa: E402
+
+import archive_pin  # noqa: E402
+import pin_caps  # noqa: E402
+import staleness  # noqa: E402
+
+
+# Formats a curator can plausibly hand-write. B, D and E are the ones a
+# part-reconstructing extractor mangles; they are here so a regression from
+# slicing back to rebuilding fails loudly rather than silently archiving a
+# whitespace-normalized variant.
+PIN_FORMATS = {
+    "canonical": "<!-- pinned: 2026-01-01 -->\n### Alpha\nbody alpha\n",
+    "blank_line_before_heading": (
+        "<!-- pinned: 2026-01-01 -->\n\n### Beta\nbody beta\n"
+    ),
+    "leading_ws_on_comment": (
+        "  <!-- pinned: 2026-01-01 -->\n### Gamma\nbody gamma\n"
+    ),
+    "trailing_ws_on_comment": (
+        "<!-- pinned: 2026-01-01 -->   \n### Delta\nbody delta\n"
+    ),
+    "two_blank_lines": (
+        "<!-- pinned: 2026-01-01 -->\n\n\n### Epsilon\nbody epsilon\n"
+    ),
+}
+
+
+@pytest.fixture
+def claude_md(tmp_path, monkeypatch):
+    """Write a CLAUDE.md and point the script's resolver at it."""
+    def _write(content):
+        path = tmp_path / "CLAUDE.md"
+        path.write_text(content, encoding="utf-8")
+        monkeypatch.setattr(
+            archive_pin, "get_project_claude_md_path", lambda: path
+        )
+        return path
+    return _write
+
+
+def _pinned_body(content):
+    """Extract the Pinned Context section body from a full CLAUDE.md."""
+    parsed = staleness._parse_pinned_section(content)
+    assert parsed is not None, "fixture has no Pinned Context section"
+    return parsed[2]
+
+
+def _two_pin_file():
+    return make_claude_md_with_pins([
+        make_pin_entry(title="First Pin", body_chars=40, date="2026-01-01"),
+        make_pin_entry(title="Second Pin", body_chars=40, date="2026-02-02"),
+    ])
+
+
+class TestExtractPinBlock_Verbatim:
+    """The extracted block must be a VERBATIM SLICE of CLAUDE.md.
+
+    This is the property that makes the containment criterion meaningful.
+    If the block is already a lossy rendering of the pin, then saving it and
+    finding it again proves only that the round-trip preserved a variant —
+    all three conjuncts hold while the verdict certifies something that is
+    not the pin. The fidelity gap would simply relocate upstream of where
+    the criterion looks.
+    """
+
+    @pytest.mark.parametrize("label", sorted(PIN_FORMATS))
+    def test_slice_is_verbatim_in_source(self, label):
+        source = PIN_FORMATS[label]
+        pins = pin_caps.parse_pins(source)
+        assert pins, f"fixture {label} parsed no pins — test would be vacuous"
+        block = archive_pin.extract_pin_block(source, 0, pins)
+        assert block in source, (
+            f"format {label!r}: extracted block is not a verbatim substring "
+            f"of the source. Block={block!r}"
+        )
+
+    @pytest.mark.parametrize("label", sorted(PIN_FORMATS))
+    def test_slice_carries_the_substance(self, label):
+        """Verbatim is necessary but not sufficient — the empty string is
+        also a substring. Pin that the block actually carries the heading
+        and the body, so a degenerate extractor cannot pass the test above."""
+        source = PIN_FORMATS[label]
+        pins = pin_caps.parse_pins(source)
+        block = archive_pin.extract_pin_block(source, 0, pins)
+        assert pins[0].heading in block
+        assert pins[0].body.strip() in block
+        assert "<!-- pinned:" in block
+
+    def test_blank_line_between_comment_and_heading_survives(self):
+        """The specific loss a part-reconstruction introduces. parse_pins
+        walks BACKWARD over blank lines to find the date comment, so a
+        rebuild drops them; a slice keeps them."""
+        source = PIN_FORMATS["blank_line_before_heading"]
+        pins = pin_caps.parse_pins(source)
+        block = archive_pin.extract_pin_block(source, 0, pins)
+        assert "-->\n\n### Beta" in block
+
+    def test_slice_beats_naive_rebuild_on_the_same_input(self):
+        """Direct comparison against the alternative implementation.
+
+        This is the test that would have caught the original approach. It
+        asserts BOTH that the slice is verbatim for every format AND that a
+        rebuild is not — so if someone 'simplifies' the extractor back to
+        concatenating parts, this fails with a message naming the formats
+        that broke. The rebuild arm is also the non-vacuity control: if it
+        ever passed for all five, the hazard would be gone and this whole
+        test would be measuring nothing.
+        """
+        slice_ok, rebuild_ok, rebuild_failures = [], [], []
+        for label, source in PIN_FORMATS.items():
+            parsed = pin_caps.parse_pins(source)
+            pin = parsed[0]
+            block = archive_pin.extract_pin_block(source, 0, parsed)
+            date_comment = pin.date_comment or ""
+            rebuild = (
+                f"{date_comment}\n{pin.heading}\n{pin.body}"
+                if date_comment else f"{pin.heading}\n{pin.body}"
+            )
+            slice_ok.append(block in source)
+            rebuild_ok.append(rebuild in source)
+            if rebuild not in source:
+                rebuild_failures.append(label)
+
+        assert all(slice_ok), "slice must be verbatim for EVERY format"
+        assert rebuild_failures, (
+            "a naive rebuild is verbatim for all formats — the hazard this "
+            "extractor defends against no longer exists, so this test is "
+            "now vacuous and should be re-aimed or retired"
+        )
+
+    def test_slice_includes_the_comment_lines_leading_indentation(self):
+        """The span rule starts at the comment LINE's first character, not at
+        the comment text. Both are verbatim substrings, so containment alone
+        cannot tell them apart — this pins the stricter of the two."""
+        source = PIN_FORMATS["leading_ws_on_comment"]
+        pins = pin_caps.parse_pins(source)
+        block = archive_pin.extract_pin_block(source, 0, pins)
+        assert block.startswith("  <!-- pinned:"), (
+            f"slice dropped the comment line's indentation: {block[:40]!r}"
+        )
+
+    def test_slice_is_not_stripped(self):
+        """The block is taken EXACTLY — no strip, rejoin or normalize.
+
+        Dropping the strip is safe and was measured, not assumed: `context`
+        is a scalar and escapes the string-list normalization, so a value
+        with trailing newlines round-trips byte-exact. Had it been stripped
+        in transit, containment would have failed for every archive — an
+        over-block on the whole feature rather than an edge case.
+        """
+        source = (
+            "<!-- pinned: 2026-01-01 -->\n### First\nbody one\n\n\n"
+            "<!-- pinned: 2026-02-02 -->\n### Second\nbody two\n"
+        )
+        pins = pin_caps.parse_pins(source)
+        block = archive_pin.extract_pin_block(source, 0, pins)
+        assert block in source
+        assert block.endswith("\n\n\n"), (
+            f"separator blank lines were stripped from the span: "
+            f"{block[-12:]!r}"
+        )
+
+    def test_index_out_of_range_is_unevaluable(self):
+        source = PIN_FORMATS["canonical"]
+        pins = pin_caps.parse_pins(source)
+        with pytest.raises(archive_pin._Unevaluable):
+            archive_pin.extract_pin_block(source, 5, pins)
+
+    def test_second_pin_slice_does_not_bleed_into_the_first(self):
+        """Block boundaries: pin 1's slice must not carry pin 0's content."""
+        content = _two_pin_file()
+        pinned = _pinned_body(content)
+        pins = pin_caps.parse_pins(pinned)
+        block = archive_pin.extract_pin_block(pinned, 1, pins)
+        assert "Second Pin" in block
+        assert "First Pin" not in block
+
+    def test_first_pin_slice_does_not_swallow_the_next_pins_date_comment(self):
+        """The FORWARD bleed, which is the easy one to miss.
+
+        A span starts at its date-comment LINE, which sits BEFORE the heading.
+        So ending pin N's block at the next `### ` heading — the obvious rule,
+        and what the spec's `end` clause says literally — puts pin N+1's date
+        comment inside pin N's archived block. The record then carries another
+        pin's pinned-date.
+
+        Containment can never catch this: the block is still a verbatim
+        substring of CLAUDE.md and every conjunct of the criterion holds. The
+        end boundary must therefore be the next pin's SPAN start, computed by
+        the same rule as its own start.
+        """
+        content = _two_pin_file()
+        pinned = _pinned_body(content)
+        pins = pin_caps.parse_pins(pinned)
+        block = archive_pin.extract_pin_block(pinned, 0, pins)
+
+        assert "First Pin" in block
+        assert pins[1].date_comment not in block, (
+            f"pin 0's block swallowed pin 1's date comment "
+            f"({pins[1].date_comment!r}) — the archived record would carry "
+            f"another pin's pinned-date"
+        )
+        assert block.count("<!-- pinned:") == 1, (
+            "exactly one date comment belongs in a pin's block"
+        )
+
+    def test_spans_partition_the_section_without_overlap(self):
+        """Stronger than the pairwise checks: every pin's span is disjoint
+        from every other's, and concatenating them in order reproduces a
+        contiguous run of the source. A boundary error in either direction
+        breaks one of these."""
+        content = _two_pin_file()
+        pinned = _pinned_body(content)
+        pins = pin_caps.parse_pins(pinned)
+        blocks = [
+            archive_pin.extract_pin_block(pinned, i, pins)
+            for i in range(len(pins))
+        ]
+        assert len(blocks) == 2, "fixture must have 2 pins or this is vacuous"
+        assert "".join(blocks) in pinned, (
+            "spans are not contiguous — they overlap or leave a gap"
+        )
+        for i, block in enumerate(blocks):
+            others = [b for j, b in enumerate(blocks) if j != i]
+            for other in others:
+                assert other not in block, f"span {i} contains another span"
+
+
+class TestArchiveMarker:
+    """The structured archive marker written into `entities[].type`.
+
+    SCOPE, stated so no reader infers more: this marker makes archives
+    DISCOVERABLE GOING FORWARD. It does not make them enumerable. Archives
+    written before it shipped carry no marker at all — including ones folded
+    into an existing record rather than saved standalone — so any count
+    obtained by scanning for it is a FLOOR over future archives, never a
+    total over all of them.
+    """
+
+    def test_marker_value_is_pinned(self):
+        """The value is pinned because `entities[].type` is unconstrained
+        free text — structured by POSITION, not by SCHEMA.
+
+        Nothing in the store validates the field, so a typo or a rename
+        ships SILENTLY: a scanner keyed on the old value returns a smaller
+        set and raises nothing. A confident undercount is worse than a loud
+        failure, and this test is what converts a silent drift into a red.
+        """
+        assert archive_pin.ARCHIVE_ENTITY_TYPE == "pact_memory_archive"
+
+    def test_record_uses_the_constant_not_a_second_literal(self):
+        """Any code that writes or scans the marker must read THIS constant.
+
+        Two copies of a free-text value drift, and the drift is invisible in
+        exactly the way a schema violation would not be. Asserting the
+        record's value IS the constant object (rather than equal to a literal
+        retyped here) is what makes this test detect a divergence instead of
+        silently agreeing with a hardcoded copy.
+        """
+        record = archive_pin._build_record("### Pin\nbody", "Pin")
+        entity = record["entities"][0]
+        assert entity["type"] == archive_pin.ARCHIVE_ENTITY_TYPE
+        assert entity["name"] == "Pin"
+        assert "demoted from CLAUDE.md" in entity["notes"]
+
+    def test_no_second_copy_of_the_literal_in_this_module(self):
+        """Guards the drift directly: the literal may appear exactly once in
+        archive_pin.py — at the constant's definition. A scan site or a
+        second writer that re-types it would be invisible to the test above,
+        because a hardcoded duplicate agrees with the constant right up until
+        someone changes one of them."""
+        source = Path(archive_pin.__file__).read_text(encoding="utf-8")
+        occurrences = source.count('"pact_memory_archive"')
+        assert occurrences == 1, (
+            f"the marker literal appears {occurrences} times in "
+            f"archive_pin.py; it must appear once (the constant) and every "
+            f"other site must reference ARCHIVE_ENTITY_TYPE"
+        )
+
+
+class TestStandaloneOnlyInvariant:
+    """Archival MUST create a standalone record, never update an existing one.
+
+    This is asserted directly rather than via a downstream symptom, because
+    the violation is INVISIBLE AT RUNTIME. An additive `update` creates no new
+    record and runs no marker code, so a folded archive is silently absent
+    from any marker scan — that already happened to prior demotions. A future
+    maintainer adding a fold path for a perfectly good reason (dedup,
+    retrieval quality, avoiding near-duplicates) would void the audit property
+    WITHOUT TOUCHING THE MARKER CODE, and nothing would fail; the symptom is a
+    missing record in somebody's later audit.
+
+    If a fold path is ever genuinely wanted, the correct move is to write the
+    marker on the update path too, or to withdraw the auditability claim in
+    the same change — not to relax this test.
+    """
+
+    def test_archival_calls_save_and_never_update(
+        self, claude_md, monkeypatch
+    ):
+        claude_md(_two_pin_file())
+        subcommands = []
+
+        def _spy(args, **kwargs):
+            subcommands.append(args[0])
+            if args[0] == "save":
+                return 0, json.dumps(
+                    {"ok": True, "result": {"memory_id": "d" * 32}}
+                ), ""
+            return 0, json.dumps({"ok": True, "result": {"context": "x"}}), ""
+
+        monkeypatch.setattr(archive_pin, "_run_memory_cli", _spy)
+        archive_pin.build_verdict(0)
+
+        assert "save" in subcommands, (
+            "no save was attempted — the spy never saw the create path, so "
+            "this test would pass vacuously"
+        )
+        assert "update" not in subcommands
+        assert set(subcommands) <= {"save", "get"}, (
+            f"archival used an unexpected subcommand: {subcommands}"
+        )
+
+    def test_archive_subcommand_constant_is_save(self):
+        """The subcommand is a named constant so a fold path cannot be
+        introduced by editing a bare string at the call site."""
+        assert archive_pin._ARCHIVE_SUBCOMMAND == "save"
+
+    def test_no_update_subcommand_anywhere_in_the_module(self):
+        """Structural backstop for the spy above, which can only observe the
+        paths a test actually drives."""
+        source = Path(archive_pin.__file__).read_text(encoding="utf-8")
+        assert '"update"' not in source
+        assert "'update'" not in source
+
+
+class TestProjectDirResolution:
+    """WHERE the archive is filed.
+
+    The memory layer detects project_id from CLAUDE_PROJECT_DIR, else git,
+    else by walking UP from the CWD to the nearest project marker — and
+    `.claude` is such a marker. Since the installed plugin lives beneath
+    `~/.claude/`, running the memory CLI from the plugin's own directory
+    files a consumer's archived pin under project `.claude`. Deriving the
+    directory from the CLAUDE.md actually read is what prevents that.
+    """
+
+    def test_dot_claude_layout_resolves_to_project_root(self):
+        got = archive_pin.project_dir_for(Path("/tmp/proj/.claude/CLAUDE.md"))
+        assert got.name == "proj"
+
+    def test_legacy_layout_resolves_to_project_root(self):
+        got = archive_pin.project_dir_for(Path("/tmp/proj/CLAUDE.md"))
+        assert got.name == "proj"
+
+    def test_project_dir_is_never_the_plugin_directory(self, tmp_path):
+        """The regression this guards: a CWD anywhere under the plugin tree
+        would resolve project_id to `.claude` for every consumer."""
+        claude_md = tmp_path / "myproject" / ".claude" / "CLAUDE.md"
+        claude_md.parent.mkdir(parents=True)
+        claude_md.write_text("x", encoding="utf-8")
+        resolved = archive_pin.project_dir_for(claude_md)
+        plugin_root = Path(archive_pin.__file__).resolve().parent.parent
+        assert resolved.name == "myproject"
+        assert plugin_root not in resolved.parents
+        assert resolved != plugin_root
+
+
+class TestArchivePin_RealCLI:
+    """End-to-end against the REAL memory CLI and a temp database.
+
+    Without at least one of these, the whole suite would be verifying its
+    own stubs. These exercise the actual save/get envelope handling, the
+    real embedding backend, and real byte round-tripping.
+    """
+
+    def test_archives_and_verifies_containment(self, claude_md, tmp_path):
+        claude_md(_two_pin_file())
+        verdict = archive_pin.build_verdict(
+            0, db_path=str(tmp_path / "mem.db")
+        )
+        assert verdict["outcome"] == "ARCHIVED"
+        assert verdict["heading"] == "First Pin"
+        assert verdict["contained"] is True
+        assert len(verdict["memory_id"]) == 32
+        assert verdict["chars"] > 0
+
+    def test_archived_record_carries_the_block_in_context_not_a_list_field(
+        self, claude_md, tmp_path
+    ):
+        """D3, verified at the destination rather than asserted in a comment.
+
+        String-list fields `.strip()` and NFC-normalize their items, so a pin
+        stored there comes back ALTERED — containment returns FALSE for a
+        perfectly good archive, which is an OVER-BLOCK refusing a legitimate
+        eviction. This is not hypothetical: the one pin-archive record
+        already in the store claims verbatim preservation while holding its
+        content in `lessons_learned`.
+        """
+        content = _two_pin_file()
+        claude_md(content)
+        db = str(tmp_path / "mem.db")
+        verdict = archive_pin.build_verdict(0, db_path=db)
+        assert verdict["outcome"] == "ARCHIVED"
+
+        fetched = _cli_get(verdict["memory_id"], db)
+        pinned = _pinned_body(content)
+        block = archive_pin.extract_pin_block(
+            pinned, 0, pin_caps.parse_pins(pinned)
+        )
+
+        assert block in fetched["context"], "block must land in `context`"
+        for list_field in ("lessons_learned", "reasoning_chains", "decisions"):
+            assert not fetched.get(list_field), (
+                f"{list_field} must stay empty — a list field cannot "
+                f"preserve the block byte-exact"
+            )
+
+    def test_adversarial_body_round_trips_byte_exact(
+        self, claude_md, tmp_path
+    ):
+        """Apostrophes, backticks, tabs, CRLF and trailing whitespace all
+        survive. These are the classes that break shell-quoted or
+        normalizing storage paths."""
+        content = (
+            "<!-- PACT_MANAGED_START -->\n## Pinned Context\n\n"
+            "<!-- pinned: 2026-01-01 -->\n"
+            "### Adversarial\n"
+            "has 'apostrophes' and `backticks`\n"
+            "\ttab-indented, trailing spaces here   \n"
+            "#### not a pin heading\n\n"
+            "<!-- PACT_MANAGED_END -->\n"
+        )
+        claude_md(content)
+        db = str(tmp_path / "mem.db")
+        verdict = archive_pin.build_verdict(0, db_path=db)
+        assert verdict["outcome"] == "ARCHIVED"
+
+        fetched = _cli_get(verdict["memory_id"], db)
+        block = archive_pin.extract_pin_block(
+            _pinned_body(content), 0,
+            pin_caps.parse_pins(_pinned_body(content)),
+        )
+        assert block in fetched["context"]
+        assert "'apostrophes'" in fetched["context"]
+        assert "`backticks`" in fetched["context"]
+        assert "\t" in fetched["context"]
+
+    def test_save_writes_to_stderr_while_stdout_stays_clean_json(
+        self, claude_md, tmp_path
+    ):
+        """The never-`2>&1` constraint, measured rather than asserted.
+
+        `save` writes an embedding progress bar to STDERR on SUCCESS. If the
+        streams were ever merged, that bar would splice into the envelope
+        and every parse would break. The stderr assertion is the NON-VACUITY
+        CONTROL: if the backend stops writing to stderr the hazard is gone
+        and this test is measuring nothing, so it should fail loudly and be
+        re-aimed rather than pass silently.
+        """
+        claude_md(_two_pin_file())
+        pinned = _pinned_body(_two_pin_file())
+        block = archive_pin.extract_pin_block(
+            pinned, 0, pin_caps.parse_pins(pinned)
+        )
+        payload = json.dumps(archive_pin._build_record(block, "First Pin"))
+
+        rc, stdout, stderr = archive_pin._run_memory_cli(
+            ["save", "--stdin"],
+            db_path=str(tmp_path / "mem.db"),
+            stdin_data=payload,
+            cwd=tmp_path,
+        )
+        assert rc == 0
+        assert stderr.strip(), (
+            "expected the embedding progress bar on stderr — without it "
+            "this test cannot detect a merged-stream regression"
+        )
+        envelope = json.loads(stdout)  # would raise if streams were merged
+        assert envelope["ok"] is True
+        assert stderr.strip() not in stdout
+
+
+def _cli_get(memory_id, db_path):
+    """Fetch a record via the real CLI, streams kept separate."""
+    cli = (
+        Path(archive_pin.__file__).resolve().parent.parent
+        / "skills" / "pact-memory" / "scripts" / "cli.py"
+    )
+    proc = subprocess.run(
+        [sys.executable, str(cli), "get", memory_id, "--db-path", db_path],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert proc.returncode == 0, f"get failed: {proc.stderr[:400]}"
+    return json.loads(proc.stdout)["result"]
+
+
+class TestArchivePin_FailureMatrix:
+    """Stubbed-CLI failure paths. Real stores cannot be made to fail on
+    demand in these specific ways, so the seam is stubbed here — while
+    TestArchivePin_RealCLI keeps the unstubbed path covered."""
+
+    def test_save_returning_no_id_is_not_archived(self, claude_md, monkeypatch):
+        """The store was reachable and said no. Definite failure, so
+        NOT_ARCHIVED rather than UNEVALUABLE."""
+        claude_md(_two_pin_file())
+        monkeypatch.setattr(
+            archive_pin, "_run_memory_cli",
+            lambda *a, **k: (
+                1, "", json.dumps({"ok": False, "error": "ValueError",
+                                   "message": "bad field"})
+            ),
+        )
+        verdict = archive_pin.build_verdict(0)
+        assert verdict["outcome"] == "NOT_ARCHIVED"
+        assert verdict["memory_id"] is None
+        assert verdict["heading"] == "First Pin"
+        assert "ValueError" in verdict["reason"]
+
+    def test_error_envelope_key_is_error_not_error_type(
+        self, claude_md, monkeypatch
+    ):
+        """cli.py's envelope key is `error`. A reader keyed on `error_type`
+        would silently render every failure as an empty reason."""
+        claude_md(_two_pin_file())
+        monkeypatch.setattr(
+            archive_pin, "_run_memory_cli",
+            lambda *a, **k: (
+                1, "", json.dumps({"ok": False, "error": "NOT_FOUND",
+                                   "message": "Memory 'x' not found"})
+            ),
+        )
+        verdict = archive_pin.build_verdict(0)
+        assert "NOT_FOUND" in verdict["reason"]
+
+    def test_containment_failure_is_not_archived(self, claude_md, monkeypatch):
+        """THE criterion. A record that exists but does not carry the pin is
+        NOT archived — this is precisely the case the old memory_id-only
+        check passed, and it is the case the founding data loss was."""
+        claude_md(_two_pin_file())
+        calls = []
+
+        def _stub(args, **kwargs):
+            calls.append(args[0])
+            if args[0] == "save":
+                return 0, json.dumps(
+                    {"ok": True, "result": {"memory_id": "a" * 32}}
+                ), ""
+            return 0, json.dumps({
+                "ok": True,
+                "result": {"context": "a summary that lost the pin body"},
+            }), ""
+
+        monkeypatch.setattr(archive_pin, "_run_memory_cli", _stub)
+        verdict = archive_pin.build_verdict(0)
+        assert verdict["outcome"] == "NOT_ARCHIVED"
+        assert verdict["memory_id"] == "a" * 32, (
+            "the id must still be reported so the orphan record is findable"
+        )
+        assert "fidelity" in verdict["reason"]
+        assert calls == ["save", "get"], "must re-fetch before judging"
+
+    def test_containment_is_substring_not_equality(
+        self, claude_md, monkeypatch
+    ):
+        """`context` may legitimately carry MORE than the block — a
+        provenance preamble, for instance. An equality assertion would
+        return false for a correct archive: an over-block in the one control
+        whose entire purpose is not destroying content."""
+        content = _two_pin_file()
+        claude_md(content)
+        pinned = _pinned_body(content)
+        block = archive_pin.extract_pin_block(
+            pinned, 0, pin_caps.parse_pins(pinned)
+        )
+
+        def _stub(args, **kwargs):
+            if args[0] == "save":
+                return 0, json.dumps(
+                    {"ok": True, "result": {"memory_id": "b" * 32}}
+                ), ""
+            return 0, json.dumps({
+                "ok": True,
+                "result": {
+                    "context": (
+                        "Archive of CLAUDE.md pin, demoted 2026-07-25 to "
+                        "free a slot.\n\n" + block + "\n\ntrailing note"
+                    )
+                },
+            }), ""
+
+        monkeypatch.setattr(archive_pin, "_run_memory_cli", _stub)
+        verdict = archive_pin.build_verdict(0)
+        assert verdict["outcome"] == "ARCHIVED", (
+            "a record wrapping the block in provenance is a GOOD archive"
+        )
+
+    def test_refetch_failure_is_unevaluable_not_not_archived(
+        self, claude_md, monkeypatch
+    ):
+        """The id came back but the record will not re-read. We cannot tell
+        whether the bytes are safe — so we must claim neither. Collapsing
+        this into NOT_ARCHIVED would be defensible; collapsing it into
+        ARCHIVED would destroy content."""
+        claude_md(_two_pin_file())
+
+        def _stub(args, **kwargs):
+            if args[0] == "save":
+                return 0, json.dumps(
+                    {"ok": True, "result": {"memory_id": "c" * 32}}
+                ), ""
+            return 1, "", json.dumps(
+                {"ok": False, "error": "NOT_FOUND", "message": "gone"}
+            )
+
+        monkeypatch.setattr(archive_pin, "_run_memory_cli", _stub)
+        verdict = archive_pin.build_verdict(0)
+        assert verdict["outcome"] == "UNEVALUABLE"
+        assert "c" * 32 in verdict["reason"]
+        assert verdict["heading"] == "First Pin"
+
+    @pytest.mark.parametrize("stdout", ["", "   ", "not json", "[]",
+                                        '{"ok": false}'])
+    def test_unparseable_save_stdout_never_reads_as_success(
+        self, claude_md, monkeypatch, stdout
+    ):
+        """NOT_FOUND, PREFIX_TOO_SHORT and an outright crash all present as
+        empty or unusable stdout. None may be mistaken for a save."""
+        claude_md(_two_pin_file())
+        monkeypatch.setattr(
+            archive_pin, "_run_memory_cli", lambda *a, **k: (0, stdout, "")
+        )
+        verdict = archive_pin.build_verdict(0)
+        assert verdict["outcome"] != "ARCHIVED"
+
+
+class TestArchivePin_Unevaluable:
+    """Every path where the pin's state cannot be established."""
+
+    def test_missing_claude_md(self, monkeypatch):
+        monkeypatch.setattr(
+            archive_pin, "get_project_claude_md_path", lambda: None
+        )
+        verdict = archive_pin.build_verdict(0)
+        assert verdict["outcome"] == "UNEVALUABLE"
+        assert verdict["heading"] is None
+
+    def test_no_pinned_section(self, claude_md):
+        claude_md("# Project\n\n## Working Memory\n\n")
+        verdict = archive_pin.build_verdict(0)
+        assert verdict["outcome"] == "UNEVALUABLE"
+
+    def test_index_beyond_pin_count(self, claude_md):
+        claude_md(_two_pin_file())
+        verdict = archive_pin.build_verdict(99)
+        assert verdict["outcome"] == "UNEVALUABLE"
+        assert "out of range" in verdict["reason"]
+
+    def test_missing_memory_cli(self, claude_md, monkeypatch):
+        claude_md(_two_pin_file())
+        monkeypatch.setattr(archive_pin, "_MEMORY_CLI", Path("/nonexistent/cli.py"))
+        verdict = archive_pin.build_verdict(0)
+        assert verdict["outcome"] == "UNEVALUABLE"
+        assert "not found" in verdict["reason"]
+
+    def test_cli_timeout(self, claude_md, monkeypatch):
+        """A hang must refuse (pin survives), never proceed."""
+        claude_md(_two_pin_file())
+
+        def _boom(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="save", timeout=1)
+
+        monkeypatch.setattr(subprocess, "run", _boom)
+        verdict = archive_pin.build_verdict(0)
+        assert verdict["outcome"] == "UNEVALUABLE"
+        assert "timed out" in verdict["reason"]
+
+    def test_unreadable_claude_md(self, claude_md, monkeypatch):
+        claude_md(_two_pin_file())
+
+        def _raise(*a, **k):
+            raise IOError("simulated")
+
+        monkeypatch.setattr(Path, "read_text", _raise)
+        verdict = archive_pin.build_verdict(0)
+        assert verdict["outcome"] == "UNEVALUABLE"
+
+    def test_lossy_extractor_is_caught_before_any_write(
+        self, claude_md, monkeypatch
+    ):
+        """The source-side tripwire.
+
+        The slice makes 'block is verbatim in CLAUDE.md' true BY
+        CONSTRUCTION, so this check costs nothing in normal operation. It
+        exists to fail loudly if the extractor ever regresses into a lossy
+        rebuild — and it fires BEFORE the save, so a broken extractor writes
+        nothing rather than persisting a variant and certifying it.
+        """
+        claude_md(_two_pin_file())
+        monkeypatch.setattr(
+            archive_pin, "extract_pin_block",
+            lambda *a, **k: "### Not from the source at all\nfabricated",
+        )
+        called = []
+        monkeypatch.setattr(
+            archive_pin, "_run_memory_cli",
+            lambda *a, **k: called.append(a) or (0, "", ""),
+        )
+        verdict = archive_pin.build_verdict(0)
+        assert verdict["outcome"] == "UNEVALUABLE"
+        assert "not verbatim" in verdict["reason"]
+        assert called == [], "must not save when the block is not verbatim"
+
+
+class TestArchivePin_CliContract:
+    """main() surface: always exit 0, always a parseable verdict."""
+
+    @pytest.mark.parametrize("index", [0, 1, 99, -1])
+    def test_always_exits_zero(self, claude_md, capsys, index, tmp_path):
+        """SACROSANCT in-band degradation: the script reports, the command
+        decides. A non-zero exit would turn a measurement into a decision."""
+        claude_md(_two_pin_file())
+        rc = archive_pin.main(
+            ["--index", str(index), "--db-path", str(tmp_path / "m.db")]
+        )
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["outcome"] in {
+            "ARCHIVED", "NOT_ARCHIVED", "UNEVALUABLE"
+        }
+
+    def test_every_verdict_carries_outcome_and_heading_keys(
+        self, claude_md, capsys, monkeypatch, tmp_path
+    ):
+        """`heading` is present in ALL THREE verdicts so a consumer never
+        has to distinguish an absent key from a null value."""
+        claude_md(_two_pin_file())
+        db = str(tmp_path / "m.db")
+
+        seen = {}
+        # ARCHIVED (real CLI)
+        archive_pin.main(["--index", "0", "--db-path", db])
+        seen["ARCHIVED"] = json.loads(capsys.readouterr().out)
+        # UNEVALUABLE
+        archive_pin.main(["--index", "99", "--db-path", db])
+        seen["UNEVALUABLE"] = json.loads(capsys.readouterr().out)
+        # NOT_ARCHIVED
+        monkeypatch.setattr(
+            archive_pin, "_run_memory_cli", lambda *a, **k: (1, "", "boom")
+        )
+        archive_pin.main(["--index", "0", "--db-path", db])
+        seen["NOT_ARCHIVED"] = json.loads(capsys.readouterr().out)
+
+        assert set(seen) == {"ARCHIVED", "UNEVALUABLE", "NOT_ARCHIVED"}, (
+            "all three verdicts must be reachable or this test is partial"
+        )
+        for outcome, payload in seen.items():
+            assert payload["outcome"] == outcome
+            assert "heading" in payload, f"{outcome} dropped the heading key"
+
+    def test_heading_is_the_real_heading_not_an_index_echo(
+        self, claude_md, capsys, tmp_path
+    ):
+        """The caller cross-checks this value against the curator's
+        selection to catch an index shift between listing and archival —
+        which would otherwise archive one pin and evict another while
+        containment still passed, the right property measured on the wrong
+        object. An index echo would make that check compare the index
+        against itself and pass unconditionally."""
+        claude_md(_two_pin_file())
+        archive_pin.main(
+            ["--index", "1", "--db-path", str(tmp_path / "m.db")]
+        )
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["heading"] == "Second Pin"
+        assert "1" != payload["heading"]
+
+    def test_internal_error_degrades_to_unevaluable(
+        self, claude_md, capsys, monkeypatch
+    ):
+        """An unexpected exception must never crash the curator's flow."""
+        claude_md(_two_pin_file())
+
+        def _boom(*a, **k):
+            raise RuntimeError("unexpected")
+
+        monkeypatch.setattr(archive_pin, "archive_pin", _boom)
+        rc = archive_pin.main(["--index", "0"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["outcome"] == "UNEVALUABLE"
+        assert "RuntimeError" in payload["reason"]

--- a/pact-plugin/tests/test_archive_pin.py
+++ b/pact-plugin/tests/test_archive_pin.py
@@ -400,12 +400,28 @@ class TestProjectDirResolution:
         assert resolved != plugin_root
 
 
+@pytest.mark.requires_embedding_backend
 class TestArchivePin_RealCLI:
     """End-to-end against the REAL memory CLI and a temp database.
 
     Without at least one of these, the whole suite would be verifying its
     own stubs. These exercise the actual save/get envelope handling, the
     real embedding backend, and real byte round-tripping.
+
+    DECLARED EXTERNAL DEPENDENCY (marker registered in conftest.py). The
+    `save` path spins the embedding backend, which reads its model from a
+    local cache. Every measurement behind these tests was taken against a
+    WARM cache; cold-cache behaviour is UNMEASURED, and on a cold cache
+    that read becomes a network download. In a container with no network
+    it is not a slower test, it is a DIFFERENT FAILURE.
+
+    The marker does not skip. These run by default, so the dependency
+    cannot be satisfied by quietly not exercising the one path that keeps
+    the suite from verifying its own stubs; a constrained environment
+    deselects with `-m 'not requires_embedding_backend'`, which shows up
+    in the pytest header rather than inside the skip count. The point is
+    that the dependency is now NAMED: if it bites, it presents as a
+    deselected marker or a legible failure, not as unexplained flakiness.
     """
 
     def test_archives_and_verifies_containment(self, claude_md, tmp_path):

--- a/pact-plugin/tests/test_archive_pin.py
+++ b/pact-plugin/tests/test_archive_pin.py
@@ -235,7 +235,12 @@ class TestExtractPinBlock_Verbatim:
             f"another pin's pinned-date"
         )
         assert block.count("<!-- pinned:") == 1, (
-            "exactly one date comment belongs in a pin's block"
+            "this fixture's pins carry one date comment each, so a second "
+            "one in pin 0's block means it swallowed pin 1's. NOT a general "
+            "invariant: a pin whose body documents the pin format "
+            "legitimately contains two, and that slice is correct. The "
+            "fixture-independent property is the assertion above — a block "
+            "contains its OWN pin's comment and not its successor's."
         )
 
     def test_spans_partition_the_section_without_overlap(self):

--- a/pact-plugin/tests/test_archive_pin_emit.py
+++ b/pact-plugin/tests/test_archive_pin_emit.py
@@ -1,0 +1,626 @@
+"""
+Tests for the `delete_string` emit contract and the uniqueness precondition.
+
+Location: pact-plugin/tests/test_archive_pin_emit.py
+
+WHAT THIS SUITE CLAIMS, AND WHAT IT DOES NOT. Every test here constrains
+THE HANDLE the verdict emits — never THE EDIT the command performs. The
+removal is an LLM-executed `Edit`, which pytest cannot observe. So the
+claim is "the verdict emits a correct, unambiguous, verbatim handle bound
+to a named file", NOT "the removal deletes the right bytes".
+
+That distinction is the whole design. `delete_string` exists so the command
+stops RE-DERIVING the span from prose: a second derivation is what let the
+delete range and the archive range disagree. With one derivation there is
+nothing left to disagree, so coextensivity is not VERIFIED here — it is made
+UNFALSIFIABLE by removing the second derivation. No docstring in this file
+may claim the stronger property.
+
+The error directions are not symmetric. A false ARCHIVED destroys content
+(CLAUDE.md is gitignored, so there is no git fallback); a false refusal
+costs an over-block and loses nothing. Tests weight accordingly.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+sys.path.insert(0, str(Path(__file__).parent))
+
+from helpers import make_claude_md_with_pins, make_pin_entry  # noqa: E402
+
+import archive_pin  # noqa: E402
+import staleness  # noqa: E402
+
+
+@pytest.fixture
+def claude_md(tmp_path, monkeypatch):
+    """Write a CLAUDE.md and point the script's resolver at it."""
+    def _write(content):
+        path = tmp_path / "CLAUDE.md"
+        path.write_text(content, encoding="utf-8")
+        monkeypatch.setattr(
+            archive_pin, "get_project_claude_md_path", lambda: path
+        )
+        return path
+    return _write
+
+
+def _two_pin_file():
+    return make_claude_md_with_pins([
+        make_pin_entry(title="First Pin", body_chars=40, date="2026-01-01"),
+        make_pin_entry(title="Second Pin", body_chars=40, date="2026-02-02"),
+    ])
+
+
+def _pinned_body(content):
+    parsed = staleness._parse_pinned_section(content)
+    assert parsed is not None, "fixture has no Pinned Context section"
+    return parsed[2]
+
+
+def _expected_block(content, index):
+    """Compute the block INDEPENDENTLY of the verdict.
+
+    Deliberately re-derived from the source rather than read back off the
+    verdict — comparing a field against itself is the vacuity mode this
+    row exists to avoid.
+    """
+    pinned = _pinned_body(content)
+    pins = archive_pin.parse_pins(pinned)
+    return archive_pin.extract_pin_block(pinned, index, pins)
+
+
+def _ok_stub(context_value):
+    """A save/get seam that succeeds and returns `context_value` on get."""
+    def _stub(args, **kwargs):
+        if args[0] == "save":
+            return 0, json.dumps(
+                {"ok": True, "result": {"memory_id": "a" * 32}}
+            ), ""
+        return 0, json.dumps(
+            {"ok": True, "result": {"context": context_value}}
+        ), ""
+    return _stub
+
+
+class TestDeleteStringEmitContract:
+    """`delete_string` is a property of WHICH PIN, not of whether the
+    archive worked — so it is emitted wherever the pin RESOLVES and is null
+    only where it does not.
+
+    BOUND: these tests pin the FIELD. They say nothing about whether the
+    command uses it.
+    """
+
+    def test_present_and_non_null_on_archived(self, claude_md, monkeypatch):
+        content = _two_pin_file()
+        claude_md(content)
+        block = _expected_block(content, 0)
+        monkeypatch.setattr(archive_pin, "_run_memory_cli", _ok_stub(block))
+
+        verdict = archive_pin.build_verdict(0)
+
+        # Non-vacuity: prove the arm was actually taken. Without this the
+        # assertion below passes on any outcome that happens to carry a key.
+        assert verdict["outcome"] == "ARCHIVED"
+        assert verdict["delete_string"] == block
+
+    def test_present_on_not_archived_because_the_pin_still_resolved(
+        self, claude_md, monkeypatch
+    ):
+        """The archive failed; the pin did not. The curator still needs the
+        handle to know WHICH pin the refusal is about."""
+        content = _two_pin_file()
+        claude_md(content)
+        monkeypatch.setattr(
+            archive_pin, "_run_memory_cli",
+            lambda *a, **k: (
+                1, "", json.dumps({"ok": False, "error": "ValueError",
+                                   "message": "bad field"})
+            ),
+        )
+
+        verdict = archive_pin.build_verdict(0)
+
+        assert verdict["outcome"] == "NOT_ARCHIVED"
+        assert verdict["memory_id"] is None, "the archive must have failed"
+        assert verdict["delete_string"] == _expected_block(content, 0)
+
+    def test_present_on_a_located_pin_unevaluable(self, claude_md, monkeypatch):
+        """UNEVALUABLE reached AFTER the pin resolved still carries it."""
+        content = _two_pin_file()
+        claude_md(content)
+
+        def _refetch_fails(args, **kwargs):
+            if args[0] == "save":
+                return 0, json.dumps(
+                    {"ok": True, "result": {"memory_id": "a" * 32}}
+                ), ""
+            return 1, "", json.dumps(
+                {"ok": False, "error": "NOT_FOUND", "message": "gone"}
+            )
+
+        monkeypatch.setattr(archive_pin, "_run_memory_cli", _refetch_fails)
+        verdict = archive_pin.build_verdict(0)
+
+        assert verdict["outcome"] == "UNEVALUABLE"
+        # heading non-null is what PROVES the pin resolved before the failure
+        assert verdict["heading"] == "First Pin"
+        assert verdict["delete_string"] == _expected_block(content, 0)
+
+    @pytest.mark.parametrize("bad_index", [99, -1])
+    def test_null_when_the_pin_does_not_resolve(self, claude_md, bad_index):
+        """THE DISCRIMINATING ROW.
+
+        If `delete_string` were merely "the block we happened to compute",
+        a non-resolving verdict could carry a stale or defaulted value. Null
+        here is what makes it a property of WHICH PIN.
+
+        NON-VACUITY CONTROL IS LOAD-BEARING: a test asserting only `is None`
+        passes trivially if the field is ALWAYS None. The resolving control
+        below is what makes the null meaningful.
+        """
+        content = _two_pin_file()
+        claude_md(content)
+
+        unresolved = archive_pin.build_verdict(bad_index)
+        assert unresolved["outcome"] == "UNEVALUABLE"
+        assert unresolved["heading"] is None
+        assert unresolved["delete_string"] is None
+
+        # CONTROL: the same file, a resolving index, must be NON-null.
+        # Without this the assertion above cannot distinguish "null because
+        # the pin did not resolve" from "null always".
+        resolving = archive_pin.build_verdict(0)
+        assert resolving["delete_string"] is not None, (
+            "delete_string is null even on a RESOLVING pin — the null above "
+            "proves nothing"
+        )
+
+    def test_key_is_present_even_when_the_value_is_null(self, claude_md):
+        """`null` and `absent` are different failures for a consumer.
+
+        The contract says "null when the pin does not resolve" — a claim
+        about the VALUE that is silent about the KEY. A consumer doing
+        `verdict["delete_string"]` must not raise KeyError.
+        """
+        claude_md(_two_pin_file())
+        verdict = archive_pin.build_verdict(99)
+        assert "delete_string" in verdict
+        assert "claude_md_path" in verdict
+
+    def test_equals_an_independently_computed_extract_pin_block(
+        self, claude_md, monkeypatch
+    ):
+        """A WIRING check, and deliberately named as one.
+
+        BOUND, stated because the stronger reading is tempting: this proves
+        the emitted field is the BLOCK — not the heading, not a truncation,
+        not a reconstruction. It is NOT a coextensivity proof. Once the
+        archiver emits the same string it archived, comparing the two is
+        near-tautological; the property that matters is guaranteed by there
+        being ONE derivation, not by this assertion.
+        """
+        content = _two_pin_file()
+        claude_md(content)
+        block = _expected_block(content, 1)
+        monkeypatch.setattr(archive_pin, "_run_memory_cli", _ok_stub(block))
+
+        verdict = archive_pin.build_verdict(1)
+
+        assert verdict["delete_string"] == block
+        assert verdict["delete_string"] != verdict["heading"]
+        assert len(verdict["delete_string"]) > len("### Second Pin")
+
+    def test_is_verbatim_in_the_file_at_the_emitted_path(
+        self, claude_md, monkeypatch
+    ):
+        """The handle and its target must agree.
+
+        A content handle without a bound target is the defect that put
+        `claude_md_path` in the verdict: the archive read one file and the
+        removal could edit another. Asserting the handle is verbatim IN the
+        emitted path binds the two.
+        """
+        content = _two_pin_file()
+        path = claude_md(content)
+        block = _expected_block(content, 0)
+        monkeypatch.setattr(archive_pin, "_run_memory_cli", _ok_stub(block))
+
+        verdict = archive_pin.build_verdict(0)
+
+        assert verdict["claude_md_path"] == str(path)
+        on_disk = Path(verdict["claude_md_path"]).read_text(encoding="utf-8")
+        assert verdict["delete_string"] in on_disk
+
+    def test_retains_its_trailing_blank_line_for_a_non_last_pin(
+        self, claude_md, monkeypatch
+    ):
+        """No-strip: the span is `source[start:end]` exactly.
+
+        SCOPED TO A NON-LAST PIN ON PURPOSE. The last pin's span ends at
+        the end of the section, so a blanket "ends with a blank line"
+        assertion is FALSE for it. Asserting it universally would pin an
+        invariant the code does not have — a guard that fossilizes a wrong
+        rule is worse than no guard.
+
+        The trailing blank line is what makes consecutive spans a
+        PARTITION rather than an overlap.
+        """
+        content = _two_pin_file()
+        claude_md(content)
+        block = _expected_block(content, 0)
+        monkeypatch.setattr(archive_pin, "_run_memory_cli", _ok_stub(block))
+
+        verdict = archive_pin.build_verdict(0)
+
+        assert verdict["delete_string"].endswith("\n\n"), (
+            "the block was stripped in transit; consecutive spans no longer "
+            "partition and the next pin's date comment is orphaned"
+        )
+
+
+class TestDeleteStringUniqueness:
+    """A content handle is only usable if it identifies exactly one place.
+
+    BOUND: uniqueness is verified AS OF THE VERDICT. Anything that writes
+    CLAUDE.md between the verdict and the Edit re-opens the ambiguity, and
+    that window is outside this script's control. No test here closes it.
+    """
+
+    def _duplicate_fixture(self, content, block):
+        """Place a second verbatim copy of the block OUTSIDE the pinned
+        section, which is what a Working Memory projection did before the
+        sync was suppressed."""
+        return content.replace(
+            "## Working Memory", "## Working Memory\n\n" + block, 1
+        ) if "## Working Memory" in content else content + "\n" + block
+
+    def test_a_duplicated_block_is_archived_delete_unsafe(
+        self, claude_md, monkeypatch
+    ):
+        """Archive SUCCEEDED, removal refused. A distinct outcome, because
+        collapsing it into UNEVALUABLE would inherit the escape hatch and
+        hand an ambiguous string back to a human with 'proceed anyway'
+        attached."""
+        base = _two_pin_file()
+        block = _expected_block(base, 0)
+        content = self._duplicate_fixture(base, block)
+
+        # NON-VACUITY: the fixture must genuinely discriminate. If this is
+        # 1, the test below measures nothing.
+        assert content.count(block) == 2, (
+            "duplicate fixture does not actually duplicate the block"
+        )
+
+        claude_md(content)
+        monkeypatch.setattr(archive_pin, "_run_memory_cli", _ok_stub(block))
+        verdict = archive_pin.build_verdict(0)
+
+        assert verdict["outcome"] == "ARCHIVED_DELETE_UNSAFE"
+        assert verdict["memory_id"] == "a" * 32, (
+            "the archive SUCCEEDED — the id must be reported so the curator "
+            "knows the content is safe before removing the pin by hand"
+        )
+        assert verdict["occurrences"] == 2
+
+    def test_exactly_once_is_the_pass_condition(self, claude_md, monkeypatch):
+        """`>= 1` would accept the very case the check exists to reject."""
+        content = _two_pin_file()
+        claude_md(content)
+        block = _expected_block(content, 0)
+        monkeypatch.setattr(archive_pin, "_run_memory_cli", _ok_stub(block))
+
+        verdict = archive_pin.build_verdict(0)
+
+        assert verdict["outcome"] == "ARCHIVED"
+        assert verdict["occurrences"] == 1
+
+    def test_a_vanished_block_is_also_delete_unsafe_not_just_a_duplicate(
+        self, claude_md, monkeypatch
+    ):
+        """ZERO occurrences, reached by a CONCURRENT MODIFICATION.
+
+        The predicate is `occurrences != 1`, so absence routes here too —
+        and absence is a different hazard from duplication. A guard written
+        as `occurrences > 1` would be FALSE on this verdict while looking
+        correct, so the assertion is `!= 1`.
+
+        Reachable without adversarial construction: the curator has
+        CLAUDE.md open in an editor that writes during the archive.
+        """
+        content = _two_pin_file()
+        path = claude_md(content)
+        block = _expected_block(content, 0)
+
+        def _writer_removes_the_pin(args, **kwargs):
+            if args[0] == "save":
+                path.write_text(content.replace(block, "", 1), encoding="utf-8")
+                return 0, json.dumps(
+                    {"ok": True, "result": {"memory_id": "a" * 32}}
+                ), ""
+            return 0, json.dumps(
+                {"ok": True, "result": {"context": block}}
+            ), ""
+
+        monkeypatch.setattr(
+            archive_pin, "_run_memory_cli", _writer_removes_the_pin
+        )
+        verdict = archive_pin.build_verdict(0)
+
+        assert verdict["outcome"] == "ARCHIVED_DELETE_UNSAFE"
+        assert verdict["occurrences"] == 0
+        assert verdict["occurrences"] != 1
+        # The two causes must be distinguishable by the curator: telling them
+        # "ambiguous" when the block VANISHED sends them hunting a copy that
+        # does not exist.
+        assert "ambiguous" not in verdict["reason"].lower()
+
+    def test_locations_are_absent_from_the_outcome_that_permits_deletion(
+        self, claude_md, monkeypatch
+    ):
+        """`locations` are character offsets — DIAGNOSTIC, never a handle.
+
+        A positional handle computed now and consumed later is silently
+        wrong if the file moved. The strongest mechanical guard is that the
+        field is not even PRESENT on ARCHIVED, the one outcome that permits
+        the Edit, so it cannot be picked up and used as a delete target.
+
+        BOUND: this cannot stop a consumer misusing `locations` on
+        ARCHIVED_DELETE_UNSAFE, where removal is already refused.
+        """
+        content = _two_pin_file()
+        claude_md(content)
+        block = _expected_block(content, 0)
+        monkeypatch.setattr(archive_pin, "_run_memory_cli", _ok_stub(block))
+
+        verdict = archive_pin.build_verdict(0)
+
+        assert verdict["outcome"] == "ARCHIVED"
+        assert "locations" not in verdict
+
+    def test_locations_actually_index_the_occurrences(
+        self, claude_md, monkeypatch
+    ):
+        """Non-vacuity for the diagnostic itself: an offset list that does
+        not point at the block would be a confident, wrong diagnostic."""
+        base = _two_pin_file()
+        block = _expected_block(base, 0)
+        content = self._duplicate_fixture(base, block)
+        claude_md(content)
+        monkeypatch.setattr(archive_pin, "_run_memory_cli", _ok_stub(block))
+
+        verdict = archive_pin.build_verdict(0)
+
+        assert len(verdict["locations"]) == verdict["occurrences"]
+        for offset in verdict["locations"]:
+            assert content[offset:offset + len(block)] == block
+
+
+class TestStartEdgeDoesNotOrphanTheDateComment:
+    """The START edge is a PRIVILEGE boundary, not a tidiness one.
+
+    WHICH CLASS THIS BELONGS TO — read this before deleting or citing it.
+
+    This guards a WRONG SINGLE DERIVATION. It is NOT a divergence test.
+
+    The divergence class — the command RE-DERIVING the span from prose and
+    disagreeing with the archiver — was ELIMINATED by the emitted-handle
+    design: the verdict emits `delete_string` and the removal is keyed on
+    that content, so there is no second derivation left to disagree. This
+    test is NOT evidence that the retired class is still live, and it must
+    not be cited as such.
+
+    What the emitted handle does NOT close is a span that is WRONG IN THE
+    FIRST PLACE. One derivation cannot disagree with itself, but it can be
+    incorrect, and the command then faithfully deletes exactly those wrong
+    bytes — coextensivity holds while correctness does not. That residual is
+    what this class covers.
+
+    THE HARM. A span starting at the `### ` heading leaves the evicted pin's
+    date comment behind. `parse_pins` walks backward to the nearest preceding
+    non-blank line, so the orphan attaches to the FOLLOWING pin — and if it
+    carried a `pin-size-override`, the retained pin INHERITS an override it
+    was never granted. An override grants unlimited size, so an unrelated
+    eviction silently bypasses the 1500-char cap on a pin nobody touched.
+
+    RELATION TO test_archive_pin.py:172. That test
+    (`block.startswith("  <!-- pinned:")`) goes red on the same regression,
+    at the MECHANISM level. This one covers the CONSEQUENCE, in the
+    vocabulary of the harm: an unearned override and a bypassed cap. Keep
+    both — the mechanism test says WHAT broke, this says WHY IT MATTERS.
+
+    BOUND: proves `delete_string`'s SPAN closes the hazard. Cannot prove an
+    LLM honours `delete_string` rather than re-deriving a span of its own.
+    """
+
+    OVERRIDE = (
+        "<!-- pinned: 2026-01-01, pin-size-override: load-bearing verbatim -->"
+    )
+
+    def _fixture(self):
+        """Pin A carries an override; pin B has NO date comment of its own,
+        so B is the pin that would inherit A's."""
+        return (
+            "# P\n\n## Pinned Context\n\n"
+            f"{self.OVERRIDE}\n"
+            "### Alpha Pin\nAlpha body.\n\n"
+            "### Beta Pin\nBeta body.\n\n"
+            "## Working Memory\n"
+        )
+
+    def test_removing_delete_string_does_not_grant_the_next_pin_an_override(
+        self, claude_md, monkeypatch
+    ):
+        """The property, measured on the RESULT rather than the span.
+
+        The counter-arm is what makes this non-vacuous: it applies the
+        REJECTED start rule to the same fixture and proves the inheritance
+        actually happens, so a pass on the shipped rule is a real
+        discrimination and not a fixture that could never have failed.
+        """
+        content = self._fixture()
+        claude_md(content)
+        block = _expected_block(content, 0)
+        monkeypatch.setattr(archive_pin, "_run_memory_cli", _ok_stub(block))
+        verdict = archive_pin.build_verdict(0)
+
+        after = content.replace(verdict["delete_string"], "", 1)
+        pins = archive_pin.parse_pins(_pinned_body(after))
+        assert [p.heading for p in pins] == ["### Beta Pin"]
+        assert pins[0].override_rationale is None, (
+            "Beta inherited Alpha's pin-size-override and can now exceed the "
+            "size cap without the curator ever granting it"
+        )
+        assert pins[0].date_comment is None
+
+        # COUNTER-ARM: the rejected rule, on the same fixture.
+        heading_start = content.index("### Alpha Pin")
+        orphaning = content[heading_start:content.index("### Beta Pin")]
+        regressed = content.replace(orphaning, "", 1)
+        regressed_pins = archive_pin.parse_pins(_pinned_body(regressed))
+        assert regressed_pins[0].override_rationale == (
+            "load-bearing verbatim"
+        ), (
+            "the fixture does not discriminate the two start rules, so the "
+            "assertion above proves nothing"
+        )
+
+
+class TestSyncSuppressionSeam:
+    """The ALWAYS-RUNS half of the suppression guard.
+
+    BOUND, stated plainly: this asserts THE CALL, not THE EFFECT. It cannot
+    tell whether `--no-sync` actually suppressed anything. Its job is to be
+    PRESENT when the effect-level test is deselected — a conditionally
+    deselected guard is ABSENT, not weak, and absence has no symptom.
+    """
+
+    def test_archival_save_passes_no_sync(self, claude_md, monkeypatch):
+        content = _two_pin_file()
+        claude_md(content)
+        block = _expected_block(content, 0)
+        seen = []
+
+        def _record(args, **kwargs):
+            seen.append(list(args))
+            if args[0] == "save":
+                return 0, json.dumps(
+                    {"ok": True, "result": {"memory_id": "a" * 32}}
+                ), ""
+            return 0, json.dumps(
+                {"ok": True, "result": {"context": block}}
+            ), ""
+
+        monkeypatch.setattr(archive_pin, "_run_memory_cli", _record)
+        archive_pin.build_verdict(0)
+
+        save_calls = [a for a in seen if a and a[0] == "save"]
+        assert len(save_calls) == 1, "expected exactly one save call"
+        assert "--no-sync" in save_calls[0], (
+            "the archival save would write the record back into CLAUDE.md, "
+            "duplicating the very block used as the removal handle"
+        )
+
+
+@pytest.mark.requires_embedding_backend
+class TestSyncSuppressionEffect:
+    """The EFFECT-level half — three arms, none of which is optional.
+
+    DECLARED EXTERNAL DEPENDENCY: inherits `requires_embedding_backend`,
+    so `-m 'not requires_embedding_backend'` DESELECTS this class. That
+    shows in the pytest header as `(N deselected)` and NEVER in the skip
+    count, so a gate watching skips reports normal while this is gone.
+    Gate on `0 deselected`. `TestSyncSuppressionSeam` above is what remains
+    when this is absent.
+
+    WHY THREE ARMS. A crashed save and a working suppression produce
+    IDENTICAL EVIDENCE: both leave CLAUDE.md untouched. Asserting only that
+    the file is unchanged would certify suppression by observing a crash —
+    which has already happened once, from a save that died on a str/Path
+    mismatch and reported exactly the number the design predicted.
+    """
+
+    def test_suppressed_save_leaves_the_file_byte_identical(
+        self, claude_md, tmp_path
+    ):
+        content = _two_pin_file()
+        path = claude_md(content)
+        before = path.read_bytes()
+
+        verdict = archive_pin.build_verdict(
+            0, db_path=str(tmp_path / "mem.db")
+        )
+
+        # ARM 1 — THE EFFECT. Byte-identity, deliberately not
+        # `count(block) == 1`: a count is conditioned on the hypothesis it
+        # tests (it only sees a writer that duplicates THIS block), while
+        # byte-identity fails on ANY writer, including one nobody imagined.
+        assert path.read_bytes() == before, (
+            "the archival save modified CLAUDE.md"
+        )
+
+        # ARM 2 — THE OPERATION SUCCEEDED. Without this, ARM 1 passes on a
+        # save that crashed before writing anything.
+        assert verdict["outcome"] == "ARCHIVED"
+        memory_id = verdict["memory_id"]
+        assert memory_id and len(memory_id) == 32
+        record = _cli_get(memory_id, str(tmp_path / "mem.db"))
+        assert verdict["delete_string"] in record["context"], (
+            "the record did not persist — ARM 1 is satisfied by failure"
+        )
+
+    def test_unsuppressed_control_proves_the_harness_can_see_a_write(
+        self, claude_md, tmp_path
+    ):
+        """ARM 3 — the negative control.
+
+        Without it, arms 1 and 2 can both pass against a harness that is
+        blind to writes in BOTH directions, and the suite would report
+        suppression working in a world where nothing ever writes.
+
+        This test FAILS LOUDLY if the sync stops writing for an unrelated
+        reason — at which point arm 1 has stopped measuring suppression and
+        this file must be revisited.
+        """
+        content = _two_pin_file()
+        path = claude_md(content)
+        block = _expected_block(content, 0)
+        before = path.read_bytes()
+
+        payload = json.dumps(
+            archive_pin._build_record(block, "First Pin")
+        )
+        rc, stdout, stderr = archive_pin._run_memory_cli(
+            ["save", "--stdin"],                      # NO --no-sync
+            db_path=str(tmp_path / "mem.db"),
+            stdin_data=payload,
+            cwd=archive_pin.project_dir_for(path),
+        )
+        assert rc == 0, f"unsuppressed save failed: {stderr[:300]}"
+
+        assert path.read_bytes() != before, (
+            "an UNSUPPRESSED save left CLAUDE.md unchanged — the harness "
+            "cannot detect a write at all, so the suppression assertions "
+            "prove nothing"
+        )
+
+
+def _cli_get(memory_id, db_path):
+    """Fetch a record via the real CLI, streams kept separate."""
+    cli = (
+        Path(archive_pin.__file__).resolve().parent.parent
+        / "skills" / "pact-memory" / "scripts" / "cli.py"
+    )
+    proc = subprocess.run(
+        [sys.executable, str(cli), "get", memory_id, "--db-path", db_path],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert proc.returncode == 0, f"get failed: {proc.stderr[:400]}"
+    return json.loads(proc.stdout)["result"]

--- a/pact-plugin/tests/test_archive_pin_raise_census.py
+++ b/pact-plugin/tests/test_archive_pin_raise_census.py
@@ -1,0 +1,262 @@
+"""Structural guard on archive_pin's verdict-context invariant.
+
+    EACH FIELD IS PRESENT IFF THE FACT IT NAMES WAS ACTUALLY ESTABLISHED.
+
+      `claude_md_path`  the file this run read       -- established at resolution
+      `heading`         which pin                    -- established at location
+      `delete_string`   a USABLE handle for the Edit -- established once the
+                        block is sliced AND non-empty AND verbatim in source
+
+WHY THIS IS A TEST AND NOT A ONE-OFF SCRIPT. The contract it guards was
+previously stated only in a docstring, and that docstring was FALSE THE DAY
+IT WAS WRITTEN -- it described what the author intended rather than what the
+code did, which is exactly why nothing caught it. A docstring backed by a
+tested invariant is a different artifact from one backed by intent; shipping
+the invariant with only a scratchpad script behind it would reproduce the
+original defect inside its own fix.
+
+WHY IT IS DERIVED RATHER THAN A LIST. Three violating sites were originally
+found by exercising three triggers. A hand-list contains only what someone
+already noticed, so it cannot produce a case that refutes its own framing --
+and the derived walk did exactly that: it surfaced TWO further post-resolution
+sites that LOOK like the defect and are correct, which is what made the
+invariant load-bearing rather than merely tidier.
+
+IT ALSO GUARDS TWO FUTURE-CODE HAZARDS a one-time census cannot:
+  * `_run_memory_cli` raises bare; that is safe only because `_cli` is its
+    sole caller and enriches. Nothing else enforces that.
+  * `_cli` re-raises using `block` from the enclosing scope, so a call site
+    added BEFORE the slice would raise NameError inside an exception handler
+    -- losing ALL context, strictly worse than the bug this fixed.
+Naming those is this file's job. CLOSING them is a separate decision and is
+deliberately not done here.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+SOURCE = (
+    Path(__file__).resolve().parent.parent / "scripts" / "archive_pin.py"
+)
+
+INVARIANT = (
+    "INVARIANT: each verdict field is present iff the fact it names was "
+    "actually established.\n"
+    "  claude_md_path -> the file this run read (established at resolution)\n"
+    "  heading        -> which pin (established at location)\n"
+    "  delete_string  -> a USABLE delete handle (established once the block "
+    "is sliced AND non-empty AND verbatim in source)\n"
+    "A post-resolution raise must therefore carry heading + claude_md_path, "
+    "and must ALSO carry delete_string UNLESS it is one of the sites that "
+    "proved the handle unusable (empty block, or the verbatim tripwire). "
+    "Those two omit it CORRECTLY -- emitting a handle known to be bad is "
+    "worse than emitting none, because the caller's only reason to trust it "
+    "is that it was checked. Do NOT 'fix' them by adding the field."
+)
+
+
+@pytest.fixture(scope="module")
+def tree():
+    return ast.parse(SOURCE.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def lines():
+    return SOURCE.read_text(encoding="utf-8").splitlines()
+
+
+def _enclosing_function(node, tree):
+    best = None
+    for fn in ast.walk(tree):
+        if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if fn.lineno <= node.lineno <= (fn.end_lineno or fn.lineno):
+                if best is None or fn.lineno > best.lineno:
+                    best = fn
+    return best
+
+
+def _block_binding_line(tree):
+    """Line where `block` becomes bound inside archive_pin() -- the frontier
+    that separates pre- from post-resolution raises."""
+    fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "archive_pin"
+    )
+    at = None
+    for n in ast.walk(fn):
+        if isinstance(n, ast.Assign):
+            for t in n.targets:
+                if isinstance(t, ast.Name) and t.id == "block":
+                    if at is None or n.lineno < at:
+                        at = n.lineno
+    return at
+
+
+def _raises(tree):
+    out = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Raise) or node.exc is None:
+            continue
+        call = node.exc
+        if not (isinstance(call, ast.Call)
+                and getattr(call.func, "id", "") == "_Unevaluable"):
+            continue
+        fn = _enclosing_function(node, tree)
+        out.append((
+            node.lineno,
+            fn.name if fn else "<module>",
+            {kw.arg for kw in call.keywords if kw.arg},
+        ))
+    return sorted(out)
+
+
+def _handle_provably_unusable(lineno, lines):
+    """True at the two sites that computed a block and proved it NOT a usable
+    handle. Read from the raise's own reason text so the classification comes
+    from the code rather than from a line-number list that would rot."""
+    window = " ".join(lines[max(0, lineno - 2):lineno + 3])
+    return ("is empty" in window) or ("not verbatim" in window)
+
+
+class TestRaiseCensusIsLive:
+    """Non-vacuity. Every assertion below iterates the census, so an empty or
+    narrowed walk would make all of them pass over nothing -- the exact
+    reports-success-while-measuring-nothing failure this file exists for."""
+
+    def test_source_is_readable_and_parses(self, tree):
+        assert tree is not None
+
+    def test_census_finds_a_substantial_number_of_raises(self, tree):
+        found = _raises(tree)
+        assert len(found) >= 10, (
+            f"the AST walk found only {len(found)} `raise _Unevaluable` "
+            f"sites; the walk is narrowed or the exception was renamed, and "
+            f"every assertion in this file would pass over nothing"
+        )
+
+    def test_the_resolution_frontier_is_locatable(self, tree):
+        assert _block_binding_line(tree) is not None, (
+            "`block` is no longer assigned in archive_pin(), so pre- vs "
+            "post-resolution cannot be derived and this whole guard is inert"
+        )
+
+    def test_both_deliberate_omission_sites_are_still_present(self, tree, lines):
+        """The two correct-looking exceptions must remain FINDABLE. If they
+        vanish, the classifier below silently stops exercising its harder
+        axis and this file quietly weakens."""
+        post = _post_resolution(tree)
+        unusable = [r for r in post if _handle_provably_unusable(r[0], lines)]
+        assert len(unusable) == 2, (
+            f"expected exactly 2 provably-unusable-handle sites, found "
+            f"{len(unusable)}. If a site was removed, drop it here "
+            f"deliberately; if one was ADDED, confirm it truly proves the "
+            f"handle unusable rather than merely failing.\n\n{INVARIANT}"
+        )
+
+
+def _post_resolution(tree):
+    """Raises that can only execute after the pin is located."""
+    frontier = _block_binding_line(tree)
+    out = []
+    for lineno, fname, kwargs in _raises(tree):
+        if fname == "archive_pin" and frontier and lineno > frontier:
+            out.append((lineno, fname, kwargs))
+        elif fname == "_cli":
+            out.append((lineno, fname, kwargs))
+    return out
+
+
+class TestVerdictContextInvariant:
+    """The invariant itself, over every raise site."""
+
+    def test_every_post_resolution_raise_carries_the_established_facts(
+        self, tree, lines
+    ):
+        offenders = []
+        for lineno, fname, kwargs in _post_resolution(tree):
+            required = {"heading", "claude_md_path"}
+            if not _handle_provably_unusable(lineno, lines):
+                required |= {"delete_string"}
+            missing = required - kwargs
+            if missing:
+                offenders.append(
+                    f"  {SOURCE.name}:{lineno} in {fname}() "
+                    f"missing {sorted(missing)} (carries {sorted(kwargs)})"
+                )
+        assert not offenders, (
+            "post-resolution UNEVALUABLE raise(s) drop context that WAS "
+            "established:\n" + "\n".join(offenders) + "\n\n" + INVARIANT
+            + "\n\nConsequence if shipped: the later a failure occurs the "
+            "LESS the verdict reports, which is backwards -- and a CLI "
+            "timeout or missing CLI is the canonical cannot-tell case, so "
+            "the escape hatch would lose its delete boundary in exactly its "
+            "own primary use case."
+        )
+
+    def test_pre_resolution_raises_are_not_required_to_carry_a_handle(
+        self, tree
+    ):
+        """The other half of the invariant, and the reason it is an `iff`.
+        A pre-resolution raise legitimately reports LESS -- the facts were
+        not established. Asserting this keeps the guard from drifting into
+        'every raise must carry everything', which would be false."""
+        frontier = _block_binding_line(tree)
+        pre = [
+            (l, f, k) for l, f, k in _raises(tree)
+            if f == "archive_pin" and frontier and l < frontier
+        ]
+        assert pre, "no pre-resolution raises found — classifier is degenerate"
+        for lineno, fname, kwargs in pre:
+            assert "delete_string" not in kwargs, (
+                f"{SOURCE.name}:{lineno} carries delete_string before the "
+                f"block exists.\n\n{INVARIANT}"
+            )
+
+
+class TestEnrichmentSeamHazards:
+    """Two hazards a one-time census cannot catch, because they are future
+    CODE CHANGES rather than current state. Naming them is the deliverable;
+    closing them is a separate decision."""
+
+    def test_run_memory_cli_is_only_reached_through_the_enricher(self, tree):
+        """`_run_memory_cli` raises BARE -- correct, since it is a generic
+        subprocess helper with no idea which pin is being archived. That is
+        safe ONLY because `_cli` is its sole caller and enriches on the way
+        out. A direct call added elsewhere would bypass the enrichment
+        silently and reintroduce the exact defect."""
+        callers = []
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Call)
+                    and getattr(node.func, "id", "") == "_run_memory_cli"):
+                fn = _enclosing_function(node, tree)
+                callers.append((node.lineno, fn.name if fn else "<module>"))
+        assert callers, "no _run_memory_cli call sites found — walk is narrowed"
+        bad = [c for c in callers if c[1] != "_cli"]
+        assert not bad, (
+            f"_run_memory_cli called outside the enriching wrapper at "
+            f"{bad}. Those calls raise BARE, so a post-resolution failure "
+            f"there would report no heading, no claude_md_path and no "
+            f"delete_string.\n\n{INVARIANT}"
+        )
+
+    def test_every_enricher_call_site_is_after_the_block_is_bound(self, tree):
+        """`_cli` re-raises using `block` from the enclosing scope. A call
+        site added BEFORE the slice raises NameError inside an exception
+        handler — surfacing as `internal error: NameError` with ALL context
+        lost, which is strictly worse than the bug this guard exists for."""
+        frontier = _block_binding_line(tree)
+        sites = [
+            node.lineno for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and getattr(node.func, "id", "") == "_cli"
+        ]
+        assert sites, "no _cli call sites found — walk is narrowed"
+        early = [ln for ln in sites if frontier and ln < frontier]
+        assert not early, (
+            f"_cli called at line(s) {early}, before `block` is bound at "
+            f"{frontier}. Its except-handler references `block`, so a failure "
+            f"there raises NameError INSIDE the handler and the verdict loses "
+            f"everything — worse than the defect this guards.\n\n{INVARIANT}"
+        )

--- a/pact-plugin/tests/test_archive_pin_resolver.py
+++ b/pact-plugin/tests/test_archive_pin_resolver.py
@@ -342,3 +342,200 @@ class TestVerdictCarriesTheResolvedPath:
         assert rc == 0
         payload = json.loads(capsys.readouterr().out)
         assert "claude_md_path" in payload
+
+
+class TestSyncSuppressionAndDeleteString:
+    """The archival save must not write the block back, and must hand the
+    caller a content handle for the removal.
+
+    THE SUPPRESSION IS MEASURED BY BYTE-IDENTITY, not by a block count. A
+    count check is conditioned on the hypothesis it tests — it only detects a
+    writer that duplicates THIS block. Byte-identity fails if anything at all
+    writes, including a writer nobody has thought of. That distinction is not
+    academic here: if some other path also writes the block back, uniqueness
+    never holds and the emit-time check redirects EVERY eviction to manual
+    removal — a de-facto disabling of the automated path, arriving through
+    the fix rather than the defect.
+    """
+
+    def test_archival_save_leaves_claude_md_byte_identical(
+        self, isolated, monkeypatch, tmp_path
+    ):
+        a = _make_project(isolated / "project_a", "PIN A")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(a))
+        monkeypatch.chdir(a)
+        claude_md = a / ".claude" / "CLAUDE.md"
+
+        before = claude_md.read_bytes()
+        verdict = archive_pin.build_verdict(0, db_path=str(tmp_path / "m.db"))
+
+        assert verdict["outcome"] == "ARCHIVED", verdict
+        assert verdict["memory_id"], (
+            "the archive must have PERSISTED — a crashed save also leaves the "
+            "file untouched, and the two are indistinguishable without this"
+        )
+        assert claude_md.read_bytes() == before, (
+            "the archival save wrote to CLAUDE.md; the Working Memory "
+            "projection is putting back the bytes the archive exists to remove"
+        )
+
+    def test_delete_string_is_the_verbatim_span_and_unique(
+        self, isolated, monkeypatch, tmp_path
+    ):
+        a = _make_project(isolated / "project_a", "PIN A")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(a))
+        monkeypatch.chdir(a)
+        verdict = archive_pin.build_verdict(0, db_path=str(tmp_path / "m.db"))
+
+        content = (a / ".claude" / "CLAUDE.md").read_text(encoding="utf-8")
+        handle = verdict["delete_string"]
+        assert handle in content, "delete_string must be verbatim in the file"
+        assert content.count(handle) == 1, (
+            "a non-unique handle makes the curator's Edit ambiguous"
+        )
+        assert "### PIN A" in handle
+        assert verdict["occurrences"] == 1
+
+    def test_delete_string_present_on_a_located_pin_unevaluable(
+        self, isolated, monkeypatch
+    ):
+        """It is a property of WHICH PIN, not of whether the archive worked —
+        so the escape-hatch path gets a mechanical boundary too and no
+        consumer has to re-derive one."""
+        a = _make_project(isolated / "project_a", "PIN A")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(a))
+        monkeypatch.chdir(a)
+
+        def _stub(args, **kwargs):
+            if args[0] == "save":
+                return 0, json.dumps(
+                    {"ok": True, "result": {"memory_id": "e" * 32}}
+                ), ""
+            return 1, "", json.dumps({"ok": False, "error": "NOT_FOUND",
+                                      "message": "gone"})
+
+        monkeypatch.setattr(archive_pin, "_run_memory_cli", _stub)
+        verdict = archive_pin.build_verdict(0)
+        assert verdict["outcome"] == "UNEVALUABLE"
+        assert verdict["delete_string"] is not None
+        assert "### PIN A" in verdict["delete_string"]
+
+    def test_unresolvable_pin_has_null_delete_string(
+        self, isolated, monkeypatch
+    ):
+        a = _make_project(isolated / "project_a", "PIN A")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(a))
+        monkeypatch.chdir(a)
+        verdict = archive_pin.build_verdict(99)
+        assert verdict["outcome"] == "UNEVALUABLE"
+        assert verdict["delete_string"] is None
+
+
+class TestArchivedDeleteUnsafe:
+    """The FOURTH outcome: archive succeeded, removal unsafe.
+
+    Not UNEVALUABLE — that means *cannot tell*, and a duplicated block is a
+    KNOWN-BAD precondition. Not NOT_ARCHIVED — that asserts the archive
+    failed, which is false, and putting a falsehood in the one report whose
+    job is truthful measurement is the defect this feature exists to remove.
+
+    It is a distinct outcome rather than a reason on an existing one because
+    THE OUTCOME NAME MUST DETERMINE THE DISPOSITION. One outcome with two
+    dispositions forces a reason table, and a reason table is how a
+    permission gets inherited by a condition it was never designed for.
+    """
+
+    def _duplicated_project(self, root):
+        """A CLAUDE.md where the pin's whole span appears twice."""
+        root.mkdir(parents=True, exist_ok=True)
+        (root / ".claude").mkdir(parents=True, exist_ok=True)
+        # The duplicate must match the SPAN, not just the block: the span
+        # runs to the next pin's start and so carries the trailing blank
+        # line. A copy without it is a different string and the uniqueness
+        # check would correctly pass -- the fixture, not the code, would be
+        # wrong. The precondition assertion in the test catches that.
+        block = "<!-- pinned: 2026-01-01 -->\n### DUP\nbody of DUP\n"
+        (root / ".claude" / "CLAUDE.md").write_text(
+            "# P\n\n## Pinned Context\n\n" + block + "\n"
+            "## Working Memory\n\n" + block + "\n",
+            encoding="utf-8",
+        )
+        return root
+
+    def test_duplicate_block_yields_archived_delete_unsafe(
+        self, isolated, monkeypatch, tmp_path
+    ):
+        a = self._duplicated_project(isolated / "dup_project")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(a))
+        monkeypatch.chdir(a)
+
+        content = (a / ".claude" / "CLAUDE.md").read_text(encoding="utf-8")
+        verdict = archive_pin.build_verdict(0, db_path=str(tmp_path / "m.db"))
+
+        # Precondition: the fixture really does duplicate the span, or this
+        # test passes for the wrong reason.
+        assert content.count(verdict["delete_string"]) > 1, (
+            "fixture did not actually duplicate the block — the unsafe "
+            "verdict below would be measuring something else"
+        )
+        assert verdict["outcome"] == "ARCHIVED_DELETE_UNSAFE", verdict
+        assert verdict["memory_id"], (
+            "the archive SUCCEEDED — the verdict must carry its id, because "
+            "the content being safe is what makes this a redirect and not a trap"
+        )
+        assert verdict["occurrences"] > 1
+        assert len(verdict["locations"]) == verdict["occurrences"]
+        assert verdict["delete_string"] is not None
+
+    def test_unsafe_is_not_mislabelled_as_a_failed_archive(
+        self, isolated, monkeypatch, tmp_path
+    ):
+        """Reusing NOT_ARCHIVED here would assert the archive failed when it
+        succeeded — and downstream that maps to the `archive_refused` journal
+        row, whose stated purpose is detecting a BROKEN ARCHIVER. A run of
+        them would read as a failing archiver while every archive worked."""
+        a = self._duplicated_project(isolated / "dup_project2")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(a))
+        monkeypatch.chdir(a)
+        verdict = archive_pin.build_verdict(0, db_path=str(tmp_path / "m.db"))
+        assert verdict["outcome"] not in ("NOT_ARCHIVED", "UNEVALUABLE")
+        assert verdict["contained"] is True
+
+    def test_zero_occurrences_is_described_as_absence_not_ambiguity(self):
+        """`occurrences != 1` catches BOTH directions, and they are different
+        conditions with different curator responses.
+
+        Zero means the block was read from the file moments earlier and is
+        gone from the post-save re-read — concurrent modification, a live
+        hazard on a file the curator may have open. A curator told
+        "ambiguous" goes hunting for a second copy that does not exist.
+        The disposition must be readable from what the verdict SAYS.
+        """
+        zero = archive_pin._unsafe_reason(0, "/p/CLAUDE.md", "a" * 32)
+        many = archive_pin._unsafe_reason(3, "/p/CLAUDE.md", "a" * 32)
+
+        assert "ambiguous" not in zero, (
+            "zero occurrences is ABSENCE, not ambiguity — there is no second "
+            "copy for the curator to disambiguate against"
+        )
+        assert "NO LONGER PRESENT" in zero
+        assert "concurrently" in zero
+        assert "ambiguous" in many, "the >1 case genuinely IS ambiguous"
+        assert "occurs 3 times" in many
+        # Both must still report the archive succeeded — that is what makes
+        # either a redirect rather than a trap at the cap.
+        for reason in (zero, many):
+            assert "archive SUCCEEDED" in reason
+            assert "a" * 32 in reason
+
+    def test_both_unsafe_directions_share_the_outcome(self, isolated,
+                                                      monkeypatch, tmp_path):
+        """Same outcome name, different explanation — the split is in the
+        reason, never in the disposition."""
+        a = self._duplicated_project(isolated / "dup_project3")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(a))
+        monkeypatch.chdir(a)
+        verdict = archive_pin.build_verdict(0, db_path=str(tmp_path / "m.db"))
+        assert verdict["outcome"] == "ARCHIVED_DELETE_UNSAFE"
+        assert "ambiguous" in verdict["reason"]
+        assert verdict["occurrences"] == 2

--- a/pact-plugin/tests/test_archive_pin_resolver.py
+++ b/pact-plugin/tests/test_archive_pin_resolver.py
@@ -539,3 +539,164 @@ class TestArchivedDeleteUnsafe:
         assert verdict["outcome"] == "ARCHIVED_DELETE_UNSAFE"
         assert "ambiguous" in verdict["reason"]
         assert verdict["occurrences"] == 2
+
+
+class TestPostResolutionFailuresKeepPinContext:
+    """A failure AFTER the pin resolved must not report LESS than one before.
+
+    Every failure `_run_memory_cli` can raise happens once CLAUDE.md has been
+    read, the pins parsed and the block sliced — so the verdict can still
+    name the file, the heading and the delete handle. It previously reported
+    none of them, which made the LATER a failure occurred, the LESS context
+    survived. Backwards, and not something anyone would choose: the
+    pre-resolution control below reported MORE than a post-resolution CLI
+    timeout did.
+
+    It bit hardest exactly where it mattered most. A CLI timeout and a
+    missing CLI are the canonical CANNOT-TELL cases — they are precisely when
+    the escape hatch runs — so the hatch had no mechanical delete boundary in
+    its own primary use case. Found by `coder-prose`, who blocked a deletion
+    that depended on the contract rather than trusting it.
+
+    Patched at the SUBPROCESS seam, not at `_run_memory_cli`: stubbing the
+    function under test would bypass the branch under test.
+    """
+
+    def _project(self, isolated, monkeypatch, name):
+        a = _make_project(isolated / name, "CTX PIN")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(a))
+        monkeypatch.chdir(a)
+        return a
+
+    def _assert_full_context(self, verdict, label, reason_marker):
+        """`reason_marker` is what stops a FALSE CLEAR.
+
+        Asserting only the outcome and the fields lets a test pass by
+        exercising a DIFFERENT path that happens to produce the same shape —
+        which is exactly how `coder-prose`'s second probe reported CLEARED
+        while verifying one path twice under two labels. Two green rows that
+        were secretly the same row. So each test also proves the trigger it
+        intended actually reached the verdict.
+        """
+        assert verdict["outcome"] == "UNEVALUABLE", f"{label}: {verdict}"
+        assert reason_marker in verdict["reason"], (
+            f"{label}: the intended trigger did not reach the verdict — "
+            f"expected {reason_marker!r} in reason, got {verdict['reason']!r}. "
+            f"This test would otherwise pass on any path with the same shape."
+        )
+        assert verdict["heading"] == "CTX PIN", (
+            f"{label}: heading lost — the pin WAS resolved before this failure"
+        )
+        assert verdict["claude_md_path"] is not None, (
+            f"{label}: claude_md_path lost — the file was read before this "
+            f"failure, so the verdict can name it"
+        )
+        assert verdict["delete_string"] is not None, (
+            f"{label}: delete_string lost — this is a CANNOT-TELL case, so it "
+            f"is exactly when the escape hatch runs and needs a boundary"
+        )
+        assert "CTX PIN" in verdict["delete_string"]
+
+    def test_cli_timeout_keeps_context(self, isolated, monkeypatch):
+        self._project(isolated, monkeypatch, "t1")
+
+        def _boom(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="save", timeout=1)
+
+        monkeypatch.setattr(subprocess, "run", _boom)
+        self._assert_full_context(archive_pin.build_verdict(0), "timeout",
+                                  "timed out")
+
+    def test_cli_launch_failure_keeps_context(self, isolated, monkeypatch):
+        self._project(isolated, monkeypatch, "t2")
+
+        def _boom(*a, **k):
+            raise OSError("cannot launch")
+
+        monkeypatch.setattr(subprocess, "run", _boom)
+        self._assert_full_context(archive_pin.build_verdict(0), "launch",
+                                  "could not launch")
+
+    def test_missing_cli_keeps_context(self, isolated, monkeypatch):
+        self._project(isolated, monkeypatch, "t3")
+        monkeypatch.setattr(
+            archive_pin, "_MEMORY_CLI", Path("/nonexistent/cli.py")
+        )
+        self._assert_full_context(archive_pin.build_verdict(0), "missing cli",
+                                  "not found")
+
+    def test_pre_resolution_failure_still_reports_less(
+        self, isolated, monkeypatch
+    ):
+        """THE CONTROL, and the reason the above is a defect rather than a
+        design choice. A genuinely pre-resolution failure — the pin never
+        resolved — correctly reports no heading and no delete handle, while
+        still naming the file, because resolution itself succeeded. If this
+        ever started reporting a heading, the tests above would be passing
+        for the wrong reason."""
+        self._project(isolated, monkeypatch, "t4")
+        verdict = archive_pin.build_verdict(99)
+        assert verdict["outcome"] == "UNEVALUABLE"
+        assert verdict["heading"] is None
+        assert verdict["delete_string"] is None
+        assert verdict["claude_md_path"] is not None
+
+
+class TestDeliberateDeleteStringOmissions:
+    """Two post-resolution paths omit `delete_string` ON PURPOSE.
+
+    A derived census of every `_Unevaluable` raise flagged these two as
+    "post-resolution without full context" — and they are correct. That is
+    the distinction the contract invariant exists to make legible:
+
+        each field is present iff THE FACT IT NAMES was established.
+
+    `delete_string` does not name "the block"; it names *a usable handle for
+    the removal Edit*. On both paths a block was computed and is NOT usable:
+    an empty block is no handle at all, and a block failing the source-side
+    verbatim tripwire is one an Edit provably cannot match. **Emitting a
+    handle known to be bad is worse than emitting none**, because the
+    caller's entire reason to trust it is that it was checked.
+
+    `heading` and `claude_md_path` ARE present on both, because those facts
+    were established. This class exists so a future "consistency fix" that
+    adds `delete_string` here goes red with the reason attached.
+    """
+
+    def test_empty_block_omits_the_handle_but_keeps_the_rest(
+        self, isolated, monkeypatch
+    ):
+        a = _make_project(isolated / "empty_block", "EB PIN")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(a))
+        monkeypatch.chdir(a)
+        monkeypatch.setattr(archive_pin, "extract_pin_block",
+                            lambda *args, **kw: "   \n  ")
+        verdict = archive_pin.build_verdict(0)
+        assert verdict["outcome"] == "UNEVALUABLE"
+        assert "empty" in verdict["reason"]
+        assert verdict["delete_string"] is None, (
+            "an empty block is not a usable delete handle; emitting it would "
+            "hand the caller something an Edit cannot match"
+        )
+        assert verdict["heading"] == "EB PIN"
+        assert verdict["claude_md_path"] is not None
+
+    def test_non_verbatim_block_omits_the_handle_but_keeps_the_rest(
+        self, isolated, monkeypatch
+    ):
+        a = _make_project(isolated / "not_verbatim", "NV PIN")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(a))
+        monkeypatch.chdir(a)
+        monkeypatch.setattr(
+            archive_pin, "extract_pin_block",
+            lambda *args, **kw: "### Fabricated\nnot from the source",
+        )
+        verdict = archive_pin.build_verdict(0)
+        assert verdict["outcome"] == "UNEVALUABLE"
+        assert "not verbatim" in verdict["reason"]
+        assert verdict["delete_string"] is None, (
+            "a block that fails the verbatim tripwire is a handle an Edit "
+            "provably cannot match — worse than none"
+        )
+        assert verdict["heading"] == "NV PIN"
+        assert verdict["claude_md_path"] is not None

--- a/pact-plugin/tests/test_archive_pin_resolver.py
+++ b/pact-plugin/tests/test_archive_pin_resolver.py
@@ -1,0 +1,344 @@
+"""The REAL CLAUDE.md resolution path for archive_pin — driven, not mocked.
+
+THIS FILE EXISTS BECAUSE NOTHING ELSE EXERCISES THE ACTUAL RESOLVER.
+`get_project_claude_md_path` is monkeypatched in both places it appears
+(test_check_pin_caps.py's `patched_claude_md`, test_archive_pin.py's
+`claude_md` fixture), so every existing test hands the code a path it already
+decided on. That is precisely why a resolver defect survived PREPARE,
+ARCHITECT, CODE, TEST and three reviews: no test could see it, because no
+test ever asked the resolver a question.
+
+So nothing here patches `get_project_claude_md_path`, `resolve_claude_md`, or
+`_resolve_project_claude_md_with_base`. The tests set `CLAUDE_PROJECT_DIR`
+and the working directory — the two real inputs — and let resolution run.
+
+THE DEFECT UNDER TEST. Resolution order is CLAUDE_PROJECT_DIR -> git
+common-dir parent -> CWD, and a miss at any step falls through SILENTLY. A
+CLAUDE_PROJECT_DIR naming a directory with no CLAUDE.md therefore does not
+fail; it resolves to a DIFFERENT project's file and the archival reports a
+confident success for a pin the invocation never named. The command's Step 3
+heading cross-check is structurally blind to it, because check_pin_caps.py
+uses the SAME resolver — the listing step and the archival step agree on the
+same wrong file and every heading matches. That check catches an index shift
+WITHIN a file; nothing catches a wrong FILE.
+
+WHY THE REFUSAL IS NARROW, and why that matters more than making it strict.
+PACT's own primary workflow sets CLAUDE_PROJECT_DIR to a WORKTREE, where
+CLAUDE.md is gitignored and therefore absent, and depends on the git
+fall-through to reach the main checkout's file. A blanket "env dir has no
+CLAUDE.md -> refuse" rule would break that on every single invocation — a
+cardinal over-block. `test_same_repository_fallthrough_is_allowed` is the
+guard on that, and it is the more important half of this file.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import archive_pin  # noqa: E402
+
+
+PINNED = (
+    "# Project\n\n## Pinned Context\n\n"
+    "<!-- pinned: 2026-01-01 -->\n"
+    "### {title}\n"
+    "body of {title}\n"
+)
+
+
+def _make_project(root: Path, title, layout="dot_claude"):
+    """Create a project dir; `title=None` means NO CLAUDE.md at all."""
+    root.mkdir(parents=True, exist_ok=True)
+    if title is None:
+        return root
+    if layout == "dot_claude":
+        target = root / ".claude" / "CLAUDE.md"
+        target.parent.mkdir(parents=True, exist_ok=True)
+    else:
+        target = root / "CLAUDE.md"
+    target.write_text(PINNED.format(title=title), encoding="utf-8")
+    return root
+
+
+@pytest.fixture
+def isolated(tmp_path, monkeypatch):
+    """A tmpdir guaranteed to be OUTSIDE any git repository.
+
+    Without this the git fall-through could reach the PACT repo itself and
+    quietly supply a real CLAUDE.md, which would make these tests measure the
+    developer's checkout instead of the fixture. Asserted, not assumed.
+    """
+    probe = subprocess.run(
+        ["git", "-C", str(tmp_path), "rev-parse", "--git-common-dir"],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert probe.returncode != 0, (
+        f"tmp_path is inside a git repo ({probe.stdout.strip()}) — the git "
+        "fall-through would reach a real CLAUDE.md and these tests would "
+        "measure the checkout, not the fixture"
+    )
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    return tmp_path
+
+
+class TestResolutionIsDriven:
+    """Controls first: the resolver must behave correctly when it is right,
+    or a later refusal proves nothing about discrimination."""
+
+    def test_env_dir_with_claude_md_is_used(self, isolated, monkeypatch):
+        a = _make_project(isolated / "project_a", "PIN A")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(a))
+        monkeypatch.chdir(a)
+        path, base = archive_pin.resolve_claude_md()
+        assert path == a / ".claude" / "CLAUDE.md"
+        assert "### PIN A" in path.read_text(encoding="utf-8")
+        assert Path(base) == a
+
+    def test_legacy_layout_is_used(self, isolated, monkeypatch):
+        a = _make_project(isolated / "legacy", "PIN L", layout="legacy")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(a))
+        monkeypatch.chdir(a)
+        path, _ = archive_pin.resolve_claude_md()
+        assert path == a / "CLAUDE.md"
+
+    def test_no_claude_md_anywhere_is_unevaluable(self, isolated, monkeypatch):
+        empty = _make_project(isolated / "empty", None)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(empty))
+        monkeypatch.chdir(empty)
+        with pytest.raises(archive_pin._Unevaluable) as exc:
+            archive_pin.resolve_claude_md()
+        assert "not found" in exc.value.reason
+
+
+class TestCrossProjectFallthroughIsRefused:
+    """THE F-B GUARD. Fails on the pre-fix code, which returned project_a's
+    file for an invocation that named project_b."""
+
+    def test_cross_project_fallthrough_raises(self, isolated, monkeypatch):
+        a = _make_project(isolated / "project_a", "PIN A")
+        b = _make_project(isolated / "project_b", None)
+        # Precondition, asserted so the test cannot pass for the wrong reason:
+        # b must genuinely have no CLAUDE.md, or there is no fall-through.
+        assert not (b / "CLAUDE.md").exists()
+        assert not (b / ".claude" / "CLAUDE.md").exists()
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(b))
+        monkeypatch.chdir(a)
+
+        with pytest.raises(archive_pin._Unevaluable) as exc:
+            archive_pin.resolve_claude_md()
+        reason = exc.value.reason
+        assert str(b) in reason, "refusal must name the directory that was set"
+        assert "different project" in reason
+        assert "project_a" in reason, (
+            "refusal must name the file it would otherwise have used, or the "
+            "curator cannot tell what was about to happen"
+        )
+
+    def test_the_fallthrough_target_really_was_reachable(
+        self, isolated, monkeypatch
+    ):
+        """NON-VACUITY CONTROL for the test above.
+
+        The refusal is only meaningful if resolution WOULD have succeeded on
+        the wrong file. Drive the underlying resolver directly — the one
+        `resolve_claude_md` wraps — and confirm it happily returns project_a
+        while the environment names project_b. If this ever stops returning a
+        path, the test above would pass because nothing resolved at all,
+        which is a different and much safer world.
+        """
+        a = _make_project(isolated / "project_a", "PIN A")
+        b = _make_project(isolated / "project_b", None)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(b))
+        monkeypatch.chdir(a)
+
+        path, _base = archive_pin._resolve_project_claude_md_with_base()
+        assert path is not None, "no fall-through occurred — refusal is moot"
+        assert "PIN A" in path.read_text(encoding="utf-8"), (
+            "the unguarded resolver did NOT return the other project's file, "
+            "so this suite is no longer testing the defect it was written for"
+        )
+
+
+class TestSameRepositoryFallthroughIsAllowed:
+    """THE OVER-BLOCK GUARD, and the more important half of this file.
+
+    PACT sets CLAUDE_PROJECT_DIR to a worktree where CLAUDE.md is gitignored
+    and absent, and relies on the git fall-through to reach the main
+    checkout. If the refusal above were written as "env dir has no CLAUDE.md
+    -> refuse", it would fire on every PACT invocation. This proves it does
+    not.
+    """
+
+    def test_same_repository_fallthrough_is_allowed(
+        self, isolated, monkeypatch
+    ):
+        repo = isolated / "repo"
+        _make_project(repo, "PIN ROOT")
+        init = subprocess.run(["git", "init", "-q", str(repo)],
+                              capture_output=True, text=True, timeout=30)
+        assert init.returncode == 0, f"git init failed: {init.stderr}"
+
+        # A subdirectory of the SAME repo, with no CLAUDE.md of its own --
+        # structurally the worktree case: env names it, resolution falls
+        # through to the repo root, and the root is the same project.
+        sub = repo / "subproject"
+        sub.mkdir()
+        assert not (sub / "CLAUDE.md").exists()
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(sub))
+        monkeypatch.chdir(sub)
+
+        path, base = archive_pin.resolve_claude_md()   # must NOT raise
+        assert "PIN ROOT" in path.read_text(encoding="utf-8")
+        assert Path(base).resolve() == repo.resolve()
+
+    def test_same_repository_predicate_is_true_for_a_subdir(
+        self, isolated
+    ):
+        """The discriminator itself, tested directly."""
+        repo = isolated / "repo2"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q", str(repo)],
+                       capture_output=True, timeout=30)
+        sub = repo / "nested"
+        sub.mkdir()
+        assert archive_pin._same_repository(sub, repo) is True
+
+    def test_same_repository_predicate_is_false_across_repos(self, isolated):
+        one = isolated / "one"; one.mkdir()
+        two = isolated / "two"; two.mkdir()
+        subprocess.run(["git", "init", "-q", str(one)],
+                       capture_output=True, timeout=30)
+        subprocess.run(["git", "init", "-q", str(two)],
+                       capture_output=True, timeout=30)
+        assert archive_pin._same_repository(one, two) is False
+
+    def test_same_repository_predicate_fails_safe_outside_git(self, isolated):
+        """A non-repo directory returns False, routing to a refusal. On a
+        destructive path, declining to guess is the safe direction."""
+        plain = isolated / "plain"; plain.mkdir()
+        assert archive_pin._same_repository(plain, plain) is False
+
+
+class TestSymlinkedClaudeMdAttribution:
+    """FOLDED IN from the implementation review's symlink Minor — same defect
+    family as F-B: a resolver producing a plausible wrong answer with no
+    signal.
+
+    The archive's project is now taken from the resolver's own `base` (the
+    directory it found the file under, captured BEFORE descending into
+    `.claude`) rather than re-derived from the returned path with `.resolve()`,
+    which followed a leaf symlink and attributed the archive to the link
+    target's parent.
+    """
+
+    def test_symlinked_claude_md_attributes_to_the_project_not_the_target(
+        self, isolated, monkeypatch
+    ):
+        """Asserts on the CWD `archive_pin` actually hands the memory CLI,
+        NOT on the resolver's base.
+
+        The first version of this test checked `resolve_claude_md()[1]` and
+        passed against the pre-fix code — the resolver's base was always
+        right; what was wrong was `archive_pin` re-deriving the project from
+        the leaf path instead of using that base. Testing the resolver
+        measured the correct property on the wrong object, which is the same
+        mistake this whole feature exists to catch. The mutation sweep caught
+        it: reverting the attribution left the suite green.
+
+        The memory layer detects `project_id` from CLAUDE_PROJECT_DIR, else
+        git, else by walking up from the CWD — so the cwd handed to the
+        subprocess IS the archive's project attribution.
+        """
+        proj = isolated / "myproject"; proj.mkdir()
+        store = isolated / "elsewhere"; store.mkdir()
+        real = store / "CLAUDE.md"
+        real.write_text(PINNED.format(title="PIN S"), encoding="utf-8")
+        os.symlink(real, proj / "CLAUDE.md")
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(proj))
+        monkeypatch.chdir(proj)
+
+        seen = {}
+
+        def _spy(args, db_path=None, stdin_data=None, cwd=None):
+            seen["cwd"] = cwd
+            if args[0] == "save":
+                return 0, json.dumps(
+                    {"ok": True, "result": {"memory_id": "a" * 32}}
+                ), ""
+            return 0, json.dumps(
+                {"ok": True, "result": {"context": stdin_data or ""}}
+            ), ""
+
+        monkeypatch.setattr(archive_pin, "_run_memory_cli", _spy)
+        archive_pin.build_verdict(0)
+
+        assert seen, "the memory CLI was never invoked — nothing was measured"
+        assert Path(seen["cwd"]).name == "myproject", (
+            f"archive filed under {Path(seen['cwd']).name!r} — the symlink "
+            f"TARGET's directory — rather than the project that owns the pin"
+        )
+
+
+class TestVerdictCarriesTheResolvedPath:
+    """`claude_md_path` in every verdict, so a wrong file is visible.
+
+    A boolean 'resolved ok' would reproduce the defect exactly: correct-
+    looking and silent about WHICH file. The curator has to be able to read
+    the literal path and recognise it.
+    """
+
+    def test_unevaluable_from_bad_index_still_names_the_file(
+        self, isolated, monkeypatch
+    ):
+        a = _make_project(isolated / "project_a", "PIN A")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(a))
+        monkeypatch.chdir(a)
+        verdict = archive_pin.build_verdict(99)
+        assert verdict["outcome"] == "UNEVALUABLE"
+        assert verdict["claude_md_path"] is not None
+        assert "project_a" in verdict["claude_md_path"]
+
+    def test_unresolvable_reports_null_path_not_a_guess(
+        self, isolated, monkeypatch
+    ):
+        empty = _make_project(isolated / "empty", None)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(empty))
+        monkeypatch.chdir(empty)
+        verdict = archive_pin.build_verdict(0)
+        assert verdict["outcome"] == "UNEVALUABLE"
+        assert verdict["claude_md_path"] is None, (
+            "null means no file was resolved; inventing a path here would be "
+            "worse than reporting none"
+        )
+
+    def test_archived_verdict_names_the_file(self, isolated, monkeypatch,
+                                             tmp_path):
+        a = _make_project(isolated / "project_a", "PIN A")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(a))
+        monkeypatch.chdir(a)
+        verdict = archive_pin.build_verdict(
+            0, db_path=str(tmp_path / "mem.db")
+        )
+        assert verdict["outcome"] == "ARCHIVED", verdict
+        assert verdict["claude_md_path"] == str(
+            (a / ".claude" / "CLAUDE.md")
+        ), verdict["claude_md_path"]
+
+    def test_cli_emits_the_path_as_json(self, isolated, monkeypatch, capsys):
+        a = _make_project(isolated / "project_a", "PIN A")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(a))
+        monkeypatch.chdir(a)
+        rc = archive_pin.main(["--index", "99"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert "claude_md_path" in payload

--- a/pact-plugin/tests/test_check_pin_caps.py
+++ b/pact-plugin/tests/test_check_pin_caps.py
@@ -26,6 +26,7 @@ curator ever reaches post-demotion (hook denies first).
 import io
 import json
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -221,6 +222,247 @@ class TestCheckPinCaps_Advisory_EvictablePins:
         rc, payload = _run_cli(["--status"])
         for entry in payload["evictable_pins"]:
             assert not entry["heading"].startswith("### ")
+
+
+def _days_ago(n):
+    """A YYYY-MM-DD string exactly `n` days before now (UTC).
+
+    CLI-level age tests derive their dates RELATIVE to now rather than
+    hard-coding a calendar date. A hard-coded date drifts: a fixture pinned
+    at a literal `2026-04-20` is 5 days old the week it is written and 400
+    days old a year later, so any `overdue is False` assertion built on one
+    is a date bomb that passes until it silently does not. Relative dates
+    are time-invariant by construction — this pin is 60 days old whenever
+    the suite runs.
+
+    Unit-level tests inject an explicit clock instead (see
+    TestPinAgeDays_Unit), which is stronger; this helper exists for the
+    end-to-end path where the clock is not reachable from outside.
+    """
+    return (
+        datetime.now(timezone.utc) - timedelta(days=n)
+    ).strftime("%Y-%m-%d")
+
+
+class TestPinAgeDays_Unit:
+    """_pin_age_days — the D7 age computation, with an INJECTED clock.
+
+    Every case here pins an exact expected integer against a frozen `now`,
+    so these assertions are deterministic forever and cannot rot into a
+    date bomb.
+    """
+
+    NOW = datetime(2026, 7, 25, tzinfo=timezone.utc)
+
+    def test_canonical_date_comment_yields_age(self):
+        import check_pin_caps
+        age = check_pin_caps._pin_age_days(
+            "<!-- pinned: 2026-05-26 -->", now=self.NOW
+        )
+        assert age == 60
+
+    def test_reconfirmed_date_resets_the_clock(self):
+        """The behavioural point of the re-confirmation grammar.
+
+        Without the reset, re-confirming a pin would change nothing
+        observable — the curator would re-attest a pin and it would stay
+        flagged overdue, which makes the whole grammar decorative. The
+        original `pinned:` date here is ~2.5 years old; the reconfirmation
+        is 5 days old, and 5 is what must surface.
+        """
+        import check_pin_caps
+        age = check_pin_caps._pin_age_days(
+            "<!-- pinned: 2024-01-01, reconfirmed: 2026-07-20 because the "
+            "parser-scoping answer is still the one people reach for -->",
+            now=self.NOW,
+        )
+        assert age == 5
+
+    def test_reconfirmed_reason_containing_a_date_does_not_confuse_it(self):
+        """A free-text reason may itself mention a date; the reconfirmation
+        date is the one adjacent to the `reconfirmed:` key, never the first
+        date-shaped run in the comment."""
+        import check_pin_caps
+        age = check_pin_caps._pin_age_days(
+            "<!-- pinned: 2024-01-01, reconfirmed: 2026-07-20 because it "
+            "supersedes the 2020-01-01 rule -->",
+            now=self.NOW,
+        )
+        assert age == 5
+
+    def test_size_override_comment_still_yields_age(self):
+        """The override form carries a trailing clause too; age must still
+        parse out of it, or every oversized pin would report unknown."""
+        import check_pin_caps
+        age = check_pin_caps._pin_age_days(
+            "<!-- pinned: 2026-05-26, pin-size-override: verbatim dispatch "
+            "form is load-bearing -->",
+            now=self.NOW,
+        )
+        assert age == 60
+
+    @pytest.mark.parametrize("comment", [
+        None,                              # no date comment at all
+        "<!-- pinned: 2026-13-45 -->",     # well-formed shape, invalid date
+        "<!-- pinned: sometime -->",       # no date-shaped run
+        "",                                # empty
+    ])
+    def test_undatable_pin_yields_none_not_zero(self, comment):
+        """Unknown is None, never 0. A 0 would render as a brand-new pin —
+        the most-protected state — for a pin whose provenance we cannot
+        establish at all."""
+        import check_pin_caps
+        assert check_pin_caps._pin_age_days(comment, now=self.NOW) is None
+
+    def test_future_date_yields_negative_not_clamped(self):
+        """A future-dated pin is a data anomaly and stays visible as one.
+        Clamping to 0 would silently render it as freshly pinned."""
+        import check_pin_caps
+        age = check_pin_caps._pin_age_days(
+            "<!-- pinned: 2026-08-25 -->", now=self.NOW
+        )
+        assert age == -31
+
+
+class TestCheckPinCaps_AgeSignal_D7:
+    """age_days / overdue on the evictable_pins surface (D7).
+
+    Additive: `stale` and the marker machinery are untouched. These tests
+    pin BOTH halves of that claim — that the new fields are correct, and
+    that the old field's meaning did not move.
+    """
+
+    def test_threshold_boundary_is_inclusive(self, patched_claude_md):
+        """overdue is `age >= PINNED_STALENESS_DAYS`. Pinning both sides of
+        the boundary is what makes this non-vacuous: an off-by-one in
+        either direction fails exactly one of these two assertions."""
+        import check_pin_caps
+        threshold = check_pin_caps.PINNED_STALENESS_DAYS
+        patched_claude_md(make_claude_md_with_pins([
+            make_pin_entry(title="At threshold", body_chars=10,
+                           date=_days_ago(threshold)),
+            make_pin_entry(title="One day under", body_chars=10,
+                           date=_days_ago(threshold - 1)),
+        ]))
+        rc, payload = _run_cli(["--status"])
+        assert rc == 0
+        at, under = payload["evictable_pins"]
+        assert at["age_days"] == threshold
+        assert at["overdue"] is True
+        assert under["age_days"] == threshold - 1
+        assert under["overdue"] is False
+
+    def test_undatable_pin_reports_unknown_not_not_overdue(
+        self, patched_claude_md
+    ):
+        """THE load-bearing assertion of D7's three-state contract.
+
+        A pin whose date cannot be established reports `overdue: null`, not
+        `overdue: false`. False would silently EXEMPT the pin from review —
+        it would be treated as fresh — and the pins we cannot date are
+        exactly the ones most likely to be stale, because an undated pin is
+        one nobody has maintained. Collapsing unknown into a clean verdict
+        is the defect this whole feature exists to remove; here it would be
+        shipped inside the signal built to fix it.
+        """
+        patched_claude_md(make_claude_md_with_pins([
+            make_pin_entry(title="Undatable", body_chars=10,
+                           date="not-a-date"),
+        ]))
+        rc, payload = _run_cli(["--status"])
+        assert rc == 0
+        entry = payload["evictable_pins"][0]
+        assert entry["age_days"] is None
+        assert entry["overdue"] is None
+        assert entry["overdue"] is not False, (
+            "unknown age must not render as not-overdue"
+        )
+
+    def test_old_pin_is_overdue_while_stale_stays_false(
+        self, patched_claude_md
+    ):
+        """The two signals are independent, and this is D7's whole reason
+        to exist.
+
+        `stale` is MARKER-based: true only once staleness.py has written a
+        `<!-- STALE: ... -->` marker into the body. `overdue` is AGE-based.
+        A 60-day-old pin carrying no marker must report overdue=True and
+        stale=False. If a future change ever made `overdue` merely mirror
+        `stale`, this test goes red — which is the point, because a mirror
+        would reintroduce the conflation the separate naming prevents.
+        """
+        patched_claude_md(make_claude_md_with_pins([
+            make_pin_entry(title="Old but unmarked", body_chars=10,
+                           date=_days_ago(60)),
+        ]))
+        rc, payload = _run_cli(["--status"])
+        entry = payload["evictable_pins"][0]
+        assert entry["age_days"] == 60
+        assert entry["overdue"] is True
+        assert entry["stale"] is False, (
+            "stale must remain marker-based and independent of age"
+        )
+
+    def test_stale_marker_does_not_imply_overdue(self, patched_claude_md):
+        """The converse independence: a RECENTLY-pinned entry carrying a
+        stale marker reports stale=True but overdue=False. Together with
+        the previous test this pins both diagonals, so neither field can
+        collapse into the other without a red."""
+        patched_claude_md(make_claude_md_with_pins([
+            make_pin_entry(title="Marked but fresh", body_chars=10,
+                           date=_days_ago(1), stale_date="2020-01-01"),
+        ]))
+        rc, payload = _run_cli(["--status"])
+        entry = payload["evictable_pins"][0]
+        assert entry["stale"] is True
+        assert entry["overdue"] is False
+
+    def test_reconfirmation_clears_overdue_end_to_end(
+        self, patched_claude_md
+    ):
+        """The re-confirmation grammar, exercised through the real parser
+        and the real CLI rather than only at unit level — an old pin that
+        has been re-confirmed recently is no longer overdue."""
+        content = make_claude_md_with_pins([
+            make_pin_entry(title="Reconfirmed", body_chars=10,
+                           date=_days_ago(400)),
+        ]).replace(
+            f"<!-- pinned: {_days_ago(400)} -->",
+            f"<!-- pinned: {_days_ago(400)}, reconfirmed: {_days_ago(2)} "
+            f"because still the first thing a new session needs -->",
+        )
+        patched_claude_md(content)
+        rc, payload = _run_cli(["--status"])
+        entry = payload["evictable_pins"][0]
+        assert entry["age_days"] == 2, (
+            "re-confirmation must reset the clock end-to-end, not just in "
+            "the unit-level helper"
+        )
+        assert entry["overdue"] is False
+
+    def test_age_fields_are_additive_not_replacing(self, patched_claude_md):
+        """D7 adds columns; it removes and renames nothing. A consumer
+        reading the pre-D7 shape must still find every field it had."""
+        patched_claude_md(_make_pinned_content(2, pin_body_chars=50))
+        rc, payload = _run_cli(["--status"])
+        for entry in payload["evictable_pins"]:
+            assert set(entry) == {
+                "index", "heading", "chars", "stale", "override",
+                "age_days", "overdue",
+            }
+
+    def test_threshold_is_not_a_second_constant(self):
+        """PINNED_STALENESS_DAYS has ONE definition. This module re-exports
+        staleness's value rather than declaring its own, so `overdue` and
+        the SessionStart stale-block directive cannot drift to different
+        thresholds. Pinning identity (not equality to a literal 30) is what
+        makes this catch a divergence rather than a value change."""
+        import check_pin_caps
+        import staleness
+        assert (
+            check_pin_caps.PINNED_STALENESS_DAYS
+            is staleness.PINNED_STALENESS_DAYS
+        )
 
 
 class TestCheckPinCaps_Advisory_NeverExit2:

--- a/pact-plugin/tests/test_memory_cli.py
+++ b/pact-plugin/tests/test_memory_cli.py
@@ -2481,3 +2481,138 @@ class TestCliHelpOutput:
         captured = capsys.readouterr()
         assert "--limit" in captured.out
         assert "query" in captured.out.lower()
+
+
+# ---------------------------------------------------------------------------
+# save(sync_to_claude=...) — the Working Memory projection, made optional
+# ---------------------------------------------------------------------------
+
+
+class TestSaveSyncSuppression:
+    """`save()` gained `sync_to_claude`, completing a half-built symmetry.
+
+    `search()` has carried this parameter all along and the CLI's search path
+    already passes False; `save()` never got it and called the sync
+    unconditionally. That asymmetry is why the pin-archival path could not
+    avoid writing the archived block straight back into the CLAUDE.md it was
+    removing it from — freeing the pin SLOT while leaving the bytes.
+
+    THE DEFAULT DIRECTION IS THE ONE THAT MATTERS HERE. Suppressing the sync
+    for a caller that did not ask is the damaging failure: it presents as a
+    projection quietly not appearing, which nobody notices. So the default
+    path is tested by asserting the sync ACTUALLY FIRES, not merely that the
+    save returned an id.
+    """
+
+    def _spy(self, monkeypatch):
+        calls = []
+        import scripts.memory_api as memory_api
+        monkeypatch.setattr(
+            memory_api, "sync_to_claude_md",
+            lambda *a, **k: calls.append((a, k)),
+        )
+        return calls
+
+    def test_default_still_syncs(self, tmp_path, monkeypatch):
+        """A caller that omits the parameter must be byte-identical to before."""
+        calls = self._spy(monkeypatch)
+        memory = PACTMemory(db_path=tmp_path / "d.db")
+        memory_id = memory.save(make_cli_memory_dict())
+        assert memory_id, "save must still return an id"
+        assert memory.get(memory_id) is not None, (
+            "save must still persist — otherwise the sync assertion below is "
+            "measuring a crash rather than a default"
+        )
+        assert len(calls) == 1, (
+            "the default path MUST still sync; silently suppressing it for "
+            "every existing caller is the damaging direction of this change"
+        )
+
+    def test_explicit_true_syncs(self, tmp_path, monkeypatch):
+        calls = self._spy(monkeypatch)
+        memory = PACTMemory(db_path=tmp_path / "d.db")
+        memory.save(make_cli_memory_dict(), sync_to_claude=True)
+        assert len(calls) == 1
+
+    def test_false_suppresses(self, tmp_path, monkeypatch):
+        calls = self._spy(monkeypatch)
+        memory = PACTMemory(db_path=tmp_path / "d.db")
+        memory_id = memory.save(make_cli_memory_dict(), sync_to_claude=False)
+        assert memory.get(memory_id) is not None, (
+            "the save must PERSIST — a crashed save also produces zero sync "
+            "calls, and the two are indistinguishable without this assertion"
+        )
+        assert calls == [], "sync_to_claude=False must not project"
+
+    def test_signature_mirrors_search(self):
+        """The parameter exists on both, with the same name and default."""
+        import inspect
+        save_p = inspect.signature(PACTMemory.save).parameters
+        search_p = inspect.signature(PACTMemory.search).parameters
+        assert "sync_to_claude" in save_p
+        assert save_p["sync_to_claude"].default is True
+        assert search_p["sync_to_claude"].default is True
+
+    def test_claude_md_untouched_when_suppressed(self, tmp_path):
+        """End-to-end against the REAL file the autouse fixture seeded.
+
+        Byte-identity rather than a content check: it fails if ANYTHING
+        writes, including a writer nobody has thought of, whereas a check for
+        one specific string only fails for the writer you already suspected.
+        """
+        # The autouse fixture seeds the PREFERRED layout, .claude/CLAUDE.md,
+        # not the legacy sibling — asserted rather than assumed, because a
+        # wrong path here would make every byte comparison below vacuous.
+        claude_md = tmp_path / ".claude" / "CLAUDE.md"
+        assert claude_md.exists(), "isolation fixture must have seeded a file"
+
+        before = claude_md.read_bytes()
+        memory = PACTMemory(db_path=tmp_path / "s.db")
+        memory_id = memory.save(make_cli_memory_dict(), sync_to_claude=False)
+        assert memory.get(memory_id) is not None
+        assert claude_md.read_bytes() == before, (
+            "suppressed save wrote to CLAUDE.md"
+        )
+
+        # CONTROL: the unsuppressed path MUST change the file, or the
+        # assertion above passes for a harness that cannot detect a write.
+        memory.save(make_cli_memory_dict(), sync_to_claude=True)
+        assert claude_md.read_bytes() != before, (
+            "the unsuppressed control did not write — this test cannot "
+            "distinguish suppression from an inert sync"
+        )
+
+
+class TestCliNoSyncFlag:
+    """`--no-sync` on the save subcommand, threading to the parameter."""
+
+    def test_flag_parses_and_defaults_false(self):
+        parser = build_parser()
+        assert parser.parse_args(["save", "{}"]).no_sync is False
+        assert parser.parse_args(["save", "{}", "--no-sync"]).no_sync is True
+
+    def test_flag_threads_to_the_api(self, tmp_path, monkeypatch):
+        seen = {}
+
+        def _capture(self, memory, files=None, include_tracked=True,
+                     sync_to_claude=True):
+            seen["sync_to_claude"] = sync_to_claude
+            return "a" * 32
+
+        monkeypatch.setattr(PACTMemory, "save", _capture)
+        parser = build_parser()
+
+        with pytest.raises(SystemExit):
+            cmd_save(parser.parse_args(
+                ["save", json.dumps(make_cli_memory_dict()), "--no-sync"]
+            ), db_path=str(tmp_path / "x.db"))
+        assert seen["sync_to_claude"] is False
+
+        seen.clear()
+        with pytest.raises(SystemExit):
+            cmd_save(parser.parse_args(
+                ["save", json.dumps(make_cli_memory_dict())]
+            ), db_path=str(tmp_path / "x.db"))
+        assert seen["sync_to_claude"] is True, (
+            "omitting --no-sync must reach the API as True, not as absent"
+        )

--- a/pact-plugin/tests/test_pin_caps.py
+++ b/pact-plugin/tests/test_pin_caps.py
@@ -937,6 +937,26 @@ class TestDenyReasonTemplates_Constants:
         assert str(PIN_COUNT_CAP) in rendered
         assert "prune-memory" in rendered
 
+    def test_count_template_frames_removal_as_demotion_not_deletion(self):
+        """AC-B3: the cap deny is where a curator decides whether to give up
+        a pin, so it must say what happens to the content.
+
+        `demote` names the destination; `evict` named only the removal and
+        read as loss. The negative arm is the load-bearing half — a template
+        that says "demote" while still threatening deletion would satisfy a
+        keyword check and defeat the intent.
+        """
+        from pin_caps import DENY_REASON_COUNT, PIN_COUNT_CAP
+        rendered = DENY_REASON_COUNT.format(
+            count=PIN_COUNT_CAP + 1, cap=PIN_COUNT_CAP
+        ).lower()
+        assert "demote" in rendered or "demotion" in rendered
+        assert "long-term memory" in rendered
+        assert "evict" not in rendered, (
+            "deletion framing reintroduced — AC-B3 requires demotion framing"
+        )
+        assert "delete" not in rendered
+
     def test_size_template_renders(self):
         from pin_caps import DENY_REASON_SIZE, PIN_SIZE_CAP
         rendered = DENY_REASON_SIZE.format(chars=PIN_SIZE_CAP + 100, cap=PIN_SIZE_CAP)

--- a/pact-plugin/tests/test_pin_caps_integration.py
+++ b/pact-plugin/tests/test_pin_caps_integration.py
@@ -13,6 +13,7 @@ Covers:
 Risk tier: CRITICAL.
 """
 
+import re
 import sys
 from pathlib import Path
 
@@ -403,12 +404,14 @@ class TestPruneMemoryCommand_Grammar:
     """/PACT:prune-memory contract assertions (cycle-8 commit 7).
 
     The prune flow that pin-memory.md previously embedded now lives in
-    a dedicated command. prune-memory.md describes a 4-step interactive
+    a dedicated command. prune-memory.md describes a 5-step interactive
     flow:
         1. Invoke check_pin_caps.py --status to get evictable_pins
         2. AskUserQuestion (paginated) on the list
-        3. Edit CLAUDE.md to remove the selected block
-        4. Report + commit
+        3. Archive the selected pin and verify it arrived; refuse the
+           eviction on anything short of a verified archive
+        4. Edit CLAUDE.md to remove the selected block
+        5. Report (+ journal event)
 
     Tests here pin the informational contract (CLI invocation shape,
     pagination structure, cross-references) so structural refactors
@@ -469,19 +472,39 @@ class TestPruneMemoryCommand_Grammar:
         workflow is discoverable from either direction."""
         assert "/PACT:pin-memory" in prune_memory_content
 
-    def test_no_shell_scaffolding_heredoc(self, prune_memory_content):
-        """Regression guard: prune-memory.md MUST NOT introduce the
-        shell-scaffolding surface that pin-memory.md shed in cycle-8.
-        The `check_pin_caps.py --status` invocation is pure (no body
-        input required) so no heredoc is needed."""
-        assert "<<'" not in prune_memory_content
-        assert '<<"' not in prune_memory_content
-        # One `bash` fence is allowed (the plain CLI invocation); it
-        # takes no stdin, so no heredoc form should appear.
-        heredoc_markers = prune_memory_content.count("<<")
-        assert heredoc_markers == 0, (
-            "prune-memory.md contains heredoc marker(s); the advisory "
-            "CLI reads no stdin, so heredoc forms should not appear here."
+    def test_no_expanding_heredoc(self, prune_memory_content):
+        """Regression guard, NARROWED — and the original rationale is
+        retracted rather than merely relaxed.
+
+        The previous assertion banned every heredoc marker on a NECESSITY
+        premise: "the `check_pin_caps.py --status` invocation is pure (no
+        body input required) so no heredoc is needed." That premise no
+        longer holds. prune-memory.md now emits skip/prune journal events
+        whose payload carries curator free text, and this project's
+        mandated journal-write form is a QUOTED heredoc — adopted
+        precisely because an unquoted one let an apostrophe in a
+        substituted value close the bash quote and silently abort the
+        write under `set -e`.
+
+        The security concern was never heredocs as such; it was SHELL
+        EXPANSION inside them. So the quoted form is permitted and the
+        expanding form stays banned. Note the archival path does NOT
+        widen this surface: `archive_pin.py --index N` passes no body
+        through the shell and needs no heredoc at all.
+
+        The sibling guard on pin-memory.md (`test_no_heredoc_scaffolding`)
+        rests on a SECURITY claim rather than a necessity claim, remains
+        true, and is deliberately NOT narrowed.
+        """
+        assert '<<"' not in prune_memory_content, (
+            "expanding heredoc in prune-memory.md; use the quoted form <<'DELIM' "
+            "so bash performs no substitution inside the payload."
+        )
+        bare = re.findall(r"<<(?!['\"])\w+", prune_memory_content)
+        assert bare == [], (
+            f"unquoted heredoc delimiter(s) in prune-memory.md: {bare}. "
+            "An unquoted delimiter re-enables shell expansion inside the "
+            "payload — quote it as <<'DELIM'."
         )
 
 

--- a/pact-plugin/tests/test_pin_caps_integration.py
+++ b/pact-plugin/tests/test_pin_caps_integration.py
@@ -524,23 +524,34 @@ class TestPruneMemoryCommand_Grammar:
         from the regex -- deriving it would make this test agree with the
         implementation by construction and assert nothing.
         """
-        # A REQUIRED-SET, not `len(...) == 14`. A count conflates deletion
-        # with addition and fails BOTH ways: swap `<<-EOF` for `<<~EOF` and
-        # the count holds at 14 while a load-bearing expanding form silently
-        # loses coverage, and a legitimate 15th form fails a guard that
-        # should not care. Naming the forms whose coverage is load-bearing
-        # -- every form bash EXPANDS, plus the quoted/escaped controls --
-        # makes deletion fail regardless of what was added alongside it.
-        required = {
-            "<<EOF", "<<-EOF", "<< EOF", "<<   EOF",      # expanding
-            "<<'EOF'", '<<"EOF"', "<<\\EOF",              # non-expanding controls
-        }
+        # A REQUIRED-SET over EVERY form, not a count and not a subset.
+        # Measured against five mutations; only this shape gets all five
+        # right (count: 2 wrong, 7-form subset: 1, count+subset: 1):
+        #   delete a listed row      -> caught (a count catches this too)
+        #   SWAP one form for another-> caught; A COUNT PASSES IT at 14
+        #                               while a form silently loses coverage
+        #   add a legitimate 15th    -> ALLOWED; a count wrongly fails it
+        #   empty table              -> caught
+        # A count conflates deletion with addition; a subset cannot see the
+        # deletion of a row outside it. Enumerating every form makes the
+        # table's contents the contract and leaves it free to grow.
+        #
+        # This literal is deliberately NOT derived from _HEREDOC_FORMS.
+        # `{f for f, _ in TABLE} - {f for f, _ in TABLE}` is empty by
+        # construction -- a self-referential guard that can never fail.
+        required = frozenset({
+            "<<EOF", "<<-EOF", "<< EOF", "<<   EOF", "<<$VAR",      # expanding
+            "<<'EOF'", '<<"EOF"', "<<-'EOF'", '<<-"EOF"',           # quoted
+            "<< 'EOF'", '<< "EOF"', "<<-  'EOF'", "<<-\t'EOF'",     # quoted + space/tab
+            "<<\\EOF",                                              # escaped
+        })
         missing = required - {form for form, _ in self._HEREDOC_FORMS}
         assert not missing, (
-            f"heredoc form table lost coverage of: {sorted(missing)}. These "
-            "forms are load-bearing -- each expanding one was a real hole in "
-            "a shipped revision of this guard, and each control pins a form "
-            "an earlier revision wrongly banned."
+            f"heredoc form table lost coverage of: {sorted(missing)}. Every "
+            "expanding form listed was a real hole in a shipped revision of "
+            "this guard, and every quoted/escaped form pins one that a "
+            "revision wrongly banned. Adding forms is free; removing one "
+            "means re-deriving why it stopped mattering."
         )
         for form, expands in self._HEREDOC_FORMS:
             flagged = bool(self._expanding(f"cat {form}\npayload\nEOF\n"))

--- a/pact-plugin/tests/test_pin_caps_integration.py
+++ b/pact-plugin/tests/test_pin_caps_integration.py
@@ -472,39 +472,115 @@ class TestPruneMemoryCommand_Grammar:
         workflow is discoverable from either direction."""
         assert "/PACT:pin-memory" in prune_memory_content
 
-    def test_no_expanding_heredoc(self, prune_memory_content):
-        """Regression guard, NARROWED — and the original rationale is
-        retracted rather than merely relaxed.
+    # Bash disables parameter expansion when ANY part of the heredoc
+    # delimiter word is quoted OR escaped -- single quotes, double quotes
+    # and a backslash are equivalent for this purpose.
+    #
+    # BOTH `<<`-guards are load-bearing and each was found by a different
+    # reviewer failing the other's case. `<<<` is a HERESTRING, a distinct
+    # operator, and it must not be reported as an unquoted heredoc:
+    #   (?<!<) stops the match starting on the SECOND `<` of `<<<`
+    #   (?!<)  stops it starting on the FIRST
+    # Drop either and `cat <<<$VAR` is flagged. Drop `\\` from the
+    # non-expanding set and `<<\EOF` -- which bash does NOT expand -- is
+    # flagged. Three independently-authored predicates each carried
+    # exactly one of these defects; this is the intersection.
+    _DELIM_RE = re.compile(r"(?<!<)<<-?[ \t]*(?!<)(.)")
+    _NON_EXPANDING_LEAD = ("'", '"', "\\")
 
-        The previous assertion banned every heredoc marker on a NECESSITY
-        premise: "the `check_pin_caps.py --status` invocation is pure (no
-        body input required) so no heredoc is needed." That premise no
-        longer holds. prune-memory.md now emits skip/prune journal events
-        whose payload carries curator free text, and this project's
-        mandated journal-write form is a QUOTED heredoc — adopted
-        precisely because an unquoted one let an apostrophe in a
-        substituted value close the bash quote and silently abort the
-        write under `set -e`.
+    @staticmethod
+    def _expanding(text):
+        """Every heredoc operator in `text` whose delimiter is UNQUOTED."""
+        cls = TestPruneMemoryCommand_Grammar
+        return [
+            m.group(0) for m in cls._DELIM_RE.finditer(text)
+            if m.group(1) not in cls._NON_EXPANDING_LEAD
+        ]
 
-        The security concern was never heredocs as such; it was SHELL
-        EXPANSION inside them. So the quoted form is permitted and the
-        expanding form stays banned. Note the archival path does NOT
-        widen this surface: `archive_pin.py --index N` passes no body
-        through the shell and needs no heredoc at all.
+    # (form, expands?) -- `expands` measured against real bash, not reasoned.
+    _HEREDOC_FORMS = [
+        ("<<EOF", True), ("<<'EOF'", False), ('<<"EOF"', False),
+        ("<<-EOF", True), ("<<-'EOF'", False), ('<<-"EOF"', False),
+        ("<< EOF", True), ("<< 'EOF'", False), ('<< "EOF"', False),
+        ("<<   EOF", True), ("<<-  'EOF'", False), ("<<-\t'EOF'", False),
+        ("<<\\EOF", False), ("<<$VAR", True),
+    ]
 
-        The sibling guard on pin-memory.md (`test_no_heredoc_scaffolding`)
-        rests on a SECURITY claim rather than a necessity claim, remains
-        true, and is deliberately NOT narrowed.
+    def test_expanding_heredoc_predicate_matches_bash(self):
+        """The PREDICATE, tested as a pure function against a fixed table.
+
+        Split deliberately from the file scan below, because one regex was
+        being asked two different questions -- "is this form expanding?"
+        (a pure function) and "is the shipped file clean?" (a document
+        scan). Conflating them is why three successive revisions of this
+        guard each traded one error direction for another: it shipped with
+        holes (`<<-EOF`, `<< EOF`, `<<   EOF` all expand and were
+        permitted), was then corrected into an OVER-BLOCK that banned
+        `<<"EOF"` under a message calling it expanding when bash does not
+        expand it, and a scoped fix after that could pass while scanning
+        nothing.
+
+        `expands` in the table is MEASURED against real bash, not derived
+        from the regex -- deriving it would make this test agree with the
+        implementation by construction and assert nothing.
         """
-        assert '<<"' not in prune_memory_content, (
-            "expanding heredoc in prune-memory.md; use the quoted form <<'DELIM' "
-            "so bash performs no substitution inside the payload."
+        # A REQUIRED-SET, not `len(...) == 14`. A count conflates deletion
+        # with addition and fails BOTH ways: swap `<<-EOF` for `<<~EOF` and
+        # the count holds at 14 while a load-bearing expanding form silently
+        # loses coverage, and a legitimate 15th form fails a guard that
+        # should not care. Naming the forms whose coverage is load-bearing
+        # -- every form bash EXPANDS, plus the quoted/escaped controls --
+        # makes deletion fail regardless of what was added alongside it.
+        required = {
+            "<<EOF", "<<-EOF", "<< EOF", "<<   EOF",      # expanding
+            "<<'EOF'", '<<"EOF"', "<<\\EOF",              # non-expanding controls
+        }
+        missing = required - {form for form, _ in self._HEREDOC_FORMS}
+        assert not missing, (
+            f"heredoc form table lost coverage of: {sorted(missing)}. These "
+            "forms are load-bearing -- each expanding one was a real hole in "
+            "a shipped revision of this guard, and each control pins a form "
+            "an earlier revision wrongly banned."
         )
-        bare = re.findall(r"<<(?!['\"])\w+", prune_memory_content)
-        assert bare == [], (
-            f"unquoted heredoc delimiter(s) in prune-memory.md: {bare}. "
-            "An unquoted delimiter re-enables shell expansion inside the "
-            "payload — quote it as <<'DELIM'."
+        for form, expands in self._HEREDOC_FORMS:
+            flagged = bool(self._expanding(f"cat {form}\npayload\nEOF\n"))
+            assert flagged == expands, (
+                f"{form!r}: bash expands={expands} but the guard "
+                f"{'flags' if flagged else 'permits'} it — "
+                + ("a HOLE (expanding form permitted)" if expands
+                   else "an OVER-BLOCK (safe quoted form banned)")
+            )
+
+    def test_shipped_file_has_no_expanding_heredoc(self, prune_memory_content):
+        """The SCAN. prune-memory.md's own fenced shell must be clean.
+
+        Reads the WHOLE document. There is deliberately no fence
+        extraction, and removing that component is the point rather than a
+        simplification: every prior defect in this guard lived in the part
+        trying to be precise about WHERE to look. It was a total `<<` ban,
+        then a holed regex, then a ```bash-scoped scan that passed while
+        scanning nothing when the fences were renamed. A component that
+        has been wrong three times and can fail SILENTLY is worth deleting,
+        not narrowing a fourth time.
+
+        ACCEPTED WART, so nobody 'fixes' it later: documenting the banned
+        form unquoted in this file's prose WILL fail this test. That is an
+        over-block -- a red test resolved in minutes by quoting the example
+        -- and it is the deliberate price of removing a failure mode that
+        reported success forever. Do not reintroduce fence-scoping to
+        soften it.
+        """
+        assert "<<'JSON'" in prune_memory_content, (
+            "the legitimate quoted heredoc is missing from prune-memory.md — "
+            "this guard's subject is gone, so a clean result below would mean "
+            "nothing. POSITIVE CONTROL: it proves the scan reached the real "
+            "surface, which merely asserting the file is non-empty would not."
+        )
+        bad = self._expanding(prune_memory_content)
+        assert bad == [], (
+            f"unquoted (expanding) heredoc delimiter(s) in prune-memory.md: "
+            f"{bad}. An unquoted delimiter re-enables shell expansion inside "
+            "the payload — quote it as <<'DELIM'."
         )
 
 

--- a/pact-plugin/tests/test_pin_caps_integration.py
+++ b/pact-plugin/tests/test_pin_caps_integration.py
@@ -568,11 +568,12 @@ class TestPruneMemoryCommand_Grammar:
         })
         missing = required - {form for form, _ in self._HEREDOC_FORMS}
         assert not missing, (
-            f"heredoc form table lost coverage of: {sorted(missing)}. Every "
-            "expanding form listed was a real hole in a shipped revision of "
-            "this guard, and every quoted/escaped form pins one that a "
-            "revision wrongly banned. Adding forms is free; removing one "
-            "means re-deriving why it stopped mattering."
+            f"heredoc form table lost coverage of: {sorted(missing)}. Four "
+            "of the five expanding forms listed were real holes in a "
+            "shipped revision of this guard; `<<EOF` is the control the "
+            "original regex caught correctly. The quoted and escaped forms "
+            "pin cases a revision wrongly banned. Adding forms is free; "
+            "removing one means re-deriving why it stopped mattering."
         )
         for form, expands in self._HEREDOC_FORMS:
             flagged = bool(self._expanding(f"cat {form}\npayload\nEOF\n"))

--- a/pact-plugin/tests/test_pin_caps_integration.py
+++ b/pact-plugin/tests/test_pin_caps_integration.py
@@ -485,6 +485,23 @@ class TestPruneMemoryCommand_Grammar:
     # non-expanding set and `<<\EOF` -- which bash does NOT expand -- is
     # flagged. Three independently-authored predicates each carried
     # exactly one of these defects; this is the intersection.
+    #
+    # KNOWN RESIDUAL, deliberately not fixed: arithmetic left-shift inside
+    # `$(( ))` is flagged as an expanding heredoc -- `x=$((1<<3))` and
+    # `x=$((a<<b))` both match. It is an OVER-BLOCK, so it surfaces as a red
+    # test a human investigates rather than as a hole something slips
+    # through, and it is currently unreachable: this file contains no
+    # arithmetic. TWO FIXES WERE TRIED AND REJECTED, recorded so neither is
+    # re-attempted:
+    #   (?<![<0-9])  fixes `1<<3` but NOT `a<<b` -- half the case for real
+    #                added complexity.
+    #   excluding a preceding identifier character fixes both and BREAKS a
+    #                valid heredoc: `cat<<EOF` with no space is legal bash
+    #                (measured), so a letter may legitimately precede `<<`.
+    # A documented over-block on a construct that cannot currently occur is
+    # a better resting place than a more complex pattern with its own
+    # untested edges. This guard has already been wrong three times from
+    # exactly that instinct.
     _DELIM_RE = re.compile(r"(?<!<)<<-?[ \t]*(?!<)(.)")
     _NON_EXPANDING_LEAD = ("'", '"', "\\")
 
@@ -504,6 +521,10 @@ class TestPruneMemoryCommand_Grammar:
         ("<< EOF", True), ("<< 'EOF'", False), ('<< "EOF"', False),
         ("<<   EOF", True), ("<<-  'EOF'", False), ("<<-\t'EOF'", False),
         ("<<\\EOF", False), ("<<$VAR", True),
+        # Backslash-escaped delimiters, added because they LOOK unquoted at a
+        # glance and are the forms most likely to be got wrong by a future
+        # edit. All three measured non-expanding.
+        ("<< \\EOF", False), ("<<-  \\EOF", False), ("<<-\\EOF", False),
     ]
 
     def test_expanding_heredoc_predicate_matches_bash(self):
@@ -543,7 +564,7 @@ class TestPruneMemoryCommand_Grammar:
             "<<EOF", "<<-EOF", "<< EOF", "<<   EOF", "<<$VAR",      # expanding
             "<<'EOF'", '<<"EOF"', "<<-'EOF'", '<<-"EOF"',           # quoted
             "<< 'EOF'", '<< "EOF"', "<<-  'EOF'", "<<-\t'EOF'",     # quoted + space/tab
-            "<<\\EOF",                                              # escaped
+            "<<\\EOF", "<< \\EOF", "<<-  \\EOF", "<<-\\EOF",         # escaped
         })
         missing = required - {form for form, _ in self._HEREDOC_FORMS}
         assert not missing, (

--- a/pact-plugin/tests/test_prune_memory_integration.py
+++ b/pact-plugin/tests/test_prune_memory_integration.py
@@ -379,8 +379,13 @@ class TestPruneMemoryProseContract:
         assert headings, (
             "no '### Step N — ' headings found in prune-memory.md — this "
             "guard cannot verify a sequence it cannot locate. Re-aim the "
-            "pattern rather than deleting this line: an empty match set "
-            "would satisfy every assertion below by vacuity."
+            "pattern rather than deleting this line. NOTE this is a "
+            "DIAGNOSTIC, not a vacuity guard: measured, an empty match set "
+            "already fails every assertion below (the bijection finds no "
+            "match for the first required name, and the floor fails at 0 "
+            "of 5). It exists so the failure names the real cause — a "
+            "broken pattern — instead of surfacing as a confusing report "
+            "that every required step is missing."
         )
         # BIJECTION, not `any(required in h for h in headings)`. Matching
         # each required name against ANY heading lets ONE heading satisfy

--- a/pact-plugin/tests/test_prune_memory_integration.py
+++ b/pact-plugin/tests/test_prune_memory_integration.py
@@ -463,6 +463,45 @@ class TestPruneMemoryProseContract:
                 f"prune-memory.md missing evictable_pins field {field!r}"
             )
 
+    def test_json_example_honors_the_three_state_age_contract(self, prune_md):
+        """The RULE and the EXAMPLE are two independent claims and can
+        disagree — this pins the example, because the example is the one
+        that gets copied.
+
+        prune-memory.md states that `age_days: null` is a third state and
+        is NOT `overdue: false`; `check_pin_caps.py` emits
+        `None if age_days is None else ...`, so the pairing the example
+        showed is one the code never produces. Found by `coder-prose`, and
+        verified by OBSERVATION rather than by reading the ternary: a
+        `--status` run over a CLAUDE.md with one dated and one undated pin
+        returned `age_days=2397, overdue=True` and `age_days=None,
+        overdue=None`. The dated pin is the positive control — an all-null
+        result would have meant a broken harness rather than a finding.
+
+        WHY THE EXAMPLE AND NOT THE RULE. The failure mode is a curator
+        COPYING the example, so the misleading artifact is the example
+        itself; adjacent prose is more likely to be skimmed than a JSON
+        block is to be mis-transcribed. A curator reasoning from
+        `overdue: false` treats an undated pin as not-overdue, silently
+        exempting the pin most likely to have sat longest — which is the
+        failure the third state exists to prevent.
+        """
+        pairs = re.findall(
+            r'"age_days":\s*(null|\d+),\s*"overdue":\s*(null|true|false)',
+            prune_md,
+        )
+        assert pairs, (
+            "no age_days/overdue pair found in prune-memory.md's JSON "
+            "example — this guard cannot check an example it cannot locate"
+        )
+        for age, overdue in pairs:
+            if age == "null":
+                assert overdue == "null", (
+                    f'example pairs "age_days": null with "overdue": '
+                    f"{overdue} — the code emits null; an unknown age is "
+                    "not the same as not-overdue"
+                )
+
     def test_declares_pagination_rule(self, prune_md):
         """Pagination (3-per-page + Show more, last page + Cancel) must
         survive as a grammar-observable contract."""

--- a/pact-plugin/tests/test_prune_memory_integration.py
+++ b/pact-plugin/tests/test_prune_memory_integration.py
@@ -450,6 +450,61 @@ class TestPruneMemoryProseContract:
                     "must not imply the pin is discarded"
                 )
 
+    def test_step_4_consumes_the_handle_and_derives_no_boundary(self, prune_md):
+        """Step 4 removes an emitted string; it must NOT restate the span rule.
+
+        The span rule lived in BOTH `archive_pin.py` and this prose, and the
+        two diverged: the prose kept an end-boundary the script had already
+        corrected, so the destroy range was a superset of the archive range
+        and the excess was a RETAINED pin's date comment. The fix was to
+        delete the second copy, not to correct it — a corrected copy is still
+        a copy, and the copy is the drift mechanism.
+
+        So after the deletion, any reappearance of span-derivation vocabulary
+        in Step 4 IS the defect returning, which is why the negative arm is
+        the point of this test.
+
+        POSITIVE AND NEGATIVE ARMS ARE COUPLED HERE DELIBERATELY — DO NOT
+        SPLIT THEM. A bare `not in` assertion passes trivially over an empty
+        string: delete Step 4, restructure the file, or let the section
+        extraction miss, and it goes green forever. A negative assertion has
+        no natural non-vacuity arm, because absence is exactly what it seeks
+        — it cannot distinguish "the bad thing is gone" from "nothing is
+        here". The positive arm is what establishes the surface exists, so
+        the negative one means something. Split across two tests, the
+        positive reads as trivially true, someone deletes it, and the
+        negative silently becomes decoration.
+        """
+        section = re.search(
+            r"^### Step 4 — .*?(?=^### Step \d+ — )", prune_md,
+            re.MULTILINE | re.DOTALL)
+        assert section, (
+            "Step 4 section not found in prune-memory.md — the extraction is "
+            "broken or the step was removed. Re-aim rather than deleting: "
+            "without this, the negative assertions below pass over an empty "
+            "string and this guard silently protects nothing."
+        )
+        body = section.group(0)
+
+        # POSITIVE: the step consumes the emitted handle at the resolved path.
+        for required in ("delete_string", "claude_md_path"):
+            assert required in body, (
+                f"Step 4 no longer references {required!r}. It must remove the "
+                "string the verdict emitted, at the path the verdict reports — "
+                "not a boundary it works out for itself."
+            )
+
+        # NEGATIVE: and it derives no boundary of its own.
+        for banned in ("span start", "date comment line", "next `### ` heading",
+                       "preserving surrounding blank lines"):
+            assert banned not in body, (
+                f"Step 4 restates the span rule ({banned!r}). That is a SECOND "
+                "copy of a rule the archiver already owns, and the two diverged "
+                "once already — the prose kept an end-boundary the script had "
+                "corrected, destroying a retained pin's date comment. Remove "
+                "the restatement; the emitted handle is the boundary."
+            )
+
     def test_references_advisory_cli(self, prune_md):
         """Step 1 must point curators at check_pin_caps --status."""
         assert "check_pin_caps.py" in prune_md

--- a/pact-plugin/tests/test_prune_memory_integration.py
+++ b/pact-plugin/tests/test_prune_memory_integration.py
@@ -376,13 +376,32 @@ class TestPruneMemoryProseContract:
         rename or removal of a named step still fails.
         """
         headings = re.findall(r"^### Step \d+ — (.+)$", prune_md, re.MULTILINE)
+        assert headings, (
+            "no '### Step N — ' headings found in prune-memory.md — this "
+            "guard cannot verify a sequence it cannot locate. Re-aim the "
+            "pattern rather than deleting this line: an empty match set "
+            "would satisfy every assertion below by vacuity."
+        )
+        # BIJECTION, not `any(required in h for h in headings)`. Matching
+        # each required name against ANY heading lets ONE heading satisfy
+        # TWO requirements, so folding a step into a sibling's title --
+        # "### Step 3 — Archive the selected pin and Report" while renaming
+        # step 5 -- DELETES a step and still passes, with the >= 5 floor met
+        # by whatever filler remains. Measured: `any()` passes that
+        # mutation, this does not. Consuming each match makes "every
+        # required step exists as its OWN heading" the actual assertion,
+        # which is what the docstring above has always claimed.
+        remaining = list(headings)
         for required in ("Read the evictable-pin list", "Ask the curator",
                          "Archive the selected pin", "Remove the selected pin",
                          "Report"):
-            assert any(required in h for h in headings), (
-                f"prune-memory.md missing required step {required!r}; "
-                f"found {headings}"
+            match = next((h for h in remaining if required in h), None)
+            assert match is not None, (
+                f"prune-memory.md missing required step {required!r} as a "
+                f"distinct heading; unconsumed headings: {remaining} "
+                f"(all headings: {headings})"
             )
+            remaining.remove(match)
         assert len(headings) >= 5, (
             f"prune-memory.md should have at least 5 steps, found "
             f"{len(headings)}: {headings}"

--- a/pact-plugin/tests/test_prune_memory_integration.py
+++ b/pact-plugin/tests/test_prune_memory_integration.py
@@ -6,7 +6,10 @@ Risk tier: HIGH. These tests exercise the full evict-retry loop that
 curators will run when the count cap fires:
   1. Curator attempts to add a 13th pin → pin_caps_gate DENIES (count cap).
   2. Curator runs `check_pin_caps --status` → JSON lists 12 evictable pins.
-  3. Curator simulates prune-memory.md's Step 3: Edit removing one pin.
+  3. Curator simulates prune-memory.md's Step 4: Edit removing one pin.
+     (Step 3, the archive-and-verify gate that must pass before that Edit
+     is emitted, is exercised separately — this round-trip covers the
+     gate/CLI interlock, not the archival path.)
      → pin_caps_gate ALLOWS (post < pre → net-worse=False).
   4. Curator retries the original add → pin_caps_gate ALLOWS (under cap now).
 
@@ -136,20 +139,46 @@ class TestMockCuratorRoundTrip:
         assert "Pin count cap" in result
 
     def test_cli_status_lists_all_evictable_pins(self, curator_env):
-        """Step 2: CLI --status returns the evictable-pin list."""
+        """Step 2: CLI --status returns the evictable-pin list.
+
+        The key set is asserted as an EXACT equality and the contract has
+        GROWN: `age_days` and `overdue` joined the original five when the
+        additive age signal landed, because the eviction ordering needs a
+        signal that actually fires (the marker-based `stale` flag does not
+        fire on the canonical pin format).
+
+        Kept as `==` rather than relaxed to a subset check when it grew.
+        prune-memory.md instructs curators to parse these entries BY NAME,
+        so a field that silently vanishes breaks the command just as badly
+        as one that silently appears, and a subset check can only see the
+        second. Widening the expected set records the new contract;
+        loosening the operator would have discarded the property.
+        """
         curator_env["reset_state"](n_pins=12)
         rc, payload = curator_env["call_cli"](["--status"])
         assert rc == 0
         assert payload["allowed"] is True
         assert len(payload["evictable_pins"]) == 12
-        # Each entry has the documented shape.
+        # Each entry has the documented shape. Kept as an EXACT set rather
+        # than a subset check: prune-memory.md tells curators to parse these
+        # entries by name, so an unannounced field addition or rename in the
+        # CLI contract should fail here rather than surface as a curator
+        # reading a key that is no longer there. `age_days` / `overdue` are
+        # the additive age signal the eviction ordering keys on.
         for entry in payload["evictable_pins"]:
             assert set(entry.keys()) == {
-                "index", "heading", "chars", "stale", "override"
+                "index", "heading", "chars", "stale", "override",
+                "age_days", "overdue",
             }
             assert isinstance(entry["index"], int)
             assert isinstance(entry["heading"], str)
             assert not entry["heading"].startswith("### ")  # Stripped per CLI.
+            # Dated fixture pins, so both age fields are populated here. The
+            # unknown-age third state (both null) is covered where the age
+            # computation itself is tested; what matters for the prune flow
+            # is that `overdue` is never a bare False standing in for null.
+            assert isinstance(entry["age_days"], int)
+            assert isinstance(entry["overdue"], bool)
 
     def test_prune_edit_allowed_when_count_decreases(self, curator_env):
         """Step 3: Edit removing one pin block is ALLOWED.
@@ -329,14 +358,73 @@ class TestPruneMemoryProseContract:
         )
         return path.read_text(encoding="utf-8")
 
-    def test_has_four_step_process(self, prune_md):
-        """Spec is structured as four steps. A step deletion would
-        silently amputate the workflow."""
-        step_headings = re.findall(r"^### Step \d+", prune_md, re.MULTILINE)
-        assert len(step_headings) == 4, (
-            f"prune-memory.md should have exactly 4 steps, found "
-            f"{len(step_headings)}: {step_headings}"
+    def test_has_all_required_steps(self, prune_md):
+        """Spec is a named step sequence, and a step deletion would
+        silently amputate the workflow.
+
+        This guard's STATED purpose has always been deletion-detection.
+        It previously spelled that as `len(step_headings) == 4`, which
+        is both stricter and weaker than the intent: stricter because it
+        rejects a justified ADDITION, and weaker because a count cannot
+        say WHICH step vanished — swapping two steps for two others
+        passes it. Pinning the steps BY NAME is strictly better
+        deletion-detection, so the rewrite is a correction to the
+        assertion rather than a relaxation of the guard.
+
+        The floor permits justified addition — an archive-and-verify
+        step was added when eviction became archive-gated — while any
+        rename or removal of a named step still fails.
+        """
+        headings = re.findall(r"^### Step \d+ — (.+)$", prune_md, re.MULTILINE)
+        for required in ("Read the evictable-pin list", "Ask the curator",
+                         "Archive the selected pin", "Remove the selected pin",
+                         "Report"):
+            assert any(required in h for h in headings), (
+                f"prune-memory.md missing required step {required!r}; "
+                f"found {headings}"
+            )
+        assert len(headings) >= 5, (
+            f"prune-memory.md should have at least 5 steps, found "
+            f"{len(headings)}: {headings}"
         )
+
+    def test_decision_prompt_frames_removal_as_demotion(self, prune_md):
+        """The AskUserQuestion prompt is the DECISION SURFACE — the one
+        sentence the curator reads at the moment they choose to give up a
+        pin — so it is where the demotion framing has to hold. Prose
+        elsewhere in the file explaining that demotion preserves content
+        does not reach a curator who reads only the prompt.
+
+        SCOPED TO THE PROMPT TEXT, deliberately. A file-wide ban on
+        'evict' is impossible and would be wrong: `evictable_pins` is the
+        CLI's field name, and 'eviction' is the accurate technical term
+        in the instructions addressed to the executing agent. The word is
+        only misleading where it describes the CONSEQUENCE to the curator,
+        which is this one line.
+
+        The negative arm is what makes this non-vacuous: a positive-only
+        check passes on a prompt reading 'Demote or evict?'.
+        """
+        prompts = re.findall(r'^\s*question:\s*"([^"]*)"', prune_md, re.MULTILINE)
+        # Guard the guard: if the AskUserQuestion block is ever restructured
+        # so no prompt is extractable, this test must fail loudly rather
+        # than pass over an empty list.
+        assert prompts, (
+            "no AskUserQuestion `question:` line found in prune-memory.md — "
+            "this guard cannot verify a decision surface it cannot locate"
+        )
+        for prompt in prompts:
+            assert re.search(r"demote", prompt, re.IGNORECASE), (
+                f"decision prompt {prompt!r} does not frame the action as "
+                "demotion; AC-B3 requires the curator-facing wording to say "
+                "the content is preserved, not removed"
+            )
+            for banned in ("evict", "delete"):
+                assert banned not in prompt.lower(), (
+                    f"decision prompt {prompt!r} contains {banned!r}; the "
+                    "prompt describes the consequence to the curator and "
+                    "must not imply the pin is discarded"
+                )
 
     def test_references_advisory_cli(self, prune_md):
         """Step 1 must point curators at check_pin_caps --status."""

--- a/pact-plugin/tests/test_prune_telemetry_contract.py
+++ b/pact-plugin/tests/test_prune_telemetry_contract.py
@@ -116,18 +116,54 @@ def test_documented_payload_validates_against_the_shipped_schema(
     example rather than parsing freeform prose. If either side drifts, the
     documented example stops validating.
     """
-    payloads = re.findall(r"<<'JSON'\n(.*?)\nJSON", prune_md, re.DOTALL)
-    assert payloads, (
-        "no quoted-heredoc JSON payload found in prune-memory.md — this "
-        "test cannot validate an example it cannot locate. Re-aim the "
-        "extraction rather than deleting this line: without it, zero "
-        "payloads would pass as 'all payloads valid'."
+    # EACH FENCE IS PARSED AS A UNIT — the type and the payload are taken
+    # from the SAME block. This replaces an earlier form that gathered two
+    # flat lists over the document and `zip`ped them, which had three
+    # defects, all silent:
+    #   - a bare `--type` in PROSE joined the type list and SHIFTED the
+    #     pairing, validating a payload against the WRONG schema — and
+    #     passing;
+    #   - `zip` TRUNCATED to the shorter list, so a surplus payload or type
+    #     vanished and the completeness half went vacuous while green;
+    #   - even at equal length the lists could be MIS-ORDERED, which a count
+    #     assertion is blind to by construction.
+    # Pairing within a block removes all three by construction rather than
+    # detecting them. The first was found by `coder-prose` in this test,
+    # which is my own.
+    #
+    # The ordering risk was NOT hypothetical: two emit sites exist, and a
+    # swapped pairing was caught only because the two schemas happen to
+    # differ enough to fail validation. That is the SCHEMAS doing the work,
+    # not this test, and it stops the moment two events share a field shape.
+    blocks = re.findall(r"```bash\n(.*?)```", prune_md, re.DOTALL)
+    assert blocks, (
+        "no ```bash fence found in prune-memory.md — this test cannot "
+        "locate the emit sites it validates. Re-aim rather than deleting: "
+        "an empty scan yields zero pairs, which would pass as "
+        "'all payloads valid'."
     )
 
-    emitted_types = re.findall(r"--type\s+(\S+)", prune_md)
-    assert emitted_types, "no `--type` invocation found in prune-memory.md"
+    pairs = []
+    for block in blocks:
+        types = re.findall(r"--type\s+(\S+)", block)
+        payloads = re.findall(r"<<'JSON'\n(.*?)\nJSON", block, re.DOTALL)
+        if not types and not payloads:
+            continue  # a fence that emits nothing (e.g. a plain CLI call)
+        assert len(types) == 1 and len(payloads) == 1, (
+            f"a bash fence carries {len(types)} `--type` invocation(s) and "
+            f"{len(payloads)} JSON payload(s); each emit fence must carry "
+            "exactly one of each so the pairing is unambiguous. Split the "
+            "fence rather than relaxing this — a fence with two of either "
+            "cannot be paired without reintroducing positional guessing."
+        )
+        pairs.append((types[0], payloads[0]))
 
-    for raw, event_type in zip(payloads, emitted_types):
+    assert pairs, (
+        "no bash fence contains BOTH a `--type` invocation and a JSON "
+        "payload — this test cannot validate an emit it cannot locate."
+    )
+
+    for event_type, raw in pairs:
         assert event_type in pin_event_types, (
             f"prune-memory.md emits --type {event_type!r}, which is not "
             "registered in _REQUIRED_FIELDS_BY_TYPE. An unregistered type "

--- a/pact-plugin/tests/test_prune_telemetry_contract.py
+++ b/pact-plugin/tests/test_prune_telemetry_contract.py
@@ -1,0 +1,194 @@
+"""The prose<->journal-registry seam for /PACT:prune-memory telemetry.
+
+THIS TEST DELIBERATELY SPANS TWO OWNERS, and that is the reason it exists
+rather than an awkwardness to apologise for.
+
+`commands/prune-memory.md` (command prose) EMITS journal events.
+`hooks/shared/session_journal.py` (Python) VALIDATES them. Neither file's
+own test suite can see the other: the suites reading the prose carry no
+`session_journal` import, and the suites exercising the registry never read
+the prose. So the contract between them was correct only BY INSPECTION --
+a rename, a field change or a typo on either side would drift silently,
+with both suites green.
+
+That is the same shape as two defects already found in this feature's CODE
+phase: a contract spanning two agents' file boundaries, invisible from
+inside either scope by construction. A test that belongs to neither owner
+is the only kind that can hold it.
+
+WHAT THIS DOES *NOT* COVER, stated so a later reader does not over-trust it:
+the `outcome` VALUE set (`cancelled` / `no_candidates` / `unknown_state` /
+`archive_refused` / `unverified_eviction`) has NO single source of truth.
+`_REQUIRED_FIELDS_BY_TYPE` types `outcome` as `str`, not as a value set, and
+the writer is not enum-gated -- so `outcome="banana"` validates green today.
+Pinning those five strings HERE would mint a THIRD source of truth (prose,
+this test, and nowhere authoritative) rather than connect two, so it is
+deliberately not done. Tracked as a named residual; the fix is to constrain
+the value set at the registry, which is where a value-set contract belongs.
+"""
+import importlib.util
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load(name, relpath):
+    spec = importlib.util.spec_from_file_location(name, _PLUGIN_ROOT / relpath)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def journal():
+    return _load("session_journal", "hooks/shared/session_journal.py")
+
+
+@pytest.fixture(scope="module")
+def prune_md():
+    return (_PLUGIN_ROOT / "commands" / "prune-memory.md").read_text(
+        encoding="utf-8"
+    )
+
+
+@pytest.fixture(scope="module")
+def pin_event_types(journal):
+    """The registry's pin-related event types, read from the REGISTRY.
+
+    Derived from the Python side rather than from a literal list here, so a
+    newly registered `pin_*` type is picked up automatically and must then
+    justify its absence from the prose.
+    """
+    return {
+        name: fields
+        for name, fields in journal._REQUIRED_FIELDS_BY_TYPE.items()
+        if name.startswith("pin_")
+    }
+
+
+def test_registry_pin_types_are_the_expected_two(pin_event_types):
+    """NON-VACUITY GATE for every test below that iterates this selection.
+
+    A `pin_` prefix typo, a rename, or a registry restructure yields an
+    EMPTY selection -- and an empty selection makes every loop below pass
+    over nothing. That is the vacuous-loop green: a test reporting success
+    while measuring nothing, which is the exact defect this whole feature
+    exists to remove. Asserting the cardinality BEFORE anything iterates is
+    what stops this suite shipping that defect inside the test written to
+    close a seam.
+    """
+    assert set(pin_event_types) == {"pin_prune_skipped", "pin_pruned"}, (
+        f"expected exactly the two pin telemetry types, got "
+        f"{sorted(pin_event_types)}"
+    )
+
+
+def test_every_registered_pin_type_appears_in_the_prose(
+    pin_event_types, prune_md
+):
+    """Driven FROM the registry, which catches drift in BOTH directions.
+
+    Rename the registry key and the new name is absent from the prose ->
+    fails. Rename it in the prose and the registered key is absent -> fails.
+    A prose-driven check would only catch the first.
+    """
+    for event_type in pin_event_types:
+        assert event_type in prune_md, (
+            f"journal type {event_type!r} is registered in "
+            f"_REQUIRED_FIELDS_BY_TYPE but never named in prune-memory.md — "
+            "the emitting prose and the validating schema have drifted"
+        )
+
+
+def test_documented_payload_validates_against_the_shipped_schema(
+    journal, prune_md, pin_event_types
+):
+    """The payload a curator is TOLD to emit must pass the schema that will
+    validate it.
+
+    This is stronger than comparing key names, and it is why the parse here
+    is safe rather than a new drift surface: the prose carries a real
+    heredoc JSON literal, so this extracts a bounded, machine-checkable
+    example rather than parsing freeform prose. If either side drifts, the
+    documented example stops validating.
+    """
+    payloads = re.findall(r"<<'JSON'\n(.*?)\nJSON", prune_md, re.DOTALL)
+    assert payloads, (
+        "no quoted-heredoc JSON payload found in prune-memory.md — this "
+        "test cannot validate an example it cannot locate. Re-aim the "
+        "extraction rather than deleting this line: without it, zero "
+        "payloads would pass as 'all payloads valid'."
+    )
+
+    emitted_types = re.findall(r"--type\s+(\S+)", prune_md)
+    assert emitted_types, "no `--type` invocation found in prune-memory.md"
+
+    for raw, event_type in zip(payloads, emitted_types):
+        assert event_type in pin_event_types, (
+            f"prune-memory.md emits --type {event_type!r}, which is not "
+            "registered in _REQUIRED_FIELDS_BY_TYPE. An unregistered type "
+            "validates VACUOUSLY — the writer is not enum-gated."
+        )
+        event = dict(json.loads(raw), type=event_type, v=1)
+        ok, message = journal._validate_event_schema(event)
+        assert ok, (
+            f"the payload prune-memory.md documents for {event_type!r} does "
+            f"NOT validate against the shipped schema: {message}"
+        )
+
+
+def test_the_validator_rejects_malformed_payloads(journal):
+    """NON-VACUITY CONTROL for the test above.
+
+    A validator that accepted everything would make the documented-payload
+    check pass while measuring nothing. These prove it discriminates, so a
+    green above means the example is genuinely well-formed.
+    """
+    base = {
+        "type": "pin_prune_skipped", "v": 1, "outcome": "cancelled",
+        "pin_count": 12,
+        "age_distribution": {"oldest": 60, "newest": 3, "median": 33},
+    }
+    assert journal._validate_event_schema(base)[0], "control payload must pass"
+
+    for description, mutation in [
+        ("missing required field", {k: v for k, v in base.items()
+                                    if k != "pin_count"}),
+        ("wrong scalar type", dict(base, pin_count="12")),
+        ("bool where int expected", dict(base, pin_count=True)),
+        ("empty required string", dict(base, outcome="")),
+        ("wrong container type", dict(base, age_distribution="oldest=60")),
+    ]:
+        ok, _ = journal._validate_event_schema(mutation)
+        assert not ok, f"validator accepted a malformed payload: {description}"
+
+
+def test_pin_pruned_cannot_be_emitted_for_an_unverified_eviction(journal):
+    """The escape-hatch invariant, enforced STRUCTURALLY rather than by prose.
+
+    An escape-hatch eviction has no `memory_id` — that is what makes it
+    unverified. `pin_pruned` requires a non-empty one, so the success event
+    is unemittable on that path by construction and such an eviction can
+    only be filed under `pin_prune_skipped`. The schema enforces the
+    semantic instead of trusting the prose to, which matters because prose
+    rules failing is this feature's founding premise.
+    """
+    for value in ("", "   ", "\t"):
+        ok, _ = journal._validate_event_schema({
+            "type": "pin_pruned", "v": 1, "heading": "Some Pin",
+            "memory_id": value, "pin_count": 12,
+        })
+        assert not ok, (
+            f"pin_pruned validated with memory_id={value!r} — an eviction "
+            "with no archive record could then be filed as a SUCCESS"
+        )
+
+    ok, _ = journal._validate_event_schema({
+        "type": "pin_pruned", "v": 1, "heading": "Some Pin",
+        "memory_id": "a" * 32, "pin_count": 12,
+    })
+    assert ok, "a well-formed pin_pruned event must still validate"

--- a/pact-plugin/tests/test_prune_telemetry_contract.py
+++ b/pact-plugin/tests/test_prune_telemetry_contract.py
@@ -177,6 +177,81 @@ def test_documented_payload_validates_against_the_shipped_schema(
         )
 
 
+def test_emitted_outcomes_are_declared_in_the_exit_table(prune_md):
+    """Narrow value-set pin for THIS event family only.
+
+    WHY THIS EXISTS NOW WHEN THIS FILE'S OWN DOCSTRING DECLINED IT. The
+    module header states that the `outcome` VALUE set has no SSOT and that
+    pinning the values here would mint a THIRD source of truth. That was
+    the right call when the value set was incidental. A design change made
+    it load-bearing: the registry pins event TYPES, so a new type surfaces
+    as a completeness failure, but NOTHING pins values — so reusing an
+    existing outcome for a new situation passes every test we have.
+
+    The cost is specific rather than cosmetic. `session_journal.py` calls
+    `archive_refused` "the highest-value row — a run of refusals is the
+    signal that the archival mechanism itself is broken." Reusing it for a
+    case where the archive SUCCEEDED poisons the diagnostic that row
+    exists to carry: a run of them reads as a broken archiver while every
+    archive in the run worked. A false positive built into the monitoring
+    channel of the feature whose purpose is a trustworthy audit trail.
+
+    NO THIRD COPY IS MINTED. The exit table in prune-memory.md is treated
+    as the SSOT and this test is only its checker — the values are read
+    from the table, never restated here. That is the same shape as the
+    type bridge above, one level down from type to value.
+
+    WHAT THIS DOES NOT CATCH, stated because the bound is the point:
+      - the TABLE itself declaring a wrong value — it is the source, so
+        this cannot audit it;
+      - SEMANTIC misuse, i.e. a payload correctly using a declared value
+        for the wrong situation. That is the `archive_refused`-for-a-
+        delete-unsafe case, and it is not mechanically decidable here;
+      - runtime rejection. `_validate_event_schema` still accepts any
+        string for `outcome`; general enum-gating of the registry is
+        deliberately a separate cycle. This pins the DOCUMENT, not the
+        writer.
+    """
+    declared = set(
+        re.findall(
+            r"^\|[^|]+\|\s*`pin_prune_skipped`\s*\|\s*`([a-z_]+)`\s*\|",
+            prune_md,
+            re.MULTILINE,
+        )
+    )
+    assert declared, (
+        "no `pin_prune_skipped` rows found in prune-memory.md's exit table "
+        "— this test cannot check emitted values against a declaration it "
+        "cannot locate. Re-aim the extraction rather than deleting this "
+        "line: an empty declared set makes every membership check below "
+        "pass vacuously."
+    )
+
+    blocks = re.findall(r"```bash\n(.*?)```", prune_md, re.DOTALL)
+    emitted = set()
+    for block in blocks:
+        if "--type pin_prune_skipped" not in block:
+            continue
+        for raw in re.findall(r"<<'JSON'\n(.*?)\nJSON", block, re.DOTALL):
+            value = json.loads(raw).get("outcome")
+            if value is not None:
+                emitted.add(value)
+
+    assert emitted, (
+        "no `pin_prune_skipped` payload carrying an `outcome` was found in "
+        "a bash fence — nothing to check against the exit table."
+    )
+
+    undeclared = emitted - declared
+    assert not undeclared, (
+        f"payload(s) emit outcome(s) {sorted(undeclared)} that the exit "
+        f"table does not declare (declared: {sorted(declared)}). An "
+        "undeclared value validates green today — the schema types "
+        "`outcome` as `str` — so this document check is the only thing "
+        "standing between a typo and a poisoned audit trail."
+    )
+
+
 def test_the_validator_rejects_malformed_payloads(journal):
     """NON-VACUITY CONTROL for the test above.
 

--- a/pact-plugin/tests/test_session_journal.py
+++ b/pact-plugin/tests/test_session_journal.py
@@ -3405,6 +3405,20 @@ class TestValidateEventSchemaPerType:
             "feature": "handoff-artifact-durability",
             "paths": ["/tmp/wt/docs/preparation/handoff-artifact-durability.md"],
         },
+        # Required fields only — `reason` is optional (not obtainable on a
+        # bare Cancel), so it must NOT appear here: the missing-field test
+        # strips each sample key and expects rejection, which holds only for
+        # required ones.
+        "pin_prune_skipped": {
+            "outcome": "archive_refused",
+            "pin_count": 12,
+            "age_distribution": {"oldest": 60, "newest": 4, "median": 21},
+        },
+        "pin_pruned": {
+            "heading": "Coupling-via-substring-count",
+            "memory_id": "396c1c8bfd013ecab3bc1608ed813627",
+            "pin_count": 12,
+        },
     }
 
     def test_samples_mirror_required_fields_dict(self):
@@ -3858,6 +3872,131 @@ class TestValidateOptionalFieldTypes:
         from shared.session_journal import _OPTIONAL_FIELDS_BY_TYPE
 
         assert _OPTIONAL_FIELDS_BY_TYPE.get("session_start") == {"source": str}
+
+    def test_pin_pruned_requires_a_memory_id(self):
+        """`memory_id` is what makes the success claim CHECKABLE.
+
+        pin_caps_gate ALLOWS the eviction Edit by construction, so nothing
+        mechanically enforces that the archive ran — detectability is the
+        whole remaining control. An event that asserted "pruned" without an
+        id would be a success report with nothing behind it; with the id an
+        auditor can fetch the record and confirm.
+        """
+        from shared.session_journal import (
+            _REQUIRED_FIELDS_BY_TYPE,
+            _validate_event_schema,
+            make_event,
+        )
+
+        assert _REQUIRED_FIELDS_BY_TYPE["pin_pruned"]["memory_id"] is str
+        ok, reason = _validate_event_schema(
+            make_event("pin_pruned", heading="H", pin_count=12)
+        )
+        assert ok is False
+        assert "memory_id" in reason
+
+    def test_pin_pruned_cannot_be_emitted_for_an_unverified_eviction(self):
+        """A structural property the two schemas give us for free, and the
+        reason the escape-hatch eviction is filed under the SKIP event.
+
+        An UNEVALUABLE archive yields no memory_id, and `str` fields reject
+        empty and whitespace-only values — so there is no way to emit
+        pin_pruned for an eviction that was never archived. The schema
+        enforces the semantic rather than trusting the prose to remember it.
+        """
+        from shared.session_journal import _validate_event_schema, make_event
+
+        for unusable in ("", "   ", None):
+            ok, _ = _validate_event_schema(
+                make_event("pin_pruned", heading="H", memory_id=unusable,
+                           pin_count=12)
+            )
+            assert ok is False, (
+                f"memory_id={unusable!r} must not produce a valid pin_pruned "
+                f"— that would let an unverified eviction masquerade as an "
+                f"archived one"
+            )
+
+    def test_pin_pruned_carries_no_outcome_field(self):
+        """Deliberate asymmetry with pin_prune_skipped.
+
+        Only REQUIRED fields are validated. An `outcome` on pin_pruned would
+        be unvalidated, so it would sit in the audit trail looking
+        authoritative while guaranteed by nothing. The event's existence IS
+        its outcome.
+        """
+        from shared.session_journal import (
+            _OPTIONAL_FIELDS_BY_TYPE,
+            _REQUIRED_FIELDS_BY_TYPE,
+        )
+
+        assert "outcome" not in _REQUIRED_FIELDS_BY_TYPE["pin_pruned"]
+        assert "outcome" not in _OPTIONAL_FIELDS_BY_TYPE.get("pin_pruned", {})
+        assert "outcome" in _REQUIRED_FIELDS_BY_TYPE["pin_prune_skipped"], (
+            "the skip event still needs its outcome — this test pins the "
+            "asymmetry, not the absence of outcomes everywhere"
+        )
+
+    def test_pin_count_is_int_and_rejects_bool_on_both_pin_events(self):
+        """`bool` subclasses `int`, so an unquoted `true` in the --data JSON
+        would satisfy a naive isinstance check and land a nonsense count."""
+        from shared.session_journal import _validate_event_schema, make_event
+
+        ok, _ = _validate_event_schema(
+            make_event("pin_pruned", heading="H", memory_id="a" * 32,
+                       pin_count=True)
+        )
+        assert ok is False
+        ok, _ = _validate_event_schema(
+            make_event("pin_prune_skipped", outcome="cancelled",
+                       pin_count=True, age_distribution={})
+        )
+        assert ok is False
+
+    def test_pin_prune_skipped_reason_declared_optional(self):
+        """`reason` is optional on pin_prune_skipped, and that is a decision
+        rather than an oversight.
+
+        A bare Cancel elicits no reason. Requiring the field would force
+        either an extra prompt on every cancellation or a fabricated value —
+        and emitting a field we cannot populate is a success report with no
+        measurement behind it, the exact defect class this feature exists to
+        remove. Declaring it optional-with-a-type keeps the contract (a
+        non-string reason is still rejected) without demanding a value the
+        flow cannot supply.
+        """
+        from shared.session_journal import (
+            _OPTIONAL_FIELDS_BY_TYPE,
+            _REQUIRED_FIELDS_BY_TYPE,
+        )
+
+        assert _OPTIONAL_FIELDS_BY_TYPE.get("pin_prune_skipped") == {
+            "reason": str
+        }
+        assert "reason" not in _REQUIRED_FIELDS_BY_TYPE["pin_prune_skipped"]
+
+    def test_pin_prune_skipped_accepts_reason_and_rejects_wrong_type(self):
+        """Optional means absent-is-fine, present-must-be-typed."""
+        from shared.session_journal import _validate_event_schema, make_event
+
+        base = {
+            "outcome": "archive_refused",
+            "pin_count": 12,
+            "age_distribution": {"oldest": 60, "newest": 4, "median": 21},
+        }
+        ok, _ = _validate_event_schema(make_event("pin_prune_skipped", **base))
+        assert ok is True, "absent reason must validate"
+
+        ok, _ = _validate_event_schema(
+            make_event("pin_prune_skipped", **base,
+                       reason="archival refused: containment failed")
+        )
+        assert ok is True, "string reason must validate"
+
+        ok, _ = _validate_event_schema(
+            make_event("pin_prune_skipped", **base, reason=["a", "list"])
+        )
+        assert ok is False, "non-string reason must be rejected"
 
     def test_session_refreshed_optionals_declared(self):
         """session_refreshed declares the seven optional mid-flight fields.


### PR DESCRIPTION
`/PACT:prune-memory` could destroy the only copy of a pin, and `/PACT:pin-memory` reported a durable commit it had not made. Both are fixed, and the behavioural acceptance criteria filed against `/PACT:prune-memory` are implemented.

## What changed

**Demotion, not deletion.** `archive_pin.py` saves the pin's verbatim source span to pact-memory, and the command refuses the eviction unless containment is confirmed at the destination. Verdicts are three-outcome — archived / not-archived / unevaluable — and an unevaluable result refuses, so the pin survives rather than the eviction proceeding. Spans are sliced from the source rather than rebuilt from parts, with both edges computed by one helper so they partition: rebuilding was verbatim for only 2 of 5 plausible pin formats, and ending a span at the next heading put the following pin's date comment inside it for 10 of 11 live pins. Neither defect is visible to a containment check, which tests a span's contents and not its boundaries.

**An age signal that fires.** `check_pin_caps --status` gains additive `age_days` / `overdue` computed from the pinned-date comment. The marker-based `stale` flag never fires on the documented pin format — 6 of 11 live pins are past the 30-day threshold and none were flagged. Eviction review orders stale-first and asks for justification on the evicted and borderline pins.

**Telemetry that can detect a skip.** Every invocation emits exactly one journal event — `pin_pruned` on success, `pin_prune_skipped` on the five no-eviction exits — so a silent invocation is itself the anomaly. Both types are registered in `_REQUIRED_FIELDS_BY_TYPE` and `TestValidateEventSchemaPerType`; an unregistered type validates vacuously. `pin_pruned` requires a non-empty `memory_id`, which makes it structurally impossible to emit on the escape-hatch path.

**Commit verification that checks the right thing.** Both commands verify `CLAUDE.md`'s presence in the resulting commit rather than the commit's exit status. A commit touching only an ignored `CLAUDE.md` exits 1; a blanket `commit -am` sweeping other changed files exits 0 and omits it silently. The conditional voice preserves durability for consumers whose `CLAUDE.md` is tracked — the original unconditional form would have stripped it.

## Guard repairs

Three shipped guards asserted less than they read as asserting:

- The heredoc guard stopped covering three expanding forms it covered at base, while banning `<<"EOF"`, which bash does not expand. Replaced by a form table measured against real bash plus a whole-document scan, each with its own non-vacuity assertion. Fence-scoping is deliberately not used: a scoped scan passes over a renamed fence and misses a heredoc that moves outside one.
- The step-name assertion used `any()`, so one heading could satisfy two required names and folding a step into a sibling's title still passed. Replaced with a consuming bijection.
- An assert message stated a general rule its assertion only established for its fixture. A passing assert never renders its message, so the false generalisation was invisible to the suite.

A new cross-boundary test bridges the command prose to the journal registry. The contract spans two files owned by different specialists, and no test read one against the other — which is why it exists in its own file.

## Verification

12793 passed, 15 skipped, 0 errors. **Skip count unchanged from baseline**, so nothing was quietly skipped. Each commit verified in isolation via `git archive` against a base control. Guards counter-tested by importing the shipped test classes and invoking their methods against mutated content, so the assertions proven are the assertions that ship.

## Known residuals

- The journal's `outcome` field is typed `str` with no value constraint, so a typo validates green. Registering the event type closed one axis; the value set has no SSOT. Ruled to its own cycle — the fix is a general validator capability, not a local patch.
- The heredoc predicate flags arithmetic left-shift. Documented rather than fixed: excluding a preceding identifier character would break `cat<<EOF`, which is legal bash. The direction is an over-block on a construct the guarded file does not contain.