### PR TITLE
Make the pin-comment oracles agree, close a size-cap bypass, and bound the strip to a line

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.24",
+      "version": "4.6.25",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.24/     # Plugin version
+│               └── 4.6.25/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.24",
+  "version": "4.6.25",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.24
+> **Version**: 4.6.25
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/commands/prune-memory.md
+++ b/pact-plugin/commands/prune-memory.md
@@ -127,10 +127,9 @@ curator keeps, collect a one-line reason and extend its date comment in place:
 <!-- pinned: 2026-05-26, reconfirmed: 2026-07-25 because {concrete reason} -->
 ```
 
-The reason MUST be single-line and MUST NOT contain `>` — the parser reads the
-comment as `<!--\s*pinned:\s*[^>]+?-->`, so a `>` truncates it. Re-confirming
-resets the clock: age computes from the `reconfirmed:` date once present. The
-reason is free text and is subject to the same concreteness rule above.
+The reason MUST be single-line. Re-confirming resets the clock: age computes
+from the `reconfirmed:` date once present. The reason is free text and is
+subject to the same concreteness rule above.
 
 Scope note: justification is asked for the pin being evicted and for
 age-flagged borderline pins only — **not for every retained pin**. At 12 pins

--- a/pact-plugin/hooks/pin_caps.py
+++ b/pact-plugin/hooks/pin_caps.py
@@ -160,6 +160,23 @@ def _extract_body_chars(body: str) -> int:
     is a lower bar for POST to clear and DENIES an edit that repairs the file.
     Splitting first gives the strip the same notion of a line the attribution
     path already has.
+
+    The rejoin is a single "\\n" ON PURPOSE, and it is a NORMALISATION rather
+    than a side effect. `splitlines()` recognises more codepoints than "\\n",
+    so the rejoin folds every one of them to a single newline. CRLF is the only
+    fold that changes the LENGTH; every other separator it recognises (\\v, \\f,
+    FS, NEL, U+2028, U+2029) is one character before and after.
+
+    Measured on one body of identical prose, varying only the line ending:
+
+        whole-body strip   LF 1238    CRLF 1246   (+8, one per line break)
+        per-line strip     LF 1199    CRLF 1199   (+0)
+
+    So the previous whole-body strip charged a CRLF author eight characters
+    more for the same text, and the per-line strip charges them the same as
+    everyone else. The fold does not introduce a distortion, it REMOVES one.
+    Do NOT "repair" this join to preserve the original separators: that would
+    restore the per-line-ending penalty those numbers measure.
     """
     kept = []
     for line in body.splitlines():

--- a/pact-plugin/hooks/pin_caps.py
+++ b/pact-plugin/hooks/pin_caps.py
@@ -41,28 +41,50 @@ PIN_STALE_BLOCK_THRESHOLD = 2
 # rationale from itself becoming a back-channel for oversized pins.
 OVERRIDE_RATIONALE_MAX = 120
 
-# Strict regex for the combined pin date + size-override comment.
-# Live form (CLAUDE.md:69):
-#   <!-- pinned: 2026-04-11, pin-size-override: verbatim dispatch form... -->
-# Capture group 1 = rationale text — matches any character EXCEPT a run
-# that terminates the HTML comment (`-->`). Reluctant `.+?` was sufficient
-# under .fullmatch() but is vulnerable to future .search()/.match() misuse
-# by a downstream consumer. Self-anchoring via \A...\Z + a rationale
-# pattern that positively refuses to consume `-->` closes both a
-# latent-misuse vector (Sec-M2) and call-convention drift (Sec-F5).
+# Single source for the pin-comment grammar. Both oracles below are built
+# from these four fragments, so the strip path and the attribution path
+# cannot drift apart on the shape of a comment.
 #
-# Rationale pattern: `(?:[^-]|-(?!->))+` — one or more chars that are
-# either not `-` at all, or `-` NOT followed by `->`. Equivalent to "any
-# char except the `-->` terminator" without resorting to reluctant
-# backtracking.
+# `_COMMENT_CHAR` is one character of a comment interior: either a character
+# that is not `-`, or a `-` that does not start `-->`. A run of this class
+# cannot contain `-->`, so no match can cross the end of a closed comment.
+# This is the positive terminator refusal the override pattern already used.
+# It replaces the older `[^>]` class, which refused EVERY `>` and so made the
+# strip path blind to a comment that held one, while attribution still saw it.
+#
+# `_COMMENT_CHAR_NO_COMMA` is the same rule for the date field, which the
+# comma delimits. It refuses the terminator too, so attribution cannot accept
+# a line whose override clause sits after an early `-->`.
+#
+# The property these fragments deliver is DOMINANCE: every line that
+# attribution accepts, the strip removes in full. The strip may remove more.
+# It must never remove less, because less is a charge against the neighbour.
+#
+# Every fragment is NON-CAPTURING. `OVERRIDE_COMMENT_RE.groups` must stay 1,
+# because `parse_pins` reads the rationale as `group(1)`.
+_COMMENT_CHAR = r'(?:[^-]|-(?!->))'
+_COMMENT_CHAR_NO_COMMA = r'(?:[^-,]|-(?!->))'
+_PIN_COMMENT_OPEN = r'<!--\s*pinned:\s*'
+_PIN_COMMENT_CLOSE = r'-->'
+
+# Strict regex for the combined pin date + size-override comment.
+# Live form:
+#   <!-- pinned: 2026-04-11, pin-size-override: verbatim dispatch form... -->
+# Capture group 1 = rationale text. Self-anchoring via \A...\Z plus a body
+# class that positively refuses `-->` closes both a latent-misuse vector
+# (Sec-M2) and call-convention drift (Sec-F5).
 OVERRIDE_COMMENT_RE = re.compile(
-    r'\A<!--\s*pinned:\s*[^,]+,\s*pin-size-override:\s*((?:[^-]|-(?!->))+?)\s*-->\Z',
+    rf'\A{_PIN_COMMENT_OPEN}{_COMMENT_CHAR_NO_COMMA}+,\s*'
+    rf'pin-size-override:\s*({_COMMENT_CHAR}+?)\s*{_PIN_COMMENT_CLOSE}\Z',
     re.IGNORECASE,
 )
 
 # Standalone <!-- pinned: YYYY-MM-DD[, ...] --> comment without override.
+# Unanchored BY DESIGN: `_extract_body_chars` runs it with `.sub` over a whole
+# pin body, so it cannot be anchored. Terminator refusal, not anchoring, is
+# what keeps it safe under every call convention (Sec-M2).
 _DATE_COMMENT_RE = re.compile(
-    r'<!--\s*pinned:\s*[^>]+?-->',
+    rf'{_PIN_COMMENT_OPEN}{_COMMENT_CHAR}+?{_PIN_COMMENT_CLOSE}',
     re.IGNORECASE,
 )
 

--- a/pact-plugin/hooks/pin_caps.py
+++ b/pact-plugin/hooks/pin_caps.py
@@ -162,10 +162,14 @@ def _extract_body_chars(body: str) -> int:
     path already has.
 
     The rejoin is a single "\\n" ON PURPOSE, and it is a NORMALISATION rather
-    than a side effect. `splitlines()` recognises more codepoints than "\\n",
+    than a side effect. `splitlines()` recognises more separators than "\\n",
     so the rejoin folds every one of them to a single newline. CRLF is the only
-    fold that changes the LENGTH; every other separator it recognises (\\v, \\f,
-    FS, NEL, U+2028, U+2029) is one character before and after.
+    fold that changes the LENGTH, and the reason is structural rather than a
+    list to memorise: CRLF is the only separator that is TWO characters. Every
+    other separator `splitlines()` recognises is a single codepoint, so it is
+    one character before the fold and one character after. (The sibling comment
+    on `_FORBIDDEN_TERMINATOR_TABLE` above enumerates the set, and that is the
+    place to look it up — an enumeration repeated here would drift.)
 
     Measured on one body of identical prose, varying only the line ending:
 

--- a/pact-plugin/hooks/pin_caps.py
+++ b/pact-plugin/hooks/pin_caps.py
@@ -171,16 +171,37 @@ def _extract_body_chars(body: str) -> int:
     on `_FORBIDDEN_TERMINATOR_TABLE` above enumerates the set, and that is the
     place to look it up — an enumeration repeated here would drift.)
 
-    Measured on one body of identical prose, varying only the line ending:
+    THE CLAIM IS A DELTA, NOT A PAIR OF TOTALS, AND IT IS STATED THAT WAY SO
+    IT CAN BE RE-DERIVED. Take any body whose lines are joined once with LF
+    and once with CRLF — identical text, only the separator differs — and
+    measure the charge under each:
 
-        whole-body strip   LF 1238    CRLF 1246   (+8, one per line break)
-        per-line strip     LF 1199    CRLF 1199   (+0)
+        before (base)     CRLF minus LF  =  +1 PER LINE BREAK
+        after (shipped)   CRLF minus LF  =   0
 
-    So the previous whole-body strip charged a CRLF author eight characters
-    more for the same text, and the per-line strip charges them the same as
-    everyone else. The fold does not introduce a distortion, it REMOVES one.
+    On an eight-break body that is +8 and +0. The absolute totals depend
+    entirely on how long the filler happens to be, so they are not quoted
+    here: a reader who reproduces this with different prose gets different
+    totals and the SAME two deltas, which is the whole point.
+
+    READ THE COLUMNS, NOT THE ROWS. The claim is the LF-versus-CRLF difference
+    WITHIN a row: base charges a CRLF author one character more per line for
+    the same text, and the shipped code charges them the same as everyone
+    else. That difference IS the fold, and it is what the rejoin fixes.
+
+    THE ROW DELTA IS NOT THE FOLD, AND THE LABELS DELIBERATELY DO NOT CLAIM IT
+    IS. On a pure-LF body the split-and-rejoin is IDENTITY — splitting on
+    newlines and rejoining with a newline cannot change anything — so the
+    arity change contributes ZERO there. Any drop between the two rows comes
+    entirely from the widened body class stripping a comment the old class
+    could not — measurable by running the base class and the shipped class
+    over the same pure-LF body.
+    An earlier version of this table labelled its rows by mechanism and so
+    attributed that drop to the rejoin, which would tell a reader the join is
+    doing something it is not.
+
     Do NOT "repair" this join to preserve the original separators: that would
-    restore the per-line-ending penalty those numbers measure.
+    restore the per-line-ending penalty the COLUMNS measure.
     """
     kept = []
     for line in body.splitlines():

--- a/pact-plugin/hooks/pin_caps.py
+++ b/pact-plugin/hooks/pin_caps.py
@@ -148,10 +148,23 @@ def _extract_body_chars(body: str) -> int:
     """Count body chars excluding auto-generated markers.
 
     The date comment and STALE marker are plugin-managed — they MUST NOT
-    count against the user's 1500-char budget. Prevents self-referential
-    inflation from override rationale + tool-generated markers.
+    count against the user's 1500-char budget.
+
+    The date-comment strip runs PER LINE. `parse_pins` attributes a comment
+    only after `splitlines()`, so a comment that spans a line break is not a
+    comment to the attribution path. An unanchored strip across the whole body
+    does not share that discipline: it runs from an unterminated marker
+    forward to the next `-->`, which may belong to a different pin, and
+    removes real prose from the count. A lower charge is not a safe error —
+    `compute_deny_reason` compares PRE against POST, so an under-counted PRE
+    is a lower bar for POST to clear and DENIES an edit that repairs the file.
+    Splitting first gives the strip the same notion of a line the attribution
+    path already has.
     """
-    stripped = _DATE_COMMENT_RE.sub("", body)
+    kept = []
+    for line in body.splitlines():
+        kept.append(_DATE_COMMENT_RE.sub("", line))
+    stripped = "\n".join(kept)
     stripped = _STALE_MARKER_RE.sub("", stripped)
     return len(stripped.strip())
 

--- a/pact-plugin/scripts/check_pin_caps.py
+++ b/pact-plugin/scripts/check_pin_caps.py
@@ -139,8 +139,9 @@ PINNED_STALENESS_DAYS = _staleness.PINNED_STALENESS_DAYS
 # Both are `search`, not `fullmatch`, because the comment legitimately carries
 # trailing content after the date — a size-override rationale
 # (`, pin-size-override: ...`) or a re-confirmation clause
-# (`, reconfirmed: YYYY-MM-DD because ...`). The upstream pattern is `[^>]+?`,
-# so that trailing content parses with no regex change anywhere.
+# (`, reconfirmed: YYYY-MM-DD because ...`). The upstream body class refuses
+# the `-->` terminator and nothing else, so that trailing content reaches
+# these two patterns intact and parses with no regex change anywhere.
 _PINNED_DATE_RE = re.compile(r"pinned:\s*(\d{4}-\d{2}-\d{2})", re.IGNORECASE)
 _RECONFIRMED_DATE_RE = re.compile(
     r"reconfirmed:\s*(\d{4}-\d{2}-\d{2})", re.IGNORECASE

--- a/pact-plugin/tests/test_pin_comment_dominance.py
+++ b/pact-plugin/tests/test_pin_comment_dominance.py
@@ -1,0 +1,522 @@
+"""
+Tests for the pin-comment DOMINANCE invariant in hooks/pin_caps.py.
+
+Location: pact-plugin/tests/test_pin_comment_dominance.py
+
+Summary: pins the safety property that ties the two pin-comment oracles
+together. `OVERRIDE_COMMENT_RE` and `_DATE_COMMENT_RE` recognise one concept.
+Attribution uses both. The strip uses `_DATE_COMMENT_RE` alone. If the strip
+is NARROWER than attribution, a comment that annotates pin N stays inside the
+slice of pin N-1, and its characters are charged to that neighbour. The
+neighbour then takes a size deny that the curator did not cause.
+
+DOMINANCE, stated over a single line `L`:
+
+    OVERRIDE_COMMENT_RE.fullmatch(L) is not None
+      or _DATE_COMMENT_RE.fullmatch(L) is not None
+    =>  _DATE_COMMENT_RE.sub("", L) == ""
+
+The strip may remove MORE than attribution accepts. It must never remove
+less, because less is a charge against the neighbour.
+
+Used with: hooks/pin_caps.py (the two patterns and the four fragments they
+are built from) and hooks/pin_caps_gate.py (one lead-frame integration
+witness). Sibling coverage of the same module lives in test_pin_caps.py;
+this file owns the cross-oracle property only.
+
+Test organization uses scope-suffix class naming per the convention in
+test_pin_caps.py — duplicate test class basenames across files silently drop
+the losing file's tests.
+"""
+
+import itertools
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+sys.path.insert(0, str(Path(__file__).parent))
+
+from helpers import make_claude_md_with_pins  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# The corpus grammar.
+#
+# THESE AXES ARE LITERAL ON PURPOSE. Do NOT rebuild them from the fragments in
+# pin_caps.py, and do not import `_COMMENT_CHAR` or its siblings here.
+#
+# A corpus derived from the module under test asserts that module against
+# itself. It goes red on the old code and green on the new code, so it LOOKS
+# certified, and it protects nothing: a later editor who moves a fragment
+# moves the corpus with it, and the property stays green while the behaviour
+# breaks. Independence from the implementation is the whole value of this
+# file, because a shared-source rule is structural and this property is not.
+#
+# The axes are curator-shaped, not exhaustive. Each one carries at least one
+# member that the old body class refused: a `>` in prose, a `>=` comparison, a
+# quoted blockquote marker, an arrow, and a date field that closes the comment
+# early.
+# ---------------------------------------------------------------------------
+
+CORPUS_OPENERS = [
+    "<!-- pinned: ",
+    "<!--pinned:",
+    "<!--  PINNED:  ",
+    "<!-- Pinned: ",
+]
+
+CORPUS_DATES = [
+    "2026-01-01",
+    "a > b",
+    "a -> b",
+    "x-->y",
+    "2026-01-01 ",
+    "",
+]
+
+CORPUS_CLAUSES = [
+    "",
+    ", pin-size-override: plain",
+    ", pin-size-override: a -> b",
+    ", pin-size-override: use >= not >",
+    ', pin-size-override: quote "> foo"',
+    ", pin-size-override: keep <!-- pinned: form",
+    ", pin-size-override: dash-heavy -- text",
+    ", reconfirmed: 2026-03-01 because A -> B",
+    ", reconfirmed: 2026-03-01 because n > 2",
+]
+
+CORPUS_CLOSERS = [
+    " -->",
+    "-->",
+    "  -->",
+]
+
+# Non-vacuity floor on the ATTRIBUTED population.
+#
+# Dominance is an IMPLICATION, so every line that attribution REFUSES
+# satisfies it for free. A corpus that drifts toward refused shapes therefore
+# reaches zero violations for the wrong reason, and a passing test cannot tell
+# the difference. This floor makes the antecedent load-bearing.
+#
+# Measured attributed count with the shipped patterns: 539 of 648 generated
+# lines. The floor sits at 500, so the measured headroom is 39 lines. A change
+# that narrows attribution past that trips this floor instead of quietly
+# emptying the property.
+#
+# The floor is itself a predicate, so it is proved by mutation in
+# TestPinCommentDominance_FloorGuard rather than asserted.
+MIN_ATTRIBUTED = 500
+
+
+def build_corpus(openers, dates, clauses, closers):
+    """Return every `opener + date + clause + closer` combination."""
+    return [
+        opener + date + clause + closer
+        for opener, date, clause, closer in itertools.product(
+            openers, dates, clauses, closers
+        )
+    ]
+
+
+def measure_corpus(corpus):
+    """Return (attributed, violations) for a list of candidate lines.
+
+    A line is ATTRIBUTED when either oracle full-matches it. An attributed
+    line is a VIOLATION when the strip leaves a residue.
+    """
+    from pin_caps import OVERRIDE_COMMENT_RE, _DATE_COMMENT_RE
+
+    attributed = 0
+    violations = 0
+    for line in corpus:
+        if (OVERRIDE_COMMENT_RE.fullmatch(line) is not None
+                or _DATE_COMMENT_RE.fullmatch(line) is not None):
+            attributed += 1
+            if _DATE_COMMENT_RE.sub("", line) != "":
+                violations += 1
+    return attributed, violations
+
+
+def two_pin_section(body_a, comment_b, title_a="PinA", title_b="PinB"):
+    """Build a two-pin Pinned Context body.
+
+    The comment of pin B sits inside the forward slice of pin A, which is the
+    overlap the strip exists to compensate for. So `parse_pins(...)[0]
+    .body_chars` equals `len(body_a)` exactly when the strip removes the
+    comment of pin B in full.
+    """
+    entry_a = f"<!-- pinned: 2026-01-01 -->\n### {title_a}\n{body_a}"
+    entry_b = f"{comment_b}\n### {title_b}\nshort"
+    return entry_a + "\n\n" + entry_b + "\n"
+
+
+class TestPinCommentDominance_Property:
+    """The generative invariant, over a corpus declared in this file."""
+
+    def test_dominance_holds_over_the_generated_corpus(self):
+        corpus = build_corpus(
+            CORPUS_OPENERS, CORPUS_DATES, CORPUS_CLAUSES, CORPUS_CLOSERS
+        )
+        from pin_caps import _DATE_COMMENT_RE, OVERRIDE_COMMENT_RE
+
+        offenders = []
+        for line in corpus:
+            attributed = (
+                OVERRIDE_COMMENT_RE.fullmatch(line) is not None
+                or _DATE_COMMENT_RE.fullmatch(line) is not None
+            )
+            if attributed and _DATE_COMMENT_RE.sub("", line) != "":
+                offenders.append((line, _DATE_COMMENT_RE.sub("", line)))
+
+        assert offenders == [], (
+            f"{len(offenders)} line(s) are attributed as a pin comment but are "
+            f"not stripped in full. Each residue is charged to the PRECEDING "
+            f"pin. First offender: {offenders[0] if offenders else None}"
+        )
+
+    def test_attributed_population_is_non_vacuous(self):
+        """The implication is worthless if almost nothing satisfies it."""
+        corpus = build_corpus(
+            CORPUS_OPENERS, CORPUS_DATES, CORPUS_CLAUSES, CORPUS_CLOSERS
+        )
+        attributed, _ = measure_corpus(corpus)
+        assert attributed >= MIN_ATTRIBUTED, (
+            f"only {attributed} of {len(corpus)} corpus lines are attributed "
+            f"as pin comments (floor {MIN_ATTRIBUTED}). Dominance is an "
+            f"implication, so a shrunken antecedent makes it pass vacuously."
+        )
+
+    def test_realistic_curator_lines_are_attributed_and_stripped(self):
+        """Named shapes, so the floor cannot be met by uninteresting lines."""
+        from pin_caps import _DATE_COMMENT_RE, OVERRIDE_COMMENT_RE
+
+        lines = [
+            "<!-- pinned: 2026-01-01 -->",
+            "<!-- pinned: 2026-01-01, pin-size-override: verbatim form -->",
+            "<!-- pinned: 2026-01-01, pin-size-override: a -> b -->",
+            "<!-- pinned: 2026-01-01, pin-size-override: use >= not > -->",
+            "<!-- pinned: 2026-01-01, pin-size-override: keep <!-- pinned: form -->",
+            "<!-- pinned: 2026-05-26, reconfirmed: 2026-07-25 because n > 2 -->",
+            "<!-- PINNED: 2026-01-01 -->",
+        ]
+        for line in lines:
+            attributed = (
+                OVERRIDE_COMMENT_RE.fullmatch(line) is not None
+                or _DATE_COMMENT_RE.fullmatch(line) is not None
+            )
+            assert attributed, f"not attributed as a pin comment: {line!r}"
+            assert _DATE_COMMENT_RE.sub("", line) == "", (
+                f"attributed but not stripped in full: {line!r}"
+            )
+
+
+class TestPinCommentDominance_FloorGuard:
+    """Prove the non-vacuity floor by mutation. A floor that cannot fail is
+    not a floor — it is a second assertion that passes for every
+    implementation and reads as rigour while it supplies none."""
+
+    # Every date field closes the comment early, so the shipped patterns
+    # refuse the whole corpus at attribution.
+    DRIFTED_DATES = ["x-->y", "2026-01-01-->", "a-->b"]
+
+    def test_drifted_corpus_satisfies_dominance_vacuously(self):
+        """The property alone cannot detect the drift. This is the hazard."""
+        drifted = build_corpus(
+            CORPUS_OPENERS, self.DRIFTED_DATES, CORPUS_CLAUSES, CORPUS_CLOSERS
+        )
+        _, violations = measure_corpus(drifted)
+        assert violations == 0, (
+            "expected the drifted corpus to satisfy dominance vacuously; if it "
+            "does not, this guard no longer demonstrates the hazard it exists for"
+        )
+
+    def test_floor_trips_on_the_drifted_corpus(self):
+        """The floor DOES detect the drift. This is the mutation proof."""
+        drifted = build_corpus(
+            CORPUS_OPENERS, self.DRIFTED_DATES, CORPUS_CLAUSES, CORPUS_CLOSERS
+        )
+        attributed, _ = measure_corpus(drifted)
+        assert attributed < MIN_ATTRIBUTED, (
+            f"the drifted corpus reported {attributed} attributed lines, which "
+            f"meets the floor of {MIN_ATTRIBUTED}. The floor therefore does not "
+            f"discriminate a healthy corpus from a vacuous one."
+        )
+
+    def test_healthy_corpus_clears_the_floor(self):
+        """Both directions, so the floor is not simply always false."""
+        healthy = build_corpus(
+            CORPUS_OPENERS, CORPUS_DATES, CORPUS_CLAUSES, CORPUS_CLOSERS
+        )
+        attributed, _ = measure_corpus(healthy)
+        assert attributed >= MIN_ATTRIBUTED
+
+
+class TestPinCommentCharge_Metamorphic:
+    """The defect stated as a property rather than as one example."""
+
+    def test_neighbour_charge_is_invariant_under_equal_length_rationales(self):
+        from pin_caps import parse_pins
+
+        body_a = "x" * 40
+        arrow = "<!-- pinned: 2026-02-02, pin-size-override: keep a -> b now -->"
+        plain = "<!-- pinned: 2026-02-02, pin-size-override: keep a to b now -->"
+        assert len(arrow) == len(plain), "fixture error: comments differ in length"
+
+        charge_arrow = parse_pins(two_pin_section(body_a, arrow))[0].body_chars
+        charge_plain = parse_pins(two_pin_section(body_a, plain))[0].body_chars
+
+        assert charge_arrow == charge_plain, (
+            f"pin A is charged {charge_arrow} chars with an arrow in pin B's "
+            f"rationale and {charge_plain} without it, though the two comments "
+            f"are the same length. The rationale TEXT of one pin must not move "
+            f"the size of its neighbour."
+        )
+        assert charge_arrow == len(body_a)
+
+
+class TestPinCommentTrigger_AnyGreaterThan:
+    """The trigger is any `>` character, not the arrow.
+
+    A repair that special-cased the arrow would pass an arrow-only test and
+    still leave every other `>` shape broken.
+    """
+
+    @pytest.mark.parametrize("rationale", [
+        "a > b",
+        "use >= not >",
+        "> quoted blockquote",
+        "C++ -> Rust",
+        "a -> b",
+        "count > 2 and count < 9",
+    ])
+    def test_neighbour_is_not_charged_for_the_comment(self, rationale):
+        from pin_caps import parse_pins
+
+        body_a = "x" * 40
+        comment_b = f"<!-- pinned: 2026-02-02, pin-size-override: {rationale} -->"
+        pins = parse_pins(two_pin_section(body_a, comment_b))
+        assert pins[0].body_chars == len(body_a), (
+            f"pin A charged {pins[0].body_chars} chars, expected {len(body_a)}. "
+            f"The comment of pin B leaked into pin A's slice for rationale "
+            f"{rationale!r}."
+        )
+
+
+class TestPinCommentReconfirmed_Repair:
+    """A `reconfirmed:` clause holding `>` fails BOTH oracles on the old code.
+
+    The pin loses its date, so its age degrades to unknown in silence, AND the
+    neighbour is still charged. Both halves are asserted, because both fail.
+    """
+
+    @pytest.mark.parametrize("clause", [
+        "reconfirmed: 2026-03-01 because A -> B",
+        "reconfirmed: 2026-03-01 because n > 2",
+    ])
+    def test_date_survives_and_neighbour_is_not_charged(self, clause):
+        from pin_caps import parse_pins
+
+        body_a = "x" * 40
+        comment_b = f"<!-- pinned: 2026-01-01, {clause} -->"
+        pins = parse_pins(two_pin_section(body_a, comment_b))
+
+        assert pins[1].date_comment == comment_b, (
+            "pin B lost its date comment, so its age degrades to unknown"
+        )
+        assert pins[0].body_chars == len(body_a), (
+            f"pin A charged {pins[0].body_chars} chars, expected {len(body_a)}"
+        )
+
+    def test_reconfirmed_date_is_recoverable_for_age(self):
+        """The whole point of the clause is that the age reads from it."""
+        import re
+
+        from pin_caps import parse_pins
+
+        body_a = "x" * 40
+        comment_b = (
+            "<!-- pinned: 2026-01-01, reconfirmed: 2026-03-01 because n > 2 -->"
+        )
+        pins = parse_pins(two_pin_section(body_a, comment_b))
+        found = re.search(
+            r"reconfirmed:\s*(\d{4}-\d{2}-\d{2})", pins[1].date_comment or ""
+        )
+        assert found is not None and found.group(1) == "2026-03-01"
+
+
+class TestPinCommentDateField_BypassClosure:
+    """A date field that closes the comment early must not grant an override.
+
+    In the rendered document the comment ENDS at the first `-->`. Everything
+    after it is ordinary visible prose. An override granted on the strength of
+    that prose is an unlimited-size grant bought with text that is not inside
+    a comment at all.
+    """
+
+    EARLY_CLOSING = "<!-- pinned: 2026-01-01--> tail, pin-size-override: r -->"
+
+    def test_oversized_body_with_early_closing_date_field_denies(self):
+        from pin_caps import PIN_SIZE_CAP, evaluate_full_state, parse_pins
+
+        body = "y" * (PIN_SIZE_CAP + 100)
+        section = f"{self.EARLY_CLOSING}\n### Oversized\n{body}\n"
+        pins = parse_pins(section)
+        violation = evaluate_full_state(pins)
+
+        assert violation is not None, (
+            "the size cap was bypassed: an override was granted from text that "
+            "sits outside the rendered comment"
+        )
+        assert violation.kind == "size"
+
+    def test_early_closing_date_field_grants_no_rationale(self):
+        from pin_caps import parse_pins
+
+        section = f"{self.EARLY_CLOSING}\n### Oversized\nshort\n"
+        pins = parse_pins(section)
+        assert pins[0].override_rationale is None
+
+    def test_faithful_override_still_grants(self):
+        """The closure must not refuse an honest curator line."""
+        from pin_caps import PIN_SIZE_CAP, evaluate_full_state, parse_pins
+
+        body = "y" * (PIN_SIZE_CAP + 100)
+        comment = (
+            "<!-- pinned: 2026-01-01, pin-size-override: verbatim dispatch form -->"
+        )
+        section = f"{comment}\n### Oversized\n{body}\n"
+        pins = parse_pins(section)
+
+        assert pins[0].override_rationale == "verbatim dispatch form"
+        assert evaluate_full_state(pins) is None
+
+
+class TestPinCommentStrip_NoCrossBoundary:
+    """The strip must not run from one comment into the next.
+
+    A run of the body class cannot contain `-->`, so the first terminator at
+    or after the body start ends the match, and `re.sub` resumes after it.
+    """
+
+    @pytest.mark.parametrize("body,expected", [
+        (
+            "KEEP1 <!-- pinned: 2026-01-01 --> KEEP2 "
+            "<!-- pinned: 2026-02-02 --> KEEP3",
+            "KEEP1  KEEP2  KEEP3",
+        ),
+        (
+            "KEEP1 <!-- pinned: 2026-01-01, pin-size-override: a -> b --> KEEP2 "
+            "<!-- pinned: 2026-02-02 --> KEEP3",
+            "KEEP1  KEEP2  KEEP3",
+        ),
+        (
+            "KEEP1 <!-- just a note --> KEEP3",
+            "KEEP1 <!-- just a note --> KEEP3",
+        ),
+        (
+            "KEEP1 <!-- pinned: 2026-01-01 KEEP2 --> KEEP3",
+            "KEEP1  KEEP3",
+        ),
+        (
+            "KEEP1 <!-- pinned: 2026-01-01 a > b KEEP2 --> KEEP3",
+            "KEEP1  KEEP3",
+        ),
+        (
+            "KEEP1 <!-- pinned: 2026-01-01 KEEP2 KEEP3",
+            "KEEP1 <!-- pinned: 2026-01-01 KEEP2 KEEP3",
+        ),
+    ])
+    def test_strip_residue(self, body, expected):
+        from pin_caps import _DATE_COMMENT_RE
+        assert _DATE_COMMENT_RE.sub("", body) == expected
+
+    def test_only_a_pin_comment_is_ever_stripped(self):
+        from pin_caps import _DATE_COMMENT_RE
+        body = "<!-- STALE: Last relevant 2026-01-01 --> <!-- other -->"
+        assert _DATE_COMMENT_RE.sub("", body) == body
+
+
+class TestPinCommentFragments_NonCapturing:
+    """Every grammar fragment must stay non-capturing.
+
+    `parse_pins` reads the rationale as `group(1)`. A capturing fragment
+    shifts the group index, so the parser would silently read the date field
+    as the rationale.
+    """
+
+    def test_override_pattern_has_exactly_one_group(self):
+        from pin_caps import OVERRIDE_COMMENT_RE
+        assert OVERRIDE_COMMENT_RE.groups == 1
+
+    def test_group_one_is_the_rationale_not_the_date(self):
+        """The behavioural half. The count alone cannot catch a swap."""
+        from pin_caps import OVERRIDE_COMMENT_RE
+        line = "<!-- pinned: 2026-01-01, pin-size-override: keep a -> b -->"
+        found = OVERRIDE_COMMENT_RE.fullmatch(line)
+        assert found is not None
+        assert found.group(1) == "keep a -> b"
+
+    def test_both_patterns_stay_case_insensitive(self):
+        import re
+
+        from pin_caps import OVERRIDE_COMMENT_RE, _DATE_COMMENT_RE
+        assert OVERRIDE_COMMENT_RE.flags & re.IGNORECASE
+        assert _DATE_COMMENT_RE.flags & re.IGNORECASE
+
+
+@pytest.fixture
+def dominance_gate_env(tmp_path, monkeypatch, pact_context):
+    """Point the gate at a temporary CLAUDE.md and return its path."""
+    claude_md = tmp_path / "CLAUDE.md"
+    pact_context(
+        team_name="test-team",
+        session_id="session-dominance",
+        project_dir=str(tmp_path),
+    )
+    import staleness
+    monkeypatch.setattr(staleness, "get_project_claude_md_path", lambda: claude_md)
+    return claude_md
+
+
+class TestPinCommentGate_LeadFrameWitness:
+    """One integration witness, in a LEAD frame.
+
+    A gate assertion in a NON-lead frame would be a predicate that cannot
+    fail: the role check precedes the path match, so no decision payload is
+    formed and an ALLOW assertion passes for every implementation, broken ones
+    included. The pure-function tests above carry the certification; this test
+    only witnesses that the repair reaches the real gate.
+    """
+
+    def test_over_block_on_the_neighbour_is_gone(self, dominance_gate_env):
+        from pin_caps_gate import _check_tool_allowed
+
+        claude_md = dominance_gate_env
+        clean = make_claude_md_with_pins([
+            "<!-- pinned: 2026-01-01 -->\n### Baseline\nshort"
+        ])
+        claude_md.write_text(clean, encoding="utf-8")
+
+        # Pin A sits just under the cap on its own. Pin B's comment carries a
+        # `>`, so on the old code it was charged to pin A and pushed it over.
+        body_a = "x" * 1480
+        entries = [
+            f"<!-- pinned: 2026-01-01 -->\n### PinA\n{body_a}",
+            "<!-- pinned: 2026-02-02, pin-size-override: keep a -> b -->\n"
+            "### PinB\nshort",
+        ]
+        result = _check_tool_allowed({
+            "tool_name": "Write",
+            "agent_type": "pact-orchestrator",
+            "tool_input": {
+                "file_path": str(claude_md),
+                "content": make_claude_md_with_pins(entries),
+            },
+        })
+        assert result is None, (
+            f"the gate denied a faithful curator edit: {result}. Pin A is "
+            f"{len(body_a)} chars on its own; the deny can only come from the "
+            f"comment of pin B being charged to it."
+        )

--- a/pact-plugin/tests/test_pin_comment_dominance.py
+++ b/pact-plugin/tests/test_pin_comment_dominance.py
@@ -64,6 +64,19 @@ CORPUS_OPENERS = [
     "<!--pinned:",
     "<!--  PINNED:  ",
     "<!-- Pinned: ",
+    # The opener's separators are `\s*`, which accepts 28 characters, 18 of
+    # them INLINE rather than line separators. All 18 are attributed by the
+    # shipped pattern, and the four openers above express exactly ONE of them
+    # — the plain space. A corpus built only from shapes a curator TYPES
+    # cannot see a change to what the pattern TOLERATES, so narrowing `\s*`
+    # to ` *` used to leave every number here identical.
+    #
+    # TAB is ordinary. NBSP is what a paste from a rendered document or a word
+    # processor inserts, and it is INVISIBLE IN EVERY EDITOR — which is why it
+    # is written here as an escape and MUST STAY one. A literal would be a
+    # character nobody can see in the fixture that exists to make it visible.
+    "<!--\tpinned:\t",
+    "<!--\u00a0pinned:\u00a0",
 ]
 
 CORPUS_DATES = [
@@ -100,14 +113,22 @@ CORPUS_CLOSERS = [
 # reaches zero violations for the wrong reason, and a passing test cannot tell
 # the difference. This floor makes the antecedent load-bearing.
 #
-# Measured attributed count with the shipped patterns: 539 of 648 generated
-# lines. The floor sits at 500, so the measured headroom is 39 lines. A change
+# Measured attributed count with the shipped patterns: 809 of 972 generated
+# lines. The floor sits at 750, so the measured headroom is 59 lines. A change
 # that narrows attribution past that trips this floor instead of quietly
 # emptying the property.
 #
+# THE FLOOR MOVED WITH THE CORPUS, ON PURPOSE. Adding the TAB and NBSP openers
+# took the corpus from 648 lines to 972 and the attributed count from 539 to
+# 809. Leaving the floor at its old 500 would have widened the headroom from
+# 39 to 309 — the guard would still have passed, and it would have stopped
+# detecting anything short of a two-thirds collapse. A floor is only as good
+# as its distance from the measurement, so widening the corpus without moving
+# the floor SILENTLY WEAKENS it.
+#
 # The floor is itself a predicate, so it is proved by mutation in
 # TestPinCommentDominance_FloorGuard rather than asserted.
-MIN_ATTRIBUTED = 500
+MIN_ATTRIBUTED = 750
 
 
 def build_corpus(openers, dates, clauses, closers):
@@ -457,6 +478,54 @@ class TestPinCommentFragments_NonCapturing:
         found = OVERRIDE_COMMENT_RE.fullmatch(line)
         assert found is not None
         assert found.group(1) == "keep a -> b"
+
+    def test_the_override_anchors_hold_against_a_search_caller(self):
+        """`\\A...\\Z` must not be loosened to `^...$`.
+
+        The module documents the self-anchor as protection against a FUTURE
+        `.search` or `.match` caller. `\\Z` matches only at the very end of the
+        string; `$` also matches before a trailing newline, so the caret form
+        would let a `.search` caller accept a line with a newline after the
+        terminator. Nothing in the dominance corpus can see that, because the
+        property is quantified over `fullmatch` and fullmatch is False on BOTH
+        forms for every trailing-newline input.
+
+        *** THE EXACT INPUT IS LOAD-BEARING AND THE OBVIOUS ONE IS VACUOUS. ***
+        `$` matches only before a SINGLE trailing newline sitting IMMEDIATELY
+        after the terminator. Measured on both forms:
+
+            terminator flush then \\n   shipped False   caret TRUE   <- the only
+                                                                       discriminator
+            a SPACE before the \\n      shipped False   caret False
+            two newlines               shipped False   caret False
+            no newline (control)       shipped True    caret True
+
+        TWO OF THE THREE CORPUS CLOSERS BEGIN WITH A SPACE, so copying one and
+        appending a newline — the natural way to write this test — produces an
+        input that passes on both forms and looks like a guard. Do NOT "tidy"
+        the spacing below: adding a space or a second newline silently disarms
+        this test.
+        """
+        from pin_caps import OVERRIDE_COMMENT_RE
+
+        flush = "<!-- pinned: 2026-01-01, pin-size-override: r -->\n"
+        assert OVERRIDE_COMMENT_RE.search(flush) is None, (
+            "a `.search` caller accepted a line with a newline after the "
+            "terminator, which means the self-anchor has been loosened from "
+            "`\\A...\\Z` to `^...$`"
+        )
+
+    def test_the_search_anchor_probe_is_not_vacuous(self):
+        """CONTROL. The same string WITHOUT the trailing newline must match.
+
+        Without this, the assertion above also passes for a pattern that
+        matches nothing at all.
+        """
+        from pin_caps import OVERRIDE_COMMENT_RE
+
+        assert OVERRIDE_COMMENT_RE.search(
+            "<!-- pinned: 2026-01-01, pin-size-override: r -->"
+        ) is not None
 
     def test_both_patterns_stay_case_insensitive(self):
         import re

--- a/pact-plugin/tests/test_pin_comment_pipeline.py
+++ b/pact-plugin/tests/test_pin_comment_pipeline.py
@@ -574,6 +574,106 @@ class TestPinCommentCorruptedMarker_RuledAcceptance:
             )
 
 
+class TestPinCommentMixedLine_RuledAcceptance:
+    """RULED ACCEPTANCE for a comment that SHARES A LINE WITH PROSE.
+
+    Attribution reads only whole lines: `parse_pins` runs `fullmatch` on the
+    STRIPPED line, so a line carrying prose either side of a comment is NEVER
+    attributed — it sets no date and grants no override. The strip is a
+    `.sub`, so it removes that comment's substring from the line anyway.
+
+    SO THE STRIP REMOVES WHAT ATTRIBUTION NEVER ATTRIBUTES, and the counted
+    body comes out LOWER than an attribution-consistent count. A lower charge
+    is a lower bar for the post state to clear, which is the same mechanism as
+    the stray-opener fault above.
+
+    Measured on one mixed line, comment interior varied:
+
+      comment holds `>`     previous code  charges it in full (its `[^>]`
+                            class cannot cross the `>`, so it never matches)
+                            per-line strip REMOVES it
+      comment holds no `>`  BOTH remove it — so this is PRE-EXISTING on the
+                            previous code and not introduced here
+
+    The widening EXTENDED an existing asymmetry to `>`-bearing comments; it
+    did not create one. A line bound cannot reach it, because the whole shape
+    lives inside a single line.
+
+    WHY IT IS ACCEPTED RATHER THAN CLOSED. Closing it means making the strip
+    agree with attribution about what a comment IS — a per-line `fullmatch`
+    instead of a `sub`. That RAISES charges, and raising charges is the
+    direction measured to push pins over the cap and manufacture fresh denies.
+    It would trade a known, bounded residual for an unmeasured one. Live
+    reachability was measured at ZERO across 50 project files, behind a
+    positive control of 41 pin-comment openers, so no real file reaches it.
+
+    DO NOT "FIX" THIS. It reads like an oversight and it is a decision.
+
+    STANDING ORDER: if these tests ever fail, RE-OPEN THE RULING. Do not
+    adjust the test to match new behaviour — a failure here means the strip
+    and the attribution path have changed their relationship, which is the
+    thing the ruling was made about.
+    """
+
+    LEAD = "lead prose "
+    TRAIL = " trail prose"
+    COMMENT_GT = "<!-- pinned: 2026-02-02, note > threshold -->"
+    COMMENT_PLAIN = "<!-- pinned: 2026-02-02, note ok here -->"
+    MIXED_GT = LEAD + COMMENT_GT + TRAIL
+    MIXED_PLAIN = LEAD + COMMENT_PLAIN + TRAIL
+    ALONE = COMMENT_GT
+
+    def test_the_strip_removes_a_mixed_line_comment_anyway(self):
+        """The accepted behaviour, asserted as a DIRECT OBSERVATION.
+
+        The residue is the prose ALONE. Deliberately not compared against a
+        computed attribution-consistent count: computing one would put a
+        SECOND IMPLEMENTATION of the code under test inside this file, and
+        the test would then check two implementations against each other
+        rather than check correctness.
+
+        Deliberately no verdict and no character budget either — whether a
+        given pin is denied depends on where it sits relative to the cap, so
+        pinning a verdict would make an unrelated size change look like a
+        regression.
+        """
+        from pin_caps import _DATE_COMMENT_RE
+
+        for line in (self.MIXED_GT, self.MIXED_PLAIN):
+            assert _DATE_COMMENT_RE.sub("", line) == self.LEAD + self.TRAIL, (
+                f"expected the strip to remove the embedded comment from "
+                f"{line!r} and leave the prose alone, which is the accepted "
+                f"behaviour recorded above"
+            )
+
+    def test_attribution_refuses_a_mixed_line(self):
+        """The ruling's PREMISE, checked rather than remembered.
+
+        The acceptance rests on attribution never attributing a mixed line.
+        If that stopped being true the two paths would agree and the residual
+        would not exist, so the ruling would need re-reading rather than
+        re-asserting.
+        """
+        from pin_caps import OVERRIDE_COMMENT_RE, _DATE_COMMENT_RE
+
+        for line in (self.MIXED_GT, self.MIXED_PLAIN):
+            stripped = line.strip()
+            assert _DATE_COMMENT_RE.fullmatch(stripped) is None
+            assert OVERRIDE_COMMENT_RE.fullmatch(stripped) is None
+
+    def test_the_same_comment_alone_on_its_line_is_attributed(self):
+        """CONTROL, and it must PASS for the class above to mean anything.
+
+        Same comment text, nothing else on the line. Attribution accepts it
+        and the strip removes it completely. Without this the two assertions
+        above would also hold for a pattern that simply matched nothing.
+        """
+        from pin_caps import _DATE_COMMENT_RE, _extract_body_chars
+
+        assert _DATE_COMMENT_RE.fullmatch(self.ALONE) is not None
+        assert _extract_body_chars(self.ALONE) == 0
+
+
 class TestPinCommentMultiLine_Characterization:
     """CHARACTERIZATION OF CURRENT BEHAVIOUR. This is NOT a requirement.
 

--- a/pact-plugin/tests/test_pin_comment_pipeline.py
+++ b/pact-plugin/tests/test_pin_comment_pipeline.py
@@ -674,6 +674,93 @@ class TestPinCommentMixedLine_RuledAcceptance:
         assert _extract_body_chars(self.ALONE) == 0
 
 
+class TestPinCommentSplitComment_RuledAcceptance:
+    """RULED ACCEPTANCE for a pin comment SPLIT ACROSS TWO LINES.
+
+    THIS PINS THE CHARGE, AND IT IS A REQUIREMENT. Do not confuse it with
+    `TestPinCommentMultiLine_Characterization` directly below, which pins the
+    PATTERN and says in its own docstring that a remediation is expected to
+    change its values. That class disclaims what it appears to guard; THIS one
+    does not. A failure here is not a delta to review and absorb — it is a
+    ruling being reversed.
+
+    THE BEHAVIOUR. `_extract_body_chars` strips per line, so a comment that
+    spans a line break is not stripped at all and every one of its characters
+    counts against the curator's budget.
+
+    WHY THAT IS CORRECT RATHER THAN A COST TO BE REPAID. `parse_pins`
+    attributes only after `splitlines()`, so a comment spanning a line break is
+    NOT A COMMENT to the attribution path — it sets no date and grants no
+    override. The previous whole-body strip removed it anyway, which is the
+    two-oracles-disagree defect this whole change exists to remove. Charging it
+    is what AGREEMENT between the two paths looks like, not a regression that a
+    later fix should undo.
+
+    THIS WAS THE FIRST OF THE FOUR RULINGS AND IT WAS RULED DELIBERATELY. The
+    charge rises for this shape, and near the cap that turns some edits from
+    allowed into denied. Live reachability was measured at ZERO. The ruling
+    weighed a bounded, measured cost against re-opening the defect.
+
+    DO NOT "FIX" THIS. The repair someone reaches for first is to keep the line
+    bound and add a second whole-body pass that re-strips the split comment.
+    That silently reverses this ruling, and before this class existed it passed
+    the entire suite.
+
+    STANDING ORDER: if these tests fail, RE-OPEN THE RULING. Do not adjust the
+    test to match new behaviour.
+    """
+
+    OPEN = "<!-- pinned: 2026-02-02,"
+    CLOSE = "ratio > 3 -->"
+    SPLIT = OPEN + "\n" + CLOSE
+    JOINED = OPEN + " " + CLOSE
+
+    def test_a_split_comment_is_not_stripped_and_its_characters_count(self):
+        """The ruled behaviour, as a DIRECT OBSERVATION with no magic number.
+
+        Nothing is removed, so the charge is the whole string. Asserted against
+        the fixture's own length rather than a literal, so re-wording the
+        fixture cannot make this a false regression.
+        """
+        from pin_caps import _extract_body_chars
+
+        assert _extract_body_chars(self.SPLIT) == len(self.SPLIT), (
+            "a comment spanning a line break must NOT be stripped; its "
+            "characters count, which is the ruled acceptance recorded above"
+        )
+
+    def test_the_same_text_on_one_line_is_stripped_to_nothing(self):
+        """CONTROL, and it must PASS for the assertion above to mean anything.
+
+        Identical text, one line instead of two. Here the strip and attribution
+        agree that it IS a comment, and it costs nothing. The CONTRAST between
+        the two is the finding: the line break is the only difference, and it
+        is what decides whether the characters count.
+        """
+        from pin_caps import _extract_body_chars
+
+        assert _extract_body_chars(self.JOINED) == 0
+
+    def test_a_split_comment_inside_a_pin_body_is_charged_to_that_pin(self):
+        """The same fact where a curator meets it, rather than on a bare string.
+
+        Without this the class would pin a helper's behaviour on an input no
+        document produces.
+        """
+        from pin_caps import parse_pins
+
+        body = "prose line one"
+        region = (
+            "<!-- pinned: 2026-01-01 -->\n"
+            f"### Alpha\n{body}\n{self.SPLIT}\n"
+        )
+        pin = parse_pins(region)[0]
+        assert pin.body_chars == len(body) + 1 + len(self.SPLIT), (
+            "the split comment's characters must be charged to the pin whose "
+            "body contains them"
+        )
+
+
 class TestPinCommentMultiLine_Characterization:
     """CHARACTERIZATION OF CURRENT BEHAVIOUR. This is NOT a requirement.
 

--- a/pact-plugin/tests/test_pin_comment_pipeline.py
+++ b/pact-plugin/tests/test_pin_comment_pipeline.py
@@ -318,36 +318,36 @@ class TestPinCommentTwoState_Pipeline:
         post = parse_pins(self._region(None))
         return compute_deny_reason(pre, post, "")
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "OPEN FINDING, reported and not yet dispositioned. The curator "
-            "deletes a stray unterminated pin-comment opener, which removes "
-            "characters and adds none, and the edit is DENIED. The widened "
-            "strip reaches past the `>` to the next terminator, so the "
-            "PRE-state charge falls, and the net-worse predicate then reads "
-            "the unchanged post state as a regression. The previous code "
-            "allowed this repair."
-        ),
-    )
     def test_repairing_a_stray_opener_is_not_denied(self):
+        """The fault this file was written for. It is fixed; keep it fixed.
+
+        A curator deletes a stray unterminated pin-comment opener. The edit
+        removes characters and adds none, so no pin grew. Before the per-line
+        strip the whole-body strip ran past the `>` to a terminator belonging
+        to the NEXT pin, which under-counted the PRE state and made the
+        unchanged POST state look like a regression.
+        """
         stray = "<!-- pinned: 2026-02-02, note > threshold"
         assert self._verdict(stray) is None, (
             "the curator's repair of their own file was denied. The edit only "
             "removes characters, so no pin grew."
         )
 
-    def test_a_stray_opener_without_a_greater_than_denies_on_both_versions(self):
-        """CONTROL, and it denies. That is the point.
+    def test_a_stray_opener_without_a_greater_than_is_also_not_denied(self):
+        """The PRE-EXISTING half of the same fault, and it is fixed too.
 
         This case shares every ingredient with the one above EXCEPT the `>`.
-        Without the `>` the previous body class also strips the region, so
-        both code versions read the same pre-state and both deny. The deny is
-        therefore not new, and the `>` is isolated as the one ingredient that
-        makes the two verdicts diverge.
+        That difference used to decide everything: without a `>` the older
+        body class also ran forward, so BOTH code versions under-counted the
+        pre-state and BOTH denied this repair. It was therefore not a
+        regression introduced by the `>` widening — it was already there.
+
+        The per-line strip closes both halves at once, which is why the
+        remediation was scoped to the root cause rather than to the widening.
+        The two tests now agree, and the `>` no longer decides the verdict.
         """
         stray = "<!-- pinned: 2026-02-02, note above threshold"
-        assert self._verdict(stray) is not None
+        assert self._verdict(stray) is None
 
     def test_removing_a_wellformed_comment_holding_a_greater_than_is_allowed(self):
         """The repair this change exists to make does NOT open a deny.
@@ -368,6 +368,256 @@ class TestPinCommentTwoState_Pipeline:
         """
         stray = "<!-- note: 2026-02-02, count > threshold"
         assert self._verdict(stray) is None
+
+
+class TestPinCommentTwoStateWellFormed_Pipeline:
+    """The same two-state SHAPE reached from a WELL-FORMED pre-state.
+
+    The sibling class above needs a malformed pre-state. This one does not,
+    and the two look identical until you ask WHICH SIDE IS MIS-MEASURING.
+
+    The shared condition is that the stripping ADVANTAGE must SHRINK across
+    the edit. That is NECESSARY for the two versions to disagree, and it is
+    NOT SUFFICIENT for the disagreement to be a fault. A fault also needs the
+    version holding the advantage to be the one measuring WRONGLY:
+
+      * malformed route: the advantage comes from running past an
+        unterminated marker and swallowing REAL PROSE. The current code is
+        the wrong one, and its refusal is a defect.
+      * this route: the advantage comes from correctly excluding a
+        PLUGIN-MANAGED comment. The previous code is the wrong one, and the
+        refusal is the cap working.
+
+    So a repair should remove the first advantage and KEEP the second. This
+    class therefore holds a RULED ACCEPTANCE rather than a pin on a defect.
+
+    WHY IT REMAINS A SEPARATE CLASS. It was staged as a second tripwire
+    because a repair could close the malformed route and leave this one, at
+    which point the sibling marker would come off and this behaviour would
+    ship unexamined. That is exactly what happened. The pin did its job, the
+    behaviour was examined and then ruled correct, and the pin stays as a
+    live record of the decision rather than being deleted.
+    """
+
+    PROSE = "Alpha prose that belongs to pin A. " * 22
+    TAIL = "Beta prose that also belongs to pin A. " * 18
+    COMMENT = "<!-- pinned: 2026-02-02, note > threshold -->"
+
+    def _region(self, comment):
+        return (
+            "<!-- pinned: 2026-01-01 -->\n"
+            f"### PinA\n{self.PROSE}\n"
+            f"{comment}\n"
+            f"{self.TAIL}\n"
+            "### PinB\nshort\n"
+        )
+
+    def _verdict(self, post_comment):
+        from pin_caps import compute_deny_reason, parse_pins
+
+        pre = parse_pins(self._region(self.COMMENT))
+        post = parse_pins(self._region(post_comment))
+        return compute_deny_reason(pre, post, "")
+
+    def test_demoting_a_pin_comment_to_a_plain_comment_is_denied(self):
+        """RULED ACCEPTANCE. This deny is CORRECT and is kept deliberately.
+
+        A curator renames the marker so a pin comment becomes an ordinary
+        comment. The file gets two characters shorter and the edit is refused.
+        That reads like an over-block and is not one, for a reason that only
+        appears when the two charges are compared:
+
+        Before the edit the comment is PLUGIN-MANAGED, and
+        `_extract_body_chars` documents that managed markers MUST NOT count
+        against the curator's budget. The comment holds a `>`, so the previous
+        code failed to strip it and counted it; the current code strips it.
+        The current pre-state figure is therefore the CORRECT one and the
+        previous figure was inflated by a mis-measurement.
+
+        After the edit the text is no longer a pin comment, so both versions
+        agree it counts. The pin then genuinely sits above the cap with no
+        override, and the refusal is the cap doing its job. The previous
+        version allowed the edit only because its inflated pre-state figure
+        made the post-state look no worse.
+
+        So this is a RULED ACCEPTANCE and not a tolerated defect. It was
+        reported, measured, and decided. If a later change makes this test
+        fail, the pin has stopped being refused — re-open the ruling rather
+        than adjusting the test.
+        """
+        verdict = self._verdict("<!-- note: 2026-02-02, note > threshold -->")
+        assert verdict is not None, (
+            "the ruled acceptance no longer holds: this edit is now allowed"
+        )
+
+    def test_renaming_a_marker_on_a_comment_without_a_greater_than_denies_alike(self):
+        """CONTROL, and it denies. The `>` is again the discriminator.
+
+        Without a `>` the previous code also stripped the comment, so both
+        code versions read the same pre-state and neither treats the rename
+        as a regression peculiar to one of them.
+        """
+        from pin_caps import compute_deny_reason, parse_pins
+
+        pre = parse_pins(self._region("<!-- pinned: 2026-02-02, note ok -->"))
+        post = parse_pins(self._region("<!-- note: 2026-02-02, note ok -->"))
+        assert compute_deny_reason(pre, post, "") is not None
+
+    def test_editing_the_rationale_without_removing_the_marker_is_allowed(self):
+        """CONTROL. The advantage must SHRINK, not merely change.
+
+        Editing the rationale leaves the comment a pin comment, so it is
+        stripped in both states, the advantage is unchanged, and no deny
+        appears. This is what separates the fault from ordinary comment edits.
+        """
+        assert self._verdict(
+            "<!-- pinned: 2026-02-02, note gt threshold -->"
+        ) is None
+
+
+class TestPinCommentCorruptedMarker_RuledAcceptance:
+    """RULED ACCEPTANCE for a deny that NOTHING SHIPPING TODAY produces.
+
+    The curator deletes the terminator of a well-formed comment holding a
+    `>`, and a LATER terminator exists further down the same pin. Three
+    arms, and the two that exist today allow for DIFFERENT WRONG REASONS:
+
+      previous code   pre 2050  post 2046  ALLOW  — pre is WRONG. It counts
+                      an intact plugin-managed comment against the curator.
+      current code    pre 1996  post 1019  ALLOW  — post is WRONG. Once the
+                      terminator is gone it runs forward to the LATER
+                      terminator and eats about a thousand characters of
+                      real prose.
+      per-line strip  pre 1996  post 2046  DENY   — correct in BOTH states.
+
+    So the refusal is correct enforcement. The comment's 54 characters were
+    exempt while it was plugin-managed; corrupting the marker makes them
+    ordinary text, and the counted body genuinely reaches 2046 against a cap
+    of 1500 with no override.
+
+    THIS WAS RULED, NOT ASSUMED, AND THE RULING WAS NOT OBVIOUS. Unlike the
+    sibling acceptance above, this deny is new relative to BOTH the previous
+    code AND the current branch — nothing in existence produces it today. It
+    was measured, escalated twice, and decided deliberately.
+
+    DO NOT "FIX" THIS DENY. It looks like a bug pinned by accident and it is
+    not. If you are about to relax it, read the three-arm arithmetic above
+    first: any change that makes this pair allowed again is re-introducing
+    one of the two measurement errors it was chosen over.
+
+    THE PER-LINE STRIP HAS LANDED, so this now asserts live behaviour. It
+    was written as a strict xfail while the arm was still a proposal, and the
+    marker came off in the same change that made it pass — a ruling and the
+    tripwire recording it must not ship one commit apart.
+    """
+
+    PROSE = "Alpha prose that belongs to pin A. " * 37
+    TAIL = "Beta prose that also belongs to pin A. " * 18
+    WELL_FORMED = "<!-- pinned: 2026-02-02, note > threshold -->"
+
+    def _region(self, comment):
+        return (
+            "<!-- pinned: 2026-01-01 -->\n"
+            f"### PinA\n{self.PROSE}\n"
+            f"{comment}\n"
+            f"{self.TAIL}\n"
+            "<!-- pinned: 2026-03-03 -->\n"
+            "### PinB\nshort\n"
+        )
+
+    def test_corrupting_a_managed_marker_is_denied(self):
+        from pin_caps import compute_deny_reason, parse_pins
+
+        unterminated = self.WELL_FORMED.replace(" -->", "")
+        assert len(self.WELL_FORMED) - len(unterminated) == 4
+
+        pre = parse_pins(self._region(self.WELL_FORMED))
+        post = parse_pins(self._region(unterminated))
+        assert compute_deny_reason(pre, post, "") is not None, (
+            "the corrupted marker's characters are counted, so the body grew "
+            "past the cap and the edit must be refused"
+        )
+
+    def test_the_current_code_allows_it_only_by_running_forward(self):
+        """The ruling's premise, checked rather than remembered.
+
+        The current code allows the pair ONLY because its post-state charge
+        FALLS — and a four-character deletion cannot legitimately reduce a
+        counted body by hundreds. That fall IS the forward run over real
+        prose, and it is the measurement error the ruling weighed.
+
+        Deliberately asserted on the CHARGES rather than on the verdict, and
+        deliberately tolerant of both arms: it holds while the forward run
+        exists and holds again once a per-line strip removes it. So it
+        records the premise without adding a second red at remediation time.
+        The single intended red is the XPASS above.
+        """
+        from pin_caps import parse_pins
+
+        unterminated = self.WELL_FORMED.replace(" -->", "")
+        pre = parse_pins(self._region(self.WELL_FORMED))[0].body_chars
+        post = parse_pins(self._region(unterminated))[0].body_chars
+        deleted = len(self.WELL_FORMED) - len(unterminated)
+
+        if post < pre:
+            # Forward run present: the drop must be far larger than the edit.
+            assert pre - post > deleted, (
+                "a fall of only the deleted characters would not be a "
+                "forward run, and the ruling's premise would not hold"
+            )
+        else:
+            # Forward run removed. The body may only grow by the characters
+            # that stopped being exempt, never by more.
+            assert post - pre == len(self.WELL_FORMED) - deleted, (
+                "the growth must equal exactly the characters that lost their "
+                "managed exemption"
+            )
+
+
+class TestPinCommentMultiLine_Characterization:
+    """CHARACTERIZATION OF CURRENT BEHAVIOUR. This is NOT a requirement.
+
+    The cross-oracle property in the sibling file is quantified over `every
+    single-line string L`, but nothing ENFORCES single-line-ness, and the
+    patterns do match a multi-line string. The property is therefore silent
+    about multi-line input, and this class records what the code does there
+    TODAY so a later change has a shared reference to compare against.
+
+    A REMEDIATION IS EXPECTED TO CHANGE THESE VALUES. A repair that stops the
+    pattern matching across a newline CLOSES this blind spot and is correct.
+    If these assertions fail, do NOT treat that as a regression: review the
+    delta, confirm it is the intended change, and update this class as part
+    of the same commit. Written as a requirement it would be a false tripwire
+    that a correct fix has to break.
+    """
+
+    MULTI_LINE = (
+        "<!-- pinned: 2026-01-01, opener here\n"
+        "a middle line of real prose\n"
+        "and another -->"
+    )
+
+    def test_strip_pattern_currently_matches_across_newlines(self):
+        from pin_caps import _DATE_COMMENT_RE
+
+        assert _DATE_COMMENT_RE.fullmatch(self.MULTI_LINE) is not None
+
+    def test_strip_currently_removes_a_multi_line_comment_entirely(self):
+        from pin_caps import _DATE_COMMENT_RE
+
+        assert _DATE_COMMENT_RE.sub("", self.MULTI_LINE) == ""
+
+    def test_the_per_line_discipline_lives_in_the_caller_not_the_pattern(self):
+        """The distinction that decides what a line-bounded repair must bind.
+
+        `parse_pins` splits with `splitlines()` before it matches, so the
+        attribution PATH is per-line. The pattern is not. A repair may bind
+        either one, and the two are different changes.
+        """
+        from pin_caps import parse_pins
+
+        pins = parse_pins(f"### P\n{self.MULTI_LINE}\n")
+        assert pins[0].date_comment is None
 
 
 class TestPinCommentBacktracking_Pipeline:

--- a/pact-plugin/tests/test_pin_comment_pipeline.py
+++ b/pact-plugin/tests/test_pin_comment_pipeline.py
@@ -1,0 +1,419 @@
+"""
+Tests for the pin-comment repair BEYOND a single line and a single state.
+
+Location: pact-plugin/tests/test_pin_comment_pipeline.py
+
+Summary: the sibling file `test_pin_comment_dominance.py` owns the cross-oracle
+property, which is quantified over ONE line and evaluated on ONE parse. This
+file owns what that shape cannot reach:
+
+  * the TWO-STATE predicate `compute_deny_reason`, which compares a pre-edit
+    parse against a post-edit parse and denies when post is strictly worse;
+  * the STALE marker path, which shares the module and was left alone;
+  * multi-pin regions, where attribution walks backward over several pins;
+  * malformed regions, where the parser promises to fail open;
+  * `>` carriers that the enumerated alphabets could not express, such as an
+    HTML fragment, an XML close tag and an angle-bracket generic;
+  * an anti-exponential tripwire on the changed date field.
+
+WHY A SIBLING FILE. The dominance file counts a corpus and asserts a floor on
+it. The cases here build documents and read charges. Mixing them lowers the
+signal of both, because a document fixture that fails takes the corpus counts
+down with it.
+
+NON-VACUITY. Tests below that CANNOT be red against the previous code are
+named as no-change controls in their own docstrings. Their content is that the
+repair leaves those cases alone, so a red there would mean the change did
+something it promised not to do.
+
+Used with: hooks/pin_caps.py.
+"""
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+sys.path.insert(0, str(Path(__file__).parent))
+
+
+STALE_MARKER = "<!-- STALE: Last relevant 2026-01-01 -->"
+
+
+def two_pin_section(body_a, comment_b):
+    """Build a two-pin body where pin B's comment sits in pin A's slice.
+
+    `parse_pins(...)[0].body_chars` equals `len(body_a)` exactly when the
+    strip removes pin B's comment in full.
+    """
+    return (
+        "<!-- pinned: 2026-01-01 -->\n"
+        f"### PinA\n{body_a}\n"
+        f"{comment_b}\n"
+        "### PinB\nshort\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# `>` carriers.
+#
+# The enumerated alphabets in this arc were built from `a1-<>!,` plus a space.
+# The carriers below hold characters and shapes that alphabet cannot express.
+# Each one is a rationale a curator could realistically write in THIS
+# repository, which documents markup grammars.
+# ---------------------------------------------------------------------------
+
+CARRIERS_WITH_GT = [
+    "render <b>bold</b> inline",
+    "ends with </tag> here",
+    "the List<Map<K,V>> shape",
+    "2 > 1 >= 0 > -1",
+    "value >> 2 and 1 >> 0",
+    "lambda x => x + 1",
+    "quote: > cited line",
+]
+
+CARRIERS_WITHOUT_GT = [
+    "see https://x.example/?a=1&b=2",
+    "the rule — and its bound",
+    "escape &gt; as an entity",
+    "flow a → b then stop",
+]
+
+
+class TestPinCommentCarriers_Pipeline:
+    """The trigger is ANY `>`, on shapes the enumerations could not express."""
+
+    @pytest.mark.parametrize("carrier", CARRIERS_WITH_GT)
+    def test_carrier_holding_a_greater_than_is_not_charged(self, carrier):
+        from pin_caps import parse_pins
+
+        body_a = "Pin A body, which the curator did not touch."
+        comment = f"<!-- pinned: 2026-03-01, pin-size-override: {carrier} -->"
+        pins = parse_pins(two_pin_section(body_a, comment))
+
+        assert pins[0].body_chars == len(body_a), (
+            f"pin A was charged {pins[0].body_chars} chars against a body of "
+            f"{len(body_a)}. The excess is pin B's comment, which holds "
+            f"{carrier!r}."
+        )
+        assert pins[1].date_comment == comment
+
+    @pytest.mark.parametrize("carrier", CARRIERS_WITHOUT_GT)
+    def test_carrier_without_a_greater_than_is_unaffected(self, carrier):
+        """NO-CHANGE CONTROL. These shapes were never broken.
+
+        They answer the other half of the question: the repair must not newly
+        refuse a faithful rationale that carries a URL, an em-dash, an HTML
+        entity or a Unicode arrow.
+        """
+        from pin_caps import parse_pins
+
+        body_a = "Pin A body, which the curator did not touch."
+        comment = f"<!-- pinned: 2026-03-01, pin-size-override: {carrier} -->"
+        pins = parse_pins(two_pin_section(body_a, comment))
+
+        assert pins[0].body_chars == len(body_a)
+        assert pins[1].override_rationale == carrier
+
+    def test_reconfirmed_clause_keeps_its_date_and_its_neighbour(self):
+        """The reconfirmed shape fails BOTH oracles on the previous code.
+
+        The pin lost its date attribution AND the neighbour was charged, so
+        both halves belong in one assertion.
+        """
+        from pin_caps import parse_pins
+
+        body_a = "Pin A body, which the curator did not touch."
+        comment = ("<!-- pinned: 2026-03-01, reconfirmed: 2026-04-01 "
+                   "because count > 2 -->")
+        pins = parse_pins(two_pin_section(body_a, comment))
+
+        assert pins[1].date_comment == comment
+        assert pins[0].body_chars == len(body_a)
+
+
+class TestPinCommentStale_Pipeline:
+    """The STALE path shares the module and was deliberately left alone.
+
+    `is_stale` reads the RAW body with `.search`, while `_extract_body_chars`
+    works on a stripped copy. The widened strip therefore cannot reach the
+    staleness signal. These tests pin that separation.
+    """
+
+    STALE_CASES = [
+        ("marker alone", "body\n" + STALE_MARKER),
+        ("date comment holding `>` then marker",
+         "body\n<!-- pinned: 2026-01-01, a > b -->\n" + STALE_MARKER),
+        ("unterminated opener holding `>` then marker",
+         "body\n<!-- pinned: 2026-01-01, a > b\nmore\n" + STALE_MARKER),
+        ("unterminated opener without `>` then marker",
+         "body\n<!-- pinned: 2026-01-01 no close\nmore\n" + STALE_MARKER),
+    ]
+
+    @pytest.mark.parametrize(
+        "label,body", STALE_CASES, ids=[c[0] for c in STALE_CASES]
+    )
+    def test_stale_signal_survives_the_widened_strip(self, label, body):
+        """NO-CHANGE CONTROL on the signal. The charge test below discriminates."""
+        from pin_caps import parse_pins
+
+        pins = parse_pins(f"### P\n{body}\n")
+        assert pins[0].is_stale is True, (
+            f"the STALE marker stopped being seen for case {label!r}. "
+            f"`is_stale` must read the RAW body, not the stripped copy."
+        )
+
+    def test_a_greater_than_comment_beside_a_stale_marker_is_not_charged(self):
+        """Both managed markers must leave the curator's budget alone."""
+        from pin_caps import parse_pins
+
+        body = ("body\n"
+                "<!-- pinned: 2026-01-01, a > b -->\n"
+                f"{STALE_MARKER}")
+        pins = parse_pins(f"### P\n{body}\n")
+
+        assert pins[0].body_chars == len("body")
+        assert pins[0].is_stale is True
+
+    def test_stale_block_threshold_is_unchanged_by_greater_than_comments(self):
+        """A region whose every comment holds `>` still reports stale overflow."""
+        from pin_caps import PIN_STALE_BLOCK_THRESHOLD, check_stale_block, parse_pins
+
+        region = ""
+        for i in range(3):
+            region += (
+                f"<!-- pinned: 2026-0{i + 1}-01, note > {i} -->\n"
+                f"### Pin {i}\nbody {i}\n{STALE_MARKER}\n"
+            )
+        pins = parse_pins(region)
+
+        assert len(pins) == 3
+        assert sum(p.is_stale for p in pins) >= PIN_STALE_BLOCK_THRESHOLD
+        violation = check_stale_block(pins)
+        assert violation is not None and violation.kind == "stale"
+
+
+class TestPinCommentMultiPin_Pipeline:
+    """Attribution walks BACKWARD over several pins, and must not overreach."""
+
+    def test_every_pin_in_a_six_pin_region_is_charged_only_its_own_body(self):
+        from pin_caps import parse_pins
+
+        bodies = [f"{'body ' * 8}pin {i}" for i in range(6)]
+        region = ""
+        for i, body in enumerate(bodies):
+            region += (
+                f"<!-- pinned: 2026-01-0{i + 1}, reason a > b for pin {i} -->\n"
+                f"### Pin {i}\n{body}\n"
+            )
+        pins = parse_pins(region)
+
+        assert len(pins) == 6
+        assert [p.body_chars for p in pins] == [len(b) for b in bodies], (
+            "at least one pin was charged for a neighbouring pin's comment"
+        )
+        assert all(p.date_comment is not None for p in pins), (
+            "a pin lost its date attribution, so its age degrades in silence"
+        )
+
+    def test_backward_walk_takes_the_nearest_comment_over_blank_lines(self):
+        """Two comments, blank lines between. The NEAREST one must win."""
+        from pin_caps import parse_pins
+
+        nearest = "<!-- pinned: 2026-03-03, second > marker -->"
+        region = (
+            "<!-- pinned: 2026-01-01 -->\n"
+            "### PinA\nbody A\n"
+            "\n"
+            "<!-- pinned: 2026-02-02, first > marker -->\n"
+            "\n"
+            f"{nearest}\n"
+            "\n"
+            "### PinB\nbody B\n"
+        )
+        pins = parse_pins(region)
+
+        assert pins[1].date_comment == nearest
+        assert pins[0].body_chars == len("body A")
+
+
+class TestPinCommentMalformed_Pipeline:
+    """`parse_pins` promises fail-open. A malformed region must not raise."""
+
+    MALFORMED = [
+        ("unterminated comment, nothing after",
+         "### P\nbody\n<!-- pinned: 2026-01-01, a > b\n", 1),
+        ("comment with no heading after it",
+         "### P\nbody\n<!-- pinned: 2026-01-01, a > b -->\n", 1),
+        ("heading with no comment before it",
+         "### P\nbody only\n### Q\nbody two\n", 2),
+        ("comment before the first heading",
+         "<!-- pinned: 2026-01-01, a > b -->\n### P\nbody\n", 1),
+        ("empty region", "", 0),
+        ("only a comment, no heading at all",
+         "<!-- pinned: 2026-01-01, a > b -->\n", 0),
+        ("closer with no opener", "### P\nbody --> tail\n", 1),
+        ("opener inside prose, closer far away",
+         "### P\nprose <!-- pinned: a > b more prose\nyet more\n--> tail\n", 1),
+        ("nested openers, one closer",
+         "### P\n<!-- pinned: <!-- pinned: x > y -->\n", 1),
+        ("comment split across two lines",
+         "### P\nbody\n<!-- pinned: 2026-01-01,\na > b -->\n", 1),
+    ]
+
+    @pytest.mark.parametrize(
+        "label,region,expected_pins", MALFORMED, ids=[c[0] for c in MALFORMED]
+    )
+    def test_malformed_region_parses_without_raising(
+        self, label, region, expected_pins
+    ):
+        """NO-CHANGE CONTROL on the pin count. The charge test below discriminates."""
+        from pin_caps import parse_pins
+
+        pins = parse_pins(region)
+        assert len(pins) == expected_pins, (
+            f"case {label!r} changed the pin count, which changes the count cap"
+        )
+
+    def test_a_trailing_comment_with_no_heading_is_still_stripped(self):
+        """A pin whose comment has no following heading still loses it.
+
+        This is the case that discriminates: the previous body class refused
+        the `>` and charged the whole comment to the pin.
+        """
+        from pin_caps import parse_pins
+
+        pins = parse_pins("### P\nbody\n<!-- pinned: 2026-01-01, a > b -->\n")
+        assert pins[0].body_chars == len("body")
+
+
+class TestPinCommentTwoState_Pipeline:
+    """`compute_deny_reason` compares TWO parses, not one.
+
+    A per-line property cannot reach this predicate, because the quantity it
+    compares does not exist until two documents have been parsed. An edit is
+    denied when the post state is strictly worse than the pre state, so a
+    LOWER pre-state charge is not a safety margin. It is a lower bar for the
+    post state to clear.
+    """
+
+    PROSE1 = "Alpha prose that belongs to pin A. " * 37
+    PROSE2 = "Beta prose that also belongs to pin A. " * 18
+    PIN_B_COMMENT = "<!-- pinned: 2026-03-03 -->"
+
+    def _region(self, stray):
+        lines = ["<!-- pinned: 2026-01-01 -->", "### PinA", self.PROSE1]
+        if stray is not None:
+            lines.append(stray)
+        lines += [self.PROSE2, self.PIN_B_COMMENT, "### PinB", "short"]
+        return "\n".join(lines) + "\n"
+
+    def _verdict(self, stray):
+        from pin_caps import compute_deny_reason, parse_pins
+
+        pre = parse_pins(self._region(stray))
+        post = parse_pins(self._region(None))
+        return compute_deny_reason(pre, post, "")
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "OPEN FINDING, reported and not yet dispositioned. The curator "
+            "deletes a stray unterminated pin-comment opener, which removes "
+            "characters and adds none, and the edit is DENIED. The widened "
+            "strip reaches past the `>` to the next terminator, so the "
+            "PRE-state charge falls, and the net-worse predicate then reads "
+            "the unchanged post state as a regression. The previous code "
+            "allowed this repair."
+        ),
+    )
+    def test_repairing_a_stray_opener_is_not_denied(self):
+        stray = "<!-- pinned: 2026-02-02, note > threshold"
+        assert self._verdict(stray) is None, (
+            "the curator's repair of their own file was denied. The edit only "
+            "removes characters, so no pin grew."
+        )
+
+    def test_a_stray_opener_without_a_greater_than_denies_on_both_versions(self):
+        """CONTROL, and it denies. That is the point.
+
+        This case shares every ingredient with the one above EXCEPT the `>`.
+        Without the `>` the previous body class also strips the region, so
+        both code versions read the same pre-state and both deny. The deny is
+        therefore not new, and the `>` is isolated as the one ingredient that
+        makes the two verdicts diverge.
+        """
+        stray = "<!-- pinned: 2026-02-02, note above threshold"
+        assert self._verdict(stray) is not None
+
+    def test_removing_a_wellformed_comment_holding_a_greater_than_is_allowed(self):
+        """The repair this change exists to make does NOT open a deny.
+
+        A WELL-FORMED comment carrying a `>` is stripped by the new code and
+        was charged by the old one. Deleting it lowers the charge on both, so
+        no new deny appears. NO-CHANGE CONTROL, and it bounds the finding
+        above to the malformed route.
+        """
+        stray = "<!-- pinned: 2026-02-02, note > threshold -->"
+        assert self._verdict(stray) is None
+
+    def test_a_non_pin_comment_opener_is_allowed_on_both_versions(self):
+        """CONTROL. The strip needs the literal `pinned:` prefix.
+
+        A stray opener that is not a pin comment is stripped by neither code
+        version, so both read the same pre-state and both allow.
+        """
+        stray = "<!-- note: 2026-02-02, count > threshold"
+        assert self._verdict(stray) is None
+
+
+class TestPinCommentBacktracking_Pipeline:
+    """An anti-exponential tripwire on the changed date field.
+
+    NO-CHANGE CONTROL against the previous code, which is faster on these
+    inputs. The guard is against a FUTURE edit that makes the alternation
+    ambiguous, because the two branches are disjoint today and a run of
+    characters therefore has exactly one decomposition.
+
+    The budget is deliberately loose. Measured growth is quadratic and the
+    worst case here costs tens of milliseconds, so a budget in seconds cannot
+    flake, and an exponential would blow through it by orders of magnitude.
+    """
+
+    BUDGET_SECONDS = 5.0
+
+    @pytest.mark.parametrize("length", [500, 1000, 2000])
+    def test_interior_whitespace_run_stays_within_budget(self, length):
+        from pin_caps import OVERRIDE_COMMENT_RE
+
+        # An interior whitespace run survives `.strip()`, so this is the shape
+        # the parser can actually receive. The trailing character closes it.
+        line = "<!-- pinned:" + " " * length + "x"
+        assert line.strip() == line
+
+        started = time.perf_counter()
+        OVERRIDE_COMMENT_RE.fullmatch(line)
+        elapsed = time.perf_counter() - started
+
+        assert elapsed < self.BUDGET_SECONDS, (
+            f"a {len(line)}-char line took {elapsed:.3f}s. The date field is a "
+            f"quantified alternation, so check whether its branches have "
+            f"stopped being disjoint."
+        )
+
+    def test_many_unterminated_openers_stay_within_budget(self):
+        from pin_caps import _DATE_COMMENT_RE
+
+        body = ("<!-- pinned: a > b " * 400) + ("word " * 40)
+
+        started = time.perf_counter()
+        _DATE_COMMENT_RE.sub("", body)
+        elapsed = time.perf_counter() - started
+
+        assert elapsed < self.BUDGET_SECONDS, (
+            f"a {len(body)}-char body took {elapsed:.3f}s to strip. Each "
+            f"unterminated opener is a fresh start position for the scan."
+        )


### PR DESCRIPTION
Fixes the live over-block reported in #1334, plus a pre-existing one it was hiding, plus a size-cap bypass found while chasing the residual.

## What was wrong

Two patterns disagreed about whether `>` may appear in a pin comment. A comment containing one was **recognised by the attribution path and unrecognised by the stripping path**, so its length was charged to the *preceding* pin — denying a pin the curator never edited. **The trigger is any `>`, not only an arrow.**

Chasing the residual violations surfaced a second defect: the date field accepted a comment terminator, so a comment could match *past* its own rendered end and grant an **unlimited-size override on text outside the comment**. Verified: a 1600-char body allowed on `main`, denied after.

A third, deeper one surfaced in TEST. Every measurement to that point — a 648-line corpus, a 37,449-case enumeration, 730,259 probes — measured a **single-line, single-state** property. The deny a curator actually meets is **two-state**: it compares a pre-edit parse against a post-edit parse. No per-line instrument reaches that predicate at any probe count. Tested there, the first fix **denied a curator deleting a stray comment opener — repairing their own file** — because over-stripping the pre-state lowered the bar the post-state had to clear.

## What ships

- **One shared, non-capturing character class** builds both patterns. The invariant is **dominance, not sameness** — sameness is a structure a later editor can satisfy while breaking the behaviour — and it ships as an executable property test with a **non-vacuity floor**, itself mutation-proved, because dominance is an implication and a corpus of refused shapes would satisfy it for free.
- **The strip runs per line**, giving it the notion of a line the attribution path already had. This closes the reported case *and* the pre-existing one that needs no `>` at all.
- **The date field is tightened**, closing the bypass.
- Two documentation surfaces that described the old pattern change in the same commit, including a command file that instructed curators to *work around* the defect.

Selected over three alternatives on measurement, not structure: bounding the pattern instead of the caller would leave the two oracles disagreeing about multi-line input — a fresh instance of the defect being removed.

## Four ruled costs

Each was measured, escalated, ruled, and **pinned by a regression test carrying the standing order: if it fails, re-open the ruling — do not adjust the test.**

| Cost | Ruling |
|---|---|
| A comment split across lines is no longer stripped, so its characters count | Accept — the strip and attribution now agree, and charging it is the consequence of that agreement |
| Demoting a pin comment denies | Accept — the new count is correct; `main` allowed only by counting a plugin-managed marker against the user |
| Deleting a terminator denies | Accept — same arithmetic; both prior arms allowed for *different* wrong reasons |
| A comment sharing a line with prose is stripped though never attributed | Accept — pre-existing without a `>`, extended here; closing it raises charges in the deny-creating direction |

The tests carry **four distinct standing orders** that must not be flattened: faults that must fail the moment they are fixed; behaviour that must not be lost; ruled acceptances that must not be reverted; and a characterization whose change is expected and must be reviewed.

## Also fixed, unlooked-for

The per-line rejoin **normalises line endings**. The previous whole-body strip charged a CRLF author one extra character per line break for identical prose. Measured: `1238` vs `1246` before, `1199` vs `1199` after.

## Limits — stated as limits, not caveats

- **Every document fixture in this work used two pins.** Pin count was subsequently measured clean at 2, 3, 6, 12 and 13 across all rulings by two independent instruments — but that measurement is the *only* thing covering it, and documents beyond 13 pins are untested.
- **Simultaneous violators were held at one or two.** More than two is unmeasured, as is a violator ordered *before* the edited pin.
- A **pre-existing under-block** (mechanism untouched here, confirmed by two instruments at an exact threshold): an untouched oversized pin masks a ruled deny, because the evaluator compares the largest violator rather than the edited one. **Reachability: not reachable on this repo's `CLAUDE.md`** (11 pins, largest 1486, none over cap); **reachable on a global `CLAUDE.md`** carrying one pin at 2507 with no override.
- A ~13 ms in-cap performance cost, accepted against an 870-fold recovery on the shape that motivated the work.

## Verification

Full suite green at **13251 passed / 15 skipped / 0 failed / 0 errors**, run against the exact committed bytes at `0dec3f37`. Every guard is proved by mutation — red on the defect, green on the fix — never by a diff-shape argument.

Eight out-of-scope findings filed separately: #1335, #1336, #1337, #1338, #1339, #1340, #1341, #1342.

Version bumped to 4.6.25 (patch).

