### PR TITLE
Refresh the pinned-context budget warning and raise the budget to 3200

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.28",
+      "version": "4.6.29",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.27",
+      "version": "4.6.28",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.27/     # Plugin version
+│               └── 4.6.28/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.28/     # Plugin version
+│               └── 4.6.29/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.27",
+  "version": "4.6.28",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.28",
+  "version": "4.6.29",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.28
+> **Version**: 4.6.29
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.27
+> **Version**: 4.6.28
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/shared/claude_md_manager.py
+++ b/pact-plugin/hooks/shared/claude_md_manager.py
@@ -558,7 +558,12 @@ def _atomic_write_text(target: Path, content: str, project_root: Path) -> None:
             # raw fd would leak (the cleanup below unlinks the temp FILE but
             # cannot close a descriptor it never received a handle for).
             try:
-                handle = os.fdopen(fd, "w", encoding="utf-8")
+                # newline="" so this handle performs NO line-ending translation.
+                # With newline=None, Python rewrites each "\n" to os.linesep,
+                # which is "\n" here and "\r\n" on Windows, so a caller that
+                # restored CRLF emits "\r\r\n" there. The caller chooses the
+                # line ending. This primitive writes the bytes it is given.
+                handle = os.fdopen(fd, "w", encoding="utf-8", newline="")
             except BaseException:
                 os.close(fd)
                 raise

