### PR TITLE
Stop the test suite writing to the live pact-memory DB, and make the sync target explicit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.20",
+      "version": "4.6.21",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.20/       # Plugin version
+│               └── 4.6.21/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.20",
+  "version": "4.6.21",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.20
+> **Version**: 4.6.21
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/agents/pact-database-engineer.md
+++ b/pact-plugin/agents/pact-database-engineer.md
@@ -146,8 +146,8 @@ You must escalate when:
 **Self-Coordination**: If working in parallel with other database agents, check S2 protocols first. Respect assigned schema boundaries. First agent's conventions (naming, indexing patterns) become standard. Report conflicts immediately.
 
 **Algedonic Authority**: You can emit algedonic signals (HALT/ALERT) when you recognize viability threats during implementation. You do not need orchestrator permission—emit immediately. Common database triggers:
-- **HALT DATA**: DELETE without WHERE clause, DROP TABLE on production data or on any data whose restore path you have not verified, PII stored unencrypted, foreign key violations risking data integrity
+- **HALT DATA**: DELETE without WHERE clause, any DROP TABLE or other destructive write against production data or against data whose restore path you have not verified by restoring from it, PII stored unencrypted, foreign key violations risking data integrity
 - **HALT SECURITY**: SQL injection vulnerability in stored procedure, overly permissive access grants
 - **ALERT QUALITY**: Migration fails repeatedly, performance degrades significantly
 
-Read [algedonic.md](../protocols/algedonic.md) immediately on detecting a DATA-integrity threat (destructive operation without rollback, schema violation, foreign-key breach, PII exposure in unencrypted columns or logs) or any irreversible change flowing from a migration or query you are authoring, whether to production data or to any data whose restore path you have not verified.
+Read [algedonic.md](../protocols/algedonic.md) immediately on detecting a DATA-integrity threat (destructive operation without rollback, schema violation, foreign-key breach, PII exposure in unencrypted columns or logs) or any irreversible change to production data, or to data whose restore path you have not verified by restoring from it, flowing from a migration or query you are authoring.

--- a/pact-plugin/agents/pact-database-engineer.md
+++ b/pact-plugin/agents/pact-database-engineer.md
@@ -146,8 +146,8 @@ You must escalate when:
 **Self-Coordination**: If working in parallel with other database agents, check S2 protocols first. Respect assigned schema boundaries. First agent's conventions (naming, indexing patterns) become standard. Report conflicts immediately.
 
 **Algedonic Authority**: You can emit algedonic signals (HALT/ALERT) when you recognize viability threats during implementation. You do not need orchestrator permission—emit immediately. Common database triggers:
-- **HALT DATA**: DELETE without WHERE clause, DROP TABLE on production data, PII stored unencrypted, foreign key violations risking data integrity
+- **HALT DATA**: DELETE without WHERE clause, DROP TABLE on production data or on any data whose restore path you have not verified, PII stored unencrypted, foreign key violations risking data integrity
 - **HALT SECURITY**: SQL injection vulnerability in stored procedure, overly permissive access grants
 - **ALERT QUALITY**: Migration fails repeatedly, performance degrades significantly
 
-Read [algedonic.md](../protocols/algedonic.md) immediately on detecting a DATA-integrity threat (destructive operation without rollback, schema violation, foreign-key breach, PII exposure in unencrypted columns or logs) or any irreversible change to production data flowing from a migration or query you are authoring.
+Read [algedonic.md](../protocols/algedonic.md) immediately on detecting a DATA-integrity threat (destructive operation without rollback, schema violation, foreign-key breach, PII exposure in unencrypted columns or logs) or any irreversible change flowing from a migration or query you are authoring, whether to production data or to any data whose restore path you have not verified.

--- a/pact-plugin/agents/pact-n8n.md
+++ b/pact-plugin/agents/pact-n8n.md
@@ -157,10 +157,10 @@ You must escalate when:
 
 **Algedonic Authority**: You can emit algedonic signals (HALT/ALERT) when you recognize viability threats during workflow implementation. You do not need orchestrator permission—emit immediately. Common n8n triggers:
 - **HALT SECURITY**: Credentials exposed in workflow, webhook lacks authentication, sensitive data logged
-- **HALT DATA**: Workflow could corrupt or delete production data or data whose restore path you have not verified, PII handled without encryption
+- **HALT DATA**: Workflow could corrupt or delete production data or data whose restore path you have not verified by restoring from it, PII handled without encryption
 - **ALERT QUALITY**: Validation errors persist after 3+ fix attempts, workflow design has fundamental issues
 
-Read [algedonic.md](../protocols/algedonic.md) immediately on detecting a SECURITY flaw (webhook accepting unauthenticated requests, credential exposure in workflow JSON or expressions, plaintext API key in HTTP node) or a DATA risk (irreversible workflow operation against production data or against data whose restore path you have not verified, missing rate-limit on external write, destructive bulk update without dry-run).
+Read [algedonic.md](../protocols/algedonic.md) immediately on detecting a SECURITY flaw (webhook accepting unauthenticated requests, credential exposure in workflow JSON or expressions, plaintext API key in HTTP node) or a DATA risk (irreversible workflow operation against production data or against data whose restore path you have not verified by restoring from it, missing rate-limit on external write, destructive bulk update without dry-run).
 
 # TEMPLATE DEPLOYMENT
 

--- a/pact-plugin/agents/pact-n8n.md
+++ b/pact-plugin/agents/pact-n8n.md
@@ -157,10 +157,10 @@ You must escalate when:
 
 **Algedonic Authority**: You can emit algedonic signals (HALT/ALERT) when you recognize viability threats during workflow implementation. You do not need orchestrator permission—emit immediately. Common n8n triggers:
 - **HALT SECURITY**: Credentials exposed in workflow, webhook lacks authentication, sensitive data logged
-- **HALT DATA**: Workflow could corrupt or delete production data, PII handled without encryption
+- **HALT DATA**: Workflow could corrupt or delete production data or data whose restore path you have not verified, PII handled without encryption
 - **ALERT QUALITY**: Validation errors persist after 3+ fix attempts, workflow design has fundamental issues
 
-Read [algedonic.md](../protocols/algedonic.md) immediately on detecting a SECURITY flaw (webhook accepting unauthenticated requests, credential exposure in workflow JSON or expressions, plaintext API key in HTTP node) or a DATA risk (irreversible workflow operation against production data, missing rate-limit on external write, destructive bulk update without dry-run).
+Read [algedonic.md](../protocols/algedonic.md) immediately on detecting a SECURITY flaw (webhook accepting unauthenticated requests, credential exposure in workflow JSON or expressions, plaintext API key in HTTP node) or a DATA risk (irreversible workflow operation against production data or against data whose restore path you have not verified, missing rate-limit on external write, destructive bulk update without dry-run).
 
 # TEMPLATE DEPLOYMENT
 

--- a/pact-plugin/scripts/archive_pin.py
+++ b/pact-plugin/scripts/archive_pin.py
@@ -898,13 +898,26 @@ def archive_pin(index: int, db_path=None) -> dict:
     }
 
 
-def build_verdict(index: int, db_path=None) -> dict:
+def build_verdict(index: int, *, db_path) -> dict:
     """Run the archival and return a verdict dict — never raises.
 
     The single place where an unevaluable state becomes an UNEVALUABLE
     verdict, so `main` only has to serialize. Keeping the mapping here
     (rather than inline in `main`) is what lets tests exercise the
     degradation paths without going through argv and stdout.
+
+    `db_path` IS REQUIRED AND KEYWORD-ONLY. It used to default to None,
+    and None means the real store -- so the seam that exists to let tests
+    reach the degradation paths was also the seam that skipped the db-path
+    guard. The decision that made testing easy removed the isolation, and
+    it was silent: a caller that simply said nothing got production.
+
+    Required makes every caller state an answer; keyword-only makes them
+    state it BY NAME, so the answer is legible at the call site rather than
+    being a bare second positional. What it does NOT do is make the answer
+    correct -- `db_path=None` still satisfies the signature and still means
+    the real store. The mechanical protection is the guard in
+    `_run_memory_cli`; this parameter is what makes the choice visible.
     """
     try:
         return archive_pin(index, db_path=db_path)

--- a/pact-plugin/scripts/archive_pin.py
+++ b/pact-plugin/scripts/archive_pin.py
@@ -183,8 +183,13 @@ _ARCHIVE_SUBCOMMAND = "save"
 # its handler and takes no flag, so it does not belong here either.
 #
 # Kept honest by a test that reads the CLI's real parser and asserts this set
-# equals the subparsers actually declaring `--no-sync`. A future syncing
-# subcommand fails that test instead of silently missing the suppression.
+# equals the subparsers actually DECLARING `--no-sync`. Note what that does and
+# does not catch: a subcommand that declares the flag and is missing from this
+# set fails the test, but a subcommand that GAINS A SYNC WITHOUT DECLARING THE
+# FLAG is invisible to it -- the detector compares against declarers, so a
+# non-declarer is outside the population it examines. Closing that would need a
+# different predicate (which handlers project into CLAUDE.md), which the parser
+# does not expose.
 _SYNC_CAPABLE_SUBCOMMANDS = frozenset({"save"})
 
 
@@ -544,9 +549,8 @@ def _run_memory_cli(args, db_path=None, stdin_data=None, cwd=None):
     # `--no-sync` is appended only for subcommands that accept it. It is
     # declared on the `save` subparser alone, so adding it to a `get` would be
     # an argparse error -- an over-block manufactured by the fix. The set is a
-    # named constant with a test pinning it against the CLI's real parser, so
-    # a future syncing subcommand fails that test rather than silently
-    # slipping past this branch.
+    # named constant pinned against the CLI's real parser by a test; see
+    # `_SYNC_CAPABLE_SUBCOMMANDS` for what that test does and does not catch.
     env = dict(os.environ)
     if cwd is not None:
         env["CLAUDE_PROJECT_DIR"] = str(cwd)

--- a/pact-plugin/scripts/archive_pin.py
+++ b/pact-plugin/scripts/archive_pin.py
@@ -466,6 +466,26 @@ def _run_memory_cli(args, db_path=None, stdin_data=None, cwd=None):
     if not _MEMORY_CLI.exists():
         raise _Unevaluable(f"memory CLI not found at {_MEMORY_CLI}")
 
+    # FALSY-BUT-PRESENT, rejected under pytest. The line below tests db_path
+    # for TRUTHINESS, so `db_path=""` takes the same branch as an omitted one
+    # and routes to production -- a required-parameter fix defeated without
+    # removing the parameter. A caller that names db_path and passes an empty
+    # value has stated an intention the truthiness test then discards.
+    #
+    # The predicate is `is not None and not db_path`, NOT plain falsiness.
+    # None is the "I am not scoping this call" sentinel and is legitimate on
+    # the paths that never spawn -- six tests reach here with db_path=None
+    # while stubbing subprocess.run or _MEMORY_CLI, and none of them can touch
+    # a store. Rejecting plain falsiness would redden all six for a hazard
+    # they do not have. A real spawn carrying None is caught at the process
+    # boundary instead, in the child, where the decision actually lands.
+    if os.environ.get("PYTEST_CURRENT_TEST") and db_path is not None and not db_path:
+        raise _Unevaluable(
+            "db_path was given as an empty value under pytest; it is falsy, "
+            "so the memory CLI would fall back to the PRODUCTION database. "
+            "Pass a real temp path, or None if this call cannot reach a store."
+        )
+
     argv = [sys.executable, str(_MEMORY_CLI), *args]
     if db_path:
         argv += ["--db-path", db_path]

--- a/pact-plugin/scripts/archive_pin.py
+++ b/pact-plugin/scripts/archive_pin.py
@@ -704,7 +704,8 @@ def archive_pin(index: int, db_path=None) -> dict:
             heading=heading, claude_md_path=claude_md_path,
         )
 
-    def _cli(args, **kwargs):
+    def _cli(args, *, _heading=heading, _block=block, _md=claude_md_path,
+             **kwargs):
         """Invoke the memory CLI, enriching any UNEVALUABLE with pin context.
 
         `_run_memory_cli` raises bare -- correctly, since it is a generic
@@ -722,15 +723,33 @@ def archive_pin(index: int, db_path=None) -> dict:
         missing CLI are the canonical CANNOT-TELL cases -- they are when the
         escape hatch runs -- so the hatch would have had no mechanical
         delete boundary in its own primary use case.
+
+        THE THREE DEFAULT ARGUMENTS ARE THE ENFORCEMENT, NOT DECORATION.
+        `_heading`, `_block` and `_md` capture their enclosing values at `def`
+        TIME instead of closing over the names. The ordering dependency between
+        this one definition site and its three binding sites is then checked by
+        the interpreter on every run: moving this `def` above any of them
+        raises NameError AT THE `def`. A closure defers that failure into the
+        `except` path below -- which runs only once something else has ALREADY
+        failed -- so the diagnostic would collapse to `internal error:
+        NameError` at precisely the moment the curator needs the delete
+        boundary. Keyword-only, and underscore-prefixed, so no caller supplies
+        them by accident and `**kwargs` still forwards the real arguments
+        untouched.
+
+        The handler reads the PARAMETERS, never the enclosing names. That is
+        load-bearing rather than stylistic: defaults nothing reads would still
+        satisfy the `def` while leaving the handler closing over the originals,
+        which restores the silent failure this shape exists to prevent.
         """
         try:
             return _run_memory_cli(args, **kwargs)
         except _Unevaluable as exc:
             raise _Unevaluable(
                 exc.reason,
-                heading=heading,
-                claude_md_path=claude_md_path,
-                delete_string=block,
+                heading=_heading,
+                claude_md_path=_md,
+                delete_string=_block,
             ) from exc
 
     # --- conjunct 1: save returned a memory_id -----------------------------

--- a/pact-plugin/scripts/archive_pin.py
+++ b/pact-plugin/scripts/archive_pin.py
@@ -166,6 +166,58 @@ _CLI_TIMEOUT_SECONDS = 120
 # generally; it identifies the ones written after it ships.
 ARCHIVE_ENTITY_TYPE = "pact_memory_archive"
 
+
+def is_archive_record(entities) -> bool:
+    """True if `entities` carries ARCHIVE_ENTITY_TYPE as an entity TYPE.
+
+    THE PREDICATE IN CODE, so an audit does not have to reconstruct it from
+    prose. Every prior use of this marker hand-rolled the match at the call
+    site, and the hand-rolled version people reach for first is a SUBSTRING
+    test over the serialised blob -- which also matches a record that merely
+    MENTIONS the marker in a name or a note. Measured on a live store: the
+    substring form returned 19 where this returns 18, and the extra row was a
+    memory ABOUT the marker. A document describing the audit joined the
+    population the audit was counting.
+
+    Accepts the stored JSON string or an already-decoded list.
+
+    TOTAL BY DESIGN: anything unparseable, or shaped unexpectedly, is False
+    rather than an exception. An audit that dies on one malformed row reports
+    nothing; one that skips it reports a floor -- and a floor is what this
+    marker yields anyway, per the scope note above.
+    """
+    if isinstance(entities, (str, bytes)):
+        try:
+            entities = json.loads(entities)
+        except (ValueError, TypeError):
+            return False
+    if not isinstance(entities, list):
+        return False
+    return any(
+        isinstance(item, dict) and item.get("type") == ARCHIVE_ENTITY_TYPE
+        for item in entities
+    )
+
+
+# The same predicate for callers querying the store directly. Bind
+# ARCHIVE_ENTITY_TYPE as the single parameter.
+#
+# ⚠️ `j.type = 'object'` IS LOAD-BEARING AND THE OBVIOUS GUARD DOES NOT WORK.
+# Entity members are not uniformly objects -- a live store held 63 JSON strings
+# among 14092 objects -- and `json_extract` on a bare string raises
+# "malformed JSON", failing the whole query rather than skipping the row.
+#
+# The natural defence, `json_type(j.value) = 'object' AND json_extract(...)`,
+# RAISES IDENTICALLY: `json_type` RE-PARSES the value, so the guard itself
+# throws before the AND can short-circuit. `j.type` is the column `json_each`
+# already computed while walking the array, so it costs no second parse and is
+# the only spelling that filters rather than raising. Verified against a real
+# store on sqlite 3.54.0.
+ARCHIVE_RECORD_COUNT_SQL = (
+    "SELECT COUNT(DISTINCT m.id) FROM memories m, json_each(m.entities) j "
+    "WHERE j.type = 'object' AND json_extract(j.value, '$.type') = ?"
+)
+
 # The memory CLI subcommand archival is permitted to use. See the STANDALONE
 # invariant on `_build_record` / `archive_pin`: an `update` would create no new
 # record and run no marker code, silently voiding the audit property.

--- a/pact-plugin/scripts/archive_pin.py
+++ b/pact-plugin/scripts/archive_pin.py
@@ -472,12 +472,31 @@ def _run_memory_cli(args, db_path=None, stdin_data=None, cwd=None):
 
     # Pin the project for the child process. CLAUDE_PROJECT_DIR is the memory
     # layer's PRIMARY detection strategy and is deterministic, unlike the git
-    # and CWD-walk fallbacks. An existing value is the platform's own
-    # statement of the project and is left alone; we only fill the gap.
+    # and CWD-walk fallbacks.
+    #
+    # An explicit `cwd` is the CALLER'S statement of which project owns this
+    # invocation, so it OVERWRITES any ambient value rather than deferring to
+    # it. This was `setdefault`, which is a no-op when the variable is already
+    # set -- so the ambient value won and the more specific answer lost to the
+    # more general one. The fail direction was inverted.
+    #
+    # That is a PRODUCTION defect, not a test concern. `project_dir_for` exists
+    # so the archive's project derives from the CLAUDE.md actually read, and
+    # `resolve_claude_md` deliberately PERMITS a worktree fall-through: the env
+    # dir is a worktree carrying no CLAUDE.md, so resolution lands on the main
+    # repo's file. Under `setdefault` that filed the archive under the WORKTREE
+    # while the pin lived in the MAIN repo -- exactly the pin/archive
+    # disagreement `project_dir_for` is there to prevent.
+    #
+    # When `cwd` is None this block does not run at all: `env` stays None, and
+    # `subprocess.run(env=None)` hands the child the parent environment
+    # VERBATIM. Nothing above applies to that path. It is not the safe case --
+    # it is the most ambient path in this function, and it resolves from
+    # whatever the invoking environment happens to be.
     env = None
     if cwd is not None:
         env = dict(os.environ)
