### PR TITLE
Correct the refuted reason the memory-repair tools give for refusing the memory package

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.30",
+      "version": "4.6.31",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.30/     # Plugin version
+│               └── 4.6.31/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.30",
+  "version": "4.6.31",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.30
+> **Version**: 4.6.31
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/scripts/memory_repair/__init__.py
+++ b/pact-plugin/scripts/memory_repair/__init__.py
@@ -2,10 +2,13 @@
 
 Location: pact-plugin/scripts/memory_repair/__init__.py
 
-Every module in this package opens `sqlite3` directly. No module here
-imports `cli.py` or `memory_api.py` from the pact-memory scripts package.
-An import of that package EXECUTES code that creates the live store
-directory, so an import is a write. These tools must run before that
-package is safe to import.
+Each module here opens `sqlite3` directly, and imports neither `cli.py` nor
+`memory_api.py` from the pact-memory scripts package. Keep each module here,
+and each module added later, the same way. In that package, functions create
+the live store directory as a side result of a path resolution, so an import
+puts each of them one call away. This rule holds so that nobody must audit
+which call is safe. Do not read an absent import as a guarantee, because a
+subprocess reaches those functions with no import at all. These tools depend
+on nothing from that package, so they run without it.
 """
 from __future__ import annotations

--- a/pact-plugin/scripts/memory_repair/__init__.py
+++ b/pact-plugin/scripts/memory_repair/__init__.py
@@ -2,9 +2,9 @@
 
 Location: pact-plugin/scripts/memory_repair/__init__.py
 
-Each module here opens `sqlite3` directly, and imports neither `cli.py` nor
-`memory_api.py` from the pact-memory scripts package. Keep each module here,
-and each module added later, the same way. In that package, functions create
+Each module here opens `sqlite3` directly and imports nothing from the
+pact-memory scripts package. Keep each module here, and each module added
+later, free of an import from that package. In that package, functions create
 the live store directory as a side result of a path resolution, so an import
 puts each of them one call away. This rule holds so that nobody must audit
 which call is safe. Do not read an absent import as a guarantee, because a

--- a/pact-plugin/scripts/memory_repair/shred_detect.py
+++ b/pact-plugin/scripts/memory_repair/shred_detect.py
@@ -36,9 +36,12 @@ the file: a `-wal` sidecar or a `-shm` sidecar stops the run. The check and
 the open both use one resolved path, so the check cannot bind to a
 different spelling of the same file.
 
-THE TOOL IMPORTS NO MODULE FROM THE PACT-MEMORY SCRIPTS PACKAGE. An import
-of that package runs code that creates the live store directory, so an
-import is a write.
+THE TOOL IMPORTS NO MODULE FROM THE PACT-MEMORY SCRIPTS PACKAGE. Functions
+in that package create the live store directory as a side result of a path
+resolution, so an import puts each of them one call away. This rule holds
+so that nobody must audit which call is safe. Do not read an absent import
+as a guarantee, because a subprocess reaches those functions with no import
+at all.
 
 THE TOOL READS THE `memories` TABLE ONLY. That table is an ordinary sqlite
 table. The tool names the `vec_memories` virtual table in no query, so it

--- a/pact-plugin/tests/test_archive_pin.py
+++ b/pact-plugin/tests/test_archive_pin.py
@@ -878,10 +878,21 @@ class TestLiveDbGuard:
     Neither covers the other's cases. The parent guard cannot see a spawn that
     bypasses it; the child guard cannot see intent that never crossed.
 
-    EVERY TEST HERE SANDBOXES `HOME`. That is not decoration: `config.py`
-    resolves the database path at USE time, so `HOME` redirects the store in
-    this process and in a child alike. Sandbox `HOME` in each test added
-    here. These tests exercise the exact production shape (no --db-path)
+    EACH SPAWN HERE SANDBOXES `HOME` FOR THE CHILD. That is not decoration.
+    `config.py` resolves the database path at USE time, and a child is a fresh
+    interpreter, so it reads `HOME` and lands in the sandbox. Sandbox `HOME` for
+    each spawn added here.
+
+    IN THIS PROCESS THE LEVER IS DIFFERENT AND `HOME` IS INERT. The autouse
+    fixture `_isolate_config_root_to_tmp` patches `Path.home` and states that it
+    deliberately does NOT set `HOME`. So an in-process `HOME` change moves no
+    store, and the in-process protection comes from that fixture rather than
+    from anything this class does. Do not read the child sandbox as in-process
+    protection, and do not build an arm on an in-process `HOME` change: it
+    measures nothing. `test_the_store_path_resolves_at_use_time` below pins the
+    use-time property that the child leg rests on.
+
+    These tests exercise the exact production shape (no --db-path)
     with zero risk to the live store, which is only possible because the
     boundary that makes the defect hard to guard is the same boundary that
     makes it safe to test.
@@ -911,6 +922,63 @@ class TestLiveDbGuard:
             [sys.executable, str(cli), "get", "f" * 32, *extra_argv],
             capture_output=True, text=True, timeout=120, env=env,
         )
+
+    def test_the_store_path_resolves_at_use_time(self, tmp_path, monkeypatch):
+        """The class docstring above states a BEHAVIOUR. This asserts it.
+
+        WHY AN ARM RATHER THAN A TEXT PIN ON THAT SENTENCE. A text pin goes red
+        when the WORDS change. This goes red when the BEHAVIOUR changes, and the
+        behaviour is the condition that makes the sentence incorrect, so it is
+        what the guard must watch. A pin on the prose is green on the day the
+        resolver changes, which is the one day it is needed.
+
+        THE CLAIM THIS DISCHARGES: `config.py` resolves the store path at USE
+        time. Under the refuted claim it bound the path once at import, and the
+        second resolution below would then repeat the first.
+
+        WHY THE LEVER IS `Path.home` AND NOT THE `HOME` VARIABLE. The autouse
+        fixture `_isolate_config_root_to_tmp` patches `Path.home` and states
+        that it deliberately does NOT set `HOME`, so an in-process `HOME` change
+        moves nothing here and an arm built on one measures nothing. This drives
+        the lever the harness leaves live.
+
+        `resolve_db_path` CREATES NO DIRECTORY, so this arm reads a location and
+        leaves no tree behind, in the sandbox or in the live store.
+        """
+        from pathlib import Path as _Path
+
+        from scripts.config import (  # the pytest harness is the stated carve-out
+            MEMORY_DIR_ENV,
+            STORE_ORIGIN_HOME,
+            resolve_db_path,
+            store_path_origin,
+        )
+
+        # THE VARIABLE OUTRANKS THE HOME LEG AND THE SUITE SETS IT FOR EACH TEST.
+        # Without this the two resolutions below agree for a reason that has
+        # nothing to do with use-time resolution, and the arm proves nothing.
+        monkeypatch.delenv(MEMORY_DIR_ENV, raising=False)
+        assert store_path_origin() == STORE_ORIGIN_HOME, (
+            "the resolver is not on its home leg, so this arm would measure an "
+            "override rather than the behaviour the class docstring claims"
+        )
+
+        first = tmp_path / "first-home"
+        monkeypatch.setattr(_Path, "home", lambda: first)
+        from_first = resolve_db_path()
+
+        second = tmp_path / "second-home"
+        monkeypatch.setattr(_Path, "home", lambda: second)
+        from_second = resolve_db_path()
+
+        assert from_first != from_second, (
+            "the resolved store did not follow the second change, so "
+            "`config.py` bound the path once instead of resolving it at use "
+            "time. The class docstring above is then incorrect, and the child "
+            "sandbox rests on a property that no longer holds."
+        )
+        assert first in from_first.parents, from_first
+        assert second in from_second.parents, from_second
 
     def test_child_refuses_the_live_db_when_spawned_under_pytest(
         self, tmp_path
@@ -1138,10 +1206,16 @@ class TestLiveDbGuard:
             "database. Most likely cause: _run_memory_cli stopped passing a "
             "full env copy."
         )
+        # THIS BLOCK PINS NOTHING IN `cli.py`. It probes the CHILD environment
+        # and compares nothing against that module, so the docstring named below
+        # can be rewritten with this suite green. A citation inside an assertion
+        # MESSAGE renders only when the assertion fails. A reader who searches
+        # for what guards a `cli.py` docstring must not stop at a hit like this
+        # one: right file, incorrect mechanism.
         assert report["pytest_importable_here"] is False, (
             "pytest IS visible in the child, so the guard could have used an "
-            "in-process check — revisit the forced-choice reasoning in "
-            "cli.py's _refuse_live_db_under_pytest docstring"
+            "in-process check. Re-read the forced-choice reasoning recorded "
+            "with the child-side live-store refusal."
         )
 
     def test_parent_rejects_falsy_but_present_db_path(self, tmp_path):

--- a/pact-plugin/tests/test_archive_pin.py
+++ b/pact-plugin/tests/test_archive_pin.py
@@ -878,13 +878,13 @@ class TestLiveDbGuard:
     Neither covers the other's cases. The parent guard cannot see a spawn that
     bypasses it; the child guard cannot see intent that never crossed.
 
-    EVERY TEST HERE SANDBOXES `HOME`. That is not decoration: `config.py` binds
-    the database path from `Path.home()` AT IMPORT, so an in-process HOME
-    change is inert -- but a child re-imports, so HOME in the CHILD'S env does
-    redirect it. These tests exercise the exact production shape (no
-    --db-path) with zero risk to the live store, which is only possible
-    because the boundary that makes the defect hard to guard is the same
-    boundary that makes it safe to test.
+    EVERY TEST HERE SANDBOXES `HOME`. That is not decoration: `config.py`
+    resolves the database path at USE time, so `HOME` redirects the store in
+    this process and in a child alike. Sandbox `HOME` in each test added
+    here. These tests exercise the exact production shape (no --db-path)
+    with zero risk to the live store, which is only possible because the
+    boundary that makes the defect hard to guard is the same boundary that
+    makes it safe to test.
     """
 
     @staticmethod

--- a/pact-plugin/tests/test_archive_pin.py
+++ b/pact-plugin/tests/test_archive_pin.py
@@ -878,10 +878,20 @@ class TestLiveDbGuard:
     Neither covers the other's cases. The parent guard cannot see a spawn that
     bypasses it; the child guard cannot see intent that never crossed.
 