--- a/pact-plugin/hooks/staleness.py
+++ b/pact-plugin/hooks/staleness.py
@@ -121,6 +121,26 @@ _BUDGET_WARNING_SHAPE = (
 # text a user wrote inside a pin body. Compare `_find_declared_end_offset`:
 # a predicate's tolerance follows its failure direction, never its resemblance
 # to a predicate that looks like it.
+#
+# THE SYMPTOM THAT WILL MAKE SOMEBODY WANT TO LOOSEN THIS, AND WHY TO REFUSE.
+# A user who moves a warning line below the head keeps it, because this
+# predicate is anchored and cannot reach it. The report arrives as "the hook
+# shows two warnings", or as "the hook reports a breach my own pins did not
+# cause", because that line is measured with the rest of the body. Both are
+# real, and both are accepted. The law is CONDITIONAL, not a constant:
+#     count = N + (1 if estimate_tokens(user_text + stranded) > BUDGET else 0)
+# where N is the number of lines the user moved below the head. No pass raises
+# the count.
+#
+# DO NOT WIDEN THIS PATTERN TO REACH THEM. It DELETES, so a wider anchor reaches
+# text a user wrote inside a pin body, and this file is frequently gitignored.
+# The correct repair separates the two questions: EXCLUDE lines of this shape
+# from the COUNT wherever they sit, and keep the DELETE on the contiguous head
+# run. Apply that exclusion to a THROWAWAY COPY at the measurement site. Never
+# modify `pinned_content` itself -- `entry_starts` holds offsets into that
+# string and the stale-marker loop writes at those offsets, so an in-place
+# exclusion puts markers in wrong positions. The exclusion looks like a pure
+# read, which is what makes that easy to miss.
 _LEADING_BUDGET_WARNING_RE = re.compile(rf"\A{_BUDGET_WARNING_SHAPE}")
 
 # RECOGNITION ONLY. NEVER GIVE THIS PATTERN TO CODE THAT DELETES. `(?m)^`
@@ -281,8 +301,11 @@ def _strip_budget_warnings(pinned_content: str) -> str:
 
     Returns the body a user would have written, with this module's own earlier
     reports taken back out. Callers measure the RESULT, never the input, so the
-    reported token count is a pure function of the user's pinned content and
-    can never include a previous report of itself.
+    reported count never includes the warning this module wrote at the HEAD. It
+    is NOT a pure function of the user's own text: a warning a user has moved
+    below the head survives this strip and is measured with the body. The note
+    at `_LEADING_BUDGET_WARNING_RE` says why the repair for that is not a wider
+    strip.
 
     A run, not a single line, because taking back N lines is the exact inverse
     of writing one -- so the function stays correct if a document somehow
@@ -712,8 +735,11 @@ def apply_staleness_markings(
       - THE NUMBER CANNOT GO STALE. It is recomputed against whatever the body
         holds now, so it tracks a growing or shrinking pinned section.
       - THE WARNING CANNOT INFLATE ITS OWN COUNT. The measured body never
-        contains a warning, on pass 1 or pass 500, so the number does not creep
-        upward as the report of it is re-read.
+        contains the warning at the HEAD, on pass 1 or pass 500, so the number
+        does not creep upward as the report of it is re-read. A warning a user
+        has moved below the head IS measured, and it is a FIXED contribution:
+        this module writes only at the head, and the head is taken back before
+        each measurement, so no pass can add a second one.
       - THE PASS IS IDEMPOTENT BY CONSTRUCTION, not by a guard. The emitted line
         is a pure function of the user's pinned body, so a second pass over
         unchanged pins produces identical bytes and writes nothing.
@@ -776,9 +802,11 @@ def apply_staleness_markings(
 
     total_stale = already_stale + len(stale_entries)
 
-    # Measure the WARNING-FREE body. Step 1 removed any earlier warning, so
-    # this holds on every pass and not only on the first one -- which is the
-    # hazard the old presence guard was reaching for, and missed.
+    # Measure the body with the HEAD warning taken back. Step 1 removes the
+    # leading run on every pass and not only on the first one, which is the
+    # hazard the old presence guard reached for and missed. A warning a user has
+    # moved below the head is NOT removed and IS measured. That is the accepted
+    # residual.
     pinned_tokens = estimate_tokens(pinned_content)
     budget_warning = ""
     if pinned_tokens > PINNED_CONTEXT_TOKEN_BUDGET:

--- a/pact-plugin/hooks/staleness.py
+++ b/pact-plugin/hooks/staleness.py
@@ -310,6 +310,65 @@ def estimate_tokens(text: str) -> int:
 _estimate_tokens = estimate_tokens
 
 
+def _detect_line_ending(claude_md_path: Path) -> str:
+    """
+    Report the line ending this file predominantly uses, as raw bytes see it.
+
+    READ THE BYTES, BECAUSE EVERY TEXT READ IN THIS MODULE HAS ALREADY LOST THE
+    ANSWER. `Path.read_text` applies universal-newline translation, so a CRLF
+    file arrives as LF and the original ending is unrecoverable from the string
+    every other function here holds. This is the only place that looks.
+
+    DOMINANT WINS, AND A TIE GOES TO LF. The write this feeds is unrecoverable,
+    because CLAUDE.md is gitignored, so the correct rule is the one that changes
+    the fewest lines. Dominant-wins minimises that count by construction. A file
+    with no CRLF at all has a dominant of LF, so no file can gain an ending it
+    did not have.
+
+    A file written only with bare carriage returns reports LF. That matches what
+    this module does with such a file today, so the rule adds no new conversion.
+
+    Args:
+        claude_md_path: The file about to be read and possibly rewritten.
+
+    Returns:
+        Either the two-character CRLF sequence or a single newline.
+    """
+    try:
+        raw = claude_md_path.read_bytes()
+    except OSError:
+        return "\n"
+    crlf_count = raw.count(b"\r\n")
+    lf_count = raw.count(b"\n") - crlf_count
+    return "\r\n" if crlf_count > lf_count else "\n"
+
+
+def _restore_line_ending(content: str, line_ending: str) -> str:
+    """
+    Re-apply `line_ending` to a string that carries LF endings.
+
+    THIS IS THE LAST STEP BEFORE THE WRITE AND IT MUST STAY THERE. Everything
+    upstream measures an LF-normalised string: `estimate_tokens` counts it, the
+    offsets in `entry_starts` index it, and the strip consumes a span of it. Move
+    this earlier and every one of those measurements changes meaning.
+
+    `content` reaches here with no carriage return in it, because it descends
+    from a `read_text` that removed them and this module writes only newlines.
+    That is what makes the substitution safe and repeatable: a second pass over
+    an unchanged file produces the same bytes.
+
+    Args:
+        content: Full file content, with LF endings.
+        line_ending: The ending to write, from `_detect_line_ending`.
+
+    Returns:
+        `content` with its endings replaced, or unchanged when the target is LF.
+    """
+    if line_ending == "\n":
+        return content
+    return content.replace("\n", line_ending)
+
+
 def _strip_budget_warnings(pinned_content: str) -> str:
     """
     Remove the run of budget-warning comment lines at the head of a pinned body.
@@ -889,6 +948,12 @@ def check_pinned_staleness(claude_md_path: Optional[Path] = None) -> Optional[st
     except (OSError, UnicodeDecodeError):
         return None
 
+    # CAPTURE THE ENDING BEFORE ANYTHING MEASURES THE TEXT. The read above has
+    # already normalised it away, so this asks the bytes instead. Nothing
+    # between here and the write sees the answer: every step below operates on
+    # the LF-normalised `content`, exactly as it did before this was added.
+    line_ending = _detect_line_ending(claude_md_path)
+
     parsed = _parse_pinned_section(content)
     if parsed is None:
         return None
@@ -959,7 +1024,16 @@ def check_pinned_staleness(claude_md_path: Optional[Path] = None) -> Optional[st
                 # write sites this one never set a mode, so `write_text` left
                 # the file's existing permissions alone; the helper normalises
                 # it to 0o600, matching every other writer in the plugin.
-                _atomic_write_text(claude_md_path, new_content, project_root)
+                #
+                # RESTORE THE ENDING HERE AND NOWHERE EARLIER. This is the last
+                # point before the bytes leave, so every measurement above ran
+                # on the same LF text it always ran on. `_atomic_write_text`
+                # translates nothing, so what this passes is what lands.
+                _atomic_write_text(
+                    claude_md_path,
+                    _restore_line_ending(new_content, line_ending),
+                    project_root,
+                )
         except ContainmentError:
             return "Pinned staleness skipped: path precondition not met."
         except TimeoutError:

--- a/pact-plugin/hooks/staleness.py
+++ b/pact-plugin/hooks/staleness.py
@@ -85,24 +85,35 @@ PINNED_CONTEXT_TOKEN_BUDGET = 3200
 # earlier one, so the writer and the reader cannot describe different things.
 _BUDGET_WARNING_PREFIX = "<!-- WARNING: Pinned context"
 
-# Matches ONE complete warning comment line at the very head of a pinned body.
+# THE SHAPE OF A WARNING LINE, WITHOUT AN ANCHOR. This is a regex SOURCE
+# STRING and not a compiled pattern, on purpose: an un-anchored shape is not
+# callable, so no call site can obtain a position-blind predicate by accident.
+# The two compositions below are the only predicates that exist.
 #
-# THE PATTERN CARRIES ITS OWN ANCHOR AND ITS OWN BOUNDS, so no call site can
-# widen it. `\A` pins the match to offset 0, the only offset this module ever
-# writes such a line to. `[^\n]*?` cannot cross a newline, so the match always
-# ends inside the line it starts on, and it is LAZY so it stops at the FIRST
-# `-->`. An HTML comment ends at its first `-->`; a greedy run to the LAST one
-# on the line would swallow whatever a user appended after the comment had
-# already closed.
+# THE SHAPE CARRIES ITS OWN BOUNDS. `[^\n]*?` cannot cross a newline, so the
+# match always ends inside the line it starts on, and it is LAZY so it stops at
+# the FIRST `-->`. An HTML comment ends at its first `-->`; a greedy run to the
+# LAST one on the line would swallow whatever a user appended after the comment
+# had already closed.
 #
 # THE `~N tokens (budget: M)` SHAPE IS LOAD-BEARING, NOT DECORATION. It is what
 # separates a line this module emitted from a line that merely opens with the
 # same words, and requiring it is what keeps the strip off a user's own prose.
 #
-# THIS PATTERN AND THE EMITTED FORMAT IN `apply_staleness_markings` ARE A
-# MATCHED PAIR. Change one and change the other in the SAME commit: a format
-# this pattern cannot match is a warning that can never be refreshed or
-# removed, and every later pass stacks another warning above it.
+# THIS SHAPE AND THE EMITTED FORMAT IN `apply_staleness_markings` ARE A MATCHED
+# PAIR. Change one and change the other in the SAME commit: a format this shape
+# cannot match is a warning that can never be refreshed or removed, and every
+# later pass stacks another warning above it.
+_BUDGET_WARNING_SHAPE = (
+    rf"{re.escape(_BUDGET_WARNING_PREFIX)} ~\d+ tokens \(budget: \d+\)[^\n]*?-->\n?"
+)
+
+# Matches ONE complete warning comment line at the very head of a pinned body.
+#
+# EACH PATTERN CARRIES ITS OWN ANCHOR, so no call site can widen it. `\A` pins
+# the match to offset 0, the only offset this module ever writes such a line to.
+# The shape above is deliberately left uncompiled, so it is not callable as a
+# predicate and the anchor cannot be chosen by a caller.
 #
 # STRICT ON PURPOSE. This predicate DELETES bytes from a user's CLAUDE.md, a
 # file that is frequently gitignored, so an over-match has no commit to recover
@@ -110,9 +121,13 @@ _BUDGET_WARNING_PREFIX = "<!-- WARNING: Pinned context"
 # text a user wrote inside a pin body. Compare `_find_declared_end_offset`:
 # a predicate's tolerance follows its failure direction, never its resemblance
 # to a predicate that looks like it.
-_LEADING_BUDGET_WARNING_RE = re.compile(
-    rf"\A{re.escape(_BUDGET_WARNING_PREFIX)} ~\d+ tokens \(budget: \d+\)[^\n]*?-->\n?"
-)
+_LEADING_BUDGET_WARNING_RE = re.compile(rf"\A{_BUDGET_WARNING_SHAPE}")
+
+# RECOGNITION ONLY. NEVER GIVE THIS PATTERN TO CODE THAT DELETES. `(?m)^`
+# reports a match at ANY line start, which is what lets `_has_budget_warning`
+# see a warning a user has moved below the head. The deleting anchor stays
+# inside the compiled object above, so this wider reach cannot travel to it.
+_ANY_BUDGET_WARNING_RE = re.compile(rf"(?m)^{_BUDGET_WARNING_SHAPE}")
 
 
 def _find_existing_claude_md(base: Path) -> Optional[Path]:
@@ -287,21 +302,51 @@ def _strip_budget_warnings(pinned_content: str) -> str:
 
 
 def _has_budget_warning(pinned_content: str) -> bool:
-    """
-    Report whether this module has already written a warning to `pinned_content`.
+    r"""
+    Report whether this module has already written a warning anywhere in
+    `pinned_content`.
 
-    Shares `_LEADING_BUDGET_WARNING_RE` with `_strip_budget_warnings` on
-    purpose: the check for "is one present" and the code that removes it must
-    agree on every input, and one pattern is the only way to guarantee that.
-    Two patterns would be two alphabets, and the narrower one decides.
+    RECOGNITION, NOT DELETION, AND THAT IS WHY THE ANCHOR DIFFERS. This
+    predicate and `_strip_budget_warnings` share ONE shape,
+    `_BUDGET_WARNING_SHAPE`, and differ only in position: the strip takes back
+    the run at offset 0, this reports a match at ANY line start. The shape is
+    what identifies a line as this module's own, so the wider anchor does not
+    widen what counts as a warning. The narrower anchor stays INSIDE the
+    pattern the strip uses, so no call site can widen what gets deleted.
+
+    DO NOT MERGE THE TWO INTO ONE PATTERN CHOSEN BY THE CALL SITE. That works
+    -- `.match` on a line-anchored pattern is identical to `\A` -- and it puts
+    the deleting anchor where a later edit can move it. The cardinal failure
+    here is deletion of a user's own text from a file that is frequently
+    gitignored.
+
+    THE ACCEPTED CONSEQUENCE, RULED ON AND NOT OVERLOOKED. A user can write a
+    complete warning line into their own pinned prose: a maintainer who pastes
+    the emitted format into a note is the realistic case. In a section with NO
+    entries, that body now enters the pass. If it ALSO exceeds the budget, this
+    module adds ONE current warning above it. BOTH conditions are required. A
+    quoted line in a body below the budget changes nothing at all.
+
+    THIS COST IS NOT NEW, AND THAT IS THE REASON TO ACCEPT IT. A section WITH
+    entries has always behaved this way, and the suite pins it: see
+    `test_user_line_quoting_the_warning_is_preserved`, which asserts a count of
+    two for a pin body that quotes the warning. The two documents differ only
+    in whether they hold an entry, so they must not differ here. The corner was
+    the inconsistency, and this is the repair.
+
+    The cost is also the smaller of the two failures, which is a second and
+    subordinate reason. One extra advisory line is visible, it stays at one on
+    every later pass, and the user can delete it. The alternative was to leave
+    the corner alone, which keeps a stale number in the document without limit
+    and announces nothing.
 
     Args:
         pinned_content: The pinned section body.
 
     Returns:
-        True when a budget warning heads the body.
+        True when a budget warning this module wrote sits at any line start.
     """
-    return _LEADING_BUDGET_WARNING_RE.match(pinned_content) is not None
+    return _ANY_BUDGET_WARNING_RE.search(pinned_content) is not None
 
 
 def _find_terminator_offset(
@@ -814,13 +859,19 @@ def check_pinned_staleness(claude_md_path: Optional[Path] = None) -> Optional[st
     # it. Delete the last pin and the old guard returned here, which stranded
     # that warning where nothing could ever reach it.
     #
-    # THE TWO DIRECTIONS ARE NOT SYMMETRIC AND MUST NOT BE MADE SO. Removing a
-    # warning from an entry-less section REPAIRS a line this module wrote.
-    # Adding one to a section that never had entries would be NEW behaviour in a
-    # document this code otherwise leaves untouched. Only the first belongs
-    # here, and the arithmetic delivers exactly that: an entry-less body reaches
-    # `apply_staleness_markings` only when a warning is already present, and
-    # keeps that warning only while the body still exceeds the budget.
+    # THE PROBE READS ANY LINE START, THE STRIP READS OFFSET 0. That gap is
+    # deliberate. A warning a user has moved below the head is still this
+    # module's own report, so the section HAS been reported on and the pass may
+    # run. The strip cannot reach that line, so this pass does not repair it: it
+    # adds one current warning above it and the old line stays. That is the
+    # ratified cost of the residual, one extra line, and it is what a section
+    # WITH entries already does in the same state.
+    #
+    # THE FORBIDDEN DIRECTION IS UNCHANGED AND MUST STAY SO. A section carrying
+    # NO line of this module's own shape never reaches the pass, whatever its
+    # size, so this code never starts a report in a document it has not written
+    # to before. The strict `~N tokens (budget: M)` shape carries that
+    # discrimination, not the anchor.
     if not entry_starts and not _has_budget_warning(pinned_content):
         return None
 

--- a/pact-plugin/hooks/staleness.py
+++ b/pact-plugin/hooks/staleness.py
@@ -992,17 +992,25 @@ def check_pinned_staleness(claude_md_path: Optional[Path] = None) -> Optional[st
     # same hardening as the other 5 (claude_md_manager + session_resume).
     # See `fcntl_sidecar_lock_pattern` for the canonical pattern.
     if modified:
+        # Function-level import to avoid circular dependency:
+        # session_init.py imports staleness at module level, and also
+        # imports from shared.claude_md_manager — a module-level
+        # import here would create a staleness → claude_md_manager →
+        # (indirectly) staleness cycle on some Python versions. That reason
+        # constrains function-versus-module level only, so the statement is
+        # free to sit here rather than lower down.
+        #
+        # KEEP IT ABOVE THE `try:` BELOW. That block handles ContainmentError,
+        # which this import binds. An import failure inside the block leaves
+        # the name unbound, so Python reports the handler and hides the cause.
+        # Do not move it back in. Do not wrap it in its own handler, because
+        # an ImportError must reach the caller.
+        from shared.claude_md_manager import (
+            ContainmentError,
+            _atomic_write_text,
+            file_lock,
+        )
         try:
-            # Function-level import to avoid circular dependency:
-            # session_init.py imports staleness at module level, and also
-            # imports from shared.claude_md_manager — a module-level
-            # import here would create a staleness → claude_md_manager →
-            # (indirectly) staleness cycle on some Python versions.
-            from shared.claude_md_manager import (
-                ContainmentError,
-                _atomic_write_text,
-                file_lock,
-            )
             with file_lock(claude_md_path):
                 # #1247: containment (in _atomic_write_text) REPLACES the
                 # former leaf is_symlink guard -- inside the lock (TOCTOU-safe).

--- a/pact-plugin/hooks/staleness.py
+++ b/pact-plugin/hooks/staleness.py
@@ -149,6 +149,13 @@ _BUDGET_WARNING_SHAPE = (
 # string and the stale-marker loop writes at those offsets, so an in-place
 # exclusion puts markers in wrong positions. The exclusion looks like a pure
 # read, which is what makes that easy to miss.
+#
+# THIS REFUSAL IS ENFORCED AND NOT ONLY STATED. A test drives this compiled
+# object over a body whose only warning sits below the head and requires it to
+# find nothing: see `test_the_deleting_pattern_cannot_reach_below_the_head`. A
+# wider anchor turns that red. No arm that drives DOCUMENTS can catch the
+# widening, because the strip reads this pattern at offset 0 only, so every
+# anchor gives byte-identical output today.
 _LEADING_BUDGET_WARNING_RE = re.compile(rf"\A{_BUDGET_WARNING_SHAPE}")
 
 # RECOGNITION ONLY. NEVER GIVE THIS PATTERN TO CODE THAT DELETES. `(?m)^`

--- a/pact-plugin/hooks/staleness.py
+++ b/pact-plugin/hooks/staleness.py
@@ -64,13 +64,20 @@ PINNED_STALENESS_DAYS = 30
 # derived from the region it bounds cannot see that region's next edit, and it
 # lands so close to the present size that an ordinary pin edit re-trips the
 # warning -- which reports "you touched a pin", not "your pins have bloated".
-# This value leaves headroom above a full set of well-written pins and still
-# sits far below what PIN_COUNT_CAP pins at PIN_SIZE_CAP would cost, so the
-# warning stays actionable in both directions.
+# This value leaves headroom above a full set of well-written pins.
 #
-# The budget is DELIBERATELY NOT derived from the caps in pin_caps.py. A
-# derived budget is large enough that no legal document ever reaches it, and an
-# advisory that never advises is of no use.
+# WHY THIS IS A FREE NUMBER RATHER THAN A VALUE DERIVED FROM THE CAPS IN
+# pin_caps.py. A derived advisory cannot fire before enforcement binds. If the
+# budget were f(caps) with f >= 1, then reaching it would require roughly full
+# legal capacity -- and at that point PIN_SIZE_CAP and PIN_COUNT_CAP are
+# already refusing edits, so the advice arrives at the wall, too late to act
+# on. Advising EARLIER requires a coefficient below 1. Derivation therefore
+# does not eliminate the free number; it relocates it into a coefficient. This
+# constant IS that coefficient, stated directly instead of hidden in a formula.
+#
+# The two also bound DIFFERENT things, which is why one cannot be read off the
+# other: PIN_SIZE_CAP counts body characters of a single pin, while this counts
+# estimated tokens of the whole section, headings and markers included.
 PINNED_CONTEXT_TOKEN_BUDGET = 3200
 
 # The exact text this module writes at the head of an over-budget pinned
@@ -80,10 +87,22 @@ _BUDGET_WARNING_PREFIX = "<!-- WARNING: Pinned context"
 
 # Matches ONE complete warning comment line at the very head of a pinned body.
 #
-# THE PATTERN CARRIES ITS OWN ANCHOR AND ITS OWN BOUND, so no call site can
-# widen it. `\A` pins the match to offset 0, which is the only offset this
-# module ever writes such a line to, and `[^\n]*` cannot cross a newline, so
-# the match always ends inside the line it starts on.
+# THE PATTERN CARRIES ITS OWN ANCHOR AND ITS OWN BOUNDS, so no call site can
+# widen it. `\A` pins the match to offset 0, the only offset this module ever
+# writes such a line to. `[^\n]*?` cannot cross a newline, so the match always
+# ends inside the line it starts on, and it is LAZY so it stops at the FIRST
+# `-->`. An HTML comment ends at its first `-->`; a greedy run to the LAST one
+# on the line would swallow whatever a user appended after the comment had
+# already closed.
+#
+# THE `~N tokens (budget: M)` SHAPE IS LOAD-BEARING, NOT DECORATION. It is what
+# separates a line this module emitted from a line that merely opens with the
+# same words, and requiring it is what keeps the strip off a user's own prose.
+#
+# THIS PATTERN AND THE EMITTED FORMAT IN `apply_staleness_markings` ARE A
+# MATCHED PAIR. Change one and change the other in the SAME commit: a format
+# this pattern cannot match is a warning that can never be refreshed or
+# removed, and every later pass stacks another warning above it.
 #
 # STRICT ON PURPOSE. This predicate DELETES bytes from a user's CLAUDE.md, a
 # file that is frequently gitignored, so an over-match has no commit to recover
@@ -92,7 +111,7 @@ _BUDGET_WARNING_PREFIX = "<!-- WARNING: Pinned context"
 # a predicate's tolerance follows its failure direction, never its resemblance
 # to a predicate that looks like it.
 _LEADING_BUDGET_WARNING_RE = re.compile(
-    rf"\A{re.escape(_BUDGET_WARNING_PREFIX)}[^\n]*-->\n?"
+    rf"\A{re.escape(_BUDGET_WARNING_PREFIX)} ~\d+ tokens \(budget: \d+\)[^\n]*?-->\n?"
 )
 
 

--- a/pact-plugin/hooks/staleness.py
+++ b/pact-plugin/hooks/staleness.py
@@ -57,9 +57,43 @@ _BOUNDARY_ALT = "|".join(PACT_BOUNDARY_PREFIXES)
 PINNED_STALENESS_DAYS = 30
 
 # Approximate token budget for the entire Pinned Context section. When
-# exceeded, a warning comment is added (no auto-deletion).
+# exceeded, a warning comment is added. No pin is ever deleted.
 # This is the sole definition of this constant; session_init.py imports it.
-PINNED_CONTEXT_TOKEN_BUDGET = 1200
+#
+# SIZED FROM CAPACITY, NOT FROM A MEASUREMENT OF THE CURRENT DOCUMENT. A bound
+# derived from the region it bounds cannot see that region's next edit, and it
+# lands so close to the present size that an ordinary pin edit re-trips the
+# warning -- which reports "you touched a pin", not "your pins have bloated".
+# This value leaves headroom above a full set of well-written pins and still
+# sits far below what PIN_COUNT_CAP pins at PIN_SIZE_CAP would cost, so the
+# warning stays actionable in both directions.
+#
+# The budget is DELIBERATELY NOT derived from the caps in pin_caps.py. A
+# derived budget is large enough that no legal document ever reaches it, and an
+# advisory that never advises is of no use.
+PINNED_CONTEXT_TOKEN_BUDGET = 3200
+
+# The exact text this module writes at the head of an over-budget pinned
+# section. It is BOTH the text of the warning and the probe that finds an
+# earlier one, so the writer and the reader cannot describe different things.
+_BUDGET_WARNING_PREFIX = "<!-- WARNING: Pinned context"
+
+# Matches ONE complete warning comment line at the very head of a pinned body.
+#
+# THE PATTERN CARRIES ITS OWN ANCHOR AND ITS OWN BOUND, so no call site can
+# widen it. `\A` pins the match to offset 0, which is the only offset this
+# module ever writes such a line to, and `[^\n]*` cannot cross a newline, so
+# the match always ends inside the line it starts on.
+#
+# STRICT ON PURPOSE. This predicate DELETES bytes from a user's CLAUDE.md, a
+# file that is frequently gitignored, so an over-match has no commit to recover
+# from. A loose variant that matched anywhere in the region would also reach
+# text a user wrote inside a pin body. Compare `_find_declared_end_offset`:
+# a predicate's tolerance follows its failure direction, never its resemblance
+# to a predicate that looks like it.
+_LEADING_BUDGET_WARNING_RE = re.compile(
+    rf"\A{re.escape(_BUDGET_WARNING_PREFIX)}[^\n]*-->\n?"
+)
 
 
 def _find_existing_claude_md(base: Path) -> Optional[Path]:
@@ -205,6 +239,50 @@ def estimate_tokens(text: str) -> int:
 
 # Backward-compatible alias (tests and session_init import the underscore name)
 _estimate_tokens = estimate_tokens
+
+
+def _strip_budget_warnings(pinned_content: str) -> str:
+    """
+    Remove the run of budget-warning comment lines at the head of a pinned body.
+
+    Returns the body a user would have written, with this module's own earlier
+    reports taken back out. Callers measure the RESULT, never the input, so the
+    reported token count is a pure function of the user's pinned content and
+    can never include a previous report of itself.
+
+    A run, not a single line, because taking back N lines is the exact inverse
+    of writing one -- so the function stays correct if a document somehow
+    carries more than one, and it can never leave a partial residue behind.
+
+    Args:
+        pinned_content: The pinned section body.
+
+    Returns:
+        The body with any leading budget-warning lines removed.
+    """
+    while True:
+        match = _LEADING_BUDGET_WARNING_RE.match(pinned_content)
+        if match is None:
+            return pinned_content
+        pinned_content = pinned_content[match.end():]
+
+
+def _has_budget_warning(pinned_content: str) -> bool:
+    """
+    Report whether this module has already written a warning to `pinned_content`.
+
+    Shares `_LEADING_BUDGET_WARNING_RE` with `_strip_budget_warnings` on
+    purpose: the check for "is one present" and the code that removes it must
+    agree on every input, and one pattern is the only way to guarantee that.
+    Two patterns would be two alphabets, and the narrower one decides.
+
+    Args:
+        pinned_content: The pinned section body.
+
+    Returns:
+        True when a budget warning heads the body.
+    """
+    return _LEADING_BUDGET_WARNING_RE.match(pinned_content) is not None
 
 
 def _find_terminator_offset(
@@ -556,9 +634,30 @@ def apply_staleness_markings(
     """
     Apply stale markers and budget warnings to pinned content.
 
-    Detects stale entries, inserts STALE markers, and adds a budget
-    warning comment if the content exceeds the token budget. Returns the
-    modified full file content.
+    Detects stale entries, inserts STALE markers, and rewrites the budget
+    warning comment to match the CURRENT content. Returns the modified full
+    file content.
+
+    THE WARNING IS REBUILT FROM THE BODY ON EVERY PASS, NEVER PATCHED IN PLACE.
+    An earlier warning is removed first, the warning-free body is measured, and
+    a fresh line goes back only when the measurement still exceeds the budget.
+
+    Three properties follow from that order, and they are the whole reason for
+    it:
+
+      - THE NUMBER CANNOT GO STALE. It is recomputed against whatever the body
+        holds now, so it tracks a growing or shrinking pinned section.
+      - THE WARNING CANNOT INFLATE ITS OWN COUNT. The measured body never
+        contains a warning, on pass 1 or pass 500, so the number does not creep
+        upward as the report of it is re-read.
+      - THE PASS IS IDEMPOTENT BY CONSTRUCTION, not by a guard. The emitted line
+        is a pure function of the user's pinned body, so a second pass over
+        unchanged pins produces identical bytes and writes nothing.
+
+    A BODY THAT DROPS BACK UNDER BUDGET LOSES ITS WARNING. A warning that
+    reports a breach which has ended is the same defect as a frozen number,
+    facing the other way. Removing it is a REPAIR of a line this module wrote,
+    which is why it is safe; this function never deletes anything a user wrote.
 
     Args:
         content: Full CLAUDE.md file content.
@@ -569,6 +668,18 @@ def apply_staleness_markings(
     Returns:
         Tuple of (new_full_content, stale_count, was_modified, budget_warning_str).
     """
+    # The bytes to compare against at the end. `was_modified` is DERIVED from
+    # this comparison rather than accumulated in a flag, so it cannot disagree
+    # with what actually changed -- and a pass that rewrites a warning to the
+    # same value reports no modification and skips the write.
+    original_pinned_content = pinned_content
+
+    # STEP 1, BEFORE ANY OFFSET IS TAKEN OR ANY TOKEN IS COUNTED: take back the
+    # warning written by an earlier pass. Every step below then sees the user's
+    # own pinned body. Order is load-bearing -- `entry_starts` holds offsets
+    # into this string, so a later strip would invalidate them.
+    pinned_content = _strip_budget_warnings(pinned_content)
+
     entry_pattern = re.compile(r'^### ', re.MULTILINE)
     entry_starts = [m.start() for m in entry_pattern.finditer(pinned_content)]
     stale_marker_pattern = re.compile(r'<!-- STALE: Last relevant \d{4}-\d{2}-\d{2} -->')
@@ -583,7 +694,6 @@ def apply_staleness_markings(
 
     # Detect new stale entries
     stale_entries = detect_stale_entries(pinned_content)
-    modified = False
 
     # Apply stale markers in reverse order so string offsets remain valid
     for idx, date_str, _heading in reversed(stale_entries):
@@ -599,26 +709,30 @@ def apply_staleness_markings(
         heading_end = nl_pos + 1
         new_entry = entry_text[:heading_end] + stale_marker + entry_text[heading_end:]
         pinned_content = pinned_content[:start] + new_entry + pinned_content[end:]
-        modified = True
 
     total_stale = already_stale + len(stale_entries)
 
-    # Check token budget BEFORE inserting the warning (so warning text
-    # does not inflate its own count)
+    # Measure the WARNING-FREE body. Step 1 removed any earlier warning, so
+    # this holds on every pass and not only on the first one -- which is the
+    # hazard the old presence guard was reaching for, and missed.
     pinned_tokens = estimate_tokens(pinned_content)
     budget_warning = ""
     if pinned_tokens > PINNED_CONTEXT_TOKEN_BUDGET:
-        budget_warning_comment = (
-            f"<!-- WARNING: Pinned context ~{pinned_tokens} tokens "
+        pinned_content = (
+            f"{_BUDGET_WARNING_PREFIX} ~{pinned_tokens} tokens "
             f"(budget: {PINNED_CONTEXT_TOKEN_BUDGET}). "
             f"Consider archiving stale pins. -->\n"
-        )
-        # Add budget warning at the top of pinned section if not present
-        if "<!-- WARNING: Pinned context" not in pinned_content:
-            pinned_content = budget_warning_comment + pinned_content
-            modified = True
+        ) + pinned_content
+        # ONE number, used by both consumers. The comment in the file and the
+        # status string returned to the caller are built from the same
+        # measurement, so a reader can never be shown two different figures for
+        # one document.
         budget_warning = f", ~{pinned_tokens} tokens (budget: {PINNED_CONTEXT_TOKEN_BUDGET})"
 
+    # Under budget, the body simply keeps no warning: the strip in step 1 has
+    # already taken the outdated one away, and nothing puts it back.
+
+    modified = pinned_content != original_pinned_content
     new_content = content[:pinned_start] + pinned_content + content[pinned_end:]
     return new_content, total_stale, modified, budget_warning
 
@@ -676,7 +790,19 @@ def check_pinned_staleness(claude_md_path: Optional[Path] = None) -> Optional[st
 
     entry_pattern = re.compile(r'^### ', re.MULTILINE)
     entry_starts = [m.start() for m in entry_pattern.finditer(pinned_content)]
-    if not entry_starts:
+
+    # A section with no entries still needs a pass when a warning is sitting in
+    # it. Delete the last pin and the old guard returned here, which stranded
+    # that warning where nothing could ever reach it.
+    #
+    # THE TWO DIRECTIONS ARE NOT SYMMETRIC AND MUST NOT BE MADE SO. Removing a
+    # warning from an entry-less section REPAIRS a line this module wrote.
+    # Adding one to a section that never had entries would be NEW behaviour in a
+    # document this code otherwise leaves untouched. Only the first belongs
+    # here, and the arithmetic delivers exactly that: an entry-less body reaches
+    # `apply_staleness_markings` only when a warning is already present, and
+    # keeps that warning only while the body still exceeds the budget.
+    if not entry_starts and not _has_budget_warning(pinned_content):
         return None
 
     new_content, stale_count, modified, budget_warning = apply_staleness_markings(

--- a/pact-plugin/hooks/staleness.py
+++ b/pact-plugin/hooks/staleness.py
@@ -78,6 +78,14 @@ PINNED_STALENESS_DAYS = 30
 # The two also bound DIFFERENT things, which is why one cannot be read off the
 # other: PIN_SIZE_CAP counts body characters of a single pin, while this counts
 # estimated tokens of the whole section, headings and markers included.
+#
+# AND A THIRD REASON, ABOUT WHO DECIDES. A derived budget would MOVE whenever
+# the caps move. A raise of PIN_SIZE_CAP is an enforcement decision about a
+# single pin, and it would then relocate an ADVISORY threshold over the whole
+# section, with nobody deciding that. The relation between the two is guarded in
+# the test suite instead, by a band that REFUSES a budget outside it. A guard
+# makes a cap change LOUD and asks for a decision. A derivation makes the same
+# change SILENT.
 PINNED_CONTEXT_TOKEN_BUDGET = 3200
 
 # The exact text this module writes at the head of an over-budget pinned

--- a/pact-plugin/skills/pact-memory/scripts/working_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/working_memory.py
@@ -473,7 +473,12 @@ def _atomic_write_text(target: Path, content: str, project_root: Path) -> None:
             # raw fd would leak (the cleanup below unlinks the temp FILE but
             # cannot close a descriptor it never received a handle for).
             try:
-                handle = os.fdopen(fd, "w", encoding="utf-8")
+                # newline="" so this handle performs NO line-ending translation.
+                # With newline=None, Python rewrites each "\n" to os.linesep,
+                # which is "\n" here and "\r\n" on Windows, so a caller that
+                # restored CRLF emits "\r\r\n" there. The caller chooses the
+                # line ending. This primitive writes the bytes it is given.
+                handle = os.fdopen(fd, "w", encoding="utf-8", newline="")
             except BaseException:
                 os.close(fd)
                 raise

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -3405,6 +3405,89 @@ class TestLineEndingsSurviveAPass:
 
 _STALENESS_SOURCE = Path(__file__).parent.parent / "hooks" / "staleness.py"
 
+
+class TestContainmentImportSitsAboveItsHandler:
+    """The import that binds `ContainmentError` must sit OUTSIDE the try that
+    handles it.
+
+    THE DEFECT, IF THE IMPORT GOES BACK INSIDE. Python must evaluate the
+    handler when the import raises. The name is unbound at that moment, so the
+    ImportError is replaced by `UnboundLocalError: cannot access local variable
+    ContainmentError`, and the cause survives only as `__context__`. Nothing is
+    written and the hook exits 0, so the whole cost is the ability to read what
+    went wrong.
+
+    IT LOOKS LIKE TIDINESS TO MOVE IT BACK. The import serves the try body and
+    nothing else, so a future editor pulls it in. That is why a comment alone
+    is not enough here, and why this guard reads structure rather than prose.
+
+    IT READS THE AST AND NOT THE TEXT. Line numbers and the spelling of the
+    import are both free to move. MEASURED, on scratch copies: a re-ordering of
+    the imported names, a split into three separate statements, and a move
+    further up the function each leave this GREEN. The pre-fix source, which
+    holds the import inside the try, turns it RED.
+
+    THE TRY IS FOUND BY ITS HANDLER, never by position. Measured on the
+    committed source: exactly one try in the whole module has a handler naming
+    `ContainmentError`. The count is NOT pinned, because a second such try
+    would be legitimate and the property holds over all of them.
+    """
+
+    @staticmethod
+    def _guarded_tries(tree):
+        """Every try whose handler names `ContainmentError`."""
+
+        def handles_containment(handler):
+            return any(
+                isinstance(node, ast.Name) and node.id == "ContainmentError"
+                for node in ast.walk(handler)
+            )
+
+        return [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Try)
+            and any(handles_containment(h) for h in node.handlers)
+        ]
+
+    def test_the_containment_import_is_not_inside_the_try_that_handles_it(self):
+        """The property, stated over structure rather than over text."""
+        tree = ast.parse(_STALENESS_SOURCE.read_text(encoding="utf-8"))
+        guarded = self._guarded_tries(tree)
+
+        # NON-VACUITY, AND IT IS THE WHOLE REASON THIS GUARD CAN FAIL AT ALL.
+        # The property is "no such import is inside any such try". With NO such
+        # try, that holds for free and this arm goes silent for ever. The
+        # precedent this technique comes from carries the same control facing
+        # the other way, where a missing try would make its own assertion
+        # vacuous. MEASURED: rename that handler and this line fires.
+        assert guarded, (
+            "no try in staleness.py has a handler naming ContainmentError, so "
+            "the property below quantifies over an empty set and this guard "
+            "reports nothing for ever. Either the handler was renamed, in "
+            "which case retarget this guard, or the try was removed, in which "
+            "case the hazard is gone and so is the reason for this arm"
+        )
+
+        offenders = []
+        for node in guarded:
+            for statement in node.body:
+                for sub in ast.walk(statement):
+                    if isinstance(sub, (ast.Import, ast.ImportFrom)):
+                        bound = [alias.asname or alias.name for alias in sub.names]
+                        if "ContainmentError" in bound:
+                            offenders.append(sub.lineno)
+
+        assert not offenders, (
+            f"an import binding ContainmentError sits INSIDE the try that "
+            f"handles it, at line(s) {offenders}. When that import raises, "
+            f"Python evaluates the handler against an unbound name, so the "
+            f"real ImportError is replaced by an UnboundLocalError and "
+            f"survives only as __context__. Move the import ABOVE the try. Do "
+            f"not wrap it in a handler of its own, because an ImportError must "
+            f"reach the caller"
+        )
+
 # THE ALPHABET IS TAKEN FROM WHAT PYTEST COLLECTS, NOT FROM WHAT WE REMEMBER
 # CITING. pytest collects `Test`-prefixed CLASSES as well as `test_`-prefixed
 # FUNCTIONS, so a pattern covering only the second is blind to half the thing it

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -6,8 +6,8 @@ Tests cover:
 2. Pinned context with recent PR -- not flagged
 3. Pinned context with old PR -- flagged stale
 4. Pinned context without PR dates -- skipped
-5. Over budget -- warning comment added
-6. Under budget -- no warning
+5. Over budget -- warning comment added, and refreshed to match later edits
+6. Under budget -- no warning, and an earlier warning removed
 7. Already-marked stale entries -- not double-marked
 8. Multiple entries with mixed staleness
 9. _estimate_tokens twin copy equivalence (staleness.py vs working_memory.py)
@@ -16,6 +16,7 @@ Tests cover:
 import ast
 import inspect
 import os
+import re
 import sys
 import tempfile
 import textwrap
@@ -29,6 +30,37 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 # Add working_memory scripts directory to path for twin-copy equivalence test
 sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts"))
+
+# Pulls the token figure out of a warning comment, so a test can compare the
+# number in the file against the number in the returned status string.
+_WARNING_NUMBER_RE = re.compile(r"<!-- WARNING: Pinned context ~(\d+) tokens")
+
+
+def over_budget_body(margin_words=200):
+    """Build a pin body whose estimated tokens exceed the pinned-context budget.
+
+    THE MAGNITUDE IS DERIVED FROM THE CONSTANT, NEVER WRITTEN AS A LITERAL.
+    `estimate_tokens` is `int(words * 1.3)`, so a word count above the budget
+    always estimates above the budget, whatever value the budget takes next.
+
+    The assertion makes that structural. A hard-coded fixture went silently
+    under a raised threshold once already -- it still passed, while no longer
+    testing the thing its comment claimed -- and only a check against the live
+    constant can refuse to repeat that.
+    """
+    from staleness import PINNED_CONTEXT_TOKEN_BUDGET, estimate_tokens
+
+    body = "word " * (PINNED_CONTEXT_TOKEN_BUDGET + margin_words)
+    assert estimate_tokens(body) > PINNED_CONTEXT_TOKEN_BUDGET, (
+        "fixture no longer exceeds the budget it is derived from"
+    )
+    return body
+
+
+def warning_number(text):
+    """Return the token figure carried by the warning comment, or None."""
+    match = _WARNING_NUMBER_RE.search(text)
+    return int(match.group(1)) if match else None
 
 
 class TestCheckPinnedStaleness:
@@ -178,8 +210,9 @@ class TestCheckPinnedStaleness:
         """Should add token budget warning when pinned content exceeds budget."""
         from session_init import check_pinned_staleness
 
-        # Create a lot of pinned content that exceeds the budget
-        big_content = "word " * 1500  # Should exceed 1200 token budget
+        # Pinned content sized from PINNED_CONTEXT_TOKEN_BUDGET, so it stays
+        # over budget after any future change to that constant.
+        big_content = over_budget_body()
 
         claude_md = self._create_project_claude_md(tmp_path, (
             "# Project Memory\n\n"
@@ -418,7 +451,9 @@ class TestBudgetWarningIdempotency:
         produce exactly one <!-- WARNING: comment, not two."""
         from session_init import check_pinned_staleness
 
-        big_content = "word " * 1500  # Exceeds 1200 token budget
+        # Sized from PINNED_CONTEXT_TOKEN_BUDGET, so a raised budget cannot
+        # leave this fixture under the threshold it claims to exceed.
+        big_content = over_budget_body()
 
         claude_md = self._create_project_claude_md(tmp_path, (
             "# Project Memory\n\n"
@@ -440,6 +475,210 @@ class TestBudgetWarningIdempotency:
         assert warning_count == 1, (
             f"Expected exactly 1 budget warning comment, found {warning_count}"
         )
+
+
+class TestBudgetWarningRefresh:
+    """The warning must describe the CURRENT pinned content.
+
+    WHICH ARMS FALSIFY THE OLD BEHAVIOUR, measured against the pre-repair code
+    rather than predicted: five of these seven FAIL there. Two PASS both before
+    and after -- `test_repeated_runs_do_not_compound` and
+    `test_entryless_section_never_gains_a_warning` -- because they guard
+    properties of the repair itself, not the defect. Each says so in its own
+    docstring. An arm that passes either way proves nothing about a fix unless
+    it declares that.
+    """
+
+    def _create_project_claude_md(self, tmp_path, content):
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text(content, encoding="utf-8")
+        return claude_md
+
+    def _pinned_doc(self, body, warning=None):
+        head = "# Project Memory\n\n## Pinned Context\n\n"
+        if warning is not None:
+            head += warning
+        return f"{head}### Big Feature\n{body}\n\n"
+
+    def test_stale_number_is_refreshed(self, tmp_path):
+        """A warning carrying an outdated number must be rewritten. FAILS before.
+
+        The pre-repair guard skipped insertion whenever any warning was
+        present, so the first number written stayed forever. A real document
+        reported roughly a third of its true size this way.
+        """
+        from staleness import check_pinned_staleness, estimate_tokens
+
+        body = over_budget_body()
+        stale_warning = (
+            "<!-- WARNING: Pinned context ~7 tokens (budget: 5). "
+            "Consider archiving stale pins. -->\n"
+        )
+        claude_md = self._create_project_claude_md(
+            tmp_path, self._pinned_doc(body, warning=stale_warning)
+        )
+        # Precondition: the wrong number really is in the parsed region.
+        assert warning_number(claude_md.read_text(encoding="utf-8")) == 7
+
+        check_pinned_staleness(claude_md_path=claude_md)
+
+        content = claude_md.read_text(encoding="utf-8")
+        assert content.count("<!-- WARNING: Pinned context") == 1
+        assert warning_number(content) == estimate_tokens(f"### Big Feature\n{body}\n\n")
+
+    def test_status_string_agrees_with_file_comment(self, tmp_path):
+        """The returned figure and the written figure must match. FAILS before.
+
+        Before the repair the two came from different measurements: the file
+        kept its original number while the status string re-measured a body
+        that now contained the warning, so the two disagreed from the second
+        run onward by the warning's own word count.
+        """
+        from staleness import check_pinned_staleness
+
+        claude_md = self._create_project_claude_md(
+            tmp_path, self._pinned_doc(over_budget_body())
+        )
+
+        check_pinned_staleness(claude_md_path=claude_md)
+        status = check_pinned_staleness(claude_md_path=claude_md)
+
+        assert status is not None
+        in_status = int(re.search(r"~(\d+) tokens", status).group(1))
+        in_file = warning_number(claude_md.read_text(encoding="utf-8"))
+        assert in_status == in_file, (
+            f"status string reports {in_status} while the file says {in_file}"
+        )
+
+    def test_warning_removed_when_back_under_budget(self, tmp_path):
+        """A breach that has ended must take its warning with it. FAILS before."""
+        from staleness import check_pinned_staleness
+
+        body = over_budget_body()
+        claude_md = self._create_project_claude_md(
+            tmp_path, self._pinned_doc(body)
+        )
+        check_pinned_staleness(claude_md_path=claude_md)
+        assert "<!-- WARNING: Pinned context" in claude_md.read_text(encoding="utf-8")
+
+        # The user archives the bulk of the pin.
+        shrunk = claude_md.read_text(encoding="utf-8").replace(body, "a short pin")
+        claude_md.write_text(shrunk, encoding="utf-8")
+
+        result = check_pinned_staleness(claude_md_path=claude_md)
+
+        content = claude_md.read_text(encoding="utf-8")
+        assert "<!-- WARNING: Pinned context" not in content
+        assert result is None or "budget" not in result.lower()
+
+    def test_warning_removed_when_last_pin_deleted(self, tmp_path):
+        """Deleting every pin must not strand the warning. FAILS before.
+
+        The entry scan returned early when no `### ` heading remained, so the
+        warning sat in a section that nothing could reach.
+        """
+        from staleness import check_pinned_staleness
+
+        body = over_budget_body()
+        claude_md = self._create_project_claude_md(
+            tmp_path, self._pinned_doc(body)
+        )
+        check_pinned_staleness(claude_md_path=claude_md)
+        assert "<!-- WARNING: Pinned context" in claude_md.read_text(encoding="utf-8")
+
+        emptied = claude_md.read_text(encoding="utf-8").replace(
+            f"### Big Feature\n{body}\n", ""
+        )
+        claude_md.write_text(emptied, encoding="utf-8")
+        assert "### " not in claude_md.read_text(encoding="utf-8")
+
+        check_pinned_staleness(claude_md_path=claude_md)
+
+        assert "<!-- WARNING: Pinned context" not in claude_md.read_text(
+            encoding="utf-8"
+        )
+
+    def test_repeated_runs_do_not_compound(self, tmp_path):
+        """Three runs give one warning and one unchanging number.
+
+        PASSES BEFORE AND AFTER. This arm guards the repair, not the defect:
+        rebuilding the warning on every pass could have let each pass measure
+        the previous one and creep upward. It cannot, because the measured body
+        never holds a warning.
+        """
+        from staleness import check_pinned_staleness
+
+        claude_md = self._create_project_claude_md(
+            tmp_path, self._pinned_doc(over_budget_body())
+        )
+
+        check_pinned_staleness(claude_md_path=claude_md)
+        after_first = claude_md.read_text(encoding="utf-8")
+        check_pinned_staleness(claude_md_path=claude_md)
+        check_pinned_staleness(claude_md_path=claude_md)
+        after_third = claude_md.read_text(encoding="utf-8")
+
+        assert after_third.count("<!-- WARNING: Pinned context") == 1
+        assert after_third == after_first, "a later pass rewrote a settled document"
+
+    def test_entryless_section_never_gains_a_warning(self, tmp_path):
+        """Prose with no `### ` entry stays untouched, over budget or not.
+
+        PASSES BEFORE AND AFTER, and that is the point. Widening the entry
+        guard so a stranded warning can be REMOVED must not also start ADDING
+        warnings to documents this code has always left alone. Removal repairs
+        a line the hook wrote; insertion here would be new behaviour.
+        """
+        from staleness import check_pinned_staleness
+
+        claude_md = self._create_project_claude_md(
+            tmp_path,
+            f"# Project Memory\n\n## Pinned Context\n\n{over_budget_body()}\n\n",
+        )
+        before = claude_md.read_text(encoding="utf-8")
+
+        result = check_pinned_staleness(claude_md_path=claude_md)
+
+        assert result is None
+        assert claude_md.read_text(encoding="utf-8") == before
+
+    def test_user_line_quoting_the_warning_is_preserved(self, tmp_path):
+        """A pin body that quotes the warning must survive, and must not silence
+        the real one. FAILS before, for a reason worth naming.
+
+        Two properties are asserted here, and only the second was expected to
+        need a test. The removal is anchored at the head of the pinned body,
+        which is the only place the hook writes a warning, so it cannot reach a
+        look-alike line inside a pin. CLAUDE.md is frequently gitignored, so an
+        over-broad strip would delete user text no commit could restore.
+
+        The pre-repair presence check searched the WHOLE region for the marker
+        as a plain substring, so a pin that merely QUOTED the warning text
+        satisfied it and the hook never wrote its own warning at all -- the
+        advisory failed open for the entire document on the strength of one
+        line of user prose. Anchoring the probe closes that as a side effect,
+        which is why this arm asserts a count of two rather than one.
+        """
+        from staleness import check_pinned_staleness
+
+        quoted = (
+            "<!-- WARNING: Pinned context ~99 tokens (budget: 1). "
+            "Consider archiving stale pins. -->"
+        )
+        claude_md = self._create_project_claude_md(
+            tmp_path,
+            "# Project Memory\n\n## Pinned Context\n\n"
+            f"### Doc Pin\nThe hook writes this line:\n{quoted}\n"
+            f"{over_budget_body()}\n\n",
+        )
+
+        check_pinned_staleness(claude_md_path=claude_md)
+        check_pinned_staleness(claude_md_path=claude_md)
+
+        content = claude_md.read_text(encoding="utf-8")
+        assert quoted in content, "the strip deleted a line a user wrote"
+        # One line the hook owns, plus the one the user quoted.
+        assert content.count("<!-- WARNING: Pinned context") == 2
 
 
 class TestStalenessErrorPaths:

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -2970,6 +2970,13 @@ class TestBudgetWarningAnchorComposition:
         red.
     The first arm alone therefore certifies nothing. That is the whole reason
     the second one exists, and it is why neither may be deleted as a duplicate.
+
+    WHAT THIS PAIR DOES NOT COVER, AND IT IS THE MODULE'S CARDINAL HAZARD.
+    MEASURED: widen the DELETING pattern's anchor and the two arms stay GREEN.
+    The equality arm slices the text, and each anchor matches at a slice start,
+    so the two sides agree on every member. The arms are not weak here. They
+    measure a property that the widening does not disturb. That widening has
+    its own gate below, in `TestDeletingAnchorStaysAtTheHead`.
     """
 
     def test_the_wide_anchor_matches_at_exactly_the_narrow_one_s_positions(self):
@@ -3062,13 +3069,82 @@ class TestBudgetWarningAnchorComposition:
             "False agree for free"
         )
         assert separating, (
-            "no corpus member carries a warning below the head, so the "
-            "equality arm cannot tell the wide anchor from the narrow one and "
-            "would pass unchanged if the two were the same pattern"
+            "no corpus member is SEPARATING: for each member the wide "
+            "predicate agrees with the narrow one at offset 0. Either the "
+            "corpus lost its below-head member, or the wide predicate no "
+            "longer sees that member because its anchor is narrower. The "
+            "equality arm above names which. The property here would pass "
+            "unchanged if the two patterns were the same"
         )
         assert len(separating) == 2, f"separating members: {sorted(separating)}"
         assert len(both_true) == 2, f"both-true members: {sorted(both_true)}"
         assert len(both_false) == 7, f"both-false members: {sorted(both_false)}"
+
+
+class TestDeletingAnchorStaysAtTheHead:
+    """The pattern that DELETES must not reach past offset 0, by any call.
+
+    THE HAZARD HERE IS THE CARDINAL ONE OF THIS MODULE. Widen this anchor and
+    a strip reaches text a user wrote inside a pin body, in a file that is
+    frequently gitignored, with no commit to recover from. The module refuses
+    that widening in its own prose. Until this arm, nothing enforced it.
+
+    WHY NO DOCUMENT-LEVEL ARM CATCHES IT, which is the reason this gate reads
+    the OBJECT. `_strip_budget_warnings` reaches the pattern by `.match()` at
+    offset 0 alone, and each anchor matches at offset 0. MEASURED: with the
+    anchor widened to a line-anchored form, the strip returns BYTE-IDENTICAL
+    output and the whole file passes. The widening changes no behaviour today.
+    It removes a GUARANTEE, and a guarantee is invisible to an arm that drives
+    documents. The composition arms above miss it for a different reason, which
+    their own docstring records.
+
+    WHY `.search` IS THE PROBE. A start-of-string anchor makes `.search` and
+    `.match` agree on every input, so `.search` is harmless as a call site.
+    THAT AGREEMENT IS THE PROPERTY. If `.search` reaches further than `.match`
+    can, the pattern no longer pins itself to offset 0.
+
+    THIS GATE HOLDS NO LITERAL. It reads neither the pattern string nor the
+    module source, so a legitimate re-spelling passes. MEASURED: a caret with
+    no MULTILINE flag is equivalent to the shipped anchor, carries no hazard,
+    and this arm passes it. A gate on the pattern string REFUSES that spelling,
+    which is why this one does not read the string.
+
+    WHAT A LATER EDIT MUST DO TO SATISFY IT. Keep the compiled object unable to
+    match anywhere except offset 0. The sanctioned repair for the residual this
+    module accepts does NOT widen the delete: it excludes lines of this shape
+    from the COUNT at the measurement site, on a throwaway copy, and leaves the
+    delete on the contiguous run at the head.
+    """
+
+    def test_the_deleting_pattern_cannot_reach_below_the_head(self):
+        """A warning below the head must be invisible to the deleting pattern.
+
+        THE NEGATIVE LEG IS THE GATE. `.search` scans every position, so it
+        reports a match wherever the pattern is able to match at all. On a body
+        whose only warning sits below the head, this pattern must find nothing.
+
+        THE POSITIVE LEG SITS IN THE SAME TEST, because "found nothing" is also
+        what a shape that matches nothing produces. Without it this gate would
+        report the cardinal hazard as covered while it checked nothing.
+        """
+        from staleness import _LEADING_BUDGET_WARNING_RE
+
+        below_head = "a note the user wrote\n" + _ONE_WARNING_LINE + "more prose\n"
+        assert _LEADING_BUDGET_WARNING_RE.search(below_head) is None, (
+            "the deleting pattern reached a warning BELOW the head, so a strip "
+            "built on it now removes text a user wrote inside a pin body, from "
+            "a file that is frequently gitignored. Do not widen this anchor. "
+            "Exclude the line from the COUNT on a throwaway copy at the "
+            "measurement site instead, and leave the delete at the head"
+        )
+
+        # POSITIVE CONTROL, in the same fixture. The absence above must be
+        # caused by the ANCHOR, and not by a shape that matches nothing at all.
+        at_head = _ONE_WARNING_LINE + "a note the user wrote\n"
+        assert _LEADING_BUDGET_WARNING_RE.search(at_head) is not None, (
+            "the deleting pattern did not find a warning AT the head, so the "
+            "negative leg above proves nothing about the anchor"
+        )
 
 
 # ===========================================================================

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -2959,14 +2959,17 @@ class TestBudgetWarningAnchorComposition:
     the shipped objects can testify about their own composition.
 
     THE TWO ARMS HAVE DIFFERENT SUBJECTS, WHICH IS WHY THERE ARE TWO. The first
-    is about the PATTERNS. The second is about the CORPUS, and only a change to
-    the corpus separates them. Measured rather than predicted: TRIM the two
-    separating members out of the corpus below and the equality arm still
-    PASSES, while the second arm goes red and says why. That is the vacuity
-    this pair exists to refuse. Re-anchor the wide pattern to the start of the
-    string, so that the two become identical patterns, and BOTH arms go red --
-    the first because the corpus separates them, the second because nothing
-    separates them any longer.
+    is about the PATTERNS; the second is about what the corpus can still tell
+    apart. THREE STATES WERE RUN, and two of them separate the arms.
+      - TRIM the separating members out of the corpus: the equality arm still
+        PASSES, the second goes red.
+      - BREAK the shared shape to a literal that never matches: the equality
+        arm PASSES AGAIN, because both sides then say False to everything, and
+        the second still goes red.
+      - RE-ANCHOR the wide pattern, so the two are identical patterns: BOTH go
+        red.
+    The first arm alone therefore certifies nothing. That is the whole reason
+    the second one exists, and it is why neither may be deleted as a duplicate.
     """
 
     def test_the_wide_anchor_matches_at_exactly_the_narrow_one_s_positions(self):
@@ -2980,6 +2983,19 @@ class TestBudgetWarningAnchorComposition:
 
         for name, text in _ANCHOR_CORPUS.items():
             wide = _ANY_BUDGET_WARNING_RE.search(text) is not None
+            # SLICE THE TEXT. DO NOT PASS AN OFFSET AS `pos`. The two look
+            # interchangeable and are not. `\A` matches only at the TRUE start
+            # of the string, and `pos` DOES NOT MOVE IT, so
+            # `.match(text, k)` with k > 0 returns None for every input --
+            # whatever the shape is, and whether the shape is right or broken.
+            # MEASURED, with a control: against a deliberately broken pattern
+            # the `pos` form gives None for both, which is INDISTINGUISHABLE,
+            # while the slice form matches for the real one and not for the
+            # broken one, which SEPARATES. So the natural-looking `pos`
+            # spelling turns this whole arm vacuous, and it would still pass.
+            # Slicing re-anchors to the slice start, which is what actually
+            # exercises the shipped object.
+            #
             # THIS CALL SHAPE IS LEGITIMATE HERE AND FORBIDDEN IN THE MODULE.
             # `_LEADING_BUDGET_WARNING_RE` is the pattern that DELETES, and
             # giving it a caller-chosen offset is the construction the module
@@ -3001,11 +3017,21 @@ class TestBudgetWarningAnchorComposition:
     def test_the_corpus_separates_the_two_anchors(self):
         """NON-VACUITY, and it guards the CORPUS rather than the predicates.
 
-        The equality above holds trivially on a corpus where both sides always
-        agree -- a corpus of empty strings satisfies it, and so would two
-        identical patterns. It is evidence only while some member tells a
-        line-start anchor apart from a start-of-string one, which means a
-        member whose ONLY warning sits below the head.
+        TWO PREDICATES AGREE FOR FREE WHEN BOTH SAY FALSE TO EVERYTHING. That
+        is the trap under the equality arm, and it has two entrances. A corpus
+        of only negative members passes it. So does a corpus of positives, if
+        the shared shape stops matching anything at all. The arm above cannot
+        see either one, because in both states its two sides agree perfectly.
+
+        SO THE CORPUS MUST CARRY BOTH KINDS AT ONCE: members that BOTH sides
+        match, and among them a member that only the LINE-START side can reach.
+        The first refuses a shape that matches nothing; the second refuses two
+        patterns that are secretly one.
+
+        MEASURED, NOT ASSERTED. Replace `_BUDGET_WARNING_SHAPE` with a literal
+        that can never match, and the equality arm above PASSES while this one
+        goes red. Re-anchor the wide pattern to the start of the string, and
+        this one goes red as well. Both states were run.
 
         THE COUNTS ARE PINNED, NOT MERELY NON-ZERO. "At least one" survives a
         trim down to one lucky member. An exact figure per class refuses any
@@ -3025,6 +3051,16 @@ class TestBudgetWarningAnchorComposition:
             else:
                 both_false.append(name)
 
+        # THE TWO ENTRANCES TO THE TRAP GET SEPARATE MESSAGES, because they
+        # have different repairs and a reader who reaches this line is trying
+        # to work out which one they broke.
+        assert separating or both_true, (
+            "the wide predicate matched NOTHING anywhere in the corpus. Either "
+            "the shared shape no longer matches the text this module writes, "
+            "or every positive member has left the corpus. The equality arm "
+            "above PASSES in that state, because two predicates that both say "
+            "False agree for free"
+        )
         assert separating, (
             "no corpus member carries a warning below the head, so the "
             "equality arm cannot tell the wide anchor from the narrow one and "

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -2725,3 +2725,123 @@ class TestBudgetWarningInteractions:
             "the positive control did not fire, so the negative arm above "
             "proves nothing"
         )
+
+
+# ===========================================================================
+# Citations from staleness.py into this file must still resolve
+# ===========================================================================
+
+_STALENESS_SOURCE = Path(__file__).parent.parent / "hooks" / "staleness.py"
+
+# THE ALPHABET IS TAKEN FROM WHAT PYTEST COLLECTS, NOT FROM WHAT WE REMEMBER
+# CITING. pytest collects `Test`-prefixed CLASSES as well as `test_`-prefixed
+# FUNCTIONS, so a pattern covering only the second is blind to half the thing it
+# measures. `Test` must be followed by an uppercase letter or an underscore, so
+# the ordinary English word "Tests" is not mistaken for a class name.
+_CITED_TEST_NAME_RE = re.compile(r"\b(?:test_[A-Za-z0-9_]+|Test[A-Z_][A-Za-z0-9_]*)\b")
+
+
+def _cited_test_names(source):
+    """Return every test symbol `source` names in its own prose.
+
+    A name immediately followed by `.py` is a FILE PATH, not a symbol, and is
+    excluded: demanding a definition called `test_staleness` would be a false
+    failure. The exclusion is applied after the match rather than inside the
+    pattern, because a lookahead lets the regex backtrack to a shorter name and
+    invent a citation that was never written.
+    """
+    found = set()
+    for match in _CITED_TEST_NAME_RE.finditer(source):
+        if source[match.end():match.end() + 3] == ".py":
+            continue
+        found.add(match.group(0))
+    return found
+
+
+def _defined_test_names(source):
+    """Return every class and function `source` DEFINES, at any nesting depth."""
+    return {
+        node.name
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+    }
+
+
+class TestStalenessCitationsResolve:
+    """A test name in source prose is a pointer with nothing holding it.
+
+    `staleness.py` cites tests from this file to justify its own behaviour, and
+    the most load-bearing of those citations is the one a reader is told to
+    check INSTEAD of trusting the author. A rename on this side turns that into
+    a dangling pointer, silently, and no existing gate covers it: the twin-parity
+    gate protects three named twin-copy tests and nothing else.
+
+    THE CITED SET IS DERIVED, NEVER HAND-LISTED. A hand list protects the names
+    somebody remembered to add to it, and its failure mode is silence, which is
+    the same defect one level up.
+
+    FAILURE DIRECTION IS DELIBERATE. Over-detection REFUSES and says which name,
+    which is loud and cheap to fix. Under-detection is silent and reinstates the
+    dangling pointer, so the alphabet is bounded rather than narrowed.
+    """
+
+    def test_the_extractor_covers_both_things_pytest_collects(self):
+        """Instrument check on a synthetic input, not on the current file.
+
+        Asserting that the LIVE citation set contains both kinds would couple
+        this to today's prose and redden when a citation is legitimately
+        removed. The alphabet is the thing under test, so the input is fixed.
+        """
+        found = _cited_test_names("see TestFooBar and test_foo_bar for why")
+        assert found == {"TestFooBar", "test_foo_bar"}
+
+    def test_the_extractor_ignores_a_file_path(self):
+        """`test_staleness.py` is a path. A bare `test_real_thing` is a symbol."""
+        assert _cited_test_names("see test_staleness.py for details") == set()
+        assert _cited_test_names("test_staleness.py defines test_real_thing") == {
+            "test_real_thing"
+        }
+        assert _cited_test_names("Tests cover the module") == set()
+
+    def test_staleness_cites_at_least_one_test(self):
+        """NON-VACUITY. An extractor returning nothing satisfies the guard below
+        perfectly and for ever, so the population is asserted before the
+        property that quantifies over it."""
+        cited = _cited_test_names(
+            _STALENESS_SOURCE.read_text(encoding="utf-8")
+        )
+        assert cited, (
+            "no test citations were extracted from staleness.py, so the "
+            "resolution check below is quantifying over an empty set"
+        )
+
+    def test_every_test_cited_by_staleness_still_exists(self):
+        """The property itself."""
+        cited = _cited_test_names(
+            _STALENESS_SOURCE.read_text(encoding="utf-8")
+        )
+        defined = _defined_test_names(
+            Path(__file__).read_text(encoding="utf-8")
+        )
+        missing = sorted(cited - defined)
+        assert not missing, (
+            f"staleness.py cites {missing} but this file no longer defines "
+            f"them; the citation is a dangling pointer and the prose that "
+            f"leans on it can no longer be checked"
+        )
+
+    def test_the_guard_detects_a_deleted_citation(self):
+        """MUTATION ARM. Proves the check reddens on the failure it exists for,
+        by removing a cited name from the defined set rather than by trusting
+        that a set difference must work."""
+        cited = _cited_test_names(
+            _STALENESS_SOURCE.read_text(encoding="utf-8")
+        )
+        defined = _defined_test_names(
+            Path(__file__).read_text(encoding="utf-8")
+        )
+        victim = sorted(cited)[0]
+        assert not (cited - defined), "fixture invalid: the real check is red"
+        assert (cited - (defined - {victim})) == {victim}, (
+            "deleting a cited definition did not surface it as missing"
+        )

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -3556,10 +3556,13 @@ def _prose_of(source):
 
     A GENERAL HAZARD, AND IT IS WHY THE POPULATION IS NARROWED RATHER THAN THE
     EXCEPTIONS LISTED. When a checker grows to read the file that holds it, the
-    OWN FIXTURES of that checker become part of its input. Synthetic data built
-    to exercise the checker then reads as live content, and the checker reports
-    on itself. That self-reference is one the widening CREATES, not one it
-    finds, so expect it whenever a population grows to cover the checker.
+    OWN FIXTURES of that checker become part of its input, because fixtures are
+    shaped to look like the thing the checker hunts. Synthetic data built to
+    exercise the checker then reads as live content, and the checker reports on
+    itself. That self-reference is one the widening CREATES, not one it finds,
+    and it arrives as false positives indistinguishable from real findings
+    until each one is read. Expect it whenever a population grows to cover the
+    checker.
     """
     chunks = []
     for node in ast.walk(ast.parse(source)):
@@ -3590,11 +3593,14 @@ def _defined_across_the_tests_tree():
     long and specific, so the risk is small, and the alternative refuses every
     legitimate cross-file citation. That trade is deliberate.
 
-    THE FAILURE DIRECTION IS WHY THE TRADE GOES THIS WAY. An accidental resolve
-    is a false GREEN, so this guard UNDER-DETECTS a cited name that collides
-    with an unrelated test. SILENCE HERE IS NOT PROOF. The alternative is a
-    false RED on correct prose, in a merge gate, and under-detection that needs
-    a name collision beats over-detection that fires on correct writing.
+    THIS GUARD UNDER-DETECTS. A cited name that collides with an unrelated test
+    anywhere in the tests tree resolves and passes, so a dangling pointer can
+    read as live. Silence from this guard is not proof that each citation
+    resolves to what its author meant.
+
+    THE TRADE GOES THIS WAY ON FAILURE DIRECTION. The alternative is a false
+    RED on correct prose, in a merge gate. Under-detection that requires a name
+    collision beats over-detection that fires on correct writing.
     """
     names = set()
     for path in sorted(Path(__file__).parent.glob("test_*.py")):

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -1283,10 +1283,10 @@ class TestParsePinnedSectionMarkerBoundary:
     r"""Direct unit tests for `staleness._parse_pinned_section`'s marker-aware
     section-end detection.
 
-    Round-4 Item 4: the integration test `TestCheckPinnedStaleness.test_pinned_content_before_memory_end_marker`
-    passes even if the next_section regex is relaxed back to `^#{1,2}\s`
-    because the fixture content has no stale entries, so no write-back occurs
-    and the marker is never touched. A unit-level test on `_parse_pinned_section`
+    An INTEGRATION test in `TestCheckPinnedStaleness` passes even if the
+    next_section regex is relaxed back to `^#{1,2}\s`, whenever its fixture
+    content has no stale entries, because no write-back occurs and the marker
+    is never touched. A unit-level test on `_parse_pinned_section`
     directly asserts that the returned `pinned_end` index stops BEFORE the
     marker — this is the differentiated behavior the round-3 fix protects.
 
@@ -3504,13 +3504,36 @@ def _cited_test_names(source):
     failure. The exclusion is applied after the match rather than inside the
     pattern, because a lookahead lets the regex backtrack to a shorter name and
     invent a citation that was never written.
+
+    A name immediately followed by `*` is a GLOB over a FAMILY of arms, and it
+    keeps its star. It is not dropped, because a glob is still a pointer and
+    can still dangle. `_unresolved` resolves it by prefix, so a family that
+    goes away is reported rather than excused.
     """
     found = set()
     for match in _CITED_TEST_NAME_RE.finditer(source):
         if source[match.end():match.end() + 3] == ".py":
             continue
-        found.add(match.group(0))
+        star = "*" if source[match.end():match.end() + 1] == "*" else ""
+        found.add(match.group(0) + star)
     return found
+
+
+def _unresolved(cited, defined):
+    """Return the cited names that nothing in `defined` satisfies.
+
+    A plain name must be present. A name that ends in `*` is a glob, and it is
+    satisfied when SOME defined name carries that prefix, so the family is
+    checked rather than waved through.
+    """
+    missing = set()
+    for name in cited:
+        if name.endswith("*"):
+            if not any(d.startswith(name[:-1]) for d in defined):
+                missing.add(name)
+        elif name not in defined:
+            missing.add(name)
+    return sorted(missing)
 
 
 def _defined_test_names(source):
@@ -3520,6 +3543,64 @@ def _defined_test_names(source):
         for node in ast.walk(ast.parse(source))
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
     }
+
+
+def _prose_of(source):
+    """Return the DOCSTRINGS and COMMENTS of `source`, and nothing else.
+
+    THIS FILE CANNOT BE READ WHOLE THE WAY A SOURCE MODULE CAN. A test module
+    holds test names in three places that are not citations at all: a local
+    variable that collects probe strings, synthetic names handed to an
+    extractor as INPUT DATA, and the definitions themselves. Prose is where a
+    citation lives, so prose is the population.
+
+    A GENERAL HAZARD, AND IT IS WHY THE POPULATION IS NARROWED RATHER THAN THE
+    EXCEPTIONS LISTED. When a checker grows to read the file that holds it, the
+    OWN FIXTURES of that checker become part of its input. Synthetic data built
+    to exercise the checker then reads as live content, and the checker reports
+    on itself. That self-reference is one the widening CREATES, not one it
+    finds, so expect it whenever a population grows to cover the checker.
+    """
+    chunks = []
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(
+            node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+        ):
+            docstring = ast.get_docstring(node, clean=False)
+            if docstring:
+                chunks.append(docstring)
+    for line in source.split("\n"):
+        hash_at = line.find("#")
+        if hash_at != -1:
+            chunks.append(line[hash_at:])
+    return "\n".join(chunks)
+
+
+def _defined_across_the_tests_tree():
+    """Every test symbol in this directory, plus every test FILE STEM.
+
+    THE RESOLUTION SET IS WIDENED WITH THE POPULATION, rather than the
+    population being narrowed by a list of exceptions. A citation to a test in
+    a sibling file is legitimate, and so is a reference to a test file by its
+    stem, so each must RESOLVE rather than be excluded by a rule somebody has
+    to keep current.
+
+    THE COST, STATED. This set is large, so a citation can resolve against an
+    unrelated test that happens to carry the name. The names in question are
+    long and specific, so the risk is small, and the alternative refuses every
+    legitimate cross-file citation. That trade is deliberate.
+
+    THE FAILURE DIRECTION IS WHY THE TRADE GOES THIS WAY. An accidental resolve
+    is a false GREEN, so this guard UNDER-DETECTS a cited name that collides
+    with an unrelated test. SILENCE HERE IS NOT PROOF. The alternative is a
+    false RED on correct prose, in a merge gate, and under-detection that needs
+    a name collision beats over-detection that fires on correct writing.
+    """
+    names = set()
+    for path in sorted(Path(__file__).parent.glob("test_*.py")):
+        names.add(path.stem)
+        names |= _defined_test_names(path.read_text(encoding="utf-8"))
+    return names
 
 
 class TestStalenessCitationsResolve:
@@ -3551,7 +3632,7 @@ class TestStalenessCitationsResolve:
         assert found == {"TestFooBar", "test_foo_bar"}
 
     def test_the_extractor_ignores_a_file_path(self):
-        """`test_staleness.py` is a path. A bare `test_real_thing` is a symbol."""
+        """A name with a `.py` suffix is a path. A bare name is a symbol."""
         assert _cited_test_names("see test_staleness.py for details") == set()
         assert _cited_test_names("test_staleness.py defines test_real_thing") == {
             "test_real_thing"
@@ -3570,6 +3651,64 @@ class TestStalenessCitationsResolve:
             "resolution check below is quantifying over an empty set"
         )
 
+    def test_each_file_supplies_its_own_citations(self):
+        """NON-VACUITY FOR THE WIDENED POPULATION, RE-DERIVED RATHER THAN CARRIED.
+
+        The arm above asserts that SOME citation was extracted, and it was
+        calibrated when one file supplied them all. Over two files that same
+        claim is much weaker: a broken extractor on the TEST file leaves the
+        source module's citations in place, the assertion holds, and half the
+        population goes silent with nothing to report it.
+
+        So the floor is PER FILE, and each figure is measured rather than
+        chosen. If a legitimate edit takes a file below its floor, lower the
+        figure and say what went, rather than delete the arm.
+
+        THAT RULE HAS BEEN APPLIED ONCE, WHEN THIS ARM WAS NEW. The committed
+        file carried 19 prose citations. Two left for good reasons: a name that
+        no test ever defined, and a synthetic name that this file's own
+        instrument tests use as INPUT rather than as a pointer. The floor is
+        the measured 17 that remains.
+        """
+        from_source = _cited_test_names(
+            _STALENESS_SOURCE.read_text(encoding="utf-8")
+        )
+        from_this_file = _cited_test_names(
+            _prose_of(Path(__file__).read_text(encoding="utf-8"))
+        )
+        assert len(from_source) >= 3, (
+            f"staleness.py supplied {len(from_source)} citations against a "
+            f"measured floor of 3, so the source half of this guard has lost "
+            f"population it used to carry"
+        )
+        assert len(from_this_file) >= 17, (
+            f"this file's prose supplied {len(from_this_file)} citations "
+            f"against a measured floor of 17, so the half of this guard that "
+            f"reads its OWN file is quantifying over less than it used to"
+        )
+
+    def test_every_test_cited_by_this_file_still_exists(self):
+        """The same property, turned on the file that holds the guard.
+
+        WHY THIS ARM EXISTS. The guard above reads the SOURCE module only. The
+        file carrying it held a dangling citation about fifteen hundred lines
+        below the guard, and the guard could not see it. A checker blind to its
+        own file is the shape it was written to refuse.
+
+        THE POPULATION IS PROSE, and the resolution set is the whole tests
+        directory. See `_prose_of` and `_defined_across_the_tests_tree` for why
+        each is drawn that way.
+        """
+        cited = _cited_test_names(
+            _prose_of(Path(__file__).read_text(encoding="utf-8"))
+        )
+        missing = _unresolved(cited, _defined_across_the_tests_tree())
+        assert not missing, (
+            f"this file's prose cites {missing}, and no test in this directory "
+            f"defines them. The prose that leans on those names can no longer "
+            f"be checked by a reader who follows the pointer"
+        )
+
     def test_every_test_cited_by_staleness_still_exists(self):
         """The property itself."""
         cited = _cited_test_names(
@@ -3578,7 +3717,7 @@ class TestStalenessCitationsResolve:
         defined = _defined_test_names(
             Path(__file__).read_text(encoding="utf-8")
         )
-        missing = sorted(cited - defined)
+        missing = _unresolved(cited, defined)
         assert not missing, (
             f"staleness.py cites {missing} but this file no longer defines "
             f"them; the citation is a dangling pointer and the prose that "

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -48,21 +48,42 @@ from staleness import _BUDGET_WARNING_PREFIX
 _WARNING_NUMBER_RE = re.compile(re.escape(_BUDGET_WARNING_PREFIX) + r" ~(\d+) tokens")
 
 
-def over_budget_body(margin_words=200):
+# Words added above the budget so the fixture clears it comfortably rather than
+# at the boundary. The limit in the docstring below is stated in terms of it.
+_OVER_BUDGET_MARGIN_WORDS = 200
+
+
+def over_budget_body():
     """Build a pin body whose estimated tokens exceed the pinned-context budget.
 
     THE MAGNITUDE IS DERIVED FROM THE CONSTANT, NEVER WRITTEN AS A LITERAL.
     `estimate_tokens` is `int(words * 1.3)`, so a word count above the budget
     always estimates above the budget, whatever value the budget takes next.
 
-    The assertion makes that structural. A hard-coded fixture went silently
-    under a raised threshold once already -- it still passed, while no longer
-    testing the thing its comment claimed -- and only a check against the live
-    constant can refuse to repeat that.
+    THE DERIVATION IS WHAT TRACKS A RAISED BUDGET. A hard-coded fixture went
+    silently under a raised threshold once already -- it still passed, while no
+    longer testing the thing its comment claimed -- and a body built from the
+    live constant is what refuses to repeat that.
+
+    WHAT THE ASSERT BELOW GUARDS, WHICH IS NOT THE BUDGET. It fires when
+    `int((B + m) * c) <= B`, where B is the budget, m is
+    `_OVER_BUDGET_MARGIN_WORDS` and c is the estimator coefficient. At a fixed
+    margin that makes it a tripwire on c, not on B. Because `int` truncates,
+    that condition is the same as `(B + m) * c < B + 1`, so the closed-form
+    boundary is `c < (B + 1) / (B + m)` -- exactly 3201/3400 at the shipped
+    values, or approximately 0.9415. Derive that from the fire condition rather
+    than trusting the fraction; note in particular that the boundary is NOT
+    `B / (B + m)`, and that a decimal is never what the predicate compares
+    against. It cannot fire for ANY budget value at the shipped coefficient of
+    1.3. It is live and not dead -- drop the coefficient below the boundary and
+    this goes red, which a companion test in this file measures rather than
+    asserts. Keep it for that reason. Do not read it as a check that the fixture
+    still exceeds a raised budget: the derivation above supplies that, and the
+    assert adds nothing to it.
     """
     from staleness import PINNED_CONTEXT_TOKEN_BUDGET, estimate_tokens
 
-    body = "word " * (PINNED_CONTEXT_TOKEN_BUDGET + margin_words)
+    body = "word " * (PINNED_CONTEXT_TOKEN_BUDGET + _OVER_BUDGET_MARGIN_WORDS)
     assert estimate_tokens(body) > PINNED_CONTEXT_TOKEN_BUDGET, (
         "fixture no longer exceeds the budget it is derived from"
     )
@@ -73,6 +94,71 @@ def warning_number(text):
     """Return the token figure carried by the warning comment, or None."""
     match = _WARNING_NUMBER_RE.search(text)
     return int(match.group(1)) if match else None
+
+
+class TestOverBudgetBodyAssertIsLive:
+    """Non-vacuity for the assert inside `over_budget_body`.
+
+    THE ASSERT CANNOT FIRE AT SHIPPED VALUES, so nothing else in this suite
+    shows that it still works. A check that cannot fail on any input the system
+    produces is not a check, and this is what makes it a guard again. The same
+    discipline is applied to the caps band elsewhere in this file, so this is a
+    local convention rather than a new one.
+
+    ONE COUPLING MAKES THE PATCH REACH THE FIXTURE. `over_budget_body` imports
+    `estimate_tokens` INSIDE its own body, so the name is looked up on the
+    `staleness` module at CALL time and the patch below reaches it. Hoisting
+    that import to module scope, or inlining the arithmetic, stops the patch
+    reaching it. Both of those were measured, and both make this test go RED
+    rather than quiet, because an arm that expects a raise fails when the raise
+    stops happening. The coupling cannot be broken silently.
+
+    THE RESIDUAL RISK RUNS THE OTHER WAY: an arm that expects a raise can pass
+    on the WRONG raise. The negative arm was checked to fire at the fixture's
+    own assert and to carry its message, not some unrelated failure.
+    """
+
+    def test_the_assert_fires_when_the_coefficient_drops_below_the_boundary(self):
+        """Below `(B + 1) / (B + m)` the fixture must refuse to build."""
+        from staleness import PINNED_CONTEXT_TOKEN_BUDGET
+
+        boundary = (PINNED_CONTEXT_TOKEN_BUDGET + 1) / (
+            PINNED_CONTEXT_TOKEN_BUDGET + _OVER_BUDGET_MARGIN_WORDS
+        )
+        below = boundary - 0.01
+        with patch(
+            "staleness.estimate_tokens",
+            lambda text: int(len(text.split()) * below),
+        ):
+            with pytest.raises(AssertionError):
+                over_budget_body()
+
+    def test_the_assert_stays_silent_just_above_the_boundary(self):
+        """The positive arm. Without it, a fixture broken for any OTHER reason
+        would satisfy the negative arm above and read as a working guard."""
+        from staleness import PINNED_CONTEXT_TOKEN_BUDGET
+
+        boundary = (PINNED_CONTEXT_TOKEN_BUDGET + 1) / (
+            PINNED_CONTEXT_TOKEN_BUDGET + _OVER_BUDGET_MARGIN_WORDS
+        )
+        above = boundary + 0.01
+        with patch(
+            "staleness.estimate_tokens",
+            lambda text: int(len(text.split()) * above),
+        ):
+            assert over_budget_body()
+
+    def test_the_shipped_coefficient_sits_above_the_boundary(self):
+        """Pins the docstring's claim that the assert cannot fire as shipped."""
+        from staleness import PINNED_CONTEXT_TOKEN_BUDGET, estimate_tokens
+
+        words = PINNED_CONTEXT_TOKEN_BUDGET + _OVER_BUDGET_MARGIN_WORDS
+        shipped_coefficient = estimate_tokens("word " * words) / words
+        boundary = (PINNED_CONTEXT_TOKEN_BUDGET + 1) / words
+        assert shipped_coefficient > boundary, (
+            "the estimator coefficient has dropped to the boundary; the "
+            "fixture assert is now one edit from firing on shipped values"
+        )
 
 
 class TestCheckPinnedStaleness:

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -2692,6 +2692,161 @@ class TestBudgetWarningInteractions:
         assert warning_number(content) > 0
 
     # ------------------------------------------------------------------
+    # The entry-less asymmetry, widened-probe half.
+    # ------------------------------------------------------------------
+    #
+    # The probe reads ANY line start; the strip reads offset 0. The three arms
+    # below pin the whole of that gap: what the wider probe buys, what it
+    # costs, and the second condition that keeps the cost from firing.
+
+    def test_entryless_section_with_a_stranded_warning_is_refreshed(self, tmp_path):
+        """A warning MOVED below the head still admits the section to the pass.
+
+        THE DEFECT THIS REMOVES. The probe used to be anchored at offset 0, so
+        a user who moved the warning down took the whole section out of the
+        pass: the figure froze at whatever it said that day, and no later pass
+        could correct it. A wider probe admits the section again.
+
+        THE STRIP DOES NOT FOLLOW THE PROBE. It still reaches offset 0 only, so
+        the moved line survives and this pass adds ONE current warning ABOVE
+        it. Two lines, not one. That is the ratified residual, not a repair.
+
+        KILLS THE ANCHOR REVERT. Put `_LEADING_BUDGET_WARNING_RE.match` back
+        into `_has_budget_warning` and this document is left untouched with its
+        frozen figure, which is the defect itself.
+        """
+        from staleness import check_pinned_staleness
+
+        stranded = self._warning_line(tokens=9999)
+        claude_md = self._create_project_claude_md(
+            tmp_path,
+            self._doc(
+                "Some prose the user keeps here.\n"
+                + stranded
+                + f"{over_budget_body()}\n"
+            ),
+        )
+
+        result = check_pinned_staleness(claude_md_path=claude_md)
+
+        content = claude_md.read_text(encoding="utf-8")
+        # One line the hook wrote at the head, plus the one it cannot reach.
+        assert self._count_warnings(content) == 2
+        assert stranded in content, "the strip reached a line below the head"
+        head_figure = warning_number(content)
+        assert head_figure is not None, "the pass wrote no warning at the head"
+        assert head_figure != 9999, (
+            "the head still carries the stranded figure -- the number froze, "
+            "which is the defect this widening removes"
+        )
+        assert result is not None and "budget" in result.lower()
+
+        # The pass settles. Later passes must change no byte and add no line.
+        settled = content
+        for _ in range(3):
+            check_pinned_staleness(claude_md_path=claude_md)
+        assert claude_md.read_text(encoding="utf-8") == settled, (
+            "a later pass rewrote a settled document"
+        )
+
+    def test_a_pasted_warning_over_budget_costs_exactly_one_extra_line(self, tmp_path):
+        """THE RULING ITSELF, pinned so the accepted cost can be falsified.
+
+        A maintainer who pastes the emitted format into a note of their own
+        writes a document this module CANNOT tell apart from the stranded case
+        above. The shape is what identifies a line as this module's own, and
+        both documents carry that shape at a line start below the head. So this
+        section enters the pass too, and gains one current warning above the
+        paste. This arm states the price rather than asserting that the price
+        is acceptable.
+
+        THE PRICE IS BOUNDED AT ONE EXTRA LINE, which is the half that matters.
+        Six passes hold the count at two and change no byte after the first, so
+        a maintainer's note cannot make the document grow without limit.
+
+        THE USER'S OWN LINE MUST SURVIVE, and that is the cardinal assertion
+        here. This module deletes from a file that is frequently gitignored, so
+        an over-broad strip removes text no commit can restore.
+        """
+        from staleness import check_pinned_staleness
+
+        pasted = self._warning_line(tokens=99, budget=1)
+        claude_md = self._create_project_claude_md(
+            tmp_path,
+            self._doc(
+                "The hook writes this line:\n"
+                + pasted
+                + f"{over_budget_body()}\n"
+            ),
+        )
+
+        result = check_pinned_staleness(claude_md_path=claude_md)
+
+        settled = claude_md.read_text(encoding="utf-8")
+        assert self._count_warnings(settled) == 2
+        assert pasted in settled, "the strip deleted a line a user wrote"
+        assert result is not None and "budget" in result.lower()
+
+        # Five further passes. The accepted cost is ONE extra line for ever,
+        # not one extra line per pass.
+        for _ in range(5):
+            check_pinned_staleness(claude_md_path=claude_md)
+        after = claude_md.read_text(encoding="utf-8")
+        assert self._count_warnings(after) == 2, (
+            "a later pass raised the count -- the accepted cost is not bounded"
+        )
+        assert after == settled, "a later pass rewrote a settled document"
+
+    def test_a_pasted_warning_under_budget_changes_nothing(self, tmp_path):
+        """BOTH CONDITIONS ARE REQUIRED, so the paste alone is inert.
+
+        The wider probe only ADMITS a section to the pass. The write decision
+        is still `pinned_tokens > PINNED_CONTEXT_TOKEN_BUDGET`, and the probe
+        is not an input to it. The same paste in a body UNDER the budget
+        therefore leaves the document byte-identical and returns None.
+
+        A POSITIVE LEG SITS IN THIS FIXTURE, and it is what makes the untouched
+        assertion mean anything. "Nothing happened" also passes for a hook that
+        never ran, a region that never parsed, and a renamed constant. The
+        second half of this test is the SAME document over the budget, which
+        must gain exactly one line.
+        """
+        from staleness import check_pinned_staleness
+
+        pasted = self._warning_line(tokens=99, budget=1)
+        quiet = self._create_project_claude_md(
+            tmp_path,
+            self._doc("The hook writes this line:\n" + pasted + "a short pin\n"),
+        )
+        before = quiet.read_text(encoding="utf-8")
+
+        result = check_pinned_staleness(claude_md_path=quiet)
+
+        assert result is None
+        assert quiet.read_text(encoding="utf-8") == before, (
+            "an under-budget body was modified -- the paste alone must be inert"
+        )
+        assert self._count_warnings(before) == 1
+
+        # POSITIVE CONTROL: the same document over the budget, in the same
+        # test. Without it the assertions above hold for a dead instrument.
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        loud = self._create_project_claude_md(
+            sub,
+            self._doc(
+                "The hook writes this line:\n"
+                + pasted
+                + f"{over_budget_body()}\n"
+            ),
+        )
+        assert check_pinned_staleness(claude_md_path=loud) is not None
+        assert self._count_warnings(loud.read_text(encoding="utf-8")) == 2, (
+            "the positive control did not fire, so the untouched assertion "
+            "above proves nothing about the budget condition"
+        )
+
+    # ------------------------------------------------------------------
     # Absence must be caused by the budget, not by a dead instrument.
     # ------------------------------------------------------------------
 
@@ -2725,6 +2880,159 @@ class TestBudgetWarningInteractions:
             "the positive control did not fire, so the negative arm above "
             "proves nothing"
         )
+
+
+# ===========================================================================
+# The two budget-warning predicates are one shape under two anchors
+# ===========================================================================
+
+
+def _line_starts(text):
+    """Every offset a `(?m)^` pattern can match at: 0, and after each newline.
+
+    A text that ends with a newline has a line start at its very end, where
+    there is nothing left to match. That position is included on purpose, so
+    this list is the multiline anchor's own position set rather than an
+    approximation of it. Measured against `re.finditer(r"(?m)^", ...)`.
+    """
+    return [0] + [match.end() for match in re.finditer(r"\n", text)]
+
+
+_ONE_WARNING_LINE = (
+    f"{_BUDGET_WARNING_PREFIX} ~42 tokens (budget: 5). "
+    "Consider archiving stale pins. -->\n"
+)
+
+# THE CORPUS IS KEYED BY NAME so a failure reports WHICH member broke the
+# property instead of an index. Every member is built from the imported
+# prefix, never from a copied literal.
+#
+# THE THREE CLASSES BELOW ARE COUNTED BY THE SECOND ARM, and each class earns
+# its place. The SEPARATING members are the only reason the equality property
+# says anything at all. The BOTH-TRUE members keep it from being a proof that
+# nothing ever matches. The BOTH-FALSE members are the shapes a user's own
+# prose can take, and they are what shows the wider anchor did not widen the
+# ALPHABET: a bare prefix, a payload with no digits, a line with no terminator,
+# and a warning that starts mid-line all stay outside both predicates.
+#
+# LINE ENDINGS ARE OUT OF SCOPE HERE and no member carries a carriage return.
+# The two predicates share one shape, so they cannot disagree about a line
+# ending, and the arc that produced them changed nothing about that behaviour.
+_ANCHOR_CORPUS = {
+    "empty": "",
+    "prose only": "an ordinary pinned note\n",
+    "leading warning": _ONE_WARNING_LINE + "the rest of the body\n",
+    "two leading warnings": _ONE_WARNING_LINE * 2 + "the rest of the body\n",
+    "stranded below the head": (
+        "an ordinary pinned note\n" + _ONE_WARNING_LINE + "more prose\n"
+    ),
+    "warning on the last line, no newline": (
+        "an ordinary pinned note\n" + _ONE_WARNING_LINE.rstrip("\n")
+    ),
+    "warning starts mid line": "quoted: " + _ONE_WARNING_LINE,
+    "bare prefix, no payload": (
+        f"{_BUDGET_WARNING_PREFIX} is what the hook writes -->\n"
+    ),
+    "payload without digits": f"{_BUDGET_WARNING_PREFIX} ~ tokens (budget: ). -->\n",
+    "payload without a terminator": (
+        f"{_BUDGET_WARNING_PREFIX} ~42 tokens (budget: 5). Consider archiving\n"
+    ),
+    "terminator on the following line": (
+        f"{_BUDGET_WARNING_PREFIX} ~42 tokens (budget: 5).\n-->\n"
+    ),
+}
+
+
+class TestBudgetWarningAnchorComposition:
+    """One shape, two anchors, and the wider one must not widen the alphabet.
+
+    `_LEADING_BUDGET_WARNING_RE` DELETES and `_ANY_BUDGET_WARNING_RE` only
+    RECOGNISES. They are composed from the same `_BUDGET_WARNING_SHAPE` so that
+    the difference between them is a position and nothing else. These arms are
+    what hold that claim up.
+
+    WHAT THIS DELIBERATELY DOES NOT DO. It compares no pattern STRINGS. An
+    assertion that one pattern ends with the shared shape certifies nothing
+    about behaviour: two patterns can share a fragment and still match
+    different sets, and two IDENTICAL patterns satisfy such an assertion
+    perfectly. Both arms below CALL the compiled objects instead, because only
+    the shipped objects can testify about their own composition.
+
+    THE TWO ARMS HAVE DIFFERENT SUBJECTS, WHICH IS WHY THERE ARE TWO. The first
+    is about the PATTERNS. The second is about the CORPUS, and only a change to
+    the corpus separates them. Measured rather than predicted: TRIM the two
+    separating members out of the corpus below and the equality arm still
+    PASSES, while the second arm goes red and says why. That is the vacuity
+    this pair exists to refuse. Re-anchor the wide pattern to the start of the
+    string, so that the two become identical patterns, and BOTH arms go red --
+    the first because the corpus separates them, the second because nothing
+    separates them any longer.
+    """
+
+    def test_the_wide_anchor_matches_at_exactly_the_narrow_one_s_positions(self):
+        """The wide predicate equals the narrow one tried at every line start.
+
+        This is the composition property stated as behaviour. If the wide
+        pattern ever gains a token the narrow one lacks, or loses one it has,
+        the two sides part company on some member of the corpus.
+        """
+        from staleness import _ANY_BUDGET_WARNING_RE, _LEADING_BUDGET_WARNING_RE
+
+        for name, text in _ANCHOR_CORPUS.items():
+            wide = _ANY_BUDGET_WARNING_RE.search(text) is not None
+            # THIS CALL SHAPE IS LEGITIMATE HERE AND FORBIDDEN IN THE MODULE.
+            # `_LEADING_BUDGET_WARNING_RE` is the pattern that DELETES, and
+            # giving it a caller-chosen offset is the construction the module
+            # refuses: it moves the anchor out of the compiled object and into
+            # a convention, where a later caller can widen what gets deleted.
+            # Nothing here deletes a byte, so that hazard cannot arise, and
+            # only the shipped object can testify about its own composition.
+            # DO NOT COPY THIS LINE INTO A CALLER.
+            narrow_anywhere = any(
+                _LEADING_BUDGET_WARNING_RE.match(text[k:])
+                for k in _line_starts(text)
+            )
+            assert wide == narrow_anywhere, (
+                f"the two anchors disagree on {name!r}: the wide pattern says "
+                f"{wide}, the narrow one tried at every line start says "
+                f"{narrow_anywhere}. They no longer share one shape."
+            )
+
+    def test_the_corpus_separates_the_two_anchors(self):
+        """NON-VACUITY, and it guards the CORPUS rather than the predicates.
+
+        The equality above holds trivially on a corpus where both sides always
+        agree -- a corpus of empty strings satisfies it, and so would two
+        identical patterns. It is evidence only while some member tells a
+        line-start anchor apart from a start-of-string one, which means a
+        member whose ONLY warning sits below the head.
+
+        THE COUNTS ARE PINNED, NOT MERELY NON-ZERO. "At least one" survives a
+        trim down to one lucky member. An exact figure per class refuses any
+        trim, and names the class that went missing. Add a member and this arm
+        asks you to say which class it joined.
+        """
+        from staleness import _ANY_BUDGET_WARNING_RE, _LEADING_BUDGET_WARNING_RE
+
+        separating, both_true, both_false = [], [], []
+        for name, text in _ANCHOR_CORPUS.items():
+            wide = _ANY_BUDGET_WARNING_RE.search(text) is not None
+            at_head = _LEADING_BUDGET_WARNING_RE.match(text) is not None
+            if wide and not at_head:
+                separating.append(name)
+            elif wide:
+                both_true.append(name)
+            else:
+                both_false.append(name)
+
+        assert separating, (
+            "no corpus member carries a warning below the head, so the "
+            "equality arm cannot tell the wide anchor from the narrow one and "
+            "would pass unchanged if the two were the same pattern"
+        )
+        assert len(separating) == 2, f"separating members: {sorted(separating)}"
+        assert len(both_true) == 2, f"both-true members: {sorted(both_true)}"
+        assert len(both_false) == 7, f"both-false members: {sorted(both_false)}"
 
 
 # ===========================================================================

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -41,7 +41,13 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "pact-memory" /
 # text is absent because nothing writes it any more, which is exactly what the
 # assertion was written to celebrate. A suite that goes green on a renamed
 # constant is worse than one that goes red.
-from staleness import _BUDGET_WARNING_PREFIX
+#
+# THE SHAPE COMES ACROSS UNCOMPILED, AND THAT IS DELIBERATE. It is the source
+# string the two anchored predicates are built from. A test that needs to
+# recognise a line this module writes composes its own predicate from the
+# SHAPE, so that a change to either compiled anchor cannot move the test and
+# the subject together. See `_WARNING_LINE_RE` for the arm that depends on it.
+from staleness import _BUDGET_WARNING_PREFIX, _BUDGET_WARNING_SHAPE
 
 # Pulls the token figure out of a warning comment, so a test can compare the
 # number in the file against the number in the returned status string.
@@ -83,6 +89,15 @@ def over_budget_body():
     """
     from staleness import PINNED_CONTEXT_TOKEN_BUDGET, estimate_tokens
 
+    # THE EXACT BYTES OF THIS BODY ARE LOAD-BEARING FOR TWO OTHER ARMS, so read
+    # this before you change the shape. `test_warning_removed_when_back_under_budget`
+    # and `test_warning_removed_when_last_pin_deleted` each call
+    # `.replace(over_budget_body(), ...)` in their SETUP. The value below is
+    # "word " repeated, so it ENDS WITH A SPACE, and a change that drops that
+    # space turns each `.replace` into a no-op. Those arms then fail on their
+    # own property assertion, for a cause that has nothing to do with their
+    # subject. MEASURED: a whitespace tidy inside the module reddens the two of
+    # them by exactly that route, and the red reads as coverage that is absent.
     body = "word " * (PINNED_CONTEXT_TOKEN_BUDGET + _OVER_BUDGET_MARGIN_WORDS)
     assert estimate_tokens(body) > PINNED_CONTEXT_TOKEN_BUDGET, (
         "fixture no longer exceeds the budget it is derived from"
@@ -3144,6 +3159,243 @@ class TestDeletingAnchorStaysAtTheHead:
         assert _LEADING_BUDGET_WARNING_RE.search(at_head) is not None, (
             "the deleting pattern did not find a warning AT the head, so the "
             "negative leg above proves nothing about the anchor"
+        )
+
+
+# ===========================================================================
+# User lines survive a pass, and a file keeps its line endings
+# ===========================================================================
+
+# THE ORACLE IS COMPOSED HERE FROM THE UNCOMPILED SHAPE, AND IT IS NOT TAKEN
+# FROM EITHER COMPILED ANCHOR. The arm below subtracts warning lines from the
+# two sides of ONE comparison. An oracle read off a compiled anchor would widen
+# that subtraction on BOTH sides together, the extra erasure would cancel, and
+# the arm would go GREEN on the mutation it exists to catch. Composed from the
+# shape, a change to either anchor cannot move this instrument.
+#
+# THE RESIDUAL, STATED RATHER THAN LEFT FOR A READER TO FIND. A widening of
+# `_BUDGET_WARNING_SHAPE` ITSELF does widen this subtraction, and it does
+# cancel. MEASURED: such a widening reddens
+# `test_the_corpus_separates_the_two_anchors` instead, so the property is
+# guarded by a different arm rather than unguarded. A literal copied into this
+# file would close the residual and open a worse one: a renamed constant leaves
+# a negative assertion passing for the reason it was written to celebrate.
+_WARNING_LINE_RE = re.compile(rf"(?m)^{_BUDGET_WARNING_SHAPE}")
+
+_STALE_MARKER_LINE_RE = re.compile(r"^<!-- STALE: Last relevant \d{4}-\d{2}-\d{2} -->$")
+
+
+def _survival_fixture():
+    """Five documents, each carrying a different way to lose a user line.
+
+    Built fresh on each call, because the bodies derive from the live budget.
+    """
+
+    def doc(body):
+        return f"# Project Memory\n\n## Pinned Context\n\n{body}\n## Working Memory\nwm\n"
+
+    return {
+        # A first pinned line behind whitespace. A `.lstrip()` at the call site
+        # eats it, and the compiled objects are untouched, so no anchor gate
+        # can see it.
+        "indented first pinned line, above budget": doc(
+            f"   indented user prose\n### Big\n{over_budget_body()}\n"
+        ),
+        # Ordinary prose ABOVE a stranded warning. A caller that clears the
+        # line before a below-head warning erases this one and leaves the
+        # warning count unmoved, so no count assertion reports it.
+        "user prose above a stranded warning, above budget": doc(
+            f"### Big\nuser prose above the stranded line\n"
+            f"{_ONE_WARNING_LINE}{over_budget_body()}\n"
+        ),
+        # A stale entry, so a STALE marker is inserted and the subtraction of
+        # permitted insertions is exercised rather than assumed.
+        "an entry with a stale date, above budget": doc(
+            f"### Old\nPR #123, merged 2020-01-01\n### Big\n{over_budget_body()}\n"
+        ),
+        # Whitespace a tidy-up edit would take. An erasure here SETTLES, so the
+        # arms that catch a runaway erasure through instability cannot see it.
+        "trailing spaces and repeated blank lines": doc(
+            f"### Big\nline with trailing spaces   \n\n\n\nlast line\n"
+            f"{over_budget_body()}\n"
+        ),
+        # The quiet member. The pass runs and writes nothing.
+        "below budget, with a stranded warning": doc(
+            f"### Small\nuser prose\n{_ONE_WARNING_LINE}a few words\n"
+        ),
+    }
+
+
+class TestUserLinesSurviveAPass:
+    """A pass may add its own lines. It may not take a line the user wrote.
+
+    THE CLOSED LIST OF PERMITTED CHANGES. Over the lines of the file, this
+    module may do THREE things and nothing else:
+      1. ADD one warning line at the head of the pinned body.
+      2. REMOVE the contiguous run of warning lines at that same head.
+      3. ADD one STALE marker line after the heading line of a stale entry.
+    Every other change to a line is a defect. The arm encodes that list as its
+    subtraction, so a later reader can tell an allowance from an oversight.
+
+    WHY THE OTHER ARMS IN THIS FILE CANNOT STAND IN FOR THIS ONE. They are
+    keyed on lines that carry the shape THIS MODULE writes. A caller that
+    erases bytes of any OTHER shape sits outside their reach, whatever kind of
+    assertion they use. That is a bound on their fixtures and their subject,
+    and not a weakness in their assertions.
+
+    IT DRIVES DOCUMENTS, AND THAT IS THE WHOLE VALUE. A property over
+    `_strip_budget_warnings` alone cannot see a call site, so it passes a
+    caller that hands the function a pre-trimmed string. That narrower form was
+    built by accident during review and it passed such a caller with nothing
+    red to report it.
+
+    IT COMPARES ONE PASS, AND THAT IS THE SECOND HALF OF THE VALUE. It reads no
+    second pass and it tests no settling. An erasure that repeats and an
+    erasure that settles look the same to it, so it does not inherit the gap
+    that an instability check leaves open.
+
+    A CHANGE TO A WARNING LINE IS INVISIBLE HERE, BY CONSTRUCTION AND NOT BY
+    OVERSIGHT. The subtraction removes warning lines from the TWO sides, so
+    this arm says nothing about a warning added, taken back, or refreshed, at
+    the head or anywhere else. Read the closed list above as a description of
+    the module, and read the SUBTRACTION as the rule of the arm. The two differ
+    on purpose, and the subtraction is wider. A reader who takes the list as
+    the rule will predict a red that cannot happen, and file a gap that is not
+    there.
+    """
+
+    def test_no_user_line_is_lost_or_moved_by_a_pass(self, tmp_path):
+        """Each non-warning line survives byte for byte and in order.
+
+        MEASURED BEHAVIOUR, on scratch copies of the committed tree:
+          baseline                                 PASS, 4 of 5 documents modified
+          call site given a pre-trimmed string     FAIL, on the indented member
+          strip widened to reach any warning line  PASS, that is another arm
+          trailing whitespace tidied on short lines FAIL, on the whitespace member
+          write path neutralised                   FAIL, on the floor below
+
+        The third row is deliberate. A mutation that erases only WARNING lines
+        belongs to the arms that are keyed on them, and this arm subtracts
+        those lines from the two sides, so it correctly says nothing.
+
+        THE FOURTH ROW IS THE ONE THIS ARM EXISTS FOR, and it needs its bound
+        stated with it. That tidy erases user bytes BELOW the head and it
+        SETTLES, so the arms that catch a runaway erasure through instability
+        cannot see it. Measured: it leaves all 100 shipped arms green. So the
+        instrument gap is PROVEN, by a SYNTHETIC mutant. Separately, and it
+        does not qualify the first half: NO PLAUSIBLE ORDINARY EDIT has been
+        found that reaches it. Nothing in this module motivates a whitespace
+        tidy. Both statements are the record, and neither cancels the other.
+
+        WHICH FIXTURE MEMBER SERVES WHICH SHAPE:
+          indented first pinned line      a call site that trims the head
+          trailing spaces, short line     a tidy that erases below the head
+          prose above a stranded warning  a caller that clears the line above
+          entry with a stale date         the STALE-marker subtraction
+          below budget, stranded warning  the quiet member, no write
+        No shipped fixture carries either whitespace shape, which is why this
+        one builds its own.
+        """
+        from staleness import check_pinned_staleness
+
+        modified = 0
+        for index, (name, before) in enumerate(_survival_fixture().items()):
+            home = tmp_path / f"doc{index}"
+            home.mkdir()
+            claude_md = home / "CLAUDE.md"
+            claude_md.write_text(before, encoding="utf-8")
+
+            check_pinned_staleness(claude_md_path=claude_md)
+
+            after = claude_md.read_text(encoding="utf-8")
+            if after != before:
+                modified += 1
+
+            kept_before = [
+                line
+                for line in before.split("\n")
+                if not _WARNING_LINE_RE.match(line + "\n")
+            ]
+            kept_after = [
+                line
+                for line in after.split("\n")
+                if not _WARNING_LINE_RE.match(line + "\n")
+                and not _STALE_MARKER_LINE_RE.match(line)
+            ]
+            if kept_after != kept_before:
+                at = next(
+                    (
+                        i
+                        for i, (b, a) in enumerate(zip(kept_before, kept_after))
+                        if b != a
+                    ),
+                    min(len(kept_before), len(kept_after)),
+                )
+                was = kept_before[at] if at < len(kept_before) else "<end>"
+                now = kept_after[at] if at < len(kept_after) else "<end>"
+                raise AssertionError(
+                    f"a pass changed a user line in {name!r}, first at line "
+                    f"{at}: {was[:60]!r} became {now[:60]!r}. This module may "
+                    f"only add a warning at the head, take back the run of "
+                    f"warnings at the head, and add a STALE marker after a "
+                    f"stale heading. Any other line change takes text a user "
+                    f"wrote, from a file that is frequently gitignored"
+                )
+
+        # NON-VACUITY, AND IT IS A MEASURED FLOOR RATHER THAN AN EQUALITY.
+        # Survival holds for a hook that never runs, so this count is what
+        # makes the assertions above evidence. The floor is 4, measured on the
+        # committed tree.
+        #
+        # WHY A FLOOR AND NOT `== 4`, because the equality was tried first and
+        # it was wrong. A mutation that modifies MORE documents does not weaken
+        # the evidence for survival, it strengthens it, so an equality reddens
+        # on a change that this arm has no business reporting. MEASURED: a
+        # strip widened to reach any warning line takes 5 of 5, and the
+        # survival property PASSES there, correctly, because that mutation
+        # erases only warning lines. The direction that threatens the evidence
+        # is FEWER, and the floor catches it.
+        assert modified >= 4, (
+            f"only {modified} of 5 fixture documents were modified by the "
+            f"pass, against a measured floor of 4. The survival assertions "
+            f"above hold for a hook that never runs, so a drop here means they "
+            f"have stopped being evidence"
+        )
+
+
+class TestLineEndingsSurviveAPass:
+    """A file written with CRLF must keep CRLF across a modifying pass.
+
+    `read_text` applies universal-newline translation, so a CRLF file arrives
+    as LF and the write puts LF back. The user sees a whole-file rewrite in
+    their diff, and the change is silent.
+    """
+
+    def test_crlf_endings_survive_a_modifying_pass(self, tmp_path):
+        """The bytes the user chose for line endings are theirs, not ours."""
+        from staleness import check_pinned_staleness
+
+        before = (
+            "# Project Memory\r\n\r\n## Pinned Context\r\n\r\n"
+            f"### Big\r\n{over_budget_body()}\r\n"
+            "## Working Memory\r\nwm\r\n"
+        ).encode("utf-8")
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_bytes(before)
+
+        check_pinned_staleness(claude_md_path=claude_md)
+
+        after = claude_md.read_bytes()
+        # NON-VACUITY FIRST. An unmodified document keeps its line endings for
+        # a reason that says nothing about a modifying pass.
+        assert after != before, (
+            "the pass wrote nothing, so this arm says nothing about what a "
+            "MODIFYING pass does to line endings"
+        )
+        assert after.count(b"\r\n") > 0, (
+            "a modifying pass converted a CRLF file to LF. Every line of the "
+            "user's file changed, which their diff reports as a whole-file "
+            "rewrite of a file they did not edit"
         )
 
 

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -31,9 +31,21 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 # Add working_memory scripts directory to path for twin-copy equivalence test
 sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "pact-memory" / "scripts"))
 
+# THE ONE SPELLING OF THE WARNING MARKER, imported rather than repeated. Every
+# assertion and fixture below is built from this, so a rename in the source
+# cannot leave this file describing text the module no longer writes.
+#
+# THE FAILURE IT PREVENTS IS ASYMMETRIC, and that asymmetry is the whole reason
+# to import rather than copy. A POSITIVE assertion against a stale literal fails
+# loudly and tells you what happened. A NEGATIVE one passes VACUOUSLY: the old
+# text is absent because nothing writes it any more, which is exactly what the
+# assertion was written to celebrate. A suite that goes green on a renamed
+# constant is worse than one that goes red.
+from staleness import _BUDGET_WARNING_PREFIX
+
 # Pulls the token figure out of a warning comment, so a test can compare the
 # number in the file against the number in the returned status string.
-_WARNING_NUMBER_RE = re.compile(r"<!-- WARNING: Pinned context ~(\d+) tokens")
+_WARNING_NUMBER_RE = re.compile(re.escape(_BUDGET_WARNING_PREFIX) + r" ~(\d+) tokens")
 
 
 def over_budget_body(margin_words=200):
@@ -229,10 +241,25 @@ class TestCheckPinnedStaleness:
 
         # File should have budget warning comment
         content = claude_md.read_text(encoding="utf-8")
-        assert "<!-- WARNING: Pinned context" in content
+        assert _BUDGET_WARNING_PREFIX in content
 
     def test_under_budget_no_warning(self, tmp_path):
-        """Should not add warning when pinned content is within budget."""
+        """Should not add warning when pinned content is within budget.
+
+        A PURE NEGATIVE. This arm asserts only that the warning is ABSENT, and
+        absence has many causes: a renamed constant, a broken region parse, or
+        the hook never running at all. Measured, with the write path neutered so
+        that no warning is ever emitted, this test still PASSED. It cannot fail
+        when its instrument is dead, so on its own it is not evidence.
+
+        ITS NON-VACUITY IS ESTABLISHED ELSEWHERE, by
+        `TestBudgetWarningInteractions.test_under_budget_absence_is_caused_by_the_budget`,
+        which drives the same shape OVER the budget in the same test and
+        requires the warning to appear. Read the two together: that arm shows
+        the instrument fires, and this one pins the under-budget case. Kept as
+        a labelled regression pin rather than repaired in place, so that a
+        reviewed assertion is not altered mid-remediation.
+        """
         from session_init import check_pinned_staleness
 
         claude_md = self._create_project_claude_md(tmp_path, (
@@ -246,7 +273,7 @@ class TestCheckPinnedStaleness:
             result = check_pinned_staleness()
 
         content = claude_md.read_text(encoding="utf-8")
-        assert "<!-- WARNING: Pinned context" not in content
+        assert _BUDGET_WARNING_PREFIX not in content
 
     def test_mixed_entries_only_old_flagged(self, tmp_path):
         """With mixed recent and old entries, only old ones should be flagged."""
@@ -471,7 +498,7 @@ class TestBudgetWarningIdempotency:
             result2 = check_pinned_staleness()
 
         content_after = claude_md.read_text(encoding="utf-8")
-        warning_count = content_after.count("<!-- WARNING: Pinned context")
+        warning_count = content_after.count(_BUDGET_WARNING_PREFIX)
         assert warning_count == 1, (
             f"Expected exactly 1 budget warning comment, found {warning_count}"
         )
@@ -511,7 +538,7 @@ class TestBudgetWarningRefresh:
 
         body = over_budget_body()
         stale_warning = (
-            "<!-- WARNING: Pinned context ~7 tokens (budget: 5). "
+            f"{_BUDGET_WARNING_PREFIX} ~7 tokens (budget: 5). "
             "Consider archiving stale pins. -->\n"
         )
         claude_md = self._create_project_claude_md(
@@ -523,7 +550,7 @@ class TestBudgetWarningRefresh:
         check_pinned_staleness(claude_md_path=claude_md)
 
         content = claude_md.read_text(encoding="utf-8")
-        assert content.count("<!-- WARNING: Pinned context") == 1
+        assert content.count(_BUDGET_WARNING_PREFIX) == 1
         assert warning_number(content) == estimate_tokens(f"### Big Feature\n{body}\n\n")
 
     def test_status_string_agrees_with_file_comment(self, tmp_path):
@@ -559,7 +586,7 @@ class TestBudgetWarningRefresh:
             tmp_path, self._pinned_doc(body)
         )
         check_pinned_staleness(claude_md_path=claude_md)
-        assert "<!-- WARNING: Pinned context" in claude_md.read_text(encoding="utf-8")
+        assert _BUDGET_WARNING_PREFIX in claude_md.read_text(encoding="utf-8")
 
         # The user archives the bulk of the pin.
         shrunk = claude_md.read_text(encoding="utf-8").replace(body, "a short pin")
@@ -568,7 +595,7 @@ class TestBudgetWarningRefresh:
         result = check_pinned_staleness(claude_md_path=claude_md)
 
         content = claude_md.read_text(encoding="utf-8")
-        assert "<!-- WARNING: Pinned context" not in content
+        assert _BUDGET_WARNING_PREFIX not in content
         assert result is None or "budget" not in result.lower()
 
     def test_warning_removed_when_last_pin_deleted(self, tmp_path):
@@ -584,7 +611,7 @@ class TestBudgetWarningRefresh:
             tmp_path, self._pinned_doc(body)
         )
         check_pinned_staleness(claude_md_path=claude_md)
-        assert "<!-- WARNING: Pinned context" in claude_md.read_text(encoding="utf-8")
+        assert _BUDGET_WARNING_PREFIX in claude_md.read_text(encoding="utf-8")
 
         emptied = claude_md.read_text(encoding="utf-8").replace(
             f"### Big Feature\n{body}\n", ""
@@ -594,7 +621,7 @@ class TestBudgetWarningRefresh:
 
         check_pinned_staleness(claude_md_path=claude_md)
 
-        assert "<!-- WARNING: Pinned context" not in claude_md.read_text(
+        assert _BUDGET_WARNING_PREFIX not in claude_md.read_text(
             encoding="utf-8"
         )
 
@@ -618,7 +645,7 @@ class TestBudgetWarningRefresh:
         check_pinned_staleness(claude_md_path=claude_md)
         after_third = claude_md.read_text(encoding="utf-8")
 
-        assert after_third.count("<!-- WARNING: Pinned context") == 1
+        assert after_third.count(_BUDGET_WARNING_PREFIX) == 1
         assert after_third == after_first, "a later pass rewrote a settled document"
 
     def test_entryless_section_never_gains_a_warning(self, tmp_path):
@@ -662,7 +689,7 @@ class TestBudgetWarningRefresh:
         from staleness import check_pinned_staleness
 
         quoted = (
-            "<!-- WARNING: Pinned context ~99 tokens (budget: 1). "
+            f"{_BUDGET_WARNING_PREFIX} ~99 tokens (budget: 1). "
             "Consider archiving stale pins. -->"
         )
         claude_md = self._create_project_claude_md(
@@ -678,7 +705,7 @@ class TestBudgetWarningRefresh:
         content = claude_md.read_text(encoding="utf-8")
         assert quoted in content, "the strip deleted a line a user wrote"
         # One line the hook owns, plus the one the user quoted.
-        assert content.count("<!-- WARNING: Pinned context") == 2
+        assert content.count(_BUDGET_WARNING_PREFIX) == 2
 
 
 class TestStalenessErrorPaths:
@@ -1862,6 +1889,169 @@ class TestPinCapsTwinCopyDrift:
         )
 
 
+# Chars per word in real pinned prose. FROZEN, not measured at test time: the
+# corpus it describes is a user's CLAUDE.md, which is gitignored and absent from
+# a fresh clone, so measuring it here would make this file pass locally and
+# error in CI -- a test that fails for a reason unrelated to its invariant
+# teaches people to ignore it.
+#
+# HOW IT WAS OBTAINED, so it can be re-derived rather than trusted: measured
+# over the STRIPPED body text, which is what pin_caps._extract_body_chars
+# returns after removing the per-line date comment and the STALE marker, across
+# a real twelve-pin document. 12,306 chars over 1,757 words.
+#
+# The value is not the fragile part; the POPULATION is. Re-derive it the same
+# way. test_measurement_method_matches_the_enforced_population below pins the
+# method, so a later re-derivation cannot quietly use a different set of bytes.
+_PINNED_PROSE_CHARS_PER_WORD = 7.004
+
+# Heading line plus date-comment line, in words, for ONE pin. Expressed per-pin
+# because that is what it is: a flat total would be correct only at the pin
+# count it happened to be authored against, and would drift silently from every
+# other count while the test stayed green.
+_PIN_CHROME_WORDS = 32
+
+# Where the advisory must sit inside the space the caps allow.
+_ADVISORY_FLOOR_FRACTION = 0.5
+
+
+class TestPinnedBudgetAgainstCapsCoherence:
+    """The advisory budget and the enforcement caps must not contradict.
+
+    PINNED_CONTEXT_TOKEN_BUDGET advises a user to archive. PIN_COUNT_CAP and
+    PIN_SIZE_CAP refuse an edit. Nothing in the repo related the two, and they
+    did contradict: a budget of 1200 against a twelve-by-1500 cap meant a
+    document FULLY LEGAL under the caps exceeded the advisory by more than
+    twice, so the advisory fired on documents it had no business flagging and
+    could not be satisfied without deleting legal content.
+
+    THE RELATION IS PINNED HERE, NOT THE VALUE. Deriving the budget from the
+    caps was considered and declined: a budget at or above the derived cost can
+    only fire once a document is at full legal capacity, which is the point
+    where the caps are already refusing edits and the advice arrives at the
+    wall. Advising earlier requires a FRACTION of the derived cost, so a free
+    coefficient is not removed by deriving -- it only moves.
+
+    WHAT THIS DESIGN ACHIEVES, which is less than eliminating the free number
+    and is the most that was available: the coefficient sits over a quantity
+    computed from the caps rather than over a measured document, so it cannot
+    go stale as prose changes; and the band is wide enough that being wrong
+    about the coefficient by a tenth changes no verdict.
+    """
+
+    def _derived_ceiling(self):
+        """Estimated tokens of a document sitting at full legal capacity.
+
+        Routed through the shipped `estimate_tokens` rather than repeating its
+        coefficient, so the ceiling follows the estimator if the estimator
+        changes.
+        """
+        import pin_caps
+        from staleness import estimate_tokens
+
+        body_words = (
+            pin_caps.PIN_COUNT_CAP
+            * pin_caps.PIN_SIZE_CAP
+            / _PINNED_PROSE_CHARS_PER_WORD
+        )
+        chrome_words = pin_caps.PIN_COUNT_CAP * _PIN_CHROME_WORDS
+        # round, not int: truncating the word count before the estimator
+        # truncates a second time and lands two tokens below the figure every
+        # written record of this decision carries.
+        return estimate_tokens("w " * round(body_words + chrome_words))
+
+    def test_budget_is_below_the_cost_of_a_maximally_legal_document(self):
+        """Above this, the advisory can never fire before the caps bind."""
+        from staleness import PINNED_CONTEXT_TOKEN_BUDGET
+
+        ceiling = self._derived_ceiling()
+        assert PINNED_CONTEXT_TOKEN_BUDGET < ceiling, (
+            f"PINNED_CONTEXT_TOKEN_BUDGET ({PINNED_CONTEXT_TOKEN_BUDGET}) is at "
+            f"or above the cost of a document at full legal capacity "
+            f"({ceiling}). The advisory could then only fire once PIN_COUNT_CAP "
+            f"and PIN_SIZE_CAP are already refusing edits. Lower the budget, or "
+            f"revisit the caps."
+        )
+
+    def test_budget_is_above_the_advisory_floor(self):
+        """Below this, the advisory fires on documents that are merely healthy."""
+        from staleness import PINNED_CONTEXT_TOKEN_BUDGET
+
+        floor = _ADVISORY_FLOOR_FRACTION * self._derived_ceiling()
+        assert PINNED_CONTEXT_TOKEN_BUDGET > floor, (
+            f"PINNED_CONTEXT_TOKEN_BUDGET ({PINNED_CONTEXT_TOKEN_BUDGET}) is at "
+            f"or below {floor:.0f}, so it flags documents well inside what the "
+            f"caps permit. If PIN_COUNT_CAP or PIN_SIZE_CAP moved, the budget "
+            f"needs revisiting in the same commit."
+        )
+
+    def test_the_band_rejects_the_value_it_was_written_to_catch(self):
+        """Non-vacuity, carried in the suite rather than run once by hand.
+
+        The historical budget of 1200 is the incoherence this guard exists to
+        refuse. If a future edit widens the band until 1200 sits inside it, the
+        guard still passes its other two arms while having stopped guarding.
+        """
+        historical_budget = 1200
+        ceiling = self._derived_ceiling()
+        floor = _ADVISORY_FLOOR_FRACTION * ceiling
+        assert not (floor < historical_budget < ceiling), (
+            f"the band ({floor:.0f}, {ceiling}) now ACCEPTS the historical 1200, "
+            f"so it no longer detects the contradiction it was written for"
+        )
+
+    def test_measurement_method_matches_the_enforced_population(self):
+        """The conversion figure must describe the bytes the cap counts.
+
+        `_PINNED_PROSE_CHARS_PER_WORD` converts a CHAR cap into the WORD unit
+        the budget is expressed in. That conversion means something only if the
+        text it was measured over is the same text PIN_SIZE_CAP is enforced
+        against. This asserts the reconstruction used to obtain it against the
+        value the shipped parser reports, for every pin of a synthetic
+        document.
+
+        Stated without a named failure mode on purpose: measure over the
+        population the constant is defined on, and assert the reconstruction
+        against the shipped value.
+        """
+        import pin_caps
+
+        pins_text = ""
+        for i in range(pin_caps.PIN_COUNT_CAP):
+            # Exercise both strip paths the enforced value applies: the longer
+            # reconfirmed date-comment spelling, and a STALE marker.
+            if i % 3 == 0:
+                comment = (
+                    f"<!-- pinned: 2026-01-0{i % 9 + 1}, reconfirmed: 2026-02-01 "
+                    f"because it still answers a live question -->"
+                )
+            else:
+                comment = f"<!-- pinned: 2026-01-0{i % 9 + 1} -->"
+            stale = "<!-- STALE: Last relevant 2026-01-01 -->" if i % 4 == 0 else ""
+            pins_text += (
+                f"{comment}\n### Pin {i}\n{stale}\nbody words for pin {i} here\n\n"
+            )
+
+        pins = pin_caps.parse_pins(pins_text)
+        assert len(pins) == pin_caps.PIN_COUNT_CAP, (
+            "fixture did not parse into the expected number of pins; the "
+            "control cannot certify a population it did not build"
+        )
+
+        for pin in pins:
+            rebuilt = "\n".join(
+                pin_caps._DATE_COMMENT_RE.sub("", line)
+                for line in pin.body.splitlines()
+            )
+            rebuilt = pin_caps._STALE_MARKER_RE.sub("", rebuilt).strip()
+            assert len(rebuilt) == pin.body_chars, (
+                f"the reconstruction used to measure "
+                f"_PINNED_PROSE_CHARS_PER_WORD counts a different set of bytes "
+                f"than pin_caps reports for {pin.heading!r}: rebuilt "
+                f"{len(rebuilt)} vs body_chars {pin.body_chars}"
+            )
+
+
 class TestFileLockTwinCopyDrift:
     """Drift detection for the file_lock twin vendored into working_memory.
 
@@ -2145,3 +2335,300 @@ class TestProjectRootLayoutKnowledgeDrift:
                 f"({_DOT_CLAUDE_RELATIVE!r}) — a third supported location or a "
                 f"rename of that constant diverges here silently"
             )
+
+
+def at_budget_body(prefix=""):
+    """Build the LARGEST pin body that still sits within the budget.
+
+    DERIVED BY SEARCH FROM THE LIVE CONSTANT, so it follows the budget to
+    whatever value it takes next, and it assumes nothing about the shape of
+    `estimate_tokens`. The two assertions below are real boundary checks and
+    CAN fire: the first if the search overshot, the second if one more word
+    does not cross. Together they pin this fixture to the exact edge rather
+    than merely somewhere below it.
+    """
+    from staleness import PINNED_CONTEXT_TOKEN_BUDGET, estimate_tokens
+
+    # A body of BUDGET words always estimates above BUDGET, so it bounds the
+    # search from above without naming a number.
+    low, high = 1, PINNED_CONTEXT_TOKEN_BUDGET
+    while low < high:
+        mid = (low + high + 1) // 2
+        if estimate_tokens(prefix + "word " * mid) <= PINNED_CONTEXT_TOKEN_BUDGET:
+            low = mid
+        else:
+            high = mid - 1
+
+    body = prefix + "word " * low
+    assert estimate_tokens(body) <= PINNED_CONTEXT_TOKEN_BUDGET, (
+        "at-budget fixture is already over the budget"
+    )
+    assert estimate_tokens(body + "word ") > PINNED_CONTEXT_TOKEN_BUDGET, (
+        "at-budget fixture is not at the edge -- one more word must cross it"
+    )
+    return body
+
+
+class TestBudgetWarningInteractions:
+    """The cells where the warning path MEETS the rest of this module.
+
+    Every arm here exists because a mutation of a property the source calls
+    load-bearing survived the whole suite. A comment is a claim; these are the
+    witnesses. Each docstring names the mutation it kills, so a later reader can
+    re-run the counter-test instead of re-deriving it.
+    """
+
+    def _create_project_claude_md(self, tmp_path, content):
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text(content, encoding="utf-8")
+        return claude_md
+
+    def _warning_line(self, tokens=9, budget=5):
+        """A warning line built from the SOURCE constant, never from a copy.
+
+        Uses the module-level `_BUDGET_WARNING_PREFIX` import. The body shape
+        matters as well as the prefix: the strip predicate requires a
+        well-formed `~N tokens (budget: N)` payload, so a line assembled by hand
+        would exercise a different branch from the one the hook writes.
+        """
+        return (
+            f"{_BUDGET_WARNING_PREFIX} ~{tokens} tokens (budget: {budget}). "
+            "Consider archiving stale pins. -->\n"
+        )
+
+    def _count_warnings(self, text):
+        return text.count(_BUDGET_WARNING_PREFIX)
+
+    def _doc(self, body):
+        """A document whose pinned region is bounded by a following section."""
+        return f"# Project Memory\n\n## Pinned Context\n\n{body}\n## Working Memory\nwm\n"
+
+    # ------------------------------------------------------------------
+    # The warning path meeting the stale-marker path.
+    # ------------------------------------------------------------------
+
+    def test_stale_marker_survives_a_leading_warning(self, tmp_path):
+        """A document with BOTH a warning and a stale entry must still be marked.
+
+        KILLS THE ORDER MUTATION. `apply_staleness_markings` strips the warning
+        BEFORE it takes entry offsets, because `entry_starts` holds offsets into
+        that string. Move the strip after the scan and the stale marker is
+        silently dropped -- one becomes zero, which is this module's primary
+        function failing quietly.
+
+        Measured before this arm existed: that inversion was killed by NO test
+        in the suite. Both arms were run over the full suite in one environment
+        and the failed sets came back byte-identical, so the test set did not
+        distinguish the two programs.
+        """
+        from staleness import check_pinned_staleness
+
+        claude_md = self._create_project_claude_md(
+            tmp_path,
+            self._doc(
+                self._warning_line()
+                + "### Old Decision\nPR #123, merged 2020-01-01\n"
+                + f"### Big Feature\n{over_budget_body()}\n"
+            ),
+        )
+
+        check_pinned_staleness(claude_md_path=claude_md)
+
+        content = claude_md.read_text(encoding="utf-8")
+        assert content.count("<!-- STALE: Last relevant 2020-01-01 -->") == 1, (
+            "the stale marker was dropped -- entry offsets and the stripped "
+            "body have gone out of step"
+        )
+        assert "PR #123, merged 2020-01-01" in content
+        assert self._count_warnings(content) == 1
+
+    # ------------------------------------------------------------------
+    # The strip removes a RUN, not a line.
+    # ------------------------------------------------------------------
+
+    def test_stacked_warnings_collapse_to_one(self, tmp_path):
+        """Two warnings at the head must BOTH be taken back.
+
+        KILLS THE SINGLE-SHOT STRIP. `_strip_budget_warnings` loops on purpose,
+        so that removing N lines is the exact inverse of writing one and no
+        partial residue survives. Replace the loop with a single match and this
+        document keeps a stale line forever; nothing else in the suite notices.
+        """
+        from staleness import check_pinned_staleness
+
+        claude_md = self._create_project_claude_md(
+            tmp_path,
+            self._doc(
+                self._warning_line(tokens=9)
+                + self._warning_line(tokens=11)
+                + f"### Big Feature\n{over_budget_body()}\n"
+            ),
+        )
+
+        check_pinned_staleness(claude_md_path=claude_md)
+
+        content = claude_md.read_text(encoding="utf-8")
+        assert self._count_warnings(content) == 1
+        # Neither stale figure survives: the run went, not merely its head.
+        assert "~9 tokens" not in content
+        assert "~11 tokens" not in content
+
+    # ------------------------------------------------------------------
+    # The accepted residual. The count is CONDITIONAL, not a constant.
+    # ------------------------------------------------------------------
+    #
+    #   count = N + (1 if estimate_tokens(user_text + stranded) > BUDGET else 0)
+    #
+    # N is the number of warnings a user has MOVED below the head, where the
+    # anchored strip cannot reach them. The arms below pin both halves of that
+    # conditional and the fact that a pass never raises the count. A single arm
+    # would state a ceiling instead of a law: two correct measurements of this
+    # behaviour, taken at N=1 and N=3, once read as a contradiction for exactly
+    # that reason.
+
+    def test_no_warning_when_the_body_sits_exactly_at_budget(self, tmp_path):
+        """At the budget with nothing stranded, the count is ZERO.
+
+        THE CELL A CONSTANT FORM GETS WRONG. The comparison is strict
+        (`tokens > BUDGET`), so a body landing exactly ON the budget is not a
+        breach. A `1 + N` reading of the residual predicts one warning here,
+        and there must be none.
+        """
+        from staleness import check_pinned_staleness
+
+        claude_md = self._create_project_claude_md(
+            tmp_path, self._doc(at_budget_body(prefix="### Big\n"))
+        )
+
+        result = check_pinned_staleness(claude_md_path=claude_md)
+
+        assert self._count_warnings(claude_md.read_text(encoding="utf-8")) == 0
+        assert result is None
+
+    def test_stranded_copies_can_cause_the_breach_they_report(self, tmp_path):
+        """A stranded warning is measured, so the module's own residue can trip it.
+
+        THE PRECONDITION THAT MAKES THE LAW CONDITIONAL. The strip is anchored
+        at the head, so a warning a user has moved below it stays in the body --
+        and the body is what gets measured. With the user's own pins sitting
+        exactly at the budget, ONE stranded line is enough to push the
+        measurement over, and the hook then reports a breach the user's own text
+        did not cause.
+
+        This is not a defect to repair here. It is the accepted residual seen
+        from its sharp end, pinned so that a later change to the strip's anchor,
+        or to the length of the warning text itself, cannot move it unnoticed.
+        """
+        from staleness import PINNED_CONTEXT_TOKEN_BUDGET, check_pinned_staleness
+        from staleness import estimate_tokens
+
+        user_text = at_budget_body(prefix="### Big\n")
+        words_only = user_text.split("\n", 1)[1]
+        claude_md = self._create_project_claude_md(
+            tmp_path,
+            self._doc("### Big\n" + self._warning_line(tokens=9999) + words_only),
+        )
+
+        result = check_pinned_staleness(claude_md_path=claude_md)
+
+        content = claude_md.read_text(encoding="utf-8")
+        # One line the hook wrote at the head, plus the one it could not reach.
+        assert self._count_warnings(content) == 2
+        # The user's own text was never over budget. The residue crossed it.
+        assert estimate_tokens(user_text) <= PINNED_CONTEXT_TOKEN_BUDGET
+        assert result is not None and "budget" in result.lower()
+
+    @pytest.mark.parametrize("stranded", [0, 1, 3])
+    def test_stranded_warnings_never_compound(self, tmp_path, stranded):
+        """Over budget, the module adds exactly ONE line however many are stranded.
+
+        The other half of the conditional: once the measured body exceeds the
+        budget the count settles at `stranded + 1`, and NO PASS EVER RAISES IT.
+        That second property is the one that matters -- the head cannot
+        accumulate, because the run at offset 0 is removed before one line goes
+        back. Neutering the strip makes every cell here fail.
+        """
+        from staleness import check_pinned_staleness
+
+        stranded_lines = "".join(
+            self._warning_line(tokens=100 + i) for i in range(stranded)
+        )
+        claude_md = self._create_project_claude_md(
+            tmp_path,
+            self._doc(f"### Big Feature\n{stranded_lines}{over_budget_body()}\n"),
+        )
+
+        check_pinned_staleness(claude_md_path=claude_md)
+        settled = claude_md.read_text(encoding="utf-8")
+        assert self._count_warnings(settled) == stranded + 1
+
+        # Three further passes must not add a fourth, a fifth, or a sixth.
+        for _ in range(3):
+            check_pinned_staleness(claude_md_path=claude_md)
+        after = claude_md.read_text(encoding="utf-8")
+        assert self._count_warnings(after) == stranded + 1, (
+            "a pass raised the count -- the head is accumulating"
+        )
+        assert after == settled, "a later pass rewrote a settled document"
+
+    # ------------------------------------------------------------------
+    # The entry-less asymmetry, over-budget half.
+    # ------------------------------------------------------------------
+
+    def test_entryless_section_refreshes_a_warning_it_already_has(self, tmp_path):
+        """An entry-less section that is STILL over budget keeps a CURRENT warning.
+
+        The half of the asymmetry the suite did not cover. `check_pinned_staleness`
+        proceeds on an entry-less section only when a warning is already there,
+        and the existing arms cover only the case where the body has since
+        dropped under budget. Here it has not, so the line must be REWRITTEN
+        with a true figure rather than left carrying its old one.
+        """
+        from staleness import check_pinned_staleness
+
+        claude_md = self._create_project_claude_md(
+            tmp_path,
+            self._doc(self._warning_line(tokens=9) + f"{over_budget_body()}\n"),
+        )
+
+        check_pinned_staleness(claude_md_path=claude_md)
+
+        content = claude_md.read_text(encoding="utf-8")
+        assert self._count_warnings(content) == 1
+        assert "~9 tokens" not in content, "the outdated figure was left in place"
+        assert warning_number(content) > 0
+
+    # ------------------------------------------------------------------
+    # Absence must be caused by the budget, not by a dead instrument.
+    # ------------------------------------------------------------------
+
+    def test_under_budget_absence_is_caused_by_the_budget(self, tmp_path):
+        """A small document gets no warning, and this arm proves WHY it got none.
+
+        A POSITIVE LEG IN THE SAME FIXTURE. `test_under_budget_no_warning`
+        asserts only that the literal is absent, so it passes for any reason at
+        all -- a renamed constant, a broken region parse, or the hook never
+        running. Measured: with the write path neutered so that no warning is
+        ever emitted, that test still PASSED. Absence is not evidence until
+        something in the same test shows the instrument fires, and a
+        renamed-constant tripwire does not supply that.
+        """
+        from staleness import check_pinned_staleness
+
+        claude_md = self._create_project_claude_md(
+            tmp_path, self._doc("### Small\n- a few words\n")
+        )
+        check_pinned_staleness(claude_md_path=claude_md)
+        assert self._count_warnings(claude_md.read_text(encoding="utf-8")) == 0
+
+        # POSITIVE CONTROL: the same shape, over budget, in the same test.
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        big = self._create_project_claude_md(
+            sub, self._doc(f"### Small\n{over_budget_body()}\n")
+        )
+        check_pinned_staleness(claude_md_path=big)
+        assert self._count_warnings(big.read_text(encoding="utf-8")) == 1, (
+            "the positive control did not fire, so the negative arm above "
+            "proves nothing"
+        )

--- a/pact-plugin/tests/test_staleness.py
+++ b/pact-plugin/tests/test_staleness.py
@@ -651,10 +651,17 @@ class TestBudgetWarningRefresh:
     def test_entryless_section_never_gains_a_warning(self, tmp_path):
         """Prose with no `### ` entry stays untouched, over budget or not.
 
-        PASSES BEFORE AND AFTER, and that is the point. Widening the entry
-        guard so a stranded warning can be REMOVED must not also start ADDING
-        warnings to documents this code has always left alone. Removal repairs
-        a line the hook wrote; insertion here would be new behaviour.
+        PASSES BEFORE AND AFTER, and that is the point. The forbidden direction
+        is a section carrying NO line of the hook's own shape: whatever its
+        size, this code must never start a report in a document it has not
+        written to before. This body is ordinary prose, so it stays untouched.
+
+        THE DISCRIMINATION IS THE SHAPE, NOT THE POSITION. The probe now reads
+        any line start, so a body whose only warning sits below the head DOES
+        enter the pass and gains a current warning above it. That is a ruled-on
+        cost, not a violation of the law this test pins. What this test asserts
+        is the other case, and the one that must never move: no line of the
+        `~N tokens (budget: M)` shape anywhere means no pass and no insertion.
         """
         from staleness import check_pinned_staleness
 


### PR DESCRIPTION
## Summary

The pinned-context budget warning froze its token count at first write, and the budget it compared against was unsatisfiable. This raises the budget to 3200 and makes the warning track the document.

## The budget was unsatisfiable

`PINNED_CONTEXT_TOKEN_BUDGET` was 1200 against a `PIN_COUNT_CAP` of 12. Twelve well-written pins measure ~2,780 tokens and twelve maximum-size pins would cost ~5,850, so a fully legal document could never satisfy the budget. The warning fired permanently rather than advising anything.

3200 is sized from capacity at 15% headroom, not derived from the document it measures. An earlier candidate of 2800 was rejected: it left 12.8 words of headroom (0.6%) against the live file, so any pin edit past a sentence would re-trip it.

`estimate_tokens` counts WORDS (`int(len(text.split()) * 1.3)`), not characters, and runs over the whole region including headings and comment lines.

## Three defects in the warning path

1. **The count froze.** Insertion was guarded by `if "<!-- WARNING: Pinned context" not in pinned_content`, so once written the number never refreshed. A real file reported ~1270 tokens against a true 3,420.
2. **A quoting pin silenced the advisory.** The presence probe searched the whole region as a plain substring, so a pin that merely quoted the warning text satisfied it and the hook then wrote nothing. Fail-open: one line of user prose could disable the advisory for an entire document. Found by a fail-before control that measured 5 failures where 4 were predicted.
3. **A deleted last pin stranded its warning.** The entry scan returned early on a section with no entries, so the removal path never ran.

## Approach

Strip warning lines from the start of the pinned body, measure the clean body, then re-add one line only when over budget. The count becomes a pure function of the warning-free body, so repeated runs are identical, cannot compound, and a block dropping back under budget loses its warning.

The strip predicate is deliberately **stricter** than the probe it replaces, and that asymmetry is load-bearing: a reviewer reaching for symmetry with the old region-wide probe would reintroduce the ability to delete user text.

The entry-guard is likewise asymmetric by design. It **removes** a warning from an entry-less section, because that repairs a line this module wrote. It never **adds** one, because that would be new behaviour in a document the code otherwise leaves untouched. Both directions are pinned by tests.

## Accepted residual

If someone moves the warning line down inside the region, the anchored strip does not find it and the next pass adds a second warning above it. Cost is one extra advisory line; no user text is ever lost. This was taken deliberately over a loose strip that could delete bytes from a file that is frequently gitignored and therefore has no commit to recover from.

## Tests

Seven new tests, each measured to fail against HEAD rather than predicted to:

- `test_stale_number_is_refreshed`
- `test_status_string_agrees_with_file_comment`
- `test_warning_removed_when_back_under_budget`
- `test_warning_removed_when_last_pin_deleted`
- `test_repeated_runs_do_not_compound`
- `test_entryless_section_never_gains_a_warning`
- `test_user_line_quoting_the_warning_is_preserved`

The two pre-existing tests whose comments claimed to "exceed 1200 token budget" now derive their magnitude from the constant, so the next budget change cannot silently void their intent.

Full suite: 13,824 passed, 15 skipped, 0 errors (scanned explicitly, not inferred from a green summary). Import hygiene: PASS.

## First-session effect

Any `CLAUDE.md` holding a warning written under the 1200 budget takes exactly one write on next session start, through the existing lock, atomic rename and containment path, all untouched.
