### PR TITLE
Point the merge-gate checklist at the tree-identity wrapper

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.36",
+      "version": "4.6.37",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.36/     # Plugin version
+│               └── 4.6.37/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.36",
+  "version": "4.6.37",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.36
+> **Version**: 4.6.37
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/testing/canary-checklist.md
+++ b/testing/canary-checklist.md
@@ -8,7 +8,7 @@ This checklist defines a 3-tier verification process for PRs that touch `pact-pl
 
 ## Tier 1: Automated Verification
 
-Run all verification scripts from the repository root. Every PR touching `pact-plugin/` must pass all four.
+Run all verification scripts from the repository root. Every PR touching `pact-plugin/` must pass all four. The pytest suite is a fifth obligation of this tier. It has its own row in the checklist below, and its own pass condition.
 
 ```bash
 bash scripts/verify-protocol-extracts.sh
@@ -31,12 +31,16 @@ Any script exiting with `VERIFICATION FAILED` (exit code 1) means the PR has bro
 
 ### Checklist
 
-**How to read these counts.** Each number is the `Passed: N` value of a run that ends with `Failed: 0`. It is the number of checks the script runs. Three of the four counts do not change. The `verify-scope-integrity.sh` count moves with the number of files in `pact-plugin/agents/`, and its row gives the rule that makes it checkable. The four rows follow:
+**How to read these counts.** Each number is the `Passed: N` value of a run that ends with `Failed: 0`. It is the number of checks the script runs. Three of the four counts do not change. The `verify-scope-integrity.sh` count moves with the number of files in `pact-plugin/agents/`, and its row gives the rule that makes it checkable. The four count rows follow, and the suite-run row follows them:
 
 - [ ] `verify-protocol-extracts.sh` passes (19 checks) -- each SSOT extract agrees with its section, anchored by H2 heading text. FIXED count: one check for each `verify` call in the script. `pact-plugin/tests/test_canary_checklist_count.py` reads this number and compares it against a run, so an edit to this row alone reddens that test.
 - [ ] `verify-scope-integrity.sh` passes (86 checks) -- cross-references, naming conventions, nesting limits, worktree integration, memory hooks, executor interface, agent persistent memory. THIS COUNT MOVES WITH THE AGENT DIRECTORY. It is 64 fixed checks, plus two loops across `pact-plugin/agents/`. The nesting-limit loop skips the 4 agents named in the `case` statement of the script and checks each remaining file. The `memory: user` loop checks each file. Today that directory holds 13 files, which gives 64 + 9 + 13 = 86. If you see a different number, count the agent files before you report a defect. `pact-plugin/tests/test_canary_checklist_count.py` reads the fixed-check count and the skip count from this row, predicts the total from a real count of the agent directory, and compares it against a run. Adding an agent file keeps that test green. Changing the fixed checks or the skip set without correcting this row reddens it.
 - [ ] `verify-task-hierarchy.sh` passes (28 checks) -- task lifecycle patterns in all command files. FIXED count: no check comes from the contents of a directory. `pact-plugin/tests/test_canary_checklist_count.py` reads this number and compares it against a run, so an edit to this row alone reddens that test. Adding a command file does not move the count.
 - [ ] `verify-worktree-protocol.sh` passes (20 checks) -- worktree skill existence, command references, path propagation. FIXED count: no check comes from the contents of a directory. `pact-plugin/tests/test_canary_checklist_count.py` reads this number and compares it against a run, so an edit to this row alone reddens that test. Adding a skill directory does not move the count.