-    EACH SPAWN HERE SANDBOXES `HOME` FOR THE CHILD. That is not decoration.
-    `config.py` resolves the database path at USE time, and a child is a fresh
-    interpreter, so it reads `HOME` and lands in the sandbox. Sandbox `HOME` for
-    each spawn added here.
+    A SPAWN THAT RESOLVES THE STORE FROM `HOME` SANDBOXES IT. That is not
+    decoration. `config.py` resolves the database path at USE time, and a child
+    is a fresh interpreter, so it reads `HOME` and lands in the sandbox.
+
+    TWO KINDS OF SPAWN HERE NEED NO SANDBOX, AND THIS IS MEASURED RATHER THAN
+    ASSUMED. A child given `--db-path` opens the store that path names and
+    resolves nothing from `HOME`, which is how the `memory_store` fixture
+    works. A child pointed at a PROBE cannot open the store at all, which is
+    how the tripwire arm works. AN INSTRUCTION DEMANDING A SANDBOX FROM EACH
+    SPAWN WOULD CONDEMN THE TWO OF THEM, so the rule is narrower than that.
+
+    `_refuse_a_store_reaching_spawn` below holds the rule as a mechanism rather
+    than as a request: a child that can reach the pact-memory CLI with no
+    `--db-path` must carry a `HOME` that does not resolve the operator's home.
 
     IN THIS PROCESS THE LEVER IS DIFFERENT AND `HOME` IS INERT. The autouse
     fixture `_isolate_config_root_to_tmp` patches `Path.home` and states that it
@@ -921,6 +931,139 @@ class TestLiveDbGuard:
         return subprocess.run(
             [sys.executable, str(cli), "get", "f" * 32, *extra_argv],
             capture_output=True, text=True, timeout=120, env=env,
+        )
+
+    @staticmethod
+    def _operator_home() -> Path:
+        """The home the OPERATOR resolves, read from the password database.
+
+        NOT `Path.home()`, which the autouse `_isolate_config_root_to_tmp`
+        fixture patches, and NOT `HOME`, which that fixture deliberately leaves
+        alone. The password database is the one source that neither lever
+        moves, so it is what says whether a child reaches the real store.
+        """
+        import pwd  # POSIX. This suite does not run where it is absent.
+
+        return Path(pwd.getpwuid(os.getuid()).pw_dir).resolve()
+
+    @pytest.fixture(autouse=True)
+    def _refuse_a_store_reaching_spawn(self, monkeypatch):
+        """Make a spawn that can reach the live store FAIL rather than ask.
+
+        The class docstring tells the next author to sandbox `HOME`. AN
+        INSTRUCTION THAT REQUESTS COMPLIANCE IS NOT A MECHANISM. This observes
+        each spawn that runs and refuses the one that can reach the store.
+
+        WHY THE PREDICATE IS THE SAFETY PROPERTY RATHER THAN `tmp_path`. A
+        sandbox below `tmp_path` is the CONVENTION here. The property that
+        keeps the store safe is different: the child must not resolve the
+        OPERATOR'S home. A spawn that points `HOME` at another temporary root
+        is safe, and a `tmp_path`-shaped assertion reddens it, which taxes an
+        author who did the safe thing in an unexpected place.
+
+        WHY IT IS SCOPED TO STORE-REACHING SPAWNS. Not each child here is a
+        hazard. `test_tripwire_the_child_actually_receives_pytest_current_test`
+        spawns a PROBE written into `tmp_path` and passes the inherited
+        environment, which carries the operator's `HOME`. That is safe, because
+        the probe cannot open the store. An arm that demanded a sandbox from
+        EACH spawn reddens that test, which is an over-block on correct work.
+
+        WHY AN EXPLICIT `--db-path` EXEMPTS A SPAWN, AND THE ARM MEASURED THIS
+        RATHER THAN ASSUMED IT. A child given `--db-path` opens the store it
+        names and resolves nothing from `HOME`, so its `HOME` cannot reach the
+        operator. The `memory_store` fixture spawns `setup --db-path` with the
+        inherited environment, and an arm without this exemption reddens it.
+        THE HAZARD IS THE PRODUCTION SHAPE WITH NO `--db-path`, which is the
+        shape this class exercises on purpose.
+
+        ITS BOUND, STATED: this sees the spawns that RUN. A skipped test
+        escapes it, and so does a spelling it does not wrap.
+        `test_no_spawn_spelling_escapes_the_guard` closes the second half.
+        """
+        real_run = subprocess.run
+        memory_package = (
+            Path(archive_pin.__file__).resolve().parent.parent
+            / "skills" / "pact-memory"
+        )
+        operator_home = self._operator_home()
+
+        def guarded(argv, *args, **kwargs):
+            words = [
+                str(word)
+                for word in (argv if isinstance(argv, (list, tuple)) else [argv])
+            ]
+            reaches_store = any(str(memory_package) in word for word in words)
+            resolves_from_home = "--db-path" not in words
+            if reaches_store and resolves_from_home:
+                env = kwargs.get("env")
+                assert env is not None, (
+                    "this spawn can reach the pact-memory CLI and passes no "
+                    "env, so the child inherits HOME and resolves the store "
+                    f"below {operator_home}. Pass an env with a sandboxed HOME."
+                )
+                home = env.get("HOME")
+                assert home, (
+                    "this spawn can reach the pact-memory CLI and its env "
+                    "carries no HOME, so the child falls back to the password "
+                    f"database and resolves the store below {operator_home}."
+                )
+                assert Path(home).resolve() != operator_home, (
+                    f"this spawn sets HOME to {home}, which resolves the "
+                    f"operator's own home at {operator_home}, so the child "
+                    "opens the LIVE memory store. Point HOME into a sandbox. "
+                    "Below tmp_path is the shape used here, and any directory "
+                    "other than the operator's home satisfies this arm."
+                )
+            return real_run(argv, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", guarded)
+
+    def test_no_spawn_spelling_escapes_the_guard(self):
+        """The fixture above wraps `subprocess.run` and nothing else.
+
+        So a spawn reached by another spelling leaves its sight. This REFUSES
+        those spellings in this class rather than widening the wrapper, because
+        a refusal has a fixed alphabet where a wrapper list grows forever.
+        """
+        source = Path(__file__).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        cls = next(
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.ClassDef) and node.name == type(self).__name__
+        )
+
+        def dotted(node):
+            parts = []
+            while isinstance(node, ast.Attribute):
+                parts.append(node.attr)
+                node = node.value
+            if isinstance(node, ast.Name):
+                parts.append(node.id)
+                return ".".join(reversed(parts))
+            return None
+
+        wrapped = "subprocess.run"
+        unwrapped = {
+            "subprocess.Popen", "subprocess.check_output", "subprocess.call",
+            "subprocess.check_call", "os.system", "os.popen", "os.execv",
+            "os.execve", "os.spawnv", "os.posix_spawn",
+        }
+        seen = [
+            dotted(node.func) for node in ast.walk(cls) if isinstance(node, ast.Call)
+        ]
+        escaping = sorted({name for name in seen if name in unwrapped})
+        assert not escaping, (
+            f"{escaping} spawn a child in this class and the guard fixture "
+            f"wraps {wrapped!r} alone, so those calls reach a child unobserved. "
+            f"Route them through `_spawn_cli`, or wrap them in the fixture too."
+        )
+
+        # THE FLOOR. Without it a renamed class or a broken walk makes the
+        # assertion above pass over an empty set, which is the shape that ships
+        # a guard reporting green because it read nothing.
+        assert seen.count(wrapped) >= 1, (
+            f"the walk over {type(self).__name__} found no {wrapped!r} call, so "
+            f"the refusal above passed over an empty set and proves nothing."
         )
 
     def test_the_store_path_resolves_at_use_time(self, tmp_path, monkeypatch):

--- a/pact-plugin/tests/test_import_bar_cause_presence.py
+++ b/pact-plugin/tests/test_import_bar_cause_presence.py
@@ -3,20 +3,36 @@ Presence pins for the import-bar cause in the memory-repair package.
 
 Location: pact-plugin/tests/test_import_bar_cause_presence.py
 
-WHAT THIS PROVES, AND IT IS NARROW ON PURPOSE. Each module in the
-memory-repair package that states the import bar also carries the sentence
-that forbids an audit of which call is safe. That sentence is the only one
-that stops a reader treating the bar as a DISTANCE to be measured rather than
-a rule to keep.
+WHAT THIS PROVES, AND IT IS NARROW ON PURPOSE. FOUR PROPERTIES, and the
+heading below states what each one leaves open. Two are a PRESENCE, one is a
+POPULATION RULE, and one is an ABSENCE.
+
+  1. PRESENCE. Each module in the memory-repair package that states the import
+     bar also carries the sentence that forbids an audit of which call is safe.
+     That sentence is the only one that stops a reader who treats the bar as a
+     DISTANCE to be measured rather than a rule to keep.
+  2. PRESENCE. The package `__init__.py` carries the obligation that binds a
+     later editor.
+  3. POPULATION RULE. Each .py file in the package states the bar or takes a
+     declared exemption, and each carrier known today stays in the derived
+     population.
+  4. ABSENCE. No file in the plugin tree carries one of the refuted spellings,
+     apart from a declared exclusion.
 
 WHAT A GREEN HERE DOES NOT MEAN. Read this before you trust it.
 
   * It does NOT check that the surrounding prose is true. No test can read a
     natural-language cause for truth.
-  * It does NOT catch an incorrect cause ADDED elsewhere, in this package or
-    outside it. The population is derived from the files that state the bar,
-    so a new file that states nothing about it is invisible here.
-  * It proves the PRESENCE of two sentences, and nothing more.
+  * It does NOT catch an incorrect cause in NEW WORDS. The refuted-spelling
+    arms hold the spellings that shipped and were removed, so they catch a
+    revert or a bad merge that reintroduces the ORIGINAL BYTES. A paraphrase
+    passes.
+  * THE REFUTED-SPELLING ARMS REACH THE PLUGIN TREE AND NO FURTHER. They walk
+    `PLUGIN_DIR`, so a refuted spelling written above that directory, at the
+    repository root, is outside the scan.
+  * A NEW FILE THAT SAYS NOTHING IS REACHED INSIDE THE PACKAGE, AND NOT
+    OUTSIDE IT. The population rule fails on a new .py in the package that does
+    not state the bar. The same file elsewhere in the tree is invisible here.
 
 THE POPULATION HAS THREE PARTS, AND EACH COVERS A FAILURE THE OTHERS MISS.
 