-        env.setdefault("CLAUDE_PROJECT_DIR", str(cwd))
+        env["CLAUDE_PROJECT_DIR"] = str(cwd)
 
     try:
         proc = subprocess.run(

--- a/pact-plugin/scripts/archive_pin.py
+++ b/pact-plugin/scripts/archive_pin.py
@@ -541,7 +541,7 @@ def _run_memory_cli(args, db_path=None, stdin_data=None, cwd=None):
 
     # FALSY-BUT-PRESENT, rejected under pytest. The line below tests db_path
     # for TRUTHINESS, so `db_path=""` takes the same branch as an omitted one
-    # and routes to production -- a required-parameter fix defeated without
+    # and routes to the live store -- a required-parameter fix defeated without
     # removing the parameter. A caller that names db_path and passes an empty
     # value has stated an intention the truthiness test then discards.
     #
@@ -555,7 +555,7 @@ def _run_memory_cli(args, db_path=None, stdin_data=None, cwd=None):
     if os.environ.get("PYTEST_CURRENT_TEST") and db_path is not None and not db_path:
         raise _Unevaluable(
             "db_path was given as an empty value under pytest; it is falsy, "
-            "so the memory CLI would fall back to the PRODUCTION database. "
+            "so the memory CLI would fall back to the LIVE database. "
             "Pass a real temp path, or None if this call cannot reach a store."
         )
 
@@ -1036,7 +1036,7 @@ def build_verdict(index: int, *, db_path) -> dict:
     and None means the real store -- so the seam that exists to let tests
     reach the degradation paths was also the seam that skipped the db-path
     guard. The decision that made testing easy removed the isolation, and
-    it was silent: a caller that simply said nothing got production.
+    it was silent: a caller that simply said nothing got the live store.
 
     Required makes every caller state an answer; keyword-only makes them
     state it BY NAME, so the answer is legible at the call site rather than

--- a/pact-plugin/scripts/archive_pin.py
+++ b/pact-plugin/scripts/archive_pin.py
@@ -171,6 +171,22 @@ ARCHIVE_ENTITY_TYPE = "pact_memory_archive"
 # record and run no marker code, silently voiding the audit property.
 _ARCHIVE_SUBCOMMAND = "save"
 
+# Memory-CLI subcommands whose handler projects into CLAUDE.md, and which
+# therefore accept `--no-sync`. `_run_memory_cli` suppresses the projection on
+# these when the caller named no project (no `cwd`), because there is then no
+# target to project INTO and inheriting an ambient one would be a guess.
+#
+# NOT a general "commands that touch memory" list, and deliberately narrow:
+# `--no-sync` is declared on the `save` subparser ONLY, so passing it to a
+# subcommand that does not declare it is an argparse error -- the fix would
+# manufacture an over-block on `get`. `search` suppresses its own sync inside
+# its handler and takes no flag, so it does not belong here either.
+#
+# Kept honest by a test that reads the CLI's real parser and asserts this set
+# equals the subparsers actually declaring `--no-sync`. A future syncing
+# subcommand fails that test instead of silently missing the suppression.
+_SYNC_CAPABLE_SUBCOMMANDS = frozenset({"save"})
+
 
 def _load_hook_module(name: str):
     """Load a module from hooks/ by explicit file path.
@@ -508,15 +524,36 @@ def _run_memory_cli(args, db_path=None, stdin_data=None, cwd=None):
     # while the pin lived in the MAIN repo -- exactly the pin/archive
     # disagreement `project_dir_for` is there to prevent.
     #
-    # When `cwd` is None this block does not run at all: `env` stays None, and
-    # `subprocess.run(env=None)` hands the child the parent environment
-    # VERBATIM. Nothing above applies to that path. It is not the safe case --
-    # it is the most ambient path in this function, and it resolves from
-    # whatever the invoking environment happens to be.
-    env = None
+    # THE ENV IS NOW ALWAYS BUILT, and the `cwd is None` case is the reason.
+    # It used to leave `env` as None, and `subprocess.run(env=None)` hands the
+    # child the parent environment VERBATIM -- so the child resolved a
+    # CLAUDE.md from whatever ambient CLAUDE_PROJECT_DIR, git anchor or working
+    # directory happened to be in scope. Measured: with the variable unset and
+    # `cwd` omitted, the child wrote to the invoking repository's real
+    # CLAUDE.md. Every configuration of that branch reached outside the
+    # intended target; only the destination varied.
+    #
+    # NO TARGET IS NOT A LICENCE TO GUESS ONE. A caller that omits `cwd` has
+    # stated no project, so the ambient value is not a weaker answer to the
+    # same question -- it is an answer to a different one. The variable is
+    # therefore REMOVED rather than inherited, and the projection that would
+    # have consumed it is SUPPRESSED. An absent target is a SKIP, never a
+    # CREATE: nothing here invents a path, and nothing writes a CLAUDE.md that
+    # did not already exist.
+    #
+    # `--no-sync` is appended only for subcommands that accept it. It is
+    # declared on the `save` subparser alone, so adding it to a `get` would be
+    # an argparse error -- an over-block manufactured by the fix. The set is a
+    # named constant with a test pinning it against the CLI's real parser, so
+    # a future syncing subcommand fails that test rather than silently
+    # slipping past this branch.
+    env = dict(os.environ)
     if cwd is not None:
-        env = dict(os.environ)
         env["CLAUDE_PROJECT_DIR"] = str(cwd)
+    else:
+        env.pop("CLAUDE_PROJECT_DIR", None)
+        if args and args[0] in _SYNC_CAPABLE_SUBCOMMANDS and "--no-sync" not in args:
+            argv.append("--no-sync")
 
     try:
         proc = subprocess.run(

--- a/pact-plugin/scripts/archive_pin.py
+++ b/pact-plugin/scripts/archive_pin.py
@@ -856,6 +856,19 @@ def archive_pin(index: int, db_path=None) -> dict:
     if not memory_id:
         # A definite failure of the save itself: the store was reachable and
         # said no. NOT_ARCHIVED, not UNEVALUABLE.
+        #
+        # ONE STATED EXCEPTION TO THAT CRITERION. The child-side guard in
+        # cli.py refuses BEFORE opening any store, so "reachable and said no"
+        # does not describe it -- yet it lands here, deliberately. UNEVALUABLE
+        # buys the escape hatch (print the pin, permit manual removal), which
+        # exists so a curator with a broken CLI is not TRAPPED; this refusal
+        # has a one-line fix, so offering hand-deletion would be more
+        # destructive than the refusal it replaced. The routing follows the
+        # DISPOSITION, not the label.
+        #
+        # ⚠️ So this criterion is narrower than it reads. Any future logic that
+        # keys on it PROGRAMMATICALLY -- "NOT_ARCHIVED implies the store
+        # answered" -- is wrong for this one cause. Read the reason string.
         return {
             "outcome": "NOT_ARCHIVED",
             "heading": heading,

--- a/pact-plugin/skills/pact-memory/scripts/cli.py
+++ b/pact-plugin/skills/pact-memory/scripts/cli.py
@@ -70,6 +70,77 @@ def _error(error_type, message, exit_code=1, **extra) -> NoReturn:
     sys.exit(exit_code)
 
 
+def _refuse_production_db_under_pytest(db_path) -> None:
+    """Refuse the production store when a TEST PROCESS spawned us.
+
+    THE DEFECT THIS CLOSES. `--db-path` is how a test scopes its writes, and
+    omitting it silently selects the developer's real `memory.db`. A test that
+    forgets it does not fail -- it succeeds, against production. Requiring the
+    parameter upstream makes the choice visible but not safe: the value may
+    still be None, and an empty string is falsy, so it takes the same branch.
+    This is the mechanical half.
+
+    WHY AN ENVIRONMENT VARIABLE AND NOT `"pytest" in sys.modules`. This process
+    is a FRESH INTERPRETER: the parent runs pytest, we do not. Measured on both
+    branches of the caller's env construction -- `"pytest" in sys.modules` is
+    FALSE here, every time. So a child-side guard cannot detect pytest by
+    introspection and must key on something INHERITED. `PYTEST_CURRENT_TEST` is
+    the only standard signal that crosses the boundary. The choice is FORCED,
+    not preferred; an in-process check is not an available alternative.
+
+    WHY IT IS GATED, AND WHY THE GATE IS NOT OPTIONAL. `archive_pin --index N`
+    is the curator's documented production invocation and it passes NO
+    `--db-path` -- production SHOULD use the real store. An ungated refusal
+    would break that command outright, and it is the command
+    `/PACT:prune-memory` keys its refuse-or-proceed decision on. That is a
+    cardinal over-block on the one path whose purpose is not destroying
+    content. Outside pytest this function returns immediately.
+
+    DEPENDENCY WITH AN `ALLOW` FAIL DIRECTION -- the reason its tripwire test
+    is not optional. This guard works only because the spawning parent hands us
+    a FULL copy of its environment. Hardening that to a minimal allowlist is a
+    plausible and otherwise desirable change, and it would DISABLE this guard
+    silently while every test still passed. Nothing here can detect that; the
+    detector is the test asserting the child actually receives the variable.
+
+    SCOPE: SPAWNED CHILDREN ONLY, and the `sys.modules` check is what enforces
+    it. `main()` is also called IN-PROCESS by the CLI's own unit tests, which
+    patch `PACTMemory` and open no store at all -- and one of them exists
+    precisely to assert that an omitted `--db-path` yields `db_path=None`.
+    Firing there would refuse a contract the CLI is supposed to have. Because
+    an in-process caller DOES have pytest imported, that case is separable,
+    and the same fact that forces the env signal for children also identifies
+    them: `"pytest" not in sys.modules` means "I am a fresh interpreter".
+
+    This is the guard's specified reach, not a concession to those tests: the
+    design bounds it to subprocess spawns and records that the in-process
+    class is out of its range, covered upstream by `build_verdict`'s required
+    parameter and by the caller-side falsy-but-present rejection. RESIDUAL,
+    stated rather than implied: an in-process `main()` call with a real
+    `PACTMemory` and no `--db-path` would still reach the production store.
+    Nothing here catches that, and nothing currently does it.
+
+    BOUNDED GAP, stated rather than implied: pytest POPS `PYTEST_CURRENT_TEST`
+    between items, so it is absent during collection and around
+    session-scoped-fixture setup. A spawn from either of those is NOT covered.
+    """
+    if db_path is not None:
+        return
+    if "pytest" in sys.modules:
+        return          # in-process caller -- out of this guard's scope
+    current_test = os.environ.get("PYTEST_CURRENT_TEST")
+    if not current_test:
+        return
+    _error(
+        "UNSCOPED_TEST_DB",
+        "refusing to open the production memory database: this process was "
+        "spawned from a pytest run and no --db-path was given, so the write "
+        "would land in the developer's real store. Pass --db-path pointing at "
+        f"a temporary database. Spawned during: {current_test}",
+        exit_code=2,
+    )
+
+
 def _scrub(msg: str) -> str:
     """
     Replace the user's home directory with '~' in an error message.
@@ -483,6 +554,12 @@ def main(argv=None):
         _error("UNKNOWN_COMMAND", f"Unknown command: {args.command}")
 
     db_path = Path(args.db_path) if args.db_path else None
+
+    # Checked AFTER the falsy coercion above, deliberately: `--db-path ""`
+    # collapses to None there, so guarding the coerced value covers the empty
+    # string on the same branch as an omitted flag rather than needing a
+    # second predicate for it.
+    _refuse_production_db_under_pytest(db_path)
 
     try:
         handler(args, db_path=db_path)

--- a/pact-plugin/skills/pact-memory/scripts/cli.py
+++ b/pact-plugin/skills/pact-memory/scripts/cli.py
@@ -70,13 +70,13 @@ def _error(error_type, message, exit_code=1, **extra) -> NoReturn:
     sys.exit(exit_code)
 
 
-def _refuse_production_db_under_pytest(db_path) -> None:
-    """Refuse the production store when a TEST PROCESS spawned us.
+def _refuse_live_db_under_pytest(db_path) -> None:
+    """Refuse the live store when a TEST PROCESS spawned us.
 
     THE DEFECT THIS CLOSES. `--db-path` is how a test scopes its writes, and
     omitting it silently selects the developer's real `memory.db`. A test that
-    forgets it does not fail -- it succeeds, against production. Requiring the
-    parameter upstream makes the choice visible but not safe: the value may
+    forgets it does not fail -- it succeeds, against the live store. Requiring
+    the parameter upstream makes the choice visible but not safe: the value may
     still be None, and an empty string is falsy, so it takes the same branch.
     This is the mechanical half.
 
@@ -131,7 +131,7 @@ def _refuse_production_db_under_pytest(db_path) -> None:
     class is out of its range, covered upstream by `build_verdict`'s required
     parameter and by the caller-side falsy-but-present rejection. RESIDUAL,
     stated rather than implied: an in-process `main()` call with a real
-    `PACTMemory` and no `--db-path` would still reach the production store.
+    `PACTMemory` and no `--db-path` would still reach the live store.
     Nothing here catches that, and nothing currently does it.
 
     BOUNDED GAP, stated rather than implied: pytest POPS `PYTEST_CURRENT_TEST`
@@ -165,7 +165,7 @@ def _refuse_production_db_under_pytest(db_path) -> None:
     # branch says do NOT pass --db-path.
     _error(
         "UNSCOPED_TEST_DB",
-        "refusing to open the production memory database: PYTEST_CURRENT_TEST "
+        "refusing to open the live memory database: PYTEST_CURRENT_TEST "
         "is set in this process's environment and no --db-path was given, so "
         "a write would land in the real store. If this IS a test, pass "
         "--db-path pointing at a temporary database. If you are ARCHIVING A "
@@ -596,7 +596,7 @@ def main(argv=None):
     # collapses to None there, so guarding the coerced value covers the empty
     # string on the same branch as an omitted flag rather than needing a
     # second predicate for it.
-    _refuse_production_db_under_pytest(db_path)
+    _refuse_live_db_under_pytest(db_path)
 
     try:
         handler(args, db_path=db_path)

--- a/pact-plugin/skills/pact-memory/scripts/cli.py
+++ b/pact-plugin/skills/pact-memory/scripts/cli.py
@@ -131,12 +131,35 @@ def _refuse_production_db_under_pytest(db_path) -> None:
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     if not current_test:
         return
+    # THE MESSAGE STATES THE OBSERVATION, NOT AN INFERENCE FROM IT. The guard
+    # sees an environment variable; it does NOT see a pytest run. Those come
+    # apart -- an exported or inherited PYTEST_CURRENT_TEST reaches a plain
+    # shell with no test anywhere -- and an earlier wording asserted the
+    # inference ("this process was spawned from a pytest run"), which is
+    # simply false in exactly the case a curator hits.
+    #
+    # IT NAMES THE VARIABLE, so the reader can check and clear it. A refusal
+    # that will not say what it keyed on cannot be self-diagnosed.
+    #
+    # ⚠️ THE REMEDY IS AUDIENCE-SPECIFIC AND THE TWO ANSWERS ARE OPPOSITE.
+    # For a test, --db-path is right. For a CURATOR archiving a pin, it is
+    # actively destructive: the archive would land in a throwaway database,
+    # the verdict would report success, and the pin would become eligible for
+    # deletion with its only copy in a file about to be discarded. An earlier
+    # wording gave the test answer to both. A correct guard with the wrong
+    # remedy can destroy exactly what the guard protected, so the curator's
+    # branch says do NOT pass --db-path.
     _error(
         "UNSCOPED_TEST_DB",
-        "refusing to open the production memory database: this process was "
-        "spawned from a pytest run and no --db-path was given, so the write "
-        "would land in the developer's real store. Pass --db-path pointing at "
-        f"a temporary database. Spawned during: {current_test}",
+        "refusing to open the production memory database: PYTEST_CURRENT_TEST "
+        "is set in this process's environment and no --db-path was given, so "
+        "a write would land in the real store. If this IS a test, pass "
+        "--db-path pointing at a temporary database. If you are ARCHIVING A "
+        "PIN and meant to use the real store, do NOT pass --db-path -- that "
+        "would archive into a throwaway database and make the pin eligible "
+        "for deletion; instead unset PYTEST_CURRENT_TEST and run again (it is "
+        "set here without a test in progress, most likely exported or "
+        f"inherited from a parent shell). PYTEST_CURRENT_TEST={current_test}",
         exit_code=2,
     )
 

--- a/pact-plugin/skills/pact-memory/scripts/cli.py
+++ b/pact-plugin/skills/pact-memory/scripts/cli.py
@@ -81,12 +81,26 @@ def _refuse_production_db_under_pytest(db_path) -> None:
     This is the mechanical half.
 
     WHY AN ENVIRONMENT VARIABLE AND NOT `"pytest" in sys.modules`. This process
-    is a FRESH INTERPRETER: the parent runs pytest, we do not. Measured on both
-    branches of the caller's env construction -- `"pytest" in sys.modules` is
-    FALSE here, every time. So a child-side guard cannot detect pytest by
-    introspection and must key on something INHERITED. `PYTEST_CURRENT_TEST` is
-    the only standard signal that crosses the boundary. The choice is FORCED,
-    not preferred; an in-process check is not an available alternative.
+    is a FRESH INTERPRETER: the parent runs pytest, we do not. So a child-side
+    guard cannot detect pytest by introspection and must key on something
+    INHERITED. `PYTEST_CURRENT_TEST` is the only standard signal that crosses
+    the boundary. The choice is FORCED, not preferred; an in-process check is
+    not an available alternative.
+
+    THE CONDITION THAT MAKES THAT TRUE, stated so it can be checked rather than
+    trusted: `pytest` stays out of this interpreter's `sys.modules` SO LONG AS
+    NO MODULE AUTO-IMPORTED AT STARTUP TRANSITIVELY REACHES IT. That is a
+    property of the environment's IMPORT GRAPH -- `sitecustomize`, `usercustomize`,
+    a `.pth` file, anything on `PYTHONPATH` that runs at startup -- and this
+    function cannot verify it. Measurements confirm it holds today; they cannot
+    establish it holds always, and an earlier wording here claimed the stronger
+    thing.
+
+    ⚠️ THE FAIL DIRECTION IS ALLOW, AND THE INSTRUMENT IS BLIND TO IT. A startup
+    module whose import closure reaches pytest would take the early return in
+    EVERY spawned child, disabling this guard everywhere at once. A spawn census
+    would look byte-identical, because a census counts spawns and cannot see
+    refusals that did not happen. Nothing here detects its own exemption.
 
     WHY IT IS GATED, AND WHY THE GATE IS NOT OPTIONAL. `archive_pin --index N`
     is the curator's documented production invocation and it passes NO

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -1049,10 +1049,33 @@ def _parse_working_memory_section(
     return before_section, WORKING_MEMORY_HEADER, after_section, existing_entries
 
 
+def _project_root_of(claude_md_path: Path) -> Path:
+    """
+    Return the project directory that owns `claude_md_path`.
+
+    CLAUDE.md lives at either `<project>/.claude/CLAUDE.md` (preferred) or
+    `<project>/CLAUDE.md` (legacy), so the root is one or two levels up
+    depending on which form the caller resolved.
+
+    Used only for an EXPLICIT target, to produce the same containment anchor
+    that `_resolve_display_claude_md_with_base` returns for a resolved one —
+    the directory captured before descending into `.claude`, never a
+    re-derivation from the leaf.
+
+    The two-layout knowledge is owned by `hooks/shared/claude_md_manager.py`
+    (`_DOT_CLAUDE_RELATIVE` / `_LEGACY_RELATIVE`); this module cannot import
+    from that package and vendors twins throughout, so this mirrors it. If a
+    THIRD location is ever supported, this must be swept with the others.
+    """
+    parent = claude_md_path.parent
+    return parent.parent if parent.name == ".claude" else parent
+
+
 def sync_to_claude_md(
     memory: Dict[str, Any],
     files: Optional[List[str]] = None,
-    memory_id: Optional[str] = None
+    memory_id: Optional[str] = None,
+    target: Optional[Path] = None
 ) -> bool:
     """
     Sync a memory entry to the Working Memory section of CLAUDE.md.
@@ -1064,15 +1087,67 @@ def sync_to_claude_md(
     exist or the sync fails for any reason, it logs a warning but doesn't
     raise an exception.
 
+    THE TARGET IS CALLER-SPECIFIABLE. Without `target` the destination is
+    resolved AMBIENTLY — from CLAUDE_PROJECT_DIR, then two git anchors, then
+    the working directory — and a caller who knows which file it means has no
+    way to say so. That is the root defect: not that the resolver is wrong,
+    but that there is no override, so a caller's knowledge cannot reach the
+    write. `target` is that override.
+
+    AN ABSENT TARGET IS A SKIP, and the guard below states it rather than
+    leaving it to be inferred. This matters because the obvious resolver to
+    compute a target with — `claude_md_manager.resolve_project_claude_md_path`
+    — is TOTAL: on a miss it returns a `"new_default"` path rather than None.
+    That is correct for a caller whose job is to create the file, and wrong
+    here, where the orchestrator owns the file's lifecycle.
+
+    MEASURED, because the stronger version of this warning is not true today
+    and repeating it would misdescribe the code: handed a path to a file that
+    does not exist, this function does NOT create it. The read precedes the
+    write, so the read raises and the degradation handler below returns False.
+    What it does do is take the sidecar lock first — leaving a `.CLAUDE.md.lock`
+    artifact in a directory it should never have touched — and report a warning
+    that reads like a real failure rather than a skip.
+
+    So the protection against creating is currently an ACCIDENT OF ORDERING,
+    not a contract: it holds only while the write path happens to read first.
+    A future change that tolerates a missing file — or writes before reading —
+    turns it into a create, and nothing would fail. The guard converts that
+    accident into a stated contract, which is the whole point of putting it
+    here rather than trusting the resolver to encode it.
+
+    So: compute the target AT THE CALLER, pass it here, and let the existence
+    check below decide.
+
     Args:
         memory: Memory dictionary with context, goal, decisions, lessons_learned, etc.
         files: Optional list of file paths associated with this memory.
         memory_id: Optional memory ID to include for database reference.
+        target: Explicit CLAUDE.md path to write. When omitted, the display
+            CLAUDE.md is resolved ambiently exactly as before, so existing
+            callers are unaffected. When given, it is used verbatim and is
+            never created if absent.
 
     Returns:
         True if sync succeeded, False otherwise.
     """
-    claude_md_path, project_root = _resolve_display_claude_md_with_base()
+    if target is not None:
+        claude_md_path = Path(target)
+        project_root = _project_root_of(claude_md_path)
+        # SEPARATE, EXPLICIT existence guard. Kept apart from resolution on
+        # purpose: an ambient resolve returns None when it finds nothing, so
+        # the skip rides along for free, but an explicit target arrives with no
+        # such promise. Writing it here means the contract holds for both
+        # paths, and holds even if a future caller computes the target with a
+        # total resolver.
+        if not claude_md_path.exists():
+            logger.debug(
+                "explicit sync target %s does not exist, skipping working "
+                "memory sync (this never creates CLAUDE.md)", claude_md_path
+            )
+            return False
+    else:
+        claude_md_path, project_root = _resolve_display_claude_md_with_base()
 
     if claude_md_path is None:
         logger.debug("CLAUDE.md not found, skipping working memory sync")

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -1406,6 +1406,36 @@ def sync_retrieved_to_claude_md(
         logger.debug("CLAUDE.md not found, skipping retrieved context sync")
         return False
 
+    # EXISTENCE GUARD. The `is None` check above is not sufficient: it covers a
+    # resolver that finds NOTHING, not a resolver that returns a path to a file
+    # that is not there. A TOTAL resolver never returns None, so it would pass
+    # straight through into the lock and the read.
+    #
+    # ONE ROUTE, ONE MESSAGE. Unlike `sync_to_claude_md` this function takes no
+    # explicit target, so there is no second way to arrive here and nothing to
+    # differentiate -- the cause is always the ambient resolver. Do not
+    # restructure it into a branch join to match its sibling: the asymmetry in
+    # the two guards reflects a real asymmetry in the two signatures.
+    #
+    # WITHOUT THIS, AN ABSENT PATH DOES NOT MERELY LEAVE A LOCK SIDECAR -- IT
+    # CREATES DIRECTORIES. `file_lock` makes the sidecar's parents, so a
+    # resolved path three levels deep materialises the whole chain before the
+    # read fails: `a/`, `a/b/`, `a/b/c/`, `a/b/c/.CLAUDE.md.lock`. Measured.
+    # That is a write to a location the caller never named, on a path whose
+    # only job was to be read.
+    #
+    # NAMES BOTH CAUSES, ASSERTS NEITHER: a file removed after it resolved is
+    # indistinguishable here from a resolver that stopped being partial, and
+    # the first is not a defect at all.
+    if not claude_md_path.exists():
+        logger.warning(
+            "resolved display CLAUDE.md %s does not exist, skipping retrieved "
+            "context sync (this never creates CLAUDE.md). Either the display "
+            "resolver stopped returning only existing paths, or the file was "
+            "removed after it resolved.", claude_md_path
+        )
+        return False
+
     try:
         # Serialize the FULL read-modify-write window under the shared sidecar
         # lock (see the "why lock the whole window" note above file_lock for the

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -1094,12 +1094,20 @@ def sync_to_claude_md(
     but that there is no override, so a caller's knowledge cannot reach the
     write. `target` is that override.
 
-    AN ABSENT TARGET IS A SKIP, and the guard below states it rather than
-    leaving it to be inferred. This matters because the obvious resolver to
-    compute a target with — `claude_md_manager.resolve_project_claude_md_path`
-    — is TOTAL: on a miss it returns a `"new_default"` path rather than None.
-    That is correct for a caller whose job is to create the file, and wrong
-    here, where the orchestrator owns the file's lifecycle.
+    AN ABSENT DESTINATION IS A SKIP — on EITHER branch, explicit or ambient.
+    The guard below the branch join states it rather than leaving it to be
+    inferred. This matters because the obvious resolver to compute a target
+    with — `claude_md_manager.resolve_project_claude_md_path` — is TOTAL: on a
+    miss it returns a `"new_default"` path rather than None. That is correct
+    for a caller whose job is to create the file, and wrong here, where the
+    orchestrator owns the file's lifecycle.
+
+    The guard covered only the explicit branch when it was first written, on
+    the reasoning that the ambient resolver returns None when it finds nothing
+    so that skip rode along free. That is true, but it is a property of the
+    RESOLVER rather than of this function — and a TOTAL resolver never returns
+    None, so the arrangement failed in exactly the case it was supposed to
+    cover. Below the join it depends on nobody else's promise.
 
     MEASURED, because the stronger version of this warning is not true today
     and repeating it would misdescribe the code: handed a path to a file that
@@ -1134,23 +1142,61 @@ def sync_to_claude_md(
     if target is not None:
         claude_md_path = Path(target)
         project_root = _project_root_of(claude_md_path)
-        # SEPARATE, EXPLICIT existence guard. Kept apart from resolution on
-        # purpose: an ambient resolve returns None when it finds nothing, so
-        # the skip rides along for free, but an explicit target arrives with no
-        # such promise. Writing it here means the contract holds for both
-        # paths, and holds even if a future caller computes the target with a
-        # total resolver.
-        if not claude_md_path.exists():
-            logger.debug(
-                "explicit sync target %s does not exist, skipping working "
-                "memory sync (this never creates CLAUDE.md)", claude_md_path
-            )
-            return False
     else:
         claude_md_path, project_root = _resolve_display_claude_md_with_base()
 
     if claude_md_path is None:
         logger.debug("CLAUDE.md not found, skipping working memory sync")
+        return False
+
+    # EXISTENCE GUARD, BELOW THE JOIN SO IT COVERS BOTH BRANCHES.
+    #
+    # It used to sit inside the explicit-target branch, on the reasoning that
+    # an ambient resolve returns None when it finds nothing so that skip rides
+    # along for free. That reasoning is TRUE, and it is a property of
+    # `_resolve_display_claude_md_with_base` -- NOT of this function. The
+    # comment then claimed the contract therefore held for both paths, which
+    # did not follow: a TOTAL resolver never returns None, so the `is None`
+    # check above would not fire and nothing else stood between it and the
+    # write. The claim was exactly inverted against the hazard it named.
+    #
+    # Down here the guard depends on no other function's promise.
+    #
+    # THE TWO WAYS TO ARRIVE ARE DIFFERENT IN KIND, so they are reported
+    # differently rather than collapsed into one message:
+    #
+    #   explicit + absent -- ORDINARY. A caller named a project whose CLAUDE.md
+    #     does not exist yet. Expected, benign, fires in normal use: debug.
+    #
+    #   ambient + absent -- SHOULD NOT HAPPEN. The resolver is documented to
+    #     return only existing paths, and a resolver that finds nothing returns
+    #     None, which the check above already absorbed. So this arm is
+    #     unreachable on the normal path, and an unreachable arm that fires is
+    #     signal rather than noise: warning.
+    #
+    # A single undifferentiated check would make a resolver that quietly went
+    # total indistinguishable from an ordinary skip, at debug level -- the same
+    # two-unrelated-causes-on-one-check problem that costs you the control.
+    #
+    # THE WARNING NAMES BOTH CAUSES AND ASSERTS NEITHER. A file removed between
+    # resolution and this line produces an identical observation and is not a
+    # defect at all; the two are indistinguishable here. The level says "look
+    # at this", the text must not say "this is a bug."
+    #
+    # NEITHER ARM CREATES. That is the contract: an absent target is a skip.
+    if not claude_md_path.exists():
+        if target is not None:
+            logger.debug(
+                "explicit sync target %s does not exist, skipping working "
+                "memory sync (this never creates CLAUDE.md)", claude_md_path
+            )
+        else:
+            logger.warning(
+                "resolved display CLAUDE.md %s does not exist, skipping "
+                "working memory sync (this never creates CLAUDE.md). Either "
+                "the display resolver stopped returning only existing paths, "
+                "or the file was removed after it resolved.", claude_md_path
+            )
         return False
 
     try:

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -497,6 +497,22 @@ def extract_managed_region(content: str) -> Optional[Tuple[str, int]]:
     """
     Extract the PACT-managed region from CLAUDE.md content.
 
+    ⚠️ THIS TWIN IS DELIBERATELY NOT BYTE-IDENTICAL, AND IS NOT DRIFT-GATED.
+    Its siblings (`file_lock`, `_atomic_write_text`) are pinned byte-for-byte;
+    this one cannot be, because two differences here are LOCAL CONVENTIONS
+    rather than divergence:
+
+      * `Optional[Tuple[str, int]]` here vs `tuple[str, int] | None` there
+      * `_MANAGED_START_MARKER` here vs `MANAGED_START_MARKER` there
+        (this module private-prefixes what that one exports)
+
+    The executable logic is otherwise identical. Do NOT "fix" either side
+    toward the other and do NOT add a byte-identity gate: it would go red on
+    arrival, on choices someone made, and a gate that is red on arrival gets
+    deleted rather than investigated. A NORMALISED gate — mapping the constant
+    names and the annotation syntax before comparing — is the real remedy and
+    is deliberately deferred rather than invented here.
+
     Twin of hooks/shared/claude_md_manager.extract_managed_region — kept
     local because skills/pact-memory/scripts/ cannot import from hooks/shared/.
 

--- a/pact-plugin/tests/test_agents_structure.py
+++ b/pact-plugin/tests/test_agents_structure.py
@@ -1201,36 +1201,65 @@ def _keys_on_recoverability(line: str) -> bool:
 
     ⚠️ WHAT THIS MEASURES IS SAME-CLAUSE ADJACENCY, NOT CO-REFERENCE, and the
     name of the thing matters more than the comfort of the name. Requiring the
-    two tokens to share a clause makes it much harder for unrelated words to
-    combine into a false certificate, but nothing here establishes that they are
-    about the SAME data. A trigger reading "...PII stored unencrypted -- verify
-    with the user before you restore anything" puts a genuine recovery word and
-    a genuine verification word in one clause while keying on deployment status,
-    and IT IS ACCEPTED. That residual is measured, not theoretical, and it is
-    the honest boundary of this check.
+    two tokens to share a clause makes it harder for unrelated words to combine
+    into a false certificate, but NOTHING HERE ESTABLISHES THAT THE TWO TOKENS
+    ARE ABOUT THE SAME DATA. Any clause carrying one of each satisfies this,
+    whatever they refer to. Two accepted wordings, deliberately different in
+    shape so the gap reads as a class rather than an edge case:
+
+        "...PII stored unencrypted -- verify with the user before you restore
+        anything"
+        "...PII stored unencrypted -- always verify your rollback and restore
+        procedure with the team lead"
+
+    The second is ordinary database-engineering boilerplate a maintainer could
+    add for reasons having nothing to do with this check, and its presence
+    silently certifies a trigger keyed on deployment status. Note also that
+    PARENTHESES ARE NOT IN `CLAUSE_BOUNDARY`, so a parenthetical aside rides
+    inside its host clause and can supply the second token from there.
+
+    THOSE ARE EXAMPLES OF THE GAP, NOT ITS EXTENT. Nothing here bounds how far
+    it reaches: ordinary prose gets past it, and the wordings above record
+    where someone has looked rather than where the failures stop.
 
     WHY CLAUSE SCOPE RATHER THAN A CHARACTER WINDOW. A distance threshold would
     have been fitted to whichever counter-example was in hand; a clause is a
-    unit of meaning that exists independently of the example. Measured across
-    every DATA-trigger line in every shipped agent body, the two agree
-    everywhere, so the principled boundary costs nothing.
+    unit of meaning that exists independently of the example. Across the
+    DATA-trigger lines PRESENT WHEN THIS WAS WRITTEN, clause scope and a
+    character window agreed everywhere, so the split cost nothing measurable.
+    That is a census rather than an invariant: a body added or a trigger
+    reworded can separate them, and nothing reddens when it does. RE-MEASURE
+    RATHER THAN TRUST IT.
 
     ⚠️ DO NOT DELETE THE CLAUSE SPLIT AS DEAD WEIGHT, and read this before
-    concluding that it is. The WORD-ANCHORING alone rejects the wording that
-    prompted this check; measured against that case, the clause split changes
-    NOTHING. It is kept as a SECOND, INDEPENDENT PATH to the same answer,
-    covering a class -- a recovery word and a verification word far apart and
-    unrelated -- that is ARGUED FOR BUT HAS NEVER BEEN EXHIBITED. That coverage
-    is SPECULATIVE, not demonstrated, and it is deliberately retained anyway
-    because its cost is measured at zero.
+    concluding that it is. The word-anchoring alone rejects the wording that
+    FIRST prompted this check, so measured against that one case the split
+    changes nothing -- which is the observation that makes it look removable.
 
-    The reason that trade is worth taking is not this check specifically. Every
-    false result caught in this codebase's recent history was caught by a
-    REDUNDANT check disagreeing with a primary one rather than by any control:
-    a search flag that silently matched nothing, a database cursor already
-    consumed, a case-sensitivity flag off by one letter. In each case no control
-    could have caught it -- only two paths to the same answer disagreeing. And
-    in each case the redundant path was the one that looked like duplication.
+    IT IS NOT REMOVABLE. THE SPLIT REJECTS A SHAPE THE ANCHORING ACCEPTS: a
+    genuine recovery token and a genuine verification token in DIFFERENT
+    clauses, each unrelated to the other and to the trigger. Anchoring asks
+    only whether both tokens appear somewhere in the line and passes; the split
+    asks whether they share a clause and refuses. Delete the split and every
+    line of that shape becomes a silent false certificate.
+
+    An instance, SUBORDINATE TO THE SHAPE ABOVE -- if a later widening of
+    `RECOVERY_PATTERN` or `CLAUSE_BOUNDARY` changes this example's verdict, the
+    SHAPE is still the claim and the example is merely stale:
+
+        "- **HALT DATA**: DROP TABLE on production data, PII stored
+        unencrypted; the nightly backup runs at 02:00, and you should verify
+        the migration plan with the DBA"
+
+    "backup" lands in one clause and "verify" in the next.
+
+    The reason that trade is worth taking is not this check specifically.
+    Several false results here were caught by a REDUNDANT check disagreeing
+    with a primary one rather than by any control: a search flag that silently
+    matched nothing, a database cursor already consumed, a case-sensitivity
+    flag off by one letter. In each of those no control could have caught it --
+    only two paths to the same answer disagreeing. And in each of those the
+    redundant path was the one that looked like duplication.
     A second path that has never fired is not evidence it is useless; it is the
     only instrument that can catch the failure where the FIRST path is wrong.
     """
@@ -1313,14 +1342,22 @@ class TestDataTriggersKeyOnRecoverability:
     on correct bodies, which is the worse failure for a detector nobody is
     watching.
 
-    HOW FAR THE SILENCE EXTENDS, MEASURED RATHER THAN ASSUMED. An escaping
-    trigger stays silent ONLY while at least one SIBLING DATA trigger in the
-    SAME FILE still classifies destructive. Once none does, `assert triggers` or
-    `assert destructive` fires and the file reddens, so A FILE CANNOT GO FULLY
-    DARK WITHOUT FAILING. The bound is therefore PER-FILE, not per-site -- and
-    since each body in scope carries exactly TWO DATA-trigger sites, ONE OF THE
-    TWO MAY SILENTLY REVERT WHILE THE OTHER HOLDS THE CHECK UP. That is the
-    precise exposure: not a dark file, a half-dark one.
+    HOW FAR THE SILENCE EXTENDS. A STRUCTURAL PROPERTY OF THE ASSERT CHAIN,
+    true regardless of what any body contains: an escaping trigger stays silent
+    ONLY while at least one SIBLING DATA trigger in the SAME FILE still
+    classifies destructive. Once none does, `assert triggers` or `assert
+    destructive` fires. So A FILE CANNOT GO FULLY DARK WITHOUT FAILING, and the
+    bound is PER-FILE rather than per-site.
+
+    WHAT THAT COSTS DEPENDS ON A COUNT, AND A COUNT IS NOT A PROPERTY -- stated
+    separately because the two are true in different ways and the sentence that
+    joined them lent the second the first one's authority. Each body in scope
+    CURRENTLY carries TWO DATA-trigger sites, so one of the two may silently
+    revert while the other holds the check up: a half-dark file rather than a
+    dark one. That figure is a function of the site count. Add a third site and
+    the arithmetic changes; remove one and the floor moves. RE-COUNT BEFORE
+    RELYING ON THE "ONE OF TWO" FIGURE -- it describes today's two bodies, not
+    the mechanism.
 
     ⚠️ A REFORMAT CAN DISARM THIS WITHOUT CHANGING A WORD OF MEANING, and it is
     the likeliest way the guard dies, because it requires no bad intent. Expand

--- a/pact-plugin/tests/test_agents_structure.py
+++ b/pact-plugin/tests/test_agents_structure.py
@@ -1218,9 +1218,11 @@ def _keys_on_recoverability(line: str) -> bool:
     PARENTHESES ARE NOT IN `CLAUSE_BOUNDARY`, so a parenthetical aside rides
     inside its host clause and can supply the second token from there.
 
-    THOSE ARE EXAMPLES OF THE GAP, NOT ITS EXTENT. Nothing here bounds how far
-    it reaches: ordinary prose gets past it, and the wordings above record
-    where someone has looked rather than where the failures stop.
+    THOSE WORDINGS ILLUSTRATE THE MECHANISM; THEY DO NOT SURVEY IT. Because the
+    only thing established is adjacency, ANY clause pairing the two families
+    passes, whatever the words are about -- so the accepted set is as wide as
+    the set of clauses that happen to contain both, which is a fact about
+    English prose rather than about this predicate.
 
     WHY CLAUSE SCOPE RATHER THAN A CHARACTER WINDOW. A distance threshold would
     have been fitted to whichever counter-example was in hand; a clause is a

--- a/pact-plugin/tests/test_agents_structure.py
+++ b/pact-plugin/tests/test_agents_structure.py
@@ -1214,6 +1214,25 @@ def _keys_on_recoverability(line: str) -> bool:
     unit of meaning that exists independently of the example. Measured across
     every DATA-trigger line in every shipped agent body, the two agree
     everywhere, so the principled boundary costs nothing.
+
+    ⚠️ DO NOT DELETE THE CLAUSE SPLIT AS DEAD WEIGHT, and read this before
+    concluding that it is. The WORD-ANCHORING alone rejects the wording that
+    prompted this check; measured against that case, the clause split changes
+    NOTHING. It is kept as a SECOND, INDEPENDENT PATH to the same answer,
+    covering a class -- a recovery word and a verification word far apart and
+    unrelated -- that is ARGUED FOR BUT HAS NEVER BEEN EXHIBITED. That coverage
+    is SPECULATIVE, not demonstrated, and it is deliberately retained anyway
+    because its cost is measured at zero.
+
+    The reason that trade is worth taking is not this check specifically. Every
+    false result caught in this codebase's recent history was caught by a
+    REDUNDANT check disagreeing with a primary one rather than by any control:
+    a search flag that silently matched nothing, a database cursor already
+    consumed, a case-sensitivity flag off by one letter. In each case no control
+    could have caught it -- only two paths to the same answer disagreeing. And
+    in each case the redundant path was the one that looked like duplication.
+    A second path that has never fired is not evidence it is useless; it is the
+    only instrument that can catch the failure where the FIRST path is wrong.
     """
     return any(
         RECOVERY_PATTERN.search(clause) and VERIFICATION_PATTERN.search(clause)

--- a/pact-plugin/tests/test_agents_structure.py
+++ b/pact-plugin/tests/test_agents_structure.py
@@ -1215,8 +1215,11 @@ def _keys_on_recoverability(line: str) -> bool:
     The second is ordinary database-engineering boilerplate a maintainer could
     add for reasons having nothing to do with this check, and its presence
     silently certifies a trigger keyed on deployment status. Note also that
-    PARENTHESES ARE NOT IN `CLAUSE_BOUNDARY`, so a parenthetical aside rides
-    inside its host clause and can supply the second token from there.
+    PARENTHESES ARE NOT IN `CLAUSE_BOUNDARY` AS IT CURRENTLY STANDS, so a
+    parenthetical aside rides inside its host clause and can supply the second
+    token from there -- and like the instance further down, that is a statement
+    about the constant's PRESENT VALUE: widen `CLAUSE_BOUNDARY` and this example
+    goes stale, while the adjacency point above is unaffected.
 
     THOSE WORDINGS ILLUSTRATE THE MECHANISM; THEY DO NOT SURVEY IT. Because the
     only thing established is adjacency, ANY clause pairing the two families
@@ -1259,11 +1262,15 @@ def _keys_on_recoverability(line: str) -> bool:
     Several false results here were caught by a REDUNDANT check disagreeing
     with a primary one rather than by any control: a search flag that silently
     matched nothing, a database cursor already consumed, a case-sensitivity
-    flag off by one letter. In each of those no control could have caught it --
-    only two paths to the same answer disagreeing. And in each of those the
-    redundant path was the one that looked like duplication.
-    A second path that has never fired is not evidence it is useless; it is the
-    only instrument that can catch the failure where the FIRST path is wrong.
+    flag off by one letter. In each of those THE CONTROLS THAT EXISTED did not
+    catch it -- only two paths to the same answer disagreeing did. And in each
+    of those the redundant path was the one that looked like duplication.
+
+    A second path that NO TEST YET EXERCISES is not evidence it is useless: the
+    instance above is a wording this split rejects and the anchoring accepts,
+    demonstrated but not pinned. And a control only excludes what it was BUILT
+    to exclude, so where the FIRST path is wrong in a way nobody anticipated,
+    disagreement between two paths is what surfaces it.
     """
     return any(
         RECOVERY_PATTERN.search(clause) and VERIFICATION_PATTERN.search(clause)
@@ -1333,9 +1340,14 @@ class TestDataTriggersKeyOnRecoverability:
     implied. `_names_destructive_operation` recognizes a fixed vocabulary, and
     a trigger that describes a destructive operation WITHOUT any of those words
     -- "schema change against production data" and "UPDATE without a WHERE
-    clause" are measured examples, and the second uses this file's own sentence
-    pattern -- is exempted from the recovery requirement rather than caught by
-    it. That gate exists to stop false positives on exposure-only triggers, so
+    clause" are measured examples -- is exempted from the recovery requirement
+    rather than caught by it. The second example differs from a wording the gate
+    DOES catch only in its VERB, since `delete` sits in DESTRUCTION_TOKENS above
+    and `update` does not, which is why reaching this gap needs no unusual
+    phrasing. That comparison is a statement about the CURRENT vocabulary: add
+    `update` to that tuple and the example goes stale while the exemption itself
+    stands. It replaces a claim about prose in another file, which could go
+    equally false and could not be checked from here. That gate exists to stop false positives on exposure-only triggers, so
     its errors run toward silence by construction. What this class DOES
     guarantee is the thing it was built for: reverting either body's DATA
     trigger to the wording that keyed on deployment status alone turns it RED,

--- a/pact-plugin/tests/test_agents_structure.py
+++ b/pact-plugin/tests/test_agents_structure.py
@@ -1138,6 +1138,226 @@ class TestAgentAlgedonicTriggersInline:
             )
 
 
+# Bodies whose DATA-tier trigger is keyed on RECOVERABILITY. Deliberately not
+# every agent: see TestDataTriggersKeyOnRecoverability for why
+# pact-devops-engineer.md is excluded.
+RECOVERABILITY_KEYED_AGENTS = ("pact-database-engineer", "pact-n8n")
+
+# A line states a DATA-tier trigger if it carries one of these markers. The
+# forms are conventional in the agent bodies: a `**HALT DATA**` bullet, and the
+# `Read algedonic.md ...` line naming "a DATA risk" or "a DATA-integrity threat".
+DATA_TRIGGER_MARKERS = ("HALT DATA", "DATA risk", "DATA-integrity")
+
+# The property, expressed as two token families that must BOTH appear.
+# "rollback" is deliberately ABSENT from the recovery family: the pre-re-key
+# wording already said "destructive operation without rollback", so accepting it
+# would make this detector pass on the very text it exists to reject.
+RECOVERY_TOKENS = ("restore", "recover", "backup")
+VERIFICATION_TOKENS = ("verif",)
+
+# Only a trigger about DESTROYING or irreversibly changing data owes a recovery
+# criterion. A DATA trigger can legitimately be about EXPOSURE instead -- PII in
+# build artifacts, sensitive data in container layers -- and demanding a restore
+# path there would be nonsense. Without this gate the check below states a
+# property that is merely ACCIDENTALLY true of the in-scope bodies, and the first
+# exposure-only DATA bullet added to either would redden it on correct text.
+DESTRUCTION_TOKENS = (
+    "delete", "drop", "truncate", "destructive", "irreversible", "corrupt",
+    "overwrite",
+)
+
+
+def _is_data_trigger(line: str) -> bool:
+    """True if `line` states a DATA-tier algedonic trigger."""
+    return any(marker in line for marker in DATA_TRIGGER_MARKERS)
+
+
+def _names_destructive_operation(line: str) -> bool:
+    """True if `line` describes destroying or irreversibly changing data."""
+    lowered = line.lower()
+    return any(token in lowered for token in DESTRUCTION_TOKENS)
+
+
+def _keys_on_recoverability(line: str) -> bool:
+    """True if `line` names a recovery criterion AND requires it be verified.
+
+    Both halves are load-bearing. A recovery noun alone ("missing backup") says
+    a backup is absent, not that its restorability was ever established;
+    requiring the verification token is what makes UNKNOWN fail CLOSED into the
+    trigger rather than out of it.
+    """
+    lowered = line.lower()
+    return (
+        any(token in lowered for token in RECOVERY_TOKENS)
+        and any(token in lowered for token in VERIFICATION_TOKENS)
+    )
+
+
+# The DATA-trigger wordings as they read BEFORE the re-key, kept verbatim as
+# literal fixtures. They are the non-vacuity control: the detector must RECOGNIZE
+# each as a DATA trigger and REJECT it. Feeding them in as literals rather than
+# reverting the working tree keeps the control available on every run, including
+# runs where the tree is mid-edit.
+PRE_REKEY_DATA_TRIGGERS = (
+    "- **HALT DATA**: DELETE without WHERE clause, DROP TABLE on production "
+    "data, PII stored unencrypted, foreign key violations risking data integrity",
+
+    "Read [algedonic.md](../protocols/algedonic.md) immediately on detecting a "
+    "DATA-integrity threat (destructive operation without rollback, schema "
+    "violation, foreign-key breach, PII exposure in unencrypted columns or "
+    "logs) or any irreversible change to production data flowing from a "
+    "migration or query you are authoring.",
+
+    "- **HALT DATA**: Workflow could corrupt or delete production data, PII "
+    "handled without encryption",
+
+    "Read [algedonic.md](../protocols/algedonic.md) immediately on detecting a "
+    "SECURITY flaw (webhook accepting unauthenticated requests, credential "
+    "exposure in workflow JSON or expressions, plaintext API key in HTTP node) "
+    "or a DATA risk (irreversible workflow operation against production data, "
+    "missing rate-limit on external write, destructive bulk update without "
+    "dry-run).",
+)
+
+
+class TestDataTriggersKeyOnRecoverability:
+    """A DATA-tier trigger must hand the agent a RECOVERABILITY criterion,
+    not only a deployment-status one.
+
+    THE DEFECT THIS CLOSES. `algedonic.md` states the DATA tier
+    consequence-neutrally -- "PII exposure, data corruption risk, integrity
+    violation". A body that glosses that tier as "production data" ALONE
+    substitutes deployment status for the property that actually matters, and
+    it misleads in BOTH directions: an agent working on an irreplaceable store
+    that nobody calls "production" reads the trigger as not applying, while an
+    agent working on production data with a tested restore path treats a HALT
+    as automatic. Deployment status is not what makes an operation
+    unrecoverable.
+
+    WHAT IS PINNED IS THE PROPERTY, NOT THE PROSE. Any wording naming a
+    recovery criterion and requiring it be VERIFIED satisfies this. A verbatim
+    pin would redden on every innocent rewrite and would teach maintainers to
+    bump a string instead of thinking about the trigger.
+
+    THIS DOES NOT REQUIRE "production data" TO SURVIVE. A body that drops the
+    phrase entirely and keys purely on recoverability still passes -- that is a
+    correct trigger, and a detector that reddened on it would be worse than no
+    detector.
+
+    SCOPE, and why it is not every agent. `pact-devops-engineer.md` is
+    deliberately excluded: for a devops agent a production deployment is a
+    genuine domain concept, and its sibling clauses ("destructive infra change
+    without rollback", "missing backup before migration") already carry the
+    recoverability criterion, so deployment status is not the sole
+    discriminator there. Forcing uniformity would make that body worse.
+
+    ⚠️ THE DESTRUCTION GATE'S FAIL DIRECTION IS EXEMPT, stated rather than
+    implied. `_names_destructive_operation` recognizes a fixed vocabulary, and
+    a trigger that describes a destructive operation WITHOUT any of those words
+    -- "schema change against production data" is a measured example -- is
+    exempted from the recovery requirement rather than caught by it. That gate
+    exists to stop false positives on exposure-only triggers, so its errors run
+    toward silence by construction. What this class DOES guarantee is the thing
+    it was built for: reverting either body's DATA trigger to the wording that
+    keyed on deployment status alone turns it RED, verified per-file rather than
+    only in combination. Widening the vocabulary to chase the gap would trade a
+    bounded silence for unbounded false positives on correct bodies, which is
+    the worse failure for a detector nobody is watching.
+    """
+
+    def test_data_triggers_name_a_verified_recovery_criterion(self):
+        """The live bodies satisfy the property."""
+        for name in RECOVERABILITY_KEYED_AGENTS:
+            path = AGENTS_DIR / f"{name}.md"
+            triggers = [
+                line for line in path.read_text(encoding="utf-8").splitlines()
+                if _is_data_trigger(line)
+            ]
+            assert triggers, (
+                f"{name}.md: no DATA-tier trigger line found at all. Either the "
+                f"body lost its DATA trigger, or the marker convention changed "
+                f"and DATA_TRIGGER_MARKERS no longer matches it -- in which case "
+                f"this whole check has been silently measuring nothing."
+            )
+            destructive = [ln for ln in triggers if _names_destructive_operation(ln)]
+            assert destructive, (
+                f"{name}.md: DATA triggers exist but none describes destroying or "
+                f"irreversibly changing data, so the requirement below is exempt "
+                f"everywhere and this check is measuring nothing."
+            )
+            for line in destructive:
+                assert _keys_on_recoverability(line), (
+                    f"{name}.md: a DATA-tier trigger about destroying or "
+                    f"irreversibly changing data names no VERIFIED recovery "
+                    f"criterion, so it keys on deployment status alone. An agent "
+                    f"holding irreplaceable data that nobody calls 'production' "
+                    f"will read this as not applying to them. Name a recovery "
+                    f"criterion and require it be verified, so an unverified "
+                    f"restore path still fires the HALT. Offending line: {line!r}"
+                )
+
+    def test_detector_rejects_the_pre_rekey_wordings(self):
+        """NON-VACUITY. The detector must reject the wordings it replaced.
+
+        Each fixture is asserted to be IN SCOPE on BOTH gates first -- recognized
+        as a DATA trigger, and recognized as describing a destructive operation.
+        A fixture failing either gate would be "rejected" for the wrong reason:
+        it would be exempt rather than caught, and the control would prove
+        nothing about a revert it is supposed to stop.
+        """
+        for wording in PRE_REKEY_DATA_TRIGGERS:
+            assert _is_data_trigger(wording), (
+                f"control fixture is not recognized as a DATA trigger, so its "
+                f"rejection below would be vacuous: {wording!r}"
+            )
+            assert _names_destructive_operation(wording), (
+                f"control fixture is not recognized as describing a destructive "
+                f"operation, so the recovery requirement would EXEMPT it rather "
+                f"than catch it, and its rejection below would be vacuous: "
+                f"{wording!r}"
+            )
+            assert not _keys_on_recoverability(wording), (
+                f"the detector ACCEPTS a pre-re-key wording that keys on "
+                f"deployment status alone. It would not catch a revert, which "
+                f"is the only thing it exists to catch: {wording!r}"
+            )
+
+    def test_exposure_only_data_triggers_are_exempt(self):
+        """A DATA trigger about EXPOSURE owes no recovery criterion.
+
+        This exemption is not hypothetical. `pact-devops-engineer.md` carries
+        exactly this shape -- a DATA trigger about PII in build artifacts and
+        sensitive data in container layers, where a restore path is a category
+        error. Without the destruction gate, the requirement would state a
+        property that is only ACCIDENTALLY true of the in-scope bodies, and the
+        first exposure-only DATA bullet added to either would redden a correct
+        body.
+        """
+        exposure_only = (
+            "- **HALT DATA**: PII in build artifacts, sensitive data exposed "
+            "through container layers"
+        )
+        assert _is_data_trigger(exposure_only)
+        assert not _names_destructive_operation(exposure_only)
+        assert not _keys_on_recoverability(exposure_only), (
+            "fixture accidentally satisfies the recovery predicate, so it "
+            "cannot demonstrate that the destruction gate is what exempts it"
+        )
+
+    def test_rollback_alone_does_not_satisfy_the_predicate(self):
+        """The recovery family excludes 'rollback' on purpose.
+
+        One pre-re-key wording already said "destructive operation without
+        rollback". Had the family accepted that token, the detector would have
+        passed on unmodified deployment-keyed text -- non-vacuous-looking and
+        wrong. This pins the exclusion so a later widening of RECOVERY_TOKENS
+        has to confront it.
+        """
+        assert not _keys_on_recoverability(
+            "- **HALT DATA**: destructive operation without rollback"
+        )
+
+
 class TestNoVestigialAgentTeamsProtocolSection:
     """Post-#366 the `# AGENT TEAMS PROTOCOL` lazy-load pointer block is
     gone. The protocol is delivered via frontmatter eager-load instead.

--- a/pact-plugin/tests/test_agents_structure.py
+++ b/pact-plugin/tests/test_agents_structure.py
@@ -9,6 +9,7 @@ Tests cover:
 5. Skills reference exists
 6. Agent body contains expected sections
 """
+import re
 from pathlib import Path
 
 import pytest
@@ -1148,12 +1149,23 @@ RECOVERABILITY_KEYED_AGENTS = ("pact-database-engineer", "pact-n8n")
 # `Read algedonic.md ...` line naming "a DATA risk" or "a DATA-integrity threat".
 DATA_TRIGGER_MARKERS = ("HALT DATA", "DATA risk", "DATA-integrity")
 
-# The property, expressed as two token families that must BOTH appear.
-# "rollback" is deliberately ABSENT from the recovery family: the pre-re-key
-# wording already said "destructive operation without rollback", so accepting it
-# would make this detector pass on the very text it exists to reject.
-RECOVERY_TOKENS = ("restore", "recover", "backup")
-VERIFICATION_TOKENS = ("verif",)
+# The property, expressed as two token families that must BOTH appear IN THE SAME
+# CLAUSE. "rollback" is deliberately ABSENT from the recovery family: the
+# pre-re-key wording already said "destructive operation without rollback", so
+# accepting it would make this detector pass on the very text it exists to reject.
+#
+# WORD-ANCHORED, and that anchoring is the load-bearing half. A bare substring
+# test counts "recover" inside "unrecoverable", which is how a trigger reading
+# "...verify with the user before anything unrecoverable" was CERTIFIED as
+# recoverability-keyed while keying on deployment status alone. `\b` refuses the
+# match because "unrecoverable" has a word character before "recover".
+RECOVERY_PATTERN = re.compile(r"\b(?:restor\w*|recover\w*|backup\w*)\b", re.IGNORECASE)
+VERIFICATION_PATTERN = re.compile(r"\bverif\w*", re.IGNORECASE)
+
+# Clause scope: a comma, semicolon, period, or spaced dash. Used INSTEAD of a
+# character-distance window, so the boundary is a unit of meaning rather than a
+# number fitted to whichever counter-example happened to be in hand.
+CLAUSE_BOUNDARY = re.compile(r"[.;,]|\s--\s|—")
 
 # Only a trigger about DESTROYING or irreversibly changing data owes a recovery
 # criterion. A DATA trigger can legitimately be about EXPOSURE instead -- PII in
@@ -1179,17 +1191,33 @@ def _names_destructive_operation(line: str) -> bool:
 
 
 def _keys_on_recoverability(line: str) -> bool:
-    """True if `line` names a recovery criterion AND requires it be verified.
+    """True if one CLAUSE of `line` names a recovery criterion AND requires it
+    be verified.
 
     Both halves are load-bearing. A recovery noun alone ("missing backup") says
     a backup is absent, not that its restorability was ever established;
     requiring the verification token is what makes UNKNOWN fail CLOSED into the
     trigger rather than out of it.
+
+    ⚠️ WHAT THIS MEASURES IS SAME-CLAUSE ADJACENCY, NOT CO-REFERENCE, and the
+    name of the thing matters more than the comfort of the name. Requiring the
+    two tokens to share a clause makes it much harder for unrelated words to
+    combine into a false certificate, but nothing here establishes that they are
+    about the SAME data. A trigger reading "...PII stored unencrypted -- verify
+    with the user before you restore anything" puts a genuine recovery word and
+    a genuine verification word in one clause while keying on deployment status,
+    and IT IS ACCEPTED. That residual is measured, not theoretical, and it is
+    the honest boundary of this check.
+
+    WHY CLAUSE SCOPE RATHER THAN A CHARACTER WINDOW. A distance threshold would
+    have been fitted to whichever counter-example was in hand; a clause is a
+    unit of meaning that exists independently of the example. Measured across
+    every DATA-trigger line in every shipped agent body, the two agree
+    everywhere, so the principled boundary costs nothing.
     """
-    lowered = line.lower()
-    return (
-        any(token in lowered for token in RECOVERY_TOKENS)
-        and any(token in lowered for token in VERIFICATION_TOKENS)
+    return any(
+        RECOVERY_PATTERN.search(clause) and VERIFICATION_PATTERN.search(clause)
+        for clause in CLAUSE_BOUNDARY.split(line)
     )
 
 
@@ -1254,15 +1282,37 @@ class TestDataTriggersKeyOnRecoverability:
     ⚠️ THE DESTRUCTION GATE'S FAIL DIRECTION IS EXEMPT, stated rather than
     implied. `_names_destructive_operation` recognizes a fixed vocabulary, and
     a trigger that describes a destructive operation WITHOUT any of those words
-    -- "schema change against production data" is a measured example -- is
-    exempted from the recovery requirement rather than caught by it. That gate
-    exists to stop false positives on exposure-only triggers, so its errors run
-    toward silence by construction. What this class DOES guarantee is the thing
-    it was built for: reverting either body's DATA trigger to the wording that
-    keyed on deployment status alone turns it RED, verified per-file rather than
-    only in combination. Widening the vocabulary to chase the gap would trade a
-    bounded silence for unbounded false positives on correct bodies, which is
-    the worse failure for a detector nobody is watching.
+    -- "schema change against production data" and "UPDATE without a WHERE
+    clause" are measured examples, and the second uses this file's own sentence
+    pattern -- is exempted from the recovery requirement rather than caught by
+    it. That gate exists to stop false positives on exposure-only triggers, so
+    its errors run toward silence by construction. What this class DOES
+    guarantee is the thing it was built for: reverting either body's DATA
+    trigger to the wording that keyed on deployment status alone turns it RED,
+    verified per-file rather than only in combination. Widening the vocabulary
+    to chase the gap would trade a bounded silence for unbounded false positives
+    on correct bodies, which is the worse failure for a detector nobody is
+    watching.
+
+    HOW FAR THE SILENCE EXTENDS, MEASURED RATHER THAN ASSUMED. An escaping
+    trigger stays silent ONLY while at least one SIBLING DATA trigger in the
+    SAME FILE still classifies destructive. Once none does, `assert triggers` or
+    `assert destructive` fires and the file reddens, so A FILE CANNOT GO FULLY
+    DARK WITHOUT FAILING. The bound is therefore PER-FILE, not per-site -- and
+    since each body in scope carries exactly TWO DATA-trigger sites, ONE OF THE
+    TWO MAY SILENTLY REVERT WHILE THE OTHER HOLDS THE CHECK UP. That is the
+    precise exposure: not a dark file, a half-dark one.
+
+    ⚠️ A REFORMAT CAN DISARM THIS WITHOUT CHANGING A WORD OF MEANING, and it is
+    the likeliest way the guard dies, because it requires no bad intent. Expand
+    a `- **HALT DATA**:` bullet into a marker line plus sub-bullets and the
+    marker line keeps the marker but loses every destruction token, while the
+    sub-bullets carry no marker and are not triggers at all. Do that while
+    KEEPING the correct recoverability wording and everything stays green, with
+    no signal that the bullet is now unwatched -- then a later edit reverts the
+    wording from that state and also stays green. Routine markdown housekeeping
+    today, silent removal of the guard tomorrow. If you reformat a DATA trigger,
+    re-read this class and confirm the marker line still carries the criterion.
     """
 
     def test_data_triggers_name_a_verified_recovery_criterion(self):
@@ -1322,6 +1372,49 @@ class TestDataTriggersKeyOnRecoverability:
                 f"is the only thing it exists to catch: {wording!r}"
             )
 
+    def test_detector_does_not_certify_a_deployment_keyed_trigger(self):
+        """A FALSE GREEN ON A TRUE NEGATIVE IS NOT A SILENCE.
+
+        The destruction gate's exemption licenses the detector to MISS a bad
+        trigger it cannot classify. It does not license the detector to
+        AFFIRMATIVELY CERTIFY one. This wording keys on deployment status alone
+        and was certified as recoverability-keyed, because a substring test
+        found "recover" inside "unrecoverable" and paired it with an unrelated
+        "verify" from a different clause.
+
+        Both halves of the repair are exercised here: word-anchoring refuses
+        "recover" inside "unrecoverable", and clause scope refuses to pair
+        tokens across a boundary.
+        """
+        certified_but_deployment_keyed = (
+            "- **HALT DATA**: DELETE without WHERE clause, DROP TABLE on "
+            "production data, PII stored unencrypted -- verify with the user "
+            "before anything unrecoverable"
+        )
+        assert _is_data_trigger(certified_but_deployment_keyed)
+        assert _names_destructive_operation(certified_but_deployment_keyed), (
+            "fixture is not classified destructive, so the recovery requirement "
+            "would EXEMPT it and this control would prove nothing"
+        )
+        assert not _keys_on_recoverability(certified_but_deployment_keyed), (
+            "the detector CERTIFIES a trigger that keys on deployment status "
+            "alone. Missing a bad trigger is the ruled-acceptable failure; "
+            "green-lighting one is not."
+        )
+
+    def test_recovery_token_is_word_anchored(self):
+        """The specific mechanism, pinned apart from the wording it defeats.
+
+        "unrecoverable" must not supply a recovery token. Kept separate from the
+        test above so a regression names the CAUSE rather than only the symptom.
+        """
+        assert not RECOVERY_PATTERN.search("anything unrecoverable")
+        assert RECOVERY_PATTERN.search("a verified restore path")
+        assert RECOVERY_PATTERN.search("recoverable within an hour"), (
+            "word-anchoring must reject 'unrecoverable' WITHOUT also rejecting "
+            "legitimate recovery vocabulary that merely shares a stem"
+        )
+
     def test_exposure_only_data_triggers_are_exempt(self):
         """A DATA trigger about EXPOSURE owes no recovery criterion.
 
@@ -1350,7 +1443,7 @@ class TestDataTriggersKeyOnRecoverability:
         One pre-re-key wording already said "destructive operation without
         rollback". Had the family accepted that token, the detector would have
         passed on unmodified deployment-keyed text -- non-vacuous-looking and
-        wrong. This pins the exclusion so a later widening of RECOVERY_TOKENS
+        wrong. This pins the exclusion so a later widening of RECOVERY_PATTERN
         has to confront it.
         """
         assert not _keys_on_recoverability(

--- a/pact-plugin/tests/test_archive_pin.py
+++ b/pact-plugin/tests/test_archive_pin.py
@@ -29,7 +29,7 @@ things:
     enclosing test stubs `_run_memory_cli` (or `subprocess.run`) or
     short-circuits before the spawn (bad index, unresolvable CLAUDE.md,
     missing `_MEMORY_CLI`, a patched extractor). `None` still MEANS the
-    production store; what makes it safe here is that nothing consumes it.
+    live store; what makes it safe here is that nothing consumes it.
 
 So `db_path=None` is a claim about the call site, not a shrug. If you delete
 the stub or the short-circuit above such a call, that claim becomes false and
@@ -720,7 +720,7 @@ class TestEnvPropagation_ExplicitCwdBeatsAmbient:
         calls = self._spy_memory_cli_spawns(monkeypatch)
         # Scoped db_path, though the spy means no child is ever launched:
         # this call enters the real `_run_memory_cli`, and naming a temp store
-        # keeps it correct under the production-DB guard rather than relying
+        # keeps it correct under the live-DB guard rather than relying
         # on the spy sitting downstream of it. None of the assertions below
         # read db_path, so it cannot perturb the property under test.
         archive_pin._run_memory_cli(
@@ -850,8 +850,8 @@ class TestArchiveRecordPredicate:
         con.close()
 
 
-class TestProductionDbGuard:
-    """The MECHANICAL closure for the production-database leak.
+class TestLiveDbGuard:
+    """The MECHANICAL closure for the live-database leak.
 
     A required `db_path` makes the choice visible; it does not make it safe.
     `None` still satisfies the signature and still means the real store, and
@@ -863,7 +863,7 @@ class TestProductionDbGuard:
 
       * PARENT (`_run_memory_cli`) rejects falsy-BUT-PRESENT db_path. It sees
         the caller's intent, so it can tell `""` from `None`.
-      * CHILD (`cli.py`) refuses the production store outright when no
+      * CHILD (`cli.py`) refuses the live store outright when no
         --db-path arrived. It sees the actual spawn, so it catches routes that
         never touch `archive_pin` at all -- including a raw
         `subprocess.run([sys.executable, cli.py, ...])`.
@@ -875,9 +875,9 @@ class TestProductionDbGuard:
     the database path from `Path.home()` AT IMPORT, so an in-process HOME
     change is inert -- but a child re-imports, so HOME in the CHILD'S env does
     redirect it. These tests exercise the exact production shape (no
-    --db-path) with zero production risk, which is only possible because the
-    boundary that makes the defect hard to guard is the same boundary that
-    makes it safe to test.
+    --db-path) with zero risk to the live store, which is only possible
+    because the boundary that makes the defect hard to guard is the same
+    boundary that makes it safe to test.
     """
 
     @staticmethod
@@ -885,7 +885,7 @@ class TestProductionDbGuard:
         """Run the memory CLI as the curator's production shape: no --db-path.
 
         HOME points into tmp_path, so the child resolves a temp database even
-        on the branch that would otherwise select production.
+        on the branch that would otherwise select the live store.
         """
         cli = (
             Path(archive_pin.__file__).resolve().parent.parent
@@ -905,13 +905,13 @@ class TestProductionDbGuard:
             capture_output=True, text=True, timeout=120, env=env,
         )
 
-    def test_child_refuses_the_production_db_when_spawned_under_pytest(
+    def test_child_refuses_the_live_db_when_spawned_under_pytest(
         self, tmp_path
     ):
         proc = self._spawn_cli(tmp_path, with_pytest_var=True)
         assert proc.returncode != 0, (
             "the child exited 0 with no --db-path under pytest — it would "
-            "have used the production database"
+            "have used the live database"
         )
         assert "UNSCOPED_TEST_DB" in proc.stderr, (
             f"guard did not fire; stderr={proc.stderr[:400]}"
@@ -1027,7 +1027,7 @@ class TestProductionDbGuard:
 
         assert report["seen"], (
             "PYTEST_CURRENT_TEST did NOT reach the child. The child-side "
-            "production-DB guard in cli.py is therefore INERT, and its fail "
+            "live-DB guard in cli.py is therefore INERT, and its fail "
             "direction is ALLOW — unscoped spawns will silently use the real "
             "database. Most likely cause: _run_memory_cli stopped passing a "
             "full env copy."
@@ -1035,11 +1035,11 @@ class TestProductionDbGuard:
         assert report["pytest_importable_here"] is False, (
             "pytest IS visible in the child, so the guard could have used an "
             "in-process check — revisit the forced-choice reasoning in "
-            "cli.py's _refuse_production_db_under_pytest docstring"
+            "cli.py's _refuse_live_db_under_pytest docstring"
         )
 
     def test_parent_rejects_falsy_but_present_db_path(self, tmp_path):
-        """`db_path=""` is falsy, so without this it routes to production.
+        """`db_path=""` is falsy, so without this it routes to the live store.
 
         The real `_MEMORY_CLI` is left in place. Repointing it at a
         non-existent file to prevent a spawn does not work here and is worth

--- a/pact-plugin/tests/test_archive_pin.py
+++ b/pact-plugin/tests/test_archive_pin.py
@@ -39,6 +39,7 @@ backstop is the guard in `_run_memory_cli`; this convention is what makes the
 choice reviewable.
 """
 
+import ast
 import json
 import os
 import subprocess
@@ -919,6 +920,181 @@ class TestProductionDbGuard:
         assert "--db-path" not in calls[0], (
             "a None db_path must not synthesize a --db-path argument"
         )
+
+
+class TestExplicitTargetBoundary:
+    """The no-`cwd` population — the one that reached OUTSIDE the sandbox.
+
+    `cwd` is an ordinary optional argument. When it was omitted the env block
+    never ran, `env` stayed None, and `subprocess.run(env=None)` handed the
+    child the parent environment VERBATIM — so the child resolved a CLAUDE.md
+    from whatever ambient variable, git anchor or working directory was in
+    scope. Measured before the fix: variable unset and `cwd` omitted, the
+    child wrote to the invoking repository's REAL CLAUDE.md. Three
+    configurations, two destinations, all of them outside the intended target.
+
+    The contract now: no target means the ambient value is REMOVED rather than
+    inherited, and the projection that would consume it is SUPPRESSED. Not a
+    guess, not a fallback — a skip.
+
+    THE TWO EXISTING LEGS MUST NOT MOVE. Both `archive_pin`'s save and get
+    calls already pass `cwd`, so they are in the closed population and this
+    change must leave them byte-identical. Their argv is pinned below: a shift
+    there is a REGRESSION, not an improvement, and would otherwise read as one.
+    """
+
+    @staticmethod
+    def _capture(monkeypatch):
+        real_run = subprocess.run
+        calls = []
+
+        class _Proc:
+            returncode = 0
+            stderr = ""
+            def __init__(self, stdout=""):
+                self.stdout = stdout
+
+        def _fake(argv, **kwargs):
+            if not (argv and argv[0] == sys.executable):
+                return real_run(argv, **kwargs)
+            calls.append((list(argv), kwargs))
+            return _Proc('{"ok": true, "result": {}}')
+
+        monkeypatch.setattr(archive_pin.subprocess, "run", _fake)
+        return calls
+
+    def test_no_cwd_strips_the_ambient_project_and_suppresses_the_sync(
+        self, tmp_path, monkeypatch
+    ):
+        decoy = tmp_path / "ambient"
+        decoy.mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(decoy))
+        assert os.environ.get("CLAUDE_PROJECT_DIR") == str(decoy), (
+            "precondition: no ambient value is set, so this test cannot show "
+            "that one is removed"
+        )
+
+        calls = self._capture(monkeypatch)
+        archive_pin._run_memory_cli(
+            ["save", "--stdin"], db_path=str(tmp_path / "m.db"),
+            stdin_data="{}", cwd=None,
+        )
+
+        assert len(calls) == 1, f"expected one spawn, captured {len(calls)}"
+        argv, kwargs = calls[0]
+        assert kwargs["env"] is not None, (
+            "env is None, so the child inherits the parent environment "
+            "verbatim — the exact hole this closes"
+        )
+        assert "CLAUDE_PROJECT_DIR" not in kwargs["env"], (
+            "the ambient project survived into a call that named no project; "
+            "an absent target must not fall back to an ambient one"
+        )
+        assert "--no-sync" in argv, (
+            "the projection was not suppressed on a call with no target — it "
+            "would resolve a destination ambiently and write there"
+        )
+        assert kwargs["cwd"] is None
+
+    def test_no_sync_is_not_added_to_subcommands_that_reject_it(
+        self, tmp_path, monkeypatch
+    ):
+        """OVER-BLOCK CONTROL. `--no-sync` is declared on `save` only, so
+        appending it to a `get` is an argparse error — a failure the fix would
+        have manufactured."""
+        calls = self._capture(monkeypatch)
+        archive_pin._run_memory_cli(
+            ["get", "a" * 32], db_path=str(tmp_path / "m.db"), cwd=None
+        )
+        argv = calls[0][0]
+        assert "--no-sync" not in argv, (
+            f"--no-sync was appended to a subcommand that does not accept it: {argv[2:]}"
+        )
+
+    def test_sync_capable_set_matches_the_cli_parser(self):
+        """DRIFT DETECTOR, mechanical rather than conventional.
+
+        The suppression fires only for subcommands in
+        `_SYNC_CAPABLE_SUBCOMMANDS`. If a future subcommand gains a sync and a
+        `--no-sync` flag but is not added there, calls with no target silently
+        stop being suppressed — the leak returns with nothing failing.
+
+        So the constant is checked against the CLI's REAL parser rather than
+        against a second hand-written list, which would only ever contain what
+        someone already remembered.
+        """
+        cli_path = (
+            Path(archive_pin.__file__).resolve().parent.parent
+            / "skills" / "pact-memory" / "scripts" / "cli.py"
+        )
+        source = cli_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        # Which `<name>_parser.add_argument("--no-sync", ...)` calls exist.
+        declaring = set()
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "add_argument"):
+                continue
+            if not (node.args and isinstance(node.args[0], ast.Constant)
+                    and node.args[0].value == "--no-sync"):
+                continue
+            recv = node.func.value
+            assert isinstance(recv, ast.Name), (
+                f"unrecognised --no-sync receiver at line {node.lineno}; the "
+                "detector must be updated rather than the assertion relaxed"
+            )
+            declaring.add(recv.id.removesuffix("_parser"))
+
+        assert declaring, (
+            "no --no-sync declaration found in cli.py at all — the detector "
+            "found nothing to compare and would pass vacuously"
+        )
+        assert declaring == set(archive_pin._SYNC_CAPABLE_SUBCOMMANDS), (
+            f"cli.py declares --no-sync on {sorted(declaring)} but "
+            f"_SYNC_CAPABLE_SUBCOMMANDS is "
+            f"{sorted(archive_pin._SYNC_CAPABLE_SUBCOMMANDS)}. A subcommand "
+            f"that syncs but is missing from the constant loses the "
+            f"suppression on no-target calls."
+        )
+
+    def test_both_existing_legs_keep_their_argv_unchanged(
+        self, claude_md, monkeypatch, tmp_path
+    ):
+        """Both archive_pin legs pass `cwd`, so neither may shift.
+
+        The save leg carries `--no-sync` EXPLICITLY and must not gain a second
+        one; the get leg carries none and must not gain one at all.
+        """
+        content = _two_pin_file()
+        path = claude_md(content)
+        calls = []
+        real_run = archive_pin._run_memory_cli
+
+        def _spy(args, **kwargs):
+            calls.append(list(args))
+            if args[0] == "save":
+                return 0, json.dumps(
+                    {"ok": True, "result": {"memory_id": "f" * 32}}
+                ), ""
+            return 0, json.dumps({"ok": True, "result": {"context": content}}), ""
+
+        monkeypatch.setattr(archive_pin, "_run_memory_cli", _spy)
+        verdict = archive_pin.build_verdict(0, db_path=str(tmp_path / "m.db"))
+        assert verdict["outcome"] == "ARCHIVED", verdict
+        assert len(calls) == 2, f"expected save+get, got {calls}"
+
+        save_args, get_args = calls
+        assert save_args == ["save", "--stdin", "--no-sync"], (
+            f"the save leg's argv changed: {save_args}"
+        )
+        assert save_args.count("--no-sync") == 1, "double-injected --no-sync"
+        assert get_args[0] == "get" and "--no-sync" not in get_args, (
+            f"the get leg's argv changed: {get_args}"
+        )
+        assert path.exists()
+        assert real_run is not None
 
 
 class _CompletedStub:

--- a/pact-plugin/tests/test_archive_pin.py
+++ b/pact-plugin/tests/test_archive_pin.py
@@ -18,6 +18,25 @@ Test strategy, stated because it is load-bearing:
   * The failure matrix stubs `_run_memory_cli`, because a real store cannot
     be made to fail on demand in the specific ways that matter.
   * Temp DBs throughout — no test touches the shared store.
+
+`db_path` IS REQUIRED AND KEYWORD-ONLY on `build_verdict`, so every call in
+this file states an answer. Two answers are legal and they mean different
+things:
+
+  * `db_path=str(tmp_path / ...)` — this call CAN reach a real save, and is
+    scoped to a temp store.
+  * `db_path=None` — this call provably never reaches a store, because the
+    enclosing test stubs `_run_memory_cli` (or `subprocess.run`) or
+    short-circuits before the spawn (bad index, unresolvable CLAUDE.md,
+    missing `_MEMORY_CLI`, a patched extractor). `None` still MEANS the
+    production store; what makes it safe here is that nothing consumes it.
+
+So `db_path=None` is a claim about the call site, not a shrug. If you delete
+the stub or the short-circuit above such a call, that claim becomes false and
+the call starts writing to the developer's real database — which is exactly
+the defect this parameter was made required to surface. The mechanical
+backstop is the guard in `_run_memory_cli`; this convention is what makes the
+choice reviewable.
 """
 
 import json
@@ -493,7 +512,7 @@ class TestStandaloneOnlyInvariant:
             return 0, json.dumps({"ok": True, "result": {"context": "x"}}), ""
 
         monkeypatch.setattr(archive_pin, "_run_memory_cli", _spy)
-        archive_pin.build_verdict(0)
+        archive_pin.build_verdict(0, db_path=None)
 
         assert "save" in subcommands, (
             "no save was attempted — the spy never saw the create path, so "
@@ -874,7 +893,7 @@ class TestArchivePin_FailureMatrix:
                                    "message": "bad field"})
             ),
         )
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
         assert verdict["outcome"] == "NOT_ARCHIVED"
         assert verdict["memory_id"] is None
         assert verdict["heading"] == "First Pin"
@@ -893,7 +912,7 @@ class TestArchivePin_FailureMatrix:
                                    "message": "Memory 'x' not found"})
             ),
         )
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
         assert "NOT_FOUND" in verdict["reason"]
 
     def test_containment_failure_is_not_archived(self, claude_md, monkeypatch):
@@ -915,7 +934,7 @@ class TestArchivePin_FailureMatrix:
             }), ""
 
         monkeypatch.setattr(archive_pin, "_run_memory_cli", _stub)
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
         assert verdict["outcome"] == "NOT_ARCHIVED"
         assert verdict["memory_id"] == "a" * 32, (
             "the id must still be reported so the orphan record is findable"
@@ -953,7 +972,7 @@ class TestArchivePin_FailureMatrix:
             }), ""
 
         monkeypatch.setattr(archive_pin, "_run_memory_cli", _stub)
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
         assert verdict["outcome"] == "ARCHIVED", (
             "a record wrapping the block in provenance is a GOOD archive"
         )
@@ -977,7 +996,7 @@ class TestArchivePin_FailureMatrix:
             )
 
         monkeypatch.setattr(archive_pin, "_run_memory_cli", _stub)
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
         assert verdict["outcome"] == "UNEVALUABLE"
         assert "c" * 32 in verdict["reason"]
         assert verdict["heading"] == "First Pin"
@@ -993,7 +1012,7 @@ class TestArchivePin_FailureMatrix:
         monkeypatch.setattr(
             archive_pin, "_run_memory_cli", lambda *a, **k: (0, stdout, "")
         )
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
         assert verdict["outcome"] != "ARCHIVED"
 
 
@@ -1004,25 +1023,25 @@ class TestArchivePin_Unevaluable:
         monkeypatch.setattr(
             archive_pin, "get_project_claude_md_path", lambda: None
         )
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
         assert verdict["outcome"] == "UNEVALUABLE"
         assert verdict["heading"] is None
 
     def test_no_pinned_section(self, claude_md):
         claude_md("# Project\n\n## Working Memory\n\n")
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
         assert verdict["outcome"] == "UNEVALUABLE"
 
     def test_index_beyond_pin_count(self, claude_md):
         claude_md(_two_pin_file())
-        verdict = archive_pin.build_verdict(99)
+        verdict = archive_pin.build_verdict(99, db_path=None)
         assert verdict["outcome"] == "UNEVALUABLE"
         assert "out of range" in verdict["reason"]
 
     def test_missing_memory_cli(self, claude_md, monkeypatch):
         claude_md(_two_pin_file())
         monkeypatch.setattr(archive_pin, "_MEMORY_CLI", Path("/nonexistent/cli.py"))
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
         assert verdict["outcome"] == "UNEVALUABLE"
         assert "not found" in verdict["reason"]
 
@@ -1034,7 +1053,7 @@ class TestArchivePin_Unevaluable:
             raise subprocess.TimeoutExpired(cmd="save", timeout=1)
 
         monkeypatch.setattr(subprocess, "run", _boom)
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
         assert verdict["outcome"] == "UNEVALUABLE"
         assert "timed out" in verdict["reason"]
 
@@ -1045,7 +1064,7 @@ class TestArchivePin_Unevaluable:
             raise IOError("simulated")
 
         monkeypatch.setattr(Path, "read_text", _raise)
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
         assert verdict["outcome"] == "UNEVALUABLE"
 
     def test_lossy_extractor_is_caught_before_any_write(
@@ -1069,7 +1088,7 @@ class TestArchivePin_Unevaluable:
             archive_pin, "_run_memory_cli",
             lambda *a, **k: called.append(a) or (0, "", ""),
         )
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
         assert verdict["outcome"] == "UNEVALUABLE"
         assert "not verbatim" in verdict["reason"]
         assert called == [], "must not save when the block is not verbatim"

--- a/pact-plugin/tests/test_archive_pin.py
+++ b/pact-plugin/tests/test_archive_pin.py
@@ -42,6 +42,7 @@ choice reviewable.
 import ast
 import json
 import os
+import sqlite3
 import subprocess
 import sys
 from pathlib import Path
@@ -738,6 +739,115 @@ class TestEnvPropagation_ExplicitCwdBeatsAmbient:
         )
         assert env["CLAUDE_PROJECT_DIR"] != str(decoy)
         assert calls[0][1]["cwd"] == str(intended)
+
+
+class TestArchiveRecordPredicate:
+    """The marker predicate, in code rather than reconstructed from prose.
+
+    Every prior audit hand-rolled this match, and the version people reach for
+    first is a substring test over the serialised blob. That is not equivalent:
+    it also matches a record that merely MENTIONS the marker. On a live store
+    the substring form returned 19 where the type-anchored form returned 18,
+    and the extra row was a memory ABOUT the marker — a document describing the
+    audit joining the population it was counting.
+    """
+
+    def test_matches_an_entity_carrying_the_marker_as_a_type(self):
+        entities = [{"name": "x", "type": archive_pin.ARCHIVE_ENTITY_TYPE}]
+        assert archive_pin.is_archive_record(entities) is True
+        assert archive_pin.is_archive_record(json.dumps(entities)) is True, (
+            "the stored form is a JSON string; a predicate that only accepts "
+            "decoded lists forces every caller to decode first"
+        )
+
+    def test_does_not_match_a_record_that_merely_mentions_the_marker(self):
+        """THE DISCRIMINATING CASE — this is the false positive measured live."""
+        mentions = [{
+            "name": f"note about {archive_pin.ARCHIVE_ENTITY_TYPE}",
+            "type": "observation",
+        }]
+        blob = json.dumps(mentions)
+        assert archive_pin.ARCHIVE_ENTITY_TYPE in blob, (
+            "fixture does not contain the marker at all — the substring form "
+            "would not match either, so this proves nothing"
+        )
+        assert archive_pin.is_archive_record(mentions) is False
+        assert archive_pin.is_archive_record(blob) is False
+
+    @pytest.mark.parametrize("bad", [
+        None, "", "not json", "{}", '"a string"', "[1, 2, 3]", '["text"]', 42,
+    ])
+    def test_is_total_and_never_raises(self, bad):
+        """An audit that dies on one malformed row reports nothing."""
+        assert archive_pin.is_archive_record(bad) is False
+
+    def test_sql_predicate_agrees_with_the_python_one(self, tmp_path):
+        db = tmp_path / "probe.db"
+        con = sqlite3.connect(str(db))
+        con.execute("CREATE TABLE memories (id TEXT PRIMARY KEY, entities TEXT)")
+        rows = [
+            ("carrier", [{"name": "n", "type": archive_pin.ARCHIVE_ENTITY_TYPE}]),
+            ("mentions", [{"name": f"about {archive_pin.ARCHIVE_ENTITY_TYPE}",
+                           "type": "observation"}]),
+            # A BARE STRING member. Real stores hold these — 63 among 14092 on
+            # the live one — and they are what breaks the naive spelling.
+            ("has_text_member", ["a bare string", {"name": "n", "type": "other"}]),
+        ]
+        for rid, ents in rows:
+            con.execute("INSERT INTO memories VALUES (?, ?)", (rid, json.dumps(ents)))
+        con.commit()
+
+        got = con.execute(
+            archive_pin.ARCHIVE_RECORD_COUNT_SQL,
+            (archive_pin.ARCHIVE_ENTITY_TYPE,),
+        ).fetchone()[0]
+        expected = sum(
+            1 for _, ents in rows if archive_pin.is_archive_record(ents)
+        )
+        assert expected == 1, "fixture drift: exactly one row should carry the marker"
+        assert got == expected, (
+            f"SQL predicate counted {got}, Python predicate {expected}"
+        )
+        con.close()
+
+    def test_the_naive_sql_spellings_raise_on_a_text_member(self, tmp_path):
+        """PIN AGAINST 'SIMPLIFICATION'. Both obvious forms fail on real data.
+
+        `json_extract` on a bare string raises `malformed JSON` and kills the
+        whole query. The natural defence — `json_type(j.value) = 'object'` —
+        raises IDENTICALLY, because `json_type` re-parses the value, so the
+        guard throws before the AND can short-circuit. Only `j.type`, the
+        column `json_each` already computed, filters without re-parsing.
+
+        Without this test, someone tidies the WHERE clause, every fixture here
+        happens to hold only objects, and the query dies on the first real
+        store it meets.
+        """
+        db = tmp_path / "naive.db"
+        con = sqlite3.connect(str(db))
+        con.execute("CREATE TABLE memories (id TEXT PRIMARY KEY, entities TEXT)")
+        con.execute(
+            "INSERT INTO memories VALUES (?, ?)",
+            ("has_text_member", json.dumps(["a bare string"])),
+        )
+        con.commit()
+
+        for label, where in (
+            ("json_extract alone", "json_extract(j.value, '$.type') = ?"),
+            ("json_type guard", "json_type(j.value) = 'object' "
+                                "AND json_extract(j.value, '$.type') = ?"),
+        ):
+            sql = ("SELECT COUNT(DISTINCT m.id) FROM memories m, "
+                   f"json_each(m.entities) j WHERE {where}")
+            with pytest.raises(sqlite3.OperationalError, match="malformed JSON"):
+                con.execute(sql, (archive_pin.ARCHIVE_ENTITY_TYPE,)).fetchone()
+
+        # The shipped spelling survives the same row.
+        assert con.execute(
+            archive_pin.ARCHIVE_RECORD_COUNT_SQL,
+            (archive_pin.ARCHIVE_ENTITY_TYPE,),
+        ).fetchone()[0] == 0
+        con.close()
 
 
 class TestProductionDbGuard:

--- a/pact-plugin/tests/test_archive_pin.py
+++ b/pact-plugin/tests/test_archive_pin.py
@@ -21,6 +21,7 @@ Test strategy, stated because it is load-bearing:
 """
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -546,6 +547,170 @@ class TestProjectDirResolution:
         assert resolved.name == "myproject"
         assert plugin_root not in resolved.parents
         assert resolved != plugin_root
+
+
+class TestEnvPropagation_ExplicitCwdBeatsAmbient:
+    """WHICH project the child process is TOLD it is in.
+
+    `_run_memory_cli` hands the child an explicit CLAUDE_PROJECT_DIR derived
+    from the caller's `cwd`. It used `env.setdefault`, which is a no-op when
+    the variable is already set — so an AMBIENT value beat an EXPLICIT caller
+    argument. The fail direction was inverted.
+
+    This is a PRODUCTION property, not test hygiene. `resolve_claude_md`
+    deliberately permits a worktree fall-through: the env dir is a worktree
+    carrying no CLAUDE.md, so resolution lands on the MAIN repo's file. Under
+    `setdefault` the archive was then filed under the WORKTREE while the pin
+    lived in the MAIN repo — precisely the pin/archive disagreement
+    `project_dir_for` exists to prevent.
+
+    Both tests fire in EVERY regime. A trigger conditioned on the ambient
+    variable already naming a CLAUDE.md-bearing directory would fire only in
+    that one cell and sit green everywhere else, which is how a control stops
+    meaning anything without anyone noticing.
+    """
+
+    @staticmethod
+    def _init_repo_with_worktree(root):
+        """Create a REAL git repo and a REAL linked worktree under `root`.
+
+        Real rather than simulated on purpose: `resolve_claude_md` refuses a
+        cross-project fall-through by asking git whether the env dir and the
+        resolved base share a repository. Stubbing that seam would patch out
+        the very permissiveness that makes this defect reachable in
+        production, and the test would then prove nothing about it.
+        """
+        main = root / "mainrepo"
+        subprocess.run(["git", "init", "-q", str(main)],
+                       capture_output=True, text=True, check=True)
+
+        def _git(*args):
+            return subprocess.run(["git", "-C", str(main), *args],
+                                  capture_output=True, text=True, check=True)
+
+        _git("config", "user.email", "t@example.com")
+        _git("config", "user.name", "t")
+        (main / "seed.txt").write_text("seed\n", encoding="utf-8")
+        _git("add", "seed.txt")
+        _git("commit", "-qm", "seed")
+        worktree = root / "linked-worktree"
+        _git("worktree", "add", "-q", "-b", "probe", str(worktree))
+        return main, worktree
+
+    @staticmethod
+    def _spy_memory_cli_spawns(monkeypatch, context=""):
+        """Capture the memory-CLI spawns AT THE PROCESS BOUNDARY.
+
+        Only the CLI spawns are intercepted. Git probes are delegated to the
+        real `subprocess.run`, because `resolve_claude_md` asks git whether
+        two paths share a repository — stubbing that would defeat the
+        fall-through under test. The boundary is the right observation point:
+        it is the last place the parent controls before the child re-imports
+        and re-resolves everything for itself.
+        """
+        real_run = subprocess.run
+        calls = []
+
+        class _Proc:
+            def __init__(self, stdout):
+                self.returncode = 0
+                self.stdout = stdout
+                self.stderr = ""
+
+        def _fake_run(argv, **kwargs):
+            if not (argv and argv[0] == sys.executable):
+                return real_run(argv, **kwargs)
+            calls.append((list(argv), kwargs))
+            subcommand = argv[2] if len(argv) > 2 else ""
+            if subcommand == "save":
+                return _Proc(json.dumps(
+                    {"ok": True, "result": {"memory_id": "e" * 32}}
+                ))
+            return _Proc(json.dumps(
+                {"ok": True, "result": {"context": context}}
+            ))
+
+        monkeypatch.setattr(archive_pin.subprocess, "run", _fake_run)
+        return calls
+
+    def test_archive_is_filed_under_the_repo_whose_claude_md_was_read(
+        self, tmp_path, monkeypatch
+    ):
+        """The production case: worktree env dir, main-repo CLAUDE.md."""
+        main, worktree = self._init_repo_with_worktree(tmp_path)
+        claude_md_path = main / "CLAUDE.md"
+        claude_md_path.write_text(_two_pin_file(), encoding="utf-8")
+        monkeypatch.setattr(
+            archive_pin, "get_project_claude_md_path", lambda: claude_md_path
+        )
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(worktree))
+
+        # PRECONDITIONS, asserted separately and FIRST. A fixture that drifts
+        # out of the regime under test then fails with its own message,
+        # instead of presenting as a regression in the one load-bearing
+        # assertion below and inviting someone to "fix" that instead.
+        assert not (worktree / "CLAUDE.md").exists(), (
+            "fixture drift: the worktree must carry NO CLAUDE.md, or the "
+            "fall-through this test depends on never happens"
+        )
+        assert archive_pin._same_repository(worktree, main), (
+            "fixture drift: git does not consider the worktree part of the "
+            "main repo, so resolve_claude_md would REFUSE rather than fall "
+            "through, and this test would measure the refusal path"
+        )
+
+        calls = self._spy_memory_cli_spawns(
+            monkeypatch, context=claude_md_path.read_text(encoding="utf-8")
+        )
+        verdict = archive_pin.build_verdict(0, db_path=str(tmp_path / "m.db"))
+
+        assert verdict["outcome"] == "ARCHIVED", verdict
+        assert calls, (
+            "the memory CLI was never spawned — nothing was measured, and a "
+            "per-call assertion over an empty list passes vacuously"
+        )
+        for argv, kwargs in calls:
+            assert kwargs["env"]["CLAUDE_PROJECT_DIR"] == str(main), (
+                f"the child was told it is in {kwargs['env']['CLAUDE_PROJECT_DIR']!r}, "
+                f"but the CLAUDE.md actually read lives in {str(main)!r}. The "
+                f"ambient value (the worktree) beat the resolved base, so the "
+                f"archive files under a different project than the pin. "
+                f"argv={argv[2:4]}"
+            )
+            assert kwargs["cwd"] == str(main)
+
+    def test_explicit_cwd_overwrites_an_ambient_project_dir(
+        self, tmp_path, monkeypatch
+    ):
+        """The fail-direction, isolated from resolution entirely."""
+        decoy = tmp_path / "decoy"
+        decoy.mkdir()
+        intended = tmp_path / "intended"
+        intended.mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(decoy))
+
+        # PRECONDITION FIRST: without a live ambient value this test cannot
+        # tell `setdefault` from assignment, and would pass under both.
+        assert os.environ.get("CLAUDE_PROJECT_DIR") == str(decoy), (
+            "precondition: the ambient decoy is not set, so this test cannot "
+            "distinguish setdefault from explicit assignment"
+        )
+
+        calls = self._spy_memory_cli_spawns(monkeypatch)
+        archive_pin._run_memory_cli(["get", "x" * 32], cwd=intended)
+
+        assert len(calls) == 1, (
+            f"expected exactly one CLI spawn, captured {len(calls)}"
+        )
+        env = calls[0][1]["env"]
+        assert env["CLAUDE_PROJECT_DIR"] == str(intended), (
+            "the ambient CLAUDE_PROJECT_DIR beat the caller's explicit cwd. "
+            "`env.setdefault` is a no-op when the variable is already set, "
+            "which inverts the fail direction: the general answer wins over "
+            "the specific one."
+        )
+        assert env["CLAUDE_PROJECT_DIR"] != str(decoy)
+        assert calls[0][1]["cwd"] == str(intended)
 
 
 @pytest.mark.requires_embedding_backend

--- a/pact-plugin/tests/test_archive_pin.py
+++ b/pact-plugin/tests/test_archive_pin.py
@@ -807,6 +807,52 @@ class TestProductionDbGuard:
             f"guard did not fire; stderr={proc.stderr[:400]}"
         )
 
+    def test_refusal_states_the_observation_and_not_an_inference(self, tmp_path):
+        """The guard sees a VARIABLE; it does not see a pytest run.
+
+        Those come apart — an exported or inherited PYTEST_CURRENT_TEST reaches
+        a plain shell with no test anywhere — and that is exactly the case a
+        curator hits. Asserting the inference makes the message false precisely
+        when someone is relying on it to understand what happened.
+        """
+        proc = self._spawn_cli(tmp_path, with_pytest_var=True)
+        stderr = proc.stderr
+        assert "PYTEST_CURRENT_TEST" in stderr, (
+            "the refusal does not name the variable it keyed on, so the "
+            f"reader cannot check or clear it: {stderr[:400]}"
+        )
+        assert "spawned from a pytest run" not in stderr, (
+            "the refusal asserts it was spawned from a pytest run — an "
+            "inference the guard cannot make and which is false when the "
+            f"variable was exported or inherited: {stderr[:400]}"
+        )
+
+    def test_refusal_does_not_advise_a_curator_to_scope_the_archive(
+        self, tmp_path
+    ):
+        """THE REMEDY IS AUDIENCE-SPECIFIC AND THE ANSWERS ARE OPPOSITE.
+
+        For a test, `--db-path` is right. For a curator archiving a pin it is
+        destructive: the archive lands in a throwaway database, the verdict
+        reports success, and the pin becomes eligible for deletion with its
+        only copy in a file about to be discarded. A correct guard with the
+        wrong remedy can destroy exactly what the guard protected.
+
+        So the message must carry BOTH branches and must tell the curator NOT
+        to pass --db-path. A message offering only the test remedy passes a
+        bare "mentions --db-path" check, which is why this asserts the
+        curator's branch specifically.
+        """
+        stderr = self._spawn_cli(tmp_path, with_pytest_var=True).stderr
+        assert "do NOT pass --db-path" in stderr, (
+            "the refusal does not warn a curator away from --db-path; "
+            "followed literally its advice archives the pin into a throwaway "
+            f"database and marks it deletion-eligible: {stderr[:400]}"
+        )
+        assert "unset PYTEST_CURRENT_TEST" in stderr, (
+            f"the refusal never states the fix that preserves the pin: {stderr[:400]}"
+        )
+
     def test_the_curator_production_path_is_not_blocked(self, tmp_path):
         """OVER-BLOCK CONTROL, and the reason the gate exists.
 

--- a/pact-plugin/tests/test_archive_pin.py
+++ b/pact-plugin/tests/test_archive_pin.py
@@ -716,7 +716,14 @@ class TestEnvPropagation_ExplicitCwdBeatsAmbient:
         )
 
         calls = self._spy_memory_cli_spawns(monkeypatch)
-        archive_pin._run_memory_cli(["get", "x" * 32], cwd=intended)
+        # Scoped db_path, though the spy means no child is ever launched:
+        # this call enters the real `_run_memory_cli`, and naming a temp store
+        # keeps it correct under the production-DB guard rather than relying
+        # on the spy sitting downstream of it. None of the assertions below
+        # read db_path, so it cannot perturb the property under test.
+        archive_pin._run_memory_cli(
+            ["get", "x" * 32], db_path=str(tmp_path / "mem.db"), cwd=intended
+        )
 
         assert len(calls) == 1, (
             f"expected exactly one CLI spawn, captured {len(calls)}"
@@ -730,6 +737,195 @@ class TestEnvPropagation_ExplicitCwdBeatsAmbient:
         )
         assert env["CLAUDE_PROJECT_DIR"] != str(decoy)
         assert calls[0][1]["cwd"] == str(intended)
+
+
+class TestProductionDbGuard:
+    """The MECHANICAL closure for the production-database leak.
+
+    A required `db_path` makes the choice visible; it does not make it safe.
+    `None` still satisfies the signature and still means the real store, and
+    `""` is falsy so it takes the same branch as an omission. This class pins
+    the two guards that turn those into failures.
+
+    The guards sit on OPPOSITE SIDES of the process boundary and that split is
+    the design, not an accident:
+
+      * PARENT (`_run_memory_cli`) rejects falsy-BUT-PRESENT db_path. It sees
+        the caller's intent, so it can tell `""` from `None`.
+      * CHILD (`cli.py`) refuses the production store outright when no
+        --db-path arrived. It sees the actual spawn, so it catches routes that
+        never touch `archive_pin` at all -- including a raw
+        `subprocess.run([sys.executable, cli.py, ...])`.
+
+    Neither covers the other's cases. The parent guard cannot see a spawn that
+    bypasses it; the child guard cannot see intent that never crossed.
+
+    EVERY TEST HERE SANDBOXES `HOME`. That is not decoration: `config.py` binds
+    the database path from `Path.home()` AT IMPORT, so an in-process HOME
+    change is inert -- but a child re-imports, so HOME in the CHILD'S env does
+    redirect it. These tests exercise the exact production shape (no
+    --db-path) with zero production risk, which is only possible because the
+    boundary that makes the defect hard to guard is the same boundary that
+    makes it safe to test.
+    """
+
+    @staticmethod
+    def _spawn_cli(tmp_path, *, with_pytest_var, extra_argv=()):
+        """Run the memory CLI as the curator's production shape: no --db-path.
+
+        HOME points into tmp_path, so the child resolves a temp database even
+        on the branch that would otherwise select production.
+        """
+        cli = (
+            Path(archive_pin.__file__).resolve().parent.parent
+            / "skills" / "pact-memory" / "scripts" / "cli.py"
+        )
+        assert cli.exists(), f"CLI not found at {cli} — this test measures nothing"
+        home = tmp_path / "sandbox-home"
+        home.mkdir(exist_ok=True)
+        env = dict(os.environ)
+        env["HOME"] = str(home)
+        if with_pytest_var:
+            env["PYTEST_CURRENT_TEST"] = "sentinel::test (call)"
+        else:
+            env.pop("PYTEST_CURRENT_TEST", None)
+        return subprocess.run(
+            [sys.executable, str(cli), "get", "f" * 32, *extra_argv],
+            capture_output=True, text=True, timeout=120, env=env,
+        )
+
+    def test_child_refuses_the_production_db_when_spawned_under_pytest(
+        self, tmp_path
+    ):
+        proc = self._spawn_cli(tmp_path, with_pytest_var=True)
+        assert proc.returncode != 0, (
+            "the child exited 0 with no --db-path under pytest — it would "
+            "have used the production database"
+        )
+        assert "UNSCOPED_TEST_DB" in proc.stderr, (
+            f"guard did not fire; stderr={proc.stderr[:400]}"
+        )
+
+    def test_the_curator_production_path_is_not_blocked(self, tmp_path):
+        """OVER-BLOCK CONTROL, and the reason the gate exists.
+
+        `archive_pin --index N` (commands/prune-memory.md) passes no
+        --db-path, and /PACT:prune-memory keys its refuse-or-proceed decision
+        on that command. An ungated guard breaks it. This asserts the guard is
+        SILENT with the variable absent — the same spawn, one variable apart.
+        """
+        proc = self._spawn_cli(tmp_path, with_pytest_var=False)
+        assert "UNSCOPED_TEST_DB" not in proc.stderr, (
+            "the guard fired OUTSIDE pytest — this is the cardinal over-block: "
+            f"`archive_pin --index N` would stop working. stderr={proc.stderr[:400]}"
+        )
+
+    def test_an_explicit_db_path_is_accepted_under_pytest(self, tmp_path):
+        """The guard must block only the UNSCOPED case, not every spawn."""
+        proc = self._spawn_cli(
+            tmp_path, with_pytest_var=True,
+            extra_argv=("--db-path", str(tmp_path / "scoped.db")),
+        )
+        assert "UNSCOPED_TEST_DB" not in proc.stderr, (
+            f"guard fired despite an explicit --db-path; stderr={proc.stderr[:400]}"
+        )
+
+    @pytest.mark.parametrize("pass_cwd", [True, False])
+    def test_tripwire_the_child_actually_receives_pytest_current_test(
+        self, tmp_path, monkeypatch, pass_cwd
+    ):
+        """NON-OPTIONAL TRIPWIRE. The guard's fail direction is ALLOW.
+
+        The child-side guard works only because `_run_memory_cli` hands the
+        child a FULL copy of this process's environment. Hardening that to a
+        minimal allowlist is plausible, otherwise desirable, and would disable
+        the guard SILENTLY — every other test in this file would still pass,
+        because they assert on the guard's behaviour given the variable rather
+        than on the variable arriving.
+
+        So this asserts the delivery itself, on BOTH branches of the env
+        construction: `cwd` passed (env is a dict copy) and `cwd` omitted
+        (env stays None, so the child inherits verbatim).
+
+        It also records WHY the signal must be inherited rather than detected:
+        `"pytest" in sys.modules` is False in the child, measured here rather
+        than asserted in a comment. A future reader proposing an in-process
+        check can see it is not available.
+        """
+        probe = tmp_path / "probe.py"
+        probe.write_text(
+            "import os, sys, json\n"
+            "print(json.dumps({\n"
+            "    'seen': os.environ.get('PYTEST_CURRENT_TEST'),\n"
+            "    'pytest_importable_here': 'pytest' in sys.modules,\n"
+            "}))\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(archive_pin, "_MEMORY_CLI", probe)
+        rc, stdout, stderr = archive_pin._run_memory_cli(
+            [], db_path=None, cwd=(tmp_path if pass_cwd else None)
+        )
+        assert rc == 0, f"probe child failed: {stderr[:300]}"
+        report = json.loads(stdout)
+
+        assert report["seen"], (
+            "PYTEST_CURRENT_TEST did NOT reach the child. The child-side "
+            "production-DB guard in cli.py is therefore INERT, and its fail "
+            "direction is ALLOW — unscoped spawns will silently use the real "
+            "database. Most likely cause: _run_memory_cli stopped passing a "
+            "full env copy."
+        )
+        assert report["pytest_importable_here"] is False, (
+            "pytest IS visible in the child, so the guard could have used an "
+            "in-process check — revisit the forced-choice reasoning in "
+            "cli.py's _refuse_production_db_under_pytest docstring"
+        )
+
+    def test_parent_rejects_falsy_but_present_db_path(self, tmp_path):
+        """`db_path=""` is falsy, so without this it routes to production.
+
+        The real `_MEMORY_CLI` is left in place. Repointing it at a
+        non-existent file to prevent a spawn does not work here and is worth
+        recording: the existence check runs BEFORE this guard, so the call
+        raises `_Unevaluable` for the WRONG REASON and a test asserting only
+        on the exception TYPE would pass while measuring the missing-CLI path.
+        No spawn happens regardless, because the guard raises before argv is
+        built. Assert on the reason, not just the type.
+        """
+        with pytest.raises(archive_pin._Unevaluable) as excinfo:
+            archive_pin._run_memory_cli(["get", "x" * 32], db_path="", cwd=tmp_path)
+        assert "empty value" in str(excinfo.value.reason), (
+            f"raised for the wrong reason: {excinfo.value.reason!r}"
+        )
+
+    def test_parent_allows_none_so_non_spawning_paths_keep_working(
+        self, tmp_path, monkeypatch
+    ):
+        """None is the not-scoping sentinel, and must NOT be rejected here.
+
+        Six tests reach `_run_memory_cli` with `db_path=None` while stubbing
+        `subprocess.run` or `_MEMORY_CLI`; none can touch a store. Rejecting
+        plain falsiness rather than falsy-but-present would redden all six for
+        a hazard they do not have — and the cheap-looking repair would be to
+        weaken the guard.
+        """
+        calls = []
+        monkeypatch.setattr(
+            archive_pin.subprocess, "run",
+            lambda argv, **kw: calls.append(argv) or _CompletedStub(),
+        )
+        archive_pin._run_memory_cli(["get", "x" * 32], db_path=None, cwd=tmp_path)
+        assert calls, "the spawn never happened — this test proves nothing"
+        assert "--db-path" not in calls[0], (
+            "a None db_path must not synthesize a --db-path argument"
+        )
+
+
+class _CompletedStub:
+    """Minimal stand-in for CompletedProcess on a path that must not spawn."""
+    returncode = 0
+    stdout = '{"ok": true, "result": {}}'
+    stderr = ""
 
 
 @pytest.mark.requires_embedding_backend

--- a/pact-plugin/tests/test_archive_pin_emit.py
+++ b/pact-plugin/tests/test_archive_pin_emit.py
@@ -29,7 +29,7 @@ claim false without changing the call.
 ONE call in this file genuinely reaches the memory CLI:
 `test_null_when_the_pin_does_not_resolve`'s resolving control. It is scoped
 to a temp `db_path`. Before that scoping it ran with the default and wrote
-into the developer's PRODUCTION database, two rows per suite run, one per
+into the developer's LIVE database, two rows per suite run, one per
 parametrization. It must STAY reaching — it is a non-vacuity control, and a
 control that stops reaching stops controlling — so it is scoped, not stubbed.
 """
@@ -184,7 +184,7 @@ class TestDeleteStringEmitContract:
         The control REACHES A REAL SAVE — it is the one place in these three
         files where a bare `build_verdict` reached the memory CLI, and with
         `db_path` defaulting to None that save landed in the DEVELOPER'S
-        PRODUCTION DATABASE. Measured at two rows per suite run, one per
+        LIVE DATABASE. Measured at two rows per suite run, one per
         parametrization. The control has to stay reaching to be a control, so
         the fix is to SCOPE it, never to stub it.
         """

--- a/pact-plugin/tests/test_archive_pin_emit.py
+++ b/pact-plugin/tests/test_archive_pin_emit.py
@@ -19,6 +19,19 @@ may claim the stronger property.
 The error directions are not symmetric. A false ARCHIVED destroys content
 (CLAUDE.md is gitignored, so there is no git fallback); a false refusal
 costs an over-block and loses nothing. Tests weight accordingly.
+
+`db_path` IS REQUIRED AND KEYWORD-ONLY on `build_verdict`. `db_path=None`
+here always means "this call provably never reaches a store" — the enclosing
+test stubs `_run_memory_cli` or short-circuits before the spawn. It is a
+claim about the call site, and deleting the stub above such a call makes the
+claim false without changing the call.
+
+ONE call in this file genuinely reaches the memory CLI:
+`test_null_when_the_pin_does_not_resolve`'s resolving control. It is scoped
+to a temp `db_path`. Before that scoping it ran with the default and wrote
+into the developer's PRODUCTION database, two rows per suite run, one per
+parametrization. It must STAY reaching — it is a non-vacuity control, and a
+control that stops reaching stops controlling — so it is scoped, not stubbed.
 """
 
 import json
@@ -104,7 +117,7 @@ class TestDeleteStringEmitContract:
         block = _expected_block(content, 0)
         monkeypatch.setattr(archive_pin, "_run_memory_cli", _ok_stub(block))
 
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
 
         # Non-vacuity: prove the arm was actually taken. Without this the
         # assertion below passes on any outcome that happens to carry a key.
@@ -126,7 +139,7 @@ class TestDeleteStringEmitContract:
             ),
         )
 
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
 
         assert verdict["outcome"] == "NOT_ARCHIVED"
         assert verdict["memory_id"] is None, "the archive must have failed"
