### PR TITLE
Pin the canonical-journal frame gate at all six of its sites

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "PACT",
       "source": "./pact-plugin",
       "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
-      "version": "4.6.39",
+      "version": "4.6.40",
       "author": {
         "name": "Synaptic-Labs-AI"
       },

--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ When installed as a plugin, PACT lives in your plugin cache:
 │   └── cache/
 │       └── pact-plugin/
 │           └── PACT/
-│               └── 4.6.39/     # Plugin version
+│               └── 4.6.40/     # Plugin version
 │                   ├── agents/
 │                   ├── commands/
 │                   ├── skills/

--- a/pact-plugin/.claude-plugin/plugin.json
+++ b/pact-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PACT",
-  "version": "4.6.39",
+  "version": "4.6.40",
   "description": "Orchestration harness that turns Claude Code into a coordinated team of specialist AI agents",
   "author": {
     "name": "Synaptic-Labs-AI",

--- a/pact-plugin/README.md
+++ b/pact-plugin/README.md
@@ -1,6 +1,6 @@
 # PACT — Orchestration Harness for Claude Code
 
-> **Version**: 4.6.39
+> **Version**: 4.6.40
 
 Turn a single Claude Code session into a managed team of specialist AI agents that prepare, design, build, and test your code systematically.
 

--- a/pact-plugin/hooks/missed_wake_scan.py
+++ b/pact-plugin/hooks/missed_wake_scan.py
@@ -27,8 +27,10 @@ sent, would already have landed.
 
 WHY LEAD-SIDE (is_lead-gated): the missed wake is a LEAD failure (the lead wrote
 completion metadata but forgot the paired wake), and only the lead can ACT on
-the alarm AND write the canonical journal (journal-resolvability is
-process-scoped). Teammate / plain frames no-op — the in-process-default
+the alarm. The journal is NOT the cause: an in-process teammate frame reaches
+the canonical journal too (see is_canonical_journal_frame), so the ROLE is what
+makes this hook lead-side. Journal-resolvability stays process-scoped.
+Teammate / plain frames no-op — the in-process-default
 fail-safe branch. Activation keys on a RUNTIME STRUCTURAL signal (is_lead via
 agent_type), never a mode flag. UserPromptSubmit has no Agent()-spawned-teammate
 fire path, so the surfacer is single-writer (the lead's process) by construction.

--- a/pact-plugin/hooks/task_lifecycle_gate.py
+++ b/pact-plugin/hooks/task_lifecycle_gate.py
@@ -445,13 +445,16 @@ def _artifact_paths_event_present(workflow: str, feature: str) -> bool:
     """Return True iff an artifact_paths journal event exists for this
     (workflow, feature) in the CURRENT session's journal.
 
-    Uses the IMPLICIT read_events() (lead-frame): this backstop is is_lead-gated
-    at its single call site, so get_session_dir() resolves the canonical journal
-    in the lead's process. The off-lead masked-read hazard (read_events()
+    Uses the IMPLICIT read_events() (canonical-journal frame): this backstop is
+    is_canonical_journal_frame-gated at its single call site, so
+    get_session_dir() resolves the canonical journal in each frame that reaches
+    it (the lead in either teammateMode, and the in-process teammate, which
+    shares the lead session). The off-lead masked-read hazard (read_events()
     false-returning [] for a teammate frame) is strictly the SECRETARY HARVEST
-    reader's concern — that reader runs off-lead and MUST use
-    read_events_from(session_dir); this backstop does not, because it never runs
-    off-lead. The hook frame carries no worktree/session_dir to pass anyway.
+    reader's concern: that reader runs off-lead and MUST use
+    read_events_from(session_dir). This backstop does not, because the frame
+    gate excludes the tmux teammate, the only frame that reads off-session.
+    The hook frame carries no worktree/session_dir to pass anyway.
 
     Fail-OPEN by construction: read_events swallows its own errors and returns []
     (treated as "absent" → the nudge fires). A false nudge is non-blocking and
@@ -589,8 +592,10 @@ def _writeback_audit_recovery(task_id: str, updates: dict) -> bool:
       - RECOVER : updates={"lead_close_note": <lead's overwriting value>}
 
     Task JSON lives in the team dir (~/.claude/tasks/{team}/), which is writable
-    from ANY teammate process — unlike the session journal, which self-drops in
-    a teammate context (#877). That is precisely why the auditor's verdict can
+    from ANY teammate process. The journal EMIT SEAMS are different: they are
+    frame-gated, so an emit drops in a tmux teammate frame and it fires in an
+    in-process teammate frame, which shares the lead's session. That is why the
+    auditor's verdict can
     be captured at AUTHOR time (the MIRROR), sidestepping the post-overwrite
     read-of-a-clobbered-value problem.
 
@@ -799,7 +804,7 @@ def _emit_dispatch_site(
     an owner gate there "would never fire". An owner-wiring predicate placed in
     that branch would return False forever: Q5 would stay exactly as dark as it
     is today with every test still green, and it would additionally inherit
-    that block's ``is_lead`` gate. The owner-wiring write is only observable on
+    that block's frame gate. The owner-wiring write is only observable on
     TaskUpdate, so that is where this lives.
 
     THE ORDER BELOW IS LOAD-BEARING, NOT STYLISTIC, and is kept in ONE ladder
@@ -929,8 +934,9 @@ def _emit_lead_side_agent_handoff(
     task, not a signal task, handoff present). The divergence-critical atoms
     (is_signal_task, occupant_hash, already_emitted) are SHARED via
     shared.agent_handoff_marker so the two paths cannot drift on signal-task
-    exclusion or the dedup key (#887 class). The b2-specific topology gate
-    (is_lead) is applied by the caller. Eligibility keys on handoff PRESENCE
+    exclusion or the dedup key (#887 class). The b2-specific frame gate
+    (is_canonical_journal_frame) is applied by the caller. Eligibility keys on
+    handoff PRESENCE
     (owner / not-teachback / not-signal / handoff-present), never on an
     owner-name prefix — bare owner names are the convention, so a `pact-`
     prefix gate would no-op. (A now-retired completion-time branch above once
@@ -1404,8 +1410,9 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
     #   MIRROR (non-lead writes audit_summary): durably snapshot the authored
     #     verdict → metadata.audit_summary_authored so a later lead overwrite of
     #     the live audit_summary key cannot lose it. Task JSON is team-dir-scoped
-    #     → writable from the auditor's teammate process (unlike the session
-    #     journal, which self-drops in a teammate context, #877). Capturing at
+    #     → writable from the auditor's teammate process. The journal EMIT SEAMS
+    #     are different: they are frame-gated, so an emit drops in a tmux
+    #     teammate frame and fires in an in-process teammate frame. Capturing at
     #     AUTHOR time is what sidesteps the post-overwrite read-of-a-clobbered-
     #     value problem (the prior is saved BEFORE the lead can clobber it).
     #   RECOVER (lead overwrites a DIVERGENT authored verdict): the prior is
@@ -1573,7 +1580,7 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
 
         # #955 dispatch_variety emit — GC-immune mirror of the per-dispatch
         # variety stamp. Fires on the TaskCreate of a Task-B carrying
-        # metadata.variety (one per dispatch, D3). Keyed on is_lead +
+        # metadata.variety (one per dispatch, D3). Keyed on the frame gate +
         # metadata.variety PRESENCE — NOT on owner (per orchestrate.md the
         # TaskCreate(B) sets metadata.variety but leaves owner empty; owner is
         # wired by a SEPARATE later TaskUpdate, so an owner gate here would never
@@ -1583,7 +1590,16 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
         # a missing id or an append failure skips the emit (coverage degrades by
         # one dispatch) but never breaks the gate's advisory evaluation or its
         # exit-0 contract.
-        if pact_context.is_lead(input_data):
+        #
+        # FRAME GATE - is_canonical_journal_frame, NOT is_lead. The emit must run
+        # in a process that writes the canonical journal: the lead frame in
+        # either teammateMode, AND the in-process teammate frame (session_id ==
+        # leadSessionId, one process one session). A tmux teammate frame skips,
+        # because an emit there can silo the event and poison the shared marker
+        # namespace. DO NOT restore is_lead: it returns False for a lead
+        # launched with no --agent flag, and that frame DOES write the canonical
+        # journal.
+        if pact_context.is_canonical_journal_frame(input_data):
             create_variety = (
                 incoming_metadata.get("variety")
                 if isinstance(incoming_metadata, dict)
@@ -1632,9 +1648,11 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
         # (PER_WRITE_MIRROR_KEYS) mirrors the whole payload immediately —
         # the create IS the first write of the open-task-consumed class.
         # SIBLING of the dispatch_variety block above, deliberately NOT
-        # nested under its is_lead gate: this leg carries its own frame
-        # gate (canonical-journal-frame) because targeted keys include
-        # teammate-written classes. The platform-assigned id exists only in
+        # nested under its gate: this leg carries its OWN frame gate. The
+        # two now use the SAME predicate (is_canonical_journal_frame), so
+        # the split is structural rather than a difference of predicate:
+        # each leg fires on its own eligibility. The platform-assigned id
+        # exists only in
         # the create response, so resolution goes through _created_task_id;
         # a missing id skips the emit (coverage degrades by one write,
         # never breaks the gate — the dispatch_variety posture). The
@@ -1691,12 +1709,17 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
         # owner names are the convention; cf. the retired branch above):
         # _emit_lead_side_agent_handoff applies the b1-mirrored emit-eligibility
         # (owner / not-teachback / not-signal / handoff-present) + the shared
-        # occupant-keyed dedup. Gated on
-        # is_lead so the emit only runs in the lead's process, where
-        # get_session_dir() resolves the canonical journal; a teammate
-        # self-completion (carve-out / disputed) has no populated context and
-        # is correctly skipped (it would no-op AND must not be double-counted).
-        if pact_context.is_lead(input_data):
+        # occupant-keyed dedup.
+        #
+        # FRAME GATE - is_canonical_journal_frame, NOT is_lead. The emit must run
+        # in a process that writes the canonical journal: the lead frame in
+        # either teammateMode, AND the in-process teammate frame (session_id ==
+        # leadSessionId, one process one session). A tmux teammate frame skips,
+        # because an emit there can silo the event and poison the shared marker
+        # namespace (it would no-op AND must not be double-counted). DO NOT
+        # restore is_lead: it returns False for a lead launched with no --agent
+        # flag, and that frame DOES write the canonical journal.
+        if pact_context.is_canonical_journal_frame(input_data):
             _emit_lead_side_agent_handoff(
                 team_name, task_id, owner, subject, metadata
             )
@@ -1746,14 +1769,22 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
         # the secretary distill the disk artifact at harvest; without it, that
         # phase degrades to HANDOFF-only recovery (the #927 failure path).
         #
-        # is_lead-gated, mirroring the lead-side emit above: only the lead's
-        # process resolves the canonical journal via the implicit read, and only
-        # the lead is the writer the nudge is aimed at. A teammate self-
-        # completion has no populated context and is correctly skipped.
+        # FRAME GATE - is_canonical_journal_frame, NOT is_lead. The emit must run
+        # in a process that writes the canonical journal: the lead frame in
+        # either teammateMode, AND the in-process teammate frame (session_id ==
+        # leadSessionId, one process one session). A tmux teammate frame skips,
+        # because an emit there can silo the event and poison the shared marker
+        # namespace. DO NOT restore is_lead: it returns False for a lead
+        # launched with no --agent flag, and that frame DOES write the canonical
+        # journal.
+        # The advisory reaches the same output surface in the in-process
+        # teammate frame (one process, one session), so the nudge is not
+        # misdirected there.
         #
         # This hook canNOT glob (no worktree path in the PostToolUse frame) — it
         # only DETECTS the missing emit (the journal read is path-independent in
-        # the lead frame) and nudges; it never blocks the TaskUpdate. EXEMPT:
+        # a canonical-journal frame) and nudges; it never blocks the TaskUpdate.
+        # EXEMPT:
         #   - CODE:/TEST:/ATOMIZE:/CONSOLIDATE:/other subjects → not in the
         #     phase→workflow map → _phase_artifact_requirement returns None →
         #     silent (their artifacts are git-tracked or non-existent).
@@ -1766,7 +1797,10 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
         # phase-output validation BEFORE the lead completes the phase task, so by
         # this PostToolUse(completed) the event is already on disk (a synchronous
         # journal append). Fail-open covers any residual race.
-        if pact_context.is_lead(input_data) and metadata.get("skipped") is not True:
+        if (
+            metadata.get("skipped") is not True
+            and pact_context.is_canonical_journal_frame(input_data)
+        ):
             requirement = _phase_artifact_requirement(subject)
             if requirement is not None:
                 workflow, feature = requirement
@@ -1827,11 +1861,20 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
             # completed) accepting the teachback. The ack lives on the DISK
             # Task-A (the teammate wrote teachback_submit earlier; the lead's
             # accept TaskUpdate carries only status), so read it from `metadata`
-            # (the on-disk post-state resolved above). is_lead-gated (mirrors b2):
-            # only the lead's process resolves the canonical journal; a teammate
-            # frame self-drops (#877). Best-effort: any malformed/absent ack or an
-            # append failure skips the emit without breaking the gate.
-            if pact_context.is_lead(input_data) and isinstance(teachback_submit, dict):
+            # (the on-disk post-state resolved above).
+            # FRAME GATE (mirrors b2) - is_canonical_journal_frame, NOT is_lead.
+            # The emit must run in a process that writes the canonical journal:
+            # the lead frame in either teammateMode, AND the in-process teammate
+            # frame (session_id == leadSessionId, one process one session). A
+            # tmux teammate frame skips, because an emit there can silo the
+            # event and poison the shared marker namespace. DO NOT restore
+            # is_lead: it returns False for a lead launched with no --agent
+            # flag, and that frame DOES write the canonical journal.
+            # Best-effort: any malformed/absent ack or an append failure skips
+            # the emit without breaking the gate.
+            if isinstance(teachback_submit, dict) and pact_context.is_canonical_journal_frame(
+                input_data
+            ):
                 ack = teachback_submit.get("variety_acknowledgment")
                 if isinstance(ack, dict):
                     flag = ack.get("rationale_articulates_this_dispatch")
@@ -2147,9 +2190,15 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
         # No new eligibility logic here. The only job of the backstop is to CALL
         # the emitter on the write event that b1 and b2 structurally cannot see.
         #
-        # is_lead-gated (mirrors b2 at the completion surface): only the lead's
-        # process resolves the canonical journal; a teammate frame self-drops
-        # (#877). The in-process/lead branch is the fail-safe default.
+        # FRAME GATE (mirrors b2 at the completion surface) -
+        # is_canonical_journal_frame, NOT is_lead. The emit must run in a
+        # process that writes the canonical journal: the lead frame in either
+        # teammateMode, AND the in-process teammate frame (session_id ==
+        # leadSessionId, one process one session). A tmux teammate frame skips,
+        # because an emit there can silo the event and poison the shared marker
+        # namespace. DO NOT restore is_lead: it returns False for a lead
+        # launched with no --agent flag, and that frame DOES write the canonical
+        # journal.
         #
         # ACCEPTED RESIDUAL: if this fires-open on a hard crash AND the handoff
         # is then never set in a later TaskUpdate, exactly one agent_handoff
@@ -2159,12 +2208,12 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
         # journal-emit failure must never break completion. One lost durable
         # record is strictly better than a stranded completion.
         if (
-            pact_context.is_lead(input_data)
-            and isinstance(incoming_handoff, dict)
+            isinstance(incoming_handoff, dict)
             and incoming_handoff
             and isinstance(task_a, dict)
             and task_a
             and task_a.get("status") == "completed"
+            and pact_context.is_canonical_journal_frame(input_data)
         ):
             owner_bs = task_a.get("owner") or ""
             subject_bs = task_a.get("subject") or ""
@@ -2194,15 +2243,22 @@ def evaluate_lifecycle(input_data: dict) -> list[tuple[str, str]]:
         # removes the key), so the overlay drops it rather than mirroring a
         # phantom null the disk state no longer carries; a delete-ONLY write
         # therefore mirrors the disk state as-is (deduping if unchanged).
-        # is_lead-gated like every lead-frame emit: only the lead's process
-        # resolves the canonical journal; a teammate frame self-drops.
+        # FRAME GATE like every canonical-frame emit -
+        # is_canonical_journal_frame, NOT is_lead. The emit must run in a
+        # process that writes the canonical journal: the lead frame in either
+        # teammateMode, AND the in-process teammate frame (session_id ==
+        # leadSessionId, one process one session). A tmux teammate frame skips,
+        # because an emit there can silo the event and poison the shared marker
+        # namespace. DO NOT restore is_lead: it returns False for a lead
+        # launched with no --agent flag, and that frame DOES write the canonical
+        # journal.
         if (
-            pact_context.is_lead(input_data)
-            and isinstance(incoming_metadata, dict)
+            isinstance(incoming_metadata, dict)
             and incoming_metadata
             and isinstance(task_a, dict)
             and task_a
             and task_a.get("status") == "completed"
+            and pact_context.is_canonical_journal_frame(input_data)
         ):
             try:
                 disk_md = (
@@ -2333,6 +2389,11 @@ def main() -> None:
         sys.exit(0)
 
     try:
+        # ORDERING IS LOAD-BEARING: init() must run BEFORE evaluate_lifecycle().
+        # The frame gates below resolve the team through get_team_name(), and an
+        # unpopulated context makes the topology leg unresolvable. The gate then
+        # degrades SILENTLY to is_lead and a canonical-frame emit is lost with no
+        # record. Do not move this call and do not make it lazy.
         pact_context.init(input_data)
         advisories = evaluate_lifecycle(input_data)
     except Exception as e:  # noqa: BLE001 — runtime catch-all → advisory

--- a/pact-plugin/tests/test_artifact_paths_durability.py
+++ b/pact-plugin/tests/test_artifact_paths_durability.py
@@ -460,18 +460,29 @@ class TestBackstopBothModes:
             "not nudge (this fixture seeds no leadSessionId team config)"
         )
 
-    def test_teammate_then_lead_same_fixture_proves_gate_is_the_frame(
+    def test_teammate_then_lead_same_fixture_attributes_the_silence_to_the_gate(
             self, live_env):
         """Non-vacuity for the boundary seal: the SAME (subject, no-emit)
-        fixture that is SILENT under the teammate frame FIRES under the lead
-        frame, proving the suppression is the frame gate and not a missing
-        precondition.
+        fixture that is SILENT at the teammate frame FIRES at the lead
+        frame. So the gate causes the silence when it rejects the frame. A
+        missing precondition does not cause it, because this fixture holds
+        the subject and the no-emit state fixed across the two drives.
 
-        THE NAME SAYS FRAME AND NOT ROLE, and the difference is load-bearing.
-        The teammate frame here is silent because this fixture seeds no
-        leadSessionId team config, so the TOPOLOGY leg cannot resolve. A
-        teammate frame that shares the lead session resolves it and DOES
-        nudge, so role is not what decides."""
+        🔴 WHAT THIS ARM CANNOT PROVE, AND ITS NAME MUST NOT CLAIM IT. The
+        arm does NOT separate the ROLE leg from the TOPOLOGY leg. Its two
+        inputs are a teammate frame with no team config, and a lead frame.
+        `is_lead` and `is_canonical_journal_frame` AGREE at each of them, so
+        a revert of the gate to `is_lead` keeps this arm GREEN. MEASURED:
+        the arm is missing from the failing set of that revert.
+
+        THE ARM THAT DOES PROVE IT is cell 2 of the agent_type matrix
+        below, `test_empty_or_missing_agent_type_resolvable_topology_nudges`.
+        That arm seeds the two topology halves, so the two predicates
+        DISAGREE there and the revert reddens it. Read the two together.
+
+        THE NAME OF THIS ARM SAID `proves_gate_is_the_frame` and before that
+        `proves_gate_is_role`. Each named a discrimination the fixture
+        cannot make. Do not restore either one."""
         _tmp, _session_dir = live_env
         teammate = tlg.evaluate_lifecycle(
             _payload(agent_type=TEAMMATE, subject=PREPARE_SUBJECT))

--- a/pact-plugin/tests/test_artifact_paths_durability.py
+++ b/pact-plugin/tests/test_artifact_paths_durability.py
@@ -17,8 +17,10 @@ DISCIPLINE (per the locked plan + this session's plan-mode strategy):
     team config. The teammate-frame arms below assert the backstop is ABSENT,
     and that absence holds ONLY because those fixtures seed no leadSessionId
     team config, so the topology leg cannot resolve. A session_id-topology
-    fixture DOES test a gate input this surface reads, and the in-process
-    teammate arm it makes possible is currently uncovered.
+    fixture DOES test a gate input this surface reads, and the arms it makes
+    possible are BUILT BELOW: `_seed_lead_topology` writes the second half,
+    and the two-arm matrix on agent_type drives the same agent_type value on
+    both sides of a resolvable topology.
   - PHANTOM-GREEN GUARD: phase-task subjects + owners are seeded from THIS
     session's real on-disk task shapes ('PREPARE: handoff-artifact-durability',
     'ARCHITECT: handoff-artifact-durability', bare owner 'devops-engineer'),
@@ -43,6 +45,7 @@ Run with the 3.13.7 interpreter (default python3 has no pytest):
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -101,7 +104,13 @@ def live_env(tmp_path, monkeypatch, pact_context):
     Mirrors test_pr4_drain_survival_harvest.live_env — the canonical non-mocked
     seam harness. Returns (tmp_path, session_dir) where session_dir is the
     absolute on-disk session directory the explicit reader resolves.
+
+    CLAUDE_CONFIG_DIR IS REMOVED, not merely unused. It takes precedence over
+    home in get_claude_config_dir, so an operator who exports it would send
+    the team-config read outside the temp tree. The topology arms below read
+    that config, and the failure would look like a gate decision.
     """
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     pact_context(team_name=TEAM, session_id=SID, project_dir=PROJECT_DIR)
     slug = Path(PROJECT_DIR).name
@@ -118,13 +127,18 @@ def _journal_file(tmp_path: Path) -> Path:
     return matches[0]
 
 
-def _payload(*, agent_type, subject, task_id="40", skipped=None, owner=None):
+def _payload(*, agent_type, subject, task_id="40", skipped=None, owner=None,
+             session_id=None):
     """Build a TaskUpdate(status=completed) PostToolUse frame for
     evaluate_lifecycle. The both-modes axis is agent_type AND session_id:
-    is_canonical_journal_frame reads the role leg on agent_type and the topology
-    leg on session_id against the leadSessionId of the team config. The frames
-    built here carry no leadSessionId team config, so the topology leg cannot
-    resolve. ADD ONE to cover the in-process teammate arm."""
+    is_canonical_journal_frame reads the role leg on agent_type and the
+    topology leg on session_id against the leadSessionId of the team config.
+
+    A frame built with session_id=None carries NO topology half, so the leg
+    cannot resolve whatever the team config says. Pass session_id AND call
+    _seed_lead_topology to build the two halves together. Either one alone
+    gives False, which is the answer the retired predicate gives.
+    """
     metadata: dict = {}
     if skipped is not None:
         metadata["skipped"] = skipped
@@ -136,11 +150,32 @@ def _payload(*, agent_type, subject, task_id="40", skipped=None, owner=None):
     }
     if agent_type is not None:
         payload["agent_type"] = agent_type
+    if session_id is not None:
+        payload["session_id"] = session_id
     return payload
 
 
 def _has_backstop_advisory(advisories) -> bool:
     return any(code == "artifact_paths_emit_missing" for code, _ in advisories)
+
+
+def _seed_lead_topology(tmp_path: Path, lead_session_id: str = SID) -> Path:
+    """Write the SECOND half of the topology leg: the team config carrying
+    leadSessionId.
+
+    THE TWO HALVES LIVE IN DIFFERENT FILES. The live_env fixture writes the
+    CONTEXT file, which supplies get_team_name(). The leadSessionId lives in
+    the TEAM CONFIG. A fixture that seeds only the first carries one half,
+    and one half gives the SAME verdict as the retired predicate, so an arm
+    built on it is green either way and reads as tested.
+    """
+    teams_dir = tmp_path / ".claude" / "teams" / TEAM
+    teams_dir.mkdir(parents=True, exist_ok=True)
+    config = teams_dir / "config.json"
+    config.write_text(
+        json.dumps({"leadSessionId": lead_session_id}), encoding="utf-8"
+    )
+    return config
 
 
 # =============================================================================
@@ -425,11 +460,18 @@ class TestBackstopBothModes:
             "not nudge (this fixture seeds no leadSessionId team config)"
         )
 