+
+The suite-run row carries no check count, because the wrapper it names runs pytest and does not print a `Passed: N` line. Read its pass condition in [The suite run, and which tree it measured](#the-suite-run-and-which-tree-it-measured) below.
+
+- [ ] The merge-gate suite run passes, and its capture gives the branch you review -- run the suite through `scripts/verify-gate-tree.sh`. THIS ROW IS NOT TICKED AGAINST THE `**Expected output**` BLOCK ABOVE. Its pass condition is the eight-part list in [The suite run, and which tree it measured](#the-suite-run-and-which-tree-it-measured). READ the capture against that list. Tick this row only after the read. A tick made when the command returns is a tick for the exit code alone.
 
 ### What failures mean
 
@@ -46,6 +50,69 @@ Any script exiting with `VERIFICATION FAILED` (exit code 1) means the PR has bro
 | `verify-scope-integrity.sh` | A cross-reference was broken, a required pattern was removed, or a new agent file is missing expected content | Trace the `✗` output to the specific check and restore the expected pattern |
 | `verify-task-hierarchy.sh` | A command file's Task Hierarchy section is missing a lifecycle keyword (`TaskCreate`, `in_progress`, `completed`) | Add the missing lifecycle pattern to the command's Task Hierarchy section |
 | `verify-worktree-protocol.sh` | A command file lost its worktree skill reference or a skill file is missing its frontmatter | Restore the worktree reference or skill frontmatter |
+
+### The suite run, and which tree it measured
+
+The four scripts above do not run the pytest suite. Run the merge-gate suite through `scripts/verify-gate-tree.sh`, so that the capture file records which tree the run measured. A summary from a different checkout is correct about that checkout. It says nothing about the branch you review, and the two summaries read the same.
+
+**Before the run**, get the head commit of the branch you review from a source that is NOT the tree you are about to measure. The PR page gives it. Record it. You compare the capture against that commit below, and a commit read from the measured tree agrees with itself and checks nothing.
+
+```bash
+cd pact-plugin
+CAPTURE="/tmp/gate-$(basename "$(cd -P .. && pwd)").txt"
+rm -f "$CAPTURE"
+env -u PYTEST_ADDOPTS ../scripts/verify-gate-tree.sh "$(cd -P .. && pwd)" "$CAPTURE" -q
+echo "wrapper exit: $?"
+```
+
+The first argument is the worktree the run must measure. The second is the capture file. Each argument after those two goes to pytest. The script writes `GATE-TREE`, `GATE-HEAD`, `GATE-DIRTY-PATHS`, `GATE-CWD` and `GATE-COMMAND` above the pytest output, then appends `GATE-PYTEST-EXIT` at the end.
+
+Five properties of that command are load-bearing. Keep each one:
+
+- **No pytest argument names a path.** A path argument moves the tests pytest collects away from the tree the stamps name. The stamps stay correct about the declared tree, and the run measures a different one.
+- **Keep `-q`.** With it, the summary line is bare, in the shape `2 passed in 0.00s`. Without it, pytest decorates the same line, in the shape `============ 2 passed in 0.00s ============`. A check anchored on the start of the line then finds nothing, and that reads the same as a suite that did not start.
+- **Quote the capture argument.** Unquoted, a capture path that holds a space breaks into fragments. The capture goes to the first fragment, and the tail fragments join the pytest command line.
+- **Resolve the declared path physically with `$(cd -P .. && pwd)`.** `$PWD/..` keeps a symlinked spelling. If a symlink sits at the `pact-plugin` component, the wrapper then refuses a run that sits in the correct tree.
+- **Keep the `env -u PYTEST_ADDOPTS` prefix.** The variable reaches pytest without touching the command line, so no stamp records it. Measured: it narrows a run to 9 tests of 14662 with an exit of 0 and a clean stamp.
+
+**The declared path comes from the current directory, so the wrapper compares the current directory against itself.** That comparison catches a run started outside a git worktree. IT DOES NOT CATCH A RUN IN AN INCORRECT CHECKOUT. Only the stamps catch that, and only when you read them.
+
+#### Pass condition
+
+Read the capture first. Tick the Tier 1 row second. All eight must hold:
+
+1. **The wrapper exit is `0`**, read from the terminal at the moment of the run. This one cannot be read from the capture. A refusal exits `2` and writes NOTHING. pytest can also exit 2, so a 2 with a capture present is an interrupted run rather than a refusal. A capture from an earlier run at the same path then survives byte for byte, and it reads clean for a run that did not occur. The `rm -f` line and this exit code are the two guards against that.
+2. **The capture file is present.** If it is absent, the run refused and wrote nothing.
+3. **`GATE-TREE`** names the worktree you review.
+4. **`GATE-HEAD`** is the commit you recorded from the PR page. A literal `HEAD` on this line is not a commit. It means the tree carries no commit.
+5. **`GATE-DIRTY-PATHS`** is `0`. A count above zero means the tree holds changes that `GATE-HEAD` does not carry, so the run did not measure that commit alone.
+6. **`GATE-PYTEST-EXIT`** is `0`.
+7. **`GATE-COMMAND`** is `python3 -m pytest -q` and nothing more. A path, a `-k` filter, a `--co` or a `--lf` narrows what pytest collected. Items 1 to 6 stay correct for a narrowed run, and a narrowed run measured a part of the suite rather than the suite. Measured: `--co` exits 0 and runs no test, and a `-k` that selects a subset exits 0.
+8. **The summary line** in the capture reads `<N> passed`, with no `deselected` and no error count. `<N>` marks the SHAPE of the line. Do not fetch a number to compare it against, because an exported `PYTEST_ADDOPTS` reaches each later run in that shell, so a second count carries the same selection. This item catches a `-k` or `-m` selection and a collect-only run, and the source does not matter. IT DOES NOT CATCH A PATH, which narrows with a clean summary, and the `env -u` prefix is what closes that one. Measured: `PYTEST_ADDOPTS='tests/test_canary_checklist_count.py'` gives a stamp of `python3 -m pytest -q`, an exit of 0, and `9 passed` from a suite of 14662.
+
+Do not merge a PR of which the capture fails one of the eight.
+
+A route stays open. A `collect_ignore` entry in the pytest configuration narrows the run with a clean summary and a clean stamp, and a `testpaths` line or a path line does the same by the same mechanism. Where that line is committed, it is visible in review and it narrows CI in the same way, so it is recorded here rather than checked. Where the file is untracked, `GATE-DIRTY-PATHS` is above zero and item 5 catches it. Where the file is untracked AND an ignore rule matches it, nothing here catches it. A default marker expression is different: it deselects, so item 8 catches it. Measured: an ignored `conftest.py` with `collect_ignore` gives `GATE-DIRTY-PATHS 0`, a clean stamp and `1 passed` of 3 tests.
+
+#### A tree the wrapper refuses
+
+The script identifies the tree with git, and it reads the working directory to do it:
+
+- If the working directory has no git ancestor, the script refuses with exit code 2 and writes no capture.
+- If the working directory has a git ancestor, and the declared path resolves to that same ancestor, the script proceeds and stamps that ancestor.
+- If the declared path resolves elsewhere, the script refuses with exit code 2, and a symlink at the pact-plugin component is one route to that.
+- The script does not test how the files arrived in the directory.
+
+So the origin of a tree does not decide the outcome. Two things do: where the working directory sits, and where the declared path resolves. Measured: an export that carries no `.git`, unpacked in an enclosing worktree, proceeds and stamps the enclosing repository. A copy made with `cp -R` carries its own `.git`, proceeds, and stamps the copy path with the head of the source.
+
+For a directory with no git ancestor, call pytest directly and keep the output:
+
+```bash
+cd pact-plugin
+env -u PYTEST_ADDOPTS python3 -m pytest -q 2>&1 | tee /tmp/gate-no-tree.txt
+```
+
+That run writes no stamp, so it says nothing about which tree it measured. Do not tick the Tier 1 row from it.
 
 ---
 
@@ -79,7 +146,7 @@ Use the PACT framework on itself (dogfooding): run `/PACT:orchestrate` or `/PACT
 - [ ] **Handoff format is correct** -- Agent responses end with the 5-item HANDOFF structure (Produced, Key decisions, Areas of uncertainty, Integration points, Open questions)
 - [ ] **Memory saves succeed** -- The `pact-memory` skill saves context without errors; saved memories are retrievable via search
 - [ ] **Worktree lifecycle completes** -- `worktree-setup` creates a worktree, agents work within it, and `worktree-cleanup` removes it after PR
-- [ ] **Verification scripts pass in the worktree** -- All Tier 1 scripts pass when run from the worktree working directory
+- [ ] **Verification obligations pass in the worktree** -- All Tier 1 obligations pass when run from the worktree working directory
 - [ ] **Task tracking is consistent** -- Task statuses follow the `pending -> in_progress -> completed` lifecycle without orphaned or stuck tasks
 - [ ] **Phase transitions are clean** -- Each PACT phase completes with a handoff before the next begins; no phase is skipped without documented rationale
 


### PR DESCRIPTION
## What this changes

18 added lines in `testing/canary-checklist.md`, the one file that states what to run as a
gate before a merge and where the four `verify-*.sh` siblings are named.

## Why

A pytest run prints a count. The capture file does not record which checkout made that count.
So a run in the wrong checkout prints a clean summary that proves nothing about the branch
under review, and it reads the same as a faithful run.

`scripts/verify-gate-tree.sh` already refuses that case and stamps the tree identity into the
capture. It is on disk and executable. Nothing told a maintainer to use it. This adds the
pointer.

The failure class is not hypothetical here: a gate population that appeared to shrink between
two runs was traced to a wrong-tree run, not to collection. A count floor did not catch it.
Tree identity does.

## What the added text says

The two arguments, the five stamps written above the pytest output (`GATE-TREE`, `GATE-HEAD`,
`GATE-DIRTY-PATHS`, `GATE-CWD`, `GATE-COMMAND`) plus `GATE-PYTEST-EXIT` at the end, and the one
escape route: an exported or copied tree has no git identity, so the script refuses it with
exit code 2 and the operator calls pytest directly.

## One placement deliberately refused

`pact-plugin/tests/runbooks/live-probe-template.md` is a rule site and the pointer was kept out
of it. That template governs a per-hook integration suite, while the wrapper self-limits to the
merge-gate run. Sending an operator to a script outside its own stated scope is the same defect
as naming a wrong argument order.

## Gate

Predicted 14662 collected before the run. Measured 14647 passed + 15 skipped = 14662. Delta
zero. Errors token 0.

## Version bump

**4.6.36 to 4.6.37, PATCH, across the four canonical files.** `testing/` sits outside
`pact-plugin/` and does not ship, so no consumer session sees the changed file. The release
ledger advances on every merge regardless, so a merged change that ships nothing still moves the
version.

An earlier revision of this body claimed no bump was needed. That was wrong against this
project's own convention and against precedent: the eight most recent merges to `main` each
touched `plugin.json`, including a CI-config-only change. Three reviewers read the incorrect
claim and none challenged it, because no reviewer was given repo-convention compliance as an
angle.

## Known residual, which no repository change can close

The canonical copy of the gate rule lives in the user-global `CLAUDE.md`, which is gitignored at
`.gitignore:18` and untracked. No repository change reaches it. That half is a user decision
about a file only the user maintains, not a permission question, and it stays open after this
merges.