@@ -147,7 +160,7 @@ class TestDeleteStringEmitContract:
             )
 
         monkeypatch.setattr(archive_pin, "_run_memory_cli", _refetch_fails)
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
 
         assert verdict["outcome"] == "UNEVALUABLE"
         # heading non-null is what PROVES the pin resolved before the failure
@@ -155,7 +168,9 @@ class TestDeleteStringEmitContract:
         assert verdict["delete_string"] == _expected_block(content, 0)
 
     @pytest.mark.parametrize("bad_index", [99, -1])
-    def test_null_when_the_pin_does_not_resolve(self, claude_md, bad_index):
+    def test_null_when_the_pin_does_not_resolve(
+        self, claude_md, bad_index, tmp_path
+    ):
         """THE DISCRIMINATING ROW.
 
         If `delete_string` were merely "the block we happened to compute",
@@ -165,11 +180,18 @@ class TestDeleteStringEmitContract:
         NON-VACUITY CONTROL IS LOAD-BEARING: a test asserting only `is None`
         passes trivially if the field is ALWAYS None. The resolving control
         below is what makes the null meaningful.
+
+        The control REACHES A REAL SAVE — it is the one place in these three
+        files where a bare `build_verdict` reached the memory CLI, and with
+        `db_path` defaulting to None that save landed in the DEVELOPER'S
+        PRODUCTION DATABASE. Measured at two rows per suite run, one per
+        parametrization. The control has to stay reaching to be a control, so
+        the fix is to SCOPE it, never to stub it.
         """
         content = _two_pin_file()
         claude_md(content)
 
