### PR TITLE
Stop the test suite reaching the live memory store

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.27",
+      "version": "4.6.28",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.27/     # Plugin version
+│               └── 4.6.28/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.27",
+  "version": "4.6.28",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.27
+> **Version**: 4.6.28
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/agents/pact-secretary.md
+++ b/pact-plugin/agents/pact-secretary.md
@@ -85,7 +85,11 @@ You are **exempted from the standard teachback** at spawn — your bootstrap tas
 
 3. **Search for calibration data**: Search pact-memory for `orchestration_calibration` entries. Summarize by domain: sample count, mean drift direction (underestimating or overestimating difficulty), and whether the 5-sample activation threshold for Learning II is met. Include this in the session briefing so the orchestrator has calibration context before any variety scoring.
 
-4. **Check for compact summary**: If `~/.claude/pact-sessions/compact-summary.txt` exists, read it and compare against pact-memory context. Flag any discrepancies between the compaction summary and institutional memory. Delete the file after processing (it is single-use — written by the postcompact_archive hook). Include findings in the session briefing.
+4. **Check for compact summary**: If `~/.claude/pact-sessions/compact-summary.txt` exists, read it and compare against pact-memory context. Flag any discrepancies between the compaction summary and institutional memory. Include findings in the session briefing.
+
+   **Archive that file. Never delete it.** After you process it, MOVE it into your session directory as `compact-summary-<YYYY-MM-DDTHH-MM-SS>.txt`. Resolve the session directory the same way your `pact-handoff-harvest` skill does, from the `- Session dir:` line in CLAUDE.md. Confirm that the moved file exists at the destination and is not empty. Report that absolute path in the session briefing.
+
+   The file is single-use, so it must leave `compact-summary.txt`: otherwise a second briefing in the same session processes it again. It does not follow that you may delete it. The `postcompact_archive` hook writes that path as a global singleton, and no second copy exists anywhere. The team-lead is told to read that same path after compaction, so a delete strands the team-lead as well. A move clears the path and keeps the bytes in one step. If you cannot resolve the session directory, or the move fails, leave the file where it is and report that in the briefing. A summary processed twice costs a duplicate paragraph. A summary deleted once costs everything it held.
 
 5. **Deliver a session briefing** to the team-lead via `SendMessage`:
 
