### PR TITLE
Wake the concurrent auditor instead of instructing it to wait

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.22",
+      "version": "4.6.23",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.22/       # Plugin version
+│               └── 4.6.23/       # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.22",
+  "version": "4.6.23",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.22
+> **Version**: 4.6.23
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/agents/pact-auditor.md
+++ b/pact-plugin/agents/pact-auditor.md
@@ -90,6 +90,8 @@ Triggered by: an orchestrator message, OR all coder tasks showing completed in T
 2. Check cross-agent consistency (parallel coders: compatible interfaces? consistent naming?)
 3. Emit summary signal (GREEN/YELLOW/RED) to orchestrator
 
+Emit RED and YELLOW as soon as you have them. Do not compress the final sweep to land a summary ahead of a commit — the workflow does not close CODE on your silence, and an audit against the committed artifact is an established path rather than a degraded one. If the commit lands first, audit the committed SHA and emit then. This relieves the verdict, not the observation: keep running Phase B cycles while coders work.
+
 ## BEHAVIORAL RULES
 
 | Rule | Rationale |

--- a/pact-plugin/agents/pact-auditor.md
+++ b/pact-plugin/agents/pact-auditor.md
@@ -59,6 +59,7 @@ These boundaries are explicit — do not cross them:
 - **Do NOT direct coders** — Ask questions, do not give instructions. Report to orchestrator, not to coders
 - **Do NOT replace TEST phase or security review** — You are an early-warning system, not a substitute for formal verification
 - **Do NOT audit half-finished code** — Stubs and TODOs are expected mid-work. Check back next cycle
+- **Do NOT end your turn with a background process as your route back** — your wake comes from the orchestrator's relay; no PACT hook sends a message, and nothing in PACT wakes you on its own. Backgrounding a long command is fine while you stay in your turn and poll it; the hazard is ending the turn, which leaves you with no way to bring **yourself** back.
 
 ## OBSERVATION PROTOCOL
 
@@ -67,7 +68,7 @@ These boundaries are explicit — do not cross them:
 1. Read all available references: architecture doc, approved plan, dispatch context
 2. Identify key interfaces, high-risk dimensions, and cross-cutting requirements
 3. Note coder assignments from TaskList (who is building what)
-4. Wait for coders to produce initial output before observing — do not audit empty files
+4. Normally the orchestrator's stage-ready relay is your signal to observe. If you have nothing to audit and no relay has arrived, poll `git status --porcelain` on a bounded cadence within your current turn rather than ending it. If the cadence is exhausted and you must end the turn, first SET the `intentional_wait` task metadata (reason `awaiting_coder_output`, resolver `lead`) so the team-lead can tell waiting from stalled; CLEAR it on the relay.
 
 ### Phase B: Observation Cycles (periodic)
 
@@ -83,7 +84,7 @@ Repeat until coders complete or orchestrator signals final observation:
 
 ### Phase C: Final Observation
 