-        unresolved = archive_pin.build_verdict(bad_index)
+        unresolved = archive_pin.build_verdict(bad_index, db_path=None)
         assert unresolved["outcome"] == "UNEVALUABLE"
         assert unresolved["heading"] is None
         assert unresolved["delete_string"] is None
@@ -177,7 +199,9 @@ class TestDeleteStringEmitContract:
         # CONTROL: the same file, a resolving index, must be NON-null.
         # Without this the assertion above cannot distinguish "null because
         # the pin did not resolve" from "null always".
-        resolving = archive_pin.build_verdict(0)
+        resolving = archive_pin.build_verdict(
+            0, db_path=str(tmp_path / "mem.db")
+        )
         assert resolving["delete_string"] is not None, (
             "delete_string is null even on a RESOLVING pin — the null above "
             "proves nothing"
@@ -191,7 +215,7 @@ class TestDeleteStringEmitContract:
         `verdict["delete_string"]` must not raise KeyError.
         """
         claude_md(_two_pin_file())
-        verdict = archive_pin.build_verdict(99)
+        verdict = archive_pin.build_verdict(99, db_path=None)
         assert "delete_string" in verdict
         assert "claude_md_path" in verdict
 
@@ -212,7 +236,7 @@ class TestDeleteStringEmitContract:
         block = _expected_block(content, 1)
         monkeypatch.setattr(archive_pin, "_run_memory_cli", _ok_stub(block))
 
-        verdict = archive_pin.build_verdict(1)
+        verdict = archive_pin.build_verdict(1, db_path=None)
 
         assert verdict["delete_string"] == block
         assert verdict["delete_string"] != verdict["heading"]
@@ -233,7 +257,7 @@ class TestDeleteStringEmitContract:
         block = _expected_block(content, 0)
         monkeypatch.setattr(archive_pin, "_run_memory_cli", _ok_stub(block))
 
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
 
         assert verdict["claude_md_path"] == str(path)
         on_disk = Path(verdict["claude_md_path"]).read_text(encoding="utf-8")
@@ -258,7 +282,7 @@ class TestDeleteStringEmitContract:
         block = _expected_block(content, 0)
         monkeypatch.setattr(archive_pin, "_run_memory_cli", _ok_stub(block))
 
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
 
         assert verdict["delete_string"].endswith("\n\n"), (
             "the block was stripped in transit; consecutive spans no longer "
@@ -301,7 +325,7 @@ class TestDeleteStringUniqueness:
 
         claude_md(content)
         monkeypatch.setattr(archive_pin, "_run_memory_cli", _ok_stub(block))
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
 
         assert verdict["outcome"] == "ARCHIVED_DELETE_UNSAFE"
         assert verdict["memory_id"] == "a" * 32, (
@@ -317,7 +341,7 @@ class TestDeleteStringUniqueness:
         block = _expected_block(content, 0)
         monkeypatch.setattr(archive_pin, "_run_memory_cli", _ok_stub(block))
 
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
 
         assert verdict["outcome"] == "ARCHIVED"
         assert verdict["occurrences"] == 1
@@ -352,7 +376,7 @@ class TestDeleteStringUniqueness:
         monkeypatch.setattr(
             archive_pin, "_run_memory_cli", _writer_removes_the_pin
         )
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
 
         assert verdict["outcome"] == "ARCHIVED_DELETE_UNSAFE"
         assert verdict["occurrences"] == 0
@@ -380,7 +404,7 @@ class TestDeleteStringUniqueness:
         block = _expected_block(content, 0)
         monkeypatch.setattr(archive_pin, "_run_memory_cli", _ok_stub(block))
 
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
 
         assert verdict["outcome"] == "ARCHIVED"
         assert "locations" not in verdict
@@ -396,7 +420,7 @@ class TestDeleteStringUniqueness:
         claude_md(content)
         monkeypatch.setattr(archive_pin, "_run_memory_cli", _ok_stub(block))
 
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
 
         assert len(verdict["locations"]) == verdict["occurrences"]
         for offset in verdict["locations"]:
@@ -469,7 +493,7 @@ class TestStartEdgeDoesNotOrphanTheDateComment:
         claude_md(content)
         block = _expected_block(content, 0)
         monkeypatch.setattr(archive_pin, "_run_memory_cli", _ok_stub(block))
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
 
         after = content.replace(verdict["delete_string"], "", 1)
         pins = archive_pin.parse_pins(_pinned_body(after))
@@ -519,7 +543,7 @@ class TestSyncSuppressionSeam:
             ), ""
 
         monkeypatch.setattr(archive_pin, "_run_memory_cli", _record)
-        archive_pin.build_verdict(0)
+        archive_pin.build_verdict(0, db_path=None)
 
         save_calls = [a for a in seen if a and a[0] == "save"]
         assert len(save_calls) == 1, "expected exactly one save call"

--- a/pact-plugin/tests/test_archive_pin_resolver.py
+++ b/pact-plugin/tests/test_archive_pin_resolver.py
@@ -29,6 +29,15 @@ fall-through to reach the main checkout's file. A blanket "env dir has no
 CLAUDE.md -> refuse" rule would break that on every single invocation — a
 cardinal over-block. `test_same_repository_fallthrough_is_allowed` is the
 guard on that, and it is the more important half of this file.
+
+`db_path` IS REQUIRED AND KEYWORD-ONLY on `build_verdict`. Every bare
+`build_verdict` call in this file passes `db_path=None`, and every one of
+them is provably inert: the enclosing test either stubs `_run_memory_cli` /
+`subprocess.run`, or short-circuits before the spawn (a bad index, an
+unresolvable CLAUDE.md, a missing `_MEMORY_CLI`, a patched extractor). `None`
+still MEANS the production store — what makes it safe is that nothing
+consumes it. Delete the stub or the short-circuit above such a call and the
+claim silently becomes false.
 """
 
 import json
@@ -280,7 +289,7 @@ class TestSymlinkedClaudeMdAttribution:
             ), ""
 
         monkeypatch.setattr(archive_pin, "_run_memory_cli", _spy)