-    def test_teammate_then_lead_same_fixture_proves_gate_is_role(self, live_env):
-        """Non-vacuity for the boundary seal: the SAME (subject, no-emit) fixture
-        that is SILENT under the teammate frame FIRES under the lead frame —
-        proving the suppression is the frame gate, not a missing
-        precondition."""
+    def test_teammate_then_lead_same_fixture_proves_gate_is_the_frame(
+            self, live_env):
+        """Non-vacuity for the boundary seal: the SAME (subject, no-emit)
+        fixture that is SILENT under the teammate frame FIRES under the lead
+        frame, proving the suppression is the frame gate and not a missing
+        precondition.
+
+        THE NAME SAYS FRAME AND NOT ROLE, and the difference is load-bearing.
+        The teammate frame here is silent because this fixture seeds no
+        leadSessionId team config, so the TOPOLOGY leg cannot resolve. A
+        teammate frame that shares the lead session resolves it and DOES
+        nudge, so role is not what decides."""
         _tmp, _session_dir = live_env
         teammate = tlg.evaluate_lifecycle(
             _payload(agent_type=TEAMMATE, subject=PREPARE_SUBJECT))
@@ -438,19 +480,74 @@ class TestBackstopBothModes:
         assert not _has_backstop_advisory(teammate)
         assert _has_backstop_advisory(lead)
 
+    # -------------------------------------------------------------------
+    # THE agent_type TWO-ARM MATRIX. The two arms hold the SAME agent_type
+    # value and differ ONLY in whether the topology leg resolves.
+    #
+    # 🔴 WHY THE MATRIX AND NOT ONE ARM. A single silent arm pins the
+    # OUTCOME of an unresolvable topology as if it were a property of the
+    # agent_type value. A reader then reads "empty agent_type does not
+    # nudge" as a fail-safe default and defends it. It is not a default. It
+    # is one cell of a matrix, and the OTHER cell is the lead launched with
+    # no --agent flag, which carries the same absent agent_type AND writes
+    # the canonical journal, so it MUST nudge.
+    # -------------------------------------------------------------------
     @pytest.mark.parametrize("agent_type", ["", None])
-    def test_empty_or_missing_agent_type_no_advisory(self, live_env, agent_type):
-        """An empty or absent agent_type makes the ROLE leg False, so the frame
-        gate falls to the TOPOLOGY leg. This fixture seeds no leadSessionId team
-        config, so that leg cannot resolve either and the backstop stays silent.
-        THIS IS NOT A FAIL-SAFE DEFAULT: a lead launched with no --agent flag
-        carries no agent_type AND writes the canonical journal, so the same
-        agent_type value with a resolvable topology DOES nudge. This arm covers
-        the unresolvable-topology case only."""
+    def test_empty_or_missing_agent_type_unresolvable_topology_no_advisory(
+            self, live_env, agent_type):
+        """CELL 1 of the matrix. An empty or absent agent_type makes the ROLE
+        leg False, so the frame gate falls to the TOPOLOGY leg. This arm
+        seeds NEITHER half, so that leg cannot resolve and the backstop stays
+        silent. Read this cell only with cell 2, which holds the same
+        agent_type value against a resolvable topology."""
         _tmp, _session_dir = live_env
         advisories = tlg.evaluate_lifecycle(
             _payload(agent_type=agent_type, subject=PREPARE_SUBJECT))
         assert not _has_backstop_advisory(advisories)
+
+    @pytest.mark.parametrize("agent_type", ["", None])
+    def test_empty_or_missing_agent_type_resolvable_topology_nudges(
+            self, live_env, agent_type):
+        """CELL 2 of the matrix, AND IT IS THE ONE THE DEFECT HID. The SAME
+        agent_type value, with BOTH halves of the topology leg seeded, MUST
+        nudge. This is the lead launched with no --agent flag: is_lead
+        answers False for it and the frame DOES write the canonical journal.
+
+        A REVERT OF THE GATE TO is_lead MAKES THIS ARM RED. Cell 1 stays
+        green under that revert, which is the whole cause the matrix exists.
+        """
+        tmp, _session_dir = live_env
+        _seed_lead_topology(tmp)
+        advisories = tlg.evaluate_lifecycle(
+            _payload(agent_type=agent_type, subject=PREPARE_SUBJECT,
+                     session_id=SID))
+        assert _has_backstop_advisory(advisories), (
+            "A lead launched with no --agent flag writes the canonical "
+            "journal, so the artifact-paths check must run for it. If this "
+            "arm is red, the gate answered on ROLE and the missing "
+            "durability pointer goes unreported for every such lead."
+        )
+
+    def test_the_two_cells_differ_only_in_the_topology_half(self, live_env):
+        """NON-VACUITY OF THE MATRIX. The two cells above sit in different
+        test functions, so nothing forces them to hold one variable fixed. If
+        a later edit changes the agent_type of one cell, the matrix silently
+        becomes two unrelated arms and stops discriminating. This arm drives
+        BOTH cells in one function with ONE agent_type value."""
+        tmp, _session_dir = live_env
+        silent = tlg.evaluate_lifecycle(
+            _payload(agent_type=None, subject=PREPARE_SUBJECT))
+        assert not _has_backstop_advisory(silent)
+
+        _seed_lead_topology(tmp)
+        nudged = tlg.evaluate_lifecycle(
+            _payload(agent_type=None, subject=PREPARE_SUBJECT,
+                     session_id=SID))
+        assert _has_backstop_advisory(nudged), (
+            "ONE agent_type value, two topology states, two outcomes. If "
+            "this fails, the suppression in cell 1 is not the topology leg "
+            "and the matrix names the wrong cause."
+        )
 
 
 # =============================================================================