@@ -26,8 +42,10 @@ THE POPULATION HAS THREE PARTS, AND EACH COVERS A FAILURE THE OTHERS MISS.
      of the population AND declared exempt, and a carrier file deleted. A
      plain rename is NOT one of them, because part 3 catches that on its own.
   3. `EXEMPT_MODULES` extends part 2 to files nobody has written yet, which
-     fixed paths cannot reach. A module leaves the population only by a
-     declared line, and not by a rename that reads as tidying.
+     fixed paths cannot reach. AGAINST A RENAME, a module leaves the
+     must-state-the-bar rule only by a declared line, and not by a rename that
+     reads as tidying. A DELETION is a second exit, and part 2 covers it for
+     the paths it holds.
 
 EACH SET IN THIS FILE IS KEYED ON A RELATIVE PATH AND NOT ON A BASENAME. A
 basename is not an identity: `__init__.py` occurs 9 times in the plugin tree,
@@ -50,12 +68,14 @@ rule narrower than the one that must hold.
 
 If you update a constant to agree with new prose, or to quiet a red, and you
 give no cause, this file becomes a MIRROR of the thing it guards, and its
-green stops meaning anything. That covers the required sentences, the subject
-phrase the population is derived from, and each set of file names.
+green stops meaning anything.
 
-MATCHING IS WHITESPACE-INSENSITIVE BY NECESSITY. Each guarded sentence wraps
-across lines in the file that carries it, so a line-oriented search or a
-literal comparison cannot find it even when it is present. Flatten first.
+MATCHING IGNORES WHITESPACE AND CASE, AND `carries` DOES THE TWO TOGETHER.
+WHITESPACE: each guarded sentence wraps across lines in the file that carries
+it, so a line-oriented search or a literal comparison cannot find it even when
+it is present. Flatten first. CASE: this repository capitalises an
+anti-permission rule for emphasis, so a strict comparison reddens on a
+legitimate re-capitalisation. The reason for each sits above `carries`.
 
 Used by: pytest.
 """
@@ -100,15 +120,15 @@ BAR_SUBJECT = "pact-memory scripts package"
 # THE FLOOR. Its unique coverage is TWO conditions, and `TestTheFloorEarnsIts
 # Place` below asserts each one by emptying this set and reading the result.
 #   1. A carrier renamed out of the population AND declared exempt. The
-#      exempt arm then passes, because the name is declared, and only this
+#      exempt arm then passes, because the path is declared, and only this
 #      floor holds.
 #   2. A carrier file deleted. It leaves the disk and the population together,
 #      so the exempt arm sees nothing missing.
 # A PLAIN RENAME IS NOT UNIQUE TO THIS FLOOR. The exempt arm catches that on
 # its own, measured with this set emptied.
 #
-# To remove a name from this floor, state a cause, as for the two sentence
-# constants above. A name removed to quiet a red turns the floor into a report
+# To remove a path from this floor, state a cause, as for the two sentence
+# constants above. A path removed to quiet a red turns the floor into a report
 # of the current population, which is the same mirror failure.
 MINIMUM_CARRIERS = frozenset({"__init__.py", "shred_detect.py"})
 
@@ -116,15 +136,28 @@ MINIMUM_CARRIERS = frozenset({"__init__.py", "shred_detect.py"})
 # `PACKAGE_DIR`, as stated above `MINIMUM_CARRIERS`. Empty today, and that is
 # the point: each .py file in this package must state the bar, or appear here.
 #
-# The floor above protects the carriers known when it was written. It cannot
-# protect a carrier written later, because its names are fixed. This closes
-# that gap from the other side: a file leaves the population ONLY by an entry
-# here, which is a visible line in a diff, rather than by a rename of the
-# subject phrase, which reads as tidying and is what defeated the derivation.
+# AN ENTRY HERE LIFTS ONE RULE AND NOT THE OTHER, AND THIS FILE USES THE WORD
+# POPULATION FOR TWO SETS. An entry removes the file from the MUST-STATE-THE-BAR
+# rule above. It does NOT remove the file from the DERIVED POPULATION, which is
+# the set of files that DO state the bar and which
+# `modules_missing_the_cause_clause` reads. So an exempt file that states the
+# bar is under the cause-clause rule as before.
 #
-# To add a name here, state a cause. A name added to quiet a red is the mirror
-# failure again. A KNOWN CARRIER CANNOT ESCAPE THIS WAY: MINIMUM_CARRIERS is
-# checked separately, so an exemption for one of those names goes red anyway.
+# The floor above protects the carriers known when it was written. It cannot
+# protect a carrier written later, because its paths are fixed. This closes
+# that gap from the other side, AGAINST A RENAME: a file leaves the
+# must-state-the-bar rule by an entry here, which is a visible line in a diff,
+# rather than by a rename of the subject phrase, which reads as tidying and is
+# what defeated the derivation. DELETION IS A SECOND EXIT AND IT TAKES NO ENTRY.
+# `MINIMUM_CARRIERS` covers a deletion for the paths it holds. A carrier added
+# later and then deleted is covered by nothing here.
+#
+# To add a path here, state a cause. A path added to quiet a red is the mirror
+# failure again. A KNOWN CARRIER CANNOT ESCAPE THIS WAY, AND THE REASON IS NOT
+# THAT AN EXEMPTION ALONE GOES RED. An exemption alone changes nothing, because
+# the file continues to state the bar and stays in the derived population. The
+# escape asks for an exemption AND a rename together, and `MINIMUM_CARRIERS`
+# reads the derived population, so it goes red on that pair.
 EXEMPT_MODULES: frozenset = frozenset()
 
 # The tree the refuted-spelling arms walk. A FILESYSTEM WALK and NOT a git
@@ -326,7 +359,7 @@ class TestThePopulationRules:
             f"derived population and their copy of the required sentence is "
             f"now unguarded. Either the docstring was rewritten, or the "
             f"subject phrase {BAR_SUBJECT!r} changed. Do not repair this by "
-            f"removing a name from MINIMUM_CARRIERS without a stated cause."
+            f"removing a path from MINIMUM_CARRIERS without a stated cause."
         )
 
     def test_each_module_states_the_bar_or_is_declared_exempt(self):
@@ -334,15 +367,18 @@ class TestThePopulationRules:
 
         MINIMUM_CARRIERS holds fixed paths, so it cannot reach a carrier added
         later. This reaches it: a new .py file must state the bar, or take a
-        line in EXEMPT_MODULES. A file then leaves the population only by a
-        visible declaration, and not by a rename of the subject phrase.
+        line in EXEMPT_MODULES. AGAINST A RENAME, a file then leaves THIS RULE
+        only by a visible declaration. A DELETED file leaves by a second exit
+        and takes no declaration, and the floor above covers that for the paths
+        it holds.
         """
         silent = modules_neither_stating_nor_exempt(PACKAGE_DIR, EXEMPT_MODULES)
         assert not silent, (
             f"{silent} do not name the guarded package. Add the import-bar "
             f"paragraph to each, or add the path to EXEMPT_MODULES with a "
-            f"stated cause. A module outside the population carries none of "
-            f"the sentences the arms below require."
+            f"stated cause. AN EXEMPTION LIFTS THIS RULE ALONE: a module that "
+            f"takes a line in EXEMPT_MODULES and states the bar anyway is "
+            f"under the cause-clause rule as before."
         )
 
 
@@ -381,7 +417,13 @@ class TestTheInstrumentIsLive:
 
 
 class TestTheCauseClauseIsPresent:
-    """The population is BOTH carrier files, and it is derived rather than listed."""
+    """The cause clause over the DERIVED population, and not over a listed one.
+
+    The first two arms read the package on disk, so a carrier added later is
+    covered on the day it arrives and no count in this class goes stale. The
+    last arm reads a package built inside the test, because the boundary it
+    pins asks for a module the shipped package does not hold.
+    """
 
     def test_each_module_stating_the_bar_carries_the_cause_clause(self):
         missing = modules_missing_the_cause_clause(PACKAGE_DIR)
@@ -401,6 +443,59 @@ class TestTheCauseClauseIsPresent:
             f"editor. A description of an invariant does not command its "
             f"preservation. Required sentence: {REQUIRED_PACKAGE_OBLIGATION!r}"
         )
+
+    def test_an_exemption_does_not_lift_the_cause_clause_requirement(
+        self, tmp_path, monkeypatch
+    ):
+        """AN EXEMPTION LIFTS ONE RULE, and the arm message once said all of them.
+
+        `modules_missing_the_cause_clause` derives from `modules_stating_the_bar`
+        and reads no exemption at all. So a module that takes a line in
+        `EXEMPT_MODULES` and states the bar anyway is under the cause-clause
+        rule as before.
+
+        THE EXEMPTION MUST DO WORK HERE, or this arm agrees with a mechanism
+        that is broken. `silent.py` carries that weight: the population
+        predicate reports it without the exemption and reports nothing with it.
+        `helpers.py` then shows the cause arm reaches an EXEMPT module. The
+        last pair is the control: it puts the clause into the same file and
+        reads the predicate again, so the red above comes from the absent
+        clause and not from the construction.
+
+        WHY `EXEMPT_MODULES` IS PATCHED, AND THE ARM IS BLIND WITHOUT IT. The
+        shipped set is EMPTY. An edit that teaches the cause arm to read that
+        set changes nothing observable while it stays empty, so a local
+        exemption alone cannot catch the edit that makes the message above
+        true. This puts the same two paths into the shipped constant, so such
+        an edit drops `helpers.py` and this arm fails.
+
+        RESIDUAL, AND IT IS THE BOUND OF THE WHOLE ARM. This pins the
+        BEHAVIOUR. It does not catch an edit to the arm message above that says
+        something incorrect about behaviour that did not change.
+        """
+        package = tmp_path / "memory_repair"
+        package.mkdir()
+        silent = package / "silent.py"
+        carrier = package / "helpers.py"
+        silent.write_text('"""This module says nothing."""\n', encoding="utf-8")
+        carrier.write_text(f'"""Names the {BAR_SUBJECT}."""\n', encoding="utf-8")
+        exempt = frozenset({"silent.py", "helpers.py"})
+        monkeypatch.setitem(globals(), "EXEMPT_MODULES", exempt)
+
+        assert modules_neither_stating_nor_exempt(package, frozenset()) == ["silent.py"]
+        assert modules_neither_stating_nor_exempt(package, exempt) == []
+
+        assert modules_missing_the_cause_clause(package) == ["helpers.py"], (
+            "the cause arm let an EXEMPT module through. An exemption lifts "
+            "the must-state-the-bar rule alone, so the arm message above is "
+            "correct only while this holds."
+        )
+
+        carrier.write_text(
+            f'"""Names the {BAR_SUBJECT}. {REQUIRED_CAUSE_CLAUSE}"""\n',
+            encoding="utf-8",
+        )
+        assert modules_missing_the_cause_clause(package) == []
 
 
 class TestTheFloorEarnsItsPlace:

