### PR TITLE
Stop the pin caps enforcing against a phantom count

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.24",
+      "version": "4.6.25",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.24/     # Plugin version
+│               └── 4.6.25/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.24",
+  "version": "4.6.25",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.24
+> **Version**: 4.6.25
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/pin_caps.py
+++ b/pact-plugin/hooks/pin_caps.py
@@ -407,10 +407,26 @@ DENY_REASON_SIZE = (
     "if the content is verbatim load-bearing."
 )
 
+# AUGMENTED, not replaced. The old text named ONE remedy — "use `#### ` or
+# bold" — which is right only when the heading was meant as in-body structure.
+# When the curator meant to add a PIN, that advice prescribes the very
+# construct that makes the block un-prunable (a `#### ` block never becomes a
+# Pin, so /PACT:prune-memory cannot reach it), and it gives no path at all
+# from the deny to the fix. Both remedies are named below, each with the
+# question that selects it.
+#
+# IT DELIBERATELY DOES NOT PROMISE THE EDIT WILL THEN BE ALLOWED. Adding the
+# date comment turns the heading into a real pin, which consumes a slot — so
+# a curator at the cap converts an embedded-pin deny into a count deny. The
+# text says what to DO, never what will HAPPEN.
 DENY_REASON_EMBEDDED_PIN = (
-    "Candidate body contains an embedded pin structure "
-    "(a `### ` heading). On reload this would be counted as an extra pin "
-    "and defeat the count cap. Use `#### ` or bold for in-body structure."
+    "Candidate body contains an embedded pin structure — a `### ` heading "
+    "with no `<!-- pinned: DATE -->` comment on the line above it. On reload "
+    "that heading parses as an extra pin and defeats the count cap. Which "
+    "fix applies depends on what you meant. If the heading IS a new pin, add "
+    "a `<!-- pinned: YYYY-MM-DD -->` comment directly above it; that makes it "
+    "a real pin and consumes a pin slot, so check your remaining slots first. "
+    "If it is structure INSIDE a pin body, use `#### ` or bold instead."
 )
 
 DENY_REASON_OVERRIDE_MISSING = (

--- a/pact-plugin/hooks/pin_caps.py
+++ b/pact-plugin/hooks/pin_caps.py
@@ -309,11 +309,11 @@ def region_count_is_untrustworthy(bounded: bool, pins: List[Pin]) -> bool:
     it, and the later, comment-less ones are content the parser swept in after
     the real pins ended. That is the phantom.
 
-    THE RESIDUAL THIS LEAVES, stated so nobody re-derives it as a defect: a
-    region of uniformly undated entries is genuinely AMBIGUOUS — legacy pins
-    and absorbed notes are byte-identical there — and this predicate resolves
-    it toward ENFORCE. That is a real choice, not an oversight, and the
-    corpus is the evidence for it.
+    A REGION OF UNIFORMLY UNDATED ENTRIES IS GENUINELY AMBIGUOUS — legacy pins
+    and absorbed notes are byte-identical there — and THIS predicate resolves
+    it toward ENFORCE, on the corpus evidence above. THE GATE RESOLVES IT THE
+    OTHER WAY: see `gate_count_is_untrustworthy`. The two surfaces differ on
+    purpose and the asymmetry is the point, not an oversight.
 
     Args:
         bounded: the region's `PinnedSection.bounded` / `RegionState.bounded`.
@@ -330,6 +330,46 @@ def region_count_is_untrustworthy(bounded: bool, pins: List[Pin]) -> bool:
     if first_dated is None:
         return False
     return any(pin.date_comment is None for pin in pins[first_dated + 1:])
+
+
+def gate_count_is_untrustworthy(bounded: bool, pins: List[Pin]) -> bool:
+    """The GATE's form of the same question. STRICTLY WIDER than the staleness
+    form, and the difference is one input class.
+
+    THE GATE DECLINES ON A UNIFORMLY UNDATED REGION; THE STALENESS SURFACES
+    ENFORCE THERE. That input is genuinely ambiguous — with no dated entry
+    anywhere, a region of legacy pins and a region of absorbed notes are
+    byte-identical — so the two surfaces are choosing which way to be wrong,
+    and they choose differently BECAUSE THEIR REMEDIES DIFFER IN KIND.
+
+    Declining at the gate costs a pause that the SessionStart directive
+    already explains: a cure the curator can perform. ENFORCING at the gate
+    hands out one they cannot — measured, a curator holding ZERO pins adding
+    one ordinary note is denied over fourteen, and told to demote pins they do
+    not have. An impossible cure on the most ordinary action there is, with no
+    construction, is the cardinal sin this control exists to avoid.
+
+    The staleness surfaces have no such asymmetry: marking a legacy pin stale
+    is correct, and the corpus this repository actually contains is built on
+    uniformly undated regions that ARE real pins. Enforcing there is right for
+    the same reason declining here is.
+
+    SO: GATE STRICTER THAN STALENESS. `gate_count_is_untrustworthy` returns
+    True everywhere `region_count_is_untrustworthy` does, plus on the
+    uniformly-undated class. Do not collapse them back into one predicate, and
+    do not invert the direction: `TestGateIsStricterThanStaleness` fails on
+    either.
+
+    Args:
+        bounded: the region's `RegionState.bounded`.
+        pins: the parsed entries of that same region.
+
+    Returns:
+        True when the GATE must decline rather than enforce.
+    """
+    if bounded:
+        return False
+    return any(pin.date_comment is None for pin in pins)
 
 
 def has_size_override(pin: Pin) -> bool:

--- a/pact-plugin/hooks/pin_caps.py
+++ b/pact-plugin/hooks/pin_caps.py
@@ -268,6 +268,70 @@ def parse_pins(pinned_content: str) -> List[Pin]:
     return pins
 
 
+def region_count_is_untrustworthy(bounded: bool, pins: List[Pin]) -> bool:
+    """Return True when the parsed pin count may not be the curator's real one.
+
+    THE ONE DEFINITION. Four surfaces consult it — the pin-cap gate's decline,
+    both staleness surfaces, and the slot-status reporter. Do not write a
+    second copy: this predicate has already been wrong once in a blunter form,
+    and a duplicated predicate makes the next correction land in one place and
+    not the others.
+
+    UNBOUNDEDNESS ALONE IS NECESSARY BUT NOT SUFFICIENT, and that is the whole
+    reason this function exists. A `## Pinned Context` section that is
+    genuinely the LAST section of the file is unbounded, yet if every entry in
+    it carries a `<!-- pinned: DATE -->` comment then every entry is a real
+    pin and the count is EXACT. Declining there switches the caps off on a
+    file where they were correct. The blunt `not bounded` form did exactly
+    that: it broke ten staleness tests built on that shape, and it silently
+    allowed a 14th pin onto a file holding 13 real ones.
+
+    WHAT MAKES A COUNT UNTRUSTWORTHY IS AN UNDATED ENTRY, because the pin
+    grammar gives every legitimately added pin a date comment. So an undated
+    `### ` inside the region is something the parser counted as a pin that the
+    curator never created as one — an absorbed Working Memory note, or a
+    heading inside another pin's body. Either way the count is inflated and
+    enforcing on it can deny a curator over pins they do not hold.
+
+    THE TEST IS "AN UNDATED ENTRY AFTER A DATED ONE", NOT "ANY UNDATED ENTRY",
+    AND THE DIFFERENCE IS LOAD-BEARING IN THE OPPOSITE DIRECTION TO THE ONE A
+    READER WILL EXPECT. An undated entry is NOT by itself evidence of a
+    non-pin: this repository's older pins carry their date in the HEADING
+    (`### Old Feature (PR #99, merged 2026-01-02)`) and no `<!-- pinned: -->`
+    comment at all. A region of uniformly undated entries is therefore
+    SELF-CONSISTENT and may be entirely real legacy pins; treating it as
+    untrustworthy switches the caps and the staleness pass off on that whole
+    population. Measured: the "any undated entry" form fails 14 tests in the
+    existing staleness corpus, which is built on exactly that shape.
+
+    What the mixture shows is what a single convention cannot: a region where
+    SOME entries carry the comment and later ones do NOT has two grammars in
+    it, and the later, comment-less ones are content the parser swept in after
+    the real pins ended. That is the phantom.
+
+    THE RESIDUAL THIS LEAVES, stated so nobody re-derives it as a defect: a
+    region of uniformly undated entries is genuinely AMBIGUOUS — legacy pins
+    and absorbed notes are byte-identical there — and this predicate resolves
+    it toward ENFORCE. That is a real choice, not an oversight, and the
+    corpus is the evidence for it.
+
+    Args:
+        bounded: the region's `PinnedSection.bounded` / `RegionState.bounded`.
+        pins: the parsed entries of that same region.
+
+    Returns:
+        True when the caller MUST NOT enforce on the count.
+    """
+    if bounded:
+        return False
+    first_dated = next(
+        (i for i, pin in enumerate(pins) if pin.date_comment is not None), None
+    )
+    if first_dated is None:
+        return False
+    return any(pin.date_comment is None for pin in pins[first_dated + 1:])
+
+
 def has_size_override(pin: Pin) -> bool:
     """Return True if this pin carries a valid pin-size-override rationale."""
     return pin.override_rationale is not None

--- a/pact-plugin/hooks/pin_caps.py
+++ b/pact-plugin/hooks/pin_caps.py
@@ -633,8 +633,7 @@ def apply_edit_and_parse(current_content: str, tool_input: dict) -> List[Pin]:
         # "no pins" — caps cannot be violated when the section is absent.
         return []
 
-    _, _, pinned_content = parsed
-    return parse_pins(pinned_content)
+    return parse_pins(parsed.content)
 
 
 def compute_deny_reason(

--- a/pact-plugin/hooks/pin_caps.py
+++ b/pact-plugin/hooks/pin_caps.py
@@ -113,6 +113,25 @@ class Pin(NamedTuple):
     is_stale: bool                   # whether a STALE marker is present
 
 
+class RegionState(NamedTuple):
+    """A parsed pinned region: its pins, its size, and whether it is bounded.
+
+    Returned by `apply_edit_and_parse` and by the gate's `_parse_baseline`,
+    so the gate can decide whether the pin measurement is trustworthy before
+    it enforces on it. No region STRING crosses a frame — `region_chars`
+    carries the size, which is all any consumer needs.
+
+    `bounded` MUST be COPIED from `staleness.PinnedSection.bounded`, never
+    recomputed here. `_parse_pinned_section` is the one definition of
+    boundedness; a second computation is a twin that drifts, and a warning
+    that disagrees with a deny is worse than either alone.
+    """
+
+    pins: List[Pin]
+    region_chars: int
+    bounded: bool
+
+
 class CapViolation(NamedTuple):
     """A cap-enforcement refusal result."""
 
@@ -554,8 +573,8 @@ def _violation_for_kind(pins: List[Pin], kind: str) -> Optional[CapViolation]:
     return None
 
 
-def apply_edit_and_parse(current_content: str, tool_input: dict) -> List[Pin]:
-    """Simulate the post-tool CLAUDE.md state and return parsed pins.
+def apply_edit_and_parse(current_content: str, tool_input: dict) -> RegionState:
+    """Simulate the post-tool CLAUDE.md state and return its `RegionState`.
 
     For Edit:
       Applies `old_string → new_string` via `str.replace(...)`. When
@@ -570,11 +589,24 @@ def apply_edit_and_parse(current_content: str, tool_input: dict) -> List[Pin]:
       replacement.
 
     After producing the simulated post-edit content, extracts the
-    Pinned Context section via `_parse_pinned_section` and returns
-    `parse_pins(pinned_content)`. Section-bounded by construction so
-    `### ` headings elsewhere (Working Memory, user prose) do NOT
-    inflate the count. If the post-edit content has no Pinned Context
-    section, returns [] (no pins → below every cap).
+    Pinned Context section via `_parse_pinned_section` and returns a
+    `RegionState` carrying the parsed pins, the region size, and the
+    region's boundedness.
+
+    SECTION-BOUNDING IS A PRECONDITION, NOT A GUARANTEE. An earlier form
+    of this docstring claimed the parse was "section-bounded by
+    construction so `### ` headings elsewhere (Working Memory, user prose)
+    do NOT inflate the count". That holds only while the region HAS a
+    terminating heading. When it does not, `_find_terminator_offset`
+    returns the end of the scanned text, the whole tail is handed to
+    `parse_pins`, and every `### ` heading in it becomes a Pin — which is
+    the inflation the sentence promised was impossible. `bounded` is how a
+    caller now tells the two states apart; the caller MUST consult it
+    before it acts on `pins`.
+
+    If the post-edit content has no Pinned Context section, returns a
+    RegionState with no pins, zero chars, and bounded=True — see the
+    branch comment for why True is load-bearing there.
 
     Raises on malformed tool_input (missing required keys, non-string
     values). The caller (pin_caps_gate.main) is responsible for wrapping
@@ -631,9 +663,22 @@ def apply_edit_and_parse(current_content: str, tool_input: dict) -> List[Pin]:
     if parsed is None:
         # No Pinned Context section in the post-edit state. Treat as
         # "no pins" — caps cannot be violated when the section is absent.
-        return []
+        #
+        # bounded=True IS LOAD-BEARING AND IT IS NOT A GUESS. The gate
+        # declines to enforce when bounded is False, so bounded=False here
+        # would silently switch the whole control OFF for every file that
+        # has no Pinned Context section — a large population, and one with
+        # no defect. "Absent" is not "untrustworthy": there is nothing to
+        # measure, the measurement of nothing is exact, and the caps cannot
+        # be violated by it. Enforcement on this path stays exactly as it
+        # is today.
+        return RegionState(pins=[], region_chars=0, bounded=True)
 
-    return parse_pins(parsed.content)
+    return RegionState(
+        pins=parse_pins(parsed.content),
+        region_chars=len(parsed.content),
+        bounded=parsed.bounded,
+    )
 
 
 def compute_deny_reason(

--- a/pact-plugin/hooks/pin_caps_gate.py
+++ b/pact-plugin/hooks/pin_caps_gate.py
@@ -100,6 +100,7 @@ try:
     from pin_caps import (
         OVERRIDE_COMMENT_RE,
         OVERRIDE_RATIONALE_MAX,
+        RegionState,
         apply_edit_and_parse,
         compute_deny_reason,
         evaluate_full_state,
@@ -127,6 +128,53 @@ _FAIL_BASELINE_READ = "pin_caps_gate_baseline_read"
 _FAIL_BASELINE_PARSE = "pin_caps_gate_baseline_parse"
 _FAIL_SIMULATE = "pin_caps_gate_simulate"
 _FAIL_UNEXPECTED = "pin_caps_gate_unexpected"
+
+# Boundedness-decline classifications. DELIBERATELY NOT `_FAIL_*`.
+#
+# A `_FAIL_*` code means the gate hit a fault it could not evaluate. An
+# unbounded pinned region is not a fault of the gate: the gate measured the
+# region correctly, found the measure untrustworthy, and declined on purpose.
+# Reusing a `_FAIL_*` value would merge a correct decline into the fault
+# population that an operator reads to find real gate bugs.
+#
+# The pre/post pair is recorded rather than a single flag because the three
+# states have different meanings to an operator. `_PRE` in particular is the
+# REPAIR case: the curator's own edit bounds a region that was unbounded, and
+# the gate MUST allow it. A single "unbounded" code cannot show that.
+_DECLINED_UNBOUNDED_BOTH = "pin_caps_gate_declined_unbounded_both"
+_DECLINED_UNBOUNDED_POST = "pin_caps_gate_declined_unbounded_post"
+_DECLINED_UNBOUNDED_PRE = "pin_caps_gate_declined_unbounded_pre"
+
+
+def _decline_classification(pre_bounded: bool, post_bounded: bool) -> str:
+    """Map a pre/post boundedness pair to its decline classification.
+
+    Takes two bools rather than the two region states, so the mapping is
+    testable on its own and carries no dependency on the caller's types.
+
+    Each branch is keyed on the side that is actually UNBOUNDED, so every
+    returned value is true of its input. Three of the four inputs decline:
+
+      pre unbounded, post unbounded -> `_DECLINED_UNBOUNDED_BOTH`
+      pre bounded,   post unbounded -> `_DECLINED_UNBOUNDED_POST`
+      pre unbounded, post bounded   -> `_DECLINED_UNBOUNDED_PRE`  (the repair)
+
+    The fourth input, both bounded, DOES NOT DECLINE, so it has no true
+    classification. The caller tests boundedness before it calls, so that
+    input does not occur on the gate path. It returns `_DECLINED_UNBOUNDED_BOTH`
+    rather than raising, because no helper on this path may raise a new
+    exception class into the SACROSANCT fail-open catch. Do not read that
+    value as a statement about the input: it is an unreachable default, and
+    `test_both_bounded_is_not_a_decline` pins it so a future reader who
+    routes a bounded pair here finds a test rather than a silent wrong code.
+    """
+    if not pre_bounded and not post_bounded:
+        return _DECLINED_UNBOUNDED_BOTH
+    if not post_bounded:
+        return _DECLINED_UNBOUNDED_POST
+    if not pre_bounded:
+        return _DECLINED_UNBOUNDED_PRE
+    return _DECLINED_UNBOUNDED_BOTH
 
 _WRITE_BASELINE_DENY_REASON = (
     "Refusing Write: could not read or parse the current CLAUDE.md to "
@@ -314,7 +362,7 @@ def _check_tool_allowed(input_data: dict) -> Optional[str]:
     # baseline_content is now known to be `str` (narrowed above). Parse
     # pre-state pins from the baseline.
     try:
-        pre_pins = _parse_baseline(baseline_content)
+        pre_state = _parse_baseline(baseline_content)
     except Exception:  # noqa: BLE001 — bounded fail-open per contract
         append_failure(
             classification=_FAIL_BASELINE_PARSE,
@@ -326,11 +374,48 @@ def _check_tool_allowed(input_data: dict) -> Optional[str]:
     # Simulate post-edit state. Helper raises on malformed tool_input;
     # caller (main) catches and fail-opens.
     try:
-        post_pins = apply_edit_and_parse(baseline_content, tool_input)
+        post_state = apply_edit_and_parse(baseline_content, tool_input)
     except Exception:  # noqa: BLE001 — bounded fail-open per contract
         append_failure(
             classification=_FAIL_SIMULATE,
             error=f"simulate failed for {claude_md_path}",
+            source=tool_name,
+        )
+        return None
+
+    # ── Boundedness decline. DO NOT MOVE THIS BLOCK DOWN. ────────────────
+    #
+    # When either region lacks a terminating heading, the pin measurement is
+    # KNOWN FALSE and the gate declines the WHOLE deny decision.
+    #
+    # WHY IT SITS HERE AND NOT LOWER. There are THREE deny paths, and the
+    # FIRST to fire is the embedded-pin check inside `compute_deny_reason`,
+    # which returns before either cap axis is consulted. So this block must
+    # precede the CALL to `compute_deny_reason`. Guarding only the count and
+    # size axes leaves 2 of the 3 over-blocks live; guarding only the size
+    # axis leaves 2 live as well.
+    #
+    # WHY THE MEASURE IS FALSE. An unbounded region runs to the end of the
+    # scanned text, so `parse_pins` absorbs every `### ` heading in the tail.
+    # This repository writes Working Memory entries as `### <date>`, so a
+    # curator holding 2 real pins measures as 14 and is denied at 15/12 —
+    # and told to prune pins they do not have. The offered cure cannot work.
+    # An unbounded region ALSO makes an ordinary undated Working Memory
+    # entry read as the embedded-pin smuggle signature, which is why the
+    # most ordinary action of the three denies first.
+    #
+    # THE TRADE, STATED PLAINLY. On an unbounded file the caps stop, so a
+    # curator can exceed them there. That fail-open is intended. The
+    # opposite trade is not available: enforcing on a false measure denies
+    # honest edits with no escape, and an over-block is the cardinal sin.
+    # The curator is not left in silence — SessionStart carries the repair
+    # directive, which can explain the cause and give a cure that works.
+    if not (pre_state.bounded and post_state.bounded):
+        append_failure(
+            classification=_decline_classification(
+                pre_state.bounded, post_state.bounded
+            ),
+            error=f"pinned region unbounded for {claude_md_path}",
             source=tool_name,
         )
         return None
@@ -340,23 +425,47 @@ def _check_tool_allowed(input_data: dict) -> Optional[str]:
     # a smuggle-heading body identically for Write and Edit (#529); see
     # its docstring for the fallback hierarchy.
     new_body = _extract_new_body(
-        tool_input, pre_pins=pre_pins, post_pins=post_pins
+        tool_input, pre_pins=pre_state.pins, post_pins=post_state.pins
     )
-    return compute_deny_reason(pre_pins, post_pins, new_body=new_body)
+    return compute_deny_reason(
+        pre_state.pins, post_state.pins, new_body=new_body
+    )
 
 
-def _parse_baseline(content: str):
-    """Parse the current CLAUDE.md into a pin list via the bounded parser.
+def _parse_baseline(content: str) -> RegionState:
+    """Parse the current CLAUDE.md into a `RegionState` via the section parser.
 
-    Section-bounded via staleness._parse_pinned_section so Working Memory
-    `### ` subheadings do NOT inflate the count (backend-coder-6 R3).
+    THE SECTION-BOUNDING CLAIM THAT USED TO SIT HERE WAS FALSE, and the
+    correction is the reason this function returns a RegionState.
+
+    It read: "Section-bounded via staleness._parse_pinned_section so Working
+    Memory `### ` subheadings do NOT inflate the count". Bounding holds only
+    while the pinned region has a TERMINATING heading. Without one the
+    parser hands the whole file tail to `parse_pins`, and Working Memory
+    `### <date>` entries — which is how this repository writes them — each
+    become a Pin. So the exact inflation the sentence ruled out is the
+    live defect, and a curator with 2 pins was denied at 15/12.
+
+    The tag on the original sentence marked it as a REMEDIATION of that same
+    defect class. It was repaired once, and it REOPENS whenever the
+    terminator is absent. Boundedness is therefore reported, not asserted:
+    `bounded` tells the caller whether the pin count means anything, and
+    the caller must consult it before enforcing.
+
+    The empty case returns bounded=True for the reason given in
+    `apply_edit_and_parse` — an absent section is exactly measurable, not
+    untrustworthy, so enforcement on it is unchanged.
     """
     from staleness import _parse_pinned_section
 
     parsed = _parse_pinned_section(content)
     if parsed is None:
-        return []
-    return parse_pins(parsed.content)
+        return RegionState(pins=[], region_chars=0, bounded=True)
+    return RegionState(
+        pins=parse_pins(parsed.content),
+        region_chars=len(parsed.content),
+        bounded=parsed.bounded,
+    )
 
 
 def _evaluate_write_as_fresh_start(tool_input: dict) -> Optional[str]:
@@ -371,11 +480,19 @@ def _evaluate_write_as_fresh_start(tool_input: dict) -> Optional[str]:
         # Best-effort simulation against an empty baseline. If apply_edit
         # raises (malformed tool_input), we cannot evaluate → return the
         # generic Write-baseline deny-reason so the user sees why.
-        post_pins = apply_edit_and_parse(current_content="", tool_input=tool_input)
+        post_state = apply_edit_and_parse(current_content="", tool_input=tool_input)
     except Exception:  # noqa: BLE001 — bounded
         return _WRITE_BASELINE_DENY_REASON
 
-    violation = evaluate_full_state(post_pins)
+    # `.pins` is a MECHANICAL shape adaptation, not a behaviour change: the
+    # helper now returns a RegionState and this arm consumes the same pin
+    # list it consumed before. Passing the RegionState itself would evaluate
+    # a NamedTuple as a pin list and silently mis-count.
+    #
+    # THIS ARM'S BOUNDEDNESS GATE IS A SEPARATE CHANGE with a separate
+    # justification, and is deliberately NOT made here. Keeping the two
+    # apart is what lets a reviewer certify either one.
+    violation = evaluate_full_state(post_state.pins)
     if violation is None:
         # Write produces a state within caps — allow despite the
         # baseline read failure. (The failure_log entry already recorded

--- a/pact-plugin/hooks/pin_caps_gate.py
+++ b/pact-plugin/hooks/pin_caps_gate.py
@@ -105,7 +105,7 @@ try:
         compute_deny_reason,
         evaluate_full_state,
         parse_pins,
-        region_count_is_untrustworthy,
+        gate_count_is_untrustworthy,
     )
 except BaseException as _module_load_error:  # noqa: BLE001 — fail-closed catch-all
     _emit_load_failure_deny("module imports", _module_load_error)
@@ -420,10 +420,10 @@ def _check_tool_allowed(input_data: dict) -> Optional[str]:
     # honest edits with no escape, and an over-block is the cardinal sin.
     # The curator is not left in silence — SessionStart carries the repair
     # directive, which can explain the cause and give a cure that works.
-    pre_untrusted = region_count_is_untrustworthy(
+    pre_untrusted = gate_count_is_untrustworthy(
         pre_state.bounded, pre_state.pins
     )
-    post_untrusted = region_count_is_untrustworthy(
+    post_untrusted = gate_count_is_untrustworthy(
         post_state.bounded, post_state.pins
     )
     if pre_untrusted or post_untrusted:
@@ -535,7 +535,7 @@ def _evaluate_write_as_fresh_start(tool_input: dict) -> Optional[str]:
     # count is inflated by every `### ` heading in its tail, so enforcing on
     # it denies a curator for pins they do not have. See the docstring for
     # why `post.bounded` alone is the faithful test on this arm.
-    if region_count_is_untrustworthy(post_state.bounded, post_state.pins):
+    if gate_count_is_untrustworthy(post_state.bounded, post_state.pins):
         append_failure(
             classification=_DECLINED_UNBOUNDED_NO_BASELINE,
             error="pinned region unbounded in written content, baseline unreadable",

--- a/pact-plugin/hooks/pin_caps_gate.py
+++ b/pact-plugin/hooks/pin_caps_gate.py
@@ -105,6 +105,7 @@ try:
         compute_deny_reason,
         evaluate_full_state,
         parse_pins,
+        region_count_is_untrustworthy,
     )
 except BaseException as _module_load_error:  # noqa: BLE001 — fail-closed catch-all
     _emit_load_failure_deny("module imports", _module_load_error)
@@ -419,10 +420,16 @@ def _check_tool_allowed(input_data: dict) -> Optional[str]:
     # honest edits with no escape, and an over-block is the cardinal sin.
     # The curator is not left in silence — SessionStart carries the repair
     # directive, which can explain the cause and give a cure that works.
-    if not (pre_state.bounded and post_state.bounded):
+    pre_untrusted = region_count_is_untrustworthy(
+        pre_state.bounded, pre_state.pins
+    )
+    post_untrusted = region_count_is_untrustworthy(
+        post_state.bounded, post_state.pins
+    )
+    if pre_untrusted or post_untrusted:
         append_failure(
             classification=_decline_classification(
-                pre_state.bounded, post_state.bounded
+                not pre_untrusted, not post_untrusted
             ),
             error=f"pinned region unbounded for {claude_md_path}",
             source=tool_name,
@@ -528,7 +535,7 @@ def _evaluate_write_as_fresh_start(tool_input: dict) -> Optional[str]:
     # count is inflated by every `### ` heading in its tail, so enforcing on
     # it denies a curator for pins they do not have. See the docstring for
     # why `post.bounded` alone is the faithful test on this arm.
-    if not post_state.bounded:
+    if region_count_is_untrustworthy(post_state.bounded, post_state.pins):
         append_failure(
             classification=_DECLINED_UNBOUNDED_NO_BASELINE,
             error="pinned region unbounded in written content, baseline unreadable",

--- a/pact-plugin/hooks/pin_caps_gate.py
+++ b/pact-plugin/hooks/pin_caps_gate.py
@@ -399,9 +399,10 @@ def _check_tool_allowed(input_data: dict) -> Optional[str]:
     # WHY IT SITS HERE AND NOT LOWER. There are THREE deny paths, and the
     # FIRST to fire is the embedded-pin check inside `compute_deny_reason`,
     # which returns before either cap axis is consulted. So this block must
-    # precede the CALL to `compute_deny_reason`. Guarding only the count and
-    # size axes leaves 2 of the 3 over-blocks live; guarding only the size
-    # axis leaves 2 live as well.
+    # precede the CALL to `compute_deny_reason`. Measured through the real
+    # gate: guarding only the count and size axes leaves ONE over-block live
+    # (the embedded-pin arm, which is the most ordinary action of the three);
+    # guarding only the size axis leaves TWO live (embedded-pin and count).
     #
     # WHY THE MEASURE IS FALSE. An unbounded region runs to the end of the
     # scanned text, so `parse_pins` absorbs every `### ` heading in the tail.

--- a/pact-plugin/hooks/pin_caps_gate.py
+++ b/pact-plugin/hooks/pin_caps_gate.py
@@ -145,6 +145,14 @@ _DECLINED_UNBOUNDED_BOTH = "pin_caps_gate_declined_unbounded_both"
 _DECLINED_UNBOUNDED_POST = "pin_caps_gate_declined_unbounded_post"
 _DECLINED_UNBOUNDED_PRE = "pin_caps_gate_declined_unbounded_pre"
 
+# FOURTH VALUE, and it is NOT one of the three above reused. The fresh-start
+# arm has NO pre-state at all — the baseline was unreadable, which is the
+# reason that arm exists. So the pre/post pair has only one half, and none of
+# the three names is TRUE of it: `_POST` in particular would assert that the
+# pre-state was BOUNDED, which is not merely unknown but unmeasurable here.
+# An operator reading `_post` would conclude a baseline had been read.
+_DECLINED_UNBOUNDED_NO_BASELINE = "pin_caps_gate_declined_unbounded_no_baseline"
+
 
 def _decline_classification(pre_bounded: bool, post_bounded: bool) -> str:
     """Map a pre/post boundedness pair to its decline classification.
@@ -475,6 +483,37 @@ def _evaluate_write_as_fresh_start(tool_input: dict) -> Optional[str]:
     evaluate the Write's content against an empty pre-state and apply
     the strict post-state predicate. If the Write itself over-caps, we
     deny; if it's clean, we allow (nothing to compare against).
+
+    BOUNDEDNESS ON THIS ARM IS GATED ON `post.bounded` ALONE, and that is
+    the rule of section 3 applied consistently rather than a new trade.
+    The conjunct `pre.bounded` has NO REFERENT here — there is no pre-state,
+    which is the whole reason this arm exists — so the faithful extension
+    keeps the half that has one. The rule is "decline when the MEASURE is
+    untrustworthy", and on this arm the code measures the WRITTEN CONTENT
+    alone, so that content's boundedness is the entire measure.
+
+    IT DOES NOT CONVERT THE FAIL-CLOSED INTO A FAIL-OPEN. Measured with the
+    baseline unreadable in every row: a PHANTOM above-cap (unbounded content,
+    2 real pins measured as 14) goes DENY -> ALLOW, which is the fix; a
+    GENUINE above-cap (bounded content, 13 real pins) stays DENY -> DENY;
+    a clean file stays ALLOW. The Sec N7 asymmetric posture survives intact
+    — only the denies driven by a measure known to be false are removed.
+    THE NAIVE FIX, DECLINING UNCONDITIONALLY, DELETES THE MIDDLE ROW and is
+    the wrong fix; that row is the whole reason this one is safe.
+
+    REACHABILITY, because the obvious route does not work: a NEW-FILE Write
+    CANNOT reach this arm. `_find_existing_claude_md` returns only a file
+    that EXISTS, so with no project CLAUDE.md the resolver returns None and
+    the gate short-circuits before it gets here — a genuinely new CLAUDE.md
+    is not gated at all. The arm needs the file to EXIST and the read or the
+    parse to FAIL.
+
+    Severity is LOW in both directions, because both sit behind that same
+    rare precondition. The reason to fix it is CONSISTENCY, not urgency: an
+    arm that enforces on a phantom count contradicts this module's own rule
+    that the gate declines when the measure is untrustworthy, and a
+    contradiction inside a control is how the next reader talks themselves
+    into the wrong branch.
     """
     try:
         # Best-effort simulation against an empty baseline. If apply_edit
@@ -484,14 +523,25 @@ def _evaluate_write_as_fresh_start(tool_input: dict) -> Optional[str]:
     except Exception:  # noqa: BLE001 — bounded
         return _WRITE_BASELINE_DENY_REASON
 
+    # Decline when the WRITTEN content's own region is unbounded: its pin
+    # count is inflated by every `### ` heading in its tail, so enforcing on
+    # it denies a curator for pins they do not have. See the docstring for
+    # why `post.bounded` alone is the faithful test on this arm.
+    if not post_state.bounded:
+        append_failure(
+            classification=_DECLINED_UNBOUNDED_NO_BASELINE,
+            error="pinned region unbounded in written content, baseline unreadable",
+            # This arm is reached ONLY on the `is_write` branch, so the
+            # tool is a Write by construction; no parameter is needed to
+            # carry a value that is already fixed by the call site.
+            source="Write",
+        )
+        return None
+
     # `.pins` is a MECHANICAL shape adaptation, not a behaviour change: the
     # helper now returns a RegionState and this arm consumes the same pin
     # list it consumed before. Passing the RegionState itself would evaluate
     # a NamedTuple as a pin list and silently mis-count.
-    #
-    # THIS ARM'S BOUNDEDNESS GATE IS A SEPARATE CHANGE with a separate
-    # justification, and is deliberately NOT made here. Keeping the two
-    # apart is what lets a reviewer certify either one.
     violation = evaluate_full_state(post_state.pins)
     if violation is None:
         # Write produces a state within caps — allow despite the

--- a/pact-plugin/hooks/pin_caps_gate.py
+++ b/pact-plugin/hooks/pin_caps_gate.py
@@ -356,8 +356,7 @@ def _parse_baseline(content: str):
     parsed = _parse_pinned_section(content)
     if parsed is None:
         return []
-    _, _, pinned_content = parsed
-    return parse_pins(pinned_content)
+    return parse_pins(parsed.content)
 
 
 def _evaluate_write_as_fresh_start(tool_input: dict) -> Optional[str]:

--- a/pact-plugin/hooks/pin_staleness_gate.py
+++ b/pact-plugin/hooks/pin_staleness_gate.py
@@ -15,7 +15,9 @@ the directive.
 Gate triggers only when ALL hold:
   1. Tool is Edit or Write (enforced by hooks.json matcher)
   2. Target file path resolves to the project CLAUDE.md
-  3. Edit locus is within the Pinned Context section (line-bounded)
+  3. The edit is ADD-shaped -- `_is_add_shaped_edit` compares the pin-comment
+     count of new_string against old_string. NOTE: this is NOT a locus check;
+     the gate does not test where in the file the edit lands.
   4. Stale-pins-pending marker exists in session_dir
   5. Not a teammate session (teammates bypass; CLAUDE.md edits are scoped to the team-lead session)
 

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -102,6 +102,7 @@ from shared.paths import get_claude_config_dir
 # Import extracted modules (decomposed for maintainability per M5 audit finding).
 from shared.symlinks import setup_plugin_symlinks
 from shared.claude_md_manager import (
+    ensure_pinned_terminator,
     ensure_project_memory_md,
     file_lock,
     migrate_to_managed_structure,
@@ -249,6 +250,82 @@ def check_pin_slot_status() -> Optional[str]:
 
         return format_slot_status(pins)
     except Exception:  # noqa: BLE001 — outer fail-open
+        return None
+
+
+def check_pinned_region_unbounded_directive(
+    input_data: dict, repair_status: Optional[str] = None
+) -> Optional[str]:
+    """Return a repair directive for additionalContext, or None.
+
+    Fires when the project CLAUDE.md has a Pinned Context section with NO
+    terminating heading. In that state the pin-cap gate DECLINES to enforce,
+    because the pin count it measures is inflated by every `### ` heading in
+    the file tail. The caps are off on that file, and nothing else tells the
+    curator so — the gate's correct silence is why this directive exists.
+
+    SIGNATURE NOTE: the design sketch took no parameter. It needs one. The
+    first trigger condition is `is_lead`, and that predicate reads the
+    harness-set `agent_type` off the input dict.
+
+    SCOPED TO THE LEAD, AND THE SCOPE IS LOAD-BEARING, NOT TIDINESS.
+    SessionStart runs for EVERY frame, teammates included. The pin-cap gate
+    returns early for a teammate, so a teammate is not gated at all. An
+    unscoped directive would therefore instruct exactly the actors the gate
+    does not control to edit a file they are not expected to touch. This
+    predicate has caused one silent-scope failure at this same branch before,
+    with the sign reversed: the gate was silently DEAD for the lead. Same
+    cause both times — the scope of the predicate read differently from how
+    it behaved.
+
+    CANNOT DENY, structurally, on three independent layers: SessionStart must
+    never exit 2 (it would break /clear and /resume), the function returns a
+    string and a string cannot deny, and the body is wrapped in a blanket
+    try/except returning None. Both sibling directives use this pattern.
+
+    Args:
+        input_data: the SessionStart stdin payload, for the `is_lead` test.
+        repair_status: what `ensure_pinned_terminator()` reported this
+            session, or None if it did not run. Surfaced verbatim so the
+            directive can say what the plugin ALREADY DID rather than ask
+            the curator to repeat it. When the automatic repair succeeded
+            this function does not fire at all, because the region is bounded
+            by then — so a status reaching here is a refusal, and the reason
+            is the part the curator needs.
+    """
+    try:
+        if not is_lead(input_data):
+            return None
+
+        path = _get_project_claude_md_path()
+        if path is None:
+            return None
+
+        try:
+            content = path.read_text(encoding="utf-8")
+        except (IOError, OSError, UnicodeDecodeError):
+            return None
+
+        parsed = _parse_pinned_section(content)
+        if parsed is None or parsed.bounded:
+            return None
+
+        plugin_action = (
+            f" The plugin tried to repair it automatically and could not: "
+            f"{repair_status}"
+            if repair_status
+            else " The plugin did not repair it automatically this session."
+        )
+        return (
+            "Pinned context: the `## Pinned Context` section of the project "
+            "CLAUDE.md has no heading after it, so it runs to the end of the "
+            "file and every `### ` heading below it counts as a pin. The pin "
+            "caps are NOT being enforced on this file while that is true."
+            f"{plugin_action} "
+            "You MUST add a `## Working Memory` heading immediately after the "
+            "last real pin to close the section."
+        )
+    except Exception:  # noqa: BLE001 — outer fail-open; SessionStart cannot deny.
         return None
 
 
@@ -890,6 +967,44 @@ def main():
             else:
                 context_parts.append(project_md_msg)
 
+        # 3a-bis. Close an unbounded Pinned Context section BEFORE the
+        # migration below. THE ORDER IS LOAD-BEARING AND IT IS MEASURED, NOT
+        # PREFERRED. On a file whose pinned region lost its terminating
+        # heading, the migration alone yields 14 pins; this repair followed
+        # by the migration yields 2. Reversed, the migration bounds the
+        # region WITHOUT correcting the placement, this repair then sees a
+        # bounded file, declines to act, and the absorbed entries are locked
+        # inside the pinned region permanently — where they inflate the count
+        # on every later session.
+        #
+        # DELIBERATELY NOT LEAD-SCOPED, and the asymmetry with the directive
+        # below is the point rather than an oversight.
+        #
+        # The lead-scope rule exists for a surface that TELLS AN ACTOR to edit
+        # a file that actor does not own and the pin gate does not control for
+        # them. That is the DIRECTIVE, and it stays scoped. THIS IS A WRITER.
+        # It instructs nobody, so it has no actor to mis-address — and the
+        # migration immediately below already writes to this same file from
+        # ANY frame, which is the precedent.
+        #
+        # Scoping the repair while leaving the migration unscoped made the
+        # outcome depend on WHICH FRAME TYPE HAPPENED TO START FIRST, and the
+        # losing branch was permanent: a non-lead frame ran the migration
+        # alone, which bounds the region WITHOUT correcting the placement, so
+        # the absorbed entries were locked inside at 14 pins with
+        # `bounded=True`. A later lead frame then declines, because the file
+        # is bounded by then, and the boundedness decline never fires either —
+        # so the over-block is re-armed with no way back. `is_lead` is False
+        # for a teammate, for a typo'd agent_type, AND for a plain session
+        # launched with no `--agent` flag, so that was not a rare frame.
+        pinned_repair_msg = ensure_pinned_terminator()
+        if pinned_repair_msg:
+            if ("failed" in pinned_repair_msg.lower()
+                    or "skipped" in pinned_repair_msg.lower()):
+                system_messages.append(pinned_repair_msg)
+            else:
+                context_parts.append(pinned_repair_msg)
+
         # 3b. One-time migration: wrap existing project CLAUDE.md in
         # PACT_MANAGED boundary and add PACT_MEMORY markers (#404).
         # Runs after ensure_project_memory_md() so newly created files
@@ -961,6 +1076,19 @@ def main():
         stale_block_msg = check_pin_stale_block_directive()
         if stale_block_msg and frame_role != "teammate":
             context_parts.append(stale_block_msg)
+
+        # 4b-bis. Tell the curator when the pinned region has no terminating
+        # heading. In that state the pin-cap gate DECLINES rather than
+        # enforcing on a count it knows is inflated, so the caps are off and
+        # the gate is correctly silent about it. This is the only surface that
+        # reports it. The helper scopes itself to the lead — it is NOT gated
+        # on `frame_role` here, because is_lead is the stricter predicate and
+        # the design names it specifically.
+        unbounded_msg = check_pinned_region_unbounded_directive(
+            input_data, repair_status=pinned_repair_msg
+        )
+        if unbounded_msg:
+            context_parts.append(unbounded_msg)
 
         # 4c. Surface plugin manifest diagnostic (#500). Tier-0 additionalContext —
         # total-function banner; always emits, even on read/parse failure.

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -75,6 +75,7 @@ from pin_caps import (  # noqa: F401
     PIN_COUNT_CAP,
     format_slot_status,
     parse_pins,
+    region_count_is_untrustworthy,
 )
 
 from shared import BOOTSTRAP_MARKER_NAME, SESSION_ID_CONTROL_CHARS_RE, build_session_path
@@ -246,6 +247,13 @@ def check_pin_slot_status() -> Optional[str]:
         try:
             pins = parse_pins(parsed.content)
         except Exception:  # noqa: BLE001 — fail-open by construction
+            return None
+
+        # Do not report a count the gate itself will not enforce on. Stating
+        # "15/12 used (FULL)" as fact, in the same payload as the directive
+        # saying the caps are off, tells the curator two contradictory things
+        # about one file -- and the 15 is not a number they can act on.
+        if region_count_is_untrustworthy(parsed.bounded, pins):
             return None
 
         return format_slot_status(pins)

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -242,9 +242,8 @@ def check_pin_slot_status() -> Optional[str]:
             # so the orchestrator sees pin headroom from session start.
             return format_slot_status([])
 
-        _, _, pinned_content = parsed
         try:
-            pins = parse_pins(pinned_content)
+            pins = parse_pins(parsed.content)
         except Exception:  # noqa: BLE001 — fail-open by construction
             return None
 

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -75,7 +75,7 @@ from pin_caps import (  # noqa: F401
     PIN_COUNT_CAP,
     format_slot_status,
     parse_pins,
-    region_count_is_untrustworthy,
+    gate_count_is_untrustworthy,
 )
 
 from shared import BOOTSTRAP_MARKER_NAME, SESSION_ID_CONTROL_CHARS_RE, build_session_path
@@ -253,7 +253,14 @@ def check_pin_slot_status() -> Optional[str]:
         # "15/12 used (FULL)" as fact, in the same payload as the directive
         # saying the caps are off, tells the curator two contradictory things
         # about one file -- and the 15 is not a number they can act on.
-        if region_count_is_untrustworthy(parsed.bounded, pins):
+        #
+        # THIS REPORTER FOLLOWS THE GATE'S PREDICATE, NOT THE STALENESS ONE,
+        # and the choice is forced. It reports the CAP state, so it must go
+        # silent on exactly the files where the cap declines. Using the
+        # narrower staleness form would restore the contradiction on the
+        # uniformly-undated class: the gate declining while this line reports
+        # "14/12 used (FULL)" about the same file, in the same payload.
+        if gate_count_is_untrustworthy(parsed.bounded, pins):
             return None
 
         return format_slot_status(pins)

--- a/pact-plugin/hooks/shared/claude_md_manager.py
+++ b/pact-plugin/hooks/shared/claude_md_manager.py
@@ -1063,6 +1063,12 @@ _REPAIR_REFUSED_PARSER_DISAGREEMENT = (
     "Pinned-region repair skipped: the pin parser and the heading scan "
     "disagree on the entry count. Add the heading by hand."
 )
+_REPAIR_REFUSED_HEADING_EXISTS = (
+    "Pinned-region repair skipped: this file already has a "
+    "`## Working Memory` heading above the Pinned Context section, so "
+    "inserting another would leave two. Move the existing heading to sit "
+    "after the last real pin instead."
+)
 
 
 def ensure_pinned_terminator() -> str | None:
@@ -1152,6 +1158,31 @@ def _ensure_pinned_terminator_inner() -> str | None:
                 # Idempotency: a bounded region is the goal state. A second
                 # run after a successful repair lands here and writes nothing.
                 return None
+
+            # GUARD 3, and its POSITION is load-bearing. It sits AFTER the
+            # bounded check above, so a file this function has already
+            # repaired returns None there as a no-op and never reaches here
+            # — otherwise every later session would report a refusal on a
+            # file that is already correct.
+            #
+            # An unbounded region plus an existing `## Working Memory`
+            # heading implies the heading sits BEFORE `## Pinned Context`:
+            # a heading AFTER the pins would have terminated the region and
+            # it would not be unbounded. So this is exactly the
+            # wrong-heading-order file, and inserting a second heading is
+            # what the guard prevents.
+            #
+            # WHY REFUSE RATHER THAN REUSE THE EXISTING HEADING. Reuse would
+            # mean MOVING a heading the curator wrote, which is a bigger
+            # edit than this function is authorised to make — its constraint
+            # is to add one heading and alter nothing else. Refusing leaves
+            # the region unbounded, which is the SAFE state: the pin gate
+            # declines rather than enforcing on a false measure, and the
+            # SessionStart directive tells the curator what to do by hand.
+            region = extract_managed_region(content)
+            region_text = region[0] if region is not None else content
+            if PINNED_TERMINATOR_HEADING in region_text:
+                return _REPAIR_REFUSED_HEADING_EXISTS
 
             pins = parse_pins(parsed.content)
             heading_starts = [

--- a/pact-plugin/hooks/shared/claude_md_manager.py
+++ b/pact-plugin/hooks/shared/claude_md_manager.py
@@ -958,8 +958,10 @@ def migrate_to_managed_structure() -> str | None:
 
     Called from session_init.py on every SessionStart. Idempotent no-op when
     PACT_MANAGED_START marker is already present. Follows the same hardening
-    pattern as the other managed-file writers: file_lock, symlink guard inside
-    the lock, fail-open on timeout/error.
+    pattern as the other managed-file writers: file_lock, containment
+    enforced inside `_atomic_write_text`, fail-open on timeout/error. The
+    former leaf symlink guard was RETIRED and replaced by that containment
+    check; it is no longer a mechanism this function carries.
 
     Idempotency guard: if PACT_MANAGED_START is already present, the
     function returns None without touching the file.
@@ -1077,6 +1079,12 @@ _REPAIR_REFUSED_PARSER_DISAGREEMENT = (
 # NAMES BOTH CURES AND PROMISES NOTHING. Neither branch says the edit will
 # then be allowed. The repair is refused either way, and the caps stay off
 # this file until a human closes the region.
+_REPAIR_REFUSED_WOULD_EXPEL_A_PIN = (
+    "Pinned-region repair skipped: the only place the terminator could go "
+    "sits before a dated pin, so inserting it would push a real pin out of "
+    "the Pinned Context section. Move the stray `### ` heading out of the "
+    "pin body above it, or add the terminator by hand."
+)
 _REPAIR_REFUSED_HEADING_EXISTS = (
     "Pinned-region repair skipped: the managed region already contains the "
     f"text `{PINNED_TERMINATOR_HEADING}`, so inserting another could leave "
@@ -1228,6 +1236,38 @@ def _ensure_pinned_terminator_inner() -> str | None:
             )
             if target_index is None:
                 return _REPAIR_REFUSED_NOTHING_ABSORBED  # Guard 2.
+
+            # GUARD 4. The insertion point was chosen by "first undated entry
+            # after a dated one" -- and that discriminator is the SAME
+            # signature the gate uses for a smuggled pin, so it cannot tell an
+            # absorbed note from a `### ` sitting inside a real pin's BODY.
+            # When the candidate is body content, the terminator lands INSIDE
+            # that pin and every pin after it falls OUTSIDE the region, where
+            # neither the caps nor /PACT:prune-memory can reach it. Measured:
+            # a genuine dated pin silently expelled, while the repair reported
+            # SUCCESS.
+            #
+            # This guard does NOT consult the candidate's own datedness, so it
+            # does not inherit that blindness. It asks a different question, of
+            # the SUFFIX rather than the candidate: would this insertion strand
+            # a DATED pin? Inserting before index `target_index` expels
+            # everything from `target_index` onward, so a dated pin at or after
+            # it is exactly a dated pin about to be lost.
+            #
+            # KNOWN RESIDUAL, recorded rather than filed because it is
+            # undecidable rather than unfixed: a `### ` inside the LAST dated
+            # pin's body has no dated pin after it, so this guard allows the
+            # repair and the body tail falls outside the region. At that
+            # position "the tail of a pin body" and "the first absorbed note"
+            # are structurally identical -- same line shape, no date comment on
+            # either -- so no rule can separate them. An adversarial attempt to
+            # show a size-cap consequence FAILED: `parse_pins` already splits
+            # that body at the embedded heading BEFORE the repair runs, so the
+            # under-measure pre-exists this function and is upstream of it.
+            if any(
+                pin.date_comment is not None for pin in pins[target_index:]
+            ):
+                return _REPAIR_REFUSED_WOULD_EXPEL_A_PIN  # Guard 4.
 
             # `parsed.start` is already absolute; `heading_starts` are relative
             # to `parsed.content`, which begins at `parsed.start`.

--- a/pact-plugin/hooks/shared/claude_md_manager.py
+++ b/pact-plugin/hooks/shared/claude_md_manager.py
@@ -1254,8 +1254,23 @@ def _ensure_pinned_terminator_inner() -> str | None:
             # everything from `target_index` onward, so a dated pin at or after
             # it is exactly a dated pin about to be lost.
             #
-            # KNOWN RESIDUAL, recorded rather than filed because it is
-            # undecidable rather than unfixed: a `### ` inside the LAST dated
+            # RESIDUAL 1, AND THE SAME CORPUS FACT THAT SHAPED THE SHARED
+            # PREDICATE INVALIDATES THIS ONE TOO -- it was applied to that
+            # predicate and NOT carried here, which is the propagation failure
+            # worth naming. This guard tests for a DATED pin after the
+            # insertion point. This repository's LEGACY pins are UNDATED: they
+            # carry their date in the heading, `### Old Feature (PR #99,
+            # merged 2026-01-02)`, with no `<!-- pinned: -->` comment. So a
+            # legacy pin at or after the insertion point does NOT trip this
+            # guard, and gets expelled -- BLOCKING 2's exact harm, in the shape
+            # the corpus says is common here. NOT FIXED, deliberately:
+            # pre-existing, genuinely undecidable at that position, and every
+            # live file measured is bounded, so the repair does not run on
+            # them. Reasoning carefully about legacy pins in one predicate and
+            # not carrying it to its sibling is how this survived.
+            #
+            # RESIDUAL 2, and its consequence is now traced rather than
+            # assumed: a `### ` inside the LAST dated
             # pin's body has no dated pin after it, so this guard allows the
             # repair and the body tail falls outside the region. At that
             # position "the tail of a pin body" and "the first absorbed note"
@@ -1264,6 +1279,11 @@ def _ensure_pinned_terminator_inner() -> str | None:
             # show a size-cap consequence FAILED: `parse_pins` already splits
             # that body at the embedded heading BEFORE the repair runs, so the
             # under-measure pre-exists this function and is upstream of it.
+            # /PACT:prune-memory was traced too: it operates on the REGION, so
+            # a truncated pin's tail sits outside it. Prune archives the
+            # truncated body, removes the pin block, and the tail remains as
+            # un-owned prose below the terminator. NO CONTENT IS LOST -- it is
+            # orphaned and de-associated, which is the whole of the harm.
             if any(
                 pin.date_comment is not None for pin in pins[target_index:]
             ):

--- a/pact-plugin/hooks/shared/claude_md_manager.py
+++ b/pact-plugin/hooks/shared/claude_md_manager.py
@@ -1043,6 +1043,178 @@ def migrate_to_managed_structure() -> str | None:
 
 
 
+PINNED_TERMINATOR_HEADING = "## Working Memory"
+
+_REPAIR_OK = (
+    "Repaired project CLAUDE.md: inserted a `{heading}` heading to close the "
+    "Pinned Context section. Entries below it are notes again, not pins."
+)
+_REPAIR_REFUSED_NO_DATED_PIN = (
+    "Pinned-region repair skipped: no entry in the Pinned Context section "
+    "carries a `<!-- pinned: DATE -->` comment, so there is no signal that "
+    "separates a pin from a note. Add the heading by hand."
+)
+_REPAIR_REFUSED_NOTHING_ABSORBED = (
+    "Pinned-region repair skipped: the Pinned Context section has no undated "
+    "`### ` entry after a dated one, so there is no absorbed content to put "
+    "outside it. Add the heading by hand."
+)
+_REPAIR_REFUSED_PARSER_DISAGREEMENT = (
+    "Pinned-region repair skipped: the pin parser and the heading scan "
+    "disagree on the entry count. Add the heading by hand."
+)
+
+
+def ensure_pinned_terminator() -> str | None:
+    """Insert a `## Working Memory` heading when the pinned region is unbounded.
+
+    A pinned region with no terminating heading runs to the end of the
+    scanned text, so every `### ` heading in the tail parses as a Pin. The
+    pin-cap gate then measures a count the curator does not have. This
+    function restores the boundary.
+
+    PLACEMENT IS THE WHOLE DESIGN, AND THE OBVIOUS PLACEMENT IS WRONG.
+    Appending the heading at the END of the region bounds the region at the
+    end it ALREADY had. The absorbed entries stay inside, `bounded` flips to
+    True, and the gate resumes enforcing on the SAME inflated count — so the
+    repair CAUSES the over-block it exists to prevent, which is measurably
+    worse than not running at all. Measured on a 2-real-pin file: no repair
+    gives 14 pins and a safe decline, END placement gives 14 pins and a deny
+    at 15/12, correct placement gives 2 pins.
+
+    So the heading goes immediately BEFORE the first `### ` entry that has NO
+    date comment and that FOLLOWS at least one dated entry. The discriminator
+    is the plugin's own pin grammar: a legitimately added pin always carries
+    `<!-- pinned: DATE -->`, and the gate's own smuggle check relies on the
+    same rule. An undated `### ` sitting after the dated pins is absorbed
+    content, and it was never a pin — it became one only when the terminator
+    went missing.
+
+    TWO REFUSAL GUARDS, BOTH MANDATORY. A refusal is not a failure: the file
+    stays unbounded, which is the SAFE state (the gate declines rather than
+    enforcing on a false measure), and the SessionStart directive tells the
+    curator what to do.
+      1. No dated entry anywhere. The file is hand-maintained and carries no
+         signal separating pins from notes. Inserting before the first `### `
+         would push EVERY pin out of the region.
+      2. No undated entry after a dated one. Nothing was absorbed.
+
+    ORDERING: the caller MUST run this BEFORE `migrate_to_managed_structure`.
+    The migration bounds the region without fixing the placement, so after it
+    runs this function sees a bounded file, declines to act, and the phantom
+    entries are locked inside permanently.
+
+    KNOWN EDGE, low risk and unrepaired: a file whose `## Working Memory`
+    heading sits BEFORE `## Pinned Context`, with nothing after the pins,
+    gains a SECOND Working Memory heading.
+
+    Returns:
+        A status string on repair or refusal (refusals contain "skipped" so
+        the caller routes them to systemMessages), or None for a no-op —
+        bounded region, no region, no file, or any error. Never raises.
+    """
+    # TOTAL BY CONSTRUCTION. Every raisable step lives inside this wrapper,
+    # including the path resolution and the function-level imports below —
+    # an ImportError from the cross-package import is exactly the kind of
+    # fault that must degrade to "did nothing", not propagate into
+    # SessionStart.
+    try:
+        return _ensure_pinned_terminator_inner()
+    except Exception:  # noqa: BLE001 — fail-open: SessionStart must not break.
+        return None
+
+
+def _ensure_pinned_terminator_inner() -> str | None:
+    """Body of `ensure_pinned_terminator`. May raise; the caller is total."""
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
+    if not project_dir:
+        return None
+
+    target_file, source = resolve_project_claude_md_path(project_dir)
+    if source == "new_default":
+        return None  # File does not exist; ensure_project_memory_md creates it.
+
+    # Function-level imports: this module lives in shared/ and these live in
+    # hooks/. A module-level import would create a cycle — staleness.py
+    # already function-level-imports THIS module for the same reason.
+    from staleness import _parse_pinned_section
+    from pin_caps import _PIN_HEADING_RE, parse_pins
+
+    try:
+        with file_lock(target_file):
+            try:
+                content = target_file.read_text(encoding="utf-8")
+            except OSError:
+                return None
+
+            parsed = _parse_pinned_section(content)
+            if parsed is None or parsed.bounded:
+                # Idempotency: a bounded region is the goal state. A second
+                # run after a successful repair lands here and writes nothing.
+                return None
+
+            pins = parse_pins(parsed.content)
+            heading_starts = [
+                m.start() for m in _PIN_HEADING_RE.finditer(parsed.content)
+            ]
+            # parse_pins builds one Pin per heading start, in order, from this
+            # same regex over this same string, so the two lists align by
+            # index. Verify it rather than assume it: if they ever disagree,
+            # the offsets would be attributed to the wrong entries and the
+            # heading would land in the middle of someone's pin body.
+            if len(pins) != len(heading_starts):
+                return _REPAIR_REFUSED_PARSER_DISAGREEMENT
+
+            first_dated = next(
+                (i for i, pin in enumerate(pins) if pin.date_comment is not None),
+                None,
+            )
+            if first_dated is None:
+                return _REPAIR_REFUSED_NO_DATED_PIN  # Guard 1.
+
+            target_index = next(
+                (
+                    i
+                    for i in range(first_dated + 1, len(pins))
+                    if pins[i].date_comment is None
+                ),
+                None,
+            )
+            if target_index is None:
+                return _REPAIR_REFUSED_NOTHING_ABSORBED  # Guard 2.
+
+            # `parsed.start` is already absolute; `heading_starts` are relative
+            # to `parsed.content`, which begins at `parsed.start`.
+            insert_at = parsed.start + heading_starts[target_index]
+            new_content = (
+                content[:insert_at]
+                + f"{PINNED_TERMINATOR_HEADING}\n\n"
+                + content[insert_at:]
+            )
+
+            try:
+                _atomic_write_text(target_file, new_content, Path(project_dir))
+            except ContainmentError:
+                return (
+                    "Pinned-region repair skipped: project CLAUDE.md path "
+                    "precondition not met."
+                )
+            except OSError as exc:
+                return f"Pinned-region repair failed: {str(exc)[:50]}"
+
+            return _REPAIR_OK.format(heading=PINNED_TERMINATOR_HEADING)
+    except TimeoutError:
+        return (
+            "Pinned-region repair skipped: could not acquire the lock on "
+            "project CLAUDE.md within 5s; will retry on next session start."
+        )
+    except OSError:
+        return (
+            "Pinned-region repair skipped: could not acquire the lock on "
+            "project CLAUDE.md (path precondition not met)."
+        )
+
+
 def _build_migrated_content(content: str) -> str:
     """
     Transform old-format CLAUDE.md content into the new managed structure.

--- a/pact-plugin/hooks/shared/claude_md_manager.py
+++ b/pact-plugin/hooks/shared/claude_md_manager.py
@@ -1063,11 +1063,26 @@ _REPAIR_REFUSED_PARSER_DISAGREEMENT = (
     "Pinned-region repair skipped: the pin parser and the heading scan "
     "disagree on the entry count. Add the heading by hand."
 )
+# WORDED FOR BOTH INPUTS THAT REACH THIS GUARD, because the guard is a
+# SUBSTRING test and not a heading test. An earlier wording asserted that the
+# file "already has a `## Working Memory` heading above the Pinned Context
+# section" and told the curator to move it. That is false on the second input:
+# a file with NO such heading, whose only occurrence of the text is prose
+# INSIDE a pin body, trips the same guard and was told to move a heading that
+# does not exist. An unfollowable cure is the defect class this work removes.
+#
+# The literal comes from PINNED_TERMINATOR_HEADING so the message cannot drift
+# from the constant the guard actually tests.
+#
+# NAMES BOTH CURES AND PROMISES NOTHING. Neither branch says the edit will
+# then be allowed. The repair is refused either way, and the caps stay off
+# this file until a human closes the region.
 _REPAIR_REFUSED_HEADING_EXISTS = (
-    "Pinned-region repair skipped: this file already has a "
-    "`## Working Memory` heading above the Pinned Context section, so "
-    "inserting another would leave two. Move the existing heading to sit "
-    "after the last real pin instead."
+    "Pinned-region repair skipped: the managed region already contains the "
+    f"text `{PINNED_TERMINATOR_HEADING}`, so inserting another could leave "
+    "two headings. If that text is a heading above the Pinned Context "
+    "section, move it to sit after the last real pin. If it is inside a pin "
+    "body, reword the mention."
 )
 
 

--- a/pact-plugin/hooks/staleness.py
+++ b/pact-plugin/hooks/staleness.py
@@ -22,7 +22,7 @@ import re
 import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, NamedTuple, Optional, Tuple
 
 from shared.claude_md_manager import (
     PACT_BOUNDARY_PREFIXES,
@@ -51,6 +51,38 @@ PINNED_STALENESS_DAYS = 30
 # exceeded, a warning comment is added (no auto-deletion).
 # This is the sole definition of this constant; session_init.py imports it.
 PINNED_CONTEXT_TOKEN_BUDGET = 1200
+
+
+class PinnedSection(NamedTuple):
+    """The Pinned Context section extract, plus whether it is TERMINATED.
+
+    Returned by `_parse_pinned_section`. The first three fields carry the
+    same values the former 3-tuple carried, in the same order, so a
+    positional unpack of three names fails loudly (`ValueError`) rather
+    than binding the wrong value.
+
+    `bounded` answers one question: did the scan find a terminator line
+    after the pins, or did it run off the end of the scanned text? When a
+    curator removes the `## Working Memory` heading that follows the
+    pins, the section extends to the end of the region and every later
+    `### ` heading -- ordinary Working Memory entries included -- parses
+    as a Pin. Consumers that enforce a cap MUST know that, because the
+    inflated count is not the curator's pin count.
+
+    THIS CLASS IS THE ONE DEFINITION OF BOUNDEDNESS. Do not recompute the
+    property at a consumer: two computations that must agree drift apart.
+
+    Fields:
+        start:   absolute offset of the section body in the full content
+        end:     absolute offset of the section end in the full content
+        content: the section body text
+        bounded: True when a terminator line closes the section
+    """
+
+    start: int
+    end: int
+    content: str
+    bounded: bool
 
 
 def _find_existing_claude_md(base: Path) -> Optional[Path]:
@@ -240,7 +272,7 @@ def _find_terminator_offset(
     return len(content)
 
 
-def _parse_pinned_section(content: str) -> Optional[Tuple[int, int, str]]:
+def _parse_pinned_section(content: str) -> Optional[PinnedSection]:
     """
     Extract the Pinned Context section from CLAUDE.md content.
 
@@ -253,13 +285,25 @@ def _parse_pinned_section(content: str) -> Optional[Tuple[int, int, str]]:
     is unnecessary. If the managed region is not present (pre-migration
     file), falls back to scanning the full content.
 
+    BOUNDEDNESS -- COMPUTE IT ON THE SCAN-RELATIVE LOCALS, NEVER ON THE
+    RETURNED OFFSETS. `_find_terminator_offset` reports "no terminator" by
+    returning `len(scan_text)`, so the test for a terminator is
+    `pinned_end < len(scan_text)` BEFORE `offset` is added. The returned
+    `start` and `end` are offset-adjusted into the full file, and
+    `end < len(content)` is a DIFFERENT and WRONG test: on a file that
+    carries the managed markers, `extract_managed_region` slices the text
+    BEFORE `PACT_MANAGED_END`, so the closing marker always follows the
+    scanned text and the full-file form reads True whether or not a
+    terminator exists. That form is wrong on exactly the population this
+    field exists to detect, and right everywhere else.
+
     Args:
         content: Full CLAUDE.md file content.
 
     Returns:
-        Tuple of (pinned_start, pinned_end, pinned_content) or None if
-        no Pinned Context section exists or it is empty. Offsets are
-        absolute positions in the original `content` string.
+        A `PinnedSection`, or None if no Pinned Context section exists or
+        it is empty. Offsets are absolute positions in the original
+        `content` string.
     """
     # Bound to managed region if available (round 10). Offset adjustment
     # converts managed-region-relative positions back to full-file positions.
@@ -290,7 +334,15 @@ def _parse_pinned_section(content: str) -> Optional[Tuple[int, int, str]]:
     if not pinned_content.strip():
         return None
 
-    return pinned_start + offset, pinned_end + offset, pinned_content
+    # Scan-relative, pre-offset. See the BOUNDEDNESS note in the docstring.
+    bounded = pinned_end < len(scan_text)
+
+    return PinnedSection(
+        start=pinned_start + offset,
+        end=pinned_end + offset,
+        content=pinned_content,
+        bounded=bounded,
+    )
 
 
 def detect_stale_entries(
@@ -497,7 +549,9 @@ def check_pinned_staleness(claude_md_path: Optional[Path] = None) -> Optional[st
     if parsed is None:
         return None
 
-    pinned_start, pinned_end, pinned_content = parsed
+    pinned_start = parsed.start
+    pinned_end = parsed.end
+    pinned_content = parsed.content
 
     entry_pattern = re.compile(r'^### ', re.MULTILINE)
     entry_starts = [m.start() for m in entry_pattern.finditer(pinned_content)]
@@ -601,7 +655,7 @@ def check_pinned_block_signal(
     if parsed is None:
         return None
 
-    _, _, pinned_content = parsed
+    pinned_content = parsed.content
 
     try:
         pins = parse_pins(pinned_content)

--- a/pact-plugin/hooks/staleness.py
+++ b/pact-plugin/hooks/staleness.py
@@ -554,14 +554,24 @@ def check_pinned_staleness(claude_md_path: Optional[Path] = None) -> Optional[st
     # Enforcing here would mark ordinary Working Memory notes STALE -- and
     # this path WRITES that marking into the user's file.
     #
+    # CHEAP-FIRST, AND THE ORDER IS A COST DECISION RATHER THAN A STYLE ONE.
+    # `bounded` is a field read; `parse_pins` is superlinear in region size and
+    # measured at 6.5x the parse cost on a typical file, 40x on a heavily
+    # pinned one. A BOUNDED region is trustworthy by definition, so testing
+    # `bounded` first means the steady-state path -- every session, every
+    # well-formed file -- never pays the parse at all. This function did NOT
+    # call `parse_pins` before this guard existed, so an eager parse here
+    # would be a new per-session cost on every file with a pinned section.
+    #
     # The parse is guarded: this function's contract is fail-open, and a
     # raising parser must not become a raise out of a SessionStart path.
-    try:
-        _region_pins = parse_pins(parsed.content)
-    except Exception:  # noqa: BLE001 — fail-open by construction
-        return None
-    if region_count_is_untrustworthy(parsed.bounded, _region_pins):
-        return None
+    if not parsed.bounded:
+        try:
+            _region_pins = parse_pins(parsed.content)
+        except Exception:  # noqa: BLE001 — fail-open by construction
+            return None
+        if region_count_is_untrustworthy(parsed.bounded, _region_pins):
+            return None
 
     pinned_start = parsed.start
     pinned_end = parsed.end

--- a/pact-plugin/hooks/staleness.py
+++ b/pact-plugin/hooks/staleness.py
@@ -33,6 +33,7 @@ from pin_caps import (
     CapViolation,
     check_stale_block,
     parse_pins,
+    region_count_is_untrustworthy,
 )
 
 # Boundary prefix alternation used by _parse_pinned_section. Built from
@@ -549,6 +550,19 @@ def check_pinned_staleness(claude_md_path: Optional[Path] = None) -> Optional[st
     if parsed is None:
         return None
 
+    # The count may be inflated by entries the curator never pinned.
+    # Enforcing here would mark ordinary Working Memory notes STALE -- and
+    # this path WRITES that marking into the user's file.
+    #
+    # The parse is guarded: this function's contract is fail-open, and a
+    # raising parser must not become a raise out of a SessionStart path.
+    try:
+        _region_pins = parse_pins(parsed.content)
+    except Exception:  # noqa: BLE001 — fail-open by construction
+        return None
+    if region_count_is_untrustworthy(parsed.bounded, _region_pins):
+        return None
+
     pinned_start = parsed.start
     pinned_end = parsed.end
     pinned_content = parsed.content
@@ -660,6 +674,12 @@ def check_pinned_block_signal(
     try:
         pins = parse_pins(pinned_content)
     except Exception:  # noqa: BLE001 — fail-open by construction
+        return None
+
+    # Never arm the stale-block gate on a count that may include entries
+    # the curator never pinned. Uses the pins parsed above rather than a
+    # second parse, so the fail-open on a raising parser still covers it.
+    if region_count_is_untrustworthy(parsed.bounded, pins):
         return None
 
     return check_stale_block(pins, threshold=PIN_STALE_BLOCK_THRESHOLD)

--- a/pact-plugin/scripts/archive_pin.py
+++ b/pact-plugin/scripts/archive_pin.py
@@ -800,7 +800,7 @@ def archive_pin(index: int, db_path=None) -> dict:
         raise _Unevaluable("no Pinned Context section",
                            claude_md_path=claude_md_path)
 
-    _, _, pinned_content = parsed
+    pinned_content = parsed.content
     try:
         pins = parse_pins(pinned_content)
     except Exception as exc:  # noqa: BLE001 -- parse fault is unevaluable

--- a/pact-plugin/scripts/check_pin_caps.py
+++ b/pact-plugin/scripts/check_pin_caps.py
@@ -257,7 +257,7 @@ def _resolve_pins():
     if parsed is None:
         return [], "no pinned section"
 
-    _, _, pinned_content = parsed
+    pinned_content = parsed.content
     try:
         pins = parse_pins(pinned_content)
     except Exception:  # noqa: BLE001 — fail-open by construction

--- a/pact-plugin/tests/test_archive_pin.py
+++ b/pact-plugin/tests/test_archive_pin.py
@@ -98,7 +98,7 @@ def _pinned_body(content):
     """Extract the Pinned Context section body from a full CLAUDE.md."""
     parsed = staleness._parse_pinned_section(content)
     assert parsed is not None, "fixture has no Pinned Context section"
-    return parsed[2]
+    return parsed.content
 
 
 def _two_pin_file():

--- a/pact-plugin/tests/test_archive_pin_emit.py
+++ b/pact-plugin/tests/test_archive_pin_emit.py
@@ -74,7 +74,7 @@ def _two_pin_file():
 def _pinned_body(content):
     parsed = staleness._parse_pinned_section(content)
     assert parsed is not None, "fixture has no Pinned Context section"
-    return parsed[2]
+    return parsed.content
 
 
 def _expected_block(content, index):

--- a/pact-plugin/tests/test_boundedness_residuals.py
+++ b/pact-plugin/tests/test_boundedness_residuals.py
@@ -1,0 +1,218 @@
+"""Handover tests for the two BLOCKING findings of the PR 1 security review.
+
+EXPECTED STATE ON THE UNFIXED TREE:
+  TestStalenessSurfacesMustDeclineWhenUnbounded
+    test_unbounded_region_gets_no_stale_markers_written   FAIL  (defect)
+    test_unbounded_region_does_not_arm_the_block_gate     FAIL  (defect)
+    test_bounded_stale_pins_are_STILL_marked              PASS  (control)
+    test_bounded_stale_pins_STILL_arm_the_block_gate      PASS  (control)
+  TestRepairMustNotExpelAGenuinePin
+    test_interleaved_file_is_refused_not_corrupted        FAIL  (defect)
+    test_normal_absorbed_file_still_repairs               PASS  (control)
+
+THE TWO CONTROLS ARE THE POINT. Each defect test asserts that something
+STOPS happening, and a fix that simply switches the whole surface off would
+satisfy it. The controls assert the surface still works where it should, so
+the pair discriminates. Do not delete a control to make a run green.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+sys.path.insert(0, str(Path(__file__).parent))
+
+
+# --- fixture builders ------------------------------------------------------
+def _pin(title, date="2026-07-01", body="ordinary pin body"):
+    return f"<!-- pinned: {date} -->\n### {title}\n\n{body}\n\n"
+
+
+def _stale_pin(title, date="2026-07-01"):
+    """A pin that is GENUINELY stale: its body carries a merged-PR date."""
+    return _pin(title, date=date, body="Landed in PR #123, merged 2026-01-05.")
+
+
+def _note(day):
+    """An ordinary Working Memory entry in this repository's own format."""
+    return f"### 2026-01-{day:02d} 09:00\n**Context**: ordinary session note.\n\n"
+
+
+def _claude_md(pins, terminated, tail=""):
+    out = "# Project Memory\n\n## Pinned Context\n\n" + pins
+    if terminated:
+        out += "## Working Memory\n\n"
+    return out + tail
+
+
+NOTES = "".join(_note(d) for d in (10, 11, 12))
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    """Write a CLAUDE.md and anchor every resolver at it."""
+    def _make(content):
+        md = tmp_path / "CLAUDE.md"
+        md.write_text(content, encoding="utf-8")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+        import staleness
+        monkeypatch.setattr(staleness, "get_project_claude_md_path", lambda: md)
+        return md
+    return _make
+
+
+def _measure(content):
+    """Precondition oracle. Asserting the region was FOUND before asserting
+    anything about it is mandatory here: a None parse and a bounded parse
+    both make the defect assertions pass for the wrong reason."""
+    from staleness import _parse_pinned_section
+    from pin_caps import parse_pins
+    parsed = _parse_pinned_section(content)
+    assert parsed is not None, "control: the fixture has no Pinned Context region"
+    return len(parse_pins(parsed.content)), parsed.bounded
+
+
+# === BLOCKING 1 ============================================================
+class TestStalenessSurfacesMustDeclineWhenUnbounded:
+    """`check_pinned_staleness` and `check_pinned_block_signal` consume
+    `parsed.content` without consulting `parsed.bounded`, so on an unbounded
+    region they treat ordinary Working Memory entries as pins."""
+
+    UNBOUNDED = _claude_md(
+        _pin("Real A", "2026-07-01") + _pin("Real B", "2026-07-02"),
+        terminated=False, tail=NOTES,
+    )
+    BOUNDED_STALE = _claude_md(
+        _stale_pin("Real A", "2026-07-01") + _stale_pin("Real B", "2026-07-02"),
+        terminated=True, tail=NOTES,
+    )
+
+    def test_unbounded_region_gets_no_stale_markers_written(self, project):
+        """DEFECT: the staleness pass MUTATES the curator's own notes."""
+        count, bounded = _measure(self.UNBOUNDED)
+        assert (count, bounded) == (5, False), (
+            "control: the fixture must parse as an UNBOUNDED region whose "
+            "count is inflated by the notes, or this is not the input class"
+        )
+        md = project(self.UNBOUNDED)
+        before = md.read_text(encoding="utf-8")
+
+        from staleness import check_pinned_staleness
+        check_pinned_staleness(claude_md_path=md)
+
+        after = md.read_text(encoding="utf-8")
+        marked = [d for d in (10, 11, 12)
+                  if f"### 2026-01-{d:02d} 09:00\n<!-- STALE:" in after]
+        assert not marked, (
+            f"STALE markers were injected into ordinary Working Memory "
+            f"entries {marked}. They are not pins. The region is unbounded, "
+            f"so the measure is the one this PR declares untrustworthy."
+        )
+        assert after == before, "an unbounded region must not be written at all"
+
+    def test_unbounded_region_does_not_arm_the_block_gate(self, project):
+        """DEFECT: the phantom stale count arms a second deny gate, whose
+        message names a cure over pins the curator does not hold."""
+        md = project(self.UNBOUNDED)
+        from staleness import check_pinned_staleness, check_pinned_block_signal
+        check_pinned_staleness(claude_md_path=md)
+        signal = check_pinned_block_signal(claude_md_path=md)
+        assert signal is None, (
+            f"block signal fired on an unbounded region: {signal!r}. "
+            f"pin_staleness_gate then denies the curator's next ADD-shaped "
+            f"edit with an impossible cure."
+        )
+
+    def test_bounded_stale_pins_are_STILL_marked(self, project):
+        """CONTROL. A fix that disables staleness outright passes the two
+        tests above and fails this one."""
+        count, bounded = _measure(self.BOUNDED_STALE)
+        assert (count, bounded) == (2, True), (
+            "control: the fixture must be a BOUNDED region of 2 real pins"
+        )
+        md = project(self.BOUNDED_STALE)
+        from staleness import check_pinned_staleness
+        status = check_pinned_staleness(claude_md_path=md)
+        after = md.read_text(encoding="utf-8")
+        assert after.count("<!-- STALE: Last relevant") == 2, (
+            f"genuinely stale pins on a BOUNDED region must still be marked. "
+            f"status={status!r}"
+        )
+
+    def test_bounded_stale_pins_STILL_arm_the_block_gate(self, project):
+        """CONTROL, on the second surface."""
+        md = project(self.BOUNDED_STALE)
+        from staleness import check_pinned_staleness, check_pinned_block_signal
+        check_pinned_staleness(claude_md_path=md)
+        signal = check_pinned_block_signal(claude_md_path=md)
+        assert signal is not None and signal.kind == "stale", (
+            f"a BOUNDED region holding 2 genuinely stale pins must still arm "
+            f"the gate. Got {signal!r}"
+        )
+
+
+# === BLOCKING 2 ============================================================
+class TestRepairMustNotExpelAGenuinePin:
+    """The placement discriminator -- first undated `### ` after a dated one
+    -- is the SAME signature the gate uses for a smuggled pin, so a `### `
+    inside a real pin body is indistinguishable from absorbed content."""
+
+    INTERLEAVED = _claude_md(
+        "<!-- pinned: 2026-07-01 -->\n### Real A\n\nbody text.\n"
+        "### Sub heading\nmore of pin A's body.\n\n"
+        "<!-- pinned: 2026-07-02 -->\n### Real B\n\nreal pin B body\n\n",
+        terminated=False, tail=NOTES,
+    )
+    NORMAL = _claude_md(
+        _pin("Real A", "2026-07-01") + _pin("Real B", "2026-07-02"),
+        terminated=False, tail=NOTES,
+    )
+
+    def test_interleaved_file_is_refused_not_corrupted(self, project):
+        """DEFECT: the terminator lands inside a pin body and expels a
+        genuine dated pin from the region."""
+        count, bounded = _measure(self.INTERLEAVED)
+        assert (count, bounded) == (6, False), (
+            "control: the fixture must parse the in-body heading as an entry "
+            "and stay unbounded, or it is not the input class it claims"
+        )
+        md = project(self.INTERLEAVED)
+        from shared.claude_md_manager import ensure_pinned_terminator
+        status = ensure_pinned_terminator()
+        after = md.read_text(encoding="utf-8")
+
+        from staleness import _parse_pinned_section
+        from pin_caps import parse_pins
+        parsed = _parse_pinned_section(after)
+        headings = [p.heading for p in parse_pins(parsed.content)] if parsed else []
+        assert "### Real B" in headings, (
+            f"the repair expelled a GENUINE dated pin from the pinned region. "
+            f"region now holds {headings}; status={status!r}. Neither the caps "
+            f"nor /PACT:prune-memory can reach an expelled pin."
+        )
+        assert after == self.INTERLEAVED, (
+            "the safe outcome is a REFUSAL that writes nothing, leaving the "
+            "region unbounded -- which this module already calls the safe state"
+        )
+
+    def test_normal_absorbed_file_still_repairs(self, project):
+        """CONTROL. A fix that refuses everything passes the test above and
+        fails this one."""
+        count, bounded = _measure(self.NORMAL)
+        assert (count, bounded) == (5, False), "control: wrong input class"
+        md = project(self.NORMAL)
+        from shared.claude_md_manager import (
+            ensure_pinned_terminator, PINNED_TERMINATOR_HEADING,
+        )
+        status = ensure_pinned_terminator()
+        after = md.read_text(encoding="utf-8")
+        assert "Repaired" in (status or ""), (
+            f"the ordinary absorbed-notes file must still repair. Got {status!r}"
+        )
+        heading_at = after.index(PINNED_TERMINATOR_HEADING)
+        assert after.index("### Real B") < heading_at < after.index("### 2026-01-10"), (
+            "the terminator must sit after the last real pin and before the "
+            "first absorbed note"
+        )

--- a/pact-plugin/tests/test_pin_caps.py
+++ b/pact-plugin/tests/test_pin_caps.py
@@ -16,6 +16,9 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+sys.path.insert(0, str(Path(__file__).parent))
+
+from helpers import make_claude_md_with_pins  # noqa: E402
 
 
 class TestParsePins_ParsingSemantics:
@@ -505,18 +508,21 @@ def _make_pin(heading="### X", body_chars=100, override=False):
     )
 
 
-def _managed_content(pinned_section_body: str) -> str:
-    """Wrap pinned-section body in the PACT_MANAGED region so
-    _parse_pinned_section can extract it. Matches the structure produced
-    by claude_md_manager.
+def _managed_content(entries: list[str]) -> str:
+    """Wrap pinned entries in a REAL PACT-managed region.
+
+    THIS HELPER USED TO HAND-SPELL ITS START MARKER as
+    `<!-- PACT_MANAGED_START -->`, which is NOT the canonical constant — the
+    real one carries a `: Managed by pact-plugin - do not edit this block`
+    suffix. The END marker DID match, which is what made the old shape look
+    right. `extract_managed_region` returned None on every fixture built
+    here, so the parser fell back to scanning the whole file and the section
+    bounding this class claims to exercise never happened. Delegating to
+    `make_claude_md_with_pins` emits both markers from the imported
+    constants, so a future marker revision propagates instead of silently
+    disarming these five fixtures.
     """
-    return (
-        "# PACT\n\n"
-        "<!-- PACT_MANAGED_START -->\n"
-        "## Pinned Context\n"
-        f"{pinned_section_body}"
-        "<!-- PACT_MANAGED_END -->\n"
-    )
+    return make_claude_md_with_pins(entries)
 
 
 class TestEvaluateFullState_Smoke:
@@ -560,13 +566,87 @@ class TestEvaluateFullState_Smoke:
 
 
 class TestApplyEditAndParse_Smoke:
-    """apply_edit_and_parse — Edit/Write simulation + section-bounded parse."""
+    """apply_edit_and_parse — Edit/Write simulation + section-bounded parse.
+
+    The section-bounding half of that name is now exercised. It was not
+    before: the local fixture helper hand-spelled its START marker, so
+    `extract_managed_region` returned None on all five fixtures and the
+    parser scanned the whole file. The two controls below assert the
+    property the name claims, so the claim fails loudly if the fixtures
+    ever drift back onto the unbounded fallback.
+    """
+
+    def test_the_fixture_is_a_real_managed_region(self):
+        """PER-FIXTURE CONTROL (design section 10.2).
+
+        RED input: hand-spell either marker. `extract_managed_region`
+        returns None, every test in this class silently moves to the
+        whole-file fallback, and each one keeps passing while measuring
+        something else.
+        """
+        from shared.claude_md_manager import extract_managed_region
+        content = _managed_content(["<!-- pinned: 2026-04-21 -->\n### A\nBody A."])
+        assert extract_managed_region(content) is not None, (
+            "the fixture markers do not match the canonical constants, so "
+            "the parser falls back to scanning the whole file and the "
+            "bounding this class is named for never happens"
+        )
+
+    def test_headings_outside_the_pinned_region_do_not_inflate_the_count(self):
+        """The bounding itself, as a two-arm pair with DIFFERENT counts.
+
+        A Working Memory `### <date>` entry is an ordinary note, not a pin.
+        It stays outside the count while the terminating heading separates
+        it, and it JOINS the count when that heading is removed. One arm
+        alone certifies nothing: a parser that counted 1 unconditionally
+        would satisfy the separated arm on its own.
+
+        BOTH ARMS ARE `bounded=True`, AND THAT IS NOT AN OVERSIGHT. The
+        terminator pattern matches an H1/H2 heading OR a plugin boundary
+        marker, and `make_claude_md_with_pins` emits `<!-- PACT_MEMORY_END -->`
+        INSIDE the managed region. So that marker terminates the pinned
+        region whether or not the heading is present, and a fixture from this
+        helper can never read `bounded=False`. The heading governs WHICH
+        entries fall inside the region; the marker governs where the region
+        stops. Do not reach for this helper to build an unbounded fixture —
+        it agrees with itself on that axis. `case_5` in
+        test_pinned_terminator_repair.py is the shape that reaches
+        `bounded=False`, because its region carries no memory markers.
+        """
+        from pin_caps import apply_edit_and_parse
+        from shared.claude_md_manager import PINNED_TERMINATOR_HEADING
+
+        note = "### 2026-04-22\nAn ordinary Working Memory note.\n"
+        base = _managed_content(["<!-- pinned: 2026-04-21 -->\n### A\nBody A."])
+        separated = base.replace(
+            f"{PINNED_TERMINATOR_HEADING}\n",
+            f"{PINNED_TERMINATOR_HEADING}\n{note}",
+        )
+        absorbed = separated.replace(f"{PINNED_TERMINATOR_HEADING}\n", "")
+        assert separated != base, "fixture anchor absent: no terminating heading"
+        assert absorbed != separated, "fixture anchor absent: nothing removed"
+
+        separated_state = apply_edit_and_parse(
+            current_content="", tool_input={"content": separated}
+        )
+        absorbed_state = apply_edit_and_parse(
+            current_content="", tool_input={"content": absorbed}
+        )
+        assert len(separated_state.pins) == 1, (
+            "the Working Memory note was counted as a pin despite sitting "
+            "after the terminating heading"
+        )
+        assert [p.heading for p in absorbed_state.pins] == [
+            "### A", "### 2026-04-22",
+        ], (
+            "removing the terminating heading must absorb the note into the "
+            "pinned region; if it does not, the two arms agree and neither "
+            "certifies the bounding"
+        )
 
     def test_write_full_replacement_parses_pins(self):
         from pin_caps import apply_edit_and_parse
-        new = _managed_content(
-            "<!-- pinned: 2026-04-21 -->\n### A\nBody A.\n\n"
-        )
+        new = _managed_content(["<!-- pinned: 2026-04-21 -->\n### A\nBody A."])
         pins = apply_edit_and_parse(
             current_content="", tool_input={"content": new}
         ).pins
@@ -575,7 +655,7 @@ class TestApplyEditAndParse_Smoke:
 
     def test_edit_single_match_adds_pin(self):
         from pin_caps import apply_edit_and_parse
-        before = _managed_content("<!-- pinned: 2026-04-21 -->\n### A\nBody.\n\n")
+        before = _managed_content(["<!-- pinned: 2026-04-21 -->\n### A\nBody."])
         tool_input = {
             "old_string": "### A\nBody.\n",
             "new_string": "### A\nBody.\n\n<!-- pinned: 2026-04-21 -->\n### B\nBody B.\n",
@@ -588,10 +668,10 @@ class TestApplyEditAndParse_Smoke:
 
     def test_edit_replace_all_applies_all_matches(self):
         from pin_caps import apply_edit_and_parse
-        before = _managed_content(
-            "<!-- pinned: 2026-04-21 -->\n### A\nKEEP.\n\n"
-            "<!-- pinned: 2026-04-21 -->\n### B\nKEEP.\n\n"
-        )
+        before = _managed_content([
+            "<!-- pinned: 2026-04-21 -->\n### A\nKEEP.",
+            "<!-- pinned: 2026-04-21 -->\n### B\nKEEP.",
+        ])
         tool_input = {
             "old_string": "KEEP.",
             "new_string": "REPLACED.",
@@ -642,10 +722,10 @@ class TestApplyEditAndParse_Smoke:
         equals pre-state -> gate's net-worse contract kicks in normally.
         """
         from pin_caps import apply_edit_and_parse
-        before = _managed_content(
-            "<!-- pinned: 2026-04-21 -->\n### A\nBody A.\n\n"
-            "<!-- pinned: 2026-04-21 -->\n### B\nBody B.\n\n"
-        )
+        before = _managed_content([
+            "<!-- pinned: 2026-04-21 -->\n### A\nBody A.",
+            "<!-- pinned: 2026-04-21 -->\n### B\nBody B.",
+        ])
         tool_input = {
             "old_string": "",
             "new_string": "JUNK",
@@ -678,20 +758,35 @@ class TestApplyEditAndParse_Smoke:
         the SMUGGLED pin, not the original. Under the F6 no-op guard,
         the original managed region is preserved → parsed pins are the
         ORIGINAL pin.
+
+        BOTH REGIONS MUST USE THE CANONICAL MARKERS, and that is what makes
+        the paragraph above describe what actually runs. When the markers are
+        hand-spelled, `extract_managed_region` returns None for BOTH regions,
+        the parser scans the whole file, and the discrimination comes from
+        whole-file scan order instead of from first-region-wins. The test
+        still went red under revert, so the defect was invisible — it was
+        right for a reason its own docstring did not state. Repointing only
+        the OUTER fixture is worse than leaving both hand-spelled: the real
+        region would then be found, the smuggled one sits OUTSIDE it, and the
+        revert would parse `### A` and PASS. Measured, not reasoned.
         """
         from pin_caps import apply_edit_and_parse
-        before = _managed_content(
-            "<!-- pinned: 2026-04-21 -->\n### A\nBody A.\n\n"
+        from shared.claude_md_manager import (
+            MANAGED_END_MARKER,
+            MANAGED_START_MARKER,
         )
+        before = _managed_content(["<!-- pinned: 2026-04-21 -->\n### A\nBody A."])
         # Smuggle payload: a full synthetic managed region wrapping an
-        # "### Evil" pin. If str.replace runs (revert), this prepends a
-        # spurious managed region at position 0 that extract_managed_region
-        # captures first — parsed pins become [Evil], not [A].
+        # "### Evil" pin, built from the SAME constants as the real region.
+        # If str.replace runs (revert), this prepends a spurious managed
+        # region at position 0. `extract_managed_region` locates its start
+        # with `content.find`, so the FIRST region wins — parsed pins become
+        # [Evil], not [A].
         smuggle_payload = (
-            "<!-- PACT_MANAGED_START -->\n"
+            f"{MANAGED_START_MARKER}\n"
             "## Pinned Context\n"
             "<!-- pinned: 2026-04-21 -->\n### Evil\nevil body.\n\n"
-            "<!-- PACT_MANAGED_END -->\n"
+            f"{MANAGED_END_MARKER}\n"
         )
         tool_input = {
             "old_string": "",

--- a/pact-plugin/tests/test_pin_caps.py
+++ b/pact-plugin/tests/test_pin_caps.py
@@ -567,7 +567,9 @@ class TestApplyEditAndParse_Smoke:
         new = _managed_content(
             "<!-- pinned: 2026-04-21 -->\n### A\nBody A.\n\n"
         )
-        pins = apply_edit_and_parse(current_content="", tool_input={"content": new})
+        pins = apply_edit_and_parse(
+            current_content="", tool_input={"content": new}
+        ).pins
         assert len(pins) == 1
         assert pins[0].heading == "### A"
 
@@ -579,7 +581,9 @@ class TestApplyEditAndParse_Smoke:
             "new_string": "### A\nBody.\n\n<!-- pinned: 2026-04-21 -->\n### B\nBody B.\n",
             "replace_all": False,
         }
-        pins = apply_edit_and_parse(current_content=before, tool_input=tool_input)
+        pins = apply_edit_and_parse(
+            current_content=before, tool_input=tool_input
+        ).pins
         assert [p.heading for p in pins] == ["### A", "### B"]
 
     def test_edit_replace_all_applies_all_matches(self):
@@ -593,7 +597,9 @@ class TestApplyEditAndParse_Smoke:
             "new_string": "REPLACED.",
             "replace_all": True,
         }
-        pins = apply_edit_and_parse(current_content=before, tool_input=tool_input)
+        pins = apply_edit_and_parse(
+            current_content=before, tool_input=tool_input
+        ).pins
         assert all("REPLACED" in p.body for p in pins)
 
     def test_missing_pinned_section_returns_empty(self):
@@ -602,7 +608,7 @@ class TestApplyEditAndParse_Smoke:
         pins = apply_edit_and_parse(
             current_content="",
             tool_input={"content": "# Some\nRandom content.\n"},
-        )
+        ).pins
         assert pins == []
 
     def test_write_non_string_content_raises(self):
@@ -645,7 +651,9 @@ class TestApplyEditAndParse_Smoke:
             "new_string": "JUNK",
             "replace_all": True,
         }
-        pins = apply_edit_and_parse(current_content=before, tool_input=tool_input)
+        pins = apply_edit_and_parse(
+            current_content=before, tool_input=tool_input
+        ).pins
         # Pre-state has 2 pins; post-state must match.
         assert len(pins) == 2
         assert [p.heading for p in pins] == ["### A", "### B"]
@@ -690,7 +698,9 @@ class TestApplyEditAndParse_Smoke:
             "new_string": smuggle_payload,
             "replace_all": False,
         }
-        pins = apply_edit_and_parse(current_content=before, tool_input=tool_input)
+        pins = apply_edit_and_parse(
+            current_content=before, tool_input=tool_input
+        ).pins
         assert len(pins) == 1
         # Load-bearing assertion: the ORIGINAL pin heading survives, NOT
         # the smuggled one. Under revert, this assertion fails because

--- a/pact-plugin/tests/test_pin_caps_boundedness.py
+++ b/pact-plugin/tests/test_pin_caps_boundedness.py
@@ -952,37 +952,103 @@ class TestUnboundedButExactCountStillEnforces:
         assert (exact is None) != (phantom is None)
 
 
-class TestUntrustworthyPredicateIsShared:
-    """One definition, four consumers. A second copy is how the next
-    correction lands in one place and not the others."""
+class TestGateIsStricterThanStaleness:
+    """REWRITTEN, NOT DELETED. This class previously asserted that all
+    consumers import ONE predicate. That invariant was deliberately broken:
+    the gate and the staleness surfaces now resolve the uniformly-undated
+    class in OPPOSITE directions, because their remedies differ in kind.
 
-    def test_every_consumer_imports_the_same_symbol(self):
+    Deleting the test to let that change pass would have certified nothing.
+    It now encodes the NEW invariant, so it still fails if a future reader
+    collapses the two predicates together OR inverts which surface is
+    stricter.
+    """
+
+    @staticmethod
+    def _pin(dated):
+        from pin_caps import Pin
+
+        return Pin(
+            heading="### X",
+            body="b",
+            body_chars=1,
+            date_comment="<!-- pinned: 2026-07-30 -->" if dated else None,
+            override_rationale=None,
+            is_stale=False,
+        )
+
+    def test_gate_declines_wherever_staleness_does(self):
+        """The gate is a SUPERSET. Any input the staleness form calls
+        untrustworthy, the gate must too."""
+        from pin_caps import (
+            gate_count_is_untrustworthy,
+            region_count_is_untrustworthy,
+        )
+
+        p = self._pin
+        shapes = [
+            [], [p(True)], [p(False)], [p(False), p(False)],
+            [p(True), p(False)], [p(False), p(True)],
+            [p(True), p(True)], [p(True), p(False), p(True)],
+        ]
+        for bounded in (True, False):
+            for pins in shapes:
+                narrow = region_count_is_untrustworthy(bounded, pins)
+                wide = gate_count_is_untrustworthy(bounded, pins)
+                assert not (narrow and not wide), (
+                    f"gate is LESS strict than staleness on bounded={bounded} "
+                    f"{[x.date_comment is not None for x in pins]}"
+                )
+
+    def test_the_two_predicates_actually_differ(self):
+        """ANTI-VACUITY. If the two became identical the superset test would
+        still pass and the split would have been silently undone."""
+        from pin_caps import (
+            gate_count_is_untrustworthy,
+            region_count_is_untrustworthy,
+        )
+
+        undated_only = [self._pin(False)]
+        assert region_count_is_untrustworthy(False, undated_only) is False
+        assert gate_count_is_untrustworthy(False, undated_only) is True
+
+    def test_each_surface_imports_its_own_predicate(self):
+        """Pin WHICH predicate each surface uses, so an edit cannot quietly
+        swap one for the other."""
         import ast
         from pathlib import Path as _P
 
         hooks = _P(__file__).resolve().parent.parent / "hooks"
-        consumers = {
-            "pin_caps_gate.py": hooks / "pin_caps_gate.py",
-            "staleness.py": hooks / "staleness.py",
-            "session_init.py": hooks / "session_init.py",
+        expected = {
+            "pin_caps_gate.py": "gate_count_is_untrustworthy",
+            "session_init.py": "gate_count_is_untrustworthy",
+            "staleness.py": "region_count_is_untrustworthy",
         }
-        for label, path in consumers.items():
-            tree = ast.parse(path.read_text(encoding="utf-8"))
-            imported = any(
-                isinstance(n, ast.ImportFrom)
-                and any(a.name == "region_count_is_untrustworthy" for a in n.names)
-                for n in ast.walk(tree)
+        for filename, wanted in expected.items():
+            tree = ast.parse((hooks / filename).read_text(encoding="utf-8"))
+            names = {
+                a.name for n in ast.walk(tree)
+                if isinstance(n, ast.ImportFrom) for a in n.names
+            }
+            assert wanted in names, f"{filename} must import {wanted}"
+            other = (
+                "region_count_is_untrustworthy"
+                if wanted.startswith("gate")
+                else "gate_count_is_untrustworthy"
             )
-            assert imported, f"{label} does not import the shared predicate"
+            assert other not in names, (
+                f"{filename} imports {other}; the surfaces must not be crossed"
+            )
 
-    def test_no_consumer_reimplements_the_predicate(self):
-        """The predicate is defined ONCE. A redefinition anywhere else is a
-        twin that will drift — this predicate has already been wrong twice."""
+    def test_each_predicate_is_defined_exactly_once(self):
         import ast
         from pathlib import Path as _P
 
         root = _P(__file__).resolve().parent.parent
-        definers = []
+        found = {
+            "region_count_is_untrustworthy": [],
+            "gate_count_is_untrustworthy": [],
+        }
         for path in root.rglob("*.py"):
             if ".git" in path.parts:
                 continue
@@ -991,12 +1057,49 @@ class TestUntrustworthyPredicateIsShared:
             except (OSError, UnicodeDecodeError, SyntaxError):
                 continue
             for node in ast.walk(tree):
-                if (
-                    isinstance(node, ast.FunctionDef)
-                    and node.name == "region_count_is_untrustworthy"
-                ):
-                    definers.append(str(path.relative_to(root)))
-        assert definers == ["hooks/pin_caps.py"], (
-            f"the shared predicate is defined in {definers}; it must be "
-            f"defined exactly once"
+                if isinstance(node, ast.FunctionDef) and node.name in found:
+                    found[node.name].append(str(path.relative_to(root)))
+        for name, where in found.items():
+            assert where == ["hooks/pin_caps.py"], f"{name} defined in {where}"
+
+
+class TestBlockingFourUniformlyUndatedRegion:
+    """A region of absorbed notes with NO dated pin is uniformly undated, and
+    there the curator holds ZERO real pins. PR 1 fixed this; the first
+    remediation re-introduced it by adopting the staleness predicate at the
+    gate. The gate must DECLINE here."""
+
+    def test_curator_holding_zero_pins_may_add_a_note(self, gate_env):
+        content = _claude_md(real_pins=0, notes=14, bounded=False)
+        add_note = {
+            "old_string": "### 2026-07-14\n**Context**: routine session note.\n",
+            "new_string": (
+                "### 2026-07-14\n**Context**: routine session note.\n\n"
+                "### 2026-07-31\n**Context**: today's note.\n"
+            ),
+            "replace_all": False,
+        }
+        assert add_note["old_string"] in content, "fixture anchor missing"
+        reason, failures = _verdict(gate_env, content, add_note)
+        assert reason is None, (
+            f"cardinal over-block: the curator holds ZERO dated pins and was "
+            f"denied over 14 absorbed notes. Got {reason!r}"
         )
+        assert failures and failures[0]["classification"].startswith(
+            "pin_caps_gate_declined_unbounded"
+        )
+
+    def test_the_staleness_surface_still_enforces_here(self, gate_env):
+        """THE ASYMMETRY, asserted directly. The same region that makes the
+        GATE decline must leave the STALENESS predicate enforcing, because
+        this repository's legacy pins are uniformly undated and marking them
+        stale is correct."""
+        from pin_caps import parse_pins, region_count_is_untrustworthy
+        from staleness import _parse_pinned_section
+
+        content = _claude_md(real_pins=0, notes=14, bounded=False)
+        parsed = _parse_pinned_section(content)
+        assert parsed is not None and parsed.bounded is False
+        assert region_count_is_untrustworthy(
+            parsed.bounded, parse_pins(parsed.content)
+        ) is False

--- a/pact-plugin/tests/test_pin_caps_boundedness.py
+++ b/pact-plugin/tests/test_pin_caps_boundedness.py
@@ -396,7 +396,7 @@ def gate_env(tmp_path, monkeypatch, pact_context):
     return {"claude_md": claude_md, "failures": failures, "tmp_path": tmp_path}
 
 
-def _verdict(env, content: str, tool_input: dict):
+def _verdict(env, content: str, tool_input: dict, tool_name: str = "Edit"):
     """Run the gate and return (deny_reason, failures).
 
     THE BINDING CONTROL LIVES HERE, NOT IN A TEST OF ITS OWN, and that
@@ -429,7 +429,7 @@ def _verdict(env, content: str, tool_input: dict):
     from pin_caps_gate import _check_tool_allowed
     env["failures"].clear()
     reason = _check_tool_allowed({
-        "tool_name": "Edit",
+        "tool_name": tool_name,
         "agent_type": "pact-orchestrator",
         "tool_input": {"file_path": str(env["claude_md"]), **tool_input},
     })
@@ -649,3 +649,132 @@ class TestRegionStateContract:
 
         state = _parse_baseline(content)
         assert 0 < state.region_chars < len(content)
+
+
+# ---------------------------------------------------------------------------
+# The fresh-start arm: Write with an UNREADABLE baseline.
+#
+# REACHABILITY, because the obvious route does not exist. A NEW-FILE Write
+# cannot reach this arm: the resolver returns only a file that EXISTS, so with
+# no project CLAUDE.md the gate short-circuits and a genuinely new file is not
+# gated at all. The arm needs the file to EXIST and the READ to FAIL. The
+# fixture below models exactly that, rather than the missing-file route, so it
+# cannot certify behaviour on a path production never takes.
+#
+# The conjunct `pre.bounded` has NO REFERENT on this arm — there is no
+# pre-state. The gate therefore tests `post.bounded` alone.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def unreadable_baseline(gate_env, monkeypatch):
+    """The file EXISTS; the baseline READ fails. The real precondition."""
+    import pin_caps_gate
+
+    monkeypatch.setattr(
+        pin_caps_gate,
+        "_read_baseline",
+        lambda _path: (None, pin_caps_gate._FAIL_BASELINE_READ),
+    )
+    return gate_env
+
+
+def _write_verdict(env, written: str):
+    """Issue a Write of `written` against an existing-but-unreadable file."""
+    return _verdict(
+        env, written, {"content": written}, tool_name="Write"
+    )
+
+
+class TestFreshStartArmBoundedness:
+
+    def test_phantom_over_cap_is_allowed(self, unreadable_baseline):
+        """2 real pins measured as 14 must not deny on this arm either."""
+        written = _claude_md(real_pins=2, notes=12, bounded=False)
+        reason, failures = _write_verdict(unreadable_baseline, written)
+        assert reason is None, (
+            f"the fresh-start arm enforced on a phantom count: {reason!r}"
+        )
+        assert "pin_caps_gate_declined_unbounded_no_baseline" in [
+            f["classification"] for f in failures
+        ]
+
+    def test_genuine_over_cap_still_denies(self, unreadable_baseline):
+        """POSITIVE CONTROL, and it is what makes this suite non-vacuous.
+
+        The verdict is bound to `_WRITE_BASELINE_DENY_REASON`, which is
+        returned at NO other site in the module. A bare "it denied" would be
+        satisfied by any of the three other deny paths; this exact string
+        proves the test reached the arm it names.
+        """
+        from pin_caps_gate import _WRITE_BASELINE_DENY_REASON
+
+        written = _claude_md(real_pins=13, notes=0, bounded=True)
+        reason, _ = _write_verdict(unreadable_baseline, written)
+        assert reason == _WRITE_BASELINE_DENY_REASON, (
+            "the Sec N7 asymmetric fail-CLOSED posture must survive: a "
+            "GENUINE above-cap Write with no readable baseline still denies. "
+            "Declining unconditionally would delete this row, and this row "
+            "is the entire reason the fix is safe."
+        )
+
+    def test_clean_content_is_allowed(self, unreadable_baseline):
+        written = _claude_md(real_pins=2, notes=0, bounded=True)
+        reason, _ = _write_verdict(unreadable_baseline, written)
+        assert reason is None
+
+    def test_the_two_arms_disagree(self, unreadable_baseline):
+        """Mandatory anti-vacuity control.
+
+        Both writes are over the count cap BY MEASUREMENT (14 and 13). They
+        differ only in whether the measurement can be trusted.
+        """
+        phantom, _ = _write_verdict(
+            unreadable_baseline, _claude_md(real_pins=2, notes=12, bounded=False)
+        )
+        genuine, _ = _write_verdict(
+            unreadable_baseline, _claude_md(real_pins=13, notes=0, bounded=True)
+        )
+        assert (phantom is None) != (genuine is None)
+
+    def test_a_readable_baseline_does_not_take_this_arm(self, gate_env):
+        """The third certification row: with a readable baseline the normal
+        path runs and this arm is not taken. Bound by the unique string."""
+        from pin_caps_gate import _WRITE_BASELINE_DENY_REASON
+
+        written = _claude_md(real_pins=13, notes=0, bounded=True)
+        reason, _ = _write_verdict(gate_env, written)
+        assert reason != _WRITE_BASELINE_DENY_REASON
+
+    def test_the_deny_string_is_returned_at_no_other_site(self):
+        """The control that LICENSES the positive control above.
+
+        `test_genuine_over_cap_still_denies` proves it reached the fresh-start
+        arm only while this string is unique to that arm. If a later change
+        returns it from somewhere else, that proof silently degrades to a
+        bare "something denied" — so the uniqueness is asserted, not assumed.
+        """
+        import ast
+        import inspect
+
+        import pin_caps_gate
+
+        source = Path(pin_caps_gate.__file__).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        owners = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for inner in ast.walk(node):
+                if (
+                    isinstance(inner, ast.Return)
+                    and isinstance(inner.value, ast.Name)
+                    and inner.value.id == "_WRITE_BASELINE_DENY_REASON"
+                ):
+                    owners.add(node.name)
+        assert owners == {"_evaluate_write_as_fresh_start"}, (
+            f"the deny string is no longer unique to the fresh-start arm; "
+            f"returned from {sorted(owners)}. The positive control that "
+            f"binds a verdict to this arm is now vacuous."
+        )
+        assert inspect.isfunction(pin_caps_gate._evaluate_write_as_fresh_start)

--- a/pact-plugin/tests/test_pin_caps_boundedness.py
+++ b/pact-plugin/tests/test_pin_caps_boundedness.py
@@ -860,3 +860,126 @@ class TestFreshStartArmBoundedness:
             f"binds a verdict to this arm is now vacuous."
         )
         assert inspect.isfunction(pin_caps_gate._evaluate_write_as_fresh_start)
+
+
+# ---------------------------------------------------------------------------
+# BLOCKING 3: unboundedness ALONE must not switch the caps off.
+#
+# The decline originally read `not (pre.bounded and post.bounded)`. A
+# `## Pinned Context` that is genuinely the LAST section of the file is
+# unbounded — and if every entry in it carries a `<!-- pinned: -->` comment,
+# every entry is a real pin and the count is EXACT. The blunt predicate
+# declined there, so the gate ALLOWED a 14th pin onto a file already holding
+# 13 real ones, and it did so PERMANENTLY: that file has no undated entry
+# after a dated one, so `ensure_pinned_terminator` refuses on it every run.
+#
+# The arms below are the same shape as the phantom arms above and must read
+# the OPPOSITE way. That opposition is the whole test — a predicate that
+# declines on everything passes the phantom arms and fails these.
+# ---------------------------------------------------------------------------
+
+
+class TestUnboundedButExactCountStillEnforces:
+
+    def test_section_last_file_with_real_pins_is_unbounded(self, gate_env):
+        """Precondition control. If this fixture were BOUNDED the arms below
+        would pass for a reason that has nothing to do with the predicate."""
+        content = _claude_md(real_pins=13, notes=0, bounded=False)
+        from staleness import _parse_pinned_section
+
+        parsed = _parse_pinned_section(content)
+        assert parsed is not None
+        assert parsed.bounded is False, "fixture must reproduce the unbounded shape"
+
+    def test_thirteen_real_pins_still_denies(self, gate_env):
+        """The count is EXACT, so the cap must still enforce."""
+        content = _claude_md(real_pins=13, notes=0, bounded=False)
+        reason, failures = _verdict(gate_env, content, _ADD_A_PIN)
+        assert reason is not None, (
+            "the caps were switched OFF on a file whose count is exact: 13 "
+            "real dated pins, no absorbed content. Unboundedness alone is "
+            "NECESSARY BUT NOT SUFFICIENT for a phantom count."
+        )
+        assert failures == [], (
+            "an exact count must take the ENFORCING path, which writes no "
+            "decline entry"
+        )
+
+    def test_the_phantom_arm_still_declines(self, gate_env):
+        """Counter-control, and it is what stops the fix over-correcting.
+
+        Same unbounded region, but carrying absorbed notes after the dated
+        pins. A predicate that simply stopped declining would pass the arm
+        above and fail this one.
+        """
+        content = _claude_md(real_pins=2, notes=12, bounded=False)
+        reason, failures = _verdict(gate_env, content, _ADD_A_PIN)
+        assert reason is None
+        assert [f["classification"] for f in failures] == [
+            "pin_caps_gate_declined_unbounded_both"
+        ]
+
+    def test_the_two_unbounded_arms_disagree(self, gate_env):
+        """Mandatory anti-vacuity control.
+
+        BOTH files are unbounded and BOTH are over the count cap by
+        measurement. They differ only in whether the entries above the cap
+        are real. If they read the same verdict, the pair certifies nothing.
+        """
+        exact, _ = _verdict(
+            gate_env, _claude_md(real_pins=13, notes=0, bounded=False), _ADD_A_PIN
+        )
+        phantom, _ = _verdict(
+            gate_env, _claude_md(real_pins=2, notes=12, bounded=False), _ADD_A_PIN
+        )
+        assert (exact is None) != (phantom is None)
+
+
+class TestUntrustworthyPredicateIsShared:
+    """One definition, four consumers. A second copy is how the next
+    correction lands in one place and not the others."""
+
+    def test_every_consumer_imports_the_same_symbol(self):
+        import ast
+        from pathlib import Path as _P
+
+        hooks = _P(__file__).resolve().parent.parent / "hooks"
+        consumers = {
+            "pin_caps_gate.py": hooks / "pin_caps_gate.py",
+            "staleness.py": hooks / "staleness.py",
+            "session_init.py": hooks / "session_init.py",
+        }
+        for label, path in consumers.items():
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            imported = any(
+                isinstance(n, ast.ImportFrom)
+                and any(a.name == "region_count_is_untrustworthy" for a in n.names)
+                for n in ast.walk(tree)
+            )
+            assert imported, f"{label} does not import the shared predicate"
+
+    def test_no_consumer_reimplements_the_predicate(self):
+        """The predicate is defined ONCE. A redefinition anywhere else is a
+        twin that will drift — this predicate has already been wrong twice."""
+        import ast
+        from pathlib import Path as _P
+
+        root = _P(__file__).resolve().parent.parent
+        definers = []
+        for path in root.rglob("*.py"):
+            if ".git" in path.parts:
+                continue
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeDecodeError, SyntaxError):
+                continue
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.FunctionDef)
+                    and node.name == "region_count_is_untrustworthy"
+                ):
+                    definers.append(str(path.relative_to(root)))
+        assert definers == ["hooks/pin_caps.py"], (
+            f"the shared predicate is defined in {definers}; it must be "
+            f"defined exactly once"
+        )

--- a/pact-plugin/tests/test_pin_caps_boundedness.py
+++ b/pact-plugin/tests/test_pin_caps_boundedness.py
@@ -26,6 +26,7 @@ from shared.claude_md_manager import (  # noqa: E402
     MANAGED_END_MARKER,
     MANAGED_START_MARKER,
     extract_managed_region,
+    match_project_claude_md,
 )
 from staleness import _parse_pinned_section  # noqa: E402
 
@@ -305,3 +306,346 @@ class TestNoPositionalIndexReadOfParserResult:
             "keeps working after the shape change and reports nothing:\n"
             + "\n".join(findings)
         )
+
+
+# ---------------------------------------------------------------------------
+# The boundedness DECLINE at the gate.
+#
+# READ THE VACUITY HAZARD FIRST, because it decides the whole design below.
+#
+# The natural fixture pair for this fix is "the same good-faith action on an
+# unbounded file and on a bounded file". That pair DEMONSTRATED the defect,
+# and it is useless for certifying the FIX: before the fix the arms read DENY
+# and ALLOW, after the fix they read ALLOW and ALLOW. A pair that agrees is
+# one arm twice, so a gate that had been deleted outright would pass it.
+#
+# So the arms below discriminate on a property the fix does NOT erase:
+#
+#   ALLOW arm   unbounded region, 14 PHANTOM pins  -> allow, and the decline
+#               classification proves WHICH branch produced the allow.
+#   DENY arm    bounded region, 13 REAL pins       -> still denies.
+#
+# Both arms are "over the count cap" by measurement. They differ only in
+# whether the measurement can be trusted, which is exactly what the gate now
+# tests. An implementation that declines unconditionally reddens the DENY
+# arm; one that never declines reddens the ALLOW arm.
+# ---------------------------------------------------------------------------
+
+_REAL_PIN = "<!-- pinned: 2026-07-30 -->\n### Real pin {n}\nShort body.\n\n"
+_NOTE = "### 2026-07-{d:02d}\n**Context**: routine session note.\n\n"
+
+_TERMINATOR = "## Working Memory\n\n"
+
+
+def _claude_md(*, real_pins: int, notes: int, bounded: bool) -> str:
+    """Build a CLAUDE.md from the REAL marker constants.
+
+    Never hand-spell a marker here. `extract_managed_region` matches the
+    full literal; a short spelling returns None, the parser silently falls
+    back to the whole file, and every arm collapses onto the branch where
+    the correct and incorrect behaviours agree.
+
+    `bounded` inserts the terminating H2 BETWEEN the dated pins and the
+    undated notes. That position is the whole point: a terminator placed
+    after the notes bounds the region at the end it already had and leaves
+    the notes inside it, which is the same phantom count with `bounded`
+    reading True.
+    """
+    body = "".join(_REAL_PIN.format(n=i) for i in range(1, real_pins + 1))
+    if bounded:
+        body += _TERMINATOR
+    body += "".join(_NOTE.format(d=d) for d in range(1, notes + 1))
+    return (
+        "# PACT Framework and Managed Project Memory\n\n"
+        f"{MANAGED_START_MARKER}\n"
+        "## Pinned Context\n\n"
+        f"{body}"
+        f"{MANAGED_END_MARKER}\n"
+    )
+
+
+@pytest.fixture
+def gate_env(tmp_path, monkeypatch, pact_context):
+    """A gate harness whose CLAUDE.md is the one in `tmp_path`.
+
+    Captures `append_failure` so a decline is observable by a POSITIVE
+    value (its classification) rather than by an absence.
+    """
+    claude_md = tmp_path / "CLAUDE.md"
+    pact_context(
+        team_name="test-team",
+        session_id="session-boundedness",
+        project_dir=str(tmp_path),
+    )
+
+    import staleness
+    monkeypatch.setattr(
+        staleness, "get_project_claude_md_path", lambda: claude_md
+    )
+
+    failures: list[dict] = []
+
+    import pin_caps_gate
+    monkeypatch.setattr(
+        pin_caps_gate,
+        "append_failure",
+        lambda classification, error=None, cwd=None, source=None: failures.append(
+            {"classification": classification, "source": source}
+        ),
+    )
+    return {"claude_md": claude_md, "failures": failures, "tmp_path": tmp_path}
+
+
+def _verdict(env, content: str, tool_input: dict):
+    """Run the gate and return (deny_reason, failures).
+
+    THE BINDING CONTROL LIVES HERE, NOT IN A TEST OF ITS OWN, and that
+    placement is deliberate. `_check_tool_allowed` short-circuits to ALLOW
+    when the target does not resolve to the canonical project CLAUDE.md. A
+    harness whose path resolution escapes the temp directory therefore
+    reports ALLOW on EVERY arm — a clean, believable, and entirely false
+    result, which is how a first run of this exact measurement once
+    concluded "no defect here".
+
+    A control in a sibling test cannot prevent that: it passes while the
+    other tests report their false verdicts. So the precondition is
+    asserted on the path that PRODUCES the verdict, and a failure here
+    WITHHOLDS the verdict rather than annotating it.
+    """
+    env["claude_md"].write_text(content, encoding="utf-8")
+
+    canonical = match_project_claude_md(str(env["claude_md"]))
+    assert canonical is not None, (
+        "BINDING CONTROL FAILED: the gate would short-circuit before "
+        "reaching the arm under test, and every verdict below would read "
+        "ALLOW for a reason that has nothing to do with boundedness."
+    )
+    assert env["tmp_path"] in canonical.parents, (
+        f"BINDING CONTROL FAILED: canonical CLAUDE.md resolved to "
+        f"{canonical}, outside the temp directory. The harness is "
+        f"measuring the real repository file."
+    )
+
+    from pin_caps_gate import _check_tool_allowed
+    env["failures"].clear()
+    reason = _check_tool_allowed({
+        "tool_name": "Edit",
+        "agent_type": "pact-orchestrator",
+        "tool_input": {"file_path": str(env["claude_md"]), **tool_input},
+    })
+    return reason, list(env["failures"])
+
+
+# A legitimate, dated pin add. The action is identical in both arms.
+_ADD_A_PIN = {
+    "old_string": "### Real pin 1\nShort body.\n",
+    "new_string": (
+        "### Real pin 1\nShort body.\n\n"
+        "<!-- pinned: 2026-07-31 -->\n### Real pin new\nShort body.\n"
+    ),
+    "replace_all": False,
+}
+
+
+class TestBoundednessDecline:
+
+    def test_unbounded_phantom_over_cap_is_allowed(self, gate_env):
+        """The over-block fix. 2 real pins measured as 14 must NOT deny."""
+        content = _claude_md(real_pins=2, notes=12, bounded=False)
+        reason, failures = _verdict(gate_env, content, _ADD_A_PIN)
+        assert reason is None, (
+            f"cardinal over-block: a curator with 2 real pins was denied "
+            f"with {reason!r}"
+        )
+        assert [f["classification"] for f in failures] == [
+            "pin_caps_gate_declined_unbounded_both"
+        ], (
+            "the allow must come from the boundedness decline. Without this "
+            "the arm cannot tell 'declined' from 'evaluated and found clean', "
+            "and a deleted gate would pass."
+        )
+
+    def test_bounded_genuine_over_cap_still_denies(self, gate_env):
+        """Enforcement survives. 13 REAL pins on a bounded region deny."""
+        content = _claude_md(real_pins=13, notes=0, bounded=True)
+        reason, failures = _verdict(gate_env, content, _ADD_A_PIN)
+        assert reason is not None, (
+            "the gate stopped enforcing on a trustworthy measurement. A "
+            "decline on every input passes the allow arm and is wrong."
+        )
+        assert "cap" in reason.lower()
+        assert failures == [], (
+            "the ENFORCED path must write no failure_log entry: the log is "
+            "a bounded ring buffer and a per-call entry evicts real faults."
+        )
+
+    def test_the_two_arms_disagree(self, gate_env):
+        """Mandatory anti-vacuity control.
+
+        Both arms are over the count cap by measurement. If they read the
+        same verdict, the pair certifies nothing.
+        """
+        allow_reason, _ = _verdict(
+            gate_env, _claude_md(real_pins=2, notes=12, bounded=False),
+            _ADD_A_PIN,
+        )
+        deny_reason, _ = _verdict(
+            gate_env, _claude_md(real_pins=13, notes=0, bounded=True),
+            _ADD_A_PIN,
+        )
+        assert (allow_reason is None) != (deny_reason is None)
+
+    def test_ordinary_note_on_unbounded_region_is_allowed(self, gate_env):
+        """PRECEDENCE. This is the arm that catches a decline placed too low.
+
+        Appending an ordinary undated Working Memory note is the most
+        common action a curator takes. On an unbounded region that note
+        matches the embedded-pin smuggle signature, and the embedded-pin
+        test fires INSIDE `compute_deny_reason`, BEFORE either cap axis.
+
+        So a decline placed after the `compute_deny_reason` call leaves
+        this arm denying while the count and size arms are fixed. Move the
+        decline below that call and this test reddens; the two cap arms
+        above do not.
+        """
+        content = _claude_md(real_pins=2, notes=12, bounded=False)
+        add_note = {
+            "old_string": "### 2026-07-12\n**Context**: routine session note.\n",
+            "new_string": (
+                "### 2026-07-12\n**Context**: routine session note.\n\n"
+                "### 2026-07-31\n**Context**: today's note.\n"
+            ),
+            "replace_all": False,
+        }
+        assert add_note["old_string"] in content, "fixture anchor not present"
+        reason, failures = _verdict(gate_env, content, add_note)
+        assert reason is None, (
+            f"cardinal over-block on the most ordinary action there is. "
+            f"The decline is placed after compute_deny_reason. Got {reason!r}"
+        )
+        assert failures and failures[0]["classification"].startswith(
+            "pin_caps_gate_declined_unbounded"
+        )
+
+    def test_repair_edit_is_allowed_and_classified_pre(self, gate_env):
+        """The curator repairs the file by hand: pre unbounded, post bounded.
+
+        The gate MUST allow it, and the classification must say `_pre` —
+        the state the operator most needs to tell apart, because it is the
+        one where the file is getting BETTER.
+        """
+        content = _claude_md(real_pins=2, notes=12, bounded=False)
+        repair = {
+            "old_string": "### 2026-07-01\n",
+            "new_string": "## Working Memory\n\n### 2026-07-01\n",
+            "replace_all": False,
+        }
+        assert repair["old_string"] in content, "fixture anchor not present"
+        reason, failures = _verdict(gate_env, content, repair)
+        assert reason is None
+        assert [f["classification"] for f in failures] == [
+            "pin_caps_gate_declined_unbounded_pre"
+        ]
+
+
+class TestDeclineClassification:
+    """The mapping is total, and every value it returns is true of its input."""
+
+    def test_each_declining_pair_maps_to_its_own_value(self):
+        from pin_caps_gate import _decline_classification
+
+        assert _decline_classification(False, False).endswith("_both")
+        assert _decline_classification(True, False).endswith("_post")
+        assert _decline_classification(False, True).endswith("_pre")
+
+    def test_the_three_values_are_distinct(self):
+        """Anti-vacuity: three names that resolve to one string certify nothing."""
+        from pin_caps_gate import _decline_classification
+
+        values = {
+            _decline_classification(False, False),
+            _decline_classification(True, False),
+            _decline_classification(False, True),
+        }
+        assert len(values) == 3
+
+    def test_no_value_collides_with_a_gate_fault_code(self):
+        """A decline is NOT a gate fault and must not land in that population."""
+        import pin_caps_gate
+
+        fault_codes = {
+            getattr(pin_caps_gate, name)
+            for name in dir(pin_caps_gate)
+            if name.startswith("_FAIL_")
+        }
+        assert fault_codes, "control: the fault codes must be discoverable"
+        declines = {
+            pin_caps_gate._DECLINED_UNBOUNDED_BOTH,
+            pin_caps_gate._DECLINED_UNBOUNDED_POST,
+            pin_caps_gate._DECLINED_UNBOUNDED_PRE,
+        }
+        assert declines.isdisjoint(fault_codes)
+
+    def test_both_bounded_is_not_a_decline(self):
+        """Pin the unreachable default so it cannot become a silent wrong code.
+
+        Both-bounded does not decline, so it has no true classification.
+        The caller tests boundedness before calling, so this input does not
+        occur on the gate path. This test exists so that a future caller who
+        DOES route a bounded pair here meets a documented expectation rather
+        than a plausible-looking `_pre` entry in the operator's log.
+        """
+        from pin_caps_gate import _DECLINED_UNBOUNDED_BOTH, _decline_classification
+
+        assert _decline_classification(True, True) == _DECLINED_UNBOUNDED_BOTH
+
+
+class TestRegionStateContract:
+
+    def test_bounded_is_copied_from_the_parser_not_recomputed(self):
+        """One definition of boundedness. Two would drift.
+
+        Asserts the value the gate carries is the value the parser
+        produced, on both arms, so a second computation inserted anywhere
+        in between has to agree with the parser to stay green.
+        """
+        from pin_caps_gate import _parse_baseline
+
+        for bounded in (True, False):
+            content = _claude_md(real_pins=2, notes=12, bounded=bounded)
+            parsed = _parse_pinned_section(content)
+            assert parsed is not None
+            assert _parse_baseline(content).bounded is parsed.bounded
+
+    def test_the_two_parsers_agree_on_the_same_content(self):
+        """`_parse_baseline` and `apply_edit_and_parse` must not disagree."""
+        from pin_caps import apply_edit_and_parse
+        from pin_caps_gate import _parse_baseline
+
+        for bounded in (True, False):
+            content = _claude_md(real_pins=2, notes=12, bounded=bounded)
+            baseline = _parse_baseline(content)
+            simulated = apply_edit_and_parse("", {"content": content})
+            assert baseline.bounded is simulated.bounded
+            assert len(baseline.pins) == len(simulated.pins)
+            assert baseline.region_chars == simulated.region_chars
+
+    def test_absent_section_is_bounded_so_enforcement_is_unchanged(self):
+        """An absent region is exactly measurable, not untrustworthy.
+
+        bounded=False here would switch the control OFF for every file
+        with no Pinned Context section — a large population with no defect.
+        """
+        from pin_caps import apply_edit_and_parse
+        from pin_caps_gate import _parse_baseline
+
+        no_section = "# Some\nRandom content.\n"
+        assert _parse_baseline(no_section) == ([], 0, True)
+        assert apply_edit_and_parse("", {"content": no_section}) == ([], 0, True)
+
+    def test_region_chars_reports_the_region_not_the_file(self):
+        content = _claude_md(real_pins=2, notes=12, bounded=True)
+        from pin_caps_gate import _parse_baseline
+
+        state = _parse_baseline(content)
+        assert 0 < state.region_chars < len(content)

--- a/pact-plugin/tests/test_pin_caps_boundedness.py
+++ b/pact-plugin/tests/test_pin_caps_boundedness.py
@@ -527,6 +527,88 @@ class TestBoundednessDecline:
             "pin_caps_gate_declined_unbounded"
         )
 
+    def test_long_prose_on_unbounded_region_is_allowed(self, gate_env):
+        """ARM 3 OF SECTION 2.1 — the SIZE axis, through the real gate.
+
+        This is the arm the plan recorded, and it was the only one of the
+        three with no gate-level test. The two probes that carried it run no
+        gate at all: they reimplement the call sequence by hand, so a guard
+        placed correctly INSIDE `_check_tool_allowed` is invisible to them.
+
+        On an unbounded region a Working Memory note parses as a pin, so
+        appending ordinary prose to that note pushes a "pin" past
+        PIN_SIZE_CAP and denies on the size axis. The curator is told to
+        shrink a pin they do not have.
+        """
+        from pin_caps import PIN_SIZE_CAP
+
+        content = _claude_md(real_pins=2, notes=12, bounded=False)
+        anchor = "### 2026-07-12\n**Context**: routine session note.\n"
+        assert anchor in content, "fixture anchor not present"
+        long_prose = {
+            "old_string": anchor,
+            "new_string": anchor + "x" * (PIN_SIZE_CAP + 500) + "\n",
+            "replace_all": False,
+        }
+        reason, failures = _verdict(gate_env, content, long_prose)
+        assert reason is None, (
+            f"cardinal over-block on the size axis: ordinary prose appended "
+            f"to a Working Memory note denied as an oversized pin. "
+            f"Got {reason!r}"
+        )
+        assert [f["classification"] for f in failures] == [
+            "pin_caps_gate_declined_unbounded_both"
+        ], (
+            "the allow must come from the boundedness decline. ALLOW is also "
+            "what a gate that never reached this arm returns, so the verdict "
+            "alone cannot tell the two apart."
+        )
+
+    def test_the_bounded_controls_allow_by_evaluating_not_by_declining(
+        self, gate_env
+    ):
+        """THE BOUNDED CONTROLS for arms 1 and 3, and the reason they need a
+        different observable from the verdict.
+
+        Section 2.1 gives every arm a bounded control that ALLOWS. After the
+        fix the unbounded arm allows too, so an ALLOW/ALLOW pair is one arm
+        twice and a gate deleted outright satisfies it. What still separates
+        them is HOW the allow was reached: the unbounded arm allows by
+        DECLINING and writes a decline classification; the bounded arm allows
+        by EVALUATING the state and finding it clean, and writes nothing.
+
+        The failure log is a bounded ring buffer, so "writes nothing" is a
+        real requirement and not merely a convenient discriminator.
+        """
+        from pin_caps import PIN_SIZE_CAP
+
+        bounded = _claude_md(real_pins=2, notes=12, bounded=True)
+        note_anchor = "### 2026-07-12\n**Context**: routine session note.\n"
+        assert note_anchor in bounded, "fixture anchor not present"
+
+        arm1 = {
+            "old_string": note_anchor,
+            "new_string": note_anchor + "\n### 2026-07-31\n**Context**: today.\n",
+            "replace_all": False,
+        }
+        arm3 = {
+            "old_string": note_anchor,
+            "new_string": note_anchor + "x" * (PIN_SIZE_CAP + 500) + "\n",
+            "replace_all": False,
+        }
+        for label, tool_input in (("arm 1", arm1), ("arm 3", arm3)):
+            reason, failures = _verdict(gate_env, bounded, tool_input)
+            assert reason is None, (
+                f"{label} bounded control: a trustworthy region holding 2 "
+                f"real pins denied an ordinary Working Memory edit. "
+                f"Got {reason!r}"
+            )
+            assert failures == [], (
+                f"{label} bounded control allowed by DECLINING, not by "
+                f"evaluating. A gate that declines on every input passes the "
+                f"unbounded arms and is wrong. Got {failures!r}"
+            )
+
     def test_repair_edit_is_allowed_and_classified_pre(self, gate_env):
         """The curator repairs the file by hand: pre unbounded, post bounded.
 

--- a/pact-plugin/tests/test_pin_caps_boundedness.py
+++ b/pact-plugin/tests/test_pin_caps_boundedness.py
@@ -792,6 +792,23 @@ class TestFreshStartArmBoundedness:
         from pin_caps_gate import _WRITE_BASELINE_DENY_REASON
 
         written = _claude_md(real_pins=13, notes=0, bounded=True)
+
+        # THE STRING BINDS THE ARM, NOT THE CAUSE. `_WRITE_BASELINE_DENY_REASON`
+        # is returned from TWO sites inside this arm: the cap-violation path,
+        # and an `except Exception` that fires when `apply_edit_and_parse`
+        # RAISES -- before any cap is evaluated at all. A fixture with
+        # malformed tool_input would satisfy a bare string match while proving
+        # nothing about the cap logic. This control excludes that branch by
+        # showing the content parses cleanly, so the deny below can only have
+        # come from the cap.
+        from pin_caps import apply_edit_and_parse
+
+        probe = apply_edit_and_parse(current_content="", tool_input={"content": written})
+        assert len(probe.pins) == 13, (
+            f"precondition: the written content must PARSE, so the deny cannot "
+            f"come from the except-branch. Parsed {len(probe.pins)} pins."
+        )
+
         reason, _ = _write_verdict(unreadable_baseline, written)
         assert reason == _WRITE_BASELINE_DENY_REASON, (
             "the Sec N7 asymmetric fail-CLOSED posture must survive: a "

--- a/pact-plugin/tests/test_pin_caps_boundedness.py
+++ b/pact-plugin/tests/test_pin_caps_boundedness.py
@@ -1,0 +1,307 @@
+"""
+Location: pact-plugin/tests/test_pin_caps_boundedness.py
+Summary: Verification tests for the pinned-region boundedness contract --
+         `staleness.PinnedSection.bounded` and the tree-wide guard that no
+         consumer reads a `_parse_pinned_section` result by integer index.
+Used by: the pytest suite. Companion to hooks/staleness.py (the parser),
+         hooks/pin_caps.py and hooks/pin_caps_gate.py (the consumers).
+
+These are CODE-phase verification tests, not the full behavioural matrix.
+They pin two properties that a green suite cannot otherwise observe.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+_HOOKS = Path(__file__).resolve().parent.parent / "hooks"
+if str(_HOOKS) not in sys.path:
+    sys.path.insert(0, str(_HOOKS))
+
+from shared.claude_md_manager import (  # noqa: E402
+    MANAGED_END_MARKER,
+    MANAGED_START_MARKER,
+    extract_managed_region,
+)
+from staleness import _parse_pinned_section  # noqa: E402
+
+# Repository root that the tree-wide guard walks. Parent of `pact-plugin`.
+_PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _managed(body: str) -> str:
+    """Wrap `body` in the REAL managed markers.
+
+    Never hand-spell a marker in a fixture. `extract_managed_region` matches
+    the full literal, so a shortened spelling makes it return None, the
+    parser falls back to scanning the whole file, and every boundedness
+    assertion below silently collapses onto the agreeing branch.
+    """
+    return f"{MANAGED_START_MARKER}\n{body}{MANAGED_END_MARKER}\n"
+
+
+_PINS = (
+    "## Pinned Context\n"
+    "<!-- pinned: 2026-01-01 -->\n"
+    "### Real pin\n"
+    "Pin body.\n"
+    "\n"
+    "### 2026-07-30\n"
+    "An ordinary Working Memory note.\n"
+)
+
+# Same pins, plus the terminator heading that closes the section.
+UNBOUNDED_FIXTURE = _managed(_PINS)
+BOUNDED_FIXTURE = _managed(_PINS + "\n## Working Memory\n- entry\n")
+
+
+class TestPinnedSectionBounded:
+    """`bounded` must discriminate, and must use the SCAN-RELATIVE formula."""
+
+    @pytest.mark.parametrize(
+        "fixture", [UNBOUNDED_FIXTURE, BOUNDED_FIXTURE]
+    )
+    def test_fixture_is_actually_managed(self, fixture):
+        """Per-fixture managed-state control.
+
+        MANDATORY, and it is not ceremony. On a file with no managed
+        markers the scan text IS the full content, so the correct and the
+        incorrect boundedness formulas coincide. A fixture that lost its
+        markers therefore passes every assertion below while measuring
+        nothing.
+        """
+        assert extract_managed_region(fixture) is not None
+
+    def test_unbounded_region_reports_not_bounded(self):
+        parsed = _parse_pinned_section(UNBOUNDED_FIXTURE)
+        assert parsed is not None
+        assert parsed.bounded is False
+
+    def test_bounded_region_reports_bounded(self):
+        parsed = _parse_pinned_section(BOUNDED_FIXTURE)
+        assert parsed is not None
+        assert parsed.bounded is True
+
+    def test_the_two_arms_disagree(self):
+        """Anti-vacuity control.
+
+        The two fixtures differ in ONE property: whether a `## Working
+        Memory` heading follows the pins. If both arms read the same, the
+        pair is one arm twice and the tests above certify nothing.
+        """
+        unbounded = _parse_pinned_section(UNBOUNDED_FIXTURE)
+        bounded = _parse_pinned_section(BOUNDED_FIXTURE)
+        assert unbounded is not None and bounded is not None
+        assert unbounded.bounded != bounded.bounded
+
+    def test_full_file_formula_would_disagree_on_a_marked_file(self):
+        """Pin the FORMULA, not only its result on this fixture.
+
+        `bounded` MUST come from the scan-relative locals
+        (`pinned_end < len(scan_text)`), computed before the managed-region
+        offset is added. The full-file form (`end < len(content)`) is the
+        one a reader naturally reaches for at the return statement, because
+        the offsets in hand there are already absolute.
+
+        On any MARKED file the full-file form is unconditionally True: the
+        scanned text is sliced to stop BEFORE `PACT_MANAGED_END`, so the
+        closing marker always follows it. This asserts the two forms
+        DIVERGE here and that `bounded` took the correct one. Swap the
+        implementation to the full-file form and this test reddens.
+        """
+        parsed = _parse_pinned_section(UNBOUNDED_FIXTURE)
+        assert parsed is not None
+        assert parsed.end < len(UNBOUNDED_FIXTURE), (
+            "precondition: the full-file form must read True here, "
+            "otherwise this test cannot discriminate the two formulas"
+        )
+        assert parsed.bounded is False, (
+            "bounded was computed from the full-file offsets. Use the "
+            "scan-relative locals: pinned_end < len(scan_text)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tree-wide guard: no integer-index read of a _parse_pinned_section result.
+#
+# WHY THIS IS TEXTUAL AND NOT BEHAVIOURAL. A three-name positional unpack of
+# the four-field NamedTuple raises ValueError, so those consumers announce
+# themselves. An INDEX read does not: `parsed[2]` and `parsed.content` return
+# the identical object on a NamedTuple, so a site left un-migrated keeps
+# working and the suite stays green. A behavioural check cannot see it, which
+# is exactly what "survives silently" means.
+# ---------------------------------------------------------------------------
+
+_PARSER_NAME = "_parse_pinned_section"
+
+
+_SCOPE_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Module)
+
+
+def _walk_scope(scope: ast.AST):
+    """Yield every descendant of `scope` WITHOUT entering a nested scope.
+
+    Scoping is load-bearing here, not tidiness. A module-wide analysis binds
+    a variable name in one function and then reports a same-named variable
+    in another. This detector caught exactly that on its first run: a
+    `parsed` bound from `parse_pins` in one test was reported against a
+    `parsed` bound from `_parse_pinned_section` in a different helper. The
+    finding was real detection with false attribution, which is a wrong
+    answer and not a gap.
+    """
+    for child in ast.iter_child_nodes(scope):
+        if isinstance(child, _SCOPE_NODES):
+            continue
+        yield child
+        yield from _walk_scope(child)
+
+
+def _index_reads_in_one_scope(scope: ast.AST) -> list[tuple[str, int]]:
+    """Bind and report within a SINGLE scope. See `_walk_scope`."""
+    bound: set[str] = set()
+    for node in _walk_scope(scope):
+        if not isinstance(node, ast.Assign):
+            continue
+        call = node.value
+        if not isinstance(call, ast.Call):
+            continue
+        func = call.func
+        called = (
+            func.id if isinstance(func, ast.Name)
+            else func.attr if isinstance(func, ast.Attribute)
+            else ""
+        )
+        if called != _PARSER_NAME:
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                bound.add(target.id)
+
+    if not bound:
+        return []
+
+    findings: list[tuple[str, int]] = []
+    for node in _walk_scope(scope):
+        if not isinstance(node, ast.Subscript):
+            continue
+        value = node.value
+        if not isinstance(value, ast.Name) or value.id not in bound:
+            continue
+        index = node.slice
+        if isinstance(index, ast.Constant) and isinstance(index.value, int):
+            findings.append((value.id, node.lineno))
+    return findings
+
+
+def _index_reads_of_parser_result(source: str) -> list[tuple[str, int]]:
+    """Return (variable, lineno) for every integer-index read of a parser result.
+
+    Finds names bound from a `_parse_pinned_section(...)` call (in any
+    spelling: bare, `staleness._parse_pinned_section`, or a module alias),
+    then reports any `name[<int>]` subscript on one of those names IN THE
+    SAME SCOPE.
+    """
+    tree = ast.parse(source)
+    scopes = [tree] + [
+        node for node in ast.walk(tree) if isinstance(node, _SCOPE_NODES[:3])
+    ]
+    findings: list[tuple[str, int]] = []
+    for scope in scopes:
+        findings.extend(_index_reads_in_one_scope(scope))
+    return sorted(findings, key=lambda item: item[1])
+
+
+def _python_sources() -> list[Path]:
+    return [
+        path
+        for path in _PLUGIN_ROOT.rglob("*.py")
+        if ".git" not in path.parts
+    ]
+
+
+class TestNoPositionalIndexReadOfParserResult:
+
+    def test_detector_fires_on_a_known_violation(self):
+        """Positive control for the detector itself.
+
+        A tree scan that reports zero findings is indistinguishable from a
+        scan whose detector is broken. Feed it the exact shape the two
+        migrated sites used and require a hit.
+        """
+        violation = (
+            "def helper(content):\n"
+            "    parsed = _parse_pinned_section(content)\n"
+            "    return parsed[2]\n"
+        )
+        assert _index_reads_of_parser_result(violation) == [("parsed", 3)]
+
+    def test_detector_accepts_the_migrated_shape(self):
+        """Counter-control: the correct shape must NOT be reported."""
+        migrated = (
+            "def helper(content):\n"
+            "    parsed = _parse_pinned_section(content)\n"
+            "    return parsed.content\n"
+        )
+        assert _index_reads_of_parser_result(migrated) == []
+
+    def test_detector_does_not_bind_across_scopes(self):
+        """The detector must not report a same-named variable in ANOTHER
+        function that was bound from a different call.
+
+        This is the false positive the first run produced. Without
+        per-scope binding the module-level `parsed` from the parser leaks
+        onto an unrelated `parsed` from `parse_pins`, and the guard
+        reports a site that is correct.
+        """
+        two_scopes = (
+            "def uses_the_parser(content):\n"
+            "    parsed = _parse_pinned_section(content)\n"
+            "    return parsed.content\n"
+            "\n"
+            "def uses_something_else(source):\n"
+            "    parsed = parse_pins(source)\n"
+            "    return parsed[0]\n"
+        )
+        assert _index_reads_of_parser_result(two_scopes) == []
+
+    def test_scan_reaches_the_files_that_call_the_parser(self):
+        """Non-empty-input control for the tree walk.
+
+        Without this, an empty rglob, a wrong root, or a rename of the
+        parser would produce a green "no findings" that means nothing.
+        """
+        callers = [
+            path for path in _python_sources()
+            if f"{_PARSER_NAME}(" in path.read_text(encoding="utf-8")
+        ]
+        assert len(callers) >= 7, (
+            f"expected the parser's call sites to be reachable from "
+            f"{_PLUGIN_ROOT}, found {len(callers)}"
+        )
+
+    def test_no_index_read_survives_anywhere_in_the_tree(self):
+        findings: list[str] = []
+        for path in _python_sources():
+            try:
+                source = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            if f"{_PARSER_NAME}" not in source:
+                continue
+            try:
+                hits = _index_reads_of_parser_result(source)
+            except SyntaxError:
+                continue
+            findings.extend(
+                f"{path}:{lineno}: {name}[...]" for name, lineno in hits
+            )
+        assert findings == [], (
+            "integer-index read of a _parse_pinned_section result. It "
+            "returns a PinnedSection; read it by field name. An index read "
+            "keeps working after the shape change and reports nothing:\n"
+            + "\n".join(findings)
+        )

--- a/pact-plugin/tests/test_pinned_terminator_repair.py
+++ b/pact-plugin/tests/test_pinned_terminator_repair.py
@@ -26,7 +26,7 @@ _HOOKS = Path(__file__).resolve().parent.parent / "hooks"
 if str(_HOOKS) not in sys.path:
     sys.path.insert(0, str(_HOOKS))
 
-from pin_caps import parse_pins  # noqa: E402
+from pin_caps import PIN_COUNT_CAP, parse_pins  # noqa: E402
 from shared.claude_md_manager import (  # noqa: E402
     MANAGED_END_MARKER,
     MANAGED_START_MARKER,
@@ -87,12 +87,39 @@ def measure(content: str) -> tuple[int, bool]:
 
 @pytest.fixture
 def project(tmp_path, monkeypatch):
-    """A project dir whose CLAUDE.md the repair will resolve and write."""
+    """A project dir whose CLAUDE.md the repair will resolve and write.
+
+    ISOLATION IS BY `CLAUDE_PROJECT_DIR`, NOT BY PATCHING THE RESOLVER, and
+    the difference is not stylistic. `session_init` binds
+    `_get_project_claude_md_path` at MODULE IMPORT, so a
+    `monkeypatch.setattr(staleness, ...)` never reaches the SessionStart
+    directive — while `claude_md_manager` imports the same name INSIDE the
+    function, where the identical patch does take effect. One target is
+    correct for one consumer and dead for the other in the same test file,
+    and the dead half reads exactly like the live half. The environment
+    variable is read at call time on every path, so it removes the accident
+    instead of detecting it.
+
+    THE CONTROL BELOW IS BINDING AND IT IS HERE RATHER THAN IN A TEST OF ITS
+    OWN. If the resolver escapes the temp directory, every consumer of this
+    fixture silently measures the REAL repository CLAUDE.md — which reports
+    a clean, plausible, entirely false result. Asserting it on the path that
+    PRODUCES the fixture means a miss raises before any verdict exists,
+    rather than annotating one that has already been believed.
+    """
     monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
     claude_md = tmp_path / "CLAUDE.md"
 
     def write(content: str) -> Path:
         claude_md.write_text(content, encoding="utf-8")
+
+        import staleness
+        resolved = staleness.get_project_claude_md_path()
+        assert resolved is not None and resolved == claude_md, (
+            f"BINDING CONTROL FAILED: the project CLAUDE.md resolved to "
+            f"{resolved}, not to {claude_md}. The test would measure a file "
+            f"outside the temp directory and report a verdict about it."
+        )
         return claude_md
 
     write.path = claude_md  # type: ignore[attr-defined]
@@ -656,14 +683,23 @@ class TestFrameTypeDoesNotChangeTheOutcome:
 # out sat under the second heading, synced and pruned by nothing.
 # ---------------------------------------------------------------------------
 
+#
+# THE PIN COUNT IS SIZED FROM `REAL_PINS` AND `NOTES`, NOT HAND-WRITTEN, and
+# that is what keeps `test_the_gate_declines_on_the_refused_file` honest. An
+# earlier three-note version parsed 5 phantom pins against a cap of 12 — UNDER
+# the cap, where an ENFORCING gate allows as well. Its `assert reason is None`
+# therefore PASSED under a removed decline (measured, not supposed), so the
+# classification assertion beside it carried the whole discriminating power.
+# Sharing the constants with `case_5` puts the count above the cap and keeps it
+# there as those constants move.
 WM_HEADING_ABOVE_PINS = (
     "# PACT Framework and Managed Project Memory\n\n"
     f"{MANAGED_START_MARKER}\n"
     f"{PINNED_TERMINATOR_HEADING}\n"
     "- an existing note\n\n"
     "## Pinned Context\n\n"
-    + "".join(_REAL_PIN.format(n=i) for i in (1, 2))
-    + "".join(_NOTE.format(d=d) for d in range(1, 4))
+    + "".join(_REAL_PIN.format(n=i) for i in range(1, REAL_PINS + 1))
+    + "".join(_NOTE.format(d=d) for d in range(1, NOTES + 1))
     + f"{MANAGED_END_MARKER}\n"
 )
 
@@ -678,7 +714,18 @@ class TestGuard3ExistingWorkingMemoryHeading:
         """
         assert WM_HEADING_ABOVE_PINS.count(PINNED_TERMINATOR_HEADING) == 1
         count, bounded = measure(WM_HEADING_ABOVE_PINS)
-        assert (count, bounded) == (5, False)
+        assert (count, bounded) == (REAL_PINS + NOTES, False)
+        # The cap comparison is not decoration. It is the property that keeps
+        # the decline test's VERDICT assertion alive: below the cap an
+        # enforcing gate allows too. Shrink the fixture, or raise the cap
+        # above it, and this reddens HERE rather than going quietly vacuous
+        # one class down.
+        assert count > PIN_COUNT_CAP, (
+            f"the fixture parses {count} phantom pins against a cap of "
+            f"{PIN_COUNT_CAP}. It must sit ABOVE the cap, or an enforcing "
+            f"gate allows on it and the decline cannot be told apart from a "
+            f"clean evaluation."
+        )
 
     def test_the_repair_refuses_and_writes_nothing(self, project):
         path = project(WM_HEADING_ABOVE_PINS)
@@ -740,19 +787,19 @@ class TestGuard3ExistingWorkingMemoryHeading:
         """THE ASSERTION THAT MATTERS, and it is not the refusal.
 
         A refusal that left the gate ENFORCING would be the impossible-cure
-        over-block again: the region still parses 5 pins against a real 2,
-        and a curator would be denied for pins they do not have. So the
-        refusal is only safe because the gate declines on it. Assert the
-        DECLINE, not the refusal.
+        over-block again: the region still parses REAL_PINS + NOTES pins
+        against a real REAL_PINS, over the cap, and a curator would be denied
+        for pins they do not have. So the refusal is only safe because the
+        gate declines on it. Assert the DECLINE, not the refusal.
+
+        BOTH assertions below are independently live, and that is a property
+        of the FIXTURE rather than of the assertions. Binding control 2 holds
+        it.
         """
         pact_context(
             team_name="test-team",
             session_id="session-guard3",
             project_dir=str(project.path.parent),
-        )
-        import staleness
-        monkeypatch.setattr(
-            staleness, "get_project_claude_md_path", lambda: project.path
         )
 
         failures: list[dict] = []
@@ -767,13 +814,28 @@ class TestGuard3ExistingWorkingMemoryHeading:
         path = project(WM_HEADING_ABOVE_PINS)
         assert ensure_pinned_terminator() is not None, "precondition: refused"
 
-        # BINDING CONTROL: without this the gate short-circuits on a
+        # BINDING CONTROL 1, REACH: without this the gate short-circuits on a
         # non-matching path and reports ALLOW for a reason unrelated to
         # boundedness. Placed before the verdict so a miss withholds it.
         canonical = match_project_claude_md(str(path))
         assert canonical is not None and path.parent in canonical.parents, (
             "BINDING CONTROL FAILED: the gate would short-circuit before "
             "reaching the boundedness decline."
+        )
+
+        # BINDING CONTROL 2, DISCRIMINABILITY: the refused file must parse
+        # ABOVE the cap, or `reason is None` below is equally true of an
+        # ENFORCING gate and certifies nothing. Not hypothetical — on the
+        # earlier under-cap fixture that assertion passed with the decline
+        # deleted. Placed before the verdict so a fixture that drifts back
+        # under the cap WITHHOLDS the verdict rather than reporting a false
+        # clean one.
+        count, bounded = measure(path.read_text(encoding="utf-8"))
+        assert bounded is False and count > PIN_COUNT_CAP, (
+            f"BINDING CONTROL FAILED: the refused file parses {count} pins "
+            f"(bounded={bounded}) against a cap of {PIN_COUNT_CAP}. Under "
+            f"the cap an enforcing gate also allows, so the verdict below "
+            f"cannot tell a decline from an enforcement."
         )
 
         reason = pin_caps_gate._check_tool_allowed({
@@ -791,9 +853,153 @@ class TestGuard3ExistingWorkingMemoryHeading:
         })
         assert reason is None, (
             f"the refused file must be DECLINED, not enforced. The region "
-            f"still parses 5 pins against a real 2, so enforcing here denies "
-            f"a curator for pins they do not have. Got {reason!r}"
+            f"still parses {count} pins against a real {REAL_PINS}, so "
+            f"enforcing here denies a curator for pins they do not have. "
+            f"Got {reason!r}"
         )
         assert [f["classification"] for f in failures] == [
             "pin_caps_gate_declined_unbounded_both"
         ], "the allow must come from the boundedness decline, not from a clean evaluation"
+
+
+# ---------------------------------------------------------------------------
+# Guard 3, SUBSTRING CASE: a pin BODY that mentions the terminator literal.
+#
+# Guard 3 tests `PINNED_TERMINATOR_HEADING in region_text` — a substring test,
+# not a heading test. So a pin whose body mentions "## Working Memory" in prose
+# trips it, and the repair refuses on a file that carries no such heading.
+#
+# THAT IS THE SAFE DIRECTION, AND THIS FIXTURE ASSERTS THE DIRECTION RATHER
+# THAN MERELY THE REFUSAL. Refusing leaves the region UNBOUNDED, and the gate
+# declines on an unbounded region — so the caps stay off and no curator is
+# denied for phantom pins. Over-caution costs one unenforced file. The opposite
+# error costs a curator a deny they cannot cure, which is the whole defect this
+# PR removes.
+#
+# THE MENTION MUST NOT SIT AT THE START OF A LINE, and that is what makes this
+# a substring case at all. `_find_terminator_offset` matches `#{1,2}\s` against
+# each line, so a line-initial mention IS a real terminator: the region would
+# read bounded, the repair would no-op at the earlier check, and guard 3 would
+# never be reached. An inline mention is invisible to the line scan and visible
+# to the substring test, which is exactly the gap.
+# ---------------------------------------------------------------------------
+
+_PIN_BODY_MENTIONS_TERMINATOR = (
+    "<!-- pinned: 2026-07-30 -->\n"
+    "### Real pin 1\n"
+    f"Keep the `{PINNED_TERMINATOR_HEADING}` heading below the pins.\n\n"
+)
+
+TERMINATOR_INSIDE_A_PIN_BODY = (
+    "# PACT Framework and Managed Project Memory\n\n"
+    f"{MANAGED_START_MARKER}\n"
+    "## Pinned Context\n\n"
+    + _PIN_BODY_MENTIONS_TERMINATOR
+    + "".join(_REAL_PIN.format(n=i) for i in range(2, REAL_PINS + 1))
+    + "".join(_NOTE.format(d=d) for d in range(1, NOTES + 1))
+    + f"{MANAGED_END_MARKER}\n"
+)
+
+
+class TestGuard3TerminatorLiteralInsideAPinBody:
+
+    def test_the_mention_is_a_substring_and_not_a_heading(self):
+        """PRECONDITION CONTROL, and it is what makes this class about the
+        substring test rather than about an ordinary heading.
+
+        RED input: move the mention to the start of a line. The line scan
+        then finds a real terminator, the region reads bounded, and every
+        assertion below stops being about guard 3.
+        """
+        assert PINNED_TERMINATOR_HEADING in TERMINATOR_INSIDE_A_PIN_BODY
+        assert not any(
+            line.startswith(PINNED_TERMINATOR_HEADING)
+            for line in TERMINATOR_INSIDE_A_PIN_BODY.splitlines()
+        ), (
+            "the mention sits at the start of a line, so it is a REAL "
+            "terminator and the region is bounded. This class would then "
+            "test the bounded no-op, not the substring guard."
+        )
+        count, bounded = measure(TERMINATOR_INSIDE_A_PIN_BODY)
+        assert bounded is False, (
+            "the region must be unbounded, or the repair no-ops at the "
+            "earlier bounded check and never reaches guard 3"
+        )
+        assert count > PIN_COUNT_CAP, (
+            f"the fixture parses {count} phantom pins against a cap of "
+            f"{PIN_COUNT_CAP}. Below the cap an enforcing gate allows too, "
+            f"and the decline assertion below would certify nothing."
+        )
+
+    def test_the_repair_refuses_and_writes_nothing(self, project):
+        """The substring test wins over the absent heading, and refusing is
+        the direction that leaves the safe state."""
+        path = project(TERMINATOR_INSIDE_A_PIN_BODY)
+        status = ensure_pinned_terminator()
+
+        assert status is not None and "skipped" in status.lower(), (
+            f"expected a refusal. A SUCCESS here would mean the repair "
+            f"placed a terminator on a file whose only mention of one is "
+            f"prose inside a pin body. Got {status!r}"
+        )
+        assert path.read_text(encoding="utf-8") == TERMINATOR_INSIDE_A_PIN_BODY, (
+            "guard 3 must not write"
+        )
+
+    def test_refusing_leaves_the_region_unbounded_so_the_caps_stay_off(
+        self, project, monkeypatch, pact_context
+    ):
+        """THE DIRECTION, ASSERTED. A refusal is only safe because the gate
+        declines on what it leaves behind."""
+        pact_context(
+            team_name="test-team",
+            session_id="session-guard3-substring",
+            project_dir=str(project.path.parent),
+        )
+
+        failures: list[dict] = []
+        import pin_caps_gate
+        monkeypatch.setattr(
+            pin_caps_gate,
+            "append_failure",
+            lambda classification, error=None, cwd=None, source=None:
+                failures.append({"classification": classification}),
+        )
+
+        path = project(TERMINATOR_INSIDE_A_PIN_BODY)
+        assert ensure_pinned_terminator() is not None, "precondition: refused"
+
+        # BINDING CONTROL 1, REACH.
+        canonical = match_project_claude_md(str(path))
+        assert canonical is not None and path.parent in canonical.parents, (
+            "BINDING CONTROL FAILED: the gate would short-circuit before "
+            "reaching the boundedness decline."
+        )
+        # BINDING CONTROL 2, DISCRIMINABILITY.
+        count, bounded = measure(path.read_text(encoding="utf-8"))
+        assert bounded is False and count > PIN_COUNT_CAP, (
+            f"BINDING CONTROL FAILED: {count} pins, bounded={bounded}. "
+            f"Under the cap an enforcing gate also allows."
+        )
+
+        reason = pin_caps_gate._check_tool_allowed({
+            "tool_name": "Edit",
+            "agent_type": "pact-orchestrator",
+            "tool_input": {
+                "file_path": str(path),
+                "old_string": "### Real pin 2\nShort body.\n",
+                "new_string": (
+                    "### Real pin 2\nShort body.\n\n"
+                    "<!-- pinned: 2026-07-31 -->\n### Real pin new\nBody.\n"
+                ),
+                "replace_all": False,
+            },
+        })
+        assert reason is None, (
+            f"the refused file must be DECLINED. It parses {count} pins "
+            f"against a real {REAL_PINS}, so enforcing denies a curator for "
+            f"pins they do not have. Got {reason!r}"
+        )
+        assert [f["classification"] for f in failures] == [
+            "pin_caps_gate_declined_unbounded_both"
+        ], "the allow must come from the decline, not from a clean evaluation"

--- a/pact-plugin/tests/test_pinned_terminator_repair.py
+++ b/pact-plugin/tests/test_pinned_terminator_repair.py
@@ -32,6 +32,7 @@ from shared.claude_md_manager import (  # noqa: E402
     MANAGED_START_MARKER,
     PINNED_TERMINATOR_HEADING,
     ensure_pinned_terminator,
+    match_project_claude_md,
     migrate_to_managed_structure,
 )
 from staleness import _parse_pinned_section  # noqa: E402
@@ -639,3 +640,160 @@ class TestFrameTypeDoesNotChangeTheOutcome:
             f"{(REAL_PINS, True)}. Convergence alone is not the property — "
             f"two frames agreeing on 14 phantom pins would also be equal."
         )
+
+
+# ---------------------------------------------------------------------------
+# Guard 3: a `## Working Memory` heading already exists in the managed region.
+#
+# THE REPAIR CREATED THIS DEFECT; IT DID NOT INHERIT IT. Measured before the
+# guard existed: on a file whose Working Memory heading sits ABOVE
+# `## Pinned Context`, the repair inserted a SECOND one. The pin outcome was
+# correct (5 pins to 2, bounded) and the repair was idempotent, so nothing in
+# the cap suite could see it. The damage showed up in a DIFFERENT module:
+# `working_memory._parse_working_memory_section` locates its section with
+# `re.search`, which takes the FIRST match, so the pact-memory writer kept
+# maintaining the heading above the pins while the entries the repair moved
+# out sat under the second heading, synced and pruned by nothing.
+# ---------------------------------------------------------------------------
+
+WM_HEADING_ABOVE_PINS = (
+    "# PACT Framework and Managed Project Memory\n\n"
+    f"{MANAGED_START_MARKER}\n"
+    f"{PINNED_TERMINATOR_HEADING}\n"
+    "- an existing note\n\n"
+    "## Pinned Context\n\n"
+    + "".join(_REAL_PIN.format(n=i) for i in (1, 2))
+    + "".join(_NOTE.format(d=d) for d in range(1, 4))
+    + f"{MANAGED_END_MARKER}\n"
+)
+
+
+class TestGuard3ExistingWorkingMemoryHeading:
+
+    def test_the_fixture_is_the_measured_broken_input(self, project):
+        """Precondition control, pinning the three rows I measured.
+
+        Without this the guard could be passing because the fixture stopped
+        reproducing the condition rather than because the guard works.
+        """
+        assert WM_HEADING_ABOVE_PINS.count(PINNED_TERMINATOR_HEADING) == 1
+        count, bounded = measure(WM_HEADING_ABOVE_PINS)
+        assert (count, bounded) == (5, False)
+
+    def test_the_repair_refuses_and_writes_nothing(self, project):
+        path = project(WM_HEADING_ABOVE_PINS)
+        status = ensure_pinned_terminator()
+
+        assert status is not None and "skipped" in status.lower()
+        after = path.read_text(encoding="utf-8")
+        assert after == WM_HEADING_ABOVE_PINS, "guard 3 must not write"
+        assert after.count(PINNED_TERMINATOR_HEADING) == 1, (
+            "the second heading reappeared. Without the guard the repair "
+            "inserts one, and the pact-memory writer then maintains the "
+            "heading ABOVE the pins while the moved entries sit under the "
+            "one below it, maintained by nothing."
+        )
+
+    def test_the_refusal_is_reported_not_silent(self, project):
+        """A SILENT refusal is worse than the duplicate heading.
+
+        The region stays unbounded, so the caps stay off on this file. If
+        nothing says why, the curator has no way to learn the state — which
+        is the condition the SessionStart directive exists to answer.
+        """
+        project(WM_HEADING_ABOVE_PINS)
+        status = ensure_pinned_terminator()
+        assert status, "the refusal must be reported, not returned as None"
+        # "skipped" is load-bearing, not decoration. Without it this test
+        # passes when the guard is REMOVED: the repair then succeeds and
+        # returns a status that also names the heading. Asserting the
+        # refusal KIND is what makes the arm discriminate.
+        assert "skipped" in status.lower(), (
+            f"expected a refusal, got a success status: {status!r}"
+        )
+        assert PINNED_TERMINATOR_HEADING in status, (
+            "the message must name the heading the curator has to move"
+        )
+
+    def test_the_refusal_reaches_the_curator_through_the_directive(
+        self, project, monkeypatch
+    ):
+        """End of the chain: refusal -> repair_status -> directive text."""
+        from session_init import check_pinned_region_unbounded_directive
+
+        import staleness
+        monkeypatch.setattr(
+            staleness, "get_project_claude_md_path", lambda: project.path
+        )
+        project(WM_HEADING_ABOVE_PINS)
+        status = ensure_pinned_terminator()
+
+        message = check_pinned_region_unbounded_directive(
+            {"agent_type": "pact-orchestrator"}, repair_status=status
+        )
+        assert message is not None
+        assert "already has a `## Working Memory` heading" in message
+
+    def test_the_gate_declines_on_the_refused_file(
+        self, project, monkeypatch, pact_context
+    ):
+        """THE ASSERTION THAT MATTERS, and it is not the refusal.
+
+        A refusal that left the gate ENFORCING would be the impossible-cure
+        over-block again: the region still parses 5 pins against a real 2,
+        and a curator would be denied for pins they do not have. So the
+        refusal is only safe because the gate declines on it. Assert the
+        DECLINE, not the refusal.
+        """
+        pact_context(
+            team_name="test-team",
+            session_id="session-guard3",
+            project_dir=str(project.path.parent),
+        )
+        import staleness
+        monkeypatch.setattr(
+            staleness, "get_project_claude_md_path", lambda: project.path
+        )
+
+        failures: list[dict] = []
+        import pin_caps_gate
+        monkeypatch.setattr(
+            pin_caps_gate,
+            "append_failure",
+            lambda classification, error=None, cwd=None, source=None:
+                failures.append({"classification": classification}),
+        )
+
+        path = project(WM_HEADING_ABOVE_PINS)
+        assert ensure_pinned_terminator() is not None, "precondition: refused"
+
+        # BINDING CONTROL: without this the gate short-circuits on a
+        # non-matching path and reports ALLOW for a reason unrelated to
+        # boundedness. Placed before the verdict so a miss withholds it.
+        canonical = match_project_claude_md(str(path))
+        assert canonical is not None and path.parent in canonical.parents, (
+            "BINDING CONTROL FAILED: the gate would short-circuit before "
+            "reaching the boundedness decline."
+        )
+
+        reason = pin_caps_gate._check_tool_allowed({
+            "tool_name": "Edit",
+            "agent_type": "pact-orchestrator",
+            "tool_input": {
+                "file_path": str(path),
+                "old_string": "### Real pin 1\nShort body.\n",
+                "new_string": (
+                    "### Real pin 1\nShort body.\n\n"
+                    "<!-- pinned: 2026-07-31 -->\n### Real pin new\nBody.\n"
+                ),
+                "replace_all": False,
+            },
+        })
+        assert reason is None, (
+            f"the refused file must be DECLINED, not enforced. The region "
+            f"still parses 5 pins against a real 2, so enforcing here denies "
+            f"a curator for pins they do not have. Got {reason!r}"
+        )
+        assert [f["classification"] for f in failures] == [
+            "pin_caps_gate_declined_unbounded_both"
+        ], "the allow must come from the boundedness decline, not from a clean evaluation"

--- a/pact-plugin/tests/test_pinned_terminator_repair.py
+++ b/pact-plugin/tests/test_pinned_terminator_repair.py
@@ -35,6 +35,15 @@ from shared.claude_md_manager import (  # noqa: E402
     match_project_claude_md,
     migrate_to_managed_structure,
 )
+# IDENTIFY A REFUSAL BY CONSTANT IDENTITY, NEVER BY MATCHING ITS TEXT. A
+# message-text assertion reddens on the next legitimate reword — which this
+# module has already had once — and that churn is what teaches people to
+# weaken assertions rather than to fix code. Importing the private names is
+# deliberate: the constant IS the contract between the guard and its test.
+from shared.claude_md_manager import (  # noqa: E402
+    _REPAIR_REFUSED_NO_DATED_PIN,
+    _REPAIR_REFUSED_NOTHING_ABSORBED,
+)
 from staleness import _parse_pinned_section  # noqa: E402
 
 _REAL_PIN = "<!-- pinned: 2026-07-30 -->\n### Real pin {n}\nShort body.\n\n"
@@ -208,15 +217,56 @@ class TestRefusalGuards:
             + "".join(_NOTE.format(d=d) for d in range(1, 4))
             + f"{MANAGED_END_MARKER}\n"
         )
+        assert measure(hand_maintained)[1] is False, (
+            "control: the fixture must be UNBOUNDED, or this refusal is "
+            "indistinguishable from the bounded no-op"
+        )
         path = project(hand_maintained)
         status = ensure_pinned_terminator()
 
-        assert status is not None and "skipped" in status.lower()
+        assert status == _REPAIR_REFUSED_NO_DATED_PIN, (
+            f"expected the no-dated-pin refusal by CONSTANT IDENTITY. "
+            f"Got {status!r}"
+        )
         assert path.read_text(encoding="utf-8") == hand_maintained, (
             "guard 1 must not write. Refusing leaves the file unbounded, "
             "which is the SAFE state: the gate declines rather than "
             "enforcing on a false measure."
         )
+
+    def test_guard_1_also_fires_when_the_section_holds_no_entries_at_all(
+        self, project
+    ):
+        """SECOND REACHABLE INPUT for the same refusal, measured not assumed.
+
+        A Pinned Context section holding prose and ZERO `### ` entries reaches
+        guard 1 as well: both the pin list and the heading scan come back
+        empty, their lengths agree, and no entry is dated. The wording holds
+        here only VACUOUSLY — "no entry carries a date comment" when there are
+        no entries — which is true rather than false, and the cure it names
+        stays followable. That is the distinction from the heading-exists
+        refusal, whose old wording asserted the existence of something absent.
+        """
+        prose_only = (
+            "# PACT Framework and Managed Project Memory\n\n"
+            f"{MANAGED_START_MARKER}\n"
+            "## Pinned Context\n\n"
+            "Some ordinary prose that carries no headings at all.\n\n"
+            f"{MANAGED_END_MARKER}\n"
+        )
+        assert measure(prose_only) == (0, False), (
+            "control: zero parsed entries AND unbounded. With entries "
+            "present this is class (a) again; bounded, and the repair "
+            "no-ops before reaching any guard."
+        )
+        path = project(prose_only)
+        status = ensure_pinned_terminator()
+
+        assert status == _REPAIR_REFUSED_NO_DATED_PIN, (
+            f"expected the no-dated-pin refusal by CONSTANT IDENTITY. "
+            f"Got {status!r}"
+        )
+        assert path.read_text(encoding="utf-8") == prose_only
 
     def test_guard_2_refuses_when_nothing_was_absorbed(self, project):
         """No undated entry after a dated one — there is nothing to exclude."""
@@ -227,8 +277,50 @@ class TestRefusalGuards:
         path = project(only_real_pins)
         status = ensure_pinned_terminator()
 
-        assert status is not None and "skipped" in status.lower()
+        assert status == _REPAIR_REFUSED_NOTHING_ABSORBED, (
+            f"expected the nothing-absorbed refusal by CONSTANT IDENTITY. "
+            f"Got {status!r}"
+        )
         assert path.read_text(encoding="utf-8") == only_real_pins
+
+    def test_guard_2_also_fires_when_the_undated_entry_precedes_the_dated_one(
+        self, project
+    ):
+        """SECOND REACHABLE INPUT for the same refusal, measured not assumed.
+
+        The predicate is not "there are no undated entries" but "no undated
+        entry follows a dated one". So a section whose undated entry sits
+        BEFORE the first dated pin reaches the same refusal, with an undated
+        entry plainly present. THE WORDING SURVIVES THIS because it restates
+        that predicate — "no undated `### ` entry AFTER a dated one" — rather
+        than claiming there are none. A wording that had said "every entry is
+        dated" would be FALSE here, which is the shape that made the
+        heading-exists message wrong.
+        """
+        undated_first = (
+            "# PACT Framework and Managed Project Memory\n\n"
+            f"{MANAGED_START_MARKER}\n"
+            "## Pinned Context\n\n"
+            + _NOTE.format(d=1)
+            + _REAL_PIN.format(n=1)
+            + f"{MANAGED_END_MARKER}\n"
+        )
+        count, bounded = measure(undated_first)
+        assert (count, bounded) == (2, False), (
+            "control: both entries must parse and the region stay unbounded, "
+            "or this is not the input class it claims to be"
+        )
+        path = project(undated_first)
+        status = ensure_pinned_terminator()
+
+        assert status == _REPAIR_REFUSED_NOTHING_ABSORBED, (
+            f"expected the nothing-absorbed refusal by CONSTANT IDENTITY. "
+            f"Got {status!r}"
+        )
+        assert path.read_text(encoding="utf-8") == undated_first, (
+            "guard 2 must not write. Inserting before the undated entry here "
+            "would push the dated pin OUT of the region and under-count it."
+        )
 
     def test_the_two_refusals_give_different_reasons(self, project):
         """Anti-vacuity: two guards that emit one string cannot be told

--- a/pact-plugin/tests/test_pinned_terminator_repair.py
+++ b/pact-plugin/tests/test_pinned_terminator_repair.py
@@ -1,0 +1,641 @@
+"""
+Location: pact-plugin/tests/test_pinned_terminator_repair.py
+Summary: Verification tests for `claude_md_manager.ensure_pinned_terminator`
+         (the case-5 repair), its placement rule, its two refusal guards, its
+         ordering against the managed-structure migration, and the SessionStart
+         directive that reports an unbounded pinned region.
+Used by: the pytest suite. Companion to hooks/shared/claude_md_manager.py and
+         hooks/session_init.py.
+
+THE PROPERTY UNDER TEST IS PLACEMENT, NOT PRESENCE. Inserting the terminating
+heading anywhere makes `bounded` read True, so any assertion that only checks
+`bounded` passes for the WRONG implementation — the one that appends at the end
+of the region, leaves the absorbed entries inside, and re-arms the very
+over-block the repair exists to prevent. Every test below asserts the PIN COUNT
+alongside boundedness, because the count is the discriminator.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_HOOKS = Path(__file__).resolve().parent.parent / "hooks"
+if str(_HOOKS) not in sys.path:
+    sys.path.insert(0, str(_HOOKS))
+
+from pin_caps import parse_pins  # noqa: E402
+from shared.claude_md_manager import (  # noqa: E402
+    MANAGED_END_MARKER,
+    MANAGED_START_MARKER,
+    PINNED_TERMINATOR_HEADING,
+    ensure_pinned_terminator,
+    migrate_to_managed_structure,
+)
+from staleness import _parse_pinned_section  # noqa: E402
+
+_REAL_PIN = "<!-- pinned: 2026-07-30 -->\n### Real pin {n}\nShort body.\n\n"
+_NOTE = "### 2026-07-{d:02d}\n**Context**: routine session note.\n\n"
+
+REAL_PINS = 2
+NOTES = 12
+
+
+def _pins_body(real_pins: int = REAL_PINS, notes: int = NOTES) -> str:
+    return (
+        "## Pinned Context\n\n"
+        + "".join(_REAL_PIN.format(n=i) for i in range(1, real_pins + 1))
+        + "".join(_NOTE.format(d=d) for d in range(1, notes + 1))
+    )
+
+
+def case_5(**kwargs) -> str:
+    """A MIGRATED file whose pinned region lost its terminating heading.
+
+    Markers come from the imported constants. A hand-spelled marker makes
+    `extract_managed_region` return None, the parser falls back to the whole
+    file, and every arm lands on the branch where right and wrong agree.
+    """
+    return (
+        "# PACT Framework and Managed Project Memory\n\n"
+        f"{MANAGED_START_MARKER}\n"
+        f"{_pins_body(**kwargs)}"
+        f"{MANAGED_END_MARKER}\n"
+    )
+
+
+def unmigrated(**kwargs) -> str:
+    """An UNMIGRATED unbounded file — no managed markers.
+
+    The ordering test needs this shape: `migrate_to_managed_structure`
+    early-returns when the start marker is present, so a migrated fixture
+    cannot show the ordering at all.
+    """
+    return "# Project Memory\n\n" + _pins_body(**kwargs)
+
+
+def measure(content: str) -> tuple[int, bool]:
+    """Return (pin count, bounded) for a CLAUDE.md body."""
+    parsed = _parse_pinned_section(content)
+    if parsed is None:
+        return 0, True
+    return len(parse_pins(parsed.content)), parsed.bounded
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    """A project dir whose CLAUDE.md the repair will resolve and write."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    claude_md = tmp_path / "CLAUDE.md"
+
+    def write(content: str) -> Path:
+        claude_md.write_text(content, encoding="utf-8")
+        return claude_md
+
+    write.path = claude_md  # type: ignore[attr-defined]
+    return write
+
+
+class TestPlacement:
+    """Certification row 6. The row that catches the defect the constraint,
+    as originally worded, would have shipped."""
+
+    def test_the_fixture_starts_in_the_broken_state(self, project):
+        """Precondition control. Without this the repair could be a no-op
+        on an already-correct file and every assertion below would pass."""
+        content = case_5()
+        count, bounded = measure(content)
+        assert bounded is False
+        assert count == REAL_PINS + NOTES == 14, (
+            "the fixture must reproduce the inflation, otherwise the repair "
+            "has nothing to fix and this file certifies nothing"
+        )
+
+    def test_repair_excludes_the_absorbed_notes(self, project):
+        """The count is the discriminator, not `bounded`.
+
+        END placement also makes `bounded` True. It leaves the count at 14.
+        """
+        path = project(case_5())
+        status = ensure_pinned_terminator()
+        assert status is not None and "Repaired" in status
+
+        count, bounded = measure(path.read_text(encoding="utf-8"))
+        assert bounded is True
+        assert count == REAL_PINS, (
+            f"placement is wrong: the region is bounded but still holds "
+            f"{count} entries. A terminator at the END of the region bounds "
+            f"it at the end it already had and re-arms the over-block."
+        )
+
+    def test_heading_lands_before_the_first_undated_entry(self, project):
+        """Pin the POSITION directly, so a count that happens to be right
+        for another reason cannot satisfy this."""
+        path = project(case_5())
+        ensure_pinned_terminator()
+        text = path.read_text(encoding="utf-8")
+
+        heading_at = text.index(PINNED_TERMINATOR_HEADING)
+        last_real_pin_at = text.index("### Real pin 2")
+        first_note_at = text.index("### 2026-07-01")
+        assert last_real_pin_at < heading_at < first_note_at
+
+    def test_the_real_pins_stay_inside_the_region(self, project):
+        """Guard against the opposite error: a heading placed too EARLY
+        pushes genuine pins out of the region and under-counts."""
+        path = project(case_5())
+        ensure_pinned_terminator()
+        parsed = _parse_pinned_section(path.read_text(encoding="utf-8"))
+        assert parsed is not None
+        headings = [pin.heading for pin in parse_pins(parsed.content)]
+        assert headings == ["### Real pin 1", "### Real pin 2"]
+
+    def test_repair_changes_no_pin_text(self, project):
+        """Constraint 1: one heading inserted, nothing else altered.
+
+        Asserts the original bytes survive as a contiguous run on each side
+        of the insertion, so the change is exactly an insertion.
+        """
+        before = case_5()
+        path = project(before)
+        ensure_pinned_terminator()
+        after = path.read_text(encoding="utf-8")
+
+        inserted = f"{PINNED_TERMINATOR_HEADING}\n\n"
+        assert after.replace(inserted, "", 1) == before
+
+
+class TestRefusalGuards:
+
+    def test_guard_1_refuses_when_no_entry_is_dated(self, project):
+        """Certification row 8. A hand-maintained file has no signal that
+        separates a pin from a note; inserting before the first `### `
+        would push EVERY pin out of the region."""
+        hand_maintained = (
+            "# PACT Framework and Managed Project Memory\n\n"
+            f"{MANAGED_START_MARKER}\n"
+            "## Pinned Context\n\n"
+            + "".join(_NOTE.format(d=d) for d in range(1, 4))
+            + f"{MANAGED_END_MARKER}\n"
+        )
+        path = project(hand_maintained)
+        status = ensure_pinned_terminator()
+
+        assert status is not None and "skipped" in status.lower()
+        assert path.read_text(encoding="utf-8") == hand_maintained, (
+            "guard 1 must not write. Refusing leaves the file unbounded, "
+            "which is the SAFE state: the gate declines rather than "
+            "enforcing on a false measure."
+        )
+
+    def test_guard_2_refuses_when_nothing_was_absorbed(self, project):
+        """No undated entry after a dated one — there is nothing to exclude."""
+        only_real_pins = case_5(notes=0)
+        # Control: this fixture must still be UNBOUNDED, or the refusal
+        # under test would be indistinguishable from the bounded no-op.
+        assert measure(only_real_pins)[1] is False
+        path = project(only_real_pins)
+        status = ensure_pinned_terminator()
+
+        assert status is not None and "skipped" in status.lower()
+        assert path.read_text(encoding="utf-8") == only_real_pins
+
+    def test_the_two_refusals_give_different_reasons(self, project):
+        """Anti-vacuity: two guards that emit one string cannot be told
+        apart by the curator who has to act on them."""
+        project(
+            "# T\n\n" + MANAGED_START_MARKER + "\n## Pinned Context\n\n"
+            + "".join(_NOTE.format(d=d) for d in range(1, 4))
+            + MANAGED_END_MARKER + "\n"
+        )
+        guard_1 = ensure_pinned_terminator()
+        project(case_5(notes=0))
+        guard_2 = ensure_pinned_terminator()
+        assert guard_1 != guard_2
+
+
+class TestIdempotence:
+    """Certification row 9.
+
+    THE ROW AS ORIGINALLY WORDED WAS VACUOUS AND IS REPAIRED HERE. Its GREEN
+    was "the second run is a no-op" and its RED was "run against a bounded
+    file, it must not write" — BOTH DIRECTIONS ASSERT A NON-WRITE. A stub
+    that always returns None and never writes satisfies both. So the
+    non-write assertions below are each paired with a POSITIVE control that
+    the repair DOES write when it should.
+    """
+
+    def test_second_run_is_a_no_op_and_the_first_run_was_not(self, project):
+        path = project(case_5())
+
+        first = ensure_pinned_terminator()
+        after_first = path.read_text(encoding="utf-8")
+        assert first is not None and "Repaired" in first
+        assert after_first != case_5(), (
+            "POSITIVE CONTROL: the first run must actually write. Without "
+            "this, a function that never writes passes the no-op assertion "
+            "below and the whole test certifies nothing."
+        )
+
+        second = ensure_pinned_terminator()
+        assert second is None
+        assert path.read_text(encoding="utf-8") == after_first
+
+    def test_bounded_file_is_untouched(self, project):
+        bounded = case_5().replace(
+            "### 2026-07-01", f"{PINNED_TERMINATOR_HEADING}\n\n### 2026-07-01", 1
+        )
+        assert measure(bounded)[1] is True, "control: fixture must be bounded"
+        path = project(bounded)
+        assert ensure_pinned_terminator() is None
+        assert path.read_text(encoding="utf-8") == bounded
+
+
+class TestOrderingAgainstMigration:
+    """Certification row 7. The order is measured, not preferred."""
+
+    def test_repair_then_migrate_yields_only_the_real_pins(self, project):
+        path = project(unmigrated())
+        assert measure(unmigrated()) == (14, False), "control: broken to start"
+
+        ensure_pinned_terminator()
+        migrate_to_managed_structure()
+
+        count, bounded = measure(path.read_text(encoding="utf-8"))
+        assert bounded is True
+        assert count == REAL_PINS
+
+    def test_migrate_first_locks_the_phantom_entries_in(self, project):
+        """The reverse order, run as a MEASUREMENT rather than described.
+
+        The migration bounds the region without correcting the placement.
+        The repair then sees a bounded file and declines, so the absorbed
+        entries stay inside the pinned region permanently.
+
+        This is the RED control for the ordering, and it also records a
+        defect in the shipped migration that outlives this change.
+        """
+        path = project(unmigrated())
+
+        migrate_to_managed_structure()
+        after_migration = measure(path.read_text(encoding="utf-8"))
+        repair_status = ensure_pinned_terminator()
+
+        count, bounded = measure(path.read_text(encoding="utf-8"))
+        assert bounded is True
+        assert repair_status is None, "the repair declines on a bounded file"
+        assert count == REAL_PINS + NOTES, (
+            f"expected the phantom entries to be locked in by the migration; "
+            f"measured {count}. If this now reads {REAL_PINS}, the migration "
+            f"itself was fixed and the ordering constraint can be revisited."
+        )
+        assert after_migration[0] == count
+
+    def test_the_two_orders_disagree(self, project):
+        """Mandatory anti-vacuity control for the ordering pair."""
+        path = project(unmigrated())
+        ensure_pinned_terminator()
+        migrate_to_managed_structure()
+        correct_order = measure(path.read_text(encoding="utf-8"))
+
+        path = project(unmigrated())
+        migrate_to_managed_structure()
+        ensure_pinned_terminator()
+        wrong_order = measure(path.read_text(encoding="utf-8"))
+
+        assert correct_order[0] != wrong_order[0]
+
+
+class TestNeverRaises:
+    """Certification row 10, on the writer. Fail open on every fault."""
+
+    def test_returns_none_when_the_parser_raises(self, project, monkeypatch):
+        project(case_5())
+        import staleness
+
+        def boom(_content):
+            raise RuntimeError("parser fault")
+
+        monkeypatch.setattr(staleness, "_parse_pinned_section", boom)
+        # PROBE CONTROL: prove the injected fault is actually reached,
+        # otherwise "returns None" is satisfied by never calling the parser.
+        with pytest.raises(RuntimeError):
+            staleness._parse_pinned_section("x")
+        assert ensure_pinned_terminator() is None
+
+    def test_returns_none_without_a_project_dir(self, project, monkeypatch):
+        project(case_5())
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        assert ensure_pinned_terminator() is None
+
+    def test_returns_none_when_the_file_is_absent(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+        assert ensure_pinned_terminator() is None
+
+
+class TestUnboundedDirective:
+    """Step 5: the SessionStart emission surface."""
+
+    @pytest.fixture(autouse=True)
+    def _resolve_to_tmp(self, project, monkeypatch):
+        import staleness
+        monkeypatch.setattr(
+            staleness, "get_project_claude_md_path", lambda: project.path
+        )
+        self.project = project
+
+    def _directive(self, agent_type="pact-orchestrator", **kwargs):
+        from session_init import check_pinned_region_unbounded_directive
+        return check_pinned_region_unbounded_directive(
+            {"agent_type": agent_type}, **kwargs
+        )
+
+    def test_fires_on_an_unbounded_region(self):
+        self.project(case_5())
+        message = self._directive()
+        assert message is not None
+        assert "Pinned Context" in message
+        assert PINNED_TERMINATOR_HEADING in message, (
+            "the directive must name the exact repair, not just report a state"
+        )
+
+    def test_silent_on_a_bounded_region(self):
+        """Anti-vacuity partner. A directive that always fires is not a signal."""
+        self.project(
+            case_5().replace(
+                "### 2026-07-01",
+                f"{PINNED_TERMINATOR_HEADING}\n\n### 2026-07-01",
+                1,
+            )
+        )
+        assert self._directive() is None
+
+    def test_silent_for_a_teammate_frame(self):
+        """SCOPE. SessionStart runs for every frame; the gate does not run
+        for a teammate. An unscoped directive would instruct exactly the
+        actors the gate does not control to edit a file they do not own."""
+        self.project(case_5())
+        assert self._directive(agent_type="pact-backend-coder") is None
+        assert self._directive(agent_type=None) is None
+
+    def test_surfaces_the_refusal_reason(self):
+        """A refusal reaching the curator is the whole point of the
+        status pass-through: the plugin says what it already tried."""
+        self.project(case_5())
+        message = self._directive(repair_status="Pinned-region repair skipped: XYZZY.")
+        assert message is not None and "XYZZY" in message
+
+    def test_says_so_when_no_repair_ran(self):
+        self.project(case_5())
+        message = self._directive()
+        assert message is not None and "did not repair it automatically" in message
+
+    def test_returns_none_when_the_parse_raises(self, monkeypatch):
+        """PATCH THE SEAM THE CALLER ACTUALLY USES.
+
+        `session_init` binds `_parse_pinned_section` with a module-level
+        `from staleness import ...`, so the name is frozen at import. Patching
+        `staleness._parse_pinned_section` leaves that binding untouched and
+        the directive runs the REAL parser — the first version of this test
+        did exactly that, and it failed by reporting a live directive where
+        it expected None. The failure was in the instrument, not the code.
+
+        The repair's own equivalent test patches `staleness` and is correct
+        to, because `_ensure_pinned_terminator_inner` imports at FUNCTION
+        level and therefore re-reads the attribute on every call. Two
+        different seams in the same change; neither patch works for the other.
+        """
+        self.project(case_5())
+        import session_init
+
+        def boom(_content):
+            raise RuntimeError("parser fault")
+
+        monkeypatch.setattr(session_init, "_parse_pinned_section", boom)
+        # PROBE CONTROL: prove the injected fault is on the path the caller
+        # takes, so "returns None" cannot be satisfied by a patch that misses.
+        with pytest.raises(RuntimeError):
+            session_init._parse_pinned_section("x")
+        assert self._directive() is None
+
+
+class TestCallOrderInSessionInit:
+    """Certification row 7 AT THE CALL SITE, driven through the real
+    `session_init.main()`.
+
+    The ordering tests above call the two functions directly, so they prove
+    the ORDER MATTERS. They cannot prove `session_init` uses the right one —
+    a coder who fixes the placement and then wires the call in after the
+    migration passes every one of them. This drives the real hook and
+    records which function ran first.
+    """
+
+    def _order(self, monkeypatch, tmp_path, agent_type="pact-orchestrator"):
+        import io
+        import json
+        from unittest.mock import patch
+
+        import session_init
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        calls: list[str] = []
+
+        stdin_data = json.dumps({
+            "session_id": "11111111-2222-3333-4444-555555555555",
+            "source": "startup",
+            "agent_type": agent_type,
+        })
+        with patch("session_init.setup_plugin_symlinks", return_value=None), \
+             patch("session_init.ensure_project_memory_md", return_value=None), \
+             patch("session_init.check_pinned_staleness", return_value=None), \
+             patch("session_init.get_task_list", return_value=None), \
+             patch("session_init.restore_last_session", return_value=None), \
+             patch("session_init.build_context_cache",
+                   return_value=(Path("/tmp/ctx.json"), {})), \
+             patch("session_init.persist_context", return_value=None), \
+             patch("session_init.append_event"), \
+             patch("session_init.update_session_info", return_value=None), \
+             patch("session_init.check_resume_state", return_value=None), \
+             patch("session_init._registry_resolve", return_value=None), \
+             patch("session_init.get_peer_context", return_value=None), \
+             patch("session_init.ensure_pinned_terminator",
+                   side_effect=lambda: calls.append("repair")), \
+             patch("session_init.migrate_to_managed_structure",
+                   side_effect=lambda: calls.append("migrate")), \
+             patch("sys.stdin", io.StringIO(stdin_data)), \
+             patch("sys.stdout", new_callable=io.StringIO):
+            with pytest.raises(SystemExit) as exc:
+                session_init.main()
+        assert exc.value.code == 0
+        return calls
+
+    def test_repair_runs_before_the_migration(self, monkeypatch, tmp_path):
+        calls = self._order(monkeypatch, tmp_path)
+        assert calls == ["repair", "migrate"], (
+            "the repair MUST precede migrate_to_managed_structure. After the "
+            "migration the file is bounded, so the repair declines and the "
+            "absorbed entries are locked inside the pinned region for good."
+        )
+
+    @pytest.mark.parametrize(
+        "agent_type",
+        ["pact-backend-coder", "pact-orchestratr", None],
+        ids=["teammate", "typo'd agent_type", "no --agent flag"],
+    )
+    def test_the_repair_runs_in_a_non_lead_frame(
+        self, monkeypatch, tmp_path, agent_type
+    ):
+        """The repair is NOT lead-scoped, asserted POSITIVELY.
+
+        THIS TEST WAS INVERTED. It previously asserted `"repair" not in
+        calls` for a teammate frame, pinning a lead scope that turned out to
+        be wrong. It is written positively on purpose: an inverted test that
+        merely STOPS asserting the old property certifies nothing, and a
+        guard silently downgraded into a rubber stamp is the exact failure
+        this suite exists to prevent.
+
+        The scope mattered because the migration below is NOT lead-scoped.
+        With the repair scoped and the migration not, a non-lead frame ran
+        the migration alone, bounded the region without fixing the
+        placement, and locked the absorbed entries inside permanently.
+
+        The parameters are the three frames where `is_lead` reads False.
+        The third is the ordinary way a session launches with no `--agent`
+        flag — the common case, not an edge case, which is what made the
+        old scoping a defect rather than a curiosity.
+        """
+        calls = self._order(monkeypatch, tmp_path, agent_type=agent_type)
+        assert "repair" in calls, (
+            "the repair MUST run in a non-lead frame. Re-scoping it to the "
+            "lead makes the outcome depend on which frame type starts a "
+            "session first, and the losing branch is permanent."
+        )
+        assert "migrate" in calls, (
+            "the migration is not lead-scoped and must not be narrowed as a "
+            "side effect. This assertion is MORE load-bearing now, not less: "
+            "the two calls' scopes finally match, so a future reader may be "
+            "tempted to 'tidy' both into a lead block and reintroduce the "
+            "defect from the other direction."
+        )
+
+    def test_the_directive_stays_lead_scoped(self, monkeypatch, tmp_path):
+        """The WRITER is unscoped; the DIRECTIVE is not. Pin the asymmetry.
+
+        Deleting the lead scope from the writer must not drag the directive
+        with it. The directive TELLS AN ACTOR to edit a file the pin gate
+        does not control for a teammate; the writer instructs nobody. Same
+        file, different surfaces, different rules.
+
+        BINDING CONTROL, and it earned its place immediately: the first
+        version of this test patched `staleness.get_project_claude_md_path`
+        and left `CLAUDE_PROJECT_DIR` alone. `session_init` binds the
+        resolver by module-level import, so that patch missed the seam and
+        the resolver read the REAL repository CLAUDE.md — which is bounded,
+        so the directive returned None for BOTH frames. The teammate
+        assertion would have passed for a reason that has nothing to do with
+        scope. The control below failed instead, which is the whole point of
+        putting it before the assertion it protects.
+        """
+        from session_init import check_pinned_region_unbounded_directive
+        from staleness import get_project_claude_md_path
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text(case_5(), encoding="utf-8")
+
+        resolved = get_project_claude_md_path()
+        assert resolved is not None and tmp_path in resolved.parents, (
+            f"BINDING CONTROL FAILED: the resolver returned {resolved}, "
+            f"outside the temp directory. Every verdict below would describe "
+            f"the real repository file rather than the fixture."
+        )
+
+        lead = check_pinned_region_unbounded_directive(
+            {"agent_type": "pact-orchestrator"}
+        )
+        teammate = check_pinned_region_unbounded_directive(
+            {"agent_type": "pact-backend-coder"}
+        )
+        assert lead is not None, (
+            "control: the directive must fire for a lead on this fixture, "
+            "otherwise the teammate assertion below is vacuous"
+        )
+        assert teammate is None
+
+
+class TestFrameTypeDoesNotChangeTheOutcome:
+    """The property Option A actually buys: SAME INPUT, ONE OUTCOME.
+
+    The absence of this property is what caused the defect. The old code
+    produced 2 pins from a lead frame and 14 permanently from any other,
+    on byte-identical input — a race whose losing branch could not be
+    recovered. This asserts the two frames converge.
+    """
+
+    def _run_session(self, tmp_path, monkeypatch, agent_type):
+        """Drive the REAL `session_init.main()` and measure the file after.
+
+        IT MUST GO THROUGH session_init, NOT CALL THE TWO FUNCTIONS DIRECTLY.
+        Neither `ensure_pinned_terminator` nor `migrate_to_managed_structure`
+        reads the frame, so a direct-call version of this test is
+        frame-independent BY CONSTRUCTION — it would pass no matter how
+        session_init gates them, which is the only thing under test here.
+        Both writers are left UNPATCHED for the same reason.
+        """
+        import io
+        import json
+        from unittest.mock import patch
+
+        import session_init
+
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text(unmigrated(), encoding="utf-8")
+
+        frame = {"agent_type": agent_type} if agent_type else {}
+        stdin_data = json.dumps({
+            "session_id": "11111111-2222-3333-4444-555555555555",
+            "source": "startup",
+            **frame,
+        })
+        with patch("session_init.setup_plugin_symlinks", return_value=None), \
+             patch("session_init.ensure_project_memory_md", return_value=None), \
+             patch("session_init.check_pinned_staleness", return_value=None), \
+             patch("session_init.get_task_list", return_value=None), \
+             patch("session_init.restore_last_session", return_value=None), \
+             patch("session_init.build_context_cache",
+                   return_value=(Path("/tmp/ctx.json"), {})), \
+             patch("session_init.persist_context", return_value=None), \
+             patch("session_init.append_event"), \
+             patch("session_init.update_session_info", return_value=None), \
+             patch("session_init.check_resume_state", return_value=None), \
+             patch("session_init._registry_resolve", return_value=None), \
+             patch("session_init.get_peer_context", return_value=None), \
+             patch("sys.stdin", io.StringIO(stdin_data)), \
+             patch("sys.stdout", new_callable=io.StringIO):
+            with pytest.raises(SystemExit) as exc:
+                session_init.main()
+        assert exc.value.code == 0
+        return measure(claude_md.read_text(encoding="utf-8"))
+
+    def test_lead_and_non_lead_frames_converge(self, tmp_path, monkeypatch):
+        lead = self._run_session(tmp_path, monkeypatch, "pact-orchestrator")
+
+        other = tmp_path / "other"
+        other.mkdir()
+        non_lead = self._run_session(other, monkeypatch, None)
+
+        assert lead == non_lead, (
+            f"byte-identical input produced different outcomes by frame "
+            f"type: lead={lead}, non-lead={non_lead}. That is the race "
+            f"Option A removes, and its losing branch is permanent."
+        )
+        assert lead == (REAL_PINS, True), (
+            f"both frames converged on the WRONG state {lead}; expected "
+            f"{(REAL_PINS, True)}. Convergence alone is not the property — "
+            f"two frames agreeing on 14 phantom pins would also be equal."
+        )

--- a/pact-plugin/tests/test_pinned_terminator_repair.py
+++ b/pact-plugin/tests/test_pinned_terminator_repair.py
@@ -779,7 +779,20 @@ class TestGuard3ExistingWorkingMemoryHeading:
             {"agent_type": "pact-orchestrator"}, repair_status=status
         )
         assert message is not None
-        assert "already has a `## Working Memory` heading" in message
+        # POSITIVE about the CURRENT property, not merely silent about the
+        # former one. The old wording asserted the file "already has a
+        # `## Working Memory` heading"; the guard is a SUBSTRING test, so that
+        # claim is false on the pin-body input. This asserts the containment
+        # framing, which the old wording could not satisfy — so a revert to
+        # the heading-presence claim reddens here rather than passing quietly.
+        assert "contains the text" in message, (
+            f"the directive must carry the containment framing. A message "
+            f"claiming a heading EXISTS is false for the pin-body input that "
+            f"reaches the same guard. Got: {message!r}"
+        )
+        assert PINNED_TERMINATOR_HEADING in message, (
+            "the message must still name the text the curator has to act on"
+        )
 
     def test_the_gate_declines_on_the_refused_file(
         self, project, monkeypatch, pact_context
@@ -901,39 +914,56 @@ TERMINATOR_INSIDE_A_PIN_BODY = (
 )
 
 
+def _require_midline_mention() -> None:
+    """WITHHOLDING PRECONDITION for the substring class. Raises rather than
+    warns, and every behavioural test calls it BEFORE it acts.
+
+    THE MENTION MUST BE MID-LINE OR THIS CLASS TESTS SOMETHING ELSE ENTIRELY,
+    and it does so while still passing. `_find_terminator_offset` matches
+    `#{1,2}\\s` against each LINE, so a line-initial mention is a genuine
+    terminator: the region reads bounded, `ensure_pinned_terminator` no-ops at
+    the earlier bounded check, and guard 3 is never reached. Every assertion
+    downstream would then be about the bounded no-op while appearing to be
+    about the guard. A mid-line mention is invisible to the line scan and
+    visible to the substring test, which is the whole gap under test.
+    """
+    assert PINNED_TERMINATOR_HEADING in TERMINATOR_INSIDE_A_PIN_BODY, (
+        "PRECONDITION FAILED: the fixture no longer mentions the terminator "
+        "text at all, so guard 3 cannot fire and nothing below is about it."
+    )
+    assert not any(
+        line.startswith(PINNED_TERMINATOR_HEADING)
+        for line in TERMINATOR_INSIDE_A_PIN_BODY.splitlines()
+    ), (
+        "PRECONDITION FAILED: the mention sits at the start of a line, so it "
+        "is a REAL terminator. The region is bounded, the repair no-ops "
+        "before guard 3, and this class silently becomes a test of the "
+        "bounded no-op."
+    )
+    count, bounded = measure(TERMINATOR_INSIDE_A_PIN_BODY)
+    assert bounded is False, (
+        "PRECONDITION FAILED: the region is bounded, so the repair no-ops at "
+        "the earlier check and never reaches guard 3."
+    )
+    assert count > PIN_COUNT_CAP, (
+        f"PRECONDITION FAILED: the fixture parses {count} phantom pins "
+        f"against a cap of {PIN_COUNT_CAP}. Below the cap an enforcing gate "
+        f"allows too, so a decline cannot be told from an enforcement."
+    )
+
+
 class TestGuard3TerminatorLiteralInsideAPinBody:
 
     def test_the_mention_is_a_substring_and_not_a_heading(self):
-        """PRECONDITION CONTROL, and it is what makes this class about the
-        substring test rather than about an ordinary heading.
-
-        RED input: move the mention to the start of a line. The line scan
-        then finds a real terminator, the region reads bounded, and every
-        assertion below stops being about guard 3.
-        """
-        assert PINNED_TERMINATOR_HEADING in TERMINATOR_INSIDE_A_PIN_BODY
-        assert not any(
-            line.startswith(PINNED_TERMINATOR_HEADING)
-            for line in TERMINATOR_INSIDE_A_PIN_BODY.splitlines()
-        ), (
-            "the mention sits at the start of a line, so it is a REAL "
-            "terminator and the region is bounded. This class would then "
-            "test the bounded no-op, not the substring guard."
-        )
-        count, bounded = measure(TERMINATOR_INSIDE_A_PIN_BODY)
-        assert bounded is False, (
-            "the region must be unbounded, or the repair no-ops at the "
-            "earlier bounded check and never reaches guard 3"
-        )
-        assert count > PIN_COUNT_CAP, (
-            f"the fixture parses {count} phantom pins against a cap of "
-            f"{PIN_COUNT_CAP}. Below the cap an enforcing gate allows too, "
-            f"and the decline assertion below would certify nothing."
-        )
+        """The precondition, asserted on its own so a fixture regression
+        names itself instead of surfacing as a confusing behavioural
+        failure three tests later."""
+        _require_midline_mention()
 
     def test_the_repair_refuses_and_writes_nothing(self, project):
         """The substring test wins over the absent heading, and refusing is
         the direction that leaves the safe state."""
+        _require_midline_mention()
         path = project(TERMINATOR_INSIDE_A_PIN_BODY)
         status = ensure_pinned_terminator()
 
@@ -946,11 +976,68 @@ class TestGuard3TerminatorLiteralInsideAPinBody:
             "guard 3 must not write"
         )
 
+    def test_the_refusal_does_not_claim_a_heading_that_is_absent(self, project):
+        """THE MESSAGE MUST BE TRUE OF THIS INPUT, not only of the other one.
+
+        Guard 3 is reached by two different files: one with a real
+        `## Working Memory` heading above the pins, and this one, which has
+        NO such heading and only prose mentioning the text. Both receive the
+        SAME constant, so the wording has to hold for both. An earlier
+        version asserted the file "already has a ... heading" and told the
+        curator to move it — an instruction nobody can follow here, which is
+        the same unfollowable-cure shape this work exists to remove.
+        """
+        _require_midline_mention()
+        content = project(TERMINATOR_INSIDE_A_PIN_BODY).read_text(encoding="utf-8")
+        headings_present = sum(
+            1 for line in content.splitlines()
+            if line.startswith(PINNED_TERMINATOR_HEADING)
+        )
+        assert headings_present == 0, (
+            "BINDING CONTROL FAILED: this fixture is supposed to carry NO "
+            "terminator heading. With one present the message's heading "
+            "claim would be true and this test would certify nothing."
+        )
+
+        status = ensure_pinned_terminator()
+        assert status is not None
+
+        # POSITIVE: the trigger is described as text CONTAINMENT, which is
+        # what the guard actually tests, and BOTH cures are named — the
+        # pin-body cure is the one the old wording had no way to express.
+        assert "contains the text" in status, (
+            f"the message must describe the trigger as containment. Got {status!r}"
+        )
+        assert "reword the mention" in status, (
+            f"the message must name the cure for THIS input. Without it a "
+            f"curator holding this file has no action to take. Got {status!r}"
+        )
+        # NEGATIVE: the specific false claim must not come back.
+        assert "already has a" not in status, (
+            f"the message asserts a heading EXISTS. It does not, on this "
+            f"input. Got {status!r}"
+        )
+
+        # 7a DISCIPLINE: state the remedy, promise no allowance. The detector
+        # is asserted able to FIRE on a doctored string, so its silence on the
+        # real one is evidence rather than an untested absence.
+        promises = ("will then be allowed", "will be allowed", "then succeed",
+                    "and the edit will", "unblocks", "will pass")
+        doctored = status + " The edit will then be allowed."
+        assert any(p in doctored for p in promises), (
+            "the promise detector cannot fire at all; its silence below "
+            "would certify nothing"
+        )
+        assert not any(p in status for p in promises), (
+            f"the refusal promises an outcome it does not control. Got {status!r}"
+        )
+
     def test_refusing_leaves_the_region_unbounded_so_the_caps_stay_off(
         self, project, monkeypatch, pact_context
     ):
         """THE DIRECTION, ASSERTED. A refusal is only safe because the gate
         declines on what it leaves behind."""
+        _require_midline_mention()
         pact_context(
             team_name="test-team",
             session_id="session-guard3-substring",

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -683,7 +683,8 @@ class TestParsePinnedSectionMarkerBoundary:
 
         result = _parse_pinned_section(content)
         assert result is not None
-        pinned_start, pinned_end, pinned_content = result
+        pinned_end = result.end
+        pinned_content = result.content
 
         # The returned pinned_content must contain the pin body but must
         # STOP before the marker line. The marker itself must NOT appear
@@ -719,7 +720,8 @@ class TestParsePinnedSectionMarkerBoundary:
 
         result = _parse_pinned_section(content)
         assert result is not None
-        _, pinned_end, pinned_content = result
+        pinned_end = result.end
+        pinned_content = result.content
 
         assert "Pin one" in pinned_content
         assert "<!-- PACT_MANAGED_END -->" not in pinned_content
@@ -752,7 +754,8 @@ class TestParsePinnedSectionMarkerBoundary:
 
         result = _parse_pinned_section(content)
         assert result is not None
-        _, pinned_end, pinned_content = result
+        pinned_end = result.end
+        pinned_content = result.content
 
         assert "Pin two" in pinned_content
         assert "<!-- PACT_ROUTING_END -->" not in pinned_content
@@ -778,7 +781,8 @@ class TestParsePinnedSectionMarkerBoundary:
 
         result = _parse_pinned_section(content)
         assert result is not None
-        _, pinned_end, pinned_content = result
+        pinned_end = result.end
+        pinned_content = result.content
 
         assert "Pre-migration pin" in pinned_content
         assert "## Working Memory" not in pinned_content
@@ -1201,7 +1205,8 @@ class TestParsePinnedSectionTerminator:
 
         result = _parse_pinned_section(content)
         assert result is not None
-        _pinned_start, pinned_end, pinned_content = result
+        pinned_end = result.end
+        pinned_content = result.content
 
         assert "Regular pin" in pinned_content
         # The marker is the terminator — pinned_content must NOT contain it
@@ -1242,7 +1247,8 @@ class TestParsePinnedSectionManagedRegionBounding:
 
         result = _parse_pinned_section(content)
         assert result is not None
-        pinned_start, pinned_end, pinned_content = result
+        pinned_start = result.start
+        pinned_content = result.content
 
         # Offsets must be in the full content, not managed-region-relative
         assert pinned_start > len(preamble), (
@@ -1268,7 +1274,7 @@ class TestParsePinnedSectionManagedRegionBounding:
 
         result = _parse_pinned_section(content)
         assert result is not None
-        _, _, pinned_content = result
+        pinned_content = result.content
         assert "Old content." in pinned_content
 
 

--- a/pact-plugin/tests/test_symlink_write_path_invariant.py
+++ b/pact-plugin/tests/test_symlink_write_path_invariant.py
@@ -1,0 +1,94 @@
+"""Standing invariant for the leaf-symlink ALLOW on the CLAUDE.md write path.
+
+WHY THIS EXISTS. `_atomic_write_text` deliberately ALLOWS a project CLAUDE.md
+that is a symlink pointing OUTSIDE the project root. That ALLOW is sound only
+because `os.replace` is renameat(2): it rebinds the directory ENTRY without
+following the link, so the payload lands on the in-project entry and the
+outside target is never touched.
+
+The ALLOW inverts into a real escape under either of two rewrites:
+  1. resolving the target once and using the resolved path downstream, or
+  2. swapping temp-create + rename for open/truncate on the target path.
+Neither touches the containment predicate, so the guard still reads correct
+while the guarantee is gone. This test fails on both.
+
+POSITIVE REACH CONTROL IS MANDATORY. The victim file must carry REPAIRABLE
+content, so the writer actually writes. With non-repairable content the repair
+no-ops and every assertion below passes without the write path executing once
+-- certifying the ALLOW without ever exercising it.
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+sys.path.insert(0, str(Path(__file__).parent))
+
+
+def _pin(title, date="2026-07-01"):
+    return f"<!-- pinned: {date} -->\n### {title}\n\nbody\n\n"
+
+
+def _note(day):
+    return f"### 2026-01-{day:02d} 09:00\n**Context**: note.\n\n"
+
+
+# Unbounded WITH absorbed content -> the repair acts. This is the reach control.
+REPAIRABLE = (
+    "# Project Memory\n\n## Pinned Context\n\n"
+    + _pin("Real A", "2026-07-01") + _pin("Real B", "2026-07-02")
+    + "".join(_note(d) for d in (10, 11, 12))
+)
+
+
+@pytest.fixture
+def outside_victim(tmp_path, monkeypatch):
+    """A project CLAUDE.md that is a symlink to a file OUTSIDE the project."""
+    outside = Path(tempfile.mkdtemp(prefix="outside-")).resolve()
+    victim = outside / "victim.md"
+    victim.write_text(REPAIRABLE, encoding="utf-8")
+
+    root = tmp_path / "project"
+    root.mkdir()
+    link = root / "CLAUDE.md"
+    link.symlink_to(victim)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(root))
+    return {"victim": victim, "link": link, "root": root}
+
+
+class TestLeafSymlinkAllowStaysAnEntryRebind:
+
+    def test_write_rebinds_the_entry_and_never_touches_the_outside_target(
+        self, outside_victim
+    ):
+        victim = outside_victim["victim"]
+        link = outside_victim["link"]
+        before = victim.read_bytes()
+
+        from shared.claude_md_manager import (
+            ensure_pinned_terminator, PINNED_TERMINATOR_HEADING,
+        )
+        status = ensure_pinned_terminator()
+
+        # REACH CONTROL, branch-unique. Without this the three assertions
+        # below are satisfied by a repair that never ran.
+        assert status is not None and "Repaired" in status, (
+            f"reach control: the writer did not act, so this test certifies "
+            f"nothing about the write path. status={status!r}"
+        )
+
+        assert victim.read_bytes() == before, (
+            "the file OUTSIDE the project root was modified. The write "
+            "followed the symlink instead of rebinding the entry -- the "
+            "leaf-symlink ALLOW has become a containment escape."
+        )
+        assert not link.is_symlink(), (
+            "the project path is still a symlink, so the payload did not "
+            "land on the in-project entry"
+        )
+        assert PINNED_TERMINATOR_HEADING in link.read_text(encoding="utf-8"), (
+            "the repaired content is not on the in-project entry"
+        )


### PR DESCRIPTION
Closes part of #1175. This is **PR 1 of the pin-cap redesign arc** — the boundedness infrastructure and the over-block fix. It does not change any cap value.

## The defect

The pinned region of a project `CLAUDE.md` is terminated by a `## Working Memory` heading. When that heading is missing, the parser scans past the region and counts ordinary `### ` entries as pins. The caps then enforce against a **phantom count**: a curator holding 2 real pins is denied at 15/12 and told to run `/PACT:prune-memory` to demote pins they do not have.

That is an **impossible cure** — the deny names a remedy the reader cannot perform.

Three distinct deny paths reach it, not one:

| Arm | Deny reason |
|---|---|
| Ordinary note added | `embedded_pin` |
| Legitimate pin added | `count`, 15/12 |
| Long prose added | `size` |

The embedded-pin check returns before either cap axis is consulted, so a guard placed around the cap logic alone leaves that arm live.

## What this PR does

1. **`_parse_pinned_section` reports boundedness.** Returns a `PinnedSection` NamedTuple; 16 call sites migrated.
2. **The gate declines enforcement when the region is unbounded**, before the call to `compute_deny_reason` so all three arms are covered. The decline records which side was unbounded, so it is observable. A bounded region over the cap still denies.
3. **The missing terminator is repaired at SessionStart**, placed before the first undated heading — a terminator at the *end* of the region reproduces the defect it exists to prevent. The repair is not frame-scoped, because the managed-structure migration it must precede has never been frame-scoped; scoping only the repair made the outcome depend on which frame type opened a session first, with the losing branch permanent.
4. **The embedded-pin deny message names both remedies**, and does not promise the edit will then be allowed.
5. **The fresh-start write arm** is gated on the written region's boundedness alone. A genuinely above-cap write still denies.
6. **The repair refuses** when the managed region already contains the terminator text, and says what it actually found rather than what it assumed.

## Certification

Every behavioural claim is certified **bidirectionally** — green on correct input, red on the defect — never by an additive-diff argument.

- **Eighteen pre-registered revert probes**, each registered before it ran. One prediction failed and is recorded rather than dropped.
- A concurrent auditor verified every commit **at rest** off `git archive` exports rather than the live tree, and re-derived an AST source-segment hash to confirm the out-of-scope `_parse_working_memory_section` is byte-unchanged.
- Suite on **Python 3.14.6**: 13,239 passed, 15 skipped, 0 failed, 0 errors, with an explicit errors-token scan. Re-run on **Python 3.13**, which is what CI gates on: **13,234 passed, 19 skipped, 0 errors**, plus one load-sensitive timing test in the merge-guard suite that passes 3/3 in isolation and shares no file with this change. Naming the interpreter because the first two attempts to run on 3.13 reported exit code 0 while executing zero tests.

Checks were found that **could not fail**, and were repaired or replaced. The count is boundary-dependent — an enumeration afterwards ran from 8 to 17 across four defensible readings — so the boundary is stated rather than left implied.

**Eight**, counted across this arc's certification artifacts: the shipped test suite AND the design document and its measurement harnesses. Some of those artifacts are gitignored and ship with nothing; they are counted because the checks and the repairs were real, not because they ship. Excluded: one row that named a discriminating verdict but paired it with a non-discriminating count assertion, so a coder could satisfy it with the weaker half — its control can fail, so it is not a member of this set. The class is checks that could not fail wherever they lived, so a defect in the design document repaired by a mechanism in the shipped suite still counts — the repair locus need not match the defect locus. Also excluded: any check an agent caught and replaced inside its own turn before another party saw it. Two examples of the eight:

- The full-file boundedness formula `end < len(content)` is **true on 100% of marked files**, bounded or not — a wrong implementation would have shipped looking complete while doing nothing. Both natural fixtures force the agreeing branch, so every boundedness fixture now asserts the region was found *before* asserting it is bounded.
- The decline test ran a five-pin fixture against a cap of twelve, so deleting the decline left its verdict assertion passing; the classification assertion beside it carried the whole test. The fixture is now sized from the cap so both halves discriminate.

The last of these found a live defect: covering the second reachable input class of the nothing-absorbed guard catches a repair that inserts the terminator *ahead* of a genuine pin and **under-counts** — the mirror image of the over-count this PR removes.

## Scope

Out of scope by ruling: `working_memory.py`'s first-match section lookup (belongs to pact-memory), and `commands/pin-memory.md`, deferred to PR 2.

Known follow-ups: #1327 (the migration bounds an unbounded region without excluding absorbed entries), #1328, #1329.