-        archive_pin.build_verdict(0)
+        archive_pin.build_verdict(0, db_path=None)
 
         assert seen, "the memory CLI was never invoked — nothing was measured"
         assert Path(seen["cwd"]).name == "myproject", (
@@ -303,7 +312,7 @@ class TestVerdictCarriesTheResolvedPath:
         a = _make_project(isolated / "project_a", "PIN A")
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(a))
         monkeypatch.chdir(a)
-        verdict = archive_pin.build_verdict(99)
+        verdict = archive_pin.build_verdict(99, db_path=None)
         assert verdict["outcome"] == "UNEVALUABLE"
         assert verdict["claude_md_path"] is not None
         assert "project_a" in verdict["claude_md_path"]
@@ -314,7 +323,7 @@ class TestVerdictCarriesTheResolvedPath:
         empty = _make_project(isolated / "empty", None)
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(empty))
         monkeypatch.chdir(empty)
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
         assert verdict["outcome"] == "UNEVALUABLE"
         assert verdict["claude_md_path"] is None, (
             "null means no file was resolved; inventing a path here would be "
@@ -415,7 +424,7 @@ class TestSyncSuppressionAndDeleteString:
                                       "message": "gone"})
 
         monkeypatch.setattr(archive_pin, "_run_memory_cli", _stub)
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
         assert verdict["outcome"] == "UNEVALUABLE"
         assert verdict["delete_string"] is not None
         assert "### PIN A" in verdict["delete_string"]