-Triggered by: orchestrator message OR all coder tasks showing completed in TaskList.
+Triggered by: an orchestrator message, OR all coder tasks showing completed in TaskList — the second is a state you check, not a message that arrives; read TaskList while in a turn rather than waiting on it.
 
 1. Sweep all modified files against references
 2. Check cross-agent consistency (parallel coders: compatible interfaces? consistent naming?)

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -766,6 +766,8 @@ Agent(
 
 The auditor stores its final signal as `metadata.audit_summary` via `TaskUpdate` before marking the task completed. On RED signal: SendMessage to the affected coder and pause their work. On YELLOW: pass finding to test engineer as focus area. See [pact-audit.md](../protocols/pact-audit.md) for the full Concurrent Audit Protocol.
 
+When a coder reports stage-ready, send a wake-SendMessage to the concurrent auditor: "coder staged — observe the staged diff now." Send this on every stage-ready, including for later commits in the same phase.
+
 **Before next phase**:
 - [ ] Implementation complete
 - [ ] All tests passing (full test suite; fix any tests your changes break)
@@ -799,6 +801,7 @@ JSON
   ```
   Do not block on completion — TEST phase proceeds in parallel.
 - [ ] **Primary HANDOFF-presence check**: on receiving each Task-complete SendMessage, verify via TaskGet — confirm status=completed AND metadata.handoff populated/non-empty. If missing, SendMessage the agent to complete HANDOFF before downstream dispatch proceeds.
+- [ ] **Concurrent-audit coverage check**: before dispatching TEST, confirm ONE of — `metadata.audit_summary` is present (verify via TaskGet), OR an audit has been dispatched against the committed artifact. If neither holds, SendMessage the auditor with the committed SHA, or dispatch a post-artifact audit, before TEST dispatch proceeds.
 - [ ] **S4 Checkpoint**: Environment stable? Model aligned? Plan viable?
 
 #### Handling Complex Sub-Tasks During CODE

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -768,6 +768,8 @@ The auditor stores its final signal as `metadata.audit_summary` via `TaskUpdate`
 
 When a coder reports stage-ready, send a wake-SendMessage to the concurrent auditor: "coder staged — observe the staged diff now." Send this on every stage-ready, including for later commits in the same phase.
 
+Pass through whatever the coder's stage-ready message claimed about the staged work — counts, paths, what it says it did not touch, anything it corrected — labelled as claims for the auditor to verify against the diff, not as findings. Forward what the coder already wrote rather than composing a summary; if that would delay the wake, send the wake line first and the claims after.
+
 **Before next phase**:
 - [ ] Implementation complete
 - [ ] All tests passing (full test suite; fix any tests your changes break)

--- a/pact-plugin/protocols/pact-audit.md
+++ b/pact-plugin/protocols/pact-audit.md
@@ -39,7 +39,7 @@ The auditor operates primarily through file observation, not messaging. This min
 1. Read all available references (architecture doc, plan, dispatch context)
 2. Identify key interfaces, high-risk dimensions, cross-cutting requirements
 3. Note coder assignments from TaskList
-4. Wait for coders to produce initial output before observing. The wake is the orchestrator's stage-ready relay — no PACT hook sends a message, so do not arm a background monitor, sleep loop, or watch process and end the turn. While waiting, SET `intentional_wait`; if no relay has arrived, poll `git status --porcelain` on a bounded cadence within the current turn rather than ending it.
+4. Wait for coders to produce initial output before observing. The wake is the orchestrator's stage-ready relay — no PACT hook sends a message, so do not end the turn with a background process as the route back; backgrounding a long command is fine while the auditor stays in its turn and polls it. If no relay has arrived, poll `git status --porcelain` on a bounded cadence within the current turn rather than ending it. If the cadence is exhausted and the turn must end, SET `intentional_wait` (reason `awaiting_coder_output`, resolver `lead`) first, and CLEAR it on the relay.
 
 **Phase B: Observation cycles** (periodic):
 1. Check modified files: `git diff`, read changed files
@@ -54,6 +54,8 @@ The auditor operates primarily through file observation, not messaging. This min
 1. Sweep all modified files
 2. Emit summary signal (GREEN/YELLOW/RED)
 3. Store audit summary in task metadata
+
+The auditor emits RED and YELLOW as soon as it has them, and does not compress the final sweep to land a summary ahead of a commit — the workflow does not close CODE on auditor silence, and an audit against the committed artifact is an established path rather than a degraded one. If the commit lands first, the auditor audits the committed SHA and emits then. This relieves the verdict, not the observation: Phase B cycles continue while coders work.
 
 ### Audit Criteria (Priority Order)
 
@@ -150,7 +152,7 @@ The auditor is **non-blocking**: never hold the workflow waiting for its verdict
 
 Treat absence as a prompt to act, not to conclude. Before dispatching TEST, confirm one of: `audit_summary` is present, or an audit has been dispatched against the committed artifact. If neither holds, SendMessage the auditor with the committed SHA, or dispatch a post-artifact audit, then proceed.
 
-The team-lead retains the authority to override an auditor verdict (a `TaskUpdate` that rewrites `audit_summary`), and that override is made safe rather than blocked. When a lead `TaskUpdate` overwrites an auditor-authored verdict, the lifecycle gate preserves the auditor's original to `metadata.audit_summary_authored`, routes the lead's value to `metadata.lead_close_note`, and emits an `audit_summary_overwrite` advisory (severity-escalated when the override lowers the verdict, e.g. RED→GREEN). The verdict is therefore never silently lost; a consumer reading the authoritative auditor signal should prefer `metadata.audit_summary_authored` when present. This front-line discipline (never overwrite on timeout-inferred silence) reduces how often the gate fires — the gate is the durable backstop, not a substitute for the discipline.
+The team-lead retains the authority to override an auditor verdict (a `TaskUpdate` that rewrites `audit_summary`), and that override is made safe rather than blocked. When a lead `TaskUpdate` overwrites an auditor-authored verdict, the lifecycle gate preserves the auditor's original to `metadata.audit_summary_authored`, routes the lead's value to `metadata.lead_close_note`, and emits an `audit_summary_overwrite` advisory (severity-escalated when the override lowers the verdict, e.g. RED→GREEN). The verdict is therefore never silently lost; a consumer reading the authoritative auditor signal should prefer `metadata.audit_summary_authored` when present. This front-line discipline (never overwrite on inferred silence) reduces how often the gate fires — the gate is the durable backstop, not a substitute for the discipline.
 
 **Reading the verdict**: to READ an auditor's verdict, prefer `metadata.audit_summary_authored` (the durable mirror written at auditor-author time) over `metadata.audit_summary` — a lead close/overwrite may have replaced `audit_summary` with a lead-authored value, and the mirror survives it. Fall back to `audit_summary` only if no mirror exists. (Today no code consumer reads the verdict VALUE — `validate_handoff` keys on `audit_summary` PRESENCE, not its content — so this is guidance for the team-lead and any future value-consumer.)
 

--- a/pact-plugin/protocols/pact-audit.md
+++ b/pact-plugin/protocols/pact-audit.md
@@ -39,7 +39,7 @@ The auditor operates primarily through file observation, not messaging. This min
 1. Read all available references (architecture doc, plan, dispatch context)
 2. Identify key interfaces, high-risk dimensions, cross-cutting requirements
 3. Note coder assignments from TaskList
-4. Wait for coders to produce initial output before observing
+4. Wait for coders to produce initial output before observing. The wake is the orchestrator's stage-ready relay — no PACT hook sends a message, so do not arm a background monitor, sleep loop, or watch process and end the turn. While waiting, SET `intentional_wait`; if no relay has arrived, poll `git status --porcelain` on a bounded cadence within the current turn rather than ending it.
 
 **Phase B: Observation cycles** (periodic):
 1. Check modified files: `git diff`, read changed files
@@ -50,7 +50,7 @@ The auditor operates primarily through file observation, not messaging. This min
    - Significant but ambiguous → SendMessage to coder (one specific question)
    - Clear violation → RED signal to orchestrator immediately
 
-**Phase C: Final observation** (triggered by orchestrator or all coders completing):
+**Phase C: Final observation** (triggered by an orchestrator message, or by all coders completing — a state the auditor checks, not a message that arrives):
 1. Sweep all modified files
 2. Emit summary signal (GREEN/YELLOW/RED)
 3. Store audit summary in task metadata
@@ -146,7 +146,9 @@ The auditor uses signal-based completion rather than standard HANDOFF:
 
 #### Lead-side handling of the audit verdict
 
-The auditor is **non-blocking**. The team-lead MUST NOT infer auditor-silence from a timeout: there is no bounded read-after-write window on the verdict, so an absent `audit_summary` means "not written yet," never "no signal." Proceed with the workflow and let the auditor self-complete on its own cadence; a send-side `success: true` on the dispatch is authoritative that the request was delivered.
+The auditor is **non-blocking**: never hold the workflow waiting for its verdict. Absence of `audit_summary` is not a verdict — do not read silence as GREEN, as RED, or as "no findings," and never write or overwrite a verdict on inferred silence. Nor is absence a guarantee that a verdict is still coming: a concurrent auditor can be waiting on a wake it never received.
+
+Treat absence as a prompt to act, not to conclude. Before dispatching TEST, confirm one of: `audit_summary` is present, or an audit has been dispatched against the committed artifact. If neither holds, SendMessage the auditor with the committed SHA, or dispatch a post-artifact audit, then proceed.
 
 The team-lead retains the authority to override an auditor verdict (a `TaskUpdate` that rewrites `audit_summary`), and that override is made safe rather than blocked. When a lead `TaskUpdate` overwrites an auditor-authored verdict, the lifecycle gate preserves the auditor's original to `metadata.audit_summary_authored`, routes the lead's value to `metadata.lead_close_note`, and emits an `audit_summary_overwrite` advisory (severity-escalated when the override lowers the verdict, e.g. RED→GREEN). The verdict is therefore never silently lost; a consumer reading the authoritative auditor signal should prefer `metadata.audit_summary_authored` when present. This front-line discipline (never overwrite on timeout-inferred silence) reduces how often the gate fires — the gate is the durable backstop, not a substitute for the discipline.
 

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -1940,7 +1940,7 @@ The auditor operates primarily through file observation, not messaging. This min
 1. Read all available references (architecture doc, plan, dispatch context)
 2. Identify key interfaces, high-risk dimensions, cross-cutting requirements
 3. Note coder assignments from TaskList
-4. Wait for coders to produce initial output before observing. The wake is the orchestrator's stage-ready relay — no PACT hook sends a message, so do not arm a background monitor, sleep loop, or watch process and end the turn. While waiting, SET `intentional_wait`; if no relay has arrived, poll `git status --porcelain` on a bounded cadence within the current turn rather than ending it.
+4. Wait for coders to produce initial output before observing. The wake is the orchestrator's stage-ready relay — no PACT hook sends a message, so do not end the turn with a background process as the route back; backgrounding a long command is fine while the auditor stays in its turn and polls it. If no relay has arrived, poll `git status --porcelain` on a bounded cadence within the current turn rather than ending it. If the cadence is exhausted and the turn must end, SET `intentional_wait` (reason `awaiting_coder_output`, resolver `lead`) first, and CLEAR it on the relay.
 
 **Phase B: Observation cycles** (periodic):
 1. Check modified files: `git diff`, read changed files
@@ -1955,6 +1955,8 @@ The auditor operates primarily through file observation, not messaging. This min
 1. Sweep all modified files
 2. Emit summary signal (GREEN/YELLOW/RED)
 3. Store audit summary in task metadata
+
+The auditor emits RED and YELLOW as soon as it has them, and does not compress the final sweep to land a summary ahead of a commit — the workflow does not close CODE on auditor silence, and an audit against the committed artifact is an established path rather than a degraded one. If the commit lands first, the auditor audits the committed SHA and emits then. This relieves the verdict, not the observation: Phase B cycles continue while coders work.
 
 ### Audit Criteria (Priority Order)
 
@@ -2051,7 +2053,7 @@ The auditor is **non-blocking**: never hold the workflow waiting for its verdict
 
 Treat absence as a prompt to act, not to conclude. Before dispatching TEST, confirm one of: `audit_summary` is present, or an audit has been dispatched against the committed artifact. If neither holds, SendMessage the auditor with the committed SHA, or dispatch a post-artifact audit, then proceed.
 
-The team-lead retains the authority to override an auditor verdict (a `TaskUpdate` that rewrites `audit_summary`), and that override is made safe rather than blocked. When a lead `TaskUpdate` overwrites an auditor-authored verdict, the lifecycle gate preserves the auditor's original to `metadata.audit_summary_authored`, routes the lead's value to `metadata.lead_close_note`, and emits an `audit_summary_overwrite` advisory (severity-escalated when the override lowers the verdict, e.g. RED→GREEN). The verdict is therefore never silently lost; a consumer reading the authoritative auditor signal should prefer `metadata.audit_summary_authored` when present. This front-line discipline (never overwrite on timeout-inferred silence) reduces how often the gate fires — the gate is the durable backstop, not a substitute for the discipline.
+The team-lead retains the authority to override an auditor verdict (a `TaskUpdate` that rewrites `audit_summary`), and that override is made safe rather than blocked. When a lead `TaskUpdate` overwrites an auditor-authored verdict, the lifecycle gate preserves the auditor's original to `metadata.audit_summary_authored`, routes the lead's value to `metadata.lead_close_note`, and emits an `audit_summary_overwrite` advisory (severity-escalated when the override lowers the verdict, e.g. RED→GREEN). The verdict is therefore never silently lost; a consumer reading the authoritative auditor signal should prefer `metadata.audit_summary_authored` when present. This front-line discipline (never overwrite on inferred silence) reduces how often the gate fires — the gate is the durable backstop, not a substitute for the discipline.
 
 **Reading the verdict**: to READ an auditor's verdict, prefer `metadata.audit_summary_authored` (the durable mirror written at auditor-author time) over `metadata.audit_summary` — a lead close/overwrite may have replaced `audit_summary` with a lead-authored value, and the mirror survives it. Fall back to `audit_summary` only if no mirror exists. (Today no code consumer reads the verdict VALUE — `validate_handoff` keys on `audit_summary` PRESENCE, not its content — so this is guidance for the team-lead and any future value-consumer.)
 

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -1940,7 +1940,7 @@ The auditor operates primarily through file observation, not messaging. This min
 1. Read all available references (architecture doc, plan, dispatch context)
 2. Identify key interfaces, high-risk dimensions, cross-cutting requirements
 3. Note coder assignments from TaskList
-4. Wait for coders to produce initial output before observing
+4. Wait for coders to produce initial output before observing. The wake is the orchestrator's stage-ready relay — no PACT hook sends a message, so do not arm a background monitor, sleep loop, or watch process and end the turn. While waiting, SET `intentional_wait`; if no relay has arrived, poll `git status --porcelain` on a bounded cadence within the current turn rather than ending it.
 
 **Phase B: Observation cycles** (periodic):
 1. Check modified files: `git diff`, read changed files
@@ -1951,7 +1951,7 @@ The auditor operates primarily through file observation, not messaging. This min
    - Significant but ambiguous → SendMessage to coder (one specific question)
    - Clear violation → RED signal to orchestrator immediately
 
-**Phase C: Final observation** (triggered by orchestrator or all coders completing):
+**Phase C: Final observation** (triggered by an orchestrator message, or by all coders completing — a state the auditor checks, not a message that arrives):
 1. Sweep all modified files
 2. Emit summary signal (GREEN/YELLOW/RED)
 3. Store audit summary in task metadata
@@ -2047,7 +2047,9 @@ The auditor uses signal-based completion rather than standard HANDOFF:
 
 #### Lead-side handling of the audit verdict
 
-The auditor is **non-blocking**. The team-lead MUST NOT infer auditor-silence from a timeout: there is no bounded read-after-write window on the verdict, so an absent `audit_summary` means "not written yet," never "no signal." Proceed with the workflow and let the auditor self-complete on its own cadence; a send-side `success: true` on the dispatch is authoritative that the request was delivered.
+The auditor is **non-blocking**: never hold the workflow waiting for its verdict. Absence of `audit_summary` is not a verdict — do not read silence as GREEN, as RED, or as "no findings," and never write or overwrite a verdict on inferred silence. Nor is absence a guarantee that a verdict is still coming: a concurrent auditor can be waiting on a wake it never received.
+
+Treat absence as a prompt to act, not to conclude. Before dispatching TEST, confirm one of: `audit_summary` is present, or an audit has been dispatched against the committed artifact. If neither holds, SendMessage the auditor with the committed SHA, or dispatch a post-artifact audit, then proceed.
 
 The team-lead retains the authority to override an auditor verdict (a `TaskUpdate` that rewrites `audit_summary`), and that override is made safe rather than blocked. When a lead `TaskUpdate` overwrites an auditor-authored verdict, the lifecycle gate preserves the auditor's original to `metadata.audit_summary_authored`, routes the lead's value to `metadata.lead_close_note`, and emits an `audit_summary_overwrite` advisory (severity-escalated when the override lowers the verdict, e.g. RED→GREEN). The verdict is therefore never silently lost; a consumer reading the authoritative auditor signal should prefer `metadata.audit_summary_authored` when present. This front-line discipline (never overwrite on timeout-inferred silence) reduces how often the gate fires — the gate is the durable backstop, not a substitute for the discipline.
 

--- a/pact-plugin/tests/fixtures/message_delivering_hook.py
+++ b/pact-plugin/tests/fixtures/message_delivering_hook.py
@@ -32,6 +32,20 @@ Summary: Synthetic NON-SHIPPED fixture for the message-delivery scanner in
          than on any argument: without it, an any-argument rule would look
          correct against the positive leg alone while calling every move OUT of
          an inbox a delivery.
+
+         IDENTIFIERS IN THE NEGATIVE LEGS ARE PART OF THE TEST CONTRACT. The
+         negative-control test locates each line it checks by searching this
+         file for literal text spelled from those identifiers -- the local
+         binding in read_only_inbox_probe and in archive_away_from_inbox, and
+         the one in unrelated_write. Renaming one removes the anchor its row
+         depends on. The test asserts every anchor is present, so a rename that
+         breaks one fails with a message naming the missing marker; update the
+         marker in the test alongside the rename.
+
+         This note deliberately does NOT reproduce the marker strings. They are
+         matched by substring against this whole file, prose included, so
+         spelling one here would make it match this line instead of the code --
+         the row would still pass while testing nothing.
 Used by: pact-plugin/tests/test_concurrent_auditor_wake.py
 """
 from __future__ import annotations

--- a/pact-plugin/tests/fixtures/message_delivering_hook.py
+++ b/pact-plugin/tests/fixtures/message_delivering_hook.py
@@ -1,0 +1,85 @@
+"""
+Location: pact-plugin/tests/fixtures/message_delivering_hook.py
+Summary: Synthetic NON-SHIPPED fixture for the message-delivery scanner in
+         test_concurrent_auditor_wake.py. It is never imported and never
+         executed -- it is read as text and parsed as an AST, exactly like a
+         real hook under the sweep.
+
+         It is the scanner's standing positive control. The auditor guidance
+         asserts a repo fact ("no PACT hook sends a message"), and a scanner
+         that reports zero findings over hooks/ is indistinguishable from a
+         scanner that cannot detect anything at all. This file makes that
+         distinction observable on every suite run instead of once, by hand,
+         at authoring time.
+
+         Four functions, deliberately paired:
+           deliver_via_write_text  -> MUST flag (INBOX-WRITE)
+           deliver_via_open_write  -> MUST flag (INBOX-WRITE, twice)
+           deliver_via_send_api    -> MUST flag (SEND-CALL)
+           read_only_inbox_probe   -> MUST NOT flag (reads an inbox path)
+           unrelated_write         -> MUST NOT flag (writes a non-inbox path)
+
+         The two negative controls are the load-bearing half. hooks/ contains
+         real inbox-path construction that is read-only, so a scanner that
+         flagged any inbox mention would be useless here -- it would fire on
+         shipped code that is behaving correctly. Pairing the positive and
+         negative legs in ONE file means neither can pass by absence.
+Used by: pact-plugin/tests/test_concurrent_auditor_wake.py
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def deliver_via_write_text(team: str, name: str, payload: dict) -> None:
+    """Delivery via Path.write_text on a path built in a prior statement.
+
+    The inbox literal is NOT inside the write call -- it is in the assignment
+    above it. A scanner that only inspects the call's own subtree misses this,
+    which is how real delivery code is shaped.
+    """
+    inbox = Path.home() / ".claude" / "teams" / team / "inboxes" / f"{name}.json"
+    inbox.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def deliver_via_open_write(team: str, name: str, payload: dict) -> None:
+    """Delivery via open(..., "w"), with the path built across TWO statements
+    and bound to a name that does not itself contain the marker."""
+    base = Path.home() / ".claude" / "teams" / team / "inboxes"
+    target = base / f"{name}.json"
+    with open(target, "w", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload))
+
+
+def deliver_via_send_api(recipient: str, body: str) -> None:
+    """Delivery via a send API call.
+
+    `send_message` is intentionally unbound -- this file is never executed, and
+    binding it would only add an import the scanner does not read.
+    """
+    send_message(to=recipient, message=body)  # noqa: F821  # fixture: never executed
+
+
+def read_only_inbox_probe(team: str, name: str) -> bool:
+    """NEGATIVE control: constructs an inbox path and only READS it.
+
+    Mirrors the shape of real shipped hook code, which uses the inbox file as a
+    witness that a teammate was dispatched. Flagging this would make the pin
+    fire on correct code.
+    """
+    inbox = Path.home() / ".claude" / "teams" / team / "inboxes" / f"{name}.json"
+    if inbox.is_file():
+        return bool(inbox.read_text(encoding="utf-8"))
+    return False
+
+
+def unrelated_write(tmp_dir: str, blob: str) -> None:
+    """NEGATIVE control: a genuine write to a path that is not an inbox.
+
+    Separates "writes a file" from "delivers a message". Without this leg, a
+    scanner that flagged every write would look correct against the positive
+    legs alone.
+    """
+    log = Path(tmp_dir) / "hook-errors.log"
+    log.write_text(blob, encoding="utf-8")

--- a/pact-plugin/tests/fixtures/message_delivering_hook.py
+++ b/pact-plugin/tests/fixtures/message_delivering_hook.py
@@ -49,8 +49,8 @@ def deliver_via_write_text(team: str, name: str, payload: dict) -> None:
     above it. A scanner that only inspects the call's own subtree misses this,
     which is how real delivery code is shaped.
     """
-    inbox = Path.home() / ".claude" / "teams" / team / "inboxes" / f"{name}.json"
-    inbox.write_text(json.dumps(payload), encoding="utf-8")
+    dest = Path.home() / ".claude" / "teams" / team / "inboxes" / f"{name}.json"
+    dest.write_text(json.dumps(payload), encoding="utf-8")
 
 
 def deliver_via_open_write(team: str, name: str, payload: dict) -> None:
@@ -71,8 +71,8 @@ def deliver_via_atomic_replace(team: str, name: str, payload: dict) -> None:
     sits in an ARGUMENT of the move rather than as the receiver, so
     _receiver_root cannot see it.
     """
-    inbox_dir = Path.home() / ".claude" / "teams" / team / "inboxes"
-    fd, tmp_path = tempfile.mkstemp(dir=str(inbox_dir), suffix=".tmp")
+    dest_dir = Path.home() / ".claude" / "teams" / team / "inboxes"
+    fd, tmp_path = tempfile.mkstemp(dir=str(dest_dir), suffix=".tmp")
     # The stream name here MUST NOT collide with the one in
     # deliver_via_open_write. Taint is module-flat, so reusing "handle" would
     # let this leg inherit that function's taint and fire even with tuple-target
@@ -81,7 +81,7 @@ def deliver_via_atomic_replace(team: str, name: str, payload: dict) -> None:
     # and a distinct name, this write goes unflagged and the count assertion reddens.
     with os.fdopen(fd, "w", encoding="utf-8") as stream:
         stream.write(json.dumps(payload))
-    os.replace(tmp_path, str(inbox_dir / f"{name}.json"))
+    os.replace(tmp_path, str(dest_dir / f"{name}.json"))
 
 
 def archive_away_from_inbox(team: str, name: str) -> None:

--- a/pact-plugin/tests/fixtures/message_delivering_hook.py
+++ b/pact-plugin/tests/fixtures/message_delivering_hook.py
@@ -12,23 +12,33 @@ Summary: Synthetic NON-SHIPPED fixture for the message-delivery scanner in
          distinction observable on every suite run instead of once, by hand,
          at authoring time.
 
-         Four functions, deliberately paired:
-           deliver_via_write_text  -> MUST flag (INBOX-WRITE)
-           deliver_via_open_write  -> MUST flag (INBOX-WRITE, twice)
-           deliver_via_send_api    -> MUST flag (SEND-CALL)
-           read_only_inbox_probe   -> MUST NOT flag (reads an inbox path)
-           unrelated_write         -> MUST NOT flag (writes a non-inbox path)
+         Deliberately paired:
+           deliver_via_write_text     -> MUST flag (INBOX-WRITE)
+           deliver_via_open_write     -> MUST flag (INBOX-WRITE, twice)
+           deliver_via_atomic_replace -> MUST flag (INBOX-WRITE + INBOX-MOVE)
+           deliver_via_send_api       -> MUST flag (SEND-CALL)
+           read_only_inbox_probe      -> MUST NOT flag (reads an inbox path)
+           unrelated_write            -> MUST NOT flag (writes a non-inbox path)
+           archive_away_from_inbox    -> MUST NOT flag (moves OUT of an inbox)
 
-         The two negative controls are the load-bearing half. hooks/ contains
-         real inbox-path construction that is read-only, so a scanner that
-         flagged any inbox mention would be useless here -- it would fire on
-         shipped code that is behaving correctly. Pairing the positive and
-         negative legs in ONE file means neither can pass by absence.
+         The negative controls are the load-bearing half. hooks/ contains real
+         inbox-path construction that is read-only, so a scanner that flagged
+         any inbox mention would be useless here -- it would fire on shipped
+         code that is behaving correctly. Pairing the positive and negative
+         legs in ONE file means neither can pass by absence.
+
+         archive_away_from_inbox is the negative twin of the atomic-write leg
+         specifically. It proves the move rule keys on the DESTINATION rather
+         than on any argument: without it, an any-argument rule would look
+         correct against the positive leg alone while calling every move OUT of
+         an inbox a delivery.
 Used by: pact-plugin/tests/test_concurrent_auditor_wake.py
 """
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from pathlib import Path
 
 
@@ -50,6 +60,40 @@ def deliver_via_open_write(team: str, name: str, payload: dict) -> None:
     target = base / f"{name}.json"
     with open(target, "w", encoding="utf-8") as handle:
         handle.write(json.dumps(payload))
+
+
+def deliver_via_atomic_replace(team: str, name: str, payload: dict) -> None:
+    """Delivery via the atomic-write idiom: mkstemp + write + os.replace.
+
+    This is the shape the repo's own durable writers use, and it defeats a
+    receiver-keyed rule twice over. The temp path arrives through a TUPLE
+    target, which a Name-only target filter drops entirely; and the inbox path
+    sits in an ARGUMENT of the move rather than as the receiver, so
+    _receiver_root cannot see it.
+    """
+    inbox_dir = Path.home() / ".claude" / "teams" / team / "inboxes"
+    fd, tmp_path = tempfile.mkstemp(dir=str(inbox_dir), suffix=".tmp")
+    # The stream name here MUST NOT collide with the one in
+    # deliver_via_open_write. Taint is module-flat, so reusing "handle" would
+    # let this leg inherit that function's taint and fire even with tuple-target
+    # binding reverted -- the leg would look like it proved the tuple fix while
+    # actually proving nothing. Verified by mutation: with the binding reverted
+    # and a distinct name, this write goes unflagged and the count assertion reddens.
+    with os.fdopen(fd, "w", encoding="utf-8") as stream:
+        stream.write(json.dumps(payload))
+    os.replace(tmp_path, str(inbox_dir / f"{name}.json"))
+
+
+def archive_away_from_inbox(team: str, name: str) -> None:
+    """NEGATIVE control: a move whose SOURCE is an inbox and whose destination
+    is not. Retiring a delivered message is not delivering one.
+
+    Pairs with deliver_via_atomic_replace to pin the move rule to the
+    destination position. An any-argument rule passes the positive leg and
+    fails here.
+    """
+    inbox = Path.home() / ".claude" / "teams" / team / "inboxes" / f"{name}.json"
+    os.replace(inbox, Path(tempfile.gettempdir()) / "archived.json")
 
 
 def deliver_via_send_api(recipient: str, body: str) -> None:

--- a/pact-plugin/tests/test_audit_protocol.py
+++ b/pact-plugin/tests/test_audit_protocol.py
@@ -464,9 +464,15 @@ class TestStructuralVerificationDiscipline:
         extract pair — including Concurrent Audit (edited by #502) and State
         Recovery (re-extracted by #505) — must be in sync with its SSOT region.
         This test fails deterministically if any future edit to pact-protocols.md
-        or any extract file desyncs the pair without bumping the script's
-        line-ranges, or if the cascade-delta rule is violated when inserting
-        content into the SSOT.
+        or any extract file desyncs the pair.
+
+        Inserting content into the SSOT carries no separate bookkeeping
+        obligation. The script anchors each section by its H2 heading text plus
+        the next H2 heading as the end sentinel, NOT by line numbers, precisely
+        so that adding or removing lines cannot shift a region out from under
+        it. What this gate checks is byte-identity between an extract and its
+        SSOT region; an edit to one half that is not mirrored into the other is
+        the only way to break it.
         """
         import subprocess
 

--- a/pact-plugin/tests/test_commands_structure.py
+++ b/pact-plugin/tests/test_commands_structure.py
@@ -738,7 +738,7 @@ class TestPerLoopDispatchSites:
         ("orchestrate.md", 463, "PREPARE"),
         ("orchestrate.md", 570, "ARCHITECT"),
         ("orchestrate.md", 705, "CODE"),
-        ("orchestrate.md", 850, "TEST"),
+        ("orchestrate.md", 853, "TEST"),
         ("comPACT.md", 233, "MultipleSpecialists"),
         ("comPACT.md", 293, "SingleSpecialist"),
         ("peer-review.md", 192, "Reviewers"),

--- a/pact-plugin/tests/test_commands_structure.py
+++ b/pact-plugin/tests/test_commands_structure.py
@@ -738,7 +738,7 @@ class TestPerLoopDispatchSites:
         ("orchestrate.md", 463, "PREPARE"),
         ("orchestrate.md", 570, "ARCHITECT"),
         ("orchestrate.md", 705, "CODE"),
-        ("orchestrate.md", 853, "TEST"),
+        ("orchestrate.md", 855, "TEST"),
         ("comPACT.md", 233, "MultipleSpecialists"),
         ("comPACT.md", 293, "SingleSpecialist"),
         ("peer-review.md", 192, "Reviewers"),

--- a/pact-plugin/tests/test_concurrent_auditor_wake.py
+++ b/pact-plugin/tests/test_concurrent_auditor_wake.py
@@ -1,0 +1,724 @@
+"""
+Location: pact-plugin/tests/test_concurrent_auditor_wake.py
+Summary: Four pins guarding the concurrent-auditor wake fix. A concurrent
+         auditor dispatched before its coders produce output went idle and
+         never woke, so a mandated quality gate was lost in silence. The fix
+         relays a wake from the orchestrator on coder stage-ready, replaces
+         the instruction that caused the wait, corrects the protocol paragraph
+         that authorised proceeding without the audit, and adds a phase-exit
+         coverage check.
+
+         Pin 1  the wait instruction never ships without naming the wake
+         Pin 2  the orchestrator is instructed to send that wake
+         Pin 3  the auditor is told not to end its turn depending on a
+                background process
+         Pin 4  the repo fact the guidance asserts is true of this repo:
+                no PACT hook can deliver a message
+
+WHAT THESE PINS DO NOT ESTABLISH -- read this before trusting a green run.
+
+  Pins 1-3 are TIER 1. They establish that specific text is present or
+  absent, that a required clause co-occurs with the instruction it qualifies
+  at a pinned cardinality, and that the surfaces carrying it do not drift
+  apart. They establish NOTHING about behaviour. In particular they do not
+  establish that any agent reading the instruction acts on it.
+
+  Every Tier-1 pin here is LITERAL-anchored. It cannot see a semantically
+  equivalent PARAPHRASE introduced at a NEW site. This is not theoretical:
+  the Phase C trigger already exhibits it, at literal occupancy 1 against
+  semantic occupancy 3. Cardinality catches a paraphrase that REPLACES a
+  known site; nothing here catches one that is ADDED elsewhere.
+
+  Pin 4 is TIER 2. It establishes that a factual claim the shipped text makes
+  is true of this repo at test time -- strictly more than presence, and still
+  not behaviour. Its own limits are documented on the class.
+
+  There is no coverage percentage. For a prose surface the number would
+  itself be the overstatement.
+
+Used by: pact-plugin test suite (standing merge gate).
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Iterator, List, Set, Tuple
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+
+AGENTS_DIR = PLUGIN_ROOT / "agents"
+COMMANDS_DIR = PLUGIN_ROOT / "commands"
+PROTOCOLS_DIR = PLUGIN_ROOT / "protocols"
+HOOKS_DIR = PLUGIN_ROOT / "hooks"
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+AUDITOR_AGENT = AGENTS_DIR / "pact-auditor.md"
+AUDIT_PROTOCOL = PROTOCOLS_DIR / "pact-audit.md"
+PROTOCOLS_SSOT = PROTOCOLS_DIR / "pact-protocols.md"
+ORCHESTRATE_CMD = COMMANDS_DIR / "orchestrate.md"
+
+
+# =============================================================================
+# Shared helpers
+# =============================================================================
+
+
+def _all_markdown() -> List[Path]:
+    """Every markdown surface in the plugin, sorted for stable diagnostics."""
+    return sorted(PLUGIN_ROOT.rglob("*.md"))
+
+
+def _occurrences(literal: str) -> List[Tuple[Path, int]]:
+    """(path, count) for every markdown file containing `literal`."""
+    hits = []
+    for path in _all_markdown():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):  # pragma: no cover - defensive
+            continue
+        count = text.count(literal)
+        if count:
+            hits.append((path, count))
+    return hits
+
+
+def _total(hits: List[Tuple[Path, int]]) -> int:
+    return sum(count for _, count in hits)
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.relative_to(PLUGIN_ROOT).as_posix()
+    except ValueError:  # pragma: no cover - defensive
+        return path.as_posix()
+
+
+def _enclosing_block(text: str, literal: str) -> Iterator[str]:
+    """Yield the blank-line-delimited block around each occurrence of `literal`.
+
+    Block, not line. Post-fix both wait-phrase occurrences happen to carry the
+    relay clause in the SAME sentence, which would make a per-line conjunction
+    very nearly a tautology -- and would silently stop meaning anything if the
+    protocol text were later split across sentences. The block is the unit that
+    keeps the conjunction honest under reformatting.
+    """
+    lines = text.splitlines()
+    start = 0
+    while start < len(lines):
+        if not lines[start].strip():
+            start += 1
+            continue
+        end = start
+        while end < len(lines) and lines[end].strip():
+            end += 1
+        block = "\n".join(lines[start:end])
+        if literal in block:
+            yield block
+        start = end
+
+
+# =============================================================================
+# Pin 1 -- the wait instruction never ships without naming the wake
+# =============================================================================
+
+
+class TestWaitInstructionCarriesTheWake:
+    """The instruction to wait must always name what ends the wait.
+
+    The defect had two halves. One surface told the auditor to wait and named
+    no wake at all; a second told the lead that an absent audit signal means
+    "not written yet, never no signal". An auditor that waits without a named
+    wake is the failure, so the property worth pinning is a CONJUNCTION: every
+    surviving wait instruction also names the relay that ends it.
+
+    A bare conjunction is not enough, and the reason is the whole point of this
+    class. "Every occurrence of X also carries Y" is vacuously TRUE when there
+    are zero occurrences of X, so DELETING the instruction would pass it in
+    silence. Cardinality is what closes that door.
+
+    The cardinality is 2, and it is exact. Post-fix the wait phrase survives
+    only in the two protocol copies; the agent body is a full replacement that
+    names the relay instead of instructing a bare wait. Exactness is
+    load-bearing rather than stylistic, and it can be checked: a floor of >= 2
+    is TRUE before the fix (3 sites) and TRUE after (2 sites), so a floor
+    cannot observe the change at all. Exact-2 is FALSE before and TRUE after.
+    Use the weakest predicate that still discriminates -- here nothing weaker
+    than exactness does.
+
+    What this pin does NOT establish: that an auditor reading either surface
+    acts on it, and that no NEW surface has introduced a paraphrased wait
+    instruction under different words. The literal anchor is blind to that.
+    """
+
+    WAIT_PHRASE = "Wait for coders to produce initial output before observing"
+    RELAY_CLAUSE = "orchestrator's stage-ready relay"
+
+    # The two surfaces that legitimately retain the wait phrase post-fix.
+    WAIT_PHRASE_SITES = {"protocols/pact-audit.md", "protocols/pact-protocols.md"}
+
+    # Every surface that must name the relay -- the protocol pair PLUS the
+    # agent body, which no longer carries the wait phrase and so is invisible
+    # to the conjunction above. Without this leg, deleting the relay clause
+    # from the agent body would leave the rest of this class green.
+    RELAY_SITES = (
+        "agents/pact-auditor.md",
+        "protocols/pact-audit.md",
+        "protocols/pact-protocols.md",
+    )
+
+    def test_markdown_sweep_is_not_empty(self):
+        """Denominator guard: a sweep that resolves nothing would make every
+        cardinality assertion below vacuously satisfiable."""
+        surfaces = _all_markdown()
+        assert len(surfaces) > 100, (
+            f"markdown sweep resolved only {len(surfaces)} files under "
+            f"{PLUGIN_ROOT} -- the cardinality pins below are measured against "
+            f"this sweep and would be meaningless on a truncated one"
+        )
+
+    def test_wait_phrase_cardinality_is_exactly_two(self):
+        hits = _occurrences(self.WAIT_PHRASE)
+        total = _total(hits)
+        assert total == 2, (
+            f"wait-phrase cardinality is {total}, expected exactly 2.\n"
+            f"found: {[(_rel(p), c) for p, c in hits]}\n"
+            f"  {total} < 2 means a wait instruction was DELETED or "
+            f"paraphrased -- the surfaces are drifting apart.\n"
+            f"  {total} > 2 means a bare wait instruction was RE-ADDED "
+            f"somewhere. That is the original defect returning: an auditor "
+            f"told to wait with no named wake does not come back.\n"
+            f"If a surface is being added or removed deliberately, change this "
+            f"constant deliberately -- do not relax it to a floor. A floor is "
+            f"TRUE both before and after the fix and cannot observe it."
+        )
+
+    def test_wait_phrase_lives_only_in_the_protocol_pair(self):
+        """Pin the site identities, not just the count.
+
+        Two occurrences that MOVED to different files would satisfy the count
+        while relocating the instruction to a surface nobody audited.
+        """
+        sites = {_rel(p) for p, _ in _occurrences(self.WAIT_PHRASE)}
+        assert sites == self.WAIT_PHRASE_SITES, (
+            f"wait phrase site set is {sorted(sites)}, expected "
+            f"{sorted(self.WAIT_PHRASE_SITES)}. The agent body must NOT carry "
+            f"the bare wait phrase -- there it was replaced by an instruction "
+            f"that names the relay."
+        )
+
+    @pytest.mark.parametrize("relpath", sorted(WAIT_PHRASE_SITES))
+    def test_each_wait_block_names_the_relay(self, relpath):
+        """The conjunction. Every block instructing a wait names the wake.
+
+        Satisfied by the RELAY clause specifically, not by the poll fallback:
+        a poll-only fix passes a laxer pin and does not close the gap, because
+        an agent that has already ended its turn cannot poll.
+        """
+        path = PLUGIN_ROOT / relpath
+        blocks = list(_enclosing_block(path.read_text(encoding="utf-8"), self.WAIT_PHRASE))
+        assert blocks, f"{relpath}: wait phrase not found in any block"
+        for block in blocks:
+            assert self.RELAY_CLAUSE in block, (
+                f"{relpath}: a block instructs the auditor to wait but does not "
+                f"name {self.RELAY_CLAUSE!r} as the wake.\n"
+                f"block:\n{block}\n"
+                f"An instruction to wait that names no wake is the defect this "
+                f"pin exists for. A bounded poll is a fallback, not the wake."
+            )
+
+    @pytest.mark.parametrize("relpath", RELAY_SITES)
+    def test_relay_clause_present_at_every_named_surface(self, relpath):
+        """Presence, not cardinality, and the asymmetry is deliberate.
+
+        Presence is already FALSE before the fix (the clause existed nowhere)
+        and TRUE after, so it discriminates on its own. An exact count would
+        add no detection and would fire on a fourth surface legitimately
+        naming the relay -- a false alarm, not a drift signal.
+
+        This is the leg that covers the agent body, which the conjunction
+        above cannot see: the fix REMOVED the wait phrase from that file, so
+        deleting its relay clause is invisible to every other test here.
+        """
+        path = PLUGIN_ROOT / relpath
+        assert path.is_file(), f"expected surface missing: {relpath}"
+        text = path.read_text(encoding="utf-8")
+        assert self.RELAY_CLAUSE in text, (
+            f"{relpath} no longer names {self.RELAY_CLAUSE!r}. Every surface "
+            f"that discusses the auditor's warm-up must name where the wake "
+            f"comes from; otherwise a reader of THIS surface learns only that "
+            f"it should wait."
+        )
+
+
+# =============================================================================
+# Pin 2 -- the orchestrator is instructed to send the wake
+# =============================================================================
+
+
+class TestOrchestratorRelaysWakeOnStageReady:
+    """The wake the auditor is told to expect must actually be instructed.
+
+    Pin 1 makes the auditor's surfaces promise a relay. If nothing tells the
+    orchestrator to send one, that promise is a dangling reference and the
+    auditor waits for a message no one was asked to send.
+
+    Anchored on "observe the staged diff", which had occupancy 0 before the
+    fix. NOT anchored on "stage-ready": that string already occurs 8 times
+    across 6 files, so a file-wide stage-ready pin would be satisfied by
+    unrelated prose and could not observe this change at all.
+
+    What this pin does NOT establish: that an orchestrator sends the relay.
+    And it cannot -- by design. The fix pairs the relay (primary) with a
+    phase-exit coverage check (backstop) that fires whenever the relay does
+    not, so no run can distinguish "the relay worked" from "the relay was
+    skipped and the gate caught it". That is the correct trade, since a
+    silently-lost audit is far worse than an unmeasurable mechanism, but it is
+    a KNOWN consequence rather than a gap someone forgot to close. Answering
+    "is the relay working?" needs a deliberate probe with the gate disarmed.
+    """
+
+    RELAY_ANCHOR = "observe the staged diff"
+    AUDITOR_DISPATCH = 'subagent_type="pact-auditor"'
+    PHASE_EXIT_MARKER = "**Before next phase**"
+
+    def test_relay_instruction_is_unique_across_the_plugin(self):
+        hits = _occurrences(self.RELAY_ANCHOR)
+        assert _total(hits) == 1 and [_rel(p) for p, _ in hits] == ["commands/orchestrate.md"], (
+            f"relay instruction anchor {self.RELAY_ANCHOR!r} found at "
+            f"{[(_rel(p), c) for p, c in hits]}, expected exactly one "
+            f"occurrence in commands/orchestrate.md. Zero means the relay "
+            f"instruction was deleted and the auditor's promised wake has no "
+            f"sender; more than one means a second, possibly divergent, relay "
+            f"instruction was introduced."
+        )
+
+    def test_relay_line_names_trigger_recipient_and_mechanism(self):
+        """The line must be actionable on its own: WHEN, TO WHOM, and HOW.
+
+        Discriminates against base, where no line in orchestrate.md paired
+        "auditor" with "stage-ready" at all.
+        """
+        text = ORCHESTRATE_CMD.read_text(encoding="utf-8")
+        line = next(ln for ln in text.splitlines() if self.RELAY_ANCHOR in ln)
+        for element, label in (
+            ("stage-ready", "the trigger"),
+            ("auditor", "the recipient"),
+            ("SendMessage", "the mechanism"),
+        ):
+            assert element in line, (
+                f"relay instruction does not name {label} ({element!r}):\n"
+                f"  {line}\n"
+                f"An orchestrator reading this line must be able to act on it "
+                f"without reconstructing the missing half from context."
+            )
+
+    def test_relay_sits_in_the_auditor_dispatch_region(self):
+        """Placement is part of the instruction.
+
+        The relay must live with the auditor dispatch, not inside the
+        phase-exit checklist. That checklist already carries a separate
+        coverage check which is a PRECONDITION of dispatching TEST; the relay
+        is an action taken during CODE. Collapsing the two into the checklist
+        would turn a continuous relay into a once-per-phase gate item.
+        """
+        text = ORCHESTRATE_CMD.read_text(encoding="utf-8")
+        dispatch_at = text.index(self.AUDITOR_DISPATCH)
+        relay_at = text.index(self.RELAY_ANCHOR)
+        checklist_at = text.index(self.PHASE_EXIT_MARKER, dispatch_at)
+        assert dispatch_at < relay_at < checklist_at, (
+            f"relay instruction is outside the auditor dispatch region "
+            f"(dispatch@{dispatch_at}, relay@{relay_at}, "
+            f"checklist@{checklist_at}). It belongs with the auditor dispatch "
+            f"during CODE, not in the phase-exit checklist."
+        )
+
+
+# =============================================================================
+# Pin 3 -- the guardrail prohibits the posture, not the mechanism
+# =============================================================================
+
+
+class TestAuditorGuardrailProhibitsTurnEndingDependence:
+    """The guardrail must prohibit the POSTURE, and be pinned where it lives.
+
+    The hazard is ending a turn with a background process as the only route
+    back. It is NOT backgrounding as such -- a long command backgrounded while
+    the agent stays in its turn and polls it is fine, and the concurrent
+    auditor for this very change did exactly that safely.
+
+    This pin is anchored on the posture headline, deliberately NOT on the word
+    "monitor". That word was removed from the guardrail when it was re-aimed
+    from mechanism-form to posture-form, and now survives only in the protocol
+    pair. An anti-"monitor" pin aimed at the agent body would therefore have
+    PASSED while pointing at the wrong file -- green, and blind to the surface
+    it was written to protect. Anchor occupancy is checked in the file the pin
+    actually asserts against, which is what makes that failure impossible here.
+
+    Presence suffices: the headline had occupancy 0 before the fix and 1 after,
+    so it discriminates without a count.
+
+    What this pin does NOT establish: that an auditor obeys the guardrail, or
+    that the prohibition is correctly scoped in prose an agent will read the
+    way it was meant. It establishes that the bullet is present, in the
+    register that carries the agent's hard boundaries.
+    """
+
+    POSTURE_HEADLINE = "end your turn with a background process as your route back"
+    BOUNDARY_REGISTER = "## WHAT YOU DO NOT DO"
+    NEXT_SECTION = "## OBSERVATION PROTOCOL"
+
+    def test_posture_headline_present_in_agent_body(self):
+        text = AUDITOR_AGENT.read_text(encoding="utf-8")
+        assert self.POSTURE_HEADLINE in text, (
+            f"agents/pact-auditor.md no longer contains the posture guardrail "
+            f"{self.POSTURE_HEADLINE!r}. Without it the agent body prohibits "
+            f"nothing about turn-ending dependence, which is the mechanism by "
+            f"which an auditor loses its route back."
+        )
+
+    def test_posture_headline_is_in_the_boundary_register(self):
+        """Scope, not just presence.
+
+        The same sentence relocated into explanatory prose stops being a hard
+        boundary. Bullet-scanners read the register; they do not read prose.
+        """
+        text = AUDITOR_AGENT.read_text(encoding="utf-8")
+        start = text.index(self.BOUNDARY_REGISTER)
+        end = text.index(self.NEXT_SECTION, start)
+        register = text[start:end]
+        assert self.POSTURE_HEADLINE in register, (
+            f"the posture guardrail is present in agents/pact-auditor.md but "
+            f"NOT inside {self.BOUNDARY_REGISTER!r}. It must sit in the "
+            f"boundary register to read as a prohibition rather than as "
+            f"commentary."
+        )
+
+    def test_guardrail_permits_backgrounding_within_a_turn(self):
+        """The narrowing is load-bearing and must not silently revert.
+
+        The earlier draft prohibited a MECHANISM. Read literally it forbade a
+        legitimate long-running command; read loosely it permitted the actual
+        failure. If the permission clause disappears, the guardrail has slid
+        back toward prohibiting the mechanism.
+        """
+        text = AUDITOR_AGENT.read_text(encoding="utf-8")
+        start = text.index(self.BOUNDARY_REGISTER)
+        end = text.index(self.NEXT_SECTION, start)
+        register = text[start:end]
+        assert "Backgrounding a long command is fine" in register, (
+            "the guardrail no longer states that backgrounding within a turn "
+            "is permitted. Without that clause the bullet reads as a ban on "
+            "the mechanism, which forbids legitimate long-running commands "
+            "and misidentifies the hazard."
+        )
+
+
+# =============================================================================
+# Pin 4 -- the repo fact: no PACT hook can deliver a message
+# =============================================================================
+#
+# The shipped guidance tells the auditor "no PACT hook sends a message". That
+# is a claim ABOUT THIS REPO, and unlike the pins above it can be checked
+# rather than merely located.
+#
+# The scan is AST-based, not textual, and it has to be: hooks/ mentions inbox
+# paths in 8 files, all of them read-only probes. A text scan would flag every
+# one of them. Structure is what separates a mention from a delivery.
+
+
+INBOX_MARKER = "inbox"
+WRITE_METHOD_NAMES = frozenset({"write", "write_text", "write_bytes", "writelines"})
+WRITE_MODE_CHARS = ("w", "a", "x", "+")
+
+# An ENUMERATION, and its limits are stated on the test class below. There is
+# no Python send-message callable in this repo -- SendMessage is a platform
+# tool with no hookable event -- so this set is a proxy for a construct that
+# does not currently exist in any form.
+SEND_CALLEE_NAMES = frozenset({
+    "send_message",
+    "sendmessage",
+    "send_msg",
+    "post_message",
+    "deliver_message",
+    "enqueue_message",
+    "notify_teammate",
+})
+
+
+def hook_python_files() -> List[Path]:
+    """The scanned denominator: every .py under hooks/, __pycache__ excluded.
+
+    The basis is stated rather than implied, because it is the vacuity guard.
+    An all-files walk would be wrong here: the repo's untracked runtime state
+    (hook-errors.log, save-session.pid, .CLAUDE.md.lock) is written while a
+    session runs, so an all-files count can change between two measurements
+    minutes apart with nobody editing anything. A flaky control is worse than
+    no control, because its red gets dismissed as noise and then its green
+    stops being read.
+    """
+    return sorted(p for p in HOOKS_DIR.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def _callee_name(node: ast.Call) -> str | None:
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _receiver_root(node: ast.Call) -> str | None:
+    """Root name of an attribute call's receiver: a.b.c.write_text() -> 'a'."""
+    func = node.func
+    if not isinstance(func, ast.Attribute):
+        return None
+    cur = func.value
+    while isinstance(cur, (ast.Attribute, ast.Subscript)):
+        cur = cur.value
+    return cur.id if isinstance(cur, ast.Name) else None
+
+
+def _mentions_inbox(node: ast.AST, tainted: Set[str]) -> bool:
+    """True if the subtree names an inbox path -- as a string literal, as an
+    identifier, or by reading a name already known to hold one."""
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+            if INBOX_MARKER in sub.value.lower():
+                return True
+        elif isinstance(sub, ast.Name):
+            if INBOX_MARKER in sub.id.lower() or sub.id in tainted:
+                return True
+        elif isinstance(sub, ast.Attribute):
+            if INBOX_MARKER in sub.attr.lower():
+                return True
+    return False
+
+
+def _tainted_names(tree: ast.AST) -> Set[str]:
+    """Names bound to an expression that mentions an inbox path.
+
+    Iterated to a fixpoint so multi-step path construction propagates. Real
+    delivery code builds the path in one statement and writes in another, so a
+    scanner that only inspected the write call's own subtree would miss it
+    entirely -- which is exactly what the fixture's first positive leg proves.
+    """
+    tainted: Set[str] = set()
+    for _ in range(8):
+        grew = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                targets, value = node.targets, node.value
+            elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+                if node.value is None:
+                    continue
+                targets, value = [node.target], node.value
+            elif isinstance(node, ast.withitem):
+                if node.optional_vars is None:
+                    continue
+                targets, value = [node.optional_vars], node.context_expr
+            else:
+                continue
+            if not _mentions_inbox(value, tainted):
+                continue
+            for target in targets:
+                if isinstance(target, ast.Name) and target.id not in tainted:
+                    tainted.add(target.id)
+                    grew = True
+        if not grew:
+            break
+    return tainted
+
+
+def _is_write_mode(call: ast.Call) -> bool:
+    if len(call.args) >= 2 and isinstance(call.args[1], ast.Constant):
+        mode = call.args[1].value
+        if isinstance(mode, str) and any(c in mode for c in WRITE_MODE_CHARS):
+            return True
+    for keyword in call.keywords:
+        if keyword.arg == "mode" and isinstance(keyword.value, ast.Constant):
+            mode = keyword.value.value
+            if isinstance(mode, str) and any(c in mode for c in WRITE_MODE_CHARS):
+                return True
+    return False
+
+
+def scan_source(source: str) -> Tuple[List[Tuple[str, int, str]], Set[str]]:
+    """Return (findings, tainted-names) for one module's source.
+
+    A finding is (rule, lineno, callee). Two rules:
+      INBOX-WRITE  a write-capable call on an inbox-derived path
+      SEND-CALL    a call to a name in the send enumeration
+    """
+    findings: List[Tuple[str, int, str]] = []
+    tree = ast.parse(source)
+    tainted = _tainted_names(tree)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _callee_name(node)
+        if name is None:
+            continue
+        if name in SEND_CALLEE_NAMES:
+            findings.append(("SEND-CALL", node.lineno, name))
+        elif name in WRITE_METHOD_NAMES:
+            root = _receiver_root(node)
+            rooted = root is not None and (root in tainted or INBOX_MARKER in root.lower())
+            if rooted or _mentions_inbox(node, tainted):
+                findings.append(("INBOX-WRITE", node.lineno, name))
+        elif name == "open" and _is_write_mode(node) and _mentions_inbox(node, tainted):
+            findings.append(("INBOX-WRITE", node.lineno, name))
+    return findings, tainted
+
+
+class TestNoPactHookCanDeliverAMessage:
+    """The claim "no PACT hook sends a message" is TRUE of this repo.
+
+    WHAT THIS DOES NOT ESTABLISH, and the first item is the important one:
+
+    1. The instruction's force rests on a CONJUNCTION -- PACT provides no wake
+       AND the platform provides none. This pin covers the PACT conjunct only.
+       If the platform later gained wake-on-process-exit, the pinned sentence
+       would remain TRUE and this pin would stay GREEN while the guidance
+       became misleading. Named, not closed; it is not pytest-testable.
+
+    2. SEND_CALLEE_NAMES is an ENUMERATION the author wrote, and there is no
+       Python send-message callable in this repo to calibrate it against. The
+       fixture proves the scanner runs and flags -- it validates the PIPELINE,
+       not the PATTERN. Delivery routed through an indirection the enumeration
+       does not anticipate (a subprocess invocation, a dynamically-built
+       attribute, a helper in a module the sweep does not cover) would not be
+       caught. Read a green here as "no delivery construct of a KNOWN SHAPE",
+       never as proof of impossibility.
+
+    3. Taint propagation is intra-module and assignment-based. A path passed
+       through a function boundary and written on the far side is not tracked.
+    """
+
+    FIXTURE = FIXTURES_DIR / "message_delivering_hook.py"
+
+    # Derived from the fixture's own structure, not copied from a run:
+    # write_text (1) + open(...,"w") (1) + handle.write (1) = 3 INBOX-WRITE,
+    # send_message (1) = 1 SEND-CALL.
+    EXPECTED_FIXTURE_FINDINGS = 4
+
+    def test_denominator_is_non_empty_and_stated(self):
+        """Vacuity guard. A scan of zero files reports zero findings."""
+        files = hook_python_files()
+        assert len(files) >= 25, (
+            f"hooks/ sweep resolved only {len(files)} python files -- the "
+            f"zero-findings assertion below would be vacuous. Basis: "
+            f"hooks/**/*.py excluding __pycache__."
+        )
+
+    def test_every_scanned_file_parses(self):
+        """Parse-success must equal file count.
+
+        A file that fails to parse is silently absent from the walk, so its
+        contents would never be examined and the scan would report a clean
+        zero over a tree it had not actually read.
+        """
+        files = hook_python_files()
+        unparsed = []
+        for path in files:
+            try:
+                ast.parse(path.read_text(encoding="utf-8"))
+            except SyntaxError as exc:
+                unparsed.append(f"{_rel(path)}: {exc}")
+        assert not unparsed, (
+            f"{len(unparsed)} of {len(files)} scanned files failed to parse; a "
+            f"file the scanner cannot parse is a file it cannot clear:\n"
+            + "\n".join(unparsed)
+        )
+
+    def test_scanner_is_live_on_the_real_tree(self):
+        """The zero below is informative only if the scanner engages here.
+
+        hooks/ really does construct inbox paths -- read-only, as witnesses
+        that a teammate was dispatched. If that construction disappeared, a
+        zero-findings result would degrade from "the scanner examined real
+        inbox handling and found no writes" to "the scanner found nothing to
+        look at", without any test going red. This is the control that keeps
+        the two distinguishable, and it is drawn from the shipped tree rather
+        than from the fixture, so it cannot pass by the fixture's construction.
+        """
+        live = [
+            _rel(path)
+            for path in hook_python_files()
+            if scan_source(path.read_text(encoding="utf-8"))[1]
+        ]
+        assert live, (
+            "no file under hooks/ constructs an inbox-derived path any more. "
+            "The scanner's taint machinery is therefore never exercised "
+            "against shipped code, and 'zero delivery constructs' no longer "
+            "distinguishes a clean tree from an inert scanner. Re-establish a "
+            "liveness control before trusting this class."
+        )
+
+    def test_no_hook_delivers_a_message(self):
+        """The pin itself."""
+        files = hook_python_files()
+        findings = []
+        for path in files:
+            for rule, lineno, callee in scan_source(path.read_text(encoding="utf-8"))[0]:
+                findings.append(f"{_rel(path)}:{lineno}: {rule} via {callee!r}")
+        assert not findings, (
+            f"{len(findings)} message-delivery construct(s) found in hooks/ "
+            f"(basis: hooks/**/*.py excluding __pycache__, {len(files)} "
+            f"files). The auditor guidance states that no PACT hook sends a "
+            f"message, and an auditor relies on that when deciding it cannot "
+            f"wake itself. If a hook now delivers messages, the guidance is "
+            f"false and must change with it:\n" + "\n".join(findings)
+        )
+
+    def test_positive_control_fixture_is_flagged(self):
+        """The scanner detects delivery it is pointed at -- on every run.
+
+        Asserted quantitatively, by rule and by count derived from the
+        fixture's structure. "Non-empty" would pass if only one of the two
+        rules worked, which is precisely the failure this control exists to
+        exclude: an authoring-time check of the scanner caught INBOX-WRITE
+        failing to fire while SEND-CALL fired, and a non-emptiness assertion
+        would have reported that broken scanner as healthy.
+        """
+        assert self.FIXTURE.is_file(), f"positive-control fixture missing: {self.FIXTURE}"
+        findings, _ = scan_source(self.FIXTURE.read_text(encoding="utf-8"))
+        rules = sorted({rule for rule, _, _ in findings})
+        assert rules == ["INBOX-WRITE", "SEND-CALL"], (
+            f"positive-control fixture fired rules {rules}, expected both "
+            f"['INBOX-WRITE', 'SEND-CALL']. A rule that never fires cannot "
+            f"clear the shipped tree of anything."
+        )
+        assert len(findings) == self.EXPECTED_FIXTURE_FINDINGS, (
+            f"positive-control fixture produced {len(findings)} findings, "
+            f"expected {self.EXPECTED_FIXTURE_FINDINGS}: "
+            f"{findings}"
+        )
+
+    def test_negative_control_reads_and_unrelated_writes_are_not_flagged(self):
+        """The scanner distinguishes mention from delivery.
+
+        Two ways to be uselessly loud: flag an inbox path that is only READ
+        (hooks/ does this legitimately, so the pin would fire on correct
+        shipped code), or flag any write at all. Both negative legs live in
+        the same fixture as the positive ones, so neither side can pass by
+        the feature being absent.
+        """
+        source = self.FIXTURE.read_text(encoding="utf-8")
+        findings, _ = scan_source(source)
+        lines = source.splitlines()
+        flagged = {lineno for _, lineno, _ in findings}
+
+        for marker, why in (
+            ("inbox.read_text(", "an inbox path that is only read"),
+            ("inbox.is_file()", "an inbox existence probe"),
+            ("log.write_text(", "a write to a path that is not an inbox"),
+        ):
+            lineno = next(i for i, ln in enumerate(lines, start=1) if marker in ln)
+            assert lineno not in flagged, (
+                f"scanner flagged {why} at fixture line {lineno} ({marker!r}). "
+                f"Over-flagging makes this pin fire on correct code, and a pin "
+                f"that fires on correct code gets relaxed rather than heeded."
+            )

--- a/pact-plugin/tests/test_concurrent_auditor_wake.py
+++ b/pact-plugin/tests/test_concurrent_auditor_wake.py
@@ -446,6 +446,23 @@ SEND_CALLEE_NAMES = frozenset({
     "notify_teammate",
 })
 
+# The atomic-write idiom: write a temp file, then move it into place. This is
+# how the repo's own durable writers work, so a delivery would almost certainly
+# be shaped this way rather than as a direct write.
+#
+# Keyed on the DOTTED (module, attr) pair, NOT on the bare callee name, and the
+# two reasons are the whole design:
+#
+#   * a bare "replace" collides with str.replace, which hooks/pin_caps.py uses
+#     heavily on file CONTENT -- an unrelated call with a wide argument surface.
+#   * pathlib's Path.rename / Path.replace are the MIRROR IMAGE: destination at
+#     args[0] with the source as the receiver. Folding them into one arm would
+#     flag moves AWAY from an inbox as deliveries, which is the opposite claim.
+#
+# The cost is stated as limit 4 on the test class: `from os import replace` and
+# the pathlib method form are both out of reach.
+MOVE_CALLEES = frozenset({("os", "replace"), ("os", "rename"), ("shutil", "move")})
+
 
 def hook_python_files() -> List[Path]:
     """The scanned denominator: every .py under hooks/, __pycache__ excluded.
@@ -481,6 +498,49 @@ def _receiver_root(node: ast.Call) -> str | None:
     return cur.id if isinstance(cur, ast.Name) else None
 
 
+def _move_destination(call: ast.Call):
+    """The DESTINATION expression of a move/rename call, or None if not one.
+
+    Destination-position keyed, deliberately not any-argument. A delivery is
+    ``os.replace(tmp, inbox)``; ``os.replace(inbox, backup)`` is a move AWAY
+    from an inbox, which is not a delivery and arguably its opposite. All three
+    callees in MOVE_CALLEES take (src, dst) with the destination second.
+    """
+    func = call.func
+    if not isinstance(func, ast.Attribute):
+        return None
+    root = func.value
+    if not isinstance(root, ast.Name) or (root.id, func.attr) not in MOVE_CALLEES:
+        return None
+    if len(call.args) >= 2:
+        return call.args[1]
+    for keyword in call.keywords:
+        if keyword.arg == "dst":
+            return keyword.value
+    return None
+
+
+def _bound_names(target: ast.AST) -> Iterator[str]:
+    """Every Name id bound by an assignment target, descending unpack forms.
+
+    A bare ``isinstance(target, ast.Name)`` filter silently drops every tuple
+    target, so ``fd, tmp = tempfile.mkstemp(dir=inbox_dir)`` propagated no taint
+    at all -- and that shape is exactly how the repo's own atomic writers open
+    their temp files.
+
+    Deliberately OVER-approximate: the form above taints BOTH ``fd`` and
+    ``tmp`` although only one is a path. Over-approximating taint is the safe
+    direction for a detector; under-approximating is what produced the gap.
+    """
+    if isinstance(target, ast.Name):
+        yield target.id
+    elif isinstance(target, (ast.Tuple, ast.List)):
+        for element in target.elts:
+            yield from _bound_names(element)
+    elif isinstance(target, ast.Starred):
+        yield from _bound_names(target.value)
+
+
 def _mentions_inbox(node: ast.AST, tainted: Set[str]) -> bool:
     """True if the subtree names an inbox path -- as a string literal, as an
     identifier, or by reading a name already known to hold one."""
@@ -500,13 +560,24 @@ def _mentions_inbox(node: ast.AST, tainted: Set[str]) -> bool:
 def _tainted_names(tree: ast.AST) -> Set[str]:
     """Names bound to an expression that mentions an inbox path.
 
-    Iterated to a fixpoint so multi-step path construction propagates. Real
-    delivery code builds the path in one statement and writes in another, so a
-    scanner that only inspected the write call's own subtree would miss it
+    Iterated to a TRUE fixpoint so multi-step path construction propagates.
+    Real delivery code builds the path in one statement and writes in another,
+    so a scanner that only inspected the write call's own subtree would miss it
     entirely -- which is exactly what the fixture's first positive leg proves.
+
+    The loop is unbounded ON PURPOSE and terminates by construction: `tainted`
+    only ever grows, a name is added at most once, and it is bounded above by
+    the finite set of Name ids in the module -- so the loop runs at most
+    |names| + 1 times. An earlier draft capped this at 8 passes, which bought
+    no termination guarantee that monotonicity does not already provide and
+    could only TRUNCATE: because ast.walk is breadth-first, a chain whose
+    producers sit deeper than their consumers propagates one link per pass, so
+    the cap became a hard depth limit. Past it the scanner returned a clean
+    zero over code it had not finished reading -- the silent false-clean this
+    whole module exists to make impossible. Do not reintroduce a cap.
     """
     tainted: Set[str] = set()
-    for _ in range(8):
+    while True:
         grew = False
         for node in ast.walk(tree):
             if isinstance(node, ast.Assign):
@@ -524,12 +595,12 @@ def _tainted_names(tree: ast.AST) -> Set[str]:
             if not _mentions_inbox(value, tainted):
                 continue
             for target in targets:
-                if isinstance(target, ast.Name) and target.id not in tainted:
-                    tainted.add(target.id)
-                    grew = True
+                for name in _bound_names(target):
+                    if name not in tainted:
+                        tainted.add(name)
+                        grew = True
         if not grew:
-            break
-    return tainted
+            return tainted
 
 
 def _is_write_mode(call: ast.Call) -> bool:
@@ -548,15 +619,29 @@ def _is_write_mode(call: ast.Call) -> bool:
 def scan_source(source: str) -> Tuple[List[Tuple[str, int, str]], Set[str]]:
     """Return (findings, tainted-names) for one module's source.
 
-    A finding is (rule, lineno, callee). Two rules:
+    A finding is (rule, lineno, callee). Three rules:
       INBOX-WRITE  a write-capable call on an inbox-derived path
+      INBOX-MOVE   a move/rename whose DESTINATION is an inbox-derived path
       SEND-CALL    a call to a name in the send enumeration
+
+    INBOX-MOVE is not a variant of INBOX-WRITE and is checked first, because
+    the two match on opposite sides of the call: INBOX-WRITE keys on the
+    RECEIVER, INBOX-MOVE on an ARGUMENT. It carries its own rule name so that
+    the positive-control assertion can prove it fires -- folded into
+    INBOX-WRITE its liveness would be invisible, since the fixture could stop
+    exercising it entirely and the rules assertion would still pass on the
+    strength of the other legs.
     """
     findings: List[Tuple[str, int, str]] = []
     tree = ast.parse(source)
     tainted = _tainted_names(tree)
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
+            continue
+        destination = _move_destination(node)
+        if destination is not None:
+            if _mentions_inbox(destination, tainted):
+                findings.append(("INBOX-MOVE", node.lineno, _callee_name(node)))
             continue
         name = _callee_name(node)
         if name is None:
@@ -584,25 +669,45 @@ class TestNoPactHookCanDeliverAMessage:
        would remain TRUE and this pin would stay GREEN while the guidance
        became misleading. Named, not closed; it is not pytest-testable.
 
-    2. SEND_CALLEE_NAMES is an ENUMERATION the author wrote, and there is no
-       Python send-message callable in this repo to calibrate it against. The
-       fixture proves the scanner runs and flags -- it validates the PIPELINE,
-       not the PATTERN. Delivery routed through an indirection the enumeration
-       does not anticipate (a subprocess invocation, a dynamically-built
-       attribute, a helper in a module the sweep does not cover) would not be
-       caught. Read a green here as "no delivery construct of a KNOWN SHAPE",
-       never as proof of impossibility.
+    2. SEND_CALLEE_NAMES and MOVE_CALLEES are ENUMERATIONS the author wrote,
+       and there is no Python send-message callable in this repo to calibrate
+       the first against. The fixture proves the scanner runs and flags -- it
+       validates the PIPELINE, not the PATTERN. Delivery routed through an
+       indirection an enumeration does not anticipate (a subprocess
+       invocation, a dynamically-built attribute, a helper in a module the
+       sweep does not cover) would not be caught. Read a green here as "no
+       delivery construct of a KNOWN SHAPE", never as proof of impossibility.
 
-    3. Taint propagation is intra-module and assignment-based. A path passed
-       through a function boundary and written on the far side is not tracked.
+    3. Taint propagation is intra-module, assignment-based, and FLOW-
+       INSENSITIVE. A path passed through a function boundary and written on
+       the far side is not tracked. Within a module the taint set is FLAT --
+       there is no per-function scoping, so a name tainted in one function
+       taints the same identifier everywhere in that module. That is the safe
+       direction (it over-approximates), but it means a finding's location is
+       evidence about the module, not proof about the enclosing function.
+       Tuple targets ARE tracked, and over-approximately: `fd, tmp =
+       mkstemp(dir=inbox_dir)` taints both names though only one is a path.
+
+    4. The move rule is keyed on the dotted (module, attr) pairs in
+       MOVE_CALLEES, so `from os import replace; replace(tmp, inbox)` and the
+       pathlib method forms `tmp.rename(inbox)` / `tmp.replace(inbox)` are NOT
+       caught. The pathlib omission is deliberate rather than an oversight:
+       those put the destination at args[0] with the SOURCE as the receiver,
+       the mirror image of os.replace, so folding them in would flag every
+       move OUT of an inbox as a delivery. Copy-family calls (shutil.copy,
+       copy2, copyfile) are also out of scope; they deliver too, and closing
+       that is a deliberate widening, not a bug fix.
     """
 
     FIXTURE = FIXTURES_DIR / "message_delivering_hook.py"
 
     # Derived from the fixture's own structure, not copied from a run:
-    # write_text (1) + open(...,"w") (1) + handle.write (1) = 3 INBOX-WRITE,
-    # send_message (1) = 1 SEND-CALL.
-    EXPECTED_FIXTURE_FINDINGS = 4
+    #   INBOX-WRITE (4) = write_text (1) + open(...,"w") (1)
+    #                     + handle.write in the open leg (1)
+    #                     + handle.write in the atomic-replace leg (1)
+    #   INBOX-MOVE  (1) = os.replace onto an inbox destination
+    #   SEND-CALL   (1) = send_message
+    EXPECTED_FIXTURE_FINDINGS = 6
 
     def test_denominator_is_non_empty_and_stated(self):
         """Vacuity guard. A scan of zero files reports zero findings."""
@@ -621,6 +726,11 @@ class TestNoPactHookCanDeliverAMessage:
         zero over a tree it had not actually read.
         """
         files = hook_python_files()
+        # Inline guard: never pass on an empty sweep. The sibling denominator
+        # test also covers this, but a universal whose non-vacuity lives in a
+        # DIFFERENT test still passes under -k selection or if that sibling is
+        # deleted. Convention borrowed from tests/test_import_hygiene.py.
+        assert len(files) >= 25, f"empty/truncated sweep: {len(files)} files"
         unparsed = []
         for path in files:
             try:
@@ -660,6 +770,11 @@ class TestNoPactHookCanDeliverAMessage:
     def test_no_hook_delivers_a_message(self):
         """The pin itself."""
         files = hook_python_files()
+        # Inline guard: a scan of zero files reports zero findings, so without
+        # this the assertion below is satisfiable by an empty sweep. The
+        # sibling denominator test covers the same condition; this one keeps
+        # THIS assertion non-vacuous on its own.
+        assert len(files) >= 25, f"empty/truncated sweep: {len(files)} files"
         findings = []
         for path in files:
             for rule, lineno, callee in scan_source(path.read_text(encoding="utf-8"))[0]:
@@ -686,15 +801,56 @@ class TestNoPactHookCanDeliverAMessage:
         assert self.FIXTURE.is_file(), f"positive-control fixture missing: {self.FIXTURE}"
         findings, _ = scan_source(self.FIXTURE.read_text(encoding="utf-8"))
         rules = sorted({rule for rule, _, _ in findings})
-        assert rules == ["INBOX-WRITE", "SEND-CALL"], (
-            f"positive-control fixture fired rules {rules}, expected both "
-            f"['INBOX-WRITE', 'SEND-CALL']. A rule that never fires cannot "
-            f"clear the shipped tree of anything."
+        assert rules == ["INBOX-MOVE", "INBOX-WRITE", "SEND-CALL"], (
+            f"positive-control fixture fired rules {rules}, expected all three "
+            f"of ['INBOX-MOVE', 'INBOX-WRITE', 'SEND-CALL']. A rule that never "
+            f"fires cannot clear the shipped tree of anything. This is also why "
+            f"the move rule carries its OWN name: folded into INBOX-WRITE its "
+            f"liveness would be invisible here, and the fixture could stop "
+            f"exercising it while this assertion still passed on the other legs."
         )
         assert len(findings) == self.EXPECTED_FIXTURE_FINDINGS, (
             f"positive-control fixture produced {len(findings)} findings, "
             f"expected {self.EXPECTED_FIXTURE_FINDINGS}: "
             f"{findings}"
+        )
+
+    def test_taint_propagation_has_no_depth_cap(self):
+        """The fixpoint is a fixpoint, at any chain depth.
+
+        An earlier draft capped the propagation loop at 8 passes. Because
+        ast.walk is breadth-first, a chain whose PRODUCERS sit deeper than
+        their CONSUMERS advances one link per pass, so the cap acted as a hard
+        depth limit -- and past it the scanner returned a clean zero over code
+        it had not finished reading. That is a silent fail-open, and the docstring
+        note saying not to reintroduce a cap is prose that nothing enforces.
+        This is the enforcement.
+
+        Depth 24 is chosen well clear of the old bound so the assertion is
+        FALSE under any small cap and TRUE only against a real fixpoint.
+        Without this row, the only thing standing between the module and a
+        reintroduced cap would be a docstring asking politely.
+        """
+        depth = 24
+        lines = ["def deliver(payload):"]
+        indent = "    "
+        for i in range(1, depth):
+            lines.append(f"{indent}a{i} = a{i + 1}")
+            lines.append(f"{indent}if True:")
+            indent += "    "
+        lines.append(f'{indent}a{depth} = Path.home() / "inboxes" / "victim.json"')
+        lines.append("    a1.write_text(payload)")
+        source = "\n".join(lines)
+
+        findings, tainted = scan_source(source)
+        assert [rule for rule, _, _ in findings] == ["INBOX-WRITE"], (
+            f"a delivery {depth} assignment-links deep was NOT detected "
+            f"(findings={findings}, {len(tainted)} of {depth} names tainted). "
+            f"The propagation loop is terminating before its fixpoint, so the "
+            f"scanner reports a clean zero over code it has not finished "
+            f"reading -- the silent false-clean this module exists to prevent. "
+            f"Do not 'fix' this by raising a cap: the loop terminates on "
+            f"monotonic growth over a finite name set and needs no bound."
         )
 
     def test_negative_control_reads_and_unrelated_writes_are_not_flagged(self):
@@ -715,6 +871,7 @@ class TestNoPactHookCanDeliverAMessage:
             ("inbox.read_text(", "an inbox path that is only read"),
             ("inbox.is_file()", "an inbox existence probe"),
             ("log.write_text(", "a write to a path that is not an inbox"),
+            ("os.replace(inbox,", "a move whose SOURCE is an inbox"),
         ):
             lineno = next(i for i, ln in enumerate(lines, start=1) if marker in ln)
             assert lineno not in flagged, (

--- a/pact-plugin/tests/test_concurrent_auditor_wake.py
+++ b/pact-plugin/tests/test_concurrent_auditor_wake.py
@@ -874,21 +874,30 @@ class TestNoPactHookCanDeliverAMessage:
         lines = source.splitlines()
         flagged = {lineno for _, lineno, _ in findings}
 
-        for marker, why in (
+        anchors = (
             ("inbox.read_text(", "an inbox path that is only read"),
             ("inbox.is_file()", "an inbox existence probe"),
             ("log.write_text(", "a write to a path that is not an inbox"),
             ("os.replace(inbox,", "a move whose SOURCE is an inbox"),
-        ):
-            lineno = next(
-                (i for i, ln in enumerate(lines, start=1) if marker in ln), None
-            )
-            # The default and this guard are ONE unit -- never add the default
-            # alone. `None not in flagged` is True, so an unchecked defaulted
-            # lookup makes a missing anchor SATISFY the assertion below, and the
-            # row silently stops guarding anything. That is strictly worse than
-            # the bare next() this replaced, which at least failed loudly.
-            assert lineno is not None, (
+        )
+        assert anchors, (
+            "the anchor table is empty, so every row below would be skipped and "
+            "this test would pass having checked nothing"
+        )
+
+        for marker, why in anchors:
+            matches = [i for i, ln in enumerate(lines, start=1) if marker in ln]
+            # Both guards live INSIDE this loop deliberately. A separate pass
+            # over a derived collection can run zero times while these rows run
+            # -- a universal over nothing, which is the failure this module
+            # exists to prevent. Sharing the iteration makes that structurally
+            # impossible rather than merely asserted.
+            #
+            # The list and these guards are ONE unit -- never take matches[0]
+            # without them. `None not in flagged` is True, so an unchecked
+            # lookup makes a missing anchor SATISFY the flagged assertion below
+            # and the row silently stops guarding anything.
+            assert matches, (
                 f"negative-control anchor {marker!r} is not present in "
                 f"{_rel(self.FIXTURE)}.\n"
                 f"These markers are matched LITERALLY: each row locates the "
@@ -899,6 +908,30 @@ class TestNoPactHookCanDeliverAMessage:
                 f"Update the marker to match the new identifier -- do not "
                 f"delete the row."
             )
+            assert len(matches) == 1, (
+                f"negative-control anchor {marker!r} matches "
+                f"{len(matches)} lines of {_rel(self.FIXTURE)} "
+                f"(lines {matches}), so which line this row checks is now "
+                f"ambiguous and the first match wins.\n"
+                f"The usual cause is prose -- a docstring or comment that "
+                f"spells an anchor out as an example. Because the search runs "
+                f"over the whole file, such a line becomes the match and the "
+                f"row starts checking the prose instead of the code, while "
+                f"still passing.\n"
+                f"Describe the anchors without reproducing them, or narrow "
+                f"this marker until it matches only the code line."
+            )
+            lineno = matches[0]
+            # KNOWN LIMIT, stated because an unstated one is what this file
+            # keeps shipping: uniqueness does not catch a marker that matches
+            # exactly one line when that line is prose. Reaching it needs a
+            # rename to remove the code occurrence AND prose to reintroduce the
+            # same text. For the leg whose rename drops two anchors at once the
+            # sibling falls to zero and the guard above still fires, so the gap
+            # is open only for the single-anchor legs. Closing it would mean
+            # classifying lines as code, whose own failure modes (a call
+            # reformatted across lines reddens a test about renaming) are worse
+            # than the residual.
             assert lineno not in flagged, (
                 f"scanner flagged {why} at fixture line {lineno} ({marker!r}). "
                 f"Over-flagging makes this pin fire on correct code, and a pin "

--- a/pact-plugin/tests/test_concurrent_auditor_wake.py
+++ b/pact-plugin/tests/test_concurrent_auditor_wake.py
@@ -453,8 +453,12 @@ SEND_CALLEE_NAMES = frozenset({
 # Keyed on the DOTTED (module, attr) pair, NOT on the bare callee name, and the
 # two reasons are the whole design:
 #
-#   * a bare "replace" collides with str.replace, which hooks/pin_caps.py uses
-#     heavily on file CONTENT -- an unrelated call with a wide argument surface.
+#   * a bare "replace" collides with str.replace. Measured over the scanned
+#     denominator itself -- hooks/**/*.py, which is all this scanner ever reads
+#     -- there are 23 such call sites across 14 files, every one an unrelated
+#     call with a wide argument surface. (Counts over wider trees are larger
+#     but describe code the scanner never opens, so they cannot justify a
+#     decision about its false-positive surface.)
 #   * pathlib's Path.rename / Path.replace are the MIRROR IMAGE: destination at
 #     args[0] with the source as the receiver. Folding them into one arm would
 #     flag moves AWAY from an inbox as deliveries, which is the opposite claim.
@@ -691,7 +695,10 @@ class TestNoPactHookCanDeliverAMessage:
     4. The move rule is keyed on the dotted (module, attr) pairs in
        MOVE_CALLEES, so `from os import replace; replace(tmp, inbox)` and the
        pathlib method forms `tmp.rename(inbox)` / `tmp.replace(inbox)` are NOT
-       caught. The pathlib omission is deliberate rather than an oversight:
+       caught. Nor is the splat form `os.replace(*args)`: the destination is
+       read positionally, and a starred argument collapses to a single
+       ast.Starred node, so `len(call.args) >= 2` is false and the call is
+       never examined. The pathlib omission is deliberate rather than an oversight:
        those put the destination at args[0] with the SOURCE as the receiver,
        the mirror image of os.replace, so folding them in would flag every
        move OUT of an inbox as a delivery. Copy-family calls (shutil.copy,

--- a/pact-plugin/tests/test_concurrent_auditor_wake.py
+++ b/pact-plugin/tests/test_concurrent_auditor_wake.py
@@ -880,7 +880,25 @@ class TestNoPactHookCanDeliverAMessage:
             ("log.write_text(", "a write to a path that is not an inbox"),
             ("os.replace(inbox,", "a move whose SOURCE is an inbox"),
         ):
-            lineno = next(i for i, ln in enumerate(lines, start=1) if marker in ln)
+            lineno = next(
+                (i for i, ln in enumerate(lines, start=1) if marker in ln), None
+            )
+            # The default and this guard are ONE unit -- never add the default
+            # alone. `None not in flagged` is True, so an unchecked defaulted
+            # lookup makes a missing anchor SATISFY the assertion below, and the
+            # row silently stops guarding anything. That is strictly worse than
+            # the bare next() this replaced, which at least failed loudly.
+            assert lineno is not None, (
+                f"negative-control anchor {marker!r} is not present in "
+                f"{_rel(self.FIXTURE)}.\n"
+                f"These markers are matched LITERALLY: each row locates the "
+                f"fixture line it checks by searching for this exact text, so "
+                f"the fixture's identifiers are part of this test's contract. "
+                f"Renaming one removes the anchor and the row loses the case it "
+                f"was written to guard.\n"
+                f"Update the marker to match the new identifier -- do not "
+                f"delete the row."
+            )
             assert lineno not in flagged, (
                 f"scanner flagged {why} at fixture line {lineno} ({marker!r}). "
                 f"Over-flagging makes this pin fire on correct code, and a pin "


### PR DESCRIPTION
Addresses issue #976 — a concurrent auditor goes idle before the coder produces output and never wakes to run its audit pass.

> Deliberately worded without a close-keyword. The issue should be closed by hand after review, not auto-closed on merge.

## The problem

The auditor was instructed to *wait* for coder output before observing. Nothing in PACT wakes an idle teammate, and no hook can send a message — so an auditor that ended its turn waiting had no route back. Twice in the arc that produced this fix, the auditor only resumed because a human-driven relay woke it.

## The fix

Replace the wait instruction with a relay, and make the relay real:

- `agents/pact-auditor.md` — guardrail rewritten from mechanism-form to posture-form: do not end your turn with a background process as your route back. Phase A now says to poll on a bounded cadence *within* the turn, and to SET `intentional_wait` if the turn must end, so the lead can distinguish waiting from stalled.
- `protocols/pact-audit.md` + `protocols/pact-protocols.md` — the wait instruction now names the orchestrator's stage-ready relay as the wake, and forbids arming a background monitor and ending the turn. Byte-identical, net +0.
- `commands/orchestrate.md` — the relay itself: on every coder stage-ready, wake the auditor. Plus a phase-exit coverage check so TEST cannot be dispatched against an audit that never ran.
- `protocols/pact-audit.md:149` — corrected an over-wide universal. Absence of `audit_summary` is not a verdict, *and* is not a guarantee that one is still coming. Treat absence as a prompt to act, not to conclude.

## Verification

Four pins, each proven non-vacuous by a **file-scoped mutation that reverts what it guards** — not by a passing suite.

| | mutation | result |
|---|---|---|
| M0 | revert all four surfaces to base | 13 failed, 7 passed |
| M1 | revert `pact-audit.md` only | 2 failed — isolates conjunction from cardinality |
| M2 | paraphrase the wait phrase away (2→1) | 3 failed — vacuity-closure direction |
| M3 | revert `pact-auditor.md` only (2→3) | 6 failed — cardinality up, plus all of Pin 3 |
| M4 | revert `orchestrate.md` only | 3 failed — all of Pin 2 |
| M5 | plant a hook that writes an inbox | 1 failed |
| M6 | remove the positive-control fixture | 2 failed |
| M7 | rename the tree's only inbox-path construction away | 1 failed, 1 passed |

The mutation matrix above is a **dated observation against `209a3366`** — the TEST-phase commit, before either remediation wave. It is kept as the record of how the original four pins were proven, not as a claim about the current head.

Suite counts, each read at the commit named:

| commit | observation |
|---|---|
| pre-pins baseline | 12961 passed, 15 skipped, 0 errors — **observed** in the worktree, not inferred |
| `209a3366` (pins) | 12981 passed, 15 skipped, exit 0, zero `FAILED`/`ERROR` — two consecutive runs |
| `962992df` (wave 1) | 12981 passed, 15 skipped — no tests added; CI `pytest` SUCCESS on this head |
| `f4a74fa2` (wave 2) | 12982 passed, 15 skipped, exit 0 — +1, the new depth-cap guard |

Every mutation restored byte-clean: `git diff HEAD` over all four instruction surfaces is empty at each stage.

**Verification is stage-scoped, not cumulative.** Wave 1 was independently re-measured against eight pre-registered occupancy predictions with the extract gate run directly (19/19); wave 2's widening was proven bidirectionally — base-vs-patched 0→0 on the 59-file tree with the taint set widened on zero files, alongside five positive shapes where base misses and patched flags. The go/no-go is CI on the pushed head.

### Two findings from the mutation campaign worth a reviewer's attention

**M7 reproduced a false-clean deliberately.** With inbox-path construction renamed away, the repo-fact pin **still passed** — a clean zero over a tree the scanner could no longer see into. It is backstopped by a liveness control drawn from the *shipped tree* rather than from the fixture, so it cannot pass by the fixture's own construction.

> **Correction, added after adversarial review.** That control is weaker than this paragraph originally claimed. `test_scanner_is_live_on_the_real_tree` asserts non-empty **taint** — which proves the taint machinery engages, *not* that write-detection does. A probe that taints its inbox names and then delivers via the repo's atomic-write idiom passes the liveness control green while its delivery goes undetected. **The M7 hole is narrower than closed.** See MAJOR-1 below.

**Pin 4's positive control caught a defect in the scanner itself.** The realistic delivery shape is `inbox.write_text(...)` with the `"inboxes"` literal in the preceding assignment; the first scanner design flagged nothing on it. Fixed with fixpoint taint propagation. Without the fixture this would have shipped as a rule that had never once fired — externally indistinguishable from a rule that correctly found nothing.

## Known limits, stated rather than closed

- **Tier 1 (pins 1–3) is literal-anchored.** Cardinality catches a paraphrase that *replaces* a known site; nothing catches one *added* at a new site.
- **Tier 2 (pin 4) covers the PACT conjunct only.** The guidance's force rests on "PACT provides no wake AND the platform provides none." If the platform gained wake-on-process-exit, the pinned sentence stays true and the pin stays green while the guidance becomes misleading.
- **The SEND-CALL rule has never fired on shipped code** and by construction may never — there is no Python send-message callable here to calibrate against. Kept deliberately: dropping it removes coverage on exactly the day someone adds a delivery helper. Its docstring states that a green means "no delivery construct of a known shape," never proof of impossibility.
- **The gate makes the relay's primary mechanism permanently unmeasurable** at this layer. Named in the plan and not papered over.
- **The phase-exit coverage check guarantees an ATTEMPT, not a verdict.** Its second disjunct is satisfied by an audit having been *dispatched*; nothing downstream checks that the post-artifact audit ever emitted. So the check closes "TEST ran with no audit ordered," not "TEST ran with no audit result."
- **`awaiting_coder_output` has no scanner.** `missed_wake_scan.py` matches only `awaiting_lead_completion`, and `teammate_idle.py` does not consume the flag at all. So the metadata *documents* the wait for later inspection rather than surfacing it to anyone in real time — its sole reader is a deliberate `TaskGet` by the lead. Tracked separately as #1301.

Both of the above are stated here rather than on any instruction surface, deliberately: "this guarantees less than it sounds" is a bound for a reader deciding whether to rely on the mechanism, not an instruction for the agent executing it.

## Two design gaps for reviewers to weigh — deliberately not fixed here

Both surfaced from *operating* the design live rather than from reading it, and neither is testable at this layer. They are unimplemented on purpose so that reviewers judge them with fresh eyes rather than inheriting one engineer's field report:

1. **The relay line is specified as a SIGNAL but was operated as a BRIEFING.** The shipped text says to send "coder staged — observe the staged diff now." In practice the relay that worked carried context about *what* had staged. Reviewers should decide whether the specified text is sufficient.
2. **`agents/pact-auditor.md` never tells the auditor that the phase-exit coverage check exists.** Reported as the single change that most improved audit quality — by removing the incentive to rush a verdict, since the auditor knows TEST cannot proceed without one. The auditor currently cannot know this from its own instruction surface.

## Residuals, stated rather than closed

Recorded because a limit nobody wrote down is what produced most of the defects this PR fixes.

- **The anchor-uniqueness check has a blind spot on single-marker functions.** A rename that removes an anchor *while* prose spells the same text back leaves the match count at one, resolving to the prose. Functions carrying two markers are covered — removing both and documenting one back leaves the sibling at zero, which fires. Closing the residual would mean classifying the matched line as code, and the strongest form of that reddens on **reformatting**, since a call's `lineno` is its first line: a test about renaming would fail on a line-wrap.
- **The non-empty anchor guard trips a `reportAssertAlwaysTrue` lint.** It is not the vacuous `assert (cond, msg)` form — verified both ways; Python emits a `SyntaxWarning` for the vacuous variant and none for this one, and emptying the table does raise. The warning reports a statically non-empty literal, which is the normal condition of a regression guard. Worth knowing because the warning reads as "useless assert" and the obvious tidy deletes the guard.
- **Two bare `next()` / `index()` lookups remain** in the Pin 2 and Pin 3 assertions. They raise rather than assert, so a missing anchor there still surfaces as a traceback that names nothing. The negative-control family is closed; these are not.

## Note on a commit message

`f4a74fa2`'s message says the atomic-write pattern was invisible "at eleven call sites across the hooks tree." **Both counts that were argued over are correct; the sentence attaches one to a description of the other.**

Measured by AST call node, not text:

| population | count | sites |
|---|---|---|
| `os.replace` + `os.rename` call sites — what the new `INBOX-MOVE` rule covers | **11** | 5 + 6 |
| the **two-statement** `mkstemp → tmp → target` atomic write — what the sentence describes | **6** | 5 `os.replace`, plus `shared/pact_context.py:1185` |

The other five `os.rename` sites are `os.rename(token_path, token_path + ".consumed")` — a single-statement consume-mark, not a two-statement write of new content.

So eleven is right about the construct the rule now sees, and six is right about the idiom the sentence names. Nothing in the code or the rule changes either way; the imprecision is confined to one clause of a commit message on a squash-merging branch, and this body is the durable record.

## Commits

- `de35dfc1` — the wake fix across four surfaces (+17/−9)
- `209a3366` — four mutation-proven pins plus a synthetic counter-example fixture (+809/−0)
- `bf9234a8` — version bump to 4.6.23


---

## Review finding — MAJOR-1: the repo's own atomic-write idiom is invisible to the Pin 4 scanner

Raised by adversarial review and **independently reproduced** before being recorded here.

> **Status.** All three reviews are complete: 0 BLOCKING, 3 MAJOR, plus MINORs. Remediation is sequenced in two waves to avoid a fixer's revert-based verification clobbering a concurrent fixer's uncommitted edits.
> - **Wave 1 — landed and verified** (`3c7205e9`, `962992df`): the instruction-surface findings, including the protocol pair's divergent guardrail and `intentional_wait` instruction, both gap rulings, and a stale line-range warning in the extract-sync test. Verified independently against eight pre-registered occupancy predictions, with the extract gate run directly (19/19) and CI green.
> - **Wave 2 — in flight**: the scanner findings below, plus a fixpoint cap that truncates silently and two Pin-4 universals that pass over an empty denominator.

The scanner misses a message-delivery construct lifted verbatim from this repo's own house style. Two independent mechanisms, both of which must be closed:

```
_tainted_names   taints ast.Name targets only
                 fd, tmp_path = tempfile.mkstemp(dir=<inbox_dir>)   -> TUPLE target -> NO taint
rules            SEND_CALLEE_NAMES | WRITE_METHOD_NAMES | open+_is_write_mode
                 os.replace: ABSENT     shutil.move: ABSENT
                 os.replace(tmp, inbox) -> invisible even with an obvious inbox destination
```

`os.replace` has **5 call sites across 4 files** (`bootstrap_marker_writer.py`, `task_claim_gate.py`, `task_lifecycle_gate.py` ×2, `claude_md_manager.py`), all the same `tmp → target` shape, and the repo *documents* it as its idiom in at least two places. The donor function sits roughly 100 lines below the very inbox construction that serves as the pin's liveness control, in the same file.

**So this is not deliberate construction.** A good-faith contributor adding delivery would copy the adjacent function, and both legs would be missed.

### Why this is a defect rather than a documented limit

Docstring limit 3 scopes taint as *"intra-module and assignment-based."* A tuple-unpack **is** an intra-module assignment. The failure therefore sits **inside the region the limit claims to cover**, not in a disclosed exclusion — a stated limit does not immunise a case its own words include.

Graded MAJOR rather than BLOCKING: the pin is a prose decay-guard rather than a security boundary, its docstring already hedges a green as "no delivery construct of a *known shape*," and the baseline zero was verified genuine.

### Also raised

- **MINOR-1** — `_is_write_mode` hardcodes the builtin `open(file, mode)` signature at `args[1]`, so `inbox.open("w")` reads as not-write-mode. The keyword form is caught; positional is not.
- **MINOR-2** — `json.dump` is unenumerated, saved today only by its pairing with a builtin `open()`.
- **MINOR-3** — the liveness control asserts taint, not write-detection (see the correction above).

### Three attacks that FAILED — recorded as full-value proven negatives

1. **Denominator/claim alignment is sound.** All 26 registered commands in `hooks.json` are `.py` under `hooks/`; no non-`.py` hooks, no symlinks; disk set == git-tracked set (59 == 59). The sweep is a strict **superset** of the registered hooks — it over-includes, never under-includes. No delivery path routes through an artifact the sweep does not treat as a hook.
2. **The parse invariant cannot silently drop a file.** Only `SyntaxError` is caught; `UnicodeDecodeError`/`ValueError` propagate loudly; null-byte input raises `SyntaxError` and is reported.
3. **Documented limits 2 and 3 behave exactly as documented** — subprocess, function boundary, cross-module constant, and unenumerated send name are all missed, as stated. Verified and deliberately *not* re-reported as findings.

The review was conducted with zero worktree mutation (`scan_source` accepts source strings), and the instrument was proven live before any negative was banked: the fixture fires both rules, the denominator resolves 59 files, taint engages on shipped code, and the baseline zero is genuine.






