### PR TITLE
Test on 3.13 and 3.14 rather than on 3.13 alone

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.31",
+      "version": "4.6.32",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -143,6 +143,36 @@ permissions:
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    # THE TESTED SET. IT IS NOT THE SUPPORTED FLOOR, AND THE TWO ARE
+    # DIFFERENT QUESTIONS THAT LIVE IN DIFFERENT FILES.
+    #   THE TESTED SET is this matrix: which interpreters CI runs.
+    #   THE SUPPORTED FLOOR is `requires-python` in pyproject.toml at the
+    #   repository root. It stays UNMEASURED. A green here on 3.13 and 3.14
+    #   says nothing about it. To settle the floor takes a run of this suite
+    #   on the lowest target, which is separate work with its own evidence.
+    #
+    # WHY 3.14 JOINED 3.13. Local runs in the release arc before this change
+    # used 3.14 while CI pinned 3.13, so a local green and a CI green were
+    # not the same green. This matrix closes that gap rather than widening
+    # coverage. NO VERSION LITERAL SITS IN THIS COMMENT ON PURPOSE: the
+    # plugin version lives in four pinned files, and one more copy here is
+    # one more thing a later bump can miss.
+    #
+    # `fail-fast: false` so a cell that reddens does not cancel the other one
+    # and hide its result.
+    #
+    # CHECK NAMES, BECAUSE A MATRIX RENAMES THEM. A single job reports a
+    # check called `pytest`. This matrix reports `pytest (3.13)` and
+    # `pytest (3.14)`, so the name `pytest` stops reporting. Measured on
+    # 2026-08-10 against this repository: NO required status check is
+    # configured, on classic branch protection or in the one active ruleset,
+    # so the rename blocks no pull request. IF SOMEBODY LATER REQUIRES A
+    # STATUS CHECK, require a stable aggregate name rather than a matrix
+    # cell, because each change to the matrix renames the cells.
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.13", "3.14"]
     steps:
       # Third-party actions are pinned to a full commit SHA (supply-chain
       # hardening: a moving tag like @v5 can be repointed to malicious code).
@@ -160,7 +190,9 @@ jobs:
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.13"
+          # The value comes from the matrix above, which this file declares.
+          # It is not event input, so it carries no injection surface.
+          python-version: ${{ matrix.python-version }}
 
       - name: Install test dependencies
         # See the "DEPENDENCY SET" header note for why each lib is required.
@@ -229,15 +261,13 @@ jobs:
   # ---------------------------------------------------------------------------
   # OPTIONAL FALLBACKS (do NOT enable without the stated verification first)
   #
-  # (1) Cross-version matrix — adopt ONLY after a one-off task confirms the
-  #     suite passes on the lowest target. The >=3.7 floor is unverified.
+  # (1) Cross-version matrix: ADOPTED, and it is live on the job above with
+  #     3.13 and 3.14. This entry stays to record what it did NOT settle.
   #
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       python-version: ["3.13", "3.12", "3.11"]   # extend downward post-verify
-  #   ...
-  #     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
+  #     THE FLOOR REMAINS OPEN AND THIS MATRIX DID NOT ANSWER IT.
+  #     `requires-python = ">=3.7"` in pyproject.toml is UNMEASURED. The
+  #     matrix records which interpreters CI runs, and that is a different
+  #     question. Do not read the tested set as the supported floor.
+  #     To extend the matrix DOWNWARD takes a run on the lower target first,
+  #     which is separate work with its own evidence.
   # ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.31/     # Plugin version
+│               └── 4.6.32/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.31",
+  "version": "4.6.32",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.31
+> **Version**: 4.6.32
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 


### PR DESCRIPTION
## A local green and a CI green were not the same green

Local runs in the preceding release arc used python 3.14 while CI pinned 3.13. That held for every local green in that arc, across four agents, so each of those greens was evidence about an interpreter CI does not use. This matrix closes that gap rather than widening coverage for its own sake.

`fail-fast: false` so a cell that reddens does not cancel the other one and hide its result.

## The tested set is not the supported floor

The two are different questions and they live in different files, so the change touches one.

- THE TESTED SET is the matrix in `.github/workflows/tests.yml`: which interpreters CI runs.
- THE SUPPORTED FLOOR is `requires-python = ">=3.7"` in `pyproject.toml`. It stays UNMEASURED. A green on 3.13 and 3.14 says nothing about it.

`requires-python` is untouched. The commented fallback block carried `# extend downward post-verify`, which invites answering the floor question while doing the tested-set one. That block now records what this change did NOT settle, and points at the file where the floor lives. To settle the floor takes a run of the suite on the lower target, which is separate work with its own evidence.

## Check names, measured before the change rather than after

A matrix renames the reported check. A single job reports `pytest`. This reports `pytest (3.13)` and `pytest (3.14)`, so the name `pytest` stops reporting. On a repository that already needs an administrator override to merge, a renamed required check would leave THE NEXT pull request unmergeable, so the damage would land on unrelated work.

Measured against the repository before the change landed:

| surface | result |
|---|---|
| classic branch protection on `main` | 404, branch not protected |
| repository rulesets | one active ruleset, `PR-Review`, on `refs/heads/main` |
| its rules | `deletion`, `non_fast_forward`, `copilot_code_review` |
| `required_status_checks` rule | ABSENT |
| observed check name on the last `main` commit | `pytest` |

The 404 is a genuine absence rather than a permission mask: the same token reads the rulesets endpoint and reports `admin: true` on the repository, so a positive control rules out the permission reading of that status code.

NO required status check reads the name `pytest`, so the rename blocks nothing. The workflow comment records the measurement and tells a later maintainer to require a stable aggregate name rather than a matrix cell, because each change to the matrix renames the cells.

One consequence worth stating plainly: because no required status check is configured, CI is ADVISORY on this repository today. This change improves the signal, not the enforcement.

## Verification

Full suite, no path argument, from `pact-plugin`, through `rtk proxy` so the errors count is not dropped: **14178 passed, 15 skipped, 0 failed, 0 errors**, on **python 3.14.6**.

The errors-token scan was controlled against a live run that produces an error, so the zero is a measurement rather than a broken query.

WHETHER THE SUITE PASSES ON A 3.14 CI RUNNER IS NOT ANSWERED BY THAT GREEN, and that is the point of this change. Different interpreter build, different platform, different dependency resolution. The first CI run on this pull request is the measurement. If 3.14 reddens there, that is a result to report with its cause rather than something to pin around.

## Version

PATCH, 4.6.31 to 4.6.32, across the four pinned files. A CI-configuration change adds no command and no agent, and shifts nothing an operator notices in operation. No version literal was added to the workflow, so the four pinned files stay the only carriers.