### PR TITLE
Codify the store-access rule, and correct an instruction that asked for statistics the store cannot return

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.32",
+      "version": "4.6.33",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,14 +13,25 @@
 #   into any consumer project's session, so it carries zero consumer-pollution
 #   risk and may reference concrete project specifics freely.
 #
-# WHY A SINGLE PYTHON (3.13), NOT A >=3.7 MATRIX
-#   The dev runtime is 3.14.x; the declared `requires-python = ">=3.7"` floor is
-#   aspirational and NOT test-verified (the suite has never been run on 3.7).
-#   The gate's value — auto-running the structural/meta-tests — needs exactly
-#   ONE Python. 3.13 is GA on ubuntu-latest and is the closest-stable to the
-#   3.14 dev runtime. A 3.7-inclusive matrix is documented as a commented
-#   fallback below, to be adopted ONLY AFTER a separate task verifies the suite
-#   actually passes there (likely 3.14-era syntax has crept in) — never on faith.
+# WHY THIS MATRIX, AND WHAT THE DECLARED FLOOR RESTS ON
+#   The dev runtime is 3.14.x. The matrix runs 3.13 and 3.14: both are GA on
+#   ubuntu-latest, and 3.14 matches the dev runtime so a local green and a CI
+#   green are the same green.
+#   The declared `requires-python = ">=3.9"` floor is NOT test-verified: the
+#   suite has been run on NO interpreter below 3.13. What the floor DOES rest
+#   on is (a) an external constraint — GUI-launched macOS sessions run the
+#   bare-python3 surfaces on /usr/bin/python3, which is 3.9.x — and (b) the
+#   static 3.9 gate in tests/test_py39_annotation_compat.py plus the
+#   `--target-version py39` lint below. Both are STATIC. That gate's own R0
+#   note records that `feature_version` NARROWS rather than replaces live 3.9
+#   verification, and it was measured false-passing PEP 701 f-strings that a
+#   3.9 interpreter rejects. So `>=3.9` is the floor the repository targets and
+#   statically enforces, NOT a floor a run has confirmed.
+#   The earlier `>=3.7` declaration was REFUTED, not merely unmeasured: an
+#   assignment expression in hooks/shared/session_resume.py needs 3.8.
+#   A matrix reaching below 3.13 is documented as a commented fallback below,
+#   to be adopted ONLY AFTER a separate task verifies the suite actually passes
+#   there — never on faith.
 #
 # WHY `working-directory: pact-plugin`
 #   `tests/conftest.py` inserts sys.path entries relative to its own location and
@@ -265,9 +276,11 @@ jobs:
   #     3.13 and 3.14. This entry stays to record what it did NOT settle.
   #
   #     THE FLOOR REMAINS OPEN AND THIS MATRIX DID NOT ANSWER IT.
-  #     `requires-python = ">=3.7"` in pyproject.toml is UNMEASURED. The
-  #     matrix records which interpreters CI runs, and that is a different
-  #     question. Do not read the tested set as the supported floor.
+  #     `requires-python = ">=3.9"` in pyproject.toml is NOT MEASURED BY A RUN.
+  #     It is the floor the repository targets and statically enforces, and no
+  #     run below 3.13 backs it. The matrix records which interpreters CI runs,
+  #     and that is a different question. Do not read the tested set as the
+  #     supported floor, and do not read the declared floor as a tested one.
   #     To extend the matrix DOWNWARD takes a run on the lower target first,
   #     which is separate work with its own evidence.
   # ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -584,20 +584,21 @@ PACT ships 20 skill modules — domain knowledge that loads on-demand, plus oper
 
 ## Memory System
 
-PACT includes a persistent memory system for cross-session learning:
+PACT includes a persistent memory system for cross-session learning. Every
+memory operation goes through the `pact-memory` CLI:
 
-```
+```bash
 # Save context, decisions, lessons learned
-memory.save({
+python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" save '{
     "context": "Building authentication system",
     "goal": "Add JWT refresh tokens",
     "lessons_learned": ["Always hash passwords with bcrypt"],
     "decisions": [{"decision": "Use Redis", "rationale": "Fast TTL"}],
     "entities": [{"name": "AuthService", "type": "component"}]
-})
+}'
 
 # Semantic search across all memories
-memory.search("rate limiting")
+python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" search "rate limiting"
 ```
 
 **Features:**

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.32/     # Plugin version
+│               └── 4.6.33/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.32",
+  "version": "4.6.33",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.32
+> **Version**: 4.6.33
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/agents/pact-secretary.md
+++ b/pact-plugin/agents/pact-secretary.md
@@ -52,6 +52,21 @@ You have access to two distinct memory systems — use each for its intended pur
 - **pact-memory** (SQLite, via the pre-loaded `pact-memory` skill): Save and retrieve **institutional knowledge** — project-wide decisions, cross-agent lessons, architectural rationale, calibration data. Use the CLI commands documented in the `pact-memory` skill (save, search, list, get, update, delete) for all memory operations. This is your primary job.
 - **Your agent memory** (the platform-given absolute path, under `~/.claude/agent-memory/` — use the path you are given, never one built from your agent type): Save **your own domain expertise** — patterns you notice about memory operations, effective query strategies, project-specific retrieval insights that help you work better next time. Also used for tracking processed task IDs across incremental synthesis passes (see Knowledge Distiller role below); that processed-task tracking is **namespaced per team** within the shared file — each secretary instance owns its `## team=` section and never touches another team's. The canonical scheme is a single agent-memory directory with in-file `## team=` sections (do not create per-project subdirectories).
 