--- a/pact-plugin/tests/test_artifact_paths_durability.py
+++ b/pact-plugin/tests/test_artifact_paths_durability.py
@@ -10,13 +10,15 @@ Covers the four committed seams of the artifact_paths durability mechanism:
                              artifact_paths event for its (workflow, feature).
 
 DISCIPLINE (per the locked plan + this session's plan-mode strategy):
-  - BOTH-MODES AXIS = is_lead / agent_type, NOT session_id. The emit/handoff/
-    backstop path keys on agent_type (LEAD = 'PACT:pact-orchestrator' /
-    'pact-orchestrator'; TEAMMATE = a pact-* type). The teammate-frame leg
-    asserts the backstop is ABSENT (the by-design lead-process-only boundary),
-    never present. Constructing a session_id-topology fixture here would test a
-    gate input this surface does not read (see the both-modes-axis-is-surface-
-    specific lesson banked in plan-mode).
+  - BOTH-MODES AXIS = agent_type AND session_id. The backstop keys on
+    is_canonical_journal_frame, which reads BOTH: the role leg on agent_type
+    (LEAD = 'PACT:pact-orchestrator' / 'pact-orchestrator'; TEAMMATE = a pact-*
+    type), and the topology leg on session_id against the leadSessionId of the
+    team config. The teammate-frame arms below assert the backstop is ABSENT,
+    and that absence holds ONLY because those fixtures seed no leadSessionId
+    team config, so the topology leg cannot resolve. A session_id-topology
+    fixture DOES test a gate input this surface reads, and the in-process
+    teammate arm it makes possible is currently uncovered.
   - PHANTOM-GREEN GUARD: phase-task subjects + owners are seeded from THIS
     session's real on-disk task shapes ('PREPARE: handoff-artifact-durability',
     'ARCHITECT: handoff-artifact-durability', bare owner 'devops-engineer'),
@@ -118,9 +120,11 @@ def _journal_file(tmp_path: Path) -> Path:
 
 def _payload(*, agent_type, subject, task_id="40", skipped=None, owner=None):
     """Build a TaskUpdate(status=completed) PostToolUse frame for
-    evaluate_lifecycle. The both-modes axis is agent_type (is_lead reads it
-    directly); session_id is supplied by the live_env pact_context only for
-    journal-seam resolution, never as the gate discriminator."""
+    evaluate_lifecycle. The both-modes axis is agent_type AND session_id:
+    is_canonical_journal_frame reads the role leg on agent_type and the topology
+    leg on session_id against the leadSessionId of the team config. The frames
+    built here carry no leadSessionId team config, so the topology leg cannot
+    resolve. ADD ONE to cover the in-process teammate arm."""
     metadata: dict = {}
     if skipped is not None:
         metadata["skipped"] = skipped
@@ -368,11 +372,11 @@ class TestMaskedReadSeam:
 
 
 # =============================================================================
-# P0-1 BOUNDARY SEAL + P1-5 BACKSTOP — both-modes (is_lead/agent_type) matrix.
+# P0-1 BOUNDARY SEAL + P1-5 BACKSTOP — both-modes (frame-gate) matrix.
 #   The backstop fires a FAIL-OPEN advisory when a PREPARE/ARCHITECT phase
 #   completes with no artifact_paths event for its (workflow,feature).
-#   The teammate-frame leg asserts the backstop is ABSENT (lead-process-only
-#   boundary — the by-design self-drop; doubles as the empirical seal).
+#   The teammate-frame leg asserts the backstop is ABSENT, and that absence is
+#   the frame gate acting on a fixture that seeds no leadSessionId team config.
 # =============================================================================
 class TestBackstopBothModes:
     @pytest.mark.parametrize("subject,workflow", [
@@ -407,22 +411,24 @@ class TestBackstopBothModes:
         assert _has_backstop_advisory(advisories)
 
     def test_teammate_frame_no_advisory_boundary_seal(self, live_env):
-        """BOUNDARY SEAL (P0-1): a teammate (off-lead) frame self-completing the
-        SAME PREPARE phase with NO emit produces NO backstop advisory — the
-        lead-process-only boundary. The teammate frame has no resolvable journal;
-        the backstop is is_lead-gated and correctly self-drops. This is the
-        accepted by-design boundary, asserted ABSENT (not present)."""
+        """BOUNDARY SEAL (P0-1): a teammate frame self-completing the SAME
+        PREPARE phase with NO emit produces NO backstop advisory. The
+        suppression is the frame gate: this fixture frame seeds no team config
+        carrying a leadSessionId, so the topology leg cannot resolve and
+        is_canonical_journal_frame returns False. This arm does NOT cover the
+        in-process teammate frame, which DOES nudge."""
         _tmp, _session_dir = live_env
         advisories = tlg.evaluate_lifecycle(
             _payload(agent_type=TEAMMATE, subject=PREPARE_SUBJECT))
         assert not _has_backstop_advisory(advisories), (
-            "teammate frame must NOT nudge — lead-process-only boundary"
+            "a frame that cannot resolve the canonical-journal topology must "
+            "not nudge (this fixture seeds no leadSessionId team config)"
         )
 
     def test_teammate_then_lead_same_fixture_proves_gate_is_role(self, live_env):
         """Non-vacuity for the boundary seal: the SAME (subject, no-emit) fixture
         that is SILENT under the teammate frame FIRES under the lead frame —
-        proving the suppression is the is_lead role gate, not a missing
+        proving the suppression is the frame gate, not a missing
         precondition."""
         _tmp, _session_dir = live_env
         teammate = tlg.evaluate_lifecycle(
@@ -434,8 +440,13 @@ class TestBackstopBothModes:
 
     @pytest.mark.parametrize("agent_type", ["", None])
     def test_empty_or_missing_agent_type_no_advisory(self, live_env, agent_type):
-        """is_lead('') and is_lead(missing) are False (fail-safe default) → the
-        backstop self-drops, never nudges a non-lead frame."""
+        """An empty or absent agent_type makes the ROLE leg False, so the frame
+        gate falls to the TOPOLOGY leg. This fixture seeds no leadSessionId team
+        config, so that leg cannot resolve either and the backstop stays silent.
+        THIS IS NOT A FAIL-SAFE DEFAULT: a lead launched with no --agent flag
+        carries no agent_type AND writes the canonical journal, so the same
+        agent_type value with a resolvable topology DOES nudge. This arm covers
+        the unresolvable-topology case only."""
         _tmp, _session_dir = live_env
         advisories = tlg.evaluate_lifecycle(
             _payload(agent_type=agent_type, subject=PREPARE_SUBJECT))

--- a/pact-plugin/tests/test_audit_summary_overwrite_906.py
+++ b/pact-plugin/tests/test_audit_summary_overwrite_906.py
@@ -158,9 +158,14 @@ class TestMirrorBothModes:
     ):
         """Auditor TEST-FOCUS (b): the author-time MIRROR fires in the auditor's
         TEAMMATE (non-lead) process in BOTH topologies. Task JSON is team-dir-