@@ -95,6 +99,7 @@ SendMessage(to="team-lead",
 - {summary 1} ({age})
 - {summary 2} ({age})
 - {summary 3} ({age})
+Compact summary: {processed, archived to {absolute archive path} | left in place, {reason} | none present}.
 No active blockers or unresolved items from prior sessions.",
   summary="Session briefing: M recent memories, N stale entries cleaned")
 ```

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -1344,10 +1344,32 @@ def main():
                         "Re-engage secretary: SendMessage(to='secretary', "
                         "message='Post-compaction: deliver session briefing with current state.')."
                     )
+                # The compact-summary path is single-use: the secretary ARCHIVES
+                # it into the session directory after processing, so a lead that
+                # reads even slightly later finds nothing there. Naming only the
+                # canonical path sends the lead to a location it is expected to
+                # vacate. Name the archive too, so the read survives the move
+                # without waiting for the briefing to arrive.
+                #
+                # session_dir is "" when session_id was missing (the ternary at
+                # the top of this function). Interpolating it blind would emit an
+                # instruction naming an empty directory — no error, just a
+                # confidently wrong sentence — so fall back to the briefing.
+                if session_dir:
+                    _archive_clause = (
+                        f'(if it is gone, the secretary archived it into '
+                        f'{session_dir} as compact-summary-<timestamp>.txt)'
+                    )
+                else:
+                    _archive_clause = (
+                        '(if it is gone, the secretary archived it into the '
+                        'session directory and names the path in its briefing)'
+                    )
                 context_parts.insert(0, (
                     f'{_team_directive} '
                     f'After bootstrap, recover session state: '
-                    f'(1) Read {get_compact_summary_path()} for prior context, '
+                    f'(1) Read {get_compact_summary_path()} for prior context '
+                    f'{_archive_clause}, '
                     f'(2) Run TaskList to find in-progress work, '
                     f'(3) TaskGet on in-progress tasks for details. '
                     f'{_secretary_clause}'

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -951,6 +951,13 @@ The feature-level CalibrationRecord above coexists with per-dispatch variety sta
 
 **Why per-dimension rationales (not a single rationale)**: A single rationale field tolerates cargo-cult ("matches feature complexity" satisfies it). Four distinct rationale fields, one per dimension, force the orchestrator to articulate four independent judgments — cargo-culting all four with one phrase is mechanically incoherent (cannot coherently explain why novelty AND scope AND uncertainty AND risk are simultaneously "the same as feature" without exposing the copy-paste).
 
+**Write-time check on each rationale**: ask what the sentence is ABOUT. If it describes the thing being changed, reviewed, or built — its behaviour, its blast radius, the class its bug belongs to — it describes the topic, and it is not a rationale. A rationale describes the WORK: what THIS dispatch must do, must know, or must not get wrong.
+
+- FAILS, on a code review: "a wrong path resolution in production writes the store somewhere unintended" — that is the reviewed change's risk, not the review's.
+- PASSES: "the review's own risks are a probe that writes to the live store, and a finding that is missed."
+
+Portability is not the fault. A rationale that names a coupled file pair or a permanent context cost transfers to other dispatches on the same artifacts because that structure is stable, and it is still a rationale. The cost of a topic-rationale is not the score, which is typically correct either way — it is where attention goes: a rationale about production blast radius argues for scrutiny of the code, while a rationale about the review argues also for discipline about the reviewer's own commands.
+
 #### Q5 Dispatch Variety Calibration (Wrap-Up Aggregation)
 
 The wrap-up retrospective's Q5 reports the CALIBRATION DELTA — the feature-level variety estimate against the distribution of per-dispatch variety the arc actually produced. It does NOT report a stamping-compliance ratio: stamping is refused at the dispatch-wiring write per the Enforcement split above, so compliance has no variance left to measure. Whether the estimate was well-calibrated is the question enforcement cannot answer, and it is the one this question keeps.

--- a/pact-plugin/protocols/pact-variety.md
+++ b/pact-plugin/protocols/pact-variety.md
@@ -150,6 +150,13 @@ The feature-level CalibrationRecord above coexists with per-dispatch variety sta
 
 **Why per-dimension rationales (not a single rationale)**: A single rationale field tolerates cargo-cult ("matches feature complexity" satisfies it). Four distinct rationale fields, one per dimension, force the orchestrator to articulate four independent judgments — cargo-culting all four with one phrase is mechanically incoherent (cannot coherently explain why novelty AND scope AND uncertainty AND risk are simultaneously "the same as feature" without exposing the copy-paste).
 
+**Write-time check on each rationale**: ask what the sentence is ABOUT. If it describes the thing being changed, reviewed, or built — its behaviour, its blast radius, the class its bug belongs to — it describes the topic, and it is not a rationale. A rationale describes the WORK: what THIS dispatch must do, must know, or must not get wrong.
+
+- FAILS, on a code review: "a wrong path resolution in production writes the store somewhere unintended" — that is the reviewed change's risk, not the review's.
+- PASSES: "the review's own risks are a probe that writes to the live store, and a finding that is missed."
+
+Portability is not the fault. A rationale that names a coupled file pair or a permanent context cost transfers to other dispatches on the same artifacts because that structure is stable, and it is still a rationale. The cost of a topic-rationale is not the score, which is typically correct either way — it is where attention goes: a rationale about production blast radius argues for scrutiny of the code, while a rationale about the review argues also for discipline about the reviewer's own commands.
+
 #### Q5 Dispatch Variety Calibration (Wrap-Up Aggregation)
 
 The wrap-up retrospective's Q5 reports the CALIBRATION DELTA — the feature-level variety estimate against the distribution of per-dispatch variety the arc actually produced. It does NOT report a stamping-compliance ratio: stamping is refused at the dispatch-wiring write per the Enforcement split above, so compliance has no variance left to measure. Whether the estimate was well-calibrated is the question enforcement cannot answer, and it is the one this question keeps.

--- a/pact-plugin/skills/pact-memory/scripts/cli.py
+++ b/pact-plugin/skills/pact-memory/scripts/cli.py
@@ -167,8 +167,10 @@ def _refuse_live_db_under_pytest(db_path) -> None:
     _error(
         "UNSCOPED_TEST_DB",
         "refusing to open the default memory database: PYTEST_CURRENT_TEST "
-        "is set in this process's environment and no --db-path was given. "
-        "Those two facts are the whole of what this guard observed. It does "
+        "is set in this process's environment, no --db-path was given, and "
+        "`pytest` is absent from this interpreter, which is what scopes this "
+        "guard to spawned children. Those three facts are the whole of what "
+        "it observed. It does "
         "NOT resolve the default location, so it cannot say WHICH database a "
         "write would reach: with PACT_TEST_MEMORY_DIR set the default is already "
         "redirected, and without it the default is the real store. If this "
@@ -176,9 +178,8 @@ def _refuse_live_db_under_pytest(db_path) -> None:
         "--db-path pointing at a temporary database. If you are ARCHIVING A "
         "PIN and meant to use the real store, do NOT pass --db-path -- that "
         "would archive into a throwaway database and make the pin eligible "
-        "for deletion; instead unset PYTEST_CURRENT_TEST and run again (it is "
-        "set here without a test in progress, most likely exported or "
-        f"inherited from a parent shell). PYTEST_CURRENT_TEST={current_test}",
+        "for deletion; instead unset PYTEST_CURRENT_TEST and run again. "
+        f"PYTEST_CURRENT_TEST={current_test}",
         exit_code=2,
     )
 

--- a/pact-plugin/skills/pact-memory/scripts/cli.py
+++ b/pact-plugin/skills/pact-memory/scripts/cli.py
@@ -74,8 +74,9 @@ def _refuse_live_db_under_pytest(db_path) -> None:
     """Refuse the live store when a TEST PROCESS spawned us.
 
     THE DEFECT THIS CLOSES. `--db-path` is how a test scopes its writes, and
-    omitting it silently selects the developer's real `memory.db`. A test that
-    forgets it does not fail -- it succeeds, against the live store. Requiring
+    omitting it selects whatever the default resolves to -- the developer's
+    real `memory.db` unless something has redirected it. A test that forgets it
+    does not fail -- it succeeds, against whichever store that is. Requiring
     the parameter upstream makes the choice visible but not safe: the value may
     still be None, and an empty string is falsy, so it takes the same branch.
     This is the mechanical half.
@@ -165,9 +166,13 @@ def _refuse_live_db_under_pytest(db_path) -> None:
     # branch says do NOT pass --db-path.
     _error(
         "UNSCOPED_TEST_DB",
-        "refusing to open the live memory database: PYTEST_CURRENT_TEST "
-        "is set in this process's environment and no --db-path was given, so "
-        "a write would land in the real store. If this IS a test, pass "
+        "refusing to open the default memory database: PYTEST_CURRENT_TEST "
+        "is set in this process's environment and no --db-path was given. "
+        "Those two facts are the whole of what this guard observed. It does "
+        "NOT resolve the default location, so it cannot say WHICH database a "
+        "write would reach: with PACT_MEMORY_DIR set the default is already "
+        "redirected, and without it the default is the real store. If this "
+        "IS a test, pass "
         "--db-path pointing at a temporary database. If you are ARCHIVING A "
         "PIN and meant to use the real store, do NOT pass --db-path -- that "
         "would archive into a throwaway database and make the pin eligible "

--- a/pact-plugin/skills/pact-memory/scripts/cli.py
+++ b/pact-plugin/skills/pact-memory/scripts/cli.py
@@ -170,7 +170,7 @@ def _refuse_live_db_under_pytest(db_path) -> None:
         "is set in this process's environment and no --db-path was given. "
         "Those two facts are the whole of what this guard observed. It does "
         "NOT resolve the default location, so it cannot say WHICH database a "
-        "write would reach: with PACT_MEMORY_DIR set the default is already "
+        "write would reach: with PACT_TEST_MEMORY_DIR set the default is already "
         "redirected, and without it the default is the real store. If this "
         "IS a test, pass "
         "--db-path pointing at a temporary database. If you are ARCHIVING A "

--- a/pact-plugin/skills/pact-memory/scripts/config.py
+++ b/pact-plugin/skills/pact-memory/scripts/config.py
@@ -42,6 +42,22 @@ from pathlib import Path
 # precedence over `Path.home()` in `get_claude_config_dir`, so honouring that
 # variable would shadow the home-redirect convention the rest of the suite is
 # built on. Narrow scope is what makes this variable safe to add.
+#
+# AN EXPLICIT DISCRIMINATOR BEATS AN INFERRED ONE, and that is the load-bearing
+# reason for this design rather than the relocation feature it also provides.
+# Isolating a test process from the real store looks like it needs the code to
+# work out whether it is under test, and every mechanism for working that out
+# can be WRONG ABOUT THE WORLD: `_refuse_live_db_under_pytest` in cli.py keys on
+# an inherited `PYTEST_CURRENT_TEST`, and its own docstring records that the
+# variable is absent during collection and around session-scoped setup, and that
+# its fail direction is ALLOW.
+#
+# This variable removes the inference entirely. A test harness SETS it and a
+# production process does not, so there is nothing to detect and nothing to get
+# wrong: the resolver cannot be mistaken about whether a variable was set. That
+# also dissolves what looks like a conflict between isolating tests and keeping
+# production working. They are not in tension, because they are distinguished by
+# an explicit signal rather than by a guess about the caller.
 MEMORY_DIR_ENV = "PACT_MEMORY_DIR"
 
 

--- a/pact-plugin/skills/pact-memory/scripts/config.py
+++ b/pact-plugin/skills/pact-memory/scripts/config.py
@@ -35,7 +35,15 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-# Environment variable that relocates the whole memory store.
+# Environment variable that relocates the store THIS MODULE resolves.
+#
+# ITS EXTENT IS NARROWER THAN THE STORE ROOT, and the gap is not obvious from
+# here. It governs `get_memory_dir()` and everything derived from it, which is
+# the database. It does NOT govern `hooks/track_files.py`: that writes
+# `session-tracking/` INSIDE the same root, but resolves it through
+# `get_claude_config_dir()`, so that subtree follows `CLAUDE_CONFIG_DIR` and is
+# unaffected by this variable. Setting only this one relocates the database and
+# leaves the tracking data where it was.
 #
 # DELIBERATELY MEMORY-SPECIFIC. It names this store and nothing else. A general
 # home or config override is the wrong shape here: `CLAUDE_CONFIG_DIR` takes
@@ -52,12 +60,22 @@ from pathlib import Path
 # variable is absent during collection and around session-scoped setup, and that
 # its fail direction is ALLOW.
 #
+# The two are complements, not alternatives: this harness sets the variable in
+# `pytest_configure`, which runs BEFORE collection -- the window that guard's
+# own docstring declares it does not cover.
+#
 # This variable removes the inference entirely. A test harness SETS it and a
-# production process does not, so there is nothing to detect and nothing to get
-# wrong: the resolver cannot be mistaken about whether a variable was set. That
-# also dissolves what looks like a conflict between isolating tests and keeping
-# production working. They are not in tension, because they are distinguished by
-# an explicit signal rather than by a guess about the caller.
+# production process does not, so there is nothing to detect: the resolver
+# cannot be mistaken about whether a variable was set.
+#
+# The guarantee is narrower than it looks, and the narrow one is what to rely
+# on. The resolver cannot be mistaken about whether the variable was SET, but
+# nothing here detects a SET value that points at the real store. The safety
+# comes from the harness, which assigns unconditionally and never with
+# `setdefault`.
+#
+# Keep this a REDIRECT, never a refusal: production is pathless by design, so a
+# resolver that refuses the real store breaks every production caller.
 MEMORY_DIR_ENV = "PACT_MEMORY_DIR"
 
 
@@ -80,8 +98,3 @@ def get_memory_dir() -> Path:
 def get_db_path() -> Path:
     """Return the memory database file path. Creates no directory."""
     return get_memory_dir() / "memory.db"
-
-
-def get_session_tracking_dir() -> Path:
-    """Return the session tracking directory."""
-    return get_memory_dir() / "session-tracking"

--- a/pact-plugin/skills/pact-memory/scripts/config.py
+++ b/pact-plugin/skills/pact-memory/scripts/config.py
@@ -7,7 +7,7 @@ Centralized configuration for the PACT Memory skill.
 All path resolution is defined here to ensure consistency across all modules.
 
 Used by:
-- database.py: Database path resolution (get_db_path, get_memory_dir)
+- database.py: Database path resolution (get_memory_dir)
 - setup_memory.py: Directory creation (get_memory_dir)
 
 EVERY PATH HERE RESOLVES AT USE TIME, NEVER AT IMPORT TIME. This module used to
@@ -101,6 +101,14 @@ def get_memory_dir() -> Path:
     return Path.home() / ".claude" / "pact-memory"
 
 
-def get_db_path() -> Path:
-    """Return the memory database file path. Creates no directory."""
+def compute_db_path() -> Path:
+    """Return the memory database file path. Creates no directory.
+
+    NAMED `compute_` TO SEPARATE IT FROM `database.get_db_path`, which resolves
+    the same location and then creates the directory with mode 0o700. The two
+    differ only in that side effect, and they used to differ only in which
+    module you imported from -- so `from .config import get_db_path` in
+    production would have silently stopped creating the directory, with nothing
+    failing loudly. There is no longer a `get_db_path` here to reach for.
+    """
     return get_memory_dir() / "memory.db"

--- a/pact-plugin/skills/pact-memory/scripts/config.py
+++ b/pact-plugin/skills/pact-memory/scripts/config.py
@@ -76,17 +76,17 @@ from pathlib import Path
 #
 # Keep this a REDIRECT, never a refusal: production is pathless by design, so a
 # resolver that refuses the real store breaks every production caller.
-MEMORY_DIR_ENV = "PACT_MEMORY_DIR"
+MEMORY_DIR_ENV = "PACT_TEST_MEMORY_DIR"
 
 
 def get_memory_dir() -> Path:
     """Return the base directory for all PACT memory data.
 
     Resolution order:
-      1. The `PACT_MEMORY_DIR` environment variable, when set and non-empty.
+      1. The `PACT_TEST_MEMORY_DIR` environment variable, when set and non-empty.
       2. `~/.claude/pact-memory`.
 
-    An empty value counts as unset, so `PACT_MEMORY_DIR=""` cannot silently
+    An empty value counts as unset, so `PACT_TEST_MEMORY_DIR=""` cannot silently
     relocate the store to the current directory.
     """
     override = os.environ.get(MEMORY_DIR_ENV)

--- a/pact-plugin/skills/pact-memory/scripts/config.py
+++ b/pact-plugin/skills/pact-memory/scripts/config.py
@@ -4,23 +4,68 @@ PACT Memory Configuration
 Location: pact-plugin/skills/pact-memory/scripts/config.py
 
 Centralized configuration for the PACT Memory skill.
-All path constants and directory configurations are defined here
-to ensure consistency across all modules.
+All path resolution is defined here to ensure consistency across all modules.
 
 Used by:
-- database.py: Database path configuration (DB_PATH, PACT_MEMORY_DIR)
-- setup_memory.py: Directory creation (PACT_MEMORY_DIR)
+- database.py: Database path resolution (get_db_path, get_memory_dir)
+- setup_memory.py: Directory creation (get_memory_dir)
+
+EVERY PATH HERE RESOLVES AT USE TIME, NEVER AT IMPORT TIME. This module used to
+export `PACT_MEMORY_DIR` and `DB_PATH` as module-level constants, each computed
+from `Path.home()` when the module first imported. That made the store location
+a property of WHEN the module was imported rather than of the environment, and
+it produced two defects a caller could not see:
+
+  1. A test that redirects `Path.home()` protected the store only when this
+     module happened to import INSIDE that test. Import it at collection time --
+     which any module-level `from scripts.memory_api import ...` does -- and the
+     constant was already bound to the real home, so the redirect reached
+     nothing. The protection existed and was ACCIDENTAL, decided by import order.
+  2. `from .config import DB_PATH` COPIED the value into a second module's
+     namespace, so patching it here did not reach that module at all.
+
+Resolving in a function removes both: no stored value can go stale, and no
+second copy can diverge. The environment variable exists because no in-process
+mechanism crosses a process boundary -- a spawned child is a fresh interpreter,
+in which a patched `Path.home()` never happened.
 """
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
-# Base directory for all PACT memory data
-PACT_MEMORY_DIR = Path.home() / ".claude" / "pact-memory"
+# Environment variable that relocates the whole memory store.
+#
+# DELIBERATELY MEMORY-SPECIFIC. It names this store and nothing else. A general
+# home or config override is the wrong shape here: `CLAUDE_CONFIG_DIR` takes
+# precedence over `Path.home()` in `get_claude_config_dir`, so honouring that
+# variable would shadow the home-redirect convention the rest of the suite is
+# built on. Narrow scope is what makes this variable safe to add.
+MEMORY_DIR_ENV = "PACT_MEMORY_DIR"
 
-# Database configuration
-DB_PATH = PACT_MEMORY_DIR / "memory.db"
 
-# Session tracking directory
-SESSION_TRACKING_DIR = PACT_MEMORY_DIR / "session-tracking"
+def get_memory_dir() -> Path:
+    """Return the base directory for all PACT memory data.
+
+    Resolution order:
+      1. The `PACT_MEMORY_DIR` environment variable, when set and non-empty.
+      2. `~/.claude/pact-memory`.
+
+    An empty value counts as unset, so `PACT_MEMORY_DIR=""` cannot silently
+    relocate the store to the current directory.
+    """
+    override = os.environ.get(MEMORY_DIR_ENV)
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".claude" / "pact-memory"
+
+
+def get_db_path() -> Path:
+    """Return the memory database file path. Creates no directory."""
+    return get_memory_dir() / "memory.db"
+
+
+def get_session_tracking_dir() -> Path:
+    """Return the session tracking directory."""
+    return get_memory_dir() / "session-tracking"

--- a/pact-plugin/skills/pact-memory/scripts/config.py
+++ b/pact-plugin/skills/pact-memory/scripts/config.py
@@ -80,7 +80,13 @@ MEMORY_DIR_ENV = "PACT_TEST_MEMORY_DIR"
 
 
 def get_memory_dir() -> Path:
-    """Return the base directory for all PACT memory data.
+    """Return the base directory for the PACT memory DATABASE.
+
+    NOT for all memory data. `hooks/track_files.py` writes `session-tracking/`
+    under the same root but resolves it through `get_claude_config_dir()`, so
+    that subtree follows `CLAUDE_CONFIG_DIR` and is unaffected by the variable
+    below. Setting only this one relocates the database and leaves the tracking
+    data where it was.
 
     Resolution order:
       1. The `PACT_TEST_MEMORY_DIR` environment variable, when set and non-empty.

--- a/pact-plugin/skills/pact-memory/scripts/database.py
+++ b/pact-plugin/skills/pact-memory/scripts/database.py
@@ -35,7 +35,7 @@ except ImportError:
     import sqlite3
     SQLITE_EXTENSIONS_ENABLED = False
 
-from .config import DB_PATH, PACT_MEMORY_DIR
+from .config import get_memory_dir
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -99,9 +99,15 @@ class AmbiguousPrefixError(LookupError):
 
 
 def get_db_path() -> Path:
-    """Get the database file path, creating parent directories if needed."""
-    PACT_MEMORY_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
-    return DB_PATH
+    """Get the database file path, creating parent directories if needed.
+
+    Resolves through `config.get_memory_dir()` on EVERY call. Holding the value
+    in a module constant is what let an import-time binding outlive a later
+    redirect, so the directory and the file are recomputed together here.
+    """
+    memory_dir = get_memory_dir()
+    memory_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    return memory_dir / "memory.db"
 
 
 def get_connection(db_path: Optional[Path] = None) -> sqlite3.Connection:

--- a/pact-plugin/skills/pact-memory/scripts/setup_memory.py
+++ b/pact-plugin/skills/pact-memory/scripts/setup_memory.py
@@ -19,15 +19,20 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from .config import PACT_MEMORY_DIR
+from .config import get_memory_dir
 
 # Configure logging
 logger = logging.getLogger(__name__)
 
 
 def ensure_directories() -> None:
-    """Create required directories if they don't exist."""
-    PACT_MEMORY_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
+    """Create required directories if they don't exist.
+
+    Resolves the location on every call. This creates a DIRECTORY rather than
+    opening a connection, so a connection-level guard cannot see it -- an
+    import-bound path here would leak past any such instrument silently.
+    """
+    get_memory_dir().mkdir(parents=True, exist_ok=True, mode=0o700)
 
 
 def check_dependencies() -> Dict[str, Any]:
@@ -99,12 +104,14 @@ def get_setup_status() -> Dict[str, Any]:
     """
     deps = check_dependencies()
 
+    memory_dir = get_memory_dir()
+
     return {
-        "initialized": PACT_MEMORY_DIR.exists(),
+        "initialized": memory_dir.exists(),
         "dependencies": deps,
         "can_use_semantic_search": deps["model2vec"] and deps["sqlite_vec"],
         "paths": {
-            "memory_dir": str(PACT_MEMORY_DIR),
+            "memory_dir": str(memory_dir),
         },
         "recommendations": _get_recommendations(deps)
     }

--- a/pact-plugin/tests/conftest.py
+++ b/pact-plugin/tests/conftest.py
@@ -478,3 +478,51 @@ def _scrub_session_id_from_test_env(monkeypatch):
     upgrade rather than a safety guarantee.
     """
     monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _reset_memory_init_state():
+    """Clear the process-global lazy-init flag before EVERY test.
+
+    `memory_init._initialized` is a MODULE-LEVEL global, and
+    `ensure_memory_ready()` returns early on it BEFORE resolving any path. Two
+    of the three things it guards are PER-DATABASE. That was coherent while the
+    store path was constant per process; it stopped being coherent once the
+    store became per-test, so a test that runs after one which initialised a
+    DIFFERENT store is told the work is already done for a store that has never
+    been touched. Measured, not inferred: with the flag left set, a second test
+    under its own `tmp_path` store received none of the work.
+
+    WHAT THIS DOES NOT CLOSE, stated here so the reset is not read as more than
+    it is. `maybe_embed_pending()` has a SECOND, INDEPENDENT guard: a marker
+    file at `/tmp/pact_embedding_attempted_<session>`, which is session-scoped
+    and shared, not per-database, and which this fixture deliberately does not
+    remove -- the marker belongs to any real session on the same machine, and
+    `memory_init` separates `clear_embedding_marker()` from
+    `reset_initialization()` for exactly that reason. So a second store still
+    gets "Already attempted this session" for the catch-up. This fixture
+    restores the migration step, not the catch-up.
+
+    NOT the API singleton. `memory_api._instance` is also process-global and
+    also unreset, but it does NOT bind a store: it holds `_db_path = None` and
+    every operation resolves through `get_db_path()` at call time. Resetting it
+    would change no store-related outcome, so it is left alone.
+
+    Imported inside the fixture on purpose. A module-level import would make
+    the whole suite's collection depend on `scripts` importing cleanly, turning
+    a missing optional dependency into a total collection failure -- the same
+    reason `_MEMORY_DIR_ENV` is duplicated as a literal above.
+    """
+    import sys
+
+    scripts_parent = Path(__file__).parent.parent / "skills" / "pact-memory"
+    if str(scripts_parent) not in sys.path:
+        sys.path.insert(0, str(scripts_parent))
+    try:
+        from scripts.memory_init import reset_initialization
+    except Exception:
+        # The suite must not fail to COLLECT because an optional dependency of
+        # the memory package is absent. A test that needs the reset will fail
+        # on its own assertion, which is a better signal than a collection error.
+        return
+    reset_initialization()

--- a/pact-plugin/tests/conftest.py
+++ b/pact-plugin/tests/conftest.py
@@ -424,12 +424,19 @@ def _isolate_config_root_to_tmp(tmp_path, monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _isolate_memory_store_to_tmp(tmp_path, monkeypatch):
-    """Redirect the PACT memory store to a per-test tmp tree for EVERY test.
+    """Redirect the PACT memory DATABASE to a per-test tmp tree for EVERY test.
 
     DELIBERATELY A SEPARATE FIXTURE from `_isolate_config_root_to_tmp`, matching
-    the one-module-per-reset convention its siblings follow. That fixture owns
-    the Claude config root; this one owns the memory store, and they redirect
-    through DIFFERENT mechanisms because they have to.
+    the one-module-per-reset convention its siblings follow.
+
+    WHICH SUBTREE EACH ONE REACHES, because neither owns the store root alone.
+    This fixture sets `PACT_TEST_MEMORY_DIR`, which governs
+    `config.get_memory_dir()` and therefore the DATABASE. The sibling patches
+    `Path.home()` and clears `CLAUDE_CONFIG_DIR`, and that is what moves
+    `session-tracking/` -- written by `hooks/track_files.py` through
+    `get_claude_config_dir()` -- even though that subtree lives INSIDE the same
+    root. Covering the whole tree takes BOTH, and they redirect through
+    DIFFERENT mechanisms because they have to.
 
     WHY AN ENVIRONMENT VARIABLE AND NOT A `Path.home()` PATCH. The sibling's
     `monkeypatch.setattr(Path, "home", ...)` is in-process only, and it was

--- a/pact-plugin/tests/conftest.py
+++ b/pact-plugin/tests/conftest.py
@@ -37,7 +37,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact
 # collection failure. The literal is pinned against its source by
 # test_memory_store_isolation.py, so a rename fails loudly instead of silently
 # un-isolating every test.
-_MEMORY_DIR_ENV = "PACT_MEMORY_DIR"
+_MEMORY_DIR_ENV = "PACT_TEST_MEMORY_DIR"
 
 # Session-wide fallback store, created once and reused. See pytest_configure.
 _SESSION_MEMORY_DIR = os.path.join(

--- a/pact-plugin/tests/conftest.py
+++ b/pact-plugin/tests/conftest.py
@@ -14,6 +14,7 @@ re-export to be discoverable, but none are currently defined there.
 import json
 import os
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -26,6 +27,22 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 # Add pact-memory scripts to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
+
+
+# Name of the environment variable that relocates the PACT memory store.
+#
+# DUPLICATED FROM `scripts.config.MEMORY_DIR_ENV` ON PURPOSE. Importing it here
+# would make the whole suite depend on the `scripts` package importing cleanly
+# during conftest load, which turns a missing optional dependency into a total
+# collection failure. The literal is pinned against its source by
+# test_memory_store_isolation.py, so a rename fails loudly instead of silently
+# un-isolating every test.
+_MEMORY_DIR_ENV = "PACT_MEMORY_DIR"
+
+# Session-wide fallback store, created once and reused. See pytest_configure.
+_SESSION_MEMORY_DIR = os.path.join(
+    tempfile.mkdtemp(prefix="pact-memory-suite-"), "pact-memory"
+)
 
 
 def pytest_configure(config):
@@ -51,6 +68,30 @@ def pytest_configure(config):
         "from a local cache. On a COLD cache that read is a network "
         "download — deselect in a sandboxed or offline environment.",
     )
+
+    # RELOCATE THE MEMORY STORE BEFORE COLLECTION BEGINS.
+    #
+    # This runs before any test module is imported, which is the property that
+    # matters and the one no fixture can offer. A fixture runs per test, so a
+    # module-level `from scripts.memory_api import ...` executed at COLLECTION
+    # time would resolve the store before any fixture had a chance to redirect
+    # it. Setting the variable here means every import, every fixture and every
+    # spawned child sees the redirected store from the first instruction.
+    #
+    # It is also the only mechanism that CROSSES A PROCESS BOUNDARY. The suite's
+    # `Path.home()` redirect cannot: a spawned CLI child is a fresh interpreter
+    # in which that patch never happened, and the subprocess tests are the
+    # larger half of the exposure this closes.
+    #
+    # DEFENCE IN DEPTH, NOT THE ONLY LAYER. `_isolate_memory_store_to_tmp`
+    # overrides this per test with a `tmp_path` store. This one is the floor:
+    # it catches anything that runs outside a fixture's reach.
+    #
+    # UNCONDITIONAL, NEVER `setdefault`. A contributor who has relocated their
+    # own store already exports this variable, and honouring an inherited value
+    # would point the whole suite at the very store this exists to protect. The
+    # fail direction of `setdefault` here is ALLOW, and it is silent.
+    os.environ[_MEMORY_DIR_ENV] = _SESSION_MEMORY_DIR
 
 
 @pytest.fixture
@@ -379,6 +420,40 @@ def _isolate_config_root_to_tmp(tmp_path, monkeypatch):
         os.environ.pop("CLAUDE_CONFIG_DIR", None)
     else:
         os.environ["CLAUDE_CONFIG_DIR"] = original_cfg
+
+
+@pytest.fixture(autouse=True)
+def _isolate_memory_store_to_tmp(tmp_path, monkeypatch):
+    """Redirect the PACT memory store to a per-test tmp tree for EVERY test.
+
+    DELIBERATELY A SEPARATE FIXTURE from `_isolate_config_root_to_tmp`, matching
+    the one-module-per-reset convention its siblings follow. That fixture owns
+    the Claude config root; this one owns the memory store, and they redirect
+    through DIFFERENT mechanisms because they have to.
+
+    WHY AN ENVIRONMENT VARIABLE AND NOT A `Path.home()` PATCH. The sibling's
+    `monkeypatch.setattr(Path, "home", ...)` is in-process only, and it was
+    measured insufficient for this store on BOTH axes:
+
+      1. It does not cross a process boundary. A spawned CLI child is a fresh
+         interpreter in which the patch never happened, so it resolved the real
+         home. The subprocess tests were the larger half of the exposure.
+      2. `scripts.config` used to bind its paths AT IMPORT, so the patch reached
+         them only when that module first imported INSIDE a test. Any
+         module-level `from scripts.memory_api import ...` imports it at
+         COLLECTION time instead, and the redirect then reached nothing. The
+         protection was real, accidental, and decided by import order.
+
+    `scripts.config` now resolves at use time, which fixes (2) on its own. The
+    variable is what fixes (1), because a child inherits the environment and
+    nothing else survives the boundary.
+
+    SCOPE: this is a redirect, not a refusal. Production is unaffected, since
+    nothing sets the variable there and the resolver falls back to the real
+    home exactly as before. Any production entry point that legitimately wants
+    the real store keeps getting it.
+    """
+    monkeypatch.setenv(_MEMORY_DIR_ENV, str(tmp_path / ".claude" / "pact-memory"))
 
 
 @pytest.fixture(autouse=True)

--- a/pact-plugin/tests/test_archive_pin.py
+++ b/pact-plugin/tests/test_archive_pin.py
@@ -42,6 +42,7 @@ choice reviewable.
 import ast
 import json
 import os
+import re
 import sqlite3
 import subprocess
 import sys
@@ -997,6 +998,47 @@ class TestLiveDbGuard:
         )
         assert "unset PYTEST_CURRENT_TEST" in stderr, (
             f"the refusal never states the fix that preserves the pin: {stderr[:400]}"
+        )
+
+    def test_no_clause_sits_between_the_remedy_and_the_observed_value(
+        self, tmp_path
+    ):
+        """The remedy is followed by the observed value and nothing else.
+
+        WHY THIS IS STRUCTURAL RATHER THAN A BANNED PHRASE, and the reasoning
+        is the point. The clause removed here claimed two things the guard
+        never observed: that no test was in progress, and where the variable
+        came from. A pin on either wording is a pin on a SPELLING -- reword it
+        to say the same thing differently and the pin passes, which is the
+        exact defect the sibling above exists to catch. So this keys on
+        POSITION: the remedy sentence must be followed immediately by the
+        observed value, with only whitespace between. Any explanatory clause
+        inserted there fails, however it is worded.
+
+        ITS BOUND, STATED BECAUSE IT IS NOT THE FULL PROPERTY. This closes the
+        POSITION, not the CLASS. An unobservable claim placed elsewhere in the
+        message still passes. Making the class unrepresentable takes assembling
+        the message from the guard's observation set, so an unobserved claim
+        has no source to come from; that is a change to the guard rather than
+        to its message, and it is not what this test is.
+        """
+        proc = self._spawn_cli(tmp_path, with_pytest_var=True)
+        stderr = proc.stderr
+        # NON-VACUITY ARM. The assertion below is satisfied for free by an
+        # empty stderr from a failed spawn, so prove the refusal is present
+        # before asserting on the shape of its tail.
+        assert "UNSCOPED_TEST_DB" in stderr, (
+            "the guard did not fire, so the structural assertion below would "
+            f"measure an empty stderr rather than the refusal: {stderr[:400]}"
+        )
+        assert re.search(
+            r"unset PYTEST_CURRENT_TEST and run again\.\s*PYTEST_CURRENT_TEST=",
+            stderr,
+        ), (
+            "something sits between the remedy and the observed value. That "
+            "position held two claims the guard cannot make -- whether a test "
+            "is in progress, and where the variable came from -- and it is "
+            f"reserved so neither can return in any wording: {stderr[:400]}"
         )
 
     def test_the_curator_production_path_is_not_blocked(self, tmp_path):

--- a/pact-plugin/tests/test_archive_pin.py
+++ b/pact-plugin/tests/test_archive_pin.py
@@ -937,6 +937,42 @@ class TestLiveDbGuard:
             f"variable was exported or inherited: {stderr[:400]}"
         )
 
+    def test_refusal_does_not_claim_the_write_would_reach_the_real_store(
+        self, tmp_path
+    ):
+        """The guard never resolves the default, so it cannot name the store.
+
+        SIBLING TO THE TEST ABOVE, AND THE SAME DEFECT ONE INFERENCE OVER. That
+        one pins the absence of "spawned from a pytest run". This pins the
+        absence of the OTHER inference the message used to draw -- that a write
+        would land in the real store -- which is false whenever the default has
+        already been redirected.
+
+        IT IS FALSE HERE, WHICH IS WHY THIS TEST BELONGS IN THIS CLASS. conftest
+        sets PACT_MEMORY_DIR for the whole suite, and the child inherits the
+        environment, so the write this refusal prevents would have reached a tmp
+        store and not the operator's. The message asserted the real store in the
+        one place it was reliably wrong.
+
+        The uncovered inference outlived the covered one because the test named
+        for this property pinned only the spelling that had already been caught.
+        """
+        proc = self._spawn_cli(tmp_path, with_pytest_var=True)
+        stderr = proc.stderr
+        # NON-VACUITY ARM, and it is not optional. The assertion below is an
+        # ABSENCE check, which an empty stderr satisfies for free -- a failed
+        # spawn would pass it while measuring nothing. This proves the refusal
+        # text is actually present before anything asserts on what it omits.
+        assert "UNSCOPED_TEST_DB" in stderr, (
+            "the guard did not fire, so the absence assertion below would "
+            f"measure an empty stderr rather than the refusal: {stderr[:400]}"
+        )
+        assert "would land in the real store" not in stderr, (
+            "the refusal asserts the write would reach the real store -- an "
+            "inference the guard cannot make, because it never resolves the "
+            f"default location: {stderr[:400]}"
+        )
+
     def test_refusal_does_not_advise_a_curator_to_scope_the_archive(
         self, tmp_path
     ):

--- a/pact-plugin/tests/test_archive_pin.py
+++ b/pact-plugin/tests/test_archive_pin.py
@@ -949,7 +949,7 @@ class TestLiveDbGuard:
         already been redirected.
 
         IT IS FALSE HERE, WHICH IS WHY THIS TEST BELONGS IN THIS CLASS. conftest
-        sets PACT_MEMORY_DIR for the whole suite, and the child inherits the
+        sets PACT_TEST_MEMORY_DIR for the whole suite, and the child inherits the
         environment, so the write this refusal prevents would have reached a tmp
         store and not the operator's. The message asserted the real store in the
         one place it was reliably wrong.

--- a/pact-plugin/tests/test_compact_summary_archive_contract.py
+++ b/pact-plugin/tests/test_compact_summary_archive_contract.py
@@ -1,0 +1,102 @@
+"""
+The compact-summary archive naming convention is stated in TWO files and
+nothing links them.
+
+  * ``agents/pact-secretary.md`` tells the secretary what to name the file it
+    archives. That is the WRITER, so it is the reference.
+  * ``hooks/session_init.py`` tells a resuming lead what to look for when the
+    canonical path is empty. That is the READER; it only describes what the
+    writer does.
+
+Neither can import from the other — one is Markdown loaded into an LLM's
+context, the other is a hook module — so a single source of truth is not
+available across that boundary and a pin is the only instrument that can see a
+divergence.
+
+WHAT THIS PIN DOES AND DOES NOT DO, stated so no reader infers more:
+
+  * It CATCHES a rename or a deletion on either side. That is the failure mode
+    worth catching: both spellings were written on the same day and agree now,
+    so any later drift is silent and leaves the lead hunting for a filename
+    that no longer exists.
+  * It does NOT prevent divergence. It converts a silent drift into a red.
+  * It does NOT check that the secretary HONOURS the convention at runtime.
+    That is LLM behaviour and nothing here observes it. A green here means the
+    two documents agree, not that the file on disk is named correctly.
+
+NON-VACUITY: the prefix is CAPTURED from each file and the two captures are
+compared with each other. It is never asserted against a literal retyped in
+this file. A test that grepped both files for ``compact-summary-`` would pass
+by construction, and would keep passing after one side was renamed to any
+other string that still contained it.
+
+REVERT CARDINALITY: change the prefix in ONE of the two files (for example
+``compact-summary-<timestamp>.txt`` to ``compaction-summary-<timestamp>.txt``
+in hooks/session_init.py) and run:
+    python3 -m pytest tests/test_compact_summary_archive_contract.py
+EXPECTED: {1 failed} — the agreement test; the arity test still passes because
+both files still state the convention exactly once.
+
+Remove the convention from one file instead and EXPECTED is {2 failed}, not
+one: the arity test fails on the count, and the agreement test fails too
+because unpacking an empty capture list raises. Both cardinalities were
+observed, not predicted — the {2 failed} case was written down as {1 failed}
+first and corrected against the run.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+
+WRITER = _PLUGIN_ROOT / "agents" / "pact-secretary.md"
+READER = _PLUGIN_ROOT / "hooks" / "session_init.py"
+
+# A literal filename prefix followed by an angle-bracket placeholder and the
+# extension: `compact-summary-<timestamp>.txt` -> `compact-summary-`. The
+# placeholder BODY deliberately does not participate — the two files describe
+# the timestamp differently on purpose, one for an LLM and one for a human
+# reading a hook, and only the prefix has to agree.
+_ARCHIVE_NAME_RE = re.compile(r"([A-Za-z0-9._-]+?)<[^>]+>\.txt")
+
+
+def _stated_prefixes(path: Path) -> list[str]:
+    return _ARCHIVE_NAME_RE.findall(path.read_text(encoding="utf-8"))
+
+
+class TestCompactSummaryArchiveNaming:
+    def test_each_file_states_the_convention_exactly_once(self):
+        """Guards the agreement test from BOTH degenerate directions.
+
+        Zero matches would make the comparison vacuous — two empty lists are
+        equal. More than one would make "the" prefix ambiguous and let a
+        second, divergent spelling sit in the same file unnoticed.
+        """
+        for path in (WRITER, READER):
+            found = _stated_prefixes(path)
+            assert len(found) == 1, (
+                f"{path.relative_to(_PLUGIN_ROOT)} states the archive filename "
+                f"convention {len(found)} times, expected exactly once: "
+                f"{found}. Zero means the convention was removed or reworded "
+                f"out of the `<placeholder>.txt` shape this pin reads; more "
+                f"than one means a second spelling can diverge invisibly."
+            )
+            assert found[0], "captured an empty prefix — the pattern matched nothing useful"
+
+    def test_the_reader_and_the_writer_agree_on_the_prefix(self):
+        """The whole point: two files, one convention, no mechanical link."""
+        (writer,) = _stated_prefixes(WRITER)
+        (reader,) = _stated_prefixes(READER)
+        assert reader == writer, (
+            f"the archive filename prefix has diverged.\n"
+            f"  writer {WRITER.relative_to(_PLUGIN_ROOT)}: {writer!r}\n"
+            f"  reader {READER.relative_to(_PLUGIN_ROOT)}: {reader!r}\n"
+            f"The secretary names the archived file; session_init tells a "
+            f"resuming lead what to look for. When they disagree the lead is "
+            f"sent after a filename that is never written, and nothing else "
+            f"fails — the instruction is only read when the canonical path is "
+            f"already empty. Update whichever side is wrong; the writer is the "
+            f"reference."
+        )

--- a/pact-plugin/tests/test_file_permissions.py
+++ b/pact-plugin/tests/test_file_permissions.py
@@ -34,7 +34,7 @@ class TestDatabasePermissions:
         memory_dir = tmp_path / "pact-memory"
         db_path = memory_dir / "memory.db"
 
-        with patch.dict(os.environ, {"PACT_MEMORY_DIR": str(memory_dir)}):
+        with patch.dict(os.environ, {"PACT_TEST_MEMORY_DIR": str(memory_dir)}):
             from scripts.database import get_db_path
             result = get_db_path()
 
@@ -86,7 +86,7 @@ class TestSetupMemoryPermissions:
         """ensure_directories() should create directory with mode 0o700."""
         memory_dir = tmp_path / "pact-memory"
 
-        with patch.dict(os.environ, {"PACT_MEMORY_DIR": str(memory_dir)}):
+        with patch.dict(os.environ, {"PACT_TEST_MEMORY_DIR": str(memory_dir)}):
             from scripts.setup_memory import ensure_directories
             ensure_directories()
 
@@ -100,7 +100,7 @@ class TestSetupMemoryPermissions:
         """Calling ensure_directories() twice should not fail or change permissions."""
         memory_dir = tmp_path / "pact-memory"
 
-        with patch.dict(os.environ, {"PACT_MEMORY_DIR": str(memory_dir)}):
+        with patch.dict(os.environ, {"PACT_TEST_MEMORY_DIR": str(memory_dir)}):
             from scripts.setup_memory import ensure_directories
             ensure_directories()
             ensure_directories()

--- a/pact-plugin/tests/test_file_permissions.py
+++ b/pact-plugin/tests/test_file_permissions.py
@@ -9,6 +9,7 @@ Verifies that:
 3. Permission hardening is applied consistently across creation points
 """
 
+import os
 import stat
 import sys
 from pathlib import Path
@@ -33,9 +34,7 @@ class TestDatabasePermissions:
         memory_dir = tmp_path / "pact-memory"
         db_path = memory_dir / "memory.db"
 
-        with patch("scripts.config.PACT_MEMORY_DIR", memory_dir), \
-             patch("scripts.database.PACT_MEMORY_DIR", memory_dir), \
-             patch("scripts.database.DB_PATH", db_path):
+        with patch.dict(os.environ, {"PACT_MEMORY_DIR": str(memory_dir)}):
             from scripts.database import get_db_path
             result = get_db_path()
 
@@ -87,8 +86,7 @@ class TestSetupMemoryPermissions:
         """ensure_directories() should create directory with mode 0o700."""
         memory_dir = tmp_path / "pact-memory"
 
-        with patch("scripts.config.PACT_MEMORY_DIR", memory_dir), \
-             patch("scripts.setup_memory.PACT_MEMORY_DIR", memory_dir):
+        with patch.dict(os.environ, {"PACT_MEMORY_DIR": str(memory_dir)}):
             from scripts.setup_memory import ensure_directories
             ensure_directories()
 
@@ -102,8 +100,7 @@ class TestSetupMemoryPermissions:
         """Calling ensure_directories() twice should not fail or change permissions."""
         memory_dir = tmp_path / "pact-memory"
 
-        with patch("scripts.config.PACT_MEMORY_DIR", memory_dir), \
-             patch("scripts.setup_memory.PACT_MEMORY_DIR", memory_dir):
+        with patch.dict(os.environ, {"PACT_MEMORY_DIR": str(memory_dir)}):
             from scripts.setup_memory import ensure_directories
             ensure_directories()
             ensure_directories()

--- a/pact-plugin/tests/test_memory_store_isolation.py
+++ b/pact-plugin/tests/test_memory_store_isolation.py
@@ -54,6 +54,57 @@ REAL_STORE_SUFFIX = os.path.join(".claude", "pact-memory")
 # because it is not the attribute the fixture replaces.
 _REAL_HOME = Path(os.path.expanduser("~"))
 
+# THE STORE OVERRIDE AS IT STOOD AT COLLECTION, captured at MODULE IMPORT.
+#
+# Bound early for the same reason as `_REAL_HOME` above, against a different
+# axis. Two isolation layers set this variable: `pytest_configure` assigns a
+# session-wide store BEFORE collection, and the autouse fixture
+# `_isolate_memory_store_to_tmp` then overrides it per test. The fixture runs
+# after collection, so BY THE TIME ANY TEST BODY EXECUTES THE SESSION VALUE IS
+# GONE -- overwritten, not merely shadowed.
+#
+# That is why removing the session layer changes NOTHING a test body can see:
+# the in-test state is identical either way, and no assertion over identical
+# state can distinguish them. Module import is the only moment inside the
+# session at which the session layer's own value is still readable, so this
+# capture is what makes `TestEachIsolationLayerHasAWitness` possible at all.
+_STORE_AT_COLLECTION = os.environ.get(MEMORY_DIR_ENV)
+
+
+def _session_floor_at_collection():
+    """The session store installed by `conftest.pytest_configure`, read now.
+
+    RESOLVED AT COLLECTION FOR TWO SEPARATE REASONS, both measured.
+
+    1. NOT VIA `import conftest`. That statement builds a SECOND module object
+       under its own `sys.modules` key and RE-EXECUTES the module body, which
+       calls `tempfile.mkdtemp` again. The value it reports is a directory no
+       test ever used, so an equality check against it can never pass -- and it
+       would fail for a reason that has nothing to do with the layer under test.
+       It also leaks an empty directory on every call.
+    2. AT COLLECTION RATHER THAN IN A TEST BODY. `TestTheConftestLiteralMatches
+       ItsSource` runs `import conftest`, which leaves TWO modules in
+       `sys.modules` sharing one `__file__`. A path-matching lookup performed
+       after that test has run finds both and cannot tell which one pytest
+       loaded. At collection only the loaded plugin exists, so the answer is
+       unambiguous. The lookup is order-dependent; the moment it runs is not.
+
+    Match on the resolved file path rather than on a module name, so this stays
+    correct however pytest keys the module.
+    """
+    target = str((Path(__file__).parent / "conftest.py").resolve())
+    found = [
+        m for m in list(sys.modules.values())
+        if getattr(m, "__file__", None)
+        and str(Path(m.__file__).resolve()) == target
+    ]
+    if len(found) != 1:
+        return None
+    return getattr(found[0], "_SESSION_MEMORY_DIR", None)
+
+
+_SESSION_FLOOR_AT_COLLECTION = _session_floor_at_collection()
+
 
 def _run_child(code: str, env: dict) -> str:
     """Run `code` in a FRESH interpreter and return its stdout, stripped.
@@ -243,4 +294,70 @@ class TestTheSuiteIsActuallyIsolatedRightNow:
         assert os.environ.get(MEMORY_DIR_ENV), (
             "no memory-store override is set, so resolution falls back to the "
             "real home for every test in this run"
+        )
+
+
+class TestEachIsolationLayerHasAWitness:
+    """One test per isolation layer, because ONE TEST CANNOT COVER BOTH.
+
+    The store is isolated twice over: `pytest_configure` assigns a session-wide
+    store before collection (the FLOOR), and an autouse fixture overrides it per
+    test (the PER-TEST redirect). The two are genuinely redundant for real-store
+    protection, so REMOVING EITHER ONE LEAVES THE SUITE GREEN -- each layer
+    covers for the other's absence. Both mutations were run and every other test
+    in this file survived both. That is the gap these two close.
+
+    WHY NOT ONE TEST. The per-test fixture OVERWRITES the session value, and it
+    runs after collection. So with the floor removed, the state visible to a test
+    body is IDENTICAL to the unmutated state, and no predicate over identical
+    state can differ. This is a structural limit, not a missing assertion: the
+    floor must be witnessed from collection time (see `_STORE_AT_COLLECTION`),
+    and the per-test redirect from inside a test body. Two vantages, two tests.
+
+    These are BEHAVIOURAL. They read the values the run actually used. The
+    sibling `TestTheSessionDefaultIsUnconditional` inspects source text instead,
+    and remains necessary: it catches a `setdefault` that is present and
+    fail-open, where these catch a layer that is absent or ineffective for ANY
+    reason. Neither subsumes the other.
+    """
+
+    def test_the_per_test_redirect_is_in_force_for_this_very_test(self, tmp_path):
+        """FAILS when the autouse per-test fixture is removed.
+
+        With that fixture gone the resolver returns the session floor, which is a
+        session-wide temp directory and NOT under this test's `tmp_path`. Nothing
+        else in this file notices that change.
+        """
+        resolved = get_memory_dir()
+        assert resolved.is_relative_to(tmp_path), (
+            f"the memory store resolves to {resolved}, which is NOT under this "
+            f"test's own tmp_path ({tmp_path}). The per-test isolation fixture "
+            f"is not in force, so tests share one store and can see each "
+            f"other's writes."
+        )
+
+    def test_the_session_floor_was_applied_before_collection(self):
+        """FAILS when the `pytest_configure` assignment is removed.
+
+        Asserts the override in force AT COLLECTION was the one the floor
+        installs. Equality against the floor's own value is deliberate: a weaker
+        'is set and is not the real store' check stays GREEN for a contributor
+        who exports `PACT_MEMORY_DIR` to some harmless directory of their own,
+        which is precisely the inherited-value fail-open the floor exists to
+        prevent.
+        """
+        expected = _SESSION_FLOOR_AT_COLLECTION
+        assert expected is not None, (
+            "could not identify the loaded conftest at collection, so this "
+            "test has no reference value to compare against. It would pass or "
+            "fail for reasons unrelated to the isolation layer -- fix the "
+            "lookup rather than the assertion it feeds."
+        )
+        assert _STORE_AT_COLLECTION == expected, (
+            f"at collection the memory store resolved to "
+            f"{_STORE_AT_COLLECTION!r}, but the session floor installs "
+            f"{expected!r}. Anything resolving outside a fixture's reach -- a "
+            f"collection-time import, session-scoped setup -- used the wrong "
+            f"store. If the value is None the floor never ran; if it is some "
+            f"other path it was inherited from the environment."
         )

--- a/pact-plugin/tests/test_memory_store_isolation.py
+++ b/pact-plugin/tests/test_memory_store_isolation.py
@@ -82,12 +82,21 @@ def _session_floor_at_collection():
        test ever used, so an equality check against it can never pass -- and it
        would fail for a reason that has nothing to do with the layer under test.
        It also leaks an empty directory on every call.
-    2. AT COLLECTION RATHER THAN IN A TEST BODY. `TestTheConftestLiteralMatches
-       ItsSource` runs `import conftest`, which leaves TWO modules in
-       `sys.modules` sharing one `__file__`. A path-matching lookup performed
-       after that test has run finds both and cannot tell which one pytest
-       loaded. At collection only the loaded plugin exists, so the answer is
-       unambiguous. The lookup is order-dependent; the moment it runs is not.
+    2. AT COLLECTION, FOR TWO STRUCTURAL REASONS. The per-test fixture overwrites
+       this variable before any test body runs, so collection is the last moment
+       the session layer's value is readable at all (see `_STORE_AT_COLLECTION`).
+       And this helper cannot use `_loaded_conftest` below even if it wanted to:
+       `request` is a fixture, so it does not exist at module import, which is
+       why the path scan survives beside the deterministic lookup.
+
+       An earlier version of this note justified collection time by the absence
+       of a duplicate module, which a re-import in
+       `TestTheConftestLiteralMatchesItsSource` used to create. That re-import is
+       gone and the justification went with it: collection excludes a duplicate
+       made by a test BODY, but not one made at another module's IMPORT time by a
+       module collected earlier. No module does that today, which is contingent
+       rather than structural. The `len(found) != 1` check below is the detector
+       either way.
 
     Match on the resolved file path rather than on a module name, so this stays
     correct however pytest keys the module.
@@ -131,10 +140,34 @@ _RESOLVE_IN_CHILD = (
 )
 
 
+def _loaded_conftest(request):
+    """Return the conftest module pytest LOADED, never a fresh import.
+
+    A bare `import conftest` does NOT return that module. It builds a SECOND
+    object from the same file and re-executes the body, leaving two entries in
+    `sys.modules` for one `__file__`. That duplication has already cost twice:
+    it contaminated another test's module lookup order-dependently, and it made
+    a live detector look dead under mutation, because patching one object left
+    the other untouched.
+
+    THE LOOKUP FAILS LOUDLY ON PURPOSE. Every caller compares against the module
+    this returns, so a silent `None` would turn those assertions vacuous while
+    every arm stayed green -- strictly worse than the fresh import it replaces.
+    """
+    path = Path(__file__).parent / "conftest.py"
+    plugin = request.config.pluginmanager.get_plugin(str(path))
+    assert plugin is not None, (
+        f"pytest has no conftest plugin registered for {path}, so this helper "
+        "cannot reach the harness. Failing here is deliberate: the assertions "
+        "that call it would otherwise pass while comparing nothing."
+    )
+    return plugin
+
+
 class TestTheConftestLiteralMatchesItsSource:
     """conftest duplicates the variable name; a rename must not un-isolate."""
 
-    def test_conftest_env_name_equals_config_env_name(self):
+    def test_conftest_env_name_equals_config_env_name(self, request):
         """The duplicated literal is pinned to its source.
 
         `conftest.py` cannot import `scripts.config` at load time without making
@@ -142,8 +175,15 @@ class TestTheConftestLiteralMatchesItsSource:
         its own copy of the name. This test is what makes that copy safe: rename
         `MEMORY_DIR_ENV` without updating conftest and this fails loudly, rather
         than every test silently resolving the operator's real store again.
+
+        IT INSPECTS THE LOADED MODULE, AND THE MESSAGE BELOW IS WHY. That message
+        asserts a property of THIS RUN -- that every test is resolving the real
+        store. Only the object whose `pytest_configure` set the variable, and
+        whose autouse fixture sets it per test, can support that claim. A fresh
+        `import conftest` proves a fact about the FILE instead, from a copy with
+        no causal role in the isolation it is reporting on.
         """
-        import conftest
+        conftest = _loaded_conftest(request)
 
         assert conftest._MEMORY_DIR_ENV == MEMORY_DIR_ENV, (
             f"conftest isolates on {conftest._MEMORY_DIR_ENV!r} but the resolver "
@@ -170,10 +210,16 @@ class TestTheSessionDefaultIsUnconditional:
     against reintroducing a known fail-open, not a proof of the runtime property.
     """
 
-    def test_pytest_configure_assigns_rather_than_setdefaults(self):
+    def test_pytest_configure_assigns_rather_than_setdefaults(self, request):
         import inspect
 
-        import conftest
+        # THIS ASSERTION IS INDIFFERENT TO WHICH OBJECT IT GETS, because
+        # `inspect.getsource` resolves through `__file__` and both objects share
+        # one. The helper is used anyway: the duplication comes from the IMPORT
+        # STATEMENT, not from the assertion, so leaving a bare import here would
+        # keep building the second module and removing it from the other test
+        # would remove none of the duplication.
+        conftest = _loaded_conftest(request)
 
         source = inspect.getsource(conftest.pytest_configure)
         assert "os.environ[_MEMORY_DIR_ENV] = " in source, (

--- a/pact-plugin/tests/test_memory_store_isolation.py
+++ b/pact-plugin/tests/test_memory_store_isolation.py
@@ -1,0 +1,246 @@
+"""The memory store must never resolve to the operator's real store under test.
+
+WHAT THESE TESTS ARE FOR, because a passing suite is not evidence here. The
+suite passed with the leak wide open: 13,812 tests green while 60 of them
+opened write-capable connections to the live store. So "the tests pass" cannot
+distinguish an isolated system from a leaking one, and every assertion below is
+written to FAIL on the pre-fix code rather than to describe the post-fix code.
+
+THE TWO MECHANISMS THAT LEAKED, each with a test here:
+  1. IMPORT-TIME BINDING. `config` computed its paths from `Path.home()` when
+     the module first imported, so a later redirect reached a value that no
+     longer existed to change. Protection depended on import ORDER.
+  2. THE PROCESS BOUNDARY. An in-process patch does not survive `exec`, so a
+     spawned CLI child resolved the real home however carefully the parent had
+     been redirected.
+
+WHAT MUST KEEP WORKING, and it outranks the isolation. Production entry points
+that pass no path SHOULD reach the real store: that is what `archive_pin
+--index N` does, and `/PACT:prune-memory` keys its refuse-or-proceed decision
+on it. A fix that isolates tests by making the default unreachable would refuse
+an honest user command, which damages real work rather than merely risking it.
+`TestProductionStillResolvesTheRealStore` is that guarantee.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_PARENT = Path(__file__).parent.parent / "skills" / "pact-memory"
+sys.path.insert(0, str(SCRIPTS_PARENT))
+
+from scripts.config import (  # noqa: E402
+    MEMORY_DIR_ENV,
+    get_db_path,
+    get_memory_dir,
+)
+
+REAL_STORE_SUFFIX = os.path.join(".claude", "pact-memory")
+
+# THE OPERATOR'S TRUE HOME, captured at MODULE IMPORT.
+#
+# Deliberately bound early, which is the opposite of what the fix does, and for
+# a reason that does not apply there: this must be the home as it was BEFORE any
+# fixture ran. The sibling autouse fixture `_isolate_config_root_to_tmp` patches
+# `Path.home()` to a tmp tree for every test, so calling `Path.home()` inside a
+# test yields the REDIRECTED home and an assertion built on it compares a tmp
+# path against itself. Module import happens at collection, before any fixture,
+# so this is the last honest reading available. `os.path.expanduser` is used
+# because it is not the attribute the fixture replaces.
+_REAL_HOME = Path(os.path.expanduser("~"))
+
+
+def _run_child(code: str, env: dict) -> str:
+    """Run `code` in a FRESH interpreter and return its stdout, stripped.
+
+    A fresh process is mandatory rather than tidy. The binding under repair is
+    evaluated at import, so an in-process check performed after redirecting
+    confirms only that the redirect took effect; it cannot observe the defect,
+    which is that the value was already fixed before the redirect happened.
+    """
+    child_env = dict(os.environ)
+    child_env.update(env)
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True, text=True, env=child_env, timeout=60,
+    )
+    assert result.returncode == 0, f"child failed: {result.stderr}"
+    return result.stdout.strip()
+
+
+_RESOLVE_IN_CHILD = (
+    "import sys; sys.path.insert(0, %r)\n"
+    "from scripts.config import get_db_path\n"
+    "print(get_db_path())\n" % str(SCRIPTS_PARENT)
+)
+
+
+class TestTheConftestLiteralMatchesItsSource:
+    """conftest duplicates the variable name; a rename must not un-isolate."""
+
+    def test_conftest_env_name_equals_config_env_name(self):
+        """The duplicated literal is pinned to its source.
+
+        `conftest.py` cannot import `scripts.config` at load time without making
+        the whole suite depend on that package importing cleanly, so it carries
+        its own copy of the name. This test is what makes that copy safe: rename
+        `MEMORY_DIR_ENV` without updating conftest and this fails loudly, rather
+        than every test silently resolving the operator's real store again.
+        """
+        import conftest
+
+        assert conftest._MEMORY_DIR_ENV == MEMORY_DIR_ENV, (
+            f"conftest isolates on {conftest._MEMORY_DIR_ENV!r} but the resolver "
+            f"honours {MEMORY_DIR_ENV!r}. Every test is running against the real "
+            f"store. Update conftest._MEMORY_DIR_ENV to match."
+        )
+
+
+class TestTheSessionDefaultIsUnconditional:
+    """The collection-time assignment must not honour an inherited value.
+
+    ADDED BECAUSE A MUTATION FOUND THE GAP, not because it was designed in.
+    Changing `pytest_configure`'s assignment to `setdefault` and pre-setting
+    `PACT_MEMORY_DIR` to the real store left every other test in this file
+    GREEN, because the per-test autouse fixture overrides the variable anyway.
+    The exposure that survives is narrower and still real: anything resolving
+    OUTSIDE a fixture's reach — collection-time imports, session-scoped setup —
+    would read the operator's own value and point at the store this exists to
+    protect. A contributor who has relocated their store exports that variable.
+
+    STRUCTURAL, AND SAID SO PLAINLY. This inspects source text rather than
+    behaviour, because the assignment happens before collection and no test can
+    observe the pre-collection state from inside the session. It is a guard
+    against reintroducing a known fail-open, not a proof of the runtime property.
+    """
+
+    def test_pytest_configure_assigns_rather_than_setdefaults(self):
+        import inspect
+
+        import conftest
+
+        source = inspect.getsource(conftest.pytest_configure)
+        assert "os.environ[_MEMORY_DIR_ENV] = " in source, (
+            "the session-wide memory-store redirect is no longer an "
+            "unconditional assignment"
+        )
+        assert "setdefault(_MEMORY_DIR_ENV" not in source, (
+            "`setdefault` honours an inherited PACT_MEMORY_DIR, so a contributor "
+            "who has relocated their own store would have collection-time "
+            "resolution point at it. The fail direction is ALLOW and it is silent."
+        )
+
+
+class TestResolutionIsLateNotImportTime:
+    """Mechanism 1: the value must not be fixed at import."""
+
+    def test_env_change_after_import_still_moves_the_store(self, tmp_path):
+        """FAILS PRE-FIX. `config.DB_PATH` was a constant, so a change made
+        after import moved nothing."""
+        first = get_db_path()
+        moved = tmp_path / "relocated"
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv(MEMORY_DIR_ENV, str(moved))
+            second = get_db_path()
+        assert second == moved / "memory.db"
+        assert second != first
+
+    def test_home_change_after_import_still_moves_the_store(self, tmp_path):
+        """FAILS PRE-FIX, and this is the ORDER-DEPENDENCE test.
+
+        With no override set, the resolver must consult `Path.home()` at CALL
+        time. Pre-fix it consulted a value captured at import, so this returned
+        the real home no matter what the patch said.
+        """
+        elsewhere = tmp_path / "elsewhere"
+        with pytest.MonkeyPatch.context() as mp:
+            mp.delenv(MEMORY_DIR_ENV, raising=False)
+            mp.setattr(Path, "home", lambda: elsewhere)
+            assert get_memory_dir() == elsewhere / ".claude" / "pact-memory"
+
+    def test_empty_override_is_treated_as_unset(self, tmp_path):
+        """An empty value must not relocate the store to a relative path."""
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv(MEMORY_DIR_ENV, "")
+            mp.setattr(Path, "home", lambda: tmp_path)
+            assert get_memory_dir() == tmp_path / ".claude" / "pact-memory"
+
+
+class TestRedirectCrossesTheProcessBoundary:
+    """Mechanism 2: a child interpreter must inherit the redirect."""
+
+    def test_child_process_honours_the_override(self, tmp_path):
+        """FAILS PRE-FIX for every spawned CLI test, which was the larger half
+        of the exposure: no in-process patch survives `exec`."""
+        target = tmp_path / "child-store"
+        out = _run_child(_RESOLVE_IN_CHILD, {MEMORY_DIR_ENV: str(target)})
+        assert out == str(target / "memory.db")
+
+    def test_child_process_does_not_reach_the_real_store(self, tmp_path):
+        """The property stated as the thing we actually care about."""
+        target = tmp_path / "child-store"
+        out = _run_child(_RESOLVE_IN_CHILD, {MEMORY_DIR_ENV: str(target)})
+        assert out == str(target / "memory.db")
+        assert not out.startswith(str(_REAL_HOME / ".claude" / "pact-memory"))
+
+
+class TestProductionStillResolvesTheRealStore:
+    """CARDINAL. Over-block is worse than the leak it would prevent.
+
+    The leak has damaged nothing to date. A refused good-faith command damages
+    the user's work immediately, so these tests rank above the isolation ones.
+    """
+
+    def test_no_override_resolves_under_the_real_home(self):
+        """A production process sets nothing, and must reach the real store."""
+        out = _run_child(
+            "import sys; sys.path.insert(0, %r)\n"
+            "import os\n"
+            "os.environ.pop('PACT_MEMORY_DIR', None)\n"
+            "from scripts.config import get_db_path\n"
+            "print(get_db_path())\n" % str(SCRIPTS_PARENT),
+            {},
+        )
+        expected = _REAL_HOME / ".claude" / "pact-memory" / "memory.db"
+        assert out == str(expected), (
+            "a production caller that sets no override must still resolve the "
+            "real store; refusing it would break `archive_pin --index N`, which "
+            "passes no --db-path on purpose"
+        )
+
+    def test_resolution_creates_nothing_by_itself(self, tmp_path):
+        """Resolving a path must not have side effects.
+
+        `get_db_path` in `config` only computes. Directory creation belongs to
+        the callers that intend it, so merely asking where the store is can
+        never create a stray tree in someone's home.
+        """
+        target = tmp_path / "never-created"
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv(MEMORY_DIR_ENV, str(target))
+            get_db_path()
+        assert not target.exists()
+
+
+class TestTheSuiteIsActuallyIsolatedRightNow:
+    """The end-to-end property, asserted from inside the running suite."""
+
+    def test_this_very_test_resolves_away_from_the_real_store(self):
+        """If the autouse fixture ever stops working, this fails immediately."""
+        resolved = str(get_db_path())
+        real = str(_REAL_HOME / ".claude" / "pact-memory")
+        assert not resolved.startswith(real), (
+            f"this test resolves the memory store to {resolved}, which is the "
+            f"operator's real store. The isolation fixture is not working."
+        )
+
+    def test_the_override_is_set_for_every_test(self):
+        assert os.environ.get(MEMORY_DIR_ENV), (
+            "no memory-store override is set, so resolution falls back to the "
+            "real home for every test in this run"
+        )

--- a/pact-plugin/tests/test_memory_store_isolation.py
+++ b/pact-plugin/tests/test_memory_store_isolation.py
@@ -157,7 +157,7 @@ class TestTheSessionDefaultIsUnconditional:
 
     ADDED BECAUSE A MUTATION FOUND THE GAP, not because it was designed in.
     Changing `pytest_configure`'s assignment to `setdefault` and pre-setting
-    `PACT_MEMORY_DIR` to the real store left every other test in this file
+    `PACT_TEST_MEMORY_DIR` to the real store left every other test in this file
     GREEN, because the per-test autouse fixture overrides the variable anyway.
     The exposure that survives is narrower and still real: anything resolving
     OUTSIDE a fixture's reach — collection-time imports, session-scoped setup —
@@ -181,7 +181,7 @@ class TestTheSessionDefaultIsUnconditional:
             "unconditional assignment"
         )
         assert "setdefault(_MEMORY_DIR_ENV" not in source, (
-            "`setdefault` honours an inherited PACT_MEMORY_DIR, so a contributor "
+            "`setdefault` honours an inherited PACT_TEST_MEMORY_DIR, so a contributor "
             "who has relocated their own store would have collection-time "
             "resolution point at it. The fail direction is ALLOW and it is silent."
         )
@@ -252,7 +252,7 @@ class TestProductionStillResolvesTheRealStore:
         out = _run_child(
             "import sys; sys.path.insert(0, %r)\n"
             "import os\n"
-            "os.environ.pop('PACT_MEMORY_DIR', None)\n"
+            "os.environ.pop('PACT_TEST_MEMORY_DIR', None)\n"
             "from scripts.config import get_db_path\n"
             "print(get_db_path())\n" % str(SCRIPTS_PARENT),
             {},
@@ -342,7 +342,7 @@ class TestEachIsolationLayerHasAWitness:
         Asserts the override in force AT COLLECTION was the one the floor
         installs. Equality against the floor's own value is deliberate: a weaker
         'is set and is not the real store' check stays GREEN for a contributor
-        who exports `PACT_MEMORY_DIR` to some harmless directory of their own,
+        who exports `PACT_TEST_MEMORY_DIR` to some harmless directory of their own,
         which is precisely the inherited-value fail-open the floor exists to
         prevent.
         """

--- a/pact-plugin/tests/test_memory_store_isolation.py
+++ b/pact-plugin/tests/test_memory_store_isolation.py
@@ -36,7 +36,7 @@ sys.path.insert(0, str(SCRIPTS_PARENT))
 
 from scripts.config import (  # noqa: E402
     MEMORY_DIR_ENV,
-    get_db_path,
+    compute_db_path,
     get_memory_dir,
 )
 
@@ -135,8 +135,8 @@ def _run_child(code: str, env: dict) -> str:
 
 _RESOLVE_IN_CHILD = (
     "import sys; sys.path.insert(0, %r)\n"
-    "from scripts.config import get_db_path\n"
-    "print(get_db_path())\n" % str(SCRIPTS_PARENT)
+    "from scripts.config import compute_db_path\n"
+    "print(compute_db_path())\n" % str(SCRIPTS_PARENT)
 )
 
 
@@ -239,11 +239,11 @@ class TestResolutionIsLateNotImportTime:
     def test_env_change_after_import_still_moves_the_store(self, tmp_path):
         """FAILS PRE-FIX. `config.DB_PATH` was a constant, so a change made
         after import moved nothing."""
-        first = get_db_path()
+        first = compute_db_path()
         moved = tmp_path / "relocated"
         with pytest.MonkeyPatch.context() as mp:
             mp.setenv(MEMORY_DIR_ENV, str(moved))
-            second = get_db_path()
+            second = compute_db_path()
         assert second == moved / "memory.db"
         assert second != first
 
@@ -299,8 +299,8 @@ class TestProductionStillResolvesTheRealStore:
             "import sys; sys.path.insert(0, %r)\n"
             "import os\n"
             "os.environ.pop('PACT_TEST_MEMORY_DIR', None)\n"
-            "from scripts.config import get_db_path\n"
-            "print(get_db_path())\n" % str(SCRIPTS_PARENT),
+            "from scripts.config import compute_db_path\n"
+            "print(compute_db_path())\n" % str(SCRIPTS_PARENT),
             {},
         )
         expected = _REAL_HOME / ".claude" / "pact-memory" / "memory.db"
@@ -313,14 +313,14 @@ class TestProductionStillResolvesTheRealStore:
     def test_resolution_creates_nothing_by_itself(self, tmp_path):
         """Resolving a path must not have side effects.
 
-        `get_db_path` in `config` only computes. Directory creation belongs to
+        `compute_db_path` in `config` only computes. Directory creation belongs to
         the callers that intend it, so merely asking where the store is can
         never create a stray tree in someone's home.
         """
         target = tmp_path / "never-created"
         with pytest.MonkeyPatch.context() as mp:
             mp.setenv(MEMORY_DIR_ENV, str(target))
-            get_db_path()
+            compute_db_path()
         assert not target.exists()
 
 
@@ -329,7 +329,7 @@ class TestTheSuiteIsActuallyIsolatedRightNow:
 
     def test_this_very_test_resolves_away_from_the_real_store(self):
         """If the autouse fixture ever stops working, this fails immediately."""
-        resolved = str(get_db_path())
+        resolved = str(compute_db_path())
         real = str(_REAL_HOME / ".claude" / "pact-memory")
         assert not resolved.startswith(real), (
             f"this test resolves the memory store to {resolved}, which is the "
@@ -340,6 +340,75 @@ class TestTheSuiteIsActuallyIsolatedRightNow:
         assert os.environ.get(MEMORY_DIR_ENV), (
             "no memory-store override is set, so resolution falls back to the "
             "real home for every test in this run"
+        )
+
+
+_LEFT_THE_FLAG_SET = False
+
+
+class TestInitStateDoesNotLeakBetweenStores:
+    """The process-global lazy-init flag must not carry across tests.
+
+    `memory_init.ensure_memory_ready()` returns early on a MODULE-LEVEL flag,
+    before resolving any path, and two of the three things it guards are
+    per-database. With the store now per-test, a test that runs after one which
+    initialised a DIFFERENT store would be told the work was already done for a
+    store nothing had touched.
+
+    AN ORDERED PAIR, WHICH IS A LIABILITY AND IS GUARDED. The first test leaves
+    the flag set; the second asserts it was cleared. If the two ever stop
+    running in this order, the second would pass for the wrong reason -- it
+    would find a clean flag because nothing had dirtied it. `_LEFT_THE_FLAG_SET`
+    exists to turn that false green into a loud failure. No ordering plugin is
+    installed in this suite today, so definition order holds; the guard is for
+    the day that stops being true.
+    """
+
+    def test_a_leaves_the_process_flag_set_for_its_own_store(self, monkeypatch):
+        """Dirty the global deliberately. This is the precondition, not a check.
+
+        The guarded work is replaced with no-ops: this pair is about the FLAG,
+        and running the real dependency check and migration here would make the
+        test slow and dependent on the environment for no added signal.
+        """
+        global _LEFT_THE_FLAG_SET
+        from scripts import memory_init
+
+        for name in (
+            "check_and_install_dependencies",
+            "maybe_migrate_embeddings",
+            "maybe_embed_pending",
+        ):
+            monkeypatch.setattr(
+                memory_init, name,
+                lambda *a, **k: {"status": "ok", "installed": [], "failed": []},
+            )
+
+        memory_init.ensure_memory_ready()
+        assert memory_init.is_initialized(), (
+            "this test could not establish its own precondition: the flag did "
+            "not become set, so the next test would prove nothing"
+        )
+        _LEFT_THE_FLAG_SET = True
+
+    def test_b_starts_from_a_clean_flag(self):
+        """FAILS without the reset fixture. Its own store would be skipped.
+
+        The failure this prevents is silent: the second store is simply told the
+        work is done, and nothing raises.
+        """
+        from scripts import memory_init
+
+        assert _LEFT_THE_FLAG_SET, (
+            "the sibling that dirties the flag did not run before this one, so "
+            "a clean flag here means nothing. The order this pair depends on "
+            "has changed -- fix the pair rather than trusting this pass."
+        )
+        assert not memory_init.is_initialized(), (
+            "the lazy-init flag arrived already set, left by a test whose store "
+            "was a DIFFERENT directory. ensure_memory_ready() would return "
+            "early for this test's store and skip the per-database work it "
+            "guards. The reset fixture in conftest is not running."
         )
 
 

--- a/pact-plugin/tests/test_session_init_integration.py
+++ b/pact-plugin/tests/test_session_init_integration.py
@@ -1,7 +1,12 @@
 """
 Location: pact-plugin/tests/test_session_init_integration.py
-Summary: NON-MOCKED L2 integration coverage for session_init's caller-3 seam —
-the post-compaction checkpoint built from get_task_list() (session_init.py
+Summary: NON-MOCKED L2 integration coverage for TWO session_init seams. Seam A
+is the caller-3 seam — the post-compaction checkpoint built from
+get_task_list(). Seam B is the session-dir resolution behind the post-compaction
+lead-read instruction; its own anti-mock invariant and non-vacuity gate are
+documented on TestCompactReadInstructionRealSeam below.
+
+Seam A — the post-compaction checkpoint built from get_task_list() (session_init.py
 ~:1211). Under Agent Teams this was PARTIAL pre-#923 (the broken get_task_list
 session_id key degraded the checkpoint to the bootstrap safety-net). The #923
 GLOBAL team-first fix in task_utils.get_task_list repaired it; this L2 is the
@@ -111,3 +116,108 @@ class TestSessionInitCheckpointRealSeam:
         cp = _build_checkpoint()
         # get_task_list() -> None -> finders get [] -> safety-net feature line.
         assert "Unable to identify feature task" in cp
+
+
+# ── Seam B: session-dir resolution behind the lead-read instruction ──────────
+
+
+def _run_compact_main(tmp_path, monkeypatch, session_id):
+    """Drive session_init.main() at source='compact' and return the emitted
+    additionalContext.
+
+    session_init is imported INSIDE the function, not at module scope, for the
+    same reason the module header gives: a collection-time import of the 73KB
+    module pulls staleness/pin_caps/claude_md_manager into every test in this
+    file. The helper in tests/test_session_init.py imports it the same way.
+    """
+    import io
+    from unittest.mock import patch
+
+    import session_init
+
+    payload: dict = {"source": "compact"}
+    if session_id is not None:
+        payload["session_id"] = session_id
+
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/test/project")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    with patch("session_init.setup_plugin_symlinks", return_value=None), \
+         patch("session_init.ensure_project_memory_md", return_value=None), \
+         patch("session_init.check_pinned_staleness", return_value=None), \
+         patch("session_init.update_session_info", return_value=None), \
+         patch("session_init.restore_last_session", return_value=None), \
+         patch("session_init.check_resume_state", return_value=None), \
+         patch("sys.stdin", io.StringIO(json.dumps(payload))), \
+         patch("sys.stdout", new_callable=io.StringIO) as out:
+        with pytest.raises(SystemExit) as exc:
+            session_init.main()
+
+    assert exc.value.code == 0
+    return json.loads(out.getvalue())["hookSpecificOutput"]["additionalContext"]
+
+
+class TestCompactReadInstructionRealSeam:
+    """The lead-read instruction must name where the compact summary WENT.
+
+    The secretary archives the single-use compact-summary file into the session
+    directory after processing it, so a lead following the instruction even
+    slightly later finds the canonical path empty. The instruction therefore
+    names the archive directory as a fallback, which puts session-dir resolution
+    into the emitted text.
+
+    ============================ ANTI-MOCK INVARIANT ========================
+    MUST NOT patch get_session_dir, get_compact_summary_path, or
+    build_context_cache. The real session-dir resolution IS this seam. The only
+    doubles are Path.home redirection plus suppressors for start-up side effects
+    (symlinks, project memory, staleness, session-info write, resume state) —
+    none of them participates in building this instruction. get_task_list is
+    NOT among them and must not be added: it is a RESOLVER_SYMBOL, and the real
+    resolver already returns None under an empty redirected home, so a double
+    would buy nothing and would forfeit the anti-mock invariant.
+
+    ========================= NON-VACUITY (source-revert) ===================
+    session_dir is "" when session_id is missing. Replace the guarded
+    _archive_clause in hooks/session_init.py with a blind interpolation of
+    session_dir, then run:
+        python3 -m pytest tests/test_session_init_integration.py -k missing_session_id
+    EXPECTED cardinality: {1 failed} — the blind form emits "archived it into
+     as compact-summary-<timestamp>.txt", naming an empty directory, so the
+    fallback-wording assertion fails. Restore -> green. The real-session_id case
+    is the positive control: it fails in the opposite direction if resolution
+    ever returns "" for a well-formed session.
+    ==========================================================================
+    """
+
+    def test_real_session_id_names_the_resolved_archive_directory(
+        self, tmp_path, monkeypatch
+    ):
+        sid = "aabb1122-0000-0000-0000-000000000000"
+        ctx = _run_compact_main(tmp_path, monkeypatch, sid)
+
+        # Canonical path stays PRIMARY — a lead resuming before any secretary
+        # has run must still be sent to the real file.
+        assert "compact-summary.txt" in ctx
+        # The archive directory is the REAL resolved one. Asserted from the
+        # inputs (home + session id), never by re-deriving the resolver, so a
+        # resolver returning "" or the wrong dir fails here.
+        assert f"archived it into {tmp_path}" in ctx
+        assert sid in ctx
+        assert "names the path in its briefing" not in ctx, (
+            "the guarded fallback fired for a well-formed session — "
+            "session-dir resolution returned empty when it should not"
+        )
+
+    def test_missing_session_id_falls_back_instead_of_naming_an_empty_dir(
+        self, tmp_path, monkeypatch
+    ):
+        ctx = _run_compact_main(tmp_path, monkeypatch, None)
+
+        assert "compact-summary.txt" in ctx
+        assert "names the path in its briefing" in ctx
+        # The two failure shapes a blind interpolation would produce.
+        assert "archived it into  as" not in ctx
+        assert "unknown-" not in ctx, (
+            "the unknown-* fallback session id must never reach an instruction "
+            "the lead may act on"
+        )

--- a/pact-plugin/tests/test_setup_memory.py
+++ b/pact-plugin/tests/test_setup_memory.py
@@ -24,14 +24,14 @@ class TestEnsureDirectories:
     def test_creates_directory(self, tmp_path):
         from scripts.setup_memory import ensure_directories
         target = tmp_path / "pact-memory"
-        with patch("scripts.setup_memory.PACT_MEMORY_DIR", target):
+        with patch.dict(os.environ, {"PACT_MEMORY_DIR": str(target)}):
             ensure_directories()
         assert target.is_dir()
 
     def test_idempotent(self, tmp_path):
         from scripts.setup_memory import ensure_directories
         target = tmp_path / "pact-memory"
-        with patch("scripts.setup_memory.PACT_MEMORY_DIR", target):
+        with patch.dict(os.environ, {"PACT_MEMORY_DIR": str(target)}):
             ensure_directories()
             ensure_directories()  # Should not raise
         assert target.is_dir()
@@ -68,7 +68,7 @@ class TestEnsureInitialized:
         from scripts.setup_memory import ensure_initialized
         target = tmp_path / "pact-memory"
         with (
-            patch("scripts.setup_memory.PACT_MEMORY_DIR", target),
+            patch.dict(os.environ, {"PACT_MEMORY_DIR": str(target)}),
             patch("scripts.setup_memory.ensure_directories"),
         ):
             result = ensure_initialized()
@@ -78,7 +78,7 @@ class TestEnsureInitialized:
         from scripts.setup_memory import ensure_initialized
         target = tmp_path / "pact-memory"
         with (
-            patch("scripts.setup_memory.PACT_MEMORY_DIR", target),
+            patch.dict(os.environ, {"PACT_MEMORY_DIR": str(target)}),
             patch("scripts.setup_memory.ensure_directories"),
         ):
             # Make the relative import fail
@@ -123,7 +123,7 @@ class TestGetRecommendations:
 class TestGetSetupStatus:
     def test_returns_expected_keys(self, tmp_path):
         from scripts.setup_memory import get_setup_status
-        with patch("scripts.setup_memory.PACT_MEMORY_DIR", tmp_path):
+        with patch.dict(os.environ, {"PACT_MEMORY_DIR": str(tmp_path)}):
             status = get_setup_status()
         assert "initialized" in status
         assert "dependencies" in status
@@ -133,21 +133,21 @@ class TestGetSetupStatus:
 
     def test_initialized_when_dir_exists(self, tmp_path):
         from scripts.setup_memory import get_setup_status
-        with patch("scripts.setup_memory.PACT_MEMORY_DIR", tmp_path):
+        with patch.dict(os.environ, {"PACT_MEMORY_DIR": str(tmp_path)}):
             status = get_setup_status()
         assert status["initialized"] is True
 
     def test_not_initialized_when_dir_missing(self, tmp_path):
         from scripts.setup_memory import get_setup_status
         missing = tmp_path / "nonexistent"
-        with patch("scripts.setup_memory.PACT_MEMORY_DIR", missing):
+        with patch.dict(os.environ, {"PACT_MEMORY_DIR": str(missing)}):
             status = get_setup_status()
         assert status["initialized"] is False
 
     def test_semantic_search_requires_both_deps(self, tmp_path):
         from scripts.setup_memory import get_setup_status
         with (
-            patch("scripts.setup_memory.PACT_MEMORY_DIR", tmp_path),
+            patch.dict(os.environ, {"PACT_MEMORY_DIR": str(tmp_path)}),
             patch("scripts.setup_memory.check_dependencies", return_value={"sqlite_vec": True, "model2vec": False}),
         ):
             status = get_setup_status()

--- a/pact-plugin/tests/test_setup_memory.py
+++ b/pact-plugin/tests/test_setup_memory.py
@@ -2,7 +2,7 @@
 Tests for pact-memory/scripts/setup_memory.py — memory system initialization.
 
 Tests cover:
-1. ensure_directories: creates PACT_MEMORY_DIR with correct permissions
+1. ensure_directories: creates the memory directory with correct permissions
 2. check_dependencies: sqlite_vec and model2vec detection
 3. ensure_initialized: directory + database init, failure handling
 4. get_setup_status: full status report
@@ -24,14 +24,14 @@ class TestEnsureDirectories:
     def test_creates_directory(self, tmp_path):
         from scripts.setup_memory import ensure_directories
         target = tmp_path / "pact-memory"
-        with patch.dict(os.environ, {"PACT_MEMORY_DIR": str(target)}):
+        with patch.dict(os.environ, {"PACT_TEST_MEMORY_DIR": str(target)}):
             ensure_directories()
         assert target.is_dir()
 
     def test_idempotent(self, tmp_path):
         from scripts.setup_memory import ensure_directories
         target = tmp_path / "pact-memory"
-        with patch.dict(os.environ, {"PACT_MEMORY_DIR": str(target)}):
+        with patch.dict(os.environ, {"PACT_TEST_MEMORY_DIR": str(target)}):
             ensure_directories()
             ensure_directories()  # Should not raise
         assert target.is_dir()
@@ -68,7 +68,7 @@ class TestEnsureInitialized:
         from scripts.setup_memory import ensure_initialized
         target = tmp_path / "pact-memory"
         with (
-            patch.dict(os.environ, {"PACT_MEMORY_DIR": str(target)}),
+            patch.dict(os.environ, {"PACT_TEST_MEMORY_DIR": str(target)}),
             patch("scripts.setup_memory.ensure_directories"),
         ):
             result = ensure_initialized()
@@ -78,7 +78,7 @@ class TestEnsureInitialized:
         from scripts.setup_memory import ensure_initialized
         target = tmp_path / "pact-memory"
         with (
-            patch.dict(os.environ, {"PACT_MEMORY_DIR": str(target)}),
+            patch.dict(os.environ, {"PACT_TEST_MEMORY_DIR": str(target)}),
             patch("scripts.setup_memory.ensure_directories"),
         ):
             # Make the relative import fail
@@ -123,7 +123,7 @@ class TestGetRecommendations:
 class TestGetSetupStatus:
     def test_returns_expected_keys(self, tmp_path):
         from scripts.setup_memory import get_setup_status
-        with patch.dict(os.environ, {"PACT_MEMORY_DIR": str(tmp_path)}):
+        with patch.dict(os.environ, {"PACT_TEST_MEMORY_DIR": str(tmp_path)}):
             status = get_setup_status()
         assert "initialized" in status
         assert "dependencies" in status
@@ -133,21 +133,21 @@ class TestGetSetupStatus:
 
     def test_initialized_when_dir_exists(self, tmp_path):
         from scripts.setup_memory import get_setup_status
-        with patch.dict(os.environ, {"PACT_MEMORY_DIR": str(tmp_path)}):
+        with patch.dict(os.environ, {"PACT_TEST_MEMORY_DIR": str(tmp_path)}):
             status = get_setup_status()
         assert status["initialized"] is True
 
     def test_not_initialized_when_dir_missing(self, tmp_path):
         from scripts.setup_memory import get_setup_status
         missing = tmp_path / "nonexistent"
-        with patch.dict(os.environ, {"PACT_MEMORY_DIR": str(missing)}):
+        with patch.dict(os.environ, {"PACT_TEST_MEMORY_DIR": str(missing)}):
             status = get_setup_status()
         assert status["initialized"] is False
 
     def test_semantic_search_requires_both_deps(self, tmp_path):
         from scripts.setup_memory import get_setup_status
         with (
-            patch.dict(os.environ, {"PACT_MEMORY_DIR": str(tmp_path)}),
+            patch.dict(os.environ, {"PACT_TEST_MEMORY_DIR": str(tmp_path)}),
             patch("scripts.setup_memory.check_dependencies", return_value={"sqlite_vec": True, "model2vec": False}),
         ):
             status = get_setup_status()


### PR DESCRIPTION
## Summary

The test suite opened write-capable connections to the developer's real memory store on every full run. This branch stops that, and the stopping is shown by measurement rather than by a passing suite.

**Scope note, stated because the commit count invites the wrong reading.** Five commits are the isolation fix and its version bump. The other six are separate concerns that surfaced during its review and are listed under *Also in this branch* below. Every one of them is small, and none is isolation work.

## Two mechanisms let it through

- The autouse isolation fixture redirected the store by patching `Path.home()`, which does not cross a process boundary, so any test spawning a child escaped it.
- The store location was bound at import time, so the redirect held only when the config module happened to first import inside a test.

## What changed

- The store location resolves at use time rather than at import. The module-level `PACT_MEMORY_DIR` path constant becomes `get_memory_dir()`, and `DB_PATH` becomes `get_db_path()`.
- **`PACT_TEST_MEMORY_DIR`** lets the harness redirect a spawned child explicitly, rather than inferring "am I under test" from the world. An inferred predicate fails silently in the allow direction; a variable cannot be wrong about whether it was set. That is the load-bearing reason for the design, not the relocation it also happens to provide.
- The name says *test* deliberately. It moves the database but **not** `session-tracking`, which answers to `CLAUDE_CONFIG_DIR`, so it is not a store-relocation feature and must not be used as one. Tracked as #1409 and #1410.
- A pathless production call still resolves the real store. This is asserted in a child process rather than argued.
- 13 tests covering the isolation guard itself, two of which fail when either isolation layer is removed.

## Verification

A green suite cannot tell the two states apart — it was green before the fix and is green after it. So the evidence here is measured.

**The controlled comparison.** One axis flips and nothing else: same fake home, same guard, same 154 tests, only the code changes.

- **109** home-derived connections on base, **0** on HEAD.
- The connecting-test set is identical across the two arms, 33 of 33.
- The fake store is byte-identical afterwards, by both `sha256` and `mtime_ns`. That witness does not depend on the probe.

**Set identity, not a count delta.** The 62 tests that connected before the fix are exactly the 62 that connect after it — zero lost, zero new, total connections preserved at 214. A count delta alone cannot rule out a zero achieved by tests silently not running. Set identity can.

**Both layers are now behaviourally tested.** The session floor and the per-test redirect each protect the real store, so each masked the other: removing either used to leave every test green. Two tests now fail on removal, proven across five mutation arms — including two that leave the source textually intact and change only behaviour, which a source-scanning test cannot see.

**Instrument coverage, stated with its bound.** The probe is a `sitecustomize` module on `PYTHONPATH`, so it enters every Python child that inherits the environment, across 478 shards in one run. It is not in-process only. Only the first `sitecustomize` on `PYTHONPATH` loads, and one test file prepends its own, so 7 memory-CLI children are unobserved. That bounds the measurement, not the fix: those children still inherit the variable.

**A positive control** aborts on an unfixed extract, so the instrument discriminates rather than always reporting clean.

### What the numbers do not show

Stated because an earlier revision of this description overclaimed on both points.

- The **207-connection baseline** was itself measured under a fake home: 207 of its 214 hits went to a scratch path, not to the developer's own store. It is a sound proxy for the size of the exposure. It is **not** a controlled before-and-after against the real store, and pairing it with a post-fix zero would change two variables at once. The one-axis flip above is the controlled comparison.
- **No reported number witnesses a real-`HOME` run.** After the fix, resolved paths are home-independent by construction, so every figure here reads identically either way.
- **The connection census cannot observe one route at all.** `hooks/track_files.py` reaches the same tree through `mkdir` and `open`, never through `connect`, so the guard cannot see it by construction. A separate file-write census measured it: 62 tests seen by connections, 83 by file writes, 21 only-file, **0 writes under the real store**. Tracked as #1409.

## Also in this branch

Six commits, each its own concern, none of them isolation work.

| commit | what |
|---|---|
| `644ddce4` | The secretary archives the compaction summary rather than deleting it. That path is a global singleton written with `O_TRUNC`, and the lead is told to read it in the same block that re-engages the secretary, so the delete raced a reader as well as destroying the only copy. Both fired for real. |
| `9edce447` | The resume instruction names the archive alongside the canonical path, guarded because the session directory is the empty string when the session id is missing. Covered by a non-mocked integration test. |
| `806b4191` | A pin on the archive filename prefix, which those two commits now state independently with nothing making them agree. |
| `3e18642f` | A write-time check on variety rationales, mirrored into the consolidated protocol in the same commit. Tracked as #1408. |
| `d51d1184` | The guard refusal said a write "would land in the real store". False once the harness assigns the directory suite-wide, and false hardest inside the test named for that property. Reworded, with the missing absence assertion added. The predicate is untouched. |
| `d4416a29` | Two `import conftest` sites replaced by asking pytest which module it loaded. The re-import built a second module object and misled two reviewers in opposite directions. Removes the smaller of two sources of leaked temp directories; the larger is untouched and tracked as #1411. |

## What this does not close

- **#1190 stays open.** Its `PACT_MEMORY_DIR` half is fixed here. Its `TOKEN_DIR` half in `hooks/shared/merge_guard_common.py` is byte-identical to `main` and untouched.
- **#1411 stays open.** One of two sources removed, and the smaller one.
- **#1408 stays open.** Its fix ships here, and it names two further faults this branch does not address.
- **#1265 stays open.** Neither leak it names is touched, though the redirected default shrinks the blast radius.

## Version

4.6.27 to 4.6.28 (patch).