+<!-- PACT_STORE_BAR_BEGIN -->
+**STORE ACCESS.** A memory operation (save, search, get, list, update or
+delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
+for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
+choose is not the store the memory of the team lives in, so a save there is
+lost rather than shared. STORE INSPECTION is different: a row count, a
+column audit, a schema check, or any question about the file itself. To
+inspect, do not run a CLI verb, do not import a module below
+`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+that `memory.db-wal` and `memory.db-shm` are both absent by their full
+names, then open the store with `mode=ro` and `immutable=1`. Without
+`immutable=1` the open fails. If a sidecar is present, stop and report.
+<!-- PACT_STORE_BAR_END -->
+The `pact-memory` skill carries the full rule.
+
 **Cross-Agent Coordination**: Read [pact-phase-transitions.md](../protocols/pact-phase-transitions.md) for workflow handoffs and phase boundaries with other specialists.
 
 # TWO ROLES

--- a/pact-plugin/agents/pact-secretary.md
+++ b/pact-plugin/agents/pact-secretary.md
@@ -98,7 +98,16 @@ You are **exempted from the standard teachback** at spawn — your bootstrap tas
 
 2. **Search pact-memory** for recent context on the current project using the `search` CLI command.
 
-3. **Search for calibration data**: Search pact-memory for `orchestration_calibration` entries. Summarize by domain: sample count, mean drift direction (underestimating or overestimating difficulty), and whether the 5-sample activation threshold for Learning II is met. Include this in the session briefing so the orchestrator has calibration context before any variety scoring.
+3. **Search for calibration data**: Search pact-memory for
+   `orchestration_calibration` entries with `--limit 20` or more. Report how
+   many entries came back, and if that number reaches the 5-sample
+   activation threshold for Learning II. The count is a floor, because the
+   search returns a capped list. Read the entries and report the recurring
+   patterns you find, with their memory ids. Do NOT report a mean, a rate or a
+   per-domain breakdown: the store holds each calibration as prose, with no
+   numeric column and no domain column, so those numbers cannot be computed
+   from it. Include this in the session briefing so the orchestrator has
+   calibration context before variety scoring.
 
 4. **Check for compact summary**: If `~/.claude/pact-sessions/compact-summary.txt` exists, read it and compare against pact-memory context. Flag any discrepancies between the compaction summary and institutional memory. Include findings in the session briefing.
 

--- a/pact-plugin/agents/pact-secretary.md
+++ b/pact-plugin/agents/pact-secretary.md
@@ -54,16 +54,19 @@ You have access to two distinct memory systems — use each for its intended pur
 
 <!-- PACT_STORE_BAR_BEGIN -->
 **STORE ACCESS.** A memory operation (save, search, get, list, update or
-delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
-for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
-choose is not the store the memory of the team lives in, so a save there is
+delete a record) goes through the pact-memory CLI. YOU DO NOT SELECT A
+STORE. Do not name a store by `--db-path`, by an environment variable, or by
+one more route somebody adds later. Let the CLI resolve it. A store you
+select is not the store the memory of the team lives in, so a save there is
 lost rather than shared. STORE INSPECTION is different: a row count, a
-column audit, a schema check, or any question about the file itself. To
-inspect, do not run a CLI verb, do not import a module below
-`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+column audit, or a schema check on the file. To inspect, do not run a CLI
+verb, do not import a module below `skills/pact-memory/scripts/`, and do not
+open the store read-write. In ONE command, against ONE resolved path, check
 that `memory.db-wal` and `memory.db-shm` are both absent by their full
-names, then open the store with `mode=ro` and `immutable=1`. Without
-`immutable=1` the open fails. If a sidecar is present, stop and report.
+names, then open with `mode=ro` and `immutable=1`. Without `immutable=1` the
+open fails. If a sidecar is present, stop and report. The read does not load
+the vector extension, so it cannot answer a question about `vec_memories`.
+Stop and report rather than take a barred route.
 <!-- PACT_STORE_BAR_END -->
 The `pact-memory` skill carries the full rule.
 
@@ -98,16 +101,49 @@ You are **exempted from the standard teachback** at spawn — your bootstrap tas
 
 2. **Search pact-memory** for recent context on the current project using the `search` CLI command.
 
-3. **Search for calibration data**: Search pact-memory for
-   `orchestration_calibration` entries with `--limit 20` or more. Report how
-   many entries came back, and if that number reaches the 5-sample
-   activation threshold for Learning II. The count is a floor, because the
-   search returns a capped list. Read the entries and report the recurring
-   patterns you find, with their memory ids. Do NOT report a mean, a rate or a
-   per-domain breakdown: the store holds each calibration as prose, with no
-   numeric column and no domain column, so those numbers cannot be computed
-   from it. Include this in the session briefing so the orchestrator has
-   calibration context before variety scoring.
+3. **Report the calibration gate**: The gate for Learning II is a count of
+   calibration records. Get that count from the store, read-only.
+
+   Before you open the store, check that `memory.db-wal` and `memory.db-shm`
+   are absent. Name the two files in full. If one of them is present, do not
+   open the store. Report the gate state `not determined`, give the full name
+   of the sidecar that is present, and continue the briefing.
+
+   If the two sidecar files are absent, open the store with `mode=ro` and
+   `immutable=1`, and run this count:
+
+   ```sql
+   SELECT COUNT(*) FROM memories
+   WHERE project_id = ?2
+     AND EXISTS (
+       SELECT 1 FROM json_each(COALESCE(memories.entities,'[]')) je
+       WHERE (je.type='object' AND json_extract(je.value,'$.name') = ?1)
+          OR (je.type='text'   AND je.value = ?1))
+   ```
+
+   Set `?1` to `orchestration_calibration` and `?2` to the project id. Keep the
+   three guards. `COALESCE` gives an empty array for a null column. The object
+   arm keeps `json_extract` off a bare string, which gives an error. The text
+   arm finds a record that holds the name in a bare string.
+
+   Report one of three gate states: at or above the Learning II threshold, less
+   than the threshold, or `not determined`. If you do not read the store, do
+   NOT use a count from a CLI search. A search gives at most the number of
+   records in its limit, so the number of results measures the limit and not
+   the population.
+
+   The count is necessary and it is not sufficient. Read the entries and report
+   the recurring patterns you find, with their memory ids. The
+   [pact-variety.md](../protocols/pact-variety.md) section "Learning II:
+   Pattern-Adjusted Scoring" holds the threshold and the score adjustment it
+   controls.
+
+   Do NOT report a mean, a rate or a per-domain breakdown. The pact-memory CLI
+   has no aggregate verb and it gives prose records, so a briefing cannot
+   include a calculated statistic.
+
+   Include the gate state and the patterns in the session briefing, so the
+   orchestrator has calibration context before variety scoring.
 
 4. **Check for compact summary**: If `~/.claude/pact-sessions/compact-summary.txt` exists, read it and compare against pact-memory context. Flag any discrepancies between the compaction summary and institutional memory. Include findings in the session briefing.
 

--- a/pact-plugin/commands/prune-memory.md
+++ b/pact-plugin/commands/prune-memory.md
@@ -139,16 +139,19 @@ exists to forbid.
 
 <!-- PACT_STORE_BAR_BEGIN -->
 **STORE ACCESS.** A memory operation (save, search, get, list, update or
-delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
-for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
-choose is not the store the memory of the team lives in, so a save there is
+delete a record) goes through the pact-memory CLI. YOU DO NOT SELECT A
+STORE. Do not name a store by `--db-path`, by an environment variable, or by
+one more route somebody adds later. Let the CLI resolve it. A store you
+select is not the store the memory of the team lives in, so a save there is
 lost rather than shared. STORE INSPECTION is different: a row count, a
-column audit, a schema check, or any question about the file itself. To
-inspect, do not run a CLI verb, do not import a module below
-`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+column audit, or a schema check on the file. To inspect, do not run a CLI
+verb, do not import a module below `skills/pact-memory/scripts/`, and do not
+open the store read-write. In ONE command, against ONE resolved path, check
 that `memory.db-wal` and `memory.db-shm` are both absent by their full
-names, then open the store with `mode=ro` and `immutable=1`. Without
-`immutable=1` the open fails. If a sidecar is present, stop and report.
+names, then open with `mode=ro` and `immutable=1`. Without `immutable=1` the
+open fails. If a sidecar is present, stop and report. The read does not load
+the vector extension, so it cannot answer a question about `vec_memories`.
+Stop and report rather than take a barred route.
 <!-- PACT_STORE_BAR_END -->
 The `pact-memory` skill carries the full rule.
 

--- a/pact-plugin/commands/prune-memory.md
+++ b/pact-plugin/commands/prune-memory.md
@@ -137,6 +137,21 @@ the exhaustive form serialises into roughly 20 prompts to evict one pin, and a
 curator facing 20 prompts answers with exactly the generalities this step
 exists to forbid.
 
+<!-- PACT_STORE_BAR_BEGIN -->
+**STORE ACCESS.** A memory operation (save, search, get, list, update or
+delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
+for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
+choose is not the store the memory of the team lives in, so a save there is
+lost rather than shared. STORE INSPECTION is different: a row count, a
+column audit, a schema check, or any question about the file itself. To
+inspect, do not run a CLI verb, do not import a module below
+`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+that `memory.db-wal` and `memory.db-shm` are both absent by their full
+names, then open the store with `mode=ro` and `immutable=1`. Without
+`immutable=1` the open fails. If a sidecar is present, stop and report.
+<!-- PACT_STORE_BAR_END -->
+The `pact-memory` skill carries the full rule.
+
 ### Step 3 — Archive the selected pin
 
 Demote the pin into long-term memory and **verify it arrived** before anything

--- a/pact-plugin/hooks/shared/agent_handoff_marker.py
+++ b/pact-plugin/hooks/shared/agent_handoff_marker.py
@@ -314,11 +314,13 @@ def _resolve_marker_target(
     # This was previously also justified as commonpath over Path.is_relative_to
     # "because pyproject pins requires-python >=3.7 and is_relative_to is 3.9+".
     # That argument is INVALID and is recorded here so it is not re-derived.
-    # pyproject does declare >=3.7, but nothing on the install path consults
-    # requires-python, so the declaration is inert; the ENFORCED floor is 3.9
-    # (the CI lint target and the 3.9 AST gate), and the oldest interpreter a
-    # consumer plausibly runs the hooks under is 3.9.6. is_relative_to is
-    # therefore available at the operative floor and rejects the prefix
+    # The declaration in pyproject.toml does not govern this. Nothing on the
+    # install path consults requires-python, so the declaration is inert and
+    # its value decides nothing here. The ENFORCED floor governs: 3.9 (the CI
+    # lint target and the 3.9 AST gate), and the oldest interpreter a consumer
+    # plausibly runs the hooks under is 3.9.6. The declaration now names that
+    # same floor, so the two agree, which only strengthens this. is_relative_to
+    # is therefore available at the operative floor and rejects the prefix
     # collision too, so either primitive would be correct -- the choice is not
     # load-bearing and only the stated reason was wrong.
     # On breach OR any resolution error: fail-open emit (return None) WITHOUT

--- a/pact-plugin/hooks/shared/merge_guard_common.py
+++ b/pact-plugin/hooks/shared/merge_guard_common.py
@@ -2780,9 +2780,10 @@ def _has_pipe_to_shell(command: str) -> bool:
 # — measured ~4x per input-doubling on pathological no-slash / all-slash input.
 # This is NOT within-match catastrophic backtracking (an anchored re.match is
 # linear, ~2x/double), so an atomic group `(?>...)` would NOT fix it (and atomic
-# groups are unavailable anyway — requires-python >=3.7). DO NOT reuse this token
-# UNGATED; if it is ever needed ungated, bound the path segments
-# `(?:[^\s)/]*/){0,K}` (the F1 mechanism), which caps the per-offset scan.
+# groups are unavailable anyway: they need 3.11, above the floor that
+# pyproject.toml declares). DO NOT reuse this token UNGATED; if it is ever
+# needed ungated, bound the path segments `(?:[^\s)/]*/){0,K}` (the F1
+# mechanism), which caps the per-offset scan.
 _PROCSUB_SHELL = r"(?:[^\s)/]*/)*(?:bash|sh|zsh)(?![\w/])"
 
 

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -2376,6 +2376,21 @@ From most to least durable:
 | **Task system** | `TaskList` / `TaskGet` | Compaction (summaries only) | Status, blocking, assignment. Task *files* (metadata) may be GC'd |
 | **pact-memory** | `~/.claude/pact-memory/memory.db` | Permanently | Cross-session knowledge (not workflow state) |
 
+<!-- PACT_STORE_BAR_BEGIN -->
+**STORE ACCESS.** A memory operation (save, search, get, list, update or
+delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
+for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
+choose is not the store the memory of the team lives in, so a save there is
+lost rather than shared. STORE INSPECTION is different: a row count, a
+column audit, a schema check, or any question about the file itself. To
+inspect, do not run a CLI verb, do not import a module below
+`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+that `memory.db-wal` and `memory.db-shm` are both absent by their full
+names, then open the store with `mode=ro` and `immutable=1`. Without
+`immutable=1` the open fails. If a sidecar is present, stop and report.
+<!-- PACT_STORE_BAR_END -->
+The `pact-memory` skill carries the full rule.
+
 ### Recovery Triggers
 
 | Trigger | What Runs | Entry Point |

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -2378,16 +2378,19 @@ From most to least durable:
 
 <!-- PACT_STORE_BAR_BEGIN -->
 **STORE ACCESS.** A memory operation (save, search, get, list, update or
-delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
-for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
-choose is not the store the memory of the team lives in, so a save there is
+delete a record) goes through the pact-memory CLI. YOU DO NOT SELECT A
+STORE. Do not name a store by `--db-path`, by an environment variable, or by
+one more route somebody adds later. Let the CLI resolve it. A store you
+select is not the store the memory of the team lives in, so a save there is
 lost rather than shared. STORE INSPECTION is different: a row count, a
-column audit, a schema check, or any question about the file itself. To
-inspect, do not run a CLI verb, do not import a module below
-`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+column audit, or a schema check on the file. To inspect, do not run a CLI
+verb, do not import a module below `skills/pact-memory/scripts/`, and do not
+open the store read-write. In ONE command, against ONE resolved path, check
 that `memory.db-wal` and `memory.db-shm` are both absent by their full
-names, then open the store with `mode=ro` and `immutable=1`. Without
-`immutable=1` the open fails. If a sidecar is present, stop and report.
+names, then open with `mode=ro` and `immutable=1`. Without `immutable=1` the
+open fails. If a sidecar is present, stop and report. The read does not load
+the vector extension, so it cannot answer a question about `vec_memories`.
+Stop and report rather than take a barred route.
 <!-- PACT_STORE_BAR_END -->
 The `pact-memory` skill carries the full rule.
 

--- a/pact-plugin/protocols/pact-state-recovery.md
+++ b/pact-plugin/protocols/pact-state-recovery.md
@@ -16,16 +16,19 @@ From most to least durable:
 
 <!-- PACT_STORE_BAR_BEGIN -->
 **STORE ACCESS.** A memory operation (save, search, get, list, update or
-delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
-for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
-choose is not the store the memory of the team lives in, so a save there is
+delete a record) goes through the pact-memory CLI. YOU DO NOT SELECT A
+STORE. Do not name a store by `--db-path`, by an environment variable, or by
+one more route somebody adds later. Let the CLI resolve it. A store you
+select is not the store the memory of the team lives in, so a save there is
 lost rather than shared. STORE INSPECTION is different: a row count, a
-column audit, a schema check, or any question about the file itself. To
-inspect, do not run a CLI verb, do not import a module below
-`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+column audit, or a schema check on the file. To inspect, do not run a CLI
+verb, do not import a module below `skills/pact-memory/scripts/`, and do not
+open the store read-write. In ONE command, against ONE resolved path, check
 that `memory.db-wal` and `memory.db-shm` are both absent by their full
-names, then open the store with `mode=ro` and `immutable=1`. Without
-`immutable=1` the open fails. If a sidecar is present, stop and report.
+names, then open with `mode=ro` and `immutable=1`. Without `immutable=1` the
+open fails. If a sidecar is present, stop and report. The read does not load
+the vector extension, so it cannot answer a question about `vec_memories`.
+Stop and report rather than take a barred route.
 <!-- PACT_STORE_BAR_END -->
 The `pact-memory` skill carries the full rule.
 

--- a/pact-plugin/protocols/pact-state-recovery.md
+++ b/pact-plugin/protocols/pact-state-recovery.md
@@ -14,6 +14,21 @@ From most to least durable:
 | **Task system** | `TaskList` / `TaskGet` | Compaction (summaries only) | Status, blocking, assignment. Task *files* (metadata) may be GC'd |
 | **pact-memory** | `~/.claude/pact-memory/memory.db` | Permanently | Cross-session knowledge (not workflow state) |
 
+<!-- PACT_STORE_BAR_BEGIN -->
+**STORE ACCESS.** A memory operation (save, search, get, list, update or
+delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
+for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
+choose is not the store the memory of the team lives in, so a save there is
+lost rather than shared. STORE INSPECTION is different: a row count, a
+column audit, a schema check, or any question about the file itself. To
+inspect, do not run a CLI verb, do not import a module below
+`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+that `memory.db-wal` and `memory.db-shm` are both absent by their full
+names, then open the store with `mode=ro` and `immutable=1`. Without
+`immutable=1` the open fails. If a sidecar is present, stop and report.
+<!-- PACT_STORE_BAR_END -->
+The `pact-memory` skill carries the full rule.
+
 ### Recovery Triggers
 
 | Trigger | What Runs | Entry Point |

--- a/pact-plugin/reference/config.md
+++ b/pact-plugin/reference/config.md
@@ -38,16 +38,19 @@ If you find the variable in a process list or in the source, these are its mecha
 
 <!-- PACT_STORE_BAR_BEGIN -->
 **STORE ACCESS.** A memory operation (save, search, get, list, update or
-delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
-for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
-choose is not the store the memory of the team lives in, so a save there is
+delete a record) goes through the pact-memory CLI. YOU DO NOT SELECT A
+STORE. Do not name a store by `--db-path`, by an environment variable, or by
+one more route somebody adds later. Let the CLI resolve it. A store you
+select is not the store the memory of the team lives in, so a save there is
 lost rather than shared. STORE INSPECTION is different: a row count, a
-column audit, a schema check, or any question about the file itself. To
-inspect, do not run a CLI verb, do not import a module below
-`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+column audit, or a schema check on the file. To inspect, do not run a CLI
+verb, do not import a module below `skills/pact-memory/scripts/`, and do not
+open the store read-write. In ONE command, against ONE resolved path, check
 that `memory.db-wal` and `memory.db-shm` are both absent by their full
-names, then open the store with `mode=ro` and `immutable=1`. Without
-`immutable=1` the open fails. If a sidecar is present, stop and report.
+names, then open with `mode=ro` and `immutable=1`. Without `immutable=1` the
+open fails. If a sidecar is present, stop and report. The read does not load
+the vector extension, so it cannot answer a question about `vec_memories`.
+Stop and report rather than take a barred route.
 <!-- PACT_STORE_BAR_END -->
 The `pact-memory` skill carries the full rule.
 

--- a/pact-plugin/reference/config.md
+++ b/pact-plugin/reference/config.md
@@ -36,6 +36,21 @@ If you find the variable in a process list or in the source, these are its mecha
 - **An empty value counts as unset.** Thus `PACT_TEST_MEMORY_DIR=""` cannot move the database to the current directory by accident.
 - **The resolver redirects. It does not refuse.** It cannot tell a test path from a live one. It sees only if you set the variable.
 
+<!-- PACT_STORE_BAR_BEGIN -->
+**STORE ACCESS.** A memory operation (save, search, get, list, update or
+delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
+for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
+choose is not the store the memory of the team lives in, so a save there is
+lost rather than shared. STORE INSPECTION is different: a row count, a
+column audit, a schema check, or any question about the file itself. To
+inspect, do not run a CLI verb, do not import a module below
+`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+that `memory.db-wal` and `memory.db-shm` are both absent by their full
+names, then open the store with `mode=ro` and `immutable=1`. Without
+`immutable=1` the open fails. If a sidecar is present, stop and report.
+<!-- PACT_STORE_BAR_END -->
+The `pact-memory` skill carries the full rule.
+
 ## Where to set the options
 
 Any env-var source works. In order of persistence:

--- a/pact-plugin/scripts/archive_pin.py
+++ b/pact-plugin/scripts/archive_pin.py
@@ -138,6 +138,20 @@ Related:
   - skills/pact-memory/scripts/cli.py -- the save/get surface, reached by
     SUBPROCESS rather than import (keeps the process boundary the rest of
     the codebase keeps, and the CLI is the tested public surface)
+<!-- PACT_STORE_BAR_BEGIN -->
+**STORE ACCESS.** A memory operation (save, search, get, list, update or
+delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
+for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
+choose is not the store the memory of the team lives in, so a save there is
+lost rather than shared. STORE INSPECTION is different: a row count, a
+column audit, a schema check, or any question about the file itself. To
+inspect, do not run a CLI verb, do not import a module below
+`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+that `memory.db-wal` and `memory.db-shm` are both absent by their full
+names, then open the store with `mode=ro` and `immutable=1`. Without
+`immutable=1` the open fails. If a sidecar is present, stop and report.
+<!-- PACT_STORE_BAR_END -->
+The `pact-memory` skill carries the full rule.
 """
 
 from __future__ import annotations

--- a/pact-plugin/scripts/archive_pin.py
+++ b/pact-plugin/scripts/archive_pin.py
@@ -140,16 +140,19 @@ Related:
     the codebase keeps, and the CLI is the tested public surface)
 <!-- PACT_STORE_BAR_BEGIN -->
 **STORE ACCESS.** A memory operation (save, search, get, list, update or
-delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
-for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
-choose is not the store the memory of the team lives in, so a save there is
+delete a record) goes through the pact-memory CLI. YOU DO NOT SELECT A
+STORE. Do not name a store by `--db-path`, by an environment variable, or by
+one more route somebody adds later. Let the CLI resolve it. A store you
+select is not the store the memory of the team lives in, so a save there is
 lost rather than shared. STORE INSPECTION is different: a row count, a
-column audit, a schema check, or any question about the file itself. To
-inspect, do not run a CLI verb, do not import a module below
-`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+column audit, or a schema check on the file. To inspect, do not run a CLI
+verb, do not import a module below `skills/pact-memory/scripts/`, and do not
+open the store read-write. In ONE command, against ONE resolved path, check
 that `memory.db-wal` and `memory.db-shm` are both absent by their full
-names, then open the store with `mode=ro` and `immutable=1`. Without
-`immutable=1` the open fails. If a sidecar is present, stop and report.
+names, then open with `mode=ro` and `immutable=1`. Without `immutable=1` the
+open fails. If a sidecar is present, stop and report. The read does not load
+the vector extension, so it cannot answer a question about `vec_memories`.
+Stop and report rather than take a barred route.
 <!-- PACT_STORE_BAR_END -->
 The `pact-memory` skill carries the full rule.
 """

--- a/pact-plugin/scripts/memory_repair/__init__.py
+++ b/pact-plugin/scripts/memory_repair/__init__.py
@@ -12,16 +12,19 @@ subprocess reaches those functions with no import at all. These tools depend
 on nothing from that package, so they run without it.
 <!-- PACT_STORE_BAR_BEGIN -->
 **STORE ACCESS.** A memory operation (save, search, get, list, update or
-delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
-for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
-choose is not the store the memory of the team lives in, so a save there is
+delete a record) goes through the pact-memory CLI. YOU DO NOT SELECT A
+STORE. Do not name a store by `--db-path`, by an environment variable, or by
+one more route somebody adds later. Let the CLI resolve it. A store you
+select is not the store the memory of the team lives in, so a save there is
 lost rather than shared. STORE INSPECTION is different: a row count, a
-column audit, a schema check, or any question about the file itself. To
-inspect, do not run a CLI verb, do not import a module below
-`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+column audit, or a schema check on the file. To inspect, do not run a CLI
+verb, do not import a module below `skills/pact-memory/scripts/`, and do not
+open the store read-write. In ONE command, against ONE resolved path, check
 that `memory.db-wal` and `memory.db-shm` are both absent by their full
-names, then open the store with `mode=ro` and `immutable=1`. Without
-`immutable=1` the open fails. If a sidecar is present, stop and report.
+names, then open with `mode=ro` and `immutable=1`. Without `immutable=1` the
+open fails. If a sidecar is present, stop and report. The read does not load
+the vector extension, so it cannot answer a question about `vec_memories`.
+Stop and report rather than take a barred route.
 <!-- PACT_STORE_BAR_END -->
 The `pact-memory` skill carries the full rule.
 """

--- a/pact-plugin/scripts/memory_repair/__init__.py
+++ b/pact-plugin/scripts/memory_repair/__init__.py
@@ -10,5 +10,19 @@ puts each of them one call away. This rule holds so that nobody must audit
 which call is safe. Do not read an absent import as a guarantee, because a
 subprocess reaches those functions with no import at all. These tools depend
 on nothing from that package, so they run without it.
+<!-- PACT_STORE_BAR_BEGIN -->
+**STORE ACCESS.** A memory operation (save, search, get, list, update or
+delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
+for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
+choose is not the store the memory of the team lives in, so a save there is
+lost rather than shared. STORE INSPECTION is different: a row count, a
+column audit, a schema check, or any question about the file itself. To
+inspect, do not run a CLI verb, do not import a module below
+`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+that `memory.db-wal` and `memory.db-shm` are both absent by their full
+names, then open the store with `mode=ro` and `immutable=1`. Without
+`immutable=1` the open fails. If a sidecar is present, stop and report.
+<!-- PACT_STORE_BAR_END -->
+The `pact-memory` skill carries the full rule.
 """
 from __future__ import annotations

--- a/pact-plugin/scripts/memory_repair/shred_detect.py
+++ b/pact-plugin/scripts/memory_repair/shred_detect.py
@@ -59,16 +59,19 @@ Exit codes:
      is absent. Nothing was scanned.
 <!-- PACT_STORE_BAR_BEGIN -->
 **STORE ACCESS.** A memory operation (save, search, get, list, update or
-delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
-for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
-choose is not the store the memory of the team lives in, so a save there is
+delete a record) goes through the pact-memory CLI. YOU DO NOT SELECT A
+STORE. Do not name a store by `--db-path`, by an environment variable, or by
+one more route somebody adds later. Let the CLI resolve it. A store you
+select is not the store the memory of the team lives in, so a save there is
 lost rather than shared. STORE INSPECTION is different: a row count, a
-column audit, a schema check, or any question about the file itself. To
-inspect, do not run a CLI verb, do not import a module below
-`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+column audit, or a schema check on the file. To inspect, do not run a CLI
+verb, do not import a module below `skills/pact-memory/scripts/`, and do not
+open the store read-write. In ONE command, against ONE resolved path, check
 that `memory.db-wal` and `memory.db-shm` are both absent by their full
-names, then open the store with `mode=ro` and `immutable=1`. Without
-`immutable=1` the open fails. If a sidecar is present, stop and report.
+names, then open with `mode=ro` and `immutable=1`. Without `immutable=1` the
+open fails. If a sidecar is present, stop and report. The read does not load
+the vector extension, so it cannot answer a question about `vec_memories`.
+Stop and report rather than take a barred route.
 <!-- PACT_STORE_BAR_END -->
 The `pact-memory` skill carries the full rule.
 """

--- a/pact-plugin/scripts/memory_repair/shred_detect.py
+++ b/pact-plugin/scripts/memory_repair/shred_detect.py
@@ -57,6 +57,20 @@ Exit codes:
      annotates and the caller decides.
   2  the no-writer precondition failed, or the file is absent, or the table
      is absent. Nothing was scanned.
+<!-- PACT_STORE_BAR_BEGIN -->
+**STORE ACCESS.** A memory operation (save, search, get, list, update or
+delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
+for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
+choose is not the store the memory of the team lives in, so a save there is
+lost rather than shared. STORE INSPECTION is different: a row count, a
+column audit, a schema check, or any question about the file itself. To
+inspect, do not run a CLI verb, do not import a module below
+`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+that `memory.db-wal` and `memory.db-shm` are both absent by their full
+names, then open the store with `mode=ro` and `immutable=1`. Without
+`immutable=1` the open fails. If a sidecar is present, stop and report.
+<!-- PACT_STORE_BAR_END -->
+The `pact-memory` skill carries the full rule.
 """
 from __future__ import annotations
 

--- a/pact-plugin/skills/pact-handoff-harvest/SKILL.md
+++ b/pact-plugin/skills/pact-handoff-harvest/SKILL.md
@@ -20,6 +20,21 @@ Determine which variant to run from the task subject/description: "harvest" or "
 
 ---
 
+<!-- PACT_STORE_BAR_BEGIN -->
+**STORE ACCESS.** A memory operation (save, search, get, list, update or
+delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
+for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
+choose is not the store the memory of the team lives in, so a save there is
+lost rather than shared. STORE INSPECTION is different: a row count, a
+column audit, a schema check, or any question about the file itself. To
+inspect, do not run a CLI verb, do not import a module below
+`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+that `memory.db-wal` and `memory.db-shm` are both absent by their full
+names, then open the store with `mode=ro` and `immutable=1`. Without
+`immutable=1` the open fails. If a sidecar is present, stop and report.
+<!-- PACT_STORE_BAR_END -->
+The `pact-memory` skill carries the full rule.
+
 ## Standard Harvest Workflow
 
 ### Read All HANDOFFs Before Saving

--- a/pact-plugin/skills/pact-handoff-harvest/SKILL.md
+++ b/pact-plugin/skills/pact-handoff-harvest/SKILL.md
@@ -22,16 +22,19 @@ Determine which variant to run from the task subject/description: "harvest" or "
 
 <!-- PACT_STORE_BAR_BEGIN -->
 **STORE ACCESS.** A memory operation (save, search, get, list, update or
-delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
-for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
-choose is not the store the memory of the team lives in, so a save there is
+delete a record) goes through the pact-memory CLI. YOU DO NOT SELECT A
+STORE. Do not name a store by `--db-path`, by an environment variable, or by
+one more route somebody adds later. Let the CLI resolve it. A store you
+select is not the store the memory of the team lives in, so a save there is
 lost rather than shared. STORE INSPECTION is different: a row count, a
-column audit, a schema check, or any question about the file itself. To
-inspect, do not run a CLI verb, do not import a module below
-`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+column audit, or a schema check on the file. To inspect, do not run a CLI
+verb, do not import a module below `skills/pact-memory/scripts/`, and do not
+open the store read-write. In ONE command, against ONE resolved path, check
 that `memory.db-wal` and `memory.db-shm` are both absent by their full
-names, then open the store with `mode=ro` and `immutable=1`. Without
-`immutable=1` the open fails. If a sidecar is present, stop and report.
+names, then open with `mode=ro` and `immutable=1`. Without `immutable=1` the
+open fails. If a sidecar is present, stop and report. The read does not load
+the vector extension, so it cannot answer a question about `vec_memories`.
+Stop and report rather than take a barred route.
 <!-- PACT_STORE_BAR_END -->
 The `pact-memory` skill carries the full rule.
 

--- a/pact-plugin/skills/pact-memory/SKILL.md
+++ b/pact-plugin/skills/pact-memory/SKILL.md
@@ -27,27 +27,32 @@ The PACT Memory skill provides:
 
 <!-- PACT_STORE_BAR_BEGIN -->
 **STORE ACCESS.** A memory operation (save, search, get, list, update or
-delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
-for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
-choose is not the store the memory of the team lives in, so a save there is
+delete a record) goes through the pact-memory CLI. YOU DO NOT SELECT A
+STORE. Do not name a store by `--db-path`, by an environment variable, or by
+one more route somebody adds later. Let the CLI resolve it. A store you
+select is not the store the memory of the team lives in, so a save there is
 lost rather than shared. STORE INSPECTION is different: a row count, a
-column audit, a schema check, or any question about the file itself. To
-inspect, do not run a CLI verb, do not import a module below
-`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+column audit, or a schema check on the file. To inspect, do not run a CLI
+verb, do not import a module below `skills/pact-memory/scripts/`, and do not
+open the store read-write. In ONE command, against ONE resolved path, check
 that `memory.db-wal` and `memory.db-shm` are both absent by their full
-names, then open the store with `mode=ro` and `immutable=1`. Without
-`immutable=1` the open fails. If a sidecar is present, stop and report.
+names, then open with `mode=ro` and `immutable=1`. Without `immutable=1` the
+open fails. If a sidecar is present, stop and report. The read does not load
+the vector extension, so it cannot answer a question about `vec_memories`.
+Stop and report rather than take a barred route.
 <!-- PACT_STORE_BAR_END -->
 
 The sections below give the detail behind each sentence above.
 
 MORE ON THE BRIGHT LINE, because an agent will look for an exception. THE RULE
 IS A POLICY, AND IT IS NOT A CLAIM ABOUT WHAT THE TOOL DOES. An agent does not
-select a store. One command carries an exemption, and the owner of the tool
-controls that exemption rather than you. The danger is NOT that the flag
-reaches the live store. The flag binds the store you name, so the danger is
-that your save lands in a store nobody reads. For a memory system, a write
-that goes nowhere costs as much as a write that goes incorrectly.
+select a store. The CLI can tell you to run `setup --db-path <path>`. That
+message is correct for the tool and it does not apply to you. You reach it
+only after you pass `--db-path`, which this rule forbids. Do not run it.
+Report it and ask the user. The danger is NOT that the flag reaches the live
+store. The flag binds the store you name, so the danger is that your save
+lands in a store nobody reads. For a memory system, a write that goes nowhere
+costs as much as a write that goes incorrectly.
 
 ### To inspect the store
 

--- a/pact-plugin/skills/pact-memory/SKILL.md
+++ b/pact-plugin/skills/pact-memory/SKILL.md
@@ -23,6 +23,103 @@ The PACT Memory skill provides:
 - **Session Tracking**: Automatic file tracking and session context
 - **Cross-Session Learning**: Memories persist across sessions for cumulative knowledge
 
+## Store access: the two routes
+
+<!-- PACT_STORE_BAR_BEGIN -->
+**STORE ACCESS.** A memory operation (save, search, get, list, update or
+delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
+for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
+choose is not the store the memory of the team lives in, so a save there is
+lost rather than shared. STORE INSPECTION is different: a row count, a
+column audit, a schema check, or any question about the file itself. To
+inspect, do not run a CLI verb, do not import a module below
+`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+that `memory.db-wal` and `memory.db-shm` are both absent by their full
+names, then open the store with `mode=ro` and `immutable=1`. Without
+`immutable=1` the open fails. If a sidecar is present, stop and report.
+<!-- PACT_STORE_BAR_END -->
+
+The sections below give the detail behind each sentence above.
+
+MORE ON THE BRIGHT LINE, because an agent will look for an exception. THE RULE
+IS A POLICY, AND IT IS NOT A CLAIM ABOUT WHAT THE TOOL DOES. An agent does not
+select a store. One command carries an exemption, and the owner of the tool
+controls that exemption rather than you. The danger is NOT that the flag
+reaches the live store. The flag binds the store you name, so the danger is
+that your save lands in a store nobody reads. For a memory system, a write
+that goes nowhere costs as much as a write that goes incorrectly.
+
+### To inspect the store
+
+1. Check that `memory.db-wal` and `memory.db-shm` are both absent. Name the
+   two files in full. Do not use a glob.
+2. If one of the two files is present, stop. Report it. Do not read the store.
+3. If neither file is present, open the store read-only:
+   `sqlite3.connect("file:<path>?mode=ro&immutable=1", uri=True)`
+
+### What you must not do, and why
+
+- Do not run a pact-memory CLI verb to inspect the store. The CLI opens a
+  read-write connection and runs `PRAGMA journal_mode=WAL` on it, which
+  creates `memory.db-wal` and `memory.db-shm`. A CLI read is thus a write
+  to the store directory. A CLI run also reaches the same functions an import
+  reaches, so it defeats the next rule.
+- Do not import a module below `skills/pact-memory/scripts/`. In that package,
+  functions create the live store directory as a side result of a path
+  resolution, so an import puts each of them one call away. Do not read an
+  absent import as a guarantee, because a subprocess reaches those functions
+  with no import at all.
+- Do not open the store with a plain `sqlite3.connect`. A read-write open
+  creates the two sidecar files. That is a write to the store directory, even
+  when no SQL runs.
+- Do not copy the store with `cp`. A copy taken while commits sit in an
+  uncheckpointed WAL is silently short of data, and it passes
+  `PRAGMA integrity_check`. If you must have a copy, use `VACUUM INTO`.
+
+### Why the two flags, and why the check comes first
+
+`mode=ro` alone cannot open this store. sqlite must create `memory.db-shm` to
+read a WAL database, and `mode=ro` forbids that creation, so the open fails
+with `unable to open database file`. `immutable=1` tells sqlite to skip the
+WAL and read the main file directly, so the open succeeds and creates nothing.
+`immutable=1` is not extra hardening. It is the only flag that opens the file.
+
+The sidecar check is not a writer detector. It is a state selector. When the
+two sidecar files are absent, no WAL data is pending, so the main file is the
+whole database. That is the state in which `immutable=1` is correct. If a
+sidecar is present, committed data can sit outside the main file, and
+`immutable=1` then returns an older image and raises no error. One flag makes
+the read possible. The check makes the read correct.
+
+### If the check refuses
+
+A refusal is information. In normal operation the CLI closes its connection
+and sqlite removes the two sidecar files on that close, so the check passes. A
+sidecar that stays is evidence that a writer did not close cleanly.
+
+If a sidecar is present:
+
+1. Report the sidecar by its full name and its size.
+2. Do not read the store with `immutable=1`.
+3. Do not delete a sidecar. A sidecar can hold committed data that is not
+   in the main file at this time.
+4. Ask the user before you go further. A recovery needs a write, and a write
+   to this store is the user's decision.
+
+### To save a memory
+
+Run the pact-memory CLI `save` command with no `--db-path`. The CLI resolves
+the default store. The store-access rule above gives the cause, and that
+cause covers a write.
+
+Do not run `python3 setup_memory.py init`. That script runs as a script, it
+writes, and it accepts no `--db-path`, so the write reaches the live store and
+you cannot steer it away. The pytest refusal in the CLI is keyed on
+`PYTEST_CURRENT_TEST`, so it does not cover a run outside pytest.
+
+Do not import a module below `skills/pact-memory/scripts/` to write. Most of
+the modules in that package carry writing SQL.
+
 ## Quick Start
 
 All commands use the CLI entry point via `${CLAUDE_SKILL_DIR}`:

--- a/pact-plugin/skills/pact-memory/SKILL.md
+++ b/pact-plugin/skills/pact-memory/SKILL.md
@@ -109,8 +109,8 @@ If a sidecar is present:
 ### To save a memory
 
 Run the pact-memory CLI `save` command with no `--db-path`. The CLI resolves
-the default store. The store-access rule above gives the cause, and that
-cause covers a write.
+the default store. The section "Store access: the two routes" above gives the
+cause, and that cause covers a write.
 
 Do not run `python3 setup_memory.py init`. That script runs as a script, it
 writes, and it accepts no `--db-path`, so the write reaches the live store and

--- a/pact-plugin/skills/pact-memory/references/memory-patterns.md
+++ b/pact-plugin/skills/pact-memory/references/memory-patterns.md
@@ -5,14 +5,29 @@
 This document provides patterns and examples for effective use of the PACT Memory
 skill across different scenarios.
 
+<!-- PACT_STORE_BAR_BEGIN -->
+**STORE ACCESS.** A memory operation (save, search, get, list, update or
+delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
+for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
+choose is not the store the memory of the team lives in, so a save there is
+lost rather than shared. STORE INSPECTION is different: a row count, a
+column audit, a schema check, or any question about the file itself. To
+inspect, do not run a CLI verb, do not import a module below
+`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+that `memory.db-wal` and `memory.db-shm` are both absent by their full
+names, then open the store with `mode=ro` and `immutable=1`. Without
+`immutable=1` the open fails. If a sidecar is present, stop and report.
+<!-- PACT_STORE_BAR_END -->
+The `pact-memory` skill carries the full rule.
+
 ## Pattern 1: Phase Completion Memory
 
 Save context after completing each PACT phase to preserve learnings.
 
 ### After Prepare Phase
 
-```python
-memory.save({
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" save '{
     "context": "Completed research phase for the API gateway authentication system on the feature/api-auth branch. The project requires securing 15+ microservices that communicate both internally and with external third-party clients. Current architecture has no centralized auth - each service handles its own validation, leading to inconsistent security policies and duplicated code. Stakeholders require SSO capability for enterprise customers and API key support for developer integrations. Evaluated three main approaches: OAuth2 with dedicated auth server, JWT tokens with shared secret, and a hybrid approach. Reviewed documentation for Auth0, Keycloak, and custom implementations.",
     "goal": "Determine the optimal authentication strategy for the API gateway that balances security requirements, implementation complexity, and support for both internal services and external third-party integrations.",
     "lessons_learned": [
@@ -34,13 +49,13 @@ memory.save({
         {"name": "AuthService", "type": "service", "notes": "New service to be created for identity management"},
         {"name": "Redis Cluster", "type": "infrastructure", "notes": "Existing cluster to be used for token blacklist"}
     ]
-})
+}'
 ```
 
 ### After Architect Phase
 
-```python
-memory.save({
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" save '{
     "context": "Designing authentication microservice architecture",
     "goal": "Create scalable auth service with token management",
     "active_tasks": [
@@ -64,13 +79,13 @@ memory.save({
         {"name": "TokenBlacklist", "type": "component", "notes": "Redis-backed"},
         {"name": "RefreshTokenStore", "type": "table"}
     ]
-})
+}'
 ```
 
 ### After Code Phase
 
-```python
-memory.save({
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" save '{
     "context": "Implemented JWT authentication with refresh tokens",
     "goal": "Complete auth service implementation",
     "lessons_learned": [
@@ -89,13 +104,13 @@ memory.save({
         {"name": "JWTHandler", "type": "class"},
         {"name": "RateLimiter", "type": "middleware"}
     ]
-})
+}'
 ```
 
 ### After Test Phase
 
-```python
-memory.save({
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" save '{
     "context": "Completed authentication service testing",
     "goal": "Ensure auth service reliability and security",
     "lessons_learned": [
@@ -110,15 +125,15 @@ memory.save({
             "alternatives": ["Skip chaos testing for MVP"]
         }
     ]
-})
+}'
 ```
 
 ## Pattern 2: Blocker Documentation
 
 When hitting a blocker, save context for future reference.
 
-```python
-memory.save({
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" save '{
     "context": "Blocked on sqlite-lembed installation on M1 Mac",
     "goal": "Enable local embeddings for memory skill",
     "lessons_learned": [
@@ -136,7 +151,7 @@ memory.save({
         {"task": "Add sentence-transformers fallback", "status": "pending", "priority": "high"},
         {"task": "Test cross-platform compatibility", "status": "pending"}
     ]
-})
+}'
 ```
 
 ## Pattern 3: Search Before Starting
@@ -144,40 +159,31 @@ memory.save({
 Query for relevant context before beginning work.
 
 ```python
+import json, subprocess
+# CLI is a list so the command is one argument per element.
+CLI = ["python3", "${CLAUDE_SKILL_DIR}/scripts/cli.py"]
 # Starting work on authentication
-results = memory.search("authentication security tokens")
+raw = subprocess.run(
+    [*CLI, "search", "authentication security tokens"], capture_output=True, text=True, check=True
+).stdout
+results = json.loads(raw)
 
 for mem in results:
     print(f"\n=== Past Context ===")
-    print(f"Context: {mem.context}")
-    print(f"Goal: {mem.goal}")
+    print(f"Context: {mem["context"]}")
+    print(f"Goal: {mem["goal"]}")
 
-    if mem.lessons_learned:
+    if mem["lessons_learned"]:
         print(f"\nLessons:")
-        for lesson in mem.lessons_learned:
+        for lesson in mem["lessons_learned"]:
             print(f"  - {lesson}")
 
-    if mem.decisions:
+    if mem["decisions"]:
         print(f"\nDecisions:")
-        for dec in mem.decisions:
-            print(f"  - {dec.decision}")
-            if dec.rationale:
-                print(f"    Rationale: {dec.rationale}")
-```
-
-## Pattern 4: File-Based Context
-
-Search for memories related to files you're working on.
-
-```python
-# Get context for the file you're editing
-current_file = "src/auth/token_manager.py"
-related = memory.search_by_file(current_file)
-
-for mem in related:
-    print(f"Previous work on related files:")
-    print(f"  Context: {mem.context}")
-    print(f"  Files: {', '.join(mem.files)}")
+        for dec in mem["decisions"]:
+            print(f"  - {dec["decision"]}")
+            if dec["rationale"]:
+                print(f"    Rationale: {dec["rationale"]}")
 ```
 
 ## Pattern 5: Decision Tracking
@@ -185,18 +191,24 @@ for mem in related:
 Use memories as a decision log across the project.
 
 ```python
+import json, subprocess
+# CLI is a list so the command is one argument per element.
+CLI = ["python3", "${CLAUDE_SKILL_DIR}/scripts/cli.py"]
 # Search for past decisions on a topic
-decisions = memory.search("caching strategy decisions")
+raw = subprocess.run(
+    [*CLI, "search", "caching strategy decisions"], capture_output=True, text=True, check=True
+).stdout
+decisions = json.loads(raw)
 
 # Compile decision history
 for mem in decisions:
-    if mem.decisions:
-        print(f"\n{mem.created_at}: {mem.context}")
-        for dec in mem.decisions:
-            print(f"  Decision: {dec.decision}")
-            print(f"  Rationale: {dec.rationale}")
-            if dec.alternatives:
-                print(f"  Alternatives: {', '.join(dec.alternatives)}")
+    if mem["decisions"]:
+        print(f"\n{mem["created_at"]}: {mem["context"]}")
+        for dec in mem["decisions"]:
+            print(f"  Decision: {dec["decision"]}")
+            print(f"  Rationale: {dec["rationale"]}")
+            if dec["alternatives"]:
+                print(f"  Alternatives: {', '.join(dec["alternatives"])}")
 ```
 
 ## Pattern 6: Entity Reference
@@ -204,20 +216,26 @@ for mem in decisions:
 Build up knowledge about system components.
 
 ```python
+import json, subprocess
+# CLI is a list so the command is one argument per element.
+CLI = ["python3", "${CLAUDE_SKILL_DIR}/scripts/cli.py"]
 # Search for memories mentioning a component
-auth_memories = memory.search("AuthService")
+raw = subprocess.run(
+    [*CLI, "search", "AuthService"], capture_output=True, text=True, check=True
+).stdout
+auth_memories = json.loads(raw)
 
 # Compile entity knowledge
 entity_notes = {}
 for mem in auth_memories:
-    for entity in mem.entities:
-        if entity.name not in entity_notes:
-            entity_notes[entity.name] = {
-                "type": entity.type,
+    for entity in mem["entities"]:
+        if entity["name"] not in entity_notes:
+            entity_notes[entity["name"]] = {
+                "type": entity["type"],
                 "notes": []
             }
-        if entity.notes:
-            entity_notes[entity.name]["notes"].append(entity.notes)
+        if entity["notes"]:
+            entity_notes[entity["name"]]["notes"].append(entity["notes"])
 
 # Display accumulated knowledge
 for name, info in entity_notes.items():
@@ -230,11 +248,8 @@ for name, info in entity_notes.items():
 
 Save comprehensive session summary before ending.
 
-```python
-# Get files modified in this session
-tracked_files = memory.get_tracked_files()
-
-memory.save({
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" save '{
     "context": "Wrapping up a 4-hour session on the feature/jwt-auth branch implementing the JWT authentication system with refresh token support. Started the session by reviewing the architecture docs from the previous phase, then implemented the core TokenManager class and RateLimiter middleware. Hit a blocker mid-session when Redis connection pooling caused memory leaks under load testing - resolved by switching from redis-py's default connection handling to explicit pool management with max_connections=50. The implementation now passes all unit tests (47 tests) and integration tests (12 tests). Deferred chaos testing based on discussion with tech lead who wants to review the core implementation first. PR #234 is ready for review with all CI checks passing.",
     "goal": "Complete the JWT authentication implementation with refresh token rotation, including rate limiting middleware, ready for code review and stakeholder demo scheduled for tomorrow.",
     "active_tasks": [
@@ -264,64 +279,61 @@ memory.save({
         {"name": "src/auth/token_manager.py", "type": "file", "notes": "Primary implementation file, 340 lines"},
         {"name": "src/middleware/rate_limit.py", "type": "file", "notes": "Rate limiting middleware, 180 lines"}
     ]
-},
-files=tracked_files,
-include_tracked=False  # We're explicitly providing files
-)
+}'
 ```
 
 ## Pattern 8: Incremental Learning
 
-Update memories as understanding evolves. `memory.update()` merges list-valued
+Update memories as understanding evolves. The `update` command merges list-valued
 fields additively with content-hash deduplication, so you can pass just the new
 items — no read-merge-write-back required.
 
-```python
+```bash
 # Append new lessons and a new entity to memory abc123.
 # The existing lessons_learned and entities are preserved; duplicates (by
 # content hash) are silently deduplicated, so this call is idempotent.
-memory.update("abc123", {
+python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" update abc123 '{
     "lessons_learned": [
         "Redis cluster mode requires different connection handling",
-        "Sentinel provides better HA than standalone Redis",
+        "Sentinel provides better HA than standalone Redis"
     ],
     "entities": [
-        {"name": "RedisSentinel", "type": "component", "notes": "HA setup"},
-    ],
-})
+        {"name": "RedisSentinel", "type": "component", "notes": "HA setup"}
+    ]
+}'
 ```
 
-**Content-hash dedup makes incremental learning cheap.** Calling `update()`
-twice with the same lesson stores it once. You don't need to check "did I
+**Content-hash dedup makes incremental learning cheap.** Two `update` calls
+with the same lesson store it once. You don't need to check "did I
 already save this?" — just call `update` and let the merge handle it.
 
 **When you genuinely want wholesale replacement** (e.g. removing a stale item
-from a list), pass `replace=True`:
+from a list), pass `--replace`:
 
-```python
+```bash
 # Replace the entire lessons_learned column with exactly this one item.
 # Any existing lessons are discarded.
-memory.update("abc123", {"lessons_learned": ["Only lesson that matters"]}, replace=True)
+python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" update abc123 '{"lessons_learned": ["Only lesson that matters"]}' --replace
 ```
 
 > ⚠️ Previously, partial list updates silently clobbered the entire column.
 > If you see code that reads → merges in Python → writes back, it's obsolete
 > — delete the read/merge scaffolding and pass just the new items directly to
-> `update()`.
+> `update`.
 
 ## Anti-Patterns to Avoid
 
 ### Too Vague
 
-```python
+```bash
 # BAD - no actionable information, future you learns nothing
-memory.save({
+python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" save '{
     "context": "Working on auth",
     "lessons_learned": ["Things were hard"]
-})
+}'
 
 # GOOD - comprehensive and actionable
-memory.save({
+python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" save '{
     "context": "Debugging JWT token validation failures on the feature/auth-fixes branch. Users reported 401 errors after ~15 minutes of activity. Investigation revealed the issue was in the token refresh logic where concurrent requests could trigger multiple refresh attempts, causing token rotation conflicts. The auth system uses access tokens (15min TTL) with refresh tokens (7 day TTL, single-use with rotation).",
     "goal": "Identify and fix the root cause of intermittent 401 errors occurring after extended user sessions.",
     "lessons_learned": [
@@ -329,17 +341,17 @@ memory.save({
         "Added a mutex pattern around token refresh - first request to detect expiry acquires lock and refreshes, others wait for the new token",
         "The bug was hard to reproduce locally because it requires high latency (>500ms) to create the race window"
     ]
-})
+}'
 ```
 
 ### Too Granular
 
-```python
+```bash
 # BAD - noise in the memory system, not worth persisting
-memory.save({
+python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" save '{
     "context": "Fixed typo in variable name",
     "lessons_learned": ["Check spelling"]
-})
+}'
 
 # Note: Small fixes don't warrant memories. Save memories for:
 # - Phase completions
@@ -350,16 +362,18 @@ memory.save({
 
 ### Missing Rationale
 
-```python
+```bash
 # BAD - decision without context is useless for future reference
-memory.save({
+# The decision below gives no rationale and no alternatives.
+# Why? What alternatives? When does this apply?
+python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" save '{
     "decisions": [
-        {"decision": "Use Redis"}  # Why? What alternatives? When does this apply?
+        {"decision": "Use Redis"}
     ]
-})
+}'
 
 # GOOD - decision with full context
-memory.save({
+python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" save '{
     "decisions": [
         {
             "decision": "Use Redis for token blacklist instead of PostgreSQL",
@@ -370,20 +384,21 @@ memory.save({
             ]
         }
     ]
-})
+}'
 ```
 
 ### No Entity Links
 
-```python
+```bash
 # BAD - hard to connect to related work, won't surface in graph search
-memory.save({
-    "context": "Refactored the authentication service",
-    # Missing: which components? what files?
-})
+# The payload below names no entities.
+# Missing: which components? what files?
+python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" save '{
+    "context": "Refactored the authentication service"
+}'
 
 # GOOD - entities enable graph-based retrieval
-memory.save({
+python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" save '{
     "context": "Refactored the authentication service to extract token management into a dedicated TokenManager class. This improves testability and separates concerns between identity validation and token lifecycle management.",
     "entities": [
         {"name": "AuthService", "type": "service", "notes": "Now delegates token ops to TokenManager"},
@@ -391,7 +406,7 @@ memory.save({
         {"name": "src/auth/auth_service.py", "type": "file", "notes": "Reduced from 450 to 280 lines"},
         {"name": "src/auth/token_manager.py", "type": "file", "notes": "New file, 200 lines"}
     ]
-})
+}'
 ```
 
 ## Best Practices Summary

--- a/pact-plugin/skills/pact-memory/references/memory-patterns.md
+++ b/pact-plugin/skills/pact-memory/references/memory-patterns.md
@@ -170,20 +170,20 @@ results = json.loads(raw)
 
 for mem in results:
     print(f"\n=== Past Context ===")
-    print(f"Context: {mem["context"]}")
-    print(f"Goal: {mem["goal"]}")
+    print(f"Context: {mem['context']}")
+    print(f"Goal: {mem['goal']}")
 
-    if mem["lessons_learned"]:
+    if mem['lessons_learned']:
         print(f"\nLessons:")
-        for lesson in mem["lessons_learned"]:
+        for lesson in mem['lessons_learned']:
             print(f"  - {lesson}")
 
-    if mem["decisions"]:
+    if mem['decisions']:
         print(f"\nDecisions:")
-        for dec in mem["decisions"]:
-            print(f"  - {dec["decision"]}")
-            if dec["rationale"]:
-                print(f"    Rationale: {dec["rationale"]}")
+        for dec in mem['decisions']:
+            print(f"  - {dec['decision']}")
+            if dec['rationale']:
+                print(f"    Rationale: {dec['rationale']}")
 ```
 
 ## Pattern 5: Decision Tracking
@@ -202,13 +202,13 @@ decisions = json.loads(raw)
 
 # Compile decision history
 for mem in decisions:
-    if mem["decisions"]:
-        print(f"\n{mem["created_at"]}: {mem["context"]}")
-        for dec in mem["decisions"]:
-            print(f"  Decision: {dec["decision"]}")
-            print(f"  Rationale: {dec["rationale"]}")
-            if dec["alternatives"]:
-                print(f"  Alternatives: {', '.join(dec["alternatives"])}")
+    if mem['decisions']:
+        print(f"\n{mem['created_at']}: {mem['context']}")
+        for dec in mem['decisions']:
+            print(f"  Decision: {dec['decision']}")
+            print(f"  Rationale: {dec['rationale']}")
+            if dec['alternatives']:
+                print(f"  Alternatives: {', '.join(dec['alternatives'])}")
 ```
 
 ## Pattern 6: Entity Reference
@@ -228,14 +228,14 @@ auth_memories = json.loads(raw)
 # Compile entity knowledge
 entity_notes = {}
 for mem in auth_memories:
-    for entity in mem["entities"]:
-        if entity["name"] not in entity_notes:
-            entity_notes[entity["name"]] = {
-                "type": entity["type"],
+    for entity in mem['entities']:
+        if entity['name'] not in entity_notes:
+            entity_notes[entity['name']] = {
+                "type": entity['type'],
                 "notes": []
             }
-        if entity["notes"]:
-            entity_notes[entity["name"]]["notes"].append(entity["notes"])
+        if entity['notes']:
+            entity_notes[entity['name']]["notes"].append(entity['notes'])
 
 # Display accumulated knowledge
 for name, info in entity_notes.items():

--- a/pact-plugin/skills/pact-memory/references/memory-patterns.md
+++ b/pact-plugin/skills/pact-memory/references/memory-patterns.md
@@ -7,16 +7,19 @@ skill across different scenarios.
 
 <!-- PACT_STORE_BAR_BEGIN -->
 **STORE ACCESS.** A memory operation (save, search, get, list, update or
-delete a record) goes through the pact-memory CLI. DO NOT USE `--db-path`,
-for one verb or for one purpose. YOU DO NOT SELECT A STORE. A path you
-choose is not the store the memory of the team lives in, so a save there is
+delete a record) goes through the pact-memory CLI. YOU DO NOT SELECT A
+STORE. Do not name a store by `--db-path`, by an environment variable, or by
+one more route somebody adds later. Let the CLI resolve it. A store you
+select is not the store the memory of the team lives in, so a save there is
 lost rather than shared. STORE INSPECTION is different: a row count, a
-column audit, a schema check, or any question about the file itself. To
-inspect, do not run a CLI verb, do not import a module below
-`skills/pact-memory/scripts/`, and do not open the store read-write. Check
+column audit, or a schema check on the file. To inspect, do not run a CLI
+verb, do not import a module below `skills/pact-memory/scripts/`, and do not
+open the store read-write. In ONE command, against ONE resolved path, check
 that `memory.db-wal` and `memory.db-shm` are both absent by their full
-names, then open the store with `mode=ro` and `immutable=1`. Without
-`immutable=1` the open fails. If a sidecar is present, stop and report.
+names, then open with `mode=ro` and `immutable=1`. Without `immutable=1` the
+open fails. If a sidecar is present, stop and report. The read does not load
+the vector extension, so it cannot answer a question about `vec_memories`.
+Stop and report rather than take a barred route.
 <!-- PACT_STORE_BAR_END -->
 The `pact-memory` skill carries the full rule.
 
@@ -159,9 +162,11 @@ python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" save '{
 Query for relevant context before beginning work.
 
 ```python
-import json, subprocess
-# CLI is a list so the command is one argument per element.
-CLI = ["python3", "${CLAUDE_SKILL_DIR}/scripts/cli.py"]
+import json, os, subprocess
+# CLI is a list so the command is one argument per element. Python does not
+# expand ${...}. Read the variable, do not write its name.
+SKILL_DIR = os.environ["CLAUDE_SKILL_DIR"]
+CLI = ["python3", os.path.join(SKILL_DIR, "scripts", "cli.py")]
 # Starting work on authentication
 raw = subprocess.run(
     [*CLI, "search", "authentication security tokens"], capture_output=True, text=True, check=True
@@ -186,14 +191,16 @@ for mem in results:
                 print(f"    Rationale: {dec['rationale']}")
 ```
 
-## Pattern 5: Decision Tracking
+## Pattern 4: Decision Tracking
 
 Use memories as a decision log across the project.
 
 ```python
-import json, subprocess
-# CLI is a list so the command is one argument per element.
-CLI = ["python3", "${CLAUDE_SKILL_DIR}/scripts/cli.py"]
+import json, os, subprocess
+# CLI is a list so the command is one argument per element. Python does not
+# expand ${...}. Read the variable, do not write its name.
+SKILL_DIR = os.environ["CLAUDE_SKILL_DIR"]
+CLI = ["python3", os.path.join(SKILL_DIR, "scripts", "cli.py")]
 # Search for past decisions on a topic
 raw = subprocess.run(
     [*CLI, "search", "caching strategy decisions"], capture_output=True, text=True, check=True
@@ -211,14 +218,16 @@ for mem in decisions:
                 print(f"  Alternatives: {', '.join(dec['alternatives'])}")
 ```
 
-## Pattern 6: Entity Reference
+## Pattern 5: Entity Reference
 
 Build up knowledge about system components.
 
 ```python
-import json, subprocess
-# CLI is a list so the command is one argument per element.
-CLI = ["python3", "${CLAUDE_SKILL_DIR}/scripts/cli.py"]
+import json, os, subprocess
+# CLI is a list so the command is one argument per element. Python does not
+# expand ${...}. Read the variable, do not write its name.
+SKILL_DIR = os.environ["CLAUDE_SKILL_DIR"]
+CLI = ["python3", os.path.join(SKILL_DIR, "scripts", "cli.py")]
 # Search for memories mentioning a component
 raw = subprocess.run(
     [*CLI, "search", "AuthService"], capture_output=True, text=True, check=True
@@ -244,13 +253,13 @@ for name, info in entity_notes.items():
         print(f"  - {note}")
 ```
 
-## Pattern 7: Session Wrap-Up
+## Pattern 6: Session Wrap-Up
 
 Save comprehensive session summary before ending.
 
 ```bash
 python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" save '{
-    "context": "Wrapping up a 4-hour session on the feature/jwt-auth branch implementing the JWT authentication system with refresh token support. Started the session by reviewing the architecture docs from the previous phase, then implemented the core TokenManager class and RateLimiter middleware. Hit a blocker mid-session when Redis connection pooling caused memory leaks under load testing - resolved by switching from redis-py's default connection handling to explicit pool management with max_connections=50. The implementation now passes all unit tests (47 tests) and integration tests (12 tests). Deferred chaos testing based on discussion with tech lead who wants to review the core implementation first. PR #234 is ready for review with all CI checks passing.",
+    "context": "Wrapping up a 4-hour session on the feature/jwt-auth branch implementing the JWT authentication system with refresh token support. Started the session by reviewing the architecture docs from the previous phase, then implemented the core TokenManager class and RateLimiter middleware. Hit a blocker mid-session when Redis connection pooling caused memory leaks under load testing - resolved by switching from the default connection handling of redis-py to explicit pool management with max_connections=50. The implementation now passes all unit tests (47 tests) and integration tests (12 tests). Deferred chaos testing based on discussion with tech lead who wants to review the core implementation first. PR #234 is ready for review with all CI checks passing.",
     "goal": "Complete the JWT authentication implementation with refresh token rotation, including rate limiting middleware, ready for code review and stakeholder demo scheduled for tomorrow.",
     "active_tasks": [
         {"task": "Add unit tests for TokenManager", "status": "completed"},
@@ -260,15 +269,15 @@ python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" save '{
     ],
     "lessons_learned": [
         "Token rotation requires careful state management - we track the previous token hash to allow a 30-second grace period for in-flight requests using the old token",
-        "Redis connection pooling is essential for performance, but redis-py's default lazy connection creation causes memory issues under burst load. Explicit pool with max_connections and socket_timeout prevents resource exhaustion",
+        "Redis connection pooling is essential for performance, but the default lazy connection creation of redis-py causes memory issues under burst load. Explicit pool with max_connections and socket_timeout prevents resource exhaustion",
         "Always log auth failures with correlation IDs - debugging token issues in production is nearly impossible without request tracing. Added X-Correlation-ID header propagation through the middleware chain",
         "Rate limiting at the gateway level catches most abuse, but service-level limits are still needed for internal service-to-service calls that bypass the gateway",
-        "PyJWT's decode() method silently accepts expired tokens unless you explicitly pass options={'verify_exp': True} - this default is dangerous and should be overridden"
+        "The decode() method of PyJWT silently accepts expired tokens unless you set verify_exp to True in the options mapping - this default is dangerous and should be overridden"
     ],
     "decisions": [
         {
             "decision": "Defer chaos testing to next sprint",
-            "rationale": "Core functionality is complete and tested. Tech lead wants to review the implementation before we invest in chaos testing. This also gives the team time to set up the chaos engineering infrastructure (Chaos Monkey integration). Stakeholder demo is tomorrow and chaos tests aren't required for that milestone.",
+            "rationale": "Core functionality is complete and tested. Tech lead wants to review the implementation before we invest in chaos testing. This also gives the team time to set up the chaos engineering infrastructure (Chaos Monkey integration). Stakeholder demo is tomorrow and chaos tests are not required for that milestone.",
             "alternatives": ["Complete chaos tests now - rejected due to time constraints and missing infrastructure", "Skip chaos tests entirely - rejected as auth service is critical path"]
         }
     ],
@@ -282,7 +291,7 @@ python3 "${CLAUDE_SKILL_DIR}/scripts/cli.py" save '{
 }'
 ```
 
-## Pattern 8: Incremental Learning
+## Pattern 7: Incremental Learning
 
 Update memories as understanding evolves. The `update` command merges list-valued
 fields additively with content-hash deduplication, so you can pass just the new

--- a/pact-plugin/tests/test_import_bar_cause_presence.py
+++ b/pact-plugin/tests/test_import_bar_cause_presence.py
@@ -262,10 +262,19 @@ REFUTED_SPELLINGS = frozenset(
         # `memories` table holds each calibration as prose, with no numeric
         # column, so no tool change closes the gap and the DEMAND had to go.
         #
-        # WHY THIS SPELLING AND NOT A WIDER ONE. `per-domain breakdown` is
-        # PRESENT TODAY in the corrected sentence, which tells the secretary
-        # NOT to report one, so an entry for it would ban a TRUE sentence. The
-        # spelling here names the impossible statistic and appears nowhere.
+        # WHY THIS SPELLING AND NOT A WIDER ONE. A wider entry would ban the
+        # NAME of the statistic rather than the DEMAND for it, and an
+        # instruction that forbids a statistic must be free to name the thing
+        # it forbids. So a name-only entry bans correct sentences as readily as
+        # incorrect ones. The spelling here carries the DEMAND, which no
+        # correct sentence needs.
+        #
+        # 🔴 THE REASON ABOVE IS INTRINSIC TO THE SPELLING, AND THAT IS
+        # DELIBERATE. An earlier wording rested on what another file says
+        # today. A justification that names another file's CURRENT CONTENT
+        # goes stale the moment that file changes, with no arm to report it,
+        # and the comment then argues for the entry from a fact that is no
+        # longer true. State a reason the spelling itself carries.
         #
         # ONE ENTRY COVERS THE REVERT. The two impossible demands, the mean and
         # the per-domain breakdown, shipped in ONE sentence, so a revert
@@ -711,14 +720,52 @@ class TestTheRefutedCauseStaysOut:
             f"spelling arms pass over an empty set."
         )
         reached = {relative_name(path, PLUGIN_DIR) for path in scanned}
+        # 🔴 ONE MEMBER OF EACH SCANNED SUFFIX, AND THE MARKDOWN ONE IS NOT
+        # DECORATION. `SCANNED_SUFFIXES` carries `.py` and `.md`. MEASURED: with
+        # the tuple narrowed to `.py` alone the walk drops 134 of its 519 files
+        # and NOTHING REDS, because a control built from `.py` members cannot
+        # see the markdown half go. AND THE LOSS IS NOT ABSTRACT: the spelling
+        # `mean drift direction` guards a sentence in `agents/pact-secretary.md`,
+        # which is markdown, so that narrowing disarms the entry in silence.
+        # A CONTROL WHOSE POPULATION DOES NOT COVER WHAT IT CERTIFIES REPORTS
+        # A CLEAN ANSWER OVER THE PART IT CANNOT REACH.
         for expected in (
             "scripts/memory_repair/__init__.py",
             "tests/test_archive_pin.py",
+            "agents/pact-secretary.md",
         ):
             assert expected in reached, (
                 f"{expected} is absent from the scanned population, so the walk "
                 f"no longer reaches the files that carried the corrected claims. "
                 f"Paths here are relative to {PLUGIN_DIR.name}."
+            )
+
+    def test_the_refused_set_is_not_empty(self):
+        """Non-vacuity ON THE SET, which is a different population from the walk.
+
+        THE WALK AND THE SET COLLAPSE SEPARATELY, and the arm above covers only
+        the first. MEASURED: with `REFUTED_SPELLINGS` emptied, the parametrized
+        arm below collects ZERO cases and the run reports 80 passed, 1 skipped,
+        exit 0. A COLLAPSED ARM REPORTS A SKIP, NOT A FAILURE, and this suite
+        already carries skips, so the loss hides in the noise of a green run.
+
+        THE SIBLING GUARD APPLIES THIS RULE TO ITS OWN CONSTANTS, so this
+        brings one file up to a standard the other holds rather than inventing
+        one.
+        """
+        assert REFUTED_SPELLINGS, (
+            "REFUTED_SPELLINGS is empty, so the arm that refuses a returned "
+            "spelling collects no case and passes by collecting nothing. "
+            "EITHER a correction removed the last entry, which must be a "
+            "deliberate act with a stated cause, OR an edit emptied the set by "
+            "accident."
+        )
+        for load_bearing in ("an import is a write", "mean drift direction"):
+            assert load_bearing in REFUTED_SPELLINGS, (
+                f"{load_bearing!r} left REFUTED_SPELLINGS. That is a control "
+                f"on the SET rather than a rule about the spelling: these two "
+                f"are load-bearing today, one from each repair this file "
+                f"records. Remove one only with a stated cause."
             )
 
     def test_each_exclusion_is_still_necessary(self):

--- a/pact-plugin/tests/test_import_bar_cause_presence.py
+++ b/pact-plugin/tests/test_import_bar_cause_presence.py
@@ -235,12 +235,27 @@ REFUTED_SPELLINGS = frozenset(
         # sentence about the test-harness variable.
         #
         # MEASURED before it was added, across 519 .py and .md files in the
-        # plugin tree: this spelling and two wider candidates each return 0
-        # hits, so the entry bans no sentence that is present. A control string
-        # that IS present returned 3 hits in the same walk, so the zero is a
-        # measured absence and not an empty read. This is PREVENTIVE, and the
-        # warning above against an entry added to quiet a red does not apply,
-        # because nothing is red.
+        # plugin tree: this spelling and two wider candidates each returned 0
+        # FILES, so the entry bans no sentence that is present. A control
+        # string that IS present returned 3 files in the same walk, so the zero
+        # is a measured absence and not an empty read. This is PREVENTIVE, and
+        # the warning above against an entry added to quiet a red does not
+        # apply, because nothing is red.
+        #
+        # 🔴 THE ZERO ABOVE WAS TAKEN BEFORE THIS COMMENT EXISTED. A re-run
+        # finds each of the three candidates INSIDE THIS FILE, because this
+        # comment names them. NO OCCURRENCE OF ONE OF THEM SITS OUTSIDE THIS
+        # FILE. That is the claim to check.
+        #
+        # STATE THE RULE AND NOT THE COUNT. A count breaks the moment a later
+        # note names one of the phrases again, so the act of confirmation can
+        # falsify the record it confirms. The rule above survives its own
+        # confirmation, because one more self-reference leaves it true.
+        #
+        # THE CLASS, and it reaches past this comment. A CLAIM ABOUT A CORPUS
+        # THAT THE CLAIM ITSELF JOINS MUST BE STATED SO THAT JOINING THE
+        # CORPUS DOES NOT FALSIFY IT. An unreproducible correct claim and an
+        # incorrect claim look the same to the next reader.
         "for test isolation only",
         # THE REFUTED CALIBRATION DEMAND. The secretary instruction asked the
         # store for a mean drift direction. The store cannot answer: the

--- a/pact-plugin/tests/test_import_bar_cause_presence.py
+++ b/pact-plugin/tests/test_import_bar_cause_presence.py
@@ -24,9 +24,10 @@ WHAT A GREEN HERE DOES NOT MEAN. Read this before you trust it.
   * It does NOT check that the surrounding prose is true. No test can read a
     natural-language cause for truth.
   * It does NOT catch an incorrect cause in NEW WORDS. The refuted-spelling
-    arms hold the spellings that shipped and were removed, so they catch a
-    revert or a bad merge that reintroduces the ORIGINAL BYTES. A paraphrase
-    passes.
+    arms hold FIXED SPELLINGS, so they catch a revert, a bad merge, or an
+    editor who restores a removed sentence from memory. A paraphrase passes.
+    SOME ENTRIES SHIPPED AND SOME DID NOT, and the rule above
+    `REFUTED_SPELLINGS` states the test that decides membership.
   * THE REFUTED-SPELLING ARMS REACH THE PLUGIN TREE AND NO FURTHER. They walk
     `PLUGIN_DIR`, so a refuted spelling written above that directory, at the
     repository root, is outside the scan.
@@ -169,8 +170,29 @@ PLUGIN_DIR = Path(__file__).resolve().parent.parent
 
 SCANNED_SUFFIXES = (".py", ".md")
 
-# Each claim below was measured incorrect and removed. A revert or a bad merge
-# reintroduces the ORIGINAL BYTES, which is the condition this catches.
+# Each claim below was measured incorrect and removed. A revert, a bad merge,
+# or an editor who restores a removed sentence from memory reproduces the
+# ORIGINAL BYTES, which is the condition this catches.
+#
+# 🔴 THE TEST FOR MEMBERSHIP, THREE PARTS, ALL MEASURED RATHER THAN ASSUMED.
+# A spelling joins this set when the three hold TOGETHER:
+#   1. THE CLAIM IS REFUTED AND SETTLED. A claim that an OPEN measurement can
+#      move does not qualify.
+#   2. THE RETURN OF THE SPELLING IS A LIVE RISK.
+#   3. BANNING THE SPELLING BANS NO TRUE SENTENCE. Measure this. A zero-hit
+#      search means nothing unless a control string that IS present returns
+#      hits in the same walk.
+#
+# WHETHER THE SPELLING SHIPPED IS NOT THE TEST, and a reader who applies that
+# rule will remove a correct member. Two entries here were drafted and removed
+# BEFORE release. A criterion that excludes a member the set holds is not the
+# criterion.
+#
+# PART 1 IS THE ONE THAT REFUSES AN ENTRY MOST OFTEN, and it refuses on a
+# TIMING ground rather than a truth ground. While a measurement that could
+# confirm a claim stays open, that claim cannot join, because A LIST THAT BANS
+# A POSSIBLY-TRUE SENTENCE GETS DISABLED BY THE FIRST PERSON IT OBSTRUCTS, and
+# the whole guard goes with it. Wait for the measurement. Then decide.
 REFUTED_SPELLINGS = frozenset(
     {
         "an import is a write",
@@ -183,6 +205,64 @@ REFUTED_SPELLINGS = frozenset(
         # The second corrected claim. It was written outside the memory-repair
         # package, which is why the population above covers the plugin tree.
         "an in-process HOME change is inert",
+        # THE PERMISSIVE `--db-path` FRAMING. It was drafted, then removed
+        # because it PERMITS the flag. The bar is a POLICY: an agent does not
+        # select a store, and a path a caller chooses is not the store the
+        # memory of the team lives in.
+        #
+        # 🔴 DO NOT RESTATE A MECHANISM HERE, AND DO NOT CORRECT ONE BACK IN.
+        # This comment held a mechanism sentence, that the flag does not reach
+        # the readiness path, and a measurement REFUTED it.
+        #
+        # NO TRUE MECHANISM SENTENCE IS AVAILABLE TO WRITE IN ITS PLACE, and
+        # that is a MEASURED result rather than a caution. The verb sweep is
+        # complete. The flag ISOLATES save, update and delete, each measured
+        # with a live control. The remaining four verbs are UNMEASURED, because
+        # their control is inert, so they are not clear and they are not
+        # refuted. A sentence about the whole flag is therefore incorrect for
+        # one part of the surface and unsupported for the rest.
+        # A POLICY CAUSE HAS NO SUCH SURFACE, so no measurement can move it.
+        #
+        # WHY THE CAUSE MATTERS AS MUCH AS THE ENTRY. A guard justified by a
+        # claim the repair removed is the defect this work closes, arriving in
+        # the enforcement. A reader who probes an incorrect cause concludes the
+        # entry is unfounded, and that is one probe from a disabled entry.
+        #
+        # THE REFUTED CONTENT IS THE WORD "only", which turns a description into
+        # a PERMISSION. That is the same reasoning this file applies to the word
+        # "before" in the entry above, so the entry is narrow for the same cause.
+        # A wider entry such as "is for test isolation" would ban a TRUE future
+        # sentence about the test-harness variable.
+        #
+        # MEASURED before it was added, across 519 .py and .md files in the
+        # plugin tree: this spelling and two wider candidates each return 0
+        # hits, so the entry bans no sentence that is present. A control string
+        # that IS present returned 3 hits in the same walk, so the zero is a
+        # measured absence and not an empty read. This is PREVENTIVE, and the
+        # warning above against an entry added to quiet a red does not apply,
+        # because nothing is red.
+        "for test isolation only",
+        # THE REFUTED CALIBRATION DEMAND. The secretary instruction asked the
+        # store for a mean drift direction. The store cannot answer: the
+        # `memories` table holds each calibration as prose, with no numeric
+        # column, so no tool change closes the gap and the DEMAND had to go.
+        #
+        # WHY THIS SPELLING AND NOT A WIDER ONE. `per-domain breakdown` is
+        # PRESENT TODAY in the corrected sentence, which tells the secretary
+        # NOT to report one, so an entry for it would ban a TRUE sentence. The
+        # spelling here names the impossible statistic and appears nowhere.
+        #
+        # ONE ENTRY COVERS THE REVERT. The two impossible demands, the mean and
+        # the per-domain breakdown, shipped in ONE sentence, so a revert
+        # restores the two together and this entry catches it. A second entry
+        # would help only against a partial restore, and it would grow the list
+        # past its purpose.
+        #
+        # MEASURED before it was added, across 519 .py and .md files: 0 hits
+        # for this spelling and 0 for `summarize by domain`. A control string
+        # that IS present returned 3 hits in the same walk, so the zero is a
+        # measured absence and not an empty read.
+        "mean drift direction",
     }
 )
 
@@ -591,11 +671,17 @@ class TestTheRefutedCauseStaysOut:
     """The negative arm, and its bound is the spellings named.
 
     This does NOT detect a new incorrect cause in new words. It detects the
-    return of a claim that shipped, which is worth catching because a revert or
-    a bad merge reintroduces the original bytes rather than a paraphrase.
+    RETURN OF A NAMED SPELLING, which is worth catching because a revert, a bad
+    merge, or an editor who restores a removed sentence from memory reproduces
+    the original bytes rather than a paraphrase.
+
+    A SPELLING HERE NEED NOT HAVE SHIPPED. Two entries were drafted and removed
+    before release, and they are members for the same reason as the rest: the
+    claim is settled, the return is a live risk, and the ban costs no true
+    sentence. The rule above `REFUTED_SPELLINGS` states that test in full.
 
     ITS POPULATION IS THE PLUGIN TREE AND NOT THE PACKAGE. A revert lands where
-    the claim was written, and one of the two claims was written outside the
+    the claim was written, and one of the claims was written outside the
     memory-repair package. A population narrower than the thing it protects
     reports a clean green over the files it happens to hold.
     """

--- a/pact-plugin/tests/test_memory_patterns_docs.py
+++ b/pact-plugin/tests/test_memory_patterns_docs.py
@@ -1,248 +1,265 @@
 """
-Doc-as-test for pact-memory reference patterns (issue #374 R.2).
+Doc-code drift check for the Pattern 8 section of the memory patterns page.
 
-This test file exists so that the code examples in
-`skills/pact-memory/references/memory-patterns.md` cannot silently drift out
-of sync with the actual `PACTMemory.update()` contract. If someone edits
-Pattern 8 in the doc but forgets to update the code (or vice versa), the
-build fails here — not two months later when an orchestrator pastes a
-pattern from the doc into a live session and gets a ValueError.
+Location: pact-plugin/tests/test_memory_patterns_docs.py
 
-Scope: the Pattern 8 "Incremental Learning" section. This is the section
-rewritten during the #374 fix to remove the obsolete read-merge-write-back
-scaffolding; its two Python snippets are the authoritative examples of the
-new additive + `replace=True` behavior.
+WHAT THIS FILE CHECKS. Pattern 8 of
+`skills/pact-memory/references/memory-patterns.md` teaches an agent how to
+update a memory. This reads that section and asserts three things about each
+fenced block in it:
 
-Mechanism:
-1. Parse the Pattern 8 section out of the markdown file by slicing between
-   the `## Pattern 8:` heading and the next top-level heading.
-2. Extract every ```python fenced block from that slice.
-3. Evaluate each block against a live in-memory fixture `memory` object that
-   has the same `.update()` signature as `PACTMemory` but uses a throwaway
-   tmp_path-scoped database. (We use the builtin ``exec`` via the builtins
-   module so static scanners don't confuse it with shell exec.)
-4. Assert no exception was raised.
+  1. The block invokes the pact-memory CLI.
+  2. Its verb is one the CLI parser accepts, DERIVED from the parser source.
+  3. Its JSON payload parses.
+
+🔴 WHAT THIS FILE STOPPED CHECKING, AND WHY THE CHANGE WAS NECESSARY.
+
+An earlier form of this file sliced the same section, took its fenced PYTHON
+blocks, and ran them against a fake memory object. That form did TWO jobs and
+one of them was redundant:
+
+  JOB 1, THE BEHAVIOUR of an additive merge and of a replace that clobbers.
+  REDUNDANT, and measured rather than assumed: `tests/test_memory_database.py`
+  holds that coverage, and it reads this page ZERO times. So the behavioural
+  claim never depended on the doc.
+
+  JOB 2, DOC-CODE DRIFT. Worth keeping. Its SUBJECT must move with the page.
+
+THE PAGE NOW TEACHES THE CLI ROUTE, because the module-API route it taught
+before is the route the store-access bar forbids. AN EXEC-BASED CHECK WOULD
+PIN A SHIPPED PAGE TO THE FORBIDDEN ROUTE, in the one section a test provably
+exercises. That is worse than no check: it enforces the contradiction the bar
+exists to remove.
+
+🔴 THE STATED BOUND, AND IT IS A LOSS RATHER THAN A TRADE.
+
+AN EXEC PROVES A SNIPPET RUNS. THIS PROVES A SNIPPET IS WELL FORMED. That is
+WEAKER and this file does not hide it. Named precisely, so a later reader can
+measure the region rather than meet a vague caution, THIS FILE DOES NOT CATCH:
+
+  * A verb the parser accepts and that FAILS at run time for this input, such
+    as an update against an id that is not present.
+  * A payload that parses and that carries a field the store rejects, or a
+    field name the schema does not hold.
+  * A flag that is spelled correctly and that the verb does not accept.
+  * A snippet that is correct alone and incorrect in sequence with the one
+    before it.
+
+THE STRONGER FORM IS A SUBPROCESS AGAINST A TEMPORARY STORE. It does not ride
+this branch, because it is a new behavioural harness for a page and this
+branch is about a rule. A tracker item carries it with this loss named.
+
+APPLY THE RULE THIS ARC PRODUCED: A STATED BOUND RECORDS A QUESTION NOBODY
+THEN PUTS. The four items above are the excluded region, written so somebody
+can measure it. Do not accept the bound without a measurement of them.
+
+WHY THE VERB SET IS DERIVED AND NOT WRITTEN DOWN. A verb list in this file
+goes stale on the day the CLI gains or renames one, and a stale list fails in
+the direction that reads as a doc defect. This reads the parser source and
+takes the names it declares. THE READ IS TEXT ONLY: this file imports no
+module below `skills/pact-memory/scripts/` and runs no CLI, so it cannot reach
+the live store.
+
+Used by: pytest.
 """
-import builtins
-import os
+from __future__ import annotations
+
+import json
 import re
-import sys
 from pathlib import Path
-from unittest.mock import patch
 
-import pytest
+PLUGIN_DIR = Path(__file__).resolve().parent.parent
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'pact-memory'))
+PATTERNS_MD = PLUGIN_DIR / "skills" / "pact-memory" / "references" / "memory-patterns.md"
 
-from helpers import create_test_schema  # noqa: E402
+# The parser this file reads for the accepted verbs. TEXT ONLY, no import.
+CLI_SOURCE = PLUGIN_DIR / "skills" / "pact-memory" / "scripts" / "cli.py"
 
-try:
-    import pysqlite3 as sqlite3
-except ImportError:
-    import sqlite3
+# The section under check. Sliced from its heading to the next top-level one.
+SECTION_HEADING = r"^## Pattern 8:.*$"
 
-
-PATTERNS_MD = (
-    Path(__file__).parent.parent
-    / "skills"
-    / "pact-memory"
-    / "references"
-    / "memory-patterns.md"
-)
+# A block invokes the CLI when it names the CLI module. The page writes the
+# path with a shell variable, so this matches the module name rather than the
+# whole path, which the page is free to spell in more than one way.
+CLI_MARKER = "cli.py"
 
 
-def _extract_pattern_8_python_blocks() -> list[str]:
+def accepted_verbs() -> set:
+    """Return the verb names the CLI parser declares.
+
+    DERIVED FROM THE PARSER SOURCE rather than written here. A list in this
+    file goes stale on the day the CLI renames a verb, and the stale form
+    reports a doc defect for a tool change, which points a reader at the wrong
+    file.
     """
-    Return the list of fenced python snippets inside the Pattern 8 section.
+    source = CLI_SOURCE.read_text(encoding="utf-8")
+    return set(re.findall(r"add_parser\(\s*[\"']([a-z0-9_-]+)[\"']", source))
 
-    Slicing rule: start at the line beginning with ``## Pattern 8``, stop at
-    the next line beginning with ``## `` (either a later pattern or the
-    ``## Anti-Patterns`` section). Within that slice, match every block of
-    the form ```python\\n...\\n```.
-    """
+
+def pattern_8_section() -> str:
+    """Return the Pattern 8 section, heading to the next top-level heading."""
     text = PATTERNS_MD.read_text(encoding="utf-8")
-    start_match = re.search(r"^## Pattern 8:.*$", text, flags=re.MULTILINE)
-    assert start_match, "Pattern 8 heading not found in memory-patterns.md"
-    start_idx = start_match.start()
-
-    # End of Pattern 8 = the next top-level heading after start_idx.
-    tail = text[start_match.end():]
-    end_match = re.search(r"^## ", tail, flags=re.MULTILINE)
-    if end_match:
-        end_idx = start_match.end() + end_match.start()
-    else:
-        end_idx = len(text)
-
-    section = text[start_idx:end_idx]
-    blocks = re.findall(r"```python\n(.*?)```", section, flags=re.DOTALL)
-    assert blocks, "no python fenced blocks found in Pattern 8 section"
-    return blocks
+    start = re.search(SECTION_HEADING, text, flags=re.MULTILINE)
+    assert start, (
+        f"the heading {SECTION_HEADING!r} is absent from {PATTERNS_MD.name}. "
+        f"EITHER the section was renamed, and this file must follow it, OR "
+        f"the section went and this file must go with it. Do not repair this "
+        f"by a wider slice: a slice that starts at the wrong place reports a "
+        f"clean result over the wrong text."
+    )
+    tail = text[start.end():]
+    end = re.search(r"^## ", tail, flags=re.MULTILINE)
+    stop = start.end() + end.start() if end else len(text)
+    return text[start.start():stop]
 
 
-def _run_python_snippet(source: str, namespace: dict, label: str) -> None:
+def fenced_blocks(section: str) -> list:
+    """Return each fenced block in `section`, whatever its language tag."""
+    return re.findall(r"```[a-z]*\n(.*?)```", section, flags=re.DOTALL)
+
+
+def json_payloads(block: str) -> list:
+    """Return each single-quoted JSON argument in a shell block.
+
+    The page passes a payload as one shell-quoted argument. This takes the
+    text between the first pair of single quotes that opens with a brace.
     """
-    Compile and evaluate a doc snippet via the builtin ``exec``. Wrapped in
-    a helper with a deliberate name so the call site reads as a doc-test
-    runner rather than a raw ``exec`` invocation — this makes the intent
-    obvious to readers and static scanners alike.
+    return re.findall(r"'(\{.*?\})'", block, flags=re.DOTALL)
+
+
+def block_verb(block: str, verbs: set) -> str | None:
+    """Return the CLI verb the block invokes, or None when it invokes none.
+
+    🔴 THE VERB IS THE TOKEN THAT FOLLOWS THE CLI MODULE, AND NOT A
+    VERB-SHAPED WORD ANYWHERE IN THE BLOCK. An earlier form of this function
+    scanned the whole block, so a comment or a JSON value satisfied it.
+    MEASURED: the word `setup` sits inside a payload of this page, in
+    `"notes": "HA setup"`. With the whole-block scan, a block that invoked an
+    UNKNOWN verb on the command line passed, because the payload supplied an
+    accepted one. The arm reported a clean result over a broken command.
+
+    THAT IS A WRONG ALPHABET RATHER THAN A WRONG QUERY: the subject is the
+    command line, and the instrument read the whole document.
     """
-    code = compile(source, label, "exec")
-    builtins.exec(code, namespace)
+    match = re.search(
+        re.escape(CLI_MARKER) + r"\"?\s+([a-z][a-z0-9_-]*)",
+        block,
+    )
+    if match is None:
+        return None
+    return match.group(1) if match.group(1) in verbs else None
 
 
-class _FakeMemory:
-    """
-    Minimal PACTMemory-shaped shim that routes `.update(memory_id, updates,
-    replace=...)` to the real `update_memory()` function against a
-    freshly-seeded fixture row.
+class TestTheInstrumentIsLive:
+    """Controls on the reader, and not rules about the page.
 
-    Why not use PACTMemory directly? PACTMemory's constructor triggers
-    project-id detection, db path resolution, and embedding-system lazy init
-    — all of which are irrelevant to verifying the doc snippet's call shape
-    and would make this test flaky across machines. The shim isolates the
-    contract we care about: "does `memory.update(id, dict, replace=...)`
-    succeed against a valid memory row?".
-
-    Placeholder convention: Pattern 8 examples in memory-patterns.md use
-    "abc123" as the memory ID. The shim's _id_map remaps that placeholder
-    to the live fixture row id. If you change the placeholder in
-    memory-patterns.md, update _id_map here too — otherwise the methods
-    below will raise KeyError loudly rather than silently exercising the
-    wrong code path.
+    AN EMPTY SECTION AGREES WITH EVERY RULE BELOW, so the first control
+    asserts the slice returns text and the second asserts it returns blocks.
     """
 
-    def __init__(self, conn, memory_id):
-        self._conn = conn
-        self._memory_id = memory_id
-        # Placeholder convention: Pattern 8 examples use "abc123" as the
-        # memory ID. If you change the placeholder in memory-patterns.md,
-        # update _id_map here too.
-        self._id_map = {"abc123": memory_id}
+    def test_the_section_is_present_and_not_empty(self):
+        section = pattern_8_section()
+        assert len(section.strip()) > 0, "the Pattern 8 slice is empty"
 
-    def _resolve(self, memory_id, method):
-        actual_id = self._id_map.get(memory_id)
-        if actual_id is None:
-            raise KeyError(
-                f"_FakeMemory.{method}: unknown memory_id {memory_id!r}. "
-                f"If Pattern 8 docs changed the placeholder from 'abc123', "
-                f"update this shim's _id_map. Known: {list(self._id_map)}"
+    def test_the_section_holds_fenced_blocks(self):
+        blocks = fenced_blocks(pattern_8_section())
+        assert blocks, (
+            "no fenced block is in the Pattern 8 section, so each arm below "
+            "passes over an empty set. EITHER the examples went, which is a "
+            "page defect, OR the fence syntax changed, which is a reader "
+            "defect. Read the section before you decide."
+        )
+
+    def test_the_verb_set_is_derived_and_not_empty(self):
+        """Non-vacuity on the derivation. An empty set accepts no verb, and
+        an arm that compares against it reports a defect for each block."""
+        verbs = accepted_verbs()
+        assert verbs, (
+            f"no verb was derived from {CLI_SOURCE.name}. The parser shape "
+            f"changed, so the pattern in `accepted_verbs` no longer finds the "
+            f"declarations. Correct the pattern rather than write a list here."
+        )
+        for expected in ("save", "update", "search"):
+            assert expected in verbs, (
+                f"{expected!r} is absent from the derived verb set {sorted(verbs)}. "
+                f"That is a control on the derivation rather than a rule about "
+                f"the CLI: these three are load-bearing in the page today."
             )
-        return actual_id
 
-    def update(self, memory_id, updates, *, replace=False):
-        from scripts.database import update_memory
-        actual_id = self._resolve(memory_id, "update")
-        return update_memory(self._conn, actual_id, updates, replace=replace)
+    def test_the_payload_reader_finds_a_payload_and_refuses_prose(self):
+        """A control on the matcher, and each half must do work."""
+        assert json_payloads("""cli.py update abc '{"a": [1]}'""") == ['{"a": [1]}']
+        assert json_payloads("cli.py list") == []
 
-    def get(self, memory_id):
-        from scripts.database import get_memory
-        actual_id = self._resolve(memory_id, "get")
-        return get_memory(self._conn, actual_id)
+    def test_the_verb_reader_reads_the_command_line_and_not_the_payload(self):
+        """🔴 THE DEFECT THIS PINS WAS LIVE AND IT PASSED A BROKEN COMMAND.
 
-    def delete(self, memory_id):
-        from scripts.database import delete_memory
-        actual_id = self._resolve(memory_id, "delete")
-        return delete_memory(self._conn, actual_id)
+        An earlier form scanned the whole block for a verb-shaped word. The
+        payload of this page holds `"notes": "HA setup"`, and `setup` is an
+        accepted verb, so a block that invoked an UNKNOWN verb on the command
+        line was accepted on the strength of a word in its data.
 
+        THE TWO HALVES ARE THE ARM. The reader must take the verb after the
+        CLI module, and it must NOT take one from a payload or a comment.
+        """
+        verbs = accepted_verbs()
+        good = """python3 "path/cli.py" update abc '{"notes": "HA setup"}'"""
+        assert block_verb(good, verbs) == "update"
 
-@pytest.fixture
-def fixture_memory(tmp_path):
-    """
-    Build an isolated DB containing a memory row the doc snippets can update.
-    Seeds with the same field shapes the doc references (lessons_learned,
-    entities) so the additive path is exercised meaningfully.
-    """
-    db_path = tmp_path / "patterns.db"
-    conn = sqlite3.connect(str(db_path))
-    conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA foreign_keys=ON")
-    create_test_schema(conn)
-
-    with patch("scripts.database.ensure_initialized"):
-        from scripts.database import create_memory
-        mem_id = create_memory(
-            conn,
-            {
-                "context": "Pattern 8 fixture",
-                "lessons_learned": ["existing lesson"],
-                "entities": [{"name": "Redis", "type": "component"}],
-            },
-        )
-        yield _FakeMemory(conn, mem_id)
-
-    conn.close()
-
-
-class TestPattern8DocAsTest:
-    """
-    R.2 per architect §10 — catch drift between memory-patterns.md Pattern 8
-    snippets and the actual PACTMemory.update() contract.
-    """
-
-    def test_pattern_8_has_expected_snippet_count(self):
-        """Pattern 8 should expose two code examples: additive and replace."""
-        blocks = _extract_pattern_8_python_blocks()
-        assert len(blocks) == 2, (
-            f"Pattern 8 code example count changed ({len(blocks)}). Update "
-            "test_memory_patterns_docs.py if the doc structure legitimately "
-            "changed, or restore the missing snippet."
+        broken = """python3 "path/cli.py" upsert abc '{"notes": "HA setup"}'"""
+        assert block_verb(broken, verbs) is None, (
+            "the verb reader accepted a word from the payload. A block with "
+            "an unknown verb on the command line then passes, which is the "
+            "measured defect this arm exists to refuse."
         )
 
-    def test_pattern_8_snippets_execute_cleanly(self, fixture_memory):
-        """
-        Each Pattern 8 snippet must evaluate against a live fixture memory
-        without raising. This is the actual drift-detection assertion.
-        """
-        blocks = _extract_pattern_8_python_blocks()
-        for idx, snippet in enumerate(blocks):
-            namespace = {"memory": fixture_memory}
-            try:
-                _run_python_snippet(
-                    snippet, namespace, f"<pattern-8 snippet {idx}>",
-                )
-            except Exception as exc:
-                pytest.fail(
-                    f"Pattern 8 snippet #{idx} in memory-patterns.md raised "
-                    f"{type(exc).__name__}: {exc}\n\nSnippet was:\n{snippet}"
-                )
+        commented = """# run update later\npython3 "path/cli.py" upsert abc"""
+        assert block_verb(commented, verbs) is None
 
-    def test_pattern_8_additive_snippet_merges_items(self, fixture_memory):
-        """
-        Stronger contract check: the first snippet is the 'additive append'
-        example. After evaluation, the fixture memory's lessons_learned must
-        include BOTH the pre-seeded existing lesson AND the two new ones.
-        """
-        from scripts.database import get_memory
-        blocks = _extract_pattern_8_python_blocks()
-        additive_snippet = blocks[0]
-        namespace = {"memory": fixture_memory}
-        _run_python_snippet(additive_snippet, namespace, "<pattern-8 additive>")
 
-        row = get_memory(fixture_memory._conn, fixture_memory._memory_id)
-        assert "existing lesson" in row["lessons_learned"], (
-            "additive snippet clobbered the existing lesson — the dedup "
-            "merge invariant is broken, or the snippet silently dropped "
-            "its additive semantics"
+class TestPattern8TeachesTheCliRoute:
+    """The drift check. Its subject is the CLI route, which is what the page
+    now teaches."""
+
+    def test_each_block_invokes_the_cli(self):
+        blocks = fenced_blocks(pattern_8_section())
+        silent = [b for b in blocks if CLI_MARKER not in b]
+        assert not silent, (
+            f"{len(silent)} fenced block(s) in Pattern 8 do not name "
+            f"{CLI_MARKER!r}. The page teaches store access, and the store-"
+            f"access rule sends a memory operation through the CLI. A block "
+            f"that reaches the store another way teaches the route the rule "
+            f"forbids. Blocks: {silent}"
         )
-        # The snippet's lessons text should be present.
-        assert any(
-            "Redis cluster" in str(item) for item in row["lessons_learned"]
-        ), f"new lesson not merged: {row['lessons_learned']}"
 
-    def test_pattern_8_replace_snippet_clobbers_list(self, fixture_memory):
-        """
-        Second snippet uses replace=True; after evaluation the
-        lessons_learned list must contain EXACTLY the replacement item,
-        not the merged history.
-        """
-        from scripts.database import get_memory
-        blocks = _extract_pattern_8_python_blocks()
-        replace_snippet = blocks[1]
-        namespace = {"memory": fixture_memory}
-        _run_python_snippet(replace_snippet, namespace, "<pattern-8 replace>")
+    def test_each_block_uses_a_verb_the_parser_accepts(self):
+        verbs = accepted_verbs()
+        unknown = []
+        for block in fenced_blocks(pattern_8_section()):
+            verb = block_verb(block, verbs)
+            if verb is None:
+                unknown.append(block)
+        assert not unknown, (
+            f"{len(unknown)} fenced block(s) in Pattern 8 name no verb the "
+            f"CLI parser accepts. Accepted today, derived from "
+            f"{CLI_SOURCE.name}: {sorted(verbs)}. EITHER the page teaches a "
+            f"verb that went, which is a doc defect, OR the CLI renamed one "
+            f"and the page did not follow, which is a drift. Read the two "
+            f"before you repair one. Blocks: {unknown}"
+        )
 
-        row = get_memory(fixture_memory._conn, fixture_memory._memory_id)
-        assert row["lessons_learned"] == ["Only lesson that matters"], (
-            f"replace snippet did not wholesale-replace the list: "
-            f"{row['lessons_learned']}"
+    def test_each_payload_parses(self):
+        bad = []
+        for block in fenced_blocks(pattern_8_section()):
+            for payload in json_payloads(block):
+                try:
+                    json.loads(payload)
+                except json.JSONDecodeError as exc:
+                    bad.append(f"{payload[:60]}... ({exc})")
+        assert not bad, (
+            f"a JSON payload in Pattern 8 does not parse: {bad}. An agent "
+            f"that copies the block gets a parse error rather than a memory "
+            f"update. THIS ARM READS THE PAYLOAD AND DOES NOT SEND IT, so a "
+            f"payload that parses can still be refused by the store. That "
+            f"gap is named in the stated bound at the top of this file."
         )

--- a/pact-plugin/tests/test_memory_patterns_docs.py
+++ b/pact-plugin/tests/test_memory_patterns_docs.py
@@ -1,16 +1,35 @@
 """
-Doc-code drift check for the Pattern 8 section of the memory patterns page.
+Doc-code drift check for the memory patterns page.
 
 Location: pact-plugin/tests/test_memory_patterns_docs.py
 
-WHAT THIS FILE CHECKS. Pattern 8 of
-`skills/pact-memory/references/memory-patterns.md` teaches an agent how to
-update a memory. This reads that section and asserts three things about each
-fenced block in it:
+WHAT THIS FILE CHECKS, AND THE TWO POPULATIONS ARE DIFFERENT ON PURPOSE.
+`skills/pact-memory/references/memory-patterns.md` teaches an agent to reach
+the store. The arms below split into two groups, and the group decides the
+population.
 
-  1. The block invokes the pact-memory CLI.
-  2. Its verb is one the CLI parser accepts, DERIVED from the parser source.
-  3. Its JSON payload parses.
+WHOLE PAGE, because a defect in one example is a defect wherever it sits:
+  1. Each shell block parses as a shell command, adjudicated by `bash -n`.
+  2. The payload argument THE SHELL BUILDS is valid JSON.
+  3. Each python block RUNS to completion against a stub CLI.
+
+THE INCREMENTAL LEARNING SECTION ALONE, because the CLI-route rule is what
+that section teaches:
+  4. The block invokes the pact-memory CLI.
+  5. Its verb is one the CLI parser accepts, DERIVED from the parser source.
+
+ITEMS 1 AND 2 ARE ONE CLAIM READ FROM ONE STRING. A block must parse as a
+command and hand that command valid JSON. Read those two from two different
+strings, as a regex over the source text does, and a repair to one half can
+break the other with no arm going red. `shlex` gives the two halves the word
+rule the shell uses, so the trade has nowhere to hide.
+
+🔴 WHY ITEMS 1 AND 2 READ THE WHOLE PAGE AND NOT ONE SECTION. MEASURED: the
+save examples sit in Phase Completion Memory, Blocker Documentation, Session
+Wrap-Up and Anti-Patterns. THE INCREMENTAL LEARNING SECTION HOLDS NO SAVE
+EXAMPLE. A payload with an apostrophe is a save-example defect, so a
+section-scoped arm can not reach the class at all. The widening is what turns
+that class from unguarded into caught.
 
 🔴 WHAT THIS FILE STOPPED CHECKING, AND WHY THE CHANGE WAS NECESSARY.
 
@@ -31,42 +50,125 @@ PIN A SHIPPED PAGE TO THE FORBIDDEN ROUTE, in the one section a test provably
 exercises. That is worse than no check: it enforces the contradiction the bar
 exists to remove.
 
-🔴 THE STATED BOUND, AND IT IS A LOSS RATHER THAN A TRADE.
+🔴 THE STATED BOUND, RE-DERIVED FROM THE ARMS ABOVE AND NOT EDITED.
 
-AN EXEC PROVES A SNIPPET RUNS. THIS PROVES A SNIPPET IS WELL FORMED. That is
-WEAKER and this file does not hide it. Named precisely, so a later reader can
-measure the region rather than meet a vague caution, THIS FILE DOES NOT CATCH:
+WHAT EACH ARM DECIDES, stated at the grain the arm can support:
+  * `bash -n` decides that a shell block PARSES. It runs nothing.
+  * The payload arm decides that the argument THE SHELL BUILDS is valid JSON.
+    An earlier form said "a snippet is well formed", which overstated: it
+    decided that a JSON SUBSTRING of the source text parsed, which is a
+    different string whenever a quote does work.
+  * The execution arm decides that a python block RUNS TO COMPLETION ON THE
+    INTERPRETER THAT RUNS THE TESTS, against a stub CLI. It does NOT decide
+    that the block runs on the DECLARED FLOOR, which is `requires-python`
+    in `pyproject.toml`. THE SOURCE IS NAMED AND ITS VALUE IS NOT QUOTED
+    HERE, because a quoted floor goes stale the day somebody corrects it,
+    and a stale bound reads as a measurement.
+
+🔴 THE FLOOR CLAIM IS THE ONE TO REFUSE, AND REFUSING IT IS THE POINT. This
+file holds ONE interpreter and cannot speak for another. `ast.parse` with
+`feature_version` looks like the tool for a floor claim and is not: it gave
+two reviewers a clean pass on this page. A CI matrix decides the floor. An
+arm here can not.
+
+🔴 A PARSER IS NOT THE JUDGE OF THE CLASS THAT HIT THIS PAGE TWICE. MEASURED
+on the python blocks, before the repair against after it:
+
+    compile()   3 of 3 parse   ->   3 of 3 parse     (moves nothing)
+    execution   0 of 3 run     ->   3 of 3 run       (separates fully)
+
+An unexpanded `${CLAUDE_SKILL_DIR}` inside a string literal PARSES PERFECTLY.
+A parse-only arm reports it absent, with a live instrument and a true result.
+That is why the execution arm exists and why `compile()` stays a cheap first
+gate rather than the judge.
+
+🔴 THE EXECUTION ARM CLOSES ONE OF THE TWO CLASSES AND NOT THE OTHER, AND THE
+DIFFERENCE IS THE INTERPRETER. MEASURED by mutation against this file:
+
+    unexpanded `${CLAUDE_SKILL_DIR}`   ->  the execution arm REDS
+    PEP 701 nested f-string            ->  NOTHING HERE REDS
+
+The second result is correct rather than a hole in the arm. PEP 701 syntax is
+VALID from 3.12, this file ran on 3.14.6, and a valid construct cannot fail a
+parse or a run. So no arm in this file can decide it, and `compile()` cannot
+either. ONLY AN INTERPRETER BELOW 3.12 DECIDES THAT CLASS, which makes it a
+CI-matrix question and not a question for any arm here.
+
+DO NOT READ A GREEN FROM THE EXECUTION ARM AS COVER FOR THE F-STRING CLASS.
+Reading it that way removes the reason to keep an old interpreter in the
+matrix, which is the only instrument that reports it.
+
+🔴 THE FIRST FORM OF THIS BOUND UNDERSTATED ITS OWN REGION, and a reviewer
+measured it rather than accept it. That form named four items as the excluded
+region. SHELL VALIDITY WAS ALSO OUTSIDE, and it was broken on this page at the
+time. A bound that names its region and omits a live member is the same defect
+as a bound nobody measures, committed by the author who wrote it honestly.
+
+🔴 AND THE INSTRUMENT THAT MISSED IT WENT ON TO REFUSE ITS OWN CURE. The
+payload reader was a regex over the source text. MEASURED: it called the
+broken command's payload valid, and it called the ORDINARY REPAIR of that
+command, an apostrophe escaped as `'"'"'`, a broken payload. So the first
+instrument accepted the defect and then reported a defect against the fix. An
+instrument with the wrong subject does not merely miss. It points.
+
+Named precisely, so a later reader can measure the region rather than meet a
+vague caution, THIS FILE DOES NOT CATCH:
 
   * A verb the parser accepts and that FAILS at run time for this input, such
     as an update against an id that is not present.
   * A payload that parses and that carries a field the store rejects, or a
-    field name the schema does not hold.
+    field name the schema does not hold. THE STUB ANSWERS EVERY KEY THE
+    BLOCKS READ, derived from the blocks, so this arm cannot decide that the
+    CLI returns those keys. That choice is deliberate: a hand-written stub
+    goes stale and reds a correct page, which is the worse failure.
   * A flag that is spelled correctly and that the verb does not accept.
   * A snippet that is correct alone and incorrect in sequence with the one
     before it.
+  * A behaviour that depends on the REAL CLI. The stub returns one record and
+    exits 0, so nothing here reaches the store or the network.
+  * 🔴 THE MARKED REGION MOVED INTO A CODE FENCE. MEASURED by a reviewer over
+    a ten-cell mutation matrix: eight cells fire and this is one of the two
+    that do not, at a copy and at the source alike. DISCLOSED AND NOT CLOSED,
+    by ruling. Its severity is low because an LLM reads raw bytes, so a fenced
+    rule keeps its words. That severity rests on the raw-byte reading. If a
+    consumer ever renders this text instead, the cell becomes a defect and
+    belongs on the tracker rather than in this list.
 
-THE STRONGER FORM IS A SUBPROCESS AGAINST A TEMPORARY STORE. It does not ride
-this branch, because it is a new behavioural harness for a page and this
-branch is about a rule. A tracker item carries it with this loss named.
+🔴 AND THE LIST ABOVE IS A MEASURED FLOOR RATHER THAN A CLOSED SET. A bound
+records a question nobody then puts, so measure the region it excludes before
+you accept it. That is how shell validity was found, and a later reader must
+assume one more member sits outside this list.
 
 APPLY THE RULE THIS ARC PRODUCED: A STATED BOUND RECORDS A QUESTION NOBODY
-THEN PUTS. The four items above are the excluded region, written so somebody
-can measure it. Do not accept the bound without a measurement of them.
+THEN PUTS. The items above are written so somebody can measure them. Do not
+accept the bound without that measurement, and do not read the list as closed.
 
 WHY THE VERB SET IS DERIVED AND NOT WRITTEN DOWN. A verb list in this file
 goes stale on the day the CLI gains or renames one, and a stale list fails in
 the direction that reads as a doc defect. This reads the parser source and
-takes the names it declares. THE READ IS TEXT ONLY: this file imports no
-module below `skills/pact-memory/scripts/` and runs no CLI, so it cannot reach
-the live store.
+takes the names it declares, BY A TEXT READ and with no import.
+
+🔴 HOW THE EXECUTION ARM STAYS AWAY FROM THE STORE, and the mechanism is the
+page's own code rather than a promise. Each python block builds its command
+from `os.environ["CLAUDE_SKILL_DIR"]`. The arm points that variable at a
+temporary directory holding a STUB `cli.py`. So the path the block builds
+resolves inside the temporary directory, and the real CLI is unreachable BY
+CONSTRUCTION rather than by care. This file imports no module below
+`skills/pact-memory/scripts/` and runs no real CLI verb.
 
 Used by: pytest.
 """
 from __future__ import annotations
 
 import json
+import os
 import re
+import shlex
+import subprocess
+import tempfile
 from pathlib import Path
+
+import pytest
 
 PLUGIN_DIR = Path(__file__).resolve().parent.parent
 
@@ -75,13 +177,46 @@ PATTERNS_MD = PLUGIN_DIR / "skills" / "pact-memory" / "references" / "memory-pat
 # The parser this file reads for the accepted verbs. TEXT ONLY, no import.
 CLI_SOURCE = PLUGIN_DIR / "skills" / "pact-memory" / "scripts" / "cli.py"
 
-# The section under check. Sliced from its heading to the next top-level one.
-SECTION_HEADING = r"^## Pattern 8:.*$"
+# The section the CLI-route arms read. Sliced from its heading to the next
+# top-level one.
+#
+# 🔴 ANCHORED ON THE TITLE AND NOT ON THE NUMBER, and that is a repair rather
+# than a preference. An earlier form held `^## Pattern 8:`. The page skipped
+# Pattern 4, and the repair for that skip renumbers the later headings, which
+# renames the section this file reads. SO THIS FILE BLOCKED A CORRECT PAGE
+# EDIT: an author fixing the numbering met a red gate and had to choose
+# between the fix and the test.
+#
+# THE NUMBER BELONGS TO THE PAGE AND THE TITLE IS THE STABLE PART. A test that
+# pins the volatile half of a heading reds on a correct repair, which is the
+# failure this file argues against everywhere else.
+SECTION_HEADING = r"^## Pattern \d+: Incremental Learning\s*$"
 
 # A block invokes the CLI when it names the CLI module. The page writes the
 # path with a shell variable, so this matches the module name rather than the
 # whole path, which the page is free to spell in more than one way.
 CLI_MARKER = "cli.py"
+
+# The fence tags this file classifies. An unknown tag must go red rather than
+# be skipped: a skipped block is a block no arm reads, and the arms below then
+# report a clean result over a set that lost a member.
+SHELL_TAGS = frozenset({"bash", ""})
+PYTHON_TAGS = frozenset({"python"})
+KNOWN_TAGS = SHELL_TAGS | PYTHON_TAGS
+
+# The environment name the page's python examples read to find the CLI. The
+# execution arm points this at a temporary directory, which is what keeps the
+# run away from the real CLI.
+SKILL_DIR_VAR = "CLAUDE_SKILL_DIR"
+
+# Keys the stub record answers whatever the blocks ask for. Membership is
+# DERIVED from the blocks, so a block that reads a new key does not red a
+# correct page. The cost is stated in the bound: this arm cannot decide that
+# the CLI returns these keys.
+LIST_VALUED_KEYS = frozenset({"decisions", "entities", "lessons_learned"})
+
+# A run that hangs is a failed run, not a slow one.
+BLOCK_TIMEOUT_SECONDS = 60
 
 
 def accepted_verbs() -> set:
@@ -96,8 +231,12 @@ def accepted_verbs() -> set:
     return set(re.findall(r"add_parser\(\s*[\"']([a-z0-9_-]+)[\"']", source))
 
 
-def pattern_8_section() -> str:
-    """Return the Pattern 8 section, heading to the next top-level heading."""
+def incremental_learning_section() -> str:
+    """Return the Incremental Learning section, heading to the next heading.
+
+    NAMED FOR THE TITLE AND NOT THE NUMBER, for the reason recorded at
+    `SECTION_HEADING`: the number belongs to the page and moves with it.
+    """
     text = PATTERNS_MD.read_text(encoding="utf-8")
     start = re.search(SECTION_HEADING, text, flags=re.MULTILINE)
     assert start, (
@@ -113,18 +252,122 @@ def pattern_8_section() -> str:
     return text[start.start():stop]
 
 
-def fenced_blocks(section: str) -> list:
-    """Return each fenced block in `section`, whatever its language tag."""
-    return re.findall(r"```[a-z]*\n(.*?)```", section, flags=re.DOTALL)
+def page_text() -> str:
+    """Return the whole page.
 
-
-def json_payloads(block: str) -> list:
-    """Return each single-quoted JSON argument in a shell block.
-
-    The page passes a payload as one shell-quoted argument. This takes the
-    text between the first pair of single quotes that opens with a brace.
+    THE SHELL AND EXECUTION ARMS READ THIS, and not a section. A defect in an
+    example is a defect wherever the example sits, and the save examples that
+    carry the apostrophe risk sit outside the Incremental Learning section.
     """
-    return re.findall(r"'(\{.*?\})'", block, flags=re.DOTALL)
+    return PATTERNS_MD.read_text(encoding="utf-8")
+
+
+def stub_record(blocks: list) -> dict:
+    """Return one memory-shaped record that answers each key the blocks read.
+
+    DERIVED FROM THE BLOCKS BY DESIGN. A hand-written record goes stale on the
+    day an example reads a new field, and it then reds a CORRECT page and sends
+    the author to the page rather than to this file. MEASURED while this arm
+    was built: a first form scanned only `mem['...']` and missed the nested
+    `alternatives`, so a correct block failed on a hole in the stub.
+
+    THE COST IS REAL AND THE BOUND NAMES IT: a stub that answers each key
+    cannot detect a block that reads a key the CLI does not return.
+    """
+    keys = set()
+    for body in blocks:
+        keys |= set(re.findall(r"\[\s*[\"'](\w+)[\"']\s*\]", body))
+    keys -= {SKILL_DIR_VAR}
+    keys |= {"context", "goal", "created_at"}
+
+    def leaf(key: str) -> str:
+        return "2026-01-01T00:00:00Z" if key.endswith("_at") else f"stub-{key}"
+
+    inner = {k: (["stub"] if k in LIST_VALUED_KEYS else leaf(k)) for k in keys}
+    return {k: ([inner] if k in LIST_VALUED_KEYS else leaf(k)) for k in keys}
+
+
+def run_python_block(body: str, skill_dir: Path) -> subprocess.CompletedProcess:
+    """Run one python block with the CLI path pointed at `skill_dir`."""
+    environment = dict(os.environ)
+    environment[SKILL_DIR_VAR] = str(skill_dir)
+    return subprocess.run(
+        ["python3", "-c", body],
+        capture_output=True,
+        text=True,
+        env=environment,
+        cwd=str(skill_dir),
+        timeout=BLOCK_TIMEOUT_SECONDS,
+    )
+
+
+def write_stub_cli(skill_dir: Path, record: dict) -> Path:
+    """Write a stub `cli.py` that prints one record and exits 0."""
+    scripts = skill_dir / "scripts"
+    scripts.mkdir(parents=True, exist_ok=True)
+    target = scripts / "cli.py"
+    target.write_text(
+        "import json\nprint(json.dumps(" + json.dumps([record]) + "))\n",
+        encoding="utf-8",
+    )
+    return target
+
+
+def tagged_blocks(section: str) -> list:
+    """Return each fenced block in `section` as a (tag, body) pair.
+
+    THE TAG IS PART OF THE READING. An arm that adjudicates a shell command
+    must not receive a python block, and an unknown tag must reach an arm that
+    refuses it rather than a filter that drops it.
+    """
+    return re.findall(r"```([a-z]*)\n(.*?)```", section, flags=re.DOTALL)
+
+
+def fenced_blocks(section: str) -> list:
+    """Return the body of each fenced block, whatever its tag."""
+    return [body for _, body in tagged_blocks(section)]
+
+
+def shell_blocks(section: str) -> list:
+    """Return the body of each block a shell reads."""
+    return [body for tag, body in tagged_blocks(section) if tag in SHELL_TAGS]
+
+
+def payload_arguments(block: str) -> list:
+    """Return each brace-leading ARGUMENT the shell hands to the command.
+
+    🔴 THE SUBJECT IS THE ARGUMENT THE COMMAND RECEIVES, AND NOT THE SOURCE
+    TEXT THAT SPELLS IT. An earlier form took the text between a pair of
+    single quotes with a regex. Those are two different strings the moment a
+    quote does work, and the difference is not cosmetic. MEASURED on four
+    fixtures, with the regex against this function:
+
+      | fixture                          | bash -n | regex payload | this |
+      |----------------------------------|---------|---------------|------|
+      | apostrophe inside single quotes  | rc=2    | VALID json    | red  |
+      | trailing comma in the payload    | rc=0    | red           | red  |
+      | apostrophe escaped as `'"'"'`    | rc=0    | RED, FALSELY  | pass |
+      | clean                            | rc=0    | pass          | pass |
+
+    ROW 1 AND ROW 3 ARE THE WHOLE REASON THIS FUNCTION IS NOT A REGEX. Row 1
+    is a command that does not parse, and the regex called its payload clean.
+    Row 3 is the ORDINARY REPAIR of row 1, and the regex called it broken. So
+    the regex accepted the defect and then refused its own cure, which sends a
+    reader to the payload when the instrument is at fault.
+
+    `shlex` applies the word rule the shell applies, so the two halves you
+    must keep true at once, a command that parses and a payload that parses,
+    are read from ONE string rather than two that can be traded. It is a
+    tokenizer: it runs nothing and reaches no store.
+
+    An unbalanced quote raises `ValueError`. Let it out. The shell-parse arm
+    is the place that reports it, and a caught-and-dropped quote fault here
+    is the silent half of the trade this function must close.
+    """
+    return [
+        word for word in shlex.split(block, comments=True)
+        if word.lstrip().startswith("{")
+    ]
 
 
 def block_verb(block: str, verbs: set) -> str | None:
@@ -158,13 +401,14 @@ class TestTheInstrumentIsLive:
     """
 
     def test_the_section_is_present_and_not_empty(self):
-        section = pattern_8_section()
-        assert len(section.strip()) > 0, "the Pattern 8 slice is empty"
+        section = incremental_learning_section()
+        assert len(section.strip()) > 0, "the Incremental Learning slice is empty"
 
     def test_the_section_holds_fenced_blocks(self):
-        blocks = fenced_blocks(pattern_8_section())
+        blocks = fenced_blocks(incremental_learning_section())
         assert blocks, (
-            "no fenced block is in the Pattern 8 section, so each arm below "
+            "no fenced block is in the Incremental Learning section, so the "
+            "section arms below "
             "passes over an empty set. EITHER the examples went, which is a "
             "page defect, OR the fence syntax changed, which is a reader "
             "defect. Read the section before you decide."
@@ -186,10 +430,60 @@ class TestTheInstrumentIsLive:
                 f"the CLI: these three are load-bearing in the page today."
             )
 
-    def test_the_payload_reader_finds_a_payload_and_refuses_prose(self):
-        """A control on the matcher, and each half must do work."""
-        assert json_payloads("""cli.py update abc '{"a": [1]}'""") == ['{"a": [1]}']
-        assert json_payloads("cli.py list") == []
+    def test_every_block_carries_a_tag_this_file_classifies(self):
+        """🔴 THE FILTER IS THE HAZARD, AND THIS IS ITS NET.
+
+        The shell arm reads the blocks tagged `bash` or untagged. A block with
+        a tag no arm claims is a block NO ARM READS, and the suite then reports
+        a clean result over a set that quietly lost a member.
+
+        MEASURED on the page today: 15 blocks, 12 `bash`, 3 `python`, none
+        untagged. So the filter drops nothing now. This arm is what makes that
+        stay true rather than a fact somebody once checked.
+
+        🔴 THIS READS THE WHOLE PAGE AND NOT THE SECTION. It must cover the
+        population the widest arm reads, and the shell and execution arms read
+        the page. A section-scoped tag control leaves each block outside the
+        section free to carry a tag no arm claims.
+        """
+        unknown = {
+            tag for tag, _ in tagged_blocks(page_text())
+            if tag not in KNOWN_TAGS
+        }
+        assert not unknown, (
+            f"the page holds a fenced block tagged {sorted(unknown)}, "
+            f"which this file does not classify. Known: {sorted(KNOWN_TAGS)}. "
+            f"DO NOT ADD THE TAG TO `SHELL_TAGS` WITHOUT A READING: `bash -n` "
+            f"is the adjudicator for a shell block and it is the wrong "
+            f"instrument for another kind. Decide which arms own the new tag."
+        )
+
+    def test_the_payload_reader_reads_the_argument_and_not_the_source_text(self):
+        """🔴 A SEPARATION MATRIX, AND EACH ROW MUST DO WORK ONLY IT DOES.
+
+        Row 3 is the row that matters. `'"'"'` is the ordinary way to put an
+        apostrophe inside a single-quoted shell argument, and it is the repair
+        for row 1. The regex this replaced reported row 3 as a broken payload,
+        so it refused the cure for the defect it had accepted.
+        """
+        clean = """python3 "$D/cli.py" update abc '{"a": [1]}'"""
+        assert payload_arguments(clean) == ['{"a": [1]}']
+
+        # An escaped apostrophe: the shell hands the command `it's fine`.
+        escaped = """python3 "$D/cli.py" update abc '{"note": "it'"'"'s fine"}'"""
+        assert payload_arguments(escaped) == ['{"note": "it\'s fine"}'], (
+            "the payload reader returned the source text rather than the "
+            "argument. It is a regex again, and a correctly escaped apostrophe "
+            "now reports as a broken payload."
+        )
+        json.loads(payload_arguments(escaped)[0])
+
+        # A bare apostrophe ends the argument early. The reader must not
+        # invent a payload the command does not receive.
+        with pytest.raises(ValueError):
+            payload_arguments("""python3 "$D/cli.py" update abc '{"n": "redis-py's"}'""")
+
+        assert payload_arguments("cli.py list") == []
 
     def test_the_verb_reader_reads_the_command_line_and_not_the_payload(self):
         """🔴 THE DEFECT THIS PINS WAS LIVE AND IT PASSED A BROKEN COMMAND.
@@ -217,49 +511,231 @@ class TestTheInstrumentIsLive:
         assert block_verb(commented, verbs) is None
 
 
-class TestPattern8TeachesTheCliRoute:
-    """The drift check. Its subject is the CLI route, which is what the page
-    now teaches."""
+class TestThePagePatternNumbering:
+    """🔴 THIS ARM IS THE OTHER HALF OF THE ANCHOR REPAIR.
 
-    def test_each_block_invokes_the_cli(self):
-        blocks = fenced_blocks(pattern_8_section())
-        silent = [b for b in blocks if CLI_MARKER not in b]
-        assert not silent, (
-            f"{len(silent)} fenced block(s) in Pattern 8 do not name "
-            f"{CLI_MARKER!r}. The page teaches store access, and the store-"
-            f"access rule sends a memory operation through the CLI. A block "
-            f"that reaches the store another way teaches the route the rule "
-            f"forbids. Blocks: {silent}"
+    `SECTION_HEADING` reads a `\\d+` because the number belongs to the page. A
+    mutant that renumbers the section reddens NOTHING, which is the correct
+    result for the anchor AND which leaves the numbering itself unguarded. A
+    hand check of the numbering does not survive the next editor.
+
+    SO THE COUPLING IS REPLACED RATHER THAN REMOVED. The arm below is about
+    the PROPERTY, that the headings run 1 to N with no hole and no repeat,
+    and not about one number that a later edit is free to move.
+
+    THE DEFECT THIS REFUSES IS A MOVED HOLE, NOT A MISSING NUMBER. The page
+    ran 1, 2, 3, 5, 6, 7, 8, and a partial repair gives 1, 2, 3, 4, 5, 6, 8.
+    That reads as progress and carries the hole to the end.
+    """
+
+    def test_the_pattern_headings_run_one_to_n_with_no_hole(self):
+        numbers = [
+            int(m.group(1))
+            for m in re.finditer(r"^## Pattern (\d+):", page_text(), flags=re.MULTILINE)
+        ]
+        assert numbers, (
+            "no `## Pattern N:` heading is on the page, so this arm walks an "
+            "empty set and passes for that reason alone. EITHER the headings "
+            "were renamed, and this arm must follow, OR the page changed shape."
+        )
+        assert numbers == list(range(1, len(numbers) + 1)), (
+            f"the pattern headings read {numbers} and must read "
+            f"{list(range(1, len(numbers) + 1))}. A hole or a repeat sends a "
+            f"reader to a section that is absent. REPAIR THE WHOLE RUN AT "
+            f"ONCE: a partial renumber moves the hole to the end rather than "
+            f"closes it, and it reads as progress while it does so."
         )
 
-    def test_each_block_uses_a_verb_the_parser_accepts(self):
+
+class TestThePageTeachesTheCliRoute:
+    """The drift check. Its subject is the CLI route, which is what the page
+    now teaches.
+
+    🔴 TWO POPULATIONS IN ONE CLASS, AND THE SPLIT IS DELIBERATE. The shell and
+    execution arms read the WHOLE PAGE, because a defect in an example is a
+    defect wherever it sits. The CLI-route arms read the Incremental Learning
+    SECTION, because that is the section whose subject is the route.
+
+    🔴 EACH ARM HOLDS A MUTANT ONLY IT CATCHES. Measured against a copy of the
+    plugin tree, with the unmutated copy green first, so a red below is the
+    mutation and not the copy:
+
+      | mutation of the page or the reader    | shell | payload | tag | reader |
+      |---------------------------------------|-------|---------|-----|--------|
+      | bare apostrophe in a payload          |  RED  |   RED   |  .  |   .    |
+      | unterminated `if`, payload untouched  |  RED  |    .    |  .  |   .    |
+      | trailing comma, quoting untouched     |   .   |   RED   |  .  |   .    |
+      | a block retagged `console`            |   .   |    .    | RED |   .    |
+      | the payload reader put back to a regex|   .   |    .    |  .  |  RED   |
+      | each shell fence retagged             |  RED  |   RED   |  .  |   .    |
+      | THE CURE, apostrophe as `'"'"'`       | green |  green  |green| green  |
+
+    THE LAST TWO ROWS ARE THE ONES THAT ARE EASY TO LEAVE OUT. The retag row
+    is the vacuity arm: it empties the population and the arms must refuse an
+    empty set rather than pass over it. THE CURE ROW IS A COUNTER-TEST: a
+    guard that reds on the correct repair is worse than absent, because it
+    argues against the fix while looking like diligence.
+
+    THE EXECUTION ARM HOLDS ITS OWN SEPARATION, recorded at its own docstring,
+    because a parser and a run disagree about the class that hit this page.
+    """
+
+    def test_each_block_in_the_section_invokes_the_cli(self):
+        blocks = fenced_blocks(incremental_learning_section())
+        silent = [b for b in blocks if CLI_MARKER not in b]
+        assert not silent, (
+            f"{len(silent)} fenced block(s) in the Incremental Learning "
+            f"section do not name {CLI_MARKER!r}. The page teaches store "
+            f"access, and the store-access rule sends a memory operation "
+            f"through the CLI. A block that reaches the store another way "
+            f"teaches the route the rule forbids. Blocks: {silent}"
+        )
+
+    def test_each_block_in_the_section_uses_a_verb_the_parser_accepts(self):
         verbs = accepted_verbs()
         unknown = []
-        for block in fenced_blocks(pattern_8_section()):
+        for block in fenced_blocks(incremental_learning_section()):
             verb = block_verb(block, verbs)
             if verb is None:
                 unknown.append(block)
         assert not unknown, (
-            f"{len(unknown)} fenced block(s) in Pattern 8 name no verb the "
-            f"CLI parser accepts. Accepted today, derived from "
-            f"{CLI_SOURCE.name}: {sorted(verbs)}. EITHER the page teaches a "
-            f"verb that went, which is a doc defect, OR the CLI renamed one "
-            f"and the page did not follow, which is a drift. Read the two "
-            f"before you repair one. Blocks: {unknown}"
+            f"{len(unknown)} fenced block(s) in the Incremental Learning "
+            f"section name no verb the CLI parser accepts. Accepted today, "
+            f"derived from {CLI_SOURCE.name}: {sorted(verbs)}. EITHER the page "
+            f"teaches a verb that went, which is a doc defect, OR the CLI "
+            f"renamed one and the page did not follow, which is a drift. Read "
+            f"the two before you repair one. Blocks: {unknown}"
         )
 
-    def test_each_payload_parses(self):
+    def test_every_shell_block_parses_as_a_shell_command(self):
+        """🔴 THE ADJUDICATOR OF A PARSE CLAIM IS THE PARSER.
+
+        This file claims each block invokes the CLI. A regex answers a
+        DIFFERENT question and can agree with the shell by luck. MEASURED on
+        this page: a payload holding `redis-py's` terminates the single-quoted
+        shell argument, so the command does not parse, while a regex reports
+        the payload clean.
+
+        THIS WALKS EACH SHELL BLOCK IN THE SLICE rather than a block somebody
+        found broken, and it reports the count that parse against the count
+        that exist. A named block is a defect that was repaired once. A count
+        is a property that holds.
+
+        `bash -n` reads the syntax and runs nothing, so this reaches no store.
+        """
+        blocks = shell_blocks(page_text())
+        assert blocks, (
+            f"no shell block is on the page, so this arm walks an empty set "
+            f"and passes for that reason alone. Tags read as shell: "
+            f"{sorted(SHELL_TAGS)}."
+        )
+        broken = []
+        for index, block in enumerate(blocks):
+            result = subprocess.run(
+                ["bash", "-n"], input=block, capture_output=True, text=True
+            )
+            if result.returncode != 0:
+                broken.append(f"block {index}: {result.stderr.strip()[:120]}")
+        assert not broken, (
+            f"{len(blocks) - len(broken)} of {len(blocks)} shell block(s) in "
+            f"the page parse. These do not: {broken}. An agent that copies "
+            f"one gets a shell syntax error. THE COMMON CAUSE IS AN APOSTROPHE "
+            f"inside a single-quoted payload, which ends the argument early. "
+            f"THE REPAIR IS `'\"'\"'`, and the payload arm accepts it: that arm "
+            f"reads the argument the shell builds, so the two arms cannot be "
+            f"traded against each other."
+        )
+
+    def test_every_shell_block_hands_the_command_a_payload_that_parses(self):
+        """🔴 THE TWO HALVES ARE ONE ARM, BECAUSE A TRADE BETWEEN THEM IS
+        SILENT. A block must parse as a command AND hand that command valid
+        JSON. Read those from two different strings and a repair to one half
+        can break the other with no arm going red.
+
+        This reads the ARGUMENT, through `shlex`, so the two halves come from one
+        string. The command that does not parse has no argument to read, and
+        this arm names it rather than skip it.
+        """
+        blocks = shell_blocks(page_text())
+        assert blocks, "no shell block is on the page"
         bad = []
-        for block in fenced_blocks(pattern_8_section()):
-            for payload in json_payloads(block):
+        checked = 0
+        for index, block in enumerate(blocks):
+            try:
+                payloads = payload_arguments(block)
+            except ValueError as exc:
+                bad.append(
+                    f"block {index}: the shell cannot split it ({exc}), so no "
+                    f"argument reaches the command. Repair the quoting first."
+                )
+                continue
+            for payload in payloads:
+                checked += 1
                 try:
                     json.loads(payload)
                 except json.JSONDecodeError as exc:
-                    bad.append(f"{payload[:60]}... ({exc})")
+                    bad.append(f"block {index}: {payload[:60]}... ({exc})")
         assert not bad, (
-            f"a JSON payload in Pattern 8 does not parse: {bad}. An agent "
-            f"that copies the block gets a parse error rather than a memory "
-            f"update. THIS ARM READS THE PAYLOAD AND DOES NOT SEND IT, so a "
-            f"payload that parses can still be refused by the store. That "
-            f"gap is named in the stated bound at the top of this file."
+            f"{checked} payload argument(s) read across {len(blocks)} shell "
+            f"block(s), and these are not valid JSON: {bad}. An agent that "
+            f"copies the block gets a parse error rather than a memory update. "
+            f"THIS ARM READS THE PAYLOAD AND DOES NOT SEND IT, so a payload "
+            f"that parses can be refused by the store. That gap is named "
+            f"in the stated bound at the top of this file."
+        )
+
+    def test_each_python_block_runs_to_completion(self):
+        """🔴 THE PARSER IS NOT THE JUDGE OF THIS CLASS. A RUN IS.
+
+        MEASURED on this page, the repair before against after:
+
+            compile()   3 of 3 parse  ->  3 of 3 parse    (moves nothing)
+            execution   0 of 3 run    ->  3 of 3 run      (separates fully)
+
+        An unexpanded `${CLAUDE_SKILL_DIR}` inside a string literal PARSES
+        PERFECTLY and fails at the moment the command runs. PEP 701 nested
+        f-strings parse on an interpreter at 3.12 or above. Each defect class
+        that hit this page is invisible to a parse-only arm, which reports a
+        true result with a live instrument and answers a question nobody
+        asked.
+
+        WHAT THIS DECIDES: the block runs on THE INTERPRETER THAT RUNS THE
+        TESTS. It does NOT decide the declared floor. A CI matrix decides
+        that, and the stated bound at the top of this file says so.
+
+        THE RUN CANNOT REACH THE STORE, and the mechanism is the page's own
+        code. Each block builds its command from the `CLAUDE_SKILL_DIR`
+        environment variable, so pointing that at a temporary directory makes
+        the real CLI unreachable by construction.
+        """
+        blocks = [b for tag, b in tagged_blocks(page_text()) if tag in PYTHON_TAGS]
+        assert blocks, (
+            f"no python block is on the page, so this arm walks an empty set "
+            f"and passes for that reason alone. Tags read as python: "
+            f"{sorted(PYTHON_TAGS)}. EITHER the examples went, which is a page "
+            f"defect, OR the tag changed, which is a reader defect."
+        )
+        failed = []
+        with tempfile.TemporaryDirectory() as work_dir:
+            skill_dir = Path(work_dir)
+            stub = write_stub_cli(skill_dir, stub_record(blocks))
+            # A control on the harness. If the stub is absent, each block below
+            # fails for a harness reason and the message points at the page.
+            assert stub.is_file(), f"the stub CLI was not written at {stub}"
+            for index, body in enumerate(blocks):
+                result = run_python_block(body, skill_dir)
+                if result.returncode != 0:
+                    tail = result.stderr.strip().splitlines()
+                    failed.append(
+                        f"block {index}: rc={result.returncode} "
+                        f"{tail[-1][:160] if tail else '(no stderr)'}"
+                    )
+        assert not failed, (
+            f"{len(blocks) - len(failed)} of {len(blocks)} python block(s) run "
+            f"to completion. These do not: {failed}. AN AGENT THAT COPIES ONE "
+            f"GETS THAT ERROR. Read the failure before you reach for the "
+            f"harness: a `${{{SKILL_DIR_VAR}}}` that survives into a command "
+            f"is the page writing a variable name where it must read the "
+            f"variable, and no parser reports it. DO NOT REPAIR THIS BY A "
+            f"CHANGE TO THE STUB unless the block reads a key no CLI returns."
         )

--- a/pact-plugin/tests/test_store_access_bar_presence.py
+++ b/pact-plugin/tests/test_store_access_bar_presence.py
@@ -280,6 +280,22 @@ ROUTE_TOKENS = {
 #
 # THESE TOKENS DO SELECT FOR ARM 3. A file that names one reaches the store,
 # so it needs the rule, and it needs it more than a file that uses the CLI.
+# 🔴 STATED BOUND: THIS ALPHABET IS BOUND TO A BINDING NAME AND CANNOT SEE A
+# REBIND. Each token below spells the receiver as `memory`. A reader who writes
+# `m = PACTMemory()` and then `m.save(...)` reaches the store by the forbidden
+# route and selects NOTHING here. MEASURED, and the instance is live outside
+# this guard: a repository testing scenario binds `m` and calls `m.list(...)`.
+#
+# THE DANGEROUS DIRECTION IS THE REPAIR. An author who converts `memory.save(`
+# to a different receiver satisfies this guard and keeps the forbidden route.
+# So a green from arm 3 says "no token matched", and it does NOT say "no file
+# reaches the store by the module API".
+#
+# DO NOT CLOSE THIS BY MORE SPELLINGS. A longer name list is the same defect
+# with more rows, because the receiver is free. The repair is a predicate over
+# the CALL rather than over the text. It is not on this branch, and the tracker
+# carries it with the population widening, because either repair alone leaves
+# the question open.
 FORBIDDEN_ROUTE_TOKENS = {
     "memory.save(": "the module API, which the bar forbids",
     "memory.search(": "the module API, which the bar forbids",
@@ -302,8 +318,11 @@ ALPHABET_FLOOR = frozenset(path for path in DECLARED_CARRIERS if path.endswith("
 # Keys are relative to `PLUGIN_DIR`. Values state the cause.
 #
 # EMPTY TODAY. THE RESULT THAT MADE IT EMPTY IS A FLOOR AND NOT A CENSUS, and
-# it is stated as the search that produced it: the eight tokens above, applied
-# to the five patterns below, selected the markdown carriers and no other file.
+# it is stated as the search that produced it: the tokens in `ROUTE_TOKENS`,
+# applied to `POPULATION_PATTERNS`, selected the markdown carriers and no other
+# file. THE COUNTS ARE NAMED BY THEIR CONSTANT RATHER THAN WRITTEN OUT, because
+# a written count goes stale on the day a token or a pattern is added, and the
+# stale form reads as a measurement.
 # A WIDER ALPHABET REACHES MORE. An eighteen-token set reaches two further
 # instruction surfaces, and the team-lead ruled those OUT on ACTIONABILITY: they
 # give an INTENT a reader cannot type, so the reader must open the memory skill
@@ -624,11 +643,31 @@ def copies_that_differ_only_by_case(root: Path) -> list[str]:
 
 
 def population_files(root: Path) -> list[Path]:
-    """Each instruction surface the arm-3 walk covers, at the five patterns."""
+    """Each instruction surface the arm-3 walk covers.
+
+    THE PATTERNS ARE `POPULATION_PATTERNS`, and this docstring does not count
+    them. A count here goes stale on the day one is added.
+
+    🔴 THE YIELD IS DE-DUPLICATED AND THE DECLARATION IS NOT TOUCHED. Two of
+    the patterns overlap on purpose, so one file can arrive two times.
+    MEASURED: 76 paths yielded and 75 distinct, with
+    `skills/pact-memory/SKILL.md` matched by `skills/*/SKILL.md` and by
+    `skills/pact-memory/**/*.md`.
+
+    DE-DUPLICATION HERE IS SET-IDENTICAL. It loses NO member, so it is neither
+    a widening nor a narrowing of the covered population. Removal of a glob
+    is a change to the DECLARED population, which must not move, so the
+    repair belongs to the yield rather than to `POPULATION_PATTERNS`.
+
+    WHY IT MATTERS WHEN NO ARM COUNTS. Each arm here asks `any(...)` or keys
+    on the path, so a repeat cannot move a verdict. THE FRAGILITY CENSUS
+    COUNTS, and that count decides whether a route token is one edit away from
+    idle. AN INFLATED COUNT READS AS SAFETY.
+    """
     found: list[Path] = []
     for pattern in POPULATION_PATTERNS:
         found.extend(root.glob(pattern))
-    return sorted(found)
+    return sorted(set(found))
 
 
 def files_reaching_the_store(root: Path, tokens: dict, ignore_bar: bool = False) -> dict:
@@ -1042,6 +1081,44 @@ class TestTheAlphabetDoesNotSelectItself:
     THE ALPHABET FLOOR CARRIES HALF OF THIS PROPERTY, by reading the stripped
     text. The arm below carries the other half, over the tokens.
     """
+
+    def test_the_population_holds_no_duplicate_path(self):
+        """🔴 THE CLASS, NOT THE INSTANCE.
+
+        `POPULATION_PATTERNS` holds two globs that overlap, so one file can
+        arrive two times. `population_files` de-duplicates the yield, and THIS
+        ARM GUARDS THAT DE-DUPLICATION.
+
+        🔴 STATED ACCURATELY, BECAUSE A MUTANT CORRECTED THE FIRST WORDING.
+        This arm does NOT detect a new overlapping glob, and it does not need
+        to. MEASURED: with a third overlapping glob added, the arm stays
+        GREEN, because the de-duplication absorbs the overlap and no duplicate
+        reaches the yield. A new glob is harmless while the de-duplication
+        stands. WHAT REDS IS THE REMOVAL OF THE DE-DUPLICATION, measured, and
+        that is the one edit that re-opens the defect.
+
+        THE FAILURE DIRECTION IS WHAT EARNS THE ROW. NO SHIPPED ARM COUNTS
+        THIS POPULATION: each one asks `any(...)` or keys on the path, so a
+        repeat moves no verdict and stays invisible. The fragility census is
+        the one instrument that counts, and its count decides whether a route
+        token sits one edit away from idle. AN INFLATED COUNT READS AS SAFETY,
+        so the defect hides in the direction of a clean answer.
+
+        MEASURED before the repair: 76 paths yielded, 75 distinct, the repeat
+        being `skills/pact-memory/SKILL.md`.
+        """
+        paths = population_files(PLUGIN_DIR)
+        repeated = sorted(
+            {str(p) for p in paths if paths.count(p) > 1}
+        )
+        assert not repeated, (
+            f"`population_files` yields {len(paths)} paths and "
+            f"{len(set(paths))} distinct. Repeated: {repeated}. TWO PATTERNS "
+            f"IN `POPULATION_PATTERNS` OVERLAP. DO NOT REPAIR THIS BY REMOVAL "
+            f"OF A PATTERN: that changes the DECLARED population, and the "
+            f"declaration must not move. De-duplicate the YIELD instead, which "
+            f"loses no member and is set-identical."
+        )
 
     def test_each_token_does_work_outside_the_bar_text(self):
         """No token may live only inside the marked regions."""

--- a/pact-plugin/tests/test_store_access_bar_presence.py
+++ b/pact-plugin/tests/test_store_access_bar_presence.py
@@ -148,6 +148,12 @@ DECLARED_CARRIERS = frozenset(
         "protocols/pact-state-recovery.md",
         "protocols/pact-protocols.md",
         "skills/pact-handoff-harvest/SKILL.md",
+        # A REFERENCE PAGE, and the first carrier that is not a SKILL.md. It
+        # teaches module-level API calls against the store. The route alphabet
+        # missed it, because it names the calls and no path, no CLI and no
+        # store file. MEASURED across the 44 markdown files below a skill
+        # directory that are not SKILL.md: this is the ONE live member.
+        "skills/pact-memory/references/memory-patterns.md",
         "scripts/memory_repair/__init__.py",
         "scripts/memory_repair/shred_detect.py",
         "scripts/archive_pin.py",
@@ -192,7 +198,36 @@ POPULATION_PATTERNS = (
     "protocols/*.md",
     "reference/*.md",
     "skills/*/SKILL.md",
+    # THE MEMORY SKILL OWN DIRECTORY, and the cause is measured. A reference
+    # page beside the skill that teaches store access taught 21 module-level
+    # API calls, named the CLI zero times, and held no rule. `skills/*/SKILL.md`
+    # cannot reach a reference page, so the page was outside the walk.
+    # THIS IS NOT THE WIDENING REFUSED EARLIER. That one reached the memory
+    # package and each hook, which reach the store legitimately. This reaches
+    # one skill directory, where a page about the store is expected rather than
+    # incidental, and it reaches the NEXT page written there.
+    "skills/pact-memory/**/*.md",
+    # THE MEMORY-REPAIR TOOLING DIRECTORY. `scripts/archive_pin.py` names three
+    # route tokens outside the bar, so the alphabet reaches it. This gives it a
+    # net that does NOT depend on `DECLARED_CARRIERS`. MEASURED: the one other
+    # file here, `check_pin_caps.py`, names no route token, so this pattern
+    # needs no exemption. It does NOT reach the memory package or the hooks.
+    "scripts/*.py",
 )
+
+# THE MEMORY-REPAIR PACKAGE, walked as a DIRECTORY rather than as a path list.
+# Each module here must carry the bar, so a module added later joins the rule
+# on the day it arrives, and a path dropped from `DECLARED_CARRIERS` does not
+# take the coverage with it.
+#
+# WHY A DIRECTORY AND NOT AN ALPHABET. MEASURED: with the bar region removed,
+# the two modules here name NO route token at all. So no widening of
+# `ROUTE_TOKENS` can reach them, and only membership of this directory can.
+REPAIR_PACKAGE_DIR = "scripts/memory_repair"
+
+# MODULES HERE THAT DO NOT HAVE TO CARRY THE BAR. Empty today. Add a path only
+# with a stated cause, as for each other set in this file.
+REPAIR_PACKAGE_EXEMPTIONS: dict = {}
 
 # A FILE REACHES THE STORE WHEN IT NAMES ONE OF THESE. The token set is derived
 # from the THREE ROUTES the acceptance test names, which are the CLI, an import,
@@ -219,7 +254,41 @@ ROUTE_TOKENS = {
     "search --query": "the CLI, by a verb instruction",
     "--limit": "the CLI, by a verb instruction",
     "archive_pin.py": "the CLI, at one remove",
+    # THE IMPORT ROUTE, SPELLED AS A MODULE-LEVEL CALL. A page taught
+    # `memory.save(...)` and `memory.search(...)` and named no package path, no
+    # CLI and no store file, so each token above missed it. The route was
+    # present and the SPELLING was new, which is the same miss this file has
+    # recorded three times. These name the route as a caller writes it.
 }
+
+# 🔴 THE FORBIDDEN ROUTE, AND IT TAKES THE OPPOSITE RULE. These name the
+# module API, which the store-access bar forbids. A file that teaches one of
+# them teaches the route the rule removes.
+#
+# EACH TOKEN HERE IS EXPECTED TO BE IDLE. That is the whole difference from
+# the set above. `ROUTE_TOKENS` name LEGITIMATE routes, so a token there that
+# selects nothing is decay and an arm reports it. A token HERE that selects
+# nothing means the tree is HEALTHY, and an arm that reddens on that is
+# measuring the wrong thing.
+#
+# THE HISTORY THAT PRODUCED THE SPLIT, because a later reader will meet the
+# same pressure. These three sat in `ROUTE_TOKENS`. A page taught the module
+# API, the repair converted it to the CLI, and the tokens went idle one by
+# one. The must-do-work arm reddened each time, and each red invited a token
+# removal that would have left the guard blind to the NEXT page that teaches
+# the forbidden route. ONE RULE OVER TWO KINDS OF TOKEN WAS THE DEFECT.
+#
+# THESE TOKENS DO SELECT FOR ARM 3. A file that names one reaches the store,
+# so it needs the rule, and it needs it more than a file that uses the CLI.
+FORBIDDEN_ROUTE_TOKENS = {
+    "memory.save(": "the module API, which the bar forbids",
+    "memory.search(": "the module API, which the bar forbids",
+    "memory.update(": "the module API, which the bar forbids",
+}
+
+# The set arm 3 selects with. A file that reaches the store by ONE route needs
+# the rule, and the two kinds of route select alike.
+SELECTING_TOKENS = {**ROUTE_TOKENS, **FORBIDDEN_ROUTE_TOKENS}
 
 # THE ALPHABET FLOOR, and it is NOT the same set as `DECLARED_CARRIERS`. The
 # alphabet exists to reach INSTRUCTION SURFACES, so its floor holds the markdown
@@ -456,6 +525,29 @@ def compared_carriers(root: Path) -> list[str]:
     see, because a file with no marker is not in the derived set.
     """
     return sorted(set(derived_carriers(root)) | set(DECLARED_CARRIERS))
+
+
+def repair_modules_without_the_bar(root: Path, exemptions: dict) -> list[str]:
+    """Modules of the memory-repair package that hold no begin marker.
+
+    🔴 THE SECOND NET, AND ITS INDEPENDENCE IS THE WHOLE POINT. The declared
+    floor is a LIST, so an edit that drops a path from the list takes the
+    coverage with it. This reads the DIRECTORY, so the same edit changes
+    nothing here.
+
+    MEASURED, and it is why the net is a directory rather than an alphabet:
+    with the bar region removed, neither module here names one route token, so
+    arm 3 cannot reach them by any widening of `ROUTE_TOKENS`.
+    """
+    package = root / REPAIR_PACKAGE_DIR
+    if not package.is_dir():
+        return []
+    return sorted(
+        relative_name(path, root)
+        for path in package.glob("*.py")
+        if relative_name(path, root) not in exemptions
+        and MARKER_BEGIN not in path.read_text(encoding="utf-8", errors="replace")
+    )
 
 
 def declared_carriers_without_a_marker(root: Path) -> list[str]:
@@ -728,6 +820,23 @@ class TestEveryDeclaredCarrierIsPlaced:
     a larger set reporting green.
     """
 
+    def test_each_repair_module_holds_the_marker(self):
+        """THE SECOND NET, INDEPENDENT OF THE DECLARED LIST.
+
+        A carrier loses ALL coverage when one edit drops its path from
+        `DECLARED_CARRIERS` and a second drops its region. This arm reads the
+        DIRECTORY, so the first edit cannot reach it.
+        """
+        missing = repair_modules_without_the_bar(PLUGIN_DIR, REPAIR_PACKAGE_EXEMPTIONS)
+        assert not missing, (
+            f"these modules of {REPAIR_PACKAGE_DIR} hold no begin marker: "
+            f"{missing}. Each module of that package carries the store-access "
+            f"rule. Place the marked region from {SOURCE_HOME}, or add the "
+            f"path to REPAIR_PACKAGE_EXEMPTIONS WITH A STATED CAUSE. DO NOT "
+            f"repair this by an edit to DECLARED_CARRIERS: that list is a "
+            f"separate net and this arm is the one that survives its removal."
+        )
+
     def test_each_declared_carrier_holds_the_marker(self):
         missing = declared_carriers_without_a_marker(PLUGIN_DIR)
         assert not missing, (
@@ -865,9 +974,32 @@ class TestEachStoreReachingSurfaceCarriesTheBar:
             f"arm 3 while each other arm keeps passing. Restore the token."
         )
 
+    def test_no_forbidden_route_token_is_taught_without_the_bar(self):
+        """A file that teaches the FORBIDDEN route needs the rule most.
+
+        THIS ARM IS EXPECTED TO PASS OVER AN EMPTY SELECTION, and that is the
+        one place in this file where an empty set is the GOOD outcome. The
+        companion arm that refuses an idle token applies to `ROUTE_TOKENS`
+        alone, for that reason.
+        """
+        teaching = sorted(
+            name
+            for name, hits in files_reaching_the_store(
+                PLUGIN_DIR, FORBIDDEN_ROUTE_TOKENS
+            ).items()
+            if marker_fault(read_carrier(PLUGIN_DIR, name)) is not None
+        )
+        assert not teaching, (
+            f"{teaching} teach the module API and hold no marked region. The "
+            f"bar forbids that route, so a reader of one of these files is "
+            f"taught the thing the rule removes, with no rule beside it. "
+            f"Place the marked region from {SOURCE_HOME}, or correct the file "
+            f"to the CLI route."
+        )
+
     def test_no_store_reaching_surface_is_silent(self):
         silent = store_reaching_files_without_the_bar(
-            PLUGIN_DIR, ROUTE_TOKENS, POPULATION_EXEMPTIONS
+            PLUGIN_DIR, SELECTING_TOKENS, POPULATION_EXEMPTIONS
         )
         assert not silent, (
             f"{silent} name a route to the memory store and hold no readable "
@@ -921,6 +1053,10 @@ class TestTheAlphabetDoesNotSelectItself:
         for token in sorted(ROUTE_TOKENS):
             if not any(carries(text, token) for text in stripped):
                 idle.append(token)
+        # FORBIDDEN_ROUTE_TOKENS ARE NOT READ HERE, and the omission is the
+        # ruling rather than an oversight. A forbidden-route token that
+        # selects nothing means no file teaches that route, which is the
+        # outcome the bar exists to produce.
         assert not idle, (
             f"these tokens appear only inside the bar text, or nowhere: "
             f"{idle}. A token taken from the guarded wording selects the "
@@ -1031,12 +1167,28 @@ def _model_tree(tmp_path: Path) -> Path:
         "protocols/pact-state-recovery.md": "The store file is memory.db.",
         "protocols/pact-protocols.md": "The store file is memory.db.",
         "skills/pact-handoff-harvest/SKILL.md": "Run search --query for context.",
+        # THE MODEL MUST AGREE WITH THE TREE ON THIS ONE. archive_pin.py names
+        # three route tokens OUTSIDE its marked region, so the alphabet is its
+        # second net. A model that gave it no token would report a hole this
+        # carrier does not have.
+        "scripts/archive_pin.py": "# Reached by cli.py, writes through archive_pin.py.",
     }
-    # A CARRIER ADDED LATER MUST NOT CRASH THE MODEL. An unknown key once raised
-    # KeyError here, so a maintainer who added a carrier saw each model arm fail
-    # with a stack trace rather than the one arm that had a thing to say.
+    # 🔴 THE DEFAULT DEPENDS ON THE FILE TYPE, AND THAT IS A FIX FOR A CLASS
+    # RATHER THAN FOR ONE PATH. A markdown carrier joins `ALPHABET_FLOOR`, so
+    # it must name a route token OUTSIDE the bar. A Python carrier does not,
+    # and two of them name no token at all.
+    #
+    # ONE DEFAULT FOR THE TWO TYPES BROKE THE MODEL WHEN A MARKDOWN CARRIER WAS
+    # DECLARED. Two model arms failed, in the model, while the tree was
+    # correct. So a maintainer who did the live work correctly read a stale
+    # model rather than a missing sentence. A type-aware default makes that
+    # unrepresentable, so the NEXT markdown carrier costs no edit here.
     for name in sorted(DECLARED_CARRIERS):
-        text = prose.get(name, "This module states the bar and names no route.")
+        if name.endswith(".py"):
+            default = "This module states the bar and names no route."
+        else:
+            default = "The store file is memory.db."
+        text = prose.get(name, default)
         comment = "#" if name.endswith(".py") else ""
         _write(root, name, f"{comment} Heading\n\n{text}\n\n{_region()}")
     _write(root, "agents/pact-preparer.md", "This file teaches research.\n")
@@ -1046,6 +1198,14 @@ def _model_tree(tmp_path: Path) -> Path:
 
 def _mutate(path: Path, old: str, new: str) -> None:
     """Replace `old` with `new`, and refuse a mutation that changes nothing."""
+    assert path.is_file(), (
+        f"{path.name} is absent from the model tree, so this mutation cannot "
+        f"run. THE LIKELY CAUSE IS A CARRIER PATH REMOVED FROM "
+        f"DECLARED_CARRIERS, because the model builds one file for each "
+        f"declared path. READ THAT SET BEFORE YOU EDIT THIS MODEL. A carrier "
+        f"dropped from the declared list loses one of its two nets, and the "
+        f"repair is to restore the path rather than to repair this arm."
+    )
     text = path.read_text(encoding="utf-8")
     mutated = text.replace(old, new)
     assert mutated != text, (
@@ -1215,6 +1375,45 @@ class TestTheFloorGoesRed:
         assert absent == [SOURCE_HOME]
         assert declared_carriers_without_a_marker(root) == [SOURCE_HOME]
         assert SOURCE_HOME in pointer_warning(absent)
+
+    def test_a_carrier_keeps_a_net_when_its_declared_path_goes(self, tmp_path):
+        """🔴 THE TWO-EDIT ATTACK, AND IT IS THE ONE THAT DEFEATED THIS GUARD.
+
+        Edit one drops a path from `DECLARED_CARRIERS`. Edit two drops that
+        file region. The floor cannot report a path it no longer holds, and
+        the derived population cannot see a file with no marker. So the
+        carrier had NO net and the suite stayed green.
+
+        EACH CARRIER MUST KEEP A SECOND NET THAT THE FIRST EDIT CANNOT REACH.
+        A Python module of the repair package keeps the DIRECTORY net. Each
+        other carrier keeps the ROUTE ALPHABET, measured with its region
+        removed, so the token comes from the file rather than from the bar.
+        """
+        root = _model_tree(tmp_path)
+        for victim in sorted(DECLARED_CARRIERS):
+            _mutate(root / victim, _region(), "")
+            reduced = frozenset(DECLARED_CARRIERS - {victim})
+
+            floor_net = victim in [
+                name
+                for name in reduced
+                if MARKER_BEGIN not in read_carrier(root, name)
+            ]
+            package_net = victim in repair_modules_without_the_bar(
+                root, REPAIR_PACKAGE_EXEMPTIONS
+            )
+            alphabet_net = victim in store_reaching_files_without_the_bar(
+                root, ROUTE_TOKENS, POPULATION_EXEMPTIONS
+            )
+            assert not floor_net, "the floor saw a path it no longer holds"
+            assert package_net or alphabet_net, (
+                f"{victim} has NO net once its declared path goes. One edit to "
+                f"DECLARED_CARRIERS and one to the file then pass in silence. "
+                f"Give it a second net: the repair package uses the directory, "
+                f"and each other carrier must name a route token OUTSIDE its "
+                f"marked region."
+            )
+            root = _model_tree(tmp_path)
 
     def test_the_floor_is_not_the_derived_population(self, tmp_path):
         """A carrier nobody declared joins the comparison, with no edit here."""

--- a/pact-plugin/tests/test_store_access_bar_presence.py
+++ b/pact-plugin/tests/test_store_access_bar_presence.py
@@ -849,6 +849,52 @@ class TestTheInstrumentIsLive:
             is not None
         )
 
+    def test_the_region_stripper_takes_the_region_and_leaves_the_rest(self):
+        """A unit pin on the helper the alphabet floor rests on.
+
+        WITHOUT THIS ARM THE STRIPPER CAN BREAK IN SILENCE. Measured on the
+        live tree: the floor returns the same list with the strip working and
+        with it disabled, because each markdown carrier names a route token
+        outside its region anyway. So no shipped arm reads the difference.
+
+        🔴 THE FIXTURE REGION MUST SPAN MORE THAN ONE LINE, and that is the
+        whole design rather than a detail. The strip matches with `re.DOTALL`.
+        A ONE-LINE fixture passes with that flag removed, so it catches a
+        stripper that returns its input and MISSES a stripper that lost the
+        flag. A fixture that cannot express one of the two faults is the
+        wrong-alphabet failure this file records elsewhere, written into a
+        control.
+
+        THE SECOND HALF IS THE OTHER DIRECTION. A strip that takes too much
+        removes a token the file names OF ITS OWN, which sends the floor the
+        opposite lie.
+        """
+        text = (
+            "Prose above names archive_pin.py for its own reason.\n"
+            f"{MARKER_BEGIN}\n"
+            "The rule names memory.db-wal and it wraps here, then it\n"
+            "names skills/pact-memory/scripts on a second line.\n"
+            f"{MARKER_END}\n"
+            "Prose below names cli.py for its own reason.\n"
+        )
+        stripped = strip_marked_regions(text)
+        for token in ("memory.db", "skills/pact-memory/scripts"):
+            assert not carries(stripped, token), (
+                f"{token!r} survived the strip, so a route token that sits "
+                f"INSIDE the bar still selects the carrier holding it. The "
+                f"alphabet floor then asks whether a file names a route OF "
+                f"ITS OWN and reads the bar's answer instead, which makes the "
+                f"floor unable to fire. TWO CAUSES: the strip returns its "
+                f"input, or its pattern lost `re.DOTALL` and so cannot cross "
+                f"the line break in the region above."
+            )
+        for token in ("archive_pin.py", "cli.py"):
+            assert carries(stripped, token), (
+                f"{token!r} sits OUTSIDE the marked region and the strip "
+                f"removed it. The strip must take the region alone, or the "
+                f"floor stops seeing a route a file names for its own reason."
+            )
+
 
 class TestEveryDeclaredCarrierIsPlaced:
     """The anti-shrinkage floor.
@@ -874,6 +920,45 @@ class TestEveryDeclaredCarrierIsPlaced:
             f"path to REPAIR_PACKAGE_EXEMPTIONS WITH A STATED CAUSE. DO NOT "
             f"repair this by an edit to DECLARED_CARRIERS: that list is a "
             f"separate net and this arm is the one that survives its removal."
+        )
+
+    def test_each_repair_exemption_can_do_work(self):
+        """An entry that no walk reaches excludes nothing and reads as coverage.
+
+        THE TWO SIBLING SETS HOLD THIS RULE AND THIS ONE DID NOT.
+        `POPULATION_EXEMPTIONS` and `DERIVED_POPULATION_EXCLUSIONS` each carry
+        an arm that refuses an idle entry. MEASURED: an idle key added to
+        `REPAIR_PACKAGE_EXEMPTIONS` left the suite green, so the third set
+        took a rule the file states for the other two.
+
+        A STALE KEY FAILS SAFE, because the module rejoins the package walk
+        and `test_each_repair_module_holds_the_marker` reddens. AN ENTRY THAT
+        CANNOT DO WORK FAILS OPEN. So the burden sits on REMOVAL.
+        """
+        package = PLUGIN_DIR / REPAIR_PACKAGE_DIR
+        walked = {relative_name(path, PLUGIN_DIR) for path in package.glob("*.py")}
+        idle = sorted(key for key in REPAIR_PACKAGE_EXEMPTIONS if key not in walked)
+        assert not idle, (
+            f"these repair-package exemptions cannot do work: {idle}. The "
+            f"package walk covers {REPAIR_PACKAGE_DIR}/*.py, so a key outside "
+            f"it excludes nothing from any arm and reads as coverage that was "
+            f"considered. MEMBERSHIP OF THE WALK IS THE TEST, not `is_file()`: "
+            f"a module present under another directory passes an existence "
+            f"check and joins no population. Paths are relative to "
+            f"{PLUGIN_DIR.name}."
+        )
+
+    def test_each_repair_exemption_states_a_cause(self):
+        """An entry with no cause is a name, and a name goes stale in silence."""
+        bare = sorted(
+            key for key, cause in REPAIR_PACKAGE_EXEMPTIONS.items()
+            if not str(cause).strip()
+        )
+        assert not bare, (
+            f"these repair-package exemptions state no cause: {bare}. A "
+            f"module is exempt from the store-access rule for a reason, and a "
+            f"reader who meets the entry without one cannot judge whether it "
+            f"continues to hold."
         )
 
     def test_each_declared_carrier_holds_the_marker(self):
@@ -1603,6 +1688,50 @@ class TestArmThreeGoesRed:
         ):
             text = strip_marked_regions(read_carrier(root, name))
             assert not any(carries(text, token) for token in ROUTE_TOKENS)
+
+    def test_the_floor_needs_the_strip_to_name_a_carrier(self, tmp_path):
+        """🔴 THE ONE CASE IN WHICH THE STRIP DECIDES THE ANSWER.
+
+        NEITHER STANDING POPULATION CAN SHOW THIS, and the two causes are
+        mirrors. MEASURED on the live tree: each markdown carrier names a route
+        token OUTSIDE its region, so the floor returns the same list with the
+        strip working and with it disabled. MEASURED on the model tree: its
+        region holds NO route token, so removal of the region changes nothing.
+        A DISCRIMINATING CASE NEEDS THE TWO CONDITIONS TOGETHER.
+
+        SO THIS BUILDS THEM. The region carries a route token, as the shipped
+        rule does. One markdown carrier names NO token outside its region. With
+        the strip working, that carrier is unreached and the floor NAMES it.
+        With the strip disabled, the token inside its own region selects it and
+        the floor names nothing.
+
+        WHY IT IS NOT THE MODEL TREE. `_model_tree` gives each markdown carrier
+        a token outside the region ON PURPOSE, because the alphabet floor is
+        its second net. Changing that would move a property four other arms
+        rest on. This builds a local tree instead and leaves the model alone.
+        """
+        root = tmp_path / "plugin"
+        victim = "reference/config.md"
+        assert victim in ALPHABET_FLOOR, (
+            f"{victim} left ALPHABET_FLOOR, so this arm no longer builds the "
+            f"case it describes. Choose another markdown carrier."
+        )
+        # THE REGION NAMES A ROUTE TOKEN, as the shipped rule does through
+        # `memory.db-wal`. That is what makes a carrier select ITSELF when the
+        # strip fails.
+        body = "STORE ACCESS. Check memory.db-wal and memory.db-shm.\n"
+        for name in sorted(ALPHABET_FLOOR):
+            own = "" if name == victim else "This page names cli.py.\n"
+            _write(root, name, f"Heading\n\n{own}\n{_region(body=body)}")
+
+        assert surfaces_the_alphabet_does_not_reach(root, ROUTE_TOKENS) == [victim], (
+            f"with a correct strip the floor must name {victim}, which names "
+            f"no route token outside its own region. IF THIS READS AS AN EMPTY "
+            f"LIST, THE STRIP IS NOT REMOVING THE REGION, so the token inside "
+            f"the bar selected the file and the floor lost the one question it "
+            f"asks. TWO CAUSES: the strip returns its input, or its pattern "
+            f"lost `re.DOTALL`."
+        )
 
 
 class TestArmFourGoesRed:

--- a/pact-plugin/tests/test_store_access_bar_presence.py
+++ b/pact-plugin/tests/test_store_access_bar_presence.py
@@ -1,0 +1,1375 @@
+"""
+Cross-file copy fidelity for the store-access bar.
+
+Location: pact-plugin/tests/test_store_access_bar_presence.py
+
+WHAT THIS FILE IS FOR, STATED AS THE JOB AND NOT AS THE RULE. The store-access
+bar is ONE text that ships in many files. A rule held in many places drifts.
+One editor corrects a sentence in the file they opened, the others keep the old
+sentence, and no reader of any single file can tell. This keeps the copies IN
+SYNC WITH EACH OTHER, for as long as they ship.
+
+🔴 WHAT A GREEN HERE DOES NOT MEAN, AND READ IT BEFORE YOU TRUST ONE.
+
+  * IT DOES NOT TELL YOU THE SOURCE BLOCK IS CORRECT. It tells you the copies
+    agree with the source. Somebody who edits the source and each copy together
+    passes this file, and that is BY DESIGN: a deliberate reword must be able
+    to land. The one-time check that the first placement matched the design was
+    a separate act by a separate agent, and it is not repeatable from here.
+  * IT DOES NOT CHECK THAT THE CAUSE IN THE PROSE IS TRUE. No test reads a
+    natural-language cause for truth. If `PRAGMA journal_mode=WAL` leaves the
+    connection function, or the context manager stops the close, the shipped
+    cause goes stale and each arm here stays green.
+  * IT DOES NOT COVER THE CALIBRATION SENTENCE. The same repair corrected an
+    instruction in `agents/pact-secretary.md` about calibration statistics.
+    That sentence ships with no arm in this file.
+  * ITS WALK REACHES `pact-plugin/` AND NO FURTHER. A store-access surface
+    written above that directory is outside each population here.
+
+FOUR ARMS, AND EACH COVERS A FAILURE THE OTHERS MISS.
+
+  1. FIDELITY. Each carrier holds one marked region, and each copy agrees with
+     the source. A MISSING MARKER FAILS.
+  2. EMPHASIS. A copy that agrees with the source apart from CAPITALISATION
+     fails. The block shouts its bright line, and a quiet copy is a weaker rule
+     that arm 1 passes in silence.
+  3. POPULATION. Each instruction surface that reaches the store, and that
+     takes no declared exemption, carries a marked region. This reaches a NEW
+     teaching surface on the day it arrives.
+  4. FACT. `setup_memory.py` holds no `--db-path` literal, and the source home
+     names that file. The claim sits in one file and its evidence sits in
+     another, which is the shape that earns a guard its place.
+
+🔴 TWO POPULATIONS, AND ONE LIST CANNOT SERVE THE TWO.
+
+  THE CARRIER POPULATION, for arms 1 and 2, is DERIVED FROM THE MARKER across
+  ANY file type. A file that holds the begin marker is a carrier, whatever its
+  extension and wherever it sits. A carrier added next month joins the
+  comparison with no edit here, and no count in any document can go stale
+  against it.
+
+  THE INSTRUCTION-SURFACE POPULATION, for arm 3, is the five markdown patterns
+  below. Arm 3 asks a different question: does a file hand a reader a route to
+  the store with no rule attached. Widening THAT to Python would reach the
+  memory package and each hook, which reach the store legitimately, and the
+  result would be findings that are not defects.
+
+🔴 AND A DECLARED FLOOR SITS BEHIND THE DERIVATION, BECAUSE DERIVATION ALONE
+HAS A BLIND SPOT. Derivation notices a file that HAS a marker. Only the floor
+notices a file that SHOULD have one and does not. A dropped marker removes a
+file from the compared set in silence, and a smaller set that reports green
+reads the same as a larger set that reports green.
+
+MEASURED, AND IT IS WHY THE FLOOR CANNOT BE DROPPED IN FAVOUR OF AN ALPHABET:
+of the three Python carriers, `archive_pin.py` names three route tokens and the
+two memory-repair modules name NONE. So no widened alphabet reaches the two,
+and a declared list is the only instrument that covers a member no alphabet can
+speak to.
+
+WHAT THIS GUARD HOLDS, AND WHAT IT MUST NOT.
+
+  HOLDS: the two marker literals, which are the ADDRESS of the region. The
+  declared carrier paths. The route tokens. The normalisation rule.
+
+  DOES NOT HOLD: the block text. A copy of the guarded prose inside a test
+  makes the TEST the specification, and it gives a prose maintainer one more
+  place to edit, in the file they are least likely to open. Do not add the
+  block here to make an arm stricter. ARM 2 OBEYS THIS TOO: it derives the
+  emphasis from the source at run time rather than hold a sentence.
+
+  THE BOUND ON THAT SENTENCE, because a reader applies a short rule more widely
+  than it holds: THE MARKERS STAY. A marker is an address and not content. A
+  test that drops the markers to obey the rule above cannot find the region it
+  must compare.
+
+WHY THE MARKERS FAIL CLOSED. Some context renderings strip an HTML comment, so
+an agent that edits a carrier through such a rendering can drop a marker with
+no intent to. A marker fault is a RED and not a skip.
+
+CLASSIFY BY ROLE, NOT BY PRESENCE. THIS FILE HOLDS THE MARKER LITERALS, so a
+marker-derived walk SELECTS IT. It is a GUARD and not a carrier, so it is named
+out in `DERIVED_POPULATION_EXCLUSIONS` with its cause, and an arm below asserts
+that the exclusion continues to do work. The design document sits above
+`PLUGIN_DIR` and is outside each walk by a correct predicate, so it takes no
+entry. A carve-out written for a non-member is the sign of a predicate aimed
+wrong.
+
+TO CHANGE ANY CONSTANT IN THIS FILE, STATE A CAUSE. Each module-level constant
+sets what an arm requires, or which files an arm covers. A constant edited to
+quiet a red turns this file into a MIRROR of the text it guards, and its green
+then means nothing.
+
+Used by: pytest.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+PLUGIN_DIR = Path(__file__).resolve().parent.parent
+
+# THE ADDRESS OF THE GUARDED REGION, and not a copy of it. An HTML comment does
+# not appear when a reader renders the markdown, so the pair costs a reader
+# nothing. A test reads the bytes from disk, so it sees them. THE PYTHON
+# CARRIERS USE THE SAME SYNTAX: two marker syntaxes is two alphabets, and a
+# wrong alphabet is the failure this work has met most often.
+MARKER_BEGIN = "<!-- PACT_STORE_BAR_BEGIN -->"
+MARKER_END = "<!-- PACT_STORE_BAR_END -->"
+
+# THE SOURCE. Each copy is compared to this file, and this file is compared to
+# nothing. That direction is the whole mechanism: a source compared to its
+# copies takes the majority as truth, which lets a drifted copy win a vote.
+SOURCE_HOME = "skills/pact-memory/SKILL.md"
+
+# THE DECLARED FLOOR. Keys are POSIX paths relative to `PLUGIN_DIR`. A relative
+# path without its base is a figure without its counting rule, so the root is
+# named here. A key against another root matches nothing, the file leaves the
+# floor, and the arm reddens, which is the safe direction.
+#
+# THIS IS A FLOOR AND NOT A CENSUS. The compared population is DERIVED from the
+# marker, so it grows with no edit here. This set refuses SHRINKAGE: a carrier
+# whose marker is dropped leaves the derived population in silence, and only a
+# declared path notices the absence.
+#
+# THE THREE PYTHON CARRIERS ARE HERE FOR A MEASURED REASON. Two of them name no
+# route token at all, so arm 3 cannot reach them and no widening of its alphabet
+# would. Declaration is the only instrument that covers them.
+#
+# To remove a path, state a cause. A path removed to quiet a red turns the floor
+# into a report of the current population, which is the mirror failure.
+DECLARED_CARRIERS = frozenset(
+    {
+        SOURCE_HOME,
+        "agents/pact-secretary.md",
+        "commands/prune-memory.md",
+        "reference/config.md",
+        "protocols/pact-state-recovery.md",
+        "protocols/pact-protocols.md",
+        "skills/pact-handoff-harvest/SKILL.md",
+        "scripts/memory_repair/__init__.py",
+        "scripts/memory_repair/shred_detect.py",
+        "scripts/archive_pin.py",
+    }
+)
+
+# FILES THAT HOLD A MARKER AND ARE NOT CARRIERS. Keys are relative to
+# `PLUGIN_DIR`. Values state the cause.
+#
+# CLASSIFY BY ROLE AND NOT BY PRESENCE. A GUARD holds the address to test it. A
+# CARRIER instructs an agent. This file is the first, so a marker-derived walk
+# selects it and it must be named out. `test_each_derived_exclusion_does_work`
+# refuses an entry that no walk reaches, so a stale key cannot sit here unread.
+DERIVED_POPULATION_EXCLUSIONS = {
+    "tests/test_store_access_bar_presence.py": (
+        "This guard holds the two marker literals, because a marker is the "
+        "ADDRESS of the region it must compare. So it is a GENUINE MEMBER of "
+        "the derived walk and it must be named out. It instructs no agent, so "
+        "by role it is a GUARD and not a carrier."
+    )
+}
+
+# ARTEFACTS THAT ARE NOT SOURCE. A compiled module holds the string constants
+# of the module it came from, so a cache directory carries the marker literals
+# of THIS file and would enter the derived walk after the first run. That
+# membership appears and vanishes with the cache, which is a flake rather than
+# a finding. This is a NON-MEMBER predicate and not a carve-out.
+NON_SOURCE_PARTS = frozenset({"__pycache__"})
+NON_SOURCE_SUFFIXES = frozenset({".pyc", ".pyo"})
+
+# THE INSTRUCTION-SURFACE POPULATION, for arm 3 alone. Five patterns below
+# `PLUGIN_DIR`, which measure the set the design walked when it derived the
+# homes.
+#
+# THE BOUND OF THE PATTERNS. A markdown file below a skill directory that is
+# not `SKILL.md`, such as a reference page, is outside. Widen only with a
+# stated cause, because a wider population needs an exemption for each file it
+# reaches that teaches nothing about the store.
+POPULATION_PATTERNS = (
+    "agents/*.md",
+    "commands/*.md",
+    "protocols/*.md",
+    "reference/*.md",
+    "skills/*/SKILL.md",
+)
+
+# A FILE REACHES THE STORE WHEN IT NAMES ONE OF THESE. The token set is derived
+# from the THREE ROUTES the acceptance test names, which are the CLI, an import,
+# and a raw path. It is NOT derived from the wording of the bar.
+#
+# WHY THE DERIVATION MATTERS MORE THAN THE LIST. An alphabet read off one
+# instance of the guarded thing misses each other spelling of it. That defect
+# happened three times on this material: a census built from five sentences
+# missed a paraphrase, a token set built from the spelling of the tool missed a
+# file that instructs a bare CLI verb, and no token set reaches two of the three
+# Python carriers at all.
+#
+# NO TOKEN HERE COMES FROM THE BAR TEXT. A token taken from the block selects
+# a file BECAUSE it carries the block, so it can never reach a NEW silent
+# surface, which is the one thing this alphabet is for.
+# `TestTheAlphabetDoesNotSelectItself` measures that property rather than
+# trusting this paragraph.
+ROUTE_TOKENS = {
+    "memory.db": "raw path: the store file",
+    ".claude/pact-memory": "raw path: the store directory",
+    "skills/pact-memory/scripts": "import: the store package",
+    "cli.py": "the CLI, by module path",
+    "cli command": "the CLI, by a verb instruction",
+    "search --query": "the CLI, by a verb instruction",
+    "--limit": "the CLI, by a verb instruction",
+    "archive_pin.py": "the CLI, at one remove",
+}
+
+# THE ALPHABET FLOOR, and it is NOT the same set as `DECLARED_CARRIERS`. The
+# alphabet exists to reach INSTRUCTION SURFACES, so its floor holds the markdown
+# carriers alone. The three Python carriers are covered by declaration, and two
+# of them name no route token, so a floor that demanded the alphabet reach them
+# would demand an impossible thing and reward a widened alphabet that drowns
+# arm 3 in files that reach the store legitimately.
+ALPHABET_FLOOR = frozenset(path for path in DECLARED_CARRIERS if path.endswith(".md"))
+
+# INSTRUCTION SURFACES THAT REACH THE STORE AND DO NOT HAVE TO CARRY THE BAR.
+# Keys are relative to `PLUGIN_DIR`. Values state the cause.
+#
+# EMPTY TODAY. THE RESULT THAT MADE IT EMPTY IS A FLOOR AND NOT A CENSUS, and
+# it is stated as the search that produced it: the eight tokens above, applied
+# to the five patterns below, selected the markdown carriers and no other file.
+# A WIDER ALPHABET REACHES MORE. An eighteen-token set reaches two further
+# instruction surfaces, and the team-lead ruled those OUT on ACTIONABILITY: they
+# give an INTENT a reader cannot type, so the reader must open the memory skill
+# to learn the command, and the bar lives there. A file that gives a TYPEABLE
+# command is in.
+# SO DO NOT READ THIS EMPTINESS AS "NO OTHER FILE REACHES THE STORE". Read it
+# as "no file this alphabet selects lacks the bar".
+#
+# 🔴 DO NOT ADD AN ENTRY FOR A CARRIER THAT IS NOT PLACED YET. A placement gap
+# repaired with an exemption becomes a silent carve-out for a file the design
+# calls a genuine hole. Report the gap and leave the red.
+#
+# ONE FALSE POSITIVE IS RECORDED IN THE DESIGN AND NEEDS NO ENTRY.
+# `commands/pin-memory.md` names `PACT_MEMORY_PINNED_END`, which is a region
+# marker inside CLAUDE.md and not a route to the store. No token above reaches
+# it, so it is a NON-MEMBER by a correct predicate.
+POPULATION_EXEMPTIONS: dict = {}
+
+# A FLOOR ON THE SIZE OF THE SOURCE REGION, and it closes a hole in arm 1.
+# EMPTY REGIONS AGREE WITH EACH OTHER. An edit that empties the block in each
+# carrier, or a marker pair placed around nothing, passes the fidelity arm over
+# a comparison of one empty string with another. This measures the region rather
+# than reads it, so the guard gains no copy of the guarded text.
+#
+# 🔴 THE NUMBER IS A FLOOR AND NOT A PIN, AND IT RECORDS NO MEASUREMENT. This
+# file does NOT state the length of the region, because the length is derivable
+# from the source and a written count goes stale the moment the block is
+# reworded. The block HAS been reworded during this work, which is the evidence
+# for the rule rather than a reason to re-take the number.
+# DO NOT RAISE THIS TO THE CURRENT SIZE. A pinned length reddens on each
+# ordinary edit, which trains a reader to bump the number rather than read it.
+# Keep it far below any plausible block, so it fires on a COLLAPSE alone.
+MINIMUM_REGION_CHARS = 300
+
+# ARM 2. A SHOUTED RUN is a run of capitals long enough to be emphasis rather
+# than an acronym. The floor keeps `WAL` and `CLI` out, so an acronym that one
+# copy spells and the source does not cannot redden the arm.
+MINIMUM_SHOUT_CHARS = 8
+
+# ARM 4. The claim lives in `SOURCE_HOME` and the evidence lives here.
+EVIDENCE_FILE = "skills/pact-memory/scripts/setup_memory.py"
+
+# The flag the shipped text says this script does not accept.
+FORBIDDEN_FLAG = "--db-path"
+
+# A CONTROL TOKEN, AND IT DISCRIMINATES. `db_path` IS in the evidence file, as
+# the name of a function parameter. `--db-path`, the command-line flag, is not.
+# The two differ by two characters, so a read that finds the first and not the
+# second is a LIVE read of the correct file. Without this control, an empty read
+# and a broken path both report a clean absence, which is the failure that reads
+# as success.
+EVIDENCE_CONTROL_TOKEN = "db_path"
+
+
+def flatten(text: str) -> str:
+    """Collapse each whitespace run to one space.
+
+    The guarded region wraps across lines, and a copy can re-wrap at another
+    column with no change of meaning. Flatten first, or a comparison reports a
+    difference that no reader can see.
+    """
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def carries(text: str, needle: str) -> bool:
+    """True when `text` holds `needle`, apart from wraps and capitalisation.
+
+    ONE COMPARISON FOR EACH TEXT CHECK IN THIS FILE, so no two arms can drift
+    into opposite treatments of one input.
+    """
+    return needle.casefold() in flatten(text).casefold()
+
+
+def normalised(text: str) -> str:
+    """The one form each region comparison uses."""
+    return flatten(text).casefold()
+
+
+def shouted_runs(text: str) -> list[str]:
+    """Return the emphasised runs of `text`, sorted.
+
+    A RUN IS DERIVED AND NOT HELD. This reads the source at run time, so the
+    guard pins the EMPHASIS without holding one word of the wording.
+    """
+    runs = re.findall(r"[A-Z][A-Z ,.`'-]*[A-Z]", flatten(text))
+    return sorted(r.strip() for r in runs if len(r.strip()) >= MINIMUM_SHOUT_CHARS)
+
+
+def relative_name(path: Path, root: Path) -> str:
+    """Return `path` as a POSIX path relative to `root`."""
+    return path.relative_to(root).as_posix()
+
+
+def read_carrier(root: Path, name: str) -> str:
+    """Read one carrier by its relative path, or return an empty string.
+
+    AN ABSENT FILE RETURNS EMPTY RATHER THAN RAISES, so an arm reports WHICH
+    carrier is missing together with each other fault. An exception on the first
+    absent path hides the rest of the result.
+    """
+    path = root / name
+    if not path.is_file():
+        return ""
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def marker_fault(text: str) -> str | None:
+    """Describe the marker fault in `text`, or return None when the pair is sound.
+
+    THREE FAULTS, and each makes the region unreadable rather than wrong: a
+    count other than one for either marker, and an end that comes first. A file
+    with NO marker at all is the likely fault, because a context rendering can
+    strip an HTML comment.
+    """
+    begins = text.count(MARKER_BEGIN)
+    ends = text.count(MARKER_END)
+    if begins != 1 or ends != 1:
+        return f"{begins} begin marker(s) and {ends} end marker(s), expected 1 and 1"
+    if text.index(MARKER_BEGIN) > text.index(MARKER_END):
+        return "the end marker comes before the begin marker"
+    return None
+
+
+def marked_region(text: str) -> str:
+    """Return the bytes between the markers.
+
+    Call this only when `marker_fault` returns None.
+    """
+    start = text.index(MARKER_BEGIN) + len(MARKER_BEGIN)
+    return text[start : text.index(MARKER_END)]
+
+
+def strip_marked_regions(text: str) -> str:
+    """Return `text` with each marked region and its markers removed.
+
+    USED BY THE ALPHABET FLOOR. After the bar lands, the region names two route
+    tokens, so each carrier selects itself. This removes the region, so an arm
+    can ask whether the alphabet reaches a file FOR A REASON OF ITS OWN.
+    """
+    pattern = re.escape(MARKER_BEGIN) + ".*?" + re.escape(MARKER_END)
+    return re.sub(pattern, " ", text, flags=re.DOTALL)
+
+
+def pointer_warning(absent: list) -> str:
+    """Return the pointer consequence when the SOURCE home is one of `absent`.
+
+    THE ONE THING NO ARM HERE DETECTS, NAMED WHERE THE RED APPEARS. Each copy
+    carries a POINTER SENTENCE that names the source home. A rename of the
+    source deadens each pointer at one time. NO ARM READS A POINTER, because
+    the sentence is free text and a guard on free text is the brittle kind.
+
+    SO THIS IS GUIDANCE AND NOT DETECTION. The rename is detected by the arm
+    that calls this and by the marker floor. A THIRD ARM WOULD ADD NO
+    DETECTION AND WOULD REPORT ONE FAULT A THIRD TIME, which teaches a reader
+    that the extra reports are noise.
+    """
+    if SOURCE_HOME not in absent:
+        return ""
+    return (
+        f" 🔴 AND CHECK THE POINTERS. Each copy carries a sentence naming "
+        f"{SOURCE_HOME} as the home of the full rule. No file sits at that "
+        f"path now, so each of those sentences points at nothing. NO ARM "
+        f"READS A POINTER, so a repair of this path alone leaves them dead "
+        f"and green."
+    )
+
+
+def is_source_file(path: Path) -> bool:
+    """False for a build artefact, which is not a carrier.
+
+    A NON-MEMBER PREDICATE AND NOT A CARVE-OUT. A compiled module holds the
+    string constants of its source, so a cache directory carries the marker
+    literals of this guard and enters the walk after the first run.
+    """
+    if NON_SOURCE_PARTS.intersection(path.parts):
+        return False
+    return path.suffix not in NON_SOURCE_SUFFIXES
+
+
+# ---------------------------------------------------------------------------
+# THE POPULATION PREDICATES.
+#
+# ONE DEFINITION EACH, called by the shipped arm AND by the mutation model
+# below. A model that re-implements a predicate drifts from it, and each
+# hand-carry of an edit is correct until the one that is not.
+#
+# Each takes a root and returns a sorted list, so an empty list means the
+# property holds and a non-empty list names the files that break it.
+# ---------------------------------------------------------------------------
+
+
+def derived_carriers(root: Path) -> list[str]:
+    """Each file below `root` that holds the begin marker, by any extension.
+
+    THE POPULATION IS DERIVED, so a carrier added later joins the comparison
+    with no edit to this file, and no count in a document can go stale.
+    """
+    found = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or not is_source_file(path):
+            continue
+        name = relative_name(path, root)
+        if name in DERIVED_POPULATION_EXCLUSIONS:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if MARKER_BEGIN in text:
+            found.append(name)
+    return found
+
+
+def compared_carriers(root: Path) -> list[str]:
+    """The union of the derived population and the declared floor.
+
+    THE UNION IS THE POINT. Derivation reaches a carrier nobody declared. The
+    floor reaches a carrier whose marker was dropped, which derivation cannot
+    see, because a file with no marker is not in the derived set.
+    """
+    return sorted(set(derived_carriers(root)) | set(DECLARED_CARRIERS))
+
+
+def declared_carriers_without_a_marker(root: Path) -> list[str]:
+    """Declared carriers that hold no begin marker. The anti-shrinkage arm."""
+    return sorted(
+        name
+        for name in DECLARED_CARRIERS
+        if MARKER_BEGIN not in read_carrier(root, name)
+    )
+
+
+def carriers_with_a_marker_fault(root: Path) -> list[str]:
+    """Carriers whose marker pair cannot be read.
+
+    A DECLARED CARRIER THAT HOLDS NO MARKER AT ALL IS SKIPPED HERE and reported
+    by the arm above. One fault reported twice teaches a reader that the second
+    report is noise.
+    """
+    faults = []
+    for name in compared_carriers(root):
+        text = read_carrier(root, name)
+        if MARKER_BEGIN not in text:
+            continue
+        fault = marker_fault(text)
+        if fault is not None:
+            faults.append(f"{name} ({fault})")
+    return faults
+
+
+def _readable_regions(root: Path) -> dict:
+    """Map each carrier with a sound marker pair to its region."""
+    regions = {}
+    for name in compared_carriers(root):
+        text = read_carrier(root, name)
+        if marker_fault(text) is None:
+            regions[name] = marked_region(text)
+    return regions
+
+
+def copies_that_differ_from_the_source(root: Path) -> list[str]:
+    """Copies whose region disagrees with the region of the source."""
+    regions = _readable_regions(root)
+    if SOURCE_HOME not in regions:
+        return []
+    want = normalised(regions[SOURCE_HOME])
+    return sorted(
+        name
+        for name, region in regions.items()
+        if name != SOURCE_HOME and normalised(region) != want
+    )
+
+
+def copies_that_differ_only_by_case(root: Path) -> list[str]:
+    """Copies that agree with the source apart from CAPITALISATION.
+
+    ARM 2, AND IT IS DERIVED RATHER THAN HELD. A copy reported here says the
+    same words as the source and emphasises a different set of them. The guard
+    holds no sentence to make that judgement: it compares the source against
+    the copy, so the emphasis comes from the source at run time.
+    """
+    regions = _readable_regions(root)
+    if SOURCE_HOME not in regions:
+        return []
+    source = regions[SOURCE_HOME]
+    differ = []
+    for name, region in regions.items():
+        if name == SOURCE_HOME:
+            continue
+        if normalised(region) != normalised(source):
+            continue
+        if shouted_runs(region) != shouted_runs(source):
+            differ.append(name)
+    return sorted(differ)
+
+
+def population_files(root: Path) -> list[Path]:
+    """Each instruction surface the arm-3 walk covers, at the five patterns."""
+    found: list[Path] = []
+    for pattern in POPULATION_PATTERNS:
+        found.extend(root.glob(pattern))
+    return sorted(found)
+
+
+def files_reaching_the_store(root: Path, tokens: dict, ignore_bar: bool = False) -> dict:
+    """Map each selected instruction surface to the route tokens that selected it.
+
+    `ignore_bar` removes each marked region before the read, which asks whether
+    a file names a route OF ITS OWN. The alphabet floor needs that question and
+    the silence arm needs the other one.
+    """
+    selected = {}
+    for path in population_files(root):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if ignore_bar:
+            text = strip_marked_regions(text)
+        hits = sorted(token for token in tokens if carries(text, token))
+        if hits:
+            selected[relative_name(path, root)] = hits
+    return selected
+
+
+def store_reaching_files_without_the_bar(
+    root: Path, tokens: dict, exemptions: dict
+) -> list[str]:
+    """Selected surfaces that hold no readable marked region and take no exemption."""
+    silent = []
+    for name in sorted(files_reaching_the_store(root, tokens)):
+        if name in exemptions:
+            continue
+        if marker_fault(read_carrier(root, name)) is not None:
+            silent.append(name)
+    return silent
+
+
+def surfaces_the_alphabet_does_not_reach(root: Path, tokens: dict) -> list[str]:
+    """Markdown carriers the alphabet fails to select, WITH THE BAR REMOVED.
+
+    🔴 THIS READS THE STRIPPED TEXT, AND THE READ IS THE WHOLE ARM. The bar
+    names two route tokens, `memory.db` inside `memory.db-wal` and
+    `skills/pact-memory/scripts`, so with the bar in place EVERY carrier selects
+    itself and this floor can never fire. MEASURED on the tree: with the raw
+    text, `archive_pin.py` can leave the alphabet and no arm reddens. With the
+    bar removed, that removal drops `commands/prune-memory.md` and this floor
+    names it.
+    """
+    selected = set(files_reaching_the_store(root, tokens, ignore_bar=True))
+    return sorted(ALPHABET_FLOOR - selected)
+
+
+class TestTheInstrumentIsLive:
+    """Controls on the instrument, and not rules about the tree.
+
+    Each arm here fails when a walk or the matcher breaks, and it passes
+    whatever the guarded prose says. AN EMPTY POPULATION AGREES WITH EVERY RULE
+    BELOW, which is why the first controls assert the walks find files.
+    """
+
+    def test_the_instruction_surface_walk_finds_files(self):
+        found = population_files(PLUGIN_DIR)
+        assert found, (
+            f"the walk below {PLUGIN_DIR} at {POPULATION_PATTERNS} returned "
+            f"nothing. Arm 3 then passes over an empty set."
+        )
+
+    def test_the_derived_walk_reaches_python_and_markdown(self):
+        """The derived walk must not be a markdown walk by accident.
+
+        SOME CARRIERS ARE PYTHON. A walk that reached markdown alone would
+        compare the markdown carriers, report green, and leave each Python copy
+        uncompared. That is the drift this guard exists to stop, arriving
+        inverted: not an unmarked copy outside the population, but a MARKED
+        copy the population cannot see.
+
+        THIS WAS MEASURED AS A LIVE BLINDNESS, not reasoned. With a
+        markdown-only population, the region stripped from a Python carrier
+        produced NO red, and the same mutation on a markdown carrier produced
+        one. Same instrument, same mutation, opposite outcome, and the file
+        type was the only difference.
+        """
+        reachable = {
+            relative_name(p, PLUGIN_DIR)
+            for p in PLUGIN_DIR.rglob("*")
+            if p.is_file() and is_source_file(p)
+        }
+        for expected in (SOURCE_HOME, "scripts/archive_pin.py"):
+            assert expected in reachable, (
+                f"{expected} is outside the derived walk, so a marker there "
+                f"would never be compared."
+            )
+
+    def test_each_declared_carrier_path_is_a_file(self):
+        """A stale path fails safe, and this says which one it is.
+
+        THIS ARM ALSO COVERS A SECOND THING NO OTHER ARM REPORTS, and the
+        message below is where that coverage lives. Each copy carries a
+        POINTER SENTENCE naming the source home. A rename of the source
+        deadens each pointer at one time, and no arm reads a pointer, because
+        the sentence is free text and a guard on free text is brittle. So the
+        rename is DETECTED here and its consequence is NAMED here.
+        """
+        absent = sorted(
+            name for name in DECLARED_CARRIERS if not (PLUGIN_DIR / name).is_file()
+        )
+        assert not absent, (
+            f"{absent} are declared carriers and no file sits at those paths. "
+            f"If a carrier moved, correct the path. Do not remove it to quiet "
+            f"a red. Paths are relative to {PLUGIN_DIR.name}."
+            f"{pointer_warning(absent)}"
+        )
+
+    def test_each_derived_exclusion_does_work(self):
+        """An exclusion that no walk reaches excludes nothing and reads as coverage.
+
+        A STALE KEY FAILS SAFE, because the file rejoins the population and an
+        arm reddens. AN ENTRY THAT CANNOT DO WORK FAILS OPEN. So the burden
+        sits on REMOVAL rather than on addition.
+        """
+        idle = []
+        for name, cause in DERIVED_POPULATION_EXCLUSIONS.items():
+            path = PLUGIN_DIR / name
+            if not path.is_file():
+                idle.append(f"{name} (no file at that path)")
+            elif MARKER_BEGIN not in path.read_text(encoding="utf-8", errors="replace"):
+                idle.append(f"{name} (holds no begin marker)")
+            elif not cause.strip():
+                idle.append(f"{name} (states no cause)")
+        assert not idle, (
+            f"these derived-population exclusions cannot do work: {idle}. An "
+            f"entry for a file that no walk selects excludes nothing from any "
+            f"arm, and it reads as coverage that was considered."
+        )
+
+    def test_this_guard_is_excluded_by_role_and_not_by_accident(self):
+        """The role rule, asserted rather than written.
+
+        This file HOLDS the marker literals, so it is a genuine member of the
+        derived walk. It must be named out, and it must not appear in the
+        compared population.
+        """
+        me = relative_name(Path(__file__).resolve(), PLUGIN_DIR)
+        assert me in DERIVED_POPULATION_EXCLUSIONS
+        assert me not in compared_carriers(PLUGIN_DIR)
+
+    def test_the_comparison_survives_a_wrap_and_a_recapitalisation(self):
+        """A control on the matcher, and not on the files it reads."""
+        wrapped = "a raw path such as\n    memory.db\n    is a route"
+        assert "memory.db is a route" not in wrapped
+        assert carries(wrapped, "memory.db is a route")
+
+        shouted = "MEMORY.DB IS A ROUTE"
+        assert "memory.db is a route" not in shouted
+        assert carries(shouted, "memory.db is a route")
+
+    def test_the_comparison_rejects_a_token_that_is_absent(self):
+        """The negative direction. A matcher that agrees with anything is useless."""
+        assert not carries("nothing of the kind appears here", "memory.db")
+
+    def test_the_shout_reader_finds_emphasis_and_not_an_acronym(self):
+        """A control on arm 2, and each half must do work.
+
+        Without the floor an acronym counts as emphasis, and the arm then
+        reddens when one copy spells `WAL` in a sentence the source does not.
+        """
+        assert shouted_runs("DO NOT USE the flag") == ["DO NOT USE"]
+        assert shouted_runs("the WAL and the CLI") == []
+        assert shouted_runs("do not use the flag") == []
+
+    def test_the_region_reader_refuses_a_broken_pair(self):
+        """Each marker fault must be a fault, and a sound pair must be sound."""
+        sound = f"head {MARKER_BEGIN} body {MARKER_END} tail"
+        assert marker_fault(sound) is None
+        assert marked_region(sound) == " body "
+
+        assert marker_fault(f"head {MARKER_BEGIN} body") is not None
+        assert marker_fault(f"body {MARKER_END} tail") is not None
+        assert marker_fault("no markers at all") is not None
+        assert marker_fault(f"{MARKER_END} body {MARKER_BEGIN}") is not None
+        assert (
+            marker_fault(f"{MARKER_BEGIN} a {MARKER_END} {MARKER_BEGIN} b {MARKER_END}")
+            is not None
+        )
+
+
+class TestEveryDeclaredCarrierIsPlaced:
+    """The anti-shrinkage floor.
+
+    DERIVATION NOTICES A FILE THAT HAS A MARKER. ONLY THIS NOTICES A FILE THAT
+    SHOULD HAVE ONE AND DOES NOT. A dropped marker removes a carrier from the
+    compared set in silence, and a smaller set reporting green reads the same as
+    a larger set reporting green.
+    """
+
+    def test_each_declared_carrier_holds_the_marker(self):
+        missing = declared_carriers_without_a_marker(PLUGIN_DIR)
+        assert not missing, (
+            f"these declared carriers hold no begin marker: {missing}. TWO "
+            f"CAUSES, AND THEY MEAN OPPOSITE THINGS. EITHER the block is NOT "
+            f"PLACED THERE YET, which is a sequencing state and not a defect, "
+            f"OR a marker was dropped from a carrier that had one, which is "
+            f"the silent shrinkage this floor exists to refuse. Read the file "
+            f"before you decide. DO NOT repair either case by removal of a "
+            f"path from DECLARED_CARRIERS, and DO NOT repair it with an "
+            f"exemption. Paths are relative to {PLUGIN_DIR.name}."
+        )
+
+
+class TestTheMarkedRegionsAgree:
+    """ARM 1. FIDELITY.
+
+    The carriers hold one text. This reads the region from the source and
+    compares each copy to it.
+    """
+
+    def test_each_carrier_holds_one_readable_marker_pair(self):
+        faults = carriers_with_a_marker_fault(PLUGIN_DIR)
+        assert not faults, (
+            f"these carriers do not hold a readable marker pair: {faults}. A "
+            f"HALF-PRESENT PAIR IS A RED AND NOT A SKIP. Some context "
+            f"renderings strip an HTML comment, so a marker can go out with no "
+            f"intent behind it. Restore the pair {MARKER_BEGIN} and "
+            f"{MARKER_END} around the block."
+        )
+
+    def test_the_source_region_holds_a_rule(self):
+        """Non-vacuity for the arms below, and not a duplicate of them.
+
+        AN AGREEMENT ON NOTHING IS AN AGREEMENT. With the block emptied in each
+        carrier, the arm below compares one empty string with another and
+        reports green.
+        """
+        text = read_carrier(PLUGIN_DIR, SOURCE_HOME)
+        assert marker_fault(text) is None, (
+            f"{SOURCE_HOME} holds no readable marker pair, so there is no "
+            f"source region to measure. THE COMPARISON ARMS RETURN AN EMPTY "
+            f"LIST IN THIS STATE, so this arm is the one that reports it."
+        )
+        size = len(normalised(marked_region(text)))
+        assert size >= MINIMUM_REGION_CHARS, (
+            f"the marked region in {SOURCE_HOME} is {size} characters, below "
+            f"the floor of {MINIMUM_REGION_CHARS}. An emptied region passes "
+            f"the fidelity arm because each copy agrees with it. Restore the "
+            f"block. DO NOT clear this red by a lower floor."
+        )
+
+    def test_each_copy_agrees_with_the_source(self):
+        differ = copies_that_differ_from_the_source(PLUGIN_DIR)
+        assert not differ, (
+            f"the marked region in {differ} disagrees with the marked region "
+            f"in {SOURCE_HOME}, after whitespace and case are removed. THE "
+            f"SOURCE IS THE SOURCE: copy the region from {SOURCE_HOME} into "
+            f"each file named, rather than the other way. IF THE CHANGE IS "
+            f"DELIBERATE, edit the source and each copy in ONE commit. That "
+            f"tax is the mechanism and not an accident of it. THIS ARM CANNOT "
+            f"TELL YOU THE SOURCE IS CORRECT, only that the copies agree."
+        )
+
+
+class TestTheEmphasisSurvivesTheCopy:
+    """ARM 2. EMPHASIS.
+
+    THE CAPITALS ARE LOAD-BEARING. The block shouts one line so that it works
+    for a reader who has misunderstood everything else, and a reader under
+    context pressure obeys a shouted line more reliably than a quiet one. A copy
+    that says the same words in a quieter voice is a WEAKENED rule, and arm 1
+    casefolds, so arm 1 passes it in silence.
+
+    WHY THIS IS NOT A CASE-SENSITIVE COMPARE OF THE WHOLE BLOCK. That form
+    reddens on an ordinary capitalisation difference and its cheapest cure is a
+    constant edit, which is the mirror failure. This compares the EMPHASIS
+    alone, and it derives the emphasis from the source rather than hold a
+    sentence, so the guard keeps no copy of the wording.
+    """
+
+    def test_the_source_region_shouts_something(self):
+        """Non-vacuity, and the arm below is empty without it.
+
+        TWO EMPTY LISTS AGREE. If a reword removes each capitalised run from
+        the source, the arm below compares nothing with nothing for every copy
+        and reports green for ever. It would then read as emphasis coverage
+        while covering no emphasis at all.
+        """
+        text = read_carrier(PLUGIN_DIR, SOURCE_HOME)
+        assert marker_fault(text) is None, (
+            f"{SOURCE_HOME} holds no readable marker pair, so there is no "
+            f"source region to read emphasis from."
+        )
+        runs = shouted_runs(marked_region(text))
+        assert runs, (
+            f"the marked region in {SOURCE_HOME} holds no run of "
+            f"{MINIMUM_SHOUT_CHARS} or more capitals, so the arm below "
+            f"compares an empty list with an empty list and can never fire. "
+            f"EITHER the block lost its emphasis, which is the drift this arm "
+            f"exists to catch and which no other arm in this file reports, OR "
+            f"MINIMUM_SHOUT_CHARS was raised past the longest run. Read the "
+            f"block before you change the constant."
+        )
+
+    def test_each_copy_shouts_what_the_source_shouts(self):
+        quiet = copies_that_differ_only_by_case(PLUGIN_DIR)
+        assert not quiet, (
+            f"{quiet} say the same words as {SOURCE_HOME} and emphasise a "
+            f"different set of them. A de-emphasised bright line is a weaker "
+            f"rule for a reader who scans. Restore the capitalisation of the "
+            f"source. IF THE CHANGE IS DELIBERATE, edit the source and each "
+            f"copy in one commit."
+        )
+
+
+class TestEachStoreReachingSurfaceCarriesTheBar:
+    """ARM 3. POPULATION.
+
+    An instruction surface that hands a reader a route to the store, and no rule
+    for it, is the defect this repair closes. This reaches such a file on the
+    day it arrives.
+
+    ITS POPULATION IS INSTRUCTION SURFACES ALONE. The memory package and the
+    hooks reach the store legitimately, so a widened walk would report them and
+    the report would be noise.
+    """
+
+    def test_the_alphabet_reaches_each_markdown_carrier(self):
+        """The alphabet floor. A token set that narrows covers less in silence."""
+        unreached = surfaces_the_alphabet_does_not_reach(PLUGIN_DIR, ROUTE_TOKENS)
+        assert not unreached, (
+            f"{unreached} are markdown carriers and no token in ROUTE_TOKENS "
+            f"selects them. A token set that narrows takes a carrier out of "
+            f"arm 3 while each other arm keeps passing. Restore the token."
+        )
+
+    def test_no_store_reaching_surface_is_silent(self):
+        silent = store_reaching_files_without_the_bar(
+            PLUGIN_DIR, ROUTE_TOKENS, POPULATION_EXEMPTIONS
+        )
+        assert not silent, (
+            f"{silent} name a route to the memory store and hold no readable "
+            f"marked region. A reader who obeys one of these files reaches the "
+            f"store with no rule attached. Place the marked region from "
+            f"{SOURCE_HOME}. 🔴 IF THE CAUSE IS THAT THE BLOCK IS NOT PLACED "
+            f"THERE YET, REPORT IT AND LEAVE THE RED. Do NOT add the path to "
+            f"POPULATION_EXEMPTIONS: a placement gap repaired with an "
+            f"exemption is a silent carve-out for a file the design calls a "
+            f"genuine hole."
+        )
+
+    def test_each_exemption_can_do_work(self):
+        """An entry that no walk reaches excludes nothing and reads as coverage."""
+        reached = set(files_reaching_the_store(PLUGIN_DIR, ROUTE_TOKENS))
+        idle = sorted(key for key in POPULATION_EXEMPTIONS if key not in reached)
+        assert not idle, (
+            f"these exemption entries cannot do work: {idle}. The route "
+            f"alphabet does not select them, so each excludes a file from a "
+            f"question nobody puts."
+        )
+
+    def test_each_exemption_states_a_cause(self):
+        """An entry with no cause is a name, and a name goes stale in silence."""
+        bare = sorted(k for k, v in POPULATION_EXEMPTIONS.items() if not str(v).strip())
+        assert not bare, f"these exemption entries state no cause: {bare}."
+
+
+class TestTheAlphabetDoesNotSelectItself:
+    """The non-vacuity control for arm 3.
+
+    AFTER THE BAR LANDS, THE REGION NAMES TWO ROUTE TOKENS, which are
+    `memory.db` inside `memory.db-wal` and `skills/pact-memory/scripts`. So each
+    carrier selects itself, and the rule "a selected file carries the bar" holds
+    for those files BY CONSTRUCTION. That does not weaken arm 3, because its
+    work is over a file that names a token and holds NO region. It does make the
+    arm easy to hollow out: an alphabet built from the block wording selects the
+    carriers and reaches no new surface at all.
+
+    THE ALPHABET FLOOR CARRIES HALF OF THIS PROPERTY, by reading the stripped
+    text. The arm below carries the other half, over the tokens.
+    """
+
+    def test_each_token_does_work_outside_the_bar_text(self):
+        """No token may live only inside the marked regions."""
+        idle = []
+        stripped = [
+            strip_marked_regions(p.read_text(encoding="utf-8", errors="replace"))
+            for p in population_files(PLUGIN_DIR)
+        ]
+        for token in sorted(ROUTE_TOKENS):
+            if not any(carries(text, token) for text in stripped):
+                idle.append(token)
+        assert not idle, (
+            f"these tokens appear only inside the bar text, or nowhere: "
+            f"{idle}. A token taken from the guarded wording selects the "
+            f"carriers and reaches no new surface. Remove it, or state a cause "
+            f"for a token that names a route no file uses today."
+        )
+
+
+class TestTheWriteHalfFactHolds:
+    """ARM 4. FACT.
+
+    The shipped text tells an agent that `setup_memory.py` accepts no
+    `--db-path`, so a write through that script cannot be steered away from the
+    live store. The claim is in one file and the evidence is in another.
+
+    THIS ARM READS THE EVIDENCE FILE AS TEXT. It imports nothing below the
+    pact-memory package and it runs nothing, so it cannot reach the live store.
+    """
+
+    def test_the_evidence_file_is_readable_and_holds_its_control(self):
+        """Non-vacuity, and it discriminates.
+
+        `db_path` IS in the file as a parameter name. `--db-path`, the flag, is
+        not. A read that finds the first proves the read is live, so the
+        absence below cannot come from an empty read or from a moved file.
+        """
+        path = PLUGIN_DIR / EVIDENCE_FILE
+        assert path.is_file(), (
+            f"{EVIDENCE_FILE} is absent. THE ARM BELOW WOULD PASS OVER AN "
+            f"EMPTY STRING and report a clean absence."
+        )
+        text = path.read_text(encoding="utf-8", errors="replace")
+        assert carries(text, EVIDENCE_CONTROL_TOKEN), (
+            f"{EVIDENCE_FILE} does not hold {EVIDENCE_CONTROL_TOKEN!r}. That "
+            f"token is the control that separates a live read from an empty "
+            f"one. Without it the arm below proves nothing."
+        )
+
+    def test_the_source_home_names_the_evidence_file(self):
+        """The claim must have a carrier, or the arm below pins a fact nobody states.
+
+        THIS HOLDS AN ADDRESS AND NOT A SENTENCE. A copy of the claim here
+        would make this test the specification.
+        """
+        text = read_carrier(PLUGIN_DIR, SOURCE_HOME)
+        assert carries(text, "setup_memory.py"), (
+            f"{SOURCE_HOME} no longer names setup_memory.py. The arm below "
+            f"pins a fact about a script that the shipped text does not "
+            f"mention, so a green there tells a reader nothing."
+        )
+
+    def test_the_evidence_file_holds_no_db_path_flag(self):
+        path = PLUGIN_DIR / EVIDENCE_FILE
+        text = path.read_text(encoding="utf-8", errors="replace")
+        assert FORBIDDEN_FLAG not in text, (
+            f"{EVIDENCE_FILE} now holds {FORBIDDEN_FLAG!r}. The shipped text "
+            f"in {SOURCE_HOME} tells an agent this script accepts no such "
+            f"flag, so that claim is now stale. Correct the shipped text, or "
+            f"remove the flag from the script. DO NOT clear this red by an "
+            f"edit to FORBIDDEN_FLAG."
+        )
+
+
+# ---------------------------------------------------------------------------
+# THE MUTATION MODEL.
+#
+# A GUARD THAT HAS NOT BEEN MADE TO FAIL IS A CLAIM RATHER THAN A GATE. Each
+# arm below builds a small tree with the shape the walks expect, applies ONE
+# deliberate mutation, and reads the SAME predicate the shipped arm calls.
+#
+# EACH MUTATION ASSERTS THAT IT CHANGED THE TEXT. A mutation that silently
+# fails to mutate produces a proof of nothing, and it fails in the direction
+# that reads as success.
+#
+# WHAT THE MODEL DOES NOT PROVE. It runs against a built tree, so it cannot
+# show that a shipped arm reads the live one. The arms above close that from
+# the other side, and `TestTheModelTreeIsSound` states the bound.
+# ---------------------------------------------------------------------------
+
+BODY = "STORE ACCESS. DO NOT USE the flag. A rule stands here.\n"
+
+
+def _write(root: Path, name: str, text: str) -> Path:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _region(body: str = BODY) -> str:
+    return f"{MARKER_BEGIN}\n{body}{MARKER_END}\n"
+
+
+def _model_tree(tmp_path: Path) -> Path:
+    """Build a tree with one carrier for each route, each holding the region.
+
+    THE ROUTE TOKEN OF EACH MARKDOWN CARRIER SITS OUTSIDE THE REGION, so the
+    tree models the property the alphabet floor asserts of the live tree. The
+    PYTHON carriers name no route token, which models the measured fact that no
+    alphabet reaches two of the three.
+    """
+    root = tmp_path / "plugin"
+    prose = {
+        SOURCE_HOME: "The CLI lives at cli.py, and setup_memory.py writes.",
+        "agents/pact-secretary.md": "Use the update CLI command for a save.",
+        "commands/prune-memory.md": "Run archive_pin.py --index 3.",
+        "reference/config.md": "The package is skills/pact-memory/scripts.",
+        "protocols/pact-state-recovery.md": "The store file is memory.db.",
+        "protocols/pact-protocols.md": "The store file is memory.db.",
+        "skills/pact-handoff-harvest/SKILL.md": "Run search --query for context.",
+    }
+    # A CARRIER ADDED LATER MUST NOT CRASH THE MODEL. An unknown key once raised
+    # KeyError here, so a maintainer who added a carrier saw each model arm fail
+    # with a stack trace rather than the one arm that had a thing to say.
+    for name in sorted(DECLARED_CARRIERS):
+        text = prose.get(name, "This module states the bar and names no route.")
+        comment = "#" if name.endswith(".py") else ""
+        _write(root, name, f"{comment} Heading\n\n{text}\n\n{_region()}")
+    _write(root, "agents/pact-preparer.md", "This file teaches research.\n")
+    _write(root, EVIDENCE_FILE, "def ensure_initialized(db_path=None):\n    pass\n")
+    return root
+
+
+def _mutate(path: Path, old: str, new: str) -> None:
+    """Replace `old` with `new`, and refuse a mutation that changes nothing."""
+    text = path.read_text(encoding="utf-8")
+    mutated = text.replace(old, new)
+    assert mutated != text, (
+        f"the mutation changed nothing in {path.name}, so the arm proves "
+        f"nothing. Correct the mutation before you read its result."
+    )
+    path.write_text(mutated, encoding="utf-8")
+
+
+class TestTheModelTreeIsSound:
+    """The landing control, and the stated bound of the whole model.
+
+    WITHOUT THIS ARM EACH MUTATION ARM BELOW CAN PASS ON A BROKEN TREE, because
+    a predicate that reports every file reports the mutated one too.
+    """
+
+    def test_the_unmutated_tree_passes_each_predicate(self, tmp_path):
+        root = _model_tree(tmp_path)
+        assert declared_carriers_without_a_marker(root) == []
+        assert carriers_with_a_marker_fault(root) == []
+        assert copies_that_differ_from_the_source(root) == []
+        assert copies_that_differ_only_by_case(root) == []
+        assert surfaces_the_alphabet_does_not_reach(root, ROUTE_TOKENS) == []
+        assert (
+            store_reaching_files_without_the_bar(
+                root, ROUTE_TOKENS, POPULATION_EXEMPTIONS
+            )
+            == []
+        )
+
+    def test_the_derived_walk_reaches_the_python_carriers(self, tmp_path):
+        """The inverted-drift case, modelled.
+
+        A markdown-only walk compares the markdown carriers, reports green, and
+        leaves three marked copies uncompared.
+        """
+        root = _model_tree(tmp_path)
+        derived = derived_carriers(root)
+        for name in sorted(DECLARED_CARRIERS):
+            assert name in derived, f"{name} is outside the derived population"
+        assert any(name.endswith(".py") for name in derived)
+
+    def test_the_model_reaches_the_innocent_file(self, tmp_path):
+        """A model that reaches fewer files than it claims proves less than it says."""
+        root = _model_tree(tmp_path)
+        reached = {relative_name(p, root) for p in population_files(root)}
+        assert "agents/pact-preparer.md" in reached
+        assert "agents/pact-preparer.md" not in files_reaching_the_store(
+            root, ROUTE_TOKENS
+        )
+
+
+class TestArmOneGoesRed:
+    """FIDELITY, made to fail five ways.
+
+    WHAT THESE DO NOT PROVE: that a shipped arm reads the live tree. They run
+    against a built tree. The arms above close that half.
+    """
+
+    def test_a_drifted_copy_is_named(self, tmp_path):
+        root = _model_tree(tmp_path)
+        _mutate(root / "reference/config.md", "A rule stands here", "A rule shifted")
+        assert copies_that_differ_from_the_source(root) == ["reference/config.md"]
+
+    def test_a_drifted_python_copy_is_named(self, tmp_path):
+        """The carrier type a markdown-only population could not see."""
+        root = _model_tree(tmp_path)
+        _mutate(root / "scripts/archive_pin.py", "A rule stands here", "A rule shifted")
+        assert copies_that_differ_from_the_source(root) == ["scripts/archive_pin.py"]
+
+    def test_a_drifted_source_names_each_copy(self, tmp_path):
+        """The direction of the compare, asserted rather than described.
+
+        An edit to the SOURCE alone puts each copy out of agreement. A guard
+        that took the majority as truth would report the source instead, and
+        one drifted copy would lose that vote and pass.
+        """
+        root = _model_tree(tmp_path)
+        _mutate(root / SOURCE_HOME, "A rule stands here", "A rule shifted")
+        expected = sorted(DECLARED_CARRIERS - {SOURCE_HOME})
+        assert copies_that_differ_from_the_source(root) == expected
+
+    def test_a_dropped_marker_is_named_and_does_not_pass_in_silence(self, tmp_path):
+        """FAIL CLOSED. A half-present pair must not leave the population quietly."""
+        root = _model_tree(tmp_path)
+        _mutate(root / "protocols/pact-protocols.md", MARKER_END, "")
+        faults = carriers_with_a_marker_fault(root)
+        assert len(faults) == 1 and faults[0].startswith("protocols/pact-protocols.md")
+        assert copies_that_differ_from_the_source(root) == [], (
+            "the fidelity arm reported the same file as the marker arm. One "
+            "fault reported twice teaches a reader that the second is noise."
+        )
+
+    def test_an_emptied_block_passes_the_fidelity_arm(self, tmp_path):
+        """THE HOLE THE SIZE FLOOR CLOSES, shown rather than described."""
+        root = _model_tree(tmp_path)
+        for name in sorted(DECLARED_CARRIERS):
+            _mutate(root / name, _region(), _region(body=""))
+        assert copies_that_differ_from_the_source(root) == []
+        assert carriers_with_a_marker_fault(root) == []
+        source_region = marked_region(read_carrier(root, SOURCE_HOME))
+        assert len(normalised(source_region)) < MINIMUM_REGION_CHARS
+
+    def test_a_re_wrapped_copy_is_not_named(self, tmp_path):
+        """The false-alarm direction. A re-wrap changes no word and must pass."""
+        root = _model_tree(tmp_path)
+        _mutate(
+            root / "agents/pact-secretary.md",
+            "A rule stands here.",
+            "A rule\nstands\nhere.",
+        )
+        assert copies_that_differ_from_the_source(root) == []
+
+
+class TestTheFloorGoesRed:
+    """THE ANTI-SHRINKAGE FLOOR, and its unique coverage measured rather than claimed.
+
+    A DROPPED MARKER IS INVISIBLE TO DERIVATION, because a file with no marker
+    is not in the derived set. Only the declared floor sees the absence.
+    """
+
+    def test_a_carrier_that_loses_both_markers_is_named_by_the_floor_alone(
+        self, tmp_path
+    ):
+        root = _model_tree(tmp_path)
+        _mutate(root / "reference/config.md", _region(), "")
+        assert declared_carriers_without_a_marker(root) == ["reference/config.md"]
+        assert "reference/config.md" not in derived_carriers(root), (
+            "the derived walk still reports the file, so the floor is not the "
+            "only arm that catches this. Correct the stated cause above."
+        )
+        assert copies_that_differ_from_the_source(root) == [], (
+            "the fidelity arm caught the removal, so the floor is no longer "
+            "unique for this condition."
+        )
+
+    def test_a_python_carrier_that_is_never_placed_is_named(self, tmp_path):
+        """The state this gate sits in before the placement lands."""
+        root = _model_tree(tmp_path)
+        _mutate(root / "scripts/memory_repair/__init__.py", _region(), "")
+        assert declared_carriers_without_a_marker(root) == [
+            "scripts/memory_repair/__init__.py"
+        ]
+
+    def test_the_pointer_warning_fires_for_the_source_and_not_for_a_copy(self):
+        """A message branch nothing exercises is untested prose.
+
+        THE TWO HALVES ARE THE ARM. The warning must appear when the SOURCE is
+        the absent path, and it must stay silent for a copy, because a copy
+        carries no pointer to itself and the note would then be incorrect.
+        """
+        assert SOURCE_HOME in pointer_warning([SOURCE_HOME])
+        assert pointer_warning(["reference/config.md"]) == ""
+        assert pointer_warning([]) == ""
+
+    def test_a_rename_of_the_source_is_caught_by_two_arms_already(self, tmp_path):
+        """WHY NO THIRD ARM GUARDS THE POINTER, measured rather than argued.
+
+        A rename of the source home reddens the path arm AND the marker floor.
+        A third arm checking the same path would report one fault a third
+        time. This asserts the two, so a later reader who proposes that arm
+        meets the measurement rather than the opinion.
+        """
+        root = _model_tree(tmp_path)
+        (root / SOURCE_HOME).rename(root / "skills/pact-memory/GUIDE.md")
+        absent = sorted(n for n in DECLARED_CARRIERS if not (root / n).is_file())
+        assert absent == [SOURCE_HOME]
+        assert declared_carriers_without_a_marker(root) == [SOURCE_HOME]
+        assert SOURCE_HOME in pointer_warning(absent)
+
+    def test_the_floor_is_not_the_derived_population(self, tmp_path):
+        """A carrier nobody declared joins the comparison, with no edit here."""
+        root = _model_tree(tmp_path)
+        _write(root, "agents/pact-newcomer.md", f"New surface.\n\n{_region()}")
+        assert "agents/pact-newcomer.md" in derived_carriers(root)
+        assert "agents/pact-newcomer.md" in compared_carriers(root)
+        _mutate(root / "agents/pact-newcomer.md", "A rule stands here", "A rule shifted")
+        assert copies_that_differ_from_the_source(root) == ["agents/pact-newcomer.md"]
+
+
+class TestArmTwoGoesRed:
+    """EMPHASIS, made to fail, with the controls that keep it off ordinary prose.
+
+    WHAT THIS DOES NOT PROVE: that a shouted line is obeyed more often than a
+    quiet one. That is the cause behind the ruling, and no test reads a cause.
+    """
+
+    def test_a_de_emphasised_copy_is_named(self, tmp_path):
+        root = _model_tree(tmp_path)
+        _mutate(root / "reference/config.md", "DO NOT USE", "do not use")
+        assert copies_that_differ_only_by_case(root) == ["reference/config.md"]
+        assert copies_that_differ_from_the_source(root) == [], (
+            "the fidelity arm caught the de-emphasis, so arm 2 adds nothing. "
+            "Arm 1 casefolds, so it must not see this."
+        )
+
+    def test_a_copy_that_changes_words_is_left_to_arm_one(self, tmp_path):
+        """The two arms must not report one fault twice."""
+        root = _model_tree(tmp_path)
+        _mutate(root / "reference/config.md", "A rule stands here", "A rule shifted")
+        assert copies_that_differ_only_by_case(root) == []
+        assert copies_that_differ_from_the_source(root) == ["reference/config.md"]
+
+    def test_an_acronym_difference_does_not_redden_arm_two(self, tmp_path):
+        """The false-alarm direction, and it is why the shout floor is here."""
+        root = _model_tree(tmp_path)
+        _mutate(root / "reference/config.md", "the flag", "the WAL flag")
+        _mutate(root / SOURCE_HOME, "the flag", "the WAL flag")
+        assert copies_that_differ_only_by_case(root) == []
+
+
+class TestArmThreeGoesRed:
+    """POPULATION, made to fail two ways.
+
+    WHAT THESE DO NOT PROVE: that the alphabet reaches a new surface written in
+    WORDS OUTSIDE the token set. A file that teaches store access and names no
+    token passes in silence. That is the paraphrase hole this material has hit
+    three times, and no token list closes it. The declared floor is what covers
+    the members no alphabet reaches.
+    """
+
+    def test_a_new_silent_surface_is_named(self, tmp_path):
+        root = _model_tree(tmp_path)
+        _write(root, "agents/pact-newcomer.md", "Read the store at memory.db.\n")
+        silent = store_reaching_files_without_the_bar(
+            root, ROUTE_TOKENS, POPULATION_EXEMPTIONS
+        )
+        assert silent == ["agents/pact-newcomer.md"]
+
+    def test_the_token_is_what_selects_and_not_the_addition(self, tmp_path):
+        """The control for the arm above."""
+        root = _model_tree(tmp_path)
+        _write(root, "agents/pact-newcomer.md", "This file teaches nothing.\n")
+        assert (
+            store_reaching_files_without_the_bar(
+                root, ROUTE_TOKENS, POPULATION_EXEMPTIONS
+            )
+            == []
+        )
+
+    def test_an_exemption_lifts_the_rule_for_one_file_only(self, tmp_path):
+        root = _model_tree(tmp_path)
+        _write(root, "agents/pact-newcomer.md", "Read the store at memory.db.\n")
+        _write(root, "agents/pact-other.md", "Run archive_pin.py to prune.\n")
+        exempt = {"agents/pact-newcomer.md": "a stated cause"}
+        assert store_reaching_files_without_the_bar(root, ROUTE_TOKENS, exempt) == [
+            "agents/pact-other.md"
+        ]
+
+    def test_an_alphabet_that_narrows_reddens_the_floor(self, tmp_path):
+        """Unique coverage of the alphabet floor, measured rather than claimed."""
+        root = _model_tree(tmp_path)
+        narrowed = {k: v for k, v in ROUTE_TOKENS.items() if k != "archive_pin.py"}
+        assert surfaces_the_alphabet_does_not_reach(root, narrowed) == [
+            "commands/prune-memory.md"
+        ]
+        _mutate(root / "commands/prune-memory.md", MARKER_BEGIN, "")
+        assert (
+            "commands/prune-memory.md"
+            not in store_reaching_files_without_the_bar(
+                root, narrowed, POPULATION_EXEMPTIONS
+            )
+        ), (
+            "the silence arm caught the narrowed alphabet, so the floor is no "
+            "longer unique. Correct the stated cause above."
+        )
+
+    def test_no_alphabet_reaches_two_of_the_python_carriers(self, tmp_path):
+        """THE MEASURED FACT THAT MAKES THE DECLARED FLOOR LOAD-BEARING.
+
+        A widened walk presents as a fix and selects ONE of the three. The two
+        memory-repair modules name no route token, so no alphabet reaches them
+        and only declaration covers them.
+        """
+        root = _model_tree(tmp_path)
+        for name in (
+            "scripts/memory_repair/__init__.py",
+            "scripts/memory_repair/shred_detect.py",
+        ):
+            text = strip_marked_regions(read_carrier(root, name))
+            assert not any(carries(text, token) for token in ROUTE_TOKENS)
+
+
+class TestArmFourGoesRed:
+    """FACT, made to fail, with the control that separates it from an empty read.
+
+    WHAT THIS DOES NOT PROVE: that `setup_memory.py` cannot reach the live store
+    by another route. The arm reads ONE literal.
+    """
+
+    @staticmethod
+    def _flag_is_absent(root: Path) -> bool:
+        return FORBIDDEN_FLAG not in (root / EVIDENCE_FILE).read_text(encoding="utf-8")
+
+    def test_the_flag_returning_is_caught(self, tmp_path):
+        root = _model_tree(tmp_path)
+        assert self._flag_is_absent(root)
+        _mutate(
+            root / EVIDENCE_FILE,
+            "def ensure_initialized",
+            'parser.add_argument("--db-path")\ndef ensure_initialized',
+        )
+        assert not self._flag_is_absent(root)
+
+    def test_an_empty_file_would_read_as_a_clean_absence(self, tmp_path):
+        """THE FAILURE THAT READS AS SUCCESS, shown rather than described."""
+        root = _model_tree(tmp_path)
+        _write(root, EVIDENCE_FILE, "")
+        assert self._flag_is_absent(root), (
+            "an empty file no longer passes the flag arm, so the control that "
+            "pairs with it is no longer load-bearing."
+        )
+        assert not carries(
+            (root / EVIDENCE_FILE).read_text(encoding="utf-8"), EVIDENCE_CONTROL_TOKEN
+        ), "the control token survived an empty file, so it separates nothing."
+
+    @pytest.mark.parametrize(
+        "spelling, expect_absent",
+        [("--db-path", False), ("db_path", True), ("--db_path", True)],
+    )
+    def test_the_arm_reads_the_flag_and_not_the_parameter(
+        self, tmp_path, spelling, expect_absent
+    ):
+        """The two spellings differ by two characters and mean different things."""
+        root = _model_tree(tmp_path)
+        _write(root, EVIDENCE_FILE, f"# uses {spelling}\n")
+        assert self._flag_is_absent(root) is expect_absent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
 name = "pact-plugin"
 dynamic = ["version"]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 description = "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents"

--- a/testing/scenario-memory-layer-interaction.md
+++ b/testing/scenario-memory-layer-interaction.md
@@ -76,16 +76,13 @@ Run a task that completes successfully, triggering the memory enforcement hook.
 
 **Verification**:
 ```bash
-# Check recent pact-memory entries
-python3 -c "
-from pact_memory.scripts import PACTMemory
-m = PACTMemory()
-recent = m.list(limit=3)
-for r in recent:
-    print(f'{r.created_at}: {r.context[:80]}...')
-"
+# Check recent pact-memory entries. Run this from the repository root.
+# A memory operation goes through the pact-memory CLI. Do not import the
+# memory package, and pass no --db-path: the CLI resolves the default store.
+python3 pact-plugin/skills/pact-memory/scripts/cli.py list --limit 3
 ```
-Should show a recent entry related to the task.
+The command prints a JSON envelope with the 3 most recent records. Read the
+`created_at` and `context` fields. One record must relate to the task.
 
 ### Step 5: Verify Working Memory Sync
 


### PR DESCRIPTION
Seventeen commits. Two items the user ruled and nobody had executed, what an
independent attack found once they landed, and a remediation round in which
four fresh reviewers found nine more.

## What ships

**A store-access rule in eleven files**, one source and ten compared copies,
between `<!-- PACT_STORE_BAR_BEGIN -->` and `<!-- PACT_STORE_BAR_END -->`. A
memory operation goes through the pact-memory CLI. Store inspection is a
different act with a different route: no CLI verb, no import, both sidecars
confirmed absent by their full names in one command against one resolved path,
then `mode=ro` with `immutable=1`.

The rule bars **selecting a store as a capability**, rather than the one flag it
originally named. It also states the vector-index limit, because the sanctioned
route cannot answer a question about `vec_memories` and an unstated dead end is
what pushes an agent back to the barred route.

**A calibration gate that asks for a number the store can answer.** The briefing
step demanded statistics no CLI verb returns. A first correction replaced them
with a search count described as a floor, which was also unsupported: the search
returns `min(limit, population)` with no distance threshold, so it measures the
limit. The count now comes from a predicate the store can express, through the
read-only inspection route, and reports one of three states with no fallback.

**Two surfaces the guard could not see**, the repository README and a testing
scenario, converted off the module API. **A declared Python floor** that nobody
had measured, corrected downward to the one the repository enforces.

**Instruments that decide the claims they make**: shell parsing and execution
over every fenced block on the reference page, a contiguity arm on its
numbering, and a de-duplicated derived population.

## Three defects in the rule itself, each found independently

An adversarial reviewer with no sight of the ruling reached all three by its own
route.

`PACT_TEST_MEMORY_DIR` selected a store the same way the barred flag did. Both
CLI guards key on the same `db_path is not None` predicate, so a pathless call
passes each, and the environment origin creates the store directory. Every
imperative in the old text was obeyed and the record landed where nobody reads
it.

The inspection procedure was separable in time. A concurrent write between the
sidecar check and the read returns a stale image with no error. The repair tool
in this same tree already had that property in one function. The shipped rule
had dropped it.

The prescribed route errors on the vector index, because a plain sqlite
connection loads no extension.

## What this branch got wrong about itself

Recorded because the pattern is the subject.

A marked-region size was published as 796 by two separate actors. It is 787 raw
and 785 flattened; both slices ran token-to-token rather than comment-to-comment
and captured nine characters of the markers. **A character count of a marked
region is not checkable until its slice rule is stated beside it.**

A fenced-block count of fifteen was used as a bash count. Fifteen is the total:
12 bash, 3 python. That correction arrived inside the correction of an earlier
count error of the same shape.

`compile()` was named as the adjudicator for the page's Python blocks. It passes
3 of 3 before the fix and 3 of 3 after. The arm that separates the class is
execution against a stub, which moved 0 of 3 to 3 of 3. **"This parses" and
"this runs" are different claims.**

A search for a stale value using a regex word boundary returned empty on a file
where a literal search returns two hits. Three separate actors hit that false
absence.

**Two claims in the commit messages themselves, found by an audit of those
messages against their own diffs.** Both are counts, and neither survives the
squash, so they are corrected here where the record does survive.

One message says twelve shell fences "expand the token correctly and are
untouched". Twelve carry the token and **eleven** are untouched: that same
commit reworded the twelfth. The sentence fuses a count of the fences carrying
the token with a count of the fences left alone, and it sits three sentences
after the paragraph documenting that exact family.

One message says the calibration over-count is "entirely notes-only and
name-substring matches". The direction holds and the strict-subset claim holds,
but of 77 over-count records, 9 have a notes hit, 4 a name-substring hit, and
**64 have neither** — the token sits in prose columns. "Entirely" covers at most
13 of 77. That sentence is what a later reader would use to judge what the query
misses, and it understated the gap.

That question is now **settled, and the answer is some of each**. Reading the
whole prose-only population: some are references to calibration made inside
other records, where the query is right and only the wording was wrong. The rest
**are calibration data the name predicate cannot see**, so the gate does
under-count.

It under-counts by **three mechanisms with three different remedies**, which is
why a single number would have hidden it: one legacy record whose entity array
holds bare strings, four where the entity dict carries the token in its type
field rather than its name field, and nine that self-describe as calibration
records and carry no tag at all.

**The shipped query is not changed, and one control says why.** A single record
carries the token in a type field *and* in a name field at once, so the data
cannot say which is canonical. Widening the predicate to cover the type field
would be a guess at an unruled convention. The under-count is a data and
convention problem rather than a query defect, and no query change fixes the
nine untagged records at all.

The gate is far from its boundary on this store, at roughly 375 against a
threshold of 5, so this is dormant. The trigger is a small store.

**Three independent readings of the over-count disagreed**, at 416, 444 and 452.
The cause was a parameter none of the three readings stated: the set of columns
scanned. Measured, the same token gives 396 over the entities column alone, 420
adding context, 444 over six columns and 452 over all text columns. **A literal
count over a multi-column row is not checkable until the column set is stated
beside it** — the same shape as the region-size error above, in a different
medium.

A claim that a code file named a protocol as canonical for a threshold that
protocol does not contain. It does contain it. The real finding is sharper than
the false one: **three surfaces carry one number across three different
populations** — a pattern judgement in the protocol, a search-hit count in the
secretary body, and a minimum-matches constant in the scorer. The code and the
protocol agree. The secretary body was the outlier, and that is what the fix
reconciles.

## The argument this branch makes for itself

The floor correction created three stale twins its own author could not reach,
in files outside its permitted set. **The author reported that rather than
commit the manifest alone**, which would have shipped the exact defect the
branch exists to close, introduced by the repair.

Two were corrected. The third was left byte for byte, because it quotes a
superseded argument the surrounding comment records as invalid: a quotation is a
recorded past whose truth-maker does not move, and swapping the value there
would have made the quotation argue its own opposite. That is falsifying a
record rather than closing a stale claim.

## Gate

`rtk proxy python3 -m pytest` from `pact-plugin/`, no path argument: **14242
passed, 15 skipped, exit 0**, with the output scanned explicitly for the errors
token, which `rtk` drops from its summary. Zero occurrences.

The run was bound to index tree `21300d84`, and the tree of the branch head is
`21300d84`. **The run and the commits describe the same bytes.**

## Version

4.6.33, a patch. The tier was attacked twice and held: no consumer path resolves
the manifest, which has no build backend, a dynamic version with no provider,
and no publish workflow, so the floor change excludes nobody in operation.

## Known bounds

The two converted surfaces are correct and **unguarded**: the guard population
is rooted at the plugin directory and cannot reach them.

No instrument in the repository can decide a syntax regression valid from 3.12,
because the version check narrows rather than decides and no CI interpreter runs
below it. The stated bound in the test file says so, and reading its green as
cover would remove the reason to keep an older interpreter in the matrix.

The corrected floor is unrefuted and **unmeasured**. The earlier one was
refuted. Those are two different states.