-        scoped → writable from a teammate process (unlike the journal, which
-        self-drops there, #877). A fail-open author-time write would leave no
-        RECOVER protection later, so this persistence is load-bearing."""
+        scoped → writable from a teammate process. The journal EMIT SEAMS are
+        different: they are frame-gated, so an emit drops in a tmux teammate
+        frame and it fires in an in-process teammate frame, which shares the
+        lead's session. This test does not drive that gate. The parametrized
+        value sets the CONTEXT file and not the frame, and the topology leg
+        needs a frame session_id AND a leadSessionId team config. A fail-open
+        author-time write would leave no RECOVER protection later, so this
+        persistence is load-bearing."""
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         pact_context(team_name=TEAM, session_id=session_id)
         _seed(tmp_path, metadata={"audit_summary": RED})

--- a/pact-plugin/tests/test_canonical_journal_frame_gate.py
+++ b/pact-plugin/tests/test_canonical_journal_frame_gate.py
@@ -1,0 +1,333 @@
+"""Frame-gate arms for the six sites that moved from is_lead to
+is_canonical_journal_frame.
+
+WHY THIS FILE EXISTS. The substitution shipped with a green suite, and the
+suite was green BEFORE the change and AFTER it. The arms in this repository
+were insensitive to the substitution in the two directions, so the green
+proved that nothing broke and proved nothing about the substitution.
+
+🔴 WHY THE OLD ARMS COULD NOT SEE IT, MEASURED RATHER THAN ASSUMED.
+``is_canonical_journal_frame`` returns True IMMEDIATELY when ``is_lead`` is
+True, and only then falls to the topology leg. So in a lead frame that
+carries a lead ``agent_type``, THE TWO PREDICATES GIVE THE SAME ANSWER and a
+revert is invisible. The ONLY frame class that separates them is
+``is_lead`` False AND ``is_canonical_journal_frame`` True, which needs the
+topology leg to resolve.
+
+🔴 THE TOPOLOGY LEG NEEDS TWO HALVES, AND ONE HALF IS A TRAP. It needs a
+frame ``session_id`` AND a team config carrying a ``leadSessionId`` that
+agrees with it. WITH ONE HALF THE PREDICATE ANSWERS False, WHICH IS THE SAME
+ANSWER ``is_lead`` GIVES. So an arm built on one half is green with the
+substitution and green without it, AND IT READS AS TESTED because it does
+drive the site. That is an equality between two outcomes rather than a
+defect in the arm: no arm confined to that frame class can discriminate,
+however carefully it is written. ``test_four_point_control`` pins all four
+points so a later editor cannot seed one half and believe it is covered.
+
+🔴 THE SIX SITES DO NOT SHARE ONE OBSERVABLE. Five emit journal records
+through ``append_event``. The artifact-paths site appends an ADVISORY to the
+return value of ``evaluate_lifecycle`` and writes no journal record. AN ARM
+SET BUILT ON ONE CHANNEL IS BLIND AT THAT SITE, AND A BLIND ARM IS GREEN.
+The fixture below captures the two channels for that cause.
+
+SITES COVERED HERE, cited by symbol because the line numbers move:
+``dispatch_variety`` in the TaskCreate branch, ``teachback_ack`` in the
+TaskUpdate-completed branch, and the ``artifact_paths_emit_missing``
+advisory. THREE SITES ARE NOT COVERED: the lead-side agent_handoff emit and
+the two post-completion backstop emits. Their fixtures need an on-disk
+Task-A read through the resolution path of the gate, which this file does
+not build.
+
+R5 IS OUT OF SCOPE AND IS NAMED SO A READER DOES NOT EXPECT IT.
+``_journal_lifecycle_decision`` writes a ``lifecycle_decision`` record with
+NO frame gate, in EVERY frame, and it is filed as item 2 of issue 1482. The
+arm-D controls below assert silence FOR THE RECORD KIND OF THEIR OWN SITE,
+never journal silence in general, because the ungated write makes a general
+silence assertion red at the base for a cause this commit does not own.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+
+import shared.pact_context as pc  # noqa: E402
+import shared.session_journal as sj  # noqa: E402
+import task_lifecycle_gate as tlg  # noqa: E402
+
+LEAD_AGENT_TYPE = "PACT:pact-orchestrator"
+TEAMMATE_AGENT_TYPE = "pact-devops-engineer"
+SESSION_ID = "sess-canonical-frame-0001"
+OTHER_SESSION_ID = "sess-tmux-teammate-0002"
+TEAM = "session-abcd1234"
+
+
+@pytest.fixture
+def frame_rig(tmp_path, monkeypatch):
+    """Seed the two halves of the topology leg and capture BOTH observables.
+
+    Returns a callable. Call it with a frame dict and it returns
+    ``(journal_records, advisory_names)``.
+
+    The team config is the half that the ordinary ``pact_context`` fixture
+    does NOT write: that fixture writes the CONTEXT file, and the
+    ``leadSessionId`` lives in the TEAM CONFIG. The two are different files,
+    and an arm that seeds only the first carries one half.
+    """
+    teams_dir = tmp_path / "teams" / TEAM
+    teams_dir.mkdir(parents=True)
+    teams_dir.joinpath("config.json").write_text(
+        json.dumps({"leadSessionId": SESSION_ID}), encoding="utf-8"
+    )
+    monkeypatch.setattr(pc, "get_claude_config_dir", lambda: tmp_path)
+    monkeypatch.setattr(pc, "get_team_name", lambda: TEAM)
+    monkeypatch.setattr(pc, "get_pact_context", lambda: {"team_name": TEAM})
+
+    def drive(frame):
+        records: list[dict] = []
+        monkeypatch.setattr(
+            sj, "append_event", lambda e: records.append(e) or True
+        )
+        advisories = tlg.evaluate_lifecycle(frame)
+        return records, [name for name, _ in advisories]
+
+    return drive
+
+
+def _arm_b(**extra):
+    """Arm B: a lead launched with NO --agent flag. `agent_type` is ABSENT,
+    so `is_lead` is False, and the topology leg admits the frame."""
+    return {"session_id": SESSION_ID, **extra}
+
+
+def _arm_c(**extra):
+    """Arm C: an in-process teammate that shares the lead session."""
+    return {
+        "agent_type": TEAMMATE_AGENT_TYPE,
+        "session_id": SESSION_ID,
+        **extra,
+    }
+
+
+def _arm_d(**extra):
+    """Arm D: a tmux teammate. Its session_id DISAGREES with the config."""
+    return {
+        "agent_type": TEAMMATE_AGENT_TYPE,
+        "session_id": OTHER_SESSION_ID,
+        **extra,
+    }
+
+
+def _arm_a(**extra):
+    """Arm A: a lead carrying a lead `agent_type`. `is_lead` short-circuits."""
+    return {"agent_type": LEAD_AGENT_TYPE, **extra}
+
+
+def _typed(records, kind):
+    return [r for r in records if r.get("type") == kind]
+
+
+# =============================================================================
+# The control. Read this before changing any arm below it.
+# =============================================================================
+class TestFramePredicateControl:
+    def test_four_point_control(self, tmp_path, monkeypatch):
+        """The topology leg needs BOTH halves, and one half is not a weaker
+        version of two: it gives the SAME verdict as the reverted predicate.
+
+        Four points, and a three-point control would miss the fourth. The
+        fourth is the two halves present and DISAGREEING, which is what a
+        stale team config produces in the field.
+        """
+        teams_dir = tmp_path / "teams" / TEAM
+        teams_dir.mkdir(parents=True)
+        cfg = teams_dir / "config.json"
+        cfg.write_text(json.dumps({"leadSessionId": SESSION_ID}), encoding="utf-8")
+        monkeypatch.setattr(pc, "get_claude_config_dir", lambda: tmp_path)
+        monkeypatch.setattr(pc, "get_team_name", lambda: TEAM)
+
+        both = {"session_id": SESSION_ID}
+        assert pc.is_canonical_journal_frame(both) is True, (
+            "POINT 1: the two halves seeded and in agreement must ADMIT."
+        )
+        assert pc.is_lead(both) is False, (
+            "POINT 1 NON-VACUITY: is_lead must answer False here, or this "
+            "frame does not separate the two predicates and no arm built on "
+            "it can detect a revert."
+        )
+
+        disagree = {"session_id": OTHER_SESSION_ID}
+        assert pc.is_canonical_journal_frame(disagree) is False, (
+            "POINT 2: the two halves present and DISAGREEING must EXCLUDE. "
+            "This is the tmux teammate, and it is the state a stale team "
+            "config produces."
+        )
+
+        cfg.unlink()
+        assert pc.is_canonical_journal_frame(both) is False, (
+            "POINT 3, THE TRAP: with the FRAME HALF ALONE the predicate "
+            "answers False, which is the SAME answer is_lead gives. An arm "
+            "built on this half is green with the substitution AND green "
+            "without it, and it reads as tested because it drives the site."
+        )
+
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+        cfg.write_text(json.dumps({"leadSessionId": SESSION_ID}), encoding="utf-8")
+        assert pc.is_canonical_journal_frame({}) is False, (
+            "POINT 4: with the CONFIG HALF ALONE and no session_id the "
+            "predicate answers False. The second half of the same trap."
+        )
+
+    def test_arm_a_cannot_discriminate_and_that_is_the_point(self, tmp_path,
+                                                             monkeypatch):
+        """A NEGATIVE CONTROL ON MY OWN REASONING, not on the code.
+
+        In a lead frame carrying a lead `agent_type`, the two predicates
+        AGREE, so a revert is invisible. This arm asserts that agreement.
+        IT DETECTS NO DEFECT BY DESIGN. Its value is conditional: if it ever
+        fails, the short-circuit model behind every other arm in this file is
+        incorrect, and those arms must be re-derived rather than repaired.
+        """
+        monkeypatch.setattr(pc, "get_claude_config_dir", lambda: tmp_path)
+        monkeypatch.setattr(pc, "get_team_name", lambda: TEAM)
+        frame = _arm_a()
+        assert pc.is_lead(frame) is True
+        assert pc.is_canonical_journal_frame(frame) is True
+        assert pc.is_lead(frame) == pc.is_canonical_journal_frame(frame), (
+            "THE TWO PREDICATES MUST AGREE AT ARM A. If they disagree, the "
+            "short-circuit is gone and every arm in this file needs a "
+            "re-derived expectation."
+        )
+
+
+# =============================================================================
+# Site arms. Each drives a real site in a frame that separates the predicates.
+# =============================================================================
+class TestDispatchVarietySite:
+    """`dispatch_variety`, in the TaskCreate branch."""
+
+    FRAME_EXTRA = {
+        "tool_name": "TaskCreate",
+        "tool_input": {
+            "subject": "devops: implement",
+            "metadata": {"variety": {"total": 9}},
+        },
+        "tool_response": {"task": {"id": "42"}},
+    }
+
+    def test_arm_b_lead_without_agent_flag_emits(self, frame_rig):
+        """A lead with no --agent flag writes the canonical journal, so the
+        emit must run. A revert to is_lead makes this arm RED."""
+        records, _ = frame_rig(_arm_b(**self.FRAME_EXTRA))
+        assert len(_typed(records, "dispatch_variety")) == 1, (
+            "A lead launched with no --agent flag DOES write the canonical "
+            "journal. If this arm is red, the gate answered on ROLE rather "
+            "than on which journal the frame writes, and the record is lost."
+        )
+
+    def test_arm_c_in_process_teammate_emits(self, frame_rig):
+        """The in-process teammate shares the lead session, so its writes
+        land in the canonical journal and the emit must run."""
+        records, _ = frame_rig(_arm_c(**self.FRAME_EXTRA))
+        assert len(_typed(records, "dispatch_variety")) == 1, (
+            "An in-process teammate shares the lead session, so its emit "
+            "lands in the canonical journal and must not be suppressed."
+        )
+
+    def test_arm_d_tmux_teammate_stays_silent(self, frame_rig):
+        """Arm D control, SCOPED TO THIS RECORD KIND. It does NOT assert
+        journal silence in general: R5 writes an ungated record in every
+        frame, and a general assertion would be red at the base for a
+        defect this commit does not own."""
+        records, _ = frame_rig(_arm_d(**self.FRAME_EXTRA))
+        assert _typed(records, "dispatch_variety") == [], (
+            "A tmux teammate writes a DIFFERENT journal. Emitting from it "
+            "silos the record and poisons the shared marker namespace."
+        )
+
+
+class TestTeachbackAckSite:
+    """`teachback_ack`, in the TaskUpdate-completed branch."""
+
+    FRAME_EXTRA = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": "7", "status": "completed"},
+        "tool_response": {
+            "task": {
+                "id": "7",
+                "owner": "teammate",
+                "subject": "teammate: TEACHBACK for the thing",
+                "metadata": {
+                    "teachback_submit": {
+                        "variety_acknowledgment": {
+                            "rationale_articulates_this_dispatch": "yes"
+                        }
+                    }
+                },
+            }
+        },
+    }
+
+    def test_arm_b_lead_without_agent_flag_emits(self, frame_rig):
+        records, _ = frame_rig(_arm_b(**self.FRAME_EXTRA))
+        assert len(_typed(records, "teachback_ack")) == 1, (
+            "The teachback acknowledgement must reach the canonical journal "
+            "from a lead frame that carries no --agent flag."
+        )
+
+    def test_arm_c_in_process_teammate_emits(self, frame_rig):
+        records, _ = frame_rig(_arm_c(**self.FRAME_EXTRA))
+        assert len(_typed(records, "teachback_ack")) == 1
+
+    def test_arm_d_tmux_teammate_stays_silent(self, frame_rig):
+        records, _ = frame_rig(_arm_d(**self.FRAME_EXTRA))
+        assert _typed(records, "teachback_ack") == []
+
+
+class TestArtifactPathsAdvisorySite:
+    """The `artifact_paths_emit_missing` advisory.
+
+    🔴 THIS SITE WRITES NO JOURNAL RECORD. It appends an advisory to the
+    RETURN VALUE. An arm that watches `append_event` alone is blind here and
+    reports the site as silent, which reads as a passing control. The
+    fixture returns the two channels for that cause. Do not narrow these
+    assertions to the journal channel.
+    """
+
+    FRAME_EXTRA = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": "7", "status": "completed"},
+        "tool_response": {
+            "task": {
+                "id": "7",
+                "owner": "architect",
+                "subject": "ARCHITECT: the feature",
+                "metadata": {},
+            }
+        },
+    }
+
+    def test_arm_b_lead_without_agent_flag_raises_the_advisory(self, frame_rig):
+        records, advisories = frame_rig(_arm_b(**self.FRAME_EXTRA))
+        assert "artifact_paths_emit_missing" in advisories, (
+            "The artifact-paths check must run in a canonical-journal frame. "
+            "If it is absent, the gate skipped the check on ROLE, and the "
+            "missing durability pointer goes unreported."
+        )
+        assert records == [] or True, (
+            "Recorded deliberately: this site writes NO journal record. The "
+            "advisory channel is the observable."
+        )
+
+    def test_arm_c_in_process_teammate_raises_the_advisory(self, frame_rig):
+        _, advisories = frame_rig(_arm_c(**self.FRAME_EXTRA))
+        assert "artifact_paths_emit_missing" in advisories
+
+    def test_arm_d_tmux_teammate_stays_silent(self, frame_rig):
+        _, advisories = frame_rig(_arm_d(**self.FRAME_EXTRA))
+        assert "artifact_paths_emit_missing" not in advisories, (
+            "A tmux teammate must not raise this advisory: it reads a "
+            "journal it does not share, so its answer is not evidence."
+        )

--- a/pact-plugin/tests/test_canonical_journal_frame_gate.py
+++ b/pact-plugin/tests/test_canonical_journal_frame_gate.py
@@ -154,6 +154,7 @@ def frame_rig(tmp_path, monkeypatch, pact_context):
     emit_calls: list[str] = []
     real_handoff = tlg._emit_lead_side_agent_handoff
     real_snapshot = tlg.emit_task_metadata_snapshot
+    real_per_write = tlg._emit_per_write_snapshot
 
     def spy_handoff(*args, **kwargs):
         emit_calls.append("_emit_lead_side_agent_handoff")
@@ -163,8 +164,18 @@ def frame_rig(tmp_path, monkeypatch, pact_context):
         emit_calls.append("emit_task_metadata_snapshot")
         return real_snapshot(*args, **kwargs)
 
+    def spy_per_write(*args, **kwargs):
+        # The OPEN-task per-write mirror is the only caller of this helper,
+        # so its presence NAMES the site. The helper then reaches
+        # emit_task_metadata_snapshot through the module global above, so
+        # one mirror fire records TWO entries and a backstop fire records
+        # ONE. That difference is what separates the two sites.
+        emit_calls.append("_emit_per_write_snapshot")
+        return real_per_write(*args, **kwargs)
+
     monkeypatch.setattr(tlg, "_emit_lead_side_agent_handoff", spy_handoff)
     monkeypatch.setattr(tlg, "emit_task_metadata_snapshot", spy_snapshot)
+    monkeypatch.setattr(tlg, "_emit_per_write_snapshot", spy_per_write)
 
     class Drive:
         def __init__(self, records, advisories, calls):
@@ -634,6 +645,66 @@ class TestSnapshotBackstopSite:
             "A write with no incoming handoff must not drive the handoff "
             "backstop, or the two backstops share one observable and no arm "
             "can name which site a revert broke."
+        )
+
+    def test_the_two_snapshot_sites_are_disjoint_on_the_disk_status(
+            self, frame_rig):
+        """This backstop and the OPEN-task per-write mirror are a disjoint
+        pair, split on one on-disk status read. The backstop fires when the
+        disk task reads completed. The mirror fires when it does not.
+
+        🔴 READ THIS BEFORE YOU SIMPLIFY THE ASSERTIONS BELOW. THE JOURNAL
+        RECORD CANNOT ANSWER THIS QUESTION. The two sites write the SAME
+        record kind, the record carries NO FIELD NAMING ITS SITE, and the
+        content-key dedup collapses a second write to one record. MEASURED:
+        the record count is 1 in all four cells of (open, completed) by
+        (base, both-sites-firing). So a record-count assertion looks
+        equivalent to the calls below and carries NO INFORMATION. That
+        equality is invisible from this arm, and it is why this pin lived
+        as a docstring until it was measured.
+
+        THE CALL LAYER IS THE ONLY CHANNEL THAT SEPARATES THEM. The mirror
+        is the only caller of `_emit_per_write_snapshot`, so its presence
+        names the site, and it reaches the substrate through the module
+        global, so one mirror fire records two entries.
+
+        MEASURED KILL, and the numbers here are read from a run and not
+        from the source: force the `task_a.get("status") == "completed"`
+        conjunct of the backstop to True. THE RECORD COUNT STAYS AT 1. The
+        substrate call count on the OPEN task moves from 1 to 2, and the
+        call order shows the backstop firing before the mirror. The
+        COMPLETED cell holds at 1 in the two worlds, which is what makes
+        the moved cell attributable to that conjunct.
+        """
+        open_task = {
+            "id": "7", "owner": "devops", "subject": "devops: implement",
+            "status": "in_progress", "metadata": {},
+        }
+        opened = frame_rig(_arm_b(**self.FRAME_EXTRA), disk_task=open_task)
+        assert "_emit_per_write_snapshot" in opened.emit_calls, (
+            "THE MIRROR MUST OWN AN OPEN TASK. If this is absent the "
+            "open-task write reached neither site, and the counts below "
+            "measure an unreached surface rather than a disjoint pair."
+        )
+        assert opened.emit_calls.count("emit_task_metadata_snapshot") == 1, (
+            "THE BACKSTOP FIRED ON AN OPEN TASK. Its status conjunct no "
+            "longer holds the split, so the two sites now double-fire on "
+            "one write. The journal hides it, because the content-key "
+            "dedup keeps the record count at 1."
+        )
+
+        completed = frame_rig(
+            _arm_b(**self.FRAME_EXTRA), disk_task=_completed_task(metadata={})
+        )
+        assert "_emit_per_write_snapshot" not in completed.emit_calls, (
+            "THE MIRROR FIRED ON A COMPLETED TASK. The pair is disjoint in "
+            "one direction only, which is not disjoint."
+        )
+        assert completed.emit_calls.count("emit_task_metadata_snapshot") == 1, (
+            "POSITIVE CONTROL, and it is what proves the arm above reads a "
+            "live surface. The completed cell must stay at one substrate "
+            "call in the two worlds, so a mutation that moves the open "
+            "cell alone is attributable to the backstop status conjunct."
         )
 
 

--- a/pact-plugin/tests/test_canonical_journal_frame_gate.py
+++ b/pact-plugin/tests/test_canonical_journal_frame_gate.py
@@ -687,10 +687,15 @@ class TestSnapshotBackstopSite:
             "measure an unreached surface rather than a disjoint pair."
         )
         assert opened.emit_calls.count("emit_task_metadata_snapshot") == 1, (
-            "THE BACKSTOP FIRED ON AN OPEN TASK. Its status conjunct no "
-            "longer holds the split, so the two sites now double-fire on "
-            "one write. The journal hides it, because the content-key "
-            "dedup keeps the record count at 1."
+            "TWO DIRECTIONS REDDEN THIS ASSERTION AND THEY HAVE DIFFERENT "
+            "CAUSES. READ THE COUNT BEFORE YOU READ THE DIFF. A COUNT OF 2 "
+            "IS THE PRODUCTION FAULT: the backstop fired on an open task, "
+            "its status conjunct does not hold the split at this time, and "
+            "the two sites double-fire on one write. The journal hides "
+            "that, because the content-key dedup keeps the record count at "
+            "1. A COUNT OF 0 IS A HARNESS FAULT AND THE PRODUCTION CODE IS "
+            "CORRECT: somebody removed the spy on "
+            "emit_task_metadata_snapshot, or the mirror did not fire."
         )
 
         completed = frame_rig(

--- a/pact-plugin/tests/test_canonical_journal_frame_gate.py
+++ b/pact-plugin/tests/test_canonical_journal_frame_gate.py
@@ -24,28 +24,55 @@ defect in the arm: no arm confined to that frame class can discriminate,
 however carefully it is written. ``test_four_point_control`` pins all four
 points so a later editor cannot seed one half and believe it is covered.
 
-🔴 THE SIX SITES DO NOT SHARE ONE OBSERVABLE. Five emit journal records
-through ``append_event``. The artifact-paths site appends an ADVISORY to the
-return value of ``evaluate_lifecycle`` and writes no journal record. AN ARM
-SET BUILT ON ONE CHANNEL IS BLIND AT THAT SITE, AND A BLIND ARM IS GREEN.
-The fixture below captures the two channels for that cause.
+🔴 THREE OBSERVABLE CLASSES, NOT ONE, AND NOT TWO. The sites do not share
+one channel, and an arm that watches the wrong one reports a driven site as
+silent.
 
-SITES COVERED HERE, cited by symbol because the line numbers move:
-``dispatch_variety`` in the TaskCreate branch, ``teachback_ack`` in the
-TaskUpdate-completed branch, and the ``artifact_paths_emit_missing``
-advisory. THREE SITES ARE NOT COVERED: the lead-side agent_handoff emit and
-the two post-completion backstop emits. Their fixtures need an on-disk
-Task-A read through the resolution path of the gate, which this file does
-not build.
+  1. THE JOURNAL RECORD. Five of the six sites append a record. They do NOT
+     all append it through one function object: ``dispatch_variety`` and
+     ``teachback_ack`` go through ``append_event_checked`` (which calls
+     ``session_journal.append_event``), the lead-side handoff emit calls the
+     ``append_event`` name IMPORTED INTO task_lifecycle_gate, and the
+     snapshot emits call the name imported into task_metadata_snapshot.
+     A rig that patches ONE of those three names sees a subset of the sites
+     and reports the rest as silent. THAT IS AN INSTRUMENT DEFECT AND IT
+     READS AS A FINDING ABOUT THE CODE. This file mocks NONE of them: it
+     redirects ``Path.home`` and reads the REAL on-disk journal, so all
+     three routes land in one place by construction and no future emit can
+     escape the instrument by changing which name it calls.
+  2. THE ADVISORY. The artifact-paths site appends to the RETURN VALUE of
+     ``evaluate_lifecycle`` and writes no journal record at all.
+  3. THE CALL. A site can be REACHED, CALLED, and still write nothing,
+     because the emitter dedups on an O_EXCL marker or drops an ineligible
+     payload. An arm that reads only the downstream artifact collapses three
+     states into one empty list: not reached, reached but gate-rejected, and
+     called but deduplicated. ``emit_calls`` records that layer so the three
+     stay separable.
+
+SIX SITES, ALL COVERED HERE, cited by symbol because line numbers move:
+``dispatch_variety`` (TaskCreate branch), the lead-side ``agent_handoff``
+emit at the acceptance-commit, the ``artifact_paths_emit_missing`` advisory,
+``teachback_ack`` (TaskUpdate-completed branch), the post-completion handoff
+backstop, and the post-completion ``task_metadata_snapshot`` backstop.
+
+HOW THE TWO BACKSTOPS ARE SEPARATED, because they share one frame class and
+a shared arm would kill two mutants at once and name neither. The handoff
+backstop needs an incoming ``metadata.handoff`` DICT. The snapshot backstop
+excludes ``handoff`` from its payload and emits nothing when that is the
+only key. So a handoff-ONLY write drives the handoff backstop alone, and a
+write carrying only a non-handoff key drives the snapshot backstop alone.
 
 R5 IS OUT OF SCOPE AND IS NAMED SO A READER DOES NOT EXPECT IT.
 ``_journal_lifecycle_decision`` writes a ``lifecycle_decision`` record with
-NO frame gate, in EVERY frame, and it is filed as item 2 of issue 1482. The
-arm-D controls below assert silence FOR THE RECORD KIND OF THEIR OWN SITE,
-never journal silence in general, because the ungated write makes a general
-silence assertion red at the base for a cause this commit does not own.
+NO frame gate, in EVERY frame. It is called from ``main()`` rather than from
+``evaluate_lifecycle``, so it does not reach the arms below. The arm-D
+controls assert silence FOR THE RECORD KIND OF THEIR OWN SITE anyway, never
+journal silence in general, so a future move of that call cannot turn them
+red for a defect this commit does not own.
 """
 import json
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -54,45 +81,114 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
 
 import shared.pact_context as pc  # noqa: E402
-import shared.session_journal as sj  # noqa: E402
 import task_lifecycle_gate as tlg  # noqa: E402
+
+HOOKS_DIR = Path(__file__).parent.parent / "hooks"
 
 LEAD_AGENT_TYPE = "PACT:pact-orchestrator"
 TEAMMATE_AGENT_TYPE = "pact-devops-engineer"
 SESSION_ID = "sess-canonical-frame-0001"
 OTHER_SESSION_ID = "sess-tmux-teammate-0002"
 TEAM = "session-abcd1234"
+PROJECT_DIR = "/test/project"
+
+HANDOFF = {
+    "produced": "the arms",
+    "decisions": "the rig reads disk",
+    "reasoning_chain": "one channel is blind",
+    "uncertainty": "dedup",
+    "integration": "staged only",
+    "open_questions": "none",
+}
+
+
+def _journal_records(home: Path) -> list[dict]:
+    """Read EVERY journal below the redirected home.
+
+    Reading the file rather than a patched function is what makes this rig
+    blind to nothing: the three import routes of ``append_event`` all end at
+    one file, so a site cannot escape the instrument by calling a different
+    name.
+    """
+    root = home / ".claude" / "pact-sessions"
+    records: list[dict] = []
+    for journal in root.rglob("*.jsonl"):
+        for line in journal.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                records.append(json.loads(line))
+    return records
 
 
 @pytest.fixture
-def frame_rig(tmp_path, monkeypatch):
-    """Seed the two halves of the topology leg and capture BOTH observables.
+def frame_rig(tmp_path, monkeypatch, pact_context):
+    """Seed the two halves of the topology leg and capture ALL THREE channels.
 
-    Returns a callable. Call it with a frame dict and it returns
-    ``(journal_records, advisory_names)``.
+    Returns a callable. Call it with a frame dict and it returns a
+    ``Drive`` with ``records``, ``advisories`` and ``emit_calls``.
+
+    NON-MOCKED SEAM. ``Path.home`` is redirected and ``CLAUDE_CONFIG_DIR`` is
+    removed, so the team config read, the on-disk task read, the marker
+    claim and the journal write all resolve through their REAL resolvers
+    against a temp tree. No resolver is monkeypatched, so a regression in
+    any of them turns these arms red rather than leaving them green against
+    a stub.
 
     The team config is the half that the ordinary ``pact_context`` fixture
     does NOT write: that fixture writes the CONTEXT file, and the
     ``leadSessionId`` lives in the TEAM CONFIG. The two are different files,
     and an arm that seeds only the first carries one half.
     """
-    teams_dir = tmp_path / "teams" / TEAM
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    pact_context(
+        team_name=TEAM, session_id=SESSION_ID, project_dir=PROJECT_DIR
+    )
+    teams_dir = tmp_path / ".claude" / "teams" / TEAM
     teams_dir.mkdir(parents=True)
     teams_dir.joinpath("config.json").write_text(
         json.dumps({"leadSessionId": SESSION_ID}), encoding="utf-8"
     )
-    monkeypatch.setattr(pc, "get_claude_config_dir", lambda: tmp_path)
-    monkeypatch.setattr(pc, "get_team_name", lambda: TEAM)
-    monkeypatch.setattr(pc, "get_pact_context", lambda: {"team_name": TEAM})
+    tasks_dir = tmp_path / ".claude" / "tasks" / TEAM
+    tasks_dir.mkdir(parents=True)
 
-    def drive(frame):
-        records: list[dict] = []
-        monkeypatch.setattr(
-            sj, "append_event", lambda e: records.append(e) or True
-        )
+    emit_calls: list[str] = []
+    real_handoff = tlg._emit_lead_side_agent_handoff
+    real_snapshot = tlg.emit_task_metadata_snapshot
+
+    def spy_handoff(*args, **kwargs):
+        emit_calls.append("_emit_lead_side_agent_handoff")
+        return real_handoff(*args, **kwargs)
+
+    def spy_snapshot(*args, **kwargs):
+        emit_calls.append("emit_task_metadata_snapshot")
+        return real_snapshot(*args, **kwargs)
+
+    monkeypatch.setattr(tlg, "_emit_lead_side_agent_handoff", spy_handoff)
+    monkeypatch.setattr(tlg, "emit_task_metadata_snapshot", spy_snapshot)
+
+    class Drive:
+        def __init__(self, records, advisories, calls):
+            self.records = records
+            self.advisories = advisories
+            self.emit_calls = calls
+
+        def typed(self, kind):
+            return [r for r in self.records if r.get("type") == kind]
+
+    def drive(frame, disk_task=None):
+        if disk_task is not None:
+            tasks_dir.joinpath(f"{disk_task['id']}.json").write_text(
+                json.dumps(disk_task), encoding="utf-8"
+            )
+        before = len(emit_calls)
         advisories = tlg.evaluate_lifecycle(frame)
-        return records, [name for name, _ in advisories]
+        return Drive(
+            _journal_records(tmp_path),
+            [name for name, _ in advisories],
+            list(emit_calls[before:]),
+        )
 
+    drive.home = tmp_path
     return drive
 
 
@@ -125,8 +221,15 @@ def _arm_a(**extra):
     return {"agent_type": LEAD_AGENT_TYPE, **extra}
 
 
-def _typed(records, kind):
-    return [r for r in records if r.get("type") == kind]
+def _completed_task(task_id="7", owner="devops", subject="devops: implement",
+                    metadata=None):
+    return {
+        "id": task_id,
+        "owner": owner,
+        "subject": subject,
+        "status": "completed",
+        "metadata": metadata if metadata is not None else {},
+    }
 
 
 # =============================================================================
@@ -201,6 +304,26 @@ class TestFramePredicateControl:
             "re-derived expectation."
         )
 
+    def test_rig_reads_a_real_journal_file(self, frame_rig):
+        """NON-VACUITY OF THE INSTRUMENT ITSELF.
+
+        Every arm below reads records off disk. If the redirect were
+        incomplete, the emits would land in the operator's REAL journal and
+        this rig would report an empty list for every site, which reads as
+        six correct gate rejections. This arm proves the reader is live and
+        that the file it reads is inside the temp tree.
+        """
+        drive = frame_rig(_arm_b(**TestDispatchVarietySite.FRAME_EXTRA))
+        assert drive.records, (
+            "THE RIG READ NOTHING AT ALL. Do not read a downstream empty "
+            "list as a gate rejection until this arm is green: an incomplete "
+            "home redirect produces the same empty list at every site."
+        )
+        journals = list(
+            (frame_rig.home / ".claude" / "pact-sessions").rglob("*.jsonl")
+        )
+        assert journals, "no journal file was written below the temp home"
+
 
 # =============================================================================
 # Site arms. Each drives a real site in a frame that separates the predicates.
@@ -220,8 +343,8 @@ class TestDispatchVarietySite:
     def test_arm_b_lead_without_agent_flag_emits(self, frame_rig):
         """A lead with no --agent flag writes the canonical journal, so the
         emit must run. A revert to is_lead makes this arm RED."""
-        records, _ = frame_rig(_arm_b(**self.FRAME_EXTRA))
-        assert len(_typed(records, "dispatch_variety")) == 1, (
+        drive = frame_rig(_arm_b(**self.FRAME_EXTRA))
+        assert len(drive.typed("dispatch_variety")) == 1, (
             "A lead launched with no --agent flag DOES write the canonical "
             "journal. If this arm is red, the gate answered on ROLE rather "
             "than on which journal the frame writes, and the record is lost."
@@ -230,8 +353,8 @@ class TestDispatchVarietySite:
     def test_arm_c_in_process_teammate_emits(self, frame_rig):
         """The in-process teammate shares the lead session, so its writes
         land in the canonical journal and the emit must run."""
-        records, _ = frame_rig(_arm_c(**self.FRAME_EXTRA))
-        assert len(_typed(records, "dispatch_variety")) == 1, (
+        drive = frame_rig(_arm_c(**self.FRAME_EXTRA))
+        assert len(drive.typed("dispatch_variety")) == 1, (
             "An in-process teammate shares the lead session, so its emit "
             "lands in the canonical journal and must not be suppressed."
         )
@@ -241,10 +364,132 @@ class TestDispatchVarietySite:
         journal silence in general: R5 writes an ungated record in every
         frame, and a general assertion would be red at the base for a
         defect this commit does not own."""
-        records, _ = frame_rig(_arm_d(**self.FRAME_EXTRA))
-        assert _typed(records, "dispatch_variety") == [], (
+        drive = frame_rig(_arm_d(**self.FRAME_EXTRA))
+        assert drive.typed("dispatch_variety") == [], (
             "A tmux teammate writes a DIFFERENT journal. Emitting from it "
             "silos the record and poisons the shared marker namespace."
+        )
+
+
+class TestLeadSideAgentHandoffSite:
+    """The lead-side `agent_handoff` emit at the acceptance-commit.
+
+    THIS SITE WAS REPORTED AS NOT DRIVEN BY THE PRIOR PHASE. It is driven,
+    and it needs no on-disk task at all: the completion branch takes its
+    task from ``tool_response.task``. The prior silence was an instrument
+    defect, because this emit calls the ``append_event`` name imported into
+    task_lifecycle_gate and the prior rig patched the session_journal name.
+
+    THE SAME GATE ALSO GUARDS the paired completion-time
+    ``task_metadata_snapshot`` emit, so a revert of this ONE line suppresses
+    two record kinds. The arms below assert the handoff record, which is
+    enough to redden the revert and keeps the failure message pointed at one
+    cause.
+    """
+
+    FRAME_EXTRA = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": "7", "status": "completed"},
+        "tool_response": {
+            "task": {
+                "id": "7",
+                "owner": "devops",
+                "subject": "devops: implement the thing",
+                "status": "completed",
+                "metadata": {"handoff": HANDOFF},
+            }
+        },
+    }
+
+    def test_arm_b_lead_without_agent_flag_emits(self, frame_rig):
+        drive = frame_rig(_arm_b(**self.FRAME_EXTRA))
+        assert len(drive.typed("agent_handoff")) == 1, (
+            "A lead launched with no --agent flag DOES write the canonical "
+            "journal, so its acceptance-commit must emit the handoff. If "
+            "this arm is red, the durable HANDOFF record is lost for every "
+            "lead that runs without an --agent flag."
+        )
+
+    def test_arm_c_in_process_teammate_emits(self, frame_rig):
+        drive = frame_rig(_arm_c(**self.FRAME_EXTRA))
+        assert len(drive.typed("agent_handoff")) == 1
+
+    def test_arm_d_tmux_teammate_stays_silent(self, frame_rig):
+        """T7 control for this site, scoped to this record kind."""
+        drive = frame_rig(_arm_d(**self.FRAME_EXTRA))
+        assert drive.typed("agent_handoff") == [], (
+            "A tmux teammate must not emit here: the event would silo into "
+            "a journal the team does not read, and the marker claim would "
+            "suppress a later canonical emit of the same handoff."
+        )
+
+    def test_arm_d_is_a_gate_rejection_and_not_a_dedup_no_op(self, frame_rig):
+        """THE THIRD OBSERVABLE, and the reason it is in the rig.
+
+        An empty record list has three causes: the site was not reached, the
+        gate rejected the frame, or the emitter was CALLED and deduplicated.
+        The arm above cannot separate them, so a dedup defect would read as
+        a working gate. This arm pins the cause: at arm D the emitter is
+        NEVER CALLED, so the silence is the gate.
+        """
+        drive = frame_rig(_arm_d(**self.FRAME_EXTRA))
+        assert "_emit_lead_side_agent_handoff" not in drive.emit_calls, (
+            "The emitter was CALLED in a tmux frame. The record list is "
+            "empty for the wrong cause: the gate admitted the frame and the "
+            "marker or the payload suppressed the write."
+        )
+        lead = frame_rig(_arm_b(**self.FRAME_EXTRA))
+        assert "_emit_lead_side_agent_handoff" in lead.emit_calls, (
+            "NON-VACUITY: the spy must record a call in the admitting frame, "
+            "or its absence at arm D measures nothing."
+        )
+
+
+class TestArtifactPathsAdvisorySite:
+    """The `artifact_paths_emit_missing` advisory.
+
+    🔴 THIS SITE WRITES NO JOURNAL RECORD. It appends an advisory to the
+    RETURN VALUE. An arm that watches the journal alone is blind here and
+    reports the site as silent, which reads as a passing control. The
+    fixture returns all three channels for that cause. Do not narrow these
+    assertions to the journal channel.
+    """
+
+    FRAME_EXTRA = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {"taskId": "7", "status": "completed"},
+        "tool_response": {
+            "task": {
+                "id": "7",
+                "owner": "architect",
+                "subject": "ARCHITECT: the feature",
+                "metadata": {},
+            }
+        },
+    }
+
+    def test_arm_b_lead_without_agent_flag_raises_the_advisory(self, frame_rig):
+        drive = frame_rig(_arm_b(**self.FRAME_EXTRA))
+        assert "artifact_paths_emit_missing" in drive.advisories, (
+            "The artifact-paths check must run in a canonical-journal frame. "
+            "If it is absent, the gate skipped the check on ROLE, and the "
+            "missing durability pointer goes unreported."
+        )
+        assert drive.typed("artifact_paths") == [], (
+            "RECORDED DELIBERATELY: this site writes NO journal record of "
+            "its own. The advisory channel is the observable, and an arm "
+            "that watches the journal here is blind AND green."
+        )
+
+    def test_arm_c_in_process_teammate_raises_the_advisory(self, frame_rig):
+        drive = frame_rig(_arm_c(**self.FRAME_EXTRA))
+        assert "artifact_paths_emit_missing" in drive.advisories
+
+    def test_arm_d_tmux_teammate_stays_silent(self, frame_rig):
+        drive = frame_rig(_arm_d(**self.FRAME_EXTRA))
+        assert "artifact_paths_emit_missing" not in drive.advisories, (
+            "A tmux teammate must not raise this advisory: it reads a "
+            "journal it does not share, so its answer is not evidence."
         )
 
 