--- a/pact-plugin/tests/test_import_bar_cause_presence.py
+++ b/pact-plugin/tests/test_import_bar_cause_presence.py
@@ -7,7 +7,7 @@ WHAT THIS PROVES, AND IT IS NARROW ON PURPOSE. Each module in the
 memory-repair package that states the import bar also carries the sentence
 that forbids an audit of which call is safe. That sentence is the only one
 that stops a reader treating the bar as a DISTANCE to be measured rather than
-a rule to keep, and it was dropped once with nothing to catch it.
+a rule to keep.
 
 WHAT A GREEN HERE DOES NOT MEAN. Read this before you trust it.
 
@@ -21,13 +21,18 @@ WHAT A GREEN HERE DOES NOT MEAN. Read this before you trust it.
 THE POPULATION HAS THREE PARTS, AND EACH COVERS A FAILURE THE OTHERS MISS.
 
   1. The DERIVATION reaches a carrier written later, on the day it arrives.
-  2. `MINIMUM_CARRIERS` refuses SHRINKAGE for the carriers known today. A
-     derived population can shrink: rename the subject phrase in one file and
-     that file leaves the set, after which its copy of a required sentence is
-     deletable with each arm green.
+  2. `MINIMUM_CARRIERS` refuses SHRINKAGE for the carriers known today. It
+     catches TWO conditions that no other arm catches: a carrier renamed out
+     of the population AND declared exempt, and a carrier file deleted. A
+     plain rename is NOT one of them, because part 3 catches that on its own.
   3. `EXEMPT_MODULES` extends part 2 to files nobody has written yet, which
-     fixed names cannot reach. A module leaves the population only by a
+     fixed paths cannot reach. A module leaves the population only by a
      declared line, and not by a rename that reads as tidying.
+
+EACH SET IN THIS FILE IS KEYED ON A RELATIVE PATH AND NOT ON A BASENAME. A
+basename is not an identity: `__init__.py` occurs 9 times in the plugin tree,
+so a basename key cannot separate a top-level file from one in a subdirectory,
+and the most likely new file carries the most common basename.
 
 An arm that asserts ONE member proves the set is not empty and proves nothing
 about the rest. Non-emptiness and completeness are different properties.
@@ -57,6 +62,7 @@ Used by: pytest.
 from __future__ import annotations
 
 import re
+import shutil
 from pathlib import Path
 
 import pytest
@@ -69,8 +75,14 @@ REQUIRED_CAUSE_CLAUSE = (
 )
 
 # The obligation that reaches an edit to an EXISTING module, not new ones only.
+# THE CAUSE FOR THE CURRENT WORDING: the earlier form ended "the same way",
+# which pointed back at a description naming two files of the fourteen in the
+# guarded package. A reader could import a third module and stay inside the
+# letter of the rule. The obligation now names the property it wants, so it
+# leaves no population-shaped anchor for a successor phrase to point at.
 REQUIRED_PACKAGE_OBLIGATION = (
-    "Keep each module here, and each module added later, the same way."
+    "Keep each module here, and each module added later, free of an import "
+    "from that package."
 )
 
 # A module "states the import bar" when it names the guarded package. This
