### PR TITLE
Tell a user how to restore the task tools, and strike a refuted reason

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.35",
+      "version": "4.6.36",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -650,7 +650,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.35/     # Plugin version
+│               └── 4.6.36/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ PACT turns one AI into a coordinated dev team. Instead of a single Claude guessi
 
 ## Quick Start
 
-> **Prerequisite:** PACT requires [Agent Teams](#enabling-agent-teams), which is experimental and disabled by default. Add `"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"` to the `"env"` section of your `~/.claude/settings.json` before installing.
->
-> **Conditional prerequisite:** if specialist agents refuse to spawn once PACT is installed, one further setting may be required — see [If specialist agents will not spawn](#if-specialist-agents-will-not-spawn). Check before you set it. It carries a real cost, and most installs never need it.
+> **Prerequisite:** PACT requires [Agent Teams](#enabling-agent-teams), which is experimental and disabled by default. Add `"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"` and `"CLAUDE_CODE_ENABLE_TODO_TOOLS": "1"` to the `"env"` section of your `~/.claude/settings.json` before installing. The first enables Agent Teams. The second restores the task tools PACT must have to bootstrap.
 
 **1. Install the plugin**
 
@@ -396,7 +394,7 @@ Without the Agent Teams `env` setting, PACT commands like `/PACT:orchestrate` an
 
 #### If specialist agents will not spawn
 
-**Symptom.** Every attempt to start a specialist is refused, and the refusal blames a missing task assignment. Creating that task is itself impossible, because the tools that create tasks are absent from the session. Claude Code decides server-side, based on the model a session is running, whether to withhold them. The session cannot recover on its own — the bootstrap step never completes, so file edits and further spawns stay blocked as well.
+**Symptom.** Every attempt to start a specialist is refused, and the refusal blames a missing task assignment. Creating that task is itself impossible, because the tools that create tasks are absent from the session. The bootstrap step does not complete, so file edits and later spawns stay blocked as well. For the cause, read the vendor statement below.
 
 **First, confirm this is what you are hitting.** In the stuck session, ask Claude:
 
@@ -427,7 +425,11 @@ The value is the string `"1"`, which is the form measured to work.
 
 **Where this comes from.** The vendor documents the gate: "In Claude Code v2.1.233 and later, the following tools aren't available on Opus 4.8, Sonnet 5, Fable 5, Mythos 5, or later versions of those families unless you opt in: `TodoWrite`, `TaskCreate`, `TaskGet`, `TaskUpdate`, and `TaskList`." See [Task tool availability](https://code.claude.com/docs/en/tools-reference#task-tool-availability), which records other opt-in routes as well. This page gives the `env` block, because it persists across sessions.
 
-**If you set `DISABLE_GROWTHBOOK` on earlier advice, it is retired.** That setting was the previous remedy here, and `CLAUDE_CODE_ENABLE_TODO_TOOLS` addresses this symptom directly. The retired setting is blunt: it stops the remote configuration channel of Claude Code fully, each remotely-controlled option reverts to its built-in default, and Remote Control stops working. That channel is also the fastest route the vendor has to send a mitigation between releases. It is not a standing recommendation, so remove it, unless you set it deliberately to close the remote-configuration channel.
+**If you set `DISABLE_GROWTHBOOK` on earlier advice, it is retired, and it is not neutral.** With `CLAUDE_CODE_ENABLE_TODO_TOOLS` absent, that setting forces the declared default, and the declared default withholds the tools. So it reproduces the symptom above rather than only failing to help. It is not the one setting that does this. `DISABLE_TELEMETRY` reaches the same declared default by a different route. Those are two known routes, and not a full list.
+
+**Setting `CLAUDE_CODE_ENABLE_TODO_TOOLS` is the remedy. Removal of a retired setting is hygiene.** The two together are measured to work, so a reader who sets the new value and keeps a retired setting is safe. A reader who removes a retired setting and sets nothing can stay blocked, because a second route reaches the same default.
+
+The retired setting is blunt: it stops the remote configuration channel of Claude Code fully, each remotely-controlled option reverts to its built-in default, and Remote Control stops working. That channel is also the fastest route the vendor has to send a mitigation between releases. It is not a standing recommendation, so remove it. If you set it deliberately to close the remote-configuration channel, keep it and set `CLAUDE_CODE_ENABLE_TODO_TOOLS` as well, because what you keep is one cause of the symptom above.
 
 **To remove a setting.**
 

--- a/README.md
+++ b/README.md
@@ -360,7 +360,8 @@ Add the following to your `settings.json` (global `~/.claude/settings.json` or p
 ```json
 {
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_CODE_ENABLE_TODO_TOOLS": "1"
   },
   "permissions": {
     "additionalDirectories": [
@@ -385,11 +386,11 @@ Add the following to your `settings.json` (global `~/.claude/settings.json` or p
 }
 ```
 
-The `env` setting enables Agent Teams. The `permissions.additionalDirectories` entries allow agents to access team coordination files in `~/.claude/teams/` and session journals in `~/.claude/pact-sessions/` without permission prompts. The `permissions.allow` rules prevent recurring prompts for agent memory, session state, and Telegram config file operations.
+The `env` settings enable Agent Teams and restore the task tools PACT must have to bootstrap. The `permissions.additionalDirectories` entries allow agents to access team coordination files in `~/.claude/teams/` and session journals in `~/.claude/pact-sessions/` without permission prompts. The `permissions.allow` rules prevent recurring prompts for agent memory, session state, and Telegram config file operations.
 
 > **Note:** Bash allow rules are intentionally omitted — they are [fragile](https://docs.anthropic.com/en/docs/claude-code/settings#permission-settings) for commands with arguments. When agents run `mkdir` or `rm` in `~/.claude/` paths, select **"Yes, and always allow from this project"** to add the rule automatically.
 
-Without the `env` setting, PACT commands like `/PACT:orchestrate` and `/PACT:comPACT` will fail to spawn specialist agents. If they still fail *with* the setting in place, see [If specialist agents will not spawn](#if-specialist-agents-will-not-spawn) below.
+Without the Agent Teams `env` setting, PACT commands like `/PACT:orchestrate` and `/PACT:comPACT` cannot spawn specialist agents. A missing task-tools `env` setting stops the spawn for a different cause. See [If specialist agents will not spawn](#if-specialist-agents-will-not-spawn) below, which covers that case.
 
 > **Note:** Agent Teams have [known limitations](https://code.claude.com/docs/en/agent-teams#limitations) around session resumption, task coordination, and shutdown behavior. See the Claude Code docs for details.
 
@@ -409,24 +410,28 @@ are present.
 - **Any of the four missing** — this is the problem, and the setting below fixes it.
 - **All four present** — this is *not* the problem, and the setting below will not help. Something else is refusing the spawn; this check rules out one cause, not the rest.
 
-**The setting.** Add `DISABLE_GROWTHBOOK` to the `env` block of your `~/.claude/settings.json`, alongside the Agent Teams setting, then start a new session. A session that has already been denied the tools does not pick them up again, so the stuck one cannot be rescued:
+**The setting.** Add `CLAUDE_CODE_ENABLE_TODO_TOOLS` to the `env` block of your `~/.claude/settings.json`, alongside the Agent Teams setting, then start a new session:
 
 ```json
 {
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
-    "DISABLE_GROWTHBOOK": "1"
+    "CLAUDE_CODE_ENABLE_TODO_TOOLS": "1"
   }
 }
 ```
 
-**What it costs you.** The setting is blunt: it turns off Claude Code's remote configuration channel entirely. Every remotely-controlled option reverts to its built-in default, and Remote Control stops working. That channel is also the vendor's fastest lever for responding to an incident, so leaving this in place permanently opts you out of server-side mitigations that would otherwise reach you between releases.
+The value is the string `"1"`, which is the form measured to work.
 
-**The other side of the same trade.** Turning the channel off also means a vendor-controlled switch can no longer change how your already-installed client behaves. A reader who treats that capability as attack surface will see this setting as a hardening measure rather than a concession. Both readings are correct; which one governs depends on whether you are more exposed to a mitigation that never arrives or to a behavior change you never reviewed.
+**Why the Agent Teams setting does not cover this.** The two values gate different things, and one does not replace the other. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` enables Agent Teams. `CLAUDE_CODE_ENABLE_TODO_TOOLS` restores the task tools. A session with Agent Teams enabled and no task tools shows the symptom above. That is why the Agent Teams setting did not prevent it.
 
-**Taking it back out.** This is a workaround for current platform behavior, not a standing recommendation — the gate is server-controlled and can change without notice, so expect to remove this setting eventually.
+**Where this comes from.** The vendor documents the gate: "In Claude Code v2.1.233 and later, the following tools aren't available on Opus 4.8, Sonnet 5, Fable 5, Mythos 5, or later versions of those families unless you opt in: `TodoWrite`, `TaskCreate`, `TaskGet`, `TaskUpdate`, and `TaskList`." See [Task tool availability](https://code.claude.com/docs/en/tools-reference#task-tool-availability), which records other opt-in routes as well. This page gives the `env` block, because it persists across sessions.
 
-To find out whether you still need it, delete the entry, **start a new shell, and start a new session from that shell**, then run the check above. All three steps matter, because environment values propagate asymmetrically: a value added to `settings.json` reaches processes that are already running, but removing it does not retract it from them; a value set in a shell profile only affects shells started afterwards; and a value exported by hand in a live shell survives both. Deleting the line and re-testing in place tells you nothing.
+**If you set `DISABLE_GROWTHBOOK` on earlier advice, it is retired.** That setting was the previous remedy here, and `CLAUDE_CODE_ENABLE_TODO_TOOLS` addresses this symptom directly. The retired setting is blunt: it stops the remote configuration channel of Claude Code fully, each remotely-controlled option reverts to its built-in default, and Remote Control stops working. That channel is also the fastest route the vendor has to send a mitigation between releases. It is not a standing recommendation, so remove it, unless you set it deliberately to close the remote-configuration channel.
+
+**To remove a setting.**
+
+To find out whether you still need a setting, delete that entry, **start a new shell, and start a new session from that shell**, then run the check above. All three steps matter, because environment values propagate asymmetrically: a value added to `settings.json` reaches processes that are already running, but removing it does not retract it from them; a value set in a shell profile only affects shells started afterwards; and a value exported by hand in a live shell survives both. Deleting the line and re-testing in place tells you nothing.
 
 ### Optional dependencies
 

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.35",
+  "version": "4.6.36",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.35
+> **Version**: 4.6.36
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -18,6 +18,10 @@ Then add `~/.claude/teams` and `~/.claude/pact-sessions` to your `additionalDire
 
 ```json
 {
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_CODE_ENABLE_TODO_TOOLS": "1"
+  },
   "permissions": {
     "additionalDirectories": [
       "~/.claude/teams",
@@ -42,6 +46,8 @@ Then add `~/.claude/teams` and `~/.claude/pact-sessions` to your `additionalDire
 ```
 
 > **Note:** Bash allow rules are intentionally omitted — they are [fragile](https://docs.anthropic.com/en/docs/claude-code/settings#permission-settings) for commands with arguments. When agents run `mkdir` or `rm` in `~/.claude/` paths, select **"Yes, and always allow from this project"** to add the rule automatically.
+
+The two `env` values are prerequisites and they gate different things: Agent Teams, and the task tools PACT must have to bootstrap. If specialists will not spawn, see [If specialist agents will not spawn](https://github.com/Synaptic-Labs-AI/PACT-Plugin#if-specialist-agents-will-not-spawn).
 
 Then restart Claude Code. Requires [Agent Teams enabled](https://github.com/Synaptic-Labs-AI/PACT-Plugin#enabling-agent-teams) and the `--agent` flag wired up — see [Loading PACT at session start](https://github.com/Synaptic-Labs-AI/PACT-Plugin#upgrading-from-v3x-to-v40) for the three convenience patterns (per-project `.claude/settings.json`, the `pact` shell wrapper, or manual `claude --agent PACT:pact-orchestrator`).
 

--- a/pact-plugin/agents/pact-orchestrator.md
+++ b/pact-plugin/agents/pact-orchestrator.md
@@ -363,26 +363,6 @@ For full detail, `Read(file_path="../protocols/pact-variety.md")` when calibrati
 >
 > ⚠️ **NEVER** use plain `Agent(subagent_type=...)` without `name` and `team_name` for specialist agents. This bypasses team coordination, task tracking, and `SendMessage` communication.
 
-#### Which signal governs a tool call
-
-A tool gives you three signals about itself, and they can disagree. Rank them by distance from the thing that decides:
-
-1. **The behaviour IS the interface.** Only a call to the tool measures it.
-2. **The parameter list** (the `properties` object) **describes the interface.** It is a read, one step away.
-3. **The prose description describes the parameter list.** It is a read of a read, two steps away.
-
-Each step is a different author at a different time, so each level can go stale against the level below it. That is why the order holds. The prose is the level that reads like an answer, which is what makes it stop a search.
-
-Apply the order like this:
-
-- If the prose says a parameter is unavailable and the parameter list shows it, PASS IT.
-- If the dispatch template above and the parameter list disagree, that disagreement is a FINDING. Report it to the user. Do not pick one.
-- If your decision is about what the tool DOES rather than about what it accepts, no read is sufficient. Call the tool.
-
-**A gate that demands a parameter is evidence that the parameter is available**, because a gate cannot demand what the interface cannot express. So when a gate refuses a dispatch for a missing field you believe you cannot pass, check the belief first. Do not hunt for a different tool.
-
-**Acceptance is not action.** A tool boundary can drop an unknown key with no error, so a call that returns cleanly proves nothing about that key. To measure what a parameter does, send a marked value that has one route into the result, then look for that value in the result. A control call that carries a key name no tool uses tells you if the boundary rejects unknown keys at all.
-
 **Teachback-Gated Dispatch**:
 
 Every specialist dispatch is a Task A (TEACHBACK) + Task B (primary work, `blockedBy=[A]`) pair. Both tasks must exist with the teammate as owner BEFORE the `Agent()` spawn. The mission lives in Task B's `description`, never in the spawn prompt.
@@ -396,6 +376,22 @@ For non-exempt teammates (everyone except `pact-secretary`):
 3. `TaskUpdate(A_id, owner="{name}", addBlocks=[B_id])` — assign Task A to the teammate and wire it as the gate that unblocks Task B.
 4. `TaskUpdate(B_id, owner="{name}", addBlockedBy=[A_id])` — assign Task B to the same teammate and explicitly mirror the block edge. Do NOT pre-set `status="in_progress"` on either task — the teammate self-claims on arrival. Ensure the Task A brief reminds the teammate to claim Task B (`status="in_progress"`) before any implementation tool-use once it unblocks (the command dispatch templates carry this line) — the teammate flips it, never you.
 5. `Agent(name="{name}", team_name="{team_name}", subagent_type="pact-{type}", prompt="YOUR PACT ROLE: teammate ({name}).\n\nYou are joining team {team_name}. As your FIRST action, Invoke Skill(\"PACT:pact-team-registration\") to record your identity. Then check `TaskList` for tasks assigned to you.")` — spawn the teammate. Keep the prompt ≤ 800 chars and include the literal `TaskList` reference (or one of: `task list`, `tasks assigned`, `check your tasks`); the teammate reads the mission via `TaskGet(B_id)`, not from the prompt.
+
+#### Which signal governs a tool call
+
+A tool gives three signals about itself, and they can disagree. Trust them in this order:
+
+1. **The behaviour.** Only a call measures it.
+2. **The parameter list** (the `properties` object).
+3. **The prose description**, which describes the parameter list.
+
+A different author writes each level at a different time, so a higher level can be stale.
+
+- Prose says a parameter is not available, parameter list shows it: PASS IT.
+- Dispatch template and parameter list disagree: that is a FINDING. Report it. Do not select one.
+- Your question is what the tool DOES: call the tool.
+
+**A gate that demands a parameter is evidence the parameter is available**, because a gate cannot demand what the interface cannot express. Check that belief before you look for a different tool.
 
 #### First-spawn verification (HARD-RULE)
 

--- a/pact-plugin/agents/pact-orchestrator.md
+++ b/pact-plugin/agents/pact-orchestrator.md
@@ -399,6 +399,8 @@ For non-exempt teammates (everyone except `pact-secretary`):
 
 #### First-spawn verification (HARD-RULE)
 
+**Before you conclude the dispatch was malformed, check the tools YOU hold.** If you cannot see `TaskCreate`, `TaskUpdate`, `TaskList` and `TaskGet`, the spawn shape is not the cause and a re-spawn will not help. The host withholds those tools from some model and client-version combinations unless a session opts in. Tell the user to see [If specialist agents will not spawn](https://github.com/Synaptic-Labs-AI/PACT-Plugin#if-specialist-agents-will-not-spawn). Do not re-spawn until you rule that out.
+
 After your first specialist spawn in a session — and after any subsequent spawn where you suspect dispatch tooling may be misconfigured — verify the teammate received the full PACT protocol surface. The teammate's first message MUST demonstrate access to `TaskList`, `TaskUpdate`, and `SendMessage`. If the teammate reports any of those tools "not available", "not loaded", or otherwise missing:
 
 > ⚠️ **HARD STOP — DISPATCH PROTOCOL VIOLATION**. This is **NOT** degraded mode. **NOT** something to "work around". The dispatch was malformed (almost always: spawn shape used `Task(...)` instead of `Agent(...)`, or omitted `name=` / `team_name=`). Stop the teammate, correct the dispatch shape, and re-spawn with the canonical `Agent(name=..., team_name=..., subagent_type=...)` form documented above. Do **not** instruct the teammate to "make do" — they cannot self-recover from a malformed spawn.

--- a/pact-plugin/agents/pact-orchestrator.md
+++ b/pact-plugin/agents/pact-orchestrator.md
@@ -363,6 +363,19 @@ For full detail, `Read(file_path="../protocols/pact-variety.md")` when calibrati
 >
 > ⚠️ **NEVER** use plain `Agent(subagent_type=...)` without `name` and `team_name` for specialist agents. This bypasses team coordination, task tracking, and `SendMessage` communication.
 
+#### Which signal governs a tool call
+
+A tool gives you three signals about itself, and they can disagree. Rank them:
+
+1. **The dispatch template above** and **the tool parameter list** (the `properties` object) both govern.
+2. **The tool prose description** ranks below the two of them.
+
+If the prose says a parameter is unavailable and the parameter list shows it, PASS IT. Your default is to trust the description, because it reads like an instruction. Do not. A description can go stale against the schema in the same block.
+
+If the template and the parameter list disagree, that disagreement is a FINDING. Report it to the user. Do not pick one.
+
+**A gate that demands a parameter is evidence that the parameter is available**, because a gate cannot demand what the interface cannot express. So when a gate refuses a dispatch for a missing field you believe you cannot pass, check the belief first. Do not hunt for a different tool.
+
 **Teachback-Gated Dispatch**:
 
 Every specialist dispatch is a Task A (TEACHBACK) + Task B (primary work, `blockedBy=[A]`) pair. Both tasks must exist with the teammate as owner BEFORE the `Agent()` spawn. The mission lives in Task B's `description`, never in the spawn prompt.

--- a/pact-plugin/agents/pact-orchestrator.md
+++ b/pact-plugin/agents/pact-orchestrator.md
@@ -365,16 +365,23 @@ For full detail, `Read(file_path="../protocols/pact-variety.md")` when calibrati
 
 #### Which signal governs a tool call
 
-A tool gives you three signals about itself, and they can disagree. Rank them:
+A tool gives you three signals about itself, and they can disagree. Rank them by distance from the thing that decides:
 
-1. **The dispatch template above** and **the tool parameter list** (the `properties` object) both govern.
-2. **The tool prose description** ranks below the two of them.
+1. **The behaviour IS the interface.** Only a call to the tool measures it.
+2. **The parameter list** (the `properties` object) **describes the interface.** It is a read, one step away.
+3. **The prose description describes the parameter list.** It is a read of a read, two steps away.
 
-If the prose says a parameter is unavailable and the parameter list shows it, PASS IT. Your default is to trust the description, because it reads like an instruction. Do not. A description can go stale against the schema in the same block.
+Each step is a different author at a different time, so each level can go stale against the level below it. That is why the order holds. The prose is the level that reads like an answer, which is what makes it stop a search.
 
-If the template and the parameter list disagree, that disagreement is a FINDING. Report it to the user. Do not pick one.
+Apply the order like this:
+
+- If the prose says a parameter is unavailable and the parameter list shows it, PASS IT.
+- If the dispatch template above and the parameter list disagree, that disagreement is a FINDING. Report it to the user. Do not pick one.
+- If your decision is about what the tool DOES rather than about what it accepts, no read is sufficient. Call the tool.
 
 **A gate that demands a parameter is evidence that the parameter is available**, because a gate cannot demand what the interface cannot express. So when a gate refuses a dispatch for a missing field you believe you cannot pass, check the belief first. Do not hunt for a different tool.
+
+**Acceptance is not action.** A tool boundary can drop an unknown key with no error, so a call that returns cleanly proves nothing about that key. To measure what a parameter does, send a marked value that has one route into the result, then look for that value in the result. A control call that carries a key name no tool uses tells you if the boundary rejects unknown keys at all.
 
 **Teachback-Gated Dispatch**:
 

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -55,6 +55,8 @@ Agent(
 )
 ```
 
+> **Why store `agent_id`?** One name can belong to more than one teammate across a session. If a newer teammate gets the name of an earlier one, a message addressed to that name reaches the newer teammate. The stored id is the handle for that case. UNVERIFIED: this latest-wins behaviour comes from the `SendMessage` tool description. No measurement covers it and no document states it, so do not read the stored id as a guarantee.
+
 ### Teachback-Gated Dispatch
 
 Every specialist dispatch creates **two tasks**, not one:
@@ -940,7 +942,9 @@ After you resolve a blocker, message the teammate by name. Spawn fresh if the te
 
 `SendMessage(to="{teammate-name}", message="Blocker resolved: {details}. Continue your task.")`
 
-⚠️ **Write the message so that it works alone.** The teammate can hold none of its earlier context. Put the full resolution, the following step, and the task id into the message. A self-contained message is correct in the two cases. A message that points back at earlier context gives the teammate nothing, and the result looks like a teammate that ignored you.
+If one name went to more than one teammate this session, address the message to the stored `agent_id` and not to the name. UNVERIFIED, from the `SendMessage` tool description.
+
+⚠️ **Write the message so that it works alone.** The teammate can hold none of its earlier context. Put the full resolution, the task id, and what the teammate must do into the message. A self-contained message is correct in the two cases. A message that points back at earlier context gives the teammate nothing, and the result looks like a teammate that ignored you.
 
 **Fresh spawn pattern**: Follow the standard dispatch pattern (`TaskCreate` + `TaskUpdate` + Agent with name/team_name/subagent_type).
 

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -39,9 +39,8 @@ c. `TaskCreate`: agent task(s) as children of phase
 d. `TaskUpdate`: agent tasks owner = "{agent-name}"
 e. `TaskUpdate`: next phase addBlockedBy = [agent IDs]
 f. Spawn teammates with the canonical dispatch form (shown at each specific phase below)
-g. Store agent IDs: `TaskUpdate(taskId, metadata={"agent_id": "{id_from_Task_return}"})`
-h. Monitor via `SendMessage` (completion summaries) and `TaskList` until agents complete
-i. `TaskUpdate`: phase status = "completed" (agents self-manage their task status)
+g. Monitor via `SendMessage` (completion summaries) and `TaskList` until agents complete
+h. `TaskUpdate`: phase status = "completed" (agents self-manage their task status)
 ```
 
 The canonical `Agent()` dispatch form, referenced by every phase below:
@@ -54,8 +53,6 @@ Agent(
   prompt="YOUR PACT ROLE: teammate ({teammate-name}).\n\nYou are joining team {team_name}. As your FIRST action, Invoke Skill(\"PACT:pact-team-registration\") to record your identity. Then check `TaskList` for tasks assigned to you."
 )
 ```
-
-> **Why store `agent_id`?** One name can belong to more than one teammate across a session. If a newer teammate gets the name of an earlier one, a message addressed to that name reaches the newer teammate. The stored id is the handle for that case. UNVERIFIED: this latest-wins behaviour comes from the `SendMessage` tool description. No measurement covers it and no document states it, so do not read the stored id as a guarantee.
 
 ### Teachback-Gated Dispatch
 
@@ -941,8 +938,6 @@ After you resolve a blocker, message the teammate by name. Spawn fresh if the te
 **Message pattern**:
 
 `SendMessage(to="{teammate-name}", message="Blocker resolved: {details}. Continue your task.")`
-
-If one name went to more than one teammate this session, address the message to the stored `agent_id` and not to the name. UNVERIFIED, from the `SendMessage` tool description.
 
 ⚠️ **Write the message so that it works alone.** The teammate can hold none of its earlier context. Put the full resolution, the task id, and what the teammate must do into the message. A self-contained message is correct in the two cases. A message that points back at earlier context gives the teammate nothing, and the result looks like a teammate that ignored you.
 

--- a/pact-plugin/commands/orchestrate.md
+++ b/pact-plugin/commands/orchestrate.md
@@ -55,8 +55,6 @@ Agent(
 )
 ```
 
-> **Why store agent_id?** Enables `resume` for blocker recovery — see [Blocker Recovery](#blocker-recovery-resume-vs-fresh-spawn).
-
 ### Teachback-Gated Dispatch
 
 Every specialist dispatch creates **two tasks**, not one:
@@ -923,24 +921,28 @@ When an agent reports a blocker or algedonic signal via `SendMessage`:
 
 **HALT handling**: On HALT signal, immediately stop all running teammates using the [Lead-Side HALT Fan-Out](../protocols/algedonic.md#lead-side-halt-fan-out) idiom (one `SendMessage` per in-progress teammate by name) before presenting to user.
 
-### Blocker Recovery: Resume vs. Fresh Spawn
+### Blocker Recovery: Message the Teammate, or Spawn Fresh
 
-When a blocker is resolved, prefer resuming the original agent over spawning fresh — this preserves the agent's accumulated context.
+🔴 **The `Agent` tool has no working `resume` parameter. Do not pass one.** A call that carries `resume=` does NOT error. The tool drops the key. A FRESH agent then starts with none of the prior work. The call succeeds and reports an agent, so the call site shows no defect. The defect appears later, as a teammate that knows nothing.
+
+After you resolve a blocker, message the teammate by name. Spawn fresh if the teammate stopped, or if its approach was incorrect.
 
 **Decision matrix**:
 
 | Situation | Action | Rationale |
 |-----------|--------|-----------|
-| Blocker resolved, agent had significant partial work | `resume` | Preserve context |
-| Blocker resolved, agent's approach was wrong | Fresh spawn | Clean slate needed |
-| Agent hit `maxTurns` limit | Fresh spawn | Agent was likely looping |
-| Agent shut down for lifecycle cleanup | Fresh spawn | Context is stale |
+| Blocker resolved, teammate is `in_progress` | `SendMessage` to the teammate name | The teammate is live and can continue |
+| Blocker resolved, the approach of the teammate was incorrect | Fresh spawn | A clean slate is necessary |
+| Teammate hit the `maxTurns` limit | Fresh spawn | The teammate was probably in a loop |
+| Teammate shut down for lifecycle cleanup | Fresh spawn | It holds no context |
 
-**Resume pattern**:
-1. Read agent ID from task metadata: `TaskGet(taskId).metadata.agent_id`
-2. Resume with blocker context: `Agent(resume="{agent_id}", prompt="Blocker resolved: {details}. Continue your task.")`
+**Message pattern**:
 
-**Fresh spawn pattern** (when resume is inappropriate): Follow the standard dispatch pattern (`TaskCreate` + `TaskUpdate` + Agent with name/team_name/subagent_type).
+`SendMessage(to="{teammate-name}", message="Blocker resolved: {details}. Continue your task.")`
+
+⚠️ **Write the message so that it works alone.** The teammate can hold none of its earlier context. Put the full resolution, the following step, and the task id into the message. A self-contained message is correct in the two cases. A message that points back at earlier context gives the teammate nothing, and the result looks like a teammate that ignored you.
+
+**Fresh spawn pattern**: Follow the standard dispatch pattern (`TaskCreate` + `TaskUpdate` + Agent with name/team_name/subagent_type).
 
 ---
 

--- a/pact-plugin/hooks/bootstrap_gate.py
+++ b/pact-plugin/hooks/bootstrap_gate.py
@@ -385,8 +385,8 @@ _SECRETARY_AGENT_TYPE = "pact-secretary"
 # ritual simply has not been run yet. The clause is therefore CONDITIONED on a
 # symptom the reader can observe for themselves, never phrased as advice to go
 # change a setting. Routing a user who has merely not bootstrapped toward a
-# high-blast-radius configuration change would be actively harmful, which is
-# why the condition comes first and the pointer second.
+# configuration change would be actively harmful, which is why the condition
+# comes first and the pointer second.
 #
 # "State-independent" here means TRUE in every state, not RECOMMENDING THE SAME
 # ACTION in every state: when the condition does not hold the clause asks

--- a/pact-plugin/hooks/bootstrap_gate.py
+++ b/pact-plugin/hooks/bootstrap_gate.py
@@ -397,9 +397,9 @@ _SECRETARY_AGENT_TYPE = "pact-secretary"
 # that section — it lives in the repository README — so a reader who searches
 # their local copy for a quoted section title finds nothing, which is worse
 # than no pointer at all. This URL is already the established convention in
-# the shipped README, which links it twice. It also lands on the section
-# together with its cost paragraph, which a terse local restatement would
-# drop. Do NOT "simplify" this back to a section name.
+# the shipped README, which links it once (measured 2026-08-18 as full-URL
+# occurrences in pact-plugin/README.md, the file marketplace.json packages).
+# Do NOT "simplify" this back to a section name.
 #
 # Any change to this text must be mirrored into
 # ``_CANONICAL_DENY_REASON_LITERAL`` in tests/test_bootstrap_gate.py. That
@@ -410,7 +410,7 @@ _DENY_REASON = (
     "until bootstrap completes. Bash, Read, Glob, Grep are available. "
     "If bootstrap cannot complete because the task-management tools are "
     "unavailable, see "
-    "https://github.com/Synaptic-Labs-AI/PACT-Plugin#enabling-agent-teams"
+    "https://github.com/Synaptic-Labs-AI/PACT-Plugin#if-specialist-agents-will-not-spawn"
 )
 
 

--- a/pact-plugin/hooks/dispatch_gate.py
+++ b/pact-plugin/hooks/dispatch_gate.py
@@ -634,19 +634,17 @@ def _augment_deny_with_stale_diagnosis(
 # therefore report "not case (4)" in precisely the case that IS (4). A cue that
 # NARROWS is admissible; an assertion that ELIMINATES is not.
 #
-# The remedy for cause (3) is a pointer, never an inlined setting: it is a
-# conditional prerequisite with real blast radius, and a deny message cannot
-# carry the cost statement that has to accompany it.
+# The remedy for cause (3) is a pointer, never an inlined setting.
 #
-# That pointer is an ABSOLUTE URL rather than a section name. The README
-# shipped INSIDE the plugin package does not contain that section — it lives
-# in the repository README — so a reader searching their local copy for a
-# quoted section title finds nothing, which is worse than no pointer at all.
-# The shipped README already links this exact URL twice, so this follows an
-# established convention rather than inventing one. The URL also lands on the
-# section TOGETHER WITH its cost paragraph, which is the entire reason the
-# remedy is a pointer; a terse local restatement would drop it. Do NOT
-# "simplify" this back to a section name.
+# That pointer is an ABSOLUTE URL rather than a section name, and ONE ground
+# carries the two halves. The README shipped INSIDE the plugin package does
+# not contain that section — it lives in the repository README — so a reader
+# searching their local copy for a quoted section title finds nothing, which
+# is worse than no pointer at all. The shipped README links this exact URL
+# once (measured 2026-08-18 as full-URL occurrences in pact-plugin/README.md,
+# the file marketplace.json packages), so this follows an established
+# convention rather than inventing one.
+# Do NOT "simplify" this back to a section name.
 #
 # THE OPENING QUALIFIER IS LOAD-BEARING, not throat-clearing. The rule-⑧ base
 # message ends with an unhedged imperative — create the teachback task and the
@@ -671,8 +669,8 @@ _CAUSE_ENUMERATION = (
     "TO NARROW IT DOWN, confirm all four task tools are available to you:\n"
     "    ToolSearch \"select:TaskCreate,TaskUpdate,TaskList,TaskGet\"\n"
     "  Any missing      -> case (3) below. For the setting that restores\n"
-    "                      them, and its trade-offs, see\n"
-    "                      https://github.com/Synaptic-Labs-AI/PACT-Plugin#enabling-agent-teams\n"
+    "                      them, see\n"
+    "                      https://github.com/Synaptic-Labs-AI/PACT-Plugin#if-specialist-agents-will-not-spawn\n"
     "  All four present -> not case (3). That rules out one cause, not the rest.\n"
     "If listing the task store reports a PERMISSIONS ERROR, you are in case (4).\n"
     "\n"

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -646,13 +646,24 @@ def _build_safety_net_context(
     cost of the notice is a few hundred bytes, and the cost of withholding the
     ladder is a user who cannot use any tool.
 
-    THE None PATH IS RULED SEPARATELY AND IS NOT COVERED BY THE MEASUREMENT
-    ABOVE. No count covers a frame where the classifier did not run. THE
-    ARGUMENT, on its merits: when the role is unresolved the system knows
-    nothing about the reader, and text that claims a role AND issues a
-    governance directive asserts more than the system knows. Do not borrow the
-    census above for that branch, and do not read this "unknown" ruling as
-    settling it.
+    THE None PATH KEEPS THE LADDER TOO, AND THAT RULING REPLACED AN EARLIER
+    ONE. The earlier ruling withheld the ladder from an unresolved frame on
+    the argument that text claiming a role asserts more than the system knows.
+    It priced the cost as a REACTIVE route, because the bootstrap_gate deny
+    names its own remedy. THE FIELD REPORT RETIRED THAT PRICE: the reporter
+    did not recover through the deny text, he rolled the plugin back.
+
+    AND A FULL REVERT IS A SMALLER DELTA FROM A KNOWN-GOOD SHIPPED ARTIFACT
+    THAN A PARTIAL ONE. 4.6.34 had no None branch at all. Leaving None
+    suppressed keeps one novel behaviour of which the only justification is
+    now discredited, and it makes the drift-robustness argument for this
+    revert dishonest, because that argument rests on a return to 4.6.34
+    semantics.
+
+    WHAT SURVIVES OF THE OLD ARGUMENT IS THE CUE, NOT THE SUPPRESSION. An
+    unresolved frame does NOT receive the unknown-role notice, because that
+    notice asserts a classifier result that was never computed. It receives
+    its own sentence, which keeps it separable from a resolved-empty frame.
 
     This helper is deliberately zero-risk: only string literals, a single
     f-string interpolation of team_name (which is either None or a validated
@@ -687,27 +698,6 @@ def _build_safety_net_context(
             'session_init partially failed — check systemMessage for details. '
             'Check TaskList for tasks assigned to you.'
         )
-    if frame_role is None:
-        # The classifier DID NOT RUN, so nothing is known about this frame.
-        # Ruled separately from "unknown": the note says which of the two
-        # happened, because a reader debugging an early-window failure needs
-        # to know that the role was never resolved rather than resolved-empty.
-        #
-        # THIS BRANCH RESTS ON A DESIGN ARGUMENT, NOT ON A MEASUREMENT, and
-        # the difference is deliberate rather than an omission. NO CENSUS
-        # COVERS A FRAME WHERE THE CLASSIFIER DID NOT RUN. The 13-of-13 count
-        # cited in the docstring above covers frames that classified
-        # "unknown", which is a different population. THE ARGUMENT: when the
-        # role is unresolved the system knows nothing about the reader, and
-        # text that claims a role AND issues a governance directive asserts
-        # more than the system knows. Do not borrow that count for this
-        # branch. If you measure this population, cite the new count here and
-        # state which frames it covers.
-        return (
-            'session_init failed before the session role was resolved — check '
-            'systemMessage for details. No role instructions are delivered for '
-            'an unresolved frame.'
-        )
     prelude = (
         'YOUR PACT ROLE: orchestrator.\n\n'
         'Invoke Skill("PACT:bootstrap") immediately, without waiting for user input. '
@@ -715,11 +705,36 @@ def _build_safety_net_context(
         'Do not evaluate whether it is needed. '
         'You must invoke Skill("PACT:bootstrap") on every session start.'
     )
-    # An "unknown" frame is a primary frame launched with no `--agent`, so it
-    # keeps the ladder above and ALSO gets the operator cue. APPENDED, never
-    # prepended: the byte-0 marker contract in this docstring is what the
-    # line-anchored readers key on, and a leading notice would break it.
-    cue = f'\n\n{_UNKNOWN_ROLE_NOTICE}' if frame_role == "unknown" else ''
+    # TWO ROLES REACH THIS LADDER BESIDE "lead", AND EACH GETS ITS OWN CUE
+    # APPENDED. Appended, never prepended: the byte-0 marker contract in this
+    # docstring is what the line-anchored readers key on.
+    #
+    # "unknown" is a primary frame launched with no `--agent`, and its cue
+    # names that fact, because the classifier established it.
+    #
+    # None means the classifier DID NOT RUN. THE FRAME BEHIND IT IS THE SAME
+    # POPULATION AS EVERY OTHER FRAME, WHICH IS MOSTLY A PRIMARY USER, so
+    # withholding the ladder there denies an ordinary user their tools. The
+    # earlier ruling withheld it and priced the cost as a REACTIVE route,
+    # because the bootstrap_gate deny names its own remedy. THE FIELD REPORT
+    # IS EVIDENCE THAT ROUTE DOES NOT WORK: the reporter did not recover
+    # through the deny text, he rolled the plugin back.
+    #
+    # THE ONE HALF OF THE OLD ARGUMENT THAT SURVIVES IS THE CUE, NOT THE
+    # SUPPRESSION. An unresolved frame must NOT receive the unknown-role
+    # notice, because that notice asserts a classifier result that was never
+    # computed. It gets its own sentence instead, which keeps it separable
+    # from a resolved-empty frame for anyone who debugs the early window.
+    if frame_role == "unknown":
+        cue = f'\n\n{_UNKNOWN_ROLE_NOTICE}'
+    elif frame_role is None:
+        cue = (
+            '\n\nNote: session_init failed before the session role was '
+            'resolved, so this frame was not classified. If you are not '
+            'driving PACT as the orchestrator, ignore the instructions above.'
+        )
+    else:
+        cue = ''
     if team_name:
         return (
             f'{prelude}\n\n'

--- a/pact-plugin/hooks/session_init.py
+++ b/pact-plugin/hooks/session_init.py
@@ -613,48 +613,46 @@ def _build_safety_net_context(
     a teammate MUST NOT be handed the orchestrator-only bootstrap directive.
 
     frame_role is captured in main() BEFORE the risky assembly (alongside
-    team_name). THE THREE VALUES AND None ARE FOUR DIFFERENT CASES AND EACH IS
-    RULED SEPARATELY. "teammate" gets the teammate marker. "lead" gets the
-    orchestrator marker, which is safe because a lead frame resolves through
-    is_lead on its own evidence. "unknown" means the classifier RAN and found
-    no role, so the frame is known not to be the lead and it gets NEITHER
-    marker. None means the classifier DID NOT RUN, so nothing is known, and it
-    gets a role-free failure note.
+    team_name). THE THREE VALUES AND None ARE FOUR CASES. "teammate" gets the
+    teammate marker. "lead" and "unknown" BOTH get the orchestrator marker.
+    None means the classifier DID NOT RUN, so nothing is known, and it gets a
+    role-free failure note.
 
-    AN EARLIER FORM OF THIS DOCSTRING CALLED THE ORCHESTRATOR MARKER ON THE
-    None PATH "a known no-regression default rather than a misroute". THAT
-    CLAIM DOES NOT SURVIVE, AND THE TWO HALVES OF ITS RETIREMENT REST ON
-    DIFFERENT WARRANTS. READ WHICH IS WHICH BEFORE YOU CHANGE EITHER.
+    WHY "unknown" KEEPS THE MARKER, AND DO NOT SUPPRESS IT AGAIN WITHOUT
+    READING THIS. "unknown" means agent_type was ABSENT, and the classifier
+    docstring names what that covers: a non-PACT / no-`--agent` PRIMARY frame.
+    That is an ordinary user who typed plain `claude`. Withholding the marker
+    withholds the bootstrap directive, so the bootstrap marker is never
+    stamped, so bootstrap_gate (PreToolUse, no matcher key, every tool call)
+    denies Edit, Write and Agent. THE USER READS THAT AS A TOTAL TOOL-LOAD
+    FAILURE, AND IT WAS REPORTED FROM THE FIELD.
 
-    THE "unknown" HALF IS MEASURED. Handing the orchestrator instructions to a
-    frame that classified "unknown" is the misroute, and it was counted.
-    POPULATION OF THAT COUNT, stated so it cannot be borrowed by accident: the
-    155 files matching subagents/*.jsonl for ONE team session, of which 13
-    fired a compact SessionStart, and 13 of those 13 received the orchestrator
-    instructions. THAT CENSUS COVERS FRAMES WHERE THE CLASSIFIER RAN AND
-    RETURNED "unknown". IT COVERS NO OTHER POPULATION.
+    A PRIOR SUPPRESSION HERE CITED A CENSUS, AND THE CENSUS DID NOT MEASURE
+    THIS POPULATION. It counted subagent transcripts that received the
+    orchestrator instructions. POPULATION, re-measured: 166 files matching
+    subagents/*.jsonl for one team session, 13 of which carry a SessionStart
+    record, holding 70 such records between them. ALL 70 have
+    type == "attachment" and carry the LEAD session id, and the set of
+    distinct session ids across the 70 has exactly ONE member. They are the
+    LEAD's own hook output, which the platform attaches into the transcripts
+    of the sidechains that are live at that moment. Those frames classify
+    "lead", so a gate keyed on "unknown" cannot change one byte of them, and
+    150 of the 166 files carry no SessionStart record at all. NO SUBAGENT
+    FRAME REACHES THIS HOOK.
 
-    THE None HALF IS A DESIGN ARGUMENT AND IT IS DELIBERATELY WEAKER. NO
-    MEASUREMENT COVERS A FRAME WHERE THE CLASSIFIER DID NOT RUN. Nobody has
-    counted how frequently a raise fires above the capture, or which roles
-    reach that window. THE ARGUMENT, on its merits: when the role is
-    unresolved the system knows nothing about the reader, and text that claims
-    a role AND issues a governance directive asserts more than the system
-    knows.
+    THE OPERATOR CUE STILL RIDES ALONG. An "unknown" frame also receives
+    _UNKNOWN_ROLE_NOTICE, appended AFTER the marker so the byte-0 contract
+    above holds. The notice is ADDITIVE and must never replace the ladder: the
+    cost of the notice is a few hundred bytes, and the cost of withholding the
+    ladder is a user who cannot use any tool.
 
-    THAT ASYMMETRY IS A BOUND ON THE EVIDENCE, NOT A GAP SOMEBODY LEFT OPEN.
-    The two halves have different warrants because they cover different
-    populations, and a reader must be able to see which is which. DO NOT
-    borrow the census above for the None half: taking it means a claim about
-    frames that did not classify, which is not what was counted. DO NOT soften
-    the "unknown" half to match. If a later measurement covers the None
-    population, cite THAT one and state its population here.
-
-    ONE COST OF THE None RULING, PRICED AND MEASURED: a lead that loses this
-    marker keeps a reactive route. The bootstrap_gate PreToolUse hook is
-    lead-only and its deny names the remedy, so such a lead is told on its
-    first blocked tool call rather than up front. That is a degradation from
-    told-up-front to told-on-first-attempt, and it is not a deadlock.
+    THE None PATH IS RULED SEPARATELY AND IS NOT COVERED BY THE MEASUREMENT
+    ABOVE. No count covers a frame where the classifier did not run. THE
+    ARGUMENT, on its merits: when the role is unresolved the system knows
+    nothing about the reader, and text that claims a role AND issues a
+    governance directive asserts more than the system knows. Do not borrow the
+    census above for that branch, and do not read this "unknown" ruling as
+    settling it.
 
     This helper is deliberately zero-risk: only string literals, a single
     f-string interpolation of team_name (which is either None or a validated
@@ -667,11 +665,11 @@ def _build_safety_net_context(
                    exception fired before generate_team_name() ran.
         frame_role: Session role ("lead" / "teammate" / "unknown") captured
                     before the exception, or None if the exception fired before
-                    the capture. Four cases, four outcomes: "teammate" selects
-                    the teammate marker, "unknown" and None select a role-free
-                    note that claims no role and carries no bootstrap
-                    directive, and any other value (which is "lead" today)
-                    selects the orchestrator marker.
+                    the capture. Four cases: "teammate" selects the teammate
+                    marker, None selects a role-free note that claims no role
+                    and carries no bootstrap directive, and every other value
+                    ("lead" and "unknown" today) selects the orchestrator
+                    marker, with "unknown" also receiving the operator notice.
 
     Returns:
         Minimal additionalContext string suitable for the except-block
@@ -688,13 +686,6 @@ def _build_safety_net_context(
             'YOUR PACT ROLE: teammate.\n\n'
             'session_init partially failed — check systemMessage for details. '
             'Check TaskList for tasks assigned to you.'
-        )
-    if frame_role == "unknown":
-        # The classifier RAN and found no role, so this frame is known NOT to
-        # be the lead. It gets no role marker and no bootstrap directive.
-        return (
-            'session_init partially failed — check systemMessage for details. '
-            + _UNKNOWN_ROLE_NOTICE
         )
     if frame_role is None:
         # The classifier DID NOT RUN, so nothing is known about this frame.
@@ -724,17 +715,22 @@ def _build_safety_net_context(
         'Do not evaluate whether it is needed. '
         'You must invoke Skill("PACT:bootstrap") on every session start.'
     )
+    # An "unknown" frame is a primary frame launched with no `--agent`, so it
+    # keeps the ladder above and ALSO gets the operator cue. APPENDED, never
+    # prepended: the byte-0 marker contract in this docstring is what the
+    # line-anchored readers key on, and a leading notice would break it.
+    cue = f'\n\n{_UNKNOWN_ROLE_NOTICE}' if frame_role == "unknown" else ''
     if team_name:
         return (
             f'{prelude}\n\n'
             f'Session team: `{team_name}` (session_init partially failed — '
             f'check systemMessage for details). '
-            f'Run TaskList to check current state.'
+            f'Run TaskList to check current state.{cue}'
         )
     return (
         f'{prelude}\n\n'
         'Session team: NOT GENERATED (session_init failed early — check '
-        'systemMessage for details). The platform auto-creates the session team.'
+        f'systemMessage for details). The platform auto-creates the session team.{cue}'
     )
 
 
@@ -1514,46 +1510,43 @@ def main():
                     context_parts.insert(0, _peer_body)
             except Exception:
                 pass  # fail-open: no injection; never the orchestrator safety-net
-        elif frame_role == "unknown":
-            # THE THIRD CLASSIFIER VALUE, WHICH THIS GATE USED TO DROP. The
-            # classifier RAN and found no role, so this frame is known NOT to
-            # be the lead. It gets NEITHER the teammate body above NOR the
-            # orchestrator directive below.
-            #
-            # WHY A NOTE RATHER THAN SILENCE, and the two options were priced.
-            # Silence costs nothing to emit and has two failures. First, an
-            # arm asserting an ABSENCE cannot separate correct silence from a
-            # build path that died, because a fail-open hook emits the same
-            # bytes for both, which are none. That is the property that let
-            # this defect sit undetected, and an arm that reproduces it proves
-            # nothing. Second, the operator who meant to launch the
-            # orchestrator and forgot the flag loses the cue: the sibling
-            # notice rides systemMessage, which a session transcript does not
-            # capture. A NOTE costs a few hundred bytes on a rare frame, gives
-            # the arm a positive token to assert beside the absence, and puts
-            # the cue on a channel that is delivered. The same literal serves
-            # both channels, so the two cannot drift.
-            #
-            # INDEX 0, LIKE EVERY OTHER LIMB OF THIS GATE. The teammate limb
-            # above and each source limb below write at index 0, because this
-            # gate runs LATE: the banner (step 4c) and the pin/config
-            # surfacings are in context_parts before it. An APPEND here left
-            # the notice last, and on a frame with no pin-slot line (any
-            # checkout carrying no project CLAUDE.md) it left the BANNER
-            # first, so the role message sat below diagnostics a reader meets
-            # first. Position only. The ruling that an unknown frame gets no
-            # orchestrator ladder is unchanged.
-            #
-            # NO SOURCE GATE HERE, AND THAT IS CORRECT. The sibling emission of
-            # this literal into system_messages gates on a launch source,
-            # because that gate answers a REPETITION question, and repetition
-            # is about a reader that remembers. This limb writes to
-            # context_parts. A frame after a compact does NOT hold the earlier
-            # text, so a gate here removes the only copy that reader gets. If
-            # this limb changes to write to system_messages, the reader changes
-            # with it and a source gate becomes correct.
-            context_parts.insert(0, _UNKNOWN_ROLE_NOTICE)
         else:
+            # "lead" AND "unknown" BOTH take this branch, and the "unknown"
+            # half is the load-bearing part. DO NOT SPLIT IT OUT AGAIN WITHOUT
+            # READING THIS. "unknown" means agent_type was ABSENT, which is a
+            # non-PACT / no-`--agent` PRIMARY frame: an ordinary user who typed
+            # plain `claude`. Withholding the ladder from that frame withholds
+            # the bootstrap directive, so the bootstrap marker is never
+            # stamped, so bootstrap_gate (PreToolUse, no matcher key, every
+            # tool call) denies Edit, Write and Agent. THE USER READS THAT AS A
+            # TOTAL TOOL-LOAD FAILURE, AND IT WAS REPORTED FROM THE FIELD. The
+            # `clear` source is the worst cell: `is_marker_reset` above ERASES
+            # the marker on that path, so a `clear` frame with no ladder loses
+            # the marker AND the instruction that would rebuild it.
+            #
+            # A PRIOR SUPPRESSION HERE CITED A CENSUS THAT DID NOT MEASURE
+            # THIS POPULATION. Re-measured: of 166 files matching
+            # subagents/*.jsonl for one team session, 13 carry a SessionStart
+            # record, holding 70 records between them. All 70 have
+            # type == "attachment" and carry the LEAD session id, and the set
+            # of distinct session ids across the 70 has exactly ONE member.
+            # They are the LEAD's own hook output, attached by the platform
+            # into the transcripts of the live sidechains. Those frames
+            # classify "lead", so a gate keyed on "unknown" cannot change one
+            # byte of them, and 150 of the 166 files carry no SessionStart
+            # record at all. NO SUBAGENT FRAME REACHES THIS HOOK.
+            #
+            # AND THE ERROR THAT LET IT SHIP WAS A MODEL, NOT A MISSING CHECK,
+            # WHICH IS WHY REVIEW DID NOT CATCH IT. The comment above this
+            # module's _UNKNOWN_ROLE_NOTICE describes the no-`--agent` frame as
+            # an operator "who MEANT to launch the orchestrator and forgot the
+            # flag", and the emitted notice says the same. THAT NAMES THE FRAME
+            # AFTER A MISTAKE. Nobody wrote down that it is also the ORDINARY
+            # way a user starts Claude Code, so a branch that withheld the
+            # ladder from it read as harmless to each reviewer, because each
+            # reviewer held the same model. A missing check is caught by
+            # reading the branch. A wrong model is not.
+            #
             # The team always exists (the platform pre-creates it), so the
             # directive is source-agnostic; the per-source branches differ only
             # in the recovery/state guidance appended after it.
@@ -1682,6 +1675,24 @@ def main():
                     f'Note: unrecognized session source "{source}". '
                     f'Run TaskList to check current state.'
                 ))
+
+            # THE OPERATOR CUE, AND IT IS ADDITIVE. A frame with no agent_type
+            # keeps the whole ladder above and ALSO gets told that no role was
+            # recognized, so an operator who MEANT to launch the orchestrator
+            # and forgot the flag still sees it. INDEX 1, immediately after the
+            # ladder each source limb just wrote at index 0: the role message
+            # must stay first, because this gate runs LATE and the banner and
+            # the pin surfacings are already in context_parts. An append would
+            # leave the cue below diagnostics a reader meets first, and an
+            # insert at 0 would displace the marker the line-anchored readers
+            # key on. NO SOURCE GATE: this limb writes to context_parts, which
+            # a frame after a compact does not carry over from before, so a
+            # source gate would remove the only copy that reader gets. The
+            # sibling emission into system_messages does gate on source,
+            # because that one answers a REPETITION question about a reader
+            # that remembers.
+            if frame_role == "unknown":
+                context_parts.insert(1, _UNKNOWN_ROLE_NOTICE)
 
         # 5a. Capture the PREVIOUS session's dir from project CLAUDE.md
         # before step 5b overwrites the Current Session block with THIS

--- a/pact-plugin/protocols/algedonic.md
+++ b/pact-plugin/protocols/algedonic.md
@@ -91,7 +91,7 @@ With PACT Task integration, algedonic signals create **signal Tasks** that persi
 
 **Agent behavior on algedonic signal:**
 
-Under Agent Teams, teammates have access to Task tools (`TaskGet`, `TaskUpdate`, `TaskList`) and messaging (`SendMessage`). When an agent detects a viability threat:
+Under Agent Teams, the algedonic signal travels on `SendMessage`, which does not depend on the Task tools. If the Task tools (`TaskGet`, `TaskUpdate`, `TaskList`) are not available to you, send the signal anyway. When an agent detects a viability threat:
 1. Stop work immediately
 2. Send the signal to the team-lead via `SendMessage` (using the Signal Format above):
    ```

--- a/pact-plugin/protocols/pact-protocols.md
+++ b/pact-plugin/protocols/pact-protocols.md
@@ -1791,7 +1791,7 @@ See [rePACT.md](../commands/rePACT.md) for the full command documentation, inclu
 
 #### Future Executor: Agent Teams
 
-> **Status**: Agent Teams is experimental, gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`.
+> **Status**: Agent Teams is experimental. It is gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`, and the Task tools PACT must have are gated behind `CLAUDE_CODE_ENABLE_TODO_TOOLS=1`.
 > The API has evolved from earlier community-documented versions (monolithic `TeammateTool` with 13 operations)
 > into separate purpose-built tools. The mappings below reflect the current API shape but may change
 > before official release. This section is documentation/future reference, not current behavior.

--- a/pact-plugin/protocols/pact-scope-contract.md
+++ b/pact-plugin/protocols/pact-scope-contract.md
@@ -114,7 +114,7 @@ See [rePACT.md](../commands/rePACT.md) for the full command documentation, inclu
 
 #### Future Executor: Agent Teams
 
-> **Status**: Agent Teams is experimental, gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`.
+> **Status**: Agent Teams is experimental. It is gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`, and the Task tools PACT must have are gated behind `CLAUDE_CODE_ENABLE_TODO_TOOLS=1`.
 > The API has evolved from earlier community-documented versions (monolithic `TeammateTool` with 13 operations)
 > into separate purpose-built tools. The mappings below reflect the current API shape but may change
 > before official release. This section is documentation/future reference, not current behavior.

--- a/pact-plugin/reference/config.md
+++ b/pact-plugin/reference/config.md
@@ -84,7 +84,7 @@ managed settings → command-line args → env vars → settings files (local �
 1. **The `env` block overrides a same-named shell variable.** A value pinned in `settings.json`'s `env` block wins over a shell export of the same name — so a one-shot `PACT_PR_GREEDY_FIX=0 claude …` will **not** override a `"PACT_PR_GREEDY_FIX": "1"` pinned in the `env` block. A one-shot override works only when the variable is not pinned there.
 2. **A malformed `settings.json` is dropped WHOLESALE in headless mode.** In `-p` / headless mode, a syntax error anywhere in `settings.json` makes Claude Code silently ignore the **entire** file — including the whole `env` block, so every PACT option persisted there stops applying. `session_init` warns at startup if it reads a malformed `settings.json`. Keep the file valid JSON.
 
-**Namespace guardrail**: name every PACT option `PACT_*`. Never reuse a `CLAUDE_CODE_*` identity variable — Claude Code strips those from the `env` block.
+**Namespace guardrail**: name each PACT option `PACT_*`, and do not give a PACT option a `CLAUDE_CODE_*` name. A `PACT_*` name makes the owner of an option unambiguous.
 
 ## Migration — `autonomous-scope-detection` marker → env var
 

--- a/pact-plugin/reference/unattended-runs.md
+++ b/pact-plugin/reference/unattended-runs.md
@@ -27,6 +27,14 @@ You can also set it permanently in `~/.claude/settings.json`:
 { "teammateMode": "tmux" }
 ```
 
+> **In tmux mode, set the task-tools value too.** A teammate in its own split
+> pane is a separate Claude Code process, so the tools it gets follow its own
+> model. A lead can hold the task tools while a teammate does not. The `env`
+> block that restores them sits in the same `~/.claude/settings.json` shown
+> above, which each Claude Code process reads at start, so one entry is
+> sufficient for the lead and the teammate. See
+> [If specialist agents will not spawn](https://github.com/Synaptic-Labs-AI/PACT-Plugin#if-specialist-agents-will-not-spawn).
+
 ## If you must stay on in-process mode
 
 Keep a lightweight external heartbeat in another terminal so you periodically

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -48,7 +48,7 @@ A reply to the user that contains content the team-lead needs to act on (a block
 
 > **Worktree scope**: Files that are gitignored (e.g., `CLAUDE.md`) do not exist in a worktree, so a write there makes a new file, not an update.
 
-> **Write your blocker report so that it works alone**: When you report a blocker, the work can continue without your context. The team-lead can message you to continue, and can also spawn a new teammate for the same task. Put what you learned, what you changed, and the following step into the task, and not only into your own context. A report that is complete in the task is correct in the two cases.
+> **Write your blocker report so that it works alone**: When you report a blocker, the work can continue without your context. The team-lead can message you to continue, and can also spawn a new teammate for the same task. Put what you learned, what you changed, and what must happen after into the task, and not only into your own context. A report that is complete in the task is correct in the two cases.
 
 > **Custom start flows**: If your agent definition specifies a custom On Start sequence (e.g., the secretary's session briefing), you must explicitly re-enter this standard lifecycle after your custom flow completes — call `TaskList`, claim assigned tasks, and follow the teachback protocol from the teachback step onward.
 

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -48,7 +48,7 @@ A reply to the user that contains content the team-lead needs to act on (a block
 
 > **Worktree scope**: Files that are gitignored (e.g., `CLAUDE.md`) do not exist in a worktree, so a write there makes a new file, not an update.
 
-> **Note**: The team-lead stores your `agent_id` in task metadata after dispatch. This enables `resume` if you hit a blocker — the team-lead can resume your process with preserved context instead of spawning fresh.
+> **Write your blocker report so that it works alone**: When you report a blocker, the work can continue without your context. The team-lead can message you to continue, and can also spawn a new teammate for the same task. Put what you learned, what you changed, and the following step into the task, and not only into your own context. A report that is complete in the task is correct in the two cases.
 
 > **Custom start flows**: If your agent definition specifies a custom On Start sequence (e.g., the secretary's session briefing), you must explicitly re-enter this standard lifecycle after your custom flow completes — call `TaskList`, claim assigned tasks, and follow the teachback protocol from the teachback step onward.
 

--- a/pact-plugin/skills/pact-agent-teams/SKILL.md
+++ b/pact-plugin/skills/pact-agent-teams/SKILL.md
@@ -12,7 +12,7 @@ description: |
 
 ## You Are a Teammate
 
-You are a member of a PACT Agent Team. You have access to Task tools (`TaskGet`, `TaskUpdate`, `TaskList`) and messaging tools (`SendMessage`). Use them to coordinate with the team.
+You are a member of a PACT Agent Team. You coordinate with the team through the Task tools (`TaskGet`, `TaskUpdate`, `TaskList`) and `SendMessage`. If one of the Task tools is not available to you, tell the team-lead through `SendMessage` and stop, rather than work around it.
 
 ## Pre-Response Channel Check
 

--- a/pact-plugin/tests/test_bootstrap_gate.py
+++ b/pact-plugin/tests/test_bootstrap_gate.py
@@ -100,7 +100,7 @@ _CANONICAL_DENY_REASON_LITERAL = (
     "until bootstrap completes. Bash, Read, Glob, Grep are available. "
     "If bootstrap cannot complete because the task-management tools are "
     "unavailable, see "
-    "https://github.com/Synaptic-Labs-AI/PACT-Plugin#enabling-agent-teams"
+    "https://github.com/Synaptic-Labs-AI/PACT-Plugin#if-specialist-agents-will-not-spawn"
 )
 
 

--- a/pact-plugin/tests/test_commands_structure.py
+++ b/pact-plugin/tests/test_commands_structure.py
@@ -724,10 +724,10 @@ class TestPerLoopDispatchSites:
     # 9 per-loop dispatch sites. Each entry is
     # (relative_command_path, lead_in_line_number_1based, role_or_phase_label).
     SITES = [
-        ("orchestrate.md", 461, "PREPARE"),
-        ("orchestrate.md", 568, "ARCHITECT"),
-        ("orchestrate.md", 703, "CODE"),
-        ("orchestrate.md", 853, "TEST"),
+        ("orchestrate.md", 463, "PREPARE"),
+        ("orchestrate.md", 570, "ARCHITECT"),
+        ("orchestrate.md", 705, "CODE"),
+        ("orchestrate.md", 855, "TEST"),
         ("comPACT.md", 233, "MultipleSpecialists"),
         ("comPACT.md", 293, "SingleSpecialist"),
         ("peer-review.md", 192, "Reviewers"),

--- a/pact-plugin/tests/test_commands_structure.py
+++ b/pact-plugin/tests/test_commands_structure.py
@@ -724,10 +724,10 @@ class TestPerLoopDispatchSites:
     # 9 per-loop dispatch sites. Each entry is
     # (relative_command_path, lead_in_line_number_1based, role_or_phase_label).
     SITES = [
-        ("orchestrate.md", 463, "PREPARE"),
-        ("orchestrate.md", 570, "ARCHITECT"),
-        ("orchestrate.md", 705, "CODE"),
-        ("orchestrate.md", 855, "TEST"),
+        ("orchestrate.md", 460, "PREPARE"),
+        ("orchestrate.md", 567, "ARCHITECT"),
+        ("orchestrate.md", 702, "CODE"),
+        ("orchestrate.md", 852, "TEST"),
         ("comPACT.md", 233, "MultipleSpecialists"),
         ("comPACT.md", 293, "SingleSpecialist"),
         ("peer-review.md", 192, "Reviewers"),

--- a/pact-plugin/tests/test_commands_structure.py
+++ b/pact-plugin/tests/test_commands_structure.py
@@ -375,10 +375,10 @@ EXPECTED_SPAWN_LITERAL_COUNTS = {
 _PROMPT_LITERAL_RE = re.compile(r'prompt="((?:[^"\\]|\\.)*)"')
 
 # A teammate-spawn prompt literal always opens with the role prelude. This
-# prefix is what distinguishes a spawn literal from a non-spawn prompt such as
-# Agent(resume=..., prompt="Blocker resolved: ...") — a resumed agent already
-# registered on its INITIAL spawn, so its resume prompt must NOT carry (or be
-# required to carry) the register directive.
+# prefix is what distinguishes a spawn literal from a non-spawn prompt, such as
+# a prompt that gives an instruction to a teammate that is running. A teammate
+# registers on its OWN spawn, so a prompt with no role prelude must NOT carry
+# the register directive, and must not be required to.
 _SPAWN_LITERAL_PREFIX = "YOUR PACT ROLE: teammate ("
 
 
@@ -443,16 +443,48 @@ class TestRegisterDirectivePresentInEverySpawnLiteral:
                 f"Offending literal (truncated): {value[:90]!r}"
             )
 
-    # The former test_resume_prompt_excluded_from_directive_requirement is
-    # DELETED, on the instruction its own failure message carried: it required
-    # at least one "Blocker resolved" prompt in orchestrate.md as its
-    # non-vacuity fixture, and that prompt is gone with the resume-recovery
-    # example. MEASURED after the removal: orchestrate.md carries 6 prompt
-    # literals and all 6 are spawn literals, so ZERO non-spawn literals remain.
-    # The exclusion property is therefore UNGUARDED in this file rather than
-    # covered by the count assertion above: a widened extractor would find no
-    # extra literal to admit, so the count would not move. Restoring coverage
-    # needs a synthetic non-spawn fixture, which is a separate decision.
+    def test_a_prompt_without_the_role_prelude_is_not_a_spawn_literal(self):
+        """The extractor must EXCLUDE a prompt literal that carries no role
+        prelude, so a non-spawn prompt is never required to carry the register
+        directive.
+
+        The fixture is SYNTHETIC and that is deliberate. The predecessor of
+        this test took its fixture from a live "Blocker resolved" prompt in
+        orchestrate.md, and it went red when that prompt was removed with the
+        resume-recovery example. A fixture that lives in a document can be
+        drained by an edit to that document; this one cannot. MEASURED at the
+        time of writing: orchestrate.md carries 6 prompt literals and all 6
+        are spawn literals, so no document supplies a non-spawn fixture.
+
+        Three arms. Each one was PROVEN red under its own mutation of an
+        isolated copy, against a green control on the unmutated copy:
+          1. the extractor no longer matches a plain Agent(prompt=...)
+          2. the exclusion widens and admits a prompt with no role prelude
+          3. the exclusion narrows and drops a genuine spawn literal
+        """
+        non_spawn = 'Agent(prompt="Blocker resolved: {details}. Continue.")'
+        assert _PROMPT_LITERAL_RE.findall(non_spawn) == [
+            "Blocker resolved: {details}. Continue."
+        ], (
+            "the prompt-literal extractor no longer sees a plain "
+            "Agent(prompt=...) call. Without this the exclusion below would be "
+            "vacuously true, because there would be nothing to exclude."
+        )
+        assert _spawn_prompt_literals(non_spawn) == [], (
+            "a prompt with no role prelude leaked into the teammate-spawn "
+            "literal set. It would then be wrongly required to carry the "
+            "register directive."
+        )
+
+        spawn = (
+            'Agent(prompt="YOUR PACT ROLE: teammate (x).\\n\\nYou are joining '
+            'team t. As your FIRST action, Invoke Skill(\\"'
+            'PACT:pact-team-registration\\") to record your identity.")'
+        )
+        assert len(_spawn_prompt_literals(spawn)) == 1, (
+            "a genuine teammate-spawn literal was dropped by the extractor. "
+            "The directive requirement would then cover nothing."
+        )
 
 
 class TestTeamRegistrationSkillLiveness:

--- a/pact-plugin/tests/test_commands_structure.py
+++ b/pact-plugin/tests/test_commands_structure.py
@@ -443,28 +443,16 @@ class TestRegisterDirectivePresentInEverySpawnLiteral:
                 f"Offending literal (truncated): {value[:90]!r}"
             )
 
-    def test_resume_prompt_excluded_from_directive_requirement(self):
-        """Regression: a non-spawn prompt — Agent(resume=..., prompt="Blocker
-        resolved: ...") — is NOT a teammate-spawn literal (no role prelude) and
-        is correctly EXCLUDED from the directive requirement. Pins the exclusion
-        so a future extractor change can't start demanding the directive in a
-        resume prompt (wrong: a resumed agent already registered on its initial
-        spawn). orchestrate.md is the surface that carries the resume example."""
-        orch = (COMMANDS_DIR / "orchestrate.md").read_text(encoding="utf-8")
-        all_prompts = _PROMPT_LITERAL_RE.findall(orch)
-        resume_prompts = [v for v in all_prompts if v.startswith("Blocker resolved")]
-        assert resume_prompts, (
-            "expected at least one Agent(resume=...) 'Blocker resolved' prompt in "
-            "orchestrate.md — the resume-recovery example. If it was removed, drop "
-            "this test; if the extractor regex changed shape, fix it. Without this "
-            "fixture the exclusion below would be vacuously true."
-        )
-        # The resume prompt must NOT be classified as a spawn literal.
-        spawn = _spawn_prompt_literals(orch)
-        assert all(not v.startswith("Blocker resolved") for v in spawn), (
-            "a resume prompt leaked into the teammate-spawn literal set — it "
-            "would then be wrongly required to carry the register directive."
-        )
+    # The former test_resume_prompt_excluded_from_directive_requirement is
+    # DELETED, on the instruction its own failure message carried: it required
+    # at least one "Blocker resolved" prompt in orchestrate.md as its
+    # non-vacuity fixture, and that prompt is gone with the resume-recovery
+    # example. MEASURED after the removal: orchestrate.md carries 6 prompt
+    # literals and all 6 are spawn literals, so ZERO non-spawn literals remain.
+    # The exclusion property is therefore UNGUARDED in this file rather than
+    # covered by the count assertion above: a widened extractor would find no
+    # extra literal to admit, so the count would not move. Restoring coverage
+    # needs a synthetic non-spawn fixture, which is a separate decision.
 
 
 class TestTeamRegistrationSkillLiveness:
@@ -736,10 +724,10 @@ class TestPerLoopDispatchSites:
     # 9 per-loop dispatch sites. Each entry is
     # (relative_command_path, lead_in_line_number_1based, role_or_phase_label).
     SITES = [
-        ("orchestrate.md", 463, "PREPARE"),
-        ("orchestrate.md", 570, "ARCHITECT"),
-        ("orchestrate.md", 705, "CODE"),
-        ("orchestrate.md", 855, "TEST"),
+        ("orchestrate.md", 461, "PREPARE"),
+        ("orchestrate.md", 568, "ARCHITECT"),
+        ("orchestrate.md", 703, "CODE"),
+        ("orchestrate.md", 853, "TEST"),
         ("comPACT.md", 233, "MultipleSpecialists"),
         ("comPACT.md", 293, "SingleSpecialist"),
         ("peer-review.md", 192, "Reviewers"),

--- a/pact-plugin/tests/test_dispatch_gate_cause_enumeration.py
+++ b/pact-plugin/tests/test_dispatch_gate_cause_enumeration.py
@@ -1024,8 +1024,8 @@ _POINTER_URL_RE = re.compile(r"https://github\.com/[^\s\"'\\]+#[^\s\"'\\]+")
 # command and why a computed slug would be unsound here. Both halves are pinned
 # so an edit to EITHER side reds, which is what makes this a correspondence
 # check rather than a restatement of one side.
-_VERIFIED_ANCHOR = "enabling-agent-teams"
-_VERIFIED_HEADING = "### Enabling Agent Teams"
+_VERIFIED_ANCHOR = "if-specialist-agents-will-not-spawn"
+_VERIFIED_HEADING = "#### If specialist agents will not spawn"
 
 
 def _pointer_urls(source_name):
@@ -1092,17 +1092,22 @@ def test_readme_pointer_has_a_referent():
     to confirm they have this problem before being shown a high-blast-radius
     setting.
 
-    BE PRECISE ABOUT WHERE THAT PROTECTION LIVES — an earlier draft of this
-    docstring said the referent "opens with a falsifiable check", and it does
-    not. The pointed-at section opens with the Agent Teams settings block. The
-    check lives further down, inside its "If specialist agents will not spawn"
-    SUBSECTION, which opens with "First, confirm this is what you are hitting"
-    and only then reaches "The setting". So the ordering invariant is
-    check-before-remedy WITHIN THAT SUBSECTION, not at the top of the section
-    the gates name. The distinction matters because this paragraph exists for a
-    future auditor re-checking the ordering: one who reads "opens with" lands at
-    the section heading, finds a settings block and no check, and concludes the
-    protection has already been lost when it has not.
+    BE PRECISE ABOUT WHERE THAT PROTECTION LIVES, because an earlier state of
+    this file got it wrong in each direction. The gates now name the
+    "If specialist agents will not spawn" SUBSECTION itself, so the ordering
+    invariant and the pointer target are the same region. That subsection opens
+    with a "Symptom." statement, reaches "First, confirm this is what you are
+    hitting" with its four-tool check, and only THEN reaches "The setting". So
+    check-before-remedy holds INSIDE the pointed-at region, and an auditor who
+    follows the URL lands on the check rather than on a settings block.
+
+    WHAT THIS PARAGRAPH IS FOR, stated so it survives the next repoint: when
+    the gates named the PARENT section instead, the check sat one heading below
+    the landing point, and an auditor who read the section top-down found the
+    Agent Teams settings block first and could conclude the protection had been
+    lost when it had not. Re-check this paragraph against the pointer when the
+    anchor moves. It describes a REGION, and repointing changes the region it
+    describes.
 
     That protection is a property of the PAIR, not of either file: reorder the
     subsection to lead with the remedy and the protection is gone while this
@@ -1159,9 +1164,9 @@ def test_readme_pointer_has_a_referent():
     #
     # Verified empirically against GitHub's own renderer rather than assumed:
     #     gh api repos/<owner>/<repo>/readme -H "Accept: application/vnd.github.html"
-    # which returned id="user-content-enabling-agent-teams" for this heading.
-    # Re-run that command if either side of the pair below changes; do NOT
-    # "simplify" this into a slugger.
+    # which returned id="user-content-if-specialist-agents-will-not-spawn" for
+    # this heading, served as an <h4>. Re-run that command if either side of
+    # the pair below changes; do NOT "simplify" this into a slugger.
     anchor = url.split("#", 1)[1]
     assert anchor == _VERIFIED_ANCHOR, (
         f"the gates now point at anchor {anchor!r}, but the verified pair pins "

--- a/pact-plugin/tests/test_dispatch_gate_cause_enumeration.py
+++ b/pact-plugin/tests/test_dispatch_gate_cause_enumeration.py
@@ -28,8 +28,8 @@ of them a gap that more coverage closes:
   * Verification-before-remedy ordering in the README section the gates point
     at. ``test_readme_pointer_has_a_referent`` pins that the referent EXISTS,
     and deliberately not that it still leads with a falsifiable check before
-    showing the reader a high-blast-radius setting. That protection is a
-    property of the gate/README pair which no single artifact can enforce.
+    showing the reader the setting. That protection is a property of the
+    gate/README pair which no single artifact can enforce.
 
 NON-VACUITY DISCIPLINE — the reasons, so a later editor does not undo them:
 
@@ -1089,8 +1089,7 @@ def test_readme_pointer_has_a_referent():
 
     WHAT THIS DOES NOT PIN, and must not be read as pinning. The clause in the
     bootstrap gate is safe to over-point partly because the reader is told how
-    to confirm they have this problem before being shown a high-blast-radius
-    setting.
+    to confirm they have this problem before being shown the setting.
 
     BE PRECISE ABOUT WHERE THAT PROTECTION LIVES, because an earlier state of
     this file got it wrong in each direction. The gates now name the

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -45,6 +45,7 @@ import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -78,13 +79,18 @@ def _with_lead_role(payload: dict) -> dict:
 _TEST_SESSION_ID = "aabb1122-0000-0000-0000-000000000000"
 
 # The unknown-role notice literal. classify_session_role returns "unknown" when
-# agent_type is absent, and the role gate then emits this instead of the
-# orchestrator ladder. Kept as a fragment rather than the full sentence so a
-# re-wrap of the source literal does not redden every arm that reads it.
+# agent_type is absent, and the role gate emits this BESIDE the orchestrator
+# ladder, never in place of it. Kept as a fragment rather than the full
+# sentence so a re-wrap of the source literal does not redden every arm that
+# reads it.
 _UNKNOWN_ROLE_FRAGMENT = "relaunch with `--agent PACT:pact-orchestrator`"
 
 
-def _stdin_payload(source=None, agent_type=_LEAD_AGENT_TYPE, **extra) -> str:
+def _stdin_payload(
+    source=None,
+    agent_type: Optional[str] = _LEAD_AGENT_TYPE,
+    **extra,
+) -> str:
     """Build a stdin JSON string for a session_init driver.
 
     ``agent_type=None`` OMITS the key, which is the ONLY way to build an
@@ -113,16 +119,22 @@ def _assert_unknown_frame_body(additional: str) -> None:
     accidentally providing. Both properties stay asserted, so neither the lead
     contract nor the unknown branch loses its witness.
 
-    The positive token is load-bearing. An arm that asserted only the ABSENCE of
-    the orchestrator marker cannot separate a correct refusal from a build path
-    that died, because the two emit the same bytes: none.
+    AN UNKNOWN FRAME IS A PRIMARY FRAME AND KEEPS THE LADDER. "unknown" means
+    agent_type was ABSENT, which is a no-`--agent` primary frame: an ordinary
+    user running plain `claude`. Withholding the ladder leaves the bootstrap
+    marker unstamped, and bootstrap_gate then denies Edit, Write and Agent on
+    every call. The notice rides BESIDE the ladder, never in place of it.
+
+    BOTH ASSERTIONS ARE PRESENCES, which is what makes this helper non-vacuous
+    in a fail-open hook: a build path that died emits no bytes and fails the
+    first assertion, so neither half can pass by accident.
     """
-    assert "YOUR PACT ROLE: orchestrator." not in additional, (
-        "an unknown frame is known NOT to be the lead, so it must not receive "
-        f"the orchestrator instructions. got: {additional[:120]!r}"
+    assert "YOUR PACT ROLE: orchestrator." in additional, (
+        "an unknown frame is a no-`--agent` PRIMARY frame and must receive the "
+        f"orchestrator instructions. got: {additional[:120]!r}"
     )
     assert _UNKNOWN_ROLE_FRAGMENT in additional, (
-        "an unknown frame must receive the unknown-role notice. got: "
+        "an unknown frame must also receive the unknown-role notice. got: "
         f"{additional[:120]!r}"
     )
 
@@ -3043,7 +3055,7 @@ def _run_session_init_for_path(
     tmp_path,
     source,
     team_exists,
-    agent_type=_LEAD_AGENT_TYPE,
+    agent_type: Optional[str] = _LEAD_AGENT_TYPE,
 ):
     """Helper for the contract tests below: runs main() under stable mocks
     and returns (additionalContext, kernel_call_count, routing_call_count)."""
@@ -3340,7 +3352,7 @@ def _compact_tasks_dir(tmp_path, monkeypatch, pact_context):
 
 def _run_session_init_compact(
     monkeypatch, tmp_path, *, team_exists=True, patch_get_task_list=None,
-    agent_type=_LEAD_AGENT_TYPE,
+    agent_type: Optional[str] = _LEAD_AGENT_TYPE,
 ):
     """Drive session_init.main() with source=compact and return the
     parsed additionalContext string plus the full output dict.
@@ -3634,14 +3646,21 @@ class TestSessionInitSlotAIntegration:
 
         Suppress that line here, so the assertion rests on the role branch
         instead of on an adjacent diagnostic. The fixture sends no
-        `agent_type`, so the frame classifies "unknown": that branch emits its
-        own notice, and it MUST write at index 0 like every other role branch,
-        so the banner is not the first thing a reader meets.
+        `agent_type`, so the frame classifies "unknown", which is a no-`--agent`
+        PRIMARY frame: that branch emits the orchestrator ladder, and it MUST
+        write at index 0 like every other role branch, so the banner is not the
+        first thing a reader meets.
 
-        The three non-vacuity assertions come first, because each names a way
-        this arm could pass while measuring nothing: a run that never reached
-        Slot 4c, a run where the pin-slot line came back, and an anchor that
-        cannot hold up a prefix test.
+        THE ANCHOR IS THE LADDER MARKER, NOT THE NOTICE. The notice rides
+        BESIDE the ladder at index 1, so the marker is what sits at byte 0.
+        Anchoring the prefix test on the notice would pin a POSITION the design
+        no longer holds, while the property under test (the role branch makes
+        an index-0 write, so the banner is not first) is unchanged.
+
+        The non-vacuity assertions come first, because each names a way this
+        arm could pass while measuring nothing: a run that never reached Slot
+        4c, a run where the pin-slot line came back, and an anchor that cannot
+        hold up a prefix test.
         """
         import session_init as _session_init
         from session_init import _UNKNOWN_ROLE_NOTICE
@@ -3665,19 +3684,26 @@ class TestSessionInitSlotAIntegration:
             "non-vacuity: the pin-slot line is back, so this arm no longer "
             "reproduces the pinless-checkout condition it exists to drive"
         )
-        assert _UNKNOWN_ROLE_FRAGMENT in _UNKNOWN_ROLE_NOTICE, (
-            "non-vacuity: the anchor does not carry this module's own literal, "
-            "so the startswith below is satisfiable by a degenerate constant "
-            "and measures nothing. An imported anchor inherits any degeneracy "
-            "of the source it comes from: startswith('') is correct for every "
-            "string, and a whitespace-only anchor matches the leading space of "
-            "the join. The independent literal is the yardstick."
+        # The anchor is a literal owned by THIS module, so it cannot inherit a
+        # degeneracy from the source: startswith('') is correct for every
+        # string, and an imported anchor could become empty without reddening.
+        ladder_marker = "YOUR PACT ROLE: orchestrator."
+        assert len(ladder_marker) > 20, (
+            "non-vacuity: the anchor is too short to hold up a prefix test"
         )
-        assert additional.startswith(_UNKNOWN_ROLE_NOTICE), (
-            "the unknown-role branch must write its notice at index 0 "
-            "(context_parts.insert(0, ...)), not append it — an appended "
-            "notice leaves the banner first for a frame with no other "
+        assert additional.startswith(ladder_marker), (
+            "the role branch must write the ladder at index 0 "
+            "(context_parts.insert(0, ...)), not append it — an appended role "
+            "message leaves the banner first for a frame with no other "
             "pre-banner diagnostic"
+        )
+        assert _UNKNOWN_ROLE_FRAGMENT in _UNKNOWN_ROLE_NOTICE, (
+            "non-vacuity: the notice literal no longer carries this module's "
+            "own fragment, so the delivery assertion below measures nothing"
+        )
+        assert _UNKNOWN_ROLE_NOTICE in additional, (
+            "the unknown-role notice must still be DELIVERED, beside the "
+            "ladder rather than in place of it"
         )
         assert not additional.startswith(banner), (
             "banner (Slot 4c) is the first element of additionalContext: the "
@@ -3754,7 +3780,11 @@ class TestTeamResumeDetection:
     """
 
     def _run_main_with_team_detection(
-        self, monkeypatch, tmp_path, stdin_data=None, agent_type=_LEAD_AGENT_TYPE
+        self,
+        monkeypatch,
+        tmp_path,
+        stdin_data=None,
+        agent_type: Optional[str] = _LEAD_AGENT_TYPE,
     ):
         """Helper: run main() with Path.home() pointed at tmp_path.
 
@@ -3794,7 +3824,8 @@ class TestTeamResumeDetection:
         )
 
         _assert_unknown_frame_body(additional)
-        assert "provided by the platform for this session" not in additional
+        # The team directive rides the ladder, so a primary frame gets it too.
+        assert "provided by the platform for this session" in additional
 
     def test_fresh_session_emits_team_create(self, monkeypatch, tmp_path):
         """When no team config exists on disk, should emit unified platform directive."""
@@ -3878,7 +3909,7 @@ class TestSourceAwareness:
 
     def _run_main_with_source(
         self, monkeypatch, tmp_path, source, team_exists=False,
-        agent_type=_LEAD_AGENT_TYPE,
+        agent_type: Optional[str] = _LEAD_AGENT_TYPE,
     ):
         """Helper: run main() with given source and team state.
 
@@ -3941,7 +3972,8 @@ class TestSourceAwareness:
         )
 
         _assert_unknown_frame_body(additional)
-        assert "provided by the platform for this session" not in additional
+        # The team directive rides the ladder, so a primary frame gets it too.
+        assert "provided by the platform for this session" in additional
 
     def test_startup_no_team_creates_team(self, monkeypatch, tmp_path):
         """startup + NO on-disk team: emit unified platform directive (bare — no recovery text).
@@ -4346,7 +4378,8 @@ class TestTeamCreateStringFreshSession:
         )
 
         _assert_unknown_frame_body(additional)
-        assert "provided by the platform for this session" not in additional
+        # The team directive rides the ladder, so a primary frame gets it too.
+        assert "provided by the platform for this session" in additional
 
     def test_does_not_contain_old_conditional_directive(self, monkeypatch, tmp_path):
         """The #444 unconditional directive must fully replace the old conditional.
@@ -4390,7 +4423,8 @@ class TestTeamReuseStringResumedSession:
         )
 
         _assert_unknown_frame_body(additional)
-        assert "provided by the platform for this session" not in additional
+        # The team directive rides the ladder, so a primary frame gets it too.
+        assert "provided by the platform for this session" in additional
 
     def test_does_not_contain_old_conditional_directive(self, monkeypatch, tmp_path):
         """The #444 unconditional directive must fully replace the old conditional form."""
@@ -4568,26 +4602,25 @@ class TestBuildSafetyNetContext:
             "(line-anchored for routing block consumer check)."
         )
 
-    def test_unknown_role_gets_neither_marker_nor_bootstrap(self):
-        """frame_role='unknown' means the classifier RAN and found no role, so
-        the frame is known NOT to be the lead: it gets NEITHER role marker and
-        NOT the lead-only bootstrap directive.
+    def test_unknown_role_gets_the_marker_the_bootstrap_and_the_notice(self):
+        """frame_role='unknown' means agent_type was ABSENT, which is a
+        no-`--agent` PRIMARY frame: an ordinary user running plain `claude`. It
+        gets the role marker at byte 0, the bootstrap directive, AND the
+        operator notice beside them.
 
-        PAIRS WITH test_lead_role_starts_with_pact_role_marker. The two of them
-        separate the roles the pre-repair helper merged, so a return of the
-        merge for either role alone cannot stay green.
+        PAIRS WITH test_lead_role_starts_with_pact_role_marker. The two roles
+        emit the same ladder and are separated by the notice, which only the
+        unknown frame receives, so a merge of the two cannot stay green.
 
-        The positive token is load-bearing. An arm that asserted ONLY the
-        absence of the marker cannot separate correct silence from a build path
-        that died, because both emit the same bytes: none.
+        WITHOUT THE BOOTSTRAP DIRECTIVE no marker is ever stamped, and
+        bootstrap_gate then denies Edit, Write and Agent on every tool call.
         """
         from session_init import _build_safety_net_context
 
         result = _build_safety_net_context(None, "unknown")
 
-        assert not result.startswith("YOUR PACT ROLE: orchestrator.")
-        assert "YOUR PACT ROLE:" not in result
-        assert 'Skill("PACT:bootstrap")' not in result
+        assert result.startswith("YOUR PACT ROLE: orchestrator.")
+        assert 'Skill("PACT:bootstrap")' in result
         assert "relaunch with `--agent PACT:pact-orchestrator`" in result
 
     def test_none_role_says_the_role_was_never_resolved(self):
@@ -5096,9 +5129,9 @@ class TestMainExceptionSafetyNet:
         additional = output["hookSpecificOutput"]["additionalContext"]
 
         _assert_unknown_frame_body(additional)
-        # The team-name branch is lead-only, so its text must not ride an
-        # unknown frame either.
-        assert "NOT GENERATED" not in additional
+        # The raise fires before generate_team_name, so team_name is None and
+        # the no-team wording is the correct half of the ladder to emit here.
+        assert "NOT GENERATED" in additional
         # systemMessage must still carry the original error: the role gate
         # changes WHO is addressed, not WHETHER the failure is reported.
         assert "simulated early failure" in json.dumps(output)
@@ -5659,7 +5692,9 @@ class TestSessionInitCompactBranchExceptions:
         additional = output["hookSpecificOutput"]["additionalContext"]
 
         _assert_unknown_frame_body(additional)
-        assert 'Invoke Skill("PACT:bootstrap") immediately' not in additional
+        # The bootstrap directive is the whole point of restoring the ladder:
+        # without it no marker is stamped and bootstrap_gate denies every tool.
+        assert 'Invoke Skill("PACT:bootstrap") immediately' in additional
 
     def test_main_with_invalid_json_input_never_raises(
         self, tmp_path, monkeypatch
@@ -5834,7 +5869,13 @@ class TestSessionInitDirectiveAcrossAllSources:
     _team_reuse but never had an explicit verbatim check.
     """
 
-    def _run(self, monkeypatch, tmp_path, source, agent_type=_LEAD_AGENT_TYPE):
+    def _run(
+        self,
+        monkeypatch,
+        tmp_path,
+        source,
+        agent_type: Optional[str] = _LEAD_AGENT_TYPE,
+    ):
         """Minimal driver for a compact/clear run with team_exists=True."""
         from session_init import main
 
@@ -5874,7 +5915,9 @@ class TestSessionInitDirectiveAcrossAllSources:
         additional = self._run(monkeypatch, tmp_path, source, agent_type=None)
 
         _assert_unknown_frame_body(additional)
-        assert 'Invoke Skill("PACT:bootstrap") immediately' not in additional
+        # The bootstrap directive is the whole point of restoring the ladder:
+        # without it no marker is stamped and bootstrap_gate denies every tool.
+        assert 'Invoke Skill("PACT:bootstrap") immediately' in additional
 
     def test_compact_source_contains_all_four_directive_sentences(
         self, monkeypatch, tmp_path

--- a/pact-plugin/tests/test_session_init.py
+++ b/pact-plugin/tests/test_session_init.py
@@ -4640,9 +4640,19 @@ class TestBuildSafetyNetContext:
         assert result == _build_safety_net_context(None, None), (
             "the omitted-argument case and the explicit None case must agree"
         )
+        # The distinguishing sentence is what keeps an unresolved frame apart
+        # from a resolved-empty one. It rides BESIDE the ladder, not instead.
         assert "failed before the session role was resolved" in result
-        assert "YOUR PACT ROLE:" not in result
-        assert 'Skill("PACT:bootstrap")' not in result
+        assert result.startswith("YOUR PACT ROLE: orchestrator."), (
+            "an unresolved frame lost the orchestrator marker. The classifier "
+            "not running says nothing about who the reader is, and that frame "
+            "is mostly a primary user who would then be denied every tool."
+        )
+        assert 'Skill("PACT:bootstrap")' in result
+        assert "relaunch with `--agent PACT:pact-orchestrator`" not in result, (
+            "an unresolved frame received the unknown-role notice, which "
+            "asserts a classifier result that was never computed"
+        )
 
     # The four team_name tests below pass frame_role="lead" EXPLICITLY. The
     # team_name argument is interpolated by the LEAD branch and by no other, so
@@ -5346,10 +5356,10 @@ class TestNonDictStdinNeverRaiseDominance:
             f"non-dict stdin ({label}) must hit the unresolved-role safety net; "
             f"got: {additional[:80]!r}"
         )
-        assert not additional.startswith("YOUR PACT ROLE: orchestrator."), (
-            f"non-dict stdin ({label}) must NOT be handed the orchestrator "
-            f"instructions: the role was never resolved, so the frame is not "
-            f"known to be the lead. got: {additional[:80]!r}"
+        assert additional.startswith("YOUR PACT ROLE: orchestrator."), (
+            f"non-dict stdin ({label}) lost the orchestrator instructions. The "
+            f"role was never resolved, which says nothing about the reader, "
+            f"and that frame is mostly a primary user. got: {additional[:80]!r}"
         )
         spy.assert_not_called()
 

--- a/pact-plugin/tests/test_session_init_integration.py
+++ b/pact-plugin/tests/test_session_init_integration.py
@@ -203,26 +203,30 @@ class TestCompactReadInstructionRealSeam:
     ==========================================================================
     """
 
-    def test_unknown_frame_gets_the_notice_not_the_archive_instruction(
+    def test_unknown_frame_gets_the_notice_and_the_archive_instruction(
         self, tmp_path, monkeypatch
     ):
         """PAIRED UNKNOWN ARM, at the real-composition seam.
 
-        The two arms below drive a LEAD frame, which is the frame the archive
-        instruction is written for. This arm keeps the UNKNOWN frame they used
-        to build by accident, so the seam covers both branches of the role gate
-        rather than trading one for the other. It runs the assembled hook, so it
-        also proves the unknown branch survives composition and is not an
-        artefact of the unit mocks.
+        The two arms below drive a LEAD frame. This arm drives the UNKNOWN
+        frame, which is a no-`--agent` PRIMARY frame and takes the SAME compact
+        ladder, so the seam covers both branches of the role gate rather than
+        trading one for the other. It runs the assembled hook, so it also proves
+        the branch survives composition and is not an artefact of the unit
+        mocks.
+
+        THE NOTICE IS WHAT SEPARATES THE TWO ROLES HERE. Both frames get the
+        ladder and the archive instruction, and only the unknown frame gets the
+        notice, so a collapse of the two roles reddens this arm.
         """
         sid = "aabb1122-0000-0000-0000-000000000000"
         ctx = _run_compact_main(tmp_path, monkeypatch, sid, agent_type=None)
 
-        assert "YOUR PACT ROLE: orchestrator." not in ctx
+        assert "YOUR PACT ROLE: orchestrator." in ctx
         assert _UNKNOWN_ROLE_FRAGMENT in ctx
-        # The archive instruction is lead-only guidance, so it must not ride an
-        # unknown frame either.
-        assert "compact-summary.txt" not in ctx
+        # The archive instruction rides the compact ladder, so a primary frame
+        # that compacts receives it too.
+        assert "compact-summary.txt" in ctx
 
     def test_real_session_id_names_the_resolved_archive_directory(
         self, tmp_path, monkeypatch

--- a/pact-plugin/tests/test_session_init_primary_frame_keeps_the_ladder.py
+++ b/pact-plugin/tests/test_session_init_primary_frame_keeps_the_ladder.py
@@ -1,0 +1,255 @@
+"""A PRIMARY frame with no ``--agent`` must keep the orchestrator ladder.
+
+THE DEFECT THESE ARMS CLOSE. ``classify_session_role`` returns "unknown" when
+``agent_type`` is ABSENT, and its own docstring names what that covers: "a
+non-PACT / no-``--agent`` primary frame". A role gate that SUPPRESSES the
+orchestrator ladder for "unknown" therefore suppresses it for every user who
+runs plain ``claude``. That user is not told to bootstrap, so the bootstrap
+marker is never stamped, so ``bootstrap_gate`` (PreToolUse, no matcher key,
+runs on EVERY tool call) denies Edit, Write and Agent. The user reads that as a
+total tool-load failure.
+
+THE SUPPRESSION ALSO CANNOT REACH THE FRAMES IT WAS BUILT FOR, WHICH IS WHY
+THESE ARMS ASSERT A RESTORE RATHER THAN A NARROWING. Its stated target was
+subagent frames that received the orchestrator instructions. MEASURED, with the
+parameter beside the count. POPULATION: 166 files matching ``subagents/*.jsonl``
+for one team session. 13 of them carry a SessionStart record, and those records
+hold 70 SessionStart entries. EVERY ONE of the 70 has ``type == "attachment"``
+and carries the LEAD session id, not a subagent session id: the set of distinct
+session ids across all 70 has exactly ONE member and it is the lead. They are
+the LEAD's own hook output, which the platform attaches into the transcripts of
+the sidechains that are live at that moment. Those frames classify "lead", so
+they take the lead branch in either version, and a gate keyed on "unknown"
+cannot change one byte of them. NO SUBAGENT FRAME REACHES THIS HOOK: 150 of the
+166 files hold no SessionStart record of any kind.
+
+WHAT THE NOTICE IS FOR, AND WHY IT IS ADDITIVE. ``_UNKNOWN_ROLE_NOTICE`` tells
+an operator who MEANT to launch the orchestrator and forgot the flag. That cue
+is worth keeping. It is emitted BESIDE the ladder, never in place of it,
+because the cost of withholding the ladder is a denied user and the cost of the
+notice is a few hundred bytes.
+
+THE ARMING PROBLEM THESE ARMS ANSWER. ``session_init`` is fail-open by
+contract, so a hook that emits nothing and a hook that ran and correctly said
+nothing produce the same bytes, which are none. AN ARM THAT ASSERTS ONLY AN
+ABSENCE CANNOT SEPARATE THOSE TWO STATES. Every arm below asserts a PRESENCE
+and an ABSENCE together, so the absence half is measured inside a run that
+provably reached the emission point.
+"""
+import io
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_HOOKS = Path(__file__).parent.parent / "hooks"
+if str(_HOOKS) not in sys.path:
+    sys.path.insert(0, str(_HOOKS))
+
+import session_init  # noqa: E402
+from session_init import _build_safety_net_context, _UNKNOWN_ROLE_NOTICE  # noqa: E402
+
+LADDER = "YOUR PACT ROLE: orchestrator."
+BOOTSTRAP = 'Skill("PACT:bootstrap")'
+TEAMMATE_MARKER = "YOUR PACT ROLE: teammate."
+_SESSION_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+_PROJECT_DIR = "/tmp/pact-primary-frame-ladder"
+
+# The four lifecycle sources a primary frame can arrive with. `clear` is listed
+# because it is the WORST cell and the one an author is most likely to skip:
+# session_init sets `is_marker_reset = source == "clear"` and then ERASES the
+# bootstrap marker on that path. A primary `clear` frame with no ladder loses
+# the marker AND the instruction that would rebuild it.
+PRIMARY_SOURCES = ("startup", "resume", "compact", "clear")
+
+
+def _run_main(frame, source, monkeypatch, tmp_path):
+    """Drive the real ``session_init.main()`` and return its additionalContext.
+
+    Heavy collaborators are stubbed. THE ROLE GATE IS NOT STUBBED: the frame
+    carries the agent type the classifier reads, so the branch under test is
+    the branch the hook takes in production.
+    """
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", _PROJECT_DIR)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    stdin_data = json.dumps({"session_id": _SESSION_ID, "source": source, **frame})
+    with patch("session_init.setup_plugin_symlinks", return_value=None), \
+         patch("session_init.ensure_project_memory_md", return_value=None), \
+         patch("session_init.check_pinned_staleness", return_value=None), \
+         patch("session_init.get_task_list", return_value=None), \
+         patch("session_init.restore_last_session", return_value=None), \
+         patch("session_init.build_context_cache",
+               return_value=(Path("/tmp/ctx.json"), {})), \
+         patch("session_init.persist_context", return_value=None), \
+         patch("session_init.append_event"), \
+         patch("session_init.update_session_info", return_value=None), \
+         patch("session_init.check_resume_state", return_value=None), \
+         patch("session_init._registry_resolve", return_value=None), \
+         patch("session_init.get_peer_context", return_value=None), \
+         patch("sys.stdin", io.StringIO(stdin_data)), \
+         patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+        with pytest.raises(SystemExit) as exc:
+            session_init.main()
+    assert exc.value.code == 0
+    raw = mock_stdout.getvalue().strip()
+    if not raw:
+        return ""
+    return json.loads(raw).get("hookSpecificOutput", {}).get("additionalContext", "")
+
+
+class TestPrimaryFrameKeepsTheLadder:
+    """The live emission path, driven through ``main()``."""
+
+    @pytest.mark.parametrize("source", PRIMARY_SOURCES)
+    def test_primary_frame_keeps_the_ladder_and_the_bootstrap_directive(
+        self, source, monkeypatch, tmp_path
+    ):
+        """THE ARM THAT CLOSES THE REGRESSION, one cell for each source.
+
+        SEPARATION: the emitted block must be non-empty first, so a dead build
+        path fails on that assertion rather than on the ladder assertion. Then
+        BOTH the marker and the bootstrap directive are asserted, because the
+        marker alone does not make a lead bootstrap.
+        """
+        out = _run_main({}, source, monkeypatch, tmp_path)
+        assert out, (
+            f"a primary frame (source={source!r}, no agent_type) emitted NO "
+            f"additionalContext at all. That is the not-delivered state rather "
+            f"than the declined state: the run did not reach the emission point."
+        )
+        assert LADDER in out, (
+            f"a PRIMARY frame (source={source!r}, no agent_type) lost the "
+            f"orchestrator marker. A user who runs plain `claude` classifies "
+            f"'unknown', so suppressing the ladder for 'unknown' suppresses it "
+            f"for that user, who is then denied Edit/Write/Agent by "
+            f"bootstrap_gate because no bootstrap marker is ever stamped."
+        )
+        assert BOOTSTRAP in out, (
+            f"a PRIMARY frame (source={source!r}) kept the role marker but lost "
+            f"the bootstrap directive. The marker alone does not cause a "
+            f"bootstrap, so the marker is never stamped and the deny stands."
+        )
+
+    @pytest.mark.parametrize("source", PRIMARY_SOURCES)
+    def test_primary_frame_also_keeps_the_unknown_role_notice(
+        self, source, monkeypatch, tmp_path
+    ):
+        """The notice is ADDITIVE, not a replacement.
+
+        SEPARATION: the ladder is the presence half that proves this run took
+        the restored branch, so a green here cannot come from a build that
+        suppressed the ladder and emitted the notice alone.
+        """
+        out = _run_main({}, source, monkeypatch, tmp_path)
+        assert LADDER in out, (
+            "the ladder is missing, so this arm cannot show that the notice "
+            "rides BESIDE it rather than in place of it"
+        )
+        assert _UNKNOWN_ROLE_NOTICE in out, (
+            f"a primary frame (source={source!r}) lost the unknown-role notice. "
+            f"An operator who meant to pass `--agent` loses the only cue that "
+            f"is delivered on a channel a transcript keeps."
+        )
+
+    def test_an_unrecognized_source_still_keeps_the_ladder(
+        self, monkeypatch, tmp_path
+    ):
+        """THE FAILURE DIRECTION ON AN UNKNOWN INPUT, ARMED.
+
+        The source ladder has a final else-branch for a `source` value it does
+        not recognize. A future platform that adds a FIFTH source value lands
+        there, and it MUST land on the restore side. This arm exists so that a
+        later edit cannot quietly move the unrecognized branch to the suppress
+        side: the value below is not one of the four the ladder names, so it
+        reaches that branch by construction.
+
+        SEPARATION: the run must emit something first, then the ladder and the
+        bootstrap directive are asserted together, and the branch is confirmed
+        by its own diagnostic sentence.
+        """
+        out = _run_main({}, "a-source-nobody-has-added-yet", monkeypatch, tmp_path)
+        assert out, "the unrecognized-source branch emitted NO additionalContext"
+        assert "unrecognized session source" in out, (
+            "this run did not reach the unrecognized-source branch, so the "
+            "assertions below measure a different branch than the one named"
+        )
+        assert LADDER in out, (
+            "an unrecognized `source` value lost the orchestrator marker. The "
+            "failure direction on an unknown input must be RESTORE, so a "
+            "future platform source value cannot deny a user."
+        )
+        assert BOOTSTRAP in out, (
+            "the unrecognized-source branch kept the marker and lost the "
+            "bootstrap directive, so no marker is stamped and the deny stands"
+        )
+
+    def test_lead_frame_is_unchanged(self, monkeypatch, tmp_path):
+        """THE ARM THAT BOUNDS THE FIX. A lead frame must not move."""
+        out = _run_main(
+            {"agent_type": "PACT:pact-orchestrator"}, "startup", monkeypatch, tmp_path
+        )
+        assert out, "a lead frame emitted NO additionalContext at all"
+        assert LADDER in out, "a LEAD frame lost its orchestrator instructions"
+        assert _UNKNOWN_ROLE_NOTICE not in out, (
+            "a lead frame received the unknown-role notice, so the lead branch "
+            "now falls through to the primary-frame branch"
+        )
+
+    def test_teammate_frame_is_unchanged(self, monkeypatch, tmp_path):
+        """THE OTHER BOUND. A teammate must gain neither the ladder nor the
+        notice. If this fix were too wide, a teammate would self-identify as
+        the orchestrator, which is the defect the teammate branch exists for."""
+        out = _run_main(
+            {"agent_type": "some-teammate-name"}, "startup", monkeypatch, tmp_path
+        )
+        assert LADDER not in out, (
+            "a teammate frame received the orchestrator instructions"
+        )
+        assert _UNKNOWN_ROLE_NOTICE not in out, (
+            "a teammate frame received the unknown-role notice, so the teammate "
+            "branch now falls through to the primary-frame branch"
+        )
+
+
+class TestSafetyNetPrimaryFrame:
+    """The exception path. ``_build_safety_net_context`` is pure, so each case
+    is driven directly."""
+
+    def test_unknown_keeps_the_ladder_and_the_note(self):
+        out = _build_safety_net_context("session-x", "unknown")
+        assert out, "the safety net returned an empty string for an unknown frame"
+        assert LADDER in out, (
+            "the safety-net unknown branch withholds the orchestrator marker. "
+            "A primary frame reaching the exception window is the same user as "
+            "on the normal path and must not be denied."
+        )
+        assert BOOTSTRAP in out, (
+            "the safety-net unknown branch kept the marker but dropped the "
+            "bootstrap directive, so no marker is stamped and the deny stands"
+        )
+        assert _UNKNOWN_ROLE_NOTICE in out, (
+            "the safety-net unknown branch lost the operator cue, which must "
+            "ride BESIDE the ladder"
+        )
+        assert TEAMMATE_MARKER not in out, (
+            "an unknown frame was labelled a teammate, which claims a role the "
+            "classifier did not find"
+        )
+
+    def test_lead_is_unchanged(self):
+        out = _build_safety_net_context("session-x", "lead")
+        assert out, "the safety net returned an empty string for a lead frame"
+        assert LADDER in out, "the safety net stopped delivering the lead ladder"
+        assert _UNKNOWN_ROLE_NOTICE not in out, (
+            "a lead frame received the unknown-role notice from the safety net"
+        )
+
+    def test_teammate_is_unchanged(self):
+        out = _build_safety_net_context("session-x", "teammate")
+        assert TEAMMATE_MARKER in out, "the teammate safety-net marker is gone"
+        assert LADDER not in out, "a teammate frame received the lead ladder"
+        assert _UNKNOWN_ROLE_NOTICE not in out, (
+            "a teammate frame received the unknown-role notice"
+        )

--- a/pact-plugin/tests/test_session_init_primary_frame_keeps_the_ladder.py
+++ b/pact-plugin/tests/test_session_init_primary_frame_keeps_the_ladder.py
@@ -238,6 +238,63 @@ class TestSafetyNetPrimaryFrame:
             "classifier did not find"
         )
 
+    def test_unresolved_role_keeps_the_ladder_and_its_own_diagnostic(self):
+        """A frame that never classified STILL gets the tools.
+
+        `frame_role is None` means the classifier DID NOT RUN, because the
+        raise fired above the capture. The frame behind it is the same
+        population as every other frame: mostly a primary user. Withholding
+        the ladder there leaves the bootstrap marker unstamped and
+        bootstrap_gate denies each tool call.
+
+        THE STATED PRICE OF WITHHOLDING IT WAS A REACTIVE ROUTE, and the field
+        report is evidence that route does not work: the reporter did not
+        recover through the deny text, he rolled the plugin back.
+
+        THE DIAGNOSTIC SENTENCE IS KEPT AND IS AN ADDITION OVER 4.6.34, WHICH
+        HAD NO None BRANCH AT ALL. It is what keeps an unresolved frame
+        separable from a resolved-empty one for a reader who debugs the early
+        window. It rides BESIDE the ladder, never in place of it.
+        """
+        out = _build_safety_net_context("session-x", None)
+        assert out, "the safety net returned an empty string for an unresolved frame"
+        assert LADDER in out, (
+            "an unresolved frame lost the orchestrator marker. The classifier "
+            "not running says nothing about who the reader is, and the "
+            "population behind that frame is mostly a primary user."
+        )
+        assert BOOTSTRAP in out, (
+            "an unresolved frame kept the marker and lost the bootstrap "
+            "directive, so no marker is stamped and the deny stands"
+        )
+        assert "before the session role was resolved" in out, (
+            "the unresolved-frame case lost its distinguishing sentence, so a "
+            "reader can no longer tell it from the resolved-empty case"
+        )
+
+    def test_unresolved_does_not_claim_the_unknown_role_fact(self):
+        """None and 'unknown' stay DIFFERENT, and the difference is a fact.
+
+        The unknown-role notice asserts that no `--agent` flag was recognized.
+        For an unresolved frame the classifier did not run, so that fact was
+        never established and the notice must NOT be emitted. Asserting it
+        would claim more than the system knows, which is the one half of the
+        original None argument that survives.
+        """
+        out = _build_safety_net_context("session-x", None)
+        assert LADDER in out, (
+            "the ladder is missing, so this arm cannot show what rides beside it"
+        )
+        assert _UNKNOWN_ROLE_NOTICE not in out, (
+            "an unresolved frame received the unknown-role notice, which "
+            "asserts a classifier result that was never computed"
+        )
+        assert _build_safety_net_context("session-x", None) != \
+            _build_safety_net_context("session-x", "unknown"), (
+            "the None case and the 'unknown' case now emit identical text, so "
+            "the two have been collapsed into one"
+        )
+
     def test_lead_is_unchanged(self):
         out = _build_safety_net_context("session-x", "lead")
         assert out, "the safety net returned an empty string for a lead frame"

--- a/pact-plugin/tests/test_session_init_teammate_peer_inject.py
+++ b/pact-plugin/tests/test_session_init_teammate_peer_inject.py
@@ -176,32 +176,36 @@ class TestLeadKeepsOrchestratorBlockAndUnknownGetsNeither:
         assert _PEER_SENTINEL not in additional
         assert not mock_gpc.called, "lead frame must not call the peer-context builder"
 
-    def test_plain_unknown_frame_gets_neither_orchestrator_block_nor_peer_body(
+    def test_plain_unknown_frame_gets_the_orchestrator_block_but_no_peer_body(
         self, monkeypatch, tmp_path
     ):
-        """RETARGET, and this arm was a RETIRED EXPECTATION with the proof in
-        its own message. It used to assert the orchestrator block, and the
-        message gave the reason word for word: "unknown/plain frame behavior is
-        UNCHANGED (minimal scope) — it still receives the orchestrator block as
-        before this fix". That was a DEFERRAL, not a property: the earlier
-        change declined to touch the unknown path and said so. The role gate now
-        makes that deferred repair, so the deferral is spent.
+        """THE PLAIN FRAME KEEPS THE ORCHESTRATOR BLOCK, and the arm has now
+        held that expectation twice with one interlude.
 
-        The two surviving legs are unchanged and they are the ones the arm was
-        built for: no peer body, and no call to the peer-context builder. Only
-        the orchestrator leg flips, and it flips to the notice, not to silence,
-        so the arm asserts a POSITIVE token rather than an absence alone.
+        Its ORIGINAL message stated it word for word: "unknown/plain frame
+        behavior is UNCHANGED (minimal scope) - it still receives the
+        orchestrator block as before this fix". A later change read that as a
+        spent DEFERRAL and flipped the arm to assert suppression. THAT READING
+        WAS WRONG, and the census behind it measured a population that never
+        reaches this hook. A plain frame is a no-`--agent` PRIMARY frame: an
+        ordinary user running plain `claude`. Suppressing its block leaves the
+        bootstrap marker unstamped and bootstrap_gate then denies every tool.
+
+        The two legs this arm was BUILT for are unchanged throughout: no peer
+        body, and no call to the peer-context builder. The notice is asserted
+        beside the block, so the plain frame stays separable from a lead frame.
         """
         additional, mock_gpc = _run_main_capture(
             _stdin_for(plain_frame()), monkeypatch, tmp_path
         )
-        assert _ORCH_MARKER not in additional, (
-            "an unknown/plain frame is known NOT to be the lead, so it must not "
-            "be handed the orchestrator block"
+        assert _ORCH_MARKER in additional, (
+            "an unknown/plain frame is a no-`--agent` PRIMARY frame and must "
+            "keep the orchestrator block: without it no bootstrap marker is "
+            "stamped and bootstrap_gate denies Edit, Write and Agent"
         )
         assert "relaunch with `--agent PACT:pact-orchestrator`" in additional, (
-            "the unknown frame must receive the unknown-role notice: a bare "
-            "absence cannot separate correct silence from a build that died"
+            "the unknown frame must also receive the unknown-role notice, "
+            "which is what separates it from a genuine lead frame"
         )
         assert _PEER_SENTINEL not in additional
         assert not mock_gpc.called

--- a/pact-plugin/tests/test_session_init_teammate_peer_inject_acceptance.py
+++ b/pact-plugin/tests/test_session_init_teammate_peer_inject_acceptance.py
@@ -272,12 +272,11 @@ class TestLeadKeepsOrchestratorBlockAndUnknownGetsNeither:
         assert _ORCH_MARKER in additional
         assert _PEER_LIST_PREFIX not in additional
 
-    def test_plain_unknown_frame_emits_neither_block_nor_peer_body(self, tmp_path):
-        """RETARGET of test_plain_unknown_frame_emits_orchestrator_block_not_peer_body.
-        The unit-level twin in test_session_init_teammate_peer_inject.py carries
-        the full reasoning. This is the real-composition half: it drives the
-        assembled hook rather than a mocked seam, so it proves the unknown
-        branch survives composition and is not an artefact of the unit mocks.
+    def test_plain_unknown_frame_emits_the_block_but_no_peer_body(self, tmp_path):
+        """The unit-level twin in test_session_init_teammate_peer_inject.py
+        carries the full reasoning. This is the real-composition half: it drives
+        the assembled hook rather than a mocked seam, so it proves the branch
+        survives composition and is not an artefact of the unit mocks.
         """
         frame = {
             "session_id": _SESSION_ID,
@@ -286,7 +285,7 @@ class TestLeadKeepsOrchestratorBlockAndUnknownGetsNeither:
             "hook_event_name": "SessionStart",
         }
         additional, _ = _run_real_session_init(frame, tmp_path)
-        assert _ORCH_MARKER not in additional
+        assert _ORCH_MARKER in additional
         assert "relaunch with `--agent PACT:pact-orchestrator`" in additional
         assert _PEER_LIST_PREFIX not in additional
 

--- a/pact-plugin/tests/test_session_init_three_way_role_gate.py
+++ b/pact-plugin/tests/test_session_init_three_way_role_gate.py
@@ -187,18 +187,25 @@ class TestSafetyNetThreeWay:
         )
 
     def test_none_is_ruled_separately_from_unknown(self):
-        """None and 'unknown' are DIFFERENT facts and get DIFFERENT text. A
-        reader debugging an early-window failure must be able to tell that the
-        role was never resolved rather than resolved-empty."""
+        """None and 'unknown' are DIFFERENT facts and get DIFFERENT text.
+
+        THE TWO SHARE THE LADDER AND DIFFER IN THE CUE. An unresolved frame
+        keeps the orchestrator instructions, because the classifier not
+        running says nothing about the reader, and that frame is mostly a
+        primary user. What separates it is its own sentence, which a reader
+        who debugs the early window needs to tell an unresolved frame from a
+        resolved-empty one.
+        """
         out = _build_safety_net_context("session-x", None)
         assert out, "the safety net returned an empty string for an unresolved frame"
         assert "before the session role was resolved" in out, (
             "the unresolved-frame case lost its distinguishing sentence, so it "
             "can no longer be told apart from the resolved-empty case"
         )
-        assert LADDER not in out, (
-            "an unresolved frame received the lead ladder. An earlier comment "
-            "called that a known no-regression default. It is the misroute."
+        assert LADDER in out, (
+            "an unresolved frame lost the lead ladder. Withholding it denies "
+            "an ordinary user every tool, and the reactive route that was "
+            "supposed to cover that cost did not work in the field."
         )
         assert _build_safety_net_context("session-x", None) != \
             _build_safety_net_context("session-x", "unknown"), (

--- a/pact-plugin/tests/test_session_init_three_way_role_gate.py
+++ b/pact-plugin/tests/test_session_init_three_way_role_gate.py
@@ -1,17 +1,28 @@
-"""The session-start role gate must consume all THREE classifier values.
+"""The session-start role gate must route each classifier value correctly.
 
-WHAT WENT WRONG. `classify_session_role` returns "lead", "teammate" or
-"unknown". Both emitters of the orchestrator instructions consumed TWO of the
-three: `if frame_role == "teammate": ... else: <orchestrator ladder>`. A LEAD
-frame and an UNKNOWN frame took the same branch and emitted the same bytes, so
-a frame of unknown role was handed the instructions that do the most damage in
-the wrong hands.
+`classify_session_role` returns "lead", "teammate" or "unknown". THE ROUTING
+THESE ARMS PIN: "teammate" gets the teammate body, and "lead" AND "unknown"
+BOTH get the orchestrator ladder, with "unknown" also receiving the operator
+notice beside it.
 
-MEASURED, with the parameter beside the count. Population: the 155 files
-matching `subagents/*.jsonl` for one team session. 13 of those frames fired a
-compact SessionStart, and 13 of 13 received the orchestrator instructions. The
-branch that emits them needs an ABSENT agent type to be reached, so those
-frames classified as "unknown".
+AN EARLIER FORM OF THIS FILE ASSERTED THE OPPOSITE FOR "unknown", ON A CENSUS
+THAT DID NOT MEASURE THAT POPULATION. It read: 155 files matching
+`subagents/*.jsonl` for one team session, 13 of which fired a compact
+SessionStart and received the orchestrator instructions, concluded to be
+"unknown" frames. RE-MEASURED, with the parameter beside the count: of 166
+such files, 13 carry a SessionStart record, holding 70 records between them,
+and ALL 70 have `type == "attachment"` and carry the LEAD session id. The set
+of distinct session ids across the 70 has exactly ONE member. They are the
+LEAD's own hook output, attached by the platform into the transcripts of the
+live sidechains. Those frames classify "lead", so a gate keyed on "unknown"
+cannot change one byte of them, and 150 of the 166 files carry no SessionStart
+record at all. NO SUBAGENT FRAME REACHES THIS HOOK.
+
+WHY "unknown" MUST KEEP THE LADDER: it means agent_type was ABSENT, which is a
+no-`--agent` PRIMARY frame, an ordinary user running plain `claude`. The fuller
+coverage of that case lives in
+`test_session_init_primary_frame_keeps_the_ladder.py`, which drives all four
+lifecycle sources. The arms here pin the ROUTING of the three values.
 
 WHY A LEAD KEEPS ITS LADDER, and it is measured rather than argued: `is_lead`
 returned true for this session, proven by the session context file, which no
@@ -101,24 +112,28 @@ class TestMainSiteThreeWay:
             "is_lead on its own evidence, which is what makes this safe."
         )
 
-    def test_unknown_frame_gets_no_ladder_and_a_note(self, monkeypatch, tmp_path):
-        """THE ARM THAT CLOSES THE DEFECT, and it carries its own non-vacuity.
-        SEPARATION: the note is the PRESENCE half, so the absence of the ladder
-        is measured inside a run that provably reached the emission point. With
-        the note dropped, a dead run would satisfy the absence half alone."""
+    def test_unknown_frame_gets_the_ladder_and_the_note(self, monkeypatch, tmp_path):
+        """AN UNKNOWN FRAME IS A PRIMARY FRAME AND KEEPS THE LADDER.
+
+        SEPARATION: the emitted block must be non-empty first, so a dead build
+        path fails there rather than on the ladder. The note is asserted
+        BESIDE the ladder, which is what makes the notice additive rather than
+        a replacement."""
         out = _run_main({}, monkeypatch, tmp_path)
         assert out, (
             "an unknown frame emitted NO additionalContext at all, so this arm "
-            "cannot tell a correct decline from a dead build path."
+            "cannot tell a correct emission from a dead build path."
+        )
+        assert LADDER in out, (
+            "an UNKNOWN frame lost the orchestrator instructions. 'unknown' "
+            "means agent_type was ABSENT, which is a no-`--agent` PRIMARY "
+            "frame: an ordinary user running plain `claude`. Withholding the "
+            "ladder leaves the bootstrap marker unstamped, and bootstrap_gate "
+            "then denies Edit, Write and Agent on every call."
         )
         assert _UNKNOWN_ROLE_NOTICE in out, (
-            "the unknown branch emitted no note. Without it the absence "
-            "assertion below is unfalsifiable in a fail-open hook."
-        )
-        assert LADDER not in out, (
-            "an UNKNOWN frame received the orchestrator instructions. That is "
-            "the defect: the gate consumed two of three classifier values and "
-            "sent unknown down the lead branch."
+            "the unknown branch emitted no note, so an operator who meant to "
+            "pass `--agent` loses the cue that rides beside the ladder."
         )
 
     def test_teammate_frame_gets_neither_the_ladder_nor_the_note(
@@ -154,14 +169,17 @@ class TestSafetyNetThreeWay:
         assert TEAMMATE_MARKER in out, "the teammate safety-net marker is gone"
         assert LADDER not in out, "a teammate frame received the lead ladder"
 
-    def test_unknown_gets_the_note_and_no_ladder(self):
+    def test_unknown_gets_the_note_and_the_ladder(self):
         out = _build_safety_net_context("session-x", "unknown")
-        assert _UNKNOWN_ROLE_NOTICE in out, (
-            "the unknown safety-net branch emitted no note, so the absence "
-            "assertion below cannot separate a decline from an empty return"
+        assert out, "the safety net returned an empty string for an unknown frame"
+        assert LADDER in out, (
+            "the safety-net unknown branch withholds the orchestrator marker. "
+            "A primary frame that reaches the exception window is the same "
+            "user as on the normal path and must not be denied."
         )
-        assert LADDER not in out, (
-            "an unknown frame received the lead ladder from the safety net"
+        assert _UNKNOWN_ROLE_NOTICE in out, (
+            "the unknown safety-net branch emitted no note, so the operator "
+            "cue is gone"
         )
         assert TEAMMATE_MARKER not in out, (
             "an unknown frame was labelled a teammate, which claims a role the "


### PR DESCRIPTION
## What this fixes

Claude Code 2.1.233 inverted a tool-gate predicate from opt-out to opt-in. On the
affected model families the host withholds `TaskCreate`, `TaskUpdate`, `TaskList`,
`TaskGet` and `TodoWrite` from a session unless it opts in. PACT cannot bootstrap
without them, and the deny text a user meets blames task creation, which is the one
thing they cannot do.

The remedy is one line of setup: `"CLAUDE_CODE_ENABLE_TODO_TOOLS": "1"` in the `env`
block of `~/.claude/settings.json`. Measured live three times, and corroborated by
vendor documentation.

**The previously advised `DISABLE_GROWTHBOOK` is retired and is not neutral.** With the
opt-in absent it forces the declared default, and the declared default withholds the
tools, so it reproduces the symptom rather than only failing to help. `DISABLE_TELEMETRY`
reaches the same default by another route. Those are two known routes and not a full list.

## Commits

**User-facing setup and release**

- `dc3abf31` Tell a user to set the task-tools variable
- `a21af40b` Strike a refuted reason from the namespace guardrail
- `aae35e8d` Bump the plugin version to 4.6.36
- `977f1704` Repair three contradictions in the README setup and repair sections
- `383c9b0d` Tell a tmux reader that a split-pane teammate is its own process

**Dispatch-instruction drift**

- `c1cba44f` Replace the dead resume instruction with what is known
- `d2fc7370` Re-purpose the stored agent_id as a name-collision handle
- `893eb84f` Remove the agent_id storage step
- `5197e971` Guard the non-spawn exclusion with a synthetic fixture
- `6a5c4eb1` Rank the three signals a tool gives about itself
- `01472649` Rank the three signals by distance from what decides

**Agent-facing surfaces**

- `2ad40ef1` Point both gates at the subsection that answers the reader — **ATOMIC, 4 files**
- `1b2fbb68` Name both gates in the Agent Teams status line — **ATOMIC, 2 files**
- `f7afd24e` Stop telling an agent it holds tools it may not hold
- `38ccd577` Stop the orchestrator concluding malformed dispatch when the host is the cause
- `4bc20145` Remove the refuted cost claim from the three surviving sites
- `69b56e2b` Move the tool-signal section below the dispatch steps and condense it

**Marker restoration**

- `afb1b2b9` Restore the orchestrator marker for a primary no-agent frame
- `e0ee03cf` Restore the orchestrator marker for an unresolved frame

### Two atomicity constraints that must survive any rebase

`2ad40ef1` holds two gates plus two pins together. Split it and one of three legs
reddens: ANTI-DRIFT asserts a single emitted URL, ESSENTIAL asserts the heading is in
the root README, and the deny-reason drift detector asserts the two-site literal.

`1b2fbb68` holds the SSOT and its gated extract together. Split it and the byte-match
gate in `tests/test_audit_protocol.py` reddens from a file neither edited file touches,
so a touched-file run reports green on a desynced tree.

## Corrections owed into this body

Four commit-message claims on this repository are wrong. Their original target merged,
so they land here. A later record stating where an earlier one was wrong is this
branch's convention; the two are read together. **The fourth was added after this pull
request merged**, and how it was nearly lost is stated with it, because that is the more
useful half.

### 1. RECORDED — the byte-identical claim

`367fff54` states that two edits one byte apart produced a BYTE-IDENTICAL document with
opposite verdicts. **The documents are not byte-identical.** They differ by one newline
at offset 16485, and the pin count goes 12 to 13 in each.

**The sentence that holds:** the two edits put the same pin in the same place and got
opposite verdicts. The error was the team lead's, written into the commit message. The
catch was `rv2-test`'s, measured against the committed tree rather than against the
message.

### 2. RECOVERED — the tier reason in `8baf68ab`

`8baf68ab` justifies its PATCH tier with: *"No command or agent is added or removed and
no user-facing behaviour shifts in operation."* **The branch falsifies the second half.**
`bab34190` landed three commits earlier and does shift behaviour in operation: the
symlink refresh now runs on a compact and on a clear, so a compact can emit a
user-visible message naming failed agent links, which it could not do before, and a
repoint appends a caveat.

**The tier verdict does not move, because a bug repair is PATCH. The reason must move.**

### 3. RECOVERED — a shipped instruction contradicting its own commit

`pact-plugin/commands/pin-memory.md:41` states: *"After a `Write`, a file that had CRLF
line endings has LF line endings."* Its commit `295a99b3` says the **read** normalises
line endings and the Write emits what it receives. Under the commit's account, an agent
that builds CRLF content and calls Write does not flatten.

**The action the instruction demands is correct. The attribution is wrong.**

### How items 2 and 3 were identified

The register naming them carried a pointer and no content: its description was truncated
mid-write, so whatever was intended was never stored. **Selection rule applied:** an
event before the register was written, asserting a specific commit's message is wrong as
a verdict rather than a hypothetical. Thirteen candidates matched the phrase; nine were
rejected as dispatch prose, provenance notes, or conditionals. The two above carry SHAs,
verify against the tree, predate the reset the register names, and are commit-message
corrections — every property the register states.

**One candidate was demoted after reading it in full.** An excerpt reading *"a commit
message that says the floor is now correct overstates it"* looked like a verdict. In
context it is a **prescription** for a message not yet written. The excerpt had cut the
tense.

### 4. RECOVERED AFTER MERGE — the tier ground in `aae35e8d`

`aae35e8d`, the version-bump commit of this branch, says the release repairs
documentation only, with no command, no agent and no behaviour change. **The diff refutes
all three.** The sentence was correct for the two commits it sat on, which move five files
of documentation and version metadata. It was incorrect for the release it named, because
a version-bump commit describes what the NUMBER covers, which is every commit since the
last bump.

**The tier does not move and its ground does.** PATCH is correct because a regression
repair is a bug fix. PATCH is not correct because the release is documentation-only, which
the diff refutes.

**How this one was nearly lost, which is the reusable part.** The correction was written
into a squash-body draft, and this repository squash-merges, so the branch commit message
it corrects never reaches the merged record. The draft was the only carrier, and it needed
a person to paste it at the merge. Nobody did. It was recovered from an `open_questions`
field that a schema-shaped reader had skipped. **A correction whose only carrier is a
document somebody must remember to paste is not recorded. It is scheduled.**

## Corrections carried from an earlier merged PR

Four claims recorded as owed into a PR body that merged before they could land.

1. **A marked-region size** published as 796 by two actors independently is **787 raw,
   785 flattened**. Both slices ran token-to-token rather than comment-to-comment and
   took in nine characters of the markers. Use the flattened count as the gate: it
   survives a re-wrap and a docstring indent.
2. **A fenced-block count** was given as "the fifteen bash fences" and also as "1 of the
   15 fenced blocks". Those cannot both hold. Correct: **15 total, 12 bash, 3 python.**
3. **A Learning II threshold** was said to be absent from a file that contains it. Three
   surfaces carry one number across three different populations, and the secretary body
   is the outlier.
4. **A Python adjudicator**: `compile()` passes 3 of 3 both before and after the fix, so
   it was never the judge of that defect class. Execution against a stub with the
   environment variable exported moved 0 of 3 to 3 of 3.

## Content removed deliberately

`69b56e2b` cuts an *"Acceptance is not action"* paragraph describing how a tool boundary
can discard an unknown key with no error. It is real content, cut because it is not about
which signal governs a call. **Restore address: `4bc20145`, file line 384.**

## Review

Four reviewers across the arc. The final round scored six pre-registered conditions,
written before the diffs existed so the list could not be fitted to them: rule survival
under subtraction, sweep scope, protected-region integrity, no replacement claim, parent
commits unchanged, and an independent post-commit sweep for under-reach. All pass.

Full suite green at the correct invocation: **14662 collected, 14647 passed, 15 skipped,
no failures, no errors**, run from `pact-plugin/` with no path argument. A path argument
collects 14614 and silently drops 48 skill-loading tests that live outside `tests/`.