@@ -426,7 +435,7 @@ class TestSyncSuppressionAndDeleteString:
         a = _make_project(isolated / "project_a", "PIN A")
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(a))
         monkeypatch.chdir(a)
-        verdict = archive_pin.build_verdict(99)
+        verdict = archive_pin.build_verdict(99, db_path=None)
         assert verdict["outcome"] == "UNEVALUABLE"
         assert verdict["delete_string"] is None
 
@@ -604,7 +613,7 @@ class TestPostResolutionFailuresKeepPinContext:
             raise subprocess.TimeoutExpired(cmd="save", timeout=1)
 
         monkeypatch.setattr(subprocess, "run", _boom)
-        self._assert_full_context(archive_pin.build_verdict(0), "timeout",
+        self._assert_full_context(archive_pin.build_verdict(0, db_path=None), "timeout",
                                   "timed out")
 
     def test_cli_launch_failure_keeps_context(self, isolated, monkeypatch):
@@ -614,7 +623,7 @@ class TestPostResolutionFailuresKeepPinContext:
             raise OSError("cannot launch")
 
         monkeypatch.setattr(subprocess, "run", _boom)
-        self._assert_full_context(archive_pin.build_verdict(0), "launch",
+        self._assert_full_context(archive_pin.build_verdict(0, db_path=None), "launch",
                                   "could not launch")
 
     def test_missing_cli_keeps_context(self, isolated, monkeypatch):
@@ -622,7 +631,7 @@ class TestPostResolutionFailuresKeepPinContext:
         monkeypatch.setattr(
             archive_pin, "_MEMORY_CLI", Path("/nonexistent/cli.py")
         )
-        self._assert_full_context(archive_pin.build_verdict(0), "missing cli",
+        self._assert_full_context(archive_pin.build_verdict(0, db_path=None), "missing cli",
                                   "not found")
 
     def test_pre_resolution_failure_still_reports_less(
@@ -635,7 +644,7 @@ class TestPostResolutionFailuresKeepPinContext:
         ever started reporting a heading, the tests above would be passing
         for the wrong reason."""
         self._project(isolated, monkeypatch, "t4")
-        verdict = archive_pin.build_verdict(99)
+        verdict = archive_pin.build_verdict(99, db_path=None)
         assert verdict["outcome"] == "UNEVALUABLE"
         assert verdict["heading"] is None
         assert verdict["delete_string"] is None
@@ -671,7 +680,7 @@ class TestDeliberateDeleteStringOmissions:
         monkeypatch.chdir(a)
         monkeypatch.setattr(archive_pin, "extract_pin_block",
                             lambda *args, **kw: "   \n  ")
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
         assert verdict["outcome"] == "UNEVALUABLE"
         assert "empty" in verdict["reason"]
         assert verdict["delete_string"] is None, (
@@ -691,7 +700,7 @@ class TestDeliberateDeleteStringOmissions:
             archive_pin, "extract_pin_block",
             lambda *args, **kw: "### Fabricated\nnot from the source",
         )
-        verdict = archive_pin.build_verdict(0)
+        verdict = archive_pin.build_verdict(0, db_path=None)
         assert verdict["outcome"] == "UNEVALUABLE"
         assert "not verbatim" in verdict["reason"]
         assert verdict["delete_string"] is None, (

--- a/pact-plugin/tests/test_archive_pin_resolver.py
+++ b/pact-plugin/tests/test_archive_pin_resolver.py
@@ -35,7 +35,7 @@ guard on that, and it is the more important half of this file.
 them is provably inert: the enclosing test either stubs `_run_memory_cli` /
 `subprocess.run`, or short-circuits before the spawn (a bad index, an
 unresolvable CLAUDE.md, a missing `_MEMORY_CLI`, a patched extractor). `None`
-still MEANS the production store — what makes it safe is that nothing
+still MEANS the live store — what makes it safe is that nothing
 consumes it. Delete the stub or the short-circuit above such a call and the
 claim silently becomes false.
 """

--- a/pact-plugin/tests/test_memory_cli.py
+++ b/pact-plugin/tests/test_memory_cli.py
@@ -1433,9 +1433,28 @@ class TestProductionDbGuardScope:
         # Returns instead of raising SystemExit — the in-process branch.
         assert _refuse_production_db_under_pytest(None) is None
 
-    def test_an_explicit_db_path_is_never_refused(self, tmp_path):
-        """Non-vacuity: the exemption above must not be the ONLY reason it
-        returns. With a db_path present it returns before either check."""
+    def test_an_explicit_db_path_is_never_refused(self, tmp_path, monkeypatch):
+        """Non-vacuity: the db_path check must not be MASKED by the exemption.
+
+        Asserting this from an ordinary in-process test measures nothing. Both
+        early returns fire here — `db_path is not None` AND `pytest in
+        sys.modules` — so the call returns None whichever one is doing the
+        work, and it keeps returning None when the db_path check is deleted
+        outright. Verified by mutation: with that check removed the assertion
+        still passed, while the child-side spawn test in test_archive_pin.py
+        caught it. A control that cannot fail is not a control.
+
+        So the in-process exemption is SUPPRESSED first — pytest is hidden from
+        `sys.modules` and the inherited child signal is set, which is exactly
+        the state a spawned child is in. The db_path check is then the ONLY
+        thing that can prevent a refusal, and the assertion is coupled to it.
+        """
+        monkeypatch.delitem(sys.modules, "pytest", raising=False)
+        monkeypatch.setenv("PYTEST_CURRENT_TEST", "sentinel::test (call)")
+        assert "pytest" not in sys.modules, (
+            "precondition: the in-process exemption is still live, so this "
+            "test cannot show the db_path check is what prevents the refusal"
+        )
         assert _refuse_production_db_under_pytest(tmp_path / "x.db") is None
 
 

--- a/pact-plugin/tests/test_memory_cli.py
+++ b/pact-plugin/tests/test_memory_cli.py
@@ -36,7 +36,7 @@ from test_working_memory_concurrency_comprehensive import _seed_claude_md
 # Add pact-memory skill root to path so `from scripts.cli import ...` works
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
 
-from scripts.cli import build_parser, cmd_save, cmd_search, cmd_list, cmd_get, cmd_status, cmd_setup, cmd_update, cmd_delete, main, _COMMANDS
+from scripts.cli import build_parser, cmd_save, cmd_search, cmd_list, cmd_get, cmd_status, cmd_setup, cmd_update, cmd_delete, main, _COMMANDS, _refuse_production_db_under_pytest
 from scripts.memory_api import PACTMemory
 
 
@@ -1401,6 +1401,43 @@ class TestCliOutputFormat:
 # ---------------------------------------------------------------------------
 # Error Handling
 # ---------------------------------------------------------------------------
+
+class TestProductionDbGuardScope:
+    """The production-DB guard is scoped to SPAWNED CHILDREN, deliberately.
+
+    `_refuse_production_db_under_pytest` refuses the real store when a test
+    process spawned the CLI with no `--db-path`. It must NOT fire for the
+    in-process `main()` calls this file makes: they patch `PACTMemory` and
+    open no store, and `test_main_db_path_none_when_not_specified` exists
+    precisely to assert that an omitted `--db-path` yields `db_path=None`.
+    A guard firing there would refuse a contract the CLI is meant to have.
+
+    The separation is available because the same fact that FORCES the env
+    signal for spawned children also identifies them: a child is a fresh
+    interpreter with no `pytest` in `sys.modules`.
+
+    This is pinned rather than left implicit because the ten in-process tests
+    below pass for this reason, and a maintainer who removed the `sys.modules`
+    check would see ten failures with no statement of why the check was there.
+
+    RESIDUAL, stated: an in-process `main()` call with a REAL `PACTMemory` and
+    no `--db-path` still reaches production. Nothing catches that; nothing
+    currently does it.
+    """
+
+    def test_in_process_callers_are_exempt(self):
+        assert "pytest" in sys.modules, (
+            "pytest is absent from this process, so this test cannot "
+            "distinguish the in-process case from the spawned-child case"
+        )
+        # Returns instead of raising SystemExit — the in-process branch.
+        assert _refuse_production_db_under_pytest(None) is None
+
+    def test_an_explicit_db_path_is_never_refused(self, tmp_path):
+        """Non-vacuity: the exemption above must not be the ONLY reason it
+        returns. With a db_path present it returns before either check."""
+        assert _refuse_production_db_under_pytest(tmp_path / "x.db") is None
+
 
 class TestCliErrorHandling:
     """Test error paths, exit codes, and the main() entry point."""

--- a/pact-plugin/tests/test_memory_cli.py
+++ b/pact-plugin/tests/test_memory_cli.py
@@ -36,7 +36,7 @@ from test_working_memory_concurrency_comprehensive import _seed_claude_md
 # Add pact-memory skill root to path so `from scripts.cli import ...` works
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
 
-from scripts.cli import build_parser, cmd_save, cmd_search, cmd_list, cmd_get, cmd_status, cmd_setup, cmd_update, cmd_delete, main, _COMMANDS, _refuse_production_db_under_pytest
+from scripts.cli import build_parser, cmd_save, cmd_search, cmd_list, cmd_get, cmd_status, cmd_setup, cmd_update, cmd_delete, main, _COMMANDS, _refuse_live_db_under_pytest
 from scripts.memory_api import PACTMemory
 
 
@@ -1402,10 +1402,10 @@ class TestCliOutputFormat:
 # Error Handling
 # ---------------------------------------------------------------------------
 
-class TestProductionDbGuardScope:
-    """The production-DB guard is scoped to SPAWNED CHILDREN, deliberately.
+class TestLiveDbGuardScope:
+    """The live-DB guard is scoped to SPAWNED CHILDREN, deliberately.
 
-    `_refuse_production_db_under_pytest` refuses the real store when a test
+    `_refuse_live_db_under_pytest` refuses the real store when a test
     process spawned the CLI with no `--db-path`. It must NOT fire for the
     in-process `main()` calls this file makes: they patch `PACTMemory` and
     open no store, and `test_main_db_path_none_when_not_specified` exists
@@ -1421,7 +1421,7 @@ class TestProductionDbGuardScope:
     check would see ten failures with no statement of why the check was there.
 
     RESIDUAL, stated: an in-process `main()` call with a REAL `PACTMemory` and
-    no `--db-path` still reaches production. Nothing catches that; nothing
+    no `--db-path` still reaches the live store. Nothing catches that; nothing
     currently does it.
     """
 
@@ -1431,7 +1431,7 @@ class TestProductionDbGuardScope:
             "distinguish the in-process case from the spawned-child case"
         )
         # Returns instead of raising SystemExit — the in-process branch.
-        assert _refuse_production_db_under_pytest(None) is None
+        assert _refuse_live_db_under_pytest(None) is None
 
     def test_an_explicit_db_path_is_never_refused(self, tmp_path, monkeypatch):
         """Non-vacuity: the db_path check must not be MASKED by the exemption.
@@ -1455,7 +1455,7 @@ class TestProductionDbGuardScope:
             "precondition: the in-process exemption is still live, so this "
             "test cannot show the db_path check is what prevents the refusal"
         )
-        assert _refuse_production_db_under_pytest(tmp_path / "x.db") is None
+        assert _refuse_live_db_under_pytest(tmp_path / "x.db") is None
 
 
 class TestCliErrorHandling:

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -13,9 +13,11 @@ Tests cover:
 9. _estimate_tokens twin copy equivalence (staleness.py vs working_memory.py)
 """
 
+import ast
 import inspect
 import os
 import sys
+import tempfile
 import textwrap
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -1533,3 +1535,108 @@ class TestAtomicWriteTwinCopyDrift:
             f"canonical body:\n{canonical_body}\n\n"
             f"twin body:\n{twin_body}"
         )
+
+
+class TestContainmentErrorTwinCopyDrift:
+    """Drift detection for the ContainmentError twin.
+
+    `working_memory` vendors this from `hooks/shared/claude_md_manager` for the
+    same reason as its siblings — skills/ cannot import from hooks/shared/ —
+    and it is the exception the containment check raises, so the two copies
+    disagreeing means the hook and skill paths signal a containment failure
+    differently.
+
+    IT IS GATED ON AST EQUALITY, NOT BYTE EQUALITY, and that is not a
+    weakening. The two copies are already not byte-identical: each docstring
+    points at the other, which is exactly the divergence the sibling gates
+    permit by stripping docstrings before comparing. A byte gate here would go
+    red on day one, and a gate that is red on arrival gets deleted rather than
+    investigated.
+    """
+
+    @staticmethod
+    def _executable_shape(obj) -> str:
+        """AST dump of the definition with any leading docstring removed."""
+        node = ast.parse(textwrap.dedent(inspect.getsource(obj))).body[0]
+        if (node.body and isinstance(node.body[0], ast.Expr)
+                and isinstance(node.body[0].value, ast.Constant)):
+            node.body = node.body[1:]
+        return ast.dump(node)
+
+    def test_containment_error_shapes_are_identical(self):
+        from shared.claude_md_manager import ContainmentError as canonical
+        from working_memory import ContainmentError as twin
+
+        assert self._executable_shape(canonical) == self._executable_shape(twin), (
+            "ContainmentError twin drift between "
+            "hooks/shared/claude_md_manager.py and "
+            "skills/pact-memory/scripts/working_memory.py — the containment "
+            "failure signal must stay identical across the copies; update "
+            "both in the SAME commit."
+        )
+
+    def test_the_gate_can_tell_the_shapes_apart(self):
+        """NON-VACUITY. An AST comparison that returns equal for everything
+        would pass the assertion above forever."""
+        from working_memory import ContainmentError as twin
+        from working_memory import _project_root_of as unrelated
+
+        assert self._executable_shape(twin) != self._executable_shape(unrelated), (
+            "the shape extractor cannot distinguish two different definitions, "
+            "so the drift assertion above proves nothing"
+        )
+
+
+class TestProjectRootLayoutKnowledgeDrift:
+    """`_project_root_of` duplicates LAYOUT KNOWLEDGE, not a function body.
+
+    Its siblings above are twin-copied implementations, compared against their
+    originals. This one has no original to compare with: it is the INVERSE of
+    `claude_md_manager.resolve_project_claude_md_path` (path -> root rather
+    than root -> path), so no copy of it exists to diverge from. What it
+    duplicates is the two-layout rule — that CLAUDE.md lives at
+    `<project>/.claude/CLAUDE.md` or `<project>/CLAUDE.md` — whose SSOT is
+    `_DOT_CLAUDE_RELATIVE` / `_LEGACY_RELATIVE`.
+
+    SO IT IS PINNED AGAINST THE CONSTANTS RATHER THAN AGAINST A TWIN, and the
+    difference matters: measured, renaming the SSOT constant breaks 21 tests
+    elsewhere in the tree and ZERO in the memory layer. The knowledge is fully
+    decoupled, so a third supported location — or a rename — diverges here in
+    silence. `archive_pin.project_dir_for` carries the same rule and the same
+    exposure.
+    """
+
+    def test_inverts_the_canonical_resolver_for_both_layouts(self):
+        from shared.claude_md_manager import (
+            _DOT_CLAUDE_RELATIVE,
+            _LEGACY_RELATIVE,
+            resolve_project_claude_md_path,
+        )
+        from working_memory import _project_root_of
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+
+            # Legacy layout: seed the file the SSOT constant names.
+            legacy_root = root / "legacy"
+            (legacy_root).mkdir()
+            (legacy_root / _LEGACY_RELATIVE).write_text("x", encoding="utf-8")
+            resolved, source = resolve_project_claude_md_path(legacy_root)
+            assert source == "legacy", f"fixture drift: got source={source!r}"
+            assert _project_root_of(resolved) == legacy_root, (
+                "_project_root_of does not invert the canonical resolver for "
+                f"the legacy layout named by _LEGACY_RELATIVE ({_LEGACY_RELATIVE!r})"
+            )
+
+            # Dot layout.
+            dot_root = root / "dot"
+            (dot_root / _DOT_CLAUDE_RELATIVE).parent.mkdir(parents=True)
+            (dot_root / _DOT_CLAUDE_RELATIVE).write_text("x", encoding="utf-8")
+            resolved, source = resolve_project_claude_md_path(dot_root)
+            assert source == "dot_claude", f"fixture drift: got source={source!r}"
+            assert _project_root_of(resolved) == dot_root, (
+                "_project_root_of does not invert the canonical resolver for "
+                f"the dot layout named by _DOT_CLAUDE_RELATIVE "
+                f"({_DOT_CLAUDE_RELATIVE!r}) — a third supported location or a "
+                f"rename of that constant diverges here silently"
+            )

--- a/pact-plugin/tests/test_working_memory_worktree_sync.py
+++ b/pact-plugin/tests/test_working_memory_worktree_sync.py
@@ -21,6 +21,7 @@ session; every test here builds an isolated synthetic repo under tmp_path and
 never touches real session state.
 """
 
+import logging
 import os
 import re
 import subprocess
@@ -166,6 +167,137 @@ def _install_find_spy(monkeypatch):
 # ---------------------------------------------------------------------------
 # Explicit sync target — the caller-specifiable override
 # ---------------------------------------------------------------------------
+
+class TestAmbientBranchAbsentTarget:
+    """The AMBIENT branch must skip an absent destination too.
+
+    The existence guard originally sat inside the explicit-target branch, on
+    the reasoning that the ambient resolver returns None when it finds nothing
+    so that skip rode along free. True — but it is a property of the RESOLVER,
+    not of `sync_to_claude_md`, and a TOTAL resolver never returns None. So the
+    arrangement failed in precisely the case its own comment claimed to cover:
+    a resolver made total, which is the named hazard this whole parameter
+    exists to defend against.
+
+    THE DISCRIMINATING OBSERVABLE IS THE LOCK SIDECAR, NOT THE ABSENT FILE.
+    Unguarded, the sync still does not CREATE the CLAUDE.md — the read precedes
+    the write, so it raises and degrades to False. So `assert not
+    md.exists()` passes against the broken code and measures nothing. What the
+    unguarded path leaves behind is `.CLAUDE.md.lock`, in a directory the sync
+    should never have touched. These assert the directory is ENTIRELY EMPTY.
+    """
+
+    @staticmethod
+    def _force_total_resolver(monkeypatch, path):
+        """Make the ambient resolver TOTAL — the plan's named hazard, verbatim.
+
+        A total resolver hands back a path for a file that does not exist
+        instead of returning None. Patched on `scripts.working_memory` because
+        that is the module object `sync_to_claude_md` resolves the name
+        through; patching the defining module would not rebind the caller.
+        """
+        import scripts.working_memory as wm
+        monkeypatch.setattr(
+            wm, "_resolve_display_claude_md_with_base",
+            lambda: (path, path.parent),
+        )
+
+    def test_ambient_absent_destination_is_a_skip_and_touches_nothing(
+        self, tmp_path, clean_env
+    ):
+        project = tmp_path / "ambient-empty"
+        project.mkdir()
+        missing = project / "CLAUDE.md"
+        self._force_total_resolver(clean_env, missing)
+
+        ok = sync_to_claude_md(
+            {"context": "ctx", "goal": "ambient must not write"},
+            memory_id="e" * 32,
+        )
+
+        assert ok is False, "an absent ambient destination must report failure"
+        assert not missing.exists(), "the sync CREATED a CLAUDE.md"
+        leftovers = sorted(p.name for p in project.iterdir())
+        assert leftovers == [], (
+            f"the sync left artifacts in a directory it should never have "
+            f"touched: {leftovers}. A `.CLAUDE.md.lock` here means the guard "
+            f"did not cover the ambient branch and the skip is being produced "
+            f"by the read failing rather than by the contract."
+        )
+
+    def test_live_control_the_harness_reaches_the_write_path(
+        self, tmp_path, clean_env
+    ):
+        """Without this, the assertions above pass against a broken harness.
+
+        Same total resolver, same call — but the file EXISTS. If the sync does
+        not write here, then 'nothing was written' above is evidence about the
+        harness rather than about the guard.
+        """
+        project = tmp_path / "ambient-present"
+        project.mkdir()
+        present = project / "CLAUDE.md"
+        present.write_text(
+            WORKING_MEMORY_SCAFFOLD.format(title="Ambient Present"),
+            encoding="utf-8",
+        )
+        self._force_total_resolver(clean_env, present)
+
+        ok = sync_to_claude_md(
+            {"context": "ctx", "goal": "live control writes"},
+            memory_id="f" * 32,
+        )
+
+        assert ok is True, "the control did not write — the harness is broken"
+        assert "live control writes" in present.read_text(encoding="utf-8")
+
+    def test_ambient_absent_warns_while_explicit_absent_stays_quiet(
+        self, tmp_path, clean_env, caplog
+    ):
+        """The two absent cases are reported differently, on purpose.
+
+        Ambient-absent is unreachable on the normal path — a resolver that
+        finds nothing returns None, which the `is None` check absorbs — so an
+        arm that fires here is signal. Explicit-absent is an ordinary caller
+        condition and fires in normal use.
+
+        The warning must NAME both causes and ASSERT neither: a file removed
+        between resolution and the check is indistinguishable here and is not
+        a defect. The level says "look at this"; the text must not say "this
+        is a bug."
+        """
+        project = tmp_path / "levels"
+        project.mkdir()
+        missing = project / "CLAUDE.md"
+
+        with caplog.at_level(logging.DEBUG, logger="scripts.working_memory"):
+            self._force_total_resolver(clean_env, missing)
+            sync_to_claude_md({"context": "c", "goal": "g"}, memory_id="a" * 32)
+        ambient = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert ambient, (
+            "ambient-absent did not warn — a resolver that quietly went total "
+            "would be indistinguishable from an ordinary skip"
+        )
+        text = ambient[0].getMessage()
+        assert "removed after it resolved" in text and "stopped returning" in text, (
+            f"the warning must name BOTH causes; got: {text}"
+        )
+        for accusation in ("bug", "must not", "invalid", "illegal"):
+            assert accusation not in text.lower(), (
+                f"the warning accuses rather than reports ({accusation!r}): {text}"
+            )
+
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG, logger="scripts.working_memory"):
+            sync_to_claude_md(
+                {"context": "c", "goal": "g"}, memory_id="b" * 32,
+                target=missing,
+            )
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING], (
+            "explicit-absent warned; it is an ordinary caller condition that "
+            "fires in normal use and must stay at debug"
+        )
+
 
 class TestExplicitSyncTarget:
     """`sync_to_claude_md(target=...)` — the caller-specifiable override.

--- a/pact-plugin/tests/test_working_memory_worktree_sync.py
+++ b/pact-plugin/tests/test_working_memory_worktree_sync.py
@@ -37,6 +37,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "skills", "pact
 from scripts.working_memory import (
     _project_root_of,
     _resolve_display_claude_md_path,
+    sync_retrieved_to_claude_md,
     sync_to_claude_md,
 )
 from scripts.memory_api import PACTMemory
@@ -297,6 +298,144 @@ class TestAmbientBranchAbsentTarget:
             "explicit-absent warned; it is an ordinary caller condition that "
             "fires in normal use and must stay at debug"
         )
+
+
+class TestRetrievedSyncAbsentTarget:
+    """`sync_retrieved_to_claude_md` must skip an absent destination too.
+
+    The sibling of `sync_to_claude_md`, and the other write caller named in
+    `_resolve_display_claude_md_path`'s docstring. It had the same defect and
+    it was found INDEPENDENTLY by two reviewers on different routes — one by
+    enumerating the truth-conditions of the guarded function's claim, one by
+    asking which other callers take the same lock.
+
+    ITS GUARD IS SHAPED DIFFERENTLY FROM ITS SIBLING'S, ON PURPOSE. This
+    function takes no explicit target, so there is one route to a destination
+    and nothing to differentiate — the check follows the `is None` check and
+    the message is unconditionally about the ambient resolver. The asymmetry
+    between the two guards reflects a real asymmetry in the two signatures;
+    making them match would be tidiness, not correctness.
+
+    THE UNGUARDED FAILURE IS WORSE HERE THAN A STRAY SIDECAR. `file_lock`
+    creates the sidecar's parent directories, so an absent path several levels
+    deep materialises the entire chain before the read fails.
+    """
+
+    @staticmethod
+    def _force_total_resolver(monkeypatch, path):
+        import scripts.working_memory as wm
+        monkeypatch.setattr(
+            wm, "_resolve_display_claude_md_with_base",
+            lambda: (path, path.parent),
+        )
+
+    def test_absent_destination_is_a_skip_and_touches_nothing(
+        self, tmp_path, clean_env
+    ):
+        project = tmp_path / "retrieved-empty"
+        project.mkdir()
+        missing = project / "CLAUDE.md"
+        self._force_total_resolver(clean_env, missing)
+
+        ok = sync_retrieved_to_claude_md(
+            [{"context": "ctx", "goal": "must not write"}], "query",
+            memory_ids=["c" * 32],
+        )
+
+        assert ok is False
+        assert not missing.exists(), "the sync CREATED a CLAUDE.md"
+        leftovers = sorted(p.name for p in project.iterdir())
+        assert leftovers == [], (
+            f"artifacts left in a directory the sync should never have "
+            f"touched: {leftovers}. A `.CLAUDE.md.lock` here means the guard "
+            f"is absent and the skip is produced by the read failing."
+        )
+
+    def test_absent_parent_directories_are_not_created(
+        self, tmp_path, clean_env
+    ):
+        """The variant that makes this worse than a stray sidecar.
+
+        `file_lock` builds the sidecar's parents, so without the guard a
+        resolved path three levels deep materialises `a/`, `a/b/`, `a/b/c/`
+        and the lock file inside it — directories the caller never named, on a
+        path whose only job was to be read. Measured before the fix.
+        """
+        root = tmp_path / "retrieved-deep"
+        root.mkdir()
+        ghost = root / "a" / "b" / "c" / "CLAUDE.md"
+        self._force_total_resolver(clean_env, ghost)
+
+        ok = sync_retrieved_to_claude_md(
+            [{"context": "ctx", "goal": "must not mkdir"}], "query",
+            memory_ids=["d" * 32],
+        )
+
+        assert ok is False
+        created = sorted(str(p.relative_to(root)) for p in root.rglob("*"))
+        assert created == [], (
+            f"the sync created filesystem entries under a path it only had to "
+            f"read: {created}"
+        )
+
+    def test_live_control_the_harness_reaches_the_write_path(
+        self, tmp_path, clean_env
+    ):
+        """Without this, the two assertions above are about a broken harness.
+
+        NOTE the control asserts CONTENT, not an empty directory: a SUCCESSFUL
+        write leaves `.CLAUDE.md.lock` behind too, so an empty-directory
+        assertion is correct only on the absent arms.
+        """
+        project = tmp_path / "retrieved-present"
+        project.mkdir()
+        present = project / "CLAUDE.md"
+        present.write_text(
+            RETRIEVED_CONTEXT_SCAFFOLD.format(title="Retrieved Present"),
+            encoding="utf-8",
+        )
+        self._force_total_resolver(clean_env, present)
+
+        ok = sync_retrieved_to_claude_md(
+            [{"context": "ctx", "goal": "live control writes"}], "query",
+            memory_ids=["e" * 32],
+        )
+
+        assert ok is True, "the control did not write — the harness is broken"
+        assert "live control writes" in present.read_text(encoding="utf-8")
+
+    def test_absent_destination_warns_naming_both_causes(
+        self, tmp_path, clean_env, caplog
+    ):
+        """Assert the SPECIFIC message, never the level.
+
+        The generic degradation handler already warned on this path before the
+        guard existed, so a level-only assertion is true on both sides of the
+        fix and discriminates nothing.
+        """
+        project = tmp_path / "retrieved-levels"
+        project.mkdir()
+        missing = project / "CLAUDE.md"
+
+        with caplog.at_level(logging.DEBUG, logger="scripts.working_memory"):
+            self._force_total_resolver(clean_env, missing)
+            sync_retrieved_to_claude_md(
+                [{"context": "c", "goal": "g"}], "q", memory_ids=["f" * 32]
+            )
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, "no warning on a should-never-fire path"
+        text = warnings[0].getMessage()
+        assert "retrieved context sync" in text, (
+            f"the warning does not identify which sync skipped: {text}"
+        )
+        assert "removed after it resolved" in text and "stopped returning" in text, (
+            f"the warning must name BOTH causes; got: {text}"
+        )
+        for accusation in ("bug", "must not", "invalid", "illegal"):
+            assert accusation not in text.lower(), (
+                f"the warning accuses rather than reports ({accusation!r}): {text}"
+            )
 
 
 class TestExplicitSyncTarget:

--- a/pact-plugin/tests/test_working_memory_worktree_sync.py
+++ b/pact-plugin/tests/test_working_memory_worktree_sync.py
@@ -438,6 +438,90 @@ class TestRetrievedSyncAbsentTarget:
             )
 
 
+class TestBothWriteCallersAgreeOnAbsentDestinations:
+    """DIFFERENTIAL: both write callers, one injected condition, compared.
+
+    `sync_to_claude_md` and `sync_retrieved_to_claude_md` are the two write
+    callers named in `_resolve_display_claude_md_path`'s docstring. Asserting
+    them separately records two facts that happen to match; asserting them
+    together records the INVARIANT — every write caller skips an absent
+    destination without touching the filesystem. A third one added later has
+    an obvious place to be registered, and a divergence between them fails
+    here rather than being noticed by whoever looks second.
+
+    THIS CATCHES DIVERGENCE. It does NOT catch a guard misplaced in BOTH
+    functions the same way — measured, not assumed. That failure is covered by
+    `test_resolver_returning_none_does_not_reach_the_guard` below, which is a
+    different arm for a different reason. Keep both.
+    """
+
+    @staticmethod
+    def _drivers():
+        """(name, callable) for every write caller that syncs to CLAUDE.md."""
+        return [
+            ("sync_to_claude_md", lambda: sync_to_claude_md(
+                {"context": "ctx", "goal": "differential"}, memory_id="a" * 32)),
+            ("sync_retrieved_to_claude_md", lambda: sync_retrieved_to_claude_md(
+                [{"context": "ctx", "goal": "differential"}], "query",
+                memory_ids=["b" * 32])),
+        ]
+
+    @pytest.mark.parametrize("layout", ["flat", "absent-parents"])
+    def test_no_write_caller_touches_the_filesystem(
+        self, tmp_path, clean_env, layout
+    ):
+        import scripts.working_memory as wm
+
+        observations = {}
+        for name, drive in self._drivers():
+            root = tmp_path / f"{layout}-{name}"
+            root.mkdir()
+            ghost = (root / "CLAUDE.md" if layout == "flat"
+                     else root / "a" / "b" / "c" / "CLAUDE.md")
+            clean_env.setattr(
+                wm, "_resolve_display_claude_md_with_base",
+                lambda g=ghost: (g, g.parent),
+            )
+            returned = drive()
+            # tuple, not list: these are compared as a set below to detect
+            # divergence between callers, and a list is unhashable.
+            created = tuple(sorted(str(p.relative_to(root)) for p in root.rglob("*")))
+            observations[name] = (returned, created)
+
+        assert len(observations) == len(self._drivers()), "a driver was skipped"
+        for name, (returned, created) in observations.items():
+            assert returned is False, f"{name} reported success on an absent destination"
+            assert created == (), (
+                f"{name} created filesystem entries under a path it only had to "
+                f"read: {list(created)}"
+            )
+        distinct = set(observations.values())
+        assert len(distinct) == 1, (
+            f"the write callers DIVERGED under one condition: {observations}. "
+            f"Both must skip an absent destination identically."
+        )
+
+    def test_resolver_returning_none_does_not_reach_the_guard(
+        self, tmp_path, clean_env
+    ):
+        """PLACEMENT pin — the guard must sit BELOW the `is None` check.
+
+        Above it, `None.exists()` raises AttributeError, and the raise is
+        outside the degradation `try` so it propagates to the caller. Measured:
+        with the guard relocated above the join, every one of the 319
+        memory-layer tests still passed, because nothing drove this path on the
+        retrieved caller. This is that arm.
+        """
+        import scripts.working_memory as wm
+        clean_env.setattr(
+            wm, "_resolve_display_claude_md_with_base", lambda: (None, None)
+        )
+        for name, drive in self._drivers():
+            assert drive() is False, (
+                f"{name} did not skip cleanly when the resolver found nothing"
+            )
+
+
 class TestExplicitSyncTarget:
     """`sync_to_claude_md(target=...)` — the caller-specifiable override.
 

--- a/pact-plugin/tests/test_working_memory_worktree_sync.py
+++ b/pact-plugin/tests/test_working_memory_worktree_sync.py
@@ -33,7 +33,11 @@ import pytest
 # scripts/ is a package; add skills/pact-memory so `scripts.*` imports resolve.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "skills", "pact-memory"))
 
-from scripts.working_memory import _resolve_display_claude_md_path, sync_to_claude_md
+from scripts.working_memory import (
+    _project_root_of,
+    _resolve_display_claude_md_path,
+    sync_to_claude_md,
+)
 from scripts.memory_api import PACTMemory
 
 
@@ -157,6 +161,159 @@ def _install_find_spy(monkeypatch):
 
     monkeypatch.setattr(wm, "_find_existing_claude_md", spy)
     return calls
+
+
+# ---------------------------------------------------------------------------
+# Explicit sync target — the caller-specifiable override
+# ---------------------------------------------------------------------------
+
+class TestExplicitSyncTarget:
+    """`sync_to_claude_md(target=...)` — the caller-specifiable override.
+
+    Without it the destination is resolved ambiently (CLAUDE_PROJECT_DIR, two
+    git anchors, then the working directory) and a caller who knows which file
+    it means has no way to say so. The root defect is not that the resolver is
+    wrong; it is that there is no override, so the caller's knowledge cannot
+    reach the write.
+
+    THE LOAD-BEARING PROPERTY IS THAT AN ABSENT TARGET SKIPS. The natural
+    resolver to compute a target with,
+    `claude_md_manager.resolve_project_claude_md_path`, is TOTAL — it returns a
+    "new_default" path rather than None on a miss. That is right for a caller
+    whose job is to create the file and wrong for the sync, where the
+    orchestrator owns the lifecycle.
+
+    MEASURED RATHER THAN ASSUMED, because the stronger claim is false today:
+    with the guard removed, an absent target does NOT produce a CLAUDE.md. The
+    read precedes the write, so it raises and the degradation handler returns
+    False. It does leave a `.CLAUDE.md.lock` sidecar in a directory the sync
+    should never have touched.
+
+    That makes the current protection an ACCIDENT OF ORDERING rather than a
+    contract — it holds only while the write path happens to read first. The
+    tests below pin the contract itself, so a future reordering fails here
+    instead of quietly becoming a create.
+    """
+
+    def test_explicit_target_is_written_and_the_ambient_one_is_not(
+        self, tmp_path, clean_env
+    ):
+        intended = tmp_path / "intended"
+        intended.mkdir()
+        (intended / "CLAUDE.md").write_text(
+            WORKING_MEMORY_SCAFFOLD.format(title="Intended"), encoding="utf-8"
+        )
+        decoy = tmp_path / "decoy"
+        decoy.mkdir()
+        decoy_md = decoy / "CLAUDE.md"
+        decoy_md.write_text(
+            WORKING_MEMORY_SCAFFOLD.format(title="Decoy"), encoding="utf-8"
+        )
+        # The ambient answer points at the decoy; the explicit target must win.
+        clean_env.setenv("CLAUDE_PROJECT_DIR", str(decoy))
+        decoy_before = decoy_md.read_bytes()
+
+        ok = sync_to_claude_md(
+            {"context": "ctx", "goal": "explicit target goal"},
+            memory_id="a" * 32,
+            target=intended / "CLAUDE.md",
+        )
+
+        assert ok is True
+        # POSITIVE: assert where it landed, not merely that the decoy is clean.
+        # "The other file is untouched" is equally consistent with the sync
+        # having silently skipped.
+        written = (intended / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "explicit target goal" in written, (
+            "the entry did not land in the explicit target"
+        )
+        assert decoy_md.read_bytes() == decoy_before, (
+            "the ambient target was written despite an explicit one"
+        )
+
+    def test_absent_target_is_a_skip_and_touches_nothing(
+        self, tmp_path, clean_env
+    ):
+        """An absent target must SKIP — and skip without side effects.
+
+        The directory-empty assertion is the discriminating one. Removing the
+        guard still leaves `missing.exists()` False (the read raises first),
+        so a test asserting only "no CLAUDE.md was created" passes against the
+        unguarded code and measures nothing. What the unguarded path DOES
+        leave is a `.CLAUDE.md.lock` sidecar, which is why the assertion is on
+        the whole directory rather than on the one filename.
+        """
+        project = tmp_path / "empty-project"
+        project.mkdir()
+        missing = project / "CLAUDE.md"
+        assert not missing.exists(), "precondition: the target must be absent"
+
+        ok = sync_to_claude_md(
+            {"context": "ctx", "goal": "must not create"},
+            memory_id="b" * 32,
+            target=missing,
+        )
+
+        assert ok is False, "an absent target must report failure, not success"
+        assert not missing.exists(), (
+            "the sync CREATED a CLAUDE.md that did not exist — this moves the "
+            "file's lifecycle from the orchestrator to the memory layer"
+        )
+        assert not (project / ".claude").exists(), (
+            "the sync created a .claude/ directory for a file it must not make"
+        )
+        leftovers = sorted(p.name for p in project.iterdir())
+        assert leftovers == [], (
+            f"the sync left artifacts in a project it should never have "
+            f"touched: {leftovers}. A lock sidecar here means the guard was "
+            f"bypassed and the skip is being produced by the read failing "
+            f"rather than by the contract."
+        )
+
+    def test_omitting_target_keeps_the_ambient_behaviour(self, tmp_path, clean_env):
+        """Existing callers are unaffected — the parameter is additive."""
+        project = tmp_path / "ambient"
+        project.mkdir()
+        md = project / "CLAUDE.md"
+        md.write_text(
+            WORKING_MEMORY_SCAFFOLD.format(title="Ambient"), encoding="utf-8"
+        )
+        clean_env.setenv("CLAUDE_PROJECT_DIR", str(project))
+
+        ok = sync_to_claude_md(
+            {"context": "ctx", "goal": "ambient path still works"},
+            memory_id="c" * 32,
+        )
+
+        assert ok is True
+        assert "ambient path still works" in md.read_text(encoding="utf-8")
+
+    def test_dot_claude_target_resolves_the_project_root_for_containment(
+        self, tmp_path, clean_env
+    ):
+        """The containment anchor must be the PROJECT dir, not `.claude/`.
+
+        `_atomic_write_text` checks the target against this base, so deriving
+        it one level too deep would either break the write or make the check
+        vacuous.
+        """
+        project = tmp_path / "dotproj"
+        (project / ".claude").mkdir(parents=True)
+        md = project / ".claude" / "CLAUDE.md"
+        md.write_text(
+            WORKING_MEMORY_SCAFFOLD.format(title="Dot"), encoding="utf-8"
+        )
+
+        assert _project_root_of(md) == project
+        assert _project_root_of(project / "CLAUDE.md") == project
+
+        ok = sync_to_claude_md(
+            {"context": "ctx", "goal": "dot layout target"},
+            memory_id="d" * 32,
+            target=md,
+        )
+        assert ok is True
+        assert "dot layout target" in md.read_text(encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The pact-plugin test suite wrote into the developer's **live** pact-memory database on every run, and the Working Memory sync resolved its CLAUDE.md target ambiently with no caller-specifiable override. This lands the first five steps of the remediation plan.

**Two anchors, bound at different times, so no single boundary closes both:**

| | binds | via | consequence |
|---|---|---|---|
| **Anchor 1** — which DB | at **import** | `config.py`'s `Path.home()` | reach is bounded by *process identity*, not lexical scope |
| **Anchor 2** — which CLAUDE.md | at **call** | `os.environ`, through a four-branch probe-and-continue resolver | a parent-process patch cannot reach a re-importing child |

Fixing anchor 1 alone would have **hidden** anchor 2. That is why they ship together.

## Measured outcome

Leak A's live writer is closed, and the claim is **predicate-shaped and positively corroborated** rather than an absence:

- **A post-fix full-suite run adds ZERO archive-marker rows**, against a stable pre-fix **+2 per run**. That delta is the claim.
  > ⚠️ **No absolute is cited here, deliberately.** An earlier draft cited 14 as the production baseline. Decomposed and bound to a moment: **4 legitimate + 10 leaked at 05:43Z; 4 + 14 at 06:10Z** as review tooling exercised pre-fix commits. (No share is quoted — a ratio over a moving quantity drifts for the same reason the absolute does.) **An absolute over a shared, mutable production store is not a claim-bearing quantity.** If you cite one, decompose it; a re-measurer finding a different number is seeing pre-fix execution, not a regression.
- **The formerly-leaking saves now land in tmpdirs whose basenames are *exactly* the `project_id` values on the polluted rows** — same producer, demonstrably relocated. That correspondence, not a count, is what makes the closure positive rather than an absence.
  > ⚠️ **Spawn counts are NOT reconciled and are deliberately not cited as a result.** *(Final clean-tree measurement at `d35f6dec`: two probes at different install points both report **99**, blind-window **0**, closure **18 → 18** under the shipped predicate. The 99-vs-93 gap remains open and is now against a different tree again — +2 spawning tests were added in remediation.)* Two instruments measured overlapping populations and disagree: a `run`-layer wrapper reported **93 spawns / 0 unscoped**; a `Popen`-layer wrapper at HEAD reports **97 / 3 unscoped** (itself a correction — an earlier figure of 194/6 double-counted, because `run()` delegates through the replaced global). The **4-spawn and 3-vs-0 gaps are open**, and the second may be **definitional rather than factual** — the two instruments may not share a meaning for "unscoped." The three are adjudicated: two are **HOME-sandboxed** (omitting `--db-path` is the point of the test), one is **short-circuit-safe only** — `cli.py` with no args exits before any handler runs. That third is itself an inertness claim of the class residual 2 describes. **What was counted matters more than how many**, which is why both raw figures are stated and neither is asserted. Neither team re-derived the other's instrument, deliberately. **The relocation evidence above does not depend on either count.**
- Suite: **12882 passed / 15 skipped / 0 errors**, errors token scanned explicitly over whole captured output (the usual summary line drops it).

`0 new rows` alone would have been an absence, equally consistent with "isolation works" and "the save never ran." The spawn-destination evidence is what makes it a result.

## What landed

| commit | |
|---|---|
| `22bc6f08` | Bind `_cli`'s pin-context values at def time, not by closure |
| `303c3333` | Overwrite `CLAUDE_PROJECT_DIR` from an explicit cwd, not `setdefault` — **production fix**, inverted fail direction |
| `4615c603` | Require `db_path` on `build_verdict` and answer it at all 41 call sites |
| `8c9e10cd` | Refuse the production memory database on test-spawned CLI processes |
| `f272f3b9` | Make the memory-CLI target explicit at the process boundary |
| `da854d68` | Couple the explicit-`db_path` control to the check it claims to guard |
| `c89a21b1` | Cover both sync branches with the existence guard, and say so truthfully |

Steps 3 and 4 are deliberately split: step 3 is **mechanical** (41 call sites, no behavioural change) and buys *legibility*, not safety — `db_path=None` still satisfies a required parameter. Step 4 is the mechanical closure.

## ⚠️ Absolute vs delta — read before citing any row count

**`15` appears repeatedly in the commit record and is the SUBSTRING-predicate count, not the type-anchored one.**

**And the type-anchored absolute is itself a snapshot, not a constant.** It was 14 when this PR was opened and 18 shortly after — any run at a pre-fix commit increments it. This section warns against citing a stale absolute, and the first draft then shipped one. **The delta is the claim; the absolute is a timestamp.**

The spread is exactly one record that merely *mentions* the marker in an entity's name/notes rather than carrying it as an entity `type`. **Deltas were unaffected**, so no closure claim falls — but a later reader citing `15` would have no way to reconstruct why.

**Use the type-anchored predicate** for any future measurement: an entity whose `type` field *equals* `ARCHIVE_ENTITY_TYPE`, read by symbol, never hardcoded. The substring form over the serialized blob has a real false-positive class. `goal LIKE 'Archived pin:%'` is worse still — a strict subset, structurally blind to the legitimate archives.

## Open residuals — named, not discovered

> ⚠️ **This list is a predicate, not a census.** It enumerates *couplings that are true at their origin and unenforced at their point of use* — it is not a claim that there are exactly this many. A census-shaped reading is what let an untreated sibling go unlisted until review. **Pin the predicate; let the count float.**
>
> That rule has three objects in this PR alone: this finding list, the predicate spread (15 vs 14), and the production row absolute. **The delta is the claim; absolutes over shared mutable state are snapshots, not baselines.**

1. **`_project_root_of`'s two-layout knowledge is unpinned** against `claude_md_manager`'s canonical constants. Confirmed by measurement: renaming the SSOT constant broke 21 tests elsewhere while the memory layer passed 103/103 — the twins are fully decoupled and would drift silently.
2. **The 40 `db_path=None` sites encode call-site inertness *claims*** that a future edit elsewhere can falsify without touching the call. A **runtime** detector does exist (step 4's child guard converts a falsified claim into a loud failure), but for the **spawning class only** — and that coverage is *one measured site plus a call-graph inference*, not 40 measurements. What is absent is a **static** detector at review time.
3. **In-process `main()` with a real `PACTMemory` and no `--db-path`** still reaches production. Uncovered by design; the guard is scoped to spawned children. ⚠️ **This residual has NO independent confirmation.** The connect-level probe cited above (0 production connections / 60 total) is the **author's own measurement**; no reviewer re-derived it. Treat it as self-reported, not corroborated.
4. **The accusation guard in the new warning test is a bounded substring denylist** — a novel phrasing such as *"this indicates a defect"* would pass it. What carries that test is its positive half, asserting both cause-clauses are present. Bounded, not broken.

## Scope

⚠️ **The scope fence had a gap, and it is worth stating.** The plan's numbered steps were partitioned into 1–5 (in) and 6–9 (out) — but the plan also carries items under **Open Questions**, which fell into neither partition and were therefore **owned by nobody**. At least two sit in that gap, one of which is the production reachability path for a defect found during review.

Steps 6–9 are **out of scope by explicit ruling**: per-site `--no-sync` at the Leak B carrier, conftest promotion, the five-entry-point AST census, and the version bump. Their absence is deliberate, not an omission.

## Notes for reviewers

- **ARM 3** in `test_archive_pin_emit.py` is **byte-untouched across all seven commits, by design.** It is an unsuppressed negative control. If it reddens, that is a signal — not a licence to edit the control.
- **A claim in the frozen plan was falsified during implementation and deliberately not propagated.** The plan stated a total resolver in the sync path would *create* CLAUDE.md files where none existed. Testing showed it does not — the read precedes the write, so it raises and degrades. What it *does* leave is a lock sidecar. The plan's direction was right and its mechanism was wrong; the source now documents what was measured. **The consequence is the larger half:** the no-create property was an *accident of ordering*, not a contract, and `c89a21b1` converts it into a stated one.
- The census is **`ast.parse` only, never grep** — a line-oriented count returns 44 because it cannot see multi-line calls. The true figure was 41 bare of 51.
- Do not encode any count in a test. **Pin the predicate; let the count float.** A pinned count fires on every innocent addition and trains maintainers to bump the number instead of investigating.

Addresses #1265 (Leak A's live writer). For #1240: **provides the caller-specifiable override the issue prescribes. The production path still resolves ambiently, because no in-tree caller passes `target` yet** — the capability is closed, the behaviour is not. Neither issue is fully retired.