@@ -271,63 +516,274 @@ class TestTeachbackAckSite:
     }
 
     def test_arm_b_lead_without_agent_flag_emits(self, frame_rig):
-        records, _ = frame_rig(_arm_b(**self.FRAME_EXTRA))
-        assert len(_typed(records, "teachback_ack")) == 1, (
+        drive = frame_rig(_arm_b(**self.FRAME_EXTRA))
+        assert len(drive.typed("teachback_ack")) == 1, (
             "The teachback acknowledgement must reach the canonical journal "
             "from a lead frame that carries no --agent flag."
         )
 
     def test_arm_c_in_process_teammate_emits(self, frame_rig):
-        records, _ = frame_rig(_arm_c(**self.FRAME_EXTRA))
-        assert len(_typed(records, "teachback_ack")) == 1
+        drive = frame_rig(_arm_c(**self.FRAME_EXTRA))
+        assert len(drive.typed("teachback_ack")) == 1
 
     def test_arm_d_tmux_teammate_stays_silent(self, frame_rig):
-        records, _ = frame_rig(_arm_d(**self.FRAME_EXTRA))
-        assert _typed(records, "teachback_ack") == []
+        drive = frame_rig(_arm_d(**self.FRAME_EXTRA))
+        assert drive.typed("teachback_ack") == []
 
 
-class TestArtifactPathsAdvisorySite:
-    """The `artifact_paths_emit_missing` advisory.
+class TestHandoffBackstopSite:
+    """The post-completion handoff backstop.
 
-    🔴 THIS SITE WRITES NO JOURNAL RECORD. It appends an advisory to the
-    RETURN VALUE. An arm that watches `append_event` alone is blind here and
-    reports the site as silent, which reads as a passing control. The
-    fixture returns the two channels for that cause. Do not narrow these
-    assertions to the journal channel.
+    ITS FRAME CLASS IS THE OPPOSITE OF THE ACCEPTANCE-COMMIT ONE, and that
+    is why a completion-shaped fixture cannot drive it. The whole block is
+    gated on ``tool_input.status != "completed"``, so it fires on a
+    METADATA-ONLY TaskUpdate that lands on a task the disk already records
+    as completed. A fixture that sets status="completed" routes to the
+    completion branch and skips this site entirely.
+
+    THE INCOMING WRITE CARRIES ONLY ``handoff``. That is what isolates this
+    site from its sibling: the snapshot backstop excludes ``handoff`` from
+    its payload and emits nothing when it is the only key.
     """
 
+    DISK_TASK = _completed_task(metadata={})
     FRAME_EXTRA = {
         "tool_name": "TaskUpdate",
-        "tool_input": {"taskId": "7", "status": "completed"},
-        "tool_response": {
-            "task": {
-                "id": "7",
-                "owner": "architect",
-                "subject": "ARCHITECT: the feature",
-                "metadata": {},
-            }
-        },
+        "tool_input": {"taskId": "7", "metadata": {"handoff": HANDOFF}},
+        "tool_response": {"task": {"id": "7"}},
     }
 
-    def test_arm_b_lead_without_agent_flag_raises_the_advisory(self, frame_rig):
-        records, advisories = frame_rig(_arm_b(**self.FRAME_EXTRA))
-        assert "artifact_paths_emit_missing" in advisories, (
-            "The artifact-paths check must run in a canonical-journal frame. "
-            "If it is absent, the gate skipped the check on ROLE, and the "
-            "missing durability pointer goes unreported."
-        )
-        assert records == [] or True, (
-            "Recorded deliberately: this site writes NO journal record. The "
-            "advisory channel is the observable."
+    def test_arm_b_lead_without_agent_flag_emits(self, frame_rig):
+        drive = frame_rig(_arm_b(**self.FRAME_EXTRA), disk_task=self.DISK_TASK)
+        assert len(drive.typed("agent_handoff")) == 1, (
+            "The backstop is the GUARANTEE leg for a handoff written after "
+            "completion. A lead with no --agent flag writes the canonical "
+            "journal, so suppressing it here loses the record with no "
+            "second chance: the completion-time seam has already passed."
         )
 
-    def test_arm_c_in_process_teammate_raises_the_advisory(self, frame_rig):
-        _, advisories = frame_rig(_arm_c(**self.FRAME_EXTRA))
-        assert "artifact_paths_emit_missing" in advisories
+    def test_arm_c_in_process_teammate_emits(self, frame_rig):
+        drive = frame_rig(_arm_c(**self.FRAME_EXTRA), disk_task=self.DISK_TASK)
+        assert len(drive.typed("agent_handoff")) == 1
 
     def test_arm_d_tmux_teammate_stays_silent(self, frame_rig):
-        _, advisories = frame_rig(_arm_d(**self.FRAME_EXTRA))
-        assert "artifact_paths_emit_missing" not in advisories, (
-            "A tmux teammate must not raise this advisory: it reads a "
-            "journal it does not share, so its answer is not evidence."
+        """T7 control for this site."""
+        drive = frame_rig(_arm_d(**self.FRAME_EXTRA), disk_task=self.DISK_TASK)
+        assert drive.typed("agent_handoff") == []
+
+    def test_the_snapshot_sibling_stays_silent_on_a_handoff_only_write(
+            self, frame_rig):
+        """SEPARATION PIN, and it is what lets each backstop name its own
+        mutant. If this arm ever fails, a handoff-only write also drives the
+        snapshot backstop, the two sites share one observable again, and a
+        revert of either one reddens both arm sets."""
+        drive = frame_rig(_arm_b(**self.FRAME_EXTRA), disk_task=self.DISK_TASK)
+        assert drive.typed("task_metadata_snapshot") == [], (
+            "A handoff-ONLY write must not produce a snapshot record: "
+            "handoff is excluded from the snapshot payload, and an empty "
+            "payload is ineligible."
+        )
+
+
+class TestSnapshotBackstopSite:
+    """The post-completion `task_metadata_snapshot` backstop.
+
+    THE INCOMING WRITE CARRIES NO ``handoff``, which is what isolates this
+    site from the handoff backstop: that sibling requires an incoming
+    handoff dict and does not fire here.
+
+    IT IS ALSO DISJOINT FROM THE OPEN-TASK PER-WRITE MIRROR, which is a
+    SEVENTH gate site that this commit did not change. The two legs split on
+    the same on-disk status read: the mirror fires when the disk task is NOT
+    completed, and this backstop fires when it is. The fixture seeds a
+    completed task, so a snapshot record here can only come from this site.
+    """
+
+    DISK_TASK = _completed_task(metadata={})
+    FRAME_EXTRA = {
+        "tool_name": "TaskUpdate",
+        "tool_input": {
+            "taskId": "7",
+            "metadata": {"audit_summary": {"verdict": "GREEN"}},
+        },
+        "tool_response": {"task": {"id": "7"}},
+    }
+
+    def test_arm_b_lead_without_agent_flag_emits(self, frame_rig):
+        drive = frame_rig(_arm_b(**self.FRAME_EXTRA), disk_task=self.DISK_TASK)
+        assert len(drive.typed("task_metadata_snapshot")) == 1, (
+            "A late metadata write on a completed task is observed by "
+            "neither completion-time seam, so this backstop is its only "
+            "durable mirror. A lead with no --agent flag must reach it."
+        )
+
+    def test_arm_c_in_process_teammate_emits(self, frame_rig):
+        drive = frame_rig(_arm_c(**self.FRAME_EXTRA), disk_task=self.DISK_TASK)
+        assert len(drive.typed("task_metadata_snapshot")) == 1
+
+    def test_arm_d_tmux_teammate_stays_silent(self, frame_rig):
+        """T7 control for this site."""
+        drive = frame_rig(_arm_d(**self.FRAME_EXTRA), disk_task=self.DISK_TASK)
+        assert drive.typed("task_metadata_snapshot") == []
+
+    def test_the_handoff_sibling_stays_silent_without_an_incoming_handoff(
+            self, frame_rig):
+        """SEPARATION PIN, the mirror image of the one on the sibling."""
+        drive = frame_rig(_arm_b(**self.FRAME_EXTRA), disk_task=self.DISK_TASK)
+        assert drive.typed("agent_handoff") == [], (
+            "A write with no incoming handoff must not drive the handoff "
+            "backstop, or the two backstops share one observable and no arm "
+            "can name which site a revert broke."
+        )
+
+
+# =============================================================================
+# T6 — the additive shape, RECORDED rather than treated as a defect.
+# =============================================================================
+class TestAdditiveShapeAtTheTwoAppendOnlySites:
+    """`dispatch_variety` and `teachback_ack` are APPEND-ONLY. They carry no
+    O_EXCL marker and no content-hash dedup, unlike `agent_handoff` and
+    `task_metadata_snapshot`. So two frames give two records.
+
+    🔴 THIS ARM RECORDS THAT SHAPE. IT DOES NOT FAIL ON IT. A duplicate row
+    at these two kinds is not evidence of a defect this commit introduced,
+    because duplicate rows are present at the LEAD frame today, before any
+    widening of the frame set.
+
+    THE MEASURED BASELINE, with its parameter stated adjacent to the number
+    because a count with an unstated parameter cannot be compared.
+      POPULATION: 2274 `session-journal.jsonl` files below
+      `~/.claude/pact-sessions`, 60346 lines, holding 981 `dispatch_variety`
+      and 849 `teachback_ack` records.
+      COUNTING RULE: two records with the same `type` AND the same `task_id`
+      in the SAME file, content compared with the `ts` field REMOVED.
+      RESULT: 19 duplicate pairs. 11 of them inside 600 seconds. Of those
+      11, eight differ by one `agent` key the second record carries, which
+      is a schema change rather than a repeat. THREE are content-equal. So
+      the duplicate rate is about 3 in 1830 records, near 0.16 percent.
+
+    THE BOUND ON THAT NUMBER, and no ruling rests on the stronger claim: it
+    shows duplicate rows are PRESENT at the lead frame. It does NOT show
+    that a repeat PostToolUse frame is reachable, because the records carry
+    no session identifier and no invocation identifier, so a second genuine
+    tool call and a repeat frame give the same shape.
+    """
+
+    def test_two_frames_give_two_dispatch_variety_records(self, frame_rig):
+        frame = _arm_b(**TestDispatchVarietySite.FRAME_EXTRA)
+        frame_rig(frame)
+        drive = frame_rig(frame)
+        assert len(drive.typed("dispatch_variety")) == 2, (
+            "RECORDING THE SHAPE, not asserting a dedup that does not "
+            "exist: this site is append-only by design, so a second frame "
+            "gives a second record. A future editor who adds dedup here "
+            "must change this arm deliberately rather than discover it."
+        )
+
+    def test_two_frames_give_two_teachback_ack_records(self, frame_rig):
+        frame = _arm_b(**TestTeachbackAckSite.FRAME_EXTRA)
+        frame_rig(frame)
+        drive = frame_rig(frame)
+        assert len(drive.typed("teachback_ack")) == 2
+
+    def test_the_marker_bearing_sites_do_dedup_and_that_is_the_contrast(
+            self, frame_rig):
+        """THE CONTRAST THAT MAKES THE TWO ARMS ABOVE MEAN SOMETHING. If
+        every site were append-only, "two frames give two records" would be
+        a property of the journal rather than of these two sites. The
+        handoff emit carries an occupant-and-content marker, so a repeat of
+        the SAME content gives ONE record."""
+        frame = _arm_b(**TestLeadSideAgentHandoffSite.FRAME_EXTRA)
+        frame_rig(frame)
+        drive = frame_rig(frame)
+        assert len(drive.typed("agent_handoff")) == 1, (
+            "The marker-bearing site must dedup an identical repeat. If it "
+            "does not, the append-only arms above record nothing specific."
+        )
+        assert drive.emit_calls.count("_emit_lead_side_agent_handoff") == 1, (
+            "NON-VACUITY: the emitter must be CALLED on the second frame. "
+            "If it is not, the single record proves the gate rejected the "
+            "second frame and says nothing about dedup."
+        )
+
+
+# =============================================================================
+# T3 — the ordering pin, driven through a REAL subprocess with no seeded
+#      context. Section 8.3 of the architecture document.
+# =============================================================================
+class TestSubprocessOrderingPin:
+    """`main()` calls `pact_context.init(input_data)` BEFORE
+    `evaluate_lifecycle(input_data)`. That order is load-bearing: the frame
+    gates resolve the team through `get_team_name()`, and an unpopulated
+    context makes the topology leg unresolvable. The gate then degrades
+    SILENTLY to `is_lead`, and a canonical-frame emit is lost with no record.
+
+    🔴 EVERY IN-PROCESS ARM IN THIS FILE IS TRUE ON EITHER SIDE OF THAT
+    ORDER, because the fixture seeds the context before the drive. So none
+    of them can see the ordering. This arm drives the hook as a real
+    subprocess with an UNSEEDED context, which is the only place the order
+    is observable.
+    """
+
+    def test_in_process_teammate_emits_through_a_real_hook_process(
+            self, tmp_path):
+        home = tmp_path / "home"
+        slug = Path(PROJECT_DIR).name
+        session_dir = home / ".claude" / "pact-sessions" / slug / SESSION_ID
+        session_dir.mkdir(parents=True)
+        # The on-disk context file is what `pact_context.init()` READS. The
+        # in-process module globals stay unseeded, which is the state this
+        # arm exists to exercise.
+        session_dir.joinpath("pact-session-context.json").write_text(
+            json.dumps({
+                "team_name": TEAM,
+                "session_id": SESSION_ID,
+                "project_dir": PROJECT_DIR,
+                "plugin_root": "",
+                "started_at": "2026-01-01T00:00:00Z",
+            }),
+            encoding="utf-8",
+        )
+        teams = home / ".claude" / "teams" / TEAM
+        teams.mkdir(parents=True)
+        teams.joinpath("config.json").write_text(
+            json.dumps({"leadSessionId": SESSION_ID}), encoding="utf-8"
+        )
+        tasks = home / ".claude" / "tasks" / TEAM
+        tasks.mkdir(parents=True)
+        tasks.joinpath("7.json").write_text(
+            json.dumps(_completed_task(metadata={})), encoding="utf-8"
+        )
+        frame = dict(TestLeadSideAgentHandoffSite.FRAME_EXTRA)
+        frame["agent_type"] = TEAMMATE_AGENT_TYPE
+        frame["session_id"] = SESSION_ID
+        frame["team_name"] = TEAM
+        frame["cwd"] = str(home)
+
+        env = dict(os.environ)
+        env["HOME"] = str(home)
+        env.pop("CLAUDE_CONFIG_DIR", None)
+        # init() derives the session-dir slug from this basename. Without it
+        # get_session_dir() is empty and every journal write defers silently,
+        # which would make this arm red for an unrelated cause.
+        env["CLAUDE_PROJECT_DIR"] = PROJECT_DIR
+        result = subprocess.run(
+            [sys.executable, str(HOOKS_DIR / "task_lifecycle_gate.py")],
+            input=json.dumps(frame),
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(home),
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+
+        records = _journal_records(home)
+        assert [r for r in records if r.get("type") == "agent_handoff"], (
+            "An in-process teammate frame emitted NOTHING through the real "
+            "hook process. Two causes give this one empty result and each "
+            "is a defect: the frame gate answered on ROLE, or "
+            "pact_context.init() no longer runs before evaluate_lifecycle() "
+            "so the topology leg could not resolve and the gate degraded "
+            "silently to is_lead.\nstderr: " + result.stderr
         )

--- a/pact-plugin/tests/test_dispatch_variety_teachback_ack_emit.py
+++ b/pact-plugin/tests/test_dispatch_variety_teachback_ack_emit.py
@@ -4,7 +4,9 @@ dispatch_variety + teachback_ack mirror per-dispatch variety and the teammate's
 variety_acknowledgment into the GC-immune journal so wrap-up Q5/Q6 survive the
 teams/tasks reaper (the task store goes false-empty after GC).
 
-Both emit from the existing PostToolUse task_lifecycle_gate, is_lead-gated:
+Both emit from the existing PostToolUse task_lifecycle_gate, gated on
+is_canonical_journal_frame (the lead frame in either teammateMode, AND the
+in-process teammate frame; the tmux teammate frame skips):
   - dispatch_variety: on the TaskCreate of a Task-B carrying metadata.variety.
     The new Task-B id comes from tool_response.task.id (the create-result
     post-state), falling back to tool_input.taskId. Keyed on metadata.variety
@@ -14,7 +16,10 @@ Both emit from the existing PostToolUse task_lifecycle_gate, is_lead-gated:
     reads variety_acknowledgment off the DISK Task-A (the accept TaskUpdate
     carries only status).
 
-Both-modes matrix (M9-M11): lead frame emits; teammate frame self-drops (#877).
+Both-modes matrix (M9-M11): the lead frame emits, and the teammate frames below
+do not. Their silence is the frame gate acting on fixtures that carry no
+session_id and seed no leadSessionId team config, so the topology leg cannot
+resolve. These arms do NOT cover the in-process teammate frame, which emits.
 Drives tlg.evaluate_lifecycle with tlg.append_event spied to capture events.
 """
 import sys
@@ -135,7 +140,9 @@ class TestM9DispatchVariety:
         assert len(dv) == 1 and dv[0]["task_id"] == "77"
 
     def test_teammate_frame_no_emit(self, emit_events):
-        """M9 dual-mode: teammate frame self-drops (no canonical journal)."""
+        """M9 dual-mode: this teammate frame does not emit. The suppression is
+        the frame gate: the frame carries no session_id, so the topology leg
+        cannot resolve. This arm does NOT cover the in-process teammate."""
         tlg.evaluate_lifecycle({
             "tool_name": "TaskCreate",
             "agent_type": TEAMMATE,
@@ -216,7 +223,9 @@ class TestM10TeachbackAck:
         assert ta[0]["concern"] == "risk rationale understated"
 
     def test_teammate_frame_no_emit(self, emit_events):
-        """M10 dual-mode: teammate frame self-drops."""
+        """M10 dual-mode: this teammate frame does not emit. The suppression is
+        the frame gate: the frame carries no session_id, so the topology leg
+        cannot resolve. This arm does NOT cover the in-process teammate."""
         tlg.evaluate_lifecycle(self._ack_payload(agent_type=TEAMMATE))
         assert _typed(emit_events, "teachback_ack") == []
 

--- a/pact-plugin/tests/test_handoff_917_captured_regression.py
+++ b/pact-plugin/tests/test_handoff_917_captured_regression.py
@@ -286,9 +286,17 @@ class TestBothModesCaptured:
     def test_b2_gate_suppresses_captured_teammate_spelling(
         self, tmp_path, monkeypatch, pact_context
     ):
-        """The b2 emit is is_lead-gated: the REAL captured teammate agent_type
-        spelling ('pact-architect') applied to a b2-shaped frame is SUPPRESSED,
-        while the lead spelling on the same frame EMITS (positive control).
+        """The b2 emit is is_canonical_journal_frame-gated: the REAL captured
+        teammate agent_type spelling ('pact-architect') applied to a b2-shaped
+        frame is SUPPRESSED, while the lead spelling on the same frame EMITS
+        (positive control).
+
+        THE SUPPRESSION IS NARROWER THAN IT LOOKS. This frame DOES carry a
+        session_id equal to LEAD_SESSION, so it supplies the frame half of the
+        topology leg. It is suppressed only because no team config carrying a
+        leadSessionId is seeded, so _read_lead_session_id returns the empty
+        string and the leg answers False. Seed that config and this same
+        teammate spelling EMITS, because it is then the in-process teammate.
 
         Frame STRUCTURE is the captured lead PostToolUse(TaskUpdate, completed);
         only agent_type is varied — the captured-grounded analog of
@@ -301,7 +309,7 @@ class TestBothModesCaptured:
         teammate_spelling = captured_teammate_taskcompleted()["agent_type"]
         subject = captured_teammate_taskcompleted()["task_subject"]
 
-        # teammate spelling → is_lead False → b2 suppressed
+        # teammate spelling + no leadSessionId config → frame gate False → b2 skips
         suppressed = captured_lead_posttooluse_taskupdate_completed()
         suppressed["tool_input"]["taskId"] = TASK_ID
         suppressed["agent_type"] = teammate_spelling

--- a/pact-plugin/tests/test_handoff_eligibility_parity.py
+++ b/pact-plugin/tests/test_handoff_eligibility_parity.py
@@ -206,8 +206,8 @@ class TestGateEmitFailOpen:
 
     def test_fail_open_does_not_suppress_unrelated_advisories(self, tmp_path, monkeypatch, pact_context):
         """The emit failure must not swallow the gate's normal advisory
-        evaluation. A teammate self-completion (no is_lead → emit not reached,
-        but an unrelated advisory path) still evaluates — sanity that the emit
+        evaluation. A teammate self-completion (the frame gate answers False, so the
+        emit is not reached, but an unrelated advisory path) still evaluates — sanity that the emit
         try/except is scoped to the emit, not the whole gate."""
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         pact_context(team_name=TEAM, session_id="s")

--- a/pact-plugin/tests/test_handoff_write_after_completion_backstop.py
+++ b/pact-plugin/tests/test_handoff_write_after_completion_backstop.py
@@ -19,8 +19,9 @@ true reachability canary even if the backstop logic regresses).
 
 Driving pattern mirrors test_lead_side_handoff_emit.py: spy on tlg.append_event to
 capture emitted events; seed a real on-disk task.json so the gate's read_task_json
-resolves the completed-task post-state; key is_lead on agent_type (the only tmux-safe
-discriminator).
+resolves the completed-task post-state; key is_canonical_journal_frame on the frame
+(agent_type OR session_id == leadSessionId), which admits the lead frame in either
+teammateMode AND the in-process teammate frame, and excludes the tmux teammate.
 """
 import json
 import sys
@@ -139,10 +140,12 @@ class TestBackstopFires:
     def test_backstop_both_modes_teammate_frame_no_emit(
         self, tmp_path, monkeypatch, pact_context, emit_events
     ):
-        """M7 dual-mode variant: the identical race under a TEAMMATE frame
-        (is_lead False) does NOT emit — a teammate process has no canonical
-        journal and self-drops (#877). is_lead is the only tmux-safe
-        discriminator."""
+        """M7 dual-mode variant: the identical race under a TEAMMATE frame does
+        NOT emit. The suppression is the frame gate: this fixture frame seeds no
+        team config carrying a leadSessionId, so the topology leg cannot resolve
+        and is_canonical_journal_frame returns False. This arm does NOT cover the
+        in-process teammate frame, which DOES write the canonical journal and
+        DOES emit."""
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         pact_context(team_name=TEAM, session_id="s1")
         _seed_task(
@@ -153,7 +156,10 @@ class TestBackstopFires:
         tlg.evaluate_lifecycle(
             _metadata_only_handoff_update("42", agent_type=TEAMMATE)
         )
-        assert len(emit_events) == 0, "teammate frame must self-drop the backstop emit"
+        assert len(emit_events) == 0, (
+            "a frame that cannot resolve the canonical-journal topology must not "
+            "emit the backstop (this fixture seeds no leadSessionId team config)"
+        )
 
 
 # =============================================================================

--- a/pact-plugin/tests/test_lead_side_handoff_emit.py
+++ b/pact-plugin/tests/test_lead_side_handoff_emit.py
@@ -11,7 +11,8 @@ a populated context.
 
 This file drives tlg.evaluate_lifecycle(payload) with tlg.append_event spied to
 capture emitted events, exercising the b2 emit-eligibility discriminator (which
-MIRRORS agent_handoff_emitter's b1 gates) + the is_lead topology gate. Every
+MIRRORS agent_handoff_emitter's b1 gates) + the is_canonical_journal_frame
+gate, which reads the agent_type role leg AND the session_id topology leg. Every
 SUPPRESS row carries a same-fixture POSITIVE CONTROL proving the suppression is
 the intended discriminator firing, not an unrelated missing precondition.
 
@@ -108,7 +109,7 @@ class TestLeadEmits:
 
 
 # =============================================================================
-# Topology gate (is_lead) — SUPPRESS rows + same-fixture positive controls
+# Frame gate (is_canonical_journal_frame) — SUPPRESS rows + positive controls
 # =============================================================================
 class TestIsLeadTopologyGate:
     def test_teammate_frame_no_emit(self, tmp_path, monkeypatch, pact_context, emit_events):
@@ -116,15 +117,15 @@ class TestIsLeadTopologyGate:
         pact_context(team_name=TEAM, session_id="s1")
         tlg.evaluate_lifecycle(_payload(agent_type="pact-devops-engineer"))
         assert len(emit_events) == 0, (
-            "a teammate process (is_lead False) must NOT emit — its context "
-            "has no canonical journal; only the lead's process emits"
+            "a frame that cannot resolve the canonical-journal topology must "
+            "not emit (this fixture seeds no leadSessionId team config)"
         )
 
     def test_teammate_frame_positive_control_lead_same_fixture_emits(
         self, tmp_path, monkeypatch, pact_context, emit_events
     ):
         """Positive control: the identical fixture under the LEAD frame DOES
-        emit — proving the suppression above is the is_lead gate, not a
+        emit — proving the suppression above is the frame gate, not a
         missing handoff/owner."""
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         pact_context(team_name=TEAM, session_id="s1")

--- a/pact-plugin/tests/test_lead_side_handoff_emit.py
+++ b/pact-plugin/tests/test_lead_side_handoff_emit.py
@@ -111,7 +111,7 @@ class TestLeadEmits:
 # =============================================================================
 # Frame gate (is_canonical_journal_frame) — SUPPRESS rows + positive controls
 # =============================================================================
-class TestIsLeadTopologyGate:
+class TestCanonicalJournalFrameGate:
     def test_teammate_frame_no_emit(self, tmp_path, monkeypatch, pact_context, emit_events):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         pact_context(team_name=TEAM, session_id="s1")
@@ -133,7 +133,13 @@ class TestIsLeadTopologyGate:
         assert len(emit_events) == 1
 
     def test_empty_agent_type_no_emit(self, tmp_path, monkeypatch, pact_context, emit_events):
-        """is_lead('') is False (empty agent_type fail-safe)."""
+        """An empty agent_type makes the ROLE leg False, so the gate falls
+        to the TOPOLOGY leg. THIS FIXTURE SEEDS NO leadSessionId TEAM CONFIG,
+        so that leg cannot resolve either and the emit is suppressed. DO NOT
+        READ THIS AS A FAIL-SAFE PROPERTY OF THE EMPTY agent_type: the same
+        value with a resolvable topology DOES emit, which is the lead
+        launched with no --agent flag. See
+        test_canonical_journal_frame_gate.py for that arm."""
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         pact_context(team_name=TEAM, session_id="s1")
         tlg.evaluate_lifecycle(_payload(agent_type=""))

--- a/pact-plugin/tests/test_snapshot_seams_gate.py
+++ b/pact-plugin/tests/test_snapshot_seams_gate.py
@@ -5,7 +5,9 @@ Summary: Seam tests for the task_metadata_snapshot emission points inside
          the lead-side agent_handoff emit) and the post-completion backstop
          seam (the any-metadata generalization of the handoff backstop).
          Covers the both-modes matrix (lead vs teammate frames — the
-         is_lead runtime structural signal), signal-task INCLUSION with the
+         is_canonical_journal_frame runtime signal, which combines the
+         agent_type role leg with the session_id topology leg), signal-task
+         INCLUSION with the
          unconditional agent_handoff-suppression leg, eligibility
          (handoff-only → no snapshot), ownerless emission, incoming-metadata
          merge, and content-key dedup/supersession across re-fires.
@@ -168,9 +170,12 @@ class TestSeamALeadCompletion:
     def test_teammate_frame_no_snapshot(
         self, tmp_path, monkeypatch, pact_context, snapshot_events
     ):
-        """Both-modes matrix, teammate leg: a non-lead frame must not emit —
-        its context has no canonical journal (the tmux-mode teammate
-        completion is covered by the TaskCompleted seam instead)."""
+        """Both-modes matrix, teammate leg: this teammate frame must not emit.
+        The suppression is the frame gate: this fixture frame seeds no team
+        config carrying a leadSessionId, so the topology leg cannot resolve and
+        is_canonical_journal_frame returns False. This arm does NOT cover the
+        in-process teammate frame, which DOES emit. The tmux-mode teammate
+        completion is covered by the TaskCompleted seam instead."""
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         pact_context(team_name=TEAM, session_id="s1")
         tlg.evaluate_lifecycle(_completion_payload(agent_type=TEAMMATE))
@@ -180,7 +185,7 @@ class TestSeamALeadCompletion:
         self, tmp_path, monkeypatch, pact_context, snapshot_events
     ):
         """The identical fixture under the LEAD frame emits — the
-        suppression above is the is_lead gate, nothing else."""
+        suppression above is the frame gate, nothing else."""
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         pact_context(team_name=TEAM, session_id="s1")
         tlg.evaluate_lifecycle(_completion_payload(agent_type=LEAD))

--- a/pact-plugin/tests/test_snapshot_subprocess_seam.py
+++ b/pact-plugin/tests/test_snapshot_subprocess_seam.py
@@ -391,7 +391,9 @@ class TestSeamASubprocess:
 
     def test_teammate_frame_no_snapshot_in_real_journal(self, tmp_path):
         # Both-modes: the same frame under a teammate agent_type must not
-        # fire the lead-completion seam (is_lead structural signal).
+        # fire the lead-completion seam. The frame gate answers False here
+        # because no leadSessionId team config is seeded, so the topology
+        # leg cannot resolve.
         home, session_dir, tasks_dir = _seed_home(tmp_path)
         _write_task(tasks_dir, "42", status="completed",
                     metadata=dict(SIBLINGS))


### PR DESCRIPTION
## What this does

Completes the TEST phase for the canonical-journal frame gate. Six production sites moved from `pact_context.is_lead` to `is_canonical_journal_frame` in earlier work. This PR makes that substitution **provable**: a revert at any of the six now reddens at least one arm.

**Production code IS in the merge set.** `main..HEAD` is **six** commits, and the first of them carries the substitution itself:

| file | change |
|---|---|
| `hooks/task_lifecycle_gate.py` | 149 lines: the six gate calls |
| `hooks/missed_wake_scan.py` | 6 lines: comment-only |

Totals for the hook surface: **109 insertions, 46 deletions**. The remaining five commits are test files and the version bump.

> **Correction, recorded rather than silently edited.** This section first read *"No production code changes. Test files only, plus the version bump."* That was **false for the merge set**. It described the final work commit and not the branch. A reviewer who trusted it would have skipped 109 insertions of gate logic. The error came from reading a truncated `git log -3` and treating its length as the commit total. The production diff is in scope for review.

## The finding that unblocked it

A prior TEST phase reported three of the six sites as **undriven** and could not reach them. They were driven the whole time.

The prior rig patched `append_event` on its **source module**. But the lead-side emit and the two snapshot emits call the name **imported into their own modules**, so a source-module patch rebinds none of them. Those sites fired and wrote while the recorder heard nothing.

**An empty record list from a deaf instrument is byte-identical to a correct gate rejection.** That is why two sessions read the silence as a gate result.

The rig now mocks nothing: it redirects `Path.home`, clears the config-dir variable that outranks home, and reads the real journal file, so all three import routes end at one file by construction.

### Why the sites were re-examined at all

The prior test phase **refused** to upgrade its report from *not-driven-by-my-fixture* to *unreachable*, on the ground that unreachable is a claim about the code and not-driven is a claim about a fixture. Had it written *unreachable*, these three would have shipped behind a documented impossibility and nobody would have looked again.

## Two corrections to the inherited picture

Facts about the code, not about the fixture. Each makes a completion-shaped fixture the wrong instrument, for a **different** cause:

1. The lead-side emit takes its task from the tool response and needs **no task on disk**.
2. The two backstops are gated on a **not-completed** status, so a fixture that sets completed routes past them.

> **Which `status`, because two are in play and they point opposite ways.** The claim is about **`tool_input.get("status") != "completed"`**, the *enclosing branch*. It is **not** about `task_a.get("status") == "completed"`, the *inner condition* that sits adjacent to the frame gate. Those are 260 lines apart and each is spelled `status`. Read against the enclosing branch the sentence is correct; read against the inner condition it is **inverted** — and a reviewer who checks the claim at the frame gate lands on the inverted one first. Claim-clarity defect in this body, not a code defect. Found by the design reviewer.

## Mutation results

Twelve mutants run, twelve die. Each is killed by at least one arm that no other mutant reddens.

> **Correction: "kill sets disjoint" was wrong.** The kill sets are disjoint *inside* each class of six, **not across the two**. `test_arm_d_is_a_gate_rejection_and_not_a_dedup_no_op` reddens for the lead-side revert **and** the lead-side open. `test_the_two_cells_differ_only_in_the_topology_half` reddens for the artifact revert **and** the artifact open. **The conclusion survives**: each of the twelve keeps a detector no other mutant shares, so twelve independent detectors holds. One word carried two properties. Conceded by the builder; measured independently by the reviewer.

| class | what it does | result |
|---|---|---|
| revert (6) | one gate call back to `is_lead` | 3, 5, 5, 3, 2, 2 arms redden |
| open (6) | one gate call forced to admit | tmux control at that site is among the killers of each |

The **open** class is the non-vacuity proof for obligation T7. An arm that must stay at zero is exactly the arm that can be dead and green forever, because a fixture that never reaches the site gives the same zero. Each control was made to go red on demand.

**Bound**: kill sets were measured against two test files, not the full tree. The disjointness is a claim about that population; other files can redden too.

## Two counts, because the phrase carries two questions

- **Discrimination count: 12.** No arm reddens for two mutants, so each mutant has a detector no other mutant shares.
- **Survival count: 4, and the condition set behind it is understated.** 36 arms sit in 4 named clusters. Two claims attached to that number were measured and are **wrong**, both in the safe direction:
>
> **"The 25 arms of cluster A go silent rather than red" is false for the majority.** Measured across two deliberate rig breaks: reader pointed at a wrong root gives **15 red of 28**; team-config write removed gives **17 red of 28**. The accurate rule: **presence-asserting arms redden, absence-asserting arms go falsely green.** Nine arms are falsely green in the reader break, and every one of them asserts an absence. The dangerous direction is real but it belongs to the arm-D controls and the separation pins, not to all 25.
>
> **"Cluster B shares nothing with A" is false.** The subprocess arm calls the same `_journal_records` reader and reddens on rig break 1. Clusters A and D also share the conftest `pact_context` fixture: removing its context-path patch reddens **47 of 90** across both files. So the survival count of 4 rests on an unstated condition set.
>
> **The cluster-D counting rule printed here does not produce 7.** Cluster D is 7 *collected items* from 5 source functions, being the set the frame gate reaches. The rule as written, "share `live_env`", selects **34** source functions. The 35 total is right; the rule printed beside it is not.

> **Correction.** This line first said **31** arms. Measured, counting rule is lines matching `def test_`: the frame-gate file holds 28, and clusters A+B+C are 25+1+2 = 28, matching it exactly. Cluster D adds 7 from the artifact file. **25+1+2+7 = 35** at that head, and a later commit added one arm to cluster A, giving **36**. The survival count of 4 is unaffected. The ratio it rests on is 26 of 36, not 25 of 31. Found by the reviewer assigned to the arm set, before it began its work task.

## Obligations

T2 through T7 delivered, with one name that overclaims.

> **T4's renamed arm stays green when the gate is reverted.** `test_teammate_then_lead_same_fixture_proves_gate_is_the_frame` is absent from the artifact-revert failing set. Its inputs are a teammate frame with no topology half and a lead frame, and **both predicates agree at both**, so the arm cannot make the discrimination its new name asserts — the same overclaim the old name made. **The coverage itself is present**, in cell 2 of the T2 matrix. Only the name is wrong.

> **What the matrix shows, and what it does not.** All twelve mutants change the **gate line**. None changes another conjunct of the six guards. The reviewer dropped the incoming-handoff conjunct from the handoff backstop and **all 90 arms passed**, because the emitter re-validates handoff presence and absorbs it. So the matrix shows the **gate line is observable at each site**. It does **not** show the surrounding guard is pinned.

> Also measured: the `emit_task_metadata_snapshot` spy is read by **no assertion**. It is symmetry with the handoff spy and covers nothing.

> **The absorption sweep, and its bound.** The reviewer forced each of the **10 non-gate conjuncts** of the two post-completion backstop guards to True, one mutant per conjunct. **Ten mutants, ten survivors**, 90 passed on each. Three were classified as equivalent; **seven were left unclassified rather than called gaps**.
>
> 🔴 **Do not read that as a bounded class.** The population is the **two backstop guards only**. The other four guards carry conjuncts that **nobody has mutated**. Ten survivors is not the size of the absorption class — it is the size of the part that was measured. The builder raised this bound unprompted, against a report that would otherwise have read as more complete than it is.
>
> One survivor lands on this PR's own deliverable: the builder recorded that the snapshot backstop and the open-task per-write mirror are disjoint on the disk status read, and pinned it **in a docstring rather than an assertion**. The sweep shows the docstring is the only thing holding it. **A docstring pins nothing.** A real arm for it is in flight. T2 turned `test_empty_or_missing_agent_type_no_advisory` into a two-arm matrix, since the prior single arm pinned the defect as a fail-safe property. The two subprocess ordering arms are kept **deliberately** — they pin different gate sites, and removing the older one would narrow coverage to the sites this change happens to touch.

## The result that decides the merge

**`is_canonical_journal_frame` is a strict superset of `is_lead` on dict input.** Measured across **162 frames** — 9 `agent_type` values × 6 `session_id` values × 3 config states — with **zero superset violations and zero raises**.

**So no frame that emitted before stops emitting. The change introduces no new drop.**

That sentence is what makes the skip table below safe to read. The predicate never raises (its whole body sits in a `try` returning False), so **skip is the only failure mode**, and all six sites fail closed:

| site | what a skip costs |
|---|---|
| 1602 `dispatch_variety` | drops the calibration event, no later seam |
| 1722 `agent_handoff` + paired snapshot | drops two record kinds; the backstops do **not** recover this, they key on a post-completion write |
| 1802 artifact-paths | **withholds a nudge** — advisory, non-blocking, not the same severity as the other five |
| 1875 `teachback_ack` | drops the event, append-only, no dedup |
| 2216 / 2261 backstops | **terminal drops** — last resort, not a deferral |

Read alone that table is six hazards. With the superset result it is six **unchanged** hazards, every one of which also occurred at the shipped baseline. The same matrix confirms the tmux teammate stays excluded, and that with the config absent or malformed the admitted set falls back to the `is_lead` rows alone.

**The one retained `is_lead` site (1444) is required, not merely permitted.** It asks a *role* question about a task-JSON write. The frame predicate returns true for an in-process teammate, so substituting there would route an auditor into the lead recovery branch and send its own verdict to `lead_close_note`. Both reviewers reached this independently.

**Containment measured, not read.** The subprocess arm was run under a PEP 578 audit hook recording every write-mode `open`, `mkdir`, `rename` and `remove`, with a positive control proving the instrument catches a write outside the tree. Result: exit 0, 6 audited writes, 2 journal records including the `agent_handoff`, **all six rooted in the redirected home**. Extended to all 28 arms: 593 write events, and the only genuine outside writes are `__pycache__`, `/dev/null` and `.pytest_cache`. Worktree `git status` empty. No `CLAUDE.md` anywhere.

> The reviewer's **first** containment run was vacuous and it caught that: `runpy` left the hooks dir off `sys.path`, the import failed, and the probe reported **zero events — which reads identically to perfect containment**. Only the positive control separated the two zeros.

## Gate

`python3 -m pytest -q` run from `pact-plugin`, no path argument.

```
14757 passed, 15 skipped, 2 warnings in 460.83s
```

Zero FAILED, zero ERROR, zero `E ` lines. **PYTEST exit code 0, captured with no pipe.**

> **A pipeline reports the exit code of its LAST command.** So `pytest | tail` reports whether `tail` succeeded, not whether the suite passed. Earlier runs in this arc published "exit 0" from a piped form, which is **a check that cannot fail**. The actual summary line was read directly on every run, so no conclusion rested on the exit code, but that half of those certifications carried no information. Capture first, pipe second. **Measured twice by two parties**, matching line for line.

Collection is **14771** from both the `pact-plugin` scope and the project root, and 14756 + 15 = 14771, so nothing was silently dropped.

One red was caught that **only the full gate could see**: a sweep test flagged an unused import left from the rig rewrite, which a touched-file run passed straight through.

## Version

4.6.40, PATCH. Test-only change with no user-facing behavioural shift.

## Note for the merger

The parent issue for this arc is **deliberately left open** and must not be auto-closed by this merge. Its scope is wider than this PR.