@@ -78,19 +90,31 @@ REQUIRED_PACKAGE_OBLIGATION = (
 # later is covered on the day it arrives.
 BAR_SUBJECT = "pact-memory scripts package"
 
-# THE FLOOR, AND THE DERIVATION ALONE IS NOT ENOUGH WITHOUT IT. A derived
-# population can SHRINK. Delete the subject phrase from one carrier and that
-# file leaves the population, after which its copy of the required sentence is
-# deletable with each arm below green. So the derivation supplies GROWTH and
-# this floor refuses SHRINKAGE. Neither half covers the other.
+# THE TWO SETS BELOW ARE KEYED ON POSIX PATHS RELATIVE TO `PACKAGE_DIR`, which
+# is a DIFFERENT root from the one `SPELLING_EXCLUSIONS` uses. This file holds
+# two roots, so each key set states the root it uses. A relative path without
+# its base is a figure without its counting rule. A key written against the
+# wrong root matches nothing, so the file loses its place in the set and an arm
+# reddens, which is the safe direction.
+#
+# THE FLOOR. Its unique coverage is TWO conditions, and `TestTheFloorEarnsIts
+# Place` below asserts each one by emptying this set and reading the result.
+#   1. A carrier renamed out of the population AND declared exempt. The
+#      exempt arm then passes, because the name is declared, and only this
+#      floor holds.
+#   2. A carrier file deleted. It leaves the disk and the population together,
+#      so the exempt arm sees nothing missing.
+# A PLAIN RENAME IS NOT UNIQUE TO THIS FLOOR. The exempt arm catches that on
+# its own, measured with this set emptied.
 #
 # To remove a name from this floor, state a cause, as for the two sentence
 # constants above. A name removed to quiet a red turns the floor into a report
 # of the current population, which is the same mirror failure.
 MINIMUM_CARRIERS = frozenset({"__init__.py", "shred_detect.py"})
 
-# MODULES THAT DO NOT HAVE TO STATE THE BAR. Empty today, and that is the
-# point: each .py file in this package must state the bar, or appear here.
+# MODULES THAT DO NOT HAVE TO STATE THE BAR. Keys are relative to
+# `PACKAGE_DIR`, as stated above `MINIMUM_CARRIERS`. Empty today, and that is
+# the point: each .py file in this package must state the bar, or appear here.
 #
 # The floor above protects the carriers known when it was written. It cannot
 # protect a carrier written later, because its names are fixed. This closes
@@ -103,6 +127,86 @@ MINIMUM_CARRIERS = frozenset({"__init__.py", "shred_detect.py"})
 # checked separately, so an exemption for one of those names goes red anyway.
 EXEMPT_MODULES: frozenset = frozenset()
 
+# The tree the refuted-spelling arms walk. A FILESYSTEM WALK and NOT a git
+# query, on purpose: outside a git context, in a packaged install or a clean
+# export, a git file listing returns nothing, the population is empty, and a
+# negative arm reports a clean green over no files at all. That is a fail-open
+# in the arm widened to close a fail-open.
+PLUGIN_DIR = Path(__file__).resolve().parent.parent
+
+SCANNED_SUFFIXES = (".py", ".md")
+
+# Each claim below was measured incorrect and removed. A revert or a bad merge
+# reintroduces the ORIGINAL BYTES, which is the condition this catches.
+REFUTED_SPELLINGS = frozenset(
+    {
+        "an import is a write",
+        "EXECUTES code that creates the live store",
+        "runs code that creates the live store",
+        # The refuted content is the word "before", which promises the package
+        # becomes safe later. The bare noun phrase is TRUE in a package-wide
+        # statement, so a wider entry bans a correct sentence.
+        "before that package is safe to import",
+        # The second corrected claim. It was written outside the memory-repair
+        # package, which is why the population above covers the plugin tree.
+        "an in-process HOME change is inert",
+    }
+)
+
+# DECLARED EXCLUSIONS, PER FILE AND PER SPELLING.
+#
+# KEYS ARE POSIX PATHS RELATIVE TO `PLUGIN_DIR`. The root is named here on
+# purpose: A RELATIVE PATH WITHOUT ITS BASE IS A FIGURE WITHOUT ITS COUNTING
+# RULE, and a reader who cannot tell which root a key uses cannot tell whether
+# the key is correct. A key against the wrong root matches nothing, so the file
+# loses its exclusion and reddens, which is the safe direction.
+#
+# WHY PER SPELLING RATHER THAN PER FILE. A document that QUOTES one refuted
+# claim in order to explain the correction is legitimate prose, and this
+# repository writes it. A whole-file exclusion would buy that document silence
+# on the other four claims as well.
+#
+# THIS IS AN ENUMERATION, so it takes the same state-a-cause discipline as the
+# other constants and it goes stale the same way. THE TWO DIRECTIONS ARE NOT
+# SYMMETRIC: a stale key fails SAFE, because the file loses its exclusion and
+# reddens. AN UNNECESSARY ENTRY FAILS OPEN, because the file keeps its silence
+# on that one spelling and no arm reddens. SO THE MAINTENANCE BURDEN IS ON
+# REMOVAL RATHER THAN ON ADDITION, which inverts the usual instinct.
+# `test_each_exclusion_is_still_necessary` turns that fail-open into a red.
+#
+# Do NOT add an entry to quiet a red, and do NOT trim REFUTED_SPELLINGS to
+# quiet a red. Either turns this arm into a mirror of the text that happens to
+# be present, which is the failure this file warns about.
+SPELLING_EXCLUSIONS: dict = {
+    # This file holds each refuted spelling as a literal, so it is a GENUINE
+    # MEMBER of the scanned population and must be named out. Compare
+    # `SCANNED_SUFFIXES`, which excludes a `.pyc` by a correct predicate rather
+    # than by a name: that is a NON-member and needs no entry here. A carve-out
+    # for a non-member is the sign of a predicate aimed wrong.
+    "tests/test_import_bar_cause_presence.py": REFUTED_SPELLINGS,
+}
+
+
+def files_scanned_for_refuted_spellings() -> list[Path]:
+    """Return the plugin-tree files the refuted-spelling arms read.
+
+    THIS WALK RETURNS EVERY FILE AND FILTERS NOTHING. The per-spelling
+    exclusion runs at the arm instead. `test_each_exclusion_is_still_necessary`
+    DEPENDS ON THAT PLACEMENT: it asks whether an exclusion key is in this
+    population, and a key excluded HERE would fail that test while doing its
+    job correctly. Move the filter into this walk and that arm breaks without
+    anybody editing it.
+    """
+    found: list[Path] = []
+    for suffix in SCANNED_SUFFIXES:
+        found.extend(PLUGIN_DIR.rglob(f"*{suffix}"))
+    return sorted(found)
+
+
+def spelling_is_excluded_for(path: Path, spelling: str) -> bool:
+    """True when `spelling` is declared out for `path` alone."""
+    return spelling in SPELLING_EXCLUSIONS.get(relative_name(path, PLUGIN_DIR), ())
+
 
 def flatten(text: str) -> str:
     """Collapse all whitespace runs to single spaces.
@@ -113,24 +217,98 @@ def flatten(text: str) -> str:
     return re.sub(r"\s+", " ", text)
 
 
+def carries(text: str, sentence: str) -> bool:
+    """True when `text` holds `sentence`, apart from wraps and capitalisation.
+
+    ONE COMPARISON FOR EACH SENTENCE CHECK IN THIS FILE, so no two arms can
+    drift into opposite treatments of the same input.
+
+    WHITESPACE: each guarded sentence wraps in the file that carries it, so a
+    literal comparison misses a sentence that is present.
+
+    CASE: this repository capitalises an anti-permission rule for emphasis. A
+    strict comparison reddens on a legitimate re-capitalisation. That is a
+    false alarm, the cheapest cure for a false alarm is a constant edit, and a
+    constant edit with no cause is the mirror failure this file warns about.
+    A strict comparison also FAILS OPEN in the other direction: a file that
+    drops out of the population by a capitalisation change takes its required
+    sentence out of reach in silence. Both directions point one way.
+    """
+    return sentence.casefold() in flatten(text).casefold()
+
+
 def modules_stating_the_bar(package_dir: Path) -> list[Path]:
     """Return each .py file in `package_dir` whose text names the guarded package."""
     return sorted(
         path
-        for path in package_dir.glob("*.py")
-        if BAR_SUBJECT.lower() in flatten(path.read_text(encoding="utf-8")).lower()
+        for path in package_dir.rglob("*.py")
+        if carries(path.read_text(encoding="utf-8"), BAR_SUBJECT)
     )
 
 
-class TestTheInstrumentIsLive:
-    """Non-vacuity. An empty population agrees with every assertion below."""
+def relative_name(path: Path, root: Path) -> str:
+    """Return `path` as a POSIX path relative to `root`.
 
-    def test_package_dir_holds_python_files(self):
-        assert PACKAGE_DIR.is_dir(), f"package directory absent: {PACKAGE_DIR}"
-        assert list(PACKAGE_DIR.glob("*.py")), (
-            f"no .py files under {PACKAGE_DIR} — the glob broke, and every "
-            f"per-module assertion below would pass over an empty set."
-        )
+    A BASENAME IS NOT AN IDENTITY. `__init__.py` occurs 9 times in the plugin
+    tree, so a set keyed on basenames cannot tell one from another: a silent
+    `helpers/__init__.py` subtracts against the top-level entry and escapes,
+    while the same silence at a unique basename reddens. The most likely new
+    file in a package carries the most common basename, so a basename key
+    misses the likely instance and catches the unlikely one.
+    """
+    return path.relative_to(root).as_posix()
+
+
+# ---------------------------------------------------------------------------
+# THE THREE POPULATION PREDICATES.
+#
+# ONE DEFINITION EACH, CALLED BY THE SHIPPED ARM AND BY THE FLOOR-CLASS MODEL.
+# The model used to re-implement them, and this file was edited twice in one
+# afternoon with the change carried into the model by hand each time. Both
+# hand-carries were correct, which is what made the drift invisible rather
+# than harmless. A shared definition makes the drift UNREPRESENTABLE, so the
+# next edit cannot be carried incorrectly because it cannot be carried at all.
+#
+# Each returns a sorted list of relative paths, so an empty list means the
+# property holds and a non-empty list names the files that break it.
+# ---------------------------------------------------------------------------
+
+
+def carriers_missing_from_the_floor(package_dir: Path, floor: frozenset) -> list[str]:
+    """Known carriers that left the derived population."""
+    present = {
+        relative_name(p, package_dir) for p in modules_stating_the_bar(package_dir)
+    }
+    return sorted(floor - present)
+
+
+def modules_neither_stating_nor_exempt(
+    package_dir: Path, exempt: frozenset
+) -> list[str]:
+    """Files on disk that do not state the bar and are not declared exempt."""
+    on_disk = {relative_name(p, package_dir) for p in package_dir.rglob("*.py")}
+    stating = {
+        relative_name(p, package_dir) for p in modules_stating_the_bar(package_dir)
+    }
+    return sorted(on_disk - stating - exempt)
+
+
+def modules_missing_the_cause_clause(package_dir: Path) -> list[str]:
+    """Carriers that state the bar and omit the required cause clause."""
+    return sorted(
+        relative_name(p, package_dir)
+        for p in modules_stating_the_bar(package_dir)
+        if not carries(p.read_text(encoding="utf-8"), REQUIRED_CAUSE_CLAUSE)
+    )
+
+
+class TestThePopulationRules:
+    """The two rules that decide WHICH files the sentence arms must cover.
+
+    These are rules and not controls: each one can fail because the tree is
+    wrong, rather than because the instrument is wrong. The controls sit in
+    `TestTheInstrumentIsLive` below.
+    """
 
     def test_each_known_carrier_stays_in_the_derived_population(self):
         """The floor. Non-emptiness is not enough, because COMPLETENESS is the
@@ -142,8 +320,7 @@ class TestTheInstrumentIsLive:
         known carrier is IN the derived population, so a file cannot leave it
         in silence.
         """
-        present = {path.name for path in modules_stating_the_bar(PACKAGE_DIR)}
-        gone = sorted(MINIMUM_CARRIERS - present)
+        gone = carriers_missing_from_the_floor(PACKAGE_DIR, MINIMUM_CARRIERS)
         assert not gone, (
             f"{gone} no longer name the guarded package, so they left the "
             f"derived population and their copy of the required sentence is "
@@ -155,37 +332,59 @@ class TestTheInstrumentIsLive:
     def test_each_module_states_the_bar_or_is_declared_exempt(self):
         """The population covers files nobody has written yet.
 
-        MINIMUM_CARRIERS holds fixed names, so it cannot reach a carrier added
+        MINIMUM_CARRIERS holds fixed paths, so it cannot reach a carrier added
         later. This reaches it: a new .py file must state the bar, or take a
         line in EXEMPT_MODULES. A file then leaves the population only by a
         visible declaration, and not by a rename of the subject phrase.
         """
-        on_disk = {path.name for path in PACKAGE_DIR.glob("*.py")}
-        stating = {path.name for path in modules_stating_the_bar(PACKAGE_DIR)}
-        silent = sorted(on_disk - stating - EXEMPT_MODULES)
+        silent = modules_neither_stating_nor_exempt(PACKAGE_DIR, EXEMPT_MODULES)
         assert not silent, (
             f"{silent} do not name the guarded package. Add the import-bar "
-            f"paragraph to each, or add the name to EXEMPT_MODULES with a "
+            f"paragraph to each, or add the path to EXEMPT_MODULES with a "
             f"stated cause. A module outside the population carries none of "
             f"the sentences the arms below require."
         )
 
-    def test_the_flatten_finds_a_wrapped_sentence(self):
-        """A control on the matcher itself, not on the files it reads."""
+
+class TestTheInstrumentIsLive:
+    """Controls on the instrument, not rules about the tree.
+
+    Each arm here fails when the reader or the matcher breaks, and passes
+    whatever the guarded prose says. An empty population agrees with every
+    rule above, which is why the first control asserts the walk finds files.
+    """
+
+    def test_package_dir_holds_python_files(self):
+        assert PACKAGE_DIR.is_dir(), f"package directory absent: {PACKAGE_DIR}"
+        assert list(PACKAGE_DIR.rglob("*.py")), (
+            f"no .py files below {PACKAGE_DIR}. The walk broke, and each "
+            f"per-module assertion then passes over an empty set."
+        )
+
+    def test_the_comparison_survives_a_wrap_and_a_recapitalisation(self):
+        """A control on the matcher itself, not on the files it reads.
+
+        Each half must fail a literal comparison and pass `carries`. Without
+        that pairing the control agrees with a matcher that ignores its input.
+        """
         wrapped = "This rule holds so that\n    nobody must audit which\n    call is safe."
         assert REQUIRED_CAUSE_CLAUSE not in wrapped
-        assert REQUIRED_CAUSE_CLAUSE in flatten(wrapped)
+        assert carries(wrapped, REQUIRED_CAUSE_CLAUSE)
+
+        shouted = REQUIRED_CAUSE_CLAUSE.upper()
+        assert REQUIRED_CAUSE_CLAUSE not in shouted
+        assert carries(shouted, REQUIRED_CAUSE_CLAUSE)
+
+    def test_the_comparison_rejects_a_sentence_that_is_absent(self):
+        """The negative direction. A matcher that agrees with anything is useless."""
+        assert not carries("nothing of the kind appears here", REQUIRED_CAUSE_CLAUSE)
 
 
 class TestTheCauseClauseIsPresent:
     """The population is BOTH carrier files, and it is derived rather than listed."""
 
     def test_each_module_stating_the_bar_carries_the_cause_clause(self):
-        missing = [
-            path.name
-            for path in modules_stating_the_bar(PACKAGE_DIR)
-            if REQUIRED_CAUSE_CLAUSE not in flatten(path.read_text(encoding="utf-8"))
-        ]
+        missing = modules_missing_the_cause_clause(PACKAGE_DIR)
         assert not missing, (
             f"{missing} state the import bar but omit the clause that forbids "
             f"an audit of which call is safe. Without it, 'one call away' reads "
@@ -196,37 +395,200 @@ class TestTheCauseClauseIsPresent:
 
     def test_the_package_docstring_carries_the_obligation(self):
         """The obligation is package-scoped, so its population is `__init__.py` alone."""
-        text = flatten((PACKAGE_DIR / "__init__.py").read_text(encoding="utf-8"))
-        assert REQUIRED_PACKAGE_OBLIGATION in text, (
+        text = (PACKAGE_DIR / "__init__.py").read_text(encoding="utf-8")
+        assert carries(text, REQUIRED_PACKAGE_OBLIGATION), (
             f"the package docstring lost the obligation that binds a future "
             f"editor. A description of an invariant does not command its "
             f"preservation. Required sentence: {REQUIRED_PACKAGE_OBLIGATION!r}"
         )
 
 
-class TestTheRefutedCauseStaysOut:
-    """The one negative arm here, and its bound is the spellings named.
+class TestTheFloorEarnsItsPlace:
+    """The stated cause for `MINIMUM_CARRIERS`, asserted rather than written.
 
-    This does NOT detect a new incorrect cause in new words. It detects the
-    return of the exact claim that shipped, which is worth catching because a
-    revert or a bad merge reintroduces the original bytes rather than a
-    paraphrase.
+    A GUARD'S UNIQUE COVERAGE IS VISIBLE ONLY WHEN THE GUARD COMES OUT. Each
+    MUTATION arm here runs its mutation TWICE over a copy, once with the floor
+    and once with it emptied, so a claim about what the floor catches ALONE has
+    a failing thing behind it. Without this class the stated cause above is a
+    second unchecked claim in the position of the first.
     """
 
-    @pytest.mark.parametrize(
-        "refuted",
-        [
-            "an import is a write",
-            "EXECUTES code that creates the live store",
-            "runs code that creates the live store",
-            "safe to import",
-        ],
-    )
-    def test_a_refuted_spelling_does_not_return(self, refuted):
-        for path in PACKAGE_DIR.glob("*.py"):
-            text = flatten(path.read_text(encoding="utf-8"))
-            assert refuted.lower() not in text.lower(), (
-                f"{path.name} carries {refuted!r} again. That claim was measured "
-                f"incorrect: no call that creates a directory or resolves a path "
-                f"runs at import time in the guarded package."
+    @staticmethod
+    def _copy(tmp_path: Path) -> Path:
+        target = tmp_path / "memory_repair"
+        shutil.copytree(PACKAGE_DIR, target)
+        return target
+
+    @staticmethod
+    def _arms_pass(package: Path, floor: frozenset, exempt: frozenset) -> bool:
+        """Evaluate the three population predicates against one copy.
+
+        WHY THIS ORCHESTRATOR IS KEPT RATHER THAN DELETED, since a body of
+        pure calls invites the question. The arms below must ask "would the
+        shipped arms pass over THIS copy, under THIS floor", and a test cannot
+        run pytest inside pytest to find out. This composes the answer from
+        the SAME predicates the shipped arms call, so it holds no rule of its
+        own. KEEP IT THAT WAY: one line of predicate logic here re-creates the
+        drift this class exists to close.
+        """
+        return not (
+            carriers_missing_from_the_floor(package, floor)
+            or modules_neither_stating_nor_exempt(package, exempt)
+            or modules_missing_the_cause_clause(package)
+        )
+
+    @staticmethod
+    def _rename_the_subject(path: Path) -> None:
+        text = path.read_text(encoding="utf-8")
+        renamed = text.replace(BAR_SUBJECT.upper(), "REDACTED").replace(
+            BAR_SUBJECT, "REDACTED"
+        )
+        assert renamed != text, "the mutation changed nothing, so the arm proves nothing"
+        path.write_text(renamed, encoding="utf-8")
+
+    def test_a_plain_rename_is_caught_without_the_floor(self, tmp_path):
+        """The condition the OLD stated cause named, and it is not unique."""
+        package = self._copy(tmp_path)
+        self._rename_the_subject(package / "shred_detect.py")
+        assert not self._arms_pass(package, MINIMUM_CARRIERS, EXEMPT_MODULES)
+        assert not self._arms_pass(package, frozenset(), EXEMPT_MODULES), (
+            "a plain rename passed with the floor emptied, so the floor would "
+            "be its only guard. Measurement says the exempt arm catches it."
+        )
+
+    def test_only_the_floor_catches_a_rename_that_is_declared_exempt(self, tmp_path):
+        """Unique coverage 1. The exemption escape."""
+        package = self._copy(tmp_path)
+        self._rename_the_subject(package / "shred_detect.py")
+        exempt = frozenset({"shred_detect.py"})
+        assert not self._arms_pass(package, MINIMUM_CARRIERS, exempt)
+        assert self._arms_pass(package, frozenset(), exempt), (
+            "another arm caught the exemption escape, so this is no longer "
+            "unique to the floor. Correct the stated cause above."
+        )
+
+    def test_only_the_floor_catches_a_deleted_carrier_file(self, tmp_path):
+        """Unique coverage 2. A carrier leaves the disk and the population together."""
+        package = self._copy(tmp_path)
+        (package / "shred_detect.py").unlink()
+        assert not self._arms_pass(package, MINIMUM_CARRIERS, EXEMPT_MODULES)
+        assert self._arms_pass(package, frozenset(), EXEMPT_MODULES), (
+            "another arm caught the deletion, so this is no longer unique to "
+            "the floor. Correct the stated cause above."
+        )
+
+    def test_the_unmutated_copy_passes_under_both_floors(self, tmp_path):
+        """A landing control. Without it each arm above can pass on a broken copy."""
+        package = self._copy(tmp_path)
+        assert self._arms_pass(package, MINIMUM_CARRIERS, EXEMPT_MODULES)
+        assert self._arms_pass(package, frozenset(), EXEMPT_MODULES)
+
+
+class TestTheRefutedCauseStaysOut:
+    """The negative arm, and its bound is the spellings named.
+
+    This does NOT detect a new incorrect cause in new words. It detects the
+    return of a claim that shipped, which is worth catching because a revert or
+    a bad merge reintroduces the original bytes rather than a paraphrase.
+
+    ITS POPULATION IS THE PLUGIN TREE AND NOT THE PACKAGE. A revert lands where
+    the claim was written, and one of the two claims was written outside the
+    memory-repair package. A population narrower than the thing it protects
+    reports a clean green over the files it happens to hold.
+    """
+
+    def test_the_scanned_population_is_not_empty(self):
+        """Non-vacuity ON THE WIDENED SET. An arm on the old set is not one on
+        the new set, and each assertion below agrees with an empty population.
+        """
+        scanned = files_scanned_for_refuted_spellings()
+        assert scanned, (
+            f"the walk below {PLUGIN_DIR} returned nothing, so the refuted-"
+            f"spelling arms pass over an empty set."
+        )
+        reached = {relative_name(path, PLUGIN_DIR) for path in scanned}
+        for expected in (
+            "scripts/memory_repair/__init__.py",
+            "tests/test_archive_pin.py",
+        ):
+            assert expected in reached, (
+                f"{expected} is absent from the scanned population, so the walk "
+                f"no longer reaches the files that carried the corrected claims. "
+                f"Paths here are relative to {PLUGIN_DIR.name}."
             )
+
+    def test_each_exclusion_is_still_necessary(self):
+        """Closes TWO of the THREE ways an exclusion entry goes bad.
+
+        A stale KEY fails safe, because the file loses its exclusion and
+        reddens. AN ENTRY THAT DOES NO WORK FAILS OPEN: the file keeps its
+        silence on that spelling and nothing reports it. So the maintenance
+        burden sits on REMOVAL rather than on addition.
+
+        WHAT THIS CLOSES, each measured:
+          1. An entry whose file no longer carries the spelling.
+          2. An entry that CANNOT do work: a key outside the scanned
+             population, or a spelling outside REFUTED_SPELLINGS. Neither
+             excludes anything from any arm, and `is_file()` cannot see it.
+
+        WHAT THIS DOES NOT CLOSE, AND THE BOUND IS MEASURED RATHER THAN
+        REASONED. An entry whose file continues to carry the spelling FOR A
+        CHANGED REASON. A document that QUOTES a refuted claim earns its
+        exclusion. The same document that later ASSERTS the claim does not,
+        and the two are the SAME SUBSTRING. Measured: with the entry present
+        each arm reports green, and with the entry removed the detection arm
+        reddens, so the exclusion is what confers the silence. THIS ARM
+        MEASURES THAT A FILE CARRIES A SPELLING. What earns an exclusion is
+        WHY, and no substring comparison reaches a reason.
+        """
+        scanned = {
+            relative_name(p, PLUGIN_DIR): p
+            for p in files_scanned_for_refuted_spellings()
+        }
+        unreachable = []
+        idle = []
+        for rel, spellings in SPELLING_EXCLUSIONS.items():
+            path = scanned.get(rel)
+            if path is None:
+                # MEMBERSHIP, NOT `is_file()`. A key can name a file that is
+                # present and never scanned, because its suffix sits outside
+                # SCANNED_SUFFIXES. `is_file()` says yes and the entry does
+                # nothing.
+                unreachable.append(f"{rel} (not in the scanned population)")
+                continue
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for spelling in spellings:
+                if spelling not in REFUTED_SPELLINGS:
+                    # A spelling no arm asks about. The entry excludes it from
+                    # a question nobody puts.
+                    unreachable.append(f"{rel} -> {spelling!r} (not a refuted spelling)")
+                elif not carries(text, spelling):
+                    idle.append(f"{rel} -> {spelling!r}")
+        assert not unreachable, (
+            f"these exclusion entries cannot do work: {sorted(unreachable)}. A "
+            f"key outside the scanned population, or a spelling outside "
+            f"REFUTED_SPELLINGS, excludes nothing from any arm. Correct the "
+            f"key or the spelling. Paths are relative to {PLUGIN_DIR.name}."
+        )
+        assert not idle, (
+            f"these exclusion entries do no work ANY ARM CAN SEE: "
+            f"{sorted(idle)}. THAT IS NARROWER THAN UNNECESSARY: this arm "
+            f"measures presence, and it does not measure why the file carries "
+            f"the spelling. If the file dropped the spelling, remove the "
+            f"entry. IF THE FILE MOVED, UPDATE THE KEY rather than remove the "
+            f"entry. Paths are relative to {PLUGIN_DIR.name}."
+        )
+
+    @pytest.mark.parametrize("refuted", sorted(REFUTED_SPELLINGS))
+    def test_a_refuted_spelling_does_not_return(self, refuted):
+        for path in files_scanned_for_refuted_spellings():
+            if spelling_is_excluded_for(path, refuted):
+                continue
+            if carries(path.read_text(encoding="utf-8", errors="replace"), refuted):
+                raise AssertionError(
+                    f"{relative_name(path, PLUGIN_DIR)} carries {refuted!r} "
+                    f"again. Each spelling here was measured incorrect and "
+                    f"removed. Do not clear this red by a spelling removed from "
+                    f"REFUTED_SPELLINGS, and do not add an entry to "
+                    f"SPELLING_EXCLUSIONS to quiet it."
+                )

--- a/pact-plugin/tests/test_import_bar_cause_presence.py
+++ b/pact-plugin/tests/test_import_bar_cause_presence.py
@@ -1,0 +1,232 @@
+"""
+Presence pins for the import-bar cause in the memory-repair package.
+
+Location: pact-plugin/tests/test_import_bar_cause_presence.py
+
+WHAT THIS PROVES, AND IT IS NARROW ON PURPOSE. Each module in the
+memory-repair package that states the import bar also carries the sentence
+that forbids an audit of which call is safe. That sentence is the only one
+that stops a reader treating the bar as a DISTANCE to be measured rather than
+a rule to keep, and it was dropped once with nothing to catch it.
+
+WHAT A GREEN HERE DOES NOT MEAN. Read this before you trust it.
+
+  * It does NOT check that the surrounding prose is true. No test can read a
+    natural-language cause for truth.
+  * It does NOT catch an incorrect cause ADDED elsewhere, in this package or
+    outside it. The population is derived from the files that state the bar,
+    so a new file that states nothing about it is invisible here.
+  * It proves the PRESENCE of two sentences, and nothing more.
+
+THE POPULATION HAS THREE PARTS, AND EACH COVERS A FAILURE THE OTHERS MISS.
+
+  1. The DERIVATION reaches a carrier written later, on the day it arrives.
+  2. `MINIMUM_CARRIERS` refuses SHRINKAGE for the carriers known today. A
+     derived population can shrink: rename the subject phrase in one file and
+     that file leaves the set, after which its copy of a required sentence is
+     deletable with each arm green.
+  3. `EXEMPT_MODULES` extends part 2 to files nobody has written yet, which
+     fixed names cannot reach. A module leaves the population only by a
+     declared line, and not by a rename that reads as tidying.
+
+An arm that asserts ONE member proves the set is not empty and proves nothing
+about the rest. Non-emptiness and completeness are different properties.
+
+THE FAILURE DIRECTION IS DELIBERATE. A legitimate reword trips these tests,
+so they fail toward a FALSE ALARM and somebody must look. The pin to avoid is
+the one that goes stale in silence. This is its opposite.
+
+TO CHANGE ANY CONSTANT IN THIS FILE, STATE A CAUSE. The rule is stated over
+the CLASS and not over a list of names, on purpose. Each module-level constant
+here sets what the arms require, or which files the arms cover, so each one
+weakens the guard if it changes for no reason. A list of names would go stale
+the moment a constant is added, and a reader who trusts the list then learns a
+rule narrower than the one that must hold.
+
+If you update a constant to agree with new prose, or to quiet a red, and you
+give no cause, this file becomes a MIRROR of the thing it guards, and its
+green stops meaning anything. That covers the required sentences, the subject
+phrase the population is derived from, and each set of file names.
+
+MATCHING IS WHITESPACE-INSENSITIVE BY NECESSITY. Each guarded sentence wraps
+across lines in the file that carries it, so a line-oriented search or a
+literal comparison cannot find it even when it is present. Flatten first.
+
+Used by: pytest.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+PACKAGE_DIR = Path(__file__).resolve().parent.parent / "scripts" / "memory_repair"
+
+# The anti-permission clause. Its absence is the defect this file exists for.
+REQUIRED_CAUSE_CLAUSE = (
+    "This rule holds so that nobody must audit which call is safe."
+)
+
+# The obligation that reaches an edit to an EXISTING module, not new ones only.
+REQUIRED_PACKAGE_OBLIGATION = (
+    "Keep each module here, and each module added later, the same way."
+)
+
+# A module "states the import bar" when it names the guarded package. This
+# derives the population from the property, so a third carrier file added
+# later is covered on the day it arrives.
+BAR_SUBJECT = "pact-memory scripts package"
+
+# THE FLOOR, AND THE DERIVATION ALONE IS NOT ENOUGH WITHOUT IT. A derived
+# population can SHRINK. Delete the subject phrase from one carrier and that
+# file leaves the population, after which its copy of the required sentence is
+# deletable with each arm below green. So the derivation supplies GROWTH and
+# this floor refuses SHRINKAGE. Neither half covers the other.
+#
+# To remove a name from this floor, state a cause, as for the two sentence
+# constants above. A name removed to quiet a red turns the floor into a report
+# of the current population, which is the same mirror failure.
+MINIMUM_CARRIERS = frozenset({"__init__.py", "shred_detect.py"})
+
+# MODULES THAT DO NOT HAVE TO STATE THE BAR. Empty today, and that is the
+# point: each .py file in this package must state the bar, or appear here.
+#
+# The floor above protects the carriers known when it was written. It cannot
+# protect a carrier written later, because its names are fixed. This closes
+# that gap from the other side: a file leaves the population ONLY by an entry
+# here, which is a visible line in a diff, rather than by a rename of the
+# subject phrase, which reads as tidying and is what defeated the derivation.
+#
+# To add a name here, state a cause. A name added to quiet a red is the mirror
+# failure again. A KNOWN CARRIER CANNOT ESCAPE THIS WAY: MINIMUM_CARRIERS is
+# checked separately, so an exemption for one of those names goes red anyway.
+EXEMPT_MODULES: frozenset = frozenset()
+
+
+def flatten(text: str) -> str:
+    """Collapse all whitespace runs to single spaces.
+
+    A guarded sentence wraps across lines, so it is not a contiguous substring
+    of any single line. This is what makes the comparison find it.
+    """
+    return re.sub(r"\s+", " ", text)
+
+
+def modules_stating_the_bar(package_dir: Path) -> list[Path]:
+    """Return each .py file in `package_dir` whose text names the guarded package."""
+    return sorted(
+        path
+        for path in package_dir.glob("*.py")
+        if BAR_SUBJECT.lower() in flatten(path.read_text(encoding="utf-8")).lower()
+    )
+
+
+class TestTheInstrumentIsLive:
+    """Non-vacuity. An empty population agrees with every assertion below."""
+
+    def test_package_dir_holds_python_files(self):
+        assert PACKAGE_DIR.is_dir(), f"package directory absent: {PACKAGE_DIR}"
+        assert list(PACKAGE_DIR.glob("*.py")), (
+            f"no .py files under {PACKAGE_DIR} — the glob broke, and every "
+            f"per-module assertion below would pass over an empty set."
+        )
+
+    def test_each_known_carrier_stays_in_the_derived_population(self):
+        """The floor. Non-emptiness is not enough, because COMPLETENESS is the
+        property at issue.
+
+        An arm that asserts one member proves the set is not empty and proves
+        nothing about the rest. Drop a second carrier out of the derivation and
+        such an arm keeps passing while coverage halves. This asserts each
+        known carrier is IN the derived population, so a file cannot leave it
+        in silence.
+        """
+        present = {path.name for path in modules_stating_the_bar(PACKAGE_DIR)}
+        gone = sorted(MINIMUM_CARRIERS - present)
+        assert not gone, (
+            f"{gone} no longer name the guarded package, so they left the "
+            f"derived population and their copy of the required sentence is "
+            f"now unguarded. Either the docstring was rewritten, or the "
+            f"subject phrase {BAR_SUBJECT!r} changed. Do not repair this by "
+            f"removing a name from MINIMUM_CARRIERS without a stated cause."
+        )
+
+    def test_each_module_states_the_bar_or_is_declared_exempt(self):
+        """The population covers files nobody has written yet.
+
+        MINIMUM_CARRIERS holds fixed names, so it cannot reach a carrier added
+        later. This reaches it: a new .py file must state the bar, or take a
+        line in EXEMPT_MODULES. A file then leaves the population only by a
+        visible declaration, and not by a rename of the subject phrase.
+        """
+        on_disk = {path.name for path in PACKAGE_DIR.glob("*.py")}
+        stating = {path.name for path in modules_stating_the_bar(PACKAGE_DIR)}
+        silent = sorted(on_disk - stating - EXEMPT_MODULES)
+        assert not silent, (
+            f"{silent} do not name the guarded package. Add the import-bar "
+            f"paragraph to each, or add the name to EXEMPT_MODULES with a "
+            f"stated cause. A module outside the population carries none of "
+            f"the sentences the arms below require."
+        )
+
+    def test_the_flatten_finds_a_wrapped_sentence(self):
+        """A control on the matcher itself, not on the files it reads."""
+        wrapped = "This rule holds so that\n    nobody must audit which\n    call is safe."
+        assert REQUIRED_CAUSE_CLAUSE not in wrapped
+        assert REQUIRED_CAUSE_CLAUSE in flatten(wrapped)
+
+
+class TestTheCauseClauseIsPresent:
+    """The population is BOTH carrier files, and it is derived rather than listed."""
+
+    def test_each_module_stating_the_bar_carries_the_cause_clause(self):
+        missing = [
+            path.name
+            for path in modules_stating_the_bar(PACKAGE_DIR)
+            if REQUIRED_CAUSE_CLAUSE not in flatten(path.read_text(encoding="utf-8"))
+        ]
+        assert not missing, (
+            f"{missing} state the import bar but omit the clause that forbids "
+            f"an audit of which call is safe. Without it, 'one call away' reads "
+            f"as a DISTANCE, and a maintainer concludes they may import so long "
+            f"as they audit which functions resolve a path. Required sentence: "
+            f"{REQUIRED_CAUSE_CLAUSE!r}"
+        )
+
+    def test_the_package_docstring_carries_the_obligation(self):
+        """The obligation is package-scoped, so its population is `__init__.py` alone."""
+        text = flatten((PACKAGE_DIR / "__init__.py").read_text(encoding="utf-8"))
+        assert REQUIRED_PACKAGE_OBLIGATION in text, (
+            f"the package docstring lost the obligation that binds a future "
+            f"editor. A description of an invariant does not command its "
+            f"preservation. Required sentence: {REQUIRED_PACKAGE_OBLIGATION!r}"
+        )
+
+
+class TestTheRefutedCauseStaysOut:
+    """The one negative arm here, and its bound is the spellings named.
+
+    This does NOT detect a new incorrect cause in new words. It detects the
+    return of the exact claim that shipped, which is worth catching because a
+    revert or a bad merge reintroduces the original bytes rather than a
+    paraphrase.
+    """
+
+    @pytest.mark.parametrize(
+        "refuted",
+        [
+            "an import is a write",
+            "EXECUTES code that creates the live store",
+            "runs code that creates the live store",
+            "safe to import",
+        ],
+    )
+    def test_a_refuted_spelling_does_not_return(self, refuted):
+        for path in PACKAGE_DIR.glob("*.py"):
+            text = flatten(path.read_text(encoding="utf-8"))
+            assert refuted.lower() not in text.lower(), (
+                f"{path.name} carries {refuted!r} again. That claim was measured "
+                f"incorrect: no call that creates a directory or resolves a path "
+                f"runs at import time in the guarded package."
+            )

--- a/pact-plugin/tests/test_import_bar_cause_presence.py
+++ b/pact-plugin/tests/test_import_bar_cause_presence.py
@@ -355,11 +355,19 @@ class TestThePopulationRules:
         """
         gone = carriers_missing_from_the_floor(PACKAGE_DIR, MINIMUM_CARRIERS)
         assert not gone, (
-            f"{gone} no longer name the guarded package, so they left the "
-            f"derived population and their copy of the required sentence is "
-            f"now unguarded. Either the docstring was rewritten, or the "
-            f"subject phrase {BAR_SUBJECT!r} changed. Do not repair this by "
-            f"removing a path from MINIMUM_CARRIERS without a stated cause."
+            f"{gone} are in MINIMUM_CARRIERS and are NOT in the derived "
+            f"population. A path is in that population only while a file at "
+            f"that path carries the subject phrase {BAR_SUBJECT!r}. A FAILURE "
+            f"OF ONE HALF IS ENOUGH, and the causes named below are EXAMPLES "
+            f"and not a closed set. HALF 1, no file is at that path, such as "
+            f"after a deletion or a move. HALF 2, a file is at that path and "
+            f"its text does not carry the phrase, such as after a docstring "
+            f"rewrite or a change to BAR_SUBJECT. READ THE DISK FOR EACH PATH "
+            f"BEFORE YOU REPAIR, because this result can hold paths that left "
+            f"for different reasons at the same time. While a path is out, "
+            f"the cause-clause arm covers nothing at that path. Do not repair "
+            f"this by removal of a path from MINIMUM_CARRIERS without a "
+            f"stated cause."
         )
 
     def test_each_module_states_the_bar_or_is_declared_exempt(self):


### PR DESCRIPTION
## The reason was measured false by the arc that shipped it

Two docstrings in `pact-plugin/scripts/memory_repair/` justified the bar on importing the pact-memory scripts package by asserting that an import is itself a write. An AST pass over all 14 modules of that package found no call that creates a directory or resolves a path at import time.

The control that makes that empty answer a result rather than a miss, stated so a reader can re-derive it: parse each of the 14 modules, prune function and class bodies, and count the calls that remain. That gives **36** module-level calls across the package, and **2** in `config.py`, which is the same figure quoted further down.

An earlier draft of this paragraph gave the control as 12 and named no counting rule. A reviewer could not reproduce 12 under that rule or under four others, while reproducing the `config.py` figure of 2 exactly. The conclusion is unaffected, because any non-zero control shows the empty answer was a result. What was wrong is that a bare number with no definition cannot be re-derived by the reader it exists to convince, which is the one failure a control exists to prevent. The number and its counting rule now travel together.

The instruction does not change. Its reason does, and the corrected reason forbids more rather than less. Several functions create the live store directory as a side result of resolving a path, so an import puts each of them one call away, and the rule holds so that nobody must audit which call is safe. A subprocess reaches those functions with no import at all, so an absent import is not a guarantee.

The reader of those docstrings is the agent deciding whether importing the package is safe. A reader who tested the stated reason, found it false, and dropped the bar had done nothing unreasonable. That is the harm the old wording carried.

The subprocess sentence states the limit of a test and forbids no mechanism. `scripts/archive_pin.py` reaches the same CLI by subprocess on purpose, and the two files do not force a reader to choose, because the boundary is about whether a caller intends to touch the live store rather than about which mechanism it uses.

## A second refuted import-time claim, in a different subject

`pact-plugin/tests/test_archive_pin.py` said `config.py` binds the database path from `Path.home()` at import, so an in-process HOME change is inert. Both clauses are wrong. The module body of `config.py` holds two module-level calls and `Path.home()` sits inside a function, so the path resolves at use time and an in-process HOME change does take effect.

`config.py` states that in its own docstring, and two further sites state it correctly in the past tense, so four sites agreed and one was out of step. The correction adds protection rather than removing it: sandboxing HOME covers the in-process resolution and the child alike, where the old text claimed it covered the child alone. The practice stays mandatory, and the docstring now says so as an instruction to the next test rather than as a description of the present ones.

## The guard, and why its population has three parts

A test pins the two sentences. Its green means they are present, and means nothing about whether the surrounding prose is correct.

Each part covers what the others miss:

- a **derivation** reaches a carrier written later;
- an **exemption list** means a module leaves the population only by a declared entry, so a rename of the subject phrase, which reads as tidying, reddens rather than narrowing the population in silence;
- a **floor** of known carrier names covers the two cases neither of those reaches: a known carrier renamed **and** declared exempt, and a carrier file deleted outright.

An exemption cannot free a name the floor holds.

An earlier draft of that middle claim attributed the plain-rename case to the floor. A harness that empties the floor and re-runs five mutations shows the exemption arm catches the rename on its own, so the floor's unique coverage is the two cases named above and not the rename. The correction is the same class as the one this PR exists to make: a stated cause that was approved rather than proved. It is now proved, and the shipped guard carries arms that re-run those mutations with the floor emptied, so the claim stays checkable rather than resting on this paragraph.

The comparison normalises whitespace, because both guarded sentences wrap. A pin on an exact substring cannot find a sentence that is present, and the cheapest cure for that red is to edit the constant until it agrees with the reflowed text, which turns the pin into a mirror of what it guards.

The rule for changing any constant in that file is stated over the class rather than over a list of names. A list is narrow on the day it is written and narrower at the next constant, and a reader who trusts it learns a rule weaker than the one that must hold.

## What the exclusion map allows, and what its own arm reaches

Some documentation legitimately quotes the refuted claim, so an exclusion map exempts a file-and-spelling pair from the check. An exclusion only ever relaxes: its single consumer guards a `continue`, so an entry can only cause a skip, and removing one strictly adds checks. A wrongly removed entry therefore reddens later and permits nothing.

An arm holds that map to account, because the burden on an exclusion list sits on removal rather than on addition. A stale entry keeps conferring silence and nothing complains, so a mechanism beats a note.

That arm now cross-checks each key against the two populations that give it meaning: the file must be one the scan actually reads, and the spelling must be one the scan actually refuses. Without those, an entry naming an unscanned suffix or a non-refuted spelling sat in the map doing nothing while the arm called it necessary. Both were measured, and both went from green to red.

Two sentences about that arm claimed more than it does, and both are corrected rather than softened:

- It reports that an entry does no work **any arm can see**, which is narrower than unnecessary. The message now states that bound where it states the finding, so the reader is not invited to delete on a claim the instrument cannot make. Where the key names a file that has moved, the repair is to update the key rather than remove the entry, and the message says so.
- The docstring claimed the arm closes *the* fail-open direction. There are two. It closes the entry that stops doing work; it does not reach an entry that keeps doing work for a **changed** reason, because a quotation and an assertion are the same substring and only the intent differs. That bound was measured against the built code rather than derived, then written from what the run reported.

## Verification

Mutation arms, each run against an isolated copy built from the index, with no edit to the tree. Every arm agrees with its expectation: the control passes, each deletion of a required sentence reddens, narrowing the population reddens, emptying it reddens, returning the refuted spelling reddens, misusing the exemption to free a known carrier reddens, and a new module that legitimately states the bar passes with no declaration.

Several arms are controls on the harness rather than on the guard. One feeds a wrap-blind deletion and confirms it is a no-op, because a mutation that silently fails to mutate produces a proof that proves nothing. Another pair feeds one identical module and differs only by the exemption rewrite, red then green, so the rewrite is shown effective rather than assumed. A third pair separates the exclusion from the file it names, so a green is known to come from the entry rather than from an instrument that is not live.

Suite: 14175 passed, 15 skipped, 0 failed, 0 errors, with no path argument. That figure is unchanged across a round that added an arm, which is also the signature of a file that stopped being collected, so it was reconciled rather than reported: the guard yields 18 cases in each round, exactly one arm left and exactly one arrived, and a whole-suite collection dump lists the file's cases by name. Import hygiene passes on each modified file. Those runs are on Python 3.14.6 and CI pins 3.13, so they are evidence that the code is sound rather than evidence that CI passes.

The two files in the last commit cannot be separated. The guard requires an obligation sentence that only the corrected docstring carries, so a guard-only commit would be red.

## Residuals, stated rather than left silent

- The guard proves the presence of sentences. No test reads prose for truth.
- The necessity arm cannot separate a quotation from an assertion. An excluded document that flips from quoting a refuted claim to asserting it keeps its silence, and no arm reddens. Closing that needs a judgement about intent, which no substring test can make.
- Rot is undetectable from one snapshot. A later commit that edits a constant and the prose together turns a pin into a mirror. The state-a-cause rules sit inline at each constant, and they are an instruction rather than a mechanism.
- A future carrier exempted with no stated cause is unguarded. That takes a deliberate line in a diff.
- The necessity arm depends on the scan filtering nothing during its walk. A filter moved into the walk would break that arm without anybody editing it, so the dependency is recorded where an editor would be standing.
- The `test_archive_pin.py` sentence is not pinned. A behavioural arm elsewhere covers the property beneath it, so the prose could return to the refuted claim with the suite green, which is a documentation risk rather than a correctness one.

## Version

Patch, 4.6.30 to 4.6.31, across the four pinned files. A corrective text change to shipped agent-facing instruction.
